### PR TITLE
Add opam files to allow pinning

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "ocaml-variants"
+version: "4.08.0+dev"
+synopsis: "OCaml development version"
+depends: [
+  "ocaml" {= "4.08.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  ["./configure" "-prefix" prefix "-cc" "cc" "-aspp" "cc -c"]
+    {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "-j%{jobs}%" "world"]
+  [make "-j%{jobs}%" "world.opt"]
+]
+install: [make "install"]
+maintainer: "caml-list@inria.fr"
+homepage: "https://ocaml.org"
+bug-reports: "https://caml.inria.fr/mantis/"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]

--- a/ocaml.opam
+++ b/ocaml.opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "ocaml"
+version: "4.08.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "caml-list@inria.fr"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.08.0"} |
+  "ocaml-variants" {>= "4.08.0" & < "4.08.1~"} |
+  "ocaml-system" {= "4.08.0"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://caml.inria.fr/mantis/"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
This PR adds two opam files to the distribution. These enable you to pin the compiler with opam 2. So you can do:
```bash
$ opam switch create . --empty
$ opam install .
```
to get a local opam switch with the current compiler installed from the source directory. This is useful for quickly testing packages with a modified compiler.

I cobbled the files together based on the ones in the main opam-repository. Possibly they could be simpler since we don't need to support things like system compilers, but these ones do at least work. Maybe @AltGr, @dra27 or @avsm have some thoughts on how they might be simplified.

I also added support for passing `-j` through to make, so `opam install -j 16 .` should run `make` with `-j 16` to speed things up.

The files shouldn't need much maintenance -- they just need their version numbers updated when we change the number in the VERSION file.