### PR TITLE
Add function human name, module path and arity fields in the backend

### DIFF
--- a/Changes
+++ b/Changes
@@ -416,6 +416,11 @@ Working version
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)
 
+- GPR#2087: Add human name, module path and arity fields variously throughout
+  types in the backend used for transporting function information.  Populate
+  human name and module path fields in [Closure].
+  (Mark Shinwell)
+
 ### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -18,6 +18,7 @@
 val compile_implementation_flambda :
     ?toplevel:(string -> bool) ->
     string ->
+    unit_name:Ident.t ->
     required_globals:Ident.Set.t ->
     backend:(module Backend_intf.S) ->
     ppf_dump:Format.formatter -> Flambda.program -> unit
@@ -25,6 +26,7 @@ val compile_implementation_flambda :
 val compile_implementation_clambda :
     ?toplevel:(string -> bool) ->
     string ->
+    unit_name:Ident.t ->
     ppf_dump:Format.formatter -> Lambda.program -> unit
 
 val compile_phrase :

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -111,14 +111,16 @@ let make_package_object ~ppf_dump members targetobj targetname coercion
           ~module_initializer:lam
       in
       Asmgen.compile_implementation_flambda
-        prefixname ~backend ~required_globals:Ident.Set.empty ~ppf_dump flam;
+        prefixname ~unit_name:module_ident ~backend
+        ~required_globals:Ident.Set.empty ~ppf_dump flam;
     end else begin
       let main_module_block_size, code =
         Translmod.transl_store_package
           components (Ident.create_persistent targetname) coercion in
       Asmgen.compile_implementation_clambda
