### PR TITLE
typing/typedecl: split and factorize fixpoint computations for variance and immediacy

### DIFF
--- a/Changes
+++ b/Changes
@@ -578,6 +578,10 @@ Working version
   [Proc.stack_ptr_dwarf_register_number].
   (Mark Shinwell, review by Bernhard Schommer)
 
+- GPR#2152: refactorize the fixpoint to compute type-system properties
+  of mutually-recursive type declarations.
+  (Gabriel Scherer, review by Armaël Guéneau)
+
 ### Bug fixes:
 
 - MPR#7867: Fix #mod_use raising an exception for filenames with no

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1738,7 +1738,7 @@ let type_classes define_class approx kind env cls =
   Ctype.end_def ();
   let res = List.rev_map (final_decl env define_class) res in
   let decls = List.fold_right extract_type_decls res [] in
-  let decls = Typedecl.compute_variance_decls env decls in
+  let decls = Typedecl.compute_variance_class_decls env decls in
   let res = List.map2 merge_type_decls res decls in
   let env = List.fold_left (final_env define_class) env res in
   let res = List.map (check_coercions env) res in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1194,7 +1194,7 @@ let add_injectivity =
     )
 
 (* for typeclass.ml *)
-let compute_variance_decls env cldecls =
+let compute_variance_class_decls env cldecls =
   let decls, required =
     List.fold_right
       (fun (obj_id, obj_abbr, _cl_abbr, _clty, _cltydef, ci) (decls, req) ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1140,37 +1140,89 @@ let add_types_to_env decls env =
     (fun (id, decl) env -> add_type ~check:true id decl env)
     decls env
 
-let rec compute_variances_fixpoint env decls required variances =
-  let new_decls =
-    List.map2
-      (fun (id, decl) variance ->
-         id, {decl with type_variance = variance;})
-      decls variances
+type decl = Types.type_declaration
+
+(** An abstract interface for properties of type definitions, such as
+   variance and immediacy, that are computed by a fixpoint on
+   mutually-recursive type declarations. This interface contains all
+   the operations needed to initialize and run the fixpoint
+   computation, and then (optionally) check that the result is
+   consistent with the declaration or user expectations.
+
+   ['prop] represents the type of property values
+   ({!Types.Variance.t}, just 'bool' for immediacy, etc).
+
+   ['req] represents the property value required by the author of the
+   declaration, if they gave an expectation: [type +'a t = ...].
+
+   Some properties have no natural notion of user requirement, or
+   their requirement is global, or already stored in
+   [type_declaration]; they can just use [unit] as ['req] parameter. *)
+type ('prop, 'req) property = {
+  eq : 'prop -> 'prop -> bool;
+  merge : prop:'prop -> new_prop:'prop -> 'prop;
+
+  default : decl -> 'prop;
+  compute : Env.t -> decl -> 'req -> 'prop;
+  update_decl : decl -> 'prop -> decl;
+
+  check : Env.t -> Ident.t -> decl -> 'req -> unit;
+}
+
+let compute_property
+: ('prop, 'req) property -> Env.t ->
+  (Ident.t * decl) list -> 'req list -> (Ident.t * decl) list
+= fun property env decls required ->
+  (* [decls] and [required] must be lists of the same size,
+     with [required] containing the requirement for the corresponding
+     declaration in [decls]. *)
+  let props = List.map (fun (_id, decl) -> property.default decl) decls in
+  let rec compute_fixpoint props =
+    let new_decls =
+      List.map2 (fun (id, decl) prop ->
+          (id, property.update_decl decl prop))
+        decls props in
+    let new_env = add_types_to_env new_decls env in
+    let new_props =
+      List.map2
+        (fun (_id, decl) (prop, req) ->
+           let new_prop = property.compute new_env decl req in
+           property.merge ~prop ~new_prop)
+        new_decls (List.combine props required) in
+    if not (List.for_all2 property.eq props new_props)
+    then compute_fixpoint new_props
+    else begin
+      List.iter2
+        (fun (id, decl) req -> property.check new_env id decl req)
+        new_decls required;
+      new_decls
+    end
   in
-  let new_env = add_types_to_env new_decls env in
-  let new_variances =
-    List.map2
-      (fun (_id, decl) -> compute_variance_decl new_env false decl)
-      new_decls required
+  compute_fixpoint props
+
+type variance_req = (bool * bool * bool) list * Location.t
+let variance : (Variance.t list, variance_req) property =
+  let eq li1 li2 =
+    try List.for_all2 Variance.eq li1 li2 with _ -> false in
+  let merge ~prop ~new_prop = List.map2 Variance.union prop new_prop in
+  let default decl =
+    List.map (fun _ -> Variance.null) decl.type_params in
+  let compute env decl req =
+    compute_variance_decl env false decl req in
+  let update_decl decl variance =
+    { decl with type_variance = variance } in
+  let check env id decl req =
+    if not (is_hash id) then
+      ignore (compute_variance_decl env true decl req)
   in
-  let new_variances =
-    List.map2 (List.map2 Variance.union) new_variances variances in
-  if new_variances <> variances then
-    compute_variances_fixpoint env decls required new_variances
-  else begin
-    (* List.iter (fun (id, decl) ->
-      Printf.eprintf "%s:" (Ident.name id);
-      List.iter (fun (v : Variance.t) ->
-        Printf.eprintf " %x" (Obj.magic v : int))
-        decl.type_variance;
-      prerr_endline "")
-      new_decls; *)
-    List.iter2
-      (fun (id, decl) req -> if not (is_hash id) then
-        ignore (compute_variance_decl new_env true decl req))
-      new_decls required;
-    new_decls
-  end
+  {
+    eq;
+    merge;
+    default;
+    compute;
+    update_decl;
+    check;
+  }
 
 let rec compute_immediacies_fixpoint env decls immediacies =
   let new_decls =
@@ -1196,9 +1248,6 @@ let rec compute_immediacies_fixpoint env decls immediacies =
     new_decls
   end
 
-let init_variance (_id, decl) =
-  List.map (fun _ -> Variance.null) decl.type_params
-
 let add_injectivity =
   List.map
     (function
@@ -1217,10 +1266,7 @@ let compute_variance_class_decls env cldecls =
         (add_injectivity variance, ci.ci_loc) :: req)
       cldecls ([],[])
   in
-  let decls =
-    compute_variances_fixpoint env decls required
-      (List.map init_variance decls)
-  in
+  let decls = compute_property variance env decls required in
   List.map2
     (fun (_,decl) (_, _, cl_abbr, clty, cltydef, _) ->
       let variance = decl.type_variance in
@@ -1408,8 +1454,7 @@ let transl_type_decl env rec_flag sdecl_list =
         )
         sdecl_list
     in
-    compute_variances_fixpoint env decls required
-      (List.map init_variance decls)
+    compute_property variance env decls required
   in
   (* Add immediacies to the declarations *)
   let decls =

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -55,7 +55,7 @@ val check_coherence:
 val is_fixed_type : Parsetree.type_declaration -> bool
 
 (* for typeclass.ml *)
-val compute_variance_decls:
+val compute_variance_class_decls:
     Env.t ->
     (Ident.t * Types.type_declaration * Types.type_declaration *
      Types.class_declaration * Types.class_type_declaration *

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -125,6 +125,7 @@ module Variance = struct
   let union v1 v2 = v1 lor v2
   let inter v1 v2 = v1 land v2
   let subset v1 v2 = (v1 land v2 = v1)
+  let eq (v1 : t) v2 = (v1 = v2)
   let set x b v =
     if b then v lor single x else  v land (lnot (single x))
   let mem x = subset (single x)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -278,6 +278,7 @@ module Variance : sig
   val union  : t -> t -> t
   val inter  : t -> t -> t
   val subset : t -> t -> bool
+  val eq : t -> t -> bool
   val set : f -> bool -> t -> t
   val mem : f -> t -> bool
   val conjugate : t -> t                (* exchange positive and negative *)


### PR DESCRIPTION
Many properties of (potentially mutually-recursive) type declarations need to be computed by an iterative fixpoint. The OCaml type-checker currently knows of two, variance of type parameters, and immediacy (the `immediate` attribute, see [documentation](http://caml.inria.fr/pub/docs/manual-ocaml-4.07/extn.html#sec260)).

Currently variance and immediacy are computed in a single fixpoint loop, iterating on both as long as one of them has not reached a stable result. This is a bit wasteful (one of them is going to be recomputed more than necessary), and it also makes the code non-modular and annoying to extend if we want to add new properties (precisely my goal, with a new fixpoint computation for `unboxed` type declarations).

This PR first splits the single loop into two independent loops, and then it implements a new generic loop (on an abstract notion of "typedecl property" with suitable operations) and ports both variance and immediacy to use this new, more generic framework.