### PR TITLE
Mark the String.equal external as not-allocating C.

### DIFF
--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -320,7 +320,7 @@ let rcontains_from s i c =
 type t = bytes
 
 let compare (x: t) (y: t) = Stdlib.compare x y
-external equal : t -> t -> bool = "caml_bytes_equal"
+external equal : t -> t -> bool = "caml_bytes_equal" [@@noalloc]
 
 (* Deprecated functions implemented via other deprecated functions *)
 [@@@ocaml.warning "-3"]

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -200,7 +200,7 @@ let uncapitalize_ascii s =
 type t = string
 
 let compare (x: t) (y: t) = Stdlib.compare x y
-external equal : string -> string -> bool = "caml_string_equal"
+external equal : string -> string -> bool = "caml_string_equal" [@@noalloc]
 
 let split_on_char sep s =
   let r = ref [] in


### PR DESCRIPTION
It is indeed a mere loop that does not allocate. This function was probably forgotten because its code was hidden deep in the module.

Fixes Mantis#7874.