### PR TITLE
Typedecl: split variance and immediacy logic into separate compilation units

### DIFF
--- a/.depend
+++ b/.depend
@@ -410,27 +410,35 @@ typing/typecore.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi \
     typing/annot.cmi
 typing/typedecl.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typedtree.cmi typing/subst.cmi \
-    typing/printtyp.cmi typing/primitive.cmi typing/predef.cmi \
-    typing/path.cmi parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/includecore.cmi \
-    typing/ident.cmi typing/env.cmi typing/datarepr.cmi typing/ctype.cmi \
-    utils/config.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
-    typing/btype.cmi parsing/attr_helper.cmi parsing/asttypes.cmi \
-    parsing/ast_iterator.cmi parsing/ast_helper.cmi typing/typedecl.cmi
+    typing/types.cmi typing/typedtree.cmi typing/typedecl_properties.cmi \
+    typing/subst.cmi typing/printtyp.cmi typing/primitive.cmi \
+    typing/predef.cmi typing/path.cmi parsing/parsetree.cmi typing/oprint.cmi \
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    typing/includecore.cmi typing/ident.cmi typing/env.cmi \
+    typing/datarepr.cmi typing/ctype.cmi utils/config.cmi utils/clflags.cmi \
+    parsing/builtin_attributes.cmi typing/btype.cmi parsing/attr_helper.cmi \
+    parsing/asttypes.cmi parsing/ast_iterator.cmi parsing/ast_helper.cmi \
+    typing/typedecl.cmi
 typing/typedecl.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typedtree.cmx typing/subst.cmx \
-    typing/printtyp.cmx typing/primitive.cmx typing/predef.cmx \
-    typing/path.cmx parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/includecore.cmx \
-    typing/ident.cmx typing/env.cmx typing/datarepr.cmx typing/ctype.cmx \
-    utils/config.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
-    typing/btype.cmx parsing/attr_helper.cmx parsing/asttypes.cmi \
-    parsing/ast_iterator.cmx parsing/ast_helper.cmx typing/typedecl.cmi
+    typing/types.cmx typing/typedtree.cmx typing/typedecl_properties.cmx \
+    typing/subst.cmx typing/printtyp.cmx typing/primitive.cmx \
+    typing/predef.cmx typing/path.cmx parsing/parsetree.cmi typing/oprint.cmx \
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    typing/includecore.cmx typing/ident.cmx typing/env.cmx \
+    typing/datarepr.cmx typing/ctype.cmx utils/config.cmx utils/clflags.cmx \
+    parsing/builtin_attributes.cmx typing/btype.cmx parsing/attr_helper.cmx \
+    parsing/asttypes.cmi parsing/ast_iterator.cmx parsing/ast_helper.cmx \
+    typing/typedecl.cmi
 typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/includecore.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
     parsing/asttypes.cmi
+typing/typedecl_properties.cmo : typing/types.cmi typing/ident.cmi \
+    typing/env.cmi typing/typedecl_properties.cmi
+typing/typedecl_properties.cmx : typing/types.cmx typing/ident.cmx \
+    typing/env.cmx typing/typedecl_properties.cmi
+typing/typedecl_properties.cmi : typing/types.cmi typing/ident.cmi \
+    typing/env.cmi
 typing/typedtree.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \

--- a/.depend
+++ b/.depend
@@ -411,28 +411,40 @@ typing/typecore.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     typing/annot.cmi
 typing/typedecl.cmo : utils/warnings.cmi typing/typetexp.cmi \
     typing/types.cmi typing/typedtree.cmi typing/typedecl_variance.cmi \
-    typing/typedecl_properties.cmi typing/subst.cmi typing/printtyp.cmi \
-    typing/primitive.cmi typing/predef.cmi typing/path.cmi \
-    parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/includecore.cmi \
-    typing/ident.cmi typing/env.cmi typing/datarepr.cmi typing/ctype.cmi \
-    utils/config.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
-    typing/btype.cmi parsing/attr_helper.cmi parsing/asttypes.cmi \
-    parsing/ast_iterator.cmi parsing/ast_helper.cmi typing/typedecl.cmi
+    typing/typedecl_unboxed.cmi typing/typedecl_immediacy.cmi \
+    typing/subst.cmi typing/printtyp.cmi typing/primitive.cmi \
+    typing/predef.cmi typing/path.cmi parsing/parsetree.cmi typing/oprint.cmi \
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    typing/includecore.cmi typing/ident.cmi typing/env.cmi \
+    typing/datarepr.cmi typing/ctype.cmi utils/config.cmi utils/clflags.cmi \
+    parsing/builtin_attributes.cmi typing/btype.cmi parsing/attr_helper.cmi \
+    parsing/asttypes.cmi parsing/ast_iterator.cmi parsing/ast_helper.cmi \
+    typing/typedecl.cmi
 typing/typedecl.cmx : utils/warnings.cmx typing/typetexp.cmx \
     typing/types.cmx typing/typedtree.cmx typing/typedecl_variance.cmx \
-    typing/typedecl_properties.cmx typing/subst.cmx typing/printtyp.cmx \
-    typing/primitive.cmx typing/predef.cmx typing/path.cmx \
-    parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/includecore.cmx \
-    typing/ident.cmx typing/env.cmx typing/datarepr.cmx typing/ctype.cmx \
-    utils/config.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
-    typing/btype.cmx parsing/attr_helper.cmx parsing/asttypes.cmi \
-    parsing/ast_iterator.cmx parsing/ast_helper.cmx typing/typedecl.cmi
+    typing/typedecl_unboxed.cmx typing/typedecl_immediacy.cmx \
+    typing/subst.cmx typing/printtyp.cmx typing/primitive.cmx \
+    typing/predef.cmx typing/path.cmx parsing/parsetree.cmi typing/oprint.cmx \
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    typing/includecore.cmx typing/ident.cmx typing/env.cmx \
+    typing/datarepr.cmx typing/ctype.cmx utils/config.cmx utils/clflags.cmx \
+    parsing/builtin_attributes.cmx typing/btype.cmx parsing/attr_helper.cmx \
+    parsing/asttypes.cmi parsing/ast_iterator.cmx parsing/ast_helper.cmx \
+    typing/typedecl.cmi
 typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi \
-    typing/typedecl_variance.cmi typing/path.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/includecore.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi
+    typing/typedecl_variance.cmi typing/typedecl_immediacy.cmi \
+    typing/path.cmi parsing/parsetree.cmi parsing/longident.cmi \
+    parsing/location.cmi typing/includecore.cmi typing/ident.cmi \
+    typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi
+typing/typedecl_immediacy.cmo : typing/types.cmi typing/typedecl_unboxed.cmi \
+    typing/typedecl_properties.cmi parsing/location.cmi typing/ctype.cmi \
+    parsing/builtin_attributes.cmi typing/typedecl_immediacy.cmi
+typing/typedecl_immediacy.cmx : typing/types.cmx typing/typedecl_unboxed.cmx \
+    typing/typedecl_properties.cmx parsing/location.cmx typing/ctype.cmx \
+    parsing/builtin_attributes.cmx typing/typedecl_immediacy.cmi
+typing/typedecl_immediacy.cmi : typing/types.cmi \
+    typing/typedecl_properties.cmi parsing/location.cmi typing/ident.cmi \
+    typing/env.cmi
 typing/typedecl_properties.cmo : typing/types.cmi typing/ident.cmi \
     typing/env.cmi parsing/builtin_attributes.cmi \
     typing/typedecl_properties.cmi
@@ -441,6 +453,11 @@ typing/typedecl_properties.cmx : typing/types.cmx typing/ident.cmx \
     typing/typedecl_properties.cmi
 typing/typedecl_properties.cmi : typing/types.cmi typing/ident.cmi \
     typing/env.cmi
