### PR TITLE
[RFC] Support long path names on Windows

### DIFF
--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -153,6 +153,9 @@ extern value caml_copy_string_of_utf16(const wchar_t *s);
 
 extern int caml_win32_isatty(int fd);
 
+/* Get the full path name */
+CAMLextern wchar_t * caml_get_full_path_name(const wchar_t * name);
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -182,7 +182,7 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
 {
   CAMLparam3(path, vflags, vperm);
   int fd, flags, perm;
-  char_os * p;
+  char_os * p, * q;
 
 #if defined(O_CLOEXEC)
   flags = O_CLOEXEC;
@@ -194,6 +194,11 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
 
   caml_sys_check_path(path);
   p = caml_stat_strdup_to_os(String_val(path));
+#ifdef _WIN32
+  q = caml_get_full_path_name(p);
+  caml_stat_free(p);
+  p = q;
+#endif
   flags |= caml_convert_flag_list(vflags, sys_open_flags);
   perm = Int_val(vperm);
   /* open on a named FIFO can block (PR#1533) */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1035,3 +1035,27 @@ int caml_num_rows_fd(int fd)
 {
   return -1;
 }
+
+CAMLexport WCHAR* caml_get_full_path_name(const WCHAR* lpFileName)
+{
+  WCHAR *lpBuffer;
+  DWORD nBufferLength = wcslen(lpFileName) + 1;
+  DWORD retcode;
+
+  while (1) {
+    lpBuffer = caml_stat_alloc((nBufferLength + 4) * sizeof(WCHAR));
+    retcode = GetFullPathNameW(lpFileName, nBufferLength, lpBuffer + 4, NULL);
+
+    if (retcode == 0)
+      caml_win32_sys_error(GetLastError());
+
+    if (retcode < nBufferLength)
+      break;
+
+    caml_stat_free(lpBuffer);
+    nBufferLength = retcode;
+  }
+
+  lpBuffer[0] = '\\'; lpBuffer[1] = '\\'; lpBuffer[2] = '?'; lpBuffer[3] = '\\';
+  return lpBuffer;
+}


### PR DESCRIPTION
Recently the [esy](https://github.com/esy/esy) project had problems compiling files with long paths under Windows (> 260 characters). Windows supports longer path names but they need to be prefixed with `\\?\` (and made absolute in a precise sense).

This PR adapts one tiny bit of the runtime system so that long path names can be used when reading and writing files using the functions in `Stdlib` (`open_in`, `open_out`, etc.). In particular this applies to the compiler.

This is just a proof of concept; other functions would also need to be adapted.

All opinions welcome! /cc @dra27 

@jordwalke @ulrikstrid: could you try to see if this helps you?