### PR TITLE
Avoid page table lookup in Pervasives.compare with no-naked-pointers

### DIFF
--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -133,7 +133,8 @@ static intnat do_compare_val(struct compare_stack* stk,
         return Long_val(v1) - Long_val(v2);
       /* Subtraction above cannot overflow and cannot result in UNORDERED */
 #ifndef NO_NAKED_POINTERS
-      if (Is_in_value_area(v2)) {
+      if (!Is_in_value_area(v2))
+        return LESS;
 #endif
         switch (Tag_val(v2)) {
         case Forward_tag:
@@ -151,14 +152,12 @@ static intnat do_compare_val(struct compare_stack* stk,
         }
         default: /*fallthrough*/;
         }
-#ifndef NO_NAKED_POINTERS
-      }
-#endif
       return LESS;                /* v1 long < v2 block */
     }
     if (Is_long(v2)) {
 #ifndef NO_NAKED_POINTERS
-      if (Is_in_value_area(v1)) {
+      if (!Is_in_value_area(v1))
+        return GREATER;
 #endif
         switch (Tag_val(v1)) {
         case Forward_tag:
@@ -176,9 +175,6 @@ static intnat do_compare_val(struct compare_stack* stk,
         }
         default: /*fallthrough*/;
         }
-#ifndef NO_NAKED_POINTERS
-      }
-#endif
       return GREATER;            /* v1 block > v2 long */
     }
 #ifndef NO_NAKED_POINTERS

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -132,7 +132,9 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (Is_long(v2))
         return Long_val(v1) - Long_val(v2);
       /* Subtraction above cannot overflow and cannot result in UNORDERED */
+#ifndef NO_NAKED_POINTERS
       if (Is_in_value_area(v2)) {
+#endif
         switch (Tag_val(v2)) {
         case Forward_tag:
           v2 = Forward_val(v2);
@@ -149,11 +151,15 @@ static intnat do_compare_val(struct compare_stack* stk,
         }
         default: /*fallthrough*/;
         }
+#ifndef NO_NAKED_POINTERS
       }
+#endif
       return LESS;                /* v1 long < v2 block */
     }
     if (Is_long(v2)) {
+#ifndef NO_NAKED_POINTERS
       if (Is_in_value_area(v1)) {
+#endif
         switch (Tag_val(v1)) {
         case Forward_tag:
           v1 = Forward_val(v1);
@@ -170,9 +176,12 @@ static intnat do_compare_val(struct compare_stack* stk,
         }
         default: /*fallthrough*/;
         }
+#ifndef NO_NAKED_POINTERS
       }
+#endif
       return GREATER;            /* v1 block > v2 long */
     }
+#ifndef NO_NAKED_POINTERS
     /* If one of the objects is outside the heap (but is not an atom),
        use address comparison. Since both addresses are 2-aligned,
        shift lsb off to avoid overflow in subtraction. */
@@ -181,6 +190,7 @@ static intnat do_compare_val(struct compare_stack* stk,
       return (v1 >> 1) - (v2 >> 1);
       /* Subtraction above cannot result in UNORDERED */
     }
+#endif
     t1 = Tag_val(v1);
     t2 = Tag_val(v2);
     if (t1 == Forward_tag) { v1 = Forward_val (v1); continue; }


### PR DESCRIPTION
__Background__

OCaml values are either (a) immediates (b) pointers into the OCaml heap, or (c) pointers to some off-heap data. The (c) case is also known as foreign or naked pointers.

To accommodate these naked pointers, the runtime takes care to look up addresses in the page table. On 64-bit architectures, the page table is implemented as a hash table.

There is a configure-time `--no-naked-pointers` option, which disables these page table lookups in the garbage collector. However, even with this option enabled, `Pervasives.compare` will still perform page table lookups.

__This change__

If the `--no-naked-pointers` option is enabled, the runtime can be sure that all pointers will point to some OCaml value. Like the GC, we will follow these pointers and assume the referenced data has the expected structure.

In workloads with large heaps that also perform many polymorphic comparisons, this change will eliminate the overhead of these lookups.

__Justification__

The current code checks if values pass the `Is_in_value_area` check. This check is defined as `(Classify_addr(a) & (In_heap | In_young | In_static_data))` where `Classify_addr` is the page table lookup.

The compare code wraps this check around three sections:

1. v1 = long && v2 = block

    This section does a tag check in case v2 is either a Forward_tag (lazy) or Custom_tag (custom compare function). These tag checks are unsafe if v2 is a naked pointer to some arbitrary data. Without this possibility, it is safe to perform the tag check.

2. v1 = block && v2 = long

    The justification for this case is the same as for case 1.

3. v1 = block && v2 = block

    In this section, we have determined that both v1 and v2 are pointers. The following code walks values structurally, which is unsafe if either v1 or v2 are naked pointers to arbitrary data. Without this possibility, it is safe to perform the tag checks directly.

No change entry needed