### PR TITLE
Fix configure of flambda

### DIFF
--- a/configure
+++ b/configure
@@ -16895,13 +16895,14 @@ else
   ocamldoc=ocamldoc
 fi
 
-if test x"$enable_flambda" = "xyes"
+if test x"$enable_flambda" = "xyes"; then :
   flambda=true
   if test x"$enable_flambda_invariants" = "xyes"; then :
   flambda_invariants=true
 else
   flambda_invariants=false
-fi; then :
+fi
+else
   flambda=false
   flambda_invariants=false
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1637,7 +1637,7 @@ AS_IF([test x"$enable_ocamldoc" = "xno"],
   [ocamldoc=""],
   [ocamldoc=ocamldoc])
 
-AS_IF([test x"$enable_flambda" = "xyes"]
+AS_IF([test x"$enable_flambda" = "xyes"],
   [flambda=true
   AS_IF([test x"$enable_flambda_invariants" = "xyes"],
     [flambda_invariants=true],


### PR DESCRIPTION
The new autoconf configure doesn't allow you to turn on flambda due to a missing comma in the `configure.ac` file. This PR adds that comma.