### PR TITLE
Fix printing of type variables with a quote on 2nd character

### DIFF
--- a/.depend
+++ b/.depend
@@ -118,12 +118,12 @@ parsing/location.cmi : utils/warnings.cmi
 parsing/longident.cmo : utils/misc.cmi parsing/longident.cmi
 parsing/longident.cmx : utils/misc.cmx parsing/longident.cmi
 parsing/longident.cmi :
-parsing/parse.cmo : parsing/syntaxerr.cmi parsing/parser.cmi \
-    parsing/location.cmi parsing/lexer.cmi parsing/docstrings.cmi \
-    parsing/parse.cmi
-parsing/parse.cmx : parsing/syntaxerr.cmx parsing/parser.cmx \
-    parsing/location.cmx parsing/lexer.cmx parsing/docstrings.cmx \
-    parsing/parse.cmi
+parsing/parse.cmo : parsing/syntaxerr.cmi parsing/pprintast.cmi \
+    parsing/parser.cmi parsing/location.cmi parsing/lexer.cmi \
+    parsing/docstrings.cmi parsing/parse.cmi
+parsing/parse.cmx : parsing/syntaxerr.cmx parsing/pprintast.cmx \
+    parsing/parser.cmx parsing/location.cmx parsing/lexer.cmx \
+    parsing/docstrings.cmx parsing/parse.cmi
 parsing/parse.cmi : parsing/parsetree.cmi
 parsing/parser.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
     parsing/longident.cmi parsing/location.cmi parsing/docstrings.cmi \
@@ -137,17 +137,17 @@ parsing/parser.cmi : parsing/parsetree.cmi parsing/location.cmi \
     parsing/docstrings.cmi parsing/camlinternalMenhirLib.cmi
 parsing/parsetree.cmi : parsing/longident.cmi parsing/location.cmi \
     parsing/asttypes.cmi
-parsing/pprintast.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    parsing/asttypes.cmi parsing/ast_helper.cmi parsing/pprintast.cmi
-parsing/pprintast.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    parsing/asttypes.cmi parsing/ast_helper.cmx parsing/pprintast.cmi
+parsing/pprintast.cmo : parsing/parsetree.cmi utils/misc.cmi \
+    parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \
+    parsing/ast_helper.cmi parsing/pprintast.cmi
+parsing/pprintast.cmx : parsing/parsetree.cmi utils/misc.cmx \
+    parsing/longident.cmx parsing/location.cmx parsing/asttypes.cmi \
+    parsing/ast_helper.cmx parsing/pprintast.cmi
 parsing/pprintast.cmi : parsing/parsetree.cmi parsing/longident.cmi
-parsing/printast.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
+parsing/printast.cmo : parsing/pprintast.cmi parsing/parsetree.cmi \
     utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
     parsing/asttypes.cmi parsing/printast.cmi
-parsing/printast.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
+parsing/printast.cmx : parsing/pprintast.cmx parsing/parsetree.cmi \
     utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
     parsing/asttypes.cmi parsing/printast.cmi
 parsing/printast.cmi : parsing/parsetree.cmi
@@ -261,9 +261,9 @@ typing/mtype.cmx : typing/types.cmx typing/subst.cmx typing/path.cmx \
     typing/mtype.cmi
 typing/mtype.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi \
     typing/env.cmi
-typing/oprint.cmo : parsing/syntaxerr.cmi typing/outcometree.cmi \
+typing/oprint.cmo : parsing/pprintast.cmi typing/outcometree.cmi \
     parsing/asttypes.cmi typing/oprint.cmi
-typing/oprint.cmx : parsing/syntaxerr.cmx typing/outcometree.cmi \
+typing/oprint.cmx : parsing/pprintast.cmx typing/outcometree.cmi \
     parsing/asttypes.cmi typing/oprint.cmi
 typing/oprint.cmi : typing/outcometree.cmi
 typing/outcometree.cmi : parsing/asttypes.cmi
