### PR TITLE
Refactor driver/compile_common

### DIFF
--- a/Changes
+++ b/Changes
@@ -529,8 +529,9 @@ Working version
 - GPR#1610: Remove positions from paths
   (Leo White, review by Frédéric Bour and Thomas Refis)
 
-- GPR#1703, GPR#1944: Add the module Compile_common, which factorizes the common
-  part in Compile and Optcompile. This also makes the pipeline more modular.
+- GPR#1703, GPR#1944, GPR#2213: Add the module Compile_common,
+  which factorizes the common part in Compile and Optcompile.
+  This also makes the pipeline more modular.
   (Gabriel Radanne, help from Gabriel Scherer and Valentin Gatien-Baron,
    review by Mark Shinwell and Gabriel Radanne)
 

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -594,12 +594,12 @@ let process_action
   | ProcessImplementation name ->
       readenv ppf (Before_compile name);
       let opref = output_prefix name in
-      implementation ~sourcefile:name ~outputprefix:opref;
+      implementation ~source_file:name ~output_prefix:opref;
       objfiles := (opref ^ ocaml_mod_ext) :: !objfiles
   | ProcessInterface name ->
       readenv ppf (Before_compile name);
       let opref = output_prefix name in
-      interface ~sourcefile:name ~outputprefix:opref;
+      interface ~source_file:name ~output_prefix:opref;
       if !make_package then objfiles := (opref ^ ".cmi") :: !objfiles
   | ProcessCFile name ->
       readenv ppf (Before_compile name);

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -70,9 +70,9 @@ val intf : string -> unit
 
 val process_deferred_actions :
   Format.formatter *
-  (sourcefile:string -> outputprefix:string -> unit) *
+  (source_file:string -> output_prefix:string -> unit) *
   (* compile implementation *)
-  (sourcefile:string -> outputprefix:string -> unit) *
+  (source_file:string -> output_prefix:string -> unit) *
   (* compile interface *)
   string * (* ocaml module extension *)
   string -> (* ocaml library extension *)

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -25,14 +25,14 @@ let interface = Compile_common.interface ~tool_name
 let to_bytecode i (typedtree, coercion) =
   (typedtree, coercion)
   |> Profile.(record transl)
-    (Translmod.transl_implementation i.modulename)
+    (Translmod.transl_implementation i.module_name)
   |> Profile.(record ~accumulate:true generate)
     (fun { Lambda.code = lambda; required_globals } ->
        lambda
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
-       |> Simplif.simplify_lambda i.sourcefile
+       |> Simplif.simplify_lambda i.source_file
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
-       |> Bytegen.compile_implementation i.modulename
+       |> Bytegen.compile_implementation i.module_name
        |> print_if i.ppf_dump Clflags.dump_instr Printinstr.instrlist
        |> fun bytecode -> bytecode, required_globals
     )
@@ -46,7 +46,7 @@ let emit_bytecode i (bytecode, required_globals) =
     (fun () ->
        bytecode
        |> Profile.(record ~accumulate:true generate)
-         (Emitcode.to_file oc i.modulename cmofile ~required_globals);
+         (Emitcode.to_file oc i.module_name cmofile ~required_globals);
     )
 
 let implementation =

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -18,12 +18,11 @@ open Compile_common
 
 let tool_name = "ocamlc"
 
-let init =
-  Compile_common.init ~native:false ~tool_name
+let with_info =
+  Compile_common.with_info ~native:false ~tool_name
 
 let interface ~source_file ~output_prefix =
-  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
-  let info = init ~ppf_dump ~source_file ~output_prefix in
+  with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
   Compile_common.interface info
 
 (** Bytecode compilation backend for .ml files. *)
@@ -56,10 +55,9 @@ let emit_bytecode i (bytecode, required_globals) =
     )
 
 let implementation ~source_file ~output_prefix =
-  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmo") @@ fun ppf_dump ->
-  let info = init ~ppf_dump ~source_file ~output_prefix in
   let backend info typed =
     let bytecode = to_bytecode info typed in
     emit_bytecode info bytecode
   in
+  with_info ~source_file ~output_prefix ~dump_ext:"cmo" @@ fun info ->
   Compile_common.implementation info ~backend

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -23,7 +23,7 @@ let init =
 
 let interface ~source_file ~output_prefix =
   Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
