### PR TITLE
TODO list for cleaning up the typechecker implementation

### DIFF
--- a/typing/TODO.md
+++ b/typing/TODO.md
@@ -24,7 +24,7 @@ everyone to get an idea of planned tasks, refine them through Pull
 Requests, suggest more cleanups, or even start working on specific
 tasks (ideally after discussing it first with maintainers).
 
-Not all ideas have been thorougly discussed, and there might not be a
+Not all ideas have been thoroughly discussed, and there might not be a
 consensus for all of them.
 
 - Make the level generator be part of `Env.t` instead of being global.

--- a/typing/TODO.md
+++ b/typing/TODO.md
@@ -8,11 +8,24 @@ incremental cleanup steps are certainly accessible and could bring the
 current implementation in a better shape at a relatively small cost
 and in a reasonnably distant future.
 
+Goals of the cleanup:
+
+ - Make the implementation more maintainable and less fragile.
+
+ - Allow new contributors, or people involved in bigger rewriting
+   projects, to get familiar with the code base more easily.
+
+ - Pave the way for future extensions or bigger structural changes to
+   the implementation.
+
 This file collects specific cleanup ideas which have been discussed
 amongst maintainers.  Having the list committed in the repo allows for
 everyone to get an idea of planned tasks, refine them through Pull
 Requests, suggest more cleanups, or even start working on specific
 tasks (ideally after discussing it first with maintainers).
+
+Not all ideas have been thorougly discussed, and there might not be a
+consensus for all of them.
 
 - Make the level generator be part of `Env.t` instead of being global.
 

--- a/typing/TODO.md
+++ b/typing/TODO.md
@@ -62,3 +62,7 @@ tasks (ideally after discussing it first with maintainers).
   warnings in a less invasive and less imperative way.
 
 - Deprecated -nolabels, or even get rid of it?
+
+- Using e.g. bisect_ppx, monitor coverage of the typechecker
+  implementation while running the testsuite, and expand the testsuite
+  and/or kill dead code in the typechecker to increase coverage ratio.

--- a/typing/TODO.md
+++ b/typing/TODO.md
@@ -1,0 +1,64 @@
+TODO for the OCaml typechecker implementation
+=============================================
+
+There is a consensus that the current implementation of the OCaml
+typechecker is overly complex and fragile.  A big rewriting "from
+scratch" might be possible or desirable at some point, or not, but
+incremental cleanup steps are certainly accessible and could bring the
+current implementation in a better shape at a relatively small cost
+and in a reasonnably distant future.
+
+This file collects specific cleanup ideas which have been discussed
+amongst maintainers.  Having the list committed in the repo allows for
+everyone to get an idea of planned tasks, refine them through Pull
+Requests, suggest more cleanups, or even start working on specific
+tasks (ideally after discussing it first with maintainers).
+
+- Make the level generator be part of `Env.t` instead of being global.
+
+- Introduce an abstraction boundary between "the type algebra" and
+  "the type checker" (at first between Ctype and Typecore) so that the
+  type checker is forced to go through a propoer API to access/mutate
+  type nodes.  This would make it impossible to "forget" a call
+  to `repr` and will allow further changes on the internal representation.
+
+- Tidy up Typeclass (use records instead of 14-tuples, avoid
+  "#"-encoding, etc).
+
+- Collect all global state of the type checker in a single place,
+  possibly a single reference to a persistent data structure
+  (e.g. maps instead of hashtables).
+
+- Get rid of Tsubst.  With the unique ids on each type node, copying
+  can be implemented rather efficiently with a map.
+
+- Document row_desc, get rid of row_bound.
+
+- Implement union-find with more a asbtract/persistent datastructure
+  (be careful about memory leaks with the naive approach of representing
+  links with a persistent heap).
+
+- Make the logic for record/constructor disambiguation more readable.
+
+- Tidy up destructive substitution.
+
+- Well-formedness for module signature.
+
+- Get rid of syntactic encodings (generating Parsetree fragments
+  during type-checking, cf optional arguments or classes).
+
+- Track "string literals" in the type-checker, which often acts as
+  magic "internal" names which should be avoided.
+
+- Get rid of -annot.
+
+- Warning settings (+other context) as part of `Env.t`.
+
+- Parse attributes understood (e.g. the deprecated attribute) by the
+  compiler into a structured representation during type-checking.
+
+- Introduce a notion of syntactic "path-like location" to point to
+  allow pointing to AST fragments, and use that to implement "unused"
+  warnings in a less invasive and less imperative way.
+
+- Deprecated -nolabels, or even get rid of it?

--- a/typing/TODO.md
+++ b/typing/TODO.md
@@ -18,7 +18,7 @@ tasks (ideally after discussing it first with maintainers).
 
 - Introduce an abstraction boundary between "the type algebra" and
   "the type checker" (at first between Ctype and Typecore) so that the
-  type checker is forced to go through a propoer API to access/mutate
+  type checker is forced to go through a proper API to access/mutate
   type nodes.  This would make it impossible to "forget" a call
   to `repr` and will allow further changes on the internal representation.
 
@@ -34,7 +34,7 @@ tasks (ideally after discussing it first with maintainers).
 
 - Document row_desc, get rid of row_bound.
 
-- Implement union-find with more a asbtract/persistent datastructure
+- Implement union-find with a more abstract/persistent datastructure
   (be careful about memory leaks with the naive approach of representing
   links with a persistent heap).
 
@@ -42,17 +42,15 @@ tasks (ideally after discussing it first with maintainers).
 
 - Tidy up destructive substitution.
 
-- Well-formedness for module signature.
-
 - Get rid of syntactic encodings (generating Parsetree fragments
   during type-checking, cf optional arguments or classes).
 
-- Track "string literals" in the type-checker, which often acts as
+- Track "string literals" in the type-checker, which often act as
   magic "internal" names which should be avoided.
 
 - Get rid of -annot.
 
-- Warning settings (+other context) as part of `Env.t`.
+- Consider storing warning settings (+other context) as part of `Env.t`?
 
 - Parse attributes understood (e.g. the deprecated attribute) by the
   compiler into a structured representation during type-checking.
@@ -61,7 +59,7 @@ tasks (ideally after discussing it first with maintainers).
   allow pointing to AST fragments, and use that to implement "unused"
   warnings in a less invasive and less imperative way.
 
-- Deprecated -nolabels, or even get rid of it?
+- Deprecate -nolabels, or even get rid of it?
 
 - Using e.g. bisect_ppx, monitor coverage of the typechecker
   implementation while running the testsuite, and expand the testsuite


### PR DESCRIPTION
There is a consensus that the current implementation of the OCaml typechecker is overly complex and fragile.  A big rewriting "from scratch" might be possible or desirable at some point, or not, but incremental cleanup steps are certainly accessible and could bring the current implementation in a better shape at a relatively small cost and in a reasonnably distant future.

This PR adds a file that collects specific cleanup ideas which have been discussed amongst maintainers.  Having the list committed in the repo allows for everyone to get an idea of planned tasks, refine them through Pull Requests, suggest more cleanups, or even start working on specific tasks (ideally after discussing it first with maintainers).

This PR is **not** intended to trigger discussions around specific items listed in the file.  This is only a chance for people who were part of the original discussion to refine some points (or to object about the principle of keeping the list as part of the repo).  Further PRs can be opened by everyone to amend the list.