### PR TITLE
rewrite partition without using rev

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -234,10 +234,11 @@ let find_all p =
 let filter = find_all
 
 let partition p l =
-  let rec part yes no = function
-  | [] -> (rev yes, rev no)
-  | x :: l -> if p x then part (x :: yes) no l else part yes (x :: no) l in
-  part [] [] l
+  let rec part = function
+    [] -> [], []
+  | x :: l when p x -> let yes, no = part l in x :: yes, no
+  | x :: l -> let yes, no = part l in yes, x :: no
+  in part l
 
 let rec split = function
     [] -> ([], [])


### PR DESCRIPTION
We don't have to use rev and in fact it speeder because we traverse the list only one time.