### PR TITLE
Refactoring: use type aliases (in utils/Misc) to improve interfaces readability

### DIFF
--- a/.depend
+++ b/.depend
@@ -44,10 +44,13 @@ utils/config.cmx : \
     utils/config.cmi
 utils/config.cmi :
 utils/consistbl.cmo : \
+    utils/misc.cmi \
     utils/consistbl.cmi
 utils/consistbl.cmx : \
+    utils/misc.cmx \
     utils/consistbl.cmi
-utils/consistbl.cmi :
+utils/consistbl.cmi : \
+    utils/misc.cmi
 utils/identifiable.cmo : \
     utils/misc.cmi \
     utils/identifiable.cmi
@@ -472,6 +475,7 @@ typing/cmt_format.cmx : \
 typing/cmt_format.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
+    utils/misc.cmi \
     parsing/location.cmi \
     typing/env.cmi \
     typing/cmi_format.cmi
@@ -1699,6 +1703,7 @@ bytecomp/bytelink.cmx : \
     bytecomp/bytelink.cmi
 bytecomp/bytelink.cmi : \
     bytecomp/symtable.cmi \
+    utils/misc.cmi \
     bytecomp/cmo_format.cmi
 bytecomp/bytepackager.cmo : \
     typing/typemod.cmi \
@@ -1749,6 +1754,7 @@ bytecomp/bytesections.cmx : \
     bytecomp/bytesections.cmi
 bytecomp/bytesections.cmi :
 bytecomp/cmo_format.cmi : \
+    utils/misc.cmi \
     bytecomp/lambda.cmi \
     typing/ident.cmi
 bytecomp/dll.cmo : \
@@ -2478,6 +2484,7 @@ asmcomp/asmlink.cmx : \
     asmcomp/asmgen.cmx \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmi : \
+    utils/misc.cmi \
     asmcomp/cmx_format.cmi
 asmcomp/asmpackager.cmo : \
     typing/typemod.cmi \
@@ -2778,6 +2785,7 @@ asmcomp/cmmgen.cmi : \
     asmcomp/cmm.cmi \
     asmcomp/clambda.cmi
 asmcomp/cmx_format.cmi : \
+    utils/misc.cmi \
     asmcomp/export_info.cmi \
     asmcomp/clambda.cmi
 asmcomp/coloring.cmo : \

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -23,15 +23,15 @@ open Compilenv
 module String = Misc.Stdlib.String
 
 type error =
-    File_not_found of string
-  | Not_an_object_file of string
-  | Missing_implementations of (string * string list) list
-  | Inconsistent_interface of string * string * string
-  | Inconsistent_implementation of string * string * string
-  | Assembler_error of string
+  | File_not_found of filepath
+  | Not_an_object_file of filepath
+  | Missing_implementations of (modname * string list) list
+  | Inconsistent_interface of modname * filepath * filepath
+  | Inconsistent_implementation of modname * filepath * filepath
+  | Assembler_error of filepath
   | Linking_error
-  | Multiple_definition of string * string * string
-  | Missing_cmx of string * string
+  | Multiple_definition of modname * filepath * filepath
+  | Missing_cmx of filepath * modname
 
 exception Error of error
 

--- a/asmcomp/asmlink.mli
+++ b/asmcomp/asmlink.mli
@@ -15,6 +15,7 @@
 
 (* Link a set of .cmx/.o files and produce an executable or a plugin *)
 
+open Misc
 open Format
 
 val link: ppf_dump:formatter -> string list -> string -> unit
@@ -24,20 +25,20 @@ val link_shared: ppf_dump:formatter -> string list -> string -> unit
 val call_linker_shared: string list -> string -> unit
 
 val reset : unit -> unit
-val check_consistency: string -> Cmx_format.unit_infos -> Digest.t -> unit
-val extract_crc_interfaces: unit -> (string * Digest.t option) list
-val extract_crc_implementations: unit -> (string * Digest.t option) list
+val check_consistency: filepath -> Cmx_format.unit_infos -> Digest.t -> unit
+val extract_crc_interfaces: unit -> crcs
+val extract_crc_implementations: unit -> crcs
 
 type error =
