### PR TITLE
Fix reading of typo.prune in CI

### DIFF
--- a/tools/check-typo
+++ b/tools/check-typo
@@ -30,7 +30,7 @@
 # - presence of a copyright header (missing-header)
 # - absence of a leftover "$Id" string (svn-keyword)
 
-# Exceptions are handled with a git attribute: "ocaml-typo".
+# Exceptions are handled with git attributes: "typo.*".
 # Its value for a given file is a comma-separated list of rule names,
 # which lists the rules that should be disabled for this file.
 # The rule names are the ones shown above in parentheses.
@@ -57,8 +57,8 @@
 # This program ignores any file that is not under git control, unless
 # explicitly given on the command line.
 
-# If a directory has the git attribute "ocaml-typo" set to "prune",
-# then it and its contents are ignored.
+# If a directory has the git attribute "typo.prune" then it and its contents are
+# ignored.
 
 # You can ignore a rule by giving the option -<rule> on the command
 # line (before any file names).

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -190,8 +190,8 @@ not_pruned () {
   if [ "$DIR" = "." ] ; then
     return 0
   else
-    case ",$(git check-attr ocaml-typo "$DIR" | sed -e 's/.*: //')," in
-      ,prune,)
+    case ",$(git check-attr typo.prune "$DIR" | sed -e 's/.*: //')," in
+      ,set,)
       return 1
       ;;
       *)
@@ -217,7 +217,7 @@ CheckTypoTree () {
         touch check-typo-failed
       fi
     else
-      echo "NOT checking $1: $path (ocaml-typo=prune)"
+      echo "NOT checking $1: $path (typo.prune)"
     fi
   done)
   rm -f tmp-index

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -15,7 +15,7 @@
 
 # Bump this on any changes. It's vital that HOOK_VERSION followed by equals
 # appears nowhere else in these sources!
-HOOK_VERSION=2
+HOOK_VERSION=3
 
 # For what it's worth, allow for empty trees!
 if git rev-parse --verify HEAD >/dev/null 2>&1
@@ -60,8 +60,8 @@ not_pruned () {
   if [ "$DIR" = "." ] ; then
     return 0
   else
-    case ",$(git check-attr ocaml-typo "$DIR" | sed -e 's/.*: //')," in
-      ,prune,)
+    case ",$(git check-attr typo.prune "$DIR" | sed -e 's/.*: //')," in
+      ,set,)
       return 1
       ;;
       *)


### PR DESCRIPTION
Follow-up to changes made in #1910.

This fixes the reading of `typo.prune` both for the Travis `check-typo` job and also for the Git pre-commit hook.

This fixes the CI failure in #2139.
