### PR TITLE
Fix caml_make_float_vect

### DIFF
--- a/Changes
+++ b/Changes
@@ -184,6 +184,9 @@ Working version
   hint that can emit non-whitespace characters.
   (Vladimir Keleshev and Pierre Weis, review by Josh Berdine, Gabriel Radanne)
 
+- GPR#2183: Fix segfault in Array.create_float with -no-flat-float-array
+  (Damien Doligez, review by Gabriel Scherer and Jeremy Yallop)
+
 - GPR#2185: Add `List.filter_map`
   (Thomas Refis, review by Alain Frisch and Gabriel Scherer)
 

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -275,7 +275,7 @@ CAMLprim value caml_floatarray_create(value len)
 #undef Setup_for_gc
 #undef Restore_after_gc
   }else if (wosize > Max_wosize)
-    caml_invalid_argument("Array.Floatarray.create");
+    caml_invalid_argument("Float.Array.create");
   else {
     result = caml_alloc_shr (wosize, Double_array_tag);
     result = caml_check_urgent_gc (result);

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -290,7 +290,18 @@ CAMLprim value caml_make_float_vect(value len)
 #ifdef FLAT_FLOAT_ARRAY
   return caml_floatarray_create (len);
 #else
-  return caml_alloc (Long_val (len), 0);
+  CAMLparam0 ();
+  CAMLlocal2 (result, x);
+  mlsize_t wosize = Long_val (len);
+  mlsize_t i;
+
+  if (wosize > Max_wosize) caml_invalid_argument ("Array.create_float");
+  result = caml_alloc (Long_val (len), 0);
+  for (i = 0; i < wosize; i++){
+    x = caml_alloc_small (Double_wosize, Double_tag);
+    Store_field (result, i, x);
+  }
+  CAMLreturn (result);
 #endif
 }
 

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -335,10 +335,6 @@ CAMLprim value caml_make_vect(value len, value init)
   CAMLreturn (res);
 }
 
-#ifndef FLAT_FLOAT_ARRAY
-static value uninitialized_float = Val_unit;
-#endif
-
 /* [len] is a [value] representing number of floats */
 /* [ int -> float array ] */
 CAMLprim value caml_make_float_vect(value len)
@@ -346,9 +342,10 @@ CAMLprim value caml_make_float_vect(value len)
 #ifdef FLAT_FLOAT_ARRAY
   return caml_floatarray_create (len);
 #else
+  static value uninitialized_float = Val_unit;
   if (uninitialized_float == Val_unit){
-    caml_register_global_root (&uninitialized_float);
     uninitialized_float = caml_alloc_shr (Double_wosize, Double_tag);
+    caml_register_generational_global_root (&uninitialized_float);
   }
   return caml_make_vect (len, uninitialized_float);
 #endif


### PR DESCRIPTION
This PR fixes bugs revealed by the test file of #1936.

When OCaml is configured with `-no-flat-float-array`, the `Array.create_float` primitive is completely wrong:

Before this patch:
```
ocaml
        OCaml version 4.08.0+dev0-2018-04-09

# Array.create_float (-1);;
Out of memory during evaluation.
# Array.create_float 3;;
Segmentation fault: 11
```

After this patch:
```
ocaml
        OCaml version 4.08.0+dev0-2018-04-09

# Array.create_float (-1);;
Exception: Invalid_argument "Array.create_float".
# Array.create_float 3;;
- : float array = [|0.; 0.; 0.|]
```

cc @gasche
