### PR TITLE
Env: remove prefix_idents cache

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ Working version
 
 (Changes that can break existing programs are marked with a "*")
 
+### Internal/compiler-libs changes:
+
+- GPR#2229: Env: remove prefix_idents cache
+  (Thomas Refis, review by Frédéric Bour)
+
 OCaml 4.08.0
 ------------
 

--- a/Changes
+++ b/Changes
@@ -6,7 +6,7 @@ Working version
 ### Internal/compiler-libs changes:
 
 - GPR#2229: Env: remove prefix_idents cache
-  (Thomas Refis, review by Frédéric Bour)
+  (Thomas Refis, review by Frédéric Bour and Gabriel Scherer)
 
 OCaml 4.08.0
 ------------

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -56,8 +56,6 @@ let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t
   = Hashtbl.create 16
 
-let prefixed_sg = Hashtbl.create 113
-
 type error =
   | Illegal_renaming of modname * modname * filepath
   | Inconsistent_import of modname * filepath * filepath
@@ -891,8 +889,7 @@ let reset_cache () =
   Hashtbl.clear value_declarations;
   Hashtbl.clear type_declarations;
   Hashtbl.clear module_declarations;
-  Hashtbl.clear used_constructors;
-  Hashtbl.clear prefixed_sg
+  Hashtbl.clear used_constructors
 
 let reset_cache_toplevel () =
   (* Delete 'missing cmi' entries from the cache. *)
@@ -905,8 +902,7 @@ let reset_cache_toplevel () =
   Hashtbl.clear value_declarations;
   Hashtbl.clear type_declarations;
   Hashtbl.clear module_declarations;
-  Hashtbl.clear used_constructors;
-  Hashtbl.clear prefixed_sg
+  Hashtbl.clear used_constructors
 
 
 let set_unit_name name =
@@ -1790,25 +1786,6 @@ let rec prefix_idents root sub = function
         prefix_idents root (Subst.add_type id p sub) rem
       in
       (p::pl, final_sub)
-
-let prefix_idents root sub sg =
-  if sub = Subst.identity then
-    let sgs =
-      try
-        Hashtbl.find prefixed_sg root
-      with Not_found ->
-        let sgs = ref [] in
-        Hashtbl.add prefixed_sg root sgs;
-        sgs
-    in
-    try
-      List.assq sg !sgs
-    with Not_found ->
-      let r = prefix_idents root sub sg in
-      sgs := (sg, r) :: !sgs;
-      r
-  else
-    prefix_idents root sub sg
 
 (* Compute structure descriptions *)
 


### PR DESCRIPTION
Removes a cache around `Env.prefix_idents` that has been made obsolete by #834 .
Cf. [MPR#5877](https://caml.inria.fr/mantis/view.php?id=5877) for the history.

For the record, building a non-negligible subset of janestreet's codebase with 4.07.1 takes 16m55s (±5s), building the same subset with 4.07.1 with this cache removed takes 15m05s (±5s).

I don't know if this deserves a changelog entry.