### PR TITLE
Towards autoconf #3: ocamlmklib and INT64_LITERAL

### DIFF
--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -158,9 +158,6 @@ MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
-#ml let mklib out files opts =
-#ml   Printf.sprintf "%sar rcs %s %s %s"
-#ml                  toolpref opts out files;;
 
 ### Canonicalize the name of a system library
 SYSLIB=-l$(1)

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -198,7 +198,6 @@ INSTALL_BYTECODE_PROGRAMS=true
 OTHERLIBRARIES=win32unix str win32graph dynlink bigarray systhreads
 
 ############# for the testsuite makefiles
-#ml let topdir = "" and wintopdir = "";;
 OTOPDIR=$(WINTOPDIR)
 CTOPDIR=$(TOPDIR)
 CYGPATH=cygpath -m

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -164,7 +164,6 @@ MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
 
 ### Canonicalize the name of a system library
 SYSLIB=-l$(1)
-#ml let syslib x = "-l"^x;;
 
 ### The ranlib command
 RANLIB=$(TOOLPREF)ranlib

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -158,9 +158,6 @@ MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
-#ml let mklib out files opts =
-#ml   Printf.sprintf "%sar rcs %s %s %s"
-#ml                  toolpref opts out files;;
 
 ### Canonicalize the name of a system library
 SYSLIB=-l$(1)

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -198,7 +198,6 @@ INSTALL_BYTECODE_PROGRAMS=true
 OTHERLIBRARIES=win32unix str win32graph dynlink bigarray systhreads
 
 ############# for the testsuite makefiles
-#ml let topdir = "" and wintopdir = "";;
 OTOPDIR=$(WINTOPDIR)
 CTOPDIR=$(TOPDIR)
 CYGPATH=cygpath -m

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -164,7 +164,6 @@ MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
 
 ### Canonicalize the name of a system library
 SYSLIB=-l$(1)
-#ml let syslib x = "-l"^x;;
 
 ### The ranlib command
 RANLIB=$(TOOLPREF)ranlib

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -153,8 +153,6 @@ MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=link -lib -nologo -out:$(1) $(2)
-#ml let mklib out files opts =
-#ml   Printf.sprintf "link -lib -nologo -out:%s %s %s" out opts files;;
 MKSHAREDLIBRPATH=
 
 ### Canonicalize the name of a system library

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -159,7 +159,6 @@ MKSHAREDLIBRPATH=
 
 ### Canonicalize the name of a system library
 SYSLIB=$(1).lib
-#ml let syslib x = x ^ ".lib";;
 
 ### The ranlib command
 RANLIB=echo

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -200,7 +200,6 @@ WITH_OCAMLDOC=ocamldoc
 OTHERLIBRARIES=win32unix systhreads str win32graph dynlink bigarray
 
 ############# for the testsuite makefiles
-#ml let topdir = "" and wintopdir = "";;
 OTOPDIR=$(WINTOPDIR)
 CTOPDIR=$(WINTOPDIR)
 CYGPATH=cygpath -m

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -203,7 +203,6 @@ WITH_OCAMLDOC=ocamldoc
 OTHERLIBRARIES=win32unix systhreads str win32graph dynlink bigarray
 
 ############# for the testsuite makefiles
-#ml let topdir = "" and wintopdir = "";;
 OTOPDIR=$(WINTOPDIR)
 CTOPDIR=$(WINTOPDIR)
 CYGPATH=cygpath -m

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -162,7 +162,6 @@ MKSHAREDLIBRPATH=
 
 ### Canonicalize the name of a system library
 SYSLIB=$(1).lib
-#ml let syslib x = x ^ ".lib";;
 
 ### The ranlib command
 RANLIB=echo

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -155,9 +155,6 @@ MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=link -lib -nologo -machine:AMD64 /out:$(1) $(2)
-#ml let mklib out files opts =
-#ml   Printf.sprintf "link -lib -nologo -machine:AMD64 -out:%s %s %s"
-#ml                  out opts files;;
 MKSHAREDLIBRPATH=
 
 ### Canonicalize the name of a system library

--- a/config/m-nt.h
+++ b/config/m-nt.h
@@ -55,11 +55,4 @@
 
 #define PROFINFO_WIDTH 0
 
-/* Microsoft introduced the LL integer literal suffix in Visual C++ .NET 2003 */
-#if defined(_MSC_VER) && _MSC_VER < 1400
-#define INT64_LITERAL(s) s ## i64
-#else
-#define INT64_LITERAL(s) s ## LL
-#endif
-
 #define FLAT_FLOAT_ARRAY

--- a/configure
+++ b/configure
@@ -1987,9 +1987,6 @@ SYSLIB=-l\$(1)
 
 ### How to build a static library
 MKLIB=rm -f \$(1) && ${TOOLPREF}ar rc \$(1) \$(2) && ${TOOLPREF}ranlib \$(1)
