### PR TITLE
Move stack calculations from Emit to Proc

### DIFF
--- a/Changes
+++ b/Changes
@@ -745,6 +745,9 @@ OCaml 4.08.0
 - GPR#2088: Add [Clambda.usymbol_provenance].
   (Mark Shinwell, review by Damien Doligez)
 
+- GPR#2090: Move stack frame layout calculations from [Emit] into [Proc].
+  (Mark Shinwell, review by Xavier Leroy)
+
 - GPR#2152, GPR#2517: refactorize the fixpoint to compute type-system
   properties of mutually-recursive type declarations.
   (Gabriel Scherer and Rodolphe Lepigre, review by Armaël Guéneau)
@@ -772,6 +775,8 @@ OCaml 4.08.0
 - GPR#2100: Fix Unix.getaddrinfo when called on strings containing
   null bytes; it would crash the GC later on.
   (Armaël Guéneau, report and fix by Joe, review by Sébastien Hinderer)
+
+### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the
   (Menhir-generated) parser encountered a syntax error in a certain

--- a/Changes
+++ b/Changes
@@ -31,6 +31,11 @@ Working version
   [Misc.Stdlib.List]
   (Mark Shinwell, review by Alain Frisch and Stephen Dolan)
 
+- GPR#2292: Add [Proc.frame_required] and [Proc.prologue_required].
+  Move tail recursion label creation to [Linearize].  Correctly position
+  [Lprologue] relative to [Iname_for_debugger] operations.
+  (Mark Shinwell)
+
 ### Runtime system:
 
 - GPR#1725: Deprecate Obj.set_tag

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -73,9 +73,6 @@ let stack_offset = ref 0
 
 (* Layout of the stack frame *)
 
-let frame_required () =
-  fp || !contains_calls || num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
-
 let frame_size () =                     (* includes return address *)
   if frame_required() then begin
     let sz =
@@ -503,6 +500,7 @@ let emit_instr fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
+    assert (Proc.prologue_required ());
     if fp then begin
       I.push rbp;
       cfi_adjust_cfa_offset 8;
@@ -516,8 +514,7 @@ let emit_instr fallthrough i =
         I.sub (int n) rsp;
         cfi_adjust_cfa_offset n;
       end;
-    end;
-    def_label !tailrec_entry_point
+    end
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
       if src.loc <> dst.loc then
@@ -907,7 +904,7 @@ let all_functions = ref []
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -73,23 +73,10 @@ let stack_offset = ref 0
 
 (* Layout of the stack frame *)
 
-let frame_size () =                     (* includes return address *)
-  if frame_required() then begin
-    let sz =
-      (!stack_offset + 8 * (num_stack_slots.(0) + num_stack_slots.(1)) + 8
-       + (if fp then 8 else 0))
-    in Misc.align sz 16
-  end else
-    !stack_offset + 8
+let frame_size () = frame_size ~stack_offset:!stack_offset
 
-let slot_offset loc cl =
-  match loc with
-  | Incoming n -> frame_size() + n
-  | Local n ->
-      if cl = 0
-      then !stack_offset + n * 8
-      else !stack_offset + (num_stack_slots.(0) + n) * 8
-  | Outgoing n -> n
+let slot_offset loc reg_class =
+  slot_offset loc ~reg_class ~stack_offset:!stack_offset
 
 (* Symbols *)
 
@@ -869,13 +856,13 @@ let emit_instr fallthrough i =
       I.push r14;
       cfi_adjust_cfa_offset 8;
       I.mov rsp r14;
-      stack_offset := !stack_offset + 16
+      stack_offset := !stack_offset + trap_frame_size_in_bytes
   | Lpoptrap ->
       I.pop r14;
       cfi_adjust_cfa_offset (-8);
       I.add (int 8) rsp;
       cfi_adjust_cfa_offset (-8);
