### PR TITLE
Emacs: use symbol boundaries in regular expressions

### DIFF
--- a/Changes
+++ b/Changes
@@ -247,6 +247,10 @@ Working version
   fixes an imenu crash.
   (Wilfred Hughes, review by Christophe Troestler)
 
+- MPR#7850: Emacs, use symbol boundaries in regular expressions,
+  fixes an imenu crash.
+  (Wilfred Hughes, review by Christophe Troestler)
+
 - GPR#1711: the new 'open' flag in OCAMLRUNPARAM takes a comma-separated list of
   modules to open as if they had been passed via the command line -open flag.
   (Nicolás Ojeda Bär, review by Mark Shinwell)

--- a/emacs/caml.el
+++ b/emacs/caml.el
@@ -461,7 +461,7 @@ have caml-electric-indent on, which see.")
 (make-variable-buffer-local 'caml-imenu-shown)
 
 (defconst caml-imenu-search-regexp
-  (concat "\\<in\\>\\|"
+  (concat "\\_<in\\_>\\|"
           "^[ \t]*\\(let\\|class\\|type\\|m\\(odule\\|ethod\\)"
           "\\|functor\\|and\\|val\\)[ \t]+"
           "\\(\\('[a-zA-Z0-9]+\\|([^)]+)"
@@ -935,8 +935,8 @@ whole string."
 ;didn't seem right to me.
 
 (defconst caml-phrase-start-keywords
-  (concat "\\<\\(class\\|ex\\(ternal\\|ception\\)\\|functor"
-          "\\|let\\|module\\|open\\|type\\|val\\)\\>")
+  (concat "\\_<\\(class\\|ex\\(ternal\\|ception\\)\\|functor"
+          "\\|let\\|module\\|open\\|type\\|val\\)\\_>")
   "Keywords starting phrases in files")
 
 ;; a phrase starts when a toplevel keyword is at the beginning of a line
@@ -1102,12 +1102,12 @@ Returns nil for the parenthesis opening a comment."
 ;; Various constants and regexps
 
 (defconst caml-before-expr-prefix
-  (concat "\\<\\(asr\\|begin\\|class\\|do\\(wnto\\)?\\|else"
+  (concat "\\_<\\(asr\\|begin\\|class\\|do\\(wnto\\)?\\|else"
           "\\|i\\(f\\|n\\(herit\\|itializer\\)?\\)"
           "\\|f\\(or\\|un\\(ct\\(ion\\|or\\)\\)?\\)"
           "\\|l\\(and\\|or\\|s[lr]\\|xor\\)\\|m\\(atch\\|od\\)"
           "\\|o[fr]\\|parser\\|s\\(ig\\|truct\\)\\|t\\(hen\\|o\\|ry\\)"
-          "\\|w\\(h\\(en\\|ile\\)\\|ith\\)\\)\\>\\|:begin\\>"
+          "\\|w\\(h\\(en\\|ile\\)\\|ith\\)\\)\\_>\\|:begin\\_>"
           "\\|[=<>@^|&+-*/$%][!$%*+-./:<=>?@^|~]*\\|:[:=]\\|[[({,;]")
 
   "Keywords that may appear immediately before an expression.
@@ -1115,8 +1115,8 @@ Used to distinguish it from toplevel let construct.")
 
 (defconst caml-matching-kw-regexp
   (concat
-   "\\<\\(and\\|do\\(ne\\|wnto\\)?\\|e\\(lse\\|nd\\)\\|in\\|t\\(hen\\|o\\)"
-   "\\|with\\)\\>\\|[^[|]|")
+   "\\_<\\(and\\|do\\(ne\\|wnto\\)?\\|e\\(lse\\|nd\\)\\|in\\|t\\(hen\\|o\\)"
+   "\\|with\\)\\_>\\|[^[|]|")
   "Regexp used in caml mode for skipping back over nested blocks.")
 
 (defconst caml-matching-kw-alist
@@ -1270,17 +1270,17 @@ the line where the governing keyword occurs.")
 
 (aset caml-kwop-regexps 0
       (concat
-       "\\<\\(begin\\|object\\|for\\|s\\(ig\\|truct\\)\\|while\\)\\>"
+       "\\_<\\(begin\\|object\\|for\\|s\\(ig\\|truct\\)\\|while\\)\\_>"
        "\\|:begin\\>\\|[[({]\\|;;"))
 (aset caml-kwop-regexps 1
-      (concat (aref caml-kwop-regexps 0) "\\|\\<\\(class\\|module\\)\\>"))
+      (concat (aref caml-kwop-regexps 0) "\\|\\_<\\(class\\|module\\)\\_>"))
 (aset caml-kwop-regexps 2
       (concat
        (aref caml-kwop-regexps 1)
-       "\\|\\<\\(fun\\(ction\\)?\\|initializer\\|let\\|m\\(atch\\|ethod\\)"
-       "\\|parser\\|try\\|val\\)\\>\\|->"))
+       "\\|\\_<\\(fun\\(ction\\)?\\|initializer\\|let\\|m\\(atch\\|ethod\\)"
+       "\\|parser\\|try\\|val\\)\\_>\\|->"))
 (aset caml-kwop-regexps 3
-      (concat (aref caml-kwop-regexps 2) "\\|\\<if\\|when\\>"))
+      (concat (aref caml-kwop-regexps 2) "\\|\\_<if\\|when\\_>"))
 (aset caml-kwop-regexps 4
       (concat (aref caml-kwop-regexps 3) "\\|:=\\|<-"))
 (aset caml-kwop-regexps 5
@@ -1290,17 +1290,17 @@ the line where the governing keyword occurs.")
 (aset caml-kwop-regexps 7
       (concat
        (aref caml-kwop-regexps 0)
-       "\\|\\<\\(constraint\\|exception\\|in\\(herit\\|clude\\)"
-       "\\|o\\(f\\|pen\\)\\|type\\|val\\)\\>"))
+       "\\|\\_<\\(constraint\\|exception\\|in\\(herit\\|clude\\)"
+       "\\|o\\(f\\|pen\\)\\|type\\|val\\)\\_>"))
 (aset caml-kwop-regexps 8
       (concat (aref caml-kwop-regexps 6)
-       "\\|\\<\\(constraint\\|exception\\|in\\(herit\\|clude\\)"
-       "\\|o\\(f\\|pen\\)\\|type\\)\\>"))
+              "\\|\\_<\\(constraint\\|exception\\|in\\(herit\\|clude\\)"
+              "\\|o\\(f\\|pen\\)\\|type\\)\\>"))
 
 (defun caml-find-done-match ()
   (let ((unbalanced 1) (kwop t))
     (while (and (not (= 0 unbalanced)) kwop)
-      (setq kwop (caml-find-kwop "\\<\\(done\\|for\\|while\\)\\>"))
+      (setq kwop (caml-find-kwop "\\_<\\(done\\|for\\|while\\)\\_>"))
       (cond
        ((not kwop))
        ((string= kwop "done") (setq unbalanced (1+ unbalanced)))
@@ -1312,7 +1312,7 @@ the line where the governing keyword occurs.")
     (while (and (not (= 0 unbalanced)) kwop)
       (setq kwop
             (caml-find-kwop
-             "\\<\\(end\\|begin\\|object\\|s\\(ig\\|truct\\)\\)\\>\\|:begin\\>\\|;;"))
+             "\\_<\\(end\\|begin\\|object\\|s\\(ig\\|truct\\)\\)\\_>\\|:begin\\_>\\|;;"))
       (cond
        ((not kwop))
        ((string= kwop ";;") (setq kwop nil) (forward-line 1))
@@ -1324,7 +1324,7 @@ the line where the governing keyword occurs.")
 (defun caml-find-in-match ()
   (let ((unbalanced 1) (kwop t))
     (while (and (not (= 0 unbalanced)) kwop)
-      (setq kwop (caml-find-kwop "\\<\\(in\\|let\\|end\\)\\>"))
+      (setq kwop (caml-find-kwop "\\_<\\(in\\|let\\|end\\)\\_>"))
       (cond
        ((not kwop))
        ((string= kwop "end") (caml-find-end-match))
@@ -1336,8 +1336,8 @@ the line where the governing keyword occurs.")
   (let ((unbalanced 1) (kwop t))
     (while (and (not (= 0 unbalanced)) kwop)
       (setq kwop
-        (caml-find-kwop
-         "\\<\\(with\\|try\\|m\\(atch\\|odule\\)\\|functor\\)\\>\\|[{}()]"))
+            (caml-find-kwop
+             "\\_<\\(with\\|try\\|m\\(atch\\|odule\\)\\|functor\\)\\_>\\|[{}()]"))
       (cond
        ((not kwop))
        ((caml-at-sexp-close-p)
@@ -1371,7 +1371,7 @@ the line where the governing keyword occurs.")
     (while (not done)
       (setq kwop
             (caml-find-kwop
-             "\\<\\(e\\(nd\\|lse\\)\\|done\\|then\\|if\\|with\\)\\>\\|[])};]"))
+             "\\_<\\(e\\(nd\\|lse\\)\\|done\\|then\\|if\\|with\\)\\_>\\|[])};]"))
       (cond
        ((not kwop) (setq done t))
        ((caml-at-sexp-close-p)
@@ -1388,8 +1388,8 @@ the line where the governing keyword occurs.")
 (defun caml-find-pipe-match ()
   (let ((done nil) (kwop)
         (re (concat
-             "\\<\\(try\\|match\\|with\\|function\\|parser\\|type"
-             "\\|e\\(nd\\|lse\\)\\|done\\|then\\|in\\)\\>"
+             "\\_<\\(try\\|match\\|with\\|function\\|parser\\|type"
+             "\\|e\\(nd\\|lse\\)\\|done\\|then\\|in\\)\\_>"
              "\\|[^[|]|\\|[])}]")))
     (while (not done)
       (setq kwop (caml-find-kwop re))
@@ -1405,7 +1405,7 @@ the line where the governing keyword occurs.")
         (setq kwop (caml-find-with-match))
         (setq done t))
        ((string= kwop "parser")
-        (if (re-search-backward "\\<with\\>" (- (point) 5) t)
+        (if (re-search-backward "\\_<with\\_>" (- (point) 5) t)
             (setq kwop (caml-find-with-match)))
         (setq done t))
        ((string= kwop "done") (caml-find-done-match))
@@ -1420,7 +1420,7 @@ the line where the governing keyword occurs.")
   (let ((done nil) (kwop))
     (while (not done)
       (setq kwop (caml-find-kwop
-                  "\\<\\(object\\|exception\\|let\\|type\\|end\\|in\\)\\>"))
+                  "\\_<\\(object\\|exception\\|let\\|type\\|end\\|in\\)\\_>"))
       (cond
        ((not kwop) (setq done t))
        ((string= kwop "end") (caml-find-end-match))
@@ -1468,7 +1468,7 @@ the line where the governing keyword occurs.")
                (setq kwop "let-in")
                (setq done t))))
        ((and (string= kwop "parser") (>= prio 2)
-             (re-search-backward "\\<with\\>" (- (point) 5) t))
+             (re-search-backward "\\_<with\\_>" (- (point) 5) t))
         (setq kwop (caml-find-with-match))
         (setq done t))
        ((setq matching-fun (cdr-safe (assoc kwop caml-matching-kw-alist)))
@@ -1536,7 +1536,7 @@ Does not preserve point."
            (t
             (let ((pos (point)))
               (back-to-indentation)
-;             (if (looking-at "\\<let\\>") (goto-char pos))
+;             (if (looking-at "\\_<let\\_>") (goto-char pos))
               (- (symbol-value (nth 3 kwop-info))
                  (if (looking-at "|") caml-|-extra-indent 0))))))
          (extra (if in-expr caml-apply-extra-indent 0)))
@@ -1544,8 +1544,8 @@ Does not preserve point."
 
 (defconst caml-leading-kwops-regexp
   (concat
-   "\\<\\(and\\|do\\(ne\\|wnto\\)?\\|e\\(lse\\|nd\\)\\|in"
-   "\\|t\\(hen\\|o\\)\\|with\\)\\>\\|[]|})]")
+   "\\_<\\(and\\|do\\(ne\\|wnto\\)?\\|e\\(lse\\|nd\\)\\|in"
+   "\\|t\\(hen\\|o\\)\\|with\\)\\_>\\|[]|})]")
 
   "Regexp matching caml keywords which need special indentation.")
 


### PR DESCRIPTION
`\<` is a word boundary, whereas `\_<` is a symbol boundary. Word boundaries meant that we got confused by variables like `in_foo` or `end_foo`.

This crashed imenu on files that contain variables with names of this form.

Fixes
https://github.com/ocaml/tuareg/issues/190
https://caml.inria.fr/mantis/view.php?id=7850