### PR TITLE
Improve error message when bytecode program runs out of fds

### DIFF
--- a/Changes
+++ b/Changes
@@ -65,6 +65,9 @@ OCaml 4.12.0
 
 ### Runtime system:
 
+- #2195: Improve error message in bytecode stack trace printing
+  (David Allsopp, review by Gabriel Scherer and Xavier Leroy)
+
 - #9756: garbage collector colors change
   removes the gray color from the major gc
   (Sadiq Jaffer and Stephen Dolan reviewed by Xavier Leroy,

--- a/Changes
+++ b/Changes
@@ -65,7 +65,8 @@ OCaml 4.12.0
 
 ### Runtime system:
 
-- #2195: Improve error message in bytecode stack trace printing
+- #2195: Improve error message in bytecode stack trace printing and load
+  debug information during bytecode startup if OCAMLRUNPARAM=b=2.
   (David Allsopp, review by Gabriel Scherer and Xavier Leroy)
 
 - #9756: garbage collector colors change

--- a/manual/manual/cmds/runtime.etex
+++ b/manual/manual/cmds/runtime.etex
@@ -112,8 +112,13 @@ The following environment variables are also consulted:
 \fi
   \begin{options}
   \item[b] (backtrace) Trigger the printing of a stack backtrace
-        when an uncaught exception aborts the program.
-        This option takes no argument.
+        when an uncaught exception aborts the program. An optional argument can
+        be provided: "b=0" turns backtrace printing off; "b=1" is equivalent to
+        "b" and turns backtrace printing on; "b=2" turns backtrace printing on
+        and forces the runtime system to load debugging information at program
+        startup time instead of at backtrace printing time. "b=2" can be used if
+        the runtime is unable to load debugging information at backtrace
+        printing time, for example if there are no file descriptors available.
   \item[p] (parser trace) Turn on debugging support for
         "ocamlyacc"-generated parsers.  When this option is on,
         the pushdown automaton that executes the parsers prints a

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -123,6 +123,7 @@ CAMLexport void caml_print_exception_backtrace(void)
     }
   }
 
+  /* See also printexc.ml */
   switch (caml_debug_info_status()) {
   case FILE_NOT_FOUND:
     fprintf(stderr,
@@ -143,7 +144,7 @@ CAMLexport void caml_print_exception_backtrace(void)
     fprintf(stderr,
             "(Cannot print locations:\n "
              "bytecode executable program file cannot be opened;\n "
-             "-- too many open files)\n");
+             "-- too many open files. Try running with OCAMLRUNPARAM=b=2)\n");
     break;
   }
 }

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -27,6 +27,7 @@
 #include "caml/backtrace_prim.h"
 #include "caml/fail.h"
 #include "caml/debugger.h"
+#include "caml/startup.h"
 
 void caml_init_backtrace(void)
 {
@@ -121,6 +122,37 @@ CAMLexport void caml_print_exception_backtrace(void)
       print_location(&li, i);
     }
   }
+
+  switch (caml_debug_info_status()) {
+  case FILE_NOT_FOUND:
+    fprintf(stderr,
+            "(Cannot print locations:\n "
+             "bytecode executable program file not found)\n");
+    break;
+  case BAD_BYTECODE:
+    fprintf(stderr,
+            "(Cannot print locations:\n "
+             "bytecode executable program file appears to be corrupt)\n");
+    break;
+  case WRONG_MAGIC:
+    fprintf(stderr,
+            "(Cannot print locations:\n "
+             "bytecode executable program file has wrong magic number)\n");
+    break;
+  case NO_FDS:
+    fprintf(stderr,
+            "(Cannot print locations:\n "
+             "bytecode executable program file cannot be opened;\n "
+             "-- too many open files)\n");
+    break;
+  }
+}
+
+/* Return the status of loading backtrace information (error reporting in
+   bytecode) */
+CAMLprim value caml_ml_debug_info_status(value unit)
+{
+  return Val_int(caml_debug_info_status());
 }
 
 /* Get a copy of the latest backtrace */

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -377,8 +377,9 @@ static void read_main_debug_info(struct debug_info *di)
   }
 
   fd = caml_attempt_open(&exec_name, &trail, 1);
-  if (fd < 0){
-    caml_fatal_error ("executable program file not found");
+  if (fd < 0) {
+    /* Record the failure of caml_attempt_open in di->already-read */
+    di->already_read = fd;
     CAMLreturn0;
   }
 
@@ -407,6 +408,8 @@ static void read_main_debug_info(struct debug_info *di)
     caml_close_channel(chan);
 
     di->events = process_debug_events(caml_start_code, events, &di->num_events);
+  } else {
+    close(fd);
   }
 
   CAMLreturn0;
@@ -421,6 +424,15 @@ CAMLexport void caml_init_debug_info(void)
 int caml_debug_info_available(void)
 {
   return (caml_debug_info.size != 0);
+}
+
+int caml_debug_info_status(void)
+{
+  if (!caml_debug_info_available()) {
+    return 0;
+  } else {
+    return ((struct debug_info *)caml_debug_info.contents[0])->already_read;
+  }
 }
 
 /* Search the event index for the given PC.  Return -1 if not found. */

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -421,6 +421,13 @@ CAMLexport void caml_init_debug_info(void)
   caml_add_debug_info(caml_start_code, Val_long(caml_code_size), Val_unit);
 }
 
