### PR TITLE
remove old GC-triggering heuristic

### DIFF
--- a/Changes
+++ b/Changes
@@ -300,6 +300,9 @@ Working version
   bigarrays and I/O channels.
   (Damien Doligez, review by Alain Frisch)
 
+- MPR#7676, GPR#2144: Remove old GC heuristic
+  (Damien Doligez, report and review by Alain Frisch)
+
 - GPR#1793: add the -m and -M command-line options to ocamlrun.
   (Sébastien Hinderer, review by Xavier Clerc and Damien Doligez)
 
@@ -320,9 +323,6 @@ Working version
 - GPR#2079: Avoid page table lookup in Pervasives.compare with
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
-
-- GPR#2144, MPR#7676: Remove old GC heuristic
-  (Damien Doligez, report and review by Alain Frisch)
 
 ### Tools
 

--- a/Changes
+++ b/Changes
@@ -321,6 +321,9 @@ Working version
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
+- GPR#2144, MPR#7676: Remove old GC heuristic
+  (Damien Doligez, report and review by Alain Frisch)
+
 ### Tools
 
 - MPR#7843, GPR#2013: ocamldoc, better handling of {{!label}text} in the latex

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -618,12 +618,6 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
     caml_extra_heap_resources = 1.0;
     caml_request_major_slice ();
   }
-  if (caml_extra_heap_resources
-           > (double) caml_minor_heap_wsz / 2.0
-             / (double) caml_stat_heap_wsz) {
-    CAML_INSTR_INT ("request_major/adjust_gc_speed_2@", 1);
-    caml_request_major_slice ();
-  }
 }
 
 /* You must use [caml_initialize] to store the initial value in a field of


### PR DESCRIPTION
As pointed out in [MPR#7676](https://caml.inria.fr/mantis/view.php?id=7676) and https://github.com/ocaml/ocaml/pull/1738#issuecomment-384343082, this old GC heuristic doesn't really make sense.

AFAICT, the idea was to avoid an accumulation of "debt" in caml_extra_heap_resources when lots of resources are allocated between two major slices, with very little allocations in the minor heap. The danger is to have a large major slice with a large latency.

If this problem ever arises in practice, it can be mitigated by the GC smoothing introduced by #297.
