### PR TITLE
Raise exception when waitpid would block.

### DIFF
--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -184,6 +184,10 @@ type wait_flag =
     WNOHANG
   | WUNTRACED
 
+exception Waitpid_would_block
+
+let _ = Callback.register_exception "Unix.Waitpid_would_block" Waitpid_would_block
+
 let stdin = 0
 let stdout = 1
 let stderr = 2

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -202,6 +202,10 @@ type wait_flag =
     WNOHANG
   | WUNTRACED
 
+exception Waitpid_would_block
+
+let _ = Callback.register_exception "Unix.Waitpid_would_block" Waitpid_would_block
+
 external execv : string -> string array -> 'a = "unix_execv"
 external execve : string -> string array -> string array -> 'a = "unix_execve"
 external execvp : string -> string array -> 'a = "unix_execvp"

--- a/otherlibs/unix/wait.c
+++ b/otherlibs/unix/wait.c
@@ -17,6 +17,7 @@
 
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
+#include <caml/callback.h>
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -42,6 +43,9 @@
 static value alloc_process_status(int pid, int status)
 {
   value st, res;
+
+  if (pid == 0)
+    caml_raise_constant(*caml_named_value("Unix.Waitpid_would_block"));
 
   if (WIFEXITED(status)) {
     st = caml_alloc_small(1, TAG_WEXITED);


### PR DESCRIPTION
This PR handles the case when `waitpid` is called with `WNOHANG` and returns `0` for the pid. In this case, process status is undefined but the C binding code currently will always return a `WSIGNALED` type with undefined parameter. This PR make it so it raises an exception instead.

The windows case isn't yet covered. It seems that the windows C does not return a tagged type at all but just the process's exit code. Is that intended? That seems like a bug as well.