### PR TITLE
Print full paths in spellchecking suggestions when needed for disambiguation

### DIFF
--- a/Changes
+++ b/Changes
@@ -209,7 +209,6 @@ Working version
 * GPR#1979: Remove support for TERM=norepeat when displaying errors
   (Armaël Guéneau, review by Gabriel Scherer and Florian Angeletti)
 
-
 - GPR#1960: The parser keeps previous location when relocating ast node.
   (Hugo Heuzard, review by Jérémie Dimino)
 
@@ -217,6 +216,9 @@ Working version
   specify a list of additional include directories for the ocaml toplevel.
   (Nicolás Ojeda Bär, request by Daniel Bünzli, review by Daniel Bünzli and
   Damien Doligez)
+
+- MPR#7864, GPR#2109: remove duplicates from spelling suggestions.
+  (Nicolás Ojeda Bär, review by Armaël Guéneau)
 
 ### Code generation and optimizations:
 

--- a/testsuite/tests/typing-core-bugs/ocamltests
+++ b/testsuite/tests/typing-core-bugs/ocamltests
@@ -1,3 +1,4 @@
 missing_rec_hint.ml
 unit_fun_hints.ml
 type_expected_explanation.ml
+repeated_did_you_mean.ml

--- a/testsuite/tests/typing-core-bugs/repeated_did_you_mean.ml
+++ b/testsuite/tests/typing-core-bugs/repeated_did_you_mean.ml
@@ -1,0 +1,22 @@
+(* TEST
+   * expect
+*)
+
+(* MPR 7864 *)
+
+let foo = 12
+module M = struct
+  let foo = 13
+end
+open M
+
+let _ = fox;;
+[%%expect{|
+val foo : int = 12
+module M : sig val foo : int end
+Line 7, characters 8-11:
+7 | let _ = fox;;
+            ^^^
+Error: Unbound value fox
+Hint: Did you mean foo?
+|}]

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -546,6 +546,7 @@ let spellcheck env name =
          else if dist = best_dist then (head :: best_choice, dist)
          else acc
   in
+  let env = List.sort_uniq (fun s1 s2 -> String.compare s2 s1) env in
   fst (List.fold_left (compare name) ([], max_int) env)
 
 let did_you_mean ppf get_choices =


### PR DESCRIPTION
See [MPR#7864](https://caml.inria.fr/mantis/view.php?id=7864). It's a bit hackish, so suggestions welcome!

Before:
<img width="277" alt="image" src="https://user-images.githubusercontent.com/113560/47167185-31925580-d2fe-11e8-875f-85c1ab2d1bf5.png">

After:
<img width="277" alt="image" src="https://user-images.githubusercontent.com/113560/47167160-23443980-d2fe-11e8-8df1-375532e09ab4.png">
