### PR TITLE
Add Targetint.print

### DIFF
--- a/Changes
+++ b/Changes
@@ -407,6 +407,9 @@ Working version
   use [Backend_var.With_provenance] for variables in binding position.
   (Mark Shinwell, review by Pierre Chambart)
 
+- GPR#2076: Add [Targetint.print].
+  (Mark Shinwell)
+
 ### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the

--- a/utils/targetint.ml
+++ b/utils/targetint.ml
@@ -55,6 +55,7 @@ module type S = sig
   val compare: t -> t -> int
   val equal: t -> t -> bool
   val repr: t -> repr
+  val print : Format.formatter -> t -> unit
 end
 
 let size = Sys.word_size
@@ -80,6 +81,7 @@ module Int32 = struct
   let of_int64 = Int64.to_int32
   let to_int64 = Int64.of_int32
   let repr x = Int32 x
+  let print ppf t = Format.fprintf ppf "%ld" t
 end
 
 module Int64 = struct
@@ -88,6 +90,7 @@ module Int64 = struct
   let of_int64 x = x
   let to_int64 x = x
   let repr x = Int64 x
+  let print ppf t = Format.fprintf ppf "%Ld" t
 end
 
 include (val

--- a/utils/targetint.mli
+++ b/utils/targetint.mli
@@ -190,3 +190,6 @@ type repr =
 
 val repr : t -> repr
 (** The concrete representation of a native integer. *)
+
+val print : Format.formatter -> t -> unit
+(** Print a target integer to a formatter. *)


### PR DESCRIPTION
This patch adds support for printing values of type `Targetint.t` to formatters.