### PR TITLE
Makefile.menhir enhancement

### DIFF
--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -46,12 +46,7 @@
 
 MENHIR ?= menhir
 
-## Menhir compilation flags
-
-MENHIRFLAGS := --explain --dump --ocamlc "$(CAMLC) $(COMPFLAGS)" --infer \
-	--lalr --strict --table -lg 1 -la 1 \
-        --unused-token COMMENT --unused-token DOCSTRING --unused-token EOL\
-        --unused-token GREATERRBRACKET --fixed-exception
+## Unused tokens
 
 # tokens COMMENT, DOCSTRING and EOL are produced by special lexer
 # modes used by other consumers than the parser.
@@ -60,6 +55,13 @@ MENHIRFLAGS := --explain --dump --ocamlc "$(CAMLC) $(COMPFLAGS)" --infer \
 # (which is used in polymorphic variant), but is not currently used by
 # the grammar.
 
+unused_tokens := COMMENT DOCSTRING EOL GREATERRBRACKET
+
+## Menhir compilation flags
+
+MENHIRFLAGS := --explain --dump --ocamlc "$(CAMLC) $(COMPFLAGS)" --infer \
+	--lalr --strict --table -lg 1 -la 1 \
+        $(addprefix --unused-token ,$(unused_tokens)) --fixed-exception
 
 ## promote-menhir
 


### PR DESCRIPTION
This PR factorizes the way the menhir flags for unused tokens
is defined. It also brings the comments explaining why tokens are
unused above the definition of the unused_tokens variable.

Currently, only the root Makefile includes Makefile.menhir. I was wondering
what would be the best way to make the menhir-related definitiions
available to the sub-makefiles of those directories containing parsers one may
want to port to Menhir. One way would be to include Makefile.menhir in each
of these makefiles, but I'm not fully convinced that would be the right way
to go. Another possibility would be to more the definition of the MENHIR
variable to Makefile.config, but that would mean that this becomes available
only after the repository has been configured. One may also want to share
some of menhir's flags between all the invocations for consistency purposes.

If there are suggestions I'd be happy to implement them as part of this PR.