-  let info = init ppf_dump ~source_file ~output_prefix in
+  let info = init ~ppf_dump ~source_file ~output_prefix in
   Compile_common.interface info
 
 (** Bytecode compilation backend for .ml files. *)
@@ -57,7 +57,7 @@ let emit_bytecode i (bytecode, required_globals) =
 
 let implementation ~source_file ~output_prefix =
   Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmo") @@ fun ppf_dump ->
-  let info = init ppf_dump ~source_file ~output_prefix in
+  let info = init ~ppf_dump ~source_file ~output_prefix in
   let backend info typed =
     let bytecode = to_bytecode info typed in
     emit_bytecode info bytecode

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -16,9 +16,9 @@
 (** Bytecode compilation for .ml and .mli files. *)
 
 val interface:
-  sourcefile:string -> outputprefix:string -> unit
+  source_file:string -> output_prefix:string -> unit
 val implementation:
-  sourcefile:string -> outputprefix:string -> unit
+  source_file:string -> output_prefix:string -> unit
 
 (** {2 Internal functions} **)
 

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -81,12 +81,8 @@ let emit_signature info ast tsg =
   Typemod.save_signature info.module_name tsg
     info.output_prefix info.source_file info.env sg
 
-let interface ~tool_name ~source_file ~output_prefix =
-  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
-  Profile.record_call source_file @@ fun () ->
-  let info =
-    init ppf_dump ~native:false ~tool_name ~source_file ~output_prefix
-  in
+let interface info =
+  Profile.record_call info.source_file @@ fun () ->
   let ast = parse_intf info in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let tsg = typecheck_intf info ast in
@@ -114,13 +110,9 @@ let typecheck_impl i parsetree =
       Printtyped.implementation_with_coercion
   )
 
-let implementation ~tool_name ~native ~backend ~source_file ~output_prefix =
-  let suf, sufs = if native then ".cmx", [ cmx; obj ] else ".cmo", [ cmo ] in
-  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ suf) @@ fun ppf_dump ->
-  let info =
-    init ppf_dump ~native ~tool_name ~source_file ~output_prefix
-  in
+let implementation info ~backend =
   Profile.record_call info.source_file @@ fun () ->
+  let sufs = if info.native then [ cmx; obj ] else [ cmo ] in
   let parsed = parse_impl info in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let typed = typecheck_impl info parsed in

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -31,7 +31,7 @@ let obj i = i.output_prefix ^ Config.ext_obj
 let cmo i = i.output_prefix ^ ".cmo"
 let annot i = i.output_prefix ^ ".annot"
 
-let init ppf_dump ~native ~tool_name ~source_file ~output_prefix =
+let init ~ppf_dump ~native ~tool_name ~source_file ~output_prefix =
   Compmisc.init_path native;
   let module_name = module_of_filename source_file output_prefix in
   Env.set_unit_name module_name;

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -31,8 +31,8 @@ let obj i = i.output_prefix ^ Config.ext_obj
 let cmo i = i.output_prefix ^ ".cmo"
 let annot i = i.output_prefix ^ ".annot"
 
-let init ppf_dump ~init_path ~tool_name ~source_file ~output_prefix =
-  Compmisc.init_path init_path;
+let init ppf_dump ~native ~tool_name ~source_file ~output_prefix =
+  Compmisc.init_path native;
   let module_name = module_of_filename source_file output_prefix in
   Env.set_unit_name module_name;
   let env = Compmisc.initial_env() in
@@ -77,7 +77,7 @@ let interface ~tool_name ~source_file ~output_prefix =
   Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
   Profile.record_call source_file @@ fun () ->
   let info =
-    init ppf_dump ~init_path:false ~tool_name ~source_file ~output_prefix
+    init ppf_dump ~native:false ~tool_name ~source_file ~output_prefix
   in
   let ast = parse_intf info in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
@@ -110,7 +110,7 @@ let implementation ~tool_name ~native ~backend ~source_file ~output_prefix =
   let suf, sufs = if native then ".cmx", [ cmx; obj ] else ".cmo", [ cmo ] in
   Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ suf) @@ fun ppf_dump ->
   let info =
