### PR TITLE
MPR7565 bis: more context for universal variable in error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -171,7 +171,7 @@ Working version
   (Arthur Charguéraud and Armaël Guéneau, with help and advice
    from Gabriel Scherer, Frédéric Bour, Xavier Clerc and Leo White)
 
-- GPR#1733,1993,1998,2058,2094: Typing error message improvements
+- GPR#1733,1993,1998,2058,2094,2140: Typing error message improvements
     - GPR#1733, change the perspective of the unexpected existential error
       message.
     - GPR#1993, expanded error messages for universal quantification failure
@@ -179,6 +179,8 @@ Working version
     - GPR#2058, full explanation for unsafe cycles in recursive module
       definitions (suggestion by Ivan Gotovchits)
     - GPR#2094, rewording for "constructor has no type" error
+    - MPR#7565, GPR#2140, more context for universal variable escape
+      in method type
   (Florian Angeletti, reviews by Jacques Garrique, Gabriel Radanne,
    Gabriel Scherer and Jeremy Yallop)
 

--- a/Changes
+++ b/Changes
@@ -181,8 +181,8 @@ Working version
     - GPR#2094, rewording for "constructor has no type" error
     - MPR#7565, GPR#2140, more context for universal variable escape
       in method type
-  (Florian Angeletti, reviews by Jacques Garrique, Gabriel Radanne,
-   Gabriel Scherer and Jeremy Yallop)
+  (Florian Angeletti, reviews by Jacques Garrique, Armaël Guéneau,
+   Gabriel Radanne, Gabriel Scherer and Jeremy Yallop)
 
 - GPR#1748: do not error when instantiating polymorphic fields in patterns.
   (Thomas Refis, review by Gabriel Scherer)

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -38,5 +38,48 @@ Line 4, characters 49-50:
                                                      ^
 Error: This expression has type < a : 'a; b : 'a >
        but an expression was expected of type < a : 'a; b : 'a0. 'a0 >
+       The method b has type 'a, but the expected method type was 'a0. 'a0
+       The universal variable 'a0 would escape its scope
+|}]
+
+
+(** MPR 7565 *)
+class type t_a = object
+    method f: 'a. 'a -> int
+  end
+let f (o:t_a) = o # f 0
+let _ = f (object
+    method f _ = 0
+ end);;
+[%%expect {|
+class type t_a = object method f : 'a -> int end
+val f : t_a -> int = <fun>
+Line 5, characters 10-42:
+5 | ..........(object
+6 |     method f _ = 0
+7 |  end)..
+Error: This expression has type < f : 'a -> int >
+       but an expression was expected of type t_a
+       The method f has type 'a -> int, but the expected method type was
+       'a0. 'a0 -> int
+       The universal variable 'a0 would escape its scope
+|}
+]
+
+type uv = [ `A of <f: 'a. 'a -> int > ]
+type 'a v = [ `A of <f: 'a -> int > ]
+let f (`A o:uv) = o # f 0
+let () = f ( `A (object method f _ = 0 end): _ v);;
+[%%expect {|
+type uv = [ `A of < f : 'a. 'a -> int > ]
+type 'a v = [ `A of < f : 'a -> int > ]
+val f : uv -> int = <fun>
+Line 4, characters 11-49:
+4 | let () = f ( `A (object method f _ = 0 end): _ v);;
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a v but an expression was expected of type
+         uv
+       The method f has type 'a -> int, but the expected method type was
+       'a0. 'a0 -> int
        The universal variable 'a0 would escape its scope
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -456,6 +456,8 @@ Line 9, characters 41-42:
                                              ^
 Error: This expression has type < m : 'b. 'b -> 'b list >
        but an expression was expected of type < m : 'b. 'b -> 'c >
+       The method m has type 'b. 'b -> 'b list,
+       but the expected method type was 'b. 'b -> 'c
        The universal variable 'b would escape its scope
 |}];;
 
@@ -1098,6 +1100,8 @@ Line 2, characters 3-4:
 Error: This expression has type < m : 'a. 'a * < m : 'a * 'b > > as 'b
        but an expression was expected of type
          < m : 'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd) >
+       The method m has type 'a. 'a * 'd, but the expected method type was
+       'c. 'c * 'd
        The universal variable 'a would escape its scope
 |}];;
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1723,11 +1723,9 @@ let rec trace fst txt ppf = function
 
 let is_discarded is_last = function
   | Trace.(Diff { got=t1, t1'; expected=t2, t2'}) ->
-      if is_constr_row ~allow_ident:true t1'
+      is_constr_row ~allow_ident:true t1'
       || is_constr_row ~allow_ident:true t2'
-      || same_path t1 t1' && same_path t2 t2' && not is_last then
-        true
-      else false
+      || same_path t1 t1' && same_path t2 t2' && not is_last
   | _ -> false
 
 (** Flatten the trace and remove elements that are always discarded

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1882,15 +1882,14 @@ let explanation intro prev env = function
       Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
             type_expr x type_expr y)
 
-let mismatch intro env =
-  let rec mismatch intro prev env = function
-      h :: rem ->
-        begin match mismatch intro (Some h) env rem with
-          Some _ as m -> m
-        | None -> explanation intro prev env h
-        end
-    | [] -> None in
-  mismatch intro None env
+let mismatch intro env trace =
+  let rec mismatch intro env = function
+    | [] -> None
+    | [h] -> explanation intro None env h
+    | h :: (prev :: _ as rem) -> match explanation intro (Some prev) env h with
+      | Some _ as m -> m
+      | None -> mismatch intro env rem in
+  mismatch intro env (List.rev trace)
 
 let explain mis ppf =
   match mis with


### PR DESCRIPTION
[Mantis 7565:](https://caml.inria.fr/mantis/view.php?id=7565)

This PR is a follow-up of #1212, it proposes to give more context for universal type variables that escape their scope when unifying methods, by precising the actual type and expected type at the method level, as suggested by @garrigue in #1212 .

For instance, the following code

 ```OCaml
type uv = [ `A of <f: 'a. 'a -> int > ]
type 'a v = [ `A of <f: 'a -> int > ]
let f (`A o:uv) = o # f 0
let () = f ( `A (object method f _ = 0 end): _ v)
```
currently raises an error message
> Error: This expression has type 'a v but an expression was expected of type uv
       The universal variable 'a0 would escape its scope

where the universal variable is mysteriously introduced on the last line (and is slightly renamed compared to the original type abbreviation ).

This PR adds a new line to this error message in order to introduce the universal variable:

> The method f has type 'a -> int, but the expected method type was 
    'a0. 'a0 -> int

In the current implementation, this line is  added whenever a universal variable introduced by a method escape its field. This can lead to quite redundant error messages like

>Error: This expression has type < a : 'a; b : 'a >
       but an expression was expected of type < a : 'a; b : 'a0. 'a0 >
       The method b has type 'a, but the expected method type was 'a0. 'a0
       The universal variable 'a0 would escape its scope

However, this behavior seemed mostly harmless and it could be avoided with further tuning.