### PR TITLE
Hashtbl.MakeSeeded.{add,replace,of}_seq use wrong hash function

### DIFF
--- a/Changes
+++ b/Changes
@@ -325,6 +325,10 @@ OCaml 4.08.0
 - GPR#1525: Make function set_max_indent respect documentation
   (Pierre Weis, Richard Bonichon, review by Florian Angeletti)
 
+- GPR#2202: Correct Hashtbl.MakeSeeded.{add_seq,replace_seq,of_seq} to use
+  functor hash function instead of default hash function.
+  (David Allsopp, review by Alain Frisch)
+
 ### Other libraries:
 
 - GPR#2222: Set default status in waitpid when pid is zero. Otherwise,

--- a/Changes
+++ b/Changes
@@ -326,7 +326,8 @@ OCaml 4.08.0
   (Pierre Weis, Richard Bonichon, review by Florian Angeletti)
 
 - GPR#2202: Correct Hashtbl.MakeSeeded.{add_seq,replace_seq,of_seq} to use
-  functor hash function instead of default hash function.
+  functor hash function instead of default hash function. Hashtbl.Make.of_seq
+  shouldn't create randomized hash tables.
   (David Allsopp, review by Alain Frisch)
 
 ### Other libraries:

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -482,6 +482,10 @@ module K1 = struct
         let hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
+    let of_seq i =
+      let tbl = create 16 in
+      replace_seq tbl i;
+      tbl
   end
 
 end
@@ -570,6 +574,10 @@ module K2 = struct
           let hash (_seed: int) x = H2.hash x
         end)
     let create sz = create ~random:false sz
+    let of_seq i =
+      let tbl = create 16 in
+      replace_seq tbl i;
+      tbl
   end
 
 end
@@ -670,5 +678,9 @@ module Kn = struct
         let hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
+    let of_seq i =
+      let tbl = create 16 in
+      replace_seq tbl i;
+      tbl
   end
 end

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -599,4 +599,8 @@ module Make(H: HashedType): (S with type key = H.t) =
         let hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
+    let of_seq i =
+      let tbl = create 16 in
+      replace_seq tbl i;
+      tbl
   end

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -570,6 +570,17 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
           H.equal k key || mem_in_bucket next in
       mem_in_bucket h.data.(key_index h key)
 
+    let add_seq tbl i =
+      Seq.iter (fun (k,v) -> add tbl k v) i
+
+    let replace_seq tbl i =
+      Seq.iter (fun (k,v) -> replace tbl k v) i
+
+    let of_seq i =
+      let tbl = create 16 in
+      replace_seq tbl i;
+      tbl
+
     let iter = iter
     let filter_map_inplace = filter_map_inplace
     let fold = fold
@@ -578,9 +589,6 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
     let to_seq = to_seq
     let to_seq_keys = to_seq_keys
     let to_seq_values = to_seq_values
-    let add_seq = add_seq
-    let replace_seq = replace_seq
-    let of_seq = of_seq
   end
 
 module Make(H: HashedType): (S with type key = H.t) =


### PR DESCRIPTION
This GPR initially addresses a bug, which is that `Hashtbl.Make.of_seq` creates hash tables in randomized mode, if it has been turned on (e.g. with `OCAMLRUNPARAM=R`). It then goes one step further and, given that it wraps `Hashtbl.create`, adds the `?random` parameter to `Hashtbl.of_seq`. `of_seq` also creates hash tables with a hard-coded initial size of `16`, so while I was there, I added `?size`. This gets propagated to `Ephemeron`.

The first commit should really go in 4.08 ~~- the interface change in the second only adds optional parameters, so should also be safe to go in, even at this stage~~? Are we planning 4.07.2 (@damiendoligez)?

cc @c-cube, @bobot 