### PR TITLE
Add Filename.temp_dir to generate temporary directories

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -192,6 +192,7 @@ extern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
 #define rename_os caml_win32_rename
 #define chdir_os _wchdir
 #define getcwd_os _wgetcwd
+#define mkdir_os _wmkdir
 #define system_os _wsystem
 #define rmdir_os _wrmdir
 #define putenv_os _wputenv
@@ -222,6 +223,7 @@ extern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
 #define rename_os rename
 #define chdir_os chdir
 #define getcwd_os getcwd
+#define mkdir_os mkdir
 #define system_os system
 #define rmdir_os rmdir
 #define putenv_os putenv

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -260,3 +260,16 @@ let open_temp_file ?(mode = [Open_text]) ?(perms = 0o600)
     with Sys_error _ as e ->
       if counter >= 1000 then raise e else try_name (counter + 1)
   in try_name 0
+
+external mkdir : string -> unit = "caml_sys_mkdir"
+
+let temp_dir ?(perms = 0o600) ?(temp_dir = !current_temp_dir_name)
+             prefix suffix =
+  let rec try_name counter =
+    let name = temp_file_name temp_dir prefix suffix in
+    try
+      mkdir name perms;
+      name
+    with Sys_error _ as e ->
+      if counter >= 1000 then raise e else try_name (counter + 1)
+  in try_name 0

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -131,6 +131,19 @@ val open_temp_file :
    @before 3.11.2 no ?temp_dir optional argument
 *)
 
+val temp_dir : ?perms: int -> ?temp_dir: string -> string -> string -> string
+(** [temp_dir prefix suffix] returns the name of a fresh temporary
+   sub-directory in the temporary directory.  The base name of the
+   temporary directory is formed by concatenating [prefix], then a
+   suitably chosen integer number, then [suffix].  The optional
+   argument [temp_dir] indicates the temporary directory to use,
+   defaulting to the current result of {!Filename.get_temp_dir_name}.
+   The temporary directory is created empty, with permissions [0o700]
+   (readable, writable and "executable" only by the file owner).  The file
+   is guaranteed to be different from any other file and directory
+   that existed when [temp_file] was called.  Raise [Sys_error] if the
+   directory cannot be created. *)
+
 val get_temp_dir_name : unit -> string
 (** The name of the temporary directory:
     Under Unix, the value of the [TMPDIR] environment variable, or "/tmp"


### PR DESCRIPTION
This PR is not complete but this is to see whether there is interest in a `Filename.temp_dir` function.