### PR TITLE
manual: move bigarray indexing to core chapters

### DIFF
--- a/Changes
+++ b/Changes
@@ -427,11 +427,13 @@ Working version
   GPR#1702, GPR#1765, GPR#1863, and Gabriel Scherer's GPR#1903.
   (Gabriel Scherer, review by Florian Angeletti)
 
-- GPR#1788, 1831, 2007, 2198, move language extensions to the core chapters:
+- GPR#1788, 1831, 2007, 2198, 2201, move language extensions
+  to the core chapters:
      - GPR#1788: quoted string description
      - GPR#1831: local exceptions and exception cases
      - GPR#2007: 32-bit, 64-bit and native integer literals
      - GPR#2198: lazy patterns
+     - GPR#2201: bigarray indexing
   (Florian Angeletti, review by Xavier Clerc, Perry E. Metzger, Gabriel Scherer
    and Jeremy Yallop)
 

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -53,6 +53,8 @@ expr:
   | expr '.(' expr ')' '<-' expr
   | expr '.[' expr ']'
   | expr '.[' expr ']' '<-' expr
+  | expr '.{' expr { ',' expr } '}'
+  | expr '.{' expr { ',' expr } '}' '<-' expr
   | 'if' expr 'then' expr [ 'else' expr ]
   | 'while' expr 'do' expr 'done'
   | 'for' value-name '=' expr ( 'to' || 'downto' ) expr 'do' expr 'done'
@@ -116,7 +118,6 @@ See also the following language extensions:
 \hyperref[s:object-notations]{object notations},
 \hyperref[s-first-class-modules]{first-class modules},
 \hyperref[s:explicit-overriding-open]{overriding in open statements},
-\hyperref[s:bigarray-access]{syntax for Bigarray access},
 \hyperref[s:attributes]{attributes},
 \hyperref[s:extension-nodes]{extension nodes} and
 \hyperref[s:index-operators]{extended indexing operators}.
@@ -144,7 +145,7 @@ precedence come first. For infix and prefix symbols, we write
 \ikwd{asr\@\texttt{asr}}
 \begin{tableau}{|l|l|}{Construction or operator}{Associativity}
 \entree{prefix-symbol}{--}
