### PR TITLE
Fix Unix.getaddrinfo when called on strings containing null bytes

### DIFF
--- a/Changes
+++ b/Changes
@@ -434,6 +434,10 @@ Working version
 
 ### Bug fixes:
 
+- GPR#2100: Fix Unix.getaddrinfo when called on strings containing
+  null bytes; it would crash the GC later on.
+  (Armaël Guéneau, report and fix by Joe, review by Sébastien Hinderer)
+
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the
   (Menhir-generated) parser encountered a syntax error in a certain
   specific state.

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -65,7 +65,7 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   int retcode;
 
   if (! (caml_string_is_c_safe(vnode) && caml_string_is_c_safe(vserv)))
-    return Val_int(0);
+    CAMLreturn (Val_int(0));
 
   /* Extract "node" parameter */
   if (caml_string_length(vnode) == 0) {

--- a/testsuite/tests/lib-unix/common/getaddrinfo.ml
+++ b/testsuite/tests/lib-unix/common/getaddrinfo.ml
@@ -1,0 +1,13 @@
+(* TEST
+include unix
+*)
+
+let () =
+  let x = Unix.getaddrinfo "\000" "" [] in
+  Gc.full_major ();
+  assert (x = []);;
+
+let () =
+  let x = Unix.getaddrinfo "" "\000" [] in
+  Gc.full_major ();
+  assert (x = []);;

--- a/testsuite/tests/lib-unix/common/ocamltests
+++ b/testsuite/tests/lib-unix/common/ocamltests
@@ -8,3 +8,4 @@ rename.ml
 test_unix_cmdline.ml
 utimes.ml
 wait_nohang.ml
+getaddrinfo.ml


### PR DESCRIPTION
```
utop # Unix.getaddrinfo "\000" "" [];;
Segmentation fault
```
(in batch mode, add a `Gc.full_major()` afterwards to crash the program)

This PR fixes a bug found and tracked down by Joe at the mirage hack retreat. `Unix.getaddrinfo` crashes the GC when called on a string containing null bytes because of a `return` that should be a `CAMLreturn`.
