### PR TITLE
Thread.yield fairness with multiple busy yielding threads

### DIFF
--- a/Changes
+++ b/Changes
@@ -584,6 +584,11 @@ Working version
 
 ### Bug fixes:
 
+- GPR#2112: Fix Thread.yield unfairness with busy threads yielding to each
+  other.
+  (Andrew Hunter, review by Jacques-Henri Jourdan, Spiros Eliopoulos, Stephen
+  Weeks, & Mark Shinwell)
+
 - MPR#7867: Fix #mod_use raising an exception for filenames with no
   extension.
   (Geoff Gole)

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -15,6 +15,7 @@
 
 /* POSIX thread implementation of the "st" interface */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
@@ -91,22 +92,6 @@ static void st_thread_join(st_thread_id thr)
   /* best effort: ignore errors */
 }
 
-/* Scheduling hints */
-
-static INLINE void st_thread_yield(void)
-{
-#ifdef __linux__
-  /* sched_yield() doesn't do what we want in Linux 2.6 and up (PR#2663) */
-  /* but not doing anything here would actually disable preemption (PR#7669) */
-  struct timespec t;
-  t.tv_sec = 0;
-  t.tv_nsec = 1;
-  nanosleep(&t, NULL);
-#else
-  sched_yield();
-#endif
-}
-
 /* Thread-specific state */
 
 typedef pthread_key_t st_tlskey;
@@ -169,6 +154,44 @@ static void st_masterlock_release(st_masterlock * m)
 static INLINE int st_masterlock_waiters(st_masterlock * m)
 {
   return m->waiters;
+}
+
+/* Scheduling hints */
+
+/* This is mostly equivalent to release(); acquire(), but better. In particular,
+   release(); acquire(); leaves both us and the waiter we signal() racing to
+   acquire the lock. Calling yield or sleep helps there but does not solve the
+   problem. Sleeping ourselves is much more reliable--and since we're handing
+   off the lock to a waiter we know exists, it's safe, as they'll certainly
+   re-wake us later.
+*/
+static INLINE void st_thread_yield(st_masterlock * m)
+{
+  pthread_mutex_lock(&m->lock);
+  /* We must hold the lock to call this. */
+  assert(m->busy);
+
+  /* We already checked this without the lock, but we might have raced--if
+     there's no waiter, there's nothing to do and no one to wake us if we did
+     wait, so just keep going. */
+  if (m->waiters == 0) {
+    pthread_mutex_unlock(&m->lock);
+    return;
+  }
+
+  m->busy = 0;
+  pthread_cond_signal(&m->is_free);
+  m->waiters++;
+  do {
+    /* Note: the POSIX spec prevents the above signal from pairing with this
+       wait, which is good: we'll reliably continue waiting until the next
+       yield() or enter_blocking_section() call (or we see a spurious condvar
+       wakeup, which are rare at best.) */
+       pthread_cond_wait(&m->is_free, &m->lock);
+  } while (m->busy);
+  m->busy = 1;
+  m->waiters--;
+  pthread_mutex_unlock(&m->lock);
 }
 
 /* Mutexes */

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -737,9 +737,19 @@ CAMLprim value caml_thread_exit(value unit)   /* ML */
 CAMLprim value caml_thread_yield(value unit)        /* ML */
 {
   if (st_masterlock_waiters(&caml_master_lock) == 0) return Val_unit;
-  caml_enter_blocking_section();
-  st_thread_yield();
-  caml_leave_blocking_section();
+
+  /* Do all the parts of a blocking section enter/leave except lock
+     manipulation, which we'll do more efficiently in st_thread_yield. (Since
+     our blocking section doesn't contain anything interesting, don't bother
+     with saving errno.)
+  */
+  caml_process_pending_signals();
+  caml_thread_save_runtime_state();
+  st_thread_yield(&caml_master_lock);
+  curr_thread = st_tls_get(thread_descriptor_key);
+  caml_thread_restore_runtime_state();
+  caml_process_pending_signals();
+
   return Val_unit;
 }
 

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -99,13 +99,6 @@ static void st_thread_join(st_thread_id thr)
   WaitForSingleObject(thr, INFINITE);
 }
 
-/* Scheduling hints */
-
-static INLINE void st_thread_yield(void)
-{
-  Sleep(0);
-}
-
 /* Thread-specific state */
 
 typedef DWORD st_tlskey;
