### PR TITLE
make alldepend

### DIFF
--- a/.depend
+++ b/.depend
@@ -485,11 +485,6 @@ typing/typedtreeIter.cmo : typing/typedtree.cmi utils/misc.cmi \
 typing/typedtreeIter.cmx : typing/typedtree.cmx utils/misc.cmx \
     parsing/asttypes.cmi typing/typedtreeIter.cmi
 typing/typedtreeIter.cmi : typing/typedtree.cmi parsing/asttypes.cmi
-typing/typedtreeMap.cmo : typing/typedtree.cmi utils/misc.cmi \
-    typing/typedtreeMap.cmi
-typing/typedtreeMap.cmx : typing/typedtree.cmx utils/misc.cmx \
-    typing/typedtreeMap.cmi
-typing/typedtreeMap.cmi : typing/typedtree.cmi
 typing/typemod.cmo : utils/warnings.cmi typing/typetexp.cmi typing/types.cmi \
     typing/typedtree.cmi typing/typedecl.cmi typing/typecore.cmi \
     typing/typeclass.cmi typing/subst.cmi typing/stypes.cmi \

--- a/otherlibs/threads/.depend
+++ b/otherlibs/threads/.depend
@@ -23,13 +23,15 @@ marshal.cmx :
 mutex.cmo : thread.cmi mutex.cmi
 mutex.cmx : thread.cmx mutex.cmi
 mutex.cmi :
-stdlib.cmo : unix.cmo marshal.cmo
-stdlib.cmx : unix.cmx marshal.cmx
-thread.cmo : unix.cmo thread.cmi
+stdlib.cmo : unix.cmi marshal.cmo stdlib.cmi
+stdlib.cmx : unix.cmx marshal.cmx stdlib.cmi
+stdlib.cmi : marshal.cmo
+thread.cmo : unix.cmi thread.cmi
 thread.cmx : unix.cmx thread.cmi
-thread.cmi : unix.cmo
-threadUnix.cmo : unix.cmo thread.cmi threadUnix.cmi
+thread.cmi : unix.cmi
+threadUnix.cmo : unix.cmi thread.cmi threadUnix.cmi
 threadUnix.cmx : unix.cmx thread.cmx threadUnix.cmi
-threadUnix.cmi : unix.cmo
-unix.cmo : stdlib.cmo
-unix.cmx : stdlib.cmx
+threadUnix.cmi : unix.cmi
+unix.cmo : stdlib.cmi unix.cmi
+unix.cmx : stdlib.cmx unix.cmi
+unix.cmi : stdlib.cmi

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -69,9 +69,9 @@ stdlib__filename.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__random.cmi std
 stdlib__filename.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__random.cmx stdlib__printf.cmx stdlib__lazy.cmx stdlib__buffer.cmx \
     stdlib__filename.cmi
 stdlib__filename.cmi :
-stdlib__float.cmo : stdlib.cmi stdlib__float.cmi
-stdlib__float.cmx : stdlib.cmx stdlib__float.cmi
-stdlib__float.cmi : stdlib.cmi
+stdlib__float.cmo : stdlib.cmi stdlib__seq.cmi stdlib__list.cmi stdlib__array.cmi stdlib__float.cmi
+stdlib__float.cmx : stdlib.cmx stdlib__seq.cmx stdlib__list.cmx stdlib__array.cmx stdlib__float.cmi
+stdlib__float.cmi : stdlib.cmi stdlib__seq.cmi
 stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__queue.cmi stdlib__list.cmi stdlib__int.cmi \
     camlinternalFormatBasics.cmi camlinternalFormat.cmi stdlib__buffer.cmi stdlib__format.cmi
 stdlib__format.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx stdlib__int.cmx \
@@ -264,8 +264,8 @@ stdlib__filename.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__random.cmi std
     stdlib__filename.cmi
 stdlib__filename.p.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__random.cmx stdlib__printf.cmx stdlib__lazy.cmx stdlib__buffer.cmx \
     stdlib__filename.cmi
-stdlib__float.cmo : stdlib.cmi stdlib__float.cmi
-stdlib__float.p.cmx : stdlib.cmx stdlib__float.cmi
+stdlib__float.cmo : stdlib.cmi stdlib__seq.cmi stdlib__list.cmi stdlib__array.cmi stdlib__float.cmi
+stdlib__float.p.cmx : stdlib.cmx stdlib__seq.cmx stdlib__list.cmx stdlib__array.cmx stdlib__float.cmi
 stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__queue.cmi stdlib__list.cmi stdlib__int.cmi \
     camlinternalFormatBasics.cmi camlinternalFormat.cmi stdlib__buffer.cmi stdlib__format.cmi
 stdlib__format.p.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx stdlib__int.cmx \


### PR DESCRIPTION
This seems to fix the parallel build of world.opt on my machine.

Also, the changes look reasonable.

Ping @gasche (who  ran `make depend` recently)