-    init ppf_dump ~init_path:native ~tool_name ~source_file ~output_prefix
+    init ppf_dump ~native ~tool_name ~source_file ~output_prefix
   in
   Profile.record_call info.source_file @@ fun () ->
   let parsed = parse_impl info in

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -17,32 +17,32 @@ open Misc
 open Compenv
 
 type info = {
-  sourcefile : string;
-  modulename : string;
-  outputprefix : string;
+  source_file : string;
+  module_name : string;
+  output_prefix : string;
   env : Env.t;
   ppf_dump : Format.formatter;
   tool_name : string;
 }
 
 
-let cmx i = i.outputprefix ^ ".cmx"
-let obj i = i.outputprefix ^ Config.ext_obj
-let cmo i = i.outputprefix ^ ".cmo"
-let annot i = i.outputprefix ^ ".annot"
+let cmx i = i.output_prefix ^ ".cmx"
+let obj i = i.output_prefix ^ Config.ext_obj
+let cmo i = i.output_prefix ^ ".cmo"
+let annot i = i.output_prefix ^ ".annot"
 
-let init ppf_dump ~init_path ~tool_name ~sourcefile ~outputprefix =
+let init ppf_dump ~init_path ~tool_name ~source_file ~output_prefix =
   Compmisc.init_path init_path;
-  let modulename = module_of_filename sourcefile outputprefix in
-  Env.set_unit_name modulename;
+  let module_name = module_of_filename source_file output_prefix in
+  Env.set_unit_name module_name;
   let env = Compmisc.initial_env() in
-  { modulename; outputprefix; env; sourcefile; ppf_dump; tool_name }
+  { module_name; output_prefix; env; source_file; ppf_dump; tool_name }
 
 
 (** Compile a .mli file *)
 
 let parse_intf i =
-  Pparse.parse_interface ~tool_name:i.tool_name i.sourcefile
+  Pparse.parse_interface ~tool_name:i.tool_name i.source_file
   |> print_if i.ppf_dump Clflags.dump_parsetree Printast.interface
   |> print_if i.ppf_dump Clflags.dump_source Pprintast.signature
 
@@ -50,14 +50,14 @@ let typecheck_intf info ast =
   Profile.(record_call typing) @@ fun () ->
   let tsg =
     ast
-    |> Typemod.type_interface info.sourcefile info.env
+    |> Typemod.type_interface info.source_file info.env
     |> print_if info.ppf_dump Clflags.dump_typedtree Printtyped.interface
   in
   let sg = tsg.Typedtree.sig_type in
   if !Clflags.print_types then
     Printtyp.wrap_printing_env ~error:false info.env (fun () ->
         Format.(fprintf std_formatter) "%a@."
-          (Printtyp.printed_signature info.sourcefile)
+          (Printtyp.printed_signature info.source_file)
           sg);
   ignore (Includemod.signatures info.env sg sg);
   Typecore.force_delayed_checks ();
@@ -68,16 +68,16 @@ let emit_signature info ast tsg =
   let sg =
     let alerts = Builtin_attributes.alerts_of_sig ast in
     Env.save_signature ~alerts tsg.Typedtree.sig_type
-      info.modulename (info.outputprefix ^ ".cmi")
+      info.module_name (info.output_prefix ^ ".cmi")
   in
-  Typemod.save_signature info.modulename tsg
-    info.outputprefix info.sourcefile info.env sg
+  Typemod.save_signature info.module_name tsg
+    info.output_prefix info.source_file info.env sg
 
-let interface ~tool_name ~sourcefile ~outputprefix =
-  Compmisc.with_ppf_dump ~fileprefix:(outputprefix ^ ".cmi") @@ fun ppf_dump ->
-  Profile.record_call sourcefile @@ fun () ->
+let interface ~tool_name ~source_file ~output_prefix =
+  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
+  Profile.record_call source_file @@ fun () ->
   let info =
-    init ppf_dump ~init_path:false ~tool_name ~sourcefile ~outputprefix
+    init ppf_dump ~init_path:false ~tool_name ~source_file ~output_prefix
   in
   let ast = parse_intf info in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
@@ -91,7 +91,7 @@ let interface ~tool_name ~sourcefile ~outputprefix =
 (** Frontend for a .ml file *)
 
 let parse_impl i =
