### PR TITLE
Fix the location highlight tag for alerts

### DIFF
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -671,8 +671,8 @@ let batch_mode_printer : report_printer =
       | Report_warning_as_error _
       | Report_alert_as_error _
       | Report_error -> "error"
-      | Report_warning _ -> "warning"
-      | Report_alert _ -> "alert"
+      | Report_warning _
+      | Report_alert _ -> "warning"
     in
     let highlight ppf loc =
       match error_style () with

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -105,7 +105,7 @@ Line 1, characters 8-15:
 Error: Cannot create values of the private type Test2.t
 Line 3, characters 40-63:
 3 | module Test2 : module type of Test with type t = private Test.t = Test;;
-                                            <alert>^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                                            ^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: spurious use of private
 module Test2 : sig type t = Test.t = private A end
 type t = private < x : int; .. >

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -105,7 +105,7 @@ Line 1, characters 8-15:
 Error: Cannot create values of the private type Test2.t
 Line 3, characters 40-63:
 3 | module Test2 : module type of Test with type t = private Test.t = Test;;
-                                            <alert>^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                                            ^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: spurious use of private
 module Test2 : sig type t = Test.t = private A end
 type t = private < x : int; .. >

--- a/testsuite/tests/warnings/deprecated_module.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module.compilers.reference
@@ -1,8 +1,8 @@
 File "deprecated_module.ml", line 16, characters 8-11:
 16 | let _ = M.x
-             <alert>^^^</alert>
+             ^^^
 Alert deprecated: module M
 File "deprecated_module.ml", line 17, characters 8-9:
 17 | include M
-             <alert>^</alert>
+             ^
 Alert deprecated: module M

--- a/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
@@ -1,138 +1,138 @@
 File "deprecated_module_assigment.ml", line 17, characters 33-34:
 17 | module Y : sig val x : int end = X
-                                      <alert>^</alert>
+                                      ^
 Alert deprecated: x
 DEPRECATED
 File "deprecated_module_assigment.ml", line 12, characters 2-41:
 12 |   val x : int [@@deprecated "DEPRECATED"]
-       <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 17, characters 15-26:
 17 | module Y : sig val x : int end = X
-                    <alert>^^^^^^^^^^^</alert>
+                    ^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 23, characters 13-14:
 23 | module B = F(X)
-                  <alert>^</alert>
+                  ^
 Alert deprecated: x
 DEPRECATED
 File "deprecated_module_assigment.ml", line 12, characters 2-41:
 12 |   val x : int [@@deprecated "DEPRECATED"]
-       <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 21, characters 17-28:
 21 | module F(A : sig val x : int end) = struct let _ = A.x end
-                      <alert>^^^^^^^^^^^</alert>
+                      ^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 33, characters 39-78:
 33 | module CSTR : sig type t = A | B end = struct type t = A [@deprecated] | B end
-                                            <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: A
 File "deprecated_module_assigment.ml", line 33, characters 55-70:
 33 | module CSTR : sig type t = A | B end = struct type t = A [@deprecated] | B end
-                                                            <alert>^^^^^^^^^^^^^^^</alert>
+                                                            ^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 33, characters 27-28:
 33 | module CSTR : sig type t = A | B end = struct type t = A [@deprecated] | B end
-                                <alert>^</alert>
+                                ^
   Expected signature
 File "deprecated_module_assigment.ml", line 37, characters 2-20:
 37 |   type s = t = A | B
-       <alert>^^^^^^^^^^^^^^^^^^</alert>
+       ^^^^^^^^^^^^^^^^^^
 Alert deprecated: A
 File "deprecated_module_assigment.ml", line 36, characters 11-26:
 36 |   type t = A [@deprecated] | B
-                <alert>^^^^^^^^^^^^^^^</alert>
+                ^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 37, characters 15-16:
 37 |   type s = t = A | B
-                    <alert>^</alert>
+                    ^
   Expected signature
 File "deprecated_module_assigment.ml", line 45, characters 0-58:
 45 | struct type t = {mutable x: int [@deprecated_mutable]} end
-     <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: mutating field x
 File "deprecated_module_assigment.ml", line 45, characters 17-53:
 45 | struct type t = {mutable x: int [@deprecated_mutable]} end
-                      <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 44, characters 14-28:
 44 | sig type t = {mutable x: int} end =
-                   <alert>^^^^^^^^^^^^^^</alert>
+                   ^^^^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 49, characters 2-31:
 49 |   type s = t = {mutable x: int}
-       <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: mutating field x
 File "deprecated_module_assigment.ml", line 48, characters 12-48:
 48 |   type t = {mutable x: int [@deprecated_mutable]}
