### PR TITLE
Asm_directives and Target_system

### DIFF
--- a/.depend
+++ b/.depend
@@ -354,8 +354,7 @@ typing/subst.cmo : typing/types.cmi typing/path.cmi parsing/parsetree.cmi \
 typing/subst.cmx : typing/types.cmx typing/path.cmx parsing/parsetree.cmi \
     utils/misc.cmx parsing/location.cmx typing/ident.cmx utils/clflags.cmx \
     typing/btype.cmx parsing/ast_mapper.cmx typing/subst.cmi
-typing/subst.cmi : typing/types.cmi typing/path.cmi parsing/location.cmi \
-    typing/ident.cmi
+typing/subst.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
 typing/tast_mapper.cmo : typing/typedtree.cmi typing/env.cmi \
     parsing/asttypes.cmi typing/tast_mapper.cmi
 typing/tast_mapper.cmx : typing/typedtree.cmx typing/env.cmx \
@@ -715,14 +714,14 @@ bytecomp/translcore.cmi : typing/typedtree.cmi typing/path.cmi \
     parsing/asttypes.cmi
 bytecomp/translmod.cmo : typing/types.cmi typing/typedtree.cmi \
     bytecomp/translprim.cmi bytecomp/translobj.cmi bytecomp/translcore.cmi \
-    bytecomp/translclass.cmi bytecomp/translattribute.cmi typing/printtyp.cmi \
+    bytecomp/translclass.cmi bytecomp/translattribute.cmi \
     typing/primitive.cmi typing/predef.cmi typing/path.cmi typing/mtype.cmi \
     utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
     bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
     utils/clflags.cmi parsing/asttypes.cmi bytecomp/translmod.cmi
 bytecomp/translmod.cmx : typing/types.cmx typing/typedtree.cmx \
     bytecomp/translprim.cmx bytecomp/translobj.cmx bytecomp/translcore.cmx \
-    bytecomp/translclass.cmx bytecomp/translattribute.cmx typing/printtyp.cmx \
+    bytecomp/translclass.cmx bytecomp/translattribute.cmx \
     typing/primitive.cmx typing/predef.cmx typing/path.cmx typing/mtype.cmx \
     utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
     bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
@@ -760,13 +759,15 @@ asmcomp/CSEgen.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
 asmcomp/CSEgen.cmi : asmcomp/mach.cmi
 asmcomp/afl_instrument.cmo : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
     asmcomp/cmm.cmi utils/clflags.cmi asmcomp/backend_var.cmi \
-    parsing/asttypes.cmi asmcomp/afl_instrument.cmi
+    asmcomp/backend_sym.cmi parsing/asttypes.cmi asmcomp/afl_instrument.cmi
 asmcomp/afl_instrument.cmx : bytecomp/lambda.cmx middle_end/debuginfo.cmx \
     asmcomp/cmm.cmx utils/clflags.cmx asmcomp/backend_var.cmx \
-    parsing/asttypes.cmi asmcomp/afl_instrument.cmi
+    asmcomp/backend_sym.cmx parsing/asttypes.cmi asmcomp/afl_instrument.cmi
 asmcomp/afl_instrument.cmi : asmcomp/cmm.cmi
-asmcomp/arch.cmo : utils/config.cmi utils/clflags.cmi
-asmcomp/arch.cmx : utils/config.cmx utils/clflags.cmx
+asmcomp/arch.cmo : utils/config.cmi utils/clflags.cmi \
+    asmcomp/backend_sym.cmi
+asmcomp/arch.cmx : utils/config.cmx utils/clflags.cmx \
+    asmcomp/backend_sym.cmx
 asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
     middle_end/base_types/symbol.cmi asmcomp/split.cmi asmcomp/spill.cmi \
     asmcomp/selection.cmi asmcomp/scheduling.cmi asmcomp/reload.cmi \
@@ -781,8 +782,8 @@ asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
     utils/config.cmi asmcomp/compilenv.cmi asmcomp/comballoc.cmi \
     asmcomp/coloring.cmi asmcomp/cmmgen.cmi asmcomp/cmm.cmi \
     asmcomp/closure.cmi utils/clflags.cmi asmcomp/clambda.cmi asmcomp/CSE.cmo \
-    asmcomp/build_export_info.cmi asmcomp/debug/available_regs.cmi \
-    asmcomp/asmgen.cmi
+    asmcomp/build_export_info.cmi asmcomp/backend_sym.cmi \
+    asmcomp/debug/available_regs.cmi asmcomp/asmgen.cmi
 asmcomp/asmgen.cmx : asmcomp/un_anf.cmx bytecomp/translmod.cmx \
     middle_end/base_types/symbol.cmx asmcomp/split.cmx asmcomp/spill.cmx \
     asmcomp/selection.cmx asmcomp/scheduling.cmx asmcomp/reload.cmx \
@@ -797,10 +798,11 @@ asmcomp/asmgen.cmx : asmcomp/un_anf.cmx bytecomp/translmod.cmx \
     utils/config.cmx asmcomp/compilenv.cmx asmcomp/comballoc.cmx \
     asmcomp/coloring.cmx asmcomp/cmmgen.cmx asmcomp/cmm.cmx \
     asmcomp/closure.cmx utils/clflags.cmx asmcomp/clambda.cmx asmcomp/CSE.cmx \
-    asmcomp/build_export_info.cmx asmcomp/debug/available_regs.cmx \
-    asmcomp/asmgen.cmi
+    asmcomp/build_export_info.cmx asmcomp/backend_sym.cmx \
+    asmcomp/debug/available_regs.cmx asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/flambda.cmi asmcomp/cmm.cmi middle_end/backend_intf.cmi
+    middle_end/flambda.cmi asmcomp/cmm.cmi asmcomp/backend_sym.cmi \
+    middle_end/backend_intf.cmi
 asmcomp/asmlibrarian.cmo : utils/misc.cmi parsing/location.cmi \
     asmcomp/export_info.cmi utils/config.cmi asmcomp/compilenv.cmi \
     asmcomp/cmx_format.cmi utils/clflags.cmi asmcomp/clambda.cmi \
@@ -814,12 +816,14 @@ asmcomp/asmlink.cmo : bytecomp/runtimedef.cmi utils/profile.cmi \
     utils/misc.cmi parsing/location.cmi asmcomp/emitaux.cmi asmcomp/emit.cmi \
     utils/consistbl.cmi utils/config.cmi asmcomp/compilenv.cmi \
     asmcomp/cmx_format.cmi asmcomp/cmmgen.cmi asmcomp/cmm.cmi \
-    utils/clflags.cmi utils/ccomp.cmi asmcomp/asmgen.cmi asmcomp/asmlink.cmi
+    utils/clflags.cmi utils/ccomp.cmi asmcomp/backend_sym.cmi \
+    asmcomp/asmgen.cmi asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : bytecomp/runtimedef.cmx utils/profile.cmx \
     utils/misc.cmx parsing/location.cmx asmcomp/emitaux.cmx asmcomp/emit.cmx \
     utils/consistbl.cmx utils/config.cmx asmcomp/compilenv.cmx \
     asmcomp/cmx_format.cmi asmcomp/cmmgen.cmx asmcomp/cmm.cmx \
-    utils/clflags.cmx utils/ccomp.cmx asmcomp/asmgen.cmx asmcomp/asmlink.cmi
+    utils/clflags.cmx utils/ccomp.cmx asmcomp/backend_sym.cmx \
+    asmcomp/asmgen.cmx asmcomp/asmlink.cmi
 asmcomp/asmlink.cmi : asmcomp/cmx_format.cmi
 asmcomp/asmpackager.cmo : typing/typemod.cmi bytecomp/translmod.cmi \
     utils/profile.cmi utils/misc.cmi middle_end/middle_end.cmi \
@@ -838,10 +842,18 @@ asmcomp/asmpackager.cmx : typing/typemod.cmx bytecomp/translmod.cmx \
     utils/clflags.cmx utils/ccomp.cmx asmcomp/asmlink.cmx asmcomp/asmgen.cmx \
     asmcomp/asmpackager.cmi
 asmcomp/asmpackager.cmi : typing/env.cmi middle_end/backend_intf.cmi
-asmcomp/backend_var.cmo : typing/printtyp.cmi typing/path.cmi \
-    typing/ident.cmi middle_end/debuginfo.cmi asmcomp/backend_var.cmi
-asmcomp/backend_var.cmx : typing/printtyp.cmx typing/path.cmx \
-    typing/ident.cmx middle_end/debuginfo.cmx asmcomp/backend_var.cmi
+asmcomp/backend_sym.cmo : middle_end/base_types/symbol.cmi \
+    middle_end/base_types/linkage_name.cmi utils/identifiable.cmi \
+    middle_end/base_types/compilation_unit.cmi asmcomp/backend_sym.cmi
+asmcomp/backend_sym.cmx : middle_end/base_types/symbol.cmx \
+    middle_end/base_types/linkage_name.cmx utils/identifiable.cmx \
+    middle_end/base_types/compilation_unit.cmx asmcomp/backend_sym.cmi
+asmcomp/backend_sym.cmi : middle_end/base_types/symbol.cmi \
+    utils/identifiable.cmi
+asmcomp/backend_var.cmo : typing/path.cmi typing/ident.cmi \
+    middle_end/debuginfo.cmi asmcomp/backend_var.cmi
+asmcomp/backend_var.cmx : typing/path.cmx typing/ident.cmx \
+    middle_end/debuginfo.cmx asmcomp/backend_var.cmi
 asmcomp/backend_var.cmi : typing/path.cmi typing/ident.cmi \
     middle_end/debuginfo.cmi
 asmcomp/branch_relaxation.cmo : utils/misc.cmi asmcomp/mach.cmi \
@@ -893,14 +905,14 @@ asmcomp/clambda.cmi : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
 asmcomp/closure.cmo : utils/warnings.cmi bytecomp/switch.cmi \
     bytecomp/simplif.cmi bytecomp/semantics_of_primitives.cmi \
     typing/primitive.cmi utils/numbers.cmi utils/misc.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/env.cmi \
+    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi \
     middle_end/debuginfo.cmi utils/config.cmi asmcomp/compilenv.cmi \
     utils/clflags.cmi asmcomp/clambda.cmi asmcomp/backend_var.cmi \
     parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/closure.cmi
 asmcomp/closure.cmx : utils/warnings.cmx bytecomp/switch.cmx \
     bytecomp/simplif.cmx bytecomp/semantics_of_primitives.cmx \
     typing/primitive.cmx utils/numbers.cmx utils/misc.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/env.cmx \
+    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx \
     middle_end/debuginfo.cmx utils/config.cmx asmcomp/compilenv.cmx \
     utils/clflags.cmx asmcomp/clambda.cmx asmcomp/backend_var.cmx \
     parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/closure.cmi
@@ -916,27 +928,29 @@ asmcomp/closure_offsets.cmx : middle_end/base_types/variable.cmx \
 asmcomp/closure_offsets.cmi : middle_end/base_types/var_within_closure.cmi \
     middle_end/flambda.cmi middle_end/base_types/closure_id.cmi
 asmcomp/cmm.cmo : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
-    asmcomp/backend_var.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
-    asmcomp/cmm.cmi
+    asmcomp/backend_var.cmi asmcomp/backend_sym.cmi parsing/asttypes.cmi \
+    asmcomp/arch.cmo asmcomp/cmm.cmi
 asmcomp/cmm.cmx : bytecomp/lambda.cmx middle_end/debuginfo.cmx \
-    asmcomp/backend_var.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
-    asmcomp/cmm.cmi
+    asmcomp/backend_var.cmx asmcomp/backend_sym.cmx parsing/asttypes.cmi \
+    asmcomp/arch.cmx asmcomp/cmm.cmi
 asmcomp/cmm.cmi : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
-    asmcomp/backend_var.cmi parsing/asttypes.cmi
+    asmcomp/backend_var.cmi asmcomp/backend_sym.cmi parsing/asttypes.cmi
 asmcomp/cmmgen.cmo : asmcomp/un_anf.cmi typing/types.cmi bytecomp/switch.cmi \
     asmcomp/strmatch.cmi asmcomp/proc.cmi bytecomp/printlambda.cmi \
     typing/primitive.cmi utils/numbers.cmi utils/misc.cmi bytecomp/lambda.cmi \
     middle_end/debuginfo.cmi utils/config.cmi asmcomp/compilenv.cmi \
     asmcomp/cmx_format.cmi asmcomp/cmm.cmi utils/clflags.cmi \
-    asmcomp/clambda.cmi asmcomp/backend_var.cmi parsing/asttypes.cmi \
-    asmcomp/arch.cmo asmcomp/afl_instrument.cmi asmcomp/cmmgen.cmi
+    asmcomp/clambda.cmi asmcomp/backend_var.cmi asmcomp/backend_sym.cmi \
+    parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/afl_instrument.cmi \
+    asmcomp/cmmgen.cmi
 asmcomp/cmmgen.cmx : asmcomp/un_anf.cmx typing/types.cmx bytecomp/switch.cmx \
     asmcomp/strmatch.cmx asmcomp/proc.cmx bytecomp/printlambda.cmx \
     typing/primitive.cmx utils/numbers.cmx utils/misc.cmx bytecomp/lambda.cmx \
     middle_end/debuginfo.cmx utils/config.cmx asmcomp/compilenv.cmx \
     asmcomp/cmx_format.cmi asmcomp/cmm.cmx utils/clflags.cmx \
-    asmcomp/clambda.cmx asmcomp/backend_var.cmx parsing/asttypes.cmi \
-    asmcomp/arch.cmx asmcomp/afl_instrument.cmx asmcomp/cmmgen.cmi
+    asmcomp/clambda.cmx asmcomp/backend_var.cmx asmcomp/backend_sym.cmx \
+    parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/afl_instrument.cmx \
+    asmcomp/cmmgen.cmi
 asmcomp/cmmgen.cmi : asmcomp/cmx_format.cmi asmcomp/cmm.cmi \
     asmcomp/clambda.cmi
 asmcomp/cmx_format.cmi : asmcomp/export_info.cmi asmcomp/clambda.cmi
@@ -978,16 +992,24 @@ asmcomp/deadcode.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
 asmcomp/deadcode.cmi : asmcomp/mach.cmi
 asmcomp/emit.cmo : asmcomp/x86_proc.cmi asmcomp/x86_masm.cmi \
     asmcomp/x86_gas.cmi asmcomp/x86_dsl.cmi asmcomp/x86_ast.cmi \
-    asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi asmcomp/mach.cmi \
+    utils/targetint.cmi asmcomp/target_system.cmi asmcomp/reg.cmi \
+    asmcomp/proc.cmi utils/numbers.cmi utils/misc.cmi asmcomp/mach.cmi \
     asmcomp/linearize.cmi asmcomp/emitaux.cmi middle_end/debuginfo.cmi \
-    utils/config.cmi asmcomp/compilenv.cmi asmcomp/cmm.cmi utils/clflags.cmi \
-    asmcomp/branch_relaxation.cmi asmcomp/arch.cmo asmcomp/emit.cmi
+    utils/config.cmi asmcomp/cmm.cmi utils/clflags.cmi \
+    asmcomp/branch_relaxation.cmi asmcomp/backend_sym.cmi \
+    asmcomp/asm_target/asm_symbol.cmi asmcomp/asm_target/asm_section.cmi \
+    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_directives.cmi \
+    asmcomp/arch.cmo asmcomp/emit.cmi
 asmcomp/emit.cmx : asmcomp/x86_proc.cmx asmcomp/x86_masm.cmx \
     asmcomp/x86_gas.cmx asmcomp/x86_dsl.cmx asmcomp/x86_ast.cmi \
-    asmcomp/reg.cmx asmcomp/proc.cmx utils/misc.cmx asmcomp/mach.cmx \
+    utils/targetint.cmx asmcomp/target_system.cmx asmcomp/reg.cmx \
+    asmcomp/proc.cmx utils/numbers.cmx utils/misc.cmx asmcomp/mach.cmx \
     asmcomp/linearize.cmx asmcomp/emitaux.cmx middle_end/debuginfo.cmx \
-    utils/config.cmx asmcomp/compilenv.cmx asmcomp/cmm.cmx utils/clflags.cmx \
-    asmcomp/branch_relaxation.cmx asmcomp/arch.cmx asmcomp/emit.cmi
+    utils/config.cmx asmcomp/cmm.cmx utils/clflags.cmx \
+    asmcomp/branch_relaxation.cmx asmcomp/backend_sym.cmx \
+    asmcomp/asm_target/asm_symbol.cmx asmcomp/asm_target/asm_section.cmx \
+    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_directives.cmx \
+    asmcomp/arch.cmx asmcomp/emit.cmi
 asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : middle_end/debuginfo.cmi utils/config.cmi \
     asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
@@ -1102,12 +1124,12 @@ asmcomp/interval.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
 asmcomp/interval.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
 asmcomp/linearize.cmo : asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi \
     asmcomp/mach.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi asmcomp/linearize.cmi
+    asmcomp/cmm.cmi asmcomp/backend_sym.cmi asmcomp/linearize.cmi
 asmcomp/linearize.cmx : asmcomp/reg.cmx asmcomp/proc.cmx utils/misc.cmx \
     asmcomp/mach.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx asmcomp/linearize.cmi
+    asmcomp/cmm.cmx asmcomp/backend_sym.cmx asmcomp/linearize.cmi
 asmcomp/linearize.cmi : asmcomp/reg.cmi asmcomp/mach.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi
+    middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_sym.cmi
 asmcomp/linscan.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/interval.cmi \
     asmcomp/linscan.cmi
 asmcomp/linscan.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/interval.cmx \
@@ -1123,14 +1145,14 @@ asmcomp/liveness.cmi : asmcomp/mach.cmi
 asmcomp/mach.cmo : asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
-    asmcomp/arch.cmo asmcomp/mach.cmi
+    asmcomp/backend_sym.cmi asmcomp/arch.cmo asmcomp/mach.cmi
 asmcomp/mach.cmx : asmcomp/debug/reg_with_debug_info.cmx \
     asmcomp/debug/reg_availability_set.cmx asmcomp/reg.cmx \
     middle_end/debuginfo.cmx asmcomp/cmm.cmx asmcomp/backend_var.cmx \
-    asmcomp/arch.cmx asmcomp/mach.cmi
+    asmcomp/backend_sym.cmx asmcomp/arch.cmx asmcomp/mach.cmi
 asmcomp/mach.cmi : asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
-    asmcomp/arch.cmo
+    asmcomp/backend_sym.cmi asmcomp/arch.cmo
 asmcomp/printclambda.cmo : bytecomp/printlambda.cmi bytecomp/lambda.cmi \
     asmcomp/clambda.cmi asmcomp/backend_var.cmi parsing/asttypes.cmi \
     asmcomp/printclambda.cmi
@@ -1139,29 +1161,29 @@ asmcomp/printclambda.cmx : bytecomp/printlambda.cmx bytecomp/lambda.cmx \
     asmcomp/printclambda.cmi
 asmcomp/printclambda.cmi : asmcomp/clambda.cmi
 asmcomp/printcmm.cmo : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
-    asmcomp/cmm.cmi asmcomp/backend_var.cmi parsing/asttypes.cmi \
-    asmcomp/printcmm.cmi
+    asmcomp/cmm.cmi asmcomp/backend_var.cmi asmcomp/backend_sym.cmi \
+    parsing/asttypes.cmi asmcomp/printcmm.cmi
 asmcomp/printcmm.cmx : bytecomp/lambda.cmx middle_end/debuginfo.cmx \
-    asmcomp/cmm.cmx asmcomp/backend_var.cmx parsing/asttypes.cmi \
-    asmcomp/printcmm.cmi
+    asmcomp/cmm.cmx asmcomp/backend_var.cmx asmcomp/backend_sym.cmx \
+    parsing/asttypes.cmi asmcomp/printcmm.cmi
 asmcomp/printcmm.cmi : middle_end/debuginfo.cmi asmcomp/cmm.cmi
 asmcomp/printlinear.cmo : asmcomp/printmach.cmi asmcomp/printcmm.cmi \
     asmcomp/mach.cmi asmcomp/linearize.cmi middle_end/debuginfo.cmi \
-    asmcomp/printlinear.cmi
+    asmcomp/backend_sym.cmi asmcomp/printlinear.cmi
 asmcomp/printlinear.cmx : asmcomp/printmach.cmx asmcomp/printcmm.cmx \
     asmcomp/mach.cmx asmcomp/linearize.cmx middle_end/debuginfo.cmx \
-    asmcomp/printlinear.cmi
+    asmcomp/backend_sym.cmx asmcomp/printlinear.cmi
 asmcomp/printlinear.cmi : asmcomp/linearize.cmi
 asmcomp/printmach.cmo : asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/printcmm.cmi asmcomp/mach.cmi \
     asmcomp/interval.cmi middle_end/debuginfo.cmi utils/config.cmi \
     asmcomp/cmm.cmi utils/clflags.cmi asmcomp/backend_var.cmi \
-    asmcomp/arch.cmo asmcomp/printmach.cmi
+    asmcomp/backend_sym.cmi asmcomp/arch.cmo asmcomp/printmach.cmi
 asmcomp/printmach.cmx : asmcomp/debug/reg_availability_set.cmx \
     asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/printcmm.cmx asmcomp/mach.cmx \
     asmcomp/interval.cmx middle_end/debuginfo.cmx utils/config.cmx \
     asmcomp/cmm.cmx utils/clflags.cmx asmcomp/backend_var.cmx \
-    asmcomp/arch.cmx asmcomp/printmach.cmi
+    asmcomp/backend_sym.cmx asmcomp/arch.cmx asmcomp/printmach.cmi
 asmcomp/printmach.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
 asmcomp/proc.cmo : asmcomp/x86_proc.cmi asmcomp/reg.cmi utils/misc.cmi \
     asmcomp/mach.cmi utils/config.cmi asmcomp/cmm.cmi asmcomp/arch.cmo \
@@ -1196,33 +1218,35 @@ asmcomp/scheduling.cmi : asmcomp/linearize.cmi
 asmcomp/selectgen.cmo : bytecomp/simplif.cmi asmcomp/reg.cmi \
     asmcomp/proc.cmi utils/numbers.cmi utils/misc.cmi asmcomp/mach.cmi \
     bytecomp/lambda.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi asmcomp/backend_var.cmi parsing/asttypes.cmi \
-    asmcomp/arch.cmo asmcomp/selectgen.cmi
+    asmcomp/cmm.cmi asmcomp/backend_var.cmi asmcomp/backend_sym.cmi \
+    parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/selectgen.cmi
 asmcomp/selectgen.cmx : bytecomp/simplif.cmx asmcomp/reg.cmx \
     asmcomp/proc.cmx utils/numbers.cmx utils/misc.cmx asmcomp/mach.cmx \
     bytecomp/lambda.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx asmcomp/backend_var.cmx parsing/asttypes.cmi \
-    asmcomp/arch.cmx asmcomp/selectgen.cmi
+    asmcomp/cmm.cmx asmcomp/backend_var.cmx asmcomp/backend_sym.cmx \
+    parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/selectgen.cmi
 asmcomp/selectgen.cmi : asmcomp/reg.cmi asmcomp/mach.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
     asmcomp/arch.cmo
 asmcomp/selection.cmo : asmcomp/spacetime_profiling.cmi \
     asmcomp/selectgen.cmi asmcomp/proc.cmi asmcomp/mach.cmi utils/config.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/selection.cmi
+    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/backend_sym.cmi \
+    asmcomp/arch.cmo asmcomp/selection.cmi
 asmcomp/selection.cmx : asmcomp/spacetime_profiling.cmx \
     asmcomp/selectgen.cmx asmcomp/proc.cmx asmcomp/mach.cmx utils/config.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/selection.cmi
+    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/backend_sym.cmx \
+    asmcomp/arch.cmx asmcomp/selection.cmi
 asmcomp/selection.cmi : asmcomp/mach.cmi asmcomp/cmm.cmi
 asmcomp/spacetime_profiling.cmo : asmcomp/selectgen.cmi asmcomp/proc.cmi \
     utils/misc.cmi asmcomp/mach.cmi bytecomp/lambda.cmi \
     middle_end/debuginfo.cmi utils/config.cmi asmcomp/cmm.cmi \
-    asmcomp/backend_var.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
-    asmcomp/spacetime_profiling.cmi
+    asmcomp/backend_var.cmi asmcomp/backend_sym.cmi parsing/asttypes.cmi \
+    asmcomp/arch.cmo asmcomp/spacetime_profiling.cmi
 asmcomp/spacetime_profiling.cmx : asmcomp/selectgen.cmx asmcomp/proc.cmx \
     utils/misc.cmx asmcomp/mach.cmx bytecomp/lambda.cmx \
     middle_end/debuginfo.cmx utils/config.cmx asmcomp/cmm.cmx \
-    asmcomp/backend_var.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
-    asmcomp/spacetime_profiling.cmi
+    asmcomp/backend_var.cmx asmcomp/backend_sym.cmx parsing/asttypes.cmi \
+    asmcomp/arch.cmx asmcomp/spacetime_profiling.cmi
 asmcomp/spacetime_profiling.cmi : asmcomp/selectgen.cmi
 asmcomp/spill.cmo : asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi \
     asmcomp/mach.cmi asmcomp/cmm.cmi utils/clflags.cmi asmcomp/spill.cmi
@@ -1242,6 +1266,11 @@ asmcomp/strmatch.cmx : parsing/location.cmx bytecomp/lambda.cmx \
     parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/strmatch.cmi
 asmcomp/strmatch.cmi : parsing/location.cmi middle_end/debuginfo.cmi \
     asmcomp/cmm.cmi
+asmcomp/target_system.cmo : utils/targetint.cmi utils/misc.cmi \
+    utils/config.cmi asmcomp/target_system.cmi
+asmcomp/target_system.cmx : utils/targetint.cmx utils/misc.cmx \
+    utils/config.cmx asmcomp/target_system.cmi
+asmcomp/target_system.cmi :
 asmcomp/traverse_for_exported_symbols.cmo : \
     middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
@@ -1277,20 +1306,32 @@ asmcomp/un_anf.cmx : bytecomp/semantics_of_primitives.cmx \
     middle_end/debuginfo.cmx utils/clflags.cmx asmcomp/clambda.cmx \
     asmcomp/backend_var.cmx parsing/asttypes.cmi asmcomp/un_anf.cmi
 asmcomp/un_anf.cmi : asmcomp/clambda.cmi
-asmcomp/x86_ast.cmi :
+asmcomp/x86_ast.cmi : asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_directives.cmi
 asmcomp/x86_dsl.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
+    asmcomp/asm_target/asm_symbol.cmi asmcomp/asm_target/asm_label.cmi \
     asmcomp/x86_dsl.cmi
 asmcomp/x86_dsl.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
+    asmcomp/asm_target/asm_symbol.cmx asmcomp/asm_target/asm_label.cmx \
     asmcomp/x86_dsl.cmi
-asmcomp/x86_dsl.cmi : asmcomp/x86_ast.cmi
+asmcomp/x86_dsl.cmi : asmcomp/x86_ast.cmi asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_label.cmi
 asmcomp/x86_gas.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
-    utils/misc.cmi asmcomp/x86_gas.cmi
+    utils/misc.cmi asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_directives.cmi \
+    asmcomp/x86_gas.cmi
 asmcomp/x86_gas.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
-    utils/misc.cmx asmcomp/x86_gas.cmi
+    utils/misc.cmx asmcomp/asm_target/asm_symbol.cmx \
+    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_directives.cmx \
+    asmcomp/x86_gas.cmi
 asmcomp/x86_gas.cmi : asmcomp/x86_ast.cmi
 asmcomp/x86_masm.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
+    utils/misc.cmi asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_directives.cmi \
     asmcomp/x86_masm.cmi
 asmcomp/x86_masm.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
+    utils/misc.cmx asmcomp/asm_target/asm_symbol.cmx \
+    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_directives.cmx \
     asmcomp/x86_masm.cmi
 asmcomp/x86_masm.cmi : asmcomp/x86_ast.cmi
 asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi utils/misc.cmi utils/config.cmi \
@@ -2298,16 +2339,6 @@ middle_end/base_types/variable.cmx : utils/misc.cmx \
 middle_end/base_types/variable.cmi : middle_end/internal_variable_names.cmi \
     utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
-asmcomp/debug/asm_directives.cmo : utils/targetint.cmi \
-    asmcomp/debug/target_system.cmi utils/numbers.cmi utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi utils/config.cmi asmcomp/cmm.cmi \
-    utils/clflags.cmi asmcomp/arch.cmo asmcomp/debug/asm_directives.cmi
-asmcomp/debug/asm_directives.cmx : utils/targetint.cmx \
-    asmcomp/debug/target_system.cmx utils/numbers.cmx utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx utils/config.cmx asmcomp/cmm.cmx \
-    utils/clflags.cmx asmcomp/arch.cmx asmcomp/debug/asm_directives.cmi
-asmcomp/debug/asm_directives.cmi : utils/targetint.cmi \
-    asmcomp/debug/target_system.cmi utils/numbers.cmi asmcomp/cmm.cmi
 asmcomp/debug/available_regs.cmo : asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi asmcomp/proc.cmi \
     asmcomp/printmach.cmi utils/misc.cmi asmcomp/mach.cmi utils/clflags.cmi \
@@ -2325,25 +2356,44 @@ asmcomp/debug/reg_availability_set.cmx : \
     asmcomp/debug/reg_availability_set.cmi
 asmcomp/debug/reg_availability_set.cmi : \
     asmcomp/debug/reg_with_debug_info.cmi asmcomp/reg.cmi
-<<<<<<< HEAD
 asmcomp/debug/reg_with_debug_info.cmo : asmcomp/reg.cmi \
     asmcomp/backend_var.cmi asmcomp/debug/reg_with_debug_info.cmi
 asmcomp/debug/reg_with_debug_info.cmx : asmcomp/reg.cmx \
     asmcomp/backend_var.cmx asmcomp/debug/reg_with_debug_info.cmi
 asmcomp/debug/reg_with_debug_info.cmi : asmcomp/reg.cmi \
     asmcomp/backend_var.cmi
-=======
-asmcomp/debug/reg_with_debug_info.cmo : asmcomp/reg.cmi typing/ident.cmi \
-    asmcomp/debug/reg_with_debug_info.cmi
-asmcomp/debug/reg_with_debug_info.cmx : asmcomp/reg.cmx typing/ident.cmx \
-    asmcomp/debug/reg_with_debug_info.cmi
-asmcomp/debug/reg_with_debug_info.cmi : asmcomp/reg.cmi typing/ident.cmi
-asmcomp/debug/target_system.cmo : utils/targetint.cmi utils/misc.cmi \
-    utils/config.cmi asmcomp/debug/target_system.cmi
-asmcomp/debug/target_system.cmx : utils/targetint.cmx utils/misc.cmx \
-    utils/config.cmx asmcomp/debug/target_system.cmi
-asmcomp/debug/target_system.cmi :
->>>>>>> 719c984c63... GPR#2073 (Asm_directives and Target_system)
+asmcomp/asm_target/asm_directives.cmo : utils/targetint.cmi \
+    asmcomp/target_system.cmi utils/numbers.cmi utils/misc.cmi \
+    utils/config.cmi utils/clflags.cmi asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_section.cmi asmcomp/asm_target/asm_label.cmi \
+    asmcomp/asm_target/asm_directives.cmi
+asmcomp/asm_target/asm_directives.cmx : utils/targetint.cmx \
+    asmcomp/target_system.cmx utils/numbers.cmx utils/misc.cmx \
+    utils/config.cmx utils/clflags.cmx asmcomp/asm_target/asm_symbol.cmx \
+    asmcomp/asm_target/asm_section.cmx asmcomp/asm_target/asm_label.cmx \
+    asmcomp/asm_target/asm_directives.cmi
+asmcomp/asm_target/asm_directives.cmi : utils/targetint.cmi \
+    asmcomp/target_system.cmi utils/numbers.cmi \
+    asmcomp/asm_target/asm_symbol.cmi asmcomp/asm_target/asm_section.cmi \
+    asmcomp/asm_target/asm_label.cmi
+asmcomp/asm_target/asm_label.cmo : asmcomp/target_system.cmi utils/misc.cmi \
+    asmcomp/asm_target/asm_label.cmi
+asmcomp/asm_target/asm_label.cmx : asmcomp/target_system.cmx utils/misc.cmx \
+    asmcomp/asm_target/asm_label.cmi
+asmcomp/asm_target/asm_label.cmi :
+asmcomp/asm_target/asm_section.cmo : asmcomp/target_system.cmi \
+    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_section.cmi
+asmcomp/asm_target/asm_section.cmx : asmcomp/target_system.cmx \
+    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_section.cmi
+asmcomp/asm_target/asm_section.cmi : asmcomp/asm_target/asm_label.cmi
+asmcomp/asm_target/asm_symbol.cmo : asmcomp/target_system.cmi \
+    utils/identifiable.cmi asmcomp/backend_sym.cmi \
+    asmcomp/asm_target/asm_symbol.cmi
+asmcomp/asm_target/asm_symbol.cmx : asmcomp/target_system.cmx \
+    utils/identifiable.cmx asmcomp/backend_sym.cmx \
+    asmcomp/asm_target/asm_symbol.cmi
+asmcomp/asm_target/asm_symbol.cmi : utils/identifiable.cmi \
+    asmcomp/backend_sym.cmi
 driver/compdynlink.cmi :
 driver/compenv.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
     parsing/location.cmi utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
@@ -2506,9 +2556,9 @@ toplevel/opttoploop.cmo : utils/warnings.cmi typing/types.cmi \
     asmcomp/import_approx.cmi typing/ident.cmi toplevel/genprintval.cmi \
     typing/env.cmi utils/config.cmi driver/compmisc.cmi asmcomp/compilenv.cmi \
     driver/compenv.cmi driver/compdynlink.cmi utils/clflags.cmi \
-    typing/btype.cmi middle_end/backend_intf.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi asmcomp/asmlink.cmi asmcomp/asmgen.cmi \
-    asmcomp/arch.cmo toplevel/opttoploop.cmi
+    typing/btype.cmi asmcomp/backend_sym.cmi middle_end/backend_intf.cmi \
+    parsing/asttypes.cmi parsing/ast_helper.cmi asmcomp/asmlink.cmi \
+    asmcomp/asmgen.cmi asmcomp/arch.cmo toplevel/opttoploop.cmi
 toplevel/opttoploop.cmx : utils/warnings.cmx typing/types.cmx \
     typing/typemod.cmx typing/typedtree.cmx typing/typecore.cmx \
     bytecomp/translmod.cmx bytecomp/simplif.cmx asmcomp/proc.cmx \
@@ -2521,9 +2571,9 @@ toplevel/opttoploop.cmx : utils/warnings.cmx typing/types.cmx \
     asmcomp/import_approx.cmx typing/ident.cmx toplevel/genprintval.cmx \
     typing/env.cmx utils/config.cmx driver/compmisc.cmx asmcomp/compilenv.cmx \
     driver/compenv.cmx driver/compdynlink.cmi utils/clflags.cmx \
-    typing/btype.cmx middle_end/backend_intf.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmx asmcomp/asmlink.cmx asmcomp/asmgen.cmx \
-    asmcomp/arch.cmx toplevel/opttoploop.cmi
+    typing/btype.cmx asmcomp/backend_sym.cmx middle_end/backend_intf.cmi \
+    parsing/asttypes.cmi parsing/ast_helper.cmx asmcomp/asmlink.cmx \
+    asmcomp/asmgen.cmx asmcomp/arch.cmx toplevel/opttoploop.cmi
 toplevel/opttoploop.cmi : utils/warnings.cmi typing/types.cmi \
     typing/path.cmi parsing/parsetree.cmi typing/outcometree.cmi \
     parsing/longident.cmi parsing/location.cmi typing/env.cmi

--- a/.depend
+++ b/.depend
@@ -213,8 +213,10 @@ typing/envaux.cmo : typing/subst.cmi typing/printtyp.cmi typing/path.cmi \
 typing/envaux.cmx : typing/subst.cmx typing/printtyp.cmx typing/path.cmx \
     typing/ident.cmx typing/env.cmx typing/envaux.cmi
 typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
-typing/ident.cmo : utils/identifiable.cmi utils/clflags.cmi typing/ident.cmi
-typing/ident.cmx : utils/identifiable.cmx utils/clflags.cmx typing/ident.cmi
+typing/ident.cmo : utils/misc.cmi utils/identifiable.cmi utils/clflags.cmi \
+    typing/ident.cmi
+typing/ident.cmx : utils/misc.cmx utils/identifiable.cmx utils/clflags.cmx \
+    typing/ident.cmi
 typing/ident.cmi : utils/identifiable.cmi
 typing/includeclass.cmo : typing/types.cmi typing/printtyp.cmi \
     typing/path.cmi typing/ctype.cmi parsing/builtin_attributes.cmi \
@@ -308,17 +310,17 @@ typing/printpat.cmi : typing/typedtree.cmi parsing/asttypes.cmi
 typing/printtyp.cmo : utils/warnings.cmi typing/types.cmi \
     typing/primitive.cmi typing/predef.cmi typing/path.cmi \
     parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmi \
-    utils/numbers.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
-    parsing/asttypes.cmi typing/printtyp.cmi
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
+    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
+    typing/printtyp.cmi
 typing/printtyp.cmx : utils/warnings.cmx typing/types.cmx \
     typing/primitive.cmx typing/predef.cmx typing/path.cmx \
     parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmx \
-    utils/numbers.cmx utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/clflags.cmx parsing/builtin_attributes.cmx typing/btype.cmx \
-    parsing/asttypes.cmi typing/printtyp.cmi
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
+    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
+    typing/printtyp.cmi
 typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
@@ -2296,6 +2298,16 @@ middle_end/base_types/variable.cmx : utils/misc.cmx \
 middle_end/base_types/variable.cmi : middle_end/internal_variable_names.cmi \
     utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
+asmcomp/debug/asm_directives.cmo : utils/targetint.cmi \
+    asmcomp/debug/target_system.cmi utils/numbers.cmi utils/misc.cmi \
+    middle_end/base_types/linkage_name.cmi utils/config.cmi asmcomp/cmm.cmi \
+    utils/clflags.cmi asmcomp/arch.cmo asmcomp/debug/asm_directives.cmi
+asmcomp/debug/asm_directives.cmx : utils/targetint.cmx \
+    asmcomp/debug/target_system.cmx utils/numbers.cmx utils/misc.cmx \
+    middle_end/base_types/linkage_name.cmx utils/config.cmx asmcomp/cmm.cmx \
+    utils/clflags.cmx asmcomp/arch.cmx asmcomp/debug/asm_directives.cmi
+asmcomp/debug/asm_directives.cmi : utils/targetint.cmi \
+    asmcomp/debug/target_system.cmi utils/numbers.cmi asmcomp/cmm.cmi
 asmcomp/debug/available_regs.cmo : asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi asmcomp/proc.cmi \
     asmcomp/printmach.cmi utils/misc.cmi asmcomp/mach.cmi utils/clflags.cmi \
@@ -2313,12 +2325,25 @@ asmcomp/debug/reg_availability_set.cmx : \
     asmcomp/debug/reg_availability_set.cmi
 asmcomp/debug/reg_availability_set.cmi : \
     asmcomp/debug/reg_with_debug_info.cmi asmcomp/reg.cmi
+<<<<<<< HEAD
 asmcomp/debug/reg_with_debug_info.cmo : asmcomp/reg.cmi \
     asmcomp/backend_var.cmi asmcomp/debug/reg_with_debug_info.cmi
 asmcomp/debug/reg_with_debug_info.cmx : asmcomp/reg.cmx \
     asmcomp/backend_var.cmx asmcomp/debug/reg_with_debug_info.cmi
 asmcomp/debug/reg_with_debug_info.cmi : asmcomp/reg.cmi \
     asmcomp/backend_var.cmi
+=======
+asmcomp/debug/reg_with_debug_info.cmo : asmcomp/reg.cmi typing/ident.cmi \
+    asmcomp/debug/reg_with_debug_info.cmi
+asmcomp/debug/reg_with_debug_info.cmx : asmcomp/reg.cmx typing/ident.cmx \
+    asmcomp/debug/reg_with_debug_info.cmi
+asmcomp/debug/reg_with_debug_info.cmi : asmcomp/reg.cmi typing/ident.cmi
+asmcomp/debug/target_system.cmo : utils/targetint.cmi utils/misc.cmi \
+    utils/config.cmi asmcomp/debug/target_system.cmi
+asmcomp/debug/target_system.cmx : utils/targetint.cmx utils/misc.cmx \
+    utils/config.cmx asmcomp/debug/target_system.cmi
+asmcomp/debug/target_system.cmi :
+>>>>>>> 719c984c63... GPR#2073 (Asm_directives and Target_system)
 driver/compdynlink.cmi :
 driver/compenv.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
     parsing/location.cmi utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
@@ -2460,14 +2485,14 @@ toplevel/genprintval.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi typing/env.cmi
 toplevel/opttopdirs.cmo : utils/warnings.cmi typing/types.cmi \
     typing/printtyp.cmi toplevel/opttoploop.cmi utils/misc.cmi \
-    parsing/longident.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/config.cmi driver/compdynlink.cmi utils/clflags.cmi \
-    asmcomp/asmlink.cmi toplevel/opttopdirs.cmi
+    parsing/longident.cmi typing/env.cmi typing/ctype.cmi utils/config.cmi \
+    driver/compdynlink.cmi utils/clflags.cmi asmcomp/asmlink.cmi \
+    toplevel/opttopdirs.cmi
 toplevel/opttopdirs.cmx : utils/warnings.cmx typing/types.cmx \
     typing/printtyp.cmx toplevel/opttoploop.cmx utils/misc.cmx \
-    parsing/longident.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/config.cmx driver/compdynlink.cmi utils/clflags.cmx \
-    asmcomp/asmlink.cmx toplevel/opttopdirs.cmi
+    parsing/longident.cmx typing/env.cmx typing/ctype.cmx utils/config.cmx \
+    driver/compdynlink.cmi utils/clflags.cmx asmcomp/asmlink.cmx \
+    toplevel/opttopdirs.cmi
 toplevel/opttopdirs.cmi : parsing/longident.cmi
 toplevel/opttoploop.cmo : utils/warnings.cmi typing/types.cmi \
     typing/typemod.cmi typing/typedtree.cmi typing/typecore.cmi \

--- a/.depend
+++ b/.depend
@@ -849,7 +849,7 @@ asmcomp/backend_sym.cmx : middle_end/base_types/symbol.cmx \
     middle_end/base_types/linkage_name.cmx utils/identifiable.cmx \
     middle_end/base_types/compilation_unit.cmx asmcomp/backend_sym.cmi
 asmcomp/backend_sym.cmi : middle_end/base_types/symbol.cmi \
-    utils/identifiable.cmi
+    utils/identifiable.cmi middle_end/base_types/compilation_unit.cmi
 asmcomp/backend_var.cmo : typing/path.cmi typing/ident.cmi \
     middle_end/debuginfo.cmi asmcomp/backend_var.cmi
 asmcomp/backend_var.cmx : typing/path.cmx typing/ident.cmx \
@@ -897,11 +897,13 @@ asmcomp/build_export_info.cmx : middle_end/base_types/variable.cmx \
 asmcomp/build_export_info.cmi : middle_end/flambda.cmi \
     asmcomp/export_info.cmi middle_end/backend_intf.cmi
 asmcomp/clambda.cmo : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
-    asmcomp/backend_var.cmi parsing/asttypes.cmi asmcomp/clambda.cmi
+    asmcomp/backend_var.cmi asmcomp/backend_sym.cmi parsing/asttypes.cmi \
+    asmcomp/clambda.cmi
 asmcomp/clambda.cmx : bytecomp/lambda.cmx middle_end/debuginfo.cmx \
-    asmcomp/backend_var.cmx parsing/asttypes.cmi asmcomp/clambda.cmi
+    asmcomp/backend_var.cmx asmcomp/backend_sym.cmx parsing/asttypes.cmi \
+    asmcomp/clambda.cmi
 asmcomp/clambda.cmi : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
-    asmcomp/backend_var.cmi parsing/asttypes.cmi
+    asmcomp/backend_var.cmi asmcomp/backend_sym.cmi parsing/asttypes.cmi
 asmcomp/closure.cmo : utils/warnings.cmi bytecomp/switch.cmi \
     bytecomp/simplif.cmi bytecomp/semantics_of_primitives.cmi \
     typing/primitive.cmi utils/numbers.cmi utils/misc.cmi \
@@ -995,21 +997,21 @@ asmcomp/emit.cmo : asmcomp/x86_proc.cmi asmcomp/x86_masm.cmi \
     utils/targetint.cmi asmcomp/target_system.cmi asmcomp/reg.cmi \
     asmcomp/proc.cmi utils/numbers.cmi utils/misc.cmi asmcomp/mach.cmi \
     asmcomp/linearize.cmi asmcomp/emitaux.cmi middle_end/debuginfo.cmi \
-    utils/config.cmi asmcomp/cmm.cmi utils/clflags.cmi \
-    asmcomp/branch_relaxation.cmi asmcomp/backend_sym.cmi \
-    asmcomp/asm_target/asm_symbol.cmi asmcomp/asm_target/asm_section.cmi \
-    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_directives.cmi \
-    asmcomp/arch.cmo asmcomp/emit.cmi
+    utils/config.cmi middle_end/base_types/compilation_unit.cmi \
+    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/branch_relaxation.cmi \
+    asmcomp/backend_sym.cmi asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_section.cmi asmcomp/asm_target/asm_label.cmi \
+    asmcomp/asm_target/asm_directives.cmi asmcomp/arch.cmo asmcomp/emit.cmi
 asmcomp/emit.cmx : asmcomp/x86_proc.cmx asmcomp/x86_masm.cmx \
     asmcomp/x86_gas.cmx asmcomp/x86_dsl.cmx asmcomp/x86_ast.cmi \
     utils/targetint.cmx asmcomp/target_system.cmx asmcomp/reg.cmx \
     asmcomp/proc.cmx utils/numbers.cmx utils/misc.cmx asmcomp/mach.cmx \
     asmcomp/linearize.cmx asmcomp/emitaux.cmx middle_end/debuginfo.cmx \
-    utils/config.cmx asmcomp/cmm.cmx utils/clflags.cmx \
-    asmcomp/branch_relaxation.cmx asmcomp/backend_sym.cmx \
-    asmcomp/asm_target/asm_symbol.cmx asmcomp/asm_target/asm_section.cmx \
-    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_directives.cmx \
-    asmcomp/arch.cmx asmcomp/emit.cmi
+    utils/config.cmx middle_end/base_types/compilation_unit.cmx \
+    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/branch_relaxation.cmx \
+    asmcomp/backend_sym.cmx asmcomp/asm_target/asm_symbol.cmx \
+    asmcomp/asm_target/asm_section.cmx asmcomp/asm_target/asm_label.cmx \
+    asmcomp/asm_target/asm_directives.cmx asmcomp/arch.cmx asmcomp/emit.cmi
 asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : middle_end/debuginfo.cmi utils/config.cmi \
     asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
@@ -1154,11 +1156,11 @@ asmcomp/mach.cmi : asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
     asmcomp/backend_sym.cmi asmcomp/arch.cmo
 asmcomp/printclambda.cmo : bytecomp/printlambda.cmi bytecomp/lambda.cmi \
-    asmcomp/clambda.cmi asmcomp/backend_var.cmi parsing/asttypes.cmi \
-    asmcomp/printclambda.cmi
+    asmcomp/clambda.cmi asmcomp/backend_var.cmi asmcomp/backend_sym.cmi \
+    parsing/asttypes.cmi asmcomp/printclambda.cmi
 asmcomp/printclambda.cmx : bytecomp/printlambda.cmx bytecomp/lambda.cmx \
-    asmcomp/clambda.cmx asmcomp/backend_var.cmx parsing/asttypes.cmi \
-    asmcomp/printclambda.cmi
+    asmcomp/clambda.cmx asmcomp/backend_var.cmx asmcomp/backend_sym.cmx \
+    parsing/asttypes.cmi asmcomp/printclambda.cmi
 asmcomp/printclambda.cmi : asmcomp/clambda.cmi
 asmcomp/printcmm.cmo : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
     asmcomp/cmm.cmi asmcomp/backend_var.cmi asmcomp/backend_sym.cmi \
@@ -2364,36 +2366,44 @@ asmcomp/debug/reg_with_debug_info.cmi : asmcomp/reg.cmi \
     asmcomp/backend_var.cmi
 asmcomp/asm_target/asm_directives.cmo : utils/targetint.cmi \
     asmcomp/target_system.cmi utils/numbers.cmi utils/misc.cmi \
-    utils/config.cmi utils/clflags.cmi asmcomp/asm_target/asm_symbol.cmi \
-    asmcomp/asm_target/asm_section.cmi asmcomp/asm_target/asm_label.cmi \
-    asmcomp/asm_target/asm_directives.cmi
+    utils/identifiable.cmi utils/config.cmi \
+    middle_end/base_types/compilation_unit.cmi utils/clflags.cmi \
+    asmcomp/asm_target/asm_symbol.cmi asmcomp/asm_target/asm_section.cmi \
+    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_directives.cmi
 asmcomp/asm_target/asm_directives.cmx : utils/targetint.cmx \
     asmcomp/target_system.cmx utils/numbers.cmx utils/misc.cmx \
-    utils/config.cmx utils/clflags.cmx asmcomp/asm_target/asm_symbol.cmx \
-    asmcomp/asm_target/asm_section.cmx asmcomp/asm_target/asm_label.cmx \
-    asmcomp/asm_target/asm_directives.cmi
+    utils/identifiable.cmx utils/config.cmx \
+    middle_end/base_types/compilation_unit.cmx utils/clflags.cmx \
+    asmcomp/asm_target/asm_symbol.cmx asmcomp/asm_target/asm_section.cmx \
+    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_directives.cmi
 asmcomp/asm_target/asm_directives.cmi : utils/targetint.cmi \
     asmcomp/target_system.cmi utils/numbers.cmi \
     asmcomp/asm_target/asm_symbol.cmi asmcomp/asm_target/asm_section.cmi \
     asmcomp/asm_target/asm_label.cmi
 asmcomp/asm_target/asm_label.cmo : asmcomp/target_system.cmi utils/misc.cmi \
+    utils/identifiable.cmi asmcomp/asm_target/asm_section.cmi \
     asmcomp/asm_target/asm_label.cmi
 asmcomp/asm_target/asm_label.cmx : asmcomp/target_system.cmx utils/misc.cmx \
+    utils/identifiable.cmx asmcomp/asm_target/asm_section.cmx \
     asmcomp/asm_target/asm_label.cmi
-asmcomp/asm_target/asm_label.cmi :
+asmcomp/asm_target/asm_label.cmi : utils/identifiable.cmi \
+    asmcomp/asm_target/asm_section.cmi
 asmcomp/asm_target/asm_section.cmo : asmcomp/target_system.cmi \
-    asmcomp/asm_target/asm_label.cmi asmcomp/asm_target/asm_section.cmi
+    utils/clflags.cmi asmcomp/asm_target/asm_section.cmi
 asmcomp/asm_target/asm_section.cmx : asmcomp/target_system.cmx \
-    asmcomp/asm_target/asm_label.cmx asmcomp/asm_target/asm_section.cmi
-asmcomp/asm_target/asm_section.cmi : asmcomp/asm_target/asm_label.cmi
-asmcomp/asm_target/asm_symbol.cmo : asmcomp/target_system.cmi \
-    utils/identifiable.cmi asmcomp/backend_sym.cmi \
-    asmcomp/asm_target/asm_symbol.cmi
-asmcomp/asm_target/asm_symbol.cmx : asmcomp/target_system.cmx \
-    utils/identifiable.cmx asmcomp/backend_sym.cmx \
-    asmcomp/asm_target/asm_symbol.cmi
-asmcomp/asm_target/asm_symbol.cmi : utils/identifiable.cmi \
-    asmcomp/backend_sym.cmi
+    utils/clflags.cmx asmcomp/asm_target/asm_section.cmi
+asmcomp/asm_target/asm_section.cmi :
+asmcomp/asm_target/asm_symbol.cmo : asmcomp/target_system.cmi utils/misc.cmi \
+    middle_end/base_types/linkage_name.cmi utils/identifiable.cmi \
+    middle_end/base_types/compilation_unit.cmi asmcomp/backend_sym.cmi \
+    asmcomp/asm_target/asm_section.cmi asmcomp/asm_target/asm_symbol.cmi
+asmcomp/asm_target/asm_symbol.cmx : asmcomp/target_system.cmx utils/misc.cmx \
+    middle_end/base_types/linkage_name.cmx utils/identifiable.cmx \
+    middle_end/base_types/compilation_unit.cmx asmcomp/backend_sym.cmx \
+    asmcomp/asm_target/asm_section.cmx asmcomp/asm_target/asm_symbol.cmi
+asmcomp/asm_target/asm_symbol.cmi : middle_end/base_types/linkage_name.cmi \
+    utils/identifiable.cmi middle_end/base_types/compilation_unit.cmi \
+    asmcomp/backend_sym.cmi asmcomp/asm_target/asm_section.cmi
 driver/compdynlink.cmi :
 driver/compenv.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
     parsing/location.cmi utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \

--- a/Changes
+++ b/Changes
@@ -422,9 +422,9 @@ Working version
 - GPR#2072: Always associate a scope to a type
   (Thomas Refis, review by Jacques Garrigue and Leo White)
 
-- GPR#2073: Add [Asm_directives] and [Target_system], initially only for
-  the use of the DWARF debugging information emitter.
-  (Mark Shinwell)
+- GPR#2073: Add [Asm_directives], [Asm_label], [Asm_section], [Asm_symbol],
+  [Backend_sym] and [Target_system].
+  (Mark Shinwell, review by Damien Doligez)
 
 - GPR#2074: Correct naming of record field inside [Ialloc] terms.
   (Mark Shinwell, review by Jérémie Dimino)

--- a/Changes
+++ b/Changes
@@ -422,6 +422,10 @@ Working version
 - GPR#2072: Always associate a scope to a type
   (Thomas Refis, review by Jacques Garrigue and Leo White)
 
+- GPR#2073: Add [Asm_directives] and [Target_system], initially only for
+  the use of the DWARF debugging information emitter.
+  (Mark Shinwell)
+
 - GPR#2074: Correct naming of record field inside [Ialloc] terms.
   (Mark Shinwell, review by Jérémie Dimino)
 

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ ASMCOMP=\
   asmcomp/deadcode.cmo \
   asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \
+  asmcomp/debug/target_system.cmo \
+  asmcomp/debug/asm_directives.cmo \
   asmcomp/schedgen.cmo asmcomp/scheduling.cmo \
   asmcomp/branch_relaxation_intf.cmo \
   asmcomp/branch_relaxation.cmo \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink
 ARCHES=amd64 i386 arm arm64 power s390x
 INCLUDES=-I utils -I parsing -I typing -I bytecomp -I middle_end \
         -I middle_end/base_types -I asmcomp -I asmcomp/debug \
-        -I driver -I toplevel
+        -I asmcomp/asm_target -I driver -I toplevel
 
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-41-42-44-45-48 \
 	  -warn-error A \
@@ -144,9 +144,15 @@ ARCH_SPECIFIC_ASMCOMP=$(INTEL_ASM)
 endif
 
 ASMCOMP=\
+  asmcomp/backend_var.cmo \
+  asmcomp/backend_sym.cmo \
+  asmcomp/target_system.cmo \
+  asmcomp/asm_target/asm_label.cmo \
+  asmcomp/asm_target/asm_symbol.cmo \
+  asmcomp/asm_target/asm_section.cmo \
+  asmcomp/asm_target/asm_directives.cmo \
   $(ARCH_SPECIFIC_ASMCOMP) \
   asmcomp/arch.cmo \
-  asmcomp/backend_var.cmo \
   asmcomp/cmm.cmo asmcomp/printcmm.cmo \
   asmcomp/reg.cmo asmcomp/debug/reg_with_debug_info.cmo \
   asmcomp/debug/reg_availability_set.cmo \
@@ -177,8 +183,6 @@ ASMCOMP=\
   asmcomp/deadcode.cmo \
   asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \
-  asmcomp/debug/target_system.cmo \
-  asmcomp/debug/asm_directives.cmo \
   asmcomp/schedgen.cmo asmcomp/scheduling.cmo \
   asmcomp/branch_relaxation_intf.cmo \
   asmcomp/branch_relaxation.cmo \
@@ -1355,7 +1359,8 @@ partialclean::
 
 partialclean::
 	for d in utils parsing typing bytecomp asmcomp middle_end \
-	         middle_end/base_types asmcomp/debug driver toplevel tools; do \
+	         middle_end/base_types asmcomp/debug asmcomp/asm_target \
+           driver toplevel tools; do \
 	  rm -f $$d/*.cm[ioxt] $$d/*.cmti $$d/*.annot $$d/*.$(S) \
 	    $$d/*.$(O) $$d/*.$(SO) $d/*~; \
 	done
@@ -1364,7 +1369,7 @@ partialclean::
 .PHONY: depend
 depend: beforedepend
 	(for d in utils parsing typing bytecomp asmcomp middle_end \
-	 middle_end/base_types asmcomp/debug driver toplevel; \
+	 middle_end/base_types asmcomp/debug asmcomp/asm_target driver toplevel; \
 	 do $(CAMLDEP) -slash $(DEPFLAGS) $$d/*.mli $$d/*.ml || exit; \
 	 done) > .depend
 	$(CAMLDEP) -slash $(DEPFLAGS) -native \

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,6 @@ MIDDLE_END=\
   middle_end/int_replace_polymorphic_compare.cmo \
   middle_end/debuginfo.cmo \
   middle_end/base_types/tag.cmo \
-  middle_end/base_types/linkage_name.cmo \
   middle_end/base_types/compilation_unit.cmo \
   middle_end/internal_variable_names.cmo \
   middle_end/base_types/variable.cmo \

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -20,8 +20,8 @@ open Cmm
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
-let afl_area_ptr = Cconst_symbol "caml_afl_area_ptr"
-let afl_prev_loc = Cconst_symbol "caml_afl_prev_loc"
+let afl_area_ptr = Cconst_symbol Backend_sym.Names.caml_afl_area_ptr
+let afl_prev_loc = Cconst_symbol Backend_sym.Names.caml_afl_prev_loc
 let afl_map_size = 1 lsl 16
 
 let rec with_afl_logging b =
@@ -92,7 +92,7 @@ let instrument_initialiser c =
      calls *)
   with_afl_logging
     (Csequence
-       (Cop (Cextcall ("caml_setup_afl", typ_int, false, None),
+       (Cop (Cextcall (Backend_sym.Names.caml_setup_afl, typ_int, false, None),
              [Cconst_int 0],
              Debuginfo.none),
         c))

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -26,7 +26,7 @@ let command_line_options =
 open Format
 
 type addressing_mode =
-    Ibased of string * int              (* symbol + displ *)
+    Ibased of Backend_sym.t * int       (* symbol + displ *)
   | Iindexed of int                     (* reg + displ *)
   | Iindexed2 of int                    (* reg + reg + displ *)
   | Iscaled of int * int                (* reg * scale + displ *)
@@ -87,9 +87,9 @@ let num_args_addressing = function
 let print_addressing printreg addr ppf arg =
   match addr with
   | Ibased(s, 0) ->
-      fprintf ppf "\"%s\"" s
+      fprintf ppf "\"%a\"" Backend_sym.print s
   | Ibased(s, n) ->
-      fprintf ppf "\"%s\" + %i" s n
+      fprintf ppf "\"%a\" + %i" Backend_sym.print s n
   | Iindexed n ->
       let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
       fprintf ppf "%a%s" printreg arg.(0) idx

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -27,7 +27,6 @@ open Emitaux
 open X86_ast
 open X86_proc
 open X86_dsl
-module String = Misc.Stdlib.String
 
 (* [Branch_relaxation] is not used in this file, but is required by
    emit.mlp files for certain other targets; the reference here ensures
@@ -35,7 +34,10 @@ module String = Misc.Stdlib.String
    for all targets. *)
 open! Branch_relaxation
 
-let _label s = D.label ~typ:QWORD s
+module D = Asm_directives
+module L = Asm_label
+module S = Asm_symbol
+open Asm_symbol.Names
 
 (* Override proc.ml *)
 
@@ -57,8 +59,8 @@ let cfi_startproc () =
 let cfi_endproc () =
   if Config.asm_cfi_supported then D.cfi_endproc ()
 
-let cfi_adjust_cfa_offset n =
-  if Config.asm_cfi_supported then D.cfi_adjust_cfa_offset n
+let cfi_adjust_cfa_offset bytes =
+  if Config.asm_cfi_supported then D.cfi_adjust_cfa_offset ~bytes
 
 let emit_debug_info dbg =
   emit_debug_info_gen dbg D.file D.loc
@@ -94,52 +96,47 @@ let slot_offset loc cl =
       else !stack_offset + (num_stack_slots.(0) + n) * 8
   | Outgoing n -> n
 
-(* Symbols *)
-
-let symbol_prefix = if system = S_macosx then "_" else ""
-
-let emit_symbol s = string_of_symbol symbol_prefix s
-
 (* Record symbols used and defined - at the end generate extern for those
    used but not defined *)
 
-let symbols_defined = ref String.Set.empty
-let symbols_used = ref String.Set.empty
+let symbols_defined = ref S.Set.empty
+let symbols_used = ref S.Set.empty
 
-let add_def_symbol s = symbols_defined := String.Set.add s !symbols_defined
-let add_used_symbol s = symbols_used := String.Set.add s !symbols_used
+let add_def_symbol s = symbols_defined := S.Set.add s !symbols_defined
+let add_used_symbol s = symbols_used := S.Set.add s !symbols_used
 
-let imp_table = Hashtbl.create 16
+let imp_table = S.Tbl.create 16
 
-let reset_imp_table () = Hashtbl.clear imp_table
+let reset_imp_table () = S.Tbl.clear imp_table
 
 let get_imp_symbol s =
-  match Hashtbl.find imp_table s with
+  match S.Tbl.find imp_table s with
   | exception Not_found ->
-      let imps = "__caml_imp_" ^ s in
-      Hashtbl.add imp_table s imps;
+      let imps_name = "__caml_imp_%s" ^ (S.encode s) in
+      let imps = S.of_external_name imps_name in
+      S.Tbl.add imp_table s imps;
       imps
   | imps -> imps
 
 let emit_imp_table () =
   let f s imps =
-    _label (emit_symbol imps);
-    D.qword (ConstLabel (emit_symbol s))
+    D.define_data_symbol imps;
+    D.symbol s
   in
   D.data();
   D.comment "relocation table start";
-  D.align 8;
-  Hashtbl.iter f imp_table;
+  D.align ~bytes:8;
+  S.Tbl.iter f imp_table;
   D.comment "relocation table end"
 
 let mem__imp s =
   let imp_s = get_imp_symbol s in
-  mem64_rip QWORD (emit_symbol imp_s)
+  mem64_rip QWORD (Symbol imp_s)
 
 let rel_plt s =
   if windows && !Clflags.dlcode then mem__imp s
-  else
-    sym (if use_plt then emit_symbol s ^ "@PLT" else emit_symbol s)
+  else if use_plt then sym ~reloc:"@PLT" s
+  else sym s
 
 let emit_call s = I.call (rel_plt s)
 
@@ -149,26 +146,19 @@ let load_symbol_addr s arg =
   if !Clflags.dlcode then
     if windows then begin
       (* I.mov (mem__imp s) arg (\* mov __caml_imp_foo(%rip), ... *\) *)
-      I.mov (sym (emit_symbol s)) arg (* movabsq $foo, ... *)
-    end else I.mov (mem64_rip QWORD (emit_symbol s ^ "@GOTPCREL")) arg
+      I.mov (sym s) arg (* movabsq $foo, ... *)
+    end else I.mov (mem64_rip QWORD (Symbol s) ~reloc:"@GOTPCREL") arg
   else if !Clflags.pic_code then
-    I.lea (mem64_rip NONE (emit_symbol s)) arg
+    I.lea (mem64_rip NONE (Symbol s)) arg
   else
-    I.mov (sym (emit_symbol s)) arg
+    I.mov (sym s) arg
 
 (* Output a label *)
 
-let emit_label lbl =
-  match system with
-  | S_macosx | S_win64 -> "L" ^ string_of_int lbl
-  | _ -> ".L" ^ string_of_int lbl
-
-let label s = sym (emit_label s)
-
-let def_label s = D.label (emit_label s)
+let def_label lbl = D.define_label (L.create_int lbl)
 
 let emit_Llabel fallthrough lbl =
-  if not fallthrough && !fastcode_flag then D.align 4;
+  if not fallthrough && !fastcode_flag then D.align ~bytes:4;
   def_label lbl
 
 (* Output a pseudo-register *)
@@ -218,8 +208,9 @@ let res32 i n = emit_subreg reg_low_32_name DWORD i.res.(n)
 let addressing addr typ i n =
   match addr with
   | Ibased(s, ofs) ->
+      let s = S.create s in
       add_used_symbol s;
-      mem64_rip typ (emit_symbol s) ~ofs
+      mem64_rip typ (Symbol s) ~ofs
   | Iindexed d ->
       mem64 typ d (arg64 i n)
   | Iindexed2 d ->
@@ -292,9 +283,9 @@ let emit_call_gc gc =
     assert Config.spacetime;
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
-  emit_call "caml_call_gc";
+  emit_call caml_call_gc;
   def_label gc.gc_frame;
-  I.jmp (label gc.gc_return_lbl)
+  I.jmp (label (L.create_int gc.gc_return_lbl))
 
 (* Record calls to caml_ml_array_bound_error.
    In -g mode, or when using Spacetime profiling, we maintain one call to
@@ -331,14 +322,14 @@ let emit_call_bound_error bd =
   | Some (node_ptr, index) ->
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
-  emit_call "caml_ml_array_bound_error";
+  emit_call caml_ml_array_bound_error;
   def_label bd.bd_frame
 
 let emit_call_bound_errors () =
   List.iter emit_call_bound_error !bound_error_sites;
   if !bound_error_call > 0 then begin
     def_label !bound_error_call;
-    emit_call "caml_ml_array_bound_error"
+    emit_call caml_ml_array_bound_error
   end
 
 (* Names for instructions *)
@@ -399,8 +390,8 @@ let emit_float_test cmp i lbl =
   | CFeq ->
       let next = new_label() in
       I.ucomisd (arg i 1) (arg i 0);
-      I.jp (label next);          (* skip if unordered *)
-      I.je lbl;                   (* branch taken if x=y *)
+      I.jp (label (L.create_int next));  (* skip if unordered *)
+      I.je lbl;                          (* branch taken if x=y *)
       def_label next
   | CFneq ->
       I.ucomisd (arg i 1) (arg i 0);
@@ -463,15 +454,24 @@ let add_float_constant cst =
     lbl
 
 let emit_float_constant f lbl =
-  _label (emit_label lbl);
-  D.qword (Const f)
+  def_label lbl;
+  D.int64 f
 
-let emit_global_label s =
-  let lbl = Compilenv.make_symbol (Some s) in
-  add_def_symbol lbl;
-  let lbl = emit_symbol lbl in
-  D.global lbl;
-  _label lbl
+(* Definition of global symbols *)
+
+let define_global_symbol0 base_name =
+  let sym = S.create (Backend_sym.create ~base_name) in
+  add_def_symbol sym;
+  D.global sym;
+  sym
+
+let define_global_data_symbol base_name =
+  let sym = define_global_symbol0 base_name in
+  D.define_data_symbol sym
+
+let define_global_text_symbol base_name =
+  let sym = define_global_symbol0 base_name in
+  D.define_function_symbol sym
 
 (* Emission of the profiling prelude *)
 
@@ -486,14 +486,14 @@ let emit_profile () =
     if not fp then I.mov rsp rbp;
     (* No Spacetime instrumentation needed: [mcount] cannot call anything
        OCaml-related. *)
-    emit_call "mcount";
+    emit_call mcount;
     I.pop r10
   end
 
 (* Output the assembly code for an instruction *)
 
 (* Name of current function *)
-let function_name = ref ""
+let function_name = ref None
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
@@ -540,15 +540,17 @@ let emit_instr fallthrough i =
           I.xorpd (res i 0) (res i 0)
       | _ ->
           let lbl = add_float_constant f in
-          I.movsd (mem64_rip NONE (emit_label lbl)) (res i 0)
+          I.movsd (mem64_rip NONE (Label (L.create_int lbl))) (res i 0)
       end
   | Lop(Iconst_symbol s) ->
+      let s = S.create s in
       add_used_symbol s;
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind { label_after; }) ->
       I.call (arg i 0);
       record_frame i.live false i.dbg ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
+      let func = S.create func in
       add_used_symbol func;
       emit_call func;
       record_frame i.live false i.dbg ~label:label_after
@@ -560,10 +562,13 @@ let emit_instr fallthrough i =
         end
       end
   | Lop(Itailcall_imm { func; label_after; }) ->
-      begin
-        if func = !function_name then
-          I.jmp (label !tailrec_entry_point)
-        else begin
+      let func = S.create func in
+      begin match !function_name with
+      | None -> Misc.fatal_error "[function_name] not set"
+      | Some function_name ->
+        if S.equal func function_name then begin
+          I.jmp (label (L.create_int !tailrec_entry_point))
+        end else begin
           output_epilogue begin fun () ->
             add_used_symbol func;
             emit_jump func
@@ -574,10 +579,11 @@ let emit_instr fallthrough i =
         record_frame Reg.Set.empty false i.dbg ~label:label_after
       end
   | Lop(Iextcall { func; alloc; label_after; }) ->
+      let func = S.create func in
       add_used_symbol func;
       if alloc then begin
         load_symbol_addr func rax;
-        emit_call "caml_c_call";
+        emit_call caml_c_call;
         record_frame i.live false i.dbg ~label:label_after;
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
@@ -587,7 +593,7 @@ let emit_instr fallthrough i =
              If we do the same for Win64, we probably need to change
              amd64nt.asm accordingly.
           *)
-          load_symbol_addr "caml_young_ptr" r11;
+          load_symbol_addr caml_young_ptr r11;
           I.mov (mem64 QWORD 0 R11) r15
         end
       end else begin
@@ -658,13 +664,13 @@ let emit_instr fallthrough i =
           if spacetime_node_hole_ptr_is_in_rax then begin
             I.push rax
           end;
-          load_symbol_addr "caml_young_limit" rax;
+          load_symbol_addr caml_young_limit rax;
           I.cmp (mem64 QWORD 0 RAX) r15;
           if spacetime_node_hole_ptr_is_in_rax then begin
             I.pop rax  (* this does not affect the flags *)
           end
         end else
-          I.cmp (mem64_rip QWORD (emit_symbol "caml_young_limit")) r15;
+          I.cmp (mem64_rip QWORD (Symbol caml_young_limit)) r15;
         let lbl_call_gc = new_label() in
         let dbg =
           if not Config.spacetime then Debuginfo.none
@@ -673,7 +679,7 @@ let emit_instr fallthrough i =
         let lbl_frame =
           record_frame_label ?label:label_after_call_gc i.live false dbg
         in
-        I.jb (label lbl_call_gc);
+        I.jb (label (L.create_int lbl_call_gc));
         I.lea (mem64 NONE 8 R15) (res i 0);
         let gc_spacetime =
           if not Config.spacetime then None
@@ -690,12 +696,12 @@ let emit_instr fallthrough i =
             ~index:spacetime_index;
         end;
         begin match n with
-        | 16 -> emit_call "caml_alloc1"
-        | 24 -> emit_call "caml_alloc2"
-        | 32 -> emit_call "caml_alloc3"
+        | 16 -> emit_call caml_alloc1
+        | 24 -> emit_call caml_alloc2
+        | 32 -> emit_call caml_alloc3
         | _  ->
             I.mov (int n) rax;
-            emit_call "caml_allocN"
+            emit_call caml_allocN
         end;
         let label =
           record_frame_label ?label:label_after_call_gc i.live false
@@ -719,7 +725,7 @@ let emit_instr fallthrough i =
       in
       let lbl = bound_error_label ?label:label_after_error i.dbg ~spacetime in
       I.cmp (arg i 1) (arg i 0);
-      I.jbe (label lbl)
+      I.jbe (label (L.create_int lbl))
   | Lop(Iintop_imm(Icheckbound { label_after_error; spacetime_index; }, n)) ->
       let spacetime =
         if not Config.spacetime then None
@@ -727,7 +733,7 @@ let emit_instr fallthrough i =
       in
       let lbl = bound_error_label ?label:label_after_error i.dbg ~spacetime in
       I.cmp (int n) (arg i 0);
-      I.jbe (label lbl)
+      I.jbe (label (L.create_int lbl))
   | Lop(Iintop(Idiv | Imod)) ->
       I.cqo ();
       I.idiv (arg i 1)
@@ -749,9 +755,9 @@ let emit_instr fallthrough i =
       (* We have i.arg.(0) = i.res.(0) *)
       instr_for_intop op (int n) (res i 0)
   | Lop(Inegf) ->
-      I.xorpd (mem64_rip OWORD (emit_symbol "caml_negf_mask")) (res i 0)
+      I.xorpd (mem64_rip OWORD (Symbol caml_negf_mask)) (res i 0)
   | Lop(Iabsf) ->
-      I.andpd (mem64_rip OWORD (emit_symbol "caml_absf_mask")) (res i 0)
+      I.andpd (mem64_rip OWORD (Symbol caml_absf_mask)) (res i 0)
   | Lop(Iaddf | Isubf | Imulf | Idivf as floatop) ->
       instr_for_floatop floatop (arg i 1) (res i 0)
   | Lop(Ifloatofint) ->
@@ -792,9 +798,9 @@ let emit_instr fallthrough i =
   | Llabel lbl ->
       emit_Llabel fallthrough lbl
   | Lbranch lbl ->
-      I.jmp (label lbl)
+      I.jmp (label (L.create_int lbl))
   | Lcondbranch(tst, lbl) ->
-      let lbl = label lbl in
+      let lbl = label (L.create_int lbl) in
       begin match tst with
       | Itruetest ->
           output_test_zero i.arg.(0);
@@ -825,18 +831,18 @@ let emit_instr fallthrough i =
       I.cmp (int 1) (arg i 0);
       begin match lbl0 with
       | None -> ()
-      | Some lbl -> I.jb (label lbl)
+      | Some lbl -> I.jb (label (L.create_int lbl))
       end;
       begin match lbl1 with
       | None -> ()
-      | Some lbl -> I.je (label lbl)
+      | Some lbl -> I.je (label (L.create_int lbl))
       end;
       begin match lbl2 with
       | None -> ()
-      | Some lbl -> I.jg (label lbl)
+      | Some lbl -> I.jg (label (L.create_int lbl))
       end
   | Lswitch jumptbl ->
-      let lbl = emit_label (new_label()) in
+      let lbl = new_label () in
       (* rax and rdx are clobbered by the Lswitch,
          meaning that no variable that is live across the Lswitch
          is assigned to rax or rdx.  However, the argument to Lswitch
@@ -847,26 +853,22 @@ let emit_instr fallthrough i =
         then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
         else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
 
-      I.lea (mem64_rip NONE lbl) (reg tmp1);
+      I.lea (mem64_rip NONE (Label (L.create_int lbl))) (reg tmp1);
       I.movsxd (mem64 DWORD 0 (arg64 i 0) ~scale:4 ~base:(reg64 tmp1))
                (reg tmp2);
       I.add (reg tmp2) (reg tmp1);
       I.jmp (reg tmp1);
 
-      begin match system with
-      | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-      | S_macosx | S_win64 -> () (* with LLVM/OS X and MASM, use the text segment *)
-      | _ -> D.section [".rodata"] None []
-      end;
-      D.align 4;
-      _label lbl;
+      D.switch_to_section Asm_section.Jump_tables;
+      D.align ~bytes:4;
+      def_label lbl;
       for i = 0 to Array.length jumptbl - 1 do
-        D.long (ConstSub (ConstLabel(emit_label jumptbl.(i)),
-                         ConstLabel lbl))
+        D.between_labels_32bit ~upper:(L.create_int jumptbl.(i))
+          ~lower:(L.create_int lbl)
       done;
       D.text ()
   | Lsetuptrap lbl ->
-      I.call (label lbl)
+      I.call (label (L.create_int lbl))
   | Lpushtrap ->
       cfi_adjust_cfa_offset 8;
       I.push r14;
@@ -885,7 +887,7 @@ let emit_instr fallthrough i =
          trie is [caml_stash_backtrace], and it does not. *)
       begin match k with
       | Cmm.Raise_withtrace ->
-          emit_call "caml_raise_exn";
+          emit_call caml_raise_exn;
           record_frame Reg.Set.empty true i.dbg
       | Cmm.Raise_notrace ->
           I.mov r14 rsp;
@@ -905,7 +907,8 @@ let all_functions = ref []
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  function_name := Some fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := new_label();
   stack_offset := 0;
@@ -914,16 +917,16 @@ let fundecl fundecl =
   bound_error_call := 0;
   all_functions := fundecl :: !all_functions;
   D.text ();
-  D.align 16;
-  add_def_symbol fundecl.fun_name;
-  if system = S_macosx
+  D.align ~bytes:16;
+  add_def_symbol fun_name;
+  if Target_system.macos_like ()
   && not !Clflags.output_c_object
-  && is_generic_function fundecl.fun_name
+  && S.is_generic_function fun_name
   then (* PR#4690 *)
-    D.private_extern (emit_symbol fundecl.fun_name)
+    D.private_extern fun_name
   else
-    D.global (emit_symbol fundecl.fun_name);
-  D.label (emit_symbol fundecl.fun_name);
+    D.global fun_name;
+  D.define_function_symbol fun_name;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
   emit_all true fundecl.fun_body;
@@ -936,32 +939,28 @@ let fundecl fundecl =
       cfi_adjust_cfa_offset (-n);
     end;
   end;
-  cfi_endproc ();
-  begin match system with
-  | S_gnu | S_linux ->
-      D.type_ (emit_symbol fundecl.fun_name) "@function";
-      D.size (emit_symbol fundecl.fun_name)
-        (ConstSub (
-            ConstThis,
-            ConstLabel (emit_symbol fundecl.fun_name)))
-  | _ -> ()
-  end
+  cfi_endproc ()
 
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> D.global (emit_symbol s)
-  | Cdefine_symbol s -> add_def_symbol s; _label (emit_symbol s)
-  | Cint8 n -> D.byte (const n)
-  | Cint16 n -> D.word (const n)
-  | Cint32 n -> D.long (const_nat n)
-  | Cint n -> D.qword (const_nat n)
-  | Csingle f -> D.long  (Const (Int64.of_int32 (Int32.bits_of_float f)))
-  | Cdouble f -> D.qword (Const (Int64.bits_of_float f))
-  | Csymbol_address s -> add_used_symbol s; D.qword (ConstLabel (emit_symbol s))
-  | Cstring s -> D.bytes s
-  | Cskip n -> if n > 0 then D.space n
-  | Calign n -> D.align n
+  | Cglobal_symbol s -> D.global (S.create s)
+  | Cdefine_symbol s ->
+    let s = S.create s in
+    add_def_symbol s; D.define_data_symbol s
+  | Cint8 n -> D.int8 (Numbers.Int8.of_int_exn n)
+  | Cint16 n -> D.int16 (Numbers.Int16.of_int_exn n)
+  | Cint32 n -> D.int32 (Nativeint.to_int32 n)
+  (* CR mshinwell: Add [Targetint.of_nativeint] *)
+  | Cint n -> D.targetint (Targetint.of_int64 (Int64.of_nativeint n))
+  | Csingle f -> D.float32 f
+  | Cdouble f -> D.float64 f
+  | Csymbol_address s ->
+    let s = S.create s in
+    add_used_symbol s; D.symbol s
+  | Cstring s -> D.string s
+  | Cskip n -> if n > 0 then D.space ~bytes:n
+  | Calign n -> D.align ~bytes:n
 
 let data l =
   D.data ();
@@ -975,59 +974,57 @@ let begin_assembly() =
   reset_imp_table();
   float_constants := [];
   all_functions := [];
-  if system = S_win64 then begin
-    D.extrn "caml_young_ptr" QWORD;
-    D.extrn "caml_young_limit" QWORD;
-    D.extrn "caml_exception_pointer" QWORD;
-    D.extrn "caml_call_gc" NEAR;
-    D.extrn "caml_c_call" NEAR;
-    D.extrn "caml_allocN" NEAR;
-    D.extrn "caml_alloc1" NEAR;
-    D.extrn "caml_alloc2" NEAR;
-    D.extrn "caml_alloc3" NEAR;
-    D.extrn "caml_ml_array_bound_error" NEAR;
-    D.extrn "caml_raise_exn" NEAR;
+  Asm_label.initialize ~new_label:Cmm.new_label;
+  Asm_directives.initialize ~big_endian:Arch.big_endian
+    ~emit:(fun dir -> directive (Directive dir));
+  if Target_system.win64 () then begin
+    let module D = X86_dsl.MASM in
+    D.extrn caml_young_ptr QWORD;
+    D.extrn caml_young_limit QWORD;
+    D.extrn caml_exception_pointer QWORD;
+    D.extrn caml_call_gc NEAR;
+    D.extrn caml_c_call NEAR;
+    D.extrn caml_allocN NEAR;
+    D.extrn caml_alloc1 NEAR;
+    D.extrn caml_alloc2 NEAR;
+    D.extrn caml_alloc3 NEAR;
+    D.extrn caml_ml_array_bound_error NEAR;
+    D.extrn caml_raise_exn NEAR;
   end;
 
 
-  if !Clflags.dlcode || Arch.win64 then begin
-    (* from amd64.S; could emit these constants on demand *)
-    begin match system with
-    | S_macosx -> D.section ["__TEXT";"__literal16"] None ["16byte_literals"]
-    | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-    | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst8"] (Some "a") ["@progbits"]
-    end;
-    D.align 16;
-    _label (emit_symbol "caml_negf_mask");
-    D.qword (Const 0x8000000000000000L);
-    D.qword (Const 0L);
-    D.align 16;
-    _label (emit_symbol "caml_absf_mask");
-    D.qword (Const 0x7FFFFFFFFFFFFFFFL);
-    D.qword (Const 0xFFFFFFFFFFFFFFFFL);
+  if !Clflags.dlcode || Target_system.win64 () then begin
+    D.switch_to_section Asm_section.Eight_byte_literals;
+    D.align ~bytes:16;
+    D.define_data_symbol caml_negf_mask;
+    D.int64 0x8000000000000000L;
+    D.int64 0L;
+    D.align ~bytes:16;
+    D.define_data_symbol caml_absf_mask;
+    D.int64 0x7FFFFFFFFFFFFFFFL;
+    D.int64 0xFFFFFFFFFFFFFFFFL;
   end;
 
   D.data ();
-  emit_global_label "data_begin";
+  define_global_data_symbol "data_begin";
 
   D.text ();
-  emit_global_label "code_begin";
-  if system = S_macosx then I.nop (); (* PR#4690 *)
+  define_global_text_symbol "code_begin";
+  if Target_system.macos_like () then I.nop (); (* PR#4690 *)
   ()
 
 let emit_spacetime_shapes () =
   D.data ();
-  D.align 8;
-  emit_global_label "spacetime_shapes";
+  D.align ~bytes:8;
+  define_global_data_symbol "spacetime_shapes";
   List.iter (fun fundecl ->
       (* CR-someday mshinwell: some of this should be platform independent *)
       begin match fundecl.fun_spacetime_shape with
       | None -> ()
       | Some shape ->
-        let funsym = emit_symbol fundecl.fun_name in
-        D.comment ("Shape for " ^ funsym ^ ":");
-        D.qword (ConstLabel funsym);
+        let fun_name = S.create fundecl.fun_name in
+        D.comment ("Shape for " ^ (S.encode fun_name) ^ ":");
+        D.symbol fun_name;
         List.iter (fun (part_of_shape, label) ->
             let tag =
               match part_of_shape with
@@ -1035,92 +1032,72 @@ let emit_spacetime_shapes () =
               | Indirect_call_point -> 2
               | Allocation_point -> 3
             in
-            D.qword (Const (Int64.of_int tag));
-            D.qword (ConstLabel (emit_label label));
+            D.int64 (Int64.of_int tag);
+            D.label (L.create_int label);
             begin match part_of_shape with
-            | Direct_call_point { callee; } ->
-              D.qword (ConstLabel (emit_symbol callee))
+            | Direct_call_point { callee; } -> D.symbol (S.create callee)
             | Indirect_call_point -> ()
             | Allocation_point -> ()
             end)
           shape;
-          D.qword (Const 0L)
+          D.int64 0L
       end)
     !all_functions;
-  D.qword (Const 0L);
+  D.int64 0L;
   D.comment "End of Spacetime shapes."
 
 let end_assembly() =
   if !float_constants <> [] then begin
-    begin match system with
-    | S_macosx -> D.section ["__TEXT";"__literal8"] None ["8byte_literals"]
-    | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-    | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst8"] (Some "a") ["@progbits"]
-    end;
+    D.switch_to_section Asm_section.Eight_byte_literals;
     List.iter (fun (cst,lbl) -> emit_float_constant cst lbl) !float_constants
   end;
 
   D.text ();
-  if system = S_macosx then I.nop ();
+  if Target_system.macos_like () then I.nop ();
   (* suppress "ld warning: atom sorting error" *)
 
-  emit_global_label "code_end";
+  define_global_text_symbol "code_end";
 
   emit_imp_table();
 
   D.data ();
-  D.qword (const 0);  (* PR#6329 *)
-  emit_global_label "data_end";
-  D.qword (const 0);
+  D.int64 0L;  (* PR#6329 *)
+  define_global_data_symbol "data_end";
+  D.int64 0L;
 
-  D.align 8;                            (* PR#7591 *)
-  emit_global_label "frametable";
+  D.align ~bytes:8;                            (* PR#7591 *)
+  define_global_data_symbol "frametable";
 
-  let setcnt = ref 0 in
   emit_frames
-    { efa_code_label = (fun l -> D.qword (ConstLabel (emit_label l)));
-      efa_data_label = (fun l -> D.qword (ConstLabel (emit_label l)));
-      efa_16 = (fun n -> D.word (const n));
-      efa_32 = (fun n -> D.long (const_32 n));
-      efa_word = (fun n -> D.qword (const n));
-      efa_align = D.align;
+    { efa_code_label = (fun l -> D.label (L.create_int l));
+      efa_data_label = (fun l -> D.label (L.create_int l));
+      efa_16 = (fun n -> D.int16 (Numbers.Int16.of_int_exn n));
+      efa_32 = (fun n -> D.int32 n);
+      efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
+      efa_align = (fun bytes -> D.align ~bytes);
       efa_label_rel =
         (fun lbl ofs ->
-           let c =
-             ConstAdd (
-               ConstSub(ConstLabel(emit_label lbl), ConstThis),
-               const_32 ofs
-             ) in
-           if system = S_macosx then begin
-             incr setcnt;
-             let s = Printf.sprintf "L$set$%d" !setcnt in
-             D.setvar (s, c);
-             D.long (ConstLabel s)
-           end else
-             D.long c
-        );
-      efa_def_label = (fun l -> _label (emit_label l));
-      efa_string = (fun s -> D.bytes (s ^ "\000"))
+          D.between_this_and_label_offset_32bit ~upper:(L.create_int lbl)
+            ~offset_upper:(Targetint.of_int32 ofs));
+      efa_def_label = (fun lbl -> def_label lbl);
+      efa_string = (fun s -> D.string (s ^ "\000"))
     };
 
   if Config.spacetime then begin
     emit_spacetime_shapes ()
   end;
 
-  if system = S_linux then
-    (* Mark stack as non-executable, PR#4564 *)
-    D.section [".note.GNU-stack"] (Some "") [ "%progbits" ];
+  D.mark_stack_non_executable ();
 
-  if system = S_win64 then begin
+  if Target_system.win64 () then begin
     D.comment "External functions";
-    String.Set.iter
+    S.Set.iter
       (fun s ->
-         if not (String.Set.mem s !symbols_defined) then
-           D.extrn (emit_symbol s) NEAR)
+         if not (S.Set.mem s !symbols_defined) then
+           X86_dsl.MASM.extrn s NEAR)
       !symbols_used;
-    symbols_used := String.Set.empty;
-    symbols_defined := String.Set.empty;
+    symbols_used := S.Set.empty;
+    symbols_defined := S.Set.empty;
   end;
 
   let asm =

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -34,6 +34,7 @@ open X86_dsl
    for all targets. *)
 open! Branch_relaxation
 
+module AS = Asm_section
 module D = Asm_directives
 module L = Asm_label
 module S = Asm_symbol
@@ -113,7 +114,10 @@ let get_imp_symbol s =
   match S.Tbl.find imp_table s with
   | exception Not_found ->
       let imps_name = "__caml_imp_%s" ^ (S.encode s) in
-      let imps = S.of_external_name imps_name in
+      let compilation_unit = Compilation_unit.get_current_exn () in
+      let imps =
+        S.of_external_name AS.Data compilation_unit imps_name
+      in
       S.Tbl.add imp_table s imps;
       imps
   | imps -> imps
@@ -155,11 +159,13 @@ let load_symbol_addr s arg =
 
 (* Output a label *)
 
-let def_label lbl = D.define_label (L.create_int lbl)
+let def_label section lbl = D.define_int_label section lbl
 
-let emit_Llabel fallthrough lbl =
+let emit_Llabel section fallthrough lbl =
   if not fallthrough && !fastcode_flag then D.align ~bytes:4;
-  def_label lbl
+  def_label section lbl
+
+let int_label section lbl = D.label (AS.create_int section lbl)
 
 (* Output a pseudo-register *)
 
@@ -248,7 +254,7 @@ let record_frame_label ?label live raise_ dbg =
 
 let record_frame ?label live raise_ dbg =
   let lbl = record_frame_label ?label live raise_ dbg in
-  def_label lbl
+  def_label AS.Text lbl
 
 (* Spacetime instrumentation *)
 
@@ -276,7 +282,7 @@ type gc_call =
 let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
-  def_label gc.gc_lbl;
+  def_label AS.Text gc.gc_lbl;
   begin match gc.gc_spacetime with
   | None -> assert (not Config.spacetime)
   | Some (node_ptr, index) ->
@@ -284,8 +290,8 @@ let emit_call_gc gc =
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
   emit_call caml_call_gc;
-  def_label gc.gc_frame;
-  I.jmp (label (L.create_int gc.gc_return_lbl))
+  def_label AS.Text gc.gc_frame;
+  I.jmp (int_label AS.Text gc.gc_return_lbl)
 
 (* Record calls to caml_ml_array_bound_error.
    In -g mode, or when using Spacetime profiling, we maintain one call to
@@ -316,19 +322,19 @@ let bound_error_label ?label dbg ~spacetime =
   end
 
 let emit_call_bound_error bd =
-  def_label bd.bd_lbl;
+  def_label AS.Text bd.bd_lbl;
   begin match bd.bd_spacetime with
   | None -> ()
   | Some (node_ptr, index) ->
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
   emit_call caml_ml_array_bound_error;
-  def_label bd.bd_frame
+  def_label AS.Text bd.bd_frame
 
 let emit_call_bound_errors () =
   List.iter emit_call_bound_error !bound_error_sites;
   if !bound_error_call > 0 then begin
-    def_label !bound_error_call;
+    def_label AS.Text !bound_error_call;
     emit_call caml_ml_array_bound_error
   end
 
@@ -390,9 +396,9 @@ let emit_float_test cmp i lbl =
   | CFeq ->
       let next = new_label() in
       I.ucomisd (arg i 1) (arg i 0);
-      I.jp (label (L.create_int next));  (* skip if unordered *)
+      I.jp (int_label AS.Text next);  (* skip if unordered *)
       I.je lbl;                          (* branch taken if x=y *)
-      def_label next
+      def_label AS.Text next
   | CFneq ->
       I.ucomisd (arg i 1) (arg i 0);
       I.jp lbl;                   (* branch taken if unordered *)
@@ -454,23 +460,25 @@ let add_float_constant cst =
     lbl
 
 let emit_float_constant f lbl =
-  def_label lbl;
+  def_label AS.Eight_byte_literals lbl;
   D.int64 f
 
 (* Definition of global symbols *)
 
-let define_global_symbol0 base_name =
-  let sym = S.create (Backend_sym.create ~base_name) in
+let define_global_data_symbol base_name =
+  let sym =
+    S.create (Backend_sym.create ~base_name Backend_sym.Data)
+  in
   add_def_symbol sym;
   D.global sym;
-  sym
-
-let define_global_data_symbol base_name =
-  let sym = define_global_symbol0 base_name in
   D.define_data_symbol sym
 
 let define_global_text_symbol base_name =
-  let sym = define_global_symbol0 base_name in
+  let sym =
+    S.create (Backend_sym.create ~base_name Backend_sym.Text)
+  in
+  add_def_symbol sym;
+  D.global sym;
   D.define_function_symbol sym
 
 (* Emission of the profiling prelude *)
@@ -517,7 +525,7 @@ let emit_instr fallthrough i =
         cfi_adjust_cfa_offset n;
       end;
     end;
-    def_label !tailrec_entry_point
+    def_label AS.Text !tailrec_entry_point
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
       if src.loc <> dst.loc then
@@ -540,7 +548,8 @@ let emit_instr fallthrough i =
           I.xorpd (res i 0) (res i 0)
       | _ ->
           let lbl = add_float_constant f in
-          I.movsd (mem64_rip NONE (Label (L.create_int lbl))) (res i 0)
+          I.movsd (mem64_rip NONE (
+            Label (L.create_int AS.Eight_byte_literals lbl))) (res i 0)
       end
   | Lop(Iconst_symbol s) ->
       let s = S.create s in
@@ -567,8 +576,9 @@ let emit_instr fallthrough i =
       | None -> Misc.fatal_error "[function_name] not set"
       | Some function_name ->
         if S.equal func function_name then begin
-          I.jmp (label (L.create_int !tailrec_entry_point))
+          I.jmp (int_label !tailrec_entry_point)
         end else begin
+          I.jmp (int_label AS.Text !tailrec_entry_point);
           output_epilogue begin fun () ->
             add_used_symbol func;
             emit_jump func
@@ -651,7 +661,7 @@ let emit_instr fallthrough i =
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; }) ->
       if !fastcode_flag then begin
         let lbl_redo = new_label() in
-        def_label lbl_redo;
+        def_label AS.Text lbl_redo;
         I.sub (int n) r15;
         let spacetime_node_hole_ptr_is_in_rax =
           Config.spacetime && (i.arg.(0).loc = Reg 0)
@@ -679,7 +689,7 @@ let emit_instr fallthrough i =
         let lbl_frame =
           record_frame_label ?label:label_after_call_gc i.live false dbg
         in
-        I.jb (label (L.create_int lbl_call_gc));
+        I.jb (int_label AS.Text lbl_call_gc);
         I.lea (mem64 NONE 8 R15) (res i 0);
         let gc_spacetime =
           if not Config.spacetime then None
@@ -695,6 +705,8 @@ let emit_instr fallthrough i =
           spacetime_before_uninstrumented_call ~node_ptr:(arg i 0)
             ~index:spacetime_index;
         end;
+        let lbl_before = new_label () in
+        def_label AS.Text lbl_before;
         begin match n with
         | 16 -> emit_call caml_alloc1
         | 24 -> emit_call caml_alloc2
@@ -707,7 +719,7 @@ let emit_instr fallthrough i =
           record_frame_label ?label:label_after_call_gc i.live false
             Debuginfo.none
         in
-        def_label label;
+        def_label AS.Text label;
         I.lea (mem64 NONE 8 R15) (res i 0)
       end
   | Lop(Iintop(Icomp cmp)) ->
@@ -725,7 +737,7 @@ let emit_instr fallthrough i =
       in
       let lbl = bound_error_label ?label:label_after_error i.dbg ~spacetime in
       I.cmp (arg i 1) (arg i 0);
-      I.jbe (label (L.create_int lbl))
+      I.jbe (int_label AS.Text lbl)
   | Lop(Iintop_imm(Icheckbound { label_after_error; spacetime_index; }, n)) ->
       let spacetime =
         if not Config.spacetime then None
@@ -733,7 +745,7 @@ let emit_instr fallthrough i =
       in
       let lbl = bound_error_label ?label:label_after_error i.dbg ~spacetime in
       I.cmp (int n) (arg i 0);
-      I.jbe (label (L.create_int lbl))
+      I.jbe (int_label AS.Text lbl)
   | Lop(Iintop(Idiv | Imod)) ->
       I.cqo ();
       I.idiv (arg i 1)
@@ -755,9 +767,9 @@ let emit_instr fallthrough i =
       (* We have i.arg.(0) = i.res.(0) *)
       instr_for_intop op (int n) (res i 0)
   | Lop(Inegf) ->
-      I.xorpd (mem64_rip OWORD (Symbol caml_negf_mask)) (res i 0)
+      I.xorpd (mem64_rip OWORD (Symbol (caml_negf_mask ()))) (res i 0)
   | Lop(Iabsf) ->
-      I.andpd (mem64_rip OWORD (Symbol caml_absf_mask)) (res i 0)
+      I.andpd (mem64_rip OWORD (Symbol (caml_absf_mask ()))) (res i 0)
   | Lop(Iaddf | Isubf | Imulf | Idivf as floatop) ->
       instr_for_floatop floatop (arg i 1) (res i 0)
   | Lop(Ifloatofint) ->
@@ -796,11 +808,11 @@ let emit_instr fallthrough i =
         I.ret ()
       end
   | Llabel lbl ->
-      emit_Llabel fallthrough lbl
+      emit_Llabel AS.Text fallthrough lbl
   | Lbranch lbl ->
-      I.jmp (label (L.create_int lbl))
+      I.jmp (int_label AS.Text lbl)
   | Lcondbranch(tst, lbl) ->
-      let lbl = label (L.create_int lbl) in
+      let lbl = int_label AS.Text lbl in
       begin match tst with
       | Itruetest ->
           output_test_zero i.arg.(0);
@@ -831,15 +843,15 @@ let emit_instr fallthrough i =
       I.cmp (int 1) (arg i 0);
       begin match lbl0 with
       | None -> ()
-      | Some lbl -> I.jb (label (L.create_int lbl))
+      | Some lbl -> I.jb (int_label AS.Text lbl)
       end;
       begin match lbl1 with
       | None -> ()
-      | Some lbl -> I.je (label (L.create_int lbl))
+      | Some lbl -> I.je (int_label AS.Text lbl)
       end;
       begin match lbl2 with
       | None -> ()
-      | Some lbl -> I.jg (label (L.create_int lbl))
+      | Some lbl -> I.jg (int_label AS.Text lbl)
       end
   | Lswitch jumptbl ->
       let lbl = new_label () in
@@ -853,22 +865,23 @@ let emit_instr fallthrough i =
         then (phys_reg 4 (*rdx*), phys_reg 0 (*rax*))
         else (phys_reg 0 (*rax*), phys_reg 4 (*rdx*)) in
 
-      I.lea (mem64_rip NONE (Label (L.create_int lbl))) (reg tmp1);
+      I.lea (mem64_rip NONE (Label (L.create_int AS.Jump_tables lbl)))
+        (reg tmp1);
       I.movsxd (mem64 DWORD 0 (arg64 i 0) ~scale:4 ~base:(reg64 tmp1))
                (reg tmp2);
       I.add (reg tmp2) (reg tmp1);
       I.jmp (reg tmp1);
 
-      D.switch_to_section Asm_section.Jump_tables;
+      D.switch_to_section AS.Jump_tables;
       D.align ~bytes:4;
-      def_label lbl;
+      def_label AS.Jump_tables lbl;
       for i = 0 to Array.length jumptbl - 1 do
-        D.between_labels_32bit ~upper:(L.create_int jumptbl.(i))
-          ~lower:(L.create_int lbl)
+        D.between_labels_32bit ~upper:(L.create_int AS.Jump_tables jumptbl.(i))
+          ~lower:(L.create_int AS.Jump_tables lbl)
       done;
       D.text ()
   | Lsetuptrap lbl ->
-      I.call (label (L.create_int lbl))
+      I.call (int_label AS.Text lbl)
   | Lpushtrap ->
       cfi_adjust_cfa_offset 8;
       I.push r14;
@@ -994,7 +1007,7 @@ let begin_assembly() =
 
 
   if !Clflags.dlcode || Target_system.win64 () then begin
-    D.switch_to_section Asm_section.Eight_byte_literals;
+    D.switch_to_section AS.Eight_byte_literals;
     D.align ~bytes:16;
     D.define_data_symbol caml_negf_mask;
     D.int64 0x8000000000000000L;
@@ -1033,7 +1046,7 @@ let emit_spacetime_shapes () =
               | Allocation_point -> 3
             in
             D.int64 (Int64.of_int tag);
-            D.label (L.create_int label);
+            int_label AS.Data label;
             begin match part_of_shape with
             | Direct_call_point { callee; } -> D.symbol (S.create callee)
             | Indirect_call_point -> ()
@@ -1048,7 +1061,7 @@ let emit_spacetime_shapes () =
 
 let end_assembly() =
   if !float_constants <> [] then begin
-    D.switch_to_section Asm_section.Eight_byte_literals;
+    D.switch_to_section AS.Eight_byte_literals;
     List.iter (fun (cst,lbl) -> emit_float_constant cst lbl) !float_constants
   end;
 
@@ -1069,17 +1082,18 @@ let end_assembly() =
   define_global_data_symbol "frametable";
 
   emit_frames
-    { efa_code_label = (fun l -> D.label (L.create_int l));
-      efa_data_label = (fun l -> D.label (L.create_int l));
-      efa_16 = (fun n -> D.int16 (Numbers.Int16.of_int_exn n));
-      efa_32 = (fun n -> D.int32 n);
+    { efa_code_label = (fun l -> int_label AS.Text l);
+      efa_data_label = (fun l -> int_label AS.Data l);
+      efa_16 = (fun n -> D.uint16 (Numbers.Uint16.of_int_exn n));
+      efa_32 = (fun n -> D.uint32 (Numbers.Uint32.of_int32 n));
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
       efa_align = (fun bytes -> D.align ~bytes);
       efa_label_rel =
         (fun lbl ofs ->
-          D.between_this_and_label_offset_32bit ~upper:(L.create_int lbl)
+          D.between_this_and_label_offset_32bit
+            ~upper:(L.create_int AS.Data lbl)
             ~offset_upper:(Targetint.of_int32 ofs));
-      efa_def_label = (fun lbl -> def_label lbl);
+      efa_def_label = (fun lbl -> def_label AS.Data lbl);
       efa_string = (fun s -> D.string (s ^ "\000"))
     };
 

--- a/asmcomp/asm_target/asm_directives.ml
+++ b/asmcomp/asm_target/asm_directives.ml
@@ -7,7 +7,7 @@
 (*                                                                        *)
 (*   Copyright 2014 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -713,7 +713,7 @@ let initialize ~big_endian ~(emit : Directive.t -> unit) =
         | DWARF _ ->
           (* All of the other settings that require these DWARF sections
              imply [Debug_dwarf_functions]; see clflags.ml. *)
-          if Clflags.debug_thing Debug_dwarf_functions
+          if !Clflags.debug (* Clflags.debug_thing Debug_dwarf_functions *)
             && dwarf_supported ()
           then begin
             switch_to_section section
@@ -1002,8 +1002,9 @@ let offset_into_dwarf_section_symbol ?comment section upper
       Asm_section.print (Asm_section.DWARF section)
   end;
   (* The macOS assembler doesn't seem to allow "distance to undefined symbol
-     from start of given section".  As such we do not allow this function to
-     be used for undefined symbols on macOS at the moment.
+     from start of given section".  (Moreover, dsymutil wouldn't know what
+     to do with such a reference anyway.)  As such we do not allow this
+     function to be used for undefined symbols on macOS at the moment.
      Relevant link:
      <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82005>.
   *)

--- a/asmcomp/asm_target/asm_label.ml
+++ b/asmcomp/asm_target/asm_label.ml
@@ -1,0 +1,64 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Int of int
+  | String of string
+
+let create_int label = Int label
+let create_string label = String label
+
+let label_prefix =
+  match Target_system.architecture () with
+  | IA32 | X86_64 ->
+    begin match Target_system.system () with
+    | Linux
+    | Windows Cygwin
+    | Windows MinGW
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
+    | Generic_BSD
+    | Solaris
+    | BeOS
+    | GNU
+    | Dragonfly
+    | Unknown -> ".L"
+    | MacOS_like
+    | Windows Native -> "L"
+    end
+  | ARM
+  | AArch64
+  | POWER
+  | Z -> ".L"
+
+let encode (t : t) =
+  match t with
+  | Int label -> label_prefix ^ (string_of_int label)
+  | String label -> label_prefix ^ label
+
+let new_label_ref = ref None
+
+let not_initialized () =
+  Misc.fatal_error "[Asm_label.initialize] has not been called"
+
+let initialize ~new_label =
+  new_label_ref := Some new_label
+
+let create () =
+  match !new_label_ref with
+  | None -> not_initialized ()
+  | Some new_label -> create_int (new_label ())

--- a/asmcomp/asm_target/asm_label.ml
+++ b/asmcomp/asm_target/asm_label.ml
@@ -14,12 +14,41 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type t =
+type label =
   | Int of int
   | String of string
 
-let create_int label = Int label
-let create_string label = String label
+type t = {
+  section : Asm_section.t;
+  label : label;
+}
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 = Stdlib.compare t1.label t2.label
+
+  let equal t1 t2 = (compare t1 t2 = 0)
+
+  let hash t = Hashtbl.hash t.label
+
+  let print ppf t =
+    match t.label with
+    | Int i -> Format.fprintf ppf "L%d" i
+    | String s -> Format.fprintf ppf "L%s" s
+
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+end)
+
+let create_int section label =
+  { section;
+    label = Int label;
+  }
+
+let create_string section label =
+  { section;
+    label = String label;
+  }
 
 let label_prefix =
   match Target_system.architecture () with
@@ -46,9 +75,11 @@ let label_prefix =
   | Z -> ".L"
 
 let encode (t : t) =
-  match t with
+  match t.label with
   | Int label -> label_prefix ^ (string_of_int label)
   | String label -> label_prefix ^ label
+
+let section t = t.section
 
 let new_label_ref = ref None
 
@@ -58,7 +89,47 @@ let not_initialized () =
 let initialize ~new_label =
   new_label_ref := Some new_label
 
-let create () =
+let create section =
   match !new_label_ref with
   | None -> not_initialized ()
-  | Some new_label -> create_int (new_label ())
+  | Some new_label -> create_int section (new_label ())
+
+let text_label = lazy (create Text)
+let data_label = lazy (create Data)
+let read_only_data_label = lazy (create Read_only_data)
+let eight_byte_literals_label = lazy (create Eight_byte_literals)
+let sixteen_byte_literals_label = lazy (create Sixteen_byte_literals)
+let jump_tables_label = lazy (create Jump_tables)
+let debug_info_label = lazy (create (DWARF Debug_info))
+let debug_abbrev_label = lazy (create (DWARF Debug_abbrev))
+let debug_aranges_label = lazy (create (DWARF Debug_aranges))
+let debug_addr_label = lazy (create (DWARF Debug_addr))
+let debug_loc_label = lazy (create (DWARF Debug_loc))
+let debug_ranges_label = lazy (create (DWARF Debug_ranges))
+let debug_loclists_label = lazy (create (DWARF Debug_loclists))
+let debug_rnglists_label = lazy (create (DWARF Debug_rnglists))
+let debug_str_label = lazy (create (DWARF Debug_str))
+let debug_line_label = lazy (create (DWARF Debug_line))
+
+let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
+  match dwarf_section with
+  | Debug_info -> Lazy.force debug_info_label
+  | Debug_abbrev -> Lazy.force debug_abbrev_label
+  | Debug_aranges -> Lazy.force debug_aranges_label
+  | Debug_addr -> Lazy.force debug_addr_label
+  | Debug_loc -> Lazy.force debug_loc_label
+  | Debug_ranges -> Lazy.force debug_ranges_label
+  | Debug_loclists -> Lazy.force debug_loclists_label
+  | Debug_rnglists -> Lazy.force debug_rnglists_label
+  | Debug_str -> Lazy.force debug_str_label
+  | Debug_line -> Lazy.force debug_line_label
+
+let for_section (section : Asm_section.t) =
+  match section with
+  | Text -> Lazy.force text_label
+  | Data -> Lazy.force data_label
+  | Read_only_data -> Lazy.force read_only_data_label
+  | Eight_byte_literals -> Lazy.force eight_byte_literals_label
+  | Sixteen_byte_literals -> Lazy.force sixteen_byte_literals_label
+  | Jump_tables -> Lazy.force jump_tables_label
+  | DWARF dwarf_section -> for_dwarf_section dwarf_section

--- a/asmcomp/asm_target/asm_label.ml
+++ b/asmcomp/asm_target/asm_label.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)

--- a/asmcomp/asm_target/asm_label.mli
+++ b/asmcomp/asm_target/asm_label.mli
@@ -1,0 +1,46 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** A label in the assembly stream. They may be either numeric or textual.
+    (Numeric ones are converted to textual ones by this module.) The argument
+    to [String] should not include any platform-specific prefix (such as "L",
+    ".L", etc).
+
+    Note: Labels are not symbols---they are not accessible in the object file.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+(** Create a fresh integer-valued label (using the [new_label] function passed
+    to [initialize], below). *)
+val create : unit -> t
+
+(** Create an integer-valued label. *)
+val create_int : int -> t
+
+(** Create a textual label.  The supplied name must not require escaping. *)
+val create_string : string -> t
+
+(** Convert a label to the corresponding textual form, suitable for direct
+    emission into an assembly file.  This may be useful e.g. when emitting
+    an instruction referencing a label. *)
+val encode : t -> string
+
+(** To be called by the emitter at the very start of code generation.
+    [new_label] should always be [Cmm.new_label]. *)
+val initialize
+   : new_label:(unit -> int)
+  -> unit

--- a/asmcomp/asm_target/asm_label.mli
+++ b/asmcomp/asm_target/asm_label.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,23 +12,36 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** A label in a specific section within the assembly stream. They may be either
-    numeric or textual. (Numeric ones are converted to textual ones by this
-    module.) The argument to [String] should not include any platform-specific
-    prefix (such as "L", ".L", etc).
+(** Handling of labels in the assembly stream.
 
-    Label's numeric or textual names are unique within the assembly stream
-    for a single compilation unit, even across sections.
+    We think as labels as a construct within the assembler's metalanguage.
+    As such, we neither expect them to be accessible from outside the object
+    file in which they are defined, nor to be available for examination in
+    the object file itself (e.g. via objdump).  In other words, we do not
+    treat them like "symbols".
 
-    Note: Labels are not symbols in the usual sense---they are a construct
-    in the assembler's metalanguage and not accessible in the object
-    file---although on macOS the terminology for labels appears to be
-    "assembler local symbols".
+    Labels are tied to sections.  This enables certain checks to be performed
+    when constructions involving such labels are built (e.g. in
+    [Asm_directives]).
+
+    Labels' names must be unique within the assembly stream for a single
+    compilation unit, including across sections.  (This criterion is not
+    checked.)
 *)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+(** To be called by the emitter at the very start of code generation.
+    [new_label] should always be [Cmm.new_label]. *)
+val initialize
+   : new_label:(unit -> int)
+  -> unit
+
+(** The type of labels. *)
 type t
+
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
 
 (** Create a fresh integer-valued label (using the [new_label] function passed
     to [initialize], below). *)
@@ -37,7 +50,9 @@ val create : Asm_section.t -> t
 (** Create an integer-valued label. *)
 val create_int : Asm_section.t -> int -> t
 
-(** Create a textual label.  The supplied name must not require escaping. *)
+(** Create a textual label.  The supplied name must not require escaping.
+    The supplied name must not include any platform-specific prefix
+    (e.g. "L", ".L", etc). *)
 val create_string : Asm_section.t -> string -> t
 
 (** Convert a label to the corresponding textual form, suitable for direct
@@ -45,16 +60,8 @@ val create_string : Asm_section.t -> string -> t
     an instruction referencing a label. *)
 val encode : t -> string
 
-(** To be called by the emitter at the very start of code generation.
-    [new_label] should always be [Cmm.new_label]. *)
-val initialize
-   : new_label:(unit -> int)
-  -> unit
-
 (** Which section a label is in. *)
 val section : t -> Asm_section.t
-
-include Identifiable.S with type t := t
 
 (** Retrieve a distinguished label that is suitable for identifying the start
     of the given section within a given compilation unit's assembly file. *)

--- a/asmcomp/asm_target/asm_label.mli
+++ b/asmcomp/asm_target/asm_label.mli
@@ -12,12 +12,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** A label in the assembly stream. They may be either numeric or textual.
-    (Numeric ones are converted to textual ones by this module.) The argument
-    to [String] should not include any platform-specific prefix (such as "L",
-    ".L", etc).
+(** A label in a specific section within the assembly stream. They may be either
+    numeric or textual. (Numeric ones are converted to textual ones by this
+    module.) The argument to [String] should not include any platform-specific
+    prefix (such as "L", ".L", etc).
 
-    Note: Labels are not symbols---they are not accessible in the object file.
+    Label's numeric or textual names are unique within the assembly stream
+    for a single compilation unit, even across sections.
+
+    Note: Labels are not symbols in the usual sense---they are a construct
+    in the assembler's metalanguage and not accessible in the object
+    file---although on macOS the terminology for labels appears to be
+    "assembler local symbols".
 *)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
@@ -26,13 +32,13 @@ type t
 
 (** Create a fresh integer-valued label (using the [new_label] function passed
     to [initialize], below). *)
-val create : unit -> t
+val create : Asm_section.t -> t
 
 (** Create an integer-valued label. *)
-val create_int : int -> t
+val create_int : Asm_section.t -> int -> t
 
 (** Create a textual label.  The supplied name must not require escaping. *)
-val create_string : string -> t
+val create_string : Asm_section.t -> string -> t
 
 (** Convert a label to the corresponding textual form, suitable for direct
     emission into an assembly file.  This may be useful e.g. when emitting
@@ -44,3 +50,15 @@ val encode : t -> string
 val initialize
    : new_label:(unit -> int)
   -> unit
+
+(** Which section a label is in. *)
+val section : t -> Asm_section.t
+
+include Identifiable.S with type t := t
+
+(** Retrieve a distinguished label that is suitable for identifying the start
+    of the given section within a given compilation unit's assembly file. *)
+val for_section : Asm_section.t -> t
+
+(** Like [label], but for DWARF sections only. *)
+val for_dwarf_section : Asm_section.dwarf_section -> t

--- a/asmcomp/asm_target/asm_section.ml
+++ b/asmcomp/asm_target/asm_section.ml
@@ -1,0 +1,208 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type dwarf_section =
+  | Debug_info
+  | Debug_abbrev
+  | Debug_aranges
+  | Debug_loc
+  | Debug_str
+  | Debug_line
+
+type t =
+  | Text
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+  | DWARF of dwarf_section
+
+let all_sections_in_order = [
+  Text;
+  Data;
+  Read_only_data;
+  Eight_byte_literals;
+  Sixteen_byte_literals;
+  Jump_tables;
+  DWARF Debug_info;
+  DWARF Debug_abbrev;
+  DWARF Debug_aranges;
+  DWARF Debug_loc;
+  DWARF Debug_str;
+  DWARF Debug_line;
+]
+
+let section_is_text = function
+  | Text -> true
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+  | DWARF _ -> false
+
+(* Modified version of [TS.system] for easier matching in
+   [switch_to_section], below. *)
+type derived_system =
+  | Linux
+  | MinGW_32
+  | MinGW_64
+  | Win32
+  | Win64
+  | Cygwin
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+let derived_system () =
+  match Target_system.system (), Target_system.machine_width () with
+  | Linux, _ -> Linux
+  | Windows Cygwin, _ -> Cygwin
+  | Windows MinGW, Thirty_two -> MinGW_32
+  | Windows MinGW, Sixty_four -> MinGW_64
+  | Windows Native, Thirty_two -> Win32
+  | Windows Native, Sixty_four -> Win64
+  | MacOS_like, _ -> MacOS_like
+  | FreeBSD, _ -> FreeBSD
+  | NetBSD, _ -> NetBSD
+  | OpenBSD, _ -> OpenBSD
+  | Generic_BSD, _ -> Generic_BSD
+  | Solaris, _ -> Solaris
+  | Dragonfly, _ -> Dragonfly
+  | GNU, _ -> GNU
+  | BeOS, _ -> BeOS
+  | Unknown, _ -> Unknown
+
+type flags_for_section = {
+  names : string list;
+  flags : string option;
+  args : string list;
+}
+
+let flags t ~first_occurrence =
+  let text () = [".text"], None, [] in
+  let data () = [".data"], None, [] in
+  let rodata () = [".rodata"], None, [] in
+  let system = derived_system () in
+  let names, flags, args =
+    match t, Target_system.architecture (), system with
+    | Text, _, _ -> text ()
+    | Data, _, _ -> data ()
+    | DWARF dwarf, _, MacOS_like ->
+      let name =
+        match dwarf with
+        | Debug_info -> "__debug_info"
+        | Debug_abbrev -> "__debug_abbrev"
+        | Debug_aranges -> "__debug_aranges"
+        | Debug_loc -> "__debug_loc"
+        | Debug_str -> "__debug_str"
+        | Debug_line -> "__debug_line"
+      in
+      ["__DWARF"; name], None, ["regular"; "debug"]
+    | DWARF dwarf, _, _ ->
+      let name =
+        match dwarf with
+        | Debug_info -> ".debug_info"
+        | Debug_abbrev -> ".debug_abbrev"
+        | Debug_aranges -> ".debug_aranges"
+        | Debug_loc -> ".debug_loc"
+        | Debug_str -> ".debug_str"
+        | Debug_line -> ".debug_line"
+      in
+      let flags =
+        if first_occurrence then
+          Some ""
+        else
+          None
+      in
+      let args =
+        if first_occurrence then
+          ["%progbits"]
+        else
+          []
+      in
+      [name], flags, args
+    | (Eight_byte_literals | Sixteen_byte_literals), (ARM | AArch64 | Z), _
+    | (Eight_byte_literals | Sixteen_byte_literals), _, Solaris ->
+      rodata ()
+    | Sixteen_byte_literals, _, MacOS_like ->
+      ["__TEXT";"__literal16"], None, ["16byte_literals"]
+    | Sixteen_byte_literals, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Sixteen_byte_literals, _, (MinGW_32 | Win32 | Win64) ->
+      data ()
+    | Sixteen_byte_literals, _, _ ->
+      [".rodata.cst8"], Some "a", ["@progbits"]
+    | Eight_byte_literals, _, MacOS_like ->
+      ["__TEXT";"__literal8"], None, ["8byte_literals"]
+    | Eight_byte_literals, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Eight_byte_literals, _, (MinGW_32 | Win32 | Win64) ->
+      data ()
+    | Eight_byte_literals, _, _ ->
+      [".rodata.cst8"], Some "a", ["@progbits"]
+    | Jump_tables, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Jump_tables, _, (MinGW_32 | Win32) ->
+      data ()
+    | Jump_tables, _, (MacOS_like | Win64) ->
+      text () (* with LLVM/OS X and MASM, use the text segment *)
+    | Jump_tables, _, _ ->
+      [".rodata"], None, []
+    | Read_only_data, _, (MinGW_32 | Win32) ->
+      data ()
+    | Read_only_data, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Read_only_data, _, _ ->
+      rodata ()
+  in
+  { names; flags; args; }
+
+let text_label () = Asm_label.create ()
+let data_label () = Asm_label.create ()
+let read_only_data_label () = Asm_label.create ()
+let eight_byte_literals_label () = Asm_label.create ()
+let sixteen_byte_literals_label () = Asm_label.create ()
+let jump_tables_label () = Asm_label.create ()
+let debug_info_label () = Asm_label.create ()
+let debug_abbrev_label () = Asm_label.create ()
+let debug_aranges_label () = Asm_label.create ()
+let debug_loc_label () = Asm_label.create ()
+let debug_str_label () = Asm_label.create ()
+let debug_line_label () = Asm_label.create ()
+
+let label t =
+  match t with
+  | Text -> text_label ()
+  | Data -> data_label ()
+  | Read_only_data -> read_only_data_label ()
+  | Eight_byte_literals -> eight_byte_literals_label ()
+  | Sixteen_byte_literals -> sixteen_byte_literals_label ()
+  | Jump_tables -> jump_tables_label ()
+  | DWARF Debug_info -> debug_info_label ()
+  | DWARF Debug_abbrev -> debug_abbrev_label ()
+  | DWARF Debug_aranges -> debug_aranges_label ()
+  | DWARF Debug_loc -> debug_loc_label ()
+  | DWARF Debug_str -> debug_str_label ()
+  | DWARF Debug_line -> debug_line_label ()

--- a/asmcomp/asm_target/asm_section.ml
+++ b/asmcomp/asm_target/asm_section.ml
@@ -179,30 +179,34 @@ let flags t ~first_occurrence =
   in
   { names; flags; args; }
 
-let text_label () = Asm_label.create ()
-let data_label () = Asm_label.create ()
-let read_only_data_label () = Asm_label.create ()
-let eight_byte_literals_label () = Asm_label.create ()
-let sixteen_byte_literals_label () = Asm_label.create ()
-let jump_tables_label () = Asm_label.create ()
-let debug_info_label () = Asm_label.create ()
-let debug_abbrev_label () = Asm_label.create ()
-let debug_aranges_label () = Asm_label.create ()
-let debug_loc_label () = Asm_label.create ()
-let debug_str_label () = Asm_label.create ()
-let debug_line_label () = Asm_label.create ()
+let to_string t =
+  let { names; flags = _; args = _; } = flags t ~first_occurrence:true in
+  String.concat " " names
+
+let text_label = lazy (Asm_label.create ())
+let data_label = lazy (Asm_label.create ())
+let read_only_data_label = lazy (Asm_label.create ())
+let eight_byte_literals_label = lazy (Asm_label.create ())
+let sixteen_byte_literals_label = lazy (Asm_label.create ())
+let jump_tables_label = lazy (Asm_label.create ())
+let debug_info_label = lazy (Asm_label.create ())
+let debug_abbrev_label = lazy (Asm_label.create ())
+let debug_aranges_label = lazy (Asm_label.create ())
+let debug_loc_label = lazy (Asm_label.create ())
+let debug_str_label = lazy (Asm_label.create ())
+let debug_line_label = lazy (Asm_label.create ())
 
 let label t =
   match t with
-  | Text -> text_label ()
-  | Data -> data_label ()
-  | Read_only_data -> read_only_data_label ()
-  | Eight_byte_literals -> eight_byte_literals_label ()
-  | Sixteen_byte_literals -> sixteen_byte_literals_label ()
-  | Jump_tables -> jump_tables_label ()
-  | DWARF Debug_info -> debug_info_label ()
-  | DWARF Debug_abbrev -> debug_abbrev_label ()
-  | DWARF Debug_aranges -> debug_aranges_label ()
-  | DWARF Debug_loc -> debug_loc_label ()
-  | DWARF Debug_str -> debug_str_label ()
-  | DWARF Debug_line -> debug_line_label ()
+  | Text -> Lazy.force text_label
+  | Data -> Lazy.force data_label
+  | Read_only_data -> Lazy.force read_only_data_label
+  | Eight_byte_literals -> Lazy.force eight_byte_literals_label
+  | Sixteen_byte_literals -> Lazy.force sixteen_byte_literals_label
+  | Jump_tables -> Lazy.force jump_tables_label
+  | DWARF Debug_info -> Lazy.force debug_info_label
+  | DWARF Debug_abbrev -> Lazy.force debug_abbrev_label
+  | DWARF Debug_aranges -> Lazy.force debug_aranges_label
+  | DWARF Debug_loc -> Lazy.force debug_loc_label
+  | DWARF Debug_str -> Lazy.force debug_str_label
+  | DWARF Debug_line -> Lazy.force debug_line_label

--- a/asmcomp/asm_target/asm_section.mli
+++ b/asmcomp/asm_target/asm_section.mli
@@ -1,0 +1,64 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of object file sections. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** Sections that hold DWARF debugging information. *)
+type dwarf_section =
+  | Debug_info
+  | Debug_abbrev
+  | Debug_aranges
+  | Debug_loc
+  | Debug_str
+  | Debug_line
+
+(** The linker may share constants in [Eight_byte_literals] and
+    [Sixteen_byte_literals] sections. *)
+type t =
+  | Text
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+  | DWARF of dwarf_section
+
+val all_sections_in_order : t list
+
+(** Whether the section holds code. *)
+val section_is_text : t -> bool
+
+type flags_for_section = private {
+  names : string list;
+  flags : string option;
+  args : string list;
+}
+
+(** The necessary information for a section directive.  [first_occurrence]
+    should be [true] iff the corresponding directive will be the first such
+    in the relevant assembly file for the given section. *)
+val flags : t -> first_occurrence:bool -> flags_for_section
+
+(** Retrieve a distinguished label that is suitable for use at the top of
+    the given section.
+
+    Aside: Why do we need labels at the start of sections rather than
+    just referencing sections directly?
+    They are necessary so that references (e.g. DW_FORM_ref_addr or
+    DW_FORM_sec_offset when emitting DWARF) to places that are currently
+    at the start of these sections get relocated correctly when those
+    places become not at the start (e.g. during linking). *)
+val label : t -> Asm_label.t

--- a/asmcomp/asm_target/asm_section.mli
+++ b/asmcomp/asm_target/asm_section.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -16,50 +16,76 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-(** Sections that hold DWARF debugging information. *)
+(** Sections that hold DWARF debugging information.  See:
+       http://dwarfstd.org/doc/DWARF4.pdf
+       http://dwarfstd.org/doc/DWARF5.pdf
+*)
 type dwarf_section =
   | Debug_info
+    (** The debugging information entries. *)
   | Debug_abbrev
+    (** The abbreviations table. *)
   | Debug_aranges
+    (** The address ranges table. *)
   | Debug_addr
+    (** The address table (DWARF-5 only). *)
   | Debug_loc
+    (** The table of location lists (DWARF-4 and earlier only). *)
   | Debug_ranges
+    (** The table of range lists (DWARF-4 and earlier only). *)
   | Debug_loclists
+    (** The table of location lists (DWARF-5 only). *)
   | Debug_rnglists
+    (** The table of range lists (DWARF-5 only). *)
   | Debug_str
+    (** The string table. *)
   | Debug_line
+    (** The line number table. *)
 
 (** The linker may share constants in [Eight_byte_literals] and
     [Sixteen_byte_literals] sections. *)
 type t =
   | Text
+    (** The code section. *)
   | Data
+    (** The read/write data section. *)
   | Read_only_data
+    (** The read-only data section. *)
   | Eight_byte_literals
+    (** A section containing eight-byte constants (for example unboxed floating
+        point numbers). *)
   | Sixteen_byte_literals
+    (** A section containing sixteen-byte numeric constants. *)
   | Jump_tables
+    (** A section containing the code of jump tables. *)
   | DWARF of dwarf_section
+    (** The sections holding DWARF debugging information. *)
 
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
+
+(** Concise description of values of type [t] for error messages, etc. *)
 val to_string : t -> string
 
+(** All sections that this code knows about. *)
 val all_sections_in_order : unit -> t list
 
-(** Whether the section holds code. *)
+(** [section_is_text] returns [true] if the section holds code. *)
 val section_is_text : t -> bool
 
+(** Details about a specific section, used for assembly emission. *)
 type flags_for_section = private {
   names : string list;
+  (** The name of the section.  Sometimes (e.g. on macOS for DWARF sections)
+      this has multiple parts. *)
   flags : string option;
+  (** Target-dependent flags for the section. *)
   args : string list;
+  (** Target-dependent arguments for the section. *)
 }
 
-(** The necessary information for a section directive.  [first_occurrence]
-    should be [true] iff the corresponding directive will be the first such
-    in the relevant assembly file for the given section. *)
+(** The necessary information for an assembler's ".section" directive.
+
+    [first_occurrence] should be [true] iff the corresponding directive will
+    be the first such in the relevant assembly file for the given section. *)
 val flags : t -> first_occurrence:bool -> flags_for_section
-
-val print : Format.formatter -> t -> unit
-
-val compare : t -> t -> int
-
-val equal : t -> t -> bool

--- a/asmcomp/asm_target/asm_section.mli
+++ b/asmcomp/asm_target/asm_section.mli
@@ -21,7 +21,11 @@ type dwarf_section =
   | Debug_info
   | Debug_abbrev
   | Debug_aranges
+  | Debug_addr
   | Debug_loc
+  | Debug_ranges
+  | Debug_loclists
+  | Debug_rnglists
   | Debug_str
   | Debug_line
 
@@ -36,7 +40,9 @@ type t =
   | Jump_tables
   | DWARF of dwarf_section
 
-val all_sections_in_order : t list
+val to_string : t -> string
+
+val all_sections_in_order : unit -> t list
 
 (** Whether the section holds code. *)
 val section_is_text : t -> bool
@@ -52,13 +58,8 @@ type flags_for_section = private {
     in the relevant assembly file for the given section. *)
 val flags : t -> first_occurrence:bool -> flags_for_section
 
-(** Retrieve a distinguished label that is suitable for use at the top of
-    the given section.
+val print : Format.formatter -> t -> unit
 
-    Aside: Why do we need labels at the start of sections rather than
-    just referencing sections directly?
-    They are necessary so that references (e.g. DW_FORM_ref_addr or
-    DW_FORM_sec_offset when emitting DWARF) to places that are currently
-    at the start of these sections get relocated correctly when those
-    places become not at the start (e.g. during linking). *)
-val label : t -> Asm_label.t
+val compare : t -> t -> int
+
+val equal : t -> t -> bool

--- a/asmcomp/asm_target/asm_symbol.ml
+++ b/asmcomp/asm_target/asm_symbol.ml
@@ -17,13 +17,40 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type t = Backend_sym.t
+type t = {
+  section : Asm_section.t;
+  compilation_unit : Compilation_unit.t;
+  name : string;
+  (* Just like for [Backend_sym], the [name] uniquely determines the
+     symbol. *)
+  name_without_prefix : string;
+  (* Like [name], but without any symbol prefix.  This is required for
+     emission into DWARF information in situations where GDB may look up
+     a symbol name via the minsyms table, whose entries appear to lack the
+     prefix.  In particular this happens when resolving call site chains. *)
+}
 
-let create t = t
+let escape name =
+  let spec = ref false in
+  for i = 0 to String.length name - 1 do
+    match String.unsafe_get name i with
+    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
+    | _ -> spec := true;
+  done;
+  if not !spec then begin
+    name
+  end else begin
+    let b = Buffer.create (String.length name + 10) in
+    String.iter
+      (function
+        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
+        | c -> Printf.bprintf b "$%02x" (Char.code c)
+      )
+      name;
+    Buffer.contents b
+  end
 
-let of_external_name name = Backend_sym.of_external_name name
-
-let symbol_prefix () = (* XXX *)
+let symbol_prefix () = (* CR mshinwell: needs checking *)
   match Target_system.architecture () with
   | IA32 | X86_64 ->
     begin match Target_system.system () with
@@ -47,28 +74,70 @@ let symbol_prefix () = (* XXX *)
   | POWER
   | Z -> ""
 
-let escape t =
-  let spec = ref false in
-  for i = 0 to String.length t - 1 do
-    match String.unsafe_get t i with
-    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
-    | _ -> spec := true;
-  done;
-  if not !spec then t
-  else
-    let b = Buffer.create (String.length t + 10) in
-    String.iter
-      (function
-        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
-        | c -> Printf.bprintf b "$%02x" (Char.code c)
-      )
-      t;
-    Buffer.contents b
+let encode ?without_prefix backend_sym =
+  let symbol_prefix =
+    match without_prefix with
+    | None -> symbol_prefix ()
+    | Some () -> ""
+  in
+  Backend_sym.to_escaped_string
+    ~symbol_prefix
+    ~escape backend_sym
+
+let create backend_sym =
+  let section : Asm_section.t =
+    match Backend_sym.kind backend_sym with
+    | Text -> Text
+    | Data -> Data
+  in
+  { section;
+    compilation_unit = Backend_sym.compilation_unit backend_sym;
+    name = encode backend_sym;
+    name_without_prefix = encode ~without_prefix:() backend_sym;
+  }
+
+let of_external_name section compilation_unit name =
+  let backend_sym =
+    (* The choice of [Data] is arbitrary. *)
+    Backend_sym.of_external_name compilation_unit name Data
+  in
+  { section;
+    compilation_unit;
+    name = encode backend_sym;
+    name_without_prefix = encode ~without_prefix:() backend_sym;
+  }
+
+let of_external_name_no_prefix section compilation_unit name =
+  let name =
+    (* The choice of [Data] is arbitrary. *)
+    Backend_sym.to_escaped_string ~symbol_prefix:"" ~escape
+      (Backend_sym.of_external_name compilation_unit name Data)
+  in
+  { section;
+    compilation_unit;
+    name;
+    (* CR mshinwell: [name] might have a prefix...
+       Let's look through and find where this function is being used, and
+       see whether we can supply the name without a prefix at all times. *)
+    name_without_prefix = name;
+  }
+
+let section t = t.section
 
 let encode ?reloc t =
-  Backend_sym.to_escaped_string ?suffix:reloc
-    ~symbol_prefix:(symbol_prefix ())
-    ~escape t
+  match reloc with
+  | None -> t.name
+  | Some reloc -> t.name ^ reloc
+
+let linkage_name t = Linkage_name.create t.name_without_prefix
+
+let prefix t section compilation_unit ~prefix =
+  let prefix = escape prefix in
+  { section;
+    compilation_unit;
+    name = prefix ^ t.name;
+    name_without_prefix = prefix ^ t.name_without_prefix;
+  }
 
 (* Detection of functions that can be duplicated between a DLL and
    the main program (PR#4690) *)
@@ -78,34 +147,71 @@ let isprefix s1 s2 =
     && String.sub s2 0 (String.length s1) = s1
 
 let is_generic_function t =
-  let name = encode t in
   List.exists
-    (fun p -> isprefix p name)
+    (fun p -> isprefix p t.name)
     ["caml_apply"; "caml_curry"; "caml_send"; "caml_tuplify"]
 
-include Identifiable.Make (Backend_sym)
+let compilation_unit t = t.compilation_unit
+
+include Identifiable.Make (struct
+  type nonrec t = t
+  let compare t1 t2 = String.compare t1.name t2.name
+  let equal t1 t2 = String.equal t1.name t2.name
+  let hash t = Hashtbl.hash t.name
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+  let print ppf t = Format.pp_print_string ppf t.name
+end)
 
 module Names = struct
-  let mcount = of_external_name "mcount"
-  let _mcount = of_external_name "_mcount"
-  let __gnu_mcount_nc = of_external_name "__gnu_mcount_nc"
-  let sqrt = of_external_name "sqrt"
+  let runtime = Compilation_unit.runtime
 
-  let caml_young_ptr = of_external_name "caml_young_ptr"
-  let caml_young_limit = of_external_name "caml_young_limit"
-  let caml_exception_pointer = of_external_name "caml_exception_pointer"
-  let caml_negf_mask = of_external_name "caml_negf_mask"
-  let caml_absf_mask = of_external_name "caml_absf_mask"
+  let mcount =
+    of_external_name Text runtime "mcount"
 
-  let caml_call_gc = of_external_name "caml_call_gc"
-  let caml_c_call = of_external_name "caml_c_call"
-  let caml_alloc1 = of_external_name "caml_alloc1"
-  let caml_alloc2 = of_external_name "caml_alloc2"
-  let caml_alloc3 = of_external_name "caml_alloc3"
-  let caml_allocN = of_external_name "caml_allocN"
-  let caml_ml_array_bound_error = of_external_name "caml_ml_array_bound_error"
-  let caml_raise_exn = of_external_name "caml_raise_exn"
+  let _mcount =
+    of_external_name Text runtime "_mcount"
 
-  let caml_frametable = of_external_name "caml_frametable"
-  let caml_spacetime_shapes = of_external_name "caml_spacetime_shapes"
+  let __gnu_mcount_nc =
+    of_external_name Text runtime "__gnu_mcount_nc"
+
+  let caml_young_ptr =
+    of_external_name Data runtime "caml_young_ptr"
+
+  let caml_young_limit =
+    of_external_name Data runtime "caml_young_limit"
+
+  let caml_exception_pointer =
+    of_external_name Data runtime "caml_exception_pointer"
+
+  let caml_negf_mask () =
+    let comp_unit = Compilation_unit.get_current_exn () in
+    of_external_name Eight_byte_literals comp_unit "caml_negf_mask"
+
+  let caml_absf_mask () =
+    let comp_unit = Compilation_unit.get_current_exn () in
+    of_external_name Eight_byte_literals comp_unit "caml_absf_mask"
+
+  let caml_call_gc =
+    of_external_name Text runtime "caml_call_gc"
+
+  let caml_c_call =
+    of_external_name Text runtime "caml_c_call"
+
+  let caml_alloc1 =
+    of_external_name Text runtime "caml_alloc1"
+
+  let caml_alloc2 =
+    of_external_name Text runtime "caml_alloc2"
+
+  let caml_alloc3 =
+    of_external_name Text runtime "caml_alloc3"
+
+  let caml_allocN =
+    of_external_name Text runtime "caml_allocN"
+
+  let caml_ml_array_bound_error =
+    of_external_name Text runtime "caml_ml_array_bound_error"
+
+  let caml_raise_exn =
+    of_external_name Text runtime "caml_raise_exn"
 end

--- a/asmcomp/asm_target/asm_symbol.ml
+++ b/asmcomp/asm_target/asm_symbol.ml
@@ -1,0 +1,111 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Fabrice Le Fessant, projet Gallium, INRIA Rocquencourt        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = Backend_sym.t
+
+let create t = t
+
+let of_external_name name = Backend_sym.of_external_name name
+
+let symbol_prefix () = (* XXX *)
+  match Target_system.architecture () with
+  | IA32 | X86_64 ->
+    begin match Target_system.system () with
+    | Linux
+    | Windows Cygwin
+    | Windows MinGW
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
+    | Generic_BSD
+    | Solaris
+    | BeOS
+    | GNU
+    | Dragonfly
+    | Windows Native
+    | Unknown -> "" (* checked ok. *)
+    | MacOS_like -> "_" (* checked ok. *)
+    end
+  | ARM
+  | AArch64
+  | POWER
+  | Z -> ""
+
+let escape t =
+  let spec = ref false in
+  for i = 0 to String.length t - 1 do
+    match String.unsafe_get t i with
+    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
+    | _ -> spec := true;
+  done;
+  if not !spec then t
+  else
+    let b = Buffer.create (String.length t + 10) in
+    String.iter
+      (function
+        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
+        | c -> Printf.bprintf b "$%02x" (Char.code c)
+      )
+      t;
+    Buffer.contents b
+
+let encode ?reloc t =
+  Backend_sym.to_escaped_string ?suffix:reloc
+    ~symbol_prefix:(symbol_prefix ())
+    ~escape t
+
+(* Detection of functions that can be duplicated between a DLL and
+   the main program (PR#4690) *)
+
+let isprefix s1 s2 =
+  String.length s1 <= String.length s2
+    && String.sub s2 0 (String.length s1) = s1
+
+let is_generic_function t =
+  let name = encode t in
+  List.exists
+    (fun p -> isprefix p name)
+    ["caml_apply"; "caml_curry"; "caml_send"; "caml_tuplify"]
+
+include Identifiable.Make (Backend_sym)
+
+module Names = struct
+  let mcount = of_external_name "mcount"
+  let _mcount = of_external_name "_mcount"
+  let __gnu_mcount_nc = of_external_name "__gnu_mcount_nc"
+  let sqrt = of_external_name "sqrt"
+
+  let caml_young_ptr = of_external_name "caml_young_ptr"
+  let caml_young_limit = of_external_name "caml_young_limit"
+  let caml_exception_pointer = of_external_name "caml_exception_pointer"
+  let caml_negf_mask = of_external_name "caml_negf_mask"
+  let caml_absf_mask = of_external_name "caml_absf_mask"
+
+  let caml_call_gc = of_external_name "caml_call_gc"
+  let caml_c_call = of_external_name "caml_c_call"
+  let caml_alloc1 = of_external_name "caml_alloc1"
+  let caml_alloc2 = of_external_name "caml_alloc2"
+  let caml_alloc3 = of_external_name "caml_alloc3"
+  let caml_allocN = of_external_name "caml_allocN"
+  let caml_ml_array_bound_error = of_external_name "caml_ml_array_bound_error"
+  let caml_raise_exn = of_external_name "caml_raise_exn"
+
+  let caml_frametable = of_external_name "caml_frametable"
+  let caml_spacetime_shapes = of_external_name "caml_spacetime_shapes"
+end

--- a/asmcomp/asm_target/asm_symbol.ml
+++ b/asmcomp/asm_target/asm_symbol.ml
@@ -129,8 +129,6 @@ let encode ?reloc t =
   | None -> t.name
   | Some reloc -> t.name ^ reloc
 
-let linkage_name t = Linkage_name.create t.name_without_prefix
-
 let prefix t section compilation_unit ~prefix =
   let prefix = escape prefix in
   { section;

--- a/asmcomp/asm_target/asm_symbol.ml
+++ b/asmcomp/asm_target/asm_symbol.ml
@@ -7,7 +7,7 @@
 (*                                                                        *)
 (*   Copyright 2014 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)

--- a/asmcomp/asm_target/asm_symbol.mli
+++ b/asmcomp/asm_target/asm_symbol.mli
@@ -74,9 +74,6 @@ val compilation_unit : t -> Compilation_unit.t
     no escaping applied to [reloc]) if provided. *)
 val encode : ?reloc:string -> t -> string
 
-(** Build a [Linkage_name.t] with the correct name for the given symbol. *)
-val linkage_name : t -> Linkage_name.t
-
 (** Detection of functions that can be duplicated between a DLL and the main
     program (PR#4690). *)
 val is_generic_function : t -> bool

--- a/asmcomp/asm_target/asm_symbol.mli
+++ b/asmcomp/asm_target/asm_symbol.mli
@@ -1,0 +1,69 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Symbols in the assembly stream. Unlike labels, symbols are named entities
+    that are accessible in an object file. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+(** Create an assembly symbol from a backend symbol. *)
+val create : Backend_sym.t -> t
+
+(** Create an assembly symbol from a name as found in an object file. *)
+val of_external_name : string -> t
+
+(** Convert a symbol to the corresponding textual form, suitable for direct
+    emission into an assembly file.  This may be useful e.g. when emitting
+    an instruction referencing a symbol.
+    
+    The optional [reloc] parameter will be appended to the encoded symbol (with
+    no escaping applied to [reloc]) if provided. *)
+val encode : ?reloc:string -> t -> string
+
+(** Detection of functions that can be duplicated between a DLL and the main
+    program (PR#4690). *)
+val is_generic_function : t -> bool
+
+include Identifiable.S with type t := t
+
+module Names : sig
+  (** External variables from the C library. *)
+  val mcount : t
+  val _mcount : t
+  val __gnu_mcount_nc : t
+  val sqrt : t
+
+  (** Global variables in the OCaml runtime accessed by OCaml code. *)
+  val caml_young_ptr : t
+  val caml_young_limit : t
+  val caml_exception_pointer : t
+  val caml_negf_mask : t
+  val caml_absf_mask : t
+
+  (** Entry points to the OCaml runtime from OCaml code. *)
+  val caml_call_gc : t
+  val caml_c_call : t
+  val caml_allocN : t
+  val caml_alloc1 : t
+  val caml_alloc2 : t
+  val caml_alloc3 : t
+  val caml_ml_array_bound_error : t
+  val caml_raise_exn : t
+
+  (** Standard OCaml auxiliary data structures. *)
+  val caml_frametable : t
+  val caml_spacetime_shapes : t
+end

--- a/asmcomp/asm_target/asm_symbol.mli
+++ b/asmcomp/asm_target/asm_symbol.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,23 +13,32 @@
 (**************************************************************************)
 
 (** Symbols in the assembly stream.  Unlike labels, symbols are named entities
-    that are potentially accessible from outside an object file.
+    that are potentially accessible from outside an object file; they may
+    also be seen when an object file is examined (e.g. via objdump).
 
-    These symbols are defined within sections and tied to a particular
-    compilation unit.  They may point anywhere, unlike [Backend_sym]s, where
-    those of [Data] kind must point at correctly-structured OCaml values.
+    [Asm_symbol]s are defined within sections and tied to a particular
+    compilation unit.  This enables certain checks to be performed when
+    constructions involving symbols are built (e.g. in [Asm_directives]).
+    [Asm_symbol]s may point anywhere, unlike [Backend_sym]s, where those
+    of [Data] kind must point at correctly-structured OCaml values.
 *)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+(** The type of symbols. *)
 type t
+
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
 
 (** Create an assembly symbol from a backend symbol. *)
 val create : Backend_sym.t -> t
 
+(* CR mshinwell: Maybe we need to be a bit more careful about the prefix
+   thing here.  Might the prefixes not be seen in an object file? *)
 (** Create an assembly symbol from a name as found in an object file.
     The name will be prefixed with the appropriate symbol prefix for the
-    target system. *)
+    target system's assembler. *)
 val of_external_name : Asm_section.t -> Compilation_unit.t -> string -> t
 
 (** Take an existing symbol and add a prefix to its name.  The compilation
@@ -65,14 +74,14 @@ val compilation_unit : t -> Compilation_unit.t
     no escaping applied to [reloc]) if provided. *)
 val encode : ?reloc:string -> t -> string
 
+(** Build a [Linkage_name.t] with the correct name for the given symbol. *)
 val linkage_name : t -> Linkage_name.t
 
 (** Detection of functions that can be duplicated between a DLL and the main
     program (PR#4690). *)
 val is_generic_function : t -> bool
 
-include Identifiable.S with type t := t
-
+(** The names of various predefined symbols, for convenience. *)
 module Names : sig
   (** External variables from the C library. *)
   val mcount : t

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -76,7 +76,7 @@ let raw_clambda_dump_if ppf
 
 let rec regalloc ~ppf_dump round fd =
   if round > 50 then
-    fatal_error(fd.Mach.fun_name ^
+    fatal_error(Backend_sym.to_string fd.Mach.fun_name ^
                 ": function too complex, cannot complete register allocation");
   dump_if ppf_dump dump_live "Liveness analysis" fd;
   if !use_linscan then begin

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -218,12 +218,13 @@ let flambda_gen_implementation ?toplevel ~backend ~ppf_dump
   end_gen_implementation ?toplevel ~ppf_dump
     (clambda, preallocated, constants)
 
-let lambda_gen_implementation ?toplevel ~ppf_dump
+let closure_gen_implementation ?toplevel ~ppf_dump
     (lambda:Lambda.program) =
   let clambda = Closure.intro lambda.main_module_block_size lambda.code in
+  let current_unit = Compilation_unit.get_current_exn () in
   let preallocated_block =
     Clambda.{
-      symbol = Compilenv.make_symbol None;
+      symbol = Symbol.base_symbol_for_unit current_unit;
       exported = true;
       tag = 0;
       fields = List.init lambda.main_module_block_size (fun _ -> None);
@@ -251,7 +252,7 @@ let compile_implementation_clambda ?toplevel prefixname
     ~ppf_dump (program:Lambda.program) =
   compile_implementation_gen ?toplevel prefixname
     ~required_globals:program.Lambda.required_globals
-    ~ppf_dump lambda_gen_implementation program
+    ~ppf_dump closure_gen_implementation program
 
 let compile_implementation_flambda ?toplevel prefixname
     ~required_globals ~backend ~ppf_dump (program:Flambda.program) =

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -142,7 +142,7 @@ let compile_genfuns ~ppf_dump f =
        | (Cfunction {fun_name = name}) as ph when f name ->
            compile_phrase ~ppf_dump ph
        | _ -> ())
-    (Cmmgen.generic_functions true [Compilenv.current_unit_infos ()])
+    (Cmmgen.generic_functions true [Compilation_unit.get_current_exn_infos ()])
 
 let compile_unit _output_prefix asm_filename keep_asm
       obj_filename gen =

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -16,14 +16,14 @@
 (* From lambda to assembly code *)
 
 val compile_implementation_flambda :
-    ?toplevel:(string -> bool) ->
+    ?toplevel:(Backend_sym.t -> bool) ->
     string ->
     required_globals:Ident.Set.t ->
     backend:(module Backend_intf.S) ->
     ppf_dump:Format.formatter -> Flambda.program -> unit
 
 val compile_implementation_clambda :
-    ?toplevel:(string -> bool) ->
+    ?toplevel:(Backend_sym.t -> bool) ->
     string ->
     ppf_dump:Format.formatter -> Lambda.program -> unit
 

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -205,7 +205,7 @@ let scan_file obj_name tolink = match read_file obj_name with
 
 let force_linking_of_startup ~ppf_dump =
   Asmgen.compile_phrase ~ppf_dump
-    (Cmm.Cdata ([Cmm.Csymbol_address "caml_startup"]))
+    (Cmm.Cdata ([Cmm.Csymbol_address Backend_sym.Names.caml_startup]))
 
 let make_startup_file ~ppf_dump units_list =
   let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -50,7 +50,7 @@ let read_member_info pack_path file = (
       if info.ui_name <> name
       then raise(Error(Illegal_renaming(name, file, info.ui_name)));
       if info.ui_symbol <>
-         (Compilenv.current_unit_infos()).ui_symbol ^ "__" ^ info.ui_name
+         (Compilation_unit.get_current_exn_infos()).ui_symbol ^ "__" ^ info.ui_name
       then raise(Error(Wrong_for_pack(file, pack_path)));
       Asmlink.check_consistency file info crc;
       Compilenv.cache_unit_info info;
@@ -173,20 +173,20 @@ let build_package_cmx members cmxfile =
             ui_export_info =
               Flambda
                 (Export_info_for_pack.import_for_pack ~pack_units
-                   ~pack:(Compilenv.current_unit ())
+                   ~pack:(Compilation_unit.get_current_exn ())
                    (get_export_info info)) })
         units
     else
       units
   in
-  let ui = Compilenv.current_unit_infos() in
+  let ui = Compilation_unit.get_current_exn_infos() in
   let ui_export_info =
     if Config.flambda then
       let ui_export_info =
         List.fold_left (fun acc info ->
             Export_info.merge acc (get_export_info info))
           (Export_info_for_pack.import_for_pack ~pack_units
-             ~pack:(Compilenv.current_unit ())
+             ~pack:(Compilation_unit.get_current_exn ())
              (get_export_info ui))
           units
       in

--- a/asmcomp/backend_sym.ml
+++ b/asmcomp/backend_sym.ml
@@ -1,0 +1,141 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Names of object file symbols. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = string
+type backend_sym = t
+
+let print ppf t = Format.pp_print_string ppf t
+
+let to_string t = t
+
+let of_symbol sym = Linkage_name.to_string (Symbol.label sym)
+
+let of_external_name name = name
+
+let create ~base_name =
+  let unit_name =
+    Linkage_name.to_string (Compilation_unit.get_linkage_name (
+      Compilation_unit.get_current_exn ()))
+  in
+  unit_name ^ "__" ^ base_name
+
+let add_suffix t new_suffix = t ^ new_suffix
+
+let add_suffixes t new_suffixes =
+  List.fold_left (fun t new_suffix -> add_suffix t new_suffix) t new_suffixes
+
+let add_int_suffix t new_suffix =
+  add_suffix t (string_of_int new_suffix)
+
+let to_escaped_string ?suffix ~symbol_prefix ~escape t =
+  let suffix =
+    match suffix with
+    | None -> ""
+    | Some suffix -> suffix
+  in
+  symbol_prefix ^ (escape t) ^ suffix
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 = String.compare (to_string t1) (to_string t2)
+
+  let equal t1 t2 = (compare t1 t2 = 0)
+
+  let hash t = Hashtbl.hash (to_string t)
+
+  let print t = print t
+
+  let output chn t = output_string chn (to_string t)
+end)
+
+module Names = struct
+  let sqrt = of_external_name "sqrt"
+
+  let caml_exception_pointer = of_external_name "caml_exception_pointer"
+  let caml_negf_mask = of_external_name "caml_negf_mask"
+  let caml_absf_mask = of_external_name "caml_absf_mask"
+  let caml_backtrace_pos = of_external_name "caml_backtrace_pos"
+  let caml_exn_Division_by_zero = of_external_name "caml_exn_Division_by_zero"
+  let caml_nativeint_ops = of_external_name "caml_nativeint_ops"
+  let caml_int32_ops = of_external_name "caml_int32_ops"
+  let caml_int64_ops = of_external_name "caml_int64_ops"
+
+  let caml_send n = add_int_suffix (of_external_name "caml_send") n
+  let caml_curry_n n =
+    add_int_suffix (of_external_name "caml_curry") n
+  let caml_curry_m_to_n m n =
+    add_suffixes (of_external_name "caml_curry")
+      [string_of_int m; "_"; string_of_int n]
+  let caml_curry_m_to_n_app m n =
+    add_suffixes (of_external_name "caml_curry")
+      [string_of_int m; "_"; string_of_int n; "_app"]
+  let caml_tuplify n = add_int_suffix (of_external_name "caml_tuplify") n
+  let caml_apply n = add_int_suffix (of_external_name "caml_apply") n
+
+  let caml_ba_get n = add_int_suffix (of_external_name "caml_ba_get_") n
+  let caml_ba_set n = add_int_suffix (of_external_name "caml_ba_set_") n
+
+  let caml_exn name = add_suffix (of_external_name "caml_exn_") name
+
+  let caml_call_gc = of_external_name "caml_call_gc"
+  let caml_modify = of_external_name "caml_modify"
+  let caml_initialize = of_external_name "caml_initialize"
+  let caml_get_public_method = of_external_name "caml_get_public_method"
+  let caml_alloc = of_external_name "caml_alloc"
+  let caml_ml_array_bound_error = of_external_name "caml_ml_array_bound_error"
+  let caml_raise_exn = of_external_name "caml_raise_exn"
+  let caml_make_array = of_external_name "caml_make_array"
+  let caml_bswap16_direct = of_external_name "caml_bswap16_direct"
+
+  type bswap_arg = Int32 | Int64 | Nativeint
+  let caml_direct_bswap ty =
+    let ty =
+      match ty with
+      | Int32 -> "int32"
+      | Int64 -> "int64"
+      | Nativeint -> "nativeint"
+    in
+    of_external_name (Printf.sprintf "caml_%s_direct_bswap" ty)
+
+  let caml_alloc_dummy = of_external_name "caml_alloc_dummy"
+  let caml_alloc_dummy_float = of_external_name "caml_alloc_dummy_float"
+  let caml_update_dummy = of_external_name "caml_update_dummy"
+  let caml_program = of_external_name "caml_program"
+  let caml_startup = of_external_name "caml_startup"
+  let caml_globals_inited = of_external_name "caml_globals_inited"
+  let caml_globals = of_external_name "caml_globals"
+  let caml_plugin_header = of_external_name "caml_plugin_header"
+  let caml_globals_map = of_external_name "caml_globals_map"
+  let caml_code_segments = of_external_name "caml_code_segments"
+  let caml_data_segments = of_external_name "caml_data_segments"
+
+  let caml_frametable = of_external_name "caml_frametable"
+  let caml_spacetime_shapes = of_external_name "caml_spacetime_shapes"
+
+  let caml_afl_area_ptr = of_external_name "caml_afl_area_ptr"
+  let caml_afl_prev_loc = of_external_name "caml_afl_prev_loc"
+  let caml_setup_afl = of_external_name "caml_setup_afl"
+
+  let caml_spacetime_allocate_node =
+    of_external_name "caml_spacetime_allocate_node"
+  let caml_spacetime_indirect_node_hole_ptr =
+    of_external_name "caml_spacetime_indirect_node_hole_ptr"
+  let caml_spacetime_generate_profinfo =
+    of_external_name "caml_spacetime_generate_profinfo"
+end

--- a/asmcomp/backend_sym.ml
+++ b/asmcomp/backend_sym.ml
@@ -16,25 +16,55 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type t = string
+type kind = Text | Data
+
+type t = {
+  kind : kind;
+  compilation_unit : Compilation_unit.t;
+  name : string;
+  (* The [name] uniquely determines the symbol.  The [compilation_unit] is
+     there so we can later easily distinguish between symbols from different
+     units. *)
+}
+
 type backend_sym = t
 
-let print ppf t = Format.pp_print_string ppf t
+let print ppf { name; _ } = Format.pp_print_string ppf name
 
-let to_string t = t
+let to_string { name; _ } = name
 
-let of_symbol sym = Linkage_name.to_string (Symbol.label sym)
+let of_symbol sym =
+  { kind = Data;
+    compilation_unit = Symbol.compilation_unit sym;
+    name = Linkage_name.to_string (Symbol.label sym);
+  }
 
-let of_external_name name = name
+let of_external_name compilation_unit name kind =
+  { kind;
+    compilation_unit;
+    name;
+  }
 
-let create ~base_name =
+let create ~base_name kind =
+  let compilation_unit = Compilation_unit.get_current_exn () in
   let unit_name =
-    Linkage_name.to_string (Compilation_unit.get_linkage_name (
-      Compilation_unit.get_current_exn ()))
+    Linkage_name.to_string (Compilation_unit.get_linkage_name compilation_unit)
   in
-  unit_name ^ "__" ^ base_name
+  let name = unit_name ^ "__" ^ base_name in
+  { kind;
+    compilation_unit;
+    name;
+  }
 
-let add_suffix t new_suffix = t ^ new_suffix
+let compilation_unit t = t.compilation_unit
+
+let kind t = t.kind
+
+let add_suffix t new_suffix =
+  { kind = t.kind;
+    compilation_unit = t.compilation_unit;
+    name = t.name ^ new_suffix;
+  }
 
 let add_suffixes t new_suffixes =
   List.fold_left (fun t new_suffix -> add_suffix t new_suffix) t new_suffixes
@@ -48,7 +78,7 @@ let to_escaped_string ?suffix ~symbol_prefix ~escape t =
     | None -> ""
     | Some suffix -> suffix
   in
-  symbol_prefix ^ (escape t) ^ suffix
+  symbol_prefix ^ (escape t.name) ^ suffix
 
 include Identifiable.Make (struct
   type nonrec t = t
@@ -65,45 +95,88 @@ include Identifiable.Make (struct
 end)
 
 module Names = struct
-  let sqrt = of_external_name "sqrt"
+  let runtime = Compilation_unit.runtime
+  let startup = Compilation_unit.startup
 
-  let caml_exception_pointer = of_external_name "caml_exception_pointer"
-  let caml_negf_mask = of_external_name "caml_negf_mask"
-  let caml_absf_mask = of_external_name "caml_absf_mask"
-  let caml_backtrace_pos = of_external_name "caml_backtrace_pos"
-  let caml_exn_Division_by_zero = of_external_name "caml_exn_Division_by_zero"
-  let caml_nativeint_ops = of_external_name "caml_nativeint_ops"
-  let caml_int32_ops = of_external_name "caml_int32_ops"
-  let caml_int64_ops = of_external_name "caml_int64_ops"
+  let sqrt =
+    of_external_name runtime "sqrt" Text
 
-  let caml_send n = add_int_suffix (of_external_name "caml_send") n
+  let caml_exception_pointer =
+    of_external_name runtime "caml_exception_pointer" Data
+
+  let caml_backtrace_pos =
+    of_external_name runtime "caml_backtrace_pos" Data
+
+  let caml_exn_Division_by_zero =
+    of_external_name startup "caml_exn_Division_by_zero" Data
+
+  let caml_nativeint_ops =
+    of_external_name runtime "caml_nativeint_ops" Data
+
+  let caml_int32_ops =
+    of_external_name runtime "caml_int32_ops" Data
+
+  let caml_int64_ops =
+    of_external_name runtime "caml_int64_ops" Data
+
+  let caml_send n =
+    add_int_suffix (of_external_name startup "caml_send" Text) n
+
   let caml_curry_n n =
-    add_int_suffix (of_external_name "caml_curry") n
+    add_int_suffix (of_external_name startup "caml_curry" Text) n
+
   let caml_curry_m_to_n m n =
-    add_suffixes (of_external_name "caml_curry")
+    add_suffixes (of_external_name startup "caml_curry" Text)
       [string_of_int m; "_"; string_of_int n]
+
   let caml_curry_m_to_n_app m n =
-    add_suffixes (of_external_name "caml_curry")
+    add_suffixes (of_external_name startup "caml_curry" Text)
       [string_of_int m; "_"; string_of_int n; "_app"]
-  let caml_tuplify n = add_int_suffix (of_external_name "caml_tuplify") n
-  let caml_apply n = add_int_suffix (of_external_name "caml_apply") n
 
-  let caml_ba_get n = add_int_suffix (of_external_name "caml_ba_get_") n
-  let caml_ba_set n = add_int_suffix (of_external_name "caml_ba_set_") n
+  let caml_tuplify n =
+    add_int_suffix (of_external_name startup "caml_tuplify" Text) n
 
-  let caml_exn name = add_suffix (of_external_name "caml_exn_") name
+  let caml_apply n =
+    add_int_suffix (of_external_name startup "caml_apply" Text) n
 
-  let caml_call_gc = of_external_name "caml_call_gc"
-  let caml_modify = of_external_name "caml_modify"
-  let caml_initialize = of_external_name "caml_initialize"
-  let caml_get_public_method = of_external_name "caml_get_public_method"
-  let caml_alloc = of_external_name "caml_alloc"
-  let caml_ml_array_bound_error = of_external_name "caml_ml_array_bound_error"
-  let caml_raise_exn = of_external_name "caml_raise_exn"
-  let caml_make_array = of_external_name "caml_make_array"
-  let caml_bswap16_direct = of_external_name "caml_bswap16_direct"
+  let caml_ba_get n =
+    add_int_suffix (of_external_name runtime "caml_ba_get_" Text) n
+
+  let caml_ba_set n =
+    add_int_suffix (of_external_name runtime "caml_ba_set_" Text) n
+
+  let caml_exn name =
+    add_suffix (of_external_name startup "caml_exn_" Data) name
+
+  let caml_call_gc =
+    of_external_name runtime "caml_call_gc" Text
+
+  let caml_modify =
+    of_external_name runtime "caml_modify" Text
+
+  let caml_initialize =
+    of_external_name runtime "caml_initialize" Text
+
+  let caml_get_public_method =
+    of_external_name runtime "caml_get_public_method" Text
+
+  let caml_alloc =
+    of_external_name runtime "caml_alloc" Text
+
+  let caml_ml_array_bound_error =
+    of_external_name runtime "caml_ml_array_bound_error" Text
+
+  let caml_raise_exn =
+    of_external_name runtime "caml_raise_exn" Text
+
+  let caml_make_array =
+    of_external_name runtime "caml_make_array" Text
+
+  let caml_bswap16_direct =
+    of_external_name runtime "caml_bswap16_direct" Text
 
   type bswap_arg = Int32 | Int64 | Nativeint
+
   let caml_direct_bswap ty =
     let ty =
       match ty with
@@ -111,31 +184,62 @@ module Names = struct
       | Int64 -> "int64"
       | Nativeint -> "nativeint"
     in
-    of_external_name (Printf.sprintf "caml_%s_direct_bswap" ty)
+    of_external_name runtime (Printf.sprintf "caml_%s_direct_bswap" ty) Text
 
-  let caml_alloc_dummy = of_external_name "caml_alloc_dummy"
-  let caml_alloc_dummy_float = of_external_name "caml_alloc_dummy_float"
-  let caml_update_dummy = of_external_name "caml_update_dummy"
-  let caml_program = of_external_name "caml_program"
-  let caml_startup = of_external_name "caml_startup"
-  let caml_globals_inited = of_external_name "caml_globals_inited"
-  let caml_globals = of_external_name "caml_globals"
-  let caml_plugin_header = of_external_name "caml_plugin_header"
-  let caml_globals_map = of_external_name "caml_globals_map"
-  let caml_code_segments = of_external_name "caml_code_segments"
-  let caml_data_segments = of_external_name "caml_data_segments"
+  let caml_alloc_dummy =
+    of_external_name runtime "caml_alloc_dummy" Text
 
-  let caml_frametable = of_external_name "caml_frametable"
-  let caml_spacetime_shapes = of_external_name "caml_spacetime_shapes"
+  let caml_alloc_dummy_float =
+    of_external_name runtime "caml_alloc_dummy_float" Text
 
-  let caml_afl_area_ptr = of_external_name "caml_afl_area_ptr"
-  let caml_afl_prev_loc = of_external_name "caml_afl_prev_loc"
-  let caml_setup_afl = of_external_name "caml_setup_afl"
+  let caml_update_dummy =
+    of_external_name runtime "caml_update_dummy" Text
+
+  let caml_program =
+    of_external_name startup "caml_program" Text
+
+  let caml_startup =
+    of_external_name runtime "caml_startup" Text
+
+  let caml_globals_inited =
+    of_external_name runtime "caml_globals_inited" Data
+
+  let caml_globals =
+    of_external_name startup "caml_globals" Data
+
+  let caml_plugin_header =
+    of_external_name startup "caml_plugin_header" Data
+
+  let caml_globals_map =
+    of_external_name startup "caml_globals_map" Data
+
+  let caml_code_segments =
+    of_external_name startup "caml_code_segments" Data
+
+  let caml_data_segments =
+    of_external_name startup "caml_data_segments" Data
+
+  let caml_frametable =
+    of_external_name startup "caml_frametable" Data
+
+  let caml_spacetime_shapes =
+    of_external_name startup "caml_spacetime_shapes" Data
+
+  let caml_afl_area_ptr =
+    of_external_name runtime "caml_afl_area_ptr" Data
+
+  let caml_afl_prev_loc =
+    of_external_name runtime "caml_afl_prev_loc" Data
+
+  let caml_setup_afl =
+    of_external_name runtime "caml_setup_afl" Text
 
   let caml_spacetime_allocate_node =
-    of_external_name "caml_spacetime_allocate_node"
+    of_external_name runtime "caml_spacetime_allocate_node" Text
+
   let caml_spacetime_indirect_node_hole_ptr =
-    of_external_name "caml_spacetime_indirect_node_hole_ptr"
+    of_external_name runtime "caml_spacetime_indirect_node_hole_ptr" Text
+
   let caml_spacetime_generate_profinfo =
-    of_external_name "caml_spacetime_generate_profinfo"
+    of_external_name runtime "caml_spacetime_generate_profinfo" Text
 end

--- a/asmcomp/backend_sym.mli
+++ b/asmcomp/backend_sym.mli
@@ -1,0 +1,141 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Names of object file symbols. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+type backend_sym = t
+
+(** Create a backend symbol from an Flambda-style [Symbol.t] that
+    encapsulates information both about the containing compilation unit and
+    the base name of the symbol. *)
+val of_symbol : Symbol.t -> t
+
+(** Create a backend symbol given the textual name of the symbol as found in
+    an object file.  (Any language-specific name mangling conventions must
+    have been applied to the name by the caller.  However any
+    assembler-specific conventions, such as escaping of special characters,
+    must *not* be applied by the caller. *)
+val of_external_name : string -> t
+
+(** Create a backend symbol given a base name.  The current compilation unit
+    will be used as the unit for the symbol.  The [base_name] will be
+    subject to escaping by this function. *)
+val create : base_name:string -> t
+
+(** Add the given suffix to the given symbol.  The suffix will be subject
+    to escaping. *)
+val add_suffix : t -> string -> t
+
+(** Convert the given symbol to a textual representation intended for assembly
+    emission. The caller must provide the target-specific escaping function and
+    symbol prefix.  The [symbol_prefix] is not subject to escaping.  The
+    [suffix], which is also not subject to escaping, is appended to the
+    resulting string if provided. (The [suffix] may be used to specify
+    relocation information, e.g. "@GOTPLT".) *)
+val to_escaped_string
+   : ?suffix:string
+  -> symbol_prefix:string
+  -> escape:(string -> string)
+  -> t
+  -> string
+
+(** Sets, maps, total ordering, etc.
+
+    The [print] function sends a non-escaped version of the symbol to a
+    formatter. This must not be used for assembly emission or similar. *)
+include Identifiable.S with type t := t
+
+(** Like [print] but returns a string. *)
+val to_string : t -> string
+
+module Names : sig
+  (** External variables from the C library. *)
+  val sqrt : t
+
+  (** Global variables in the OCaml runtime accessed by OCaml code. *)
+  val caml_exception_pointer : t
+  val caml_negf_mask : t
+  val caml_absf_mask : t
+  val caml_backtrace_pos : t
+  val caml_exn_Division_by_zero : t
+  val caml_nativeint_ops : t
+  val caml_int32_ops : t
+  val caml_int64_ops : t
+  val caml_globals_inited : t
+
+  (** Entry points to the OCaml runtime from OCaml code. *)
+  val caml_call_gc : t
+  val caml_modify : t
+  val caml_initialize : t
+  val caml_get_public_method : t
+  val caml_alloc : t
+  val caml_ml_array_bound_error : t
+  val caml_raise_exn : t
+  val caml_make_array : t
+  val caml_bswap16_direct : t
+
+  type bswap_arg = Int32 | Int64 | Nativeint
+  val caml_direct_bswap : bswap_arg -> t
+
+  val caml_alloc_dummy : t
+  val caml_alloc_dummy_float : t
+  val caml_update_dummy : t
+
+  (** Bigarrays. *)
+  val caml_ba_get : int -> t
+  val caml_ba_set : int -> t
+
+  (** AFL instrumentation. *)
+  val caml_afl_area_ptr : t
+  val caml_afl_prev_loc : t
+  val caml_setup_afl : t
+
+  (** Entry points to the Spacetime runtime from OCaml code. *)
+  val caml_spacetime_allocate_node : t
+  val caml_spacetime_indirect_node_hole_ptr : t
+  val caml_spacetime_generate_profinfo : t
+
+  (** Main OCaml entry point related functions. *)
+  val caml_program : t
+  val caml_startup : t
+
+  (** Header of a dynamically-loaded library. *)
+  val caml_plugin_header : t
+
+  (** Predefined exception values. *)
+  val caml_exn : string -> t
+
+  (** Various veneers generated in [Cmmgen]. *)
+  val caml_send : int -> t
+  val caml_curry_n : int -> t
+  val caml_curry_m_to_n : int -> int -> t
+  val caml_curry_m_to_n_app : int -> int -> t
+  val caml_tuplify : int -> t
+  val caml_apply : int -> t
+
+  (** Master table of globals. *)
+  val caml_globals : t
+  val caml_globals_map : t
+
+  (** Master table of module data and code segments. *)
+  val caml_code_segments : t
+  val caml_data_segments : t
+
+  (** Standard OCaml auxiliary data structures. *)
+  val caml_frametable : t
+  val caml_spacetime_shapes : t
+end

--- a/asmcomp/build_export_info.ml
+++ b/asmcomp/build_export_info.ml
@@ -55,7 +55,7 @@ module Env : sig
       export descriptions with the given global environment. *)
   val empty_of_global : Global.t -> t
 end = struct
-  let fresh_id () = Export_id.create (Compilenv.current_unit ())
+  let fresh_id () = Export_id.create (Compilation_unit.get_current_exn ())
 
   module Global = struct
     type t =
@@ -518,8 +518,8 @@ let describe_program (env : Env.Global.t) (program : Flambda.program) =
 let build_transient ~(backend : (module Backend_intf.S))
       (program : Flambda.program) : Export_info.transient =
   if !Clflags.opaque then
-    let compilation_unit = Compilenv.current_unit () in
-    let root_symbol = Compilenv.current_unit_symbol () in
+    let compilation_unit = Compilation_unit.get_current_exn () in
+    let root_symbol = Compilation_unit.get_current_exn_symbol () in
     Export_info.opaque_transient ~root_symbol ~compilation_unit
   else
     (* CR-soon pchambart: Should probably use that instead of the ident of
@@ -667,9 +667,9 @@ let build_transient ~(backend : (module Backend_intf.S))
         ~sets_of_closures_map
         ~closure_id_to_set_of_closures_id
         ~function_declarations_map
-        ~values:(Compilation_unit.Map.find (Compilenv.current_unit ()) values)
+        ~values:(Compilation_unit.Map.find (Compilation_unit.get_current_exn ()) values)
         ~symbol_id
-        ~root_symbol:(Compilenv.current_unit_symbol ())
+        ~root_symbol:(Compilation_unit.get_current_exn_symbol ())
     in
     let sets_of_closures =
       Set_of_closures_id.Map.filter_map

--- a/asmcomp/build_export_info.ml
+++ b/asmcomp/build_export_info.ml
@@ -110,7 +110,7 @@ end = struct
     with Not_found -> None
 
   let extern_symbol_descr sym =
-    if Compilenv.is_predefined_exception sym
+    if Symbol.is_predefined_exception sym
     then None
     else
       match
@@ -289,7 +289,7 @@ and descr_of_named (env : Env.t) (named : Flambda.named)
     | _ -> Value_unknown
     end
   | Prim (Pgetglobal id, _, _) ->
-    Value_symbol (Compilenv.symbol_for_global' id)
+    Value_symbol (Symbol.of_global id)
   | Prim _ -> Value_unknown
   | Set_of_closures set ->
     let descr : Export_info.descr =

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -19,7 +19,7 @@
 open Asttypes
 open Lambda
 
-type function_label = string
+type function_label = Symbol.t
 
 type ustructured_constant =
   | Uconst_float of float
@@ -29,10 +29,10 @@ type ustructured_constant =
   | Uconst_block of int * uconstant list
   | Uconst_float_array of float list
   | Uconst_string of string
-  | Uconst_closure of ufunction list * string * uconstant list
+  | Uconst_closure of ufunction list * Symbol.t * uconstant list
 
 and uconstant =
-  | Uconst_ref of string * ustructured_constant option
+  | Uconst_ref of Symbol.t * ustructured_constant option
   | Uconst_int of int
   | Uconst_ptr of int
 
@@ -93,23 +93,23 @@ type value_approximation =
   | Value_tuple of value_approximation array
   | Value_unknown
   | Value_const of uconstant
-  | Value_global_field of string * int
+  | Value_global_field of Symbol.t * int
 
 (* Preallocated globals *)
 
 type uconstant_block_field =
-  | Uconst_field_ref of string
+  | Uconst_field_ref of Symbol.t
   | Uconst_field_int of int
 
 type preallocated_block = {
-  symbol : string;
+  symbol : Symbol.t;
   exported : bool;
   tag : int;
   fields : uconstant_block_field option list;
 }
 
 type preallocated_constant = {
-  symbol : string;
+  symbol : Symbol.t;
   exported : bool;
   definition : ustructured_constant;
 }
@@ -131,7 +131,8 @@ let rec compare_float_lists l1 l2 =
 
 let compare_constants c1 c2 =
   match c1, c2 with
-  | Uconst_ref(lbl1, _c1), Uconst_ref(lbl2, _c2) -> String.compare lbl1 lbl2
+  | Uconst_ref(lbl1, _c1), Uconst_ref(lbl2, _c2) ->
+      Symbol.compare lbl1 lbl2
       (* Same labels -> same constants.
          Different labels -> different constants, even if the contents
            match, because of string constants that must not be
@@ -175,7 +176,7 @@ let compare_structured_constants c1 c2 =
       compare_float_lists l1 l2
   | Uconst_string s1, Uconst_string s2 -> String.compare s1 s2
   | Uconst_closure (_,lbl1,_), Uconst_closure (_,lbl2,_) ->
-      String.compare lbl1 lbl2
+      Symbol.compare lbl1 lbl2
   | _, _ ->
     (* no overflow possible here *)
     rank_structured_constant c1 - rank_structured_constant c2

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -19,7 +19,7 @@
 open Asttypes
 open Lambda
 
-type function_label = string
+type function_label = Symbol.t
 
 type ustructured_constant =
   | Uconst_float of float
@@ -29,10 +29,10 @@ type ustructured_constant =
   | Uconst_block of int * uconstant list
   | Uconst_float_array of float list
   | Uconst_string of string
-  | Uconst_closure of ufunction list * string * uconstant list
+  | Uconst_closure of ufunction list * Symbol.t * uconstant list
 
 and uconstant =
-  | Uconst_ref of string * ustructured_constant option
+  | Uconst_ref of Symbol.t * ustructured_constant option
   | Uconst_int of int
   | Uconst_ptr of int
 
@@ -93,7 +93,7 @@ type value_approximation =
   | Value_tuple of value_approximation array
   | Value_unknown
   | Value_const of uconstant
-  | Value_global_field of string * int
+  | Value_global_field of Symbol.t * int
 
 (* Comparison functions for constants *)
 
@@ -103,18 +103,18 @@ val compare_constants:
         uconstant -> uconstant -> int
 
 type uconstant_block_field =
-  | Uconst_field_ref of string
+  | Uconst_field_ref of Symbol.t
   | Uconst_field_int of int
 
 type preallocated_block = {
-  symbol : string;
+  symbol : Symbol.t;
   exported : bool;
   tag : int;
   fields : uconstant_block_field option list;
 }
 
 type preallocated_constant = {
-  symbol : string;
+  symbol : Symbol.t;
   exported : bool;
   definition : ustructured_constant;
 }

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -131,7 +131,7 @@ type memory_chunk =
 
 and operation =
     Capply of machtype
-  | Cextcall of string * machtype * bool * label option
+  | Cextcall of Backend_sym.t * machtype * bool * label option
     (** If specified, the given label will be placed immediately after the
         call (at the same place as any frame descriptor would reference). *)
   | Cload of memory_chunk * Asttypes.mutable_flag
@@ -153,7 +153,7 @@ type expression =
     Cconst_int of int
   | Cconst_natint of nativeint
   | Cconst_float of float
-  | Cconst_symbol of string
+  | Cconst_symbol of Backend_sym.t
   | Cconst_pointer of int
   | Cconst_natpointer of nativeint
   | Cblockheader of nativeint * Debuginfo.t
@@ -179,7 +179,7 @@ type codegen_option =
   | No_CSE
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: Backend_sym.t;
     fun_args: (Backend_var.With_provenance.t * machtype) list;
     fun_body: expression;
     fun_codegen_options : codegen_option list;
@@ -187,15 +187,15 @@ type fundecl =
   }
 
 type data_item =
-    Cdefine_symbol of string
-  | Cglobal_symbol of string
+    Cdefine_symbol of Backend_sym.t
+  | Cglobal_symbol of Backend_sym.t
   | Cint8 of int
   | Cint16 of int
   | Cint32 of nativeint
   | Cint of nativeint
   | Csingle of float
   | Cdouble of float
-  | Csymbol_address of string
+  | Csymbol_address of Backend_sym.t
   | Cstring of string
   | Cskip of int
   | Calign of int

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -108,7 +108,7 @@ type memory_chunk =
 
 and operation =
     Capply of machtype
-  | Cextcall of string * machtype * bool * label option
+  | Cextcall of Backend_sym.t * machtype * bool * label option
   | Cload of memory_chunk * Asttypes.mutable_flag
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
@@ -133,7 +133,7 @@ and expression =
     Cconst_int of int
   | Cconst_natint of nativeint
   | Cconst_float of float
-  | Cconst_symbol of string
+  | Cconst_symbol of Backend_sym.t
   | Cconst_pointer of int
   | Cconst_natpointer of nativeint
   | Cblockheader of nativeint * Debuginfo.t
@@ -159,7 +159,7 @@ type codegen_option =
   | No_CSE
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: Backend_sym.t;
     fun_args: (Backend_var.With_provenance.t * machtype) list;
     fun_body: expression;
     fun_codegen_options : codegen_option list;
@@ -167,15 +167,15 @@ type fundecl =
   }
 
 type data_item =
-    Cdefine_symbol of string
-  | Cglobal_symbol of string
+    Cdefine_symbol of Backend_sym.t
+  | Cglobal_symbol of Backend_sym.t
   | Cint8 of int
   | Cint16 of int
   | Cint32 of nativeint
   | Cint of nativeint
   | Csingle of float
   | Cdouble of float
-  | Csymbol_address of string
+  | Csymbol_address of Backend_sym.t
   | Cstring of string
   | Cskip of int
   | Calign of int

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -29,6 +29,9 @@ module String = Misc.Stdlib.String
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
+module S = Backend_sym
+open S.Names
+
 (* Environments used for translation to Cmm. *)
 
 type boxed_number =
@@ -118,6 +121,12 @@ let alloc_infix_header ofs dbg = Cblockheader (infix_header ofs, dbg)
 let alloc_boxedint32_header dbg = Cblockheader (boxedint32_header, dbg)
 let alloc_boxedint64_header dbg = Cblockheader (boxedint64_header, dbg)
 let alloc_boxedintnat_header dbg = Cblockheader (boxedintnat_header, dbg)
+
+(* Symbols *)
+
+let new_const_symbol () =
+  let mangled_name = Compilenv.new_const_symbol () in
+  S.of_external_name mangled_name
 
 (* Integers *)
 
@@ -404,7 +413,7 @@ let validate d m p =
 let raise_regular dbg exc =
   Csequence(
     Cop(Cstore (Thirtytwo_signed, Assignment),
-        [(Cconst_symbol "caml_backtrace_pos"); Cconst_int 0], dbg),
+        [(Cconst_symbol caml_backtrace_pos); Cconst_int 0], dbg),
       Cop(Craise Raise_withtrace,[exc], dbg))
 
 let raise_symbol dbg symb =
@@ -413,7 +422,7 @@ let raise_symbol dbg symb =
 let rec div_int c1 c2 is_safe dbg =
   match (c1, c2) with
     (c1, Cconst_int 0) ->
-      Csequence(c1, raise_symbol dbg "caml_exn_Division_by_zero")
+      Csequence(c1, raise_symbol dbg caml_exn_Division_by_zero)
   | (c1, Cconst_int 1) ->
       c1
   | (Cconst_int n1, Cconst_int n2) ->
@@ -455,12 +464,12 @@ let rec div_int c1 c2 is_safe dbg =
         bind "dividend" c1 (fun c1 ->
           Cifthenelse(c2,
                       Cop(Cdivi, [c1; c2], dbg),
-                      raise_symbol dbg "caml_exn_Division_by_zero")))
+                      raise_symbol dbg caml_exn_Division_by_zero)))
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
     (c1, Cconst_int 0) ->
-      Csequence(c1, raise_symbol dbg "caml_exn_Division_by_zero")
+      Csequence(c1, raise_symbol dbg caml_exn_Division_by_zero)
   | (c1, Cconst_int (1 | (-1))) ->
       Csequence(c1, Cconst_int 0)
   | (Cconst_int n1, Cconst_int n2) ->
@@ -492,7 +501,7 @@ let mod_int c1 c2 is_safe dbg =
         bind "dividend" c1 (fun c1 ->
           Cifthenelse(c2,
                       Cop(Cmodi, [c1; c2], dbg),
-                      raise_symbol dbg "caml_exn_Division_by_zero")))
+                      raise_symbol dbg caml_exn_Division_by_zero)))
 
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)
@@ -713,10 +722,10 @@ let float_array_ref dbg arr ofs =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
 
 let addr_array_set arr ofs newval dbg =
-  Cop(Cextcall("caml_modify", typ_void, false, None),
+  Cop(Cextcall(caml_modify, typ_void, false, None),
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
-  Cop(Cextcall("caml_initialize", typ_void, false, None),
+  Cop(Cextcall(caml_initialize, typ_void, false, None),
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let int_array_set arr ofs newval dbg =
   Cop(Cstore (Word_int, Assignment),
@@ -749,7 +758,7 @@ let string_length exp dbg =
 
 let lookup_tag obj tag dbg =
   bind "tag" tag (fun tag ->
-    Cop(Cextcall("caml_get_public_method", typ_val, false, None),
+    Cop(Cextcall(caml_get_public_method, typ_val, false, None),
         [obj; tag],
         dbg))
 
@@ -763,7 +772,7 @@ let call_cached_method obj tag cache pos args dbg =
   let cache = array_indexing log2_size_addr cache pos dbg in
   Compilenv.need_send_fun arity;
   Cop(Capply typ_val,
-      Cconst_symbol("caml_send" ^ string_of_int arity) ::
+      Cconst_symbol(caml_send arity) ::
         obj :: tag :: cache :: args,
       dbg)
 
@@ -779,14 +788,14 @@ let make_alloc_generic set_fn dbg tag wordsize args =
     | e1::el -> Csequence(set_fn (Cvar id) (Cconst_int idx) e1 dbg,
                           fill_fields (idx + 2) el) in
     Clet(VP.create id,
-         Cop(Cextcall("caml_alloc", typ_val, true, None),
+         Cop(Cextcall(caml_alloc, typ_val, true, None),
                  [Cconst_int wordsize; Cconst_int tag], dbg),
          fill_fields 1 args)
   end
 
 let make_alloc dbg tag args =
   let addr_array_init arr ofs newval dbg =
-    Cop(Cextcall("caml_initialize", typ_void, false, None),
+    Cop(Cextcall(caml_initialize, typ_void, false, None),
         [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
   in
   make_alloc_generic addr_array_init dbg tag (List.length args) args
@@ -871,12 +880,12 @@ let rec expr_size env = function
 (* Record application and currying functions *)
 
 let apply_function n =
-  Compilenv.need_apply_fun n; "caml_apply" ^ string_of_int n
+  Compilenv.need_apply_fun n; caml_apply n
 let curry_function n =
   Compilenv.need_curry_fun n;
   if n >= 0
-  then "caml_curry" ^ string_of_int n
-  else "caml_tuplify" ^ string_of_int (-n)
+  then caml_curry_n n
+  else caml_tuplify (-n)
 
 (* Comparisons *)
 
@@ -895,17 +904,17 @@ let transl_constant = function
       else Cconst_natpointer
               (Nativeint.add (Nativeint.shift_left (Nativeint.of_int n) 1) 1n)
   | Uconst_ref (label, _) ->
-      Cconst_symbol label
+      Cconst_symbol (S.of_external_name label)
 
 let transl_structured_constant cst =
   let label = Compilenv.new_structured_constant cst ~shared:true in
-  Cconst_symbol label
+  Cconst_symbol (S.of_external_name label)
 
 (* Translate constant closures *)
 
 type is_global = Global | Not_global
 
-type symbol_defn = string * is_global
+type symbol_defn = S.t * is_global
 
 type cmm_constant =
   | Const_closure of symbol_defn * ufunction list * uconstant list
@@ -927,9 +936,9 @@ let box_int_constant bi n =
 
 let operations_boxed_int bi =
   match bi with
-    Pnativeint -> "caml_nativeint_ops"
-  | Pint32 -> "caml_int32_ops"
-  | Pint64 -> "caml_int64_ops"
+    Pnativeint -> caml_nativeint_ops
+  | Pint32 -> caml_int32_ops
+  | Pint64 -> caml_int64_ops
 
 let alloc_header_boxed_int bi =
   match bi with
@@ -1430,7 +1439,7 @@ let make_switch arg cases actions dbg =
       | Cconst_symbol s -> Csymbol_address s
       | _ -> assert false in
     let const_actions = Array.map to_data_item actions in
-    let table = Compilenv.new_const_symbol () in
+    let table = new_const_symbol () in
     add_cmm_constant (Const_table ((table, Not_global),
         Array.to_list (Array.map (fun act ->
           const_actions.(act)) cases)));
@@ -1717,7 +1726,7 @@ let rec transl env e =
   | Uconst sc ->
       transl_constant sc
   | Uclosure(fundecls, []) ->
-      let lbl = Compilenv.new_const_symbol() in
+      let lbl = new_const_symbol() in
       add_cmm_constant (
         Const_closure ((lbl, Not_global), fundecls, []));
       List.iter (fun f -> Queue.add f functions) fundecls;
@@ -1730,13 +1739,13 @@ let rec transl env e =
             Queue.add f functions;
             let without_header =
               if f.arity = 1 || f.arity = 0 then
-                Cconst_symbol f.label ::
+                Cconst_symbol (S.of_external_name f.label) ::
                 int_const f.arity ::
                 transl_fundecls (pos + 3) rem
               else
                 Cconst_symbol(curry_function f.arity) ::
                 int_const f.arity ::
-                Cconst_symbol f.label ::
+                Cconst_symbol (S.of_external_name f.label) ::
                 transl_fundecls (pos + 4) rem
             in
             if pos = 0 then without_header
@@ -1755,6 +1764,7 @@ let rec transl env e =
       then ptr
       else Cop(Caddv, [ptr; Cconst_int(offset * size_addr)], Debuginfo.none)
   | Udirect_apply(lbl, args, dbg) ->
+      let lbl = S.of_external_name lbl in
       Cop(Capply typ_val, Cconst_symbol lbl :: List.map (transl env) args, dbg)
   | Ugeneric_apply(clos, [arg], dbg) ->
       bind "fun" (transl env clos) (fun clos ->
@@ -1796,7 +1806,7 @@ let rec transl env e =
   | Uprim(prim, args, dbg) ->
       begin match (simplif_primitive prim, args) with
         (Pgetglobal id, []) ->
-          Cconst_symbol (V.name id)
+          Cconst_symbol (S.of_external_name (V.name id))
       | (Pmakeblock _, []) ->
           assert false
       | (Pmakeblock(tag, _mut, _kind), args) ->
@@ -1967,7 +1977,7 @@ let rec transl env e =
 and transl_make_array dbg env kind args =
   match kind with
   | Pgenarray ->
-      Cop(Cextcall("caml_make_array", typ_val, true, None),
+      Cop(Cextcall(caml_make_array, typ_val, true, None),
           [make_alloc dbg 0 (List.map (transl env) args)], dbg)
   | Paddrarray | Pintarray ->
       make_alloc dbg 0 (List.map (transl env) args)
@@ -2004,7 +2014,7 @@ and transl_ccall env prim args dbg =
   in
   let args = transl_args prim.prim_native_repr_args args in
   wrap_result
-    (Cop(Cextcall(Primitive.native_name prim,
+    (Cop(Cextcall(S.of_external_name (Primitive.native_name prim),
                   typ_res, prim.prim_alloc, None), args, dbg))
 
 and transl_prim_1 env p arg dbg =
@@ -2116,16 +2126,18 @@ and transl_prim_1 env p arg dbg =
       box_int dbg bi
         (Cop(Csubi, [Cconst_int 0; transl_unbox_int dbg env bi arg], dbg))
   | Pbbswap bi ->
-      let prim = match bi with
-        | Pnativeint -> "nativeint"
-        | Pint32 -> "int32"
-        | Pint64 -> "int64" in
-      box_int dbg bi (Cop(Cextcall(Printf.sprintf "caml_%s_direct_bswap" prim,
-                               typ_int, false, None),
+      let prim : bswap_arg =
+        match bi with
+        | Pnativeint -> Nativeint
+        | Pint32 -> Int32
+        | Pint64 -> Int64
+      in
+      let sym = caml_direct_bswap prim in
+      box_int dbg bi (Cop(Cextcall(sym, typ_int, false, None),
                       [transl_unbox_int dbg env bi arg],
                       dbg))
   | Pbswap16 ->
-      tag_int (Cop(Cextcall("caml_bswap16_direct", typ_int, false, None),
+      tag_int (Cop(Cextcall(caml_bswap16_direct, typ_int, false, None),
                    [untag_int (transl env arg) dbg],
                    dbg))
               dbg
@@ -2140,12 +2152,12 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Psetfield(n, ptr, init) ->
       begin match assignment_kind ptr init with
       | Caml_modify ->
-        return_unit(Cop(Cextcall("caml_modify", typ_void, false, None),
+        return_unit(Cop(Cextcall(caml_modify, typ_void, false, None),
                         [field_address (transl env arg1) n dbg;
                          transl env arg2],
                         dbg))
       | Caml_initialize ->
-        return_unit(Cop(Cextcall("caml_initialize", typ_void, false, None),
+        return_unit(Cop(Cextcall(caml_initialize, typ_void, false, None),
                         [field_address (transl env arg1) n dbg;
                          transl env arg2],
                         dbg))
@@ -2798,10 +2810,10 @@ and transl_letrec env bindings cont =
   let rec init_blocks = function
     | [] -> fill_nonrec bsz
     | (id, _exp, RHS_block sz) :: rem ->
-        Clet(id, op_alloc "caml_alloc_dummy" sz,
+        Clet(id, op_alloc caml_alloc_dummy sz,
           init_blocks rem)
     | (id, _exp, RHS_floatblock sz) :: rem ->
-        Clet(id, op_alloc "caml_alloc_dummy_float" sz,
+        Clet(id, op_alloc caml_alloc_dummy_float sz,
           init_blocks rem)
     | (id, _exp, RHS_nonrec) :: rem ->
         Clet (id, Cconst_int 0, init_blocks rem)
@@ -2815,7 +2827,7 @@ and transl_letrec env bindings cont =
     | [] -> cont
     | (id, exp, (RHS_block _ | RHS_floatblock _)) :: rem ->
         let op =
-          Cop(Cextcall("caml_update_dummy", typ_void, false, None),
+          Cop(Cextcall(caml_update_dummy, typ_void, false, None),
               [Cvar (VP.var id); transl env exp], dbg) in
         Csequence(op, fill_blocks rem)
     | (_id, _exp, RHS_nonrec) :: rem ->
@@ -2843,7 +2855,7 @@ let transl_function ~ppf_dump f =
     else
       [ Reduce_code_size ]
   in
-  Cfunction {fun_name = f.label;
+  Cfunction {fun_name = S.of_external_name f.label;
              fun_args = List.map (fun id -> (id, typ_val)) f.params;
              fun_body = cmm_body;
              fun_codegen_options;
@@ -2871,37 +2883,38 @@ let cdefine_symbol (symb, global) =
 
 (* Emit structured constants *)
 
-let rec emit_structured_constant symb cst cont =
-  let emit_block white_header symb cont =
+let rec emit_structured_constant (symb, is_global) cst cont =
+  let emit_block white_header cont =
     (* Headers for structured constants must be marked black in case we
        are in no-naked-pointers mode.  See [caml_darken]. *)
     let black_header = Nativeint.logor white_header caml_black in
-    Cint black_header :: cdefine_symbol symb @ cont
+    Cint black_header :: cdefine_symbol (symb, is_global) @ cont
   in
   match cst with
   | Uconst_float s->
-      emit_block float_header symb (Cdouble s :: cont)
+      emit_block float_header (Cdouble s :: cont)
   | Uconst_string s ->
-      emit_block (string_header (String.length s)) symb
+      emit_block (string_header (String.length s))
         (emit_string_constant s cont)
   | Uconst_int32 n ->
-      emit_block boxedint32_header symb
+      emit_block boxedint32_header
         (emit_boxed_int32_constant n cont)
   | Uconst_int64 n ->
-      emit_block boxedint64_header symb
+      emit_block boxedint64_header
         (emit_boxed_int64_constant n cont)
   | Uconst_nativeint n ->
-      emit_block boxedintnat_header symb
+      emit_block boxedintnat_header
         (emit_boxed_nativeint_constant n cont)
   | Uconst_block (tag, csts) ->
       let cont = List.fold_right emit_constant csts cont in
-      emit_block (block_header tag (List.length csts)) symb cont
+      emit_block (block_header tag (List.length csts)) cont
   | Uconst_float_array fields ->
-      emit_block (floatarray_header (List.length fields)) symb
+      emit_block (floatarray_header (List.length fields))
         (Misc.map_end (fun f -> Cdouble f) fields cont)
   | Uconst_closure(fundecls, lbl, fv) ->
-      assert(lbl = fst symb);
-      add_cmm_constant (Const_closure (symb, fundecls, fv));
+      let lbl = S.of_external_name lbl in
+      assert(Backend_sym.equal lbl symb);
+      add_cmm_constant (Const_closure ((symb, is_global), fundecls, fv));
       List.iter (fun f -> Queue.add f functions) fundecls;
       cont
 
@@ -2911,7 +2924,7 @@ and emit_constant cst cont =
       cint_const n
       :: cont
   | Uconst_ref (label, _) ->
-      Csymbol_address label :: cont
+      Csymbol_address (S.of_external_name label) :: cont
 
 and emit_string_constant s cont =
   let n = size_int - 1 - (String.length s) mod size_int in
@@ -2920,23 +2933,23 @@ and emit_string_constant s cont =
 and emit_boxed_int32_constant n cont =
   let n = Nativeint.of_int32 n in
   if size_int = 8 then
-    Csymbol_address("caml_int32_ops") :: Cint32 n :: Cint32 0n :: cont
+    Csymbol_address caml_int32_ops :: Cint32 n :: Cint32 0n :: cont
   else
-    Csymbol_address("caml_int32_ops") :: Cint n :: cont
+    Csymbol_address caml_int32_ops :: Cint n :: cont
 
 and emit_boxed_nativeint_constant n cont =
-  Csymbol_address("caml_nativeint_ops") :: Cint n :: cont
+  Csymbol_address caml_nativeint_ops :: Cint n :: cont
 
 and emit_boxed_int64_constant n cont =
   let lo = Int64.to_nativeint n in
   if size_int = 8 then
-    Csymbol_address("caml_int64_ops") :: Cint lo :: cont
+    Csymbol_address caml_int64_ops :: Cint lo :: cont
   else begin
     let hi = Int64.to_nativeint (Int64.shift_right n 32) in
     if big_endian then
-      Csymbol_address("caml_int64_ops") :: Cint hi :: Cint lo :: cont
+      Csymbol_address caml_int64_ops :: Cint hi :: Cint lo :: cont
     else
-      Csymbol_address("caml_int64_ops") :: Cint lo :: Cint hi :: cont
+      Csymbol_address caml_int64_ops :: Cint lo :: Cint hi :: cont
   end
 
 (* Emit constant closures *)
@@ -2944,7 +2957,8 @@ and emit_boxed_int64_constant n cont =
 let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
   let closure_symbol f =
     if Config.flambda then
-      cdefine_symbol (f.label ^ "_closure", global_symb)
+      let label = S.of_external_name f.label in
+      cdefine_symbol (S.add_suffix label "_closure", global_symb)
     else
       []
   in
@@ -2964,7 +2978,7 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
           if f2.arity = 1 || f2.arity = 0 then
             Cint(infix_header pos) ::
             (closure_symbol f2) @
-            Csymbol_address f2.label ::
+            Csymbol_address (S.of_external_name f2.label) ::
             cint_const f2.arity ::
             emit_others (pos + 3) rem
           else
@@ -2972,20 +2986,20 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
             (closure_symbol f2) @
             Csymbol_address(curry_function f2.arity) ::
             cint_const f2.arity ::
-            Csymbol_address f2.label ::
+            Csymbol_address (S.of_external_name f2.label) ::
             emit_others (pos + 4) rem in
       Cint(black_closure_header (fundecls_size fundecls
                                  + List.length clos_vars)) ::
       cdefine_symbol symb @
       (closure_symbol f1) @
       if f1.arity = 1 || f1.arity = 0 then
-        Csymbol_address f1.label ::
+        Csymbol_address (S.of_external_name f1.label) ::
         cint_const f1.arity ::
         emit_others 3 remainder
       else
         Csymbol_address(curry_function f1.arity) ::
         cint_const f1.arity ::
-        Csymbol_address f1.label ::
+        Csymbol_address (S.of_external_name f1.label) ::
         emit_others 4 remainder
 
 (* Emit constant blocks *)
@@ -3000,6 +3014,7 @@ let emit_constants cont (constants:Clambda.preallocated_constant list) =
   let c = ref cont in
   List.iter
     (fun { symbol = lbl; exported; definition = cst } ->
+       let lbl = S.of_external_name lbl in
        let global = if exported then Global else Not_global in
        let cst = emit_structured_constant (lbl, global) cst [] in
          c:= Cdata(cst):: !c)
@@ -3045,10 +3060,12 @@ let transl_all_functions_and_emit_all_constants ~ppf_dump cont =
 (* Build the NULL terminated array of gc roots *)
 
 let emit_gc_roots_table ~symbols cont =
-  let table_symbol = Compilenv.make_symbol (Some "gc_roots") in
+  let table_symbol =
+    S.of_external_name (Compilenv.make_symbol (Some "gc_roots"))
+  in
   Cdata(Cglobal_symbol table_symbol ::
         Cdefine_symbol table_symbol ::
-        List.map (fun s -> Csymbol_address s) symbols @
+        List.map (fun s -> Csymbol_address (S.of_external_name s)) symbols @
         [Cint 0n])
   :: cont
 
@@ -3068,10 +3085,11 @@ let preallocate_block cont { Clambda.symbol; exported; tag; fields } =
         | Some (Uconst_field_int n) ->
             cint_const n
         | Some (Uconst_field_ref label) ->
-            Csymbol_address label)
+            Csymbol_address (S.of_external_name label))
       fields
   in
   let data =
+    let symbol = S.of_external_name symbol in
     Cint(black_block_header tag (List.length fields)) ::
     if exported then
       Cglobal_symbol symbol ::
@@ -3097,7 +3115,8 @@ let compunit ~ppf_dump (ulam, preallocated_blocks, constants) =
       Afl_instrument.instrument_initialiser (transl empty_env ulam)
     else
       transl empty_env ulam in
-  let c1 = [Cfunction {fun_name = Compilenv.make_symbol (Some "entry");
+  let fun_name = S.of_external_name (Compilenv.make_symbol (Some "entry")) in
+  let c1 = [Cfunction {fun_name;
                        fun_args = [];
                        fun_body = init_code;
                        (* This function is often large and run only once.
@@ -3244,9 +3263,8 @@ let send_function arity =
   let fun_args =
     [obj, typ_val; tag, typ_int; cache, typ_val]
     @ List.map (fun id -> (id, typ_val)) (List.tl args) in
-  let fun_name = "caml_send" ^ string_of_int arity in
   Cfunction
-   {fun_name;
+   {fun_name = caml_send arity;
     fun_args = List.map (fun (arg, ty) -> VP.create arg, ty) fun_args;
     fun_body = body;
     fun_codegen_options = [];
@@ -3255,9 +3273,8 @@ let send_function arity =
 let apply_function arity =
   let (args, clos, body) = apply_function_body arity in
   let all_args = args @ [clos] in
-  let fun_name = "caml_apply" ^ string_of_int arity in
   Cfunction
-   {fun_name;
+   {fun_name = caml_apply arity;
     fun_args = List.map (fun arg -> (VP.create arg, typ_val)) all_args;
     fun_body = body;
     fun_codegen_options = [];
@@ -3277,9 +3294,8 @@ let tuplify_function arity =
     if i >= arity
     then []
     else get_field env (Cvar arg) i dbg :: access_components(i+1) in
-  let fun_name = "caml_tuplify" ^ string_of_int arity in
   Cfunction
-   {fun_name;
+   {fun_name = caml_tuplify arity;
     fun_args = [VP.create arg, typ_val; VP.create clos, typ_val];
     fun_body =
       Cop(Capply typ_val,
@@ -3345,8 +3361,7 @@ let final_curry_function arity =
                          newclos (n-1))
     end in
   Cfunction
-   {fun_name = "caml_curry" ^ string_of_int arity ^
-               "_" ^ string_of_int (arity-1);
+   {fun_name = caml_curry_m_to_n arity (arity - 1);
     fun_args = [VP.create last_arg, typ_val; VP.create last_clos, typ_val];
     fun_body = curry_fun [] last_clos (arity-1);
     fun_codegen_options = [];
@@ -3358,25 +3373,27 @@ let rec intermediate_curry_functions arity num =
   if num = arity - 1 then
     [final_curry_function arity]
   else begin
-    let name1 = "caml_curry" ^ string_of_int arity in
-    let name2 = if num = 0 then name1 else name1 ^ "_" ^ string_of_int num in
+    let fun_name =
+      if num = 0 then caml_curry_n arity
+      else caml_curry_m_to_n arity num
+    in
     let arg = V.create_local "arg" and clos = V.create_local "clos" in
     Cfunction
-     {fun_name = name2;
+     {fun_name;
       fun_args = [VP.create arg, typ_val; VP.create clos, typ_val];
       fun_body =
          if arity - num > 2 && arity <= max_arity_optimized then
            Cop(Calloc,
                [alloc_closure_header 5 Debuginfo.none;
-                Cconst_symbol(name1 ^ "_" ^ string_of_int (num+1));
+                Cconst_symbol(caml_curry_m_to_n arity (num + 1));
                 int_const (arity - num - 1);
-                Cconst_symbol(name1 ^ "_" ^ string_of_int (num+1) ^ "_app");
+                Cconst_symbol(caml_curry_m_to_n_app arity (num + 1));
                 Cvar arg; Cvar clos],
                dbg)
          else
            Cop(Calloc,
                 [alloc_closure_header 4 Debuginfo.none;
-                 Cconst_symbol(name1 ^ "_" ^ string_of_int (num+1));
+                 Cconst_symbol(caml_curry_m_to_n arity (num + 1));
                  int_const 1; Cvar arg; Cvar clos],
                 dbg);
       fun_codegen_options = [];
@@ -3407,7 +3424,7 @@ let rec intermediate_curry_functions arity num =
           in
           let cf =
             Cfunction
-              {fun_name = name1 ^ "_" ^ string_of_int (num+1) ^ "_app";
+              {fun_name = caml_curry_m_to_n_app arity (num + 1);
                fun_args;
                fun_body = iter (num+1)
                   (List.map (fun (arg,_) -> Cvar arg) direct_args) clos;
@@ -3454,19 +3471,22 @@ let entry_point namelist =
   let dbg = Debuginfo.none in
   let incr_global_inited =
     Cop(Cstore (Word_int, Assignment),
-        [Cconst_symbol "caml_globals_inited";
+        [Cconst_symbol caml_globals_inited;
          Cop(Caddi, [Cop(Cload (Word_int, Mutable),
-                       [Cconst_symbol "caml_globals_inited"], dbg);
+                       [Cconst_symbol caml_globals_inited], dbg);
                      Cconst_int 1], dbg)], dbg) in
   let body =
     List.fold_right
       (fun name next ->
-        let entry_sym = Compilenv.make_symbol ~unitname:name (Some "entry") in
+        let entry_sym =
+          S.of_external_name (
+            Compilenv.make_symbol ~unitname:name (Some "entry"))
+        in
         Csequence(Cop(Capply typ_void,
                          [Cconst_symbol entry_sym], dbg),
                   Csequence(incr_global_inited, next)))
       namelist (Cconst_int 1) in
-  Cfunction {fun_name = "caml_program";
+  Cfunction {fun_name = caml_program;
              fun_args = [];
              fun_body = body;
              fun_codegen_options = [Reduce_code_size];
@@ -3478,31 +3498,33 @@ let cint_zero = Cint 0n
 
 let global_table namelist =
   let mksym name =
-    Csymbol_address (Compilenv.make_symbol ~unitname:name (Some "gc_roots"))
+    Csymbol_address (S.of_external_name (
+      Compilenv.make_symbol ~unitname:name (Some "gc_roots")))
   in
-  Cdata(Cglobal_symbol "caml_globals" ::
-        Cdefine_symbol "caml_globals" ::
+  Cdata(Cglobal_symbol caml_globals ::
+        Cdefine_symbol caml_globals ::
         List.map mksym namelist @
         [cint_zero])
 
 let reference_symbols namelist =
   let mksym name = Csymbol_address name in
-  Cdata(List.map mksym namelist)
+  Cdata(List.map (fun sym -> mksym (S.of_external_name sym)) namelist)
 
 let global_data name v =
   Cdata(emit_structured_constant (name, Global)
           (Uconst_string (Marshal.to_string v [])) [])
 
-let globals_map v = global_data "caml_globals_map" v
+let globals_map v = global_data caml_globals_map v
 
 (* Generate the master table of frame descriptors *)
 
 let frame_table namelist =
   let mksym name =
-    Csymbol_address (Compilenv.make_symbol ~unitname:name (Some "frametable"))
+    Csymbol_address (S.of_external_name (
+      Compilenv.make_symbol ~unitname:name (Some "frametable")))
   in
-  Cdata(Cglobal_symbol "caml_frametable" ::
-        Cdefine_symbol "caml_frametable" ::
+  Cdata(Cglobal_symbol caml_frametable ::
+        Cdefine_symbol caml_frametable ::
         List.map mksym namelist
         @ [cint_zero])
 
@@ -3510,11 +3532,11 @@ let frame_table namelist =
 
 let spacetime_shapes namelist =
   let mksym name =
-    Csymbol_address (
-      Compilenv.make_symbol ~unitname:name (Some "spacetime_shapes"))
+    Csymbol_address (S.of_external_name (
+      Compilenv.make_symbol ~unitname:name (Some "spacetime_shapes")))
   in
-  Cdata(Cglobal_symbol "caml_spacetime_shapes" ::
-        Cdefine_symbol "caml_spacetime_shapes" ::
+  Cdata(Cglobal_symbol caml_spacetime_shapes ::
+        Cdefine_symbol caml_spacetime_shapes ::
         List.map mksym namelist
         @ [cint_zero])
 
@@ -3522,8 +3544,10 @@ let spacetime_shapes namelist =
 
 let segment_table namelist symbol begname endname =
   let addsyms name lst =
-    Csymbol_address (Compilenv.make_symbol ~unitname:name (Some begname)) ::
-    Csymbol_address (Compilenv.make_symbol ~unitname:name (Some endname)) ::
+    Csymbol_address (S.of_external_name (
+      Compilenv.make_symbol ~unitname:name (Some begname))) ::
+    Csymbol_address (S.of_external_name (
+      Compilenv.make_symbol ~unitname:name (Some endname))) ::
     lst
   in
   Cdata(Cglobal_symbol symbol ::
@@ -3531,22 +3555,23 @@ let segment_table namelist symbol begname endname =
         List.fold_right addsyms namelist [cint_zero])
 
 let data_segment_table namelist =
-  segment_table namelist "caml_data_segments" "data_begin" "data_end"
+  segment_table namelist caml_data_segments "data_begin" "data_end"
 
 let code_segment_table namelist =
-  segment_table namelist "caml_code_segments" "code_begin" "code_end"
+  segment_table namelist caml_code_segments "code_begin" "code_end"
 
 (* Initialize a predefined exception *)
 
 let predef_exception i name =
-  let symname = "caml_exn_" ^ name in
+  let symname = caml_exn name in
   let cst = Uconst_string name in
-  let label = Compilenv.new_const_symbol () in
+  let label' = Compilenv.new_const_symbol () in
+  let label = S.of_external_name label' in
   let cont = emit_structured_constant (label, Not_global) cst [] in
   Cdata(emit_structured_constant (symname, Global)
           (Uconst_block(Obj.object_tag,
                        [
-                         Uconst_ref(label, Some cst);
+                         Uconst_ref(label', Some cst);
                          Uconst_int (-i-1);
                        ])) cont)
 
@@ -3560,5 +3585,5 @@ let plugin_header units =
       dynu_imports_cmx = ui.ui_imports_cmx;
       dynu_defines = ui.ui_defines
     } in
-  global_data "caml_plugin_header"
+  global_data caml_plugin_header
     { dynu_magic = Config.cmxs_magic_number; dynu_units = List.map mk units }

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1800,7 +1800,7 @@ let rec transl env e =
   | Uprim(prim, args, dbg) ->
       begin match (simplif_primitive prim, args) with
         (Pgetglobal id, []) ->
-          Cconst_symbol (S.of_global_ident id)
+          Cconst_symbol (S.of_global id)
       | (Pmakeblock _, []) ->
           assert false
       | (Pmakeblock(tag, _mut, _kind), args) ->

--- a/asmcomp/cmx_format.mli
+++ b/asmcomp/cmx_format.mli
@@ -9,7 +9,7 @@
 (*   Copyright 2010 Institut National de Recherche en Informatique et     *)
 (*     en Automatique                                                     *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -17,56 +17,65 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Format of .cmx, .cmxa and .cmxs files *)
+(** Format of .cmx, .cmxa and .cmxs files. *)
 
-(* Each .o file has a matching .cmx file that provides the following infos
-   on the compilation unit:
-     - list of other units imported, with MD5s of their .cmx files
-     - approximation of the structure implemented
-       (includes descriptions of known functions: arity and direct entry
-        points)
-     - list of currying functions and application functions needed
-   The .cmx file contains these infos (as an externed record) plus a MD5
-   of these infos *)
-
+(** Each .o file has a matching .cmx file that provides the following infos
+    on the compilation unit:
+      - list of other units imported, with MD5s of their .cmx files
+      - for Closure mode, approximation of the structure implemented
+        (includes descriptions of known functions: arity and direct entry
+         points)
+      - for Flambda mode, term language information for inlining etc.
+      - list of currying functions and application functions needed
+    The .cmx file contains these infos (as an externed record) plus a MD5
+    of these infos. *)
 type export_info =
-  | Clambda of Clambda.value_approximation
+  | Closure of Clambda.value_approximation
   | Flambda of Export_info.t
 
 type unit_infos =
-  { mutable ui_name: string;                    (* Name of unit implemented *)
-    mutable ui_symbol: Symbol.t;                (* Base symbol for unit *)
-    mutable ui_defines: Compilation_unit.Set.t; (* (Sub-)units implemented *)
-    mutable ui_imports_cmi:
-              (string * Digest.t option) list; (* Interfaces imported *)
-    mutable ui_imports_cmx:(string * Digest.t option) list; (* Infos imported *)
-    mutable ui_curry_fun: int list;             (* Currying functions needed *)
-    mutable ui_apply_fun: int list;             (* Apply functions needed *)
-    mutable ui_send_fun: int list;              (* Send functions needed *)
+  { mutable ui_name: Compilation_unit.t;
+    (** Name of unit implemented, along with any -for-pack prefix *)
+    mutable ui_defines: Compilation_unit.Set.t;
+    (** (Sub-)units implemented *)
+    mutable ui_imports_cmi: (Compilation_unit.t * Digest.t option) list;
+    (** Interfaces imported *)
+    mutable ui_imports_cmx: (Compilation_unit.t * Digest.t option) list;
+    (** Infos imported *)
+    mutable ui_curry_fun: int list;
+    (** Currying functions needed *)
+    mutable ui_apply_fun: int list;
+    (** Apply functions needed *)
+    mutable ui_send_fun: int list;
+    (** Send functions needed *)
     mutable ui_export_info: export_info;
-    mutable ui_force_link: bool }               (* Always linked *)
+    (** Term language information, e.g. for inlining *)
+    mutable ui_force_link: bool;
+    (** Whether the unit must always be linked *)
+  }
 
-(* Each .a library has a matching .cmxa file that provides the following
-   infos on the library: *)
-
+(** Each .a library has a matching .cmxa file that provides the following
+    infos on the library. *)
 type library_infos =
-  { lib_units: (unit_infos * Digest.t) list;  (* List of unit infos w/ MD5s *)
-    lib_ccobjs: string list;            (* C object files needed *)
-    lib_ccopts: string list }           (* Extra opts to C compiler *)
+  { lib_units: (unit_infos * Digest.t) list;
+    (** List of unit infos w/ MD5s *)
+    lib_ccobjs: string list;
+    (** C object files needed *)
+    lib_ccopts: string list;
+    (** Extra options to pass to the C compiler *)
+  }
 
-(* Each .cmxs dynamically-loaded plugin contains a symbol
-   "caml_plugin_header" containing the following info
-   (as an externed record) *)
+(** Each .cmxs dynamically-loaded plugin contains a symbol "caml_plugin_header"
+    containing the following info (as an externed record). *)
+type dynunit =
+  { dynu_name: Compilation_unit.t;
+    dynu_crc: Digest.t;
+    dynu_imports_cmi: (Compilation_unit.t * Digest.t option) list;
+    dynu_imports_cmx: (Compilation_unit.t * Digest.t option) list;
+    dynu_defines: string list;
+  }
 
-type dynunit = {
-  dynu_name: string;
-  dynu_crc: Digest.t;
-  dynu_imports_cmi: (string * Digest.t option) list;
-  dynu_imports_cmx: (string * Digest.t option) list;
-  dynu_defines: string list;
-}
-
-type dynheader = {
-  dynu_magic: string;
-  dynu_units: dynunit list;
-}
+type dynheader =
+  { dynu_magic: string;
+    dynu_units: dynunit list;
+  }

--- a/asmcomp/cmx_format.mli
+++ b/asmcomp/cmx_format.mli
@@ -35,8 +35,8 @@ type export_info =
 
 type unit_infos =
   { mutable ui_name: string;                    (* Name of unit implemented *)
-    mutable ui_symbol: string;            (* Prefix for symbols *)
-    mutable ui_defines: string list;      (* Unit and sub-units implemented *)
+    mutable ui_symbol: Symbol.t;                (* Base symbol for unit *)
+    mutable ui_defines: Compilation_unit.Set.t; (* (Sub-)units implemented *)
     mutable ui_imports_cmi:
               (string * Digest.t option) list; (* Interfaces imported *)
     mutable ui_imports_cmx:(string * Digest.t option) list; (* Infos imported *)

--- a/asmcomp/compilenv.mli
+++ b/asmcomp/compilenv.mli
@@ -9,7 +9,7 @@
 (*   Copyright 2010 Institut National de Recherche en Informatique et     *)
 (*     en Automatique                                                     *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2014--2016, 2019 Jane Street Group LLC                     *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -17,7 +17,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Compilation environments for compilation units *)
+(* Environments for compilation units *)
 
 open Cmx_format
 
@@ -29,52 +29,16 @@ val imported_sets_of_closures_table
   : Simple_value_approx.function_declarations option Set_of_closures_id.Tbl.t
         (* flambda-only *)
 
-val reset: ?packname:string -> string -> unit
-        (* Reset the environment and record the name of the unit being
-           compiled (arg).  Optional argument is [-for-pack] prefix. *)
-
-val unit_id_from_name: string -> Ident.t
-        (* flambda-only *)
+val reset
+   : ?for_pack_prefix:string
+  -> Compilation_unit.t
+  -> unit
+        (* Reset the environment, record the name of the unit being
+           compiled (arg) and set the current compilation unit. *)
 
 val current_unit_infos: unit -> unit_infos
         (* Return the infos for the unit being compiled *)
 
-val current_unit_name: unit -> string
-        (* Return the name of the unit being compiled
-           clambda-only *)
-
-val current_unit_linkage_name: unit -> Linkage_name.t
-        (* Return the linkage_name of the unit being compiled.
-           flambda-only *)
-
-val current_unit: unit -> Compilation_unit.t
-        (* flambda-only *)
-
-val current_unit_symbol: unit -> Symbol.t
-        (* flambda-only *)
-
-val make_symbol: ?unitname:string -> string option -> string
-        (* [make_symbol ~unitname:u None] returns the asm symbol that
-           corresponds to the compilation unit [u] (default: the current unit).
-           [make_symbol ~unitname:u (Some id)] returns the asm symbol that
-           corresponds to symbol [id] in the compilation unit [u]
-           (or the current unit). *)
-
-val symbol_in_current_unit: string -> bool
-        (* Return true if the given asm symbol belongs to the
-           current compilation unit, false otherwise. *)
-
-val is_predefined_exception: Symbol.t -> bool
-        (* flambda-only *)
-
-val unit_for_global: Ident.t -> Compilation_unit.t
-        (* flambda-only *)
-
-val symbol_for_global: Ident.t -> string
-        (* Return the asm symbol that refers to the given global identifier
-           flambda-only *)
-val symbol_for_global': Ident.t -> Symbol.t
-        (* flambda-only *)
 val global_approx: Ident.t -> Clambda.value_approximation
         (* Return the approximation for the given global identifier
            clambda-only *)
@@ -101,23 +65,14 @@ val need_send_fun: int -> unit
         (* Record the need of a currying (resp. application,
            message sending) function with the given arity *)
 
-val new_const_symbol : unit -> string
-val closure_symbol : Closure_id.t -> Symbol.t
-        (* Symbol of a function if the function is
-           closed (statically allocated)
-           flambda-only *)
-val function_label : Closure_id.t -> string
-        (* linkage name of the code of a function
-           flambda-only *)
-
 val new_structured_constant:
   Clambda.ustructured_constant ->
   shared:bool -> (* can be shared with another structurally equal constant *)
-  string
+  Symbol.t
 val structured_constants:
   unit -> Clambda.preallocated_constant list
 val clear_structured_constants: unit -> unit
-val add_exported_constant: string -> unit
+val add_exported_constant: Symbol.t -> unit
         (* clambda-only *)
 type structured_constants
         (* clambda-only *)

--- a/asmcomp/compilenv.mli
+++ b/asmcomp/compilenv.mli
@@ -17,92 +17,109 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Environments for compilation units *)
+(** Environments for compilation units. *)
 
-open Cmx_format
-
-(* CR-soon mshinwell: this is a bit ugly
-   mshinwell: deferred CR, this has been addressed in the export info
-   improvement feature.
-*)
-val imported_sets_of_closures_table
-  : Simple_value_approx.function_declarations option Set_of_closures_id.Tbl.t
-        (* flambda-only *)
-
+(** Reset the environment and set the current compilation unit. *)
 val reset
    : ?for_pack_prefix:string
   -> Compilation_unit.t
   -> unit
-        (* Reset the environment, record the name of the unit being
-           compiled (arg) and set the current compilation unit. *)
 
-val current_unit_infos: unit -> unit_infos
-        (* Return the infos for the unit being compiled *)
+(** Return the .cmx file information for the current compilation unit. *)
+val current_unit_infos : unit -> Cmx_format.unit_infos
 
-val global_approx: Ident.t -> Clambda.value_approximation
-        (* Return the approximation for the given global identifier
-           clambda-only *)
-val set_global_approx: Clambda.value_approximation -> unit
-        (* Record the approximation of the unit being compiled
-           clambda-only *)
-val record_global_approx_toplevel: unit -> unit
-        (* Record the current approximation for the current toplevel phrase
-           clambda-only *)
+module Closure_only : sig
+  (** Return the approximation for the given global identifier. *)
+  val global_approx : Ident.t -> Clambda.value_approximation
 
-val set_export_info: Export_info.t -> unit
-        (* Record the informations of the unit being compiled
-           flambda-only *)
-val approx_env: unit -> Export_info.t
-        (* Returns all the information loaded from external compilation units
-           flambda-only *)
-val approx_for_global: Compilation_unit.t -> Export_info.t option
-        (* Loads the exported information declaring the compilation_unit
-           flambda-only *)
+  (** Record the approximation of the unit being compiled. *)
+  val set_global_approx : Closure.value_approximation -> unit
 
-val need_curry_fun: int -> unit
-val need_apply_fun: int -> unit
-val need_send_fun: int -> unit
-        (* Record the need of a currying (resp. application,
-           message sending) function with the given arity *)
+  (** Record the current approximation for the current toplevel phrase. *)
+  val record_global_approx_toplevel : unit -> unit
 
-val new_structured_constant:
-  Clambda.ustructured_constant ->
-  shared:bool -> (* can be shared with another structurally equal constant *)
-  Symbol.t
-val structured_constants:
-  unit -> Clambda.preallocated_constant list
-val clear_structured_constants: unit -> unit
-val add_exported_constant: Symbol.t -> unit
-        (* clambda-only *)
-type structured_constants
-        (* clambda-only *)
-val snapshot: unit -> structured_constants
-        (* clambda-only *)
-val backtrack: structured_constants -> unit
-        (* clambda-only *)
+  (** Record that the given symbol is that of a constant which is to be
+      accessible from other units. *)
+  val add_exported_constant : Symbol.t -> unit
 
-val read_unit_info: string -> unit_infos * Digest.t
-        (* Read infos and MD5 from a [.cmx] file. *)
-val write_unit_info: unit_infos -> string -> unit
-        (* Save the given infos in the given file *)
-val save_unit_info: string -> unit
-        (* Save the infos for the current unit in the given file *)
-val cache_unit_info: unit_infos -> unit
-        (* Enter the given infos in the cache.  The infos will be
-           honored by [symbol_for_global] and [global_approx]
-           without looking at the corresponding .cmx file. *)
+  type structured_constants
 
-val require_global: Ident.t -> unit
-        (* Enforce a link dependency of the current compilation
-           unit to the required module *)
+  (** Record the current list of structured constants to be statically
+      allocated (c.f. [structured_constants], below). *)
+  val snapshot : unit -> structured_constants
 
-val read_library_info: string -> library_infos
+  (** Return the list of structured constants to be statically allocated
+      to the given earlier state. *)
+  val backtrack : structured_constants -> unit
+end
+
+module Flambda_only : sig
+  (** Record the informations of the unit being compiled. *)
+  val set_export_info : Export_info.t -> unit
+
+  (** Returns all the information loaded from external compilation units. *)
+  val approx_env : unit -> Export_info.t
+
+  (** Loads the exported information declaring the compilation_unit. *)
+  val approx_for_global : Compilation_unit.t -> Export_info.t option
+
+  (** Table recording sets of closures imported from .cmx files. *)
+  val imported_sets_of_closures_table
+    : Simple_value_approx.function_declarations option Set_of_closures_id.Tbl.t
+end
+
+(* XXX symbol_for_global needs to be back here *)
+
+(** Record the need for a currying function with the given arity. *)
+val need_curry_fun : int -> unit
+
+(** Record the need for an application function with the given arity. *)
+val need_apply_fun : int -> unit
+
+(** Record the need for a message-sending function with the given arity. *)
+val need_send_fun : int -> unit
+
+(** Record a constant to be statically allocated, assigning a symbol for it
+    in the process.  If [shared] is [true], the constant can be shared with
+    another structurally-equal constant. *)
+val new_structured_constant
+   : Clambda.ustructured_constant
+  -> shared:bool
+  -> Symbol.t
+
+(** All structured constants to be statically allocated. *)
+val structured_constants : unit -> Clambda.preallocated_constant list
+
+(** Reset the list of structured constants to be statically allocated. *)
+val clear_structured_constants : unit -> unit
+
+(** Read infos and MD5 from a [.cmx] file. *)
+val read_unit_info : cmx_file:string -> unit_infos * Digest.t
+
+(** Save the given .cmx file information in the given file. *)
+val write_unit_info : unit_infos -> cmx_file:string -> unit
+
+(** Save the .cmx file information for the current unit in the given file. *)
+val save_unit_info : cmx_file:string -> unit
+
+(** Enter the given infos in the cache. The infos will be returned by
+    [symbol_for_global] and [global_approx] without looking at the
+    corresponding .cmx file. *)
+val cache_unit_info : unit_infos -> unit
+
+(** Enforce a link-time dependency of the current compilation unit to the
+    required module. *)
+val require_global : Ident.t -> unit
+
+(** Read information about a library from a .cmxa file. *)
+val read_library_info : cmxa_file:string -> library_infos
 
 type error =
-    Not_a_unit_info of string
-  | Corrupted_unit_info of string
-  | Illegal_renaming of string * string * string
+  | Not_a_unit_info of { filename : string; }
+  | Corrupted_unit_info of { filename : string; }
+  | Illegal_renaming of { name : string; modname : string; filename : string; }
 
 exception Error of error
 
-val report_error: Format.formatter -> error -> unit
+(** Print the given error message on the given formatter. *)
+val report_error : Format.formatter -> error -> unit

--- a/asmcomp/debug/asm_directives.ml
+++ b/asmcomp/debug/asm_directives.ml
@@ -1,0 +1,1004 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Fabrice Le Fessant, projet Gallium, INRIA Rocquencourt        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+(* CR-someday mshinwell: Eliminate uses of [bprintf] from the assembly
+   generation code, then enable this warning. *)
+[@@@ocaml.warning "-3"]
+
+module Int8 = Numbers.Int8
+module Int16 = Numbers.Int16
+module TS = Target_system
+
+let dwarf_supported () =
+  match TS.object_file_format_and_abi () with
+  | ELF _ | Mach_O -> true
+  | A_out | PE | Unknown -> false
+
+type dwarf_section =
+  | Debug_info
+  | Debug_abbrev
+  | Debug_aranges
+  | Debug_loc
+  | Debug_str
+  | Debug_line
+
+type power_section =
+  | Function_descriptors
+  | Table_of_contents
+
+type ia32_section =
+  | Non_lazy_symbol_pointers
+  | Jump_table
+
+type section =
+  | Text
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+  | DWARF of dwarf_section
+  | POWER of power_section
+  | IA32 of ia32_section
+
+(* Note: the POWER backend relies on .opd being after .data, so an
+   alignment constraint can be enforced. *)
+let all_sections_in_order = [
+  Text;
+  Data;
+  Read_only_data;
+  Eight_byte_literals;
+  Sixteen_byte_literals;
+  Jump_tables;
+  DWARF Debug_info;
+  DWARF Debug_abbrev;
+  DWARF Debug_aranges;
+  DWARF Debug_loc;
+  DWARF Debug_str;
+  DWARF Debug_line;
+  POWER Function_descriptors;
+  POWER Table_of_contents;
+  IA32 Non_lazy_symbol_pointers;
+  IA32 Jump_table;
+]
+
+let current_section = ref None
+
+let section_is_text = function
+  | Text
+  | POWER Function_descriptors -> true
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+  | DWARF _
+  | POWER _
+  | IA32 _ -> false
+
+let current_section_is_text () =
+  match !current_section with
+  | None ->
+    Misc.fatal_error "Asm_directives.initialize has not been called"
+  | Some section -> section_is_text section
+
+let text_label = Cmm.new_label ()
+let data_label = Cmm.new_label ()
+let read_only_data_label = Cmm.new_label ()
+let eight_byte_literals_label = Cmm.new_label ()
+let sixteen_byte_literals_label = Cmm.new_label ()
+let jump_tables_label = Cmm.new_label ()
+let debug_info_label = Cmm.new_label ()
+let debug_abbrev_label = Cmm.new_label ()
+let debug_aranges_label = Cmm.new_label ()
+let debug_loc_label = Cmm.new_label ()
+let debug_str_label = Cmm.new_label ()
+let debug_line_label = Cmm.new_label ()
+let power_function_descriptors_label = Cmm.new_label ()
+let power_table_of_contents_label = Cmm.new_label ()
+let ia32_non_lazy_symbol_pointers_label = Cmm.new_label ()
+let ia32_jump_table_label = Cmm.new_label ()
+
+let label_for_section = function
+  | Text -> text_label
+  | Data -> data_label
+  | Read_only_data -> read_only_data_label
+  | Eight_byte_literals -> eight_byte_literals_label
+  | Sixteen_byte_literals -> sixteen_byte_literals_label
+  | Jump_tables -> jump_tables_label
+  | DWARF Debug_info -> debug_info_label
+  | DWARF Debug_abbrev -> debug_abbrev_label
+  | DWARF Debug_aranges -> debug_aranges_label
+  | DWARF Debug_loc -> debug_loc_label
+  | DWARF Debug_str -> debug_str_label
+  | DWARF Debug_line -> debug_line_label
+  | POWER Function_descriptors -> power_function_descriptors_label
+  | POWER Table_of_contents -> power_table_of_contents_label
+  | IA32 Non_lazy_symbol_pointers -> ia32_non_lazy_symbol_pointers_label
+  | IA32 Jump_table -> ia32_jump_table_label
+
+let label_prefix =
+  match TS.architecture () with
+  | IA32 | X86_64 ->
+    begin match TS.system () with
+    | Linux
+    | Windows Cygwin
+    | Windows MinGW
+    | FreeBSD
+    | NetBSD
+    | OpenBSD
+    | Generic_BSD
+    | Solaris
+    | BeOS
+    | GNU
+    | Dragonfly
+    | Unknown -> ".L"
+    | MacOS_like
+    | Windows Native -> "L"
+    end
+  | ARM
+  | AArch64
+  | POWER
+  | Z -> ".L"
+
+let string_of_label label_name = label_prefix ^ (string_of_int label_name)
+
+let bprintf = Printf.bprintf
+
+module Directive = struct
+  module Constant = struct
+    type t =
+      | Signed_int of Int64.t
+      | This
+      | Named_thing of string
+      | Add of t * t
+      | Sub of t * t
+      | Div of t * int
+
+    let rec print buf t =
+      match t with
+      | Named_thing _ | Signed_int _ | This as c -> print_subterm buf c
+      | Add (c1, c2) ->
+        bprintf buf "%a + %a" print_subterm c1 print_subterm c2
+      | Sub (c1, c2) ->
+        bprintf buf "%a - %a" print_subterm c1 print_subterm c2
+      | Div (c1, c2) ->
+        bprintf buf "%a / %d" print_subterm c1 c2
+
+    and print_subterm buf t =
+      match t with
+      | This ->
+        begin match TS.assembler () with
+        | MacOS | GAS_like -> Buffer.add_string buf "."
+        | MASM -> Buffer.add_string buf "THIS BYTE"
+        end
+      | Named_thing name -> Buffer.add_string buf name
+      | Signed_int n ->
+        begin match TS.assembler () with
+        | MacOS | GAS_like -> bprintf buf "0x%Lx" n
+        | MASM ->
+          if n >= -0x8000_0000L && n <= 0x7fff_ffffL then
+            Buffer.add_string buf (Int64.to_string n)
+          else
+            bprintf buf "0%LxH" n
+        end
+      | Add (c1, c2) ->
+        bprintf buf "(%a + %a)" print_subterm c1 print_subterm c2
+      | Sub (c1, c2) ->
+        bprintf buf "(%a - %a)" print_subterm c1 print_subterm c2
+      | Div (c1, c2) ->
+        bprintf buf "(%a / %d)" print_subterm c1 c2
+
+    let rec evaluate t =
+      let (>>=) = Misc.Stdlib.Option.(>>=) in
+      match t with
+      | Signed_int i -> Some i
+      | This -> None
+      | Named_thing _ -> None
+      | Add (t1, t2) ->
+        evaluate t1
+        >>= fun i1 ->
+        evaluate t2
+        >>= fun i2 ->
+        Some (Int64.add i1 i2)
+      | Sub (t1, t2) ->
+        evaluate t1
+        >>= fun i1 ->
+        evaluate t2
+        >>= fun i2 ->
+        Some (Int64.sub i1 i2)
+      | Div (t, divisor) ->
+        evaluate t
+        >>= fun i ->
+        if divisor = 0 then begin
+          Misc.fatal_error "Division by zero when evaluating constant"
+        end;
+        Some (Int64.div i (Int64.of_int divisor))
+  end
+
+  module Constant_with_width = struct
+    type width_in_bytes =
+      | Eight
+      | Sixteen
+      | Thirty_two
+      | Sixty_four
+
+    let int_of_width_in_bytes = function
+      | Eight -> 8
+      | Sixteen -> 16
+      | Thirty_two -> 32
+      | Sixty_four -> 64
+
+    type t = {
+      constant : Constant.t;
+      width_in_bytes : width_in_bytes;
+    }
+
+    let create constant width_in_bytes =
+      begin match Constant.evaluate constant with
+      | None -> ()
+      | Some n ->
+        let in_range =
+          match width_in_bytes with
+          | Eight -> n >= -0x80L && n <= 0x7fL
+          | Sixteen -> n >= -0x8000L && n <= 0x7fffL
+          | Thirty_two -> n >= -0x8000_0000L && n <= 0x7fff_ffffL
+          | Sixty_four -> true
+        in
+        if not in_range then begin
+          Misc.fatal_errorf "Signed integer constant %Ld does not fit in \
+              %d bits"
+            n (int_of_width_in_bytes width_in_bytes)
+        end
+      end;
+      { constant;
+        width_in_bytes;
+      }
+
+    let constant t = t.constant
+    let width_in_bytes t = t.width_in_bytes
+  end
+
+  type thing_after_label =
+    | Code
+    | Machine_width_data
+
+  type comment = string
+
+  type t =
+    | Align of { bytes : int; }
+    | Bytes of string
+    | Cfi_adjust_cfa_offset of int
+    | Cfi_endproc
+    | Cfi_offset of { reg : int; offset : int; }
+    | Cfi_startproc
+    | Comment of comment
+    | Const of { constant : Constant_with_width.t; comment : string option; }
+    | Direct_assignment of string * Constant.t
+    | File of { file_num : int option; filename : string; }
+    | Global of string
+    | Indirect_symbol of string
+    | Loc of { file_num : int; line : int; col : int; }
+    | New_label of string * thing_after_label
+    | Private_extern of string
+    | Section of {
+        names : string list;
+        flags : string option;
+        args : string list;
+      }
+    | Size of string * Constant.t
+    | Sleb128 of Constant.t
+    | Space of { bytes : int; }
+    | Type of string * string
+    | Uleb128 of Constant.t
+
+  let bprintf = Printf.bprintf
+
+  let string_of_string_literal s =
+    let buf = Buffer.create (String.length s + 2) in
+    let last_was_escape = ref false in
+    for i = 0 to String.length s - 1 do
+      let c = s.[i] in
+      if c >= '0' && c <= '9' then
+        if !last_was_escape
+        then Printf.bprintf buf "\\%o" (Char.code c)
+        else Buffer.add_char buf c
+      else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' then begin
+        Buffer.add_char buf c;
+        last_was_escape := false
+      end else begin
+        Printf.bprintf buf "\\%o" (Char.code c);
+        last_was_escape := true
+      end
+    done;
+    Buffer.contents buf
+
+  let buf_bytes_directive buf ~directive s =
+    let pos = ref 0 in
+    for i = 0 to String.length s - 1 do
+      if !pos = 0
+      then begin
+        if i > 0 then Buffer.add_char buf '\n';
+        Buffer.add_char buf '\t';
+        Buffer.add_string buf directive;
+        Buffer.add_char buf '\t';
+      end
+      else Buffer.add_char buf ',';
+      Printf.bprintf buf "%d" (Char.code s.[i]);
+      incr pos;
+      if !pos >= 16 then begin pos := 0 end
+    done
+
+  let print_gas buf t =
+    let gas_comment_opt = function
+      | None -> ""
+      | Some comment -> Printf.sprintf "\t/* %s */" comment
+    in
+    match t with
+    | Align { bytes = n; } ->
+      (* Some assemblers interpret the integer n as a 2^n alignment and
+         others as a number of bytes. *)
+      let n =
+        match TS.assembler (), TS.architecture () with
+        | MacOS, _
+        | GAS_like, (ARM | AArch64 | POWER) -> Misc.log2 n
+        | _, _ -> n
+      in
+      bprintf buf "\t.align\t%d" n
+    | Const { constant; comment; } ->
+      let directive =
+        match Constant_with_width.width_in_bytes constant with
+        | Eight -> "byte"
+        | Sixteen ->
+          begin match TS.system () with
+          | Solaris -> "value"
+          | _ ->
+            (* Apple's documentation says that ".word" is i386-specific, so
+               we use ".short" instead.
+               Additionally, it appears on ARM that ".word" may be 32 bits wide,
+               not 16 bits. *)
+            "short"
+          end
+        | Thirty_two -> "long"
+        | Sixty_four -> "quad"
+      in
+      let comment = gas_comment_opt comment in
+      bprintf buf "\t.%s\t%a%s"
+        directive
+        Constant.print (Constant_with_width.constant constant)
+        comment
+    | Bytes s ->
+      begin match TS.system (), TS.architecture () with
+      | Solaris, _
+      | _, POWER -> buf_bytes_directive buf ~directive:".byte" s
+      | _ -> bprintf buf "\t.ascii\t\"%s\"" (string_of_string_literal s)
+      end
+    | Comment s -> bprintf buf "\t\t\t\t/* %s */" s
+    | Global s -> bprintf buf "\t.globl\t%s" s
+    | New_label (s, _typ) -> bprintf buf "%s:" s
+    | Section { names = [".data"]; _ } -> bprintf buf "\t.data"
+    | Section { names = [".text"]; _ } -> bprintf buf "\t.text"
+    | Section { names; flags; args; } ->
+      bprintf buf "\t.section %s" (String.concat "," names);
+      begin match flags with
+      | None -> ()
+      | Some flags -> bprintf buf ",%S" flags
+      end;
+      begin match args with
+      | [] -> ()
+      | _ -> bprintf buf ",%s" (String.concat "," args)
+      end
+    | Space { bytes; } ->
+      begin match TS.system () with
+      | Solaris -> bprintf buf "\t.zero\t%d" bytes
+      | _ -> bprintf buf "\t.space\t%d" bytes
+      end
+    | Cfi_adjust_cfa_offset n -> bprintf buf "\t.cfi_adjust_cfa_offset %d" n
+    | Cfi_endproc -> bprintf buf "\t.cfi_endproc"
+    | Cfi_offset { reg; offset; } ->
+      bprintf buf "\t.cfi_offset %d, %d" reg offset
+    | Cfi_startproc -> bprintf buf "\t.cfi_startproc"
+    | File { file_num = None; filename; } ->
+      bprintf buf "\t.file\t\"%s\"" filename
+    | File { file_num = Some file_num; filename; } ->
+      bprintf buf "\t.file\t%d\t\"%s\""
+        file_num (string_of_string_literal filename)
+    | Indirect_symbol s -> bprintf buf "\t.indirect_symbol %s" s
+    | Loc { file_num; line; col; } ->
+      (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
+      if col >= 0 then bprintf buf "\t.loc\t%d\t%d\t%d" file_num line col
+      else bprintf buf "\t.loc\t%d\t%d" file_num line
+    | Private_extern s -> bprintf buf "\t.private_extern %s" s
+    | Size (s, c) -> bprintf buf "\t.size %s,%a" s Constant.print c
+    | Sleb128 c -> bprintf buf "\t.sleb128 %a" Constant.print c
+    | Type (s, typ) ->
+      (* We use the "STT" forms when they are supported as they are
+         unambiguous across platforms
+         (cf. https://sourceware.org/binutils/docs/as/Type.html ). *)
+      bprintf buf "\t.type %s %s" s typ
+    | Uleb128 c -> bprintf buf "\t.uleb128 %a" Constant.print c
+    | Direct_assignment (var, const) ->
+      begin match TS.assembler () with
+      | MacOS -> bprintf buf "%s = %a" var Constant.print const
+      | _ ->
+        Misc.fatal_error "Cannot emit [Direct_assignment] except on macOS-like \
+          assemblers"
+      end
+
+  let print_masm buf t =
+    let masm_comment_opt = function
+      | None -> ""
+      | Some comment -> Printf.sprintf "\t; %s" comment
+    in
+    match t with
+    | Align { bytes; } -> bprintf buf "\tALIGN\t%d" bytes
+    | Bytes s -> buf_bytes_directive buf ~directive:"BYTE" s
+    | Comment s -> bprintf buf " ; %s " s
+    | Const { constant; comment; } ->
+      let directive =
+        match Constant_with_width.width_in_bytes constant with
+        | Eight -> "BYTE"
+        | Sixteen -> "WORD"
+        | Thirty_two -> "DWORD"
+        | Sixty_four -> "QWORD"
+      in
+      let comment = masm_comment_opt comment in
+      bprintf buf "\t%s\t%a%s"
+        directive
+        Constant.print (Constant_with_width.constant constant)
+        comment
+    | Global s -> bprintf buf "\tPUBLIC\t%s" s
+    | Section { names = [".data"]; _ } -> bprintf buf "\t.DATA"
+    | Section { names = [".text"]; _ } -> bprintf buf "\t.CODE"
+    | Section _ -> assert false
+    | Space { bytes; } -> bprintf buf "\tBYTE\t%d DUP (?)" bytes
+    | New_label (label, Code) -> bprintf buf "%s:" label
+    | New_label (label, Machine_width_data) ->
+      begin match TS.machine_width () with
+      | Thirty_two -> bprintf buf "%s LABEL DWORD" label
+      | Sixty_four -> bprintf buf "%s LABEL QWORD" label
+      end
+    | Cfi_adjust_cfa_offset _ ->
+      Misc.fatal_error "Unsupported asm directive [Cfi_adjust_cfa_offset] \
+        for MASM"
+    | Cfi_endproc ->
+      Misc.fatal_error "Unsupported asm directive [Cfi_endproc] for MASM"
+    | Cfi_offset _ ->
+      Misc.fatal_error "Unsupported asm directive [Cfi_offset] for MASM"
+    | Cfi_startproc ->
+      Misc.fatal_error "Unsupported asm directive [Cfi_startproc] for MASM"
+    | File _ ->
+      Misc.fatal_error "Unsupported asm directive [File] for MASM"
+    | Indirect_symbol _ ->
+      Misc.fatal_error "Unsupported asm directive [Indirect_symbol] for MASM"
+    | Loc _ ->
+      Misc.fatal_error "Unsupported asm directive [Loc] for MASM"
+    | Private_extern _ ->
+      Misc.fatal_error "Unsupported asm directive [Private_extern] for MASM"
+    | Size _ ->
+      Misc.fatal_error "Unsupported asm directive [Size] for MASM"
+    | Sleb128 _ ->
+      Misc.fatal_error "Unsupported asm directive [Sleb128] for MASM"
+    | Type _ ->
+      Misc.fatal_error "Unsupported asm directive [Type] for MASM"
+    | Uleb128 _ ->
+      Misc.fatal_error "Unsupported asm directive [Uleb128] for MASM"
+    | Direct_assignment _ ->
+      Misc.fatal_error "Unsupported asm directive [Direct_assignment] for MASM"
+
+  let print b t =
+    match TS.assembler () with
+    | MASM -> print_masm b t
+    | MacOS | GAS_like -> print_gas b t
+end
+
+(* A higher-level version of [Constant.t] which contains some more
+   abstractions (e.g. use of [Cmm.label], and in the future distinguished
+   types to represent symbols and symbol references before they are mangled
+   to plain [string]s for [Constant.t]). *)
+type proto_constant =
+  | Signed_int of Int64.t
+  | This
+  | Label of Cmm.label
+  | Symbol of string
+  | Symbol_reloc of string
+    (* [Symbol_reloc] represents a reference to a symbol with an optional
+       relocation suffix.  It is kept separate from [Symbol] to facilitate the
+       future introduction of a distinguished type for such references. *)
+  | Add of proto_constant * proto_constant
+  | Sub of proto_constant * proto_constant
+  | Div of proto_constant * int
+
+let rec lower_proto_constant (cst : proto_constant) : Directive.Constant.t =
+  match cst with
+  | Signed_int n -> Signed_int n
+  | This -> This
+  | Label lbl -> Named_thing (string_of_label lbl)
+  | Symbol sym -> Named_thing sym
+  | Symbol_reloc sym -> Named_thing sym
+  | Add (cst1, cst2) ->
+    Add (lower_proto_constant cst1, lower_proto_constant cst2)
+  | Sub (cst1, cst2) ->
+    Sub (lower_proto_constant cst1, lower_proto_constant cst2)
+  | Div (cst1, cst2) -> Div (lower_proto_constant cst1, cst2)
+
+let emit_ref = ref None
+
+let emit (d : Directive.t) =
+  match !emit_ref with
+  | Some emit -> emit d
+  | None -> Misc.fatal_error "initialize not called"
+
+let emit_non_masm (d : Directive.t) =
+  match TS.assembler () with
+  | MASM ->  ()
+  | MacOS | GAS_like -> emit d
+
+let section ~names ~flags ~args = emit (Section { names; flags; args; })
+
+let align ~bytes = emit (Align { bytes; })
+
+let should_generate_cfi () =
+  (* We generate CFI info even if we're not generating any other debugging
+     information.  This is in fact necessary on macOS, where it may be
+     expected that OCaml stack frames are unwindable (see
+     testsuite/tests/unwind/README for more information). *)
+  Config.asm_cfi_supported
+
+let cfi_adjust_cfa_offset ~bytes =
+  if should_generate_cfi () && bytes <> 0 then begin
+    emit (Cfi_adjust_cfa_offset bytes)
+    end
+
+let cfi_endproc () =
+  if should_generate_cfi () then emit Cfi_endproc
+
+let cfi_offset ~reg ~offset =
+  if should_generate_cfi () && offset <> 0 then begin
+    emit (Cfi_offset { reg; offset; })
+  end
+
+let cfi_startproc () =
+  if should_generate_cfi () then emit Cfi_startproc
+
+let comment text = emit (Comment text)
+let loc ~file_num ~line ~col = emit_non_masm (Loc { file_num; line; col; })
+let space ~bytes = emit (Space { bytes; })
+let string str = emit (Bytes str)
+
+let global ~symbol = emit (Global symbol)
+let indirect_symbol ~symbol = emit (Indirect_symbol symbol)
+let private_extern ~symbol = emit (Private_extern symbol)
+let size name cst = emit (Size (name, (lower_proto_constant cst)))
+let type_ name ~type_ = emit (Type (name, type_))
+
+let sleb128 i = emit (Sleb128 (Directive.Constant.Signed_int i))
+let uleb128 i = emit (Uleb128 (Directive.Constant.Signed_int i))
+
+let direct_assignment var cst =
+  emit (Direct_assignment (var, lower_proto_constant cst))
+
+let const ?comment constant
+      (width : Directive.Constant_with_width.width_in_bytes) =
+  let constant = lower_proto_constant constant in
+  let constant = Directive.Constant_with_width.create constant width in
+  emit (Const { constant; comment; })
+
+let const_machine_width ?comment constant =
+  match Target_system.machine_width () with
+  | Thirty_two -> const ?comment constant Thirty_two
+  | Sixty_four -> const ?comment constant Sixty_four
+
+let float32 f =
+  let comment = Printf.sprintf "%.12f" f in
+  let f_int32 = Int64.of_int32 (Int32.bits_of_float f) in
+  const ~comment (Signed_int f_int32) Sixty_four
+
+let float64_core f f_int64 =
+  match TS.machine_width () with
+  | Sixty_four ->
+    let comment = Printf.sprintf "%.12g" f in
+    const ~comment (Signed_int f_int64) Sixty_four
+  | Thirty_two ->
+    let comment_lo = Printf.sprintf "low part of %.12g" f in
+    let comment_hi = Printf.sprintf "high part of %.12g" f in
+    let lo = Signed_int (Int64.logand f_int64 0xffff_ffffL) in
+    let hi = Signed_int (Int64.shift_right_logical f_int64 32) in
+    if Arch.big_endian then begin
+      const ~comment:comment_hi hi Thirty_two;
+      const ~comment:comment_lo lo Thirty_two
+    end else begin
+      const ~comment:comment_lo lo Thirty_two;
+      const ~comment:comment_hi hi Thirty_two
+    end
+
+let float64 f = float64_core f (Int64.bits_of_float f)
+let float64_from_bits f = float64_core (Int64.float_of_bits f) f
+
+let size ?size_of_symbol ~symbol =
+  match TS.system () with
+  | GNU | Linux | FreeBSD | NetBSD | OpenBSD | Generic_BSD ->
+    let size_of_symbol =
+      match size_of_symbol with
+      | None -> symbol
+      | Some size_of_symbol -> size_of_symbol
+    in
+    size size_of_symbol (Sub (This, Symbol symbol))
+  | _ -> ()
+
+let label label_name = const_machine_width (Label label_name)
+
+let define_label label_name =
+  let typ : Directive.thing_after_label =
+    if current_section_is_text () then Code
+    else Machine_width_data
+  in
+  emit (New_label (string_of_label label_name, typ))
+
+let sections_seen = ref []
+
+(* Modified version of [Target_system.system] for easier matching in
+   [switch_to_section], below. *)
+type derived_system =
+  | Linux
+  | MinGW_32
+  | MinGW_64
+  | Win32
+  | Win64
+  | Cygwin
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+let derived_system () =
+  match TS.system (), TS.machine_width () with
+  | Linux, _ -> Linux
+  | Windows Cygwin, _ -> Cygwin
+  | Windows MinGW, Thirty_two -> MinGW_32
+  | Windows MinGW, Sixty_four -> MinGW_64
+  | Windows Native, Thirty_two -> Win32
+  | Windows Native, Sixty_four -> Win64
+  | MacOS_like, _ -> MacOS_like
+  | FreeBSD, _ -> FreeBSD
+  | NetBSD, _ -> NetBSD
+  | OpenBSD, _ -> OpenBSD
+  | Generic_BSD, _ -> Generic_BSD
+  | Solaris, _ -> Solaris
+  | Dragonfly, _ -> Dragonfly
+  | GNU, _ -> GNU
+  | BeOS, _ -> BeOS
+  | Unknown, _ -> Unknown
+
+let switch_to_section (section : section) =
+  let first_occurrence =
+    if List.mem section !sections_seen then false
+    else begin
+      sections_seen := section::!sections_seen;
+      true
+    end
+  in
+  current_section := Some section;
+  let names, flags, args =
+    let text () = [".text"], None, [] in
+    let data () = [".data"], None, [] in
+    let rodata () = [".rodata"], None, [] in
+    let system = derived_system () in
+    match section, TS.architecture (), system with
+    | Text, _, _ -> text ()
+    | Data, _, _ -> data ()
+    | DWARF dwarf, _, MacOS_like ->
+      let name =
+        match dwarf with
+        | Debug_info -> "__debug_info"
+        | Debug_abbrev -> "__debug_abbrev"
+        | Debug_aranges -> "__debug_aranges"
+        | Debug_loc -> "__debug_loc"
+        | Debug_str -> "__debug_str"
+        | Debug_line -> "__debug_line"
+      in
+      ["__DWARF"; name], None, ["regular"; "debug"]
+    | DWARF dwarf, _, _ ->
+      let name =
+        match dwarf with
+        | Debug_info -> ".debug_info"
+        | Debug_abbrev -> ".debug_abbrev"
+        | Debug_aranges -> ".debug_aranges"
+        | Debug_loc -> ".debug_loc"
+        | Debug_str -> ".debug_str"
+        | Debug_line -> ".debug_line"
+      in
+      let flags =
+        if first_occurrence then
+          Some ""
+        else
+          None
+      in
+      let args =
+        if first_occurrence then
+          ["%progbits"]
+        else
+          []
+      in
+      [name], flags, args
+    | (Eight_byte_literals | Sixteen_byte_literals), (ARM | AArch64 | Z), _
+    | (Eight_byte_literals | Sixteen_byte_literals), _, Solaris ->
+      rodata ()
+    | Sixteen_byte_literals, _, MacOS_like ->
+      ["__TEXT";"__literal16"], None, ["16byte_literals"]
+    | Sixteen_byte_literals, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Sixteen_byte_literals, _, (MinGW_32 | Win32 | Win64) ->
+      data ()
+    | Sixteen_byte_literals, _, _ ->
+      [".rodata.cst8"], Some "a", ["@progbits"]
+    | Eight_byte_literals, _, MacOS_like ->
+      ["__TEXT";"__literal8"], None, ["8byte_literals"]
+    | Eight_byte_literals, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Eight_byte_literals, _, (MinGW_32 | Win32 | Win64) ->
+      data ()
+    | Eight_byte_literals, _, _ ->
+      [".rodata.cst8"], Some "a", ["@progbits"]
+    | Jump_tables, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Jump_tables, _, (MinGW_32 | Win32) ->
+      data ()
+    | Jump_tables, _, (MacOS_like | Win64) ->
+      text () (* with LLVM/OS X and MASM, use the text segment *)
+    | Jump_tables, _, _ ->
+      [".rodata"], None, []
+    | Read_only_data, _, (MinGW_32 | Win32) ->
+      data ()
+    | Read_only_data, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Read_only_data, _, _ ->
+      rodata ()
+    | POWER Function_descriptors, POWER, _ ->
+      [".opd"], Some "aw", []
+    | POWER Table_of_contents, POWER, _ ->
+      [".toc"], Some "aw", []
+    | POWER _, _, _ ->
+      Misc.fatal_error "Cannot switch to POWER section on non-POWER \
+        architecture"
+    | IA32 Non_lazy_symbol_pointers, IA32, MacOS_like ->
+      [ "__IMPORT"; "__pointers"], None, ["non_lazy_symbol_pointers" ]
+    | IA32 Jump_table, IA32, MacOS_like ->
+      [ "__IMPORT"; "__jump_table"], None,
+        [ "symbol_stubs"; "self_modifying_code+pure_instructions"; "5" ]
+    | IA32 _, _, _ ->
+      Misc.fatal_error "Cannot switch to IA32 section on non-IA32 \
+        architecture or IA32 non-Darwin system"
+  in
+  emit (Section { names; flags; args; });
+  if first_occurrence then begin
+    define_label (label_for_section section)
+  end
+
+let cached_strings = ref ([] : (string * Cmm.label) list)
+let temp_var_counter = ref 0
+
+let reset () =
+  cached_strings := [];
+  sections_seen := [];
+  temp_var_counter := 0
+
+let file ?file_num ~file_name () =
+  emit_non_masm (File { file_num = file_num; filename = file_name; })
+
+let initialize ~(emit : Directive.t -> unit) =
+  emit_ref := Some emit;
+  reset ();
+  begin match TS.assembler () with
+  | MASM | MacOS -> ()
+  | GAS_like ->
+    (* Forward label references are illegal in gas.  Just put them in for
+       all assemblers, they won't harm. *)
+    List.iter (fun section ->
+        match section with
+        | Text
+        | Data
+        | Read_only_data
+        | Eight_byte_literals
+        | Sixteen_byte_literals
+        | Jump_tables -> switch_to_section section
+        | DWARF _ ->
+          if !Clflags.debug && dwarf_supported () then begin
+            switch_to_section section
+          end
+        | POWER (Function_descriptors | Table_of_contents) ->
+          begin match TS.architecture () with
+          | POWER -> switch_to_section section
+          | IA32 | X86_64 | ARM | AArch64 |  Z -> ()
+          end
+        | IA32 (Non_lazy_symbol_pointers | Jump_table) ->
+          begin match TS.architecture () with
+          | IA32 when TS.macos_like () -> switch_to_section section
+          | IA32 | POWER | X86_64 | ARM | AArch64 | Z -> ()
+          end)
+      all_sections_in_order
+  end;
+  file ~file_name:"" ();  (* PR#7037 *)
+  switch_to_section Text
+
+let file ~file_num ~file_name = file ~file_num ~file_name ()
+
+let define_data_symbol ~symbol =
+  emit (New_label (symbol, Machine_width_data));
+  begin match TS.assembler (), TS.windows () with
+  | GAS_like, false -> type_ symbol ~type_:"STT_OBJECT"
+  | GAS_like, true | MacOS, _ | MASM, _ -> ()
+  end
+
+let define_function_symbol ~symbol =
+  if not (current_section_is_text ()) then begin
+    Misc.fatal_error "[define_function_symbol] can only be called when \
+      emitting to a text section"
+  end;
+  emit (New_label (symbol, Code));
+  begin match TS.assembler (), TS.windows () with
+  | GAS_like, false -> type_ symbol ~type_:"STT_FUNC"
+  | GAS_like, true | MacOS, _ | MASM, _ -> ()
+  end
+
+let symbol sym = const_machine_width (Symbol_reloc sym)
+
+let symbol_plus_offset ~symbol ~offset_in_bytes =
+  let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
+  const_machine_width (Add (Symbol_reloc symbol, Signed_int offset_in_bytes))
+
+let new_temp_var () =
+  let id = !temp_var_counter in
+  incr temp_var_counter;
+  Printf.sprintf "Ltemp%d" id
+
+(* To avoid callers of this module having to worry about whether operands
+   involved in displacement calculations are or are not relocatable, and to
+   guard against clever linkers doing e.g. branch relaxation at link time, we
+   always force such calculations to be done in a relocatable manner at
+   link time.  On macOS this requires use of the "direct assignment"
+   syntax rather than ".set": the latter forces expressions to be evaluated
+   as absolute assembly-time constants. *)
+
+let force_relocatable expr =
+  match TS.assembler () with
+  | MacOS ->
+    let temp = new_temp_var () in
+    direct_assignment temp expr;
+    Symbol_reloc temp  (* not really a symbol, but OK (same below) *)
+  | GAS_like | MASM ->
+    expr
+
+let between_symbols ~upper ~lower =
+  let expr = Sub (Symbol_reloc upper, Symbol_reloc lower) in
+  const_machine_width (force_relocatable expr)
+
+let between_labels_32bit ~upper ~lower =
+  let expr = Sub (Label upper, Label lower) in
+  const (force_relocatable expr) Thirty_two
+
+let between_symbol_and_label_offset ~upper ~lower ~offset_upper =
+  let offset_upper = Targetint.to_int64 offset_upper in
+  let expr =
+    Sub (Add (Label upper, Signed_int offset_upper), Symbol_reloc lower)
+  in
+  const_machine_width (force_relocatable expr)
+
+let between_symbol_and_label_offset' ~upper ~lower ~offset_lower =
+  let offset_lower = Targetint.to_int64 offset_lower in
+  let expr =
+    Sub (Symbol_reloc upper, Add (Label lower, Signed_int offset_lower))
+  in
+  const_machine_width (force_relocatable expr)
+
+let between_this_and_label_offset_32bit ~upper ~offset_upper =
+  let offset_upper = Targetint.to_int64 offset_upper in
+  let expr =
+    Sub (Add (Label upper, Signed_int offset_upper), This)
+  in
+  const (force_relocatable expr) Thirty_two
+
+let scaled_distance_between_this_and_label_offset ~upper ~divide_by =
+  let expr = Div (Sub (Label upper, This), divide_by) in
+  const_machine_width (force_relocatable expr)
+
+let offset_into_section_label ~section ~label:upper
+      ~(width : Target_system.machine_width) =
+  let lower = label_for_section section in
+  let expr : proto_constant =
+    (* The meaning of a label reference depends on the assembler:
+       - On Mac OS X, it appears to be the distance from the label back to
+         the start of the assembly file.
+       - On gas, it is the distance from the label back to the start of the
+         current section. *)
+    match TS.assembler () with
+    | MacOS ->
+      let temp = new_temp_var () in
+      direct_assignment temp (Sub (Label upper, Label lower));
+      Symbol_reloc temp
+    | GAS_like | MASM ->
+      Label upper
+  in
+  let width : Directive.Constant_with_width.width_in_bytes =
+    match width with
+    | Thirty_two -> Thirty_two
+    | Sixty_four -> Sixty_four
+  in
+  const expr width
+
+let offset_into_section_symbol ~section ~symbol:upper
+      ~(width : Target_system.machine_width) =
+  let lower = label_for_section section in
+  let expr : proto_constant =
+    (* The same thing as for [offset_into_section_label] applies here. *)
+    match TS.assembler () with
+    | MacOS ->
+      let temp = new_temp_var () in
+      direct_assignment temp (Sub (Symbol_reloc upper, Label lower));
+      Symbol_reloc temp
+    | GAS_like | MASM -> Symbol_reloc upper
+  in
+  let width : Directive.Constant_with_width.width_in_bytes =
+    match width with
+    | Thirty_two -> Thirty_two
+    | Sixty_four -> Sixty_four
+  in
+  const expr width
+
+let int8 i = const (Signed_int (Int64.of_int (Int8.to_int i))) Eight
+let int16 i = const (Signed_int (Int64.of_int (Int16.to_int i))) Sixteen
+let int32 i = const (Signed_int (Int64.of_int32 i)) Thirty_two
+let int64 i = const (Signed_int i) Sixty_four
+
+let targetint n =
+  match Targetint.repr n with
+  | Int32 n -> int32 n
+  | Int64 n -> int64 n
+
+let cache_string str =
+  match List.assoc str !cached_strings with
+  | label -> label
+  | exception Not_found ->
+    let label = Cmm.new_label () in
+    cached_strings := (str, label) :: !cached_strings;
+    label
+
+let emit_cached_strings () =
+  List.iter (fun (str, label_name) ->
+      define_label label_name;
+      string str;
+      int8 Int8.zero)
+    !cached_strings;
+  cached_strings := []
+
+let mark_stack_non_executable () =
+  let current_section = !current_section in
+  match TS.system () with
+  | Linux ->
+    section ~names:[".note.GNU-stack"] ~flags:(Some "") ~args:["%progbits"];
+    begin match current_section with
+    | None -> ()
+    | Some current_section -> switch_to_section current_section
+    end
+  | _ -> ()

--- a/asmcomp/debug/asm_directives.mli
+++ b/asmcomp/debug/asm_directives.mli
@@ -1,0 +1,365 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Fabrice Le Fessant, projet Gallium, INRIA Rocquencourt        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Abstraction layer for the emission of assembly directives that conceals
+    many intricate details differing between target systems. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* CR-someday mshinwell: Use this module throughout the backends as per
+   the original GPR. *)
+
+(* CR-someday mshinwell: Throughout the backend change to using a new
+   type [Backend_sym.t] instead of [string] for symbols.  There should also
+   be another type that corresponds to symbol references, which may include
+   relocation information. *)
+
+(** Sections that hold DWARF debugging information. *)
+type dwarf_section =
+  | Debug_info
+  | Debug_abbrev
+  | Debug_aranges
+  | Debug_loc
+  | Debug_str
+  | Debug_line
+
+(** Sections for the POWER architecture only. *)
+type power_section =
+  | Function_descriptors
+  | Table_of_contents
+
+(** Sections for the IA32 architecture only. *)
+type ia32_section =
+  | Non_lazy_symbol_pointers
+  | Jump_table
+
+(** The linker may share constants in [Eight_byte_literals] and
+    [Sixteen_byte_literals] sections. *)
+type section =
+  | Text
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+  | DWARF of dwarf_section
+  | POWER of power_section
+  | IA32 of ia32_section
+
+(** Emit subsequent directives to the given section.  If this function
+    has not been called before on the particular section, a label
+    declaration will be emitted after declaring the section.
+    Such labels may seem strange, but they are necessary so that
+    references (e.g. DW_FORM_ref_addr / DW_FORM_sec_offset when emitting
+    DWARF) to places that are currently at the start of these sections
+    get relocated correctly when those places become not at the start
+    (e.g. during linking). *)
+val switch_to_section : section -> unit
+
+(** Emit an 8-bit signed integer.  There is no padding or sign extension. *)
+val int8 : Numbers.Int8.t -> unit
+
+(** Emit a 16-bit signed integer.  There is no padding or sign extension. *)
+val int16 : Numbers.Int16.t -> unit
+
+(** Emit a 32-bit signed integer.  There is no padding or sign extension. *)
+val int32 : Int32.t -> unit
+
+(** Emit a 64-bit signed integer. *)
+val int64 : Int64.t -> unit
+
+(** Emit a signed integer whose width is that of an address on the target
+    machine.  There is no padding or sign extension. *)
+val targetint : Targetint.t -> unit
+
+(** Emit a 64-bit integer in unsigned LEB128 variable-length encoding
+    (cf. DWARF debugging information standard). *)
+val uleb128 : Int64.t -> unit
+
+(** Emit a 64-bit integer in signed LEB128 variable-length encoding. *)
+val sleb128 : Int64.t -> unit
+
+(** Emit a 32-bit-wide floating point number. *)
+val float32 : float -> unit
+
+(** Emit a 64-bit-wide floating point number. *)
+val float64 : float -> unit
+
+(** Emit a 64-bit-wide floating point number whose bits are contained
+    in an [Int64.t]. *)
+val float64_from_bits : Int64.t -> unit
+
+(** Emit a string (directly into the current section).  This function
+    does not write a terminating null. *)
+val string : string -> unit
+
+(** Cache a string for later emission.  The returned label may be used to
+    obtain the address of the string in the section.  This function does
+    not emit anything.  (See [emit_cached_strings], below.)
+    If a string is supplied to this function that is already in the cache
+    then the previously-assigned label is returned, not a new one. *)
+val cache_string : string -> Cmm.label
+
+(** Emit the sequence of:
+      label definition:
+        <string><null terminator>
+    pairs as per previous calls to [cache_string].  This function clears
+    the cache. *)
+val emit_cached_strings : unit -> unit
+
+(** Emit a comment. *)
+val comment : string -> unit
+
+(** Assign a file number to a filename. *)
+val file : file_num:int -> file_name:string -> unit
+
+(** Mark the source location of the current assembly position. *)
+val loc : file_num:int -> line:int -> col:int -> unit
+
+(** Adjust the current frame address offset by the given number of bytes.
+    This and other CFI functions will not emit anything in the case where
+    CFI is not supported on the target. *)
+val cfi_adjust_cfa_offset : bytes:int -> unit
+
+(** Note that the previous value of [reg] is saved at [offset] from
+    the current frame address. *)
+val cfi_offset : reg:int -> offset:int -> unit
+
+(** Mark the beginning of a function, for CFI purposes. *)
+val cfi_startproc : unit -> unit
+
+(** Mark the end of a function, for CFI purposes. *)
+val cfi_endproc : unit -> unit
+
+(** Mark that the call stack is not to be executable at runtime.  Not
+    supported on all platforms. *)
+val mark_stack_non_executable : unit -> unit
+
+(** Leave as much space as is required to achieve the given alignment. *)
+val align : bytes:int -> unit
+
+(** Emit a directive giving the displacement between the given symbol and
+    the current position.  This should only be used to state sizes of
+    blocks (e.g. functions) emitted immediately prior into the assembly stream.
+    [size_of] may be specified when the symbol used for measurement differs
+    from that whose size is being stated (e.g. on POWER with ELF ABI v1). *)
+val size : ?size_of_symbol:string -> symbol:string -> unit
+
+(** Leave a gap in the object file. *)
+val space : bytes:int -> unit
+
+(** Define a data ("object") symbol at the current output position.  When
+    emitting for MASM this will cause loads and stores to/from the symbol to
+    be treated as if they are loading machine-width words (unless the
+    instruction has an explicit width suffix). *)
+val define_data_symbol : symbol:string -> unit
+
+(** Define a function symbol at the current output position.  An exception
+    will be raised if the current section is not a text section. *)
+val define_function_symbol : symbol:string -> unit
+
+(** Mark a symbol as global. *)
+val global : symbol:string -> unit
+
+(** Emit a machine-width reference to the given symbol. *)
+val symbol : string -> unit
+
+(** Mark a symbol as "private extern" (see assembler documentation for
+    details). *)
+val private_extern : symbol:string -> unit
+
+(** Marker inside the definition of a lazy symbol stub (see platform or
+    assembler documentation for details). *)
+val indirect_symbol : symbol:string -> unit
+
+(** Define a label at the current position in the current section.
+    The treatment for MASM when emitting into non-text sections is as for
+    [define_symbol], above. *)
+val define_label : Cmm.label -> unit
+
+(** Emit a machine-width reference to the given label. *)
+val label : Cmm.label -> unit
+
+(** Emit a machine-width reference to the address formed by adding the
+    given byte offset to the address of the given symbol. *)
+val symbol_plus_offset
+   : symbol:string
+  -> offset_in_bytes:Targetint.t
+  -> unit
+
+(** The following functions calculate distances between various entities
+    such as labels and symbols.  These distances are calculated at link time
+    after the entities concerned have been relocated.  This means that they
+    can be safely used even when the linker may insert (or remove) code or
+    data between the points being measured. *)
+
+(** Emit a machine-width reference giving the displacement between two given
+    labels.  To obtain a positive result the symbol at the lower address
+    should be the second argument, as for normal subtraction. *)
+val between_symbols
+   : upper:string
+  -> lower:string
+  -> unit
+
+(** Like [between_symbols], but for two labels, emitting a 32-bit-wide
+    reference.  The behaviour upon overflow is unspecified. *)
+val between_labels_32bit : upper:Cmm.label -> lower:Cmm.label -> unit
+
+(** Emit a machine-width reference giving the displacement between the
+    lower symbol and the sum of the address of the upper label plus
+    [offset_upper]. *)
+val between_symbol_and_label_offset
+   : upper:Cmm.label
+  -> lower:string
+  -> offset_upper:Targetint.t
+  -> unit
+
+(** As for [between_symbol_and_label_offset], but with the types of the
+    lower and upper bounds transposed. *)
+val between_symbol_and_label_offset'
+   : upper:string
+  -> lower:Cmm.label
+  -> offset_lower:Targetint.t
+  -> unit
+
+(** Emit a 32-bit-wide reference giving the displacement between obtained
+    by subtracting the current assembly location from the sum of the address
+    of the given label plus the given offset. *)
+val between_this_and_label_offset_32bit
+   : upper:Cmm.label
+  -> offset_upper:Targetint.t
+  -> unit
+
+val scaled_distance_between_this_and_label_offset
+   : upper:Cmm.label
+  -> divide_by:int
+  -> unit
+
+(** Emit an integer giving the distance obtained by subtracting the
+    address of [base] from the address of [label].  [width] specifies the
+    size of the integer. *)
+val offset_into_section_label
+   : section:section
+  -> label:Cmm.label
+  -> width:Target_system.machine_width
+  -> unit
+
+(** As for [offset_into_section_label], but using a symbol instead of
+    a label as one end of the measurement. *)
+val offset_into_section_symbol
+   : section:section
+  -> symbol:string
+  -> width:Target_system.machine_width
+  -> unit
+
+(** Retrieve the label that [switch_to_section] (below) will put at the start
+    of the given section.  This function may be called before
+    [switch_to_section] for the section concerned.
+
+    Aside: Why do we need labels at the start of sections rather than
+    just referencing sections directly?
+    They are necessary so that references (e.g. DW_FORM_ref_addr or
+    DW_FORM_sec_offset when emitting DWARF) to places that are currently
+    at the start of these sections get relocated correctly when those
+    places become not at the start (e.g. during linking). *)
+val label_for_section : section -> Cmm.label
+
+module Directive : sig
+  module Constant : sig
+    type t = private
+      | Signed_int of Int64.t
+      | This
+      | Named_thing of string
+      (** [Named_thing] covers symbols, labels and variables. (Name mangling
+          conventions have by now been applied to these entities.) *)
+      | Add of t * t
+      | Sub of t * t
+      | Div of t * int
+  end
+
+  module Constant_with_width : sig
+    (** A constant together with a width indicating the number of bytes in
+        the object file within which the constant is to fit.  Some validation
+        is performed on values of type [t] to try to ensure that this is the
+        case, but it cannot be exhaustive, as the values of [This] and
+        [Named_thing] constructions are not known. *)
+    type t
+
+    val constant : t -> Constant.t
+
+    type width_in_bytes = private
+      | Eight
+      | Sixteen
+      | Thirty_two
+      | Sixty_four
+
+    val width_in_bytes : t -> width_in_bytes
+  end
+
+  type thing_after_label = private
+    | Code
+    | Machine_width_data
+
+  type comment = private string
+
+  (** Internal representation of directives.  Only needed if writing a custom
+      assembler or printer instead of using [print], below. *)
+  type t = private
+    | Align of { bytes : int; }
+    | Bytes of string
+    | Cfi_adjust_cfa_offset of int
+    | Cfi_endproc
+    | Cfi_offset of { reg : int; offset : int; }
+    | Cfi_startproc
+    | Comment of comment
+    | Const of { constant : Constant_with_width.t; comment : string option; }
+    | Direct_assignment of string * Constant.t
+    | File of { file_num : int option; filename : string; }
+    | Global of string
+    | Indirect_symbol of string
+    | Loc of { file_num : int; line : int; col : int; }
+    | New_label of string * thing_after_label
+    | Private_extern of string
+    | Section of {
+        names : string list;
+        flags : string option;
+        args : string list;
+      }
+    | Size of string * Constant.t
+    | Sleb128 of Constant.t
+    | Space of { bytes : int; }
+    | Type of string * string
+    | Uleb128 of Constant.t
+
+  (** Translate the given directive to textual form.  This produces output
+      suitable for either gas or MASM as appropriate. *)
+  val print : Buffer.t -> t -> unit
+end
+
+(** To be called by the emitter at the very start of code generation.
+    Calling the functions in this module will cause directives to be passed
+    to the given [emit] function (a typical implementation of which will just
+    call [Directive.print] on its parameter).
+    This function switches to the text section. *)
+val initialize : emit:(Directive.t -> unit) -> unit
+
+(** Reinitialize the emitter before compiling a different source file. *)
+val reset : unit -> unit
+
+(** The name mangling used for labels.  This may be useful e.g. when
+    emitting an instruction referencing a label. *)
+val string_of_label : Cmm.label -> string

--- a/asmcomp/debug/target_system.ml
+++ b/asmcomp/debug/target_system.ml
@@ -1,0 +1,189 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2017--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type elf_abi =
+  | ARM_GNU_EABI
+  | ARM_GNU_EABI_hard_float
+  | AArch64
+  | IA32
+  | POWER_ELF32
+  | POWER_ELF64v1
+  | POWER_ELF64v2
+  | X86_64
+  | Z
+
+type object_file_format_and_abi =
+  | A_out
+  | ELF of elf_abi
+  | Mach_O
+  | PE
+  | Unknown
+
+type windows_system =
+  | Cygwin
+  | MinGW
+  | Native
+
+type system =
+  | Linux
+  | Windows of windows_system
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+(* Some references remain to Solaris in the configure script, although it
+   appears that [Config.system] never gets set to "solaris" any more. *)
+let (_ : system) = Solaris
+
+type architecture =
+  | IA32
+  | X86_64
+  | ARM
+  | AArch64
+  | POWER
+  | Z
+
+type assembler =
+  | GAS_like
+  | MacOS
+  | MASM
+
+type machine_width =
+  | Thirty_two
+  | Sixty_four
+
+let architecture () =
+  match Config.architecture with
+  | "i386" -> IA32
+  | "amd64" -> X86_64
+  | "arm" -> ARM
+  | "arm64" -> AArch64
+  | "power" -> POWER
+  | "s390x" -> Z
+  | arch -> Misc.fatal_errorf "Unknown architecture `%s'" arch
+
+let system_and_object_file_format_and_abi ()
+      : system * object_file_format_and_abi =
+  match architecture (), Config.model, Config.system with
+  | IA32, _, "linux_aout" -> Linux, A_out
+  | IA32, _, "linux_elf" -> Linux, ELF IA32
+  | IA32, _, "bsd_aout" -> Generic_BSD, A_out
+  | IA32, _, "bsd_elf" -> Generic_BSD, ELF IA32
+  | IA32, _, "beos" -> BeOS, ELF IA32
+  | IA32, _, "cygwin" -> Windows Cygwin, PE
+  | (X86_64 | IA32), _, "macosx" -> MacOS_like, Mach_O
+  | IA32, _, "gnu" -> GNU, ELF IA32
+  | IA32, _, "mingw" -> Windows MinGW, PE
+  | IA32, _, "win32" -> Windows Native, PE
+  | POWER, "ppc64le", "elf" -> Linux, ELF POWER_ELF64v2
+  | POWER, "ppc64", "elf" -> Linux, ELF POWER_ELF64v1
+  | POWER, "ppc", "elf" -> Linux, ELF POWER_ELF32
+  | POWER, "ppc", "netbsd" -> NetBSD, ELF IA32
+  | POWER, "ppc", "bsd_elf" -> OpenBSD, ELF IA32
+  | Z, _, "elf" -> Linux, ELF Z
+  | ARM, _, "linux_eabihf" -> Linux, ELF ARM_GNU_EABI_hard_float
+  | ARM, _, "linux_eabi" -> Linux, ELF ARM_GNU_EABI
+  | ARM, _, "bsd" -> OpenBSD, ELF IA32
+  | X86_64, _, "linux" -> Linux, ELF X86_64
+  | X86_64, _, "gnu" -> GNU, ELF X86_64
+  | X86_64, _, "dragonfly" -> Dragonfly, ELF X86_64
+  | X86_64, _, "freebsd" -> FreeBSD, ELF X86_64
+  | X86_64, _, "netbsd" -> NetBSD, ELF X86_64
+  | X86_64, _, "openbsd" -> OpenBSD, ELF X86_64
+  | X86_64, _, "darwin" -> MacOS_like, Mach_O
+  | X86_64, _, "mingw" -> Windows MinGW, PE
+  | AArch64, _, "linux" -> Linux, ELF AArch64
+  | X86_64, _, "cygwin" -> Windows Cygwin, PE
+  | X86_64, _, "win64" -> Windows Native, PE
+  | _, _, "unknown" -> Unknown, Unknown
+  | _, _, _ ->
+    Misc.fatal_errorf "Cannot determine system type (model %s, system %s): \
+        ensure `target_system.ml' matches `configure'"
+      Config.model Config.system
+
+let system () =
+  fst (system_and_object_file_format_and_abi ())
+
+let object_file_format_and_abi () =
+  snd (system_and_object_file_format_and_abi ())
+
+let string_of_architecture arch =
+  match arch with
+  | IA32 -> "IA32"
+  | X86_64 -> "X86_64"
+  | ARM -> "ARM"
+  | AArch64 -> "AArch64"
+  | POWER -> "POWER"
+  | Z -> "Z"
+
+let windows () =
+  match system () with
+  | Windows _ -> true
+  | Linux
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> false
+
+let assembler () =
+  match system () with
+  | Windows Native -> MASM
+  | MacOS_like -> MacOS
+  | Linux
+  | Windows _
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> GAS_like
+
+let machine_width () =
+  match Targetint.size with
+  | 32 -> Thirty_two
+  | 64 -> Sixty_four
+  | bits -> Misc.fatal_errorf "Unknown machine width: %d" bits
+
+let win32 () =
+  match system (), machine_width () with
+  | Windows Native, Thirty_two -> true
+  | _, _ -> false
+
+let win64 () =
+  match system (), machine_width () with
+  | Windows Native, Sixty_four -> true
+  | _, _ -> false
+
+let macos_like () =
+  match system () with
+  | MacOS_like -> true
+  | _ -> false

--- a/asmcomp/debug/target_system.mli
+++ b/asmcomp/debug/target_system.mli
@@ -1,0 +1,104 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2017--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Types corresponding to the compiler's target machine. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type elf_abi = private
+  | ARM_GNU_EABI
+  | ARM_GNU_EABI_hard_float
+  | AArch64
+  | IA32
+  | POWER_ELF32
+  | POWER_ELF64v1
+  | POWER_ELF64v2
+  | X86_64
+  | Z
+
+type object_file_format_and_abi = private
+  | A_out
+  | ELF of elf_abi
+  | Mach_O
+  | PE
+  | Unknown
+
+type windows_system = private
+  | Cygwin
+  | MinGW
+  | Native
+
+type system = private
+  | Linux
+  | Windows of windows_system
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+type architecture = private
+  | IA32
+  | X86_64
+  | ARM
+  | AArch64
+  | POWER
+  | Z
+
+type assembler = private
+  | GAS_like
+  | MacOS
+  | MASM
+
+type machine_width = private
+  | Thirty_two
+  | Sixty_four
+
+(** The target system of the OCaml compiler. *)
+val system : unit -> system
+
+(** The target object file format and ABI of the OCaml compiler. *)
+val object_file_format_and_abi : unit -> object_file_format_and_abi
+
+(** Whether the target system is a Windows platform. *)
+val windows : unit -> bool
+
+(** Whether the target system is a Windows 32-bit native platform (not
+    MinGW or Cygwin). *)
+val win32 : unit -> bool
+
+(** Whether the target system is a Windows 64-bit native platform (not
+    MinGW or Cygwin). *)
+val win64 : unit -> bool
+
+(** Whether the target system is Mac OS X, macOS, or some other system
+    running a Darwin kernel and associated userland tools. *)
+val macos_like : unit -> bool
+
+(** The architecture of the target system. *)
+val architecture : unit -> architecture
+
+(** Convert an architecture to a string. *)
+val string_of_architecture : architecture -> string
+
+(** The assembler being used. *)
+val assembler : unit -> assembler
+
+(** The natural machine width of the target system. *)
+val machine_width : unit -> machine_width

--- a/asmcomp/debug/target_system.mli
+++ b/asmcomp/debug/target_system.mli
@@ -66,7 +66,7 @@ type assembler = private
   | MacOS
   | MASM
 
-type machine_width = private
+type machine_width =
   | Thirty_two
   | Sixty_four
 

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -219,18 +219,6 @@ let emit_frames a =
   Hashtbl.iter emit_filename filenames;
   frame_descriptors := []
 
-(* Detection of functions that can be duplicated between a DLL and
-   the main program (PR#4690) *)
-
-let isprefix s1 s2 =
-  String.length s1 <= String.length s2
-  && String.sub s2 0 (String.length s1) = s1
-
-let is_generic_function name =
-  List.exists
-    (fun p -> isprefix p name)
-    ["caml_apply"; "caml_curry"; "caml_send"; "caml_tuplify"]
-
 (* CFI directives *)
 
 let is_cfi_enabled () =

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -59,8 +59,6 @@ type emit_frame_actions =
 
 val emit_frames: emit_frame_actions -> unit
 
-val is_generic_function: string -> bool
-
 val cfi_startproc : unit -> unit
 val cfi_endproc : unit -> unit
 val cfi_adjust_cfa_offset : int -> unit

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -35,7 +35,7 @@ type t = {
 
 let get_fun_offset t closure_id =
   let fun_offset_table =
-    if Closure_id.in_compilation_unit closure_id (Compilenv.current_unit ())
+    if Closure_id.in_compilation_unit closure_id (Compilation_unit.get_current_exn ())
     then
       t.current_unit.fun_offset_table
     else
@@ -49,7 +49,7 @@ let get_fun_offset t closure_id =
 let get_fv_offset t var_within_closure =
   let fv_offset_table =
     if Var_within_closure.in_compilation_unit var_within_closure
-        (Compilenv.current_unit ())
+        (Compilation_unit.get_current_exn ())
     then t.current_unit.fv_offset_table
     else t.imported_units.fv_offset_table
   in

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -435,7 +435,7 @@ and to_clambda_switch t env cases num_keys default =
 
 and to_clambda_direct_apply t func args direct_func dbg env : Clambda.ulambda =
   let closed = is_function_constant t direct_func in
-  let label = Compilenv.function_label direct_func in
+  let label = Closure_id.function_label direct_func in
   let uargs =
     let uargs = subst_vars env args in
     (* Remove the closure argument if the closure is closed.  (Note that the
@@ -525,7 +525,7 @@ and to_clambda_set_of_closures t env
           env, id :: params)
         function_decl.params (env, [])
     in
-    { label = Compilenv.function_label closure_id;
+    { label = Closure_id.function_label closure_id;
       arity = Flambda_utils.function_arity function_decl;
       params = List.map (fun var -> VP.create var) (params @ [env_var]);
       body = to_clambda t env_body function_decl.body;
@@ -554,7 +554,7 @@ and to_clambda_closed_set_of_closures t env symbol
     let env =
       List.fold_left (fun env (var, _) ->
           let closure_id = Closure_id.wrap var in
-          let symbol = Compilenv.closure_symbol closure_id in
+          let symbol = Closure_id.closure_symbol closure_id in
           Env.add_subst env var (to_clambda_symbol env symbol))
         (Env.keep_only_symbols env)
         functions
@@ -565,7 +565,7 @@ and to_clambda_closed_set_of_closures t env symbol
           env, id :: params)
         function_decl.params (env, [])
     in
-    { label = Compilenv.function_label (Closure_id.wrap id);
+    { label = Closure_id.function_label (Closure_id.wrap id);
       arity = Flambda_utils.function_arity function_decl;
       params = List.map (fun var -> VP.create var) params;
       body = to_clambda t env_body function_decl.body;

--- a/asmcomp/import_approx.ml
+++ b/asmcomp/import_approx.ml
@@ -26,7 +26,7 @@ let import_set_of_closures =
     let sym_to_fun_var_map (clos : A.function_declarations) =
       Variable.Map.fold (fun fun_var _ acc ->
            let closure_id = Closure_id.wrap fun_var in
-           let sym = Compilenv.closure_symbol closure_id in
+           let sym = Closure_id.closure_symbol closure_id in
            Symbol.Map.add sym fun_var acc)
         clos.funs Symbol.Map.empty
     in
@@ -186,7 +186,7 @@ and import_approx (ap : Export_info.approx) =
   | Value_symbol sym -> A.value_symbol sym
 
 let import_symbol sym =
-  if Compilenv.is_predefined_exception sym then
+  if Symbol.is_predefined_exception sym then
     A.value_unknown Other
   else begin
     let compilation_unit = Symbol.compilation_unit sym in

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -50,7 +50,7 @@ let has_fallthrough = function
   | _ -> true
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: Backend_sym.t;
     fun_body: instruction;
     fun_fast: bool;
     fun_dbg : Debuginfo.t;

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -48,7 +48,7 @@ val instr_cons:
 val invert_test: Mach.test -> Mach.test
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: Backend_sym.t;
     fun_body: instruction;
     fun_fast: bool;
     fun_dbg : Debuginfo.t;

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -45,12 +45,12 @@ type operation =
   | Ireload
   | Iconst_int of nativeint
   | Iconst_float of int64
-  | Iconst_symbol of string
+  | Iconst_symbol of Backend_sym.t
   | Icall_ind of { label_after : label; }
-  | Icall_imm of { func : string; label_after : label; }
+  | Icall_imm of { func : Backend_sym.t; label_after : label; }
   | Itailcall_ind of { label_after : label; }
-  | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Itailcall_imm of { func : Backend_sym.t; label_after : label; }
+  | Iextcall of { func : Backend_sym.t; alloc : bool; label_after : label; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
@@ -88,14 +88,14 @@ and instruction_desc =
   | Iraise of Cmm.raise_kind
 
 type spacetime_part_of_shape =
-  | Direct_call_point of { callee : string; }
+  | Direct_call_point of { callee : Backend_sym.t; }
   | Indirect_call_point
   | Allocation_point
 
 type spacetime_shape = (spacetime_part_of_shape * Cmm.label) list
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: Backend_sym.t;
     fun_args: Reg.t array;
     fun_body: instruction;
     fun_codegen_options : Cmm.codegen_option list;

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -52,12 +52,12 @@ type operation =
   | Ireload
   | Iconst_int of nativeint
   | Iconst_float of int64
-  | Iconst_symbol of string
+  | Iconst_symbol of Backend_sym.t
   | Icall_ind of { label_after : label; }
-  | Icall_imm of { func : string; label_after : label; }
+  | Icall_imm of { func : Backend_sym.t; label_after : label; }
   | Itailcall_ind of { label_after : label; }
-  | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Itailcall_imm of { func : Backend_sym.t; label_after : label; }
+  | Iextcall of { func : Backend_sym.t; alloc : bool; label_after : label; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
@@ -104,7 +104,7 @@ and instruction_desc =
   | Iraise of Cmm.raise_kind
 
 type spacetime_part_of_shape =
-  | Direct_call_point of { callee : string; (* the symbol *) }
+  | Direct_call_point of { callee : Backend_sym.t; }
   | Indirect_call_point
   | Allocation_point
 
@@ -117,7 +117,7 @@ type spacetime_part_of_shape =
 type spacetime_shape = (spacetime_part_of_shape * Cmm.label) list
 
 type fundecl =
-  { fun_name: string;
+  { fun_name: Backend_sym.t;
     fun_args: Reg.t array;
     fun_body: instruction;
     fun_codegen_options : Cmm.codegen_option list;

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -1175,8 +1175,9 @@ let begin_assembly() =
      sections are in different pages.  .opd comes after .data,
      so aligning .opd is enough.  To save space, we do it only
      for the startup file, not for every OCaml compilation unit. *)
-  let c = Compilenv.current_unit_name() in
-  if abi = ELF64v1 && (c = "_startup" || c = "_shared_startup") then begin
+  let cu = Compilation_unit.get_current_exn () in
+  if abi = ELF64v1 && Compilation_unit.equal cu Compilation_unit.startup
+  then begin
     `	.p2align	12\n`
   end;
   declare_global_data lbl_begin;

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -55,19 +55,20 @@ let rec structured_constant ppf = function
       let idents ppf =
         List.iter (fprintf ppf "@ %a" VP.print) in
       let one_fun ppf f =
-        fprintf ppf "(fun@ %s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-          f.label f.arity idents f.params lam f.body in
+        fprintf ppf "(fun@ %a@ %d@ @[<2>%a@]@ @[<2>%a@])"
+          Backend_sym.print f.label f.arity idents f.params lam f.body in
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
       let sconsts ppf scl =
         List.iter (fun sc -> fprintf ppf "@ %a" uconstant sc) scl in
-      fprintf ppf "@[<2>(const_closure%a %s@ %a)@]" funs clos sym sconsts fv
+      fprintf ppf "@[<2>(const_closure%a %a@ %a)@]"
+        funs clos Backend_sym.print sym sconsts fv
 
 
 and uconstant ppf = function
   | Uconst_ref (s, Some c) ->
-      fprintf ppf "%S=%a" s structured_constant c
-  | Uconst_ref (s, None) -> fprintf ppf "%S"s
+      fprintf ppf "%a=%a" Backend_sym.print s structured_constant c
+  | Uconst_ref (s, None) -> Backend_sym.print ppf s
   | Uconst_int i -> fprintf ppf "%i" i
   | Uconst_ptr i -> fprintf ppf "%ia" i
 
@@ -78,7 +79,7 @@ and lam ppf = function
   | Udirect_apply(f, largs, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      fprintf ppf "@[<2>(apply*@ %s %a)@]" f lams largs
+      fprintf ppf "@[<2>(apply*@ %a %a)@]" Backend_sym.print f lams largs
   | Ugeneric_apply(lfun, largs, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
@@ -87,8 +88,8 @@ and lam ppf = function
       let idents ppf =
         List.iter (fprintf ppf "@ %a" VP.print) in
       let one_fun ppf f =
-        fprintf ppf "@[<2>(fun@ %s@ %d @[<2>%a@]@ @[<2>%a@]@])"
-          f.label f.arity idents f.params lam f.body in
+        fprintf ppf "@[<2>(fun@ %a@ %d @[<2>%a@]@ @[<2>%a@]@])"
+          Backend_sym.print f.label f.arity idents f.params lam f.body in
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
       let lams ppf =
@@ -210,8 +211,8 @@ let clambda ppf ulam =
 
 let rec approx ppf = function
     Value_closure(fundesc, a) ->
-      Format.fprintf ppf "@[<2>function %s@ arity %i"
-        fundesc.fun_label fundesc.fun_arity;
+      Format.fprintf ppf "@[<2>function %a@ arity %i"
+        Backend_sym.print fundesc.fun_label fundesc.fun_arity;
       if fundesc.fun_closed then begin
         Format.fprintf ppf "@ (closed)"
       end;
@@ -231,4 +232,4 @@ let rec approx ppf = function
   | Value_const c ->
       fprintf ppf "@[const(%a)@]" uconstant c
   | Value_global_field (s, i) ->
-      fprintf ppf "@[global(%s,%i)@]" s i
+      fprintf ppf "@[global(%a,%i)@]" Backend_sym.print s i

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -79,7 +79,9 @@ let raise_kind fmt = function
 let operation d = function
   | Capply _ty -> "app" ^ Debuginfo.to_string d
   | Cextcall(lbl, _ty, _alloc, _) ->
-      Printf.sprintf "extcall \"%s\"%s" lbl (Debuginfo.to_string d)
+      Printf.sprintf "extcall \"%s\"%s"
+        (Backend_sym.to_string lbl)
+        (Debuginfo.to_string d)
   | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
   | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
   | Calloc -> "alloc" ^ Debuginfo.to_string d
@@ -127,7 +129,7 @@ let rec expr ppf = function
     fprintf ppf "block-hdr(%s)%s"
       (Nativeint.to_string n) (Debuginfo.to_string d)
   | Cconst_float n -> fprintf ppf "%F" n
-  | Cconst_symbol s -> fprintf ppf "\"%s\"" s
+  | Cconst_symbol s -> fprintf ppf "\"%a\"" Backend_sym.print s
   | Cconst_pointer n -> fprintf ppf "%ia" n
   | Cconst_natpointer n -> fprintf ppf "%sa" (Nativeint.to_string n)
   | Cvar id -> V.print ppf id
@@ -225,20 +227,20 @@ let fundecl ppf f =
        if !first then first := false else fprintf ppf "@ ";
        fprintf ppf "%a: %a" VP.print id machtype ty)
      cases in
-  fprintf ppf "@[<1>(function%s %s@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
-         (Debuginfo.to_string f.fun_dbg) f.fun_name
+  fprintf ppf "@[<1>(function%s %a@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
+         (Debuginfo.to_string f.fun_dbg) Backend_sym.print f.fun_name
          print_cases f.fun_args sequence f.fun_body
 
 let data_item ppf = function
-  | Cdefine_symbol s -> fprintf ppf "\"%s\":" s
-  | Cglobal_symbol s -> fprintf ppf "global \"%s\"" s
+  | Cdefine_symbol s -> fprintf ppf "\"%a\":" Backend_sym.print s
+  | Cglobal_symbol s -> fprintf ppf "global \"%a\"" Backend_sym.print s
   | Cint8 n -> fprintf ppf "byte %i" n
   | Cint16 n -> fprintf ppf "int16 %i" n
   | Cint32 n -> fprintf ppf "int32 %s" (Nativeint.to_string n)
   | Cint n -> fprintf ppf "int %s" (Nativeint.to_string n)
   | Csingle f -> fprintf ppf "single %F" f
   | Cdouble f -> fprintf ppf "double %F" f
-  | Csymbol_address s -> fprintf ppf "addr \"%s\"" s
+  | Csymbol_address s -> fprintf ppf "addr \"%a\"" Backend_sym.print s
   | Cstring s -> fprintf ppf "string \"%s\"" s
   | Cskip n -> fprintf ppf "skip %i" n
   | Calign n -> fprintf ppf "align %i" n

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -20,6 +20,8 @@ open Mach
 open Printmach
 open Linearize
 
+module S = Backend_sym
+
 let label ppf l =
   Format.fprintf ppf "L%i" l
 
@@ -82,4 +84,4 @@ let fundecl ppf f =
       ""
     else
       " " ^ Debuginfo.to_string f.fun_dbg in
-  fprintf ppf "@[<v 2>%s:%s@,%a@]" f.fun_name dbg all_instr f.fun_body
+  fprintf ppf "@[<v 2>%a:%s@,%a@]" S.print f.fun_name dbg all_instr f.fun_body

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -123,13 +123,15 @@ let operation op arg ppf res =
   | Ireload -> fprintf ppf "%a (reload)" regs arg
   | Iconst_int n -> fprintf ppf "%s" (Nativeint.to_string n)
   | Iconst_float f -> fprintf ppf "%F" (Int64.float_of_bits f)
-  | Iconst_symbol s -> fprintf ppf "\"%s\"" s
+  | Iconst_symbol s -> fprintf ppf "\"%a\"" Backend_sym.print s
   | Icall_ind _ -> fprintf ppf "call %a" regs arg
-  | Icall_imm { func; _ } -> fprintf ppf "call \"%s\" %a" func regs arg
+  | Icall_imm { func; _ } ->
+    fprintf ppf "call \"%a\" %a" Backend_sym.print func regs arg
   | Itailcall_ind _ -> fprintf ppf "tailcall %a" regs arg
-  | Itailcall_imm { func; } -> fprintf ppf "tailcall \"%s\" %a" func regs arg
+  | Itailcall_imm { func; } ->
+    fprintf ppf "tailcall \"%a\" %a" Backend_sym.print func regs arg
   | Iextcall { func; alloc; _ } ->
-      fprintf ppf "extcall \"%s\" %a%s" func regs arg
+      fprintf ppf "extcall \"%a\" %a%s" Backend_sym.print func regs arg
       (if alloc then "" else " (noalloc)")
   | Istackoffset n ->
       fprintf ppf "offset stack %i" n
@@ -244,8 +246,8 @@ let fundecl ppf f =
       ""
     else
       " " ^ Debuginfo.to_string f.fun_dbg in
-  fprintf ppf "@[<v 2>%s(%a)%s@,%a@]"
-    f.fun_name regs f.fun_args dbg instr f.fun_body
+  fprintf ppf "@[<v 2>%a(%a)%s@,%a@]"
+    Backend_sym.print f.fun_name regs f.fun_args dbg instr f.fun_body
 
 let phase msg ppf f =
   fprintf ppf "*** %s@.%a@." msg fundecl f

--- a/asmcomp/target_system.ml
+++ b/asmcomp/target_system.ml
@@ -136,6 +136,21 @@ let string_of_architecture arch =
   | POWER -> "POWER"
   | Z -> "Z"
 
+let linux () =
+  match system () with
+  | Linux -> true
+  | Windows _
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> false
+
 let windows () =
   match system () with
   | Windows _ -> true

--- a/asmcomp/target_system.mli
+++ b/asmcomp/target_system.mli
@@ -76,6 +76,9 @@ val system : unit -> system
 (** The target object file format and ABI of the OCaml compiler. *)
 val object_file_format_and_abi : unit -> object_file_format_and_abi
 
+(** Whether the target system is a Linux platform. *)
+val linux : unit -> bool
+
 (** Whether the target system is a Windows platform. *)
 val windows : unit -> bool
 

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -26,7 +26,8 @@
 
 open X86_ast
 
-val sym: string -> arg
+val sym: ?reloc:string -> Asm_symbol.t -> arg
+val label: Asm_label.t -> arg
 val nat: nativeint -> arg
 val int: int -> arg
 val const_32: int32 -> constant
@@ -55,45 +56,26 @@ val st0: arg
 val st1: arg
 
 val mem32:
-  data_type -> ?scale:int -> ?base:reg64 -> ?sym:string ->
+  data_type -> ?scale:int -> ?base:reg64 -> ?symbol_or_label:symbol_or_label ->
   int -> reg64 -> arg
 
 val mem64:
-  data_type -> ?scale:int -> ?base:reg64 -> ?sym:string ->
+  data_type -> ?scale:int -> ?base:reg64 -> ?symbol_or_label:symbol_or_label ->
   int -> reg64 -> arg
 
-val mem64_rip: data_type -> ?ofs:int -> string -> arg
+val mem64_rip
+   : ?reloc:string
+  -> data_type
+  -> ?ofs:int
+  -> symbol_or_label
+  -> arg
 
+module MASM : sig
+  (* MASM-specific directives.  For everything else, call [Asm_directives]. *)
 
-module D : sig
-  (** Directives *)
-
-  val align: int -> unit
-  val byte: constant -> unit
-  val bytes: string -> unit
-  val cfi_adjust_cfa_offset: int -> unit
-  val cfi_endproc: unit -> unit
-  val cfi_startproc: unit -> unit
-  val comment: string -> unit
-  val data: unit -> unit
-  val extrn: string -> data_type -> unit
-  val file: file_num:int -> file_name:string -> unit
-  val global: string -> unit
-  val indirect_symbol: string -> unit
-  val label: ?typ:data_type -> string -> unit
-  val loc: file_num:int -> line:int -> col:int -> unit
-  val long: constant -> unit
-  val mode386: unit -> unit
-  val model: string -> unit
-  val private_extern: string -> unit
-  val qword: constant -> unit
-  val section: string list -> string option -> string list -> unit
-  val setvar: string * constant -> unit
-  val size: string -> constant -> unit
-  val space: int -> unit
-  val text: unit -> unit
-  val type_: string -> string -> unit
-  val word: constant -> unit
+  val extrn : Asm_symbol.t -> data_type -> unit
+  val mode386 : unit -> unit
+  val model : string -> unit
 end
 
 module I : sig

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -58,60 +58,6 @@ let windows =
   | S_mingw64 | S_cygwin | S_win64 -> true
   | _ -> false
 
-let string_of_string_literal s =
-  let b = Buffer.create (String.length s + 2) in
-  let last_was_escape = ref false in
-  for i = 0 to String.length s - 1 do
-    let c = s.[i] in
-    if c >= '0' && c <= '9' then
-      if !last_was_escape
-      then Printf.bprintf b "\\%o" (Char.code c)
-      else Buffer.add_char b c
-    else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' then begin
-      Buffer.add_char b c;
-      last_was_escape := false
-    end else begin
-      Printf.bprintf b "\\%o" (Char.code c);
-      last_was_escape := true
-    end
-  done;
-  Buffer.contents b
-
-let string_of_symbol prefix s =
-  let spec = ref false in
-  for i = 0 to String.length s - 1 do
-    match String.unsafe_get s i with
-    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
-    | _ -> spec := true;
-  done;
-  if not !spec then if prefix = "" then s else prefix ^ s
-  else
-    let b = Buffer.create (String.length s + 10) in
-    Buffer.add_string b prefix;
-    String.iter
-      (function
-        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
-        | c -> Printf.bprintf b "$%02x" (Char.code c)
-      )
-      s;
-    Buffer.contents b
-
-let buf_bytes_directive b directive s =
-  let pos = ref 0 in
-  for i = 0 to String.length s - 1 do
-    if !pos = 0
-    then begin
-      if i > 0 then Buffer.add_char b '\n';
-      Buffer.add_char b '\t';
-      Buffer.add_string b directive;
-      Buffer.add_char b '\t';
-    end
-    else Buffer.add_char b ',';
-    Printf.bprintf b "%d" (Char.code s.[i]);
-    incr pos;
-    if !pos >= 16 then begin pos := 0 end
-  done
-
 let string_of_reg64 = function
   | RAX -> "rax"
   | RBX -> "rbx"

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -26,12 +26,8 @@ val string_of_reg16: reg64 -> string
 val string_of_reg32: reg64 -> string
 val string_of_reg64: reg64 -> string
 val string_of_registerf: registerf -> string
-val string_of_string_literal: string -> string
 val string_of_condition: condition -> string
-val string_of_symbol: (*prefix*) string -> string -> string
 val string_of_rounding: rounding -> string
-val buf_bytes_directive:
-  Buffer.t -> (*directive*) string -> (*data*)string -> unit
 
 
 (** Buffer of assembly code *)

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -75,9 +75,10 @@ let implementation ~backend =
   Compile_common.implementation ~tool_name
     ~native:true ~backend:(fun info typed ->
       let compilation_unit =
-        Compilation_unit.create info.modulename
+        Compilation_unit.create ?for_pack_prefix:!Clflags.for_package
+          info.modulename
       in
-      Compilenv.reset ?for_pack_prefix:!Clflags.for_package compilation_unit;
+      Compilenv.reset compilation_unit;
       if Config.flambda
       then flambda info backend typed
       else clambda info typed

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -74,7 +74,10 @@ let clambda i typed =
 let implementation ~backend =
   Compile_common.implementation ~tool_name
     ~native:true ~backend:(fun info typed ->
-      Compilenv.reset ?packname:!Clflags.for_package info.modulename;
+      let compilation_unit =
+        Compilation_unit.create info.modulename
+      in
+      Compilenv.reset ?for_pack_prefix:!Clflags.for_package compilation_unit;
       if Config.flambda
       then flambda info backend typed
       else clambda info typed

--- a/middle_end/base_types/closure_id.ml
+++ b/middle_end/base_types/closure_id.ml
@@ -18,3 +18,21 @@
 open! Int_replace_polymorphic_compare
 
 include Closure_element
+
+let closure_symbol fv =
+  let compilation_unit = Closure_id.get_compilation_unit fv in
+  let unitname =
+    Linkage_name.to_string (Compilation_unit.get_linkage_name compilation_unit)
+  in
+  let linkage_name =
+    concat_symbol unitname ((Closure_id.unique_name fv) ^ "_closure")
+  in
+  Symbol.of_global_linkage compilation_unit (Linkage_name.create linkage_name)
+
+let function_label fv =
+  let compilation_unit = Closure_id.get_compilation_unit fv in
+  let unitname =
+    Linkage_name.to_string
+      (Compilation_unit.get_linkage_name compilation_unit)
+  in
+  (concat_symbol unitname (Closure_id.unique_name fv))

--- a/middle_end/base_types/closure_id.mli
+++ b/middle_end/base_types/closure_id.mli
@@ -25,3 +25,12 @@
     (viz. [Project_closure]). *)
 
 include module type of Closure_element
+
+val closure_symbol : Closure_id.t -> Symbol.t
+        (* Symbol of a function if the function is
+           closed (statically allocated)
+           flambda-only *)
+
+val function_label : Closure_id.t -> Backend_sym.t
+        (* linkage name of the code of a function
+           flambda-only *)

--- a/middle_end/base_types/compilation_unit.ml
+++ b/middle_end/base_types/compilation_unit.ml
@@ -6,7 +6,7 @@
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -19,7 +19,7 @@ open! Int_replace_polymorphic_compare
 
 type t = {
   id : Ident.t;
-  linkage_name : Linkage_name.t;
+  linkage_name : Linkage_name.t;  (* Why is this here? XXX *)
   hash : int;
 }
 
@@ -61,8 +61,21 @@ let create (id : Ident.t) linkage_name =
   end;
   { id; linkage_name; hash = Hashtbl.hash (Ident.name id); }
 
+let current_unit_linkage_name () =
+  Linkage_name.create (make_symbol ~unitname:current_unit.ui_symbol None)
+
+let runtime_and_external_libs =
+  create (Ident.create_persistent "*runtime*")
+    (Linkage_name.create "*runtime_or_external*")
+
+let startup =
+  create (Ident.create_persistent "caml_startup")
+    (Linkage_name.create "caml_startup")
+
 let get_persistent_ident cu = cu.id
 let get_linkage_name cu = cu.linkage_name
+
+let name t = Ident.name cu.id
 
 let current = ref None
 let is_current arg =
@@ -76,3 +89,8 @@ let get_current_exn () =
   | Some current -> current
   | None -> Misc.fatal_error "Compilation_unit.get_current_exn"
 let get_current_id_exn () = get_persistent_ident (get_current_exn ())
+
+(* for_global *)
+let unit_for_global id =
+  let sym_label = Linkage_name.create (symbol_for_global id) in
+  Compilation_unit.create id sym_label

--- a/middle_end/base_types/compilation_unit.ml
+++ b/middle_end/base_types/compilation_unit.ml
@@ -6,7 +6,7 @@
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,83 +14,86 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
 open! Int_replace_polymorphic_compare
 
 type t = {
   id : Ident.t;
-  linkage_name : Linkage_name.t;  (* Why is this here? XXX *)
+  for_pack_prefix : string option;
   hash : int;
 }
-
-let string_for_printing t = Ident.name t.id
 
 include Identifiable.Make (struct
   type nonrec t = t
 
-  (* Multiple units can have the same [id] if they come from different packs.
-     To distinguish these we also keep the linkage name, which contains the
-     name of the pack. *)
-  let compare v1 v2 =
-    if v1 == v2 then 0
+  let compare
+        ({ id = id1; for_pack_prefix = for_pack_prefix1; hash = hash1; } as t1)
+        ({ id = id2; for_pack_prefix = for_pack_prefix2; hash = hash2; } as t2)
+        =
+    if t1 == t2 then 0
     else
-      let c = compare v1.hash v2.hash in
-      if c = 0 then
-        let v1_id = Ident.name v1.id in
-        let v2_id = Ident.name v2.id in
-        let c = String.compare v1_id v2_id in
-        if c = 0 then
-          Linkage_name.compare v1.linkage_name v2.linkage_name
+      let c = Stdlib.compare t1.hash t2.hash in
+      if c <> 0 then c
+      else
+        let c = String.compare (Ident.name t1.id) (Ident.name t2.id) in
+        if c <> 0 then c
         else
-          c
-      else c
+          Misc.Stdlib.Option.compare String.compare
+            t1.for_pack_prefix t2.for_pack_prefix
 
   let equal x y =
     if x == y then true
     else compare x y = 0
 
-  let print ppf t = Format.pp_print_string ppf (string_for_printing t)
+  let print ppf t = Format.pp_print_string ppf (Ident.name t.id)
+  let output oc t = output_string oc (Ident.name t.id)
 
-  let output oc x = output_string oc (Ident.name x.id)
-  let hash x = x.hash
+  let hash t = t.hash
 end)
 
-let create (id : Ident.t) linkage_name =
+let create ~for_pack_prefix name =
+  let id = Ident.create_persistent name in
   if not (Ident.persistent id) then begin
     Misc.fatal_error "Compilation_unit.create with non-persistent Ident.t"
   end;
-  { id; linkage_name; hash = Hashtbl.hash (Ident.name id); }
+  begin match for_pack_prefix with
+  | Some "" -> Misc.fatal_error "[for_pack_prefix] is [Some] but empty"
+  | None | Some _ -> ()
+  end;
+  { id;
+    for_pack_prefix;
+    hash = Hashtbl.hash (Ident.name id, for_pack_prefix);
+  }
 
-let current_unit_linkage_name () =
-  Linkage_name.create (make_symbol ~unitname:current_unit.ui_symbol None)
+let name t = Ident.name t.id
+let for_pack_prefix t = t.for_pack_prefix
 
-let runtime_and_external_libs =
-  create (Ident.create_persistent "*runtime*")
-    (Linkage_name.create "*runtime_or_external*")
+(* The string here must match the symbol names in the .S files in runtime/. *)
+let runtime_and_external_libs = create "_system"
 
-let startup =
-  create (Ident.create_persistent "caml_startup")
-    (Linkage_name.create "caml_startup")
+let startup = create "_startup"
+let shared_startup = create "_shared_startup"
 
-let get_persistent_ident cu = cu.id
-let get_linkage_name cu = cu.linkage_name
+let is_startup_or_shared_startup t =
+  equal t startup || equal t shared_startup
 
-let name t = Ident.name cu.id
+let predefined_exn = create "_predef_exn"
 
 let current = ref None
-let is_current arg =
+
+let is_current_exn arg =
   match !current with
-  | None -> Misc.fatal_error "Current compilation unit is not set!"
+  | None -> Misc.fatal_error "Current compilation unit is not set"
   | Some cur -> equal cur arg
+
 let set_current t = current := Some t
+
 let get_current () = !current
+
 let get_current_exn () =
   match !current with
   | Some current -> current
-  | None -> Misc.fatal_error "Compilation_unit.get_current_exn"
-let get_current_id_exn () = get_persistent_ident (get_current_exn ())
+  | None -> Misc.fatal_error "Current compilation unit is not set"
 
-(* for_global *)
-let unit_for_global id =
-  let sym_label = Linkage_name.create (symbol_for_global id) in
-  Compilation_unit.create id sym_label
+let get_current_id_exn () = get_persistent_ident (get_current_exn ())

--- a/middle_end/base_types/compilation_unit.mli
+++ b/middle_end/base_types/compilation_unit.mli
@@ -6,7 +6,7 @@
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -32,3 +32,29 @@ val get_current_exn : unit -> t
 val get_current_id_exn : unit -> Ident.t
 
 val string_for_printing : t -> string
+
+(** The name of the persistent identifier associated with the
+    compilation unit. *)
+val name : t -> string
+
+(** The compilation unit for entities defined in the startup file for
+    an executable. *)
+val startup : t
+
+(** The compilation unit for entities defined in the startup file for
+    a shared_library. *)
+val shared_startup : t
+
+(** Returns [true] iff the supplied compilation unit corresponds either to the
+    startup or shared startup file. *)
+val is_startup_or_shared_startup : t -> bool
+
+(** The compilation unit for entities defined in the C runtime code or other
+    external libraries. *)
+(* XXX Looks like this will need to be called "_system" *)
+val runtime_and_external_libs : t
+
+(** The compilation unit for predefined exception values. *)
+val predefined_exn : t
+
+val for_global : Ident.t -> t

--- a/middle_end/base_types/compilation_unit.mli
+++ b/middle_end/base_types/compilation_unit.mli
@@ -6,7 +6,7 @@
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,28 +14,48 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+(** The name of a "compilation unit" along with any "-for-pack" prefix that
+    was specified when the unit was compiled.  By "compilation unit" we
+    usually mean the code and data associated with the compilation of a
+    single .ml source file.  However some compilation units may correspond to
+    other "virtual" groupings of code and data, for example those forming
+    part of the runtime, or external libraries. *)
 
-include Identifiable.S
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
-(* The [Ident.t] must be persistent.  This function raises an exception
-   if that is not the case. *)
-val create : Ident.t -> Linkage_name.t -> t
+(** The type of compilation unit names. *)
+type t
 
-val get_persistent_ident : t -> Ident.t
-val get_linkage_name : t -> Linkage_name.t
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
 
-val is_current : t -> bool
+(** Create a compilation unit with the given [name] (which is not encoded or
+    mangled in any way) and an optional "-for-pack" prefix. *)
+val create : ?for_pack_prefix:string -> name:string -> t
+
+(** Whether the specified compilation unit is that of the current unit
+    being compiled.  An exception will be raised if [set_current] has not
+    previously been called. *)
+val is_current_exn : t -> bool
+
+(** Record that the given value of type [t] is that of the current unit being
+    compiled. *)
 val set_current : t -> unit
-val get_current : unit -> t option
+
+(** Get the value of type [t] corresponding to the current unit being
+    compiled.  An exception will be raised if [set_current] has not
+    previously been called. *)
 val get_current_exn : unit -> t
-val get_current_id_exn : unit -> Ident.t
 
-val string_for_printing : t -> string
+(** Like [get_current_exn], but returns an option instead of raising an
+    exception. *)
+val get_current : unit -> t option
 
-(** The name of the persistent identifier associated with the
-    compilation unit. *)
+(** The name of the compilation unit, excluding any [for_pack_prefix]. *)
 val name : t -> string
+
+(** Any [for_pack_prefix] specified to [create]. *)
+val for_pack_prefix : t -> string option
 
 (** The compilation unit for entities defined in the startup file for
     an executable. *)
@@ -51,10 +71,7 @@ val is_startup_or_shared_startup : t -> bool
 
 (** The compilation unit for entities defined in the C runtime code or other
     external libraries. *)
-(* XXX Looks like this will need to be called "_system" *)
 val runtime_and_external_libs : t
 
 (** The compilation unit for predefined exception values. *)
 val predefined_exn : t
-
-val for_global : Ident.t -> t

--- a/middle_end/base_types/symbol.ml
+++ b/middle_end/base_types/symbol.ml
@@ -103,3 +103,40 @@ let print_opt ppf = function
 
 let compare_lists l1 l2 =
   Misc.Stdlib.List.compare compare l1 l2
+
+
+let predefined_exception_compilation_unit =
+  Compilation_unit.create (Ident.create_persistent "__dummy__")
+    (Linkage_name.create "__dummy__")
+
+let is_predefined_exception sym =
+  Compilation_unit.equal
+    predefined_exception_compilation_unit
+    (Symbol.compilation_unit sym)
+
+(* of_global *)
+let symbol_for_global' id =
+  let sym_label = Linkage_name.create (symbol_for_global id) in
+  if Ident.is_predef id then
+    Symbol.of_global_linkage predefined_exception_compilation_unit sym_label
+  else
+    Symbol.of_global_linkage (unit_for_global id) sym_label
+
+let current_unit_symbol () =
+  Symbol.of_global_linkage (current_unit ()) (current_unit_linkage_name ())
+
+(* this is the base name one
+let symbolname_for_pack pack name =
+  match pack with
+  | None -> name
+  | Some p ->
+      let b = Buffer.create 64 in
+      for i = 0 to String.length p - 1 do
+        match p.[i] with
+        | '.' -> Buffer.add_string b "__"
+        |  c  -> Buffer.add_char b c
+      done;
+      Buffer.add_string b "__";
+      Buffer.add_string b name;
+      Buffer.contents b
+*)

--- a/middle_end/base_types/symbol.ml
+++ b/middle_end/base_types/symbol.ml
@@ -6,7 +6,7 @@
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -15,8 +15,8 @@
 (**************************************************************************)
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
-open! Int_replace_polymorphic_compare
 
+open! Int_replace_polymorphic_compare
 
 type t =
   | Linkage of
@@ -104,15 +104,8 @@ let print_opt ppf = function
 let compare_lists l1 l2 =
   Misc.Stdlib.List.compare compare l1 l2
 
-
-let predefined_exception_compilation_unit =
-  Compilation_unit.create (Ident.create_persistent "__dummy__")
-    (Linkage_name.create "__dummy__")
-
-let is_predefined_exception sym =
-  Compilation_unit.equal
-    predefined_exception_compilation_unit
-    (Symbol.compilation_unit sym)
+let is_predefined_exn t =
+  Compilation_unit.equal (compilation_unit t) Compilation_unit.predefined_exn
 
 (* of_global *)
 let symbol_for_global' id =

--- a/middle_end/base_types/symbol.mli
+++ b/middle_end/base_types/symbol.mli
@@ -30,6 +30,17 @@ include Identifiable.S
 
 val of_variable : Variable.t -> t
 
+val of_global : Ident.t -> t
+
+(* used to be Compilenv.symbolname_for_pack, not make_symbol *)
+(* can't go in Compilation_unit.t due to dep *)
+val base_symbol_for_unit
+   : ?for_pack_prefix:string
+  -> Compilation_unit.t
+  -> t
+
+val to_string : t -> string
+
 (* Create the symbol without prefixing with the compilation unit.
    Used for global symbols like predefined exceptions *)
 val of_global_linkage : Compilation_unit.t -> Linkage_name.t -> t
@@ -42,3 +53,5 @@ val label : t -> Linkage_name.t
 val print_opt : Format.formatter -> t option -> unit
 
 val compare_lists : t list -> t list -> int
+
+val is_predefined_exception : t -> bool

--- a/middle_end/base_types/symbol.mli
+++ b/middle_end/base_types/symbol.mli
@@ -6,7 +6,7 @@
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -16,42 +16,43 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-(** A symbol identifies a constant provided by either:
-    - another compilation unit; or
-    - a top-level module.
+(** Middle-end symbols: names of statically-allocated constants.  These
+    symbols are used inside Closure and Flambda.  They always point at
+    well-formed OCaml values in a data section, never at code. *)
 
-    * [sym_unit] is the compilation unit containing the value.
-    * [sym_label] is the linkage name of the variable.
+(** The type of middle-end symbols. *)
+type t
 
-    The label must be globally unique: two compilation units linked in the
-    same program must not share labels. *)
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
 
-include Identifiable.S
-
-val of_variable : Variable.t -> t
-
-val of_global : Ident.t -> t
-
-(* used to be Compilenv.symbolname_for_pack, not make_symbol *)
-(* can't go in Compilation_unit.t due to dep *)
-val base_symbol_for_unit
-   : ?for_pack_prefix:string
-  -> Compilation_unit.t
-  -> t
-
-val to_string : t -> string
-
-(* Create the symbol without prefixing with the compilation unit.
-   Used for global symbols like predefined exceptions *)
-val of_global_linkage : Compilation_unit.t -> Linkage_name.t -> t
-
-val import_for_pack : pack:Compilation_unit.t -> t -> t
-
-val compilation_unit : t -> Compilation_unit.t
-val label : t -> Linkage_name.t
-
+(** Like [print], but for values of type [t option]. *)
 val print_opt : Format.formatter -> t option -> unit
 
-val compare_lists : t list -> t list -> int
+(** Create a symbol to correspond to a pre-existing Flambda variable. *)
+val of_variable : Variable.t -> t
 
-val is_predefined_exception : t -> bool
+(** Create a symbol to correspond to the given identifier, which must be
+    persistent, in the current (or given) compilation unit. *)
+val of_global : ?compilation_unit:Compilation_unit.t -> Ident.t -> t
+
+(** Return the "base symbol" for the given compilation unit.  This takes into
+    account any "-for-pack" prefix.  The base symbol will be the same as the
+    symbol used for the compilation unit's toplevel module block; and will
+    form the prefix of other symbols (for example those of functions and
+    data) within the compilation unit. *)
+val base_symbol_for_unit : Compilation_unit.t -> t
+
+(** Adjust the given symbol's compilation unit to that specified by [pack]. *)
+(* CR mshinwell: check usage of this *)
+val import_for_pack : t -> pack:Compilation_unit.t -> t
+
+(** The compilation unit in which the given symbol's definition lies. *)
+val compilation_unit : t -> Compilation_unit.t
+
+(** Whether the given symbol is that of a predefined exception. *)
+val is_predefined_exn : t -> bool
+
+(** The name of the symbol as to be used for construction of [Backend_sym.t]
+    values. *)
+val name_for_backend : t -> string

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -78,6 +78,7 @@ CAMLC = $(CAMLRUN) $(ROOTDIR)/boot/ocamlc -g -nostdlib -I $(ROOTDIR)/boot \
 CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt -g -nostdlib -I $(ROOTDIR)/stdlib
 CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp asmcomp \
+                       asmcomp/asm_target \
                        middle_end middle_end/base_types driver toplevel)
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
  -safe-string -strict-formats -bin-annot $(INCLUDES)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -329,6 +329,7 @@ OBJINFO=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
         $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
         $(ROOTDIR)/compilerlibs/ocamlmiddleend.cma \
         $(ROOTDIR)/asmcomp/backend_var.cmo \
+        $(ROOTDIR)/asmcomp/backend_sym.cmo \
         $(ROOTDIR)/asmcomp/printclambda.cmo \
         $(ROOTDIR)/asmcomp/export_info.cmo \
         objinfo.cmo

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -149,10 +149,7 @@ let print_cmx_infos (ui, crc) =
     else
       printf "Flambda unit\n";
     if not !no_approx then begin
-      let cu =
-        Compilation_unit.create (Ident.create_persistent ui.ui_name)
-          (Linkage_name.create "__dummy__")
-      in
+      let cu = Compilation_unit.create ui.ui_name in
       Compilation_unit.set_current cu;
       let root_symbols =
         List.map (fun s ->

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -40,7 +40,7 @@ let global_symbol id =
   with _ -> fatal_error ("Opttoploop.global_symbol " ^ (Ident.unique_name id))
 
 let need_symbol sym =
-  try ignore (ndl_loadsym sym); false
+  try ignore (ndl_loadsym (Backend_sym.to_string sym)); false
   with _ -> true
 
 let dll_run dll entry =

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -91,14 +91,14 @@ and cmo_magic_number = "Caml1999O023"
 and cma_magic_number = "Caml1999A023"
 and cmx_magic_number =
   if flambda then
-    "Caml1999y023"
+    "Caml1999y024"
   else
-    "Caml1999Y023"
+    "Caml1999Y024"
 and cmxa_magic_number =
   if flambda then
-    "Caml1999z023"
+    "Caml1999z024"
   else
-    "Caml1999Z023"
+    "Caml1999Z024"
 and ast_impl_magic_number = "Caml1999M023"
 and ast_intf_magic_number = "Caml1999N023"
 and cmxs_magic_number = "Caml1999D023"

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -166,6 +166,13 @@ module Stdlib = struct
       | None -> false
       | Some _ -> true
 
+    let compare f t1 t2 =
+      match t1, t2 with
+      | None, None -> 0
+      | None, Some _ -> -1
+      | Some _, None -> 1
+      | Some contents1, Some contents2 -> f contents1 contents2
+
     let equal eq o1 o2 =
       match o1, o2 with
       | None, None -> true

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -189,6 +189,11 @@ module Stdlib = struct
       match a with
       | None -> default
       | Some a -> f a
+
+    let (>>=) t f =
+      match t with
+      | None -> None
+      | Some x -> f x
   end
 
   module Array = struct

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -131,6 +131,8 @@ module Stdlib : sig
     val map : ('a -> 'b) -> 'a t -> 'b t
     val fold : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
     val value_default : ('a -> 'b) -> default:'b -> 'a t -> 'b
+
+    val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
   end
 
   module Array : sig

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -125,6 +125,7 @@ module Stdlib : sig
     val is_none : 'a t -> bool
     val is_some : 'a t -> bool
 
+    val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
     val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
     val iter : ('a -> unit) -> 'a t -> unit

--- a/utils/numbers.ml
+++ b/utils/numbers.ml
@@ -36,6 +36,8 @@ end
 module Int8 = struct
   type t = int
 
+  let print ppf t = Format.pp_print_int ppf t
+
   let zero = 0
   let one = 1
 
@@ -50,6 +52,10 @@ end
 
 module Int16 = struct
   type t = int
+
+  let zero = 0
+
+  let print ppf t = Format.pp_print_int ppf t
 
   let of_int_exn i =
     if i < -(1 lsl 15) || i > ((1 lsl 15) - 1) then
@@ -69,6 +75,124 @@ module Int16 = struct
       Int64.to_int i
 
   let to_int t = t
+end
+
+module Uint8 = struct
+  type t = int
+
+  let print ppf t = Format.pp_print_int ppf t
+
+  let zero = 0
+  let one = 1
+
+  let of_int_exn i =
+    if i < 0 || i > ((1 lsl 8) - 1) then
+      Misc.fatal_errorf "Uint8.of_int_exn: %d is out of range" i
+    else
+      i
+
+  let to_int i = i
+end
+
+module Uint16 = struct
+  type t = int
+
+  let print ppf t = Format.pp_print_int ppf t
+
+  let of_int_exn i =
+    if i < 0 || i > ((1 lsl 16) - 1) then
+      Misc.fatal_errorf "Uint16.of_int_exn: %d is out of range" i
+    else
+      i
+
+  let upper_int64 = Int64.sub (Int64.shift_left Int64.one 16) Int64.one
+
+  let of_int64_exn i =
+    if Int64.compare i 0L < 0
+        || Int64.compare i upper_int64 > 0
+    then
+      Misc.fatal_errorf "Uint16.of_int64_exn: %Ld is out of range" i
+    else
+      Int64.to_int i
+
+  let to_int t = t
+end
+
+module Uint32 = struct
+  type t = Int64.t
+
+  let zero = 0L
+
+  let print ppf t = Format.fprintf ppf "0x%Lx" t
+
+  let upper_int64 = Int64.sub (Int64.shift_left Int64.one 32) Int64.one
+
+  let of_int_exn (i : int) =
+    if i < 0 then
+      Misc.fatal_errorf "Uint32.of_int_exn: %d is out of range" i
+    else
+      let i64 = Int64.of_int i in
+      if Int64.compare i64 upper_int64 > 0 then
+        Misc.fatal_errorf "Uint32.of_int_exn: %d is out of range" i
+      else
+        i64
+
+  let of_int64_exn i =
+    if Int64.compare i 0L < 0
+        || Int64.compare i upper_int64 > 0
+    then
+      Misc.fatal_errorf "Uint32.of_int64_exn: %Ld is out of range" i
+    else
+      i
+
+  let of_int32 i =
+    if Int32.compare i 0l < 0 then
+      Misc.fatal_errorf "Uint32.of_int64_exn: %ld is out of range" i
+    else
+      Int64.of_int32 i
+
+  let to_int64 t = t
+end
+
+module Uint64 = struct
+  type t = Int64.t
+
+  let zero = 0L
+
+  let succ t = Int64.add 1L t
+
+  let of_int_exn i =
+    if i < 0 then
+      Misc.fatal_errorf "Uint64.of_int_exn: %d is out of range" i
+    else
+      Int64.of_int i
+
+  let of_uint8 i = Int64.of_int i
+  let of_uint16 i = Int64.of_int i
+  let of_uint32 i = i
+
+  let of_int32_exn i =
+    if Int32.compare i 0l < 0 then
+      Misc.fatal_errorf "Uint64.of_int64_exn: %ld is out of range" i
+    else
+      Int64.of_int32 i
+
+  let of_int64_exn i =
+    if Int64.compare i 0L < 0 then
+      Misc.fatal_errorf "Uint64.of_int64_exn: %Ld is out of range" i
+    else
+      i
+
+  let to_int64 t = t
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+    let compare t1 t2 = Stdlib.compare t1 t2
+    let equal t1 t2 = (compare t1 t2 = 0)
+    let hash t = Hashtbl.hash t
+    let print ppf t = Format.fprintf ppf "0x%Lx" t
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
 end
 
 module Float = struct

--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -31,6 +31,8 @@ end
 module Int8 : sig
   type t
 
+  val print : Format.formatter -> t -> unit
+
   val zero : t
   val one : t
 
@@ -41,10 +43,74 @@ end
 module Int16 : sig
   type t
 
+  val print : Format.formatter -> t -> unit
+
+  val zero : t
+
   val of_int_exn : int -> t
   val of_int64_exn : Int64.t -> t
 
   val to_int : t -> int
+end
+
+(** Do not use polymorphic comparison on the unsigned integer types. *)
+
+module Uint8 : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val zero : t
+  val one : t
+
+  val of_int_exn : int -> t
+  val to_int : t -> int
+end
+
+module Uint16 : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val of_int_exn : int -> t
+  val of_int64_exn : Int64.t -> t
+
+  val to_int : t -> int
+end
+
+module Uint32 : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val zero : t
+
+  val of_int_exn : int -> t
+  val of_int32 : Int32.t -> t
+  val of_int64_exn : Int64.t -> t
+
+  val to_int64 : t -> Int64.t
+end
+
+module Uint64 : sig
+  type t
+
+  val zero : t
+
+  val succ : t -> t
+
+  val of_int_exn : int -> t
+
+  val of_uint8 : Uint8.t -> t
+  val of_uint16 : Uint16.t -> t
+  val of_uint32 : Uint32.t -> t
+
+  val of_int32_exn : Int32.t -> t
+  val of_int64_exn : Int64.t -> t
+
+  val to_int64 : t -> Int64.t
+
+  include Identifiable.S with type t := t
 end
 
 module Float : Identifiable.S with type t = float


### PR DESCRIPTION
This is a reworked version of a subset of GPR#756.  Originally, this work started from the work of @lefessan in the x86 backends.

The intention here is to provide a cross-platform abstraction that insulates us from the vagaries of the semantics of platform-specific assemblers when it comes to emitting directives (as opposed to instructions).  This is particularly important for the forthcoming DWARF support which relies on some tricky constructions for measuring distances within object files.

For the moment I am only proposing to use this abstraction for the DWARF emitter.  In the longer term, as showed on GPR#756, this abstraction can significantly reduce the amount of nearly-similar code that is duplicated across all of the assembly emitters at the present time.  Future work should also include the provision of distinguished types for representing symbols and symbol references with relocation information attached, rather than just using `string`.

For the moment however I think a level of scrutiny commensurate with that which I discussed in #2069 is appropriate.  This module does implement more than is required for the DWARF support since I don't think it is a good use of time to carefully cut out the other parts and then resurrect them later.

This module depends on knowing specific details about the target system which is provided by a new `Target_system` module.  This in turn is tightly coupled to the details of one part of the `configure` script and may need to be adapted for autoconf.  I think it would be valuable (@shindere), when thinking about the autoconf work, to actually start from `Target_system` and use that almost as a template for the system detection in `configure`.  If you look closely at the configure script at the moment, you'll see that there are various inconsistencies (for example all ARM BSDs being OpenBSD), which we should try to avoid in future.  These inconsistencies show up very easily when you see how the script's detection is reflected in `Target_system`.

@damiendoligez I wonder if you would be able to review this?  I haven't yet re-tested this since the previous version; I've changed various things to improve the code since then.  However I think a first pass of review would be sensible now.  Once that has been done the remaining pull requests for gdb will hopefully be well on the way, and it will be easier to put together a working system again to test this.

One particular point that should be borne in mind when reviewing is that issues surrounding numbers can be confusing here.  There are two concepts in play: the width of a particular integer provided by the user for writing out (all such integers being treated as signed; we should maybe provide unsigned versions in the future); and the number of bytes that such integer is able to occupy (possibly padded) in the object file.  I would appreciate particular care during review that I haven't messed something up there, because it's easy to do.

As another hint for review, the details concerning particular flags and arguments for "section" directives and the like can be checked against the existing assembly emitters.