### PR TITLE
Apply substitution to all modules when packing

### DIFF
--- a/Changes
+++ b/Changes
@@ -703,6 +703,8 @@ Working version
 - GPR#2131: fix wrong calls to Env.normalize_path on non-module paths
   (Alain Frisch, review by Jacques Garrigue)
 
+- GPR#2175: Apply substitution to all modules when packing
+  (Leo White, review by Gabriel Scherer)
 
 OCaml 4.07.1 (4 October 2018)
 -----------------------------


### PR DESCRIPTION
When creating the resulting module type from `-pack` the substitution to rewrite internal names to external names was only being applied in link order. Most of the time that works, but interface dependencies do not always follow the same ordering as implementation dependencies so really the substitution needs to be applied to all the packed modules. In particular, before this PR it was easy to accidentally create a pack containing an mli-only module which still contained references to the internal name of the module -- resulting in vary confusing type errors.