### PR TITLE
manual: move lazy patterns to core

### DIFF
--- a/Changes
+++ b/Changes
@@ -417,18 +417,16 @@ Working version
   GPR#1702, GPR#1765, GPR#1863, and Gabriel Scherer's GPR#1903.
   (Gabriel Scherer, review by Florian Angeletti)
 
-- GPR#1788: move the quoted string description to the main chapters.
-  (Florian Angeletti, review by Xavier Clerc and Perry E. Metzger)
-
-- GPR#1831: move the local exceptions and exception cases to the main chapters.
-  (Florian Angeletti, review by Perry E. Metzger and Jeremy Yallop)
+- GPR#1788, 1831, 2007, 2198, move language extensions to the core chapters:
+     - GPR#1788: quoted string description
+     - GPR#1831: local exceptions and exception cases
+     - GPR#2007: 32-bit, 64-bit and native integer literals
+     - GPR#2198: lazy patterns
+  (Florian Angeletti, review by Xavier Clerc, Perry E. Metzger, Gabriel Scherer
+   and Jeremy Yallop)
 
 - GPR#1863: caml-tex2, move to compiler-libs
   (Florian Angeletti, review by Sébastien Hinderer and Gabriel Scherer)
-
-- GPR#2007: move the documentation for 32-bit, 64-bit and native integer
-  literals to the main part of the manual.
-  (Florian Angeletti, review by Gabriel Scherer)
 
 - GPR#2105: Change verbatim to caml_example in documentation
   (Maxime Flin, review by Florian Angeletti)

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -1535,7 +1535,7 @@ let explanation_submsg (id, {reason;loc;subid}) =
 
 let report_error loc = function
   | Circular_dependency cycle ->
-      let[@manual.ref "s-recursive-modules"] chapter, section = 8, 3 in
+      let[@manual.ref "s-recursive-modules"] chapter, section = 8, 2 in
       Location.errorf ~loc ~sub:(List.map explanation_submsg cycle)
         "Cannot safely evaluate the definition of the following cycle@ \
          of recursively-defined modules:@ %a.@ \

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -76,34 +76,6 @@ An expression @@e@@ is said to be {\em immediately linked to} the variable
    is immediately linked to @name@.
 \end{itemize}
 
-\section{Lazy patterns} \label{s:lazypat}
-
-\ikwd{lazy\@\texttt{lazy}}
-
-(Introduced in Objective Caml 3.11)
-
-\begin{syntax}
-pattern: ...
-         | 'lazy' pattern
-\end{syntax}
-
-The pattern @"lazy" pattern@ matches a value \var{v} of type "Lazy.t",
-provided @pattern@ matches the result of forcing \var{v} with
-"Lazy.force". A successful match of a pattern containing @"lazy"@
-sub-patterns forces the corresponding parts of the value being matched, even
-those that imply no test such as @"lazy" value-name@ or @"lazy" "_"@.
-Matching a value with a @pattern-matching@ where some patterns
-contain @"lazy"@ sub-patterns may imply forcing parts of the value,
-even when the pattern selected in the end has no @"lazy"@ sub-pattern.
-
-For more information, see the description of module "Lazy" in the
-standard library (
-\ifouthtml
-\ahref{libref/Lazy.html}{Module \texttt{Lazy}}\else section~\ref{Lazy}\fi).
-%
-\index{Lazy (module)\@\verb`Lazy` (module)}%
-\index{force\@\verb`force`}%
-
 \section{Recursive modules} \label{s-recursive-modules}
 \ikwd{module\@\texttt{module}}
 \ikwd{and\@\texttt{and}}

--- a/manual/manual/refman/patterns.etex
+++ b/manual/manual/refman/patterns.etex
@@ -20,9 +20,10 @@ pattern:
   | pattern '::' pattern
   | '[|' pattern { ';' pattern } [ ';' ] '|]'
   | char-literal '..' char-literal
+  | 'lazy' pattern
   | 'exception' pattern
 \end{syntax}
-See also the following language extensions: \hyperref[s:lazypat]{lazy patterns},
+See also the following language extensions:
 \hyperref[s:local-opens]{local opens},
 \hyperref[s-first-class-modules]{first-class modules},
 \hyperref[s:attributes]{attributes} and
