### PR TITLE
A tail recursive List.flatten

### DIFF
--- a/Changes
+++ b/Changes
@@ -187,6 +187,10 @@ Working version
 - GPR#2185: Add `List.filter_map`
   (Thomas Refis, review by Alain Frisch and Gabriel Scherer)
 
+- GPR##2199: the implementation of List.flatten and List.concat
+  that are now tail recursive starting from a threshold.
+  (Nathan Moreau, review by ???)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/Changes
+++ b/Changes
@@ -189,7 +189,7 @@ Working version
 
 - GPR##2199: the implementation of List.flatten and List.concat
   that are now tail recursive starting from a threshold.
-  (Nathan Moreau, review by ???)
+  (Nathan Moreau, review by Alain Frisch and Jacques Garrigue)
 
 ### Other libraries:
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -119,18 +119,26 @@ let rec fold_right f l accu =
     [] -> accu
   | a::l -> f a (fold_right f l accu)
 
+let rec append_aux i l1 l2 =
+  match l1 with
+    [] -> l2
+  | first :: rest ->
+    if i > max_recursion_threshold / 2 then
+       rev_append (rev l1) l2
+    else
+       first :: append_aux (i + 1) rest l2
+
 let rev_flatten l =
   fold_left (fun accu l -> rev_append l accu) [] l
 
-let rec flatten_aux len l =
-  match l with
-    [] -> []
-  | l1 :: r ->
-    let new_len = len + length l1 in
-    if max_recursion_threshold < new_len then
-      l1 @ flatten_aux new_len r
-    else
-      rev (rev_flatten l)
+let rec flatten_aux i l =
+  if i > max_recursion_threshold / 2 then
+    rev (rev_flatten l)
+  else
+    match l with
+      [] -> []
+    | l1 :: r ->
+      append_aux 0 l1 (flatten_aux (i + 1) r)
 
 let flatten l = flatten_aux 0 l
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -123,7 +123,7 @@ let rec append_aux i l1 l2 =
   match l1 with
     [] -> l2
   | first :: rest ->
-    if i > max_recursion_threshold / 2 then
+    if i > max_recursion_threshold then
        rev_append (rev l1) l2
     else
        first :: append_aux (i + 1) rest l2
@@ -132,13 +132,13 @@ let rev_flatten l =
   fold_left (fun accu l -> rev_append l accu) [] l
 
 let rec flatten_aux i l =
-  if i > max_recursion_threshold / 2 then
+  if i > max_recursion_threshold then
     rev (rev_flatten l)
   else
     match l with
       [] -> []
     | l1 :: r ->
-      append_aux 0 l1 (flatten_aux (i + 1) r)
+      append_aux i l1 (flatten_aux (i + 1) r)
 
 let flatten l = flatten_aux 0 l
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -81,12 +81,6 @@ let init len f =
   if len > max_recursion_threshold then rev (init_tailrec_aux [] 0 len f)
   else init_aux 0 len f
 
-let rec flatten = function
-    [] -> []
-  | l::r -> l @ flatten r
-
-let concat = flatten
-
 let rec map f = function
     [] -> []
   | a::l -> let r = f a in r :: map f l
@@ -124,6 +118,23 @@ let rec fold_right f l accu =
   match l with
     [] -> accu
   | a::l -> f a (fold_right f l accu)
+
+let rev_flatten l =
+  fold_left (fun accu l -> rev_append l accu) [] l
+
+let rec flatten_aux len l =
+  match l with
+    [] -> []
+  | l1 :: r ->
+    let new_len = len + length l1 in
+    if max_recursion_threshold < new_len then
+      l1 @ flatten_aux new_len r
+    else
+      rev (rev_flatten l)
+
+let flatten l = flatten_aux 0 l
+
+let concat = flatten
 
 let rec map2 f l1 l2 =
   match (l1, l2) with

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -69,7 +69,7 @@ let rec init_aux i n f =
     let r = f i in
     r :: init_aux (i+1) n f
 
-let rev_init_threshold =
+let max_recursion_threshold =
   match Sys.backend_type with
   | Sys.Native | Sys.Bytecode -> 10_000
   (* We don't know the size of the stack, better be safe and assume it's
@@ -78,7 +78,7 @@ let rev_init_threshold =
 
 let init len f =
   if len < 0 then invalid_arg "List.init" else
-  if len > rev_init_threshold then rev (init_tailrec_aux [] 0 len f)
+  if len > max_recursion_threshold then rev (init_tailrec_aux [] 0 len f)
   else init_aux 0 len f
 
 let rec flatten = function

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -94,9 +94,7 @@ val rev_append : 'a list -> 'a list -> 'a list
 
 val concat : 'a list list -> 'a list
 (** Concatenate a list of lists.  The elements of the argument are all
-   concatenated together (in the same order) to give the result.
-   Not tail-recursive
-   (length of the argument + length of the longest sub-list). *)
+   concatenated together (in the same order) to give the result. *)
 
 val flatten : 'a list list -> 'a list
 (** An alias for [concat]. *)

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -72,4 +72,10 @@ let () =
   test (threshold + 1) (* Tail-recursive case *)
 ;;
 
+(* List.flatten *)
+let () =
+  let counter = ref (-1) in
+  let lists = List.init 10 (fun i -> List.init (i*i*i*i) (fun _ -> incr counter; !counter)) in
+  List.iteri (fun idx elt -> assert (idx = elt)) (List.flatten lists)
+
 let () = print_endline "OK";;


### PR DESCRIPTION
List.flatten is not tail recursive, and is then subject to stack overflow.

A small illustrative test is the following:
```
let n = ref 0 in
while true do
  ignore(flatten (List.init !n (fun i -> List.init (i*i*i*i) (fun _ -> 0))));
  Printf.printf "%i: ok%!\n" !n;
  incr n
done;;

```

On the trunk version this stops after ~20 iterations of the loop.

The proposed version starts like the current non tail recursive implementation, and changes strategy when the result list gets big.