@@ -308,14 +308,14 @@ typing/printpat.cmx : typing/types.cmx typing/typedtree.cmx typing/ident.cmx \
     parsing/asttypes.cmi typing/printpat.cmi
 typing/printpat.cmi : typing/typedtree.cmi parsing/asttypes.cmi
 typing/printtyp.cmo : utils/warnings.cmi typing/types.cmi \
-    parsing/syntaxerr.cmi typing/primitive.cmi typing/predef.cmi \
+    typing/primitive.cmi typing/predef.cmi parsing/pprintast.cmi \
     typing/path.cmi parsing/parsetree.cmi typing/outcometree.cmi \
     typing/oprint.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
     utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
     parsing/asttypes.cmi typing/printtyp.cmi
 typing/printtyp.cmx : utils/warnings.cmx typing/types.cmx \
-    parsing/syntaxerr.cmx typing/primitive.cmx typing/predef.cmx \
+    typing/primitive.cmx typing/predef.cmx parsing/pprintast.cmx \
     typing/path.cmx parsing/parsetree.cmi typing/outcometree.cmi \
     typing/oprint.cmx utils/misc.cmx parsing/longident.cmx \
     parsing/location.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
@@ -496,14 +496,14 @@ typing/types.cmi : typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi parsing/asttypes.cmi
 typing/typetexp.cmo : typing/types.cmi typing/typedtree.cmi \
-    parsing/syntaxerr.cmi typing/printtyp.cmi typing/predef.cmi \
+    typing/printtyp.cmi typing/predef.cmi parsing/pprintast.cmi \
     typing/path.cmi parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi typing/includemod.cmi \
     typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
     parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
     parsing/ast_helper.cmi typing/typetexp.cmi
 typing/typetexp.cmx : typing/types.cmx typing/typedtree.cmx \
-    parsing/syntaxerr.cmx typing/printtyp.cmx typing/predef.cmx \
+    typing/printtyp.cmx typing/predef.cmx parsing/pprintast.cmx \
     typing/path.cmx parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
     parsing/longident.cmx parsing/location.cmx typing/includemod.cmx \
     typing/env.cmx typing/ctype.cmx utils/clflags.cmx \

--- a/.depend
+++ b/.depend
@@ -137,19 +137,19 @@ parsing/parser.cmi : parsing/parsetree.cmi parsing/location.cmi \
     parsing/docstrings.cmi parsing/camlinternalMenhirLib.cmi
 parsing/parsetree.cmi : parsing/longident.cmi parsing/location.cmi \
     parsing/asttypes.cmi
-parsing/pprintast.cmo : parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi parsing/pprintast.cmi
-parsing/pprintast.cmx : parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx parsing/pprintast.cmi
+parsing/pprintast.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    parsing/asttypes.cmi parsing/ast_helper.cmi parsing/pprintast.cmi
+parsing/pprintast.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    parsing/asttypes.cmi parsing/ast_helper.cmx parsing/pprintast.cmi
 parsing/pprintast.cmi : parsing/parsetree.cmi parsing/longident.cmi
-parsing/printast.cmo : parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \
-    parsing/printast.cmi
-parsing/printast.cmx : parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx parsing/asttypes.cmi \
-    parsing/printast.cmi
+parsing/printast.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    parsing/asttypes.cmi parsing/printast.cmi
+parsing/printast.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    parsing/asttypes.cmi parsing/printast.cmi
 parsing/printast.cmi : parsing/parsetree.cmi
 parsing/syntaxerr.cmo : parsing/location.cmi parsing/syntaxerr.cmi
 parsing/syntaxerr.cmx : parsing/location.cmx parsing/syntaxerr.cmi
@@ -261,10 +261,10 @@ typing/mtype.cmx : typing/types.cmx typing/subst.cmx typing/path.cmx \
     typing/mtype.cmi
 typing/mtype.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi \
     typing/env.cmi