@@ -175,6 +176,33 @@ The pattern
 where \nth{c}{1}, \nth{c}{2}, \ldots, \nth{c}{n} are the characters
 that occur between \var{c} and \var{d} in the ASCII character set. For
 instance, the pattern "'0'"@'..'@"'9'" matches all characters that are digits.
+
+\subsubsection{Lazy patterns} \label{s:lazypat}
+
+\ikwd{lazy\@\texttt{lazy}}
+
+(Introduced in Objective Caml 3.11)
+
+\begin{syntax}
+pattern: ...
+\end{syntax}
+
+The pattern @"lazy" pattern@ matches a value \var{v} of type "Lazy.t",
+provided @pattern@ matches the result of forcing \var{v} with
+"Lazy.force". A successful match of a pattern containing @"lazy"@
+sub-patterns forces the corresponding parts of the value being matched, even
+those that imply no test such as @"lazy" value-name@ or @"lazy" "_"@.
+Matching a value with a @pattern-matching@ where some patterns
+contain @"lazy"@ sub-patterns may imply forcing parts of the value,
+even when the pattern selected in the end has no @"lazy"@ sub-pattern.
+
+For more information, see the description of module "Lazy" in the
+standard library (
+\ifouthtml
+\ahref{libref/Lazy.html}{Module \texttt{Lazy}}\else section~\ref{Lazy}\fi).
+%
+\index{Lazy (module)\@\verb`Lazy` (module)}%
+\index{force\@\verb`force`}%
 
 \subsubsection*{Exception patterns} \label{s:exception-match}
 (Introduced in OCaml 4.02)

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -21,7 +21,22 @@ type 'a t = 'a CamlinternalLazy.t
    expression syntax [lazy (expr)] makes a suspension of the
    computation of [expr], without computing [expr] itself yet.
    "Forcing" the suspension will then compute [expr] and return its
-   result.
+   result. Matching a suspension with the special pattern syntax
+   [lazy(pattern)] also computes the underlying expression and
+   tries to bind it to [pattern]:
+
+  {[
+    let lazy_option_map f x =
+    match x with
+    | lazy (Some x) -> Some (Lazy.force f x)
+    | _ -> None
+  ]}
+
+   Note: If lazy patterns appear in multiple cases in a pattern-matching,
+   lazy expressions may be forced even outside of the case ultimately selected
+   by the pattern matching. In the example above, the suspension [x] is always
+   computed.
+
 
    Note: [lazy_t] is the built-in type constructor used by the compiler
    for the [lazy] keyword.  You should not use it directly.  Always use

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -13,7 +13,7 @@ Line 2, characters 27-49:
                                ^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: B -> E -> D -> C -> B.
-       There are no safe modules in this cycle (see manual section 8.3).
+       There are no safe modules in this cycle (see manual section 8.2).
 Line 2, characters 10-20:
 2 | and B:sig val x: int end = struct let x = E.y end
               ^^^^^^^^^^
@@ -42,7 +42,7 @@ Line 2, characters 36-64:
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
-       There are no safe modules in this cycle (see manual section 8.3).
+       There are no safe modules in this cycle (see manual section 8.2).
 Line 2, characters 28-29:
 2 | module rec A: sig type t += A end = struct type t += A = B.A end
                                 ^
@@ -70,7 +70,7 @@ Line 4, characters 6-72:
 7 | end
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
-       There are no safe modules in this cycle (see manual section 8.3).
+       There are no safe modules in this cycle (see manual section 8.2).
 Line 2, characters 2-41:
 2 |   module F: functor(X:sig end) -> sig end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ Line 5, characters 8-62:
 8 |   end
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: A -> B -> A.
-       There are no safe modules in this cycle (see manual section 8.3).
+       There are no safe modules in this cycle (see manual section 8.2).
 Line 3, characters 4-17:
 3 |     module M: X.t
         ^^^^^^^^^^^^^


### PR DESCRIPTION
This PR moves the description of lazy patterns to the core part of the manual and adds an example of such patterns in the documentation of the Lazy module. (Incidentally, this change makes the section on recursive values and modules adjacent which is thematically nice).