### PR TITLE
Stdlib doc: harmonize heading levels again.

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -493,7 +493,7 @@ module LargeFile :
   regular integers (type [int]), thus allowing operating on files
   whose sizes are greater than [max_int]. *)
 
-(** {6 Mapping files into memory} *)
+(** {1 Mapping files into memory} *)
 
 val map_file :
   file_descr -> ?pos:int64 -> ('a, 'b) Stdlib.Bigarray.kind ->

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -303,7 +303,7 @@ let stable_sort cmp a =
 
 let fast_sort = stable_sort
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq a =
   let rec aux i () =

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -256,7 +256,7 @@ val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
 *)
 
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : 'a array -> 'a Seq.t
 (** Iterate on the array, in increasing order. Modifications of the

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -158,7 +158,7 @@ val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
    where [n] is the length of the array [a]. *)
 
 
-(** {6 Iterators on two arrays} *)
+(** {1 Iterators on two arrays} *)
 
 
 val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
@@ -175,7 +175,7 @@ val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
    @since 4.05.0 *)
 
 
-(** {6 Array scanning} *)
+(** {1 Array scanning} *)
 
 
 val exists : f:('a -> bool) -> 'a array -> bool
@@ -256,7 +256,7 @@ val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 *)
 
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : 'a array -> 'a Seq.t
 (** Iterate on the array, in increasing order

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -273,7 +273,7 @@ let truncate b len =
     else
       b.position <- len
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq b =
   let rec aux i () =

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -158,7 +158,7 @@ val truncate : t -> int -> unit
   Raise [Invalid_argument] if [len < 0] or [len > length b].
   @since 4.05.0 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t
 (** Iterate on the buffer, in increasing order.

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -330,7 +330,7 @@ let lowercase s = map Char.lowercase s
 let capitalize s = apply1 Char.uppercase s
 let uncapitalize s = apply1 Char.lowercase s
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq s =
   let rec aux i () =

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -319,7 +319,7 @@ val equal: t -> t -> bool
 (** The equality function for byte sequences.
     @since 4.03.0 *)
 
-(** {3 Unsafe conversions (for advanced users)}
+(** {1:unsafe Unsafe conversions (for advanced users)}
 
     This section describes unsafe, low-level conversion functions
     between [bytes] and [string]. They do not copy the internal data;
@@ -448,7 +448,7 @@ let s = Bytes.of_string "hello"
     [string] type for this purpose.
 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t
 (** Iterate on the string, in increasing index order. Modifications of the

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -293,7 +293,7 @@ val equal: t -> t -> bool
 (** The equality function for byte sequences.
     @since 4.05.0 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t
 (** Iterate on the string, in increasing index order. Modifications of the

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -354,7 +354,7 @@ let stats h =
     max_bucket_length = mbl;
     bucket_histogram = histo }
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq tbl =
   (* capture current array, so that even if the table is resized we

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -216,7 +216,7 @@ val stats : ('a, 'b) t -> statistics
    buckets by size.
    @since 4.00.0 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : ('a,'b) t -> ('a * 'b) Seq.t
 (** Iterate on the whole table, in unspecified order.

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -491,7 +491,7 @@ let rec compare_length_with l n =
       compare_length_with l (n-1)
 ;;
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq l =
   let rec aux l () = match l with

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -346,7 +346,7 @@ val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
     Not tail-recursive (sum of the lengths of the arguments).
 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : 'a list -> 'a Seq.t
 (** Iterate on the list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -352,7 +352,7 @@ val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
     Not tail-recursive (sum of the lengths of the arguments).
 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : 'a list -> 'a Seq.t
 (** Iterate on the list

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -306,7 +306,7 @@ module type S =
     (** Same as {!Map.S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
-    (** {6 Iterators} *)
+    (** {1 Iterators} *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order

--- a/stdlib/queue.ml
+++ b/stdlib/queue.ml
@@ -147,7 +147,7 @@ let transfer q1 q2 =
       q2.last <- q1.last;
       clear q1
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq q =
   let rec aux c () = match c with

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -91,7 +91,7 @@ val transfer : 'a t -> 'a t -> unit
    sequence [iter (fun x -> add x q2) q1; clear q1], but runs
    in constant time. *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : 'a t -> 'a Seq.t
 (** Iterate on the queue, in front-to-back order.

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -264,7 +264,7 @@ module type S =
         except perhaps for lists with many duplicated elements.
         @since 4.02.0 *)
 
-    (** {6 Iterators} *)
+    (** {1 Iterators} *)
 
     val to_seq_from : elt -> t -> elt Seq.t
     (** [to_seq_from x s] iterates on a subset of the elements of [s]

--- a/stdlib/stack.ml
+++ b/stdlib/stack.ml
@@ -53,7 +53,7 @@ let iter f s = List.iter f s.c
 
 let fold f acc s = List.fold_left f acc s.c
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq s = List.to_seq s.c
 

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -72,7 +72,7 @@ val fold : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
     and [xn] the bottom element. The stack is unchanged.
     @since 4.03 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : 'a t -> 'a Seq.t
 (** Iterate on the stack, top to bottom.

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -224,7 +224,7 @@ let capitalize s =
 let uncapitalize s =
   B.uncapitalize (bos s) |> bts
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 let to_seq s = bos s |> B.to_seq
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -333,7 +333,7 @@ val split_on_char: char -> string -> string list
     @since 4.04.0
 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t
 (** Iterate on the string, in increasing index order. Modifications of the

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -288,7 +288,7 @@ val split_on_char: sep:char -> string -> string list
     @since 4.05.0
 *)
 
-(** {6 Iterators} *)
+(** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t
 (** Iterate on the string, in increasing index order. Modifications of the


### PR DESCRIPTION
It seems a few PRs that got merged after e30e82a2198d8649d773fbe346e4ba reintroduced level 6 headings.