### PR TITLE
Change verbatim to caml_example in documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -308,6 +308,9 @@ Working version
   literals to the main part of the manual.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- GPR#2105: Change verbatim to caml_example in documentation
+  (Maxime Flin, review by Florian Angeletti)
+
 ### Compiler distribution build system:
 
 - GPR#1776: add -no-install-bytecode-programs and related configure options to

--- a/manual/README.md
+++ b/manual/README.md
@@ -142,6 +142,16 @@ In particular, toplevel examples must end with a double semi-colon `;;`,
 otherwise an error would be raised.
 The `verbatim` does not require a final `;;` and is intended to be
 a lighter mode for code examples.
+If you want to declare a signature instead of ocaml code,
+you must use the `{signature}` argument to the `caml_example` environment.
+```latex
+\begin{caml_example*}{signature}
+module A : sig
+  type t
+  val f: t -> t -> int
+end
+\end{caml_example*}
+```
 
 By default, `caml-tex` raises an error and stops if the output of one
 the `caml_example` environment contains an unexpected error or warning.

--- a/manual/README.md
+++ b/manual/README.md
@@ -134,9 +134,14 @@ let f x = x
 \end{caml_example*}
 ```
 
-The `{verbatim}` or `{toplevel}` argument of the environment corresponds
-to the the mode of the example, two modes are available `toplevel` and
-`verbatim`.
+```latex
+\begin{caml_example*}{signature}
+val none : 'a option
+\end{caml_example*}
+```
+
+The {verbatim} or {toplevel} argument of the environment corresponds
+to the the mode of the example, three modes are available toplevel, verbatim and signature.
 The `toplevel` mode mimics the appearance and behavior of the toplevel.
 In particular, toplevel examples must end with a double semi-colon `;;`,
 otherwise an error would be raised.
@@ -144,14 +149,6 @@ The `verbatim` does not require a final `;;` and is intended to be
 a lighter mode for code examples.
 If you want to declare a signature instead of ocaml code,
 you must use the `{signature}` argument to the `caml_example` environment.
-```latex
-\begin{caml_example*}{signature}
-module A : sig
-  type t
-  val f: t -> t -> int
-end
-\end{caml_example*}
-```
 
 By default, `caml-tex` raises an error and stops if the output of one
 the `caml_example` environment contains an unexpected error or warning.

--- a/manual/README.md
+++ b/manual/README.md
@@ -134,12 +134,6 @@ let f x = x
 \end{caml_example*}
 ```
 
-```latex
-\begin{caml_example*}{signature}
-val none : 'a option
-\end{caml_example*}
-```
-
 The {verbatim} or {toplevel} argument of the environment corresponds
 to the the mode of the example, three modes are available toplevel, verbatim and signature.
 The `toplevel` mode mimics the appearance and behavior of the toplevel.
@@ -149,6 +143,12 @@ The `verbatim` does not require a final `;;` and is intended to be
 a lighter mode for code examples.
 If you want to declare a signature instead of ocaml code,
 you must use the `{signature}` argument to the `caml_example` environment.
+
+```latex
+\begin{caml_example*}{signature}
+val none : 'a option
+\end{caml_example*}
+```
 
 By default, `caml-tex` raises an error and stops if the output of one
 the `caml_example` environment contains an unexpected error or warning.

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -983,14 +983,14 @@ The expression
 locally binds the module expression @module-expr@ to the identifier
 @module-name@ during the evaluation of the expression @expr@.
 It then returns the value of @expr@.  For example:
-\begin{verbatim}
-        let remove_duplicates comparison_fun string_list =
-          let module StringSet =
-            Set.Make(struct type t = string
-                            let compare = comparison_fun end) in
-          StringSet.elements
-            (List.fold_right StringSet.add string_list StringSet.empty)
-\end{verbatim}
+\begin{caml_example}{verbatim}
+let remove_duplicates comparison_fun string_list =
+  let module StringSet =
+    Set.Make(struct type t = string
+                    let compare = comparison_fun end) in
+  StringSet.elements
+    (List.fold_right StringSet.add string_list StringSet.empty)
+\end{caml_example}
 
 \subsubsection*{Local opens}
 \ikwd{let\@\texttt{let}}

--- a/manual/manual/refman/modules.etex
+++ b/manual/manual/refman/modules.etex
@@ -204,7 +204,7 @@ defining the module "B" as
 \begin{caml_example*}{verbatim}
 module B = struct include S  let y = (x + 1 : t) end
 \end{caml_example}
-is equivalent to do
+is equivalent to defining it as
 \begin{caml_example*}{verbatim}
 module B = struct type t = S.t  let x = S.x  let y = (x + 1 : t) end
 \end{caml_example}

--- a/manual/manual/refman/modules.etex
+++ b/manual/manual/refman/modules.etex
@@ -198,17 +198,17 @@ The expression @'include' module-expr@ in a structure re-exports in
 the current structure all definitions of the structure denoted by
 @module-expr@.  For instance, if the identifier "S" is bound to the
 module
-\begin{verbatim}
-        struct type t = int  let x = 2 end
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+module S = struct type t = int  let x = 2 end
+\end{caml_example}
 the module expression
-\begin{verbatim}
-        struct include S  let y = (x + 1 : t) end
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+module B = struct include S  let y = (x + 1 : t) end
+\end{caml_example}
 is equivalent to the module expression
-\begin{verbatim}
-        struct type t = S.t  let x = S.x  let y = (x + 1 : t) end
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+module B = struct type t = S.t  let x = S.x  let y = (x + 1 : t) end
+\end{caml_example}
 The difference between @'open'@ and @'include'@ is that @'open'@
 simply provides short names for the components of the opened
 structure, without defining any components of the current structure,

--- a/manual/manual/refman/modules.etex
+++ b/manual/manual/refman/modules.etex
@@ -196,16 +196,15 @@ the @"open"@ stops at the end of the structure expression.
 
 The expression @'include' module-expr@ in a structure re-exports in
 the current structure all definitions of the structure denoted by
-@module-expr@.  For instance, if the identifier "S" is bound to the
-module
+@module-expr@.  For instance, if you define a module "S" as below
 \begin{caml_example*}{verbatim}
 module S = struct type t = int  let x = 2 end
 \end{caml_example}
-the module expression
+defining the module "B" as
 \begin{caml_example*}{verbatim}
 module B = struct include S  let y = (x + 1 : t) end
 \end{caml_example}
-is equivalent to the module expression
+is equivalent to do
 \begin{caml_example*}{verbatim}
 module B = struct type t = S.t  let x = S.x  let y = (x + 1 : t) end
 \end{caml_example}


### PR DESCRIPTION
Hi !

I added a paragraph in the manual's readme about the `{signature}` option of the `caml_example` environment.

I also changed some `verbatim` environment to `caml_example` in chapters 7.7 and 7.11 where there was some code left untested.

Thanks