### PR TITLE
deprecate the mutability of Gc.control record fields

### DIFF
--- a/Changes
+++ b/Changes
@@ -160,6 +160,9 @@ Working version
   and unsigned_to_int to modules Int32, Int64, Nativeint.
   (Nicolás Ojeda Bär, review by Daniel Bünzli, Alain Frisch and Max Mouratov)
 
+- GPR#2145: Deprecate the mutability of Gc.control record fields
+  (Damien Doligez, review by Alain Frisch)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -84,10 +84,13 @@ type stat =
 
 type control =
   { mutable minor_heap_size : int;
+    [@ocaml.deprecated_mutable "Use Gc.{(get()) with minor_heap_size = ...}"]
     (** The size (in words) of the minor heap.  Changing
        this parameter will trigger a minor collection.  Default: 256k. *)
 
     mutable major_heap_increment : int;
+    [@ocaml.deprecated_mutable
+         "Use Gc.{(get()) with major_heap_increment = ...}"]
     (** How much to add to the major heap when increasing it. If this
         number is less than or equal to 1000, it is a percentage of
         the current heap size (i.e. setting it to 100 will double the heap
@@ -95,6 +98,7 @@ type control =
         number of words that will be added to the heap. Default: 15. *)
 
     mutable space_overhead : int;
+    [@ocaml.deprecated_mutable "Use Gc.{(get()) with space_overhead = ...}"]
     (** The major GC speed is computed from this parameter.
        This is the memory that will be "wasted" because the GC does not
        immediately collect unreachable blocks.  It is expressed as a
@@ -104,6 +108,7 @@ type control =
        Default: 80. *)
 
     mutable verbose : int;
+    [@ocaml.deprecated_mutable "Use Gc.{(get()) with verbose = ...}"]
     (** This value controls the GC messages on standard error output.
        It is a sum of some of the following flags, to print messages
        on the corresponding events:
@@ -121,6 +126,7 @@ type control =
        Default: 0. *)
 
     mutable max_overhead : int;
+    [@ocaml.deprecated_mutable "Use Gc.{(get()) with max_overhead = ...}"]
     (** Heap compaction is triggered when the estimated amount
        of "wasted" memory is more than [max_overhead] percent of the
        amount of live data.  If [max_overhead] is set to 0, heap
@@ -132,11 +138,13 @@ type control =
        Default: 500. *)
 
     mutable stack_limit : int;
+    [@ocaml.deprecated_mutable "Use Gc.{(get()) with stack_limit = ...}"]
     (** The maximum size of the stack (in words).  This is only
        relevant to the byte-code runtime, as the native code runtime
        uses the operating system's stack.  Default: 1024k. *)
 
     mutable allocation_policy : int;
+    [@ocaml.deprecated_mutable "Use Gc.{(get()) with allocation_policy = ...}"]
     (** The policy used for allocating in the heap.  Possible
         values are 0 and 1.  0 is the next-fit policy, which is
         quite fast but can result in fragmentation.  1 is the

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -84,13 +84,13 @@ type stat =
 
 type control =
   { mutable minor_heap_size : int;
-    [@ocaml.deprecated_mutable "Use Gc.{(get()) with minor_heap_size = ...}"]
+    [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.minor_heap_size = ...}"]
     (** The size (in words) of the minor heap.  Changing
        this parameter will trigger a minor collection.  Default: 256k. *)
 
     mutable major_heap_increment : int;
     [@ocaml.deprecated_mutable
-         "Use Gc.{(get()) with major_heap_increment = ...}"]
+         "Use {(Gc.get()) with Gc.major_heap_increment = ...}"]
     (** How much to add to the major heap when increasing it. If this
         number is less than or equal to 1000, it is a percentage of
         the current heap size (i.e. setting it to 100 will double the heap
@@ -98,7 +98,7 @@ type control =
         number of words that will be added to the heap. Default: 15. *)
 
     mutable space_overhead : int;
-    [@ocaml.deprecated_mutable "Use Gc.{(get()) with space_overhead = ...}"]
+    [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.space_overhead = ...}"]
     (** The major GC speed is computed from this parameter.
        This is the memory that will be "wasted" because the GC does not
        immediately collect unreachable blocks.  It is expressed as a
@@ -108,7 +108,7 @@ type control =
        Default: 80. *)
 
     mutable verbose : int;
-    [@ocaml.deprecated_mutable "Use Gc.{(get()) with verbose = ...}"]
+    [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.verbose = ...}"]
     (** This value controls the GC messages on standard error output.
        It is a sum of some of the following flags, to print messages
        on the corresponding events:
@@ -126,7 +126,7 @@ type control =
        Default: 0. *)
 
     mutable max_overhead : int;
-    [@ocaml.deprecated_mutable "Use Gc.{(get()) with max_overhead = ...}"]
+    [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.max_overhead = ...}"]
     (** Heap compaction is triggered when the estimated amount
        of "wasted" memory is more than [max_overhead] percent of the
        amount of live data.  If [max_overhead] is set to 0, heap
@@ -138,13 +138,14 @@ type control =
        Default: 500. *)
 
     mutable stack_limit : int;
-    [@ocaml.deprecated_mutable "Use Gc.{(get()) with stack_limit = ...}"]
+    [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.stack_limit = ...}"]
     (** The maximum size of the stack (in words).  This is only
        relevant to the byte-code runtime, as the native code runtime
        uses the operating system's stack.  Default: 1024k. *)
 
     mutable allocation_policy : int;
-    [@ocaml.deprecated_mutable "Use Gc.{(get()) with allocation_policy = ...}"]
+    [@ocaml.deprecated_mutable
+         "Use {(Gc.get()) with Gc.allocation_policy = ...}"]
     (** The policy used for allocating in the heap.  Possible
         values are 0 and 1.  0 is the next-fit policy, which is
         quite fast but can result in fragmentation.  1 is the


### PR DESCRIPTION
Follow-up to https://github.com/ocaml/ocaml/pull/297#discussion_r46124492. I'll add a `Changes` entry.