+typing/typedecl_unboxed.cmo : typing/types.cmi typing/predef.cmi \
+    typing/env.cmi typing/ctype.cmi typing/typedecl_unboxed.cmi
+typing/typedecl_unboxed.cmx : typing/types.cmx typing/predef.cmx \
+    typing/env.cmx typing/ctype.cmx typing/typedecl_unboxed.cmi
+typing/typedecl_unboxed.cmi : typing/types.cmi typing/env.cmi
 typing/typedecl_variance.cmo : typing/types.cmi typing/typedtree.cmi \
     typing/typedecl_properties.cmi parsing/parsetree.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi typing/ctype.cmi typing/btype.cmi \

--- a/.depend
+++ b/.depend
@@ -365,18 +365,18 @@ typing/tast_mapper.cmx : typing/typedtree.cmx typing/env.cmx \
 typing/tast_mapper.cmi : typing/typedtree.cmi typing/env.cmi \
     parsing/asttypes.cmi
 typing/typeclass.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typedtree.cmi typing/typedecl.cmi \
-    typing/typecore.cmi typing/subst.cmi typing/stypes.cmi \
-    typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
+    typing/types.cmi typing/typedtree.cmi typing/typedecl_variance.cmi \
+    typing/typedecl.cmi typing/typecore.cmi typing/subst.cmi \
+    typing/stypes.cmi typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
     parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi typing/includeclass.cmi \
     typing/ident.cmi typing/env.cmi typing/ctype.cmi typing/cmt_format.cmi \
     utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
     parsing/asttypes.cmi parsing/ast_helper.cmi typing/typeclass.cmi
 typing/typeclass.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typedtree.cmx typing/typedecl.cmx \
-    typing/typecore.cmx typing/subst.cmx typing/stypes.cmx \
-    typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
+    typing/types.cmx typing/typedtree.cmx typing/typedecl_variance.cmx \
+    typing/typedecl.cmx typing/typecore.cmx typing/subst.cmx \
+    typing/stypes.cmx typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
     parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
     parsing/longident.cmx parsing/location.cmx typing/includeclass.cmx \
     typing/ident.cmx typing/env.cmx typing/ctype.cmx typing/cmt_format.cmx \
@@ -410,35 +410,48 @@ typing/typecore.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi \
     typing/annot.cmi
 typing/typedecl.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typedtree.cmi typing/typedecl_properties.cmi \
-    typing/subst.cmi typing/printtyp.cmi typing/primitive.cmi \
-    typing/predef.cmi typing/path.cmi parsing/parsetree.cmi typing/oprint.cmi \
-    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/includecore.cmi typing/ident.cmi typing/env.cmi \
-    typing/datarepr.cmi typing/ctype.cmi utils/config.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/attr_helper.cmi \
-    parsing/asttypes.cmi parsing/ast_iterator.cmi parsing/ast_helper.cmi \
-    typing/typedecl.cmi
+    typing/types.cmi typing/typedtree.cmi typing/typedecl_variance.cmi \
+    typing/typedecl_properties.cmi typing/subst.cmi typing/printtyp.cmi \
+    typing/primitive.cmi typing/predef.cmi typing/path.cmi \
+    parsing/parsetree.cmi typing/oprint.cmi utils/misc.cmi \
+    parsing/longident.cmi parsing/location.cmi typing/includecore.cmi \
+    typing/ident.cmi typing/env.cmi typing/datarepr.cmi typing/ctype.cmi \
+    utils/config.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
+    typing/btype.cmi parsing/attr_helper.cmi parsing/asttypes.cmi \
+    parsing/ast_iterator.cmi parsing/ast_helper.cmi typing/typedecl.cmi
 typing/typedecl.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typedtree.cmx typing/typedecl_properties.cmx \
-    typing/subst.cmx typing/printtyp.cmx typing/primitive.cmx \
-    typing/predef.cmx typing/path.cmx parsing/parsetree.cmi typing/oprint.cmx \
-    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/includecore.cmx typing/ident.cmx typing/env.cmx \
-    typing/datarepr.cmx typing/ctype.cmx utils/config.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/attr_helper.cmx \
-    parsing/asttypes.cmi parsing/ast_iterator.cmx parsing/ast_helper.cmx \
-    typing/typedecl.cmi
-typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/includecore.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    parsing/asttypes.cmi
+    typing/types.cmx typing/typedtree.cmx typing/typedecl_variance.cmx \
+    typing/typedecl_properties.cmx typing/subst.cmx typing/printtyp.cmx \
+    typing/primitive.cmx typing/predef.cmx typing/path.cmx \
+    parsing/parsetree.cmi typing/oprint.cmx utils/misc.cmx \
+    parsing/longident.cmx parsing/location.cmx typing/includecore.cmx \
+    typing/ident.cmx typing/env.cmx typing/datarepr.cmx typing/ctype.cmx \
+    utils/config.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
+    typing/btype.cmx parsing/attr_helper.cmx parsing/asttypes.cmi \
+    parsing/ast_iterator.cmx parsing/ast_helper.cmx typing/typedecl.cmi
+typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi \
+    typing/typedecl_variance.cmi typing/path.cmi parsing/parsetree.cmi \
+    parsing/longident.cmi parsing/location.cmi typing/includecore.cmi \
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi
 typing/typedecl_properties.cmo : typing/types.cmi typing/ident.cmi \
-    typing/env.cmi typing/typedecl_properties.cmi
+    typing/env.cmi parsing/builtin_attributes.cmi \
+    typing/typedecl_properties.cmi
 typing/typedecl_properties.cmx : typing/types.cmx typing/ident.cmx \
-    typing/env.cmx typing/typedecl_properties.cmi
+    typing/env.cmx parsing/builtin_attributes.cmx \
+    typing/typedecl_properties.cmi
 typing/typedecl_properties.cmi : typing/types.cmi typing/ident.cmi \
     typing/env.cmi
+typing/typedecl_variance.cmo : typing/types.cmi typing/typedtree.cmi \
+    typing/typedecl_properties.cmi parsing/parsetree.cmi parsing/location.cmi \
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi typing/btype.cmi \
+    parsing/asttypes.cmi typing/typedecl_variance.cmi
+typing/typedecl_variance.cmx : typing/types.cmx typing/typedtree.cmx \
+    typing/typedecl_properties.cmx parsing/parsetree.cmi parsing/location.cmx \
+    typing/ident.cmx typing/env.cmx typing/ctype.cmx typing/btype.cmx \
+    parsing/asttypes.cmi typing/typedecl_variance.cmi
+typing/typedecl_variance.cmi : typing/types.cmi typing/typedtree.cmi \
+    typing/typedecl_properties.cmi parsing/parsetree.cmi parsing/location.cmi \
+    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
 typing/typedtree.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \

--- a/Changes
+++ b/Changes
@@ -585,9 +585,9 @@ Working version
   [Proc.stack_ptr_dwarf_register_number].
   (Mark Shinwell, review by Bernhard Schommer)
 
-- GPR#2152: refactorize the fixpoint to compute type-system properties
-  of mutually-recursive type declarations.
-  (Gabriel Scherer, review by Armaël Guéneau)
+- GPR#2152, GPR#2517: refactorize the fixpoint to compute type-system
+  properties of mutually-recursive type declarations.
+  (Gabriel Scherer and Rodolphe Lepigre, review by Armaël Guéneau)
 
 ### Bug fixes:
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,9 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/tast_mapper.cmo \
   typing/cmt_format.cmo typing/untypeast.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/printpat.cmo \
-  typing/parmatch.cmo typing/stypes.cmo typing/typedecl.cmo typing/typeopt.cmo \
+  typing/parmatch.cmo typing/stypes.cmo \
+  typing/typedecl_properties.cmo \
+  typing/typedecl.cmo typing/typeopt.cmo \
   typing/rec_check.cmo typing/typecore.cmo typing/typeclass.cmo \
   typing/typemod.cmo
 

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/cmt_format.cmo typing/untypeast.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/printpat.cmo \
   typing/parmatch.cmo typing/stypes.cmo \
