### PR TITLE
Rewording for "constructor has no type" error

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,12 +137,20 @@ Working version
   SUPPORTS_SHARED_LIBRARIES from Makefile.config.
   (David Allsopp, review by Gabriel Scherer and Mark Shinwell)
 
-- GPR#1733: change the perspective of the unexpected existential error message.
-  (Florian Angeletti, review by Gabriel Scherer and Jeremy Yallop)
-
 - GPR#1720: Improve error reporting for missing 'rec' in let-bindings.
   (Arthur Charguéraud and Armaël Guéneau, with help and advice
    from Gabriel Scherer, Frédéric Bour, Xavier Clerc and Leo White)
+
+- GPR#1733,1993,1998,2058,2094: Typing error message improvements
+    - GPR#1733, change the perspective of the unexpected existential error
+      message.
+    - GPR#1993, expanded error messages for universal quantification failure
+    - GPR#1998, more context for unbound type parameter error
+    - GPR#2058, full explanation for unsafe cycles in recursive module
+      definitions (suggestion by Ivan Gotovchits)
+    - GPR#2094, rewording for "constructor has no type" error
+  (Florian Angeletti, reviews by Jacques Garrique, Gabriel Radanne,
+   Gabriel Scherer and Jeremy Yallop)
 
 - GPR#1748: do not error when instantiating polymorphic fields in patterns.
   (Thomas Refis, review by Gabriel Scherer)
@@ -201,17 +209,9 @@ Working version
 * GPR#1979: Remove support for TERM=norepeat when displaying errors
   (Armaël Guéneau, review by Gabriel Scherer and Florian Angeletti)
 
-- GPR#1993: Expanded error messages for universal quantification failure
-  (Florian Angeletti, review by Jacques Garrigue)
-
-- GPR#1998: More context for unbound type parameter error
-  (Florian Angeletti, review by Gabriel Scherer)
 
 - GPR#1960: The parser keeps previous location when relocating ast node.
   (Hugo Heuzard, review by Jérémie Dimino)
-
-- GPR#2058: full explanation for unsafe cycles in recursive module definitions
-  (Florian Angeletti, review by Gabriel Scherer, suggested by Ivan Gotovchits)
 
 - GPR#1841, MPR#7808: the environment variable OCAMLTOP_INCLUDE_PATH can now
   specify a list of additional include directories for the ocaml toplevel.

--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -11,3 +11,12 @@ Error: The type variable 'an is unbound in this type declaration.
 Hint: Did you mean 'a, 'any, 'at or 'en?
 |}
 ]
+
+type mismatched = [< `A of int | `B of float > `B `C]
+[%%expect {|
+Line 1, characters 18-53:
+  type mismatched = [< `A of int | `B of float > `B `C]
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The constructor `C is missing from the upper bound of this
+       polymorphic variant type. Upper and lower bounds are mismatched.
+|}]

--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -17,6 +17,9 @@ type mismatched = [< `A of int | `B of float > `B `C]
 Line 1, characters 18-53:
   type mismatched = [< `A of int | `B of float > `B `C]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The constructor `C is missing from the upper bound of this
-       polymorphic variant type. Upper and lower bounds are mismatched.
+Error: The constructor C is missing from the upper bound (between '<'
+       and '>') of this polymorphic variant but is present in
+       its lower bound (after '>').
+       Hint: Either add `C in the upper bound, or remove it
+       from the lower bound.
 |}]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -936,7 +936,10 @@ let report_error env ppf = function
   | Present_has_conjunction l ->
       fprintf ppf "The present constructor %s has a conjunctive type" l
   | Present_has_no_type l ->
-      fprintf ppf "The present constructor %s has no type" l
+      fprintf ppf
+        "The constructor `%s is missing from the upper bound@ \
+         of@ this@ polymorphic variant type.@ \
+         Upper and lower bounds are mismatched." l
   | Constructor_mismatch (ty, ty') ->
       wrap_printing_env ~error:true env (fun ()  ->
         Printtyp.reset_and_mark_loops_list [ty; ty'];

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -937,9 +937,12 @@ let report_error env ppf = function
       fprintf ppf "The present constructor %s has a conjunctive type" l
   | Present_has_no_type l ->
       fprintf ppf
-        "The constructor `%s is missing from the upper bound@ \
-         of@ this@ polymorphic variant type.@ \
-         Upper and lower bounds are mismatched." l
+        "@[<v>@[The constructor %s is missing from the upper bound@ \
+         (between '<'@ and '>')@ of this polymorphic variant@ \
+         but is present in@ its lower bound (after '>').@]@,\
+         @[Hint: Either add `%s in the upper bound,@ \
+         or remove it@ from the lower bound.@]@]"
+         l l
   | Constructor_mismatch (ty, ty') ->
       wrap_printing_env ~error:true env (fun ()  ->
         Printtyp.reset_and_mark_loops_list [ty; ty'];


### PR DESCRIPTION
This small PR proposes to reword the error messages for 
mismatched upper and lower bounds in polymorphic variant type:

```OCaml
type t = [< `A | `B > `B `C ]
```
> Error: The present constructor C has no type

by 

> Error: The constructor `C is missing from the upper bound of this
       polymorphic variant type. Upper and lower bounds are mismatched.

The current error message refers to an implementation detail and may be interpreted as a suggestion to add

```OCaml
type t = [< `A | `B > `B (`C: [`C]) ]
```
or maybe
```OCaml
type t = [< `A | `B > `B `C of int]
```

which are both syntax error, whereas the probable fix is to add the missing `` `C `` to the upper bound:
```OCaml
type t = [< `A | `B |`C > `B `C ]
```

That is why I propose to replace this error message by

>Error: The constructor `C is missing from the upper bound of this
       polymorphic variant type. Upper and lower bounds are mismatched.

Another option that I considered was

>Error: The constructor `C is present but not accepted in this
       polymorphic variant type.

but this error message has the disadvantage that the notion of present or accepted is  quite removed from the surface syntax compared to the notion of upper and lower bound
(in other words, there is a `<` and a `>` in the syntax).

