### PR TITLE
Fix match miscompilation with flambda

### DIFF
--- a/Changes
+++ b/Changes
@@ -368,6 +368,9 @@ OCaml 4.08.0
 - MPR#6242, GPR#2143: optimize some local functions
   (Alain Frisch, review by Gabriel Scherer)
 
+- GPR#2239: Fix match miscompilation with flambda
+  (Leo White, review by Alain Frisch)
+
 ### Runtime system:
 
 - MPR#7198, MPR#7750, GPR#1738: add a function (caml_custom_alloc_mem)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1945,8 +1945,9 @@ let rec transl env e =
           (Array.map (transl env) s.us_actions_consts)
           dbg
       else if Array.length s.us_index_consts = 0 then
-        transl_switch loc env (get_tag (transl env arg) dbg)
-          s.us_index_blocks s.us_actions_blocks
+        bind "switch" (transl env arg) (fun arg ->
+          transl_switch loc env (get_tag arg dbg)
+            s.us_index_blocks s.us_actions_blocks)
       else
         bind "switch" (transl env arg) (fun arg ->
           Cifthenelse(
@@ -2815,6 +2816,7 @@ and transl_sequor env arg1 dbg1 arg2 dbg2 approx then_ else_ =
          (transl_if env arg2 dbg2 approx shareable_then else_))
     then_
 
+(* This assumes that [arg] can be safely discarded if it is not used. *)
 and transl_switch loc env arg index cases = match Array.length cases with
 | 0 -> fatal_error "Cmmgen.transl_switch"
 | 1 -> transl env cases.(0)

--- a/testsuite/tests/flambda/gpr2239.ml
+++ b/testsuite/tests/flambda/gpr2239.ml
@@ -1,0 +1,16 @@
+(* TEST
+   * flambda
+   * native
+*)
+
+let do_something () =
+  Printf.printf "Hello world\n%!"; Ok ()
+[@@inline never]
+
+let f x =
+  match do_something () with
+  | Ok () -> x
+  | Error r -> let _ = !r in x
+[@@inline never]
+
+let () = f ()

--- a/testsuite/tests/flambda/gpr2239.reference
+++ b/testsuite/tests/flambda/gpr2239.reference
@@ -1,0 +1,1 @@
+Hello world

--- a/testsuite/tests/flambda/ocamltests
+++ b/testsuite/tests/flambda/ocamltests
@@ -1,3 +1,4 @@
 approx_meet.ml
 gpr998.ml
 specialise.ml
+gpr2239.ml


### PR DESCRIPTION
The translation of the switch construct in `cmmgen.ml` assumes that the argument to a switch can safely be discarded if it is unused. This (undocumented) invariant does not hold for code coming from flambda resulting in side-effecting expressions being incorrectly discarded. This PR fixes the issue by binding the argument of the switch construct to ensure that side-effecting expressions are not discarded.