### PR TITLE
Fix uncaught Nondep_cannot_erase exception

### DIFF
--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -1,0 +1,16 @@
+(* TEST
+   * expect
+*)
+
+module F(X : sig type t end) = struct
+  let f (_ : X.t) = ()
+end;;
+[%%expect{|
+module F : functor (X : sig type t end) -> sig val f : X.t -> unit end
+|}]
+
+module M = F(struct type t = T end);;
+[%%expect{|
+Uncaught exception: Ctype.Nondep_cannot_erase(_)
+
+|}]

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -11,6 +11,11 @@ module F : functor (X : sig type t end) -> sig val f : X.t -> unit end
 
 module M = F(struct type t = T end);;
 [%%expect{|
-Uncaught exception: Ctype.Nondep_cannot_erase(_)
-
+Line 1, characters 11-35:
+1 | module M = F(struct type t = T end);;
+               ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This functor has type
+       functor (X : sig type t end) -> sig val f : X.t -> unit end
+       The parameter cannot be eliminated in the result type.
+       Please bind the argument to a module identifier.
 |}]

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -2,6 +2,7 @@ aliases.ml
 applicative_functor_type.ml
 firstclass.ml
 generative.ml
+nondep.ml
 nondep_private_abbrev.ml
 pr5911.ml
 pr6394.ml

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1621,7 +1621,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
                   "the signature of this functor application" mty_res;
                 let nondep_mty =
                   try Mtype.nondep_supertype env [param] mty_res
-                  with Not_found ->
+                  with Ctype.Nondep_cannot_erase _ ->
                     raise(Error(smod.pmod_loc, env,
                                 Cannot_eliminate_dependency mty_functor))
                 in
@@ -2259,7 +2259,7 @@ let report_error ppf = function
   | Cannot_eliminate_dependency mty ->
       fprintf ppf
         "@[This functor has type@ %a@ \
-           The parameter cannot be eliminated in the result type.@  \
+           The parameter cannot be eliminated in the result type.@ \
            Please bind the argument to a module identifier.@]" modtype mty
   | Signature_expected -> fprintf ppf "This module type is not a signature"
   | Structure_expected mty ->


### PR DESCRIPTION
The regression was present only on trunk (introduced by #1892 ), and was missed during review.

It's interesting that there weren't any test for it.

PS: I grepped for other calls to `nondep_`, I think everything is now covered.