### PR TITLE
value letrec: fix a bug in analysis of inner mutually-recursive bindings

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,9 +86,10 @@ OCaml 4.08.0
 - GPR#1909: unsharing pattern types
   (Thomas Refis, with help from Leo White, review by Jacques Garrigue)
 
-- GPR#1942: simplification of the static check for recursive definitions
+- GPR#1942, GPR#2244: simplification of the static check
+  for recursive definitions
   (Alban Reynaud and Gabriel Scherer,
-   review by Jeremy Yallop and Armaël Guéneau)
+   review by Jeremy Yallop, Armaël Guéneau and Damien Doligez)
 
 * MPR#7814, GPR#2041, GPR#2235: allow modules from include directories
   to shadow other ones, even in the toplevel

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -302,6 +302,8 @@ module Mode = struct
         in arbitrary ways. Such a value must be fully defined at the point
         of usage, it cannot be defined mutually-recursively with its context. *)
 
+  let equal = ((=) : t -> t -> bool)
+
   (* Lower-ranked modes demand/use less of the variable/expression they qualify
      -- so they allow more recursive definitions.
 
@@ -369,6 +371,10 @@ sig
   val join_list : t list -> t
   (** Environments can be joined pointwise (variable per variable) *)
 
+  val compose : Mode.t -> t -> t
+  (** Environment composition m[G] extends mode composition m1[m2]
+      by composing each mode in G pointwise *)
+
   val remove : Ident.t -> t -> t
   (** Remove an identifier from an environment. *)
 
@@ -377,11 +383,15 @@ sig
 
   val remove_list : Ident.t list -> t -> t
   (** Remove all the identifiers of a list from an environment. *)
+
+  val equal : t -> t -> bool
 end = struct
   module M = Map.Make(Ident)
 
   (** A "t" maps each rec-bound variable to an access status *)
   type t = Mode.t M.t
+
+  let equal = M.equal Mode.equal
 
   let find (id: Ident.t) (tbl: t) =
     try M.find id tbl with Not_found -> Ignore
@@ -396,6 +406,9 @@ end = struct
       x y
 
   let join_list li = List.fold_left join empty li
+
+  let compose m env =
+    M.map (Mode.compose m) env
 
   let single id mode = M.add id mode empty
 
@@ -1030,22 +1043,88 @@ and extension_constructor : Typedtree.extension_constructor -> term_judg =
 (* G |- let (rec?) (pi = ei)^i : m -| G' *)
 and value_bindings : rec_flag -> Typedtree.value_binding list -> bind_judg =
   fun rec_flag bindings mode bound_env ->
-    (*
-       (Gi |- ei : m[mi])^i       (pi : mi -| D)^i
-       G := sum(Gi - if (rec) then (pj)^j else pi)^i
-       -------------------------------------------------
-       G + (D - (pj)^j) |- let (rec)? (pi=ei)^i : m -| D
-    *)
     let all_bound_pats = List.map (fun vb -> vb.vb_pat) bindings in
-    let binding_env {vb_pat; vb_expr; _} m =
-      let bound_pats = match rec_flag with
-        | Recursive -> all_bound_pats
-        | Nonrecursive -> [vb_pat] in
-      let m' = Mode.compose m (pattern vb_pat bound_env) in
-      remove_patlist bound_pats (expression vb_expr m') in
-    Env.join
-      (list binding_env bindings mode)
-      (remove_patlist all_bound_pats bound_env)
+    let outer_env = remove_patlist all_bound_pats bound_env in
+    let bindings_env =
+      match rec_flag with
+      | Nonrecursive ->
+        (*
+           (Gi, pi:_ |- ei : m[mbody_i])^i   (pi : mbody_i -| D)^i
+           ------------------------------------------------------------
+           Sum(Gi) + (D - (pi)^i) |- let (pi=ei)^i : m -| D
+        *)
+          let binding_env {vb_pat; vb_expr; _} m =
+            let m' = Mode.compose m (pattern vb_pat bound_env) in
+            remove_pat vb_pat (expression vb_expr m') in
+          list binding_env bindings mode
+      | Recursive ->
+        (*
+           (Gi, (xj : mdef_ij)^j |- ei : m[mbody_i])^i   (xi : mbody_i -| D)^i
+           G'i = Gi + mdef_ij[G'j]
+           -------------------------------------------------------------------
+           Sum(G'i) + (D - (pi)^i) |- let rec (xi=ei)^i : m -| D
+
+           The (mdef_ij)^i,j are a family of modes over two indices:
+           mdef_ij represents the mode of use, within e_i the definition of x_i,
+           of the mutually-recursive variable x_j.
+
+           The (G'i)^i are defined from the (Gi)^i as a family of equations,
+           whose smallest solution is computed as a least fixpoint.
+
+           The (Gi)^i are the "immediate" dependencies of each (ei)^i
+           on the outer context (excluding the mutually-defined
+           variables).
+           The (G'i)^i contain the "transitive" dependencies as well:
+           if ei depends on xj, then the dependencies of G'i of xi
+           must contain the dependencies of G'j, composed by
+           the mode mdef_ij of use of xj in ei.
+
+           For example, consider:
+
+             let rec z =
+               let rec x = ref y
+               and y = ref z
+               in f x
+
+           this definition should be rejected as the body [f x]
+           dereferences [x], which can be used to access the
+           yet-unitialized value [z]. This requires realizing that [x]
+           depends on [z] through [y], which requires the transitive
+           closure computation.
+
+           An earlier version of our check would take only the (Gi)^i
+           instead of the (G'i)^i, which is incorrect and would accept
+           the example above.
+        *)
+          (* [binding_env] takes a binding (x_i = e_i)
+             and computes (Gi, (mdef_ij)^j). *)
+          let binding_env {vb_pat = x_i; vb_expr = e_i; _} =
+            let mbody_i = pattern x_i bound_env in
+            (* Gi, (x_j:mdef_ij)^j  *)
+            let rhs_env_i = expression e_i (Mode.compose mode mbody_i) in
+            (* (mdef_ij)^j (for a fixed i) *)
+            let mutual_modes =
+              let mdef_ij {vb_pat = x_j; _} = pattern x_j rhs_env_i in
+              List.map mdef_ij bindings in
+            (* Gi *)
+            let env_i = remove_patlist all_bound_pats rhs_env_i in
+            (* (Gi, (mdef_ij)^j) *)
+            (env_i, mutual_modes) in
+          let env, mdef =
+            List.split (List.map binding_env bindings) in
+          let rec transitive_closure env =
+            let transitive_deps env_i mdef_i =
+              (* Gi, (mdef_ij)^j => Gi + Sum_j mdef_ij[Gj] *)
+              Env.join env_i
+                (Env.join_list (List.map2 Env.compose mdef_i env)) in
+            let env' = List.map2 transitive_deps env mdef in
+            if List.for_all2 Env.equal env env'
+            then env'
+            else transitive_closure env'
+          in
+          let env'_i = transitive_closure env in
+          Env.join_list env'_i
+    in Env.join bindings_env outer_env
 
 (* G; m' |- (p -> e) : m
    with outputs G, m' and input m


### PR DESCRIPTION
On Friday I found a bug in my own proof of correctness of the recursive-value-declarations analysis of #1942, and @yallop swiftly turned it into a example that crashes 4.08+dev. The present PR (explains and) fixes the issue in the same way that I fixed the type system and the proof.

The issue is in the handling of inner `let rec` bindings with mutual recursion going on (single-definitions `let rec` are fine). Read the comments and testsuite entries for the details. There are two potential fixes, a fixpoint (precise/complete, slightly more complex to implement), and an overapproximation (rejects safe programs, shorter to implement). The paper, the new proof and this PR use the fixpoint approach.

The new unsafe program in the testsuite is rejected in 4.07.1, which still uses @yallop's pre-#1942 implementation, which is more conservative -- it is equivalent to the "overapproximation" mentioned above. On the other hand, the new safe program in the testsuite was rejected in 4.07.1, because the overapproximation is too conservative there -- maybe it's okay.

We should have a fix for this issue in 4.08.