-  typing/typedecl_properties.cmo \
+  typing/typedecl_properties.cmo typing/typedecl_variance.cmo \
   typing/typedecl.cmo typing/typeopt.cmo \
   typing/rec_check.cmo typing/typecore.cmo typing/typeclass.cmo \
   typing/typemod.cmo

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/printpat.cmo \
   typing/parmatch.cmo typing/stypes.cmo \
   typing/typedecl_properties.cmo typing/typedecl_variance.cmo \
+  typing/typedecl_unboxed.cmo typing/typedecl_immediacy.cmo \
   typing/typedecl.cmo typing/typeopt.cmo \
   typing/rec_check.cmo typing/typecore.cmo typing/typeclass.cmo \
   typing/typemod.cmo

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1738,7 +1738,11 @@ let type_classes define_class approx kind env cls =
   Ctype.end_def ();
   let res = List.rev_map (final_decl env define_class) res in
   let decls = List.fold_right extract_type_decls res [] in
-  let decls = Typedecl.compute_variance_class_decls env decls in
+  let decls =
+    try Typedecl_variance.update_class_decls env decls
+    with Typedecl_variance.Error(loc, err) ->
+      raise (Typedecl.Error(loc, Typedecl.Variance err))
+  in
   let res = List.map2 merge_type_decls res decls in
   let env = List.fold_left (final_env define_class) env res in
   let res = List.map (check_coercions env) res in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -47,11 +47,10 @@ type error =
   | Rebind_wrong_type of Longident.t * Env.t * Ctype.Unification_trace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
-  | Bad_variance of int * (bool * bool * bool) * (bool * bool * bool)
+  | Variance of Typedecl_variance.error
   | Unavailable_type_constructor of Path.t
   | Bad_fixed_type of string
   | Unbound_type_var_ext of type_expr * extension_constructor
-  | Varying_anonymous
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
@@ -840,280 +839,6 @@ let check_abbrev_recursion env id_loc_list to_check tdecl =
   let id = tdecl.typ_id in
   check_recursion env (List.assoc id id_loc_list) (Path.Pident id) decl to_check
 
-(* Compute variance *)
-
-let get_variance ty visited =
-  try TypeMap.find ty !visited with Not_found -> Variance.null
-
-let compute_variance env visited vari ty =
-  let rec compute_variance_rec vari ty =
-    (* Format.eprintf "%a: %x@." Printtyp.type_expr ty (Obj.magic vari); *)
-    let ty = Ctype.repr ty in
-    let vari' = get_variance ty visited in
-    if Variance.subset vari vari' then () else
-    let vari = Variance.union vari vari' in
-    visited := TypeMap.add ty vari !visited;
-    let compute_same = compute_variance_rec vari in
-    match ty.desc with
-      Tarrow (_, ty1, ty2, _) ->
-        let open Variance in
-        let v = conjugate vari in
-        let v1 =
-          if mem May_pos v || mem May_neg v
-          then set May_weak true v else v
-        in
-        compute_variance_rec v1 ty1;
-        compute_same ty2
-    | Ttuple tl ->
-        List.iter compute_same tl
-    | Tconstr (path, tl, _) ->
-        let open Variance in
-        if tl = [] then () else begin
-          try
-            let decl = Env.find_type path env in
-            let cvari f = mem f vari in
-            List.iter2
-              (fun ty v ->
-                let cv f = mem f v in
-                let strict =
-                  cvari Inv && cv Inj || (cvari Pos || cvari Neg) && cv Inv
-                in
-                if strict then compute_variance_rec full ty else
-                let p1 = inter v vari
-                and n1 = inter v (conjugate vari) in
-                let v1 =
-                  union (inter covariant (union p1 (conjugate p1)))
-                    (inter (conjugate covariant) (union n1 (conjugate n1)))
-                and weak =
-                  cvari May_weak && (cv May_pos || cv May_neg) ||
-                  (cvari May_pos || cvari May_neg) && cv May_weak
-                in
-                let v2 = set May_weak weak v1 in
-                compute_variance_rec v2 ty)
-              tl decl.type_variance
-          with Not_found ->
-            List.iter (compute_variance_rec may_inv) tl
-        end
-    | Tobject (ty, _) ->
-        compute_same ty
-    | Tfield (_, _, ty1, ty2) ->
-        compute_same ty1;
-        compute_same ty2
-    | Tsubst ty ->
-        compute_same ty
-    | Tvariant row ->
-        let row = Btype.row_repr row in
-        List.iter
-          (fun (_,f) ->
-            match Btype.row_field_repr f with
-              Rpresent (Some ty) ->
-                compute_same ty
-            | Reither (_, tyl, _, _) ->
-                let open Variance in
-                let upper =
-                  List.fold_left (fun s f -> set f true s)
-                    null [May_pos; May_neg; May_weak]
-                in
-                let v = inter vari upper in
-                (* cf PR#7269:
-                   if List.length tyl > 1 then upper else inter vari upper *)
-                List.iter (compute_variance_rec v) tyl
-            | _ -> ())
-          row.row_fields;
-        compute_same row.row_more
-    | Tpoly (ty, _) ->
-        compute_same ty
-    | Tvar _ | Tnil | Tlink _ | Tunivar _ -> ()
-    | Tpackage (_, _, tyl) ->
-        let v =
-          Variance.(if mem Pos vari || mem Neg vari then full else may_inv)
-        in
-        List.iter (compute_variance_rec v) tyl
-  in
-  compute_variance_rec vari ty
-
-let make p n i =
-  let open Variance in
-  set May_pos p (set May_neg n (set May_weak n (set Inj i null)))
-
-let compute_variance_type env check (required, loc) decl tyl =
-  (* Requirements *)
-  let required =
-    List.map (fun (c,n,i) -> if c || n then (c,n,i) else (true,true,i))
-      required
-  in
-  (* Prepare *)
-  let params = List.map Btype.repr decl.type_params in
-  let tvl = ref TypeMap.empty in
-  (* Compute occurrences in the body *)
-  let open Variance in
-  List.iter
-    (fun (cn,ty) ->
-      compute_variance env tvl (if cn then full else covariant) ty)
-    tyl;
-  if check then begin
-    (* Check variance of parameters *)
-    let pos = ref 0 in
-    List.iter2
-      (fun ty (c, n, i) ->
-        incr pos;
-        let var = get_variance ty tvl in
-        let (co,cn) = get_upper var and ij = mem Inj var in
-        if Btype.is_Tvar ty && (co && not c || cn && not n || not ij && i)
-        then raise (Error(loc, Bad_variance (!pos, (co,cn,ij), (c,n,i)))))
-      params required;
-    (* Check propagation from constrained parameters *)
-    let args = Btype.newgenty (Ttuple params) in
-    let fvl = Ctype.free_variables args in
-    let fvl = List.filter (fun v -> not (List.memq v params)) fvl in
-    (* If there are no extra variables there is nothing to do *)
-    if fvl = [] then () else
-    let tvl2 = ref TypeMap.empty in
-    List.iter2
-      (fun ty (p,n,_) ->
-        if Btype.is_Tvar ty then () else
-        let v =
-          if p then if n then full else covariant else conjugate covariant in
-        compute_variance env tvl2 v ty)
-      params required;
-    let visited = ref TypeSet.empty in
-    let rec check ty =
-      let ty = Ctype.repr ty in
-      if TypeSet.mem ty !visited then () else
-      let visited' = TypeSet.add ty !visited in
-      visited := visited';
-      let v1 = get_variance ty tvl in
-      let snap = Btype.snapshot () in
-      let v2 =
-        TypeMap.fold
-          (fun t vt v ->
-            if Ctype.equal env false [ty] [t] then union vt v else v)
-          !tvl2 null in
-      Btype.backtrack snap;
-      let (c1,n1) = get_upper v1 and (c2,n2,_,i2) = get_lower v2 in
-      if c1 && not c2 || n1 && not n2 then
-        if List.memq ty fvl then
-          let code = if not i2 then -2 else if c2 || n2 then -1 else -3 in
-          raise (Error (loc, Bad_variance (code, (c1,n1,false), (c2,n2,false))))
-        else
-          Btype.iter_type_expr check ty
-    in
-    List.iter (fun (_,ty) -> check ty) tyl;
-  end;
-  List.map2
-    (fun ty (p, n, i) ->
-      let v = get_variance ty tvl in
-      let tr = decl.type_private in
-      (* Use required variance where relevant *)
-      let concr = decl.type_kind <> Type_abstract (*|| tr = Type_new*) in
-      let (p, n) =
-        if tr = Private || not (Btype.is_Tvar ty) then (p, n) (* set *)
-        else (false, false) (* only check *)
-      and i = concr  || i && tr = Private in
-      let v = union v (make p n i) in
-      let v =
-        if not concr then v else
-        if mem Pos v && mem Neg v then full else
-        if Btype.is_Tvar ty then v else
-        union v
-          (if p then if n then full else covariant else conjugate covariant)
-      in
-      if decl.type_kind = Type_abstract && tr = Public then v else
-      set May_weak (mem May_neg v) v)
-    params required
-
-let add_false = List.map (fun ty -> false, ty)
-
-(* A parameter is constrained if it is either instantiated,
-   or it is a variable appearing in another parameter *)
-let constrained vars ty =
-  match ty.desc with
-  | Tvar _ -> List.exists (fun tl -> List.memq ty tl) vars
-  | _ -> true
-
-let for_constr = function
-  | Types.Cstr_tuple l -> add_false l
-  | Types.Cstr_record l ->
-      List.map
-        (fun {Types.ld_mutable; ld_type} -> (ld_mutable = Mutable, ld_type))
-        l
-
-let compute_variance_gadt env check (required, loc as rloc) decl
-    (tl, ret_type_opt) =
-  match ret_type_opt with
-  | None ->
-      compute_variance_type env check rloc {decl with type_private = Private}
-        (for_constr tl)
-  | Some ret_type ->
-      match Ctype.repr ret_type with
-      | {desc=Tconstr (_, tyl, _)} ->
-          (* let tyl = List.map (Ctype.expand_head env) tyl in *)
-          let tyl = List.map Ctype.repr tyl in
-          let fvl = List.map (Ctype.free_variables ?env:None) tyl in
-          let _ =
-            List.fold_left2
-              (fun (fv1,fv2) ty (c,n,_) ->
-                match fv2 with [] -> assert false
-                | fv :: fv2 ->
-                    (* fv1 @ fv2 = free_variables of other parameters *)
-                    if (c||n) && constrained (fv1 @ fv2) ty then
-                      raise (Error(loc, Varying_anonymous));
-                    (fv :: fv1, fv2))
-              ([], fvl) tyl required
-          in
-          compute_variance_type env check rloc
-            {decl with type_params = tyl; type_private = Private}
-            (for_constr tl)
-      | _ -> assert false
-
-let compute_variance_extension env check decl ext rloc =
-  compute_variance_gadt env check rloc
-    {decl with type_params = ext.ext_type_params}
-    (ext.ext_args, ext.ext_ret_type)
-
-let compute_variance_decl env check decl (required, _ as rloc) =
-  if (decl.type_kind = Type_abstract || decl.type_kind = Type_open)
-       && decl.type_manifest = None then
-    List.map
-      (fun (c, n, i) ->
-        make (not n) (not c) (decl.type_kind <> Type_abstract || i))
-      required
-  else
-  let mn =
-    match decl.type_manifest with
-      None -> []
-    | Some ty -> [false, ty]
-  in
-  match decl.type_kind with
-    Type_abstract | Type_open ->
-      compute_variance_type env check rloc decl mn
-  | Type_variant tll ->
-      if List.for_all (fun c -> c.Types.cd_res = None) tll then
-        compute_variance_type env check rloc decl
-          (mn @ List.flatten (List.map (fun c -> for_constr c.Types.cd_args)
-                                tll))
-      else begin
-        let mn =
-          List.map (fun (_,ty) -> (Types.Cstr_tuple [ty],None)) mn in
-        let tll =
-          mn @ List.map (fun c -> c.Types.cd_args, c.Types.cd_res) tll in
-        match List.map (compute_variance_gadt env check rloc decl) tll with
-        | vari :: rem ->
-            let varl = List.fold_left (List.map2 Variance.union) vari rem in
-            List.map
-              Variance.(fun v -> if mem Pos v && mem Neg v then full else v)
-              varl
-        | _ -> assert false
-      end
-  | Type_record (ftl, _) ->
-      compute_variance_type env check rloc decl
-        (mn @ List.map (fun {Types.ld_mutable; ld_type} ->
-             (ld_mutable = Mutable, ld_type)) ftl)
-
-let is_hash id =
-  let s = Ident.name id in
-  String.length s > 0 && s.[0] = '#'
-
 let marked_as_immediate decl =
   Builtin_attributes.immediate decl.type_attributes
 
