### PR TITLE
Windows - Stdlib: Format function always uses LF newlines

### DIFF
--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -818,9 +818,13 @@ let pp_set_formatter_output_functions state f g =
 let pp_get_formatter_output_functions state () =
   (state.pp_out_string, state.pp_out_flush)
 
+let newline =
+    match Sys.win32 with
+    | true -> "\r\n"
+    | false -> "\n"
 
 (* The default function to output new lines. *)
-let display_newline state () = state.pp_out_string "\n" 0  1
+let display_newline state () = state.pp_out_string newline 0  1
 
 (* The default function to output spaces. *)
 let blank_line = String.make 80 ' '


### PR DESCRIPTION
The `Format` standard library module always uses `\n` for newlines.

This came up in facebook/reason#1518 - the  `Format` module is used to pretty-print and output to a file. Some related discussion there.

I believe that, on Windows, we'd want to use the CRLF `\r\n` character for newlines - are there any concerns with making this change?

In addition, I was wondering if it would make sense to expose the platform newline via the stdlib via `Sys.eol`? It might already be available in a module, but I was unable to find it.

Please let me know if you have any feedback or concerns.

Thank you!