-                 <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 49, characters 16-30:
 49 |   type s = t = {mutable x: int}
-                     <alert>^^^^^^^^^^^^^^</alert>
+                     ^^^^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 54, characters 37-75:
 54 | module TYPE : sig type t = int end = struct type t = int [@@deprecated] end
-                                          <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: t
 File "deprecated_module_assigment.ml", line 54, characters 44-71:
 54 | module TYPE : sig type t = int end = struct type t = int [@@deprecated] end
-                                                 <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 54, characters 18-30:
 54 | module TYPE : sig type t = int end = struct type t = int [@@deprecated] end
-                       <alert>^^^^^^^^^^^^</alert>
+                       ^^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 60, characters 0-52:
 60 | struct class c = object end [@@deprecated "FOO"] end
-     <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: c
 FOO
 File "deprecated_module_assigment.ml", line 60, characters 7-48:
 60 | struct class c = object end [@@deprecated "FOO"] end
-            <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 59, characters 4-24:
 59 | sig class c : object end end =
-         <alert>^^^^^^^^^^^^^^^^^^^^</alert>
+         ^^^^^^^^^^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 64, characters 0-57:
 64 | struct class type c = object end [@@deprecated "FOO"] end
-     <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: c
 FOO
 File "deprecated_module_assigment.ml", line 64, characters 7-53:
 64 | struct class type c = object end [@@deprecated "FOO"] end
-            <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 63, characters 4-29:
 63 | sig class type c = object end end =
-         <alert>^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+         ^^^^^^^^^^^^^^^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 71, characters 0-55:
 71 | struct module type S = sig end [@@deprecated "FOO"] end
-     <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: S
 FOO
 File "deprecated_module_assigment.ml", line 71, characters 7-51:
 71 | struct module type S = sig end [@@deprecated "FOO"] end
-            <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 70, characters 4-27:
 70 | sig module type S = sig end end =
-         <alert>^^^^^^^^^^^^^^^^^^^^^^^</alert>
+         ^^^^^^^^^^^^^^^^^^^^^^^
   Expected signature
 File "deprecated_module_assigment.ml", line 82, characters 0-53:
 82 | struct module M = struct end [@@deprecated "FOO"] end
-     <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Alert deprecated: M
 FOO
 File "deprecated_module_assigment.ml", line 82, characters 7-49:
 82 | struct module M = struct end [@@deprecated "FOO"] end
-            <alert>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</alert>
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Definition
 File "deprecated_module_assigment.ml", line 81, characters 4-22:
 81 | sig module M : sig end end =
-         <alert>^^^^^^^^^^^^^^^^^^</alert>
+         ^^^^^^^^^^^^^^^^^^
   Expected signature

--- a/testsuite/tests/warnings/deprecated_module_use.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module_use.compilers.reference
@@ -1,6 +1,6 @@
 File "deprecated_module_use.ml", line 18, characters 5-22:
 18 | open Deprecated_module
-          <alert>^^^^^^^^^^^^^^^^^</alert>
+          ^^^^^^^^^^^^^^^^^
 Alert deprecated: module Deprecated_module
 
   As you could guess, Deprecated_module is deprecated.
@@ -8,17 +8,17 @@ Alert deprecated: module Deprecated_module
 
 File "deprecated_module_use.ml", line 20, characters 9-12:
 20 | type s = M.t
-              <alert>^^^</alert>
+              ^^^
 Alert deprecated: module Deprecated_module.M
 File "deprecated_module_use.ml", line 20, characters 9-12:
 20 | type s = M.t
-              <alert>^^^</alert>
+              ^^^
 Alert deprecated: Deprecated_module.M.t
 File "deprecated_module_use.ml", line 22, characters 5-6:
 22 | open M
-          <alert>^</alert>
+          ^
 Alert deprecated: module Deprecated_module.M
 File "deprecated_module_use.ml", line 23, characters 8-9:
 23 | let _ = x
-             <alert>^</alert>
+             ^
 Alert deprecated: Deprecated_module.M.x

--- a/testsuite/tests/warnings/w03.compilers.reference
+++ b/testsuite/tests/warnings/w03.compilers.reference
@@ -1,6 +1,6 @@
 File "w03.ml", line 14, characters 8-9:
 14 | let _ = A
-             <alert>^</alert>
+             ^
 Alert deprecated: A
 File "w03.ml", line 17, characters 12-26:
 17 | exception B [@@deprecated]


### PR DESCRIPTION
Fixes a bug of #1804 (since the highlighting color & tag of warnings is reused for alerts, the `alert` highlight tag does not exist, and the warnings one must be used instead).

cc @alainfrisch 