-#ml let mklib out files opts =      (* "" *)
-#ml   Printf.sprintf "${TOOLPREF}ar rc %s %s %s && ${TOOLPREF}ranlib %s"
-#ml                  out opts files out;;
 EOF
 config ARCH "$arch"
 config MODEL "$model"

--- a/configure
+++ b/configure
@@ -1984,7 +1984,6 @@ config MKSHAREDLIBRPATH "$mksharedlibrpath"
 config NATDYNLINKOPTS "$natdynlinkopts"
 cat >> ${conffile} <<EOF
 SYSLIB=-l\$(1)
-#ml let syslib x = "-l"^x;;
 
 ### How to build a static library
 MKLIB=rm -f \$(1) && ${TOOLPREF}ar rc \$(1) \$(2) && ${TOOLPREF}ranlib \$(1)

--- a/configure
+++ b/configure
@@ -673,7 +673,6 @@ echo "#define SIZEOF_LONG $2" >> m.h
 echo "#define SIZEOF_PTR $3" >> m.h
 echo "#define SIZEOF_SHORT $4" >> m.h
 echo "#define SIZEOF_LONGLONG $5" >> m.h
-echo "#define INT64_LITERAL(s) s ## LL" >> m.h
 
 # Determine endianness
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -26,6 +26,13 @@
 #endif /* __PIC__ */
 #endif /* HAS_ARCH_CODE32 */
 
+/* Microsoft introduced the LL integer literal suffix in Visual C++ .NET 2003 */
+#if defined(_MSC_VER) && _MSC_VER < 1400
+#define INT64_LITERAL(s) s ## i64
+#else
+#define INT64_LITERAL(s) s ## LL
+#endif
+
 #include "s.h"
 #ifdef BOOTSTRAPPING_FLEXLINK
 #undef SUPPORT_DYNAMIC_LINKING

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -154,8 +154,7 @@ ocamlmklibconfig.ml: $(ROOTDIR)/Makefile.config Makefile
          echo 'let supports_shared_libraries = $(SUPPORTS_SHARED_LIBRARIES)';\
          echo 'let default_rpath = "$(RPATH)"'; \
          echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"'; \
-         echo 'let toolpref = "$(TOOLPREF)"'; \
-         sed -n -e 's/^#ml //p' $(ROOTDIR)/Makefile.config) \
+         echo 'let toolpref = "$(TOOLPREF)"';) \
         > ocamlmklibconfig.ml
 
 beforedepend:: ocamlmklibconfig.ml

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -21,17 +21,15 @@ let syslib x =
 
 let mklib out files opts =
   if Config.ccomp_type = "msvc"
-  then
-    let machine =
-      if Config.architecture="amd64"
-      then "-machine:AMD64 "
-      else ""
-    in
-    Printf.sprintf "link -lib -nologo %s-out:%s %s %s"
-                   machine out opts files
-  else
-    Printf.sprintf "%s rcs %s %s %s && %s %s"
-                   Config.ar out opts files Config.ranlib out
+  then let machine =
+    if Config.architecture="amd64"
+    then "-machine:AMD64 "
+    else ""
+  in
+  Printf.sprintf "link -lib -nologo %s-out:%s %s %s"
+                 machine out opts files
+  else Printf.sprintf "%s rcs %s %s %s && %s %s"
+                      Config.ar out opts files Config.ranlib out
 
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -19,6 +19,20 @@ open Ocamlmklibconfig
 let syslib x =
   if Config.ccomp_type = "msvc" then x ^ ".lib" else "-l" ^ x
 
+let mklib out files opts =
+  if Config.ccomp_type = "msvc"
+  then
+    let machine =
+      if Config.architecture="amd64"
+      then "-machine:AMD64 "
+      else ""
+    in
+    Printf.sprintf "link -lib -nologo %s-out:%s %s %s"
+                   machine out opts files
+  else
+    Printf.sprintf "%s rcs %s %s %s && %s %s"
+                   Config.ar out opts files Config.ranlib out
+
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)
 let compiler_path name =

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -16,6 +16,9 @@
 open Printf
 open Ocamlmklibconfig
 
+let syslib x =
+  if Config.ccomp_type = "msvc" then x ^ ".lib" else "-l" ^ x
+
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)
 let compiler_path name =


### PR DESCRIPTION
Cc-ing @pgraverdy who may be interested in following this

This PR continues the story started with GRPs #2044 and #2059. It
contains two changes:

1. In `tools/`: move the definitions of the `syslib` and `mklib` functions
   from `ocamlmklibconfig.ml` to `ocamlmklib.ml`.

2. In the runtime: move the definition of the `INT64_LITERAL` C
   preprocessor macro from the generated file `m.h` to `config.h`.

The first change simplifies the generation of
`tools/ocamlmklibconfig.ml`: the special comments starting with `#ml `
which were used to include these functions in `Makefile.config` and the
`sed` commands required to extract them are no longer necessary.

Same goes for the second change.