### PR TITLE
documentation: use 'Bigarray' rather than 'big array'

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -110,10 +110,10 @@ type primitive =
   | Plsrbint of boxed_integer
   | Pasrbint of boxed_integer
   | Pbintcomp of boxed_integer * integer_comparison
-  (* Operations on big arrays: (unsafe, #dimensions, kind, layout) *)
+  (* Operations on Bigarrays: (unsafe, #dimensions, kind, layout) *)
   | Pbigarrayref of bool * int * bigarray_kind * bigarray_layout
   | Pbigarrayset of bool * int * bigarray_kind * bigarray_layout
-  (* size of the nth dimension of a big array *)
+  (* size of the nth dimension of a Bigarray *)
   | Pbigarraydim of int
   (* load/set 16,32,64 bits from a string: (unsafe)*)
   | Pstring_load_16 of bool

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -118,10 +118,10 @@ type primitive =
   | Plsrbint of boxed_integer
   | Pasrbint of boxed_integer
   | Pbintcomp of boxed_integer * integer_comparison
-  (* Operations on big arrays: (unsafe, #dimensions, kind, layout) *)
+  (* Operations on Bigarrays: (unsafe, #dimensions, kind, layout) *)
   | Pbigarrayref of bool * int * bigarray_kind * bigarray_layout
   | Pbigarrayset of bool * int * bigarray_kind * bigarray_layout
-  (* size of the nth dimension of a big array *)
+  (* size of the nth dimension of a Bigarray *)
   | Pbigarraydim of int
   (* load/set 16,32,64 bits from a string: (unsafe)*)
   | Pstring_load_16 of bool

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2024,11 +2024,11 @@ word is reserved for storing the custom operations; the other
 \var{used} and \var{max} are used to control the speed of garbage
 collection, as described for "caml_alloc_custom".
 
-\section{Advanced topic: Big arrays and the OCaml-C interface}
+\section{Advanced topic: Bigarrays and the OCaml-C interface}
 \label{s:C-Bigarrays}
 
 This section explains how C stub code that interfaces C or Fortran
-code with OCaml code can use big arrays.
+code with OCaml code can use Bigarrays.
 
 \subsection{Include file}
 
@@ -2038,12 +2038,12 @@ below.
 
 \subsection{Accessing an OCaml bigarray from C or Fortran}
 
-If \var{v} is a OCaml "value" representing a big array, the expression
+If \var{v} is a OCaml "value" representing a Bigarray, the expression
 "Caml_ba_data_val("\var{v}")" returns a pointer to the data part of the array.
 This pointer is of type "void *" and can be cast to the appropriate C
 type for the array (e.g. "double []", "char [][10]", etc).
 
-Various characteristics of the OCaml big array can be consulted from C
+Various characteristics of the OCaml Bigarray can be consulted from C
 as follows:
 \begin{tableau}{|l|l|}{C expression}{Returns}
 \entree{"Caml_ba_array_val("\var{v}")->num_dims"}{number of dimensions}
@@ -2064,7 +2064,7 @@ The kind of array elements is one of the following constants:
 \entree{"CAML_BA_NATIVE_INT"}{32- or 64-bit (platform-native) integers}
 \end{tableau}
 %
-The following example shows the passing of a two-dimensional big array
+The following example shows the passing of a two-dimensional Bigarray
 to a C function and a Fortran function.
 \begin{verbatim}
     extern void my_c_function(double * data, int dimx, int dimy);
@@ -2082,16 +2082,16 @@ to a C function and a Fortran function.
     }
 \end{verbatim}
 
-\subsection{Wrapping a C or Fortran array as an OCaml big array}
+\subsection{Wrapping a C or Fortran array as an OCaml Bigarray}
 
 A pointer \var{p} to an already-allocated C or Fortran array can be
-wrapped and returned to OCaml as a big array using the "caml_ba_alloc"
+wrapped and returned to OCaml as a Bigarray using the "caml_ba_alloc"
 or "caml_ba_alloc_dims" functions.
 \begin{itemize}
 \item
 "caml_ba_alloc("\var{kind} "|" \var{layout}, \var{numdims}, \var{p}, \var{dims}")"
 
-Return an OCaml big array wrapping the data pointed to by \var{p}.
+Return an OCaml Bigarray wrapping the data pointed to by \var{p}.
 \var{kind} is the kind of array elements (one of the "CAML_BA_"
 kind constants above).  \var{layout} is "CAML_BA_C_LAYOUT" for an
 array with C layout and "CAML_BA_FORTRAN_LAYOUT" for an array with

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -499,11 +499,11 @@ val map_file :
   file_descr -> ?pos:int64 -> ('a, 'b) Stdlib.Bigarray.kind ->
   'c Stdlib.Bigarray.layout -> bool -> int array ->
   ('a, 'b, 'c) Stdlib.Bigarray.Genarray.t
-(** Memory mapping of a file as a big array.
+(** Memory mapping of a file as a Bigarray.
   [map_file fd kind layout shared dims]
-  returns a big array of kind [kind], layout [layout],
+  returns a Bigarray of kind [kind], layout [layout],
   and dimensions as specified in [dims].  The data contained in
-  this big array are the contents of the file referred to by
+  this Bigarray are the contents of the file referred to by
   the file descriptor [fd] (as opened previously with
   [Unix.openfile], for example).  The optional [pos] parameter
   is the byte offset in the file of the data being mapped;
@@ -517,10 +517,10 @@ val map_file :
   affected.
 
   [Genarray.map_file] is much more efficient than reading
-  the whole file in a big array, modifying that big array,
+  the whole file in a Bigarray, modifying that Bigarray,
   and writing it afterwards.
 
-  To adjust automatically the dimensions of the big array to
+  To adjust automatically the dimensions of the Bigarray to
   the actual size of the file, the major dimension (that is,
   the first dimension for an array with C layout, and the last
   dimension for an array with Fortran layout) can be given as
@@ -529,11 +529,11 @@ val map_file :
   number of sub-arrays as determined by the non-major dimensions,
   otherwise [Failure] is raised.
 
-  If all dimensions of the big array are given, the file size is
-  matched against the size of the big array.  If the file is larger
-  than the big array, only the initial portion of the file is
-  mapped to the big array.  If the file is smaller than the big
-  array, the file is automatically grown to the size of the big array.
+  If all dimensions of the Bigarray are given, the file size is
+  matched against the size of the Bigarray.  If the file is larger
+  than the Bigarray, only the initial portion of the file is
+  mapped to the Bigarray.  If the file is smaller than the big
+  array, the file is automatically grown to the size of the Bigarray.
   This requires write permissions on [fd].
 
   Array accesses are bounds-checked, but the bounds are determined by

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -436,11 +436,11 @@ val map_file :
   file_descr -> ?pos:int64 -> kind:('a, 'b) Stdlib.Bigarray.kind ->
   layout:'c Stdlib.Bigarray.layout -> shared:bool -> dims:int array ->
   ('a, 'b, 'c) Stdlib.Bigarray.Genarray.t
-(** Memory mapping of a file as a big array.
+(** Memory mapping of a file as a Bigarray.
   [map_file fd kind layout shared dims]
-  returns a big array of kind [kind], layout [layout],
+  returns a Bigarray of kind [kind], layout [layout],
   and dimensions as specified in [dims].  The data contained in
-  this big array are the contents of the file referred to by
+  this Bigarray are the contents of the file referred to by
   the file descriptor [fd] (as opened previously with
   [Unix.openfile], for example).  The optional [pos] parameter
   is the byte offset in the file of the data being mapped;
@@ -454,10 +454,10 @@ val map_file :
   affected.
 
   [Genarray.map_file] is much more efficient than reading
-  the whole file in a big array, modifying that big array,
+  the whole file in a Bigarray, modifying that Bigarray,
   and writing it afterwards.
 
-  To adjust automatically the dimensions of the big array to
+  To adjust automatically the dimensions of the Bigarray to
   the actual size of the file, the major dimension (that is,
   the first dimension for an array with C layout, and the last
   dimension for an array with Fortran layout) can be given as
@@ -466,11 +466,11 @@ val map_file :
   number of sub-arrays as determined by the non-major dimensions,
   otherwise [Failure] is raised.
 
-  If all dimensions of the big array are given, the file size is
-  matched against the size of the big array.  If the file is larger
-  than the big array, only the initial portion of the file is
-  mapped to the big array.  If the file is smaller than the big
-  array, the file is automatically grown to the size of the big array.
+  If all dimensions of the Bigarray are given, the file size is
+  matched against the size of the Bigarray.  If the file is larger
+  than the Bigarray, only the initial portion of the file is
+  mapped to the Bigarray.  If the file is smaller than the big
+  array, the file is automatically grown to the size of the Bigarray.
   This requires write permissions on [fd].
 
   Array accesses are bounds-checked, but the bounds are determined by

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -16,35 +16,35 @@
 (** Large, multi-dimensional, numerical arrays.
 
    This module implements multi-dimensional arrays of integers and
-   floating-point numbers, thereafter referred to as 'big arrays',
+   floating-point numbers, thereafter referred to as 'Bigarrays',
    to distinguish them from the standard OCaml arrays described in
    {!module:Array}.
 
    The implementation allows efficient sharing of large numerical
    arrays between OCaml code and C or Fortran numerical libraries.
 
-   The main differences between 'big arrays' and standard OCaml
+   The main differences between 'Bigarrays' and standard OCaml
    arrays are as follows:
-   - Big arrays are not limited in size, unlike OCaml arrays.
+   - Bigarrays are not limited in size, unlike OCaml arrays.
      (Normal float arrays are limited to 2,097,151 elements on a 32-bit
      platform, and normal arrays of other types to 4,194,303 elements.)
-   - Big arrays are multi-dimensional.  Any number of dimensions
+   - Bigarrays are multi-dimensional.  Any number of dimensions
      between 0 and 16 is supported.  In contrast, OCaml arrays
      are mono-dimensional and require encoding multi-dimensional
      arrays as arrays of arrays.
-   - Big arrays can only contain integers and floating-point numbers,
+   - Bigarrays can only contain integers and floating-point numbers,
      while OCaml arrays can contain arbitrary OCaml data types.
-   - Big arrays provide more space-efficient storage of
+   - Bigarrays provide more space-efficient storage of
      integer and floating-point elements than normal OCaml arrays, in
      particular because they support 'small' types such as
      single-precision floats and 8 and 16-bit integers, in addition to
      the standard OCaml types of double-precision floats and 32 and
      64-bit integers.
-   - The memory layout of big arrays is entirely compatible with that
+   - The memory layout of Bigarrays is entirely compatible with that
      of arrays in C and Fortran, allowing large arrays to be passed
      back and forth between OCaml code and C / Fortran code with no
      data copying at all.
-   - Big arrays support interesting high-level operations that normal
+   - Bigarrays support interesting high-level operations that normal
      arrays do not provide efficiently, such as extracting sub-arrays
      and 'slicing' a multi-dimensional array along certain dimensions,
      all without any copying.
@@ -53,7 +53,7 @@
    source, then refer to array types and operations via short dot
    notation, e.g. [Array1.t] or [Array2.sub].
 
-   Big arrays support all the OCaml ad-hoc polymorphic operations:
+   Bigarrays support all the OCaml ad-hoc polymorphic operations:
    - comparisons ([=], [<>], [<=], etc, as well as {!Stdlib.compare});
    - hashing (module [Hash]);
    - and structured input-output (the functions from the
@@ -63,7 +63,7 @@
 
 (** {1 Element kinds} *)
 
-(** Big arrays can contain elements of the following kinds:
+(** Bigarrays can contain elements of the following kinds:
 - IEEE single precision (32 bits) floating-point numbers
    ({!Bigarray.float32_elt}),
 - IEEE double precision (64 bits) floating-point numbers
@@ -118,18 +118,18 @@ type ('a, 'b) kind =
   | Complex64 : (Complex.t, complex64_elt) kind
   | Char : (char, int8_unsigned_elt) kind (**)
 (** To each element kind is associated an OCaml type, which is
-   the type of OCaml values that can be stored in the big array
+   the type of OCaml values that can be stored in the Bigarray
    or read back from it.  This type is not necessarily the same
    as the type of the array elements proper: for instance,
-   a big array whose elements are of kind [float32_elt] contains
+   a Bigarray whose elements are of kind [float32_elt] contains
    32-bit single precision floats, but reading or writing one of
    its elements from OCaml uses the OCaml type [float], which is
    64-bit double precision floats.
 
    The GADT type [('a, 'b) kind] captures this association
-   of an OCaml type ['a] for values read or written in the big array,
+   of an OCaml type ['a] for values read or written in the Bigarray,
    and of an element kind ['b] which represents the actual contents
-   of the big array. Its constructors list all possible associations
+   of the Bigarray. Its constructors list all possible associations
    of OCaml types with element kinds, and are re-exported below for
    backward-compatibility reasons.
 
@@ -187,16 +187,16 @@ val nativeint : (nativeint, nativeint_elt) kind
 
 val char : (char, int8_unsigned_elt) kind
 (** As shown by the types of the values above,
-   big arrays of kind [float32_elt] and [float64_elt] are
-   accessed using the OCaml type [float].  Big arrays of complex kinds
+   Bigarrays of kind [float32_elt] and [float64_elt] are
+   accessed using the OCaml type [float].  Bigarrays of complex kinds
    [complex32_elt], [complex64_elt] are accessed with the OCaml type
-   {!Complex.t}. Big arrays of
+   {!Complex.t}. Bigarrays of
    integer kinds are accessed using the smallest OCaml integer
    type large enough to represent the array elements:
-   [int] for 8- and 16-bit integer bigarrays, as well as OCaml-integer
-   bigarrays; [int32] for 32-bit integer bigarrays; [int64]
-   for 64-bit integer bigarrays; and [nativeint] for
-   platform-native integer bigarrays.  Finally, big arrays of
+   [int] for 8- and 16-bit integer Bigarrays, as well as OCaml-integer
+   Bigarrays; [int32] for 32-bit integer Bigarrays; [int64]
+   for 64-bit integer Bigarrays; and [nativeint] for
+   platform-native integer Bigarrays.  Finally, Bigarrays of
    kind [int8_unsigned_elt] can also be accessed as arrays of
    characters instead of arrays of small integers, by using
    the kind value [char] instead of [int8_unsigned]. *)
@@ -214,7 +214,7 @@ type c_layout = C_layout_typ (**)
 
 type fortran_layout = Fortran_layout_typ (**)
 (** To facilitate interoperability with existing C and Fortran code,
-   this library supports two different memory layouts for big arrays,
+   this library supports two different memory layouts for Bigarrays,
    one compatible with the C conventions,
    the other compatible with the Fortran conventions.
 
@@ -256,7 +256,7 @@ val fortran_layout : fortran_layout layout
 module Genarray :
   sig
   type ('a, 'b, 'c) t
-  (** The type [Genarray.t] is the type of big arrays with variable
+  (** The type [Genarray.t] is the type of Bigarrays with variable
      numbers of dimensions.  Any number of dimensions between 0 and 16
      is supported.
 
@@ -271,27 +271,27 @@ module Genarray :
        ([c_layout] or [fortran_layout]).
 
      For instance, [(float, float32_elt, fortran_layout) Genarray.t]
-     is the type of generic big arrays containing 32-bit floats
+     is the type of generic Bigarrays containing 32-bit floats
      in Fortran layout; reads and writes in this array use the
      OCaml type [float]. *)
 
   external create: ('a, 'b) kind -> 'c layout -> int array -> ('a, 'b, 'c) t
     = "caml_ba_create"
-  (** [Genarray.create kind layout dimensions] returns a new big array
+  (** [Genarray.create kind layout dimensions] returns a new Bigarray
      whose element kind is determined by the parameter [kind] (one of
      [float32], [float64], [int8_signed], etc) and whose layout is
      determined by the parameter [layout] (one of [c_layout] or
      [fortran_layout]).  The [dimensions] parameter is an array of
-     integers that indicate the size of the big array in each dimension.
+     integers that indicate the size of the Bigarray in each dimension.
      The length of [dimensions] determines the number of dimensions
-     of the bigarray.
+     of the Bigarray.
 
      For instance, [Genarray.create int32 c_layout [|4;6;8|]]
-     returns a fresh big array of 32-bit integers, in C layout,
+     returns a fresh Bigarray of 32-bit integers, in C layout,
      having three dimensions, the three dimensions being 4, 6 and 8
      respectively.
 
-     Big arrays returned by [Genarray.create] are not initialized:
+     Bigarrays returned by [Genarray.create] are not initialized:
      the initial values of array elements is unspecified.
 
      [Genarray.create] raises [Invalid_argument] if the number of dimensions
@@ -299,29 +299,29 @@ module Genarray :
      is negative. *)
 
   external num_dims: ('a, 'b, 'c) t -> int = "caml_ba_num_dims"
-  (** Return the number of dimensions of the given big array. *)
+  (** Return the number of dimensions of the given Bigarray. *)
 
   val dims : ('a, 'b, 'c) t -> int array
-  (** [Genarray.dims a] returns all dimensions of the big array [a],
+  (** [Genarray.dims a] returns all dimensions of the Bigarray [a],
      as an array of integers of length [Genarray.num_dims a]. *)
 
   external nth_dim: ('a, 'b, 'c) t -> int -> int = "caml_ba_dim"
   (** [Genarray.nth_dim a n] returns the [n]-th dimension of the
-     big array [a].  The first dimension corresponds to [n = 0];
+     Bigarray [a].  The first dimension corresponds to [n = 0];
      the second dimension corresponds to [n = 1]; the last dimension,
      to [n = Genarray.num_dims a - 1].
      Raise [Invalid_argument] if [n] is less than 0 or greater or equal than
      [Genarray.num_dims a]. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
-  (** Return the kind of the given big array. *)
+  (** Return the kind of the given Bigarray. *)
 
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
-  (** Return the layout of the given big array. *)
+  (** Return the layout of the given Bigarray. *)
 
   external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t
       = "caml_ba_change_layout"
-  (** [Genarray.change_layout a layout] returns a bigarray with the
+  (** [Genarray.change_layout a layout] returns a Bigarray with the
       specified [layout], sharing the data with [a] (and hence having
       the same dimensions as [a]). No copying of elements is involved: the
       new array and the original array share the same storage space.
@@ -338,7 +338,7 @@ module Genarray :
     @since 4.03.0 *)
 
   external get: ('a, 'b, 'c) t -> int array -> 'a = "caml_ba_get_generic"
-  (** Read an element of a generic big array.
+  (** Read an element of a generic Bigarray.
      [Genarray.get a [|i1; ...; iN|]] returns the element of [a]
      whose coordinates are [i1] in the first dimension, [i2] in
      the second dimension, ..., [iN] in the [N]-th dimension.
@@ -358,7 +358,7 @@ module Genarray :
 
   external set: ('a, 'b, 'c) t -> int array -> 'a -> unit
     = "caml_ba_set_generic"
-  (** Assign an element of a generic big array.
+  (** Assign an element of a generic Bigarray.
      [Genarray.set a [|i1; ...; iN|] v] stores the value [v] in the
      element of [a] whose coordinates are [i1] in the first dimension,
      [i2] in the second dimension, ..., [iN] in the [N]-th dimension.
@@ -376,9 +376,9 @@ module Genarray :
 
   external sub_left: ('a, 'b, c_layout) t -> int -> int -> ('a, 'b, c_layout) t
     = "caml_ba_sub"
-  (** Extract a sub-array of the given big array by restricting the
+  (** Extract a sub-array of the given Bigarray by restricting the
      first (left-most) dimension.  [Genarray.sub_left a ofs len]
-     returns a big array with the same number of dimensions as [a],
+     returns a Bigarray with the same number of dimensions as [a],
      and the same dimensions as [a], except the first dimension,
      which corresponds to the interval [[ofs ... ofs + len - 1]]
      of the first dimension of [a].  No copying of elements is
@@ -388,7 +388,7 @@ module Genarray :
      element at coordinates [[|i1+ofs; ...; iN|]] of the original
      array [a].
 
-     [Genarray.sub_left] applies only to big arrays in C layout.
+     [Genarray.sub_left] applies only to Bigarrays in C layout.
      Raise [Invalid_argument] if [ofs] and [len] do not designate
      a valid sub-array of [a], that is, if [ofs < 0], or [len < 0],
      or [ofs + len > Genarray.nth_dim a 0]. *)
@@ -396,9 +396,9 @@ module Genarray :
   external sub_right:
     ('a, 'b, fortran_layout) t -> int -> int -> ('a, 'b, fortran_layout) t
     = "caml_ba_sub"
-  (** Extract a sub-array of the given big array by restricting the
+  (** Extract a sub-array of the given Bigarray by restricting the
      last (right-most) dimension.  [Genarray.sub_right a ofs len]
-     returns a big array with the same number of dimensions as [a],
+     returns a Bigarray with the same number of dimensions as [a],
      and the same dimensions as [a], except the last dimension,
      which corresponds to the interval [[ofs ... ofs + len - 1]]
      of the last dimension of [a].  No copying of elements is
@@ -408,7 +408,7 @@ module Genarray :
      element at coordinates [[|i1; ...; iN+ofs|]] of the original
      array [a].
 
-     [Genarray.sub_right] applies only to big arrays in Fortran layout.
+     [Genarray.sub_right] applies only to Bigarrays in Fortran layout.
      Raise [Invalid_argument] if [ofs] and [len] do not designate
      a valid sub-array of [a], that is, if [ofs < 1], or [len < 0],
      or [ofs + len > Genarray.nth_dim a (Genarray.num_dims a - 1)]. *)
@@ -416,7 +416,7 @@ module Genarray :
   external slice_left:
     ('a, 'b, c_layout) t -> int array -> ('a, 'b, c_layout) t
     = "caml_ba_slice"
-  (** Extract a sub-array of lower dimension from the given big array
+  (** Extract a sub-array of lower dimension from the given Bigarray
      by fixing one or several of the first (left-most) coordinates.
      [Genarray.slice_left a [|i1; ... ; iM|]] returns the 'slice'
      of [a] obtained by setting the first [M] coordinates to
@@ -427,14 +427,14 @@ module Genarray :
      array [a].  No copying of elements is involved: the slice and
      the original array share the same storage space.
 
-     [Genarray.slice_left] applies only to big arrays in C layout.
+     [Genarray.slice_left] applies only to Bigarrays in C layout.
      Raise [Invalid_argument] if [M >= N], or if [[|i1; ... ; iM|]]
      is outside the bounds of [a]. *)
 
   external slice_right:
     ('a, 'b, fortran_layout) t -> int array -> ('a, 'b, fortran_layout) t
     = "caml_ba_slice"
-  (** Extract a sub-array of lower dimension from the given big array
+  (** Extract a sub-array of lower dimension from the given Bigarray
      by fixing one or several of the last (right-most) coordinates.
      [Genarray.slice_right a [|i1; ... ; iM|]] returns the 'slice'
      of [a] obtained by setting the last [M] coordinates to
@@ -445,13 +445,13 @@ module Genarray :
      array [a].  No copying of elements is involved: the slice and
      the original array share the same storage space.
 
-     [Genarray.slice_right] applies only to big arrays in Fortran layout.
+     [Genarray.slice_right] applies only to Bigarrays in Fortran layout.
      Raise [Invalid_argument] if [M >= N], or if [[|i1; ... ; iM|]]
      is outside the bounds of [a]. *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
       = "caml_ba_blit"
-  (** Copy all elements of a big array in another big array.
+  (** Copy all elements of a Bigarray in another Bigarray.
      [Genarray.blit src dst] copies all elements of [src] into
      [dst].  Both arrays [src] and [dst] must have the same number of
      dimensions and equal dimensions.  Copying a sub-array of [src]
@@ -459,9 +459,9 @@ module Genarray :
      to sub-array or slices of [src] and [dst]. *)
 
   external fill: ('a, 'b, 'c) t -> 'a -> unit = "caml_ba_fill"
-  (** Set all elements of a big array to a given value.
+  (** Set all elements of a Bigarray to a given value.
      [Genarray.fill a v] stores the value [v] in all elements of
-     the big array [a].  Setting only some elements of [a] to [v]
+     the Bigarray [a].  Setting only some elements of [a] to [v]
      can be achieved by applying [Genarray.fill] to a sub-array
      or a slice of [a]. *)
   end
@@ -476,22 +476,22 @@ module Genarray :
    @since 4.05.0 *)
 module Array0 : sig
   type ('a, 'b, 'c) t
-  (** The type of zero-dimensional big arrays whose elements have
+  (** The type of zero-dimensional Bigarrays whose elements have
      OCaml type ['a], representation kind ['b], and memory layout ['c]. *)
 
   val create: ('a, 'b) kind -> 'c layout -> ('a, 'b, 'c) t
-  (** [Array0.create kind layout] returns a new bigarray of zero dimension.
+  (** [Array0.create kind layout] returns a new Bigarray of zero dimension.
      [kind] and [layout] determine the array element kind and the array
      layout as described for {!Genarray.create}. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
-  (** Return the kind of the given big array. *)
+  (** Return the kind of the given Bigarray. *)
 
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
-  (** Return the layout of the given big array. *)
+  (** Return the layout of the given Bigarray. *)
 
   val change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t
-  (** [Array0.change_layout a layout] returns a big array with the
+  (** [Array0.change_layout a layout] returns a Bigarray with the
       specified [layout], sharing the data with [a]. No copying of elements
       is involved: the new array and the original array share the same
       storage space.
@@ -509,15 +509,15 @@ module Array0 : sig
   (** [Array0.set a x v] stores the value [v] in [a]. *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit = "caml_ba_blit"
-  (** Copy the first big array to the second big array.
+  (** Copy the first Bigarray to the second Bigarray.
      See {!Genarray.blit} for more details. *)
 
   external fill: ('a, 'b, 'c) t -> 'a -> unit = "caml_ba_fill"
-  (** Fill the given big array with the given value.
+  (** Fill the given Bigarray with the given value.
      See {!Genarray.fill} for more details. *)
 
   val of_value: ('a, 'b) kind -> 'c layout -> 'a -> ('a, 'b, 'c) t
-  (** Build a zero-dimensional big array initialized from the
+  (** Build a zero-dimensional Bigarray initialized from the
      given value.  *)
 
 end
@@ -534,27 +534,27 @@ end
    faster operations, and more precise static type-checking. *)
 module Array1 : sig
   type ('a, 'b, 'c) t
-  (** The type of one-dimensional big arrays whose elements have
+  (** The type of one-dimensional Bigarrays whose elements have
      OCaml type ['a], representation kind ['b], and memory layout ['c]. *)
 
   val create: ('a, 'b) kind -> 'c layout -> int -> ('a, 'b, 'c) t
-  (** [Array1.create kind layout dim] returns a new bigarray of
+  (** [Array1.create kind layout dim] returns a new Bigarray of
      one dimension, whose size is [dim].  [kind] and [layout]
      determine the array element kind and the array layout
      as described for {!Genarray.create}. *)
 
   external dim: ('a, 'b, 'c) t -> int = "%caml_ba_dim_1"
   (** Return the size (dimension) of the given one-dimensional
-     big array. *)
+     Bigarray. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
-  (** Return the kind of the given big array. *)
+  (** Return the kind of the given Bigarray. *)
 
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
-  (** Return the layout of the given big array. *)
+  (** Return the layout of the given Bigarray. *)
 
   val change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t
-  (** [Array1.change_layout a layout] returns a bigarray with the
+  (** [Array1.change_layout a layout] returns a Bigarray with the
       specified [layout], sharing the data with [a] (and hence having
       the same dimension as [a]). No copying of elements is involved: the
       new array and the original array share the same storage space.
@@ -586,27 +586,27 @@ module Array1 : sig
 
   external sub: ('a, 'b, 'c) t -> int -> int -> ('a, 'b, 'c) t
       = "caml_ba_sub"
-  (** Extract a sub-array of the given one-dimensional big array.
+  (** Extract a sub-array of the given one-dimensional Bigarray.
      See {!Genarray.sub_left} for more details. *)
 
   val slice: ('a, 'b, 'c) t -> int -> ('a, 'b, 'c) Array0.t
   (** Extract a scalar (zero-dimensional slice) of the given one-dimensional
-     big array.  The integer parameter is the index of the scalar to
+     Bigarray.  The integer parameter is the index of the scalar to
      extract.  See {!Bigarray.Genarray.slice_left} and
      {!Bigarray.Genarray.slice_right} for more details.
      @since 4.05.0 *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
       = "caml_ba_blit"
-  (** Copy the first big array to the second big array.
+  (** Copy the first Bigarray to the second Bigarray.
      See {!Genarray.blit} for more details. *)
 
   external fill: ('a, 'b, 'c) t -> 'a -> unit = "caml_ba_fill"
-  (** Fill the given big array with the given value.
+  (** Fill the given Bigarray with the given value.
      See {!Genarray.fill} for more details. *)
 
   val of_array: ('a, 'b) kind -> 'c layout -> 'a array -> ('a, 'b, 'c) t
-  (** Build a one-dimensional big array initialized from the
+  (** Build a one-dimensional Bigarray initialized from the
      given array.  *)
 
   external unsafe_get: ('a, 'b, 'c) t -> int -> 'a = "%caml_ba_unsafe_ref_1"
@@ -631,30 +631,30 @@ end
 module Array2 :
   sig
   type ('a, 'b, 'c) t
-  (** The type of two-dimensional big arrays whose elements have
+  (** The type of two-dimensional Bigarrays whose elements have
      OCaml type ['a], representation kind ['b], and memory layout ['c]. *)
 
   val create: ('a, 'b) kind ->  'c layout -> int -> int -> ('a, 'b, 'c) t
-  (** [Array2.create kind layout dim1 dim2] returns a new bigarray of
+  (** [Array2.create kind layout dim1 dim2] returns a new Bigarray of
      two dimension, whose size is [dim1] in the first dimension
      and [dim2] in the second dimension.  [kind] and [layout]
      determine the array element kind and the array layout
      as described for {!Bigarray.Genarray.create}. *)
 
   external dim1: ('a, 'b, 'c) t -> int = "%caml_ba_dim_1"
-  (** Return the first dimension of the given two-dimensional big array. *)
+  (** Return the first dimension of the given two-dimensional Bigarray. *)
 
   external dim2: ('a, 'b, 'c) t -> int = "%caml_ba_dim_2"
-  (** Return the second dimension of the given two-dimensional big array. *)
+  (** Return the second dimension of the given two-dimensional Bigarray. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
-  (** Return the kind of the given big array. *)
+  (** Return the kind of the given Bigarray. *)
 
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
-  (** Return the layout of the given big array. *)
+  (** Return the layout of the given Bigarray. *)
 
   val change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t
-  (** [Array2.change_layout a layout] returns a bigarray with the
+  (** [Array2.change_layout a layout] returns a Bigarray with the
       specified [layout], sharing the data with [a] (and hence having
       the same dimensions as [a]). No copying of elements is involved: the
       new array and the original array share the same storage space.
@@ -688,7 +688,7 @@ module Array2 :
   external sub_left: ('a, 'b, c_layout) t -> int -> int -> ('a, 'b, c_layout) t
     = "caml_ba_sub"
   (** Extract a two-dimensional sub-array of the given two-dimensional
-     big array by restricting the first dimension.
+     Bigarray by restricting the first dimension.
      See {!Bigarray.Genarray.sub_left} for more details.
      [Array2.sub_left] applies only to arrays with C layout. *)
 
@@ -696,35 +696,35 @@ module Array2 :
     ('a, 'b, fortran_layout) t -> int -> int -> ('a, 'b, fortran_layout) t
     = "caml_ba_sub"
   (** Extract a two-dimensional sub-array of the given two-dimensional
-     big array by restricting the second dimension.
+     Bigarray by restricting the second dimension.
      See {!Bigarray.Genarray.sub_right} for more details.
      [Array2.sub_right] applies only to arrays with Fortran layout. *)
 
   val slice_left: ('a, 'b, c_layout) t -> int -> ('a, 'b, c_layout) Array1.t
   (** Extract a row (one-dimensional slice) of the given two-dimensional
-     big array.  The integer parameter is the index of the row to
+     Bigarray.  The integer parameter is the index of the row to
      extract.  See {!Bigarray.Genarray.slice_left} for more details.
      [Array2.slice_left] applies only to arrays with C layout. *)
 
   val slice_right:
     ('a, 'b, fortran_layout) t -> int -> ('a, 'b, fortran_layout) Array1.t
   (** Extract a column (one-dimensional slice) of the given
-     two-dimensional big array.  The integer parameter is the
+     two-dimensional Bigarray.  The integer parameter is the
      index of the column to extract.  See {!Bigarray.Genarray.slice_right}
      for more details.  [Array2.slice_right] applies only to arrays
      with Fortran layout. *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
     = "caml_ba_blit"
-  (** Copy the first big array to the second big array.
+  (** Copy the first Bigarray to the second Bigarray.
      See {!Bigarray.Genarray.blit} for more details. *)
 
   external fill: ('a, 'b, 'c) t -> 'a -> unit = "caml_ba_fill"
-  (** Fill the given big array with the given value.
+  (** Fill the given Bigarray with the given value.
      See {!Bigarray.Genarray.fill} for more details. *)
 
   val of_array: ('a, 'b) kind -> 'c layout -> 'a array array -> ('a, 'b, 'c) t
-  (** Build a two-dimensional big array initialized from the
+  (** Build a two-dimensional Bigarray initialized from the
      given array of arrays.  *)
 
   external unsafe_get: ('a, 'b, 'c) t -> int -> int -> 'a
@@ -747,34 +747,34 @@ end
 module Array3 :
   sig
   type ('a, 'b, 'c) t
-  (** The type of three-dimensional big arrays whose elements have
+  (** The type of three-dimensional Bigarrays whose elements have
      OCaml type ['a], representation kind ['b], and memory layout ['c]. *)
 
   val create: ('a, 'b) kind -> 'c layout -> int -> int -> int -> ('a, 'b, 'c) t
-  (** [Array3.create kind layout dim1 dim2 dim3] returns a new bigarray of
+  (** [Array3.create kind layout dim1 dim2 dim3] returns a new Bigarray of
      three dimension, whose size is [dim1] in the first dimension,
      [dim2] in the second dimension, and [dim3] in the third.
      [kind] and [layout] determine the array element kind and
      the array layout as described for {!Bigarray.Genarray.create}. *)
 
   external dim1: ('a, 'b, 'c) t -> int = "%caml_ba_dim_1"
-  (** Return the first dimension of the given three-dimensional big array. *)
+  (** Return the first dimension of the given three-dimensional Bigarray. *)
 
   external dim2: ('a, 'b, 'c) t -> int = "%caml_ba_dim_2"
-  (** Return the second dimension of the given three-dimensional big array. *)
+  (** Return the second dimension of the given three-dimensional Bigarray. *)
 
   external dim3: ('a, 'b, 'c) t -> int = "%caml_ba_dim_3"
-  (** Return the third dimension of the given three-dimensional big array. *)
+  (** Return the third dimension of the given three-dimensional Bigarray. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
-  (** Return the kind of the given big array. *)
+  (** Return the kind of the given Bigarray. *)
 
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
-  (** Return the layout of the given big array. *)
+  (** Return the layout of the given Bigarray. *)
 
 
   val change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t
-  (** [Array3.change_layout a layout] returns a bigarray with the
+  (** [Array3.change_layout a layout] returns a Bigarray with the
       specified [layout], sharing the data with [a] (and hence having
       the same dimensions as [a]). No copying of elements is involved: the
       new array and the original array share the same storage space.
@@ -808,7 +808,7 @@ module Array3 :
   external sub_left: ('a, 'b, c_layout) t -> int -> int -> ('a, 'b, c_layout) t
     = "caml_ba_sub"
   (** Extract a three-dimensional sub-array of the given
-     three-dimensional big array by restricting the first dimension.
+     three-dimensional Bigarray by restricting the first dimension.
      See {!Bigarray.Genarray.sub_left} for more details.  [Array3.sub_left]
      applies only to arrays with C layout. *)
 
@@ -816,14 +816,14 @@ module Array3 :
     ('a, 'b, fortran_layout) t -> int -> int -> ('a, 'b, fortran_layout) t
     = "caml_ba_sub"
   (** Extract a three-dimensional sub-array of the given
-     three-dimensional big array by restricting the second dimension.
+     three-dimensional Bigarray by restricting the second dimension.
      See {!Bigarray.Genarray.sub_right} for more details.  [Array3.sub_right]
      applies only to arrays with Fortran layout. *)
 
   val slice_left_1:
     ('a, 'b, c_layout) t -> int -> int -> ('a, 'b, c_layout) Array1.t
   (** Extract a one-dimensional slice of the given three-dimensional
-     big array by fixing the first two coordinates.
+     Bigarray by fixing the first two coordinates.
      The integer parameters are the coordinates of the slice to
      extract.  See {!Bigarray.Genarray.slice_left} for more details.
      [Array3.slice_left_1] applies only to arrays with C layout. *)
@@ -832,7 +832,7 @@ module Array3 :
     ('a, 'b, fortran_layout) t ->
     int -> int -> ('a, 'b, fortran_layout) Array1.t
   (** Extract a one-dimensional slice of the given three-dimensional
-     big array by fixing the last two coordinates.
+     Bigarray by fixing the last two coordinates.
      The integer parameters are the coordinates of the slice to
      extract.  See {!Bigarray.Genarray.slice_right} for more details.
      [Array3.slice_right_1] applies only to arrays with Fortran
@@ -840,7 +840,7 @@ module Array3 :
 
   val slice_left_2: ('a, 'b, c_layout) t -> int -> ('a, 'b, c_layout) Array2.t
   (** Extract a  two-dimensional slice of the given three-dimensional
-     big array by fixing the first coordinate.
+     Bigarray by fixing the first coordinate.
      The integer parameter is the first coordinate of the slice to
      extract.  See {!Bigarray.Genarray.slice_left} for more details.
      [Array3.slice_left_2] applies only to arrays with C layout. *)
@@ -848,7 +848,7 @@ module Array3 :
   val slice_right_2:
     ('a, 'b, fortran_layout) t -> int -> ('a, 'b, fortran_layout) Array2.t
   (** Extract a two-dimensional slice of the given
-     three-dimensional big array by fixing the last coordinate.
+     three-dimensional Bigarray by fixing the last coordinate.
      The integer parameter is the coordinate of the slice
      to extract.  See {!Bigarray.Genarray.slice_right} for more details.
      [Array3.slice_right_2] applies only to arrays with Fortran
@@ -856,16 +856,16 @@ module Array3 :
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
     = "caml_ba_blit"
-  (** Copy the first big array to the second big array.
+  (** Copy the first Bigarray to the second Bigarray.
      See {!Bigarray.Genarray.blit} for more details. *)
 
   external fill: ('a, 'b, 'c) t -> 'a -> unit = "caml_ba_fill"
-  (** Fill the given big array with the given value.
+  (** Fill the given Bigarray with the given value.
      See {!Bigarray.Genarray.fill} for more details. *)
 
   val of_array:
     ('a, 'b) kind -> 'c layout -> 'a array array array -> ('a, 'b, 'c) t
-  (** Build a three-dimensional big array initialized from the
+  (** Build a three-dimensional Bigarray initialized from the
      given array of arrays of arrays.  *)
 
   external unsafe_get: ('a, 'b, 'c) t -> int -> int -> int -> 'a
@@ -880,54 +880,54 @@ module Array3 :
 
 end
 
-(** {1 Coercions between generic big arrays and fixed-dimension big arrays} *)
+(** {1 Coercions between generic Bigarrays and fixed-dimension Bigarrays} *)
 
 external genarray_of_array0 :
   ('a, 'b, 'c) Array0.t -> ('a, 'b, 'c) Genarray.t = "%identity"
-(** Return the generic big array corresponding to the given zero-dimensional
-   big array. @since 4.05.0 *)
+(** Return the generic Bigarray corresponding to the given zero-dimensional
+   Bigarray. @since 4.05.0 *)
 
 external genarray_of_array1 :
   ('a, 'b, 'c) Array1.t -> ('a, 'b, 'c) Genarray.t = "%identity"
-(** Return the generic big array corresponding to the given one-dimensional
-   big array. *)
+(** Return the generic Bigarray corresponding to the given one-dimensional
+   Bigarray. *)
 
 external genarray_of_array2 :
   ('a, 'b, 'c) Array2.t -> ('a, 'b, 'c) Genarray.t = "%identity"
-(** Return the generic big array corresponding to the given two-dimensional
-   big array. *)
+(** Return the generic Bigarray corresponding to the given two-dimensional
+   Bigarray. *)
 
 external genarray_of_array3 :
   ('a, 'b, 'c) Array3.t -> ('a, 'b, 'c) Genarray.t = "%identity"
-(** Return the generic big array corresponding to the given three-dimensional
-   big array. *)
+(** Return the generic Bigarray corresponding to the given three-dimensional
+   Bigarray. *)
 
 val array0_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array0.t
-(** Return the zero-dimensional big array corresponding to the given
-   generic big array.  Raise [Invalid_argument] if the generic big array
+(** Return the zero-dimensional Bigarray corresponding to the given
+   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
    does not have exactly zero dimension.
    @since 4.05.0 *)
 
 val array1_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array1.t
-(** Return the one-dimensional big array corresponding to the given
-   generic big array.  Raise [Invalid_argument] if the generic big array
+(** Return the one-dimensional Bigarray corresponding to the given
+   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
    does not have exactly one dimension. *)
 
 val array2_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array2.t
-(** Return the two-dimensional big array corresponding to the given
-   generic big array.  Raise [Invalid_argument] if the generic big array
+(** Return the two-dimensional Bigarray corresponding to the given
+   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
    does not have exactly two dimensions. *)
 
 val array3_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array3.t
-(** Return the three-dimensional big array corresponding to the given
-   generic big array.  Raise [Invalid_argument] if the generic big array
+(** Return the three-dimensional Bigarray corresponding to the given
+   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
    does not have exactly three dimensions. *)
 
 
-(** {1 Re-shaping big arrays} *)
+(** {1 Re-shaping Bigarrays} *)
 
 val reshape : ('a, 'b, 'c) Genarray.t -> int array -> ('a, 'b, 'c) Genarray.t
-(** [reshape b [|d1;...;dN|]] converts the big array [b] to a
+(** [reshape b [|d1;...;dN|]] converts the Bigarray [b] to a
    [N]-dimensional array of dimensions [d1]...[dN].  The returned
    array and the original array [b] share their data
    and have the same layout.  For instance, assuming that [b]
@@ -937,8 +937,8 @@ val reshape : ('a, 'b, 'c) Genarray.t -> int array -> ('a, 'b, 'c) Genarray.t
    to the element [x * 3 + y] of [b].  If [b] has Fortran layout,
    the element [(x,y)] of [b'] corresponds to the element
    [x + (y - 1) * 4] of [b].
-   The returned big array must have exactly the same number of
-   elements as the original big array [b].  That is, the product
+   The returned Bigarray must have exactly the same number of
+   elements as the original Bigarray [b].  That is, the product
    of the dimensions of [b] must be equal to [i1 * ... * iN].
    Otherwise, [Invalid_argument] is raised. *)
 


### PR DESCRIPTION
As suggested in #2201 , this PR proposes to consistently use `Bigarray` instead of `big array` when referring to the multidimensional arrays introduced by the `Bigarray` module.