### PR TITLE
ocamltest: avoid unnecessary rebuilding

### DIFF
--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -191,6 +191,8 @@ ocamlcdefaultflags :=
 
 ocamloptdefaultflags := $(shell ./getocamloptdefaultflags $(TARGET))
 
+.SECONDARY: $(lexers:.mll=.ml) $(parsers:.mly=.mli) $(parsers:.mly=.ml)
+
 .PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
 all: ocamltest$(EXE)
 allopt: ocamltest.opt$(EXE)


### PR DESCRIPTION
You may have noticed that `ocamltest` is repeatedly rebuilt even when there are no pending changes. It is due to some "intermediate" files being removed at the end of the build (read https://www.gnu.org/software/make/manual/html_node/Chained-Rules.html to understand why). The following PR just marks the relevant files so that they are not removed, so that they don't have to be recreated each time (which triggers the rebuild).

Happy building!