-typing/oprint.cmo : typing/outcometree.cmi parsing/asttypes.cmi \
-    typing/oprint.cmi
-typing/oprint.cmx : typing/outcometree.cmi parsing/asttypes.cmi \
-    typing/oprint.cmi
+typing/oprint.cmo : parsing/syntaxerr.cmi typing/outcometree.cmi \
+    parsing/asttypes.cmi typing/oprint.cmi
+typing/oprint.cmx : parsing/syntaxerr.cmx typing/outcometree.cmi \
+    parsing/asttypes.cmi typing/oprint.cmi
 typing/oprint.cmi : typing/outcometree.cmi
 typing/outcometree.cmi : parsing/asttypes.cmi
 typing/parmatch.cmo : utils/warnings.cmi typing/untypeast.cmi \
@@ -308,19 +308,19 @@ typing/printpat.cmx : typing/types.cmx typing/typedtree.cmx typing/ident.cmx \
     parsing/asttypes.cmi typing/printpat.cmi
 typing/printpat.cmi : typing/typedtree.cmi parsing/asttypes.cmi
 typing/printtyp.cmo : utils/warnings.cmi typing/types.cmi \
-    typing/primitive.cmi typing/predef.cmi typing/path.cmi \
-    parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmi \
-    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
-    typing/printtyp.cmi
+    parsing/syntaxerr.cmi typing/primitive.cmi typing/predef.cmi \
+    typing/path.cmi parsing/parsetree.cmi typing/outcometree.cmi \
+    typing/oprint.cmi utils/misc.cmi parsing/longident.cmi \
+    parsing/location.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
+    utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
+    parsing/asttypes.cmi typing/printtyp.cmi
 typing/printtyp.cmx : utils/warnings.cmx typing/types.cmx \
-    typing/primitive.cmx typing/predef.cmx typing/path.cmx \
-    parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmx \
-    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
-    typing/printtyp.cmi
+    parsing/syntaxerr.cmx typing/primitive.cmx typing/predef.cmx \
+    typing/path.cmx parsing/parsetree.cmi typing/outcometree.cmi \
+    typing/oprint.cmx utils/misc.cmx parsing/longident.cmx \
+    parsing/location.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
+    utils/clflags.cmx parsing/builtin_attributes.cmx typing/btype.cmx \
+    parsing/asttypes.cmi typing/printtyp.cmi
 typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi
@@ -496,15 +496,15 @@ typing/types.cmi : typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi parsing/asttypes.cmi
 typing/typetexp.cmo : typing/types.cmi typing/typedtree.cmi \
-    typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
-    parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
+    parsing/syntaxerr.cmi typing/printtyp.cmi typing/predef.cmi \
+    typing/path.cmi parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi typing/includemod.cmi \
     typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
     parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
     parsing/ast_helper.cmi typing/typetexp.cmi
 typing/typetexp.cmx : typing/types.cmx typing/typedtree.cmx \
-    typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
-    parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
+    parsing/syntaxerr.cmx typing/printtyp.cmx typing/predef.cmx \
+    typing/path.cmx parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
     parsing/longident.cmx parsing/location.cmx typing/includemod.cmx \
     typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
     parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
@@ -2366,7 +2366,7 @@ driver/compmisc.cmo : utils/warnings.cmi typing/typemod.cmi utils/misc.cmi \
 driver/compmisc.cmx : utils/warnings.cmx typing/typemod.cmx utils/misc.cmx \
     parsing/location.cmx typing/ident.cmx typing/env.cmx utils/config.cmx \
     driver/compenv.cmx utils/clflags.cmx driver/compmisc.cmi
-driver/compmisc.cmi : typing/env.cmi
+driver/compmisc.cmi : typing/env.cmi utils/clflags.cmi
 driver/compplugin.cmo : utils/misc.cmi parsing/location.cmi utils/config.cmi \
     driver/compmisc.cmi driver/compenv.cmi driver/compdynlink.cmi \
     utils/clflags.cmi driver/compplugin.cmi

--- a/Changes
+++ b/Changes
@@ -594,6 +594,9 @@ Working version
   as a preventative measure for boxed int unboxing.
   (Thomas Refis, Mark Shinwell, Leo White)
 
