### PR TITLE
[Makefile] Fixed a bug in partialclean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1328,7 +1328,7 @@ partialclean::
 	for d in utils parsing typing bytecomp asmcomp middle_end \
 	         middle_end/base_types asmcomp/debug driver toplevel tools; do \
 	  rm -f $$d/*.cm[ioxt] $$d/*.cmti $$d/*.annot $$d/*.$(S) \
-	    $$d/*.$(O) $$d/*.$(SO) $d/*~; \
+	    $$d/*.$(O) $$d/*.$(SO) $$d/*~; \
 	done
 	rm -f *~
 


### PR DESCRIPTION
As is, this `$d/*~` transforms into `/*~`, so would the script running as root, it would remove all the files/folders from the rootfs, which ends with `~` (fortunately, it wasn't `$d/*`, which would translate into `rm -rf /*`).

P.S. I have no experience with OCaml, but this is clearly a bug which I bumped into when tried building [revery](https://github.com/revery-ui/revery).