### PR TITLE
Fix #mod_use raising exception (MPR#7867)

### DIFF
--- a/Changes
+++ b/Changes
@@ -504,6 +504,10 @@ Working version
 
 ### Bug fixes:
 
+- MPR#7867: Fix #mod_use raising an exception for filenames with no
+  extension.
+  (Geoff Gole)
+
 - GPR#2100: Fix Unix.getaddrinfo when called on strings containing
   null bytes; it would crash the GC later on.
   (Armaël Guéneau, report and fix by Joe, review by Sébastien Hinderer)

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -8,5 +8,5 @@ val g : unit -> int = <fun>
 Exception: Not_found.
 Raised at file "//toplevel//", line 2, characters 17-26
 Called from file "//toplevel//", line 1, characters 11-15
-Called from file "toplevel/toploop.ml", line 179, characters 17-27
+Called from file "toplevel/toploop.ml", line 180, characters 17-27
 

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -162,7 +162,8 @@ let input_name = Location.input_name
 
 let parse_mod_use_file name lb =
   let modname =
-    String.capitalize_ascii (Filename.chop_extension (Filename.basename name))
+    String.capitalize_ascii
+      (Filename.remove_extension (Filename.basename name))
   in
   let items =
     List.concat

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -123,7 +123,8 @@ let input_name = Location.input_name
 
 let parse_mod_use_file name lb =
   let modname =
-    String.capitalize_ascii (Filename.chop_extension (Filename.basename name))
+    String.capitalize_ascii
+      (Filename.remove_extension (Filename.basename name))
   in
   let items =
     List.concat


### PR DESCRIPTION
I tried testing this in the native toplevel, but it does not seem to have mod_use. Nonetheless the change in toploop.ml is duplicated in opttoploop as suggested by Gasche in the Mantis issue.