-        prefixname ~ppf_dump { Lambda.code; main_module_block_size;
-                         module_ident; required_globals = Ident.Set.empty }
+        prefixname ~unit_name:module_ident ~ppf_dump
+          { Lambda.code; main_module_block_size;
+            module_ident; required_globals = Ident.Set.empty }
     end;
     let objfiles =
       List.map

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -65,6 +65,8 @@ and ufunction = {
   label  : function_label;
   arity  : int;
   params : Backend_var.With_provenance.t list;
+  human_name : string;
+  module_path : Path.t option;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
@@ -80,6 +82,8 @@ and ulambda_switch =
 
 type function_description =
   { fun_label: function_label;          (* Label of direct entry point *)
+    fun_human_name: string;             (* Name used for the debugger *)
+    fun_module_path: Path.t option;     (* Path of enclosing module *)
     fun_arity: int;                     (* Number of arguments *)
     mutable fun_closed: bool;           (* True if environment not used *)
     mutable fun_inline: (Backend_var.With_provenance.t list * ulambda) option;

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -65,6 +65,8 @@ and ufunction = {
   label  : function_label;
   arity  : int;
   params : Backend_var.With_provenance.t list;
+  human_name : string;
+  module_path : Path.t option;
   body   : ulambda;
   dbg    : Debuginfo.t;
   env    : Backend_var.t option;
@@ -80,6 +82,8 @@ and ulambda_switch =
 
 type function_description =
   { fun_label: function_label;          (* Label of direct entry point *)
+    fun_human_name: string;             (* Name used for the debugger *)
+    fun_module_path: Path.t option;     (* Path of enclosing module *)
     fun_arity: int;                     (* Number of arguments *)
     mutable fun_closed: bool;           (* True if environment not used *)
     mutable fun_inline: (Backend_var.With_provenance.t list * ulambda) option;

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -818,6 +818,10 @@ let global_approx = ref([||] : value_approximation array)
 let function_nesting_depth = ref 0
 let excessive_function_nesting_depth = 5
 
+(* Maintain the current module path *)
+
+let current_module_path = ref (None : Path.t option)
+
 (* Uncurry an expression and explicitate closures.
    Also return the approximation of the expression.
    The approximation environment [fenv] maps idents to approximations.
@@ -1128,7 +1132,12 @@ let rec close fenv cenv = function
   | Lassign(id, lam) ->
       let (ulam, _) = close fenv cenv lam in
       (Uassign(id, ulam), Value_unknown)
-  | Levent(lam, _) ->
+  | Levent(lam, ev) ->
+      begin match ev.lev_kind with
+      | Lev_module_definition path ->
+        current_module_path := Some (Path.Pident path)
+      | _ -> ()
+      end;
       close fenv cenv lam
   | Lifused _ ->
       assert false
@@ -1184,14 +1193,18 @@ and close_functions fenv cenv fun_defs =
     List.map
       (function
           (id, Lfunction{kind; params; body; loc}) ->
-            let label = Compilenv.make_symbol (Some (V.unique_name id)) in
+            let fun_human_name = V.unique_name id in
+            let fun_module_path = !current_module_path in
+            let label = Compilenv.make_symbol (Some fun_human_name) in
             let arity = List.length params in
             let fundesc =
               {fun_label = label;
                fun_arity = (if kind = Tupled then -arity else arity);
                fun_closed = initially_closed;
                fun_inline = None;
-               fun_float_const_prop = !Clflags.float_const_prop } in
+               fun_float_const_prop = !Clflags.float_const_prop;
+               fun_human_name;
+               fun_module_path;} in
             let dbg = Debuginfo.from_location loc in
             (id, params, body, fundesc, dbg)
         | (_, _) -> fatal_error "Closure.close_functions")
@@ -1236,6 +1249,8 @@ and close_functions fenv cenv fun_defs =
         body   = ubody;
         dbg;
         env = Some env_param;
+        human_name = fundesc.fun_human_name;
+        module_path = fundesc.fun_module_path;
       }
     in
     (* give more chance of function with default parameters (i.e.
@@ -1411,7 +1426,8 @@ let collect_exported_structured_constants a =
 
 let reset () =
   global_approx := [||];
-  function_nesting_depth := 0
+  function_nesting_depth := 0;
+  current_module_path := None
 
 (* The entry point *)
 

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -184,6 +184,8 @@ type fundecl =
     fun_body: expression;
     fun_codegen_options : codegen_option list;
     fun_dbg : Debuginfo.t;
+    fun_human_name : string;
+    fun_module_path : Path.t option;
   }
 
 type data_item =

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -164,6 +164,8 @@ type fundecl =
     fun_body: expression;
     fun_codegen_options : codegen_option list;
     fun_dbg : Debuginfo.t;
+    fun_human_name : string;
+    fun_module_path : Path.t option;
   }
 
 type data_item =

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2824,7 +2824,7 @@ and transl_letrec env bindings cont =
 
 (* Translate a function definition *)
 
-let transl_function ~ppf_dump f =
+let transl_function ~ppf_dump (f : Clambda.ufunction) =
   let body =
     if Config.flambda then
       Un_anf.apply ~ppf_dump f.body ~what:f.label
@@ -2847,7 +2847,9 @@ let transl_function ~ppf_dump f =
              fun_args = List.map (fun id -> (id, typ_val)) f.params;
              fun_body = cmm_body;
              fun_codegen_options;
-             fun_dbg  = f.dbg}
+             fun_dbg  = f.dbg;
+             fun_human_name = f.human_name;
+             fun_module_path = f.module_path}
 
 (* Translate all function definitions *)
 
@@ -3091,12 +3093,13 @@ let emit_preallocated_blocks preallocated_blocks cont =
 
 (* Translate a compilation unit *)
 
-let compunit ~ppf_dump (ulam, preallocated_blocks, constants) =
+let compunit ~ppf_dump ~unit_name (ulam, preallocated_blocks, constants) =
   let init_code =
     if !Clflags.afl_instrument then
       Afl_instrument.instrument_initialiser (transl empty_env ulam)
     else
       transl empty_env ulam in
+  let module_path = Path.Pident unit_name in
   let c1 = [Cfunction {fun_name = Compilenv.make_symbol (Some "entry");
                        fun_args = [];
                        fun_body = init_code;
@@ -3109,10 +3112,15 @@ let compunit ~ppf_dump (ulam, preallocated_blocks, constants) =
                            No_CSE;
                          ]
                          else [ Reduce_code_size ];
-                       fun_dbg  = Debuginfo.none }] in
+                       fun_dbg  = Debuginfo.none;
+                       fun_human_name = "";
+                       fun_module_path = Some module_path }] in
   let c2 = emit_constants c1 constants in
   let c3 = transl_all_functions_and_emit_all_constants ~ppf_dump c2 in
   emit_preallocated_blocks preallocated_blocks c3
