### PR TITLE
New option "-no-insn-sched"

### DIFF
--- a/Changes
+++ b/Changes
@@ -417,6 +417,10 @@ OCaml 4.08.0
 - MPR#6242, GPR#2143: optimize some local functions
   (Alain Frisch, review by Gabriel Scherer)
 
+- GPR#2082: New options [-insn-sched] and [-no-insn-sched] to control
+  instruction scheduling.
+  (Mark Shinwell, review by Damien Doligez)
+
 - GPR#2239: Fix match miscompilation with flambda
   (Leo White, review by Alain Frisch)
 

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -383,7 +383,7 @@ method schedule_fundecl f =
       self#reschedule ready_queue 0 (schedule i try_nesting)
     end in
 
-  if f.fun_fast then begin
+  if f.fun_fast && !Clflags.insn_sched then begin
     let new_body = schedule f.fun_body 0 in
     clear_code_dag();
     { fun_name = f.fun_name;

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -341,6 +341,8 @@ let read_one_param ppf position name v =
       set "flambda-invariants" [ flambda_invariant_checks ] v
   | "linscan" ->
       set "linscan" [ use_linscan ] v
+  | "insn-sched" -> set "insn-sched" [ insn_sched ] v
+  | "no-insn-sched" -> clear "insn-sched" [ insn_sched ] v
 
   (* color output *)
   | "color" ->

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -245,6 +245,18 @@ let mk_intf_suffix_2 f =
   "-intf_suffix", Arg.String f, "<string>  (deprecated) same as -intf-suffix"
 ;;
 
+let mk_insn_sched f =
+  "-insn-sched", Arg.Unit f,
+  Printf.sprintf " Run the instruction scheduling pass%s"
+    (if Clflags.insn_sched_default then " (default)" else "")
+;;
+
+let mk_no_insn_sched f =
+  "-no-insn-sched", Arg.Unit f,
+  Printf.sprintf " Do not run the instruction scheduling pass%s"
+    (if not Clflags.insn_sched_default then " (default)" else "")
+;;
+
 let mk_keep_docs f =
   "-keep-docs", Arg.Unit f, " Keep documentation strings in .cmi files"
 ;;
@@ -1003,6 +1015,8 @@ module type Optcommon_options = sig
   val _no_unbox_specialised_args : unit -> unit
   val _o2 : unit -> unit
   val _o3 : unit -> unit
+  val _insn_sched : unit -> unit
+  val _no_insn_sched : unit -> unit
 
   val _clambda_checks : unit -> unit
   val _dflambda : unit -> unit
@@ -1281,6 +1295,7 @@ struct
     mk_inline_indirect_cost F._inline_indirect_cost;
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inlining_report F._inlining_report;
+    mk_insn_sched F._insn_sched;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
     mk_keep_docs F._keep_docs;
@@ -1299,6 +1314,7 @@ struct
     mk_noassert F._noassert;
     mk_noautolink_opt F._noautolink;
     mk_nodynlink F._nodynlink;
+    mk_no_insn_sched F._no_insn_sched;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
     mk_nopervasives F._nopervasives;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -178,6 +178,8 @@ module type Optcommon_options = sig
   val _no_unbox_specialised_args : unit -> unit
   val _o2 : unit -> unit
   val _o3 : unit -> unit
+  val _insn_sched : unit -> unit
+  val _no_insn_sched : unit -> unit
 
   val _clambda_checks : unit -> unit
   val _dflambda : unit -> unit

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -118,8 +118,9 @@ module Options = Main_args.Make_optcomp_options (struct
     Float_arg_helper.parse spec
       "Syntax: -inline-branch-factor <n> | <round>=<n>[,...]"
        inline_branch_factor
-  let _intf = intf
   let _intf_suffix s = Config.interface_suffix := s
+  let _insn_sched = set insn_sched
+  let _intf = intf
   let _keep_docs = set keep_docs
   let _no_keep_docs = clear keep_docs
   let _keep_locs = set keep_locs
@@ -139,6 +140,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _noassert = set noassert
   let _noautolink = set no_auto_link
   let _nodynlink = clear dlcode
+  let _no_insn_sched = clear insn_sched
   let _nolabels = set classic
   let _nostdlib = set no_std_include
   let _no_unbox_free_vars_of_closures = clear unbox_free_vars_of_closures

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -349,6 +349,9 @@ in a slight expansion in code size. Higher values for the
 option cause larger and larger functions to become candidate for
 inlining, but can result in a serious increase in code size.
 .TP
+.B \-insn\-sched
+Enables the instruction scheduling pass in the compiler backend.
+.TP
 .BI \-intf \ filename
 Compile the file
 .I filename
@@ -425,6 +428,9 @@ and pass the correct C libraries and options on the command line.
 .B \-nodynlink
 Allow the compiler to use some optimizations that are valid only for code
 that is never dynlinked.
+.TP
+.B \-no\-insn\-sched
+Disables the instruction scheduling pass in the compiler backend.
 .TP
 .B -nostdlib
 Do not automatically add the standard library directory to the list of

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -69,6 +69,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _inline_lifting_benefit = ignore
   let _inline_branch_factor = ignore
   let _classic_inlining = ignore
+  let _insn_sched = ignore
   let _intf _ = with_intf := true
   let _intf_suffix = ignore
   let _keep_docs = ignore
@@ -85,6 +86,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _noassert = ignore
   let _noautolink = ignore
   let _nodynlink = ignore
+  let _no_insn_sched = ignore
   let _nolabels = ignore
   let _nostdlib = ignore
   let _no_unbox_free_vars_of_closures = ignore

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -153,6 +153,8 @@ module Options = Main_args.Make_opttop_options (struct
     Int_arg_helper.parse spec
       "Syntax: -inline-max-depth <n> | <round>=<n>[,...]"
       inline_max_depth
+  let _insn_sched = set insn_sched
+  let _no_insn_sched = clear insn_sched
   let _no_unbox_free_vars_of_closures = clear unbox_free_vars_of_closures
   let _no_unbox_specialised_args = clear unbox_specialised_args
   let _o s = output_name := Some s

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -144,6 +144,9 @@ let flambda_invariant_checks =
 
 let dont_write_files = ref false        (* set to true under ocamldoc *)
 
+let insn_sched_default = true
+let insn_sched = ref insn_sched_default (* -[no-]insn-sched *)
+
 let std_include_flag prefix =
   if !no_std_include then ""
   else (prefix ^ (Filename.quote Config.standard_library))

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -229,6 +229,9 @@ val error_style_reader : Misc.Error_style.setting env_reader
 
 val unboxed_types : bool ref
 
+val insn_sched : bool ref
+val insn_sched_default : bool
+
 module Compiler_pass : sig
   type t = Parsing | Typing
   val of_string : string -> t option


### PR DESCRIPTION
This patch adds a compiler option `-no-insn-sched` (along with an associated `OCAMLPARAM` keyword) to disable instruction scheduling.  The rationale for why this is needed is given in #2068 .