### PR TITLE
check_scope_escape: also handle type constructors escapes

### DIFF
--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -41,13 +41,12 @@ type 'a local_visit_action
 type ('a, 'result, 'visit_action) context =
     Local : ('a, 'a * insert, 'a local_visit_action) context
   | Global : ('a, 'a, 'a visit_action) context
-Line 16, characters 4-10:
-    | Global -> fun _ -> raise Exit
-      ^^^^^^
-Error: This pattern matches values of type ($1, $1, visit_action) context
-       but a pattern was expected which matches values of type
+Line 15, characters 4-9:
+    | Local -> fun _ -> raise Exit
+      ^^^^^
+Error: This pattern matches values of type
          ($0, $0 * insert, visit_action) context
-       Type $1 is not compatible with type $0
+       The type constructor $0 would escape its scope
 |}];;
 
 let vexpr (type visit_action)
@@ -66,13 +65,12 @@ Error: This pattern matches values of type
          ($'a, $'a * insert, visit_action) context
        The type constructor $'a would escape its scope
 |}, Principal{|
-Line 5, characters 4-10:
-    | Global -> fun _ -> raise Exit
-      ^^^^^^
-Error: This pattern matches values of type ($1, $1, visit_action) context
-       but a pattern was expected which matches values of type
+Line 4, characters 4-9:
+    | Local -> fun _ -> raise Exit
+      ^^^^^
+Error: This pattern matches values of type
          ($0, $0 * insert, visit_action) context
-       Type $1 is not compatible with type $0
+       The type constructor $0 would escape its scope
 |}];;
 
 let vexpr (type result) (type visit_action)

--- a/testsuite/tests/typing-gadts/pr7222.ml
+++ b/testsuite/tests/typing-gadts/pr7222.ml
@@ -38,7 +38,5 @@ Line 9, characters 6-22:
     let Cons(Elt dim, _) = sh in ()
         ^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type ('a -> $0 -> nil) t
-       but a pattern was expected which matches values of type
-         ('a -> 'b -> nil) t
        The type constructor $0 would escape its scope
 |}];;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -766,6 +766,11 @@ let check_scope_escape level ty =
       ty.level <- pivot_level - ty.level;
       if level < ty.scope then
         raise(Trace.scope_escape ty);
+      begin match ty.desc with
+      | Tconstr (p, _, _) when level < Path.scope p ->
+        raise Trace.(Unify [escape (Constructor p)])
+      | _ -> ()
+      end;
       iter_type_expr aux ty
     end
   in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -759,8 +759,8 @@ let rec normalize_package_path env p =
           normalize_package_path env (Path.Pdot (p1', s, n))
       | _ -> p
 
-let check_scope_escape level ty =
-  let rec aux ty =
+let check_scope_escape env level ty =
+  let rec loop ty =
     let ty = repr ty in
     if ty.level >= lowest_level then begin
       ty.level <- pivot_level - ty.level;
@@ -768,15 +768,24 @@ let check_scope_escape level ty =
         raise(Trace.scope_escape ty);
       begin match ty.desc with
       | Tconstr (p, _, _) when level < Path.scope p ->
-        raise Trace.(Unify [escape (Constructor p)])
-      | _ -> ()
+          begin match !forward_try_expand_once env ty with
+          | ty' -> aux ty'
+          | exception Cannot_expand ->
+              raise Trace.(Unify [escape (Constructor p)])
+          end
+      | Tpackage (p, nl, tl) when level < Path.scope p ->
+          let p' = normalize_package_path env p in
+          if Path.same p p' then raise Trace.(Unify [escape (Module_type p)]);
+          aux { ty with desc = Tpackage (p', nl, tl) }
+      | _ ->
+        iter_type_expr loop ty
       end;
-      iter_type_expr aux ty
     end
-  in
-  try
-    aux ty;
+  and aux ty =
+    loop ty;
     unmark_type ty
+  in
+  try aux ty;
   with Unify [Trace.Escape x] ->
     raise Trace.(Unify[Escape { x with context = Some ty }])
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -156,8 +156,8 @@ val limited_generalize: type_expr -> type_expr -> unit
         (* Only generalize some part of the type
            Make the remaining of the type non-generalizable *)
 
-val check_scope_escape : int -> type_expr -> unit
-        (* [check_scope_escape lvl ty] ensures that [ty] could be raised
+val check_scope_escape : Env.t -> int -> type_expr -> unit
+        (* [check_scope_escape env lvl ty] ensures that [ty] could be raised
            to the level [lvl] without any scope escape.
            Raises [Unify] otherwise *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4017,7 +4017,7 @@ and type_statement ?explanation env sexp =
 
 (* Typing of match cases *)
 and check_scope_escape loc env level ty =
-  try Ctype.check_scope_escape level ty
+  try Ctype.check_scope_escape env level ty
   with Unify trace ->
     raise(Error(loc, env, Pattern_type_clash(trace)))
 


### PR DESCRIPTION
Currently `Ctype.check_scope_escape` ensures that a type doesn't escape the scope of its equation. As discussed in https://github.com/ocaml/ocaml/pull/1609#issuecomment-368804475, it is a cosmetic change but shouldn't change whether some input typechecks or not.

This PR proposes to extend the scope of that function (pun intended) to also check for existential types escapes.

PS: It should be easy to rebase #2047 on top of this PR or vice versa.