+
+let startup_path =
+  Some (Path.Pident (Ident.create_persistent "_Ocaml_startup"))
 
 (*
 CAMLprim value caml_cache_public_method (value meths, value tag, value *cache)
@@ -3250,7 +3258,10 @@ let send_function arity =
     fun_args = List.map (fun (arg, ty) -> VP.create arg, ty) fun_args;
     fun_body = body;
     fun_codegen_options = [];
-    fun_dbg  = Debuginfo.none }
+    fun_dbg  = Debuginfo.none;
+    fun_human_name = fun_name;
+    fun_module_path = startup_path;
+   }
 
 let apply_function arity =
   let (args, clos, body) = apply_function_body arity in
@@ -3262,6 +3273,8 @@ let apply_function arity =
     fun_body = body;
     fun_codegen_options = [];
     fun_dbg  = Debuginfo.none;
+    fun_human_name = fun_name;
+    fun_module_path = startup_path;
    }
 
 (* Generate tuplifying functions:
@@ -3287,6 +3300,8 @@ let tuplify_function arity =
           dbg);
     fun_codegen_options = [];
     fun_dbg  = Debuginfo.none;
+    fun_human_name = fun_name;
+    fun_module_path = startup_path;
    }
 
 (* Generate currying functions:
@@ -3344,13 +3359,18 @@ let final_curry_function arity =
                curry_fun (get_field env (Cvar clos) 3 dbg :: args)
                          newclos (n-1))
     end in
+  let fun_name =
+    "caml_curry" ^ string_of_int arity ^ "_" ^ string_of_int (arity-1)
+  in
   Cfunction
-   {fun_name = "caml_curry" ^ string_of_int arity ^
-               "_" ^ string_of_int (arity-1);
+   {fun_name;
     fun_args = [VP.create last_arg, typ_val; VP.create last_clos, typ_val];
     fun_body = curry_fun [] last_clos (arity-1);
     fun_codegen_options = [];
-    fun_dbg  = Debuginfo.none }
+    fun_dbg  = Debuginfo.none;
+    fun_human_name = fun_name;
+    fun_module_path = startup_path;
+   }
 
 let rec intermediate_curry_functions arity num =
   let dbg = Debuginfo.none in
@@ -3380,7 +3400,10 @@ let rec intermediate_curry_functions arity num =
                  int_const 1; Cvar arg; Cvar clos],
                 dbg);
       fun_codegen_options = [];
-      fun_dbg  = Debuginfo.none }
+      fun_dbg  = Debuginfo.none;
+      fun_human_name = name2;
+      fun_module_path = startup_path;
+     }
     ::
       (if arity <= max_arity_optimized && arity - num > 2 then
           let rec iter i =
@@ -3405,14 +3428,18 @@ let rec intermediate_curry_functions arity num =
             List.map (fun (arg, ty) -> VP.create arg, ty)
               (direct_args @ [clos, typ_val])
           in
+          let fun_name = name1 ^ "_" ^ string_of_int (num+1) ^ "_app" in
           let cf =
             Cfunction
-              {fun_name = name1 ^ "_" ^ string_of_int (num+1) ^ "_app";
+              {fun_name;
                fun_args;
                fun_body = iter (num+1)
                   (List.map (fun (arg,_) -> Cvar arg) direct_args) clos;
                fun_codegen_options = [];
-               fun_dbg = Debuginfo.none }
+               fun_dbg  = Debuginfo.none;
+               fun_human_name = fun_name;
+               fun_module_path = startup_path;
+              }
           in
           cf :: intermediate_curry_functions arity (num+1)
        else
@@ -3470,7 +3497,10 @@ let entry_point namelist =
              fun_args = [];
              fun_body = body;
              fun_codegen_options = [Reduce_code_size];
-             fun_dbg  = Debuginfo.none }
+             fun_dbg  = Debuginfo.none;
+             fun_human_name = "caml_program";
+             fun_module_path = startup_path;
+            }
 
 (* Generate the table of globals *)
 

--- a/asmcomp/cmmgen.mli
+++ b/asmcomp/cmmgen.mli
@@ -17,6 +17,7 @@
 
 val compunit:
   ppf_dump:Format.formatter
+  -> unit_name:Ident.t
   -> Clambda.ulambda
     * Clambda.preallocated_block list
     * Clambda.preallocated_constant list

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -531,6 +531,8 @@ and to_clambda_set_of_closures t env
       body = to_clambda t env_body function_decl.body;
       dbg = function_decl.dbg;
       env = Some env_var;
+      human_name = Closure_id.base_name closure_id;
+      module_path = None;
     }
   in
   let funs = List.map to_clambda_function all_functions in