+CAMLexport void caml_load_main_debug_info(void)
+{
+  if (Caml_state->backtrace_active > 1) {
+    read_main_debug_info(caml_debug_info.contents[0]);
+  }
+}
+
 int caml_debug_info_available(void)
 {
   return (caml_debug_info.size != 0);

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -295,3 +295,8 @@ int caml_debug_info_available(void)
 {
   return 1;
 }
+
+int caml_debug_info_status(void)
+{
+  return 1;
+}

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -109,6 +109,7 @@ CAMLextern char_os * caml_cds_file;
  * different prototype. */
 extern void caml_stash_backtrace(value exn, value * sp, int reraise);
 
+CAMLextern void caml_load_main_debug_info(void);
 #endif
 
 

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -52,6 +52,12 @@ typedef void * debuginfo;
  * Relevant for bytecode, always true for native code. */
 int caml_debug_info_available(void);
 
+/* Check load status of debug information for the main program. This is always 1
+ * for native code. For bytecode, it is 1 if the debug information has been
+ * loaded, 0 if it has not been loaded or one of the error constants in
+ * startup.h if something went wrong loading the debug information. */
+int caml_debug_info_status(void);
+
 /* Return debuginfo associated to a slot or NULL. */
 debuginfo caml_debuginfo_extract(backtrace_slot slot);
 

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -35,7 +35,8 @@ CAMLextern value caml_startup_code_exn(
   int pooling,
   char_os **argv);
 
-enum { FILE_NOT_FOUND = -1, BAD_BYTECODE = -2, WRONG_MAGIC = -3 };
+/* These enum members should all be negative */
+enum { FILE_NOT_FOUND = -1, BAD_BYTECODE = -2, WRONG_MAGIC = -3, NO_FDS = -4 };
 
 extern int caml_attempt_open(char_os **name, struct exec_trailer *trail,
                              int do_open_script);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -111,7 +111,7 @@ void caml_parse_ocamlrunparam(void)
       switch (*opt++){
       case 'a': scanmult (opt, &p); caml_set_allocation_policy ((intnat) p);
         break;
-      case 'b': scanmult (opt, &p); caml_record_backtrace(Val_bool (p));
+      case 'b': scanmult (opt, &p); caml_record_backtrace(Val_int (p));
         break;
       case 'c': scanmult (opt, &p); caml_cleanup_on_exit = (p != 0); break;
       case 'h': scanmult (opt, &caml_init_heap_wsz); break;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -454,6 +454,8 @@ CAMLexport void caml_main(char_os **argv)
   caml_oldify_mopup ();
   /* Initialize system libraries */
   caml_sys_init(exe_name, argv + pos);
+  /* Load debugging info, if b>=2 */
+  caml_load_main_debug_info();
 #ifdef _WIN32
   /* Start a thread to handle signals */
   if (caml_secure_getenv(T("CAMLSIGPIPE")))
@@ -545,6 +547,8 @@ CAMLexport value caml_startup_code_exn(
   caml_section_table_size = section_table_size;
   /* Initialize system libraries */
   caml_sys_init(exe_name, argv);
+  /* Load debugging info, if b>=2 */
+  caml_load_main_debug_info();
   /* Execute the program */
   caml_debugger(PROGRAM_START, Val_unit);
   return caml_interprete(caml_start_code, caml_code_size);

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -17,6 +17,7 @@
 
 /* Start-up code */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -128,7 +129,10 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
   if (fd == -1) {
     caml_stat_free(truename);
     caml_gc_message(0x100, "Cannot open file\n");
-    return FILE_NOT_FOUND;
+    if (errno == EMFILE)
+      return NO_FDS;
+    else
+      return FILE_NOT_FOUND;
   }
   if (!do_open_script) {
     err = read (fd, buf, 2);

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -301,7 +301,7 @@ let errors = [| "";
   (* NO_FDS *)
   "(Cannot print locations:\n \
       bytecode executable program file cannot be opened;\n \
-      -- too many open files)"
+      -- too many open files. Try running with OCAMLRUNPARAM=b=2)"
 |]
 
 let default_uncaught_exception_handler exn raw_backtrace =

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -285,9 +285,31 @@ let exn_slot_name x =
   let slot = exn_slot x in
   (Obj.obj (Obj.field slot 0) : string)
 
+external get_debug_info_status : unit -> int = "caml_ml_debug_info_status"
+
+(* Descriptions for errors in startup.h. See also backtrace.c *)
+let errors = [| "";
+  (* FILE_NOT_FOUND *)
+  "(Cannot print locations:\n \
+      bytecode executable program file not found)";
+  (* BAD_BYTECODE *)
+  "(Cannot print locations:\n \
+      bytecode executable program file appears to be corrupt)";
+  (* WRONG_MAGIC *)
+  "(Cannot print locations:\n \
+      bytecode executable program file has wrong magic number)";
+  (* NO_FDS *)
+  "(Cannot print locations:\n \
+      bytecode executable program file cannot be opened;\n \
+      -- too many open files)"
+|]
+
 let default_uncaught_exception_handler exn raw_backtrace =
   eprintf "Fatal error: exception %s\n" (to_string exn);
   print_raw_backtrace stderr raw_backtrace;
+  let status = get_debug_info_status () in
+  if status < 0 then
+    prerr_endline errors.(abs status);
   flush stderr
 
 let uncaught_exception_handler = ref default_uncaught_exception_handler

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,5 +1,4 @@
 Fatal error: exception Stdlib.Exit
 Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 399, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 404, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195-nolocs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-nolocs.byte.reference
@@ -3,4 +3,4 @@ Raised by primitive operation at unknown location
 Called from unknown location
 (Cannot print locations:
  bytecode executable program file cannot be opened;
- -- too many open files)
+ -- too many open files. Try running with OCAMLRUNPARAM=b=2)

--- a/testsuite/tests/backtrace/pr2195.byte.reference
+++ b/testsuite/tests/backtrace/pr2195.byte.reference
@@ -1,0 +1,6 @@
+Fatal error: exception Stdlib.Exit
+Raised by primitive operation at unknown location
+Called from unknown location
+(Cannot print locations:
+ bytecode executable program file cannot be opened;
+ -- too many open files)

--- a/testsuite/tests/backtrace/pr2195.ml
+++ b/testsuite/tests/backtrace/pr2195.ml
@@ -1,0 +1,22 @@
+(* TEST
+   flags += "-g"
+   exit_status = "2"
+   * bytecode
+     reference = "${test_source_directory}/pr2195.byte.reference"
+   * native
+     reference = "${test_source_directory}/pr2195.opt.reference"
+     compare_programs = "false"
+*)
+
+let () =
+  Printexc.record_backtrace true;
+  let c = open_out "foo" in
+  close_out c;
+  try
+    while true do
+      open_in "foo" |> ignore
+    done
+  with Sys_error _ ->
+    (* The message is platform-specific, so convert the exception to Exit *)
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace Exit bt

--- a/testsuite/tests/backtrace/pr2195.ml
+++ b/testsuite/tests/backtrace/pr2195.ml
@@ -2,7 +2,14 @@
    flags += "-g"
    exit_status = "2"
    * bytecode
-     reference = "${test_source_directory}/pr2195.byte.reference"
+     ocamlrunparam += ",b=0"
+     reference = "${test_source_directory}/pr2195-nolocs.byte.reference"
+   * bytecode
+     ocamlrunparam += ",b=1"
+     reference = "${test_source_directory}/pr2195-nolocs.byte.reference"
+   * bytecode
+     ocamlrunparam += ",b=2"
+     reference = "${test_source_directory}/pr2195-locs.byte.reference"
    * native
      reference = "${test_source_directory}/pr2195.opt.reference"
      compare_programs = "false"

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,0 +1,5 @@
+Fatal error: exception Stdlib.Exit
+Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 399, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml" (inlined), line 404, characters 2-45
+Called from Pr2195 in file "pr2195.ml", line 17, characters 6-19
+Re-raised at Pr2195 in file "pr2195.ml", line 22, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.run
+++ b/testsuite/tests/backtrace/pr2195.run
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# ulimit -n will have no effect on the Windows builds. The number of open files
+# on Windows is theoretically limited by available memory only, however the CRT
+# is limited to 8192 open files (including the standard handles).
+ulimit -n 32
+
+${program} > ${output} 2>&1
+echo 'exit_status="'$?'"' > ${ocamltest_response}


### PR DESCRIPTION
The following program:
```ocaml
while true do
  open_in "foo" |> ignore
done
```
would terminate with `Fatal error: executable program file not found` if backtraces were enabled which is wrong for two reasons:

1. The file was found, the issue is that all fds have been exhausted
2. This error is not fatal

Furthermore, this error would happen if user code attempted to get the backtrace information (e.g. to display an error message). In this case, the information about the exception is completely lost, since the runtime terminates.

The first commit detects `EMFILE` in `caml_attempt_open` and returns a new flag to differentiate the error. `caml_debuginfo_location` is altered to return `0` on success but to pass on the return value of `caml_attempt_open` if this fails (native runtime is unaffected by this change). `caml_print_exception_backtrace` is then altered so that it displays a more helpful error message, and the error is no longer fatal. Note that `loc_is_raise` remains valid in this case, which means that the effect on user code would be to act as though debugging information were not available (where before the runtime had terminated)

The second commit optionally extends this further by causing the debug information to be loaded during startup if backtraces are enabled. The assumption is that the system is not likely to have run out of fds at this point, though in this case the runtime would in fact fail to start. Again, native code is not affected by this change.

The background for this seemingly mundane change is a non-trivial amount of time lost debugging Dune...

cc @jonludlam