### PR TITLE
Deprecate the deprecated functions.

### DIFF
--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -246,4 +246,4 @@ let main () =
       exit 2
 
 let _ =
-  Printexc.catch (Unix.handle_unix_error main) ()
+  Unix.handle_unix_error main ()

--- a/otherlibs/bigarray/bigarray.mli
+++ b/otherlibs/bigarray/bigarray.mli
@@ -24,7 +24,7 @@ module Genarray : sig
     Unix.file_descr -> ?pos:int64 -> ('a, 'b) kind -> 'c layout ->
     bool -> int array -> ('a, 'b, 'c) t
   [@@ocaml.deprecated "\
-Use Unix.map_file instead.\n\
+use Unix.map_file\n\
 Note that Bigarray.Genarray.map_file raises Sys_error while\n\
 Unix.map_file raises Unix_error."]
 end
@@ -34,7 +34,7 @@ module Array1 : sig
   val map_file: Unix.file_descr -> ?pos:int64 -> ('a, 'b) kind -> 'c layout ->
     bool -> int -> ('a, 'b, 'c) t
   [@@ocaml.deprecated "\
-Use [array1_of_genarray (Unix.map_file ...)] instead.\n\
+use [array1_of_genarray (Unix.map_file ...)]\n\
 Note that Bigarray.Array1.map_file raises Sys_error while\n\
 Unix.map_file raises Unix_error."]
 end
@@ -44,7 +44,7 @@ module Array2 : sig
   val map_file: Unix.file_descr -> ?pos:int64 -> ('a, 'b) kind -> 'c layout ->
                 bool -> int -> int -> ('a, 'b, 'c) t
   [@@ocaml.deprecated "\
-Use [array2_of_genarray (Unix.map_file ...)] instead.\n\
+use [array2_of_genarray (Unix.map_file ...)]\n\
 Note that Bigarray.Array2.map_file raises Sys_error while\n\
 Unix.map_file raises Unix_error."]
 end
@@ -54,7 +54,7 @@ module Array3 : sig
   val map_file: Unix.file_descr -> ?pos:int64 -> ('a, 'b) kind -> 'c layout ->
              bool -> int -> int -> int -> ('a, 'b, 'c) t
   [@@ocaml.deprecated "\
-Use [array3_of_genarray (Unix.map_file ...)] instead.\n\
+use [array3_of_genarray (Unix.map_file ...)]\n\
 Note that Bigarray.Array3.map_file raises Sys_error while\n\
 Unix.map_file raises Unix_error."]
 end

--- a/otherlibs/systhreads/threadUnix.mli
+++ b/otherlibs/systhreads/threadUnix.mli
@@ -21,7 +21,7 @@
    (block the calling thread, if required, but do not block all threads
    in the process).  *)
 
-[@@@ocaml.deprecated "Use the Unix module"]
+[@@@ocaml.deprecated "use the Unix module"]
 
 (** {1 Process handling} *)
 

--- a/otherlibs/systhreads/threadUnix.mli
+++ b/otherlibs/systhreads/threadUnix.mli
@@ -21,6 +21,8 @@
    (block the calling thread, if required, but do not block all threads
    in the process).  *)
 
+[@@@ocaml.deprecated "Use the Unix module"]
+
 (** {1 Process handling} *)
 
 val execv : string -> string array -> unit

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -27,7 +27,7 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib \
       -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/unix
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
-COMPFLAGS=-w +33..39 -warn-error A -bin-annot -g -safe-string
+COMPFLAGS=-w -3+33..39 -warn-error A -bin-annot -g -safe-string
 
 C_OBJS=scheduler.o
 

--- a/otherlibs/threads/thread.mli
+++ b/otherlibs/threads/thread.mli
@@ -15,6 +15,8 @@
 
 (** Lightweight threads. *)
 
+[@@@ocaml.deprecated "use systhreads, LWT or async"]
+
 type t
 (** The type of thread handles. *)
 

--- a/otherlibs/threads/threadUnix.mli
+++ b/otherlibs/threads/threadUnix.mli
@@ -21,7 +21,7 @@
    (block the calling thread, if required, but do not block all threads
    in the process).  *)
 
-[@@@ocaml.deprecated "Use the Unix module"]
+[@@@ocaml.deprecated "use the Unix module"]
 
 (** {1 Process handling} *)
 

--- a/otherlibs/threads/threadUnix.mli
+++ b/otherlibs/threads/threadUnix.mli
@@ -21,6 +21,8 @@
    (block the calling thread, if required, but do not block all threads
    in the process).  *)
 
