### PR TITLE
Avoid losing information when using Debuginfo.from_location

### DIFF
--- a/middle_end/debuginfo.ml
+++ b/middle_end/debuginfo.ml
@@ -22,6 +22,9 @@ type item = {
   dinfo_line: int;
   dinfo_char_start: int;
   dinfo_char_end: int;
+  dinfo_start_bol: int;
+  dinfo_end_bol: int;
+  dinfo_end_line: int;
 }
 
 type t = item list
@@ -46,13 +49,22 @@ let to_string dbg =
     "{" ^ String.concat ";" items ^ "}"
 
 let item_from_location loc =
+  let valid_endpos =
+    String.equal loc.loc_end.pos_fname loc.loc_start.pos_fname in
   { dinfo_file = loc.loc_start.pos_fname;
     dinfo_line = loc.loc_start.pos_lnum;
     dinfo_char_start = loc.loc_start.pos_cnum - loc.loc_start.pos_bol;
     dinfo_char_end =
-      if String.equal loc.loc_end.pos_fname loc.loc_start.pos_fname
+      if valid_endpos
       then loc.loc_end.pos_cnum - loc.loc_start.pos_bol
       else loc.loc_start.pos_cnum - loc.loc_start.pos_bol;
+    dinfo_start_bol = loc.loc_start.pos_bol;
+    dinfo_end_bol =
+      if valid_endpos then loc.loc_end.pos_bol
+      else loc.loc_start.pos_bol;
+    dinfo_end_line =
+      if valid_endpos then loc.loc_end.pos_lnum
+      else loc.loc_start.pos_lnum;
   }
 
 let from_location loc =
@@ -64,10 +76,15 @@ let to_location = function
     let loc_start =
       { pos_fname = d.dinfo_file;
         pos_lnum = d.dinfo_line;
-        pos_bol = 0;
-        pos_cnum = d.dinfo_char_start;
+        pos_bol = d.dinfo_start_bol;
+        pos_cnum = d.dinfo_start_bol + d.dinfo_char_start;
       } in
-    let loc_end = { loc_start with pos_cnum = d.dinfo_char_end; } in
+    let loc_end =
+      { pos_fname = d.dinfo_file;
+        pos_lnum = d.dinfo_end_line;
+        pos_bol = d.dinfo_end_bol;
+        pos_cnum = d.dinfo_start_bol + d.dinfo_char_end;
+      } in
     { loc_ghost = false; loc_start; loc_end; }
 
 let inline loc t =
@@ -96,6 +113,12 @@ let compare dbg1 dbg2 =
       let c = compare d1.dinfo_char_end d2.dinfo_char_end in
       if c <> 0 then c else
       let c = compare d1.dinfo_char_start d2.dinfo_char_start in
+      if c <> 0 then c else
+      let c = compare d1.dinfo_start_bol d2.dinfo_start_bol in
+      if c <> 0 then c else
+      let c = compare d1.dinfo_end_bol d2.dinfo_end_bol in
+      if c <> 0 then c else
+      let c = compare d1.dinfo_end_line d2.dinfo_end_line in
       if c <> 0 then c else
       loop ds1 ds2
   in

--- a/middle_end/debuginfo.mli
+++ b/middle_end/debuginfo.mli
@@ -17,7 +17,10 @@ type item = private {
   dinfo_file: string;
   dinfo_line: int;
   dinfo_char_start: int;
-  dinfo_char_end: int
+  dinfo_char_end: int;
+  dinfo_start_bol: int;
+  dinfo_end_bol: int;
+  dinfo_end_line: int;
 }
 
 type t = item list


### PR DESCRIPTION
It seems the middle end can emit semi-broken locations. 
`fun x -> Debuginfo.(to_location (from_location x))` is not the identity, because a `Debuginfo.t` contains strictly less information that a `Location.t`. In particular, it forgets about the position of start/end points in the input, and only remembers their position relative to the beginning of the line.

Currently this goes unnoticed because `Debuginfo.to_location` produces a mock location that is printed the same as the original one when calling `Location.print_loc`. However, this breaks #2096 in which I rely on the full information of the locations to look for the corresponding source code in the input.

This PR adds the missing information in `Debuginfo.item` so that `to_location o from_location` can be the identity (except for locations that would contain different filenames for start/end but I don't think this happens).