### PR TITLE
Invert page table check in polymorphic hash with no-naked-pointers

### DIFF
--- a/Changes
+++ b/Changes
@@ -248,6 +248,10 @@ Working version
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
+- GPR#2079: Avoid page table lookup in polymorphc hash with
+  no-naked-pointers
+  (Sam Goldman)
+
 ### Tools
 
 - MPR#7843, GPR#2013: ocamldoc, better handling of {{!label}text} in the latex

--- a/Changes
+++ b/Changes
@@ -248,9 +248,8 @@ Working version
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
-- GPR#2079: Avoid page table lookup in polymorphc hash with
-  no-naked-pointers
-  (Sam Goldman)
+- GPR#2079: Invert page table check in polymorphic hash with no-naked-pointers
+  (Sam Goldman, review by Xavier Leroy)
 
 ### Tools
 

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -36,10 +36,14 @@
 #define Is_in_value_area(a)                                     \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
 
+#ifdef NATIVE_CODE
 #define Is_in_code_area(pc) \
  (    ((char *)(pc) >= caml_code_area_start && \
        (char *)(pc) <= caml_code_area_end)     \
    || (Classify_addr(pc) & In_code_area) )
+#else
+#define Is_in_code_area(pc) (Classify_addr(pc) & In_code_area)
+#endif
 
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
 

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -44,14 +44,16 @@ struct ext_table caml_code_fragments_table;
 
 void caml_init_code_fragments(void) {
   struct code_fragment * cf;
+  char * code_end = (char *) caml_start_code + caml_code_size;
   /* Register the code in the table of code fragments */
   cf = caml_stat_alloc(sizeof(struct code_fragment));
   cf->code_start = (char *) caml_start_code;
-  cf->code_end = (char *) caml_start_code + caml_code_size;
+  cf->code_end = code_end;
   caml_md5_block(cf->digest, caml_start_code, caml_code_size);
   cf->digest_computed = 1;
   caml_ext_table_init(&caml_code_fragments_table, 8);
   caml_ext_table_add(&caml_code_fragments_table, cf);
+  caml_page_table_add(In_code_area, (char *)caml_start_code, code_end);
 }
 
 void caml_load_code(int fd, asize_t len)

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -109,6 +109,7 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
     cf->digest_computed = 0;
   }
   caml_ext_table_add(&caml_code_fragments_table, cf);
+  caml_page_table_add(In_code_area, (char *)prog, (char *)prog + len);
 
 #ifdef ARCH_BIG_ENDIAN
   caml_fixup_endianness((code_t) prog, len);
@@ -155,6 +156,7 @@ CAMLprim value caml_static_release_bytecode(value bc)
       CAMLassert (0);
   } else {
       caml_ext_table_remove(&caml_code_fragments_table, cf);
+      caml_page_table_remove(In_code_area, cf->code_start, cf->code_end);
   }
 
 #ifndef NATIVE_CODE


### PR DESCRIPTION
Hashing will visit the fields of a closure, pushing those fields onto the queue. These fields can be code pointers, which need to be distinguished from block values.

Currently, code pointers are detected by looking them up in the page table. This also serves to identify naked pointers. Both are hashed as opaque pointer values.

In no-naked-pointers mode, there is only the need to detect code pointers. This change conditionally replaces the check based on the no-naked-pointers configuration. In no-naked-pointers mode, we use the Is_in_code_area check from address_class.h instead.

The inverse check still uses the page table, but will not pass for values are are stored outside of the heap. This makes it possible to use polymorphic hash with off-heap values.

__Bonus change__

I also noticed that the Forward_tag logic does a page table lookup. In no-naked-pointers mode, it is safe to remove as the pointed-to address will certainly be some value and not a code pointer.

__Backwards compatibility__

The table lookup could be made more granular, by only looking up the non-immediate fields of a closure. However, as the current hashing process will push all fields into the queue, to do otherwise would perturb the order of hashing operations and affect the result.

If backwards compatibility (and "sideways" compatibility between naked-pointer and no-naked-pointer modes) are not important, I am happy to make this change.

I briefly explored the possibility of communicating the extra bit of information into the queue. I believe that words are only guaranteed to be 2-aligned, and that bit is already used to distinguish long vs. block.

But assuming backwards compatibility should be maintained, in the absence of some clever trick, this change will always interrogate the code fragments table, as the page table was always interrogated before.

__Performance__

I benchmarked this on my workload, by inspecting CPU time as well as stack trace samples. Neither showed statistically significant changes. However, this is not a very good benchmark for two reasons. For one, my workload does not make much use of polymorphic hash. `caml_hash` appears in only 0.25% of samples stack traces, for example. Additionally, my workload does not make use of dynamically loaded code, which would affect the performance trade-off.

__Motivation__

I am pursuing this change not for performance, but rather because I would like to store values outside of the heap while still enjoying the polymorphic functions provided by the standard library. #2079 provides this for polymorphic compare (while also providing a nice performance boost), while this closes the loop with polymorphic hash.