### PR TITLE
Add [Clambda.usymbol_provenance]

### DIFF
--- a/Changes
+++ b/Changes
@@ -416,6 +416,9 @@ Working version
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)
 
+- GPR#2088: Add [Clambda.usymbol_provenance].
+  (Mark Shinwell)
+
 ### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -212,7 +212,9 @@ let flambda_gen_implementation ?toplevel ~backend ~ppf_dump
     List.map (fun (symbol, definition) ->
         { Clambda.symbol = Linkage_name.to_string (Symbol.label symbol);
           exported = true;
-          definition })
+          definition;
+          provenance = None;
+        })
       (Symbol.Map.bindings constants)
   in
   end_gen_implementation ?toplevel ~ppf_dump
@@ -221,12 +223,19 @@ let flambda_gen_implementation ?toplevel ~backend ~ppf_dump
 let lambda_gen_implementation ?toplevel ~ppf_dump
     (lambda:Lambda.program) =
   let clambda = Closure.intro lambda.main_module_block_size lambda.code in
+  let provenance : Clambda.usymbol_provenance =
+    { original_idents = [];
+      module_path =
+        Path.Pident (Ident.create_persistent (Compilenv.current_unit_name ()));
+    }
+  in
   let preallocated_block =
     Clambda.{
       symbol = Compilenv.make_symbol None;
       exported = true;
       tag = 0;
       fields = List.init lambda.main_module_block_size (fun _ -> None);
+      provenance = Some provenance;
     }
   in
   let clambda_and_constants =

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -97,6 +97,11 @@ type value_approximation =
 
 (* Preallocated globals *)
 
+type usymbol_provenance = {
+  original_idents : Ident.t list;
+  module_path : Path.t;
+}
+
 type uconstant_block_field =
   | Uconst_field_ref of string
   | Uconst_field_int of int
@@ -106,12 +111,14 @@ type preallocated_block = {
   exported : bool;
   tag : int;
   fields : uconstant_block_field option list;
+  provenance : usymbol_provenance option;
 }
 
 type preallocated_constant = {
   symbol : string;
   exported : bool;
   definition : ustructured_constant;
+  provenance : usymbol_provenance option;
 }
 
 (* Comparison functions for constants.  We must not use Stdlib.compare

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -102,6 +102,11 @@ val compare_structured_constants:
 val compare_constants:
         uconstant -> uconstant -> int
 
+type usymbol_provenance = {
+  original_idents : Ident.t list;
+  module_path : Path.t;
+}
+
 type uconstant_block_field =
   | Uconst_field_ref of string
   | Uconst_field_int of int
@@ -111,10 +116,12 @@ type preallocated_block = {
   exported : bool;
   tag : int;
   fields : uconstant_block_field option list;
+  provenance : usymbol_provenance option;
 }
 
 type preallocated_constant = {
   symbol : string;
   exported : bool;
   definition : ustructured_constant;
+  provenance : usymbol_provenance option;
 }

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2999,7 +2999,7 @@ let emit_constant_table symb elems =
 let emit_constants cont (constants:Clambda.preallocated_constant list) =
   let c = ref cont in
   List.iter
-    (fun { symbol = lbl; exported; definition = cst } ->
+    (fun { symbol = lbl; exported; definition = cst; provenance = _; } ->
        let global = if exported then Global else Not_global in
        let cst = emit_structured_constant (lbl, global) cst [] in
          c:= Cdata(cst):: !c)

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -391,12 +391,19 @@ let clear_structured_constants () =
   structured_constants := structured_constants_empty
 
 let structured_constants () =
+  let provenance : Clambda.usymbol_provenance =
+    { original_idents = [];
+      module_path =
+        Path.Pident (Ident.create_persistent (current_unit_name ()));
+    }
+  in
   List.map
     (fun (symbol, definition) ->
        {
          Clambda.symbol;
          exported = Hashtbl.mem exported_constants symbol;
          definition;
+         provenance = Some provenance;
        })
     (!structured_constants).strcst_all
 

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -672,6 +672,7 @@ let to_clambda_program t env constants (program : Flambda.program) =
           exported = true;
           tag = Tag.to_int tag;
           fields = constant_fields;
+          provenance = None;
         }
       in
       let e2, constants, preallocated_blocks = loop env constants program in


### PR DESCRIPTION
This pull request adds a new type and two record fields to be used for the tracking of provenance information for symbols, such that they can be referenced (e.g. for printing) by their proper module paths.  In my previous working branch these were not filled in for Closure mode but I have sketched an implementation here, which I shall test in due course.  The Flambda patch which @chambart is working on fills these fields in properly for Flambda.

The DWARF emitter reads directly from the Clambda constant definition structures, which is why the provenances are not transmitted further.  (In the future, particularly with the plan for Flambda to bypass Clambda entirely, we will probably have to change this.)