+- GPR#2130: fix printing of type variables with a quote in their name
+  (Alain Frisch, review by Armaël Guéneau and Gabriel Scherer,
+  report by Hugo Heuzard)
 
 OCaml 4.07.1 (4 October 2018)
 -----------------------------

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ UTILS=utils/config.cmo utils/build_path_prefix_map.cmo utils/misc.cmo \
 PARSING=parsing/location.cmo parsing/longident.cmo \
   parsing/docstrings.cmo parsing/syntaxerr.cmo \
   parsing/ast_helper.cmo \
+  parsing/pprintast.cmo \
   parsing/camlinternalMenhirLib.cmo parsing/parser.cmo \
   parsing/lexer.cmo parsing/parse.cmo parsing/printast.cmo \
-  parsing/pprintast.cmo \
   parsing/ast_mapper.cmo parsing/ast_iterator.cmo parsing/attr_helper.cmo \
   parsing/builtin_attributes.cmo parsing/ast_invariants.cmo parsing/depend.cmo
 

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -42,7 +42,7 @@ utils_modules := $(addprefix utils/,\
 
 parsing_modules := $(addprefix parsing/,\
   location longident docstrings syntaxerr ast_helper ast_mapper ast_iterator \
-  attr_helper builtin_attributes)
+  attr_helper builtin_attributes pprintast)
 
 typing_modules := $(addprefix typing/,\
   ident path types btype primitive typedtree subst predef datarepr \

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -87,18 +87,19 @@ let process_implementation_file sourcefile =
     in
     (Some (parsetree, typedtree), inputfile)
   with
-    e ->
-      match e with
-        Syntaxerr.Error err ->
+  | Syntaxerr.Error _ as exn ->
+      begin match Location.error_of_exn exn with
+      | Some (`Ok err) ->
           fprintf Format.err_formatter "@[%a@]@."
-            Syntaxerr.report_error err;
-          None, inputfile
-      | Failure s ->
-          prerr_endline s;
-          incr Odoc_global.errors ;
-          None, inputfile
-      | e ->
-          raise e
+            Location.print_report err
+      | _ ->
+          assert false
+      end;
+      None, inputfile
+  | Failure s ->
+      prerr_endline s;
+      incr Odoc_global.errors ;
+      None, inputfile
 
 (** Analysis of an interface file. Returns (Some signature) if
    no error occurred, else None and an error message is printed.*)

--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -120,3 +120,48 @@ and use_file = wrap_menhir Parser.Incremental.use_file
 and core_type = wrap_menhir Parser.Incremental.parse_core_type
 and expression = wrap_menhir Parser.Incremental.parse_expression
 and pattern = wrap_menhir Parser.Incremental.parse_pattern
+
+
+
+(* Error reporting for Syntaxerr *)
+(* The code has been moved here so that one can reuse Pprintast.tyvar *)
+
+let prepare_error err =
+  let open Syntaxerr in
+  match err with
+  | Unclosed(opening_loc, opening, closing_loc, closing) ->
+      Location.errorf
+        ~loc:closing_loc
+        ~sub:[
+          Location.msg ~loc:opening_loc
+            "This '%s' might be unmatched" opening
+        ]
+        "Syntax error: '%s' expected" closing
+
+  | Expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s expected." nonterm
+  | Not_expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s not expected." nonterm
+  | Applicative_path loc ->
+      Location.errorf ~loc
+        "Syntax error: applicative paths of the form F(X).t \
+         are not supported when the option -no-app-func is set."
+  | Variable_in_scope (loc, var) ->
+      Location.errorf ~loc
+        "In this scoped type, variable %a \
+         is reserved for the local type %s."
+        Pprintast.tyvar var var
+  | Other loc ->
+      Location.errorf ~loc "Syntax error"
+  | Ill_formed_ast (loc, s) ->
+      Location.errorf ~loc
+        "broken invariant in parsetree: %s" s
+  | Invalid_package_type (loc, s) ->
+      Location.errorf ~loc "invalid package type: %s" s
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Syntaxerr.Error err -> Some (prepare_error err)
+      | _ -> None
+    )

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -244,7 +244,14 @@ let iter_loc f ctxt {txt; loc = _} = f ctxt txt
 
 let constant_string f s = pp f "%S" s
 
-let tyvar = Syntaxerr.print_tyvar
+let tyvar ppf s =
+  if String.length s >= 2 && s.[1] = '\'' then
+    (* without the space, this would be parsed as
+       a character literal *)
+    Format.fprintf ppf "' %s" s
+  else
+    Format.fprintf ppf "'%s" s
+
 let tyvar_loc f str = tyvar f str.txt
 let string_quot f x = pp f "`%s" x
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -243,8 +243,9 @@ let private_flag f = function
 let iter_loc f ctxt {txt; loc = _} = f ctxt txt
 
 let constant_string f s = pp f "%S" s
-let tyvar f str = pp f "'%s" str
-let tyvar_loc f str = pp f "'%s" str.txt
+
+let tyvar = Syntaxerr.print_tyvar
+let tyvar_loc f str = tyvar f str.txt
 let string_quot f x = pp f "`%s" x
 
 (* c ['a,'b] *)
@@ -270,7 +271,7 @@ and core_type ctxt f x =
         pp f "@[<2>%a@;->@;%a@]" (* FIXME remove parens later *)
           (type_with_label ctxt) (l,ct1) (core_type ctxt) ct2
     | Ptyp_alias (ct, s) ->
-        pp f "@[<2>%a@;as@;'%s@]" (core_type1 ctxt) ct s
+        pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct tyvar s
     | Ptyp_poly ([], ct) ->
         core_type ctxt f ct
     | Ptyp_poly (sl, ct) ->

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -37,3 +37,8 @@ val string_of_structure: Parsetree.structure -> string
 
 val toplevel_phrase : Format.formatter -> Parsetree.toplevel_phrase -> unit
 val top_phrase: Format.formatter -> Parsetree.toplevel_phrase -> unit
+
+
+val tyvar: Format.formatter -> string -> unit
+  (** Print a type variable name, taking care of the special treatment
+      required for the single quote character in second position. *)

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -181,7 +181,10 @@ let rec core_type i ppf x =
       core_type i ppf ct;
   | Ptyp_poly (sl, ct) ->
       line i ppf "Ptyp_poly%a\n"
-        (fun ppf -> List.iter (fun x -> fprintf ppf " '%s" x.txt)) sl;
+        (fun ppf ->
+           List.iter (fun x -> fprintf ppf " %a" Syntaxerr.print_tyvar x.txt)
+        )
+        sl;
       core_type i ppf ct;
   | Ptyp_package (s, l) ->
       line i ppf "Ptyp_package %a\n" fmt_longident_loc s;

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -182,7 +182,7 @@ let rec core_type i ppf x =
   | Ptyp_poly (sl, ct) ->
       line i ppf "Ptyp_poly%a\n"
         (fun ppf ->
-           List.iter (fun x -> fprintf ppf " %a" Syntaxerr.print_tyvar x.txt)
+           List.iter (fun x -> fprintf ppf " %a" Pprintast.tyvar x.txt)
         )
         sl;
       core_type i ppf ct;

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -28,6 +28,14 @@ type error =
 exception Error of error
 exception Escape_error
 
+let print_tyvar ppf s =
+  if String.length s >= 2 && s.[1] = '\'' then
+    (* without the space, this would be parsed as
+       a character literal *)
+    Format.fprintf ppf "' %s" s
+  else
+    Format.fprintf ppf "'%s" s
+
 let prepare_error err =
   match err with
   | Unclosed(opening_loc, opening, closing_loc, closing) ->
@@ -49,9 +57,9 @@ let prepare_error err =
          are not supported when the option -no-app-func is set."
   | Variable_in_scope (loc, var) ->
       Location.errorf ~loc
-        "In this scoped type, variable '%s \
+        "In this scoped type, variable %a \
          is reserved for the local type %s."
-        var var
+        print_tyvar var var
   | Other loc ->
       Location.errorf ~loc "Syntax error"
   | Ill_formed_ast (loc, s) ->

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -28,57 +28,6 @@ type error =
 exception Error of error
 exception Escape_error
 
-let print_tyvar ppf s =
-  if String.length s >= 2 && s.[1] = '\'' then
-    (* without the space, this would be parsed as
-       a character literal *)
-    Format.fprintf ppf "' %s" s
-  else
-    Format.fprintf ppf "'%s" s
-
-let prepare_error err =
-  match err with
-  | Unclosed(opening_loc, opening, closing_loc, closing) ->
-      Location.errorf
-        ~loc:closing_loc
-        ~sub:[
-          Location.msg ~loc:opening_loc
-            "This '%s' might be unmatched" opening
-        ]
-        "Syntax error: '%s' expected" closing
-
-  | Expecting (loc, nonterm) ->
-      Location.errorf ~loc "Syntax error: %s expected." nonterm
-  | Not_expecting (loc, nonterm) ->
-      Location.errorf ~loc "Syntax error: %s not expected." nonterm
-  | Applicative_path loc ->
-      Location.errorf ~loc
-        "Syntax error: applicative paths of the form F(X).t \
-         are not supported when the option -no-app-func is set."
-  | Variable_in_scope (loc, var) ->
-      Location.errorf ~loc
-        "In this scoped type, variable %a \
-         is reserved for the local type %s."
-        print_tyvar var var
-  | Other loc ->
-      Location.errorf ~loc "Syntax error"
-  | Ill_formed_ast (loc, s) ->
-      Location.errorf ~loc
-        "broken invariant in parsetree: %s" s
-  | Invalid_package_type (loc, s) ->
-      Location.errorf ~loc "invalid package type: %s" s
-
-let () =
-  Location.register_error_of_exn
-    (function
-      | Error err -> Some (prepare_error err)
-      | _ -> None
-    )
-
-
-let report_error ppf err =
-  Location.print_report ppf (prepare_error err)
-
 let location_of_error = function
   | Unclosed(l,_,_,_)
   | Applicative_path l

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -20,8 +20,6 @@
 
 *)
 
-open Format
-
 type error =
     Unclosed of Location.t * string * Location.t * string
   | Expecting of Location.t * string
@@ -35,11 +33,5 @@ type error =
 exception Error of error
 exception Escape_error
 
-val report_error: formatter -> error -> unit
- (** @deprecated Use {!Location.error_of_exn}, {!Location.print_report}. *)
-
 val location_of_error: error -> Location.t
 val ill_formed_ast: Location.t -> string -> 'a
-
-
-val print_tyvar: Format.formatter -> string -> unit

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -40,3 +40,6 @@ val report_error: formatter -> error -> unit
 
 val location_of_error: error -> Location.t
 val ill_formed_ast: Location.t -> string -> 'a
+
+
+val print_tyvar: Format.formatter -> string -> unit

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7355,3 +7355,12 @@ module Indexop = struct
 end
 
 type t = |
+
+
+(* GPR#2034 *)
+
+let x = `  Foo
+let x = ` (* wait for it *) Bar
+type (+' a, -' a', ' a'b', 'ab', ' abcd', ' (* ! *) x) t =
+  ' a * ' a' * ' a'b' * 'ab' * ' abcd' * ' (* !! *) x
+  as ' a'

--- a/testsuite/tests/typing-gadts/term-conv.ml
+++ b/testsuite/tests/typing-gadts/term-conv.ml
@@ -41,8 +41,8 @@ module Typeable :
       | Fun : ('a ty * 'b ty) -> ('a -> 'b) ty
     type (_, _) eq = Eq : ('a, 'a) eq
     exception CastFailure
-    val check_eq : 't ty -> 't' ty -> ('t, 't') eq
-    val gcast : 't ty -> 't' ty -> 't -> 't'
+    val check_eq : 't ty -> ' t' ty -> ('t, ' t') eq
+    val gcast : 't ty -> ' t' ty -> 't -> ' t'
   end
 |}];;
 

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -43,3 +43,11 @@ let f x = (x :> G.t);;
 module G = M.N
 val f : [< G.t ] -> G.t = <fun>
 |}]
