### PR TITLE
alloc_sockaddr: handle abstract paths (v2)

### DIFF
--- a/Changes
+++ b/Changes
@@ -212,6 +212,10 @@ OCaml 4.08.0
 - GPR#1525: Make function set_max_indent respect documentation
   (Pierre Weis, Richard Bonichon, review by Florian Angeletti)
 
+- GPR#2233: Unix: fix handling of Linux abstract socket paths when receiving a
+  Unix socket address from the operating system.
+  (Tim Cuthbertson, review by Jérémie Dimino)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/Changes
+++ b/Changes
@@ -212,9 +212,9 @@ OCaml 4.08.0
 - GPR#1525: Make function set_max_indent respect documentation
   (Pierre Weis, Richard Bonichon, review by Florian Angeletti)
 
-- GPR#2233: Unix: fix handling of Linux abstract socket paths when receiving a
-  Unix socket address from the operating system.
-  (Tim Cuthbertson, review by Jérémie Dimino)
+- GPR#2248: Unix alloc_sockaddr: Fix read of uninitialized memory for an
+  unbound Unix socket. Add support for receiving abstract (Linux) socket paths.
+  (Tim Cuthbertson, review by Sébastien Hinderer and Jérémie Dimino)
 
 ### Other libraries:
 

--- a/otherlibs/unix/sendrecv.c
+++ b/otherlibs/unix/sendrecv.c
@@ -14,6 +14,7 @@
 /**************************************************************************/
 
 #include <string.h>