@@ -1133,51 +858,6 @@ let compute_immediacy env tdecl =
     not (Ctype.maybe_pointer_type env typ)
   | (Type_abstract, None) -> marked_as_immediate tdecl
   | _ -> false
-
-(* Computes the fixpoint for the variance and immediacy of type declarations *)
-let add_types_to_env decls env =
-  List.fold_right
-    (fun (id, decl) env -> add_type ~check:true id decl env)
-    decls env
-
-type variance_req = (bool * bool * bool) list
-let variance : (Variance.t list, variance_req) Typedecl_properties.property =
-  let open Typedecl_properties in
-  let eq li1 li2 =
-    try List.for_all2 Variance.eq li1 li2 with _ -> false in
-  let merge ~prop ~new_prop = List.map2 Variance.union prop new_prop in
-  let default decl =
-    List.map (fun _ -> Variance.null) decl.type_params in
-  let compute env decl req =
-    compute_variance_decl env false decl (req, decl.type_loc) in
-  let update_decl decl variance =
-    { decl with type_variance = variance } in
-  let check env id decl req =
-    if not (is_hash id) then
-      ignore (compute_variance_decl env true decl (req, decl.type_loc))
-  in
-  {
-    eq;
-    merge;
-    default;
-    compute;
-    update_decl;
-    check;
-  }
-
-let transl_variance : Asttypes.variance -> _ = function
-  | Covariant -> (true, false, false)
-  | Contravariant -> (false, true, false)
-  | Invariant -> (false, false, false)
-
-let variance_of_params ptype_params =
-  List.map transl_variance (List.map snd ptype_params)
-let variance_of_sdecl sdecl =
-  variance_of_params sdecl.ptype_params
-
-let compute_variance_decls env sdecls decls =
-  let required = List.map variance_of_sdecl sdecls in
-  Typedecl_properties.compute_property variance env decls required
 
 let immediacy : (bool, unit) Typedecl_properties.property =
   let open Typedecl_properties in
@@ -1203,25 +883,6 @@ let immediacy : (bool, unit) Typedecl_properties.property =
 
 let compute_immediacy_decls env decls =
   Typedecl_properties.compute_property_noreq immediacy env decls
-
-(* for typeclass.ml *)
-let compute_variance_class_decls env cldecls =
-  let decls, required =
-    List.fold_right
-      (fun (obj_id, obj_abbr, _cl_abbr, _clty, _cltydef, ci) (decls, req) ->
-        (obj_id, obj_abbr) :: decls,
-        variance_of_params ci.ci_params :: req)
-      cldecls ([],[])
-  in
-  let decls =
-    Typedecl_properties.compute_property variance env decls required in
-  List.map2
-    (fun (_,decl) (_, _, cl_abbr, clty, cltydef, _) ->
-      let variance = decl.type_variance in
-      (decl, {cl_abbr with type_variance = variance},
-       {clty with cty_variance = variance},
-       {cltydef with clty_variance = variance}))
-    decls cldecls
 
 (* Check multiple declarations of labels/constructors *)
 