@@ -571,6 +573,8 @@ and to_clambda_closed_set_of_closures t env symbol
       body = to_clambda t env_body function_decl.body;
       dbg = function_decl.dbg;
       env = None;
+      human_name = Closure_id.base_name (Closure_id.wrap id);
+      module_path = None;
     }
   in
   let ufunct = List.map to_clambda_function functions in

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -54,6 +54,9 @@ type fundecl =
     fun_body: instruction;
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
+    fun_human_name : string;
+    fun_arity : int;
+    fun_module_path : Path.t option;
     fun_spacetime_shape : Mach.spacetime_shape option;
   }
 
@@ -325,5 +328,8 @@ let fundecl f =
     fun_body;
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
+    fun_human_name = f.Mach.fun_human_name;
+    fun_arity = Array.length f.Mach.fun_args;
+    fun_module_path = f.Mach.fun_module_path;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
   }

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -52,6 +52,9 @@ type fundecl =
     fun_body: instruction;
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
+    fun_human_name : string;
+    fun_arity : int;
+    fun_module_path : Path.t option;
     fun_spacetime_shape : Mach.spacetime_shape option;
   }
 

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -100,6 +100,8 @@ type fundecl =
     fun_body: instruction;
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
+    fun_human_name : string;
+    fun_module_path : Path.t option;
     fun_spacetime_shape : spacetime_shape option;
   }
 

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -122,6 +122,8 @@ type fundecl =
     fun_body: instruction;
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
+    fun_human_name : string;
+    fun_module_path : Path.t option;
     fun_spacetime_shape : spacetime_shape option;
   }
 

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -82,4 +82,9 @@ let fundecl ppf f =
       ""
     else
       " " ^ Debuginfo.to_string f.fun_dbg in
-  fprintf ppf "@[<v 2>%s:%s@,%a@]" f.fun_name dbg all_instr f.fun_body
+  let path =
+    match f.fun_module_path with
+    | None -> ""
+    | Some path -> "(" ^ Path.name path ^ ")"
+  in
+  fprintf ppf "@[<v 2>%s%s:%s@,%a@]" path f.fun_name dbg all_instr f.fun_body

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -130,6 +130,10 @@ method fundecl f =
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
     fun_body = new_body; fun_codegen_options = f.fun_codegen_options;
-    fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape},
+    fun_dbg  = f.fun_dbg;
+    fun_human_name = f.fun_human_name;
+    fun_module_path = f.fun_module_path;
+    fun_spacetime_shape = f.fun_spacetime_shape;
+   },
    redo_regalloc)
 end

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -390,6 +390,9 @@ method schedule_fundecl f =
       fun_body = new_body;
       fun_fast = f.fun_fast;
       fun_dbg  = f.fun_dbg;
+      fun_human_name = f.fun_human_name;
+      fun_arity = f.fun_arity;
+      fun_module_path = f.fun_module_path;
       fun_spacetime_shape = f.fun_spacetime_shape;
     }
   end else

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1223,6 +1223,8 @@ method emit_fundecl f =
     fun_body = body;
     fun_codegen_options = f.Cmm.fun_codegen_options;
     fun_dbg  = f.Cmm.fun_dbg;
+    fun_human_name = f.Cmm.fun_human_name;
+    fun_module_path = f.Cmm.fun_module_path;
     fun_spacetime_shape;
   }
 

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -473,5 +473,7 @@ let fundecl f =
     fun_body = new_body;
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
+    fun_human_name = f.fun_human_name;
+    fun_module_path = f.fun_module_path;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -223,6 +223,8 @@ let fundecl f =
     fun_args = new_args;
     fun_body = new_body;
     fun_codegen_options = f.fun_codegen_options;
+    fun_human_name = f.fun_human_name;
+    fun_module_path = f.fun_module_path;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/asmcomp/un_anf.ml
+++ b/asmcomp/un_anf.ml
@@ -46,6 +46,7 @@ let ignore_var_with_provenance (_ : VP.t) = ()
 let ignore_var_with_provenance_list (_ : VP.t list) = ()
 let ignore_direction_flag (_ : Asttypes.direction_flag) = ()
 let ignore_meth_kind (_ : Lambda.meth_kind) = ()
