### PR TITLE
Add ?size and ?random to Hashtbl.of_seq and related functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,9 @@ Working version
 
 ### Standard library:
 
+* #2205: Add ?size parameter to all of_seq functions and ?random, where
+  appropriate.
+  (David Allsopp, review by Alain Frisch)
 
 ### Other libraries:
 

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -408,8 +408,8 @@ module GenHashTable = struct
     let replace_seq tbl i =
       Seq.iter (fun (k,v) -> replace tbl k v) i
 
-    let of_seq i =
-      let tbl = create 16 in
+    let of_seq ?random ?(size = 16) i =
+      let tbl = create ?random size in
       replace_seq tbl i;
       tbl
 
@@ -482,8 +482,8 @@ module K1 = struct
         let hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
-    let of_seq i =
-      let tbl = create 16 in
+    let of_seq ?(size = 16) i =
+      let tbl = create size in
       replace_seq tbl i;
       tbl
   end
@@ -574,8 +574,8 @@ module K2 = struct
           let hash (_seed: int) x = H2.hash x
         end)
     let create sz = create ~random:false sz
-    let of_seq i =
-      let tbl = create 16 in
+    let of_seq ?(size = 16) i =
+      let tbl = create size in
       replace_seq tbl i;
       tbl
   end
@@ -678,8 +678,8 @@ module Kn = struct
         let hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
-    let of_seq i =
-      let tbl = create 16 in
+    let of_seq ?(size = 16) i =
+      let tbl = create size in
       replace_seq tbl i;
       tbl
   end

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -305,7 +305,7 @@ module type S =
     val to_seq_values : 'a t -> 'a Seq.t
     val add_seq : 'a t -> (key * 'a) Seq.t -> unit
     val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
