### PR TITLE
manual: move the short object copy notation to core chapters

### DIFF
--- a/Changes
+++ b/Changes
@@ -444,11 +444,13 @@ OCaml 4.08.0
   GPR#1702, GPR#1765, GPR#1863, and Gabriel Scherer's GPR#1903.
   (Gabriel Scherer, review by Florian Angeletti)
 
-- GPR#1788, 1831, 2007, 2198, move language extensions to the core chapters:
+- GPR#1788, 1831, 2007, 2198, 2232, move language extensions to the core
+  chapters:
      - GPR#1788: quoted string description
      - GPR#1831: local exceptions and exception cases
      - GPR#2007: 32-bit, 64-bit and native integer literals
      - GPR#2198: lazy patterns
+     - GPR#2232: short object copy notation
   (Florian Angeletti, review by Xavier Clerc, Perry E. Metzger, Gabriel Scherer
    and Jeremy Yallop)
 

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -70,7 +70,7 @@ expr:
   | inst-var-name '<-' expr
   | '(' expr ':>' typexpr ')'
   | '(' expr ':' typexpr ':>' typexpr ')'
-  | '{<' [ inst-var-name '=' expr { ';' inst-var-name '=' expr } [';'] ] '>}'
+  | '{<' [ inst-var-name ['=' expr] { ';' inst-var-name ['=' expr] } [';'] ] '>}'
   | 'assert' expr
   | 'lazy' expr
   | 'let' 'module' module-name { '(' module-name ':' module-type ')' }
@@ -113,7 +113,6 @@ parameter:
   | '?' label-name ':' '(' pattern [':' typexpr] ['=' expr] ')'
 \end{syntax}
 See also the following language extensions:
-\hyperref[s:object-notations]{object notations},
 \hyperref[s-first-class-modules]{first-class modules},
 \hyperref[s:explicit-overriding-open]{overriding in open statements},
 \hyperref[s:bigarray-access]{syntax for Bigarray access},
@@ -824,10 +823,11 @@ An object can be duplicated using the library function "Oo.copy"
 (see
 \ifouthtml \ahref{libref/Oo.html}{Module \texttt{Oo}}\else
 section~\ref{Oo}\fi). Inside a method, the expression
-@ '{<' inst-var-name '=' expr { ';' inst-var-name '=' expr } '>}'@
+@ '{<' [inst-var-name ['=' expr] { ';' inst-var-name ['=' expr] }] '>}'@
 returns a copy of self with the given instance variables replaced by
-the values of the associated expressions; other instance variables
-have the same value in the returned object as in self.
+the values of the associated expressions. A single instance variable
+name @id@ stands for @id '=' id@. Other instance variables have the same
+value in the returned object as in self.
 
 \subsection{Coercions} \label{s:coercions}
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -358,30 +358,6 @@ For example, @module-path'.['pattern']'@ is equivalent to
 @module-path'.(['pattern'])'@, and @module-path'.[|' pattern '|]'@ is
 equivalent to @module-path'.([|' pattern '|])'@.
 
-\section{Object copy short notations} \label{s:object-notations}
-\ikwd{with\@\texttt{with}}
-
-(Introduced in OCaml 4.03)
-
-\begin{syntax}
-expr:
-     ...
-  | '{' '<' expr 'with' field ['=' expr] { ';' field ['=' expr] } [';'] '>' '}'
-\end{syntax}
-
-In an object copy expression,
-a single identifier @id@ stands for @id '=' id@, and a qualified identifier
-@module-path '.' id@ stands for @module-path '.' id '=' id@.
-For example, all following methods are equivalent:
-\begin{caml_example*}{verbatim}
-object
-  val x=0. val y=0. val z=0.
-  method f_0 x y = {< x; y >}
-  method f_1 x y = {< x = x; y >}
-  method f_2 x y = {< x=x ; y = y >}
-end
-\end{caml_example*}
-
 \section{Locally abstract types}
 \ikwd{type\@\texttt{type}}
 \ikwd{fun\@\texttt{fun}} \label{s:locally-abstract}

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -969,12 +969,16 @@ class functional_point y =
     val x = y
     method get_x = x
     method move d = {< x = x + d >}
+    method move_to x = {< x >}
   end;;
 let p = new functional_point 7;;
 p#get_x;;
 (p#move 3)#get_x;;
+(p#move_to 15)#get_x;;
 p#get_x;;
 \end{caml_example}
+As with records, the form "{< x >}" is an elided version of
+"{< x = x >}" which avoids the repetition of the instance variable name.
 Note that the type abbreviation "functional_point" is recursive, which can
 be seen in the class type of "functional_point": the type of self is "'a"
 and "'a" appears inside the type of the method "move".
@@ -987,6 +991,7 @@ class bad_functional_point y =
     val x = y
     method get_x = x
     method move d = new bad_functional_point (x+d)
+    method move_to x = new bad_functional_point x
   end;;
 \end{caml_example}
 While objects of either class will behave the same, objects of their


### PR DESCRIPTION
This PR proposes to move the short object copy notation,

```OCaml
class c = object
   val x = []
   method m x = {< x >}
end
```
to the core part of the manual. This move seemed reasonable to me:  this is a small enhancement of an existing syntax, introduced in 4.03, and quite similar to the record notation (which is now explained during the introduction of records in the first chapter).