+[@@@ocaml.deprecated "Use the Unix module"]
+
 (** {1 Process handling} *)
 
 val execv : string -> string array -> unit

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1422,7 +1422,7 @@ type socket_bool_option =
 type socket_int_option =
     SO_SNDBUF      (** Size of send buffer *)
   | SO_RCVBUF      (** Size of received buffer *)
-  | SO_ERROR       (** Deprecated.  Use {!Unix.getsockopt_error} instead. *)
+  | SO_ERROR [@ocaml.deprecated "use Unix.getsockopt_error"] (** Deprecated. *)
   | SO_TYPE        (** Report the socket type *)
   | SO_RCVLOWAT    (** Minimum number of bytes to process for input operations*)
   | SO_SNDLOWAT    (** Minimum number of bytes to process for output

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1188,7 +1188,7 @@ type socket_bool_option =
 type socket_int_option =
     SO_SNDBUF    (** Size of send buffer *)
   | SO_RCVBUF    (** Size of received buffer *)
-  | SO_ERROR     (** Deprecated.  Use {!Unix.getsockopt_error} instead. *)
+  | SO_ERROR [@ocaml.deprecated "use Unix.getsockopt_error"] (** Deprecated. *)
   | SO_TYPE      (** Report the socket type *)
   | SO_RCVLOWAT  (** Minimum number of bytes to process for input operations *)
   | SO_SNDLOWAT  (** Minimum number of bytes to process for output operations *)

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -52,7 +52,7 @@ external make : int -> 'a -> 'a array = "caml_make_vect"
    size is only [Sys.max_array_length / 2].*)
 
 external create : int -> 'a -> 'a array = "caml_make_vect"
-  [@@ocaml.deprecated "Use Array.make instead."]
+  [@@ocaml.deprecated "use Array.make"]
 (** @deprecated [Array.create] is an alias for {!Array.make}. *)
 
 external create_float: int -> float array = "caml_make_float_vect"
@@ -61,7 +61,7 @@ external create_float: int -> float array = "caml_make_float_vect"
     @since 4.03 *)
 
 val make_float: int -> float array
-  [@@ocaml.deprecated "Use Array.create_float instead."]
+  [@@ocaml.deprecated "use Array.create_float"]
 (** @deprecated [Array.make_float] is an alias for {!Array.create_float}. *)
 
 val init : int -> (int -> 'a) -> 'a array
@@ -88,7 +88,7 @@ val make_matrix : int -> int -> 'a -> 'a array array
    size is only [Sys.max_array_length / 2]. *)
 
 val create_matrix : int -> int -> 'a -> 'a array array
-  [@@ocaml.deprecated "Use Array.make_matrix instead."]
+  [@@ocaml.deprecated "use Array.make_matrix"]
 (** @deprecated [Array.create_matrix] is an alias for {!Array.make_matrix}. *)
 
 val append : 'a array -> 'a array -> 'a array

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -52,7 +52,7 @@ external make : int -> 'a -> 'a array = "caml_make_vect"
    size is only [Sys.max_array_length / 2].*)
 
 external create : int -> 'a -> 'a array = "caml_make_vect"
-  [@@ocaml.deprecated "Use Array.make instead."]
+  [@@ocaml.deprecated "use Array.make"]
 (** @deprecated [Array.create] is an alias for {!Array.make}. *)
 
 val init : int -> f:(int -> 'a) -> 'a array
@@ -79,7 +79,7 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
    size is only [Sys.max_array_length / 2]. *)
 
 val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-  [@@ocaml.deprecated "Use Array.make_matrix instead."]
+  [@@ocaml.deprecated "use Array.make_matrix"]
 (** @deprecated [Array.create_matrix] is an alias for
    {!Array.make_matrix}. *)
 
@@ -209,7 +209,7 @@ external create_float: int -> float array = "caml_make_float_vect"
     @since 4.03 *)
 
 val make_float: int -> float array
