### PR TITLE
Filename.chop_suffix_opt

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,9 @@ Working version
 - GPR#2119: clarify the documentation of Set.diff
   (Gabriel Scherer, suggestion by John Skaller)
 
+- MPR#7812, GPR#xxxx: Add Filename.chop_suffix_opt
+  (Alain Frisch, suggested by whitequark)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/Changes
+++ b/Changes
@@ -133,8 +133,8 @@ Working version
 - GPR#2119: clarify the documentation of Set.diff
   (Gabriel Scherer, suggestion by John Skaller)
 
-- MPR#7812, GPR#xxxx: Add Filename.chop_suffix_opt
-  (Alain Frisch, suggested by whitequark)
+- MPR#7812, GPR#2125: Add Filename.chop_suffix_opt
+  (Alain Frisch, review by Nicolás Ojeda Bär, suggestion by whitequark)
 
 ### Other libraries:
 

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -47,7 +47,18 @@ val check_suffix : string -> string -> bool
 val chop_suffix : string -> string -> string
 (** [chop_suffix name suff] removes the suffix [suff] from
    the filename [name]. The behavior is undefined if [name] does not
-   end with the suffix [suff]. *)
+   end with the suffix [suff]. It is thus recommmended to use
+   [chop_suffix_opt] instead.
+*)
+
+val chop_suffix_opt: suffix:string -> string -> string option
+(** [chop_suffix_opt ~suffix filename] removes the suffix from
+    the [filename] if possible, or return [None] if the
+    filename does not end with the suffix.
+
+    @since NEXT_VERSION
+*)
+
 
 val extension : string -> string
 (** [extension name] is the shortest suffix [ext] of [name0] where:

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -42,7 +42,12 @@ val is_implicit : string -> bool
 
 val check_suffix : string -> string -> bool
 (** [check_suffix name suff] returns [true] if the filename [name]
-   ends with the suffix [suff]. *)
+    ends with the suffix [suff].
+
+    Under Windows ports (including Cygwin), comparison is
+    case-insensitive, relying on [String.lowercase_ascii].  Note that
+    this does not match exactly the interpretation of case-insensitive
+    filename equivalence from Windows.  *)
 
 val chop_suffix : string -> string -> string
 (** [chop_suffix name suff] removes the suffix [suff] from
@@ -56,7 +61,12 @@ val chop_suffix_opt: suffix:string -> string -> string option
     the [filename] if possible, or returns [None] if the
     filename does not end with the suffix.
 
-    @since NEXT_VERSION
+    Under Windows ports (including Cygwin), comparison is
+    case-insensitive, relying on [String.lowercase_ascii].  Note that
+    this does not match exactly the interpretation of case-insensitive
+    filename equivalence from Windows.
+
+    @since 4.08
 *)
 
 

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -53,7 +53,7 @@ val chop_suffix : string -> string -> string
 
 val chop_suffix_opt: suffix:string -> string -> string option
 (** [chop_suffix_opt ~suffix filename] removes the suffix from
-    the [filename] if possible, or return [None] if the
+    the [filename] if possible, or returns [None] if the
     filename does not end with the suffix.
 
     @since NEXT_VERSION

--- a/testsuite/tests/lib-filename/ocamltests
+++ b/testsuite/tests/lib-filename/ocamltests
@@ -1,1 +1,2 @@
 extension.ml
+suffix.ml

--- a/testsuite/tests/lib-filename/suffix.ml
+++ b/testsuite/tests/lib-filename/suffix.ml
@@ -1,0 +1,27 @@
+(* TEST
+*)
+
+let () =
+  let test ~suffix name exp =
+    let r1 = Filename.chop_suffix_opt ~suffix name <> None in
+    let r2 = Filename.check_suffix name suffix in
+    assert (r1 = r2);
+    assert (r1 = exp)
+  in
+  let full_test ~suffix name =
+    test ~suffix name true;
+    match Filename.chop_suffix_opt ~suffix name with
+    | None -> assert false
+    | Some base -> assert (base ^ suffix = name)
+  in
+  let win32 = Sys.os_type = "Win32" || Sys.os_type = "Cygwin" in
+  full_test ~suffix:".txt" "foo.txt";
+  full_test ~suffix:"txt" "foo.txt";
+  full_test ~suffix:"" "foo.txt";
+  full_test ~suffix:"" "";
+  test ~suffix:".txt" "f" false;
+  test ~suffix:".txt" "" false;
+  test ~suffix:".txt" "foo.txt.bak" false;
+  test ~suffix:".txt" "foo.TXT" win32;
+  if win32 then
+    assert (Filename.chop_suffix_opt ~suffix:".txt" "foo.TXT" = Some "foo")


### PR DESCRIPTION
This supersedes #1858 and somehow addresses parts of [MPR#7812](https://caml.inria.fr/mantis/view.php?id=7812).  cc @whitequark 

A new function is added:

````ocaml
val chop_suffix_opt: suffix:string -> string -> string option
(** [chop_suffix_opt ~suffix filename] removes the suffix from
    the [filename] if possible, or returns [None] if the
    filename does not end with the suffix.
````

The goal is to deprecate `Filename.chop_suffix` eventually.  That function is dangerous: it only removes the final characters from the filename, without actually checking the suffix matches; and it raises only when the filename is "too short", which is rare enough to have the bugs fly under the radar for a long time.

Following the "modern" style in the stdlib, the new function returns an option instead of raising an exception in case of mismatch.    This could avoid bugs such as [MPR#1858](https://github.com/ocaml/ocaml/pull/1858).

The function uses a labelled argument to avoid the possible confusion between the two arguments. `check_suffix/chop_suffix` are rare cases where I always need to look up the documentation to know the ordering of arguments.

This PR does not rewrite the uses of chop_suffix in the core distribution to use the new function.  This can be done as a follow-up PR.

Also, this PR does not mark `Filename.chop_suffix` as being deprecated; in the latest caml-devel meeting, it was mentioned that having one full major version of OCaml with the new functions before deprecating the "old" ones is considered to be the polite behavior towards the community.