### PR TITLE
Avoid page table lookup in Hashtbl.hash with no-naked-pointers

### DIFF
--- a/Changes
+++ b/Changes
@@ -926,6 +926,9 @@ OCaml 4.08.0 (13 June 2019)
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
+- #2168: Avoid page table lookup in Hashtbl.hash with no-naked-pointers
+  (Sam Goldman, review by Frédéric Bour)
+
 - #7829, #8585: Fix pointer comparisons in freelist.c (for 32-bit platforms)
   (David Allsopp and Damien Doligez)
 

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -36,10 +36,15 @@
 #define Is_in_value_area(a)                                     \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
 
+#ifdef NATIVE_CODE
 #define Is_in_code_area(pc) \
  (    ((char *)(pc) >= caml_code_area_start && \
        (char *)(pc) <= caml_code_area_end)     \
    || (Classify_addr(pc) & In_code_area) )
+
+#else
+#define Is_in_code_area(pc) (Classify_addr(pc) & In_code_area)
+#endif
 
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
 

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -51,6 +51,7 @@ void caml_init_code_fragments(void) {
   cf->digest_computed = 1;
   caml_ext_table_init(&caml_code_fragments_table, 8);
   caml_ext_table_add(&caml_code_fragments_table, cf);
+  caml_page_table_add(In_code_area, cf->code_start, cf->code_end);
 }
 
 void caml_load_code(int fd, asize_t len)

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -110,6 +110,7 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
     cf->digest_computed = 0;
   }
   caml_ext_table_add(&caml_code_fragments_table, cf);
+  caml_page_table_add(In_code_area, cf->code_start, cf->code_end);
 
 #ifdef ARCH_BIG_ENDIAN
   caml_fixup_endianness((code_t) prog, len);
@@ -156,6 +157,7 @@ CAMLprim value caml_static_release_bytecode(value bc)
   caml_debugger(CODE_UNLOADED, Val_long(index));
 
   caml_ext_table_remove(&caml_code_fragments_table, cf);
+  caml_page_table_remove(In_code_area, cf->code_start, cf->code_end);
 
 #ifndef NATIVE_CODE
   caml_release_bytecode(prog, len);

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -84,6 +84,7 @@ static void init_static(void)
   cf->digest_computed = 0;
   caml_ext_table_init(&caml_code_fragments_table, 8);
   caml_ext_table_add(&caml_code_fragments_table, cf);
+  caml_page_table_add(In_code_area, cf->code_start, cf->code_end);
 }
 
 /* These are termination hooks used by the systhreads library */


### PR DESCRIPTION
This change is in the same vein as #2079, which avoids interrogating the page table during polymorphic compare in no-naked-pointers mode, where all non-immediate values can be assumed to be pointers to valid data.

Unlike polymorphic compare, polymorphic hash supports functional values which can include code pointers. To handle this case, we still check the fields of closures specifically. Code which does not hash closures does not pay the cost of the page table, however.

In testing this work, I noticed that (a) code segments were not reliably registered in the page table and (b) the `Is_in_code_area` macro was invalid in bytecode. This change also fixes these issues.

I've profiled both Hack (hacklang.org) and Flow (flow.org) with this change, and while I did see a reduction in CPU time spent in polymorphic hash, the performance improvement was not significant. Instead, my motivation for this change is to support storing OCaml values outside the OCaml heap as a kind of ancient generation, while still supporting this polymorphic operation on the off-heap values.

I also note that this is potentially a breaking change. Before this change, a closure's fields would be pushed onto the queue, while this change hashes the code pointers immediately. However, since code pointers are already unstable (change between invocations) it's unlikely that anyone actually expects stability of these hashes.