-  Pparse.parse_implementation ~tool_name:i.tool_name i.sourcefile
+  Pparse.parse_implementation ~tool_name:i.tool_name i.source_file
   |> print_if i.ppf_dump Clflags.dump_parsetree Printast.implementation
   |> print_if i.ppf_dump Clflags.dump_source Pprintast.structure
 
@@ -101,18 +101,18 @@ let typecheck_impl i parsetree =
     parsetree
     |> Profile.(record typing)
       (Typemod.type_implementation
-         i.sourcefile i.outputprefix i.modulename i.env)
+         i.source_file i.output_prefix i.module_name i.env)
     |> print_if i.ppf_dump Clflags.dump_typedtree
       Printtyped.implementation_with_coercion
   )
 
-let implementation ~tool_name ~native ~backend ~sourcefile ~outputprefix =
+let implementation ~tool_name ~native ~backend ~source_file ~output_prefix =
   let suf, sufs = if native then ".cmx", [ cmx; obj ] else ".cmo", [ cmo ] in
-  Compmisc.with_ppf_dump ~fileprefix:(outputprefix ^ suf) @@ fun ppf_dump ->
+  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ suf) @@ fun ppf_dump ->
   let info =
-    init ppf_dump ~init_path:native ~tool_name ~sourcefile ~outputprefix
+    init ppf_dump ~init_path:native ~tool_name ~source_file ~output_prefix
   in
-  Profile.record_call info.sourcefile @@ fun () ->
+  Profile.record_call info.source_file @@ fun () ->
   let parsed = parse_impl info in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let typed = typecheck_impl info parsed in

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -23,8 +23,8 @@ type info = {
   env : Env.t;
   ppf_dump : Format.formatter;
   tool_name : string;
+  native : bool;
 }
-
 
 let cmx i = i.output_prefix ^ ".cmx"
 let obj i = i.output_prefix ^ Config.ext_obj
@@ -43,6 +43,7 @@ let init ppf_dump ~native ~tool_name ~source_file ~output_prefix =
     source_file;
     ppf_dump;
     tool_name;
+    native;
   }
 
 

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -36,7 +36,14 @@ let init ppf_dump ~native ~tool_name ~source_file ~output_prefix =
   let module_name = module_of_filename source_file output_prefix in
   Env.set_unit_name module_name;
   let env = Compmisc.initial_env() in
-  { module_name; output_prefix; env; source_file; ppf_dump; tool_name }
+  {
+    module_name;
+    output_prefix;
+    env;
+    source_file;
+    ppf_dump;
+    tool_name;
+  }
 
 
 (** Compile a .mli file *)

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -31,12 +31,14 @@ let obj i = i.output_prefix ^ Config.ext_obj
 let cmo i = i.output_prefix ^ ".cmo"
 let annot i = i.output_prefix ^ ".annot"
 
-let init ~ppf_dump ~native ~tool_name ~source_file ~output_prefix =
+let with_info ~native ~tool_name ~source_file ~output_prefix ~dump_ext k =
   Compmisc.init_path native;
   let module_name = module_of_filename source_file output_prefix in
   Env.set_unit_name module_name;
   let env = Compmisc.initial_env() in
-  {
+  let dump_file = String.concat "." [output_prefix; dump_ext] in
+  Compmisc.with_ppf_dump ~file_prefix:dump_file @@ fun ppf_dump ->
+  k {
     module_name;
     output_prefix;
     env;
@@ -45,7 +47,6 @@ let init ~ppf_dump ~native ~tool_name ~source_file ~output_prefix =
     tool_name;
     native;
   }
-
 
 (** Compile a .mli file *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -54,7 +54,9 @@ val emit_signature : info -> Parsetree.signature -> Typedtree.signature -> unit
 
 val interface :
   tool_name:string ->
-  source_file:string -> output_prefix:string -> unit
+  source_file:string ->
+  output_prefix:string ->
+  unit
 (** The complete compilation pipeline for interfaces. *)
 
 (** {2 Implementations} *)

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -53,11 +53,7 @@ val emit_signature : info -> Parsetree.signature -> Typedtree.signature -> unit
     containing the given signature.
 *)
 
-val interface :
-  tool_name:string ->
-  source_file:string ->
-  output_prefix:string ->
-  unit
+val interface : info -> unit
 (** The complete compilation pipeline for interfaces. *)
 
 (** {2 Implementations} *)
@@ -73,11 +69,8 @@ val typecheck_impl :
 *)
 
 val implementation :