+#include <stdio.h>
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/fail.h>
@@ -64,11 +65,25 @@ CAMLprim value unix_recvfrom(value sock, value buff, value ofs, value len,
     numbytes = Long_val(len);
     if (numbytes > UNIX_BUFFER_SIZE) numbytes = UNIX_BUFFER_SIZE;
     addr_len = sizeof(addr);
+
+    // The sender must be in the same address family, but if the
+    // sender is an unnamed AF_UNIX socket, recvfrom writes nothing
+    // to `addr.s_gen` and sets addr_len to 0. alloc_sockaddr handles
+    // a zero-length path, but only if sa_family is set correctly.
+    //
+    // We could use getsockname here to copy the sa_family of the receiver,
+    // but since recvfrom only leaves the address uninitialized for an
+    // unnamed AF_UNIX sender, we can just set it blindly.
+#ifndef _WIN32
+    addr.s_gen.sa_family = AF_UNIX;
+#endif
+
     caml_enter_blocking_section();
     ret = recvfrom(Int_val(sock), iobuf, (int) numbytes, cv_flags,
                    &addr.s_gen, &addr_len);
     caml_leave_blocking_section();
     if (ret == -1) uerror("recvfrom", Nothing);
+    /* fprintf(stderr, "Address family %d, len = %d\n", addr.s_gen.sa_family, addr_len); */
     memmove (&Byte(buff, Long_val(ofs)), iobuf, ret);
     adr = alloc_sockaddr(&addr, addr_len, -1);
     res = caml_alloc_small(2, 0);

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -14,6 +14,7 @@
 /**************************************************************************/
 
 #include <string.h>
+#include <stdio.h>
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
@@ -106,6 +107,7 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
                      socklen_param_type adr_len, int close_on_error)
 {
   value res;
+  /* fprintf(stderr, "address family: %d\n", adr->s_gen.sa_family); */
   switch(adr->s_gen.sa_family) {
 #ifndef _WIN32
   case AF_UNIX:

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -103,7 +103,7 @@ void get_sockaddr(value mladr,
 }
 
 value alloc_unix_sockaddr(value path) {
-￼ CAMLparam1(path);
+  CAMLparam1(path);
   CAMLlocal1(res);
   res = caml_alloc_small(1, 0);
   Field(res,0) = path;

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -103,12 +103,11 @@ void get_sockaddr(value mladr,
 }
 
 value alloc_unix_sockaddr(value path) {
-  value res;
-  Begin_root (path);
-    res = caml_alloc_small(1, 0);
-    Field(res,0) = path;
-  End_roots();
-  return res;
+￼ CAMLparam1(path);
+  CAMLlocal1(res);
+  res = caml_alloc_small(1, 0);
+  Field(res,0) = path;
+  CAMLreturn(res);
 }
 
 value alloc_sockaddr(union sock_addr_union * adr /*in*/,

--- a/testsuite/tests/lib-unix/unix-socket/is-linux.sh
+++ b/testsuite/tests/lib-unix/unix-socket/is-linux.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This script is related to the 'recvfrom_linux.ml' test.
+
+uname="$(uname -s)"
+if [ "$uname" = "Linux" ]; then
+
+# Workaround: the tests that come after this script
+# (bytecode and native) depend on stdout redirection, but
+# running a script sets both of those to the empty string.
+# See https://caml.inria.fr/mantis/view.php?id=7910
+  cat > "$ocamltest_response" <<EOF
+-stdout
+-stderr
+EOF
+
+  exit ${TEST_PASS}
+else
+  echo "$uname" > "$ocamltest_response"
+  exit ${TEST_SKIP}
+fi

--- a/testsuite/tests/lib-unix/unix-socket/ocamltests
+++ b/testsuite/tests/lib-unix/unix-socket/ocamltests
@@ -1,0 +1,2 @@
+recvfrom_unix.ml
+recvfrom_linux.ml

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
@@ -1,0 +1,33 @@
+open Unix
+
+let path_of_addr = function
+  | ADDR_UNIX path -> path
+  | _ -> assert false
+;;
+
+let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
+  Printf.printf "%S" (path_of_addr client_addr);
+  let byte = Bytes.make 1 't' in
+  let sent_len = sendto client_socket byte 0 1 [] server_addr in
+  assert (sent_len = 1);
+  let buf = Bytes.make 1024 '\x00' in
+  let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
+
+  Printf.printf " as %S: " (path_of_addr sender);
+  assert (sender = client_addr);
+  assert (Bytes.sub_string buf 0 recv_len = "t");
+  print_endline "OK";;
+
+let ensure_no_file path =
+  try unlink path with Unix_error (ENOENT, _, _) -> ();;
+
+let with_socket fn =
+  let s = socket PF_UNIX SOCK_DGRAM 0 in
+  Fun.protect ~finally:(fun () -> close s) (fun () -> fn s)
+
+let with_bound_socket path fn =
+  with_socket (fun s ->
+    let addr = ADDR_UNIX path in
+    bind s addr;
+    fn addr s
+  )

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
@@ -8,26 +8,14 @@ let path_of_addr = function
 let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
   Printf.printf "%S" (path_of_addr client_addr);
   let byte = Bytes.make 1 't' in
-
-  (* Printf.printf "[sending]"; (* DEBUG *) *)
-
   let sent_len = sendto client_socket byte 0 1 [] server_addr in
   assert (sent_len = 1);
   let buf = Bytes.make 1024 '\x00' in
-
-  let sender =
-    try
-      let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
-      assert (Bytes.sub_string buf 0 recv_len = "t");
-      assert (sender = client_addr);
-      sender
-    with e -> ADDR_UNIX (Printexc.to_string e)
-  in
+  let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
 
   Printf.printf " as %S: " (path_of_addr sender);
-
-  (* Printf.printf "[receiving]"; (* DEBUG *) *)
-
+  assert (sender = client_addr);
+  assert (Bytes.sub_string buf 0 recv_len = "t");
   print_endline "OK";;
 
 let ensure_no_file path =

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
@@ -8,14 +8,26 @@ let path_of_addr = function
 let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
   Printf.printf "%S" (path_of_addr client_addr);
   let byte = Bytes.make 1 't' in
+
+  (* Printf.printf "[sending]"; (* DEBUG *) *)
+
   let sent_len = sendto client_socket byte 0 1 [] server_addr in
   assert (sent_len = 1);
   let buf = Bytes.make 1024 '\x00' in
-  let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
+
+  let sender =
+    (* try *)
+      let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
+      assert (Bytes.sub_string buf 0 recv_len = "t");
+      assert (sender = client_addr);
+      sender
+    (* with e -> ADDR_UNIX (Printexc.to_string e) *)
+  in
 
   Printf.printf " as %S: " (path_of_addr sender);
-  assert (sender = client_addr);
-  assert (Bytes.sub_string buf 0 recv_len = "t");
+
+  (* Printf.printf "[receiving]"; (* DEBUG *) *)
+
   print_endline "OK";;
 
 let ensure_no_file path =

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
@@ -16,12 +16,12 @@ let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
   let buf = Bytes.make 1024 '\x00' in
 
   let sender =
-    (* try *)
+    try
       let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
       assert (Bytes.sub_string buf 0 recv_len = "t");
       assert (sender = client_addr);
       sender
-    (* with e -> ADDR_UNIX (Printexc.to_string e) *)
+    with e -> ADDR_UNIX (Printexc.to_string e)
   in
 
   Printf.printf " as %S: " (path_of_addr sender);

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.ml
@@ -1,0 +1,21 @@
+(* TEST
+include unix
+modules = "recvfrom.ml"
+script = "sh ${test_source_directory}/is-linux.sh"
+* hasunix
+** script
+*** bytecode
+*** native
+*)
+open Recvfrom
+
+let () =
+  let server_path = "ocaml-test-socket-linux" in
+  ensure_no_file server_path;
+  at_exit (fun () -> ensure_no_file server_path);
+  with_bound_socket server_path (fun server_addr server_socket ->
+    (* abstract socket *)
+    with_bound_socket "\x00ocaml-abstract-socket" (fun client_addr client_socket ->
+      test_sender ~client_socket ~server_socket ~server_addr ~client_addr
+    );
+  )

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.reference
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_linux.reference
@@ -1,0 +1,1 @@
+"\000ocaml-abstract-socket" as "\000ocaml-abstract-socket": OK

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
@@ -1,0 +1,23 @@
+(* TEST
+include unix
+modules = "recvfrom.ml"
+* not-windows
+** bytecode
+** native
+*)
+open Recvfrom
+
+let () =
+  let server_path = "ocaml-test-socket-unix" in
+  ensure_no_file server_path;
+  at_exit (fun () -> ensure_no_file server_path);
+  with_bound_socket server_path (fun server_addr server_socket ->
+    (* path socket, just reuse server addr *)
+    test_sender ~client_socket:server_socket ~server_socket ~server_addr ~client_addr:server_addr;
+
+    (* unnamed socket *)
+    with_socket (fun client_socket ->
+      (* unbound socket should be treated as empty path *)
+      test_sender ~client_socket ~server_socket ~server_addr ~client_addr:(ADDR_UNIX "")
+    )
+  )

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.reference
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.reference
@@ -1,0 +1,2 @@
+"ocaml-test-socket-unix" as "ocaml-test-socket-unix": OK
+"" as "": OK


### PR DESCRIPTION
Attempting #2233 again.

I got the tests working on MacOS, but they only failed due to a logic error - the path of an unnamed socket was being returned as a string of 14 null bytes, rather than `""` or raising EAFNOSUPPORT. Since the first byte was null, it looked like a perfectly valid (if weird) abstract socket name. I've had to add an ugly `#ifdef __linux__` now, which makes me sad.

For context, support for returning `""` for an unnamed socket was originally added in https://caml.inria.fr/mantis/view.php?id=7039 (@xavierleroy). The dangerous part of that bug (reading past the end of the allocated space) is already fixed by using `strnlen`, so we _could_ decide that you once again get garbage for an unnamed socket. But it's probably more useful to keep the current behaviour, even if the code is a bit awkward.

/cc @diml @shindere. If you're able to run this through pre-check and find out (a) the backtrace and (b) the test output, that would be super useful. I'm assuming EAFNOSUPPORT is coming from the case where the sender has an unnamed socket. But I'd like to figure out which function is actually raising it.