-      stack_offset := !stack_offset - 16
+      stack_offset := !stack_offset - trap_frame_size_in_bytes
   | Lraise k ->
       (* No Spacetime instrumentation is required for [caml_raise_exn] and
          [caml_reraise_exn].  The only function called that might affect the
@@ -905,7 +892,7 @@ let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
-  stack_offset := 0;
+  stack_offset := initial_stack_offset;
   call_gc_sites := [];
   bound_error_sites := [];
   bound_error_call := 0;

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -377,6 +377,12 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  fp || !contains_calls || num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -413,6 +413,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> 0
     | Lprologue ->
+      assert (Proc.prologue_required ());
       let num_instrs0 =
         if !Clflags.gprofile then emit_profile()
         else 0
@@ -432,7 +433,6 @@ let emit_instr i =
           0
         end
       in
-      `{emit_label !tailrec_entry_point}:\n`;
       num_instrs0 + num_instrs1
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
@@ -905,7 +905,7 @@ let rec emit_all ninstr fallthrough i =
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   float_literals := [];
   gotrel_literals := [];
   symbol_literals := [];

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -345,6 +345,15 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  !contains_calls
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+    || num_stack_slots.(2) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -577,6 +577,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
+      assert (Proc.prologue_required ());
       if !Clflags.gprofile then emit_profile();
       let n = frame_size() in
       if n > 0 then
@@ -584,8 +585,7 @@ let emit_instr i =
       if !contains_calls then begin
         cfi_offset ~reg:30 (* return address *) ~offset:(-8);
         `	str	x30, [sp, #{emit_int (n-8)}]\n`
-      end;
-      `{emit_label !tailrec_entry_point}:\n`;
+      end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -910,7 +910,7 @@ let rec emit_all i =
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   float_literals := [];
   stack_offset := 0;
   call_gc_sites := [];

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -254,6 +254,14 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  !contains_calls
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -495,13 +495,13 @@ let emit_instr fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
+    assert (Proc.prologue_required ());
     if !Clflags.gprofile then emit_profile();
     let n = frame_size() - 4 in
     if n > 0 then  begin
       I.sub (int n) esp;
       cfi_adjust_cfa_offset n;
     end;
-    def_label !tailrec_entry_point
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
       if src.loc <> dst.loc then begin
@@ -947,7 +947,7 @@ let emit_external_symbols () =
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -242,7 +242,12 @@ let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
 let frame_required () =
-  num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
+  let frame_size_at_top_of_function =
+    (* cf. [frame_size] in emit.mlp. *)
+    Misc.align (4*num_stack_slots.(0) + 8*num_stack_slots.(1) + 4)
+      stack_alignment
+  in
+  frame_size_at_top_of_function > 4
 
 let prologue_required () =
   !Clflags.gprofile || frame_required ()

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -241,6 +241,12 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -55,6 +55,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_tailrec_entry_point_label : label;
   }
 
 (* Invert a test *)
@@ -306,20 +307,72 @@ let rec linear i n =
       copy_instr (Lraise k) i (discard_dead_code n)
 
 let add_prologue first_insn =
-  let insn = first_insn in
-  { desc = Lprologue;
-    next = insn;
-    arg = [| |];
-    res = [| |];
-    dbg = insn.dbg;
-    live = insn.live;
-  }
+  (* The prologue needs to come after any [Iname_for_debugger] operations that
+     refer to parameters.  (Such operations always come in a contiguous
+     block, cf. [Selectgen].) *)
+  let rec skip_naming_ops (insn : instruction) : label * instruction =
+    match insn.desc with
+    | Lop (Iname_for_debugger _) ->
+      let tailrec_entry_point_label, next = skip_naming_ops insn.next in
+      tailrec_entry_point_label, { insn with next; }
+    | _ ->
+      let tailrec_entry_point_label = Cmm.new_label () in
+      let tailrec_entry_point =
+        { desc = Llabel tailrec_entry_point_label;
+          next = insn;
+          arg = [| |];
+          res = [| |];
+          dbg = insn.dbg;
+          live = insn.live;
+        }
+      in
+      (* We expect [Lprologue] to expand to at least one instruction---as such,
+         if no prologue is required, we avoid adding the instruction here.
+         The reason is subtle: an empty expansion of [Lprologue] can cause
+         two labels, one either side of the [Lprologue], to point at the same
+         location.  This means that we lose the property (cf. [Coalesce_labels])
+         that we can check if two labels point at the same location by
+         comparing them for equality.  This causes trouble when the function
+         whose prologue is in question lands at the top of the object file
+         and we are emitting DWARF debugging information:
+           foo_code_begin:
+           foo:
+           .L1:
+           ; empty prologue
+           .L2:
+           ...
+         If we were to emit a location list entry from L1...L2, not realising
+         that they point at the same location, then the beginning and ending
+         points of the range would be both equal to each other and (relative to
+         "foo_code_begin") equal to zero.  This appears to confuse objdump,
+         which seemingly misinterprets the entry as an end-of-list entry
+         (which is encoded with two zero words), then complaining about a
+         "hole in location list" (as it ignores any remaining list entries
+         after the misinterpreted entry). *)
+      if Proc.prologue_required () then
+        let prologue =
+          { desc = Lprologue;
+            next = tailrec_entry_point;
+            arg = [| |];
+            res = [| |];
+            dbg = tailrec_entry_point.dbg;
+            live = Reg.Set.empty;  (* will not be used *)
+          }
+        in
+        tailrec_entry_point_label, prologue
+      else
+        tailrec_entry_point_label, tailrec_entry_point
+  in
+  skip_naming_ops first_insn
 
 let fundecl f =
