### PR TITLE
Add hooks to define new recursive module strategies

### DIFF
--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -376,6 +376,9 @@ let compile_recmodule compile_rhs bindings cont =
           bindings))
     cont
 
+(* Hook for plugins *)
+let compile_recmodule = ref compile_recmodule
+
 (* Code to translate class entries in a structure *)
 
 let transl_class_bindings cl_list =
@@ -616,7 +619,7 @@ and transl_structure loc fields cc rootpath final_env = function
             transl_structure loc ext_fields cc rootpath final_env rem
           in
           let lam =
-            compile_recmodule
+            !compile_recmodule
               (fun id modl loc ->
                  let module_body =
                    transl_module Tcoerce_none (field_path rootpath id) modl
@@ -1022,7 +1025,7 @@ let transl_store_structure glob map prims aliases str =
             transl_store rootpath subst cont rem
         | Tstr_recmodule bindings ->
             let ids = List.map (fun mb -> mb.mb_id) bindings in
-            compile_recmodule
+            !compile_recmodule
               (fun id modl _loc ->
                  Lambda.subst no_env_update subst
                    (transl_module Tcoerce_none
@@ -1356,7 +1359,7 @@ let transl_toplevel_item item =
       toploop_setvalue id lam
   | Tstr_recmodule bindings ->
       let idents = List.map (fun mb -> mb.mb_id) bindings in
-      compile_recmodule
+      !compile_recmodule
         (fun id modl _loc -> transl_module Tcoerce_none (Some(Pident id)) modl)
         bindings
         (make_sequence toploop_setvalue_id idents)

--- a/bytecomp/translmod.mli
+++ b/bytecomp/translmod.mli
@@ -59,3 +59,8 @@ exception Error of Location.t * error
 val report_error: Location.t -> error -> Location.error
 
 val reset: unit -> unit
+
+val compile_recmodule :
+  ((Ident.t -> Typedtree.module_expr -> Location.t -> Lambda.lambda) ->
+   Typedtree.module_binding list -> Lambda.lambda -> Lambda.lambda)
+    ref

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -141,3 +141,12 @@ module ImplementationHooks : Misc.HookSig
   with type t = Typedtree.structure * Typedtree.module_coercion
 module InterfaceHooks : Misc.HookSig
   with type t = Typedtree.signature
+
+val type_module_type_of : Env.t ->
+  Parsetree.module_expr -> Typedtree.module_expr * Types.module_type
+
+val transl_recmodule_modtypes_fwd :
+    (Env.t ->
+     Parsetree.module_declaration list ->
+     Typedtree.module_declaration list * Env.t)
+    ref


### PR DESCRIPTION
* Typemod.transl_recmodule_modtypes_fwd : new typing strategy for rec modules
* Translmod.compile_recmodule : new compilation strategy for rec modules

In https://caml.inria.fr/mantis/view.php?id=5286 , it was said there would be no change in the typing/compilation of recursive modules, to avoid breaking compatibility and introducing bugs. However, it was also said that some programs might compile with a different strategy. For them, we propose to add these hooks, that could be used by a compiler plugin to change these strategies for a particular program. This way, 5286 could be implemented externally without breaking backward compatibility, with only minimal changes in the compiler.