### PR TITLE
ocamldoc, manpage backend: unwrap module comment docstrings

### DIFF
--- a/Changes
+++ b/Changes
@@ -335,6 +335,9 @@ Working version
 - GPR#2105: Change verbatim to caml_example in documentation
   (Maxime Flin, review by Florian Angeletti)
 
+- GPR#2114: ocamldoc, improved manpages for documentation inside modules
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Compiler distribution build system:
 
 - GPR#1776: add -no-install-bytecode-programs and related configure options to

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -319,7 +319,8 @@ class man =
           self#man_of_text2 b t;
           bs b "\n.sp\n"
       | Odoc_info.Title (_, _, t) ->
-          self#man_of_text2 b [Odoc_info.Code (Odoc_info.string_of_text t)]
+          let txt = Odoc_info.string_of_text t in
+          bp b ".SS %s\n" txt
       | Odoc_info.Latex _ ->
           (* don't care about LaTeX stuff in HTML. *)
           ()

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -810,13 +810,13 @@ class man =
     (** Print groff string for a module comment.*)
     method man_of_module_comment b text =
       bs b "\n.PP\n";
-      self#man_of_text b [Code ("=== "^(Odoc_misc.string_of_text text)^" ===")];
+      self#man_of_text b text;
       bs b "\n.PP\n"
 
     (** Print groff string for a class comment.*)
     method man_of_class_comment b text =
       bs b "\n.PP\n";
-      self#man_of_text b [Code ("=== "^(Odoc_misc.string_of_text text)^" ===")];
+      self#man_of_text b text;
       bs b "\n.PP\n"
 
     method man_of_recfield b modname f =


### PR DESCRIPTION
Currently, the manpage back-end of ocamldoc wraps module (and class) comments inside a code environment. For instance, the [floating-point arithmetic introduction](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Pervasives.html#1_Floatingpointarithmetic) is rendered as

```man
.B === 
.B Floating\-point arithmetic
.B 
.B 
.B    OCaml\&'s floating\-point numbers follow the
.B    IEEE 754 standard, using double precision (64 bits) numbers\&.
.B    Floating\-point operations never raise an exception on overflow,
.B    underflow, division by zero, etc\&.  Instead, special IEEE numbers
.B    are returned as appropriate, such as infinity for 1\&.0 /\&. 0\&.0,
...
```
(There is a similar problem with the format introduction)
This PR proposes to remove this wrapping, to restore emphasis within the documentation comment

```man
.B Floating\-point arithmetic
.sp
OCaml\&'s floating\-point numbers follow the
IEEE 754 standard, using double precision (64 bits) numbers\&.
Floating\-point operations never raise an exception on overflow,
underflow, division by zero, etc\&.  Instead, special IEEE numbers
are returned as appropriate, such as 
.B infinity
for 
.B 1\&.0 /\&. 0\&.0
,
...
```

Another advantage is that it becomes possible to use man-specific, `{%man:...%}` content inside those module comments.