### PR TITLE
Add [end_of_function_label] to [Emit.fundecl]

### DIFF
--- a/Changes
+++ b/Changes
@@ -416,6 +416,9 @@ Working version
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)
 
+- GPR#2085: Add [end_of_function_label] to the interface of [Emit.fundecl].
+  (Mark Shinwell)
+
 ### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -904,7 +904,7 @@ let all_functions = ref []
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let fundecl fundecl ~end_of_function_label =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := new_label();
@@ -937,6 +937,7 @@ let fundecl fundecl =
     end;
   end;
   cfi_endproc ();
+  _label (emit_label end_of_function_label);
   begin match system with
   | S_gnu | S_linux ->
       D.type_ (emit_symbol fundecl.fun_name) "@function";

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -902,7 +902,7 @@ let rec emit_all ninstr fallthrough i =
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let fundecl fundecl ~end_of_function_label =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := new_label();
@@ -928,6 +928,7 @@ let fundecl fundecl =
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_call_bound_error !bound_error_sites;
   cfi_endproc();
+  `{emit_label end_of_function_label}:\n`;
   `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
   `	.size	{emit_symbol fundecl.fun_name}, .-{emit_symbol fundecl.fun_name}\n`
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -907,7 +907,7 @@ let rec emit_all i =
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let fundecl fundecl ~end_of_function_label =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := new_label();
@@ -936,6 +936,7 @@ let fundecl fundecl =
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);
   cfi_endproc();
+  `{emit_label end_of_function_label}:\n`;
   `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
   `	.size	{emit_symbol fundecl.fun_name}, .-{emit_symbol fundecl.fun_name}\n`;
   emit_literals()

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -98,6 +98,10 @@ let rec regalloc ~ppf_dump round fd =
     Reg.reinit(); Liveness.fundecl newfd; regalloc ~ppf_dump (round + 1) newfd
   end else newfd
 
+let emit fundecl =
+  let end_of_function_label = Cmm.new_label () in
+  Emit.fundecl fundecl ~end_of_function_label
+
 let (++) x f = f x
 
 let compile_fundecl ~ppf_dump fd_cmm =
@@ -125,7 +129,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
   ++ pass_dump_linear_if ppf_dump dump_linear "Linearized code"
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
-  ++ Profile.record ~accumulate:true "emit" Emit.fundecl
+  ++ Profile.record ~accumulate:true "emit" emit
 
 let compile_phrase ~ppf_dump p =
   if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;

--- a/asmcomp/emit.mli
+++ b/asmcomp/emit.mli
@@ -15,7 +15,7 @@
 
 (* Generation of assembly code *)
 
-val fundecl: Linearize.fundecl -> unit
+val fundecl: Linearize.fundecl -> end_of_function_label:Linearize.label -> unit
 val data: Cmm.data_item list -> unit
 val begin_assembly: unit -> unit
 val end_assembly: unit -> unit

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -944,7 +944,7 @@ let emit_external_symbols () =
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let fundecl fundecl ~end_of_function_label =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := new_label();
@@ -969,6 +969,7 @@ let fundecl fundecl =
   List.iter emit_call_gc !call_gc_sites;
   emit_call_bound_errors ();
   cfi_endproc ();
+  _label (emit_label end_of_function_label);
   begin match system with
   | S_linux_elf | S_bsd_elf | S_gnu ->
       D.type_ (emit_symbol fundecl.fun_name) "@function";

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -1025,7 +1025,7 @@ let rec emit_all i =
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let fundecl fundecl ~end_of_function_label =
   function_name := fundecl.fun_name;
   tailrec_entry_point := new_label();
   stack_offset := 0;
@@ -1113,7 +1113,8 @@ let fundecl fundecl =
       (fun  lbl ->
           `	.long	{emit_label lbl} - {emit_label !jumptables_lbl}\n`)
       (List.rev !jumptables)
-  end
+  end;
+  `{emit_label end_of_function_label}:\n`
 
 (* Emission of data *)
 

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -645,7 +645,7 @@ let rec emit_all i =
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let fundecl fundecl ~end_of_function_label =
   function_name := fundecl.fun_name;
   tailrec_entry_point := new_label();
   stack_offset := 0;
@@ -678,7 +678,8 @@ let fundecl fundecl =
       (fun (n, lbl) ->
         `{emit_label lbl}:	.quad	{emit_nativeint n}\n`)
       !int_literals
-  end
+  end;
+  `{emit_label end_of_function_label}:\n`
 
 (* Emission of data *)
 


### PR DESCRIPTION
This pull request adds a label declaration at the end of each function in the assembly output.  In a subsequent pull request such label will be used for measuring the size of the function for DWARF purposes.