### PR TITLE
Add infix operators for function composition

### DIFF
--- a/Changes
+++ b/Changes
@@ -126,6 +126,10 @@ Working version
   min_max_num to module Float.
   (Christophe Troestler, review by Alain Frish, Xavier Clerc and Daniel Bünzli)
 
+- GPR#2097: Add infix operators %< and %> (function composition) under
+  Stdlib.Fun.Ops
+  (Many fine eyes)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/manual/manual/library/stdlib.etex
+++ b/manual/manual/library/stdlib.etex
@@ -99,6 +99,10 @@ be called from C \\
 "Spacetime" & p.~\pageref{Spacetime} & memory profiler \\
 "Sys" & p.~\pageref{Sys} & system interface \\
 \end{tabular}
+\subsubsection{Misc:}
+\begin{tabular}{lll}
+"Fun" & p.~\pageref{Fun} & operators on functional values \\
+\end{tabular}
 \end{latexonly}
 
 \ifouthtml
@@ -119,6 +123,7 @@ be called from C \\
 \item \ahref{libref/Filename.html}{Module \texttt{Filename}: operations on file names}
 \item \ahref{libref/Float.html}{Module \texttt{Float}: Floating-point numbers}
 \item \ahref{libref/Format.html}{Module \texttt{Format}: pretty printing}
+\item \ahref{libref/Fun.html}{Module \texttt{Fun}: functional values}
 \item \ahref{libref/Gc.html}{Module \texttt{Gc}: memory management control and statistics; finalized values}
 \item \ahref{libref/Genlex.html}{Module \texttt{Genlex}: a generic lexical analyzer}
 \item \ahref{libref/Hashtbl.html}{Module \texttt{Hashtbl}: hash tables and hash functions}
@@ -171,6 +176,7 @@ be called from C \\
 \input{Filename.tex}
 \input{Float.tex}
 \input{Format.tex}
+\input{Fun.tex}
 \input{Gc.tex}
 \input{Genlex.tex}
 \input{Hashtbl.tex}

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -40,6 +40,7 @@ P=stdlib__
 
 LIB_OBJS=$(LIB)/camlinternalFormatBasics.cmo stdlib.cmo $(LIB)/$(P)bool.cmo \
   $(LIB)/$(P)seq.cmo $(LIB)/$(P)option.cmo $(LIB)/$(P)result.cmo \
+  $(LIB)/$(P)fun.cmo \
   $(LIB)/$(P)array.cmo $(LIB)/$(P)list.cmo \
   $(LIB)/$(P)char.cmo $(LIB)/$(P)bytes.cmo $(LIB)/$(P)string.cmo \
   $(LIB)/$(P)sys.cmo marshal.cmo $(LIB)/$(P)obj.cmo \

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -671,6 +671,7 @@ module Ephemeron    = Ephemeron
 module Filename     = Filename
 module Float        = Float
 module Format       = Format
+module Fun          = Fun
 module Gc           = Gc
 module Genlex       = Genlex
 module Hashtbl      = Hashtbl

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -77,6 +77,9 @@ stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__que
 stdlib__format.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx \
     camlinternalFormatBasics.cmx camlinternalFormat.cmx stdlib__buffer.cmx stdlib__format.cmi
 stdlib__format.cmi : stdlib.cmi stdlib__buffer.cmi
+stdlib__fun.cmo : stdlib__fun.cmi
+stdlib__fun.cmx : stdlib__fun.cmi
+stdlib__fun.cmi :
 stdlib__gc.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__printf.cmi stdlib__gc.cmi
 stdlib__gc.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__printf.cmx stdlib__gc.cmi
 stdlib__gc.cmi :
@@ -264,6 +267,8 @@ stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__que
     camlinternalFormatBasics.cmi camlinternalFormat.cmi stdlib__buffer.cmi stdlib__format.cmi
 stdlib__format.p.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx \
     camlinternalFormatBasics.cmx camlinternalFormat.cmx stdlib__buffer.cmx stdlib__format.cmi
+stdlib__fun.cmo : stdlib__fun.cmi
+stdlib__fun.p.cmx : stdlib__fun.cmi
 stdlib__gc.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__printf.cmi stdlib__gc.cmi
 stdlib__gc.p.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__printf.cmx stdlib__gc.cmi
 stdlib__genlex.cmo : stdlib__string.cmi stdlib__stream.cmi stdlib__list.cmi stdlib__hashtbl.cmi stdlib__char.cmi stdlib__bytes.cmi \

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -42,6 +42,7 @@ P=stdlib__
 
 OBJS=camlinternalFormatBasics.cmo stdlib.cmo $(OTHERS)
 OTHERS= $(P)pervasives.cmo $(P)seq.cmo $(P)option.cmo $(P)result.cmo \
