### PR TITLE
Avoid the use of Variable-Length Arrays

### DIFF
--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -263,13 +263,19 @@ static int handle_process_termination(
     if ( access(COREFILENAME, F_OK) == -1)
       fprintf(stderr, "Could not find core file.\n");
     else {
-      char corefile[strlen(corefilename_prefix) + 128];
-      snprintf(corefile, sizeof(corefile),
-        "%s.%d.core", corefilename_prefix, pid);
-      if ( rename(COREFILENAME, corefile) == -1)
-        fprintf(stderr, "The core file exists but could not be renamed.\n");
-      else
-        fprintf(stderr,"The core file has been renamed to %s\n", corefile);
+      size_t corefile_len = strlen(corefilename_prefix) + 128;
+      char * corefile = malloc(corefile_len);
+      if (corefile == NULL)
+        fprintf(stderr, "Out of memory while processing core file.\n");
+      else {
+        snprintf(corefile, corefile_len,
+          "%s.%d.core", corefilename_prefix, pid);
+        if ( rename(COREFILENAME, corefile) == -1)
+          fprintf(stderr, "The core file exists but could not be renamed.\n");
+        else
+          fprintf(stderr,"The core file has been renamed to %s\n", corefile);
+        free(corefile);
+      }
     }
   }
 


### PR DESCRIPTION
Variable-Length Arrays (VLAs) are a feature of ISO C 1999 that is slightly controversial.

For one thing, VLAs are an optional feature of ISO C 2011, so a C11 compliant compiler can elect not to implement them.  This is the case for CompCert.  Some of us find it worthwhile to test CompCert on the OCaml code base.

For another thing, VLAs come with a risk of stack overflow.

There is only one occurrence of a VLA in OCaml's 58 KLOC of C code. This PR replaces it by malloc() and free().