### PR TITLE
Fix a make -j bug, by ensuring Lazy depends on CamlinternalLazy.

### DIFF
--- a/Changes
+++ b/Changes
@@ -448,6 +448,9 @@ Working version
   (Sébastien Hinderer, review by Xavier Leroy, Stephen Dolan and
   Damien Doligez)
 
+- GPR#2148: fix a parallel build bug involving CamlinternalLazy.
+  (Stephen Dolan, review by Gabriel Scherer and Nicolas Ojeda Bar)
+
 ### Internal/compiler-libs changes:
 
 - GPR#292: use Menhir as the parser generator for the OCaml parser.

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -104,7 +104,7 @@ stdlib__int64.cmx : stdlib.cmx stdlib__int64.cmi
 stdlib__int64.cmi :
 stdlib__lazy.cmo : stdlib__obj.cmi camlinternalLazy.cmi stdlib__lazy.cmi
 stdlib__lazy.cmx : stdlib__obj.cmx camlinternalLazy.cmx stdlib__lazy.cmi
-stdlib__lazy.cmi :
+stdlib__lazy.cmi : camlinternalLazy.cmi
 stdlib__lexing.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__bytes.cmi stdlib__array.cmi stdlib__lexing.cmi
 stdlib__lexing.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__bytes.cmx stdlib__array.cmx stdlib__lexing.cmi
 stdlib__lexing.cmi :

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -15,6 +15,8 @@
 
 (* Internals of forcing lazy values. *)
 
+type 'a t = 'a lazy_t
+
 exception Undefined
 
 let raise_undefined = Obj.repr (fun () -> raise Undefined)

--- a/stdlib/camlinternalLazy.mli
+++ b/stdlib/camlinternalLazy.mli
@@ -19,6 +19,8 @@
 
 exception Undefined
 
+type 'a t = 'a lazy_t
+
 val force_lazy_block : 'a lazy_t -> 'a
 
 val force_val_lazy_block : 'a lazy_t -> 'a

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -47,7 +47,7 @@
    rules for the [lazy] keyword.
 *)
 
-type 'a t = 'a lazy_t
+type 'a t = 'a CamlinternalLazy.t
 
 exception Undefined = CamlinternalLazy.Undefined
 

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -15,7 +15,7 @@
 
 (** Deferred computations. *)
 
-type 'a t = 'a lazy_t
+type 'a t = 'a CamlinternalLazy.t
 (** A value of type ['a Lazy.t] is a deferred computation, called
    a suspension, that has a result of type ['a].  The special
    expression syntax [lazy (expr)] makes a suspension of the

--- a/testsuite/tests/backtrace/backtrace2.byte.reference
+++ b/testsuite/tests/backtrace/backtrace2.byte.reference
@@ -46,13 +46,13 @@ Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
-Called from file "camlinternalLazy.ml", line 27, characters 17-27
-Re-raised at file "camlinternalLazy.ml", line 34, characters 10-11
+Called from file "camlinternalLazy.ml", line 29, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 36, characters 10-11
 Called from file "backtrace2.ml", line 67, characters 11-23
 Uncaught exception Not_found
 Raised at file "hashtbl.ml", line 194, characters 19-28
 Called from file "backtrace2.ml", line 55, characters 8-41
-Re-raised at file "camlinternalLazy.ml", line 33, characters 62-63
-Called from file "camlinternalLazy.ml", line 27, characters 17-27
-Re-raised at file "camlinternalLazy.ml", line 34, characters 10-11
+Re-raised at file "camlinternalLazy.ml", line 35, characters 62-63
+Called from file "camlinternalLazy.ml", line 29, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 36, characters 10-11
 Called from file "backtrace2.ml", line 67, characters 11-23

--- a/testsuite/tests/backtrace/backtrace2.opt.reference
+++ b/testsuite/tests/backtrace/backtrace2.opt.reference
@@ -46,13 +46,13 @@ Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
 Called from file "backtrace2.ml", line 52, characters 43-52
-Called from file "camlinternalLazy.ml", line 27, characters 17-27
-Re-raised at file "camlinternalLazy.ml", line 34, characters 4-11
+Called from file "camlinternalLazy.ml", line 29, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
 Called from file "backtrace2.ml", line 67, characters 11-23
 Uncaught exception Not_found
 Raised at file "hashtbl.ml", line 194, characters 13-28
 Called from file "backtrace2.ml", line 55, characters 8-41
-Re-raised at file "camlinternalLazy.ml", line 33, characters 56-63
-Called from file "camlinternalLazy.ml", line 27, characters 17-27
-Re-raised at file "camlinternalLazy.ml", line 34, characters 4-11
+Re-raised at file "camlinternalLazy.ml", line 35, characters 56-63
+Called from file "camlinternalLazy.ml", line 29, characters 17-27
+Re-raised at file "camlinternalLazy.ml", line 36, characters 4-11
 Called from file "backtrace2.ml", line 67, characters 11-23


### PR DESCRIPTION
Without this patch, make -j often fails to build the stdlib with a message along the lines of:

    no cmx file was found in path for module CamlinternalLazy

The issue is that stdlib files that use `lazy` actually depend on `camlinternalLazy.cmi` because matching.ml expands lazy pattern matches to code that refers to `CamlinternalLazy`. However, since this dependency does not appear in the source code, there is no way for `ocamldep` to discover it. This means that when building the stdlib, there is no constraint ensuring that `CamlinternalLazy` is built before stdlib modules using `Lazy`.

This causes issues with parallel make, but the issue can be reproduced using a sequential make invocation:

    cd stdlib
    make clean
    make stdlib_stream.cmo

This patch adds a dependency on `CamlinternalLazy` into `lazy.mli`. Its presence makes ocamldep see that all files that use Lazy depend on `camlinternalLazy.cmi`.