### PR TITLE
Build system: use `boot/ocamlc -depend` rather than `tools/ocamldep`

### DIFF
--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -28,7 +28,7 @@ COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
 LINKFLAGS=-linkall -I $(UNIXDIR)
 YACCFLAGS=
 CAMLLEX=$(CAMLRUN) $(ROOTDIR)/boot/ocamllex
-CAMLDEP=$(CAMLRUN) $(ROOTDIR)/tools/ocamldep
+CAMLDEP=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -31,7 +31,7 @@ COMPFLAGS = $(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
 LINKFLAGS =
 YACCFLAGS = -v
 CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
-CAMLDEP = $(CAMLRUN) $(ROOTDIR)/tools/ocamldep
+CAMLDEP = $(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS = -slash
 DEPINCLUDES =
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -24,7 +24,7 @@ OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLC    = $(OCAMLRUN) $(ROOTDIR)/ocamlc $(STDLIBFLAGS)
 OCAMLOPT  = $(OCAMLRUN) $(ROOTDIR)/ocamlopt $(STDLIBFLAGS)
-OCAMLDEP  = $(OCAMLRUN) $(ROOTDIR)/tools/ocamldep
+OCAMLDEP  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS = -slash
 OCAMLLEX  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
 # TODO: figure out whether the DEBUG lines the following preprocessor removes

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -159,7 +159,7 @@ ocamlc := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlc $(flags)
 
 ocamlopt := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlopt $(flags)
 
-ocamldep := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/tools/ocamldep
+ocamldep := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/boot/ocamlc -depend
 depflags := -slash
 depincludes :=
 

--- a/otherlibs/bigarray/Makefile
+++ b/otherlibs/bigarray/Makefile
@@ -33,6 +33,6 @@ mmap_ba.$(O): ../unix/mmap_ba.c
 .PHONY: depend
 
 depend:
-	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml > .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
 include .depend

--- a/otherlibs/graph/Makefile
+++ b/otherlibs/graph/Makefile
@@ -29,6 +29,6 @@ include ../Makefile.otherlibs.common
 
 depend:
 	$(CC) -MM $(OC_CPPFLAGS) *.c | sed -e 's, /[^ ]*\.h,,g' > .depend
-	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
 
 include .depend

--- a/otherlibs/graph/Makefile
+++ b/otherlibs/graph/Makefile
@@ -29,6 +29,6 @@ include ../Makefile.otherlibs.common
 
 depend:
 	$(CC) -MM $(OC_CPPFLAGS) *.c | sed -e 's, /[^ ]*\.h,,g' > .depend
-	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml >> .depend
 
 include .depend

--- a/otherlibs/raw_spacetime_lib/Makefile
+++ b/otherlibs/raw_spacetime_lib/Makefile
@@ -27,7 +27,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 	$(error Dependencies cannot be regenerated using the MSVC ports)
 else
 	$(CC) -MM $(OC_CPPFLAGS) *.c | sed -e 's/\.o/.$$(O)/g' > .depend
-	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml >> .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -30,7 +30,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 	$(error Dependencies cannot be regenerated using the MSVC ports)
 else
 	$(CC) -MM $(OC_CPPFLAGS) *.c | sed -e 's/\.o/.$$(O)/g' > .depend
-	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml >> .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -161,7 +161,7 @@ depend:
 	  -DNATIVE_CODE -DTARGET_$(ARCH) -DMODEL_$(MODEL) -DSYS_$(SYSTEM) \
 	  st_stubs.c | sed -e 's/st_stubs\.o/st_stubs_n.$$(O)/' \
 	  -e 's/ st_\(posix\|win32\)\.h//g' >> .depend
-	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -161,7 +161,7 @@ depend:
 	  -DNATIVE_CODE -DTARGET_$(ARCH) -DMODEL_$(MODEL) -DSYS_$(SYSTEM) \
 	  st_stubs.c | sed -e 's/st_stubs\.o/st_stubs_n.$$(O)/' \
 	  -e 's/ st_\(posix\|win32\)\.h//g' >> .depend
-	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -153,7 +153,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 	$(error Dependencies cannot be regenerated using the MSVC ports)
 else
 	$(CC) -MM $(OC_CPPFLAGS) *.c > .depend
-	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -153,7 +153,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 	$(error Dependencies cannot be regenerated using the MSVC ports)
 else
 	$(CC) -MM $(OC_CPPFLAGS) *.c > .depend
-	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -52,7 +52,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 	$(error Dependencies cannot be regenerated using the MSVC ports)
 else
 	$(CC) -MM $(OC_CPPFLAGS) *.c > .depend
-	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -52,7 +52,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 	$(error Dependencies cannot be regenerated using the MSVC ports)
 else
 	$(CC) -MM $(OC_CPPFLAGS) *.c > .depend
-	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	$(CAMLRUN) ../../boot/ocamlc -depend -slash *.mli *.ml >> .depend
 endif
 
 include .depend

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -72,7 +72,7 @@ else
 depend: $(ALL_FILES) $(UNIX_CAML_FILES) unix.ml
 	$(CC) -MM $(OC_CPPFLAGS) -I../unix $(ALL_FILES) \
 	  | sed -e 's/\.o/.$$(O)/g' > .depend
-	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash $(UNIX_CAML_FILES) \
+	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash $(UNIX_CAML_FILES) \
 	  unix.ml >> .depend
 endif
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -33,7 +33,7 @@ OPTCOMPFLAGS=
 endif
 OPTCOMPILER=$(ROOTDIR)/ocamlopt
 CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
-CAMLDEP=$(CAMLRUN) $(ROOTDIR)/tools/ocamldep
+CAMLDEP=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS=-slash
 
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime
@@ -281,7 +281,8 @@ $(OBJS:.cmo=.cmi) std_exit.cmi: $(COMPILER_DEPS)
 $(OBJS:.cmo=.cmx) std_exit.cmx: $(OPTCOMPILER)
 $(OBJS:.cmo=.p.cmx) std_exit.p.cmx: $(OPTCOMPILER)
 
-# Dependencies on Stdlib (not tracked by ocamldep)
+# Dependencies on Stdlib (not tracked by ocamlc -depend)
+
 $(OTHERS) std_exit.cmo: stdlib.cmi
 $(OTHERS:.cmo=.cmi) std_exit.cmi: stdlib.cmi
 $(OBJS:.cmo=.cmx) std_exit.cmx: stdlib.cmi

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -425,7 +425,7 @@ clean::
 clean::
 	rm -f *.cmo *.cmi *.cma *.dll *.so *.lib *.a
 
-CAMLDEP=$(CAMLRUN) ./ocamldep
+CAMLDEP=$(CAMLRUN) ../boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 depend: beforedepend

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -425,7 +425,7 @@ clean::
 clean::
 	rm -f *.cmo *.cmi *.cma *.dll *.so *.lib *.a
 
-CAMLDEP=$(CAMLRUN) ../boot/ocamlc -depend
+CAMLDEP=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 depend: beforedepend


### PR DESCRIPTION
This PR has two commits. The first of them does exactly what the title
describes and the second one replaces hardcoded paths to the compiler
by paths that use the $(ROOTDIR) build variable.

The idea here is to minimize what is required to compute dependencies.
Although it is not yet possible to update dependencies from a clean clone of
the sources, not even from a configured one, this PR seemed a not-too-hard
step in the right direction.