### PR TITLE
Allow GADT constructors to introduce equations and existential types under or-patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,10 @@ Working version
   (Jeremy Yallop, review by Gabriel Scherer, Florian Angeletti, and
    Damien Doligez)
 
+- GPR#2110: Allow GADT constructors to introduce equations and existential types
+  under or-patterns.
+  (Thomas Refis and Leo White, review by Jacques Garrigue)
+
 ### Type system:
 
 - GPR#1826: allow expanding a type to a private abbreviation instead of

--- a/testsuite/tests/typing-gadts/ocamltests
+++ b/testsuite/tests/typing-gadts/ocamltests
@@ -3,6 +3,7 @@ didier.ml
 dynamic_frisch.ml
 nested_equations.ml
 omega07.ml
+or_patterns.ml
 pr5332.ml
 pr5689.ml
 pr5785.ml

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -19,8 +19,8 @@ let trivial t =
 
 [%%expect{|
 Line 4, characters 4-11:
-    | BoolLit -> ()
-      ^^^^^^^
+4 |   | BoolLit -> ()
+        ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
@@ -44,8 +44,8 @@ let trivial_merged t =
 
 [%%expect{|
 Line 4, characters 4-11:
-    | BoolLit -> ()
-      ^^^^^^^
+4 |   | BoolLit -> ()
+        ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
@@ -58,12 +58,7 @@ let trivial_merged_annotated (type a) (t : a t) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val trivial_merged_annotated : 'a t -> unit = <fun>
 |}]
 
 let trivial_merged_annotated_under_tuple1 (type a) (t : a t) =
@@ -73,12 +68,7 @@ let trivial_merged_annotated_under_tuple1 (type a) (t : a t) =
 ;;
 
 [%%expect{|
-Line 3, characters 8-14:
-    | _, (IntLit
-          ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val trivial_merged_annotated_under_tuple1 : 'a t -> unit = <fun>
 |}]
 
 let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
@@ -89,8 +79,8 @@ let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
 
 [%%expect{|
 Line 3, characters 22-29:
-    | IntLit, (IntLit | BoolLit) -> ()
-                        ^^^^^^^
+3 |   | IntLit, (IntLit | BoolLit) -> ()
+                          ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type a t
        Type bool is not compatible with type a = int
@@ -103,12 +93,7 @@ let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
 ;;
 
 [%%expect{|
-Line 3, characters 5-11:
-    | (IntLit | BoolLit), IntLit -> ()
-       ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val trivial_merged_annotated_under_tuple2 : 'a t * 'a t -> unit = <fun>
 |}]
 
 
@@ -122,12 +107,7 @@ let trivial_merged_annotated_under_array (type a) (t : a t array) =
 ;;
 
 [%%expect{|
-Line 3, characters 8-14:
-    | [| (IntLit | BoolLit); _ |] -> ()
-          ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val trivial_merged_annotated_under_array : 'a t array -> unit = <fun>
 |}]
 
 let simple t a =
@@ -139,15 +119,15 @@ let simple t a =
 
 [%%expect{|
 Line 4, characters 4-11:
-    | BoolLit, true -> ()
-      ^^^^^^^
+4 |   | BoolLit, true -> ()
+        ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
 |}, Principal{|
 Line 4, characters 4-17:
-    | BoolLit, true -> ()
-      ^^^^^^^^^^^^^
+4 |   | BoolLit, true -> ()
+        ^^^^^^^^^^^^^
 Error: This pattern matches values of type bool t * bool
        but a pattern was expected which matches values of type int t * int
        Type bool is not compatible with type int
@@ -173,8 +153,8 @@ let simple_merged t a =
 
 [%%expect{|
 Line 4, characters 4-11:
-    | BoolLit, true -> ()
-      ^^^^^^^
+4 |   | BoolLit, true -> ()
+        ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
@@ -188,12 +168,13 @@ let simple_merged_ambi (type a) (t : a t) a =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, (3 : a)
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+Line 4, characters 13-17:
+4 |   | BoolLit, true -> ()
+                 ^^^^
+Error: This pattern matches values of type bool
+       but a pattern was expected which matches values of type a = bool
+       This instance of bool is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 
@@ -205,12 +186,11 @@ let simple_merged_not_annotated_enough (type a) (t : a t) a =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, 3
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+Line 4, characters 13-17:
+4 |   | BoolLit, true -> ()
+                 ^^^^
+Error: This pattern matches values of type bool
+       but a pattern was expected which matches values of type int
 |}]
 
 
@@ -222,12 +202,7 @@ let simple_merged_annotated (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, 3
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated : 'a t -> 'a -> unit = <fun>
 |}]
 
 let simple_mega_merged_annotated (type a) (t : a t) (a : a) =
@@ -238,12 +213,7 @@ let simple_mega_merged_annotated (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, 3
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_mega_merged_annotated : 'a t -> 'a -> unit = <fun>
 |}]
 
 let simple_merged_annotated_return (type a) (t : a t) (a : a) =
@@ -254,12 +224,12 @@ let simple_merged_annotated_return (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, (3 as x)
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+Line 3, characters 12-20:
+3 |   | IntLit, (3 as x)
+                ^^^^^^^^
+Error: This pattern matches values of type a
+       This instance of a is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
@@ -270,12 +240,11 @@ let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, ((3 : a) as x)
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+Line 3, characters 4-57:
+3 | ....IntLit, ((3 : a) as x)
+4 |   | BoolLit, ((true : a) as x)............
+Error: The variable x on the left-hand side of this or-pattern has type
+       a but on the right-hand side it has type bool
 |}]
 
 (* test more scenarios: when the or-pattern itself is not at toplevel but under
@@ -289,12 +258,7 @@ let simple_merged_annotated_under_tuple (type a) (pair : a t * a) =
 ;;
 
 [%%expect{|
-Line 3, characters 10-16:
-    | (), ( IntLit, 3
-            ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_tuple : 'a t * 'a -> unit = <fun>
 |}]
 
 let simple_merged_annotated_under_arrays (type a) (pair : a t * a) =
@@ -305,12 +269,7 @@ let simple_merged_annotated_under_arrays (type a) (pair : a t * a) =
 ;;
 
 [%%expect{|
-Line 3, characters 16-22:
-    | [| _ ; [| ( IntLit, 3
-                  ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_arrays : 'a t * 'a -> unit = <fun>
 |}]
 
 
@@ -322,12 +281,13 @@ let simple_merged_annotated_under_poly_variant (type a) (pair : a t * a) =
 ;;
 
 [%%expect{|
-Line 3, characters 11-17:
-    | `Foo ( IntLit, 3
-             ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+Line 3, characters 19-20:
+3 |   | `Foo ( IntLit, 3
+                       ^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type a = int
+       This instance of int is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 let simple_merged_annotated_under_poly_variant_annotated (type a) pair =
@@ -338,12 +298,8 @@ let simple_merged_annotated_under_poly_variant_annotated (type a) pair =
 ;;
 
 [%%expect{|
-Line 3, characters 11-17:
-    | `Foo ( IntLit, 3
-             ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_poly_variant_annotated : 'a t * 'a -> unit =
+  <fun>
 |}]
 
 type 'a iref = { content : 'a; };;
@@ -358,12 +314,7 @@ let simple_merged_annotated_under_record (type a) (pair : a t * a) =
   | _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 18-24:
-    | { content = ( IntLit, 3
-                    ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_record : 'a t * 'a -> unit = <fun>
 |}]
 
 let simple_merged_annotated_under_mutable_record (type a) (pair : a t * a) =
@@ -373,12 +324,7 @@ let simple_merged_annotated_under_mutable_record (type a) (pair : a t * a) =
   | _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 19-25:
-    | { contents = ( IntLit, 3
-                     ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_mutable_record : 'a t * 'a -> unit = <fun>
 |}]
 
 type 'a piref = { pcontent : 'b. 'a * 'b; };;
@@ -393,12 +339,8 @@ let simple_merged_annotated_under_poly_record1 (type a) (r : (a t * a) piref) =
   | _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 19-25:
-    | { pcontent = ( IntLit, 3
-                     ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_poly_record1 : ('a t * 'a) piref -> unit =
+  <fun>
 |}]
 
 let simple_merged_annotated_under_poly_record2 (type a) (r : (a t * a) piref) =
@@ -408,12 +350,8 @@ let simple_merged_annotated_under_poly_record2 (type a) (r : (a t * a) piref) =
   | _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 20-26:
-    | { pcontent = ( (IntLit, 3), _
-                      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_poly_record2 : ('a t * 'a) piref -> unit =
+  <fun>
 |}]
 
 let simple_merged_annotated_under_constructor (type a) (pair : a t * a) =
@@ -423,12 +361,7 @@ let simple_merged_annotated_under_constructor (type a) (pair : a t * a) =
   | _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 11-17:
-    | Some ( IntLit, 3
-             ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_constructor : 'a t * 'a -> unit = <fun>
 |}]
 
 type _ gadt_opt =
@@ -446,12 +379,8 @@ let simple_merged_annotated_under_gadt_constructor (type a) (pair : a t * a) =
   | _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 12-18:
-    | GSome ( IntLit, 3
-              ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val simple_merged_annotated_under_gadt_constructor : 'a t * 'a -> unit =
+  <fun>
 |}]
 
 (* back to simpler tests. *)
@@ -464,15 +393,15 @@ let noop t a =
 
 [%%expect{|
 Line 4, characters 4-11:
-    | BoolLit, x -> x
-      ^^^^^^^
+4 |   | BoolLit, x -> x
+        ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
 |}, Principal{|
 Line 4, characters 4-14:
-    | BoolLit, x -> x
-      ^^^^^^^^^^
+4 |   | BoolLit, x -> x
+        ^^^^^^^^^^
 Error: This pattern matches values of type bool t * 'a
        but a pattern was expected which matches values of type int t * 'b
        Type bool is not compatible with type int
@@ -496,8 +425,8 @@ let noop_merged t a =
 
 [%%expect{|
 Line 4, characters 4-11:
-    | BoolLit, x -> x
-      ^^^^^^^
+4 |   | BoolLit, x -> x
+        ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
@@ -510,12 +439,7 @@ let noop_merged_annotated (type a) (t : a t) (a : a) : a =
 ;;
 
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit, x
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val noop_merged_annotated : 'a t -> 'a -> 'a = <fun>
 |}]
 
 (***)
@@ -536,8 +460,8 @@ let trivial2 t2 =
 
 [%%expect{|
 Line 4, characters 4-10:
-    | Bool _ -> ()
-      ^^^^^^
+4 |   | Bool _ -> ()
+        ^^^^^^
 Error: This pattern matches values of type bool t2
        but a pattern was expected which matches values of type int t2
        Type bool is not compatible with type int
@@ -561,8 +485,8 @@ let trivial2_merged t2 =
 
 [%%expect{|
 Line 4, characters 4-10:
-    | Bool _ -> ()
-      ^^^^^^
+4 |   | Bool _ -> ()
+        ^^^^^^
 Error: This pattern matches values of type bool t2
        but a pattern was expected which matches values of type int t2
        Type bool is not compatible with type int
@@ -575,12 +499,7 @@ let trivial2_merged_annotated (type a) (t2 : a t2) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-9:
-    | Int _
-      ^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+val trivial2_merged_annotated : 'a t2 -> unit = <fun>
 |}]
 
 
@@ -592,8 +511,8 @@ let extract t2 =
 
 [%%expect{|
 Line 4, characters 4-10:
-    | Bool _ -> x
-      ^^^^^^
+4 |   | Bool _ -> x
+        ^^^^^^
 Error: This pattern matches values of type bool t2
        but a pattern was expected which matches values of type int t2
        Type bool is not compatible with type int
@@ -617,8 +536,8 @@ let extract_merged t2 =
 
 [%%expect{|
 Line 4, characters 4-10:
-    | Bool x -> x
-      ^^^^^^
+4 |   | Bool x -> x
+        ^^^^^^
 Error: This pattern matches values of type bool t2
        but a pattern was expected which matches values of type int t2
        Type bool is not compatible with type int
@@ -632,12 +551,11 @@ let extract_merged_annotated (type a) (t2 : a t2) : a =
 
 
 [%%expect{|
-Line 3, characters 4-9:
-    | Int x
-      ^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+Line 3, characters 4-20:
+3 | ....Int x
+4 |   | Bool x.....
+Error: The variable x on the left-hand side of this or-pattern has type
+       int but on the right-hand side it has type bool
 |}]
 
 let extract_merged_super_annotated (type a) (t2 : a t2) : a =
@@ -647,12 +565,7 @@ let extract_merged_super_annotated (type a) (t2 : a t2) : a =
 ;;
 
 [%%expect{|
-Line 3, characters 4-15:
-    | Int (x : a)
-      ^^^^^^^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+val extract_merged_super_annotated : 'a t2 -> 'a = <fun>
 |}]
 
 let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
@@ -662,12 +575,11 @@ let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
 ;;
 
 [%%expect{|
-Line 3, characters 4-15:
-    | Int (x : a)
-      ^^^^^^^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+Line 3, characters 4-26:
+3 | ....Int (x : a)
+4 |   | Bool x.....
+Error: The variable x on the left-hand side of this or-pattern has type
+       a but on the right-hand side it has type bool
 |}]
 
 let extract_merged_super_lightly_annotated (type a) (t2 : a t2) =
@@ -677,12 +589,7 @@ let extract_merged_super_lightly_annotated (type a) (t2 : a t2) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-15:
-    | Int (x : a)
-      ^^^^^^^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+val extract_merged_super_lightly_annotated : 'a t2 -> 'a = <fun>
 |}]
 
 let lambiguity (type a) (t2 : a t2) =
@@ -692,12 +599,12 @@ let lambiguity (type a) (t2 : a t2) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-22:
-    | Int ((_ : a) as x)
-      ^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+Line 3, characters 8-22:
+3 |   | Int ((_ : a) as x)
+            ^^^^^^^^^^^^^^
+Error: This pattern matches values of type a
+       This instance of a is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 let rambiguity (type a) (t2 : a t2) =
@@ -707,12 +614,12 @@ let rambiguity (type a) (t2 : a t2) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-16:
-    | Int (_ as x)
-      ^^^^^^^^^^^^
-Error: This pattern matches values of type int t2
-       but a pattern was expected which matches values of type a t2
-       Type int is not compatible with type a
+Line 4, characters 9-23:
+4 |   | Bool ((_ : a) as x) -> x
+             ^^^^^^^^^^^^^^
+Error: This pattern matches values of type a
+       This instance of a is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 
@@ -742,27 +649,20 @@ let return_int (type a) (x : a t3) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-5:
-    | A | B -> 3
-      ^
-Error: This pattern matches values of type int t3
-       but a pattern was expected which matches values of type a t3
-       Type int is not compatible with type a
+val return_int : 'a t3 -> int = <fun>
 |}]
 
 let return_a (type a) (x : a t3) : a =
   match x with
-  | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of the
-                  branches of this or-pattern. *)
+  | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of
+                  the branches of this or-pattern. *)
 ;;
 
 [%%expect{|
-Line 3, characters 4-5:
-    | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of the
-      ^
-Error: This pattern matches values of type int t3
-       but a pattern was expected which matches values of type a t3
-       Type int is not compatible with type a
+Line 3, characters 13-14:
+3 |   | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of
+                 ^
+Error: This expression has type int but an expression was expected of type a
 |}]
 
 (* Making sure we don't break a frequent pattern of GADTs indexed by polymorphic
@@ -820,12 +720,7 @@ let f_ok (type a) (t : a t) (a : bool iref) (b : a iref) =
   | _, _, _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit,  ({ content = true } as x), _
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+val f_ok : 'a t -> bool iref -> 'a iref -> unit = <fun>
 |}]
 
 
@@ -836,12 +731,13 @@ let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
   | _, _, _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 4-10:
-    | IntLit,  ({ contents = true } as x), _
-      ^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type a t
-       Type int is not compatible with type a
+Line 3, characters 4-108:
+3 | ....IntLit,  ({ contents = true } as x), _
+4 |   | BoolLit,  _,                        ({ contents = true} as x)............
+Error: The variable x on the left-hand side of this or-pattern has type
+         bool ref
+       but on the right-hand side it has type a ref
+       Type bool is not compatible with type a
 |}]
 
 (********************************************)
@@ -859,9 +755,9 @@ let f = function
   | B x -> ignore x
 ;;
 [%%expect{|
-Line 2, characters 4-15:
-  ....A x
-    | B x............
-Error: The variable x on the left-hand side of this or-pattern has type
-       $A_'a but on the right-hand side it has type $B_'a
+Line 2, characters 6-7:
+2 |   | A x
+          ^
+Error: This pattern matches values of type $A_'a
+       The type constructor $A_'a would escape its scope
 |}]

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -1,0 +1,867 @@
+(* TEST
+   * expect
+*)
+
+type _ t =
+  | IntLit : int t
+  | BoolLit : bool t
+;;
+
+[%%expect{|
+type _ t = IntLit : int t | BoolLit : bool t
+|}]
+
+let trivial t =
+  match t with
+  | IntLit -> ()
+  | BoolLit -> ()
+;;
+
+[%%expect{|
+Line 4, characters 4-11:
+    | BoolLit -> ()
+      ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}]
+
+let trivial_annotated (type a) (t : a t) =
+  match t with
+  | IntLit -> ()
+  | BoolLit -> ()
+;;
+
+[%%expect{|
+val trivial_annotated : 'a t -> unit = <fun>
+|}]
+
+let trivial_merged t =
+  match t with
+  | IntLit
+  | BoolLit -> ()
+;;
+
+[%%expect{|
+Line 4, characters 4-11:
+    | BoolLit -> ()
+      ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}]
+
+let trivial_merged_annotated (type a) (t : a t) =
+  match t with
+  | IntLit
+  | BoolLit -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let trivial_merged_annotated_under_tuple1 (type a) (t : a t) =
+  match (3, t) with
+  | _, (IntLit
+       | BoolLit) -> ()
+;;
+
+[%%expect{|
+Line 3, characters 8-14:
+    | _, (IntLit
+          ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
+  match tt with
+  | IntLit, (IntLit | BoolLit) -> ()
+  | _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 22-29:
+    | IntLit, (IntLit | BoolLit) -> ()
+                        ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type a t
+       Type bool is not compatible with type a = int
+|}]
+
+let trivial_merged_annotated_under_tuple2 (type a) (tt : a t * a t) =
+  match tt with
+  | (IntLit | BoolLit), IntLit -> ()
+  | _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 5-11:
+    | (IntLit | BoolLit), IntLit -> ()
+       ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+
+let trivial_merged_annotated_under_array (type a) (t : a t array) =
+  match t with
+  | [| (IntLit | BoolLit); _ |] -> ()
+  | [| _; _; (BoolLit | IntLit) |] -> ()
+  | [| _; _; _; (BoolLit | IntLit) |]
+  | [| _; _; _; (BoolLit | IntLit); _ |] -> ()
+  | _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 8-14:
+    | [| (IntLit | BoolLit); _ |] -> ()
+          ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple t a =
+  match t, a with
+  | IntLit, 3 -> ()
+  | BoolLit, true -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 4, characters 4-11:
+    | BoolLit, true -> ()
+      ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}, Principal{|
+Line 4, characters 4-17:
+    | BoolLit, true -> ()
+      ^^^^^^^^^^^^^
+Error: This pattern matches values of type bool t * bool
+       but a pattern was expected which matches values of type int t * int
+       Type bool is not compatible with type int
+|}]
+
+let simple_annotated (type a) (t : a t) (a : a) =
+  match t, a with
+  | IntLit, 3 -> ()
+  | BoolLit, true -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+val simple_annotated : 'a t -> 'a -> unit = <fun>
+|}]
+
+let simple_merged t a =
+  match t, a with
+  | IntLit, 3
+  | BoolLit, true -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 4, characters 4-11:
+    | BoolLit, true -> ()
+      ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}]
+
+let simple_merged_ambi (type a) (t : a t) a =
+  match t, a with
+  | IntLit, (3 : a)
+  | BoolLit, true -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, (3 : a)
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+
+let simple_merged_not_annotated_enough (type a) (t : a t) a =
+  match t, a with
+  | IntLit, 3
+  | BoolLit, true -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, 3
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+
+let simple_merged_annotated (type a) (t : a t) (a : a) =
+  match t, a with
+  | IntLit, 3
+  | BoolLit, true -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, 3
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_mega_merged_annotated (type a) (t : a t) (a : a) =
+  match t, a with
+  | IntLit, 3
+  | BoolLit, true
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, 3
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_return (type a) (t : a t) (a : a) =
+  match t, a with
+  | IntLit, (3 as x)
+  | BoolLit, (true as x) -> ignore x
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, (3 as x)
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
+  match t, a with
+  | IntLit, ((3 : a) as x)
+  | BoolLit, ((true : a) as x) -> ignore x
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, ((3 : a) as x)
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+(* test more scenarios: when the or-pattern itself is not at toplevel but under
+   other patterns. *)
+
+let simple_merged_annotated_under_tuple (type a) (pair : a t * a) =
+  match (), pair with
+  | (), ( IntLit, 3
+        | BoolLit, true) -> ()
+  | _, _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 10-16:
+    | (), ( IntLit, 3
+            ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_under_arrays (type a) (pair : a t * a) =
+  match [| [| pair |] |] with
+  | [| _ ; [| ( IntLit, 3
+              | BoolLit, true) |] |] -> ()
+  | _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 16-22:
+    | [| _ ; [| ( IntLit, 3
+                  ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+
+let simple_merged_annotated_under_poly_variant (type a) (pair : a t * a) =
+  match `Foo pair with
+  | `Foo ( IntLit, 3
+         | BoolLit, true ) -> ()
+  | _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 11-17:
+    | `Foo ( IntLit, 3
+             ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_under_poly_variant_annotated (type a) pair =
+  match (`Foo pair : [ `Foo of (a t * a) ]) with
+  | `Foo ( IntLit, 3
+         | BoolLit, true ) -> ()
+  | _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 11-17:
+    | `Foo ( IntLit, 3
+             ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+type 'a iref = { content : 'a; };;
+[%%expect{|
+type 'a iref = { content : 'a; }
+|}]
+
+let simple_merged_annotated_under_record (type a) (pair : a t * a) =
+  match { content = pair } with
+  | { content = ( IntLit, 3
+                | BoolLit, true ) } -> ()
+  | _ -> ()
+;;
+[%%expect{|
+Line 3, characters 18-24:
+    | { content = ( IntLit, 3
+                    ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_under_mutable_record (type a) (pair : a t * a) =
+  match { contents = pair } with
+  | { contents = ( IntLit, 3
+                 | BoolLit, true ) } -> ()
+  | _ -> ()
+;;
+[%%expect{|
+Line 3, characters 19-25:
+    | { contents = ( IntLit, 3
+                     ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+type 'a piref = { pcontent : 'b. 'a * 'b; };;
+[%%expect{|
+type 'a piref = { pcontent : 'b. 'a * 'b; }
+|}]
+
+let simple_merged_annotated_under_poly_record1 (type a) (r : (a t * a) piref) =
+  match r with
+  | { pcontent = ( IntLit, 3
+                 | BoolLit, true ), _ } -> ()
+  | _ -> ()
+;;
+[%%expect{|
+Line 3, characters 19-25:
+    | { pcontent = ( IntLit, 3
+                     ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_under_poly_record2 (type a) (r : (a t * a) piref) =
+  match r with
+  | { pcontent = ( (IntLit, 3), _
+                 | (BoolLit, true), _ ) } -> ()
+  | _ -> ()
+;;
+[%%expect{|
+Line 3, characters 20-26:
+    | { pcontent = ( (IntLit, 3), _
+                      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+let simple_merged_annotated_under_constructor (type a) (pair : a t * a) =
+  match Some pair with
+  | Some ( IntLit, 3
+         | BoolLit, true ) -> ()
+  | _ -> ()
+;;
+[%%expect{|
+Line 3, characters 11-17:
+    | Some ( IntLit, 3
+             ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+type _ gadt_opt =
+  | GNone : 'a gadt_opt
+  | GSome : 'a -> 'a gadt_opt
+;;
+[%%expect{|
+type _ gadt_opt = GNone : 'a gadt_opt | GSome : 'a -> 'a gadt_opt
+|}]
+
+let simple_merged_annotated_under_gadt_constructor (type a) (pair : a t * a) =
+  match GSome pair with
+  | GSome ( IntLit, 3
+          | BoolLit, true ) -> ()
+  | _ -> ()
+;;
+[%%expect{|
+Line 3, characters 12-18:
+    | GSome ( IntLit, 3
+              ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+(* back to simpler tests. *)
+
+let noop t a =
+  match t, a with
+  | IntLit, x -> x
+  | BoolLit, x -> x
+;;
+
+[%%expect{|
+Line 4, characters 4-11:
+    | BoolLit, x -> x
+      ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}, Principal{|
+Line 4, characters 4-14:
+    | BoolLit, x -> x
+      ^^^^^^^^^^
+Error: This pattern matches values of type bool t * 'a
+       but a pattern was expected which matches values of type int t * 'b
+       Type bool is not compatible with type int
+|}]
+
+let noop_annotated (type a) (t : a t) (a : a) : a =
+  match t, a with
+  | IntLit, x -> x
+  | BoolLit, x -> x
+;;
+
+[%%expect{|
+val noop_annotated : 'a t -> 'a -> 'a = <fun>
+|}]
+
+let noop_merged t a =
+  match t, a with
+  | IntLit, x
+  | BoolLit, x -> x
+;;
+
+[%%expect{|
+Line 4, characters 4-11:
+    | BoolLit, x -> x
+      ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}]
+
+let noop_merged_annotated (type a) (t : a t) (a : a) : a =
+  match t, a with
+  | IntLit, x
+  | BoolLit, x -> x
+;;
+
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit, x
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+(***)
+
+type _ t2 =
+  | Int : int -> int t2
+  | Bool : bool -> bool t2
+
+[%%expect{|
+type _ t2 = Int : int -> int t2 | Bool : bool -> bool t2
+|}]
+
+let trivial2 t2 =
+  match t2 with
+  | Int _ -> ()
+  | Bool _ -> ()
+;;
+
+[%%expect{|
+Line 4, characters 4-10:
+    | Bool _ -> ()
+      ^^^^^^
+Error: This pattern matches values of type bool t2
+       but a pattern was expected which matches values of type int t2
+       Type bool is not compatible with type int
+|}]
+
+let trivial2_annotated (type a) (t2 : a t2) =
+  match t2 with
+  | Int _ -> ()
+  | Bool _ -> ()
+;;
+
+[%%expect{|
+val trivial2_annotated : 'a t2 -> unit = <fun>
+|}]
+
+let trivial2_merged t2 =
+  match t2 with
+  | Int _
+  | Bool _ -> ()
+;;
+
+[%%expect{|
+Line 4, characters 4-10:
+    | Bool _ -> ()
+      ^^^^^^
+Error: This pattern matches values of type bool t2
+       but a pattern was expected which matches values of type int t2
+       Type bool is not compatible with type int
+|}]
+
+let trivial2_merged_annotated (type a) (t2 : a t2) =
+  match t2 with
+  | Int _
+  | Bool _ -> ()
+;;
+
+[%%expect{|
+Line 3, characters 4-9:
+    | Int _
+      ^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+
+let extract t2 =
+  match t2 with
+  | Int _ -> x
+  | Bool _ -> x
+;;
+
+[%%expect{|
+Line 4, characters 4-10:
+    | Bool _ -> x
+      ^^^^^^
+Error: This pattern matches values of type bool t2
+       but a pattern was expected which matches values of type int t2
+       Type bool is not compatible with type int
+|}]
+
+let extract_annotated (type a) (t2 : a t2) : a =
+  match t2 with
+  | Int x -> x
+  | Bool x -> x
+;;
+
+[%%expect{|
+val extract_annotated : 'a t2 -> 'a = <fun>
+|}]
+
+let extract_merged t2 =
+  match t2 with
+  | Int x
+  | Bool x -> x
+;;
+
+[%%expect{|
+Line 4, characters 4-10:
+    | Bool x -> x
+      ^^^^^^
+Error: This pattern matches values of type bool t2
+       but a pattern was expected which matches values of type int t2
+       Type bool is not compatible with type int
+|}]
+
+let extract_merged_annotated (type a) (t2 : a t2) : a =
+  match t2 with
+  | Int x
+  | Bool x -> x
+;;
+
+
+[%%expect{|
+Line 3, characters 4-9:
+    | Int x
+      ^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+let extract_merged_super_annotated (type a) (t2 : a t2) : a =
+  match t2 with
+  | Int (x : a)
+  | Bool (x : a) -> x
+;;
+
+[%%expect{|
+Line 3, characters 4-15:
+    | Int (x : a)
+      ^^^^^^^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
+  match t2 with
+  | Int (x : a)
+  | Bool x -> x
+;;
+
+[%%expect{|
+Line 3, characters 4-15:
+    | Int (x : a)
+      ^^^^^^^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+let extract_merged_super_lightly_annotated (type a) (t2 : a t2) =
+  match t2 with
+  | Int (x : a)
+  | Bool (x : a) -> x
+;;
+
+[%%expect{|
+Line 3, characters 4-15:
+    | Int (x : a)
+      ^^^^^^^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+let lambiguity (type a) (t2 : a t2) =
+  match t2 with
+  | Int ((_ : a) as x)
+  | Bool (x : a) -> x
+;;
+
+[%%expect{|
+Line 3, characters 4-22:
+    | Int ((_ : a) as x)
+      ^^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+let rambiguity (type a) (t2 : a t2) =
+  match t2 with
+  | Int (_ as x)
+  | Bool ((_ : a) as x) -> x
+;;
+
+[%%expect{|
+Line 3, characters 4-16:
+    | Int (_ as x)
+      ^^^^^^^^^^^^
+Error: This pattern matches values of type int t2
+       but a pattern was expected which matches values of type a t2
+       Type int is not compatible with type a
+|}]
+
+
+(***)
+
+type _ t3 =
+  | A : int t3
+  | B : int t3
+
+[%%expect{|
+type _ t3 = A : int t3 | B : int t3
+|}]
+
+(* This was always allowed as the branches can unify. *)
+let not_annotated x =
+  match x with
+  | A | B -> 3
+;;
+
+[%%expect{|
+val not_annotated : int t3 -> int = <fun>
+|}]
+
+let return_int (type a) (x : a t3) =
+  match x with
+  | A | B -> 3
+;;
+
+[%%expect{|
+Line 3, characters 4-5:
+    | A | B -> 3
+      ^
+Error: This pattern matches values of type int t3
+       but a pattern was expected which matches values of type a t3
+       Type int is not compatible with type a
+|}]
+
+let return_a (type a) (x : a t3) : a =
+  match x with
+  | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of the
+                  branches of this or-pattern. *)
+;;
+
+[%%expect{|
+Line 3, characters 4-5:
+    | A | B -> 3 (* fails because the equation [a = int] doesn't escape any of the
+      ^
+Error: This pattern matches values of type int t3
+       but a pattern was expected which matches values of type a t3
+       Type int is not compatible with type a
+|}]
+
+(* Making sure we don't break a frequent pattern of GADTs indexed by polymorphic
+   variants, where or-patterns were already accepted under or-patterns. *)
+
+type any = [ `A | `B | `C | `D | `E | `F ]
+
+type voyel = [ `A | `E ]
+
+type _ letter =
+  | A : [< any > `A ] letter
+  | B : [< any > `B ] letter
+  | C : [< any > `C ] letter
+  | D : [< any > `D ] letter
+  | E : [< any > `E ] letter
+  | F : [< any > `F ] letter
+
+type _ cased =
+  | Up : 'a letter -> ([< any ] as 'a) cased
+  | Lo : 'a letter -> ([< any ] as 'a) cased
+
+type gvoyel = voyel cased
+type a = [ `A ] cased
+;;
+[%%expect{|
+type any = [ `A | `B | `C | `D | `E | `F ]
+type voyel = [ `A | `E ]
+type _ letter =
+    A : [< any > `A ] letter
+  | B : [< any > `B ] letter
+  | C : [< any > `C ] letter
+  | D : [< any > `D ] letter
+  | E : [< any > `E ] letter
+  | F : [< any > `F ] letter
+type _ cased =
+    Up : 'a letter -> ([< any ] as 'a) cased
+  | Lo : 'a letter -> ([< any ] as 'a) cased
+type gvoyel = voyel cased
+type a = [ `A ] cased
+|}]
+
+let gvoyel_of_a : a -> gvoyel = function
+  | Up A | Lo A as a -> a
+;;
+[%%expect{|
+val gvoyel_of_a : a -> gvoyel = <fun>
+|}]
+
+(* Some other illustrations of the issues with as-patterns. *)
+
+let f_ok (type a) (t : a t) (a : bool iref) (b : a iref) =
+  match t, a, b with
+  | IntLit,  ({ content = true } as x), _
+  | BoolLit,  _,                        ({ content = true} as x) -> ignore x
+  | _, _, _ -> ()
+;;
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit,  ({ content = true } as x), _
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+
+let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
+  match t, a, b with
+  | IntLit,  ({ contents = true } as x), _
+  | BoolLit,  _,                        ({ contents = true} as x) -> ignore x
+  | _, _, _ -> ()
+;;
+[%%expect{|
+Line 3, characters 4-10:
+    | IntLit,  ({ contents = true } as x), _
+      ^^^^^^
+Error: This pattern matches values of type int t
+       but a pattern was expected which matches values of type a t
+       Type int is not compatible with type a
+|}]
+
+(********************************************)
+
+type t =
+  | A : 'a -> t
+  | B : 'a -> t
+;;
+[%%expect{|
+type t = A : 'a -> t | B : 'a -> t
+|}]
+
+let f = function
+  | A x
+  | B x -> ignore x
+;;
+[%%expect{|
+Line 2, characters 4-15:
+  ....A x
+    | B x............
+Error: The variable x on the left-hand side of this or-pattern has type
+       $A_'a but on the right-hand side it has type $B_'a
+|}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -317,12 +317,11 @@ module Or_patterns =
 end
 ;;
 [%%expect{|
-Line 9, characters 11-19:
-9 |         | (IntLit _ | BoolLit _) -> ()
-               ^^^^^^^^
-Error: This pattern matches values of type int t
-       but a pattern was expected which matches values of type s t
-       Type int is not compatible with type s
+module Or_patterns :
+  sig
+    type _ t = IntLit : int -> int t | BoolLit : bool -> bool t
+    val eval : 's t -> unit
+  end
 |}];;
 
 module Polymorphic_variants =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -530,6 +530,7 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
             unify_vars rem1 rem2
           else begin
             begin try
+              unify_var env (newvar ()) t1;
               unify env t1 t2
             with
             | Unify trace ->
@@ -1066,6 +1067,11 @@ let all_idents_cases half_typed_cases =
 
 exception Need_backtrack
 
+let check_scope_escape loc env level ty =
+  try Ctype.check_scope_escape env level ty
+  with Unify trace ->
+    raise(Error(loc, env, Pattern_type_clash(trace)))
+
 (* type_pat propagates the expected type as well as maps for
    constructors and labels.
    Unification may update the typing environment. *)
@@ -1291,8 +1297,7 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
       in
       let expected_ty = instance expected_ty in
       (* PR#7214: do not use gadt unification for toplevel lets *)
-      if not constr.cstr_generalized || mode = Inside_or
-         || no_existentials <> None
+      if not constr.cstr_generalized || no_existentials <> None
       then unify_pat_types loc !env ty_res expected_ty
       else unify_pat_types_gadt loc env ty_res expected_ty;
       end_def ();
@@ -1418,19 +1423,37 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
         if mode = Split_or || mode = Splitting_or then raise Need_backtrack;
         let initial_pattern_variables = !pattern_variables in
         let initial_module_variables = !module_variables in
+        let equation_level = !gadt_equations_level in
+        let outter_lev = get_current_level () in
+        (* introduce a new scope *)
+        begin_def ();
+        let lev = get_current_level () in
+        gadt_equations_level := Some lev;
+        let env1 = ref !env in
         let p1 =
           try Some (type_pat ~exception_allowed ~mode:Inside_or sp1 expected_ty
-                      (fun x -> x))
+                      ~env:env1 (fun x -> x))
           with Need_backtrack -> None in
         let p1_variables = !pattern_variables in
         let p1_module_variables = !module_variables in
         pattern_variables := initial_pattern_variables;
         module_variables := initial_module_variables;
+        let env2 = ref !env in
         let p2 =
           try Some (type_pat ~exception_allowed ~mode:Inside_or sp2 expected_ty
-                      (fun x -> x))
+                      ~env:env2 (fun x -> x))
           with Need_backtrack -> None in
+        end_def ();
+        gadt_equations_level := equation_level;
         let p2_variables = !pattern_variables in
+        (* Make sure no variable with an ambiguous type gets added to the
+           environment. *)
+        List.iter (fun { pv_type; pv_loc; _ } ->
+          check_scope_escape pv_loc !env1 outter_lev pv_type
+        ) p1_variables;
+        List.iter (fun { pv_type; pv_loc; _ } ->
+          check_scope_escape pv_loc !env2 outter_lev pv_type
+        ) p2_variables;
         match p1, p2 with
           None, None -> raise Need_backtrack
         | Some p, None | None, Some p -> p (* no variables in this case *)
@@ -4016,11 +4039,6 @@ and type_statement ?explanation env sexp =
   end
 
 (* Typing of match cases *)
-and check_scope_escape loc env level ty =
-  try Ctype.check_scope_escape env level ty
-  with Unify trace ->
-    raise(Error(loc, env, Pattern_type_clash(trace)))
-
 and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
       loc caselist =
   (* ty_arg is _fully_ generalized *)


### PR DESCRIPTION
(This PR is the last part to be extracted from #1675.)

It adds limited support for GADTs under or-patterns (and nothing else): equations and existential types can be introduced in an or-pattern branch, but they are not accessible outside of that branch.

The implementation is straightforward, and it should be easier to reason about soundness than with the previous PR (which included many orthogonal changes).

Note: once again the calls to `check_scope_escape` are here only to get better error messages. They could be removed and you'd still get an error on escapes (thanks to the call to `unify_var` that was inserted in `enter_orpat_variables`, which pulls things out of the or-pattern scope), but the message would be worse.

@garrigue would you mind giving it a new look?