@@ -1287,6 +948,11 @@ let check_redefined_unit (td: Parsetree.type_declaration) =
       Location.prerr_warning td.ptype_loc (Warnings.Redefining_unit name)
   | _ ->
       ()
+
+let add_types_to_env decls env =
+  List.fold_right
+    (fun (id, decl) env -> add_type ~check:true id decl env)
+    decls env
 
 (* Translate a set of type declarations, mutually recursive or not *)
 let transl_type_decl env rec_flag sdecl_list =
@@ -1393,10 +1059,13 @@ let transl_type_decl env rec_flag sdecl_list =
   List.iter2 (check_constraints new_env) sdecl_list decls;
   (* Add type properties to declarations *)
   let decls =
-    decls
-    |> name_recursion_decls sdecl_list
-    |> compute_variance_decls env sdecl_list
-    |> compute_immediacy_decls env in
+    try
+      decls
+      |> name_recursion_decls sdecl_list
+      |> Typedecl_variance.update_decls env sdecl_list
+      |> compute_immediacy_decls env
+    with
+    | Typedecl_variance.Error (loc, err) -> raise (Error (loc, Variance err)) in
   (* Compute the final environment with variance and immediacy *)
   let final_env = add_types_to_env decls env in
   (* Check re-exportation *)
@@ -1576,7 +1245,7 @@ let transl_type_extension extend env loc styext =
       if List.for_all2
            (fun (c1, n1, _) (c2, n2, _) -> (not c2 || c1) && (not n2 || n1))
            type_variance
-           (variance_of_params styext.ptyext_params)
+           (Typedecl_variance.variance_of_params styext.ptyext_params)
       then None else Some Includecore.Variance
   in
   begin match err with
@@ -1612,13 +1281,14 @@ let transl_type_extension extend env loc styext =
   (* Check variances are correct *)
   List.iter
     (fun ext->
-       (* Note that [loc] here is distinct from [type_decl.type_loc],
-          which makes the [loc] parameter to this function
-          useful. [loc] is the location of the extension, while
-          [type_decl] points to the original type declaration being
-          extended. *)
-      ignore (compute_variance_extension env true type_decl
-                ext.ext_type (type_variance, loc)))
+       (* Note that [loc] here is distinct from [type_decl.type_loc], which
+          makes the [loc] parameter to this function useful. [loc] is the
+          location of the extension, while [type_decl] points to the original
+          type declaration being extended. *)
+       try Typedecl_variance.check_variance_extension
+             env type_decl ext (type_variance, loc)
+       with Typedecl_variance.Error (loc, err) ->
+         raise (Error (loc, Variance err)))
     constructors;
   (* Add extension constructors to the environment *)
   let newenv =
@@ -1903,9 +1573,10 @@ let transl_with_constraint env id row_path orig_decl sdecl =
   end;
   let decl = name_recursion sdecl id decl in
   let type_variance =
-    compute_variance_decl env true decl
-      (variance_of_sdecl sdecl, sdecl.ptype_loc)
-  in
+    try Typedecl_variance.compute_decl
+          env ~check:true decl (Typedecl_variance.variance_of_sdecl sdecl)
+    with Typedecl_variance.Error (loc, err) ->
+      raise (Error (loc, Variance err)) in
   let type_immediate = compute_immediacy env decl in
   let decl = {decl with type_variance; type_immediate} in
   Ctype.end_def();
@@ -2133,7 +1804,7 @@ let report_error ppf = function
         "The constructor"
         Printtyp.longident lid
         "is private"
-  | Bad_variance (n, v1, v2) ->
+  | Variance (Typedecl_variance.Bad_variance (n, v1, v2)) ->
       let variance (p,n,i) =
         let inj = if i then "injective " else "" in
         match p, n with
@@ -2150,6 +1821,7 @@ let report_error ppf = function
         | 3 when not teen -> "rd"
         | _ -> "th"
       in
+      (* FIXME: this test below is horrible, use a proper variant *)
       if n = -1 then
         fprintf ppf "@[%s@ %s@ It"
           "In this definition, a type variable has a variance that"
@@ -2174,7 +1846,7 @@ let report_error ppf = function
       fprintf ppf "The definition of type %a@ is unavailable" Printtyp.path p
   | Bad_fixed_type r ->
       fprintf ppf "This fixed type %s" r
-  | Varying_anonymous ->
+  | Variance Typedecl_variance.Varying_anonymous ->
       fprintf ppf "@[%s@ %s@ %s@]"
         "In this GADT definition," "the variance of some parameter"
         "cannot be checked"

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -57,7 +57,6 @@ val is_fixed_type : Parsetree.type_declaration -> bool
 (* for typeopt.ml *)
 val get_unboxed_type_representation: Env.t -> type_expr -> type_expr option
 
-
 type native_repr_kind = Unboxed | Untagged
 
 type error =
@@ -89,7 +88,7 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Bad_immediate_attribute
+  | Immediacy of Typedecl_immediacy.error
   | Bad_unboxed_attribute of string
   | Wrong_unboxed_type_float
   | Boxed_and_unboxed

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -54,15 +54,6 @@ val check_coherence:
 (* for fixed types *)
 val is_fixed_type : Parsetree.type_declaration -> bool
 
