### PR TITLE
MPR#7923 1/2 - fix bootstrapped flexdll

### DIFF
--- a/Changes
+++ b/Changes
@@ -832,6 +832,10 @@ OCaml 4.08.0
 - GPR#2231: Env: always freshen persistent signatures before using them
   (Thomas Refis and Leo White, review by Gabriel Radanne)
 
+- MPR#7923, GPR#2259: fix regression in FlexDLL bootstrapped build caused by
+  refactoring the root Makefile for Dune in GPR#2093)
+  (David Allsopp, report by Marc Lasson)
+
 - MPR#7929, GPR#2261: Subst.signature: call cleanup_types exactly once
   (Thomas Refis, review by Gabriel Scherer and Jacques Garrigue,
   report by Daniel Bünzli and Jon Ludlam)

--- a/Makefile
+++ b/Makefile
@@ -298,13 +298,10 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 FLEXDLL_SUBMODULE_PRESENT := $(wildcard flexdll/Makefile)
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
   BOOT_FLEXLINK_CMD =
-  FLEXDLL_DIR =
 else
   BOOT_FLEXLINK_CMD = FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
-  FLEXDLL_DIR = $(if $(wildcard flexdll/flexdll_*.$(O)),+flexdll)
 endif
 else
-  FLEXDLL_DIR =
 endif
 
 # The configuration file

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -19,6 +19,16 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.config
 
+ifeq "$(UNIX_OR_WIN32)" "win32"
+ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
+  FLEXDLL_DIR =
+else
+  FLEXDLL_DIR = $(if $(wildcard $(ROOTDIR)/flexdll/flexdll_*.$(O)),+flexdll)
+endif
+else
+  FLEXDLL_DIR =
+endif
+
 # SUBST generates the sed substitution for the variable *named* in $1
 # SUBST_QUOTE does the same, adding double-quotes around non-empty strings
 #   (see FLEXDLL_DIR which must empty if FLEXDLL_DIR is empty but an OCaml


### PR DESCRIPTION
The bootstrapped build for flexdll works, but owing to the refactoring of `Makefile` and `utils/Makefile` in #2093, `Config.flexdll_dirs` is not correctly generated so the resulting compiler will fail:

```
C:\Users\DRA\Documents>ocamlopt -o hello.exe hello.ml
** Fatal error: Cannot find file "flexdll_msvc64.obj"
File "caml_startup", line 1:
Error: Error during linking
```

This isn't picked up during the build because the FlexDLL objects are (correctly) taken from the submodule directory.

This should go into 4.08 before beta2.