-  [@@ocaml.deprecated "Use Array.create_float instead."]
+  [@@ocaml.deprecated "use Array.create_float"]
 (** @deprecated [Array.make_float] is an alias for
     {!Array.create_float}. *)
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -261,27 +261,27 @@ val rcontains_from : bytes -> int -> char -> bool
     position in [s]. *)
 
 val uppercase : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.uppercase_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.uppercase_ascii"]
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.lowercase_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.lowercase_ascii"]
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.capitalize_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.capitalize_ascii"]
 (** Return a copy of the argument, with the first character set to uppercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.uncapitalize_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.uncapitalize_ascii"]
 (** Return a copy of the argument, with the first character set to lowercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -235,27 +235,27 @@ val rcontains_from : bytes -> int -> char -> bool
     position in [s]. *)
 
 val uppercase : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.uppercase_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.uppercase_ascii"]
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.lowercase_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.lowercase_ascii"]
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.capitalize_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.capitalize_ascii"]
 (** Return a copy of the argument, with the first character set to uppercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : bytes -> bytes
-  [@@ocaml.deprecated "Use Bytes.uncapitalize_ascii instead."]
+  [@@ocaml.deprecated "use Bytes.uncapitalize_ascii"]
 (** Return a copy of the argument, with the first character set to lowercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -31,13 +31,13 @@ val escaped : char -> string
     escaped, as well as backslash, double-quote, and single-quote. *)
 
 val lowercase : char -> char
-  [@@ocaml.deprecated "Use Char.lowercase_ascii instead."]
+  [@@ocaml.deprecated "use Char.lowercase_ascii"]
 (** Convert the given character to its equivalent lowercase character,
    using the ISO Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uppercase : char -> char
-  [@@ocaml.deprecated "Use Char.uppercase_ascii instead."]
+  [@@ocaml.deprecated "use Char.uppercase_ascii"]
 (** Convert the given character to its equivalent uppercase character,
    using the ISO Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -169,7 +169,7 @@ val set_temp_dir_name : string -> unit
 *)
 
 val temp_dir_name : string
-  [@@ocaml.deprecated "Use Filename.get_temp_dir_name instead"]
+  [@@ocaml.deprecated "use Filename.get_temp_dir_name"]
 (** The name of the initial temporary directory:
     Under Unix, the value of the [TMPDIR] environment variable, or "/tmp"
     if the variable is not set.

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1272,7 +1272,7 @@ val kasprintf : (string -> 'a) -> ('b, formatter, unit, 'a) format4 -> 'b
 (** {1 Deprecated} *)
 
 val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a
-  [@@ocaml.deprecated]
+  [@@ocaml.deprecated "use Format.formatter_of_buffer and Format.fprintf"]
 (** @deprecated This function is error prone. Do not use it.
   This function is neither compositional nor incremental, since it flushes
   the pretty-printer queue at each call.
@@ -1283,7 +1283,7 @@ val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a
 *)
 
 val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
-  [@@ocaml.deprecated "Use Format.ksprintf instead."]
+  [@@ocaml.deprecated "use Format.ksprintf"]
 (** @deprecated An alias for [ksprintf]. *)
 
 val set_all_formatter_output_functions :
@@ -1292,7 +1292,7 @@ val set_all_formatter_output_functions :
   newline:(unit -> unit) ->
   spaces:(int -> unit) ->
   unit
-[@@ocaml.deprecated "Use Format.set_formatter_out_functions instead."]
+[@@ocaml.deprecated "use Format.set_formatter_out_functions"]
 (** @deprecated Subsumed by [set_formatter_out_functions]. *)
 
 val get_all_formatter_output_functions :
@@ -1301,38 +1301,38 @@ val get_all_formatter_output_functions :
   (unit -> unit) *
   (unit -> unit) *
   (int -> unit)
-[@@ocaml.deprecated "Use Format.get_formatter_out_functions instead."]
+[@@ocaml.deprecated "use Format.get_formatter_out_functions"]
 (** @deprecated Subsumed by [get_formatter_out_functions]. *)
 
 val pp_set_all_formatter_output_functions :
   formatter -> out:(string -> int -> int -> unit) -> flush:(unit -> unit) ->
   newline:(unit -> unit) -> spaces:(int -> unit) -> unit
-[@@ocaml.deprecated "Use Format.pp_set_formatter_out_functions instead."]
+[@@ocaml.deprecated "use Format.pp_set_formatter_out_functions"]
 (** @deprecated Subsumed by [pp_set_formatter_out_functions]. *)
 
 val pp_get_all_formatter_output_functions :
   formatter -> unit ->
   (string -> int -> int -> unit) * (unit -> unit) * (unit -> unit) *
   (int -> unit)
-[@@ocaml.deprecated "Use Format.pp_get_formatter_out_functions instead."]
+[@@ocaml.deprecated "use Format.pp_get_formatter_out_functions"]
 (** @deprecated Subsumed by [pp_get_formatter_out_functions]. *)
 
 (** {2 String tags} *)
 
 val pp_open_tag : formatter -> tag -> unit
-[@@ocaml.deprecated "Use Format.pp_open_stag."]
+[@@ocaml.deprecated "use Format.pp_open_stag"]
 (** @deprecated Subsumed by {!pp_open_stag}. *)
 
 val open_tag : tag -> unit
-[@@ocaml.deprecated "Use Format.open_stag."]
+[@@ocaml.deprecated "use Format.open_stag"]
 (** @deprecated Subsumed by {!open_stag}. *)
 
 val pp_close_tag : formatter -> unit -> unit
-[@@ocaml.deprecated "Use Format.pp_close_stag."]
+[@@ocaml.deprecated "use Format.pp_close_stag"]
 (** @deprecated Subsumed by {!pp_close_stag}. *)
 
 val close_tag : unit -> unit
-[@@ocaml.deprecated "Use Format.close_stag."]
+[@@ocaml.deprecated "use Format.close_stag"]
 (** @deprecated Subsumed by {!close_stag}. *)
 
 type formatter_tag_functions = {
@@ -1341,30 +1341,28 @@ type formatter_tag_functions = {
   print_open_tag : tag -> unit;
   print_close_tag : tag -> unit;
 }
-[@@ocaml.deprecated "Use formatter_stag_functions."]
+[@@ocaml.deprecated "use Format.formatter_stag_functions"]
 (** @deprecated Subsumed by {!formatter_stag_functions}. *)
 
 val pp_set_formatter_tag_functions :
   formatter -> formatter_tag_functions -> unit
-[@@ocaml.deprecated
-  "This function will erase non-string tag formatting functions. \
-   Use Format.pp_set_formatter_stag_functions."]
+[@@ocaml.deprecated "use Format.pp_set_formatter_stag_functions"]
 [@@warning "-3"]
 (** This function will erase non-string tag formatting functions.
     @deprecated Subsumed by {!pp_set_formatter_stag_functions}. *)
 
 val set_formatter_tag_functions : formatter_tag_functions -> unit
-[@@ocaml.deprecated "Use Format.set_formatter_stag_functions."]
+[@@ocaml.deprecated "use Format.set_formatter_stag_functions"]
 [@@warning "-3"]
 (** @deprecated Subsumed by {!set_formatter_stag_functions}. *)
 
 val pp_get_formatter_tag_functions :
   formatter -> unit -> formatter_tag_functions
-[@@ocaml.deprecated "Use Format.pp_get_formatter_stag_functions."]
+[@@ocaml.deprecated "use Format.pp_get_formatter_stag_functions"]
 [@@warning "-3"]
 (** @deprecated Subsumed by {!pp_get_formatter_stag_functions}. *)
 
 val get_formatter_tag_functions : unit -> formatter_tag_functions
-[@@ocaml.deprecated "Use Format.get_formatter_stag_functions."]
+[@@ocaml.deprecated "use Format.get_formatter_stag_functions"]
 [@@warning "-3"]
 (** @deprecated Subsumed by {!get_formatter_stag_functions}. *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -219,5 +219,6 @@ val equal: t -> t -> bool
 (** {1 Deprecated functions} *)
 
 external format : string -> int32 -> string = "caml_int32_format"
-(** Do not use this deprecated function.  Instead,
-   used {!Printf.sprintf} with a [%l...] format. *)
+[@@ocaml.deprecated "Use Printf.sprintf with a %l... format"]
+(** @deprecated Do not use this function.  Instead,
+   use {!Printf.sprintf} with a [%l...] format. *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -219,6 +219,6 @@ val equal: t -> t -> bool
 (** {1 Deprecated functions} *)
 
 external format : string -> int32 -> string = "caml_int32_format"
-[@@ocaml.deprecated "Use Printf.sprintf with a %l... format"]
+[@@ocaml.deprecated "use Printf.sprintf with a %l... format"]
 (** @deprecated Do not use this function.  Instead,
    use {!Printf.sprintf} with a [%l...] format. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -238,5 +238,5 @@ val equal: t -> t -> bool
 (** {1 Deprecated functions} *)
 
 external format : string -> int64 -> string = "caml_int64_format"
-(** Do not use this deprecated function.  Instead,
-   used {!Printf.sprintf} with a [%L...] format. *)
+[@@ocaml.deprecated "Use Printf.sprintf with a %L... format."]
+(** @deprecated use {!Printf.sprintf} with a [%L...] format. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -238,5 +238,5 @@ val equal: t -> t -> bool
 (** {1 Deprecated functions} *)
 
 external format : string -> int64 -> string = "caml_int64_format"
-[@@ocaml.deprecated "Use Printf.sprintf with a %L... format."]
+[@@ocaml.deprecated "use Printf.sprintf with a %L... format"]
 (** @deprecated use {!Printf.sprintf} with a [%L...] format. *)

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -98,13 +98,13 @@ val is_val : 'a t -> bool
     @since 4.00.0 *)
 
 val lazy_from_fun : (unit -> 'a) -> 'a t
-  [@@ocaml.deprecated "Use Lazy.from_fun instead."]
-(** @deprecated synonym for [from_fun]. *)
+  [@@ocaml.deprecated "use Lazy.from_fun"]
+(** @deprecated alias of [from_fun]. *)
 
 val lazy_from_val : 'a -> 'a t
-  [@@ocaml.deprecated "Use Lazy.from_val instead."]
-(** @deprecated synonym for [from_val]. *)
+  [@@ocaml.deprecated "use Lazy.from_val"]
+(** @deprecated alias of [from_val]. *)
 
 val lazy_is_val : 'a t -> bool
-  [@@ocaml.deprecated "Use Lazy.is_val instead."]
-(** @deprecated synonym for [is_val]. *)
+  [@@ocaml.deprecated "use Lazy.is_val"]
+(** @deprecated alias of [is_val]. *)

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -228,7 +228,7 @@ val equal: t -> t -> bool
 (** {1 Deprecated functions} *)
 
 external format : string -> nativeint -> string = "caml_nativeint_format"
-[@@ocaml.deprecated "Use Printf.sprintf with a %nx format"]
+[@@ocaml.deprecated "use Printf.sprintf with a %nx format"]
 (** [Nativeint.format fmt n] return the string representation of the
    native integer [n] in the format specified by [fmt].
    [fmt] is a [Printf]-style format consisting of exactly

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -228,6 +228,7 @@ val equal: t -> t -> bool
 (** {1 Deprecated functions} *)
 
 external format : string -> nativeint -> string = "caml_nativeint_format"
+[@@ocaml.deprecated "Use Printf.sprintf with a %nx format"]
 (** [Nativeint.format fmt n] return the string representation of the
    native integer [n] in the format specified by [fmt].
    [fmt] is a [Printf]-style format consisting of exactly

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -80,7 +80,7 @@ val double_tag : int
 val double_array_tag : int
 val custom_tag : int
 val final_tag : int
-  [@@ocaml.deprecated "Replaced by custom_tag."]
+  [@@ocaml.deprecated "replaced by custom_tag"]
 
 val int_tag : int
 val out_of_heap_tag : int
@@ -104,9 +104,9 @@ val [@inline always] extension_id : extension_constructor -> int
     instead. *)
 
 val marshal : t -> bytes
-  [@@ocaml.deprecated "Use Marshal.to_bytes instead."]
+  [@@ocaml.deprecated "use Marshal.to_bytes"]
 val unmarshal : bytes -> int -> t * int
-  [@@ocaml.deprecated "Use Marshal.from_bytes and Marshal.total_size instead."]
+  [@@ocaml.deprecated "use Marshal.from_bytes and Marshal.total_size"]
 
 module Ephemeron: sig
   (** Ephemeron with arbitrary arity and untyped *)

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -33,10 +33,10 @@ external ( != ) : 'a -> 'a -> bool = "%noteq"
 external not : bool -> bool = "%boolnot"
 external ( && ) : bool -> bool -> bool = "%sequand"
 external ( & ) : bool -> bool -> bool = "%sequand"
-  [@@ocaml.deprecated "Use (&&) instead."]
+  [@@ocaml.deprecated "use (&&)"]
 external ( || ) : bool -> bool -> bool = "%sequor"
 external ( or ) : bool -> bool -> bool = "%sequor"
-  [@@ocaml.deprecated "Use (||) instead."]
+  [@@ocaml.deprecated "use (||)"]
 external __LOC__ : string = "%loc_LOC"
 external __FILE__ : string = "%loc_FILE"
 external __LINE__ : int = "%loc_LINE"

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -31,6 +31,7 @@ val print: ('a -> 'b) -> 'a -> 'b
    escape a function application. *)
 
 val catch: ('a -> 'b) -> 'a -> 'b
+[@@ocaml.deprecated]
 (** [Printexc.catch fn x] is similar to {!Printexc.print}, but
    aborts the program with exit code 2 after printing the
    uncaught exception.  This function is deprecated: the runtime

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -172,5 +172,5 @@ val kbprintf : (Buffer.t -> 'd) -> Buffer.t ->
 (** Deprecated *)
 
 val kprintf : (string -> 'b) -> ('a, unit, string, 'b) format4 -> 'a
-[@@ocaml.deprecated "Use Printf.ksprintf"]
+[@@ocaml.deprecated "use Printf.ksprintf"]
 (** @deprecated alias of [ksprintf]. *)

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -172,4 +172,5 @@ val kbprintf : (Buffer.t -> 'd) -> Buffer.t ->
 (** Deprecated *)
 
 val kprintf : (string -> 'b) -> ('a, unit, string, 'b) format4 -> 'a
-(** A deprecated synonym for [ksprintf]. *)
+[@@ocaml.deprecated "Use Printf.ksprintf"]
+(** @deprecated alias of [ksprintf]. *)

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -196,7 +196,7 @@ val name_of_input : in_channel -> string
 *)
 
 val stdib : in_channel
-  [@@ocaml.deprecated "Use Scanf.Scanning.stdin instead."]
+  [@@ocaml.deprecated "use Scanf.Scanning.stdin"]
 (** A deprecated alias for {!Scanning.stdin}, the scanning buffer reading from
     {!Stdlib.stdin}.
 *)
@@ -538,7 +538,7 @@ val unescaped : string -> string
 (** {1 Deprecated} *)
 
 val fscanf : Stdlib.in_channel -> ('a, 'b, 'c, 'd) scanner
-  [@@ocaml.deprecated "Use Scanning.from_channel then Scanf.bscanf."]
+  [@@ocaml.deprecated "use Scanning.from_channel then Scanf.bscanf"]
 (** @deprecated [Scanf.fscanf] is error prone and deprecated since 4.03.0.
 
     This function violates the following invariant of the {!Scanf} module:
@@ -555,5 +555,5 @@ val fscanf : Stdlib.in_channel -> ('a, 'b, 'c, 'd) scanner
 val kfscanf :
   Stdlib.in_channel -> (Scanning.in_channel -> exn -> 'd) ->
     ('a, 'b, 'c, 'd) scanner
-  [@@ocaml.deprecated "Use Scanning.from_channel then Scanf.kscanf."]
+  [@@ocaml.deprecated "use Scanning.from_channel then Scanf.kscanf"]
 (** @deprecated [Scanf.kfscanf] is error prone and deprecated since 4.03.0. *)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -224,7 +224,7 @@ external ( && ) : bool -> bool -> bool = "%sequand"
 *)
 
 external ( & ) : bool -> bool -> bool = "%sequand"
-  [@@ocaml.deprecated "Use (&&) instead."]
+  [@@ocaml.deprecated "use (&&)"]
 (** @deprecated {!Stdlib.( && )} should be used instead.
     Right-associative operator, see {!Ocaml_operators} for more information.
 *)
@@ -237,7 +237,7 @@ external ( || ) : bool -> bool -> bool = "%sequor"
 *)
 
 external ( or ) : bool -> bool -> bool = "%sequor"
-  [@@ocaml.deprecated "Use (||) instead."]
+  [@@ocaml.deprecated "use (||)"]
 (** @deprecated {!Stdlib.( || )} should be used instead.
     Right-associative operator, see {!Ocaml_operators} for more information.
 *)
@@ -1367,7 +1367,7 @@ module Oo           = Oo
 module Option       = Option
 module Parsing      = Parsing
 module Pervasives   = Pervasives
-[@@deprecated "Use Stdlib instead.\n\
+[@@deprecated "use the Stdlib module\n\
 \n\
 If you need to stay compatible with OCaml < 4.07, you can use the \n\
 stdlib-shims library: https://github.com/ocaml/stdlib-shims"]

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -59,7 +59,7 @@ external get : string -> int -> char = "%string_safe_get"
 
 
 external set : bytes -> int -> char -> unit = "%string_safe_set"
-  [@@ocaml.deprecated "Use Bytes.set instead."]
+  [@@ocaml.deprecated "use Bytes.set"]
 (** [String.set s n c] modifies byte sequence [s] in place,
    replacing the byte at index [n] with [c].
    You can also write [s.[n] <- c] instead of [String.set s n c].
@@ -69,7 +69,7 @@ external set : bytes -> int -> char -> unit = "%string_safe_set"
    @deprecated This is a deprecated alias of {!Bytes.set}.[ ] *)
 
 external create : int -> bytes = "caml_create_string"
-  [@@ocaml.deprecated "Use Bytes.create instead."]
+  [@@ocaml.deprecated "use Bytes.create"]
 (** [String.create n] returns a fresh byte sequence of length [n].
    The sequence is uninitialized and contains arbitrary bytes.
 
@@ -108,7 +108,7 @@ val sub : string -> int -> int -> string
    designate a valid substring of [s]. *)
 
 val fill : bytes -> int -> int -> char -> unit
-  [@@ocaml.deprecated "Use Bytes.fill instead."]
+  [@@ocaml.deprecated "use Bytes.fill"]
 (** [String.fill s start len c] modifies byte sequence [s] in place,
    replacing [len] bytes with [c], starting at [start].
 
@@ -260,27 +260,27 @@ val rcontains_from : string -> int -> char -> bool
    position in [s]. *)
 
 val uppercase : string -> string
-  [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
+  [@@ocaml.deprecated "use String.uppercase_ascii"]
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : string -> string
-  [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
+  [@@ocaml.deprecated "use String.lowercase_ascii"]
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : string -> string
-  [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
+  [@@ocaml.deprecated "use String.capitalize_ascii"]
 (** Return a copy of the argument, with the first character set to uppercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : string -> string
-  [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
+  [@@ocaml.deprecated "use String.uncapitalize_ascii"]
 (** Return a copy of the argument, with the first character set to lowercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -25,7 +25,7 @@ external get : string -> int -> char = "%string_safe_get"
    Raise [Invalid_argument] if [n] not a valid index in [s]. *)
 
 external set : bytes -> int -> char -> unit = "%string_safe_set"
-  [@@ocaml.deprecated "Use BytesLabels.set instead."]
+  [@@ocaml.deprecated "use BytesLabels.set"]
 (** [String.set s n c] modifies byte sequence [s] in place,
    replacing the byte at index [n] with [c].
    You can also write [s.[n] <- c] instead of [String.set s n c].
@@ -35,7 +35,7 @@ external set : bytes -> int -> char -> unit = "%string_safe_set"
    @deprecated This is a deprecated alias of {!BytesLabels.set}. *)
 
 external create : int -> bytes = "caml_create_string"
-  [@@ocaml.deprecated "Use BytesLabels.create instead."]
+  [@@ocaml.deprecated "use BytesLabels.create"]
 (** [String.create n] returns a fresh byte sequence of length [n].
    The sequence is uninitialized and contains arbitrary bytes.
 
@@ -68,7 +68,7 @@ val sub : string -> pos:int -> len:int -> string
    designate a valid substring of [s]. *)
 
 val fill : bytes -> pos:int -> len:int -> char -> unit
-  [@@ocaml.deprecated "Use BytesLabels.fill instead."]
+  [@@ocaml.deprecated "use BytesLabels.fill"]
 (** [String.fill s start len c] modifies byte sequence [s] in place,
    replacing [len] bytes by [c], starting at [start].
 
@@ -215,27 +215,27 @@ val rcontains_from : string -> int -> char -> bool
    position in [s]. *)
 
 val uppercase : string -> string
-  [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
+  [@@ocaml.deprecated "use String.uppercase_ascii"]
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : string -> string
-  [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
+  [@@ocaml.deprecated "use String.lowercase_ascii"]
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, including accented letters of the ISO
    Latin-1 (8859-1) character set.
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : string -> string
-  [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
+  [@@ocaml.deprecated "use String.capitalize_ascii"]
 (** Return a copy of the argument, with the first character set to uppercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : string -> string
-  [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
+  [@@ocaml.deprecated "use String.uncapitalize_ascii"]
 (** Return a copy of the argument, with the first character set to lowercase,
    using the ISO Latin-1 (8859-1) character set..
    @deprecated Functions operating on Latin-1 character set are deprecated. *)

--- a/testsuite/tests/basic/boxedints.ml
+++ b/testsuite/tests/basic/boxedints.ml
@@ -1,4 +1,5 @@
-(* TEST *)
+(* TEST
+ *)
 
 (* Test the types nativeint, int32, int64 *)
 
@@ -53,7 +54,7 @@ module type TESTSIG = sig
     val minus_one: t
     val min_int: t
     val max_int: t
-    val format : string -> t -> string
+    val format : string -> t -> string [@@ocaml.deprecated]
     val to_string: t -> string
     val of_string: string -> t
   end
@@ -118,7 +119,8 @@ struct
        5, "1073741824"; 6, "2147483647"; 7, "-2147483648"];
     List.iter (fun (n, s) -> test n (format "0x%X" (of_string s)) s)
       [8, "0x0"; 9, "0x123"; 10, "0xABCDEF"; 11, "0x12345678";
-       12, "0x7FFFFFFF"; 13, "0x80000000"; 14, "0xFFFFFFFF"];
+       12, "0x7FFFFFFF"; 13, "0x80000000"; 14, "0xFFFFFFFF"]
+      [@ocaml.warning "-3"];
     test 15 (to_string max_int) "2147483647";
     test 16 (to_string min_int) "-2147483648";
     test 17 (to_string zero) "0";
@@ -376,7 +378,8 @@ struct
     List.iter (fun (n, s) -> test n ("0x" ^ format "%X" (of_string s)) s)
       [8, "0x0"; 9, "0x123"; 10, "0xABCDEF"; 11, "0x1234567812345678";
        12, "0x7FFFFFFFFFFFFFFF"; 13, "0x8000000000000000";
-       14, "0xFFFFFFFFFFFFFFFF"];
+       14, "0xFFFFFFFFFFFFFFFF"]
+      [@ocaml.warning "-3"];
     test 15 (to_string max_int) "9223372036854775807";
     test 16 (to_string min_int) "-9223372036854775808";
     test 17 (to_string zero) "0";

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -6,7 +6,7 @@ let current = ref 0;;
 let accum = ref [];;
 
 let record fmt (* args *) =
-  Printf.kprintf (fun s -> accum := s :: !accum) fmt
+  Printf.ksprintf (fun s -> accum := s :: !accum) fmt
 ;;
 
 let f_unit () = record "unit()";;

--- a/testsuite/tests/lib-marshal/intext.ml
+++ b/testsuite/tests/lib-marshal/intext.ml
@@ -629,4 +629,4 @@ let main() =
     print_newline()
   end
 
-let _ = Printexc.catch main (); exit 0
+let _ = main ()

--- a/testsuite/tests/lib-stdlib/pervasives_deprecated.ml
+++ b/testsuite/tests/lib-stdlib/pervasives_deprecated.ml
@@ -10,7 +10,7 @@ Line 3, characters 0-14:
 3 | Pervasives.(+) 1 1;;
     ^^^^^^^^^^^^^^
 Error (alert deprecated): module Stdlib.Pervasives
-Use Stdlib instead.
+use the Stdlib module
 
 If you need to stay compatible with OCaml < 4.07, you can use the
 stdlib-shims library: https://github.com/ocaml/stdlib-shims
@@ -22,7 +22,7 @@ Line 1, characters 11-21:
 1 | module X = Pervasives;;
                ^^^^^^^^^^
 Error (alert deprecated): module Stdlib.Pervasives
-Use Stdlib instead.
+use the Stdlib module
 
 If you need to stay compatible with OCaml < 4.07, you can use the
 stdlib-shims library: https://github.com/ocaml/stdlib-shims
@@ -34,7 +34,7 @@ Line 1, characters 5-15:
 1 | open Pervasives;;
          ^^^^^^^^^^
 Error (alert deprecated): module Stdlib.Pervasives
-Use Stdlib instead.
+use the Stdlib module
 
 If you need to stay compatible with OCaml < 4.07, you can use the
 stdlib-shims library: https://github.com/ocaml/stdlib-shims

--- a/testsuite/tests/misc/sorts.ml
+++ b/testsuite/tests/misc/sorts.ml
@@ -4470,4 +4470,4 @@ let main () =
     end;
 ;;
 
-if not !Sys.interactive then Printexc.catch main ();;
+if not !Sys.interactive then main ();;

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -76,4 +76,4 @@ let main () =
   close_in ic;
   close_out oc
 
-let _ = Printexc.catch main (); exit 0
+let _ = main ()

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -182,7 +182,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
-[@@ocaml.deprecated "Use Location.error_of_exn and Location.print_report"]
+[@@ocaml.deprecated "use Location.error_of_exn and Location.print_report"]
  (** @deprecated.  Use {!Location.error_of_exn}, {!Location.print_report}. *)
 
 (* Forward declaration, to be filled in by Typemod.type_module *)

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -182,6 +182,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
+[@@ocaml.deprecated "Use Location.error_of_exn and Location.print_report"]
  (** @deprecated.  Use {!Location.error_of_exn}, {!Location.print_report}. *)
 
 (* Forward declaration, to be filled in by Typemod.type_module *)

--- a/utils/build_path_prefix_map.ml
+++ b/utils/build_path_prefix_map.ml
@@ -17,7 +17,7 @@ type path = string
 type path_prefix = string
 type error_message = string
 
-let errorf fmt = Printf.kprintf (fun err -> Error err) fmt
+let errorf fmt = Printf.ksprintf (fun err -> Error err) fmt
 
 let encode_prefix str =
   let buf = Buffer.create (String.length str) in


### PR DESCRIPTION
* Add the ocaml.deprecated attribute to functions that are documented as deprecated and remove all uses of such functions in the code.
* Normalize the deprecation messages by removing the word "instead".
* Fix the testsuite accordingly.