-(* for typeclass.ml *)
-val compute_variance_class_decls:
-    Env.t ->
-    (Ident.t * Types.type_declaration * Types.type_declaration *
-     Types.class_declaration * Types.class_type_declaration *
-     'a Typedtree.class_infos) list ->
-    (Types.type_declaration * Types.type_declaration *
-     Types.class_declaration * Types.class_type_declaration) list
-
 (* for typeopt.ml *)
 val get_unboxed_type_representation: Env.t -> type_expr -> type_expr option
 
@@ -90,11 +81,10 @@ type error =
   | Rebind_wrong_type of Longident.t * Env.t * Ctype.Unification_trace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
-  | Bad_variance of int * (bool*bool*bool) * (bool*bool*bool)
+  | Variance of Typedecl_variance.error
   | Unavailable_type_constructor of Path.t
   | Bad_fixed_type of string
   | Unbound_type_var_ext of type_expr * extension_constructor
-  | Varying_anonymous
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind

--- a/typing/typedecl_immediacy.ml
+++ b/typing/typedecl_immediacy.ml
@@ -1,0 +1,62 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Types
+
+type error = Bad_immediate_attribute
+exception Error of Location.t * error
+
+let marked_as_immediate decl =
+  Builtin_attributes.immediate decl.type_attributes
+
+let compute_decl env tdecl =
+  match (tdecl.type_kind, tdecl.type_manifest) with
+  | (Type_variant [{cd_args = Cstr_tuple [arg]; _}], _)
+    | (Type_variant [{cd_args = Cstr_record [{ld_type = arg; _}]; _}], _)
+    | (Type_record ([{ld_type = arg; _}], _), _)
+  when tdecl.type_unboxed.unboxed ->
+    begin match Typedecl_unboxed.get_unboxed_type_representation env arg with
+    | Some argrepr -> not (Ctype.maybe_pointer_type env argrepr)
+    | None -> false
+    end
+  | (Type_variant (_ :: _ as cstrs), _) ->
+    not (List.exists (fun c -> c.Types.cd_args <> Types.Cstr_tuple []) cstrs)
+  | (Type_abstract, Some(typ)) ->
+    not (Ctype.maybe_pointer_type env typ)
+  | (Type_abstract, None) -> marked_as_immediate tdecl
+  | _ -> false
+
+let property : (bool, unit) Typedecl_properties.property =
+  let open Typedecl_properties in
+  let eq = (=) in
+  let merge ~prop:_ ~new_prop = new_prop in
+  let default _decl = false in
+  let compute env decl () = compute_decl env decl in
+  let update_decl decl immediacy = { decl with type_immediate = immediacy } in
+  let check _env _id decl () =
+    if (marked_as_immediate decl) && (not decl.type_immediate) then
+      raise (Error (decl.type_loc, Bad_immediate_attribute)) in
+  {
+    eq;
+    merge;
+    default;
+    compute;
+    update_decl;
+    check;
+  }
+
+let update_decls env decls =
+  Typedecl_properties.compute_property_noreq property env decls

--- a/typing/typedecl_immediacy.mli
+++ b/typing/typedecl_immediacy.mli
@@ -1,0 +1,11 @@
+type error = Bad_immediate_attribute
+exception Error of Location.t * error
+
+val compute_decl : Env.t -> Types.type_declaration -> bool
+
+val property : (bool, unit) Typedecl_properties.property
+
+val update_decls :
+  Env.t ->
+  (Ident.t * Typedecl_properties.decl) list ->
+  (Ident.t * Typedecl_properties.decl) list

--- a/typing/typedecl_immediacy.mli
+++ b/typing/typedecl_immediacy.mli
@@ -1,3 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 type error = Bad_immediate_attribute
 exception Error of Location.t * error
 

--- a/typing/typedecl_properties.ml
+++ b/typing/typedecl_properties.ml
@@ -1,0 +1,73 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type decl = Types.type_declaration
+
+type ('prop, 'req) property = {
+  eq : 'prop -> 'prop -> bool;
+  merge : prop:'prop -> new_prop:'prop -> 'prop;
+
+  default : decl -> 'prop;
+  compute : Env.t -> decl -> 'req -> 'prop;
+  update_decl : decl -> 'prop -> decl;
+
+  check : Env.t -> Ident.t -> decl -> 'req -> unit;
+}
+
+let add_type ~check id decl env =
+  let open Types in
+  Builtin_attributes.warning_scope ~ppwarning:false decl.type_attributes
+    (fun () -> Env.add_type ~check id decl env)
+
+let add_types_to_env decls env =
+  List.fold_right
+    (fun (id, decl) env -> add_type ~check:true id decl env)
+    decls env
+
+let compute_property
+: ('prop, 'req) property -> Env.t ->
+  (Ident.t * decl) list -> 'req list -> (Ident.t * decl) list
+= fun property env decls required ->
+  (* [decls] and [required] must be lists of the same size,
+     with [required] containing the requirement for the corresponding
+     declaration in [decls]. *)
+  let props = List.map (fun (_id, decl) -> property.default decl) decls in
+  let rec compute_fixpoint props =
+    let new_decls =
+      List.map2 (fun (id, decl) prop ->
+          (id, property.update_decl decl prop))
+        decls props in
+    let new_env = add_types_to_env new_decls env in
+    let new_props =
+      List.map2
+        (fun (_id, decl) (prop, req) ->
+           let new_prop = property.compute new_env decl req in
+           property.merge ~prop ~new_prop)
+        new_decls (List.combine props required) in
+    if not (List.for_all2 property.eq props new_props)
+    then compute_fixpoint new_props
+    else begin
+      List.iter2
+        (fun (id, decl) req -> property.check new_env id decl req)
+        new_decls required;
+      new_decls
+    end
+  in
+  compute_fixpoint props
+
+let compute_property_noreq property env decls =
+  let req = List.map (fun _ -> ()) decls in
+  compute_property property env decls req

--- a/typing/typedecl_properties.mli
+++ b/typing/typedecl_properties.mli
@@ -1,0 +1,39 @@
+type decl = Types.type_declaration
+
+(** An abstract interface for properties of type definitions, such as
+   variance and immediacy, that are computed by a fixpoint on
+   mutually-recursive type declarations. This interface contains all
+   the operations needed to initialize and run the fixpoint
+   computation, and then (optionally) check that the result is
+   consistent with the declaration or user expectations. *)
+
+type ('prop, 'req) property = {
+  eq : 'prop -> 'prop -> bool;
+  merge : prop:'prop -> new_prop:'prop -> 'prop;
+
+  default : decl -> 'prop;
+  compute : Env.t -> decl -> 'req -> 'prop;
+  update_decl : decl -> 'prop -> decl;
+
+  check : Env.t -> Ident.t -> decl -> 'req -> unit;
+}
+(** ['prop] represents the type of property values
+    ({!Types.Variance.t}, just 'bool' for immediacy, etc).
+
+    ['req] represents the property value required by the author of the
+    declaration, if they gave an expectation: [type +'a t = ...].
+
+    Some properties have no natural notion of user requirement, or
+    their requirement is global, or already stored in
+    [type_declaration]; they can just use [unit] as ['req] parameter. *)
+
+
+(** [compute_property prop env decls req] performs a fixpoint computation
+    to determine the final values of a property on a set of mutually-recursive
+    type declarations. The [req] argument must be a list of the same size as
+    [decls], providing the user requirement for each declaration. *)
+val compute_property : ('prop, 'req) property -> Env.t ->
+  (Ident.t * decl) list -> 'req list -> (Ident.t * decl) list
+
+val compute_property_noreq : ('prop, unit) property -> Env.t ->
+  (Ident.t * decl) list -> (Ident.t * decl) list

--- a/typing/typedecl_properties.mli
+++ b/typing/typedecl_properties.mli
@@ -1,3 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 type decl = Types.type_declaration
 
 (** An abstract interface for properties of type definitions, such as

--- a/typing/typedecl_unboxed.ml
+++ b/typing/typedecl_unboxed.ml
@@ -1,0 +1,49 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Types
+
+(* We use the Ctype.expand_head_opt version of expand_head to get access
+   to the manifest type of private abbreviations. *)
+let rec get_unboxed_type_representation env ty fuel =
+  if fuel < 0 then None else
+  let ty = Ctype.repr (Ctype.expand_head_opt env ty) in
+  match ty.desc with
+  | Tconstr (p, args, _) ->
+    begin match Env.find_type p env with
+    | exception Not_found -> Some ty
+    | {type_immediate = true; _} -> Some Predef.type_int
+    | {type_unboxed = {unboxed = false}} -> Some ty
+    | {type_params; type_kind =
+         Type_record ([{ld_type = ty2; _}], _)
+       | Type_variant [{cd_args = Cstr_tuple [ty2]; _}]
+       | Type_variant [{cd_args = Cstr_record [{ld_type = ty2; _}]; _}]}
+
+      ->
+        let ty2 = match ty2.desc with Tpoly (t, _) -> t | _ -> ty2 in
+        get_unboxed_type_representation env
+          (Ctype.apply env type_params ty2 args) (fuel - 1)
+    | {type_kind=Type_abstract} -> None
+          (* This case can occur when checking a recursive unboxed type
+             declaration. *)
+    | _ -> assert false (* only the above can be unboxed *)
+    end
+  | _ -> Some ty
+
+let get_unboxed_type_representation env ty =
+  (* Do not give too much fuel: PR#7424 *)
+  get_unboxed_type_representation env ty 100
+;;

--- a/typing/typedecl_unboxed.mli
+++ b/typing/typedecl_unboxed.mli
@@ -1,0 +1,4 @@
+open Types
+
+(* for typeopt.ml *)
+val get_unboxed_type_representation: Env.t -> type_expr -> type_expr option

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -1,0 +1,372 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Asttypes
+open Types
+
+module TypeSet = Btype.TypeSet
+module TypeMap = Btype.TypeMap
+
+type surface_variance = bool * bool * bool
+
+type error =
+| Bad_variance of int * surface_variance * surface_variance
+| Varying_anonymous
+
+exception Error of Location.t * error
+
+(* Compute variance *)
+
+let get_variance ty visited =
+  try TypeMap.find ty !visited with Not_found -> Variance.null
+
+let compute_variance env visited vari ty =
+  let rec compute_variance_rec vari ty =
+    (* Format.eprintf "%a: %x@." Printtyp.type_expr ty (Obj.magic vari); *)
+    let ty = Ctype.repr ty in
+    let vari' = get_variance ty visited in
+    if Variance.subset vari vari' then () else
+    let vari = Variance.union vari vari' in
+    visited := TypeMap.add ty vari !visited;
+    let compute_same = compute_variance_rec vari in
+    match ty.desc with
+      Tarrow (_, ty1, ty2, _) ->
+        let open Variance in
+        let v = conjugate vari in
+        let v1 =
+          if mem May_pos v || mem May_neg v
+          then set May_weak true v else v
+        in
+        compute_variance_rec v1 ty1;
+        compute_same ty2
+    | Ttuple tl ->
+        List.iter compute_same tl
+    | Tconstr (path, tl, _) ->
+        let open Variance in
+        if tl = [] then () else begin
+          try
+            let decl = Env.find_type path env in
+            let cvari f = mem f vari in
+            List.iter2
+              (fun ty v ->
+                let cv f = mem f v in
+                let strict =
+                  cvari Inv && cv Inj || (cvari Pos || cvari Neg) && cv Inv
+                in
+                if strict then compute_variance_rec full ty else
+                let p1 = inter v vari
+                and n1 = inter v (conjugate vari) in
+                let v1 =
+                  union (inter covariant (union p1 (conjugate p1)))
+                    (inter (conjugate covariant) (union n1 (conjugate n1)))
+                and weak =
+                  cvari May_weak && (cv May_pos || cv May_neg) ||
+                  (cvari May_pos || cvari May_neg) && cv May_weak
+                in
+                let v2 = set May_weak weak v1 in
+                compute_variance_rec v2 ty)
+              tl decl.type_variance
+          with Not_found ->
+            List.iter (compute_variance_rec may_inv) tl
+        end
+    | Tobject (ty, _) ->
+        compute_same ty
+    | Tfield (_, _, ty1, ty2) ->
+        compute_same ty1;
+        compute_same ty2
+    | Tsubst ty ->
+        compute_same ty
+    | Tvariant row ->
+        let row = Btype.row_repr row in
+        List.iter
+          (fun (_,f) ->
+            match Btype.row_field_repr f with
+              Rpresent (Some ty) ->
+                compute_same ty
+            | Reither (_, tyl, _, _) ->
+                let open Variance in
+                let upper =
+                  List.fold_left (fun s f -> set f true s)
+                    null [May_pos; May_neg; May_weak]
+                in
+                let v = inter vari upper in
+                (* cf PR#7269:
+                   if List.length tyl > 1 then upper else inter vari upper *)
+                List.iter (compute_variance_rec v) tyl
+            | _ -> ())
+          row.row_fields;
+        compute_same row.row_more
+    | Tpoly (ty, _) ->
+        compute_same ty
+    | Tvar _ | Tnil | Tlink _ | Tunivar _ -> ()
+    | Tpackage (_, _, tyl) ->
+        let v =
+          Variance.(if mem Pos vari || mem Neg vari then full else may_inv)
+        in
+        List.iter (compute_variance_rec v) tyl
+  in
+  compute_variance_rec vari ty
+
+let make p n i =
+  let open Variance in
+  set May_pos p (set May_neg n (set May_weak n (set Inj i null)))
+
+let compute_variance_type env ~check (required, loc) decl tyl =
+  (* Requirements *)
+  let required =
+    List.map (fun (c,n,i) -> if c || n then (c,n,i) else (true,true,i))
+      required
+  in
+  (* Prepare *)
+  let params = List.map Btype.repr decl.type_params in
+  let tvl = ref TypeMap.empty in
+  (* Compute occurrences in the body *)
+  let open Variance in
+  List.iter
+    (fun (cn,ty) ->
+      compute_variance env tvl (if cn then full else covariant) ty)
+    tyl;
+  if check then begin
+    (* Check variance of parameters *)
+    let pos = ref 0 in
+    List.iter2
+      (fun ty (c, n, i) ->
+        incr pos;
+        let var = get_variance ty tvl in
+        let (co,cn) = get_upper var and ij = mem Inj var in
+        if Btype.is_Tvar ty && (co && not c || cn && not n || not ij && i)
+        then raise (Error(loc, Bad_variance (!pos, (co,cn,ij), (c,n,i)))))
+      params required;
+    (* Check propagation from constrained parameters *)
+    let args = Btype.newgenty (Ttuple params) in
+    let fvl = Ctype.free_variables args in
+    let fvl = List.filter (fun v -> not (List.memq v params)) fvl in
+    (* If there are no extra variables there is nothing to do *)
+    if fvl = [] then () else
+    let tvl2 = ref TypeMap.empty in
+    List.iter2
+      (fun ty (p,n,_) ->
+        if Btype.is_Tvar ty then () else
+        let v =
+          if p then if n then full else covariant else conjugate covariant in
+        compute_variance env tvl2 v ty)
+      params required;
+    let visited = ref TypeSet.empty in
+    let rec check ty =
+      let ty = Ctype.repr ty in
+      if TypeSet.mem ty !visited then () else
+      let visited' = TypeSet.add ty !visited in
+      visited := visited';
+      let v1 = get_variance ty tvl in
+      let snap = Btype.snapshot () in
+      let v2 =
+        TypeMap.fold
+          (fun t vt v ->
+            if Ctype.equal env false [ty] [t] then union vt v else v)
+          !tvl2 null in
+      Btype.backtrack snap;
+      let (c1,n1) = get_upper v1 and (c2,n2,_,i2) = get_lower v2 in
+      if c1 && not c2 || n1 && not n2 then
+        if List.memq ty fvl then
+          let code = if not i2 then -2 else if c2 || n2 then -1 else -3 in
+          raise (Error (loc, Bad_variance (code, (c1,n1,false), (c2,n2,false))))
+        else
+          Btype.iter_type_expr check ty
+    in
+    List.iter (fun (_,ty) -> check ty) tyl;
+  end;
+  List.map2
+    (fun ty (p, n, i) ->
+      let v = get_variance ty tvl in
+      let tr = decl.type_private in
+      (* Use required variance where relevant *)
+      let concr = decl.type_kind <> Type_abstract (*|| tr = Type_new*) in
+      let (p, n) =
+        if tr = Private || not (Btype.is_Tvar ty) then (p, n) (* set *)
+        else (false, false) (* only check *)
+      and i = concr  || i && tr = Private in
+      let v = union v (make p n i) in
+      let v =
+        if not concr then v else
+        if mem Pos v && mem Neg v then full else
+        if Btype.is_Tvar ty then v else
+        union v
+          (if p then if n then full else covariant else conjugate covariant)
+      in
+      if decl.type_kind = Type_abstract && tr = Public then v else
+      set May_weak (mem May_neg v) v)
+    params required
+
+let add_false = List.map (fun ty -> false, ty)
+
+(* A parameter is constrained if it is either instantiated,
+   or it is a variable appearing in another parameter *)
+let constrained vars ty =
+  match ty.desc with
+  | Tvar _ -> List.exists (fun tl -> List.memq ty tl) vars
+  | _ -> true
+
+let for_constr = function
+  | Types.Cstr_tuple l -> add_false l
+  | Types.Cstr_record l ->
+      List.map
+        (fun {Types.ld_mutable; ld_type} -> (ld_mutable = Mutable, ld_type))
+        l
+
+let compute_variance_gadt env ~check (required, loc as rloc) decl
+    (tl, ret_type_opt) =
+  match ret_type_opt with
+  | None ->
+      compute_variance_type env ~check rloc {decl with type_private = Private}
+        (for_constr tl)
+  | Some ret_type ->
+      match Ctype.repr ret_type with
+      | {desc=Tconstr (_, tyl, _)} ->
+          (* let tyl = List.map (Ctype.expand_head env) tyl in *)
+          let tyl = List.map Ctype.repr tyl in
+          let fvl = List.map (Ctype.free_variables ?env:None) tyl in
+          let _ =
+            List.fold_left2
+              (fun (fv1,fv2) ty (c,n,_) ->
+                match fv2 with [] -> assert false
+                | fv :: fv2 ->
+                    (* fv1 @ fv2 = free_variables of other parameters *)
+                    if (c||n) && constrained (fv1 @ fv2) ty then
+                      raise (Error(loc, Varying_anonymous));
+                    (fv :: fv1, fv2))
+              ([], fvl) tyl required
+          in
+          compute_variance_type env ~check rloc
+            {decl with type_params = tyl; type_private = Private}
+            (for_constr tl)
+      | _ -> assert false
+
+let compute_variance_extension env ~check decl ext rloc =
+  compute_variance_gadt env ~check rloc
+    {decl with type_params = ext.ext_type_params}
+    (ext.ext_args, ext.ext_ret_type)
+
+let compute_variance_decl env ~check decl (required, _ as rloc) =
+  if (decl.type_kind = Type_abstract || decl.type_kind = Type_open)
+       && decl.type_manifest = None then
+    List.map
+      (fun (c, n, i) ->
+        make (not n) (not c) (decl.type_kind <> Type_abstract || i))
+      required
+  else
+  let mn =
+    match decl.type_manifest with
+      None -> []
+    | Some ty -> [false, ty]
+  in
+  match decl.type_kind with
+    Type_abstract | Type_open ->
+      compute_variance_type env ~check rloc decl mn
+  | Type_variant tll ->
+      if List.for_all (fun c -> c.Types.cd_res = None) tll then
+        compute_variance_type env ~check rloc decl
+          (mn @ List.flatten (List.map (fun c -> for_constr c.Types.cd_args)
+                                tll))
+      else begin
+        let mn =
+          List.map (fun (_,ty) -> (Types.Cstr_tuple [ty],None)) mn in
+        let tll =
+          mn @ List.map (fun c -> c.Types.cd_args, c.Types.cd_res) tll in
+        match List.map (compute_variance_gadt env ~check rloc decl) tll with
+        | vari :: rem ->
+            let varl = List.fold_left (List.map2 Variance.union) vari rem in
+            List.map
+              Variance.(fun v -> if mem Pos v && mem Neg v then full else v)
+              varl
+        | _ -> assert false
+      end
+  | Type_record (ftl, _) ->
+      compute_variance_type env ~check rloc decl
+        (mn @ List.map (fun {Types.ld_mutable; ld_type} ->
+             (ld_mutable = Mutable, ld_type)) ftl)
+
+let is_hash id =
+  let s = Ident.name id in
+  String.length s > 0 && s.[0] = '#'
+
+let check_variance_extension env decl ext rloc =
+  (* TODO: refactorize compute_variance_extension *)
+  ignore (compute_variance_extension env ~check:true decl
+    ext.Typedtree.ext_type rloc)
+
+let compute_decl env ~check decl req =
+  compute_variance_decl env ~check decl (req, decl.type_loc)
+
+let check_decl env decl req =
+  ignore (compute_variance_decl env ~check:true decl (req, decl.type_loc))
+
+type prop = Variance.t list
+type req = surface_variance list
+let property : (prop, req) Typedecl_properties.property =
+  let open Typedecl_properties in
+  let eq li1 li2 =
+    try List.for_all2 Variance.eq li1 li2 with _ -> false in
+  let merge ~prop ~new_prop =
+    List.map2 Variance.union prop new_prop in
+  let default decl =
+    List.map (fun _ -> Variance.null) decl.type_params in
+  let compute env decl req =
+    compute_decl env ~check:false decl req in
+  let update_decl decl variance =
+    { decl with type_variance = variance } in
+  let check env id decl req =
+    if is_hash id then () else check_decl env decl req in
+  {
+    eq;
+    merge;
+    default;
+    compute;
+    update_decl;
+    check;
+  }
+
+let transl_variance : Asttypes.variance -> _ = function
+  | Covariant -> (true, false, false)
+  | Contravariant -> (false, true, false)
+  | Invariant -> (false, false, false)
+
+let variance_of_params ptype_params =
+  List.map transl_variance (List.map snd ptype_params)
+
+let variance_of_sdecl sdecl =
+  variance_of_params sdecl.Parsetree.ptype_params
+
+let update_decls env sdecls decls =
+  let required = List.map variance_of_sdecl sdecls in
+  Typedecl_properties.compute_property property env decls required
+
+let update_class_decls env cldecls =
+  let decls, required =
+    List.fold_right
+      (fun (obj_id, obj_abbr, _cl_abbr, _clty, _cltydef, ci) (decls, req) ->
+        (obj_id, obj_abbr) :: decls,
+        variance_of_params ci.Typedtree.ci_params :: req)
+      cldecls ([],[])
+  in
+  let decls =
+    Typedecl_properties.compute_property property env decls required in
+  List.map2
+    (fun (_,decl) (_, _, cl_abbr, clty, cltydef, _) ->
+      let variance = decl.type_variance in
+      (decl, {cl_abbr with type_variance = variance},
+       {clty with cty_variance = variance},
+       {cltydef with clty_variance = variance}))
+    decls cldecls

--- a/typing/typedecl_variance.mli
+++ b/typing/typedecl_variance.mli
@@ -1,3 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*   Gabriel Scherer, projet Parsifal, INRIA Saclay                       *)
+(*   Rodolphe Lepigre, projet Deducteam, INRIA Saclay                     *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 open Types
 open Typedecl_properties
 

--- a/typing/typedecl_variance.mli
+++ b/typing/typedecl_variance.mli
@@ -1,0 +1,40 @@
+open Types
+open Typedecl_properties
+
+type surface_variance = bool * bool * bool
+
+val variance_of_params :
+  (Parsetree.core_type * Asttypes.variance) list -> surface_variance list
+val variance_of_sdecl :
+  Parsetree.type_declaration -> surface_variance list
+
+type prop = Variance.t list
+type req = surface_variance list
+val property : (Variance.t list, req) property
+
+type error =
+| Bad_variance of int * surface_variance * surface_variance
+| Varying_anonymous
+
+exception Error of Location.t * error
+
+val check_variance_extension :
+  Env.t -> type_declaration ->
+  Typedtree.extension_constructor -> req * Location.t -> unit
+
+val compute_decl :
+  Env.t -> check:bool -> type_declaration -> req -> prop
+
+val update_decls :
+  Env.t -> Parsetree.type_declaration list ->
+  (Ident.t * type_declaration) list ->
+  (Ident.t * type_declaration) list
+
+val update_class_decls :
+  Env.t ->
+  (Ident.t * Typedecl_properties.decl * Types.type_declaration *
+   Types.class_declaration * Types.class_type_declaration *
+   'a Typedtree.class_infos) list ->
+  (Typedecl_properties.decl * Types.type_declaration *
+   Types.class_declaration * Types.class_type_declaration) list
+(* FIXME: improve this horrible interface *)


### PR DESCRIPTION
This is purely a refactoring change, moving functions around on top of #2152 (generic fixpoint computation), pair-programmed with @rlepigre. We improved the API in passing, in particular for the variance functions (the `bool` parameter is now labeled `check:bool`, and some type synonyms are there to paper over the horrible types inside).

We found and kept two unpleasant data representation choices in the existing implementation, that we did not fix yet (it can come in separate PRs):
- the payload of the `Bad_variance` with its nightmaresque integer
- the tuple type of the `compute_variance_class_decls` function, used by typeclass.ml

Finally, we move some of the `get_unboxed_*` functions in typedecl.ml into their own module. We plan to move the rest as part of the upcoming unboxed-checking work (for now they need to stay in typedecl).