### PR TITLE
MPR7905: reject invalid local substitution earlier

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,8 +35,8 @@ OCaml 4.08.0
   under or-patterns.
   (Thomas Refis and Leo White, review by Jacques Garrigue)
 
-- GPR#2122: Introduce local substitutions in signatures: "type t := type_expr"
-  and "module M := Extended(Module).Path"
+- GPR#2122, GPR#2230: Introduce local substitutions in signatures:
+  "type t := type_expr" and "module M := Extended(Module).Path"
   (Thomas Refis, with help and review from Leo White, and Alain Frisch)
 
 ### Type system:

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -101,3 +101,20 @@ Line 3, characters 11-12:
                ^
 Error: Unbound type constructor t
 |}]
+
+(** MPR7905, PR2231:
+    We want to reject invalid right-hand side
+    before typing the type declaration.
+*)
+module type Rejected = sig
+  type cycle = A of cycle
+  type t := cycle = A of t
+  (** this type declaration is purposefully erroneous *)
+end
+
+[%%expect{|
+Line 3, characters 2-26:
+3 |   type t := cycle = A of t
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Only type synonyms are allowed on the right of :=
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1168,14 +1168,18 @@ and transl_signature env sg =
             sg,
             final_env
         | Psig_typesubst sdecls ->
+            List.iter (fun td ->
+              if td.ptype_kind <> Ptype_abstract || td.ptype_manifest = None ||
+                 td.ptype_private = Private
+              then
+                (* This error should be a parsing error,
+                   once we have nice error messages there. *)
+                raise (Error (td.ptype_loc, env, Invalid_type_subst_rhs))
+            ) sdecls;
             let (decls, newenv) =
               Typedecl.transl_type_decl env Nonrecursive sdecls
             in
             List.iter (fun td ->
-              if td.typ_kind <> Ttype_abstract || td.typ_manifest = None ||
-                 td.typ_private = Private
-              then
-                raise (Error (td.typ_loc, env, Invalid_type_subst_rhs));
               let info =
                   let subst =
                     Subst.add_type_function (Pident td.typ_id)


### PR DESCRIPTION
This PR proposes to reject invalid local substitutions before the typechecking of the type declaration.

Otherwise, if there is an error in the type declaration, for instance:
```OCaml
type t := M.t = A of t
```
the typechecker first complains that the type declaration is invalid
> Error: Unbound type constructor t

It is only once the type declaration  is fixed
```OCaml
type t := M.t = A of M.t
```
that the typechecker remembers that type declarations are not allowed on the right-hand side of `:=`: 
> Error: Only type synonyms are allowed on the right of :=

With this PR, this error is emitted first, so users are less likely to waste their time trying to fix their type declaration.

I am proposing this PR to be included in 4.08 since this is a minor tweak of a new feature.
 