### PR TITLE
Add assembler option for ppc64le in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -481,6 +481,10 @@ Working version
 - GPR#2148: fix a parallel build bug involving CamlinternalLazy.
   (Stephen Dolan, review by Gabriel Scherer and Nicolas Ojeda Bar)
 
+- GPR#2171: change configure for ppc64le to pass command-line option
+  -mpower8 instead of -mppc64 to the assembler.
+  (Greta Yorsh, review by ?)
+
 ### Internal/compiler-libs changes:
 
 - GPR#292: use Menhir as the parser generator for the OCaml parser.

--- a/configure
+++ b/configure
@@ -942,13 +942,15 @@ case "$arch,$system" in
                   aspp="${TOOLPREF}gcc -m64 -c";;
   i386,solaris)   as="${TOOLPREF}as"
                   aspp="${TOOLPREF}gcc -c";;
-  power,elf)      if $arch64; then
-                    as="${TOOLPREF}as -a64 -mppc64"
-                    aspp="${TOOLPREF}gcc -m64 -c"
-                  else
-                    as="${TOOLPREF}as -mppc"
-                    aspp="${TOOLPREF}gcc -m32 -c"
-                  fi;;
+  power,elf)
+                  case "$model" in
+                      ppc64le) as="${TOOLPREF}as -a64 -mpower8"
+                               aspp="${TOOLPREF}gcc -m64 -mcpu=powerpc64le -c";;
+                      ppc64)   as="${TOOLPREF}as -a64 -mppc64"
+                               aspp="${TOOLPREF}gcc -m64 -c";;
+                      ppc)     as="${TOOLPREF}as -mppc"
+                               aspp="${TOOLPREF}gcc -m32 -c";;
+                  esac;;
   s390x,elf)      as="${TOOLPREF}as -m 64 -march=$model"
                   aspp="${TOOLPREF}gcc -c -Wa,-march=$model";;
   arm,freebsd)    as="${TOOLPREF}cc -c"


### PR DESCRIPTION
Change configure for ppc64le to pass command-line option -mpower8 instead of -mppc64 to the assembler. This is a more accurate option to pass in this case, and it enables additional instructions, which we will propose the use of in the future.

This change built successfully on precheck.