-    val of_seq : (key * 'a) Seq.t -> 'a t
+    val of_seq : ?size:int -> (key * 'a) Seq.t -> 'a t
   end
 
 module type SeededS =
@@ -333,7 +333,7 @@ module type SeededS =
     val to_seq_values : 'a t -> 'a Seq.t
     val add_seq : 'a t -> (key * 'a) Seq.t -> unit
     val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
-    val of_seq : (key * 'a) Seq.t -> 'a t
+    val of_seq : ?random:bool -> ?size:int -> (key * 'a) Seq.t -> 'a t
   end
 
 module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
@@ -454,8 +454,8 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
     let replace_seq tbl i =
       Seq.iter (fun (k,v) -> replace tbl k v) i
 
-    let of_seq i =
-      let tbl = create 16 in
+    let of_seq ?random ?(size = 16) i =
+      let tbl = create ?random size in
       replace_seq tbl i;
       tbl
 
@@ -477,8 +477,9 @@ module Make(H: HashedType): (S with type key = H.t) =
         let hash (_seed: int) x = H.hash x
       end)
     let create sz = create ~random:false sz
-    let of_seq i =
-      let tbl = create 16 in
+
+    let of_seq ?(size = 16) i =
+      let tbl = create size in
       replace_seq tbl i;
       tbl
   end
@@ -607,7 +608,7 @@ let add_seq tbl i =
 let replace_seq tbl i =
   Seq.iter (fun (k,v) -> replace tbl k v) i
 
-let of_seq i =
-  let tbl = create 16 in
+let of_seq ?random ?(size = 16) i =
+  let tbl = create ?random size in
   replace_seq tbl i;
   tbl

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -245,12 +245,18 @@ val replace_seq : ('a,'b) t -> ('a * 'b) Seq.t -> unit
 (** Add the given bindings to the table, using {!replace}
     @since 4.07 *)
 
-val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
+val of_seq : ?random:bool -> ?size:int -> ('a * 'b) Seq.t -> ('a, 'b) t
 (** Build a table from the given bindings. The bindings are added
     in the same order they appear in the sequence, using {!replace_seq},
     which means that if two pairs have the same key, only the latest one
     will appear in the table.
-    @since 4.07 *)
+
+    [?random] is as for {!Hashtbl.create} and [?size] is the initial size of the
+    hash table (default is 16).
+
+    @since 4.07
+    @before 4.12 [?random] was always [OCAMLRUNPARAM]'s R flag and [?size]
+                 was 16. *)
 
 (** {1 Functorial interface} *)
 
@@ -348,8 +354,9 @@ module type S =
     val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
     (** @since 4.07 *)
 
-    val of_seq : (key * 'a) Seq.t -> 'a t
-    (** @since 4.07 *)
+    val of_seq : ?size:int -> (key * 'a) Seq.t -> 'a t
+    (** @since 4.07
+        @before 4.12 [?size] was always 16 *)
   end
 (** The output signature of the functor {!Hashtbl.Make}. *)
 
@@ -422,8 +429,10 @@ module type SeededS =
     val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
     (** @since 4.07 *)
 
-    val of_seq : (key * 'a) Seq.t -> 'a t
-    (** @since 4.07 *)
+    val of_seq : ?random:bool -> ?size:int -> (key * 'a) Seq.t -> 'a t
+    (** @since 4.07
+        @before 4.12 [?random] was [OCAMLRUNPARAM]'s R flag and [?size]
+                     was 16 *)
   end
 (** The output signature of the functor {!Hashtbl.MakeSeeded}.
     @since 4.00.0 *)

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -52,7 +52,7 @@ module Hashtbl : sig
   val to_seq_values : (_,'b) t -> 'b Seq.t
   val add_seq : ('a,'b) t -> ('a * 'b) Seq.t -> unit
   val replace_seq : ('a,'b) t -> ('a * 'b) Seq.t -> unit
-  val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
+  val of_seq : ?random:bool -> ?size:int -> ('a * 'b) Seq.t -> ('a, 'b) t
   module type HashedType = Hashtbl.HashedType
   module type SeededHashedType = Hashtbl.SeededHashedType
   module type S =
@@ -83,7 +83,7 @@ module Hashtbl : sig
       val to_seq_values : 'a t -> 'a Seq.t
       val add_seq : 'a t -> (key * 'a) Seq.t -> unit
       val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
-      val of_seq : (key * 'a) Seq.t -> 'a t
+      val of_seq : ?size:int -> (key * 'a) Seq.t -> 'a t
     end
   module type SeededS =
     sig
@@ -113,7 +113,7 @@ module Hashtbl : sig
       val to_seq_values : 'a t -> 'a Seq.t
       val add_seq : 'a t -> (key * 'a) Seq.t -> unit
       val replace_seq : 'a t -> (key * 'a) Seq.t -> unit
-      val of_seq : (key * 'a) Seq.t -> 'a t
+      val of_seq : ?random:bool -> ?size:int -> (key * 'a) Seq.t -> 'a t
     end
   module Make : functor (H : HashedType) -> S
     with type key = H.t

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 63, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 537, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 538, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 44, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 44, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 63, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", lin
 Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 63, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 537, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 538, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 51, characters 8-41
 Re-raised at CamlinternalLazy.force_lazy_block.(fun) in file "camlinternalLazy.ml", line 35, characters 56-63
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -144,7 +144,7 @@ module HofM (M: Map.S) : Hashtbl.S with type key = M.key =
     let to_seq = Hashtbl.to_seq
     let to_seq_keys = Hashtbl.to_seq_keys
     let to_seq_values = Hashtbl.to_seq_values
-    let of_seq = Hashtbl.of_seq
+    let of_seq ?size i = Hashtbl.of_seq ?size i
     let add_seq = Hashtbl.add_seq
     let replace_seq = Hashtbl.replace_seq
   end


### PR DESCRIPTION
Split off from #2202 - note that the implementation of `Hashtbl.MakeSeeded.of_seq` is therefore wrong, but this would be corrected after #2202 is merged (if this GPR is accepted).