### PR TITLE
Remove Float.of_string[_opt].

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,9 @@ Working version
 
 ### Standard library:
 
+- GPR#2098: Remove Float.of_string[_opt]
+  (Daniel C. Bünzli)
+
 - GPR#1940: Add Option module and Format.pp_print_option
   (Many fine eyes)
 

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -31,8 +31,10 @@ let min_float = Stdlib.min_float
 let epsilon = Stdlib.epsilon_float
 external of_int : int -> float = "%floatofint"
 external to_int : float -> int = "%intoffloat"
+(*
 external of_string : string -> float = "caml_float_of_string"
 let of_string_opt = Stdlib.float_of_string_opt
+*)
 let to_string = Stdlib.string_of_float
 type fpclass = Stdlib.fpclass =
     FP_normal

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -89,6 +89,7 @@ external to_int : float -> int = "%intoffloat"
     The result is unspecified if the argument is [nan] or falls outside the
     range of representable integers. *)
 
+(*
 external of_string : string -> float = "caml_float_of_string"
 (** Convert the given string to a float.  The string is read in decimal
     (by default) or in hexadecimal (marked by [0x] or [0X]).
@@ -108,6 +109,7 @@ external of_string : string -> float = "caml_float_of_string"
 
 val of_string_opt: string -> float option
 (** Same as [of_string], but returns [None] instead of raising. *)
+*)
 
 val to_string : float -> string
 (** Return the string representation of a floating-point number. *)


### PR DESCRIPTION
Given the [uncertainty](https://github.com/ocaml/ocaml/pull/2011) about `of_string`'s function's design in the stdlib. This PR removes the `Float.of_string[_opt]` functions introduced in 4.07. 

While they should be of course minimized, such adjustement in the version following the introduction of a new module have already occured in [the past](https://github.com/ocaml/ocaml/pull/1081).