-    File_not_found of string
-  | Not_an_object_file of string
-  | Missing_implementations of (string * string list) list
-  | Inconsistent_interface of string * string * string
-  | Inconsistent_implementation of string * string * string
-  | Assembler_error of string
+  | File_not_found of filepath
+  | Not_an_object_file of filepath
+  | Missing_implementations of (modname * string list) list
+  | Inconsistent_interface of modname * filepath * filepath
+  | Inconsistent_implementation of modname * filepath * filepath
+  | Assembler_error of filepath
   | Linking_error
-  | Multiple_definition of string * string * string
-  | Missing_cmx of string * string
+  | Multiple_definition of modname * filepath * filepath
+  | Missing_cmx of filepath * modname
 
 exception Error of error
 

--- a/asmcomp/cmx_format.mli
+++ b/asmcomp/cmx_format.mli
@@ -19,6 +19,8 @@
 
 (* Format of .cmx, .cmxa and .cmxs files *)
 
+open Misc
+
 (* Each .o file has a matching .cmx file that provides the following infos
    on the compilation unit:
      - list of other units imported, with MD5s of their .cmx files
@@ -34,17 +36,16 @@ type export_info =
   | Flambda of Export_info.t
 
 type unit_infos =
-  { mutable ui_name: string;                    (* Name of unit implemented *)
+  { mutable ui_name: modname;             (* Name of unit implemented *)
     mutable ui_symbol: string;            (* Prefix for symbols *)
     mutable ui_defines: string list;      (* Unit and sub-units implemented *)
-    mutable ui_imports_cmi:
-              (string * Digest.t option) list; (* Interfaces imported *)
-    mutable ui_imports_cmx:(string * Digest.t option) list; (* Infos imported *)
-    mutable ui_curry_fun: int list;             (* Currying functions needed *)
-    mutable ui_apply_fun: int list;             (* Apply functions needed *)
-    mutable ui_send_fun: int list;              (* Send functions needed *)
+    mutable ui_imports_cmi: crcs;         (* Interfaces imported *)
+    mutable ui_imports_cmx: crcs;         (* Infos imported *)
+    mutable ui_curry_fun: int list;       (* Currying functions needed *)
+    mutable ui_apply_fun: int list;       (* Apply functions needed *)
+    mutable ui_send_fun: int list;        (* Send functions needed *)
     mutable ui_export_info: export_info;
-    mutable ui_force_link: bool }               (* Always linked *)
+    mutable ui_force_link: bool }         (* Always linked *)
 
 (* Each .a library has a matching .cmxa file that provides the following
    infos on the library: *)
@@ -59,10 +60,10 @@ type library_infos =
    (as an externed record) *)
 
 type dynunit = {
-  dynu_name: string;
+  dynu_name: modname;
   dynu_crc: Digest.t;
-  dynu_imports_cmi: (string * Digest.t option) list;
-  dynu_imports_cmx: (string * Digest.t option) list;
+  dynu_imports_cmi: crcs;
+  dynu_imports_cmx: crcs;
   dynu_defines: string list;
 }
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -20,15 +20,15 @@ open Config
 open Cmo_format
 
 type error =
-    File_not_found of string
-  | Not_an_object_file of string
-  | Wrong_object_name of string
-  | Symbol_error of string * Symtable.error
-  | Inconsistent_import of string * string * string
+  | File_not_found of filepath
+  | Not_an_object_file of filepath
+  | Wrong_object_name of filepath
+  | Symbol_error of filepath * Symtable.error
+  | Inconsistent_import of modname * filepath * filepath
   | Custom_runtime
-  | File_exists of string
-  | Cannot_open_dll of string
-  | Required_module_unavailable of string
+  | File_exists of filepath
+  | Cannot_open_dll of filepath
+  | Required_module_unavailable of modname
 
 exception Error of error
 

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -13,25 +13,27 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Misc
+
 (* Link .cmo files and produce a bytecode executable. *)
 
-val link : string list -> string -> unit
+val link : filepath list -> filepath -> unit
 val reset : unit -> unit
 
-val check_consistency: string -> Cmo_format.compilation_unit -> unit
+val check_consistency: filepath -> Cmo_format.compilation_unit -> unit
 
-val extract_crc_interfaces: unit -> (string * Digest.t option) list
+val extract_crc_interfaces: unit -> crcs
 
 type error =
