### PR TITLE
alloc_sockaddr: handle abstract paths

### DIFF
--- a/Changes
+++ b/Changes
@@ -212,6 +212,10 @@ OCaml 4.08.0
 - GPR#1525: Make function set_max_indent respect documentation
   (Pierre Weis, Richard Bonichon, review by Florian Angeletti)
 
+- GPR#2233: Unix: fix handling of Linux abstract socket paths when receiving a
+  Unix socket address from the operating system.
+  (Tim Cuthbertson, review by Jérémie Dimino)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/testsuite/tests/lib-unix/unix-socket/is-linux.sh
+++ b/testsuite/tests/lib-unix/unix-socket/is-linux.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This script is related to the 'recvfrom_linux.ml' test.
+
+uname="$(uname -s)"
+if [ "$uname" = "Linux" ]; then
+
+# Workaround: the tests that come after this script
+# (bytecode and native) depend on stdout redirection, but
+# running a script sets both of those to the empty string.
+# See https://caml.inria.fr/mantis/view.php?id=7910
+  cat > "$ocamltest_response" <<EOF
+-stdout
+-stderr
+EOF
+
+  exit ${TEST_PASS}
+else
+  echo "$uname" > "$ocamltest_response"
+  exit ${TEST_SKIP}
+fi

--- a/testsuite/tests/lib-unix/unix-socket/ocamltests
+++ b/testsuite/tests/lib-unix/unix-socket/ocamltests
@@ -1,0 +1,2 @@
+recvfrom_unix.ml
+recvfrom_linux.ml

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
@@ -1,0 +1,33 @@
+open Unix
+
+let path_of_addr = function
+  | ADDR_UNIX path -> path
+  | _ -> assert false
+;;
+
+let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
+  Printf.printf "%S" (path_of_addr client_addr);
+  let byte = Bytes.make 1 't' in
+  let sent_len = sendto client_socket byte 0 1 [] server_addr in
+  assert (sent_len = 1);
+  let buf = Bytes.make 1024 '\x00' in
+  let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
+
+  Printf.printf " as %S: " (path_of_addr sender);
+  assert (sender = client_addr);
+  assert (Bytes.sub_string buf 0 recv_len = "t");
+  print_endline "OK";;
+
+let ensure_no_file path =
+  try unlink path with Unix_error (ENOENT, _, _) -> ();;
+
+let with_socket fn =
+  let s = socket PF_UNIX SOCK_DGRAM 0 in
+  Fun.protect ~finally:(fun () -> close s) (fun () -> fn s)
+
+let with_bound_socket path fn =
+  with_socket (fun s ->
+    let addr = ADDR_UNIX path in
+    bind s addr;
+    fn addr s
+  )

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.ml
@@ -1,0 +1,21 @@
+(* TEST
+include unix
+modules = "recvfrom.ml"
+script = "sh ${test_source_directory}/is-linux.sh"
+* hasunix
+** script
+*** bytecode
+*** native
+*)
+open Recvfrom
+
+let () =
+  let server_path = "ocaml-test-socket-linux" in
+  ensure_no_file server_path;
+  at_exit (fun () -> ensure_no_file server_path);
+  with_bound_socket server_path (fun server_addr server_socket ->
+    (* abstract socket *)
+    with_bound_socket "\x00ocaml-abstract-socket" (fun client_addr client_socket ->
+      test_sender ~client_socket ~server_socket ~server_addr ~client_addr
+    );
+  )

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.reference
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.reference
@@ -1,0 +1,1 @@
+"\000ocaml-abstract-socket" as "\000ocaml-abstract-socket": OK

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
@@ -1,0 +1,23 @@
+(* TEST
+include unix
+modules = "recvfrom.ml"
+* not-windows
+** bytecode
+** native
+*)
+open Recvfrom
+
+let () =
+  let server_path = "ocaml-test-socket-unix" in
+  ensure_no_file server_path;
+  at_exit (fun () -> ensure_no_file server_path);
+  with_bound_socket server_path (fun server_addr server_socket ->
+    (* path socket, just reuse server addr *)
+    test_sender ~client_socket:server_socket ~server_socket ~server_addr ~client_addr:server_addr;
+
+    (* unnamed socket *)
+    with_socket (fun client_socket ->
+      (* unbound socket should be treated as empty path *)
+      test_sender ~client_socket ~server_socket ~server_addr ~client_addr:(ADDR_UNIX "")
+    )
+  )

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.reference
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.reference
@@ -1,0 +1,2 @@
+"ocaml-test-socket-unix" as "ocaml-test-socket-unix": OK
+"" as "": OK


### PR DESCRIPTION
According to previous modifications to this code, `alloc_sockaddr` for a unix socket needs to deal with a few edge cases:

 - unbound sender: the path should be treated as an empty string (this was fixed in ed0a785f024ff6d924eea9f52de22e4f0e249787, but looks like this was later broken again)
 - path is terminated with a null byte: typically done on Linux, should not be included in the returned (ocaml) string
 - path is not terminated with a null byte: common, e.g. on Darwin / MacOS

An additional edge case it doesn't currently handle is that on Linux, "abstract" unix sockets are those beginning with '\0`, which the current code interprets as a zero-length string. Abstract sockets may contain internal null characters, so using string functions to determine their length is incorrect.

The attached patch deals with all these edge cases, with new test cases to ensure it.