### PR TITLE
Constify "identifier" in struct custom_operations

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
 - GPR#1725: Deprecate Obj.set_tag
   (Stephen Dolan, review by Gabriel Scherer and Damien Doligez)
 
+* GPR#2240: Constify "identifier" in struct custom_operations
+  (Cedric Cellier)
+
 ### Other libraries:
 
 - GPR#2248: Unix alloc_sockaddr: Fix read of uninitialized memory for an

--- a/Changes
+++ b/Changes
@@ -27,7 +27,7 @@ Working version
   (Stephen Dolan, review by Gabriel Scherer and Damien Doligez)
 
 * GPR#2240: Constify "identifier" in struct custom_operations
-  (Cedric Cellier)
+  (Cedric Cellier, review by Xavier Leroy)
 
 ### Other libraries:
 

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -28,7 +28,7 @@ struct custom_fixed_length {
 };
 
 struct custom_operations {
-  char *identifier;
+  char const *identifier;
   void (*finalize)(value v);
   int (*compare)(value v1, value v2);
   intnat (*hash)(value v);

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -537,7 +537,7 @@ static void extern_rec(value v)
     case Custom_tag: {
       uintnat sz_32, sz_64;
       char * size_header;
-      char * ident = Custom_ops_val(v)->identifier;
+      char const * ident = Custom_ops_val(v)->identifier;
       void (*serialize)(value v, uintnat * bsize_32,
                         uintnat * bsize_64)
         = Custom_ops_val(v)->serialize;


### PR DESCRIPTION
Because otherwise it is not possible to initialize it with a constant
C string when compiling with a C++ compiler without getting a warning:

    ISO C++11 does not allow conversion from string literal to 'char *'
      [-Wwritable-strings]

No tests seams to be more annoyed by this change but of course it is
always possible that some code in the wild relies on this field to be
non-const. This is indeed an API change, although a trivial one.