-  tool_name:string ->
-  native:bool ->
+  info ->
   backend:(info -> Typedtree.structure * Typedtree.module_coercion -> unit) ->
-  source_file:string ->
-  output_prefix:string ->
   unit
 (** The complete compilation pipeline for implementations. *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -23,6 +23,7 @@ type info = {
   env : Env.t;
   ppf_dump : Format.formatter;
   tool_name : string;
+  native : bool;
 }
 (** Information needed to compile a file. *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -28,10 +28,12 @@ type info = {
 
 val init :
   Format.formatter ->
-  init_path:bool ->
+  native:bool ->
   tool_name:string ->
-  source_file:string -> output_prefix:string -> info
-(** [init ppf ~init_path ~tool_name ~source_file ~output_prefix] initializes
+  source_file:string ->
+  output_prefix:string ->
+  info
+(** [init ppf ~native ~tool_name ~source_file ~output_prefix] initializes
     the various global variables and returns an {!info}.
 *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -17,9 +17,9 @@
 (** {2 Initialization} *)
 
 type info = {
-  sourcefile : string;
-  modulename : string;
-  outputprefix : string;
+  source_file : string;
+  module_name : string;
+  output_prefix : string;
   env : Env.t;
   ppf_dump : Format.formatter;
   tool_name : string;
@@ -30,8 +30,8 @@ val init :
   Format.formatter ->
   init_path:bool ->
   tool_name:string ->
-  sourcefile:string -> outputprefix:string -> info
-(** [init ppf ~init_path ~tool_name ~sourcefile ~outputprefix] initializes
+  source_file:string -> output_prefix:string -> info
+(** [init ppf ~init_path ~tool_name ~source_file ~output_prefix] initializes
     the various global variables and returns an {!info}.
 *)
 
@@ -52,7 +52,7 @@ val emit_signature : info -> Parsetree.signature -> Typedtree.signature -> unit
 
 val interface :
   tool_name:string ->
-  sourcefile:string -> outputprefix:string -> unit
+  source_file:string -> output_prefix:string -> unit
 (** The complete compilation pipeline for interfaces. *)
 
 (** {2 Implementations} *)
@@ -71,8 +71,8 @@ val implementation :
   tool_name:string ->
   native:bool ->
   backend:(info -> Typedtree.structure * Typedtree.module_coercion -> unit) ->
-  sourcefile:string ->
-  outputprefix:string ->
+  source_file:string ->
+  output_prefix:string ->
   unit
 (** The complete compilation pipeline for implementations. *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -27,15 +27,22 @@ type info = {
 }
 (** Information needed to compile a file. *)
 
-val init :
-  ppf_dump:Format.formatter ->
+val with_info :
   native:bool ->
   tool_name:string ->
   source_file:string ->
   output_prefix:string ->
-  info
-(** [init ~ppf_dump ~native ~tool_name ~source_file ~output_prefix] initializes
-    the various global variables and returns an {!info}.
+  dump_ext:string ->
+  (info -> 'a) -> 'a
+(** [with_info ~native ~tool_name ~source_file ~output_prefix ~dump_ext k]
+   invokes its continuation [k] with an [info] structure built from
+   its input, after initializing various global variables. This info
+   structure and the initialized global state are not valid anymore
+   after the continuation returns.
+
+   Due to current implementation limitations in the compiler, it is
+   unsafe to try to compile several distinct compilation units by
+   calling [with_info] several times.
 *)
 
 (** {2 Interfaces} *)

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -28,13 +28,13 @@ type info = {
 (** Information needed to compile a file. *)
 
 val init :
-  Format.formatter ->
+  ppf_dump:Format.formatter ->
   native:bool ->
   tool_name:string ->
   source_file:string ->
   output_prefix:string ->
   info
-(** [init ppf ~native ~tool_name ~source_file ~output_prefix] initializes
+(** [init ~ppf_dump ~native ~tool_name ~source_file ~output_prefix] initializes
     the various global variables and returns an {!info}.
 *)
 

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -74,12 +74,12 @@ let read_clflags_from_env () =
   set_from_env Clflags.error_style Clflags.error_style_reader;
   ()
 
-let with_ppf_dump ~fileprefix f =
+let with_ppf_dump ~file_prefix f =
   let ppf_dump, finally =
     if not !Clflags.dump_into_file
     then Format.err_formatter, ignore
     else
-       let ch = open_out (fileprefix ^ ".dump") in
+       let ch = open_out (file_prefix ^ ".dump") in
        let ppf = Format.formatter_of_out_channel ch in
        ppf,
        (fun () ->

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -20,4 +20,4 @@ val initial_env : unit -> Env.t
 val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
 val read_clflags_from_env : unit -> unit
 
-val with_ppf_dump : fileprefix:string -> (Format.formatter -> unit) -> unit
+val with_ppf_dump : file_prefix:string -> (Format.formatter -> unit) -> unit

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -20,4 +20,4 @@ val initial_env : unit -> Env.t
 val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
 val read_clflags_from_env : unit -> unit
 
-val with_ppf_dump : file_prefix:string -> (Format.formatter -> unit) -> unit
+val with_ppf_dump : file_prefix:string -> (Format.formatter -> 'a) -> 'a

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -200,7 +200,7 @@ let main () =
       Compmisc.init_path false;
       let extracted_output = extract_output !output_name in
       let revd = get_objfiles ~with_ocamlparam:false in
-      Compmisc.with_ppf_dump ~fileprefix:extracted_output (fun ppf_dump ->
+      Compmisc.with_ppf_dump ~file_prefix:extracted_output (fun ppf_dump ->
         Bytepackager.package_files ~ppf_dump (Compmisc.initial_env ())
           revd (extracted_output));
       Warnings.check_fatal ();

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -25,7 +25,7 @@ let init =
 
 let interface ~source_file ~output_prefix =
   Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
-  let info = init ppf_dump ~source_file ~output_prefix in
+  let info = init ~ppf_dump ~source_file ~output_prefix in
   Compile_common.interface info
 
 let (|>>) (x, y) f = (x, f y)
@@ -79,7 +79,7 @@ let clambda i typed =
 
 let implementation ~backend ~source_file ~output_prefix =
   Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmx") @@ fun ppf_dump ->
-  let info = init ppf_dump ~source_file ~output_prefix in
+  let info = init ~ppf_dump ~source_file ~output_prefix in
   let backend info typed =
     Compilenv.reset ?packname:!Clflags.for_package info.module_name;
     if Config.flambda

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -35,46 +35,46 @@ let flambda i backend typed =
   end;
   typed
   |> Profile.(record transl)
-      (Translmod.transl_implementation_flambda i.modulename)
+      (Translmod.transl_implementation_flambda i.module_name)
   |> Profile.(record generate)
     (fun {Lambda.module_ident; main_module_block_size;
           required_globals; code } ->
     ((module_ident, main_module_block_size), code)
     |>> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
-    |>> Simplif.simplify_lambda i.sourcefile
+    |>> Simplif.simplify_lambda i.source_file
     |>> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
     |> (fun ((module_ident, size), lam) ->
       Middle_end.middle_end
         ~ppf_dump:i.ppf_dump
-        ~prefixname:i.outputprefix
+        ~prefixname:i.output_prefix
         ~size
-        ~filename:i.sourcefile
+        ~filename:i.source_file
         ~module_ident
         ~backend
         ~module_initializer:lam)
     |> Asmgen.compile_implementation_flambda
-      i.outputprefix ~required_globals ~backend ~ppf_dump:i.ppf_dump;
+      i.output_prefix ~required_globals ~backend ~ppf_dump:i.ppf_dump;
     Compilenv.save_unit_info (cmx i))
 
 let clambda i typed =
   Clflags.use_inlining_arguments_set Clflags.classic_arguments;
   typed
   |> Profile.(record transl)
-    (Translmod.transl_store_implementation i.modulename)
+    (Translmod.transl_store_implementation i.module_name)
   |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.program
   |> Profile.(record generate)
     (fun program ->
-       let code = Simplif.simplify_lambda i.sourcefile program.Lambda.code in
+       let code = Simplif.simplify_lambda i.source_file program.Lambda.code in
        { program with Lambda.code }
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.program
        |> Asmgen.compile_implementation_clambda
-         i.outputprefix ~ppf_dump:i.ppf_dump;
+         i.output_prefix ~ppf_dump:i.ppf_dump;
        Compilenv.save_unit_info (cmx i))
 
 let implementation ~backend =
   Compile_common.implementation ~tool_name
     ~native:true ~backend:(fun info typed ->
-      Compilenv.reset ?packname:!Clflags.for_package info.modulename;
+      Compilenv.reset ?packname:!Clflags.for_package info.module_name;
       if Config.flambda
       then flambda info backend typed
       else clambda info typed

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -20,12 +20,11 @@ open Compile_common
 
 let tool_name = "ocamlopt"
 
-let init =
-  Compile_common.init ~native:true ~tool_name
+let with_info =
+  Compile_common.with_info ~native:true ~tool_name
 
 let interface ~source_file ~output_prefix =
-  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmi") @@ fun ppf_dump ->
-  let info = init ~ppf_dump ~source_file ~output_prefix in
+  with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
   Compile_common.interface info
 
 let (|>>) (x, y) f = (x, f y)
@@ -78,12 +77,11 @@ let clambda i typed =
        Compilenv.save_unit_info (cmx i))
 
 let implementation ~backend ~source_file ~output_prefix =
-  Compmisc.with_ppf_dump ~file_prefix:(output_prefix ^ ".cmx") @@ fun ppf_dump ->
-  let info = init ~ppf_dump ~source_file ~output_prefix in
   let backend info typed =
     Compilenv.reset ?packname:!Clflags.for_package info.module_name;
     if Config.flambda
     then flambda info backend typed
     else clambda info typed
   in
+  with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
   Compile_common.implementation info ~backend

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -15,11 +15,11 @@
 
 (** Native compilation for .ml and .mli files. *)
 
-val interface: sourcefile:string -> outputprefix:string -> unit
+val interface: source_file:string -> output_prefix:string -> unit
 
 val implementation:
    backend:(module Backend_intf.S)
-   -> sourcefile:string -> outputprefix:string -> unit
+   -> source_file:string -> output_prefix:string -> unit
 
 (** {2 Internal functions} **)
 

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -295,7 +295,7 @@ let main () =
     else if !make_package then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Compmisc.with_ppf_dump ~fileprefix:target (fun ppf_dump ->
+      Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
         Asmpackager.package_files ~ppf_dump (Compmisc.initial_env ())
           (get_objfiles ~with_ocamlparam:false) target ~backend);
       Warnings.check_fatal ();
@@ -303,7 +303,7 @@ let main () =
     else if !shared then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Compmisc.with_ppf_dump ~fileprefix:target (fun ppf_dump ->
+      Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
         Asmlink.link_shared ~ppf_dump
           (get_objfiles ~with_ocamlparam:false) target);
       Warnings.check_fatal ();
@@ -325,7 +325,7 @@ let main () =
           default_output !output_name
       in
       Compmisc.init_path true;
-      Compmisc.with_ppf_dump ~fileprefix:target (fun ppf_dump ->
+      Compmisc.with_ppf_dump ~file_prefix:target (fun ppf_dump ->
         Asmlink.link ~ppf_dump (get_objfiles ~with_ocamlparam:true) target);
       Warnings.check_fatal ();
     end;


### PR DESCRIPTION
I was working on a separate PR that would add a new field to the `Compile_common.info` structure, and I realized that there were small aspects of the API that I don't like much. Given that it was only added in the development version, it is time to consider small refactorings before the code reaches the end-users.

I would be interested in particular in the opinion of @Drup and @sliquister (if they have time) who worked on the original code.

This PR is best looked at commit-per-commit, and it may be the case that you like some of them and reject some others (I'm willing to remove some parts). All the commits should be exactly semantics-preserving.

I think that "consistently use `_` as word separator", "rename init_path -> native", "whitespace refactoring" and "store 'native' in 'info'" are clear wins. I believe that removing `ppf_dump` is a nice-to-have (it was a value relying on a lifetime-limited resource with unclear guarantees on liveness), but it's less clear-cut. The `make/init` split is the weakest part of the PR, and I'm interested in opinions on the final refactoring.