+
+
+(* GPR#2034 *)
+
+type (+' a', -' a'b, 'cd') t = ' a'b -> ' a'  * 'cd';;
+[%%expect{|
+type (' a', ' a'b, 'cd') t = ' a'b -> ' a' * 'cd'
+|}];;

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -115,6 +115,7 @@ CSLPROF_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo \
   camlinternalMenhirLib.cmo parser.cmo \
+  pprintast.cmo \
   lexer.cmo parse.cmo
 
 $(call byte_and_opt,ocamlprof,$(CSLPROF_IMPORTS) profiling.cmo $(CSLPROF),)

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -238,7 +238,7 @@ let rec print_list pr sep ppf =
 let pr_present =
   print_list (fun ppf s -> fprintf ppf "`%s" s) (fun ppf -> fprintf ppf "@ ")
 
-let pr_var = Syntaxerr.print_tyvar
+let pr_var = Pprintast.tyvar
 
 let pr_vars =
   print_list pr_var (fun ppf -> fprintf ppf "@ ")
@@ -381,7 +381,7 @@ let out_type = ref print_out_type
 (* Class types *)
 
 let print_type_parameter ppf s =
-  if s = "_" then fprintf ppf "_" else Syntaxerr.print_tyvar ppf s
+  if s = "_" then fprintf ppf "_" else pr_var ppf s
 
 let type_parameter ppf (ty, (co, cn)) =
   fprintf ppf "%s%a"

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -914,7 +914,7 @@ let report_error env ppf = function
         but is here applied to %i argument(s)@]"
       longident lid expected provided
   | Bound_type_variable name ->
