### PR TITLE
graphic documentation: images are bound to windows

### DIFF
--- a/otherlibs/graph/graphics.mli
+++ b/otherlibs/graph/graphics.mli
@@ -237,7 +237,10 @@ val fill_circle : int -> int -> int -> unit
 
 type image
 (** The abstract type for images, in internal representation.
-   Externally, images are represented as matrices of colors. *)
+   Externally, images are represented as matrices of colors.
+   Images are bound to the current graphics window and should not be reused
+   after closing this graphics window with {!close_graph}.
+*)
 
 val transp : color
 (** In matrices of colors, this color represent a 'transparent'


### PR DESCRIPTION
This small PR documents the fact that reusing a `Graphics.image` after closing the current graphics window can raise an error (BadDrawable on the X11 implementation).