### PR TITLE
ocamltest: fix `bsd` and `not-bsd` built-in actions

### DIFF
--- a/Changes
+++ b/Changes
@@ -415,7 +415,7 @@ Working version
 
 - GPR#2223: ocamltest: fix the "bsd" and "not-bsd" built-in actions to
   recognize all BSD variants
-  (Damien Doligez, review by Sébastien Hinderer)
+  (Damien Doligez, review by Sébastien Hinderer and David Allsopp)
 
 ### Manual and documentation:
 

--- a/Changes
+++ b/Changes
@@ -413,6 +413,10 @@ Working version
   on a new line, for more readable diffs of versioned dependencies.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- GPR#2223: ocamltest: fix the "bsd" and "not-bsd" built-in actions to
+  recognize all BSD variants
+  (Damien Doligez, review by Sébastien Hinderer)
+
 ### Manual and documentation:
 
 - MPR#7546, GPR#2020: preambles and introduction for compiler-libs.

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -108,17 +108,20 @@ let not_windows = make
     "not running on Windows"
     "running on Windows")
 
-let bsd_system = "bsd_elf"
+let is_bsd_system s =
+  match s with
+  | "bsd_elf" | "netbsd" | "freebsd" | "openbsd" -> true
+  | _ -> false
 
 let bsd = make
   "bsd"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.system = bsd_system)
+  (Actions_helpers.pass_or_skip (is_bsd_system Ocamltest_config.system)
     "on a BSD system"
     "not on a BSD system")
 
 let not_bsd = make
   "not-bsd"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.system <> bsd_system)
+  (Actions_helpers.pass_or_skip (not (is_bsd_system Ocamltest_config.system))
     "not on a BSD system"
     "on a BSD system")
 


### PR DESCRIPTION
On our CI, the openBSD machine accumulates leftover processes from the `lib-systhreads/testfork.ml` test, which is not supposed to run on BSD since it has the condition `not-bsd`.

Instead of testing only for `bsd_elf`, ocamltest should test for all 4 possible BSD values.
