### PR TITLE
[Iname_for_debugger] is not a pure operation

### DIFF
--- a/Changes
+++ b/Changes
@@ -410,6 +410,9 @@ Working version
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)
 
+- GPR#2081: Mark [Iname_for_debugger] as an impure operation.
+  (Mark Shinwell)
+
 ### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -352,6 +352,7 @@ let op_is_pure = function
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ilea _|Isextend32) -> true
   | Ispecific _ -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack frame *)

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -300,6 +300,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
   | Ispecific(Ishiftcheckbound _) -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -220,6 +220,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
   | Ispecific(Ishiftcheckbound _) -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -216,6 +216,7 @@ let op_is_pure = function
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ilea _) -> true
   | Ispecific _ -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack frame *)

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -295,6 +295,7 @@ let op_is_pure = function
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
   | Ispecific _ -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -198,6 +198,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)


### PR DESCRIPTION
The `Iname_for_debugger` pseudo-operation is not pure (in the sense of the `Proc.is_pure` judgements).  It should never be deleted even though it may look as if it is dead.  The lack of this patch when `Iname_for_debugger` was originally introduced was an oversight.

As a side note, it would be good to expand the pattern matches in the various `proc.ml` files so as to make them exhaustive; oversights like this would then have been caught automatically.