-    fprintf ppf "Already bound type parameter '%s" name
+    fprintf ppf "Already bound type parameter %a" Syntaxerr.print_tyvar name
   | Recursive_type ->
     fprintf ppf "This type is recursive"
   | Unbound_row_variable lid ->
@@ -970,8 +970,8 @@ let report_error env ppf = function
       fprintf ppf "The type variable name %s is not allowed in programs" name
   | Cannot_quantify (name, v) ->
       fprintf ppf
-        "@[<hov>The universal type variable '%s cannot be generalized:@ "
-        name;
+        "@[<hov>The universal type variable %a cannot be generalized:@ "
+        Syntaxerr.print_tyvar name;
       if Btype.is_Tvar v then
         fprintf ppf "it escapes its scope"
       else if Btype.is_Tunivar v then

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -914,7 +914,7 @@ let report_error env ppf = function
         but is here applied to %i argument(s)@]"
       longident lid expected provided
   | Bound_type_variable name ->
-    fprintf ppf "Already bound type parameter %a" Syntaxerr.print_tyvar name
+    fprintf ppf "Already bound type parameter %a" Pprintast.tyvar name
   | Recursive_type ->
     fprintf ppf "This type is recursive"
   | Unbound_row_variable lid ->
@@ -971,7 +971,7 @@ let report_error env ppf = function
   | Cannot_quantify (name, v) ->
       fprintf ppf
         "@[<hov>The universal type variable %a cannot be generalized:@ "
-        Syntaxerr.print_tyvar name;
+        Pprintast.tyvar name;
       if Btype.is_Tvar v then
         fprintf ppf "it escapes its scope"
       else if Btype.is_Tunivar v then


### PR DESCRIPTION
Type variables whose name has a single quote as the second character (such as `' a'` or `' a'b`) need to be printed with a whitespace after the initial quote symbol, in order not to be confused with a character literal. Of course, it would be even better for users not to use such variable names altogether, and they likely don't it do it in practice, but the printer should be as correct as possible, in particular (1) to support future automated rountrip testing between abstract and concrete syntax and (2) to support for code-generation tools (which might for instance add a "prime" suffix to existing names).

In #2034, it was suggested instead to reject such type variables, but I find it better to adjust the printer rather than change and complicate the specification of what a "valid name" for a type variable is in the Parsetree.  A different syntactic front-end (such as Reason) could for instance use a completely different prefix symbol for type variables, or a different syntax for character literals, and the rather ad hoc constraint one would add ("single quote not allowed in second position") would feel weird.