### PR TITLE
Use emulated fma on Cygwin64

### DIFF
--- a/Changes
+++ b/Changes
@@ -202,7 +202,7 @@ OCaml 4.08.0
   min_max_num to module Float.
   (Christophe Troestler, review by Alain Frish, Xavier Clerc and Daniel Bünzli)
 
-- GPR#1354: Add fma support to Float module.
+- GPR#1354, GPR#2177: Add fma support to Float module.
   (Laurent Thévenoux, review by Alain Frisch, Jacques-Henri Jourdan,
   Xavier Leroy)
 

--- a/configure
+++ b/configure
@@ -13965,6 +13965,13 @@ fi
   ac_fn_c_check_func "$LINENO" "fma" "ac_cv_func_fma"
 if test "x$ac_cv_func_fma" = xyes; then :
 
+      case $target in #(
+  x86_64-*-cygwin) :
+     ;; #(
+  *) :
+    $as_echo "#define HAS_WORKING_FMA 1" >>confdefs.h
+ ;;
+esac
 else
   has_c99_float_ops=false
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1003,7 +1003,9 @@ AS_CASE([$host],
   AS_IF([$has_c99_float_ops],
     [AC_CHECK_FUNC([hypot], [], [has_c99_float_ops=false])])
   AS_IF([$has_c99_float_ops],
-    [AC_CHECK_FUNC([fma], [], [has_c99_float_ops=false])])
+    [AC_CHECK_FUNC([fma], [
+      AS_CASE([$target],[x86_64-*-cygwin],[],[AC_DEFINE([HAS_WORKING_FMA])])],
+      [has_c99_float_ops=false])])
   AS_IF([$has_c99_float_ops],
     [AC_CHECK_FUNC([copysign], [AC_DEFINE([HAS_C99_FLOAT_OPS])])])])
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -51,6 +51,11 @@
 /* Define HAS_C99_FLOAT_OPS if <math.h> conforms to ISO C99.
    In particular, it should provide expm1(), log1p(), hypot(), copysign(). */
 
+#undef HAS_WORKING_FMA
+
+/* Define HAS_WORKING_FMA if the fma function is correctly implemented. The
+   newlib library (intentionally) just has return x * y + z. */
+
 #undef HAS_GETRUSAGE
 
 #undef HAS_TIMES

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -523,7 +523,7 @@ CAMLprim value caml_nextafter_float(value x, value y)
   return caml_copy_double(caml_nextafter(Double_val(x), Double_val(y)));
 }
 
-#ifndef HAS_C99_FLOAT_OPS
+#ifndef HAS_WORKING_FMA
 union double_as_int64 { double d; uint64_t i; };
 #define IEEE754_DOUBLE_BIAS 0x3ff
 #define IEEE_EXPONENT(N) (((N) >> 52) & 0x7ff)
@@ -540,7 +540,7 @@ union double_as_int64 { double d; uint64_t i; };
 
 CAMLexport double caml_fma(double x, double y, double z)
 {
-#ifdef HAS_C99_FLOAT_OPS
+#ifdef HAS_WORKING_FMA
   return fma(x, y, z);
 #else // Emulation of FMA, from S. Boldo and G. Melquiond, "Emulation
       // of a FMA and Correctly Rounded Sums: Proved Algorithms Using


### PR DESCRIPTION
Cygwin is based on newlib, not glibc, and the `fma` function is not implemented (well, it is just `return x * y + z;`). Split off `HAS_WORKING_FMA` from `HAS_C99_FLOAT_OPS`. Disable `fma` for Cygwin64 so that the fma test passes.

Cygwin32 has the same limitation, but because the intermediate result is placed in an 80 bit fp reg (unless `-ffloat-store` is given), then the fma tests pass, which is why this went unnoticed in #1354.

I have two questions:
 - Should the fma test include a case which fails with an 80 bit intermediate? This would force a failure on Cygwin32?
 - Should Cygwin32 also be using the emulation for FMA, regardless of the answer to the previous?