### PR TITLE
HACKING.adoc: fixed dead link

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -116,7 +116,7 @@ link:driver/pparse.ml[].
 ==== Typing -- link:typing/[]
 
 Type-checks the AST and produces a typed representation of the program
-(link:parsing/typedtree.mli[] has some helpful comments). See
+(link:typing/typedtree.mli[] has some helpful comments). See
 link:typing/HACKING.adoc[].
 
 ==== The bytecode compiler -- link:bytecomp/[]


### PR DESCRIPTION
Fixed a dead link within HACKING.adoc