+let ignore_path_option (_ : Path.t option) = ()
 
 (* CR-soon mshinwell: check we aren't traversing function bodies more than
    once (need to analyse exactly what the calls are from Cmmgen into this
@@ -91,8 +92,8 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ignore_debuginfo dbg
     | Uclosure (functions, captured_variables) ->
       List.iter loop captured_variables;
-      List.iter (fun (
-        { Clambda. label; arity; params; body; dbg; env; } as clos) ->
+      List.iter (fun ({ Clambda. label; arity; params; body;
+            dbg; human_name; module_path; env; } as clos) ->
           (match closure_environment_var clos with
            | None -> ()
            | Some env_var ->
@@ -103,6 +104,8 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
           ignore_var_with_provenance_list params;
           loop body;
           ignore_debuginfo dbg;
+          ignore_string human_name;
+          ignore_path_option module_path;
           ignore_var_option env)
         functions
     | Uoffset (expr, offset) ->
@@ -261,7 +264,8 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
     | Uclosure (functions, captured_variables) ->
       ignore_ulambda_list captured_variables;
       (* Start a new let stack for speed. *)
-      List.iter (fun { Clambda. label; arity; params; body; dbg; env; } ->
+      List.iter (fun { Clambda. label; arity; params; body;
+              dbg; human_name; module_path; env; } ->
           ignore_function_label label;
           ignore_int arity;
           ignore_var_with_provenance_list params;
@@ -269,6 +273,8 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
           loop body;
           let_stack := [];
           ignore_debuginfo dbg;
+          ignore_string human_name;
+          ignore_path_option module_path;
           ignore_var_option env)
         functions
     | Uoffset (expr, offset) ->

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -53,7 +53,8 @@ let flambda i backend typed =
         ~backend
         ~module_initializer:lam)
     |> Asmgen.compile_implementation_flambda
-      i.outputprefix ~required_globals ~backend ~ppf_dump:i.ppf_dump;
+      i.outputprefix ~unit_name:module_ident ~required_globals ~backend
+        ~ppf_dump:i.ppf_dump;
     Compilenv.save_unit_info (cmx i))
 
 let clambda i typed =
@@ -68,7 +69,8 @@ let clambda i typed =
        { program with Lambda.code }
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.program
        |> Asmgen.compile_implementation_clambda
-         i.outputprefix ~ppf_dump:i.ppf_dump;
+         i.outputprefix ~unit_name:program.Lambda.module_ident
+         ~ppf_dump:i.ppf_dump;
        Compilenv.save_unit_info (cmx i))
 
 let implementation ~backend =

--- a/middle_end/base_types/closure_element.ml
+++ b/middle_end/base_types/closure_element.ml
@@ -24,3 +24,5 @@ let unwrap t = t
 
 let wrap_map t = t
 let unwrap_set t = t
+
+let base_name t = name t

--- a/middle_end/base_types/closure_element.mli
+++ b/middle_end/base_types/closure_element.mli
@@ -27,6 +27,8 @@ val unwrap_set : Set.t -> Variable.Set.t
 val in_compilation_unit : t -> Compilation_unit.t -> bool
 val get_compilation_unit : t -> Compilation_unit.t
 
+val base_name : t -> string
+
 val unique_name : t -> string
 
 val output_full : out_channel -> t -> unit

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -222,11 +222,13 @@ let load_lambda ppf ~module_ident ~required_globals lam size =
   if not Config.flambda then
     Asmgen.compile_implementation_clambda
       ~toplevel:need_symbol fn ~ppf_dump:ppf
+      ~unit_name:module_ident
       { Lambda.code=slam ; main_module_block_size=size;
         module_ident; required_globals }
   else
     Asmgen.compile_implementation_flambda
       ~required_globals ~backend ~toplevel:need_symbol fn ~ppf_dump:ppf
+      ~unit_name:module_ident
       (Middle_end.middle_end ~ppf_dump:ppf ~prefixname:"" ~backend ~size
          ~module_ident ~module_initializer:slam ~filename:"toplevel");
   Asmlink.call_linker_shared [fn ^ ext_obj] dll;


### PR DESCRIPTION
This patch adds some fields to various function-describing structures in the backend.  The fields provide the user-facing name of each function, the path of the enclosing module (if such exists), and the arity of the function (the latter in `Linearize` only).  This information is required for DWARF information emission.

I need to re-test this once I have a single branch assembled from all of these pull requests, but I expect this to be close to the final version.  @chambart is working on the patch to `Flambda_to_clambda` to properly fill in these new fields.