+  $(P)fun.cmo \
   $(P)bool.cmo $(P)char.cmo $(P)uchar.cmo $(P)sys.cmo $(P)list.cmo \
   $(P)bytes.cmo $(P)string.cmo \
   $(P)marshal.cmo $(P)obj.cmo $(P)float.cmo $(P)array.cmo \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -43,6 +43,7 @@ STDLIB_MODULES=\
   $(P)filename \
   $(P)float \
   $(P)format \
+  $(P)fun \
   $(P)gc \
   $(P)genlex \
   $(P)hashtbl \

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -1,0 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Ops = struct
+  let ( %< ) f g x = f (g x)
+  let ( %> ) f g x = g (f x)
+end

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -1,0 +1,34 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functions and operators on functional values.
+
+    @since 4.08 *)
+
+module Ops : sig
+  val ( %< ) : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b
+  (** Function composition: [f %< g] is equivalent to [fun x -> f (g x)].
+      Left-associative at precedence level 7/11.
+      @since 4.08
+  *)
+
+
+  val ( %> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
+  (** Function reverse-composition: [f %> g] is equivalent to
+      [fun x -> g (f x)].
+      Left-associative at precedence level 7/11.
+      @since 4.08
+  *)
+end

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -583,6 +583,7 @@ module Ephemeron    = Ephemeron
 module Filename     = Filename
 module Float        = Float
 module Format       = Format
+module Fun          = Fun
 module Gc           = Gc
 module Genlex       = Genlex
 module Hashtbl      = Hashtbl

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1252,6 +1252,7 @@ module Ephemeron    = Ephemeron
 module Filename     = Filename
 module Float        = Float
 module Format       = Format
+module Fun          = Fun
 module Gc           = Gc
 module Genlex       = Genlex
 module Hashtbl      = Hashtbl

--- a/testsuite/tests/basic/composition.ml
+++ b/testsuite/tests/basic/composition.ml
@@ -1,0 +1,19 @@
+(* TEST *)
+
+open Fun.Ops
+
+let () =
+  let positive x = x > 0 in
+  let l = [-1; -2; 0; 3; 1] in
+
+  assert (List.filter (positive %> not) l = [-1; -2; 0]);
+  assert (List.filter (not %< positive) l = [-1; -2; 0]);
+  assert (List.filter (not %< positive %< succ) l = [-1; -2]);
+  assert (List.filter (not %< (succ %> positive)) l = [-1; -2]);
+  for i = - 3 to 3 do
+    assert (
+      (i |> succ %> positive %> not %> not)
+      =
+      (i |> succ %> positive |> not %> not)
+    )
+  done

--- a/testsuite/tests/basic/ocamltests
+++ b/testsuite/tests/basic/ocamltests
@@ -1,6 +1,7 @@
 arrays.ml
 bigints.ml
 boxedints.ml
+composition.ml
 constprop.ml
 divint.ml
 equality.ml


### PR DESCRIPTION
This PR extends Stdlib with infix operators for function composition:

````ocaml
val ( % ) : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b
(** Function composition: [f % g] is equivalent to [fun x -> f (g x)]. *)

val ( %> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
(** Function reverse-composition: [f %> g] is equivalent to [fun x -> g (f x)]. *)
````  

[EDIT: now the operators are called `%<` and `%>`, and put in a submodule Stdlib.Fun.Ops]

This addition is not intended to particularly encourage point-free programming, but to support it for cases people find it useful and to provide standard names for operations which people would expect to find in the Stdlib.

The same functions (with those names) exist in:
- Batteries: https://ocaml-batteries-team.github.io/batteries-included/hdoc2/BatPervasives.html
- Containers: https://github.com/c-cube/ocaml-containers/blob/master/src/core/CCFun.mli

F# and Elm expose those operators under different names (<< and >>). 

The question about the existence of infix operators is regularly raised on SO:
- https://stackoverflow.com/questions/16637015/is-there-an-infix-function-composition-operator-in-ocaml
- https://stackoverflow.com/questions/4997661/composite-functions-in-ocaml
- https://stackoverflow.com/questions/14410953/converting-f-pipeline-operators-to-ocaml

In #2010, it is proposed to add a `Bool.negate : ('a -> bool) -> ('a -> bool)` to support point-free programming on "Boolean predicates".  With the composition operators, `Bool.negate pred` could directly be written as `(not % pred)` or `(pred %> not)`.

(@pierreweis  expressed some [concerns](http://caml.inria.fr/pub/old_caml_site/caml-list/0838.html) about composition operators, but this was 20 years ago, and I'm not sure the arguments hold.)