@@ -156,6 +149,15 @@ static INLINE void st_masterlock_release(st_masterlock * m)
 static INLINE int st_masterlock_waiters(st_masterlock * m)
 {
   return 1;                     /* info not maintained */
+}
+
+/* Scheduling hints */
+
+static INLINE void st_thread_yield(st_masterlock * m)
+{
+  LeaveCriticalSection(m);
+  Sleep(0);
+  EnterCriticalSection(m);
 }
 
 /* Mutexes */

--- a/testsuite/tests/lib-systhreads/ocamltests
+++ b/testsuite/tests/lib-systhreads/ocamltests
@@ -1,2 +1,3 @@
 testfork.ml
 testpreempt.ml
+testyield.ml

--- a/testsuite/tests/lib-systhreads/testyield.ml
+++ b/testsuite/tests/lib-systhreads/testyield.ml
@@ -1,0 +1,51 @@
+(* TEST
+   (* Test that yielding between busy threads reliably triggers a thread
+      switch. *)
+   include systhreads
+   * not-windows
+   ** bytecode
+   ** native
+*)
+
+let threads = 4
+
+let are_ready = ref 0
+
+let yields = ref 0
+
+let iters = 50000
+
+let last = ref (-1)
+
+let report thread run_length =
+  (* The below loop tests how many times in a row a loop that calls yield runs
+     without changing threads. Ideally the answer would *always* be one, but
+     it's not clear we can reliably guarantee that unless nothing else ever
+     drops the Ocaml lock, so instead just rely on it being small. *)
+  if run_length > 3
+  then Printf.printf "Thread %d ran %d consecutive iters\n" thread run_length
+
+
+let threads =
+  List.init threads (Thread.create (fun i ->
+    incr are_ready;
+    (* Don't make any progress until all threads are spawned and properly
+       contending for the Ocaml lock. *)
+    while !are_ready < threads do
+      Thread.yield ()
+    done;
+    let consecutive = ref 0 in
+    while !yields < iters do
+      incr yields;
+      last := i;
+      Thread.yield ();
+      incr consecutive;
+      if not (!last = i)
+      then (
+        report i !consecutive;
+        consecutive := 0)
+    done;
+    if !consecutive > 0 then report i !consecutive;
+  ));;
+
+List.iter Thread.join threads


### PR DESCRIPTION
Here's a very hacky repro for the problem: the below code counts how many times a thread goes through a loop yielding before successfully *doing* so.  At trunk, this runs 10,000+ times per thread, or more if the threads are pinned to the same CPU.  With this patch, we reliably yield every time, because a yielding thread is properly marked as a waiter.
```
let threads = 4
let print = Sys.argv.(1) |> bool_of_string
let iters = Sys.argv.(2) |> int_of_string

let yields = ref 0
let are_ready = ref 0
let are_done = ref 0

let last = ref '!'

let start = ref 0.0

let stop = ref 0.0

let run_lengths = ref []

let report label cnt =
  let old = !run_lengths in
  run_lengths := (label, cnt) :: old;;

let threads =
  List.init threads (Thread.create (fun i ->
    (* Label our threads A..Z (clearer than TIDs, and integer indices are confusable
       with run lengths) *)
    let label = Char.unsafe_chr (Char.code 'A' + i) in
    incr are_ready;
    (* Don't make any progress until all threads are spawned and properly contending for
       the Ocaml lock. *)
    if !are_ready = threads then start := (Unix.gettimeofday ());
    while !are_ready < threads do
      Thread.yield ()
    done;
    let consecutive = ref 0 in
    while !yields < iters do
      incr yields;
      last := label;
      Thread.yield ();
      incr consecutive;
      if not (!last = label)
      then (
        report label !consecutive;
        consecutive := 0)
    done;
    if !consecutive > 0 then report label !consecutive;
    incr are_done;
    if !are_done = threads then stop := (Unix.gettimeofday ())
  ));;


List.iter Thread.join threads;;

let report (label, count) = Printf.printf "%c ran for %d\n" label count;;

if print then List.iter report (List.rev !run_lengths)

let time = !stop -. !start;;
let switches = List.length !run_lengths;;
Printf.printf "Executed in %fs with %d switches\n" time switches

```

I can measure no overhead in throughput from the normal volume of yielding due to the tick thread (say, with two threads merrily allocating) but I'm happy to run more tests.

Thanks!