### PR TITLE
README: add a CI badge for the 4.07 branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,13 @@
 |=====
-| Branch `trunk` | Branch `4.06` | Branch `4.05` | Branch `4.04`
+| Branch `trunk` | Branch  `4.07`  | Branch `4.06` | Branch `4.05` | Branch `4.04`
 
 | image:https://travis-ci.org/ocaml/ocaml.svg?branch=trunk["TravisCI Build Status (trunk branch)",
      link="https://travis-ci.org/ocaml/ocaml"]
   image:https://ci.appveyor.com/api/projects/status/github/ocaml/ocaml?branch=trunk&svg=true["AppVeyor Build Status (trunk branch)",
+     link="https://ci.appveyor.com/project/avsm/ocaml"]
+| image:https://travis-ci.org/ocaml/ocaml.svg?branch=4.07["TravisCI Build Status (4.07 branch)",
+     link="https://travis-ci.org/ocaml/ocaml"]
+  image:https://ci.appveyor.com/api/projects/status/github/ocaml/ocaml?branch=4.07&svg=true["AppVeyor Build Status (4.07 branch)",
      link="https://ci.appveyor.com/project/avsm/ocaml"]
 | image:https://travis-ci.org/ocaml/ocaml.svg?branch=4.06["TravisCI Build Status (4.06 branch)",
      link="https://travis-ci.org/ocaml/ocaml"]


### PR DESCRIPTION
Since there was enough horizontal space, I added a column -- the other option would be to remove the 4.04 badge.