-  let fun_body = add_prologue (linear f.Mach.fun_body end_instr) in
+  let fun_tailrec_entry_point_label, fun_body =
+    add_prologue (linear f.Mach.fun_body end_instr)
+  in
   { fun_name = f.Mach.fun_name;
     fun_body;
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
+    fun_tailrec_entry_point_label;
   }

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -53,6 +53,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_tailrec_entry_point_label : label;
   }
 
 val fundecl: Mach.fundecl -> fundecl

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -546,6 +546,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
+      assert (Proc.prologue_required ());
       if !Clflags.gprofile then emit_profile();
       let n = frame_size() in
       if n > 0 then begin
@@ -561,8 +562,7 @@ let emit_instr i =
         | ELF32 -> ()
         | ELF64v1 | ELF64v2 ->
           `	std	2, {emit_int(toc_save_offset())}(1)\n`
-      end;
-      `{emit_label !tailrec_entry_point}:\n`
+      end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -1027,7 +1027,7 @@ let rec emit_all i =
 
 let fundecl fundecl =
   function_name := fundecl.fun_name;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_label := 0;
   float_literals := [];

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -341,6 +341,26 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+(* See [reserved_stack_space] in emit.mlp. *)
+let reserved_stack_space_required () =
+  match abi with
+  | ELF32 -> false
+  | ELF64v1 | ELF64v2 -> true
+
+let frame_required () =
+  let is_elf32 =
+    match abi with
+    | ELF32 -> true
+    | ELF64v1 | ELF64v2 -> false
+  in
+  reserved_stack_space_required ()
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+    || (!contains_calls && is_elf32)
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -67,6 +67,10 @@ val op_is_pure: Mach.operation -> bool
 (* Info for laying out the stack frame *)
 val num_stack_slots: int array
 val contains_calls: bool ref
+val frame_required : unit -> bool
+
+(* Function prologues *)
+val prologue_required : unit -> bool
 
 (** For a given register class, the DWARF register numbering for that class.
     Given an allocated register with location [Reg n] and class [reg_class], the

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -67,7 +67,11 @@ val op_is_pure: Mach.operation -> bool
 (* Info for laying out the stack frame *)
 val num_stack_slots: int array
 val contains_calls: bool ref
+val initial_stack_offset : int
+val trap_frame_size_in_bytes : int
 val frame_required : unit -> bool
+val frame_size : stack_offset:int -> int
+val slot_offset : Reg.stack_location -> reg_class:int -> stack_offset:int -> int
 
 (* Function prologues *)
 val prologue_required : unit -> bool

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -308,11 +308,11 @@ let emit_instr i =
     match i.desc with
       Lend -> ()
     | Lprologue ->
+      assert (Proc.prologue_required ());
       let n = frame_size() in
       emit_stack_adjust n;
       if !contains_calls then
-        `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
-      `{emit_label !tailrec_entry_point}:\n`;
+        `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -647,7 +647,7 @@ let rec emit_all i =
 
 let fundecl fundecl =
   function_name := fundecl.fun_name;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -228,6 +228,15 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  !contains_calls
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  (* There appears to be no gprof support on this platform. *)
+  frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -391,6 +391,7 @@ method schedule_fundecl f =
       fun_fast = f.fun_fast;
       fun_dbg  = f.fun_dbg;
       fun_spacetime_shape = f.fun_spacetime_shape;
+      fun_tailrec_entry_point_label = f.fun_tailrec_entry_point_label;
     }
   end else
     f


### PR DESCRIPTION
This is a less distasteful version of GPR#2061.

By moving some of the stack offset calculation logic into `Proc` from `Emit` then I think it will be possible for the DWARF available ranges pass to get the information it needs:

- Start with a stack offset counter equal to `Proc.initial_stack_offset`.
- When traversing the linearized code, update the stack offset counter whenever a push trap, pop trap or stack offset instruction is encountered.  The size of the trap frames is exposed in `Proc`.
- This means that at any point, when an instruction is encountered whose available registers set contains a stack-allocated register, the offset of its stack slot from the current frame address can be determined.  (To do these calculations the functions moved to `Proc` are used.)

I believe it is already a requirement that a block that alters the stack offset (e.g. due to adding a trap frame) has to balance out that offset at the end of the block, so no complicated tracking of the offset is required.

I believe the mutable state that is read by the functions added to `Proc` is known to be set beforehand (for `num_stack_slots` during register allocation and for `contains_calls` during instruction selection).

If feedback on this is satisfactory then I will update this patch to make the change for all backends.