### PR TITLE
Generalized open: fix another expansiveness bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,8 +9,8 @@ Working version
   (Thomas Refis, with help and review from Alain Frisch, Gabriel Scherer, Jeremy
   Yallop, Leo White and Luc Maranget)
 
-- GPR#1506, GPR#2147, GPR#2166: Extended open to arbitrary module expression in
-  structures and to applicative paths in signatures
+- GPR#1506, GPR#2147, GPR#2166, GPR#2167: Extended open to arbitrary module
+  expression in structures and to applicative paths in signatures
   (Runhang Li, review by Alain Frisch, Florian Angeletti, Jeremy Yallop,
   Leo White and Thomas Refis)
 

--- a/testsuite/tests/generalized-open/expansiveness.ml
+++ b/testsuite/tests/generalized-open/expansiveness.ml
@@ -80,3 +80,14 @@ let kM =
 val k : '_weak3 -> '_weak3 = <fun>
 val kM : '_weak4 -> '_weak4 = <fun>
 |}]
+
+let op =
+  let module M = struct
+      open struct let r = ref [] end
+      let s = r
+  end in
+  M.s
+;;
+[%%expect{|
+val op : '_weak5 list ref = {contents = []}
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1873,10 +1873,11 @@ and is_nonexpansive_mod mexp =
       List.for_all
         (fun item -> match item.str_desc with
           | Tstr_eval _ | Tstr_primitive _ | Tstr_type _
-          | Tstr_modtype _ | Tstr_open _ | Tstr_class_type _  -> true
+          | Tstr_modtype _ | Tstr_class_type _  -> true
           | Tstr_value (_, pat_exp_list) ->
               List.for_all (fun vb -> is_nonexpansive vb.vb_expr) pat_exp_list
           | Tstr_module {mb_expr=m;_}
+          | Tstr_open {open_expr=m;_}
           | Tstr_include {incl_mod=m;_} -> is_nonexpansive_mod m
           | Tstr_recmodule id_mod_list ->
               List.for_all (fun {mb_expr=m;_} -> is_nonexpansive_mod m)


### PR DESCRIPTION
[Related: #1506, #2147, #2166].

Now that `open` accepts an arbitrary module expression, the structure item `open M` should only be considered nonexpansive if `M` is nonexpansive.

Before this PR:
```ocaml
# let f = let module M = struct open struct let r = ref [] end let s = r end in M.s;;
val f : 'a list ref = {contents = []}
# f := [3];;
- : unit = ()
# List.hd f.contents ^ "two";; 
Segmentation fault
```
After this PR:
```ocaml
# let f = let module M = struct open struct let r = ref [] end let s = r end in M.s;;
val f : '_weak1 list ref = {contents = []}
```