-    File_not_found of string
-  | Not_an_object_file of string
-  | Wrong_object_name of string
-  | Symbol_error of string * Symtable.error
-  | Inconsistent_import of string * string * string
+  | File_not_found of filepath
+  | Not_an_object_file of filepath
+  | Wrong_object_name of filepath
+  | Symbol_error of filepath * Symtable.error
+  | Inconsistent_import of modname * filepath * filepath
   | Custom_runtime
-  | File_exists of string
-  | Cannot_open_dll of string
-  | Required_module_unavailable of string
+  | File_exists of filepath
+  | Cannot_open_dll of filepath
+  | Required_module_unavailable of modname
 
 exception Error of error
 

--- a/bytecomp/cmo_format.mli
+++ b/bytecomp/cmo_format.mli
@@ -15,6 +15,8 @@
 
 (* Symbol table information for .cmo and .cma files *)
 
+open Misc
+
 (* Relocation information *)
 
 type reloc_info =
@@ -26,15 +28,14 @@ type reloc_info =
 (* Descriptor for compilation units *)
 
 type compilation_unit =
-  { cu_name: string;                    (* Name of compilation unit *)
+  { cu_name: modname;                   (* Name of compilation unit *)
     mutable cu_pos: int;                (* Absolute position in file *)
     cu_codesize: int;                   (* Size of code block *)
     cu_reloc: (reloc_info * int) list;  (* Relocation information *)
-    cu_imports:
-      (string * Digest.t option) list; (* Names and CRC of intfs imported *)
-    cu_required_globals: Ident.t list; (* Compilation units whose initialization
-                                          side effects must occur before this
-                                          one. *)
+    cu_imports: crcs;                   (* Names and CRC of intfs imported *)
+    cu_required_globals: Ident.t list;  (* Compilation units whose
+                                           initialization side effects
+                                           must occur before this one. *)
     cu_primitives: string list;         (* Primitives declared inside *)
     mutable cu_force_link: bool;        (* Must be linked even if unref'ed *)
     mutable cu_debug: int;              (* Position of debugging info, or 0 *)

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -32,14 +32,13 @@
 
 *)
 
-
 val check_alerts: Location.t -> Parsetree.attributes -> string -> unit
 val check_alerts_inclusion:
   def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
   Parsetree.attributes -> string -> unit
-val alerts_of_attrs: Parsetree.attributes -> string Misc.Stdlib.String.Map.t
-val alerts_of_sig: Parsetree.signature -> string Misc.Stdlib.String.Map.t
-val alerts_of_str: Parsetree.structure -> string Misc.Stdlib.String.Map.t
+val alerts_of_attrs: Parsetree.attributes -> Misc.alerts
+val alerts_of_sig: Parsetree.signature -> Misc.alerts
+val alerts_of_str: Parsetree.structure -> Misc.alerts
 
 val check_deprecated_mutable:
     Location.t -> Parsetree.attributes -> string -> unit

--- a/typing/cmi_format.ml
+++ b/typing/cmi_format.ml
@@ -13,23 +13,25 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Misc
+
 type pers_flags =
   | Rectypes
-  | Alerts of string Misc.Stdlib.String.Map.t
+  | Alerts of alerts
   | Opaque
   | Unsafe_string
 
 type error =
-    Not_an_interface of string
-  | Wrong_version_interface of string * string
-  | Corrupted_interface of string
+  | Not_an_interface of filepath
+  | Wrong_version_interface of filepath * string
+  | Corrupted_interface of filepath
 
 exception Error of error
 
 type cmi_infos = {
-    cmi_name : string;
+    cmi_name : Misc.modname;
     cmi_sign : Types.signature_item list;
-    cmi_crcs : (string * Digest.t option) list;
+    cmi_crcs : crcs;
     cmi_flags : pers_flags list;
 }
 

--- a/typing/cmi_format.mli
+++ b/typing/cmi_format.mli
@@ -13,16 +13,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Misc
+
 type pers_flags =
   | Rectypes
-  | Alerts of string Misc.Stdlib.String.Map.t
+  | Alerts of alerts
   | Opaque
   | Unsafe_string
 
 type cmi_infos = {
-    cmi_name : string;
+    cmi_name : modname;
     cmi_sign : Types.signature_item list;
-    cmi_crcs : (string * Digest.t option) list;
+    cmi_crcs : crcs;
     cmi_flags : pers_flags list;
 }
 
@@ -38,9 +40,9 @@ val read_cmi : string -> cmi_infos
 (* Error report *)
 
 type error =
-    Not_an_interface of string
-  | Wrong_version_interface of string * string
-  | Corrupted_interface of string
+  | Not_an_interface of filepath
+  | Wrong_version_interface of filepath * string
+  | Corrupted_interface of filepath
 
 exception Error of error
 

--- a/typing/cmt_format.mli
+++ b/typing/cmt_format.mli
@@ -15,6 +15,8 @@
 
 (** cmt and cmti files format. *)
 
+open Misc
+
 (** The layout of a cmt file is as follows:
       <cmt> := \{<cmi>\} <cmt magic> \{cmt infos\} \{<source info>\}
     where <cmi> is the cmi file format:
@@ -49,7 +51,7 @@ and binary_part =
   | Partial_module_type of module_type
 
 type cmt_infos = {
-  cmt_modname : string;
+  cmt_modname : modname;
   cmt_annots : binary_annots;
   cmt_value_dependencies :
     (Types.value_description * Types.value_description) list;
@@ -60,7 +62,7 @@ type cmt_infos = {
   cmt_loadpath : string list;
   cmt_source_digest : string option;
   cmt_initial_env : Env.t;
-  cmt_imports : (string * Digest.t option) list;
+  cmt_imports : crcs;
   cmt_interface_digest : Digest.t option;
   cmt_use_summaries : bool;
 }

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -59,10 +59,10 @@ let used_constructors :
 let prefixed_sg = Hashtbl.create 113
 
 type error =
-  | Illegal_renaming of string * string * string
-  | Inconsistent_import of string * string * string
-  | Need_recursive_types of string * string
-  | Depend_on_unsafe_string_unit of string * string
+  | Illegal_renaming of modname * modname * filepath
+  | Inconsistent_import of modname * filepath * filepath
+  | Need_recursive_types of modname * modname
+  | Depend_on_unsafe_string_unit of modname * modname
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
 
@@ -490,7 +490,7 @@ and module_declaration_lazy =
 
 and module_components =
   {
-    alerts: string Misc.Stdlib.String.Map.t;
+    alerts: alerts;
     loc: Location.t;
     comps:
       (t * Subst.t * Path.t * address_lazy * Types.module_type,
@@ -622,7 +622,7 @@ let without_cmis f x =
 
 let components_of_module' =
   ref ((fun ~alerts:_ ~loc:_ _env _sub _path _addr _mty -> assert false) :
-         alerts:string Misc.Stdlib.String.Map.t -> loc:Location.t -> t ->
+         alerts:alerts -> loc:Location.t -> t ->
        Subst.t -> Path.t -> address_lazy -> module_type ->
        module_components)
 let components_of_module_maker' =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -16,6 +16,7 @@
 (* Environment handling *)
 
 open Types
+open Misc
 
 type summary =
     Env_empty
@@ -242,23 +243,22 @@ val get_unit_name: unit -> string
 val read_signature: string -> string -> signature
         (* Arguments: module name, file name. Results: signature. *)
 val save_signature:
-  alerts:string Misc.Stdlib.String.Map.t -> signature -> string -> string ->
-  Cmi_format.cmi_infos
+  alerts:alerts -> signature -> string -> string
+  -> Cmi_format.cmi_infos
         (* Arguments: signature, module name, file name. *)
 val save_signature_with_imports:
-  alerts:string Misc.Stdlib.String.Map.t ->
-  signature -> string -> string -> (string * Digest.t option) list
+  alerts:alerts -> signature -> modname -> filepath -> crcs
   -> Cmi_format.cmi_infos
         (* Arguments: signature, module name, file name,
            imported units with their CRCs. *)
 
 (* Return the CRC of the interface of the given compilation unit *)
 
-val crc_of_unit: string -> Digest.t
+val crc_of_unit: modname -> Digest.t
 
 (* Return the set of compilation units imported, with their CRC *)
 
-val imports: unit -> (string * Digest.t option) list
+val imports: unit -> crcs
 
 (* [is_imported_opaque md] returns true if [md] is an opaque imported module  *)
 val is_imported_opaque: string -> bool
@@ -283,10 +283,10 @@ val env_of_only_summary : (summary -> Subst.t -> t) -> t -> t
 (* Error report *)
 
 type error =
-  | Illegal_renaming of string * string * string
-  | Inconsistent_import of string * string * string
-  | Need_recursive_types of string * string
-  | Depend_on_unsafe_string_unit of string * string
+  | Illegal_renaming of modname * modname * filepath
+  | Inconsistent_import of modname * filepath * filepath
+  | Need_recursive_types of modname * modname
+  | Depend_on_unsafe_string_unit of modname * modname
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
 

--- a/utils/consistbl.ml
+++ b/utils/consistbl.ml
@@ -15,15 +15,17 @@
 
 (* Consistency tables: for checking consistency of module CRCs *)
 
-type t = (string, Digest.t * string) Hashtbl.t
+open Misc
+
+type t = (modname, Digest.t * filepath) Hashtbl.t
 
 let create () = Hashtbl.create 13
 
 let clear = Hashtbl.clear
 
-exception Inconsistency of string * string * string
+exception Inconsistency of modname * filepath * filepath
 
-exception Not_available of string
+exception Not_available of modname
 
 let check tbl name crc source =
   try

--- a/utils/consistbl.mli
+++ b/utils/consistbl.mli
@@ -20,13 +20,15 @@
 
 *)
 
+open Misc
+
 type t
 
 val create: unit -> t
 
 val clear: t -> unit
 
-val check: t -> string -> Digest.t -> string -> unit
+val check: t -> modname -> Digest.t -> filepath -> unit
       (* [check tbl name crc source]
            checks consistency of ([name], [crc]) with infos previously
            stored in [tbl].  If no CRC was previously associated with
@@ -34,34 +36,34 @@ val check: t -> string -> Digest.t -> string -> unit
            [source] is the name of the file from which the information
            comes from.  This is used for error reporting. *)
 
-val check_noadd: t -> string -> Digest.t -> string -> unit
+val check_noadd: t -> modname -> Digest.t -> filepath -> unit
       (* Same as [check], but raise [Not_available] if no CRC was previously
            associated with [name]. *)
 
-val set: t -> string -> Digest.t -> string -> unit
+val set: t -> modname -> Digest.t -> filepath -> unit
       (* [set tbl name crc source] forcefully associates [name] with
          [crc] in [tbl], even if [name] already had a different CRC
          associated with [name] in [tbl]. *)
 
-val source: t -> string -> string
+val source: t -> modname -> filepath
       (* [source tbl name] returns the file name associated with [name]
          if the latter has an associated CRC in [tbl].
          Raise [Not_found] otherwise. *)
 
-val extract: string list -> t -> (string * Digest.t option) list
+val extract: modname list -> t -> crcs
       (* [extract tbl names] returns an associative list mapping each string
          in [names] to the CRC associated with it in [tbl]. If no CRC is
          associated with a name then it is mapped to [None]. *)
 
-val filter: (string -> bool) -> t -> unit
+val filter: (modname -> bool) -> t -> unit
       (* [filter pred tbl] removes from [tbl] table all (name, CRC) pairs
          such that [pred name] is [false]. *)
 
-exception Inconsistency of string * string * string
+exception Inconsistency of modname * filepath * filepath
       (* Raised by [check] when a CRC mismatch is detected.
          First string is the name of the compilation unit.
          Second string is the source that caused the inconsistency.
          Third string is the source that set the CRC. *)
 
-exception Not_available of string
+exception Not_available of modname
       (* Raised by [check_noadd] when a name doesn't have an associated CRC. *)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -880,3 +880,9 @@ let debug_prefix_map_flags () =
 let print_if ppf flag printer arg =
   if !flag then Format.fprintf ppf "%a@." printer arg;
   arg
+
+type filepath = string
+type modname = string
+type crcs = (modname * Digest.t option) list
+
+type alerts = string Stdlib.String.Map.t

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -452,3 +452,9 @@ val debug_prefix_map_flags: unit -> string list
 val print_if :
   Format.formatter -> bool ref -> (Format.formatter -> 'a -> unit) -> 'a -> 'a
 (** [print_if ppf flag fmt x] prints [x] with [fmt] on [ppf] if [b] is true. *)
+
+type filepath = string
+type modname = string
+type crcs = (modname * Digest.t option) list
+
+type alerts = string Stdlib.String.Map.t


### PR DESCRIPTION
This PR is the first part of a larger refactoring I've been working on for `typing/env`. It should be a complete no-op, as it does not touch any runtime code, only types.

(Easy to review!)