-\entree{".   .(   .[   .{" (see section~\ref{s:bigarray-access})}{--}
+\entree{".   .(   .[   .{" }{--}
 \entree{"#"\ldots}{left}
 \entree{function application, constructor application, tag
         application, "assert",
@@ -164,7 +165,7 @@ precedence come first. For infix and prefix symbols, we write
 \entree{"if"}{--}
 \entree{";"}{right}
 \entree{"let  match  fun  function  try"}{--}
-\end{tableau}
+\end{tableau}%$
 
 \subsection{Basic expressions}
 
@@ -677,6 +678,35 @@ the access is out of bounds. The value of the whole expression is @'()'@.
 compatibility with older versions of OCaml and will be removed in a
 future version. New code should use byte sequences and the "Bytes.set"
 function.
+
+\subsubsection*{Bigarrays}
+
+The expression @expr_0 '.{' expr_1 {',' expr_d} '}'@ returns the value of
+the multidimensional array (see "Bigarray"[\moduleref{Bigarray}]) @expr_0@
+at index (@expr_1@,$\ldots$,@expr_d@). Depending on the number, \var{d}, of
+indices, the expected type for @expr_0@ is
+\begin{description}
+\item[$d=1$ :]{"(_,_,_) Bigarray.Array1.t"}
+\item[$d=2$ :]{"(_,_,_) Bigarray.Array2.t"}
+\item[$d=3$ :]{"(_,_,_) Bigarray.Array3.t"}
+\item[$d \ge 4$ :]{"(_,_,_) Bigarray.Genarray.t"}
+\end{description}
+If the layout of the bigarray is C-compatible,
+the first index is $(0,\ldots,0)$ (repeated $d$ times), and the last is
+$(\var{dim}_1-1,\ldots,\var{dim}_d-1)$ where $\var{dim}_k$ is the length
+of the array along the k-th dimension. Otherwise, for Fortran-compatible
+layout, the first index is $(1,\ldots,1)$ (repeated $d$ times),
+and the last is $(\var{dim},\ldots,\var{dim}_d)$.
+The exception "Invalid_argument" is raised if the access is out of bounds.
+Accessing a non-generic Bigarray with the wrong number of indices is
+a type error. Accessing a generic Bigarray with the wrong number of
+indices raises an "Invalid_argument" exception.
+
+The expression @expr_0 '.{' expr_1 {',' expr_d} '}' '<-' expr_v@ modifies
+in-place the Bigarray denoted by @expr_0@, replacing the value
+at index (@expr_1@,$\ldots$,@expr_d@) by the value of @expr_v@.
+The exception "Invalid_argument" is raised if the access is out of bounds.
+The value of the whole expression is @'()'@.
 
 \subsection{Operators}
 \ikwd{mod\@\texttt{mod}}

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1324,48 +1324,6 @@ contradict the exhaustiveness check. Namely, builtin types (those
 defined by the compiler itself, such as "int" or "array"), and
 abstract types defined by the local module, are non-instantiable, and
 as such cause a type error rather than introduce an equation.
-
-\section{Syntax for Bigarray access}\label{s:bigarray-access}
-
-(Introduced in Objective Caml 3.00)
-
-\begin{syntax}
-expr:
-          ...
-        | expr '.{' expr { ',' expr } '}'
-        | expr '.{' expr { ',' expr } '}' '<-' expr
-\end{syntax}
-
-This extension provides syntactic sugar for getting and setting
-elements in the arrays provided by the
-"Bigarray"[\moduleref{Bigarray}] library.
-
-The short expressions are translated into calls to functions of the
-"Bigarray" module as described in the following table.
-
-\begin{tableau}{|l|l|}{expression}{translation}
-\entree{@expr_0'.{'expr_1'}'@}
-       {"Bigarray.Array1.get "@expr_0 expr_1@}
-\entree{@expr_0'.{'expr_1'}' '<-'expr@}
-       {"Bigarray.Array1.set "@expr_0 expr_1 expr@}
-\entree{@expr_0'.{'expr_1',' expr_2'}'@}
-       {"Bigarray.Array2.get "@expr_0 expr_1 expr_2@}
-\entree{@expr_0'.{'expr_1',' expr_2'}' '<-'expr@}
-       {"Bigarray.Array2.set "@expr_0 expr_1 expr_2 expr@}
-\entree{@expr_0'.{'expr_1',' expr_2',' expr_3'}'@}
-       {"Bigarray.Array3.get "@expr_0 expr_1 expr_2 expr_3@}
-\entree{@expr_0'.{'expr_1',' expr_2',' expr_3'}' '<-'expr@}
-       {"Bigarray.Array3.set "@expr_0 expr_1 expr_2 expr_3 expr@}
-\entree{@expr_0'.{'expr_1',' \ldots',' expr_n'}'@}
-       {"Bigarray.Genarray.get "@ expr_0 '[|' expr_1',' \ldots ','
-        expr_n '|]'@}
-\entree{@expr_0'.{'expr_1',' \ldots',' expr_n'}' '<-'expr@}
-       {"Bigarray.Genarray.set "@ expr_0 '[|' expr_1',' \ldots ','
-        expr_n '|]' expr@}
-\end{tableau}
-
-The last two entries are valid for any $n > 3$.
-
 \section{Attributes}\label{s:attributes}
 
 \ikwd{when\@\texttt{when}}

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -61,6 +61,45 @@
      and {!Stdlib.input_value}).
 *)
 
+(** {1 Indexing operators}
+
+   Similarly to ordinary arrays, the elements of a Bigarray, [a], can be
+   accessed using a specific syntax:
+   - for reading the value at indices [k,l]: [a.{k,l}]
+   - for assigning the value [x] at indices [k,l]: [a.{k,l}<-x]
+
+   For instance,
+   {[
+   let set_to_zero_then_check a k =
+     a.{k} <- 0.;
+     assert( a.{k} = 0. )
+   ]}
+   The expected dimension (and type) of the Bigarray [a] depends on
+   the number, [d], of indices:
+   - [d = 1] : {!Array1.t}
+   - [d = 2] : {!Array2.t}
+   - [d = 3] : {!Array3.t}
+   - [d >= 4] : {!Genarray}
+
+   Consequently, the function [set_to_zero_then_check] above has
+   type [(_, _, _) Array1.t -> int -> unit]. It can be converted to
+   three dimensional arrays ({!Array3.t}) with
+   {[
+   let set_to_zero_then_check a k l m =
+     a.{k,l,m} <- 0.;
+     assert( a.{k,l,m} = 0. )
+   ]}
+   Out-of-bounds access raises an [Invalid_argument] exception.
+   Accessing a non-generic Bigarray with the wrong number of indices is
+   a type error. Accessing a generic Bigarray with the wrong number of indices
+   raises an [Invalid_argument] exception.
+
+   A drawback of this approach is that generic multidimensional array of
+   dimension strictly inferior to [4] cannot use this operator syntax.
+   They are required to use {!Genarray.get} and {!Genarray.set}.
+
+*)
+
 (** {1 Element kinds} *)
 
 (** Bigarrays can contain elements of the following kinds:


### PR DESCRIPTION
This PR proposes to move the description of the bigarray indexing operators to the core part of the manual from the extension chapter since `Bigarray` is now part of the standard library.

The new description is (partially) duplicated between the `Bigarray` module documentation and the "language reference" to cover the most likely documentation entry points for `Bigarray` users. Another change is that the indexing operators are no longer described in term of their desugaring to the various `Bigarray.{Genarray,ArrayD}.{get,set}` functions.