### PR TITLE
Subst.signature: only call cleanup_types once.

### DIFF
--- a/Changes
+++ b/Changes
@@ -772,6 +772,10 @@ OCaml 4.08.0
 - GPR#2231: Env: always freshen persistent signatures before using them
   (Thomas Refis and Leo White, review by Gabriel Radanne)
 
+- MPR#7929, GPR#2261: Subst.signature: call cleanup_types exactly once
+  (Thomas Refis, review by Gabriel Scherer and Jacques Garrigue,
+  report by Daniel Bünzli and Jon Ludlam)
+
 OCaml 4.07.1 (4 October 2018)
 -----------------------------
 

--- a/dune
+++ b/dune
@@ -41,7 +41,7 @@
    ;; UTILS
    config build_path_prefix_map misc identifiable numbers arg_helper clflags
    profile terminfo ccomp warnings consistbl strongly_connected_components
-   targetint
+   targetint load_path
 
    ;; PARSING
    location longident docstrings syntaxerr ast_helper camlinternalMenhirLib

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -130,8 +130,8 @@ val copy_kind: field_kind -> field_kind
 module For_copy : sig
 
   type copy_scope
-        (* A token used to ensure that calls to [save_desc] or [dup_kind]
-           only happen from inside a call to [with_scope].
+        (* The private state that the primitives below are mutating, it should
+           remain scoped within a single [with_scope] call.
 
            While it is possible to circumvent that discipline in various
            ways, you should NOT do that. *)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -127,12 +127,25 @@ val copy_row:
     bool -> row_desc -> bool -> type_expr -> row_desc
 val copy_kind: field_kind -> field_kind
 
-val save_desc: type_expr -> type_desc -> unit
+module For_copy : sig
+
+  type copy_scope
+        (* A token used to ensure that calls to [save_desc] or [dup_kind]
+           only happen from inside a call to [with_scope].
+
+           While it is possible to circumvent that discipline in various
+           ways, you should NOT do that. *)
+
+  val save_desc: copy_scope -> type_expr -> type_desc -> unit
         (* Save a type description *)
-val dup_kind: field_kind option ref -> unit
+
+  val dup_kind: copy_scope -> field_kind option ref -> unit
         (* Save a None field_kind, and make it point to a fresh Fvar *)
-val cleanup_types: unit -> unit
-        (* Restore type descriptions *)
+
+  val with_scope: (copy_scope -> 'a) -> 'a
+        (* [with_scope f] calls [f] and restores saved type descriptions
+           before returning its result. *)
+end
 
 val lowest_level: int
         (* Marked type: ty.level < lowest_level *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1028,8 +1028,8 @@ let abbreviations = ref (ref Mnil)
 
 (* partial: we may not wish to copy the non generic types
    before we call type_pat *)
-let rec copy ?partial ?keep_names ty =
-  let copy = copy ?partial ?keep_names in
+let rec copy ?partial ?keep_names scope ty =
+  let copy = copy ?partial ?keep_names scope in
   let ty = repr ty in
   match ty.desc with
     Tsubst ty -> ty
@@ -1048,7 +1048,7 @@ let rec copy ?partial ?keep_names ty =
     in
     if forget <> generic_level then newty2 forget (Tvar None) else
     let desc = ty.desc in
-    save_desc ty desc;
+    For_copy.save_desc scope ty desc;
     let t = newvar() in          (* Stub *)
     set_scope t ty.scope;
     ty.desc <- Tsubst t;
@@ -1091,10 +1091,10 @@ let rec copy ?partial ?keep_names ty =
                 match more.desc with
                   Tsubst ty -> ty
                 | Tconstr _ | Tnil ->
-                    save_desc more more.desc;
+                    For_copy.save_desc scope more more.desc;
                     copy more
                 | Tvar _ | Tunivar _ ->
-                    save_desc more more.desc;
+                    For_copy.save_desc scope more more.desc;
                     if keep then more else newty more.desc
                 |  _ -> assert false
               in
@@ -1138,7 +1138,7 @@ let rec copy ?partial ?keep_names ty =
             Fabsent  -> Tlink (copy ty2)
           | Fpresent -> copy_type_desc copy desc
           | Fvar r ->
-              dup_kind r;
+              For_copy.dup_kind scope r;
               copy_type_desc copy desc
           end
       | Tobject (ty1, _) when partial <> None ->
@@ -1146,8 +1146,6 @@ let rec copy ?partial ?keep_names ty =
       | _ -> copy_type_desc ?keep_names copy desc
       end;
     t
-
-let simple_copy t = copy t
 
 (**** Variants of instantiations ****)
 
@@ -1157,9 +1155,7 @@ let instance ?partial sch =
       None -> None
     | Some keep -> Some (compute_univars sch, keep)
   in
-  let ty = copy ?partial sch in
-  cleanup_types ();
-  ty
+  For_copy.with_scope (fun scope -> copy ?partial scope sch)
 
 let generic_instance sch =
   let old = !current_level in
@@ -1169,9 +1165,7 @@ let generic_instance sch =
   ty
 
 let instance_list schl =
-  let tyl = List.map (fun t -> copy t) schl in
-  cleanup_types ();
-  tyl
+  For_copy.with_scope (fun scope -> List.map (fun t -> copy scope t) schl)
 
 let reified_var_counter = ref Vars.empty
 let reset_reified_var_counter () =
@@ -1209,43 +1203,46 @@ let existential_name cstr ty = match repr ty with
   | _ -> "$" ^ cstr.cstr_name
 
 let instance_constructor ?in_pattern cstr =
-  begin match in_pattern with
-  | None -> ()
-  | Some (env, expansion_scope) ->
-      let process existential =
-        let decl = new_declaration expansion_scope None in
-        let name = existential_name cstr existential in
-        let path =
-          Path.Pident
-            (Ident.create_scoped ~scope:expansion_scope
-               (get_new_abstract_name name))
+  For_copy.with_scope (fun scope ->
+    begin match in_pattern with
+    | None -> ()
+    | Some (env, expansion_scope) ->
+        let process existential =
+          let decl = new_declaration expansion_scope None in
+          let name = existential_name cstr existential in
+          let path =
+            Path.Pident
+              (Ident.create_scoped ~scope:expansion_scope
+                 (get_new_abstract_name name))
+          in
+          let new_env = Env.add_local_type path decl !env in
+          env := new_env;
+          let to_unify = newty (Tconstr (path,[],ref Mnil)) in
+          let tv = copy scope existential in
+          assert (is_Tvar tv);
+          link_type tv to_unify
         in
-        let new_env = Env.add_local_type path decl !env in
-        env := new_env;
-        let to_unify = newty (Tconstr (path,[],ref Mnil)) in
-        let tv = copy existential in
-        assert (is_Tvar tv);
-        link_type tv to_unify
-      in
-      List.iter process cstr.cstr_existentials
-  end;
-  let ty_res = copy cstr.cstr_res in
-  let ty_args = List.map simple_copy  cstr.cstr_args in
-  cleanup_types ();
-  (ty_args, ty_res)
+        List.iter process cstr.cstr_existentials
+    end;
+    let ty_res = copy scope cstr.cstr_res in
+    let ty_args = List.map (copy scope) cstr.cstr_args in
+    (ty_args, ty_res)
+  )
 
 let instance_parameterized_type ?keep_names sch_args sch =
-  let ty_args = List.map (fun t -> copy ?keep_names t) sch_args in
-  let ty = copy sch in
-  cleanup_types ();
-  (ty_args, ty)
+  For_copy.with_scope (fun scope ->
+    let ty_args = List.map (fun t -> copy ?keep_names scope t) sch_args in
+    let ty = copy scope sch in
+    (ty_args, ty)
+  )
 
 let instance_parameterized_type_2 sch_args sch_lst sch =
-  let ty_args = List.map simple_copy sch_args in
-  let ty_lst = List.map simple_copy sch_lst in
-  let ty = copy sch in
-  cleanup_types ();
-  (ty_args, ty_lst, ty)
+  For_copy.with_scope (fun scope ->
+    let ty_args = List.map (copy scope) sch_args in
+    let ty_lst = List.map (copy scope) sch_lst in
+    let ty = copy scope sch in
+    (ty_args, ty_lst, ty)
+  )
 
 let map_kind f = function
   | Type_abstract -> Type_abstract
@@ -1268,14 +1265,12 @@ let map_kind f = function
 
 
 let instance_declaration decl =
-  let decl =
-    {decl with type_params = List.map simple_copy decl.type_params;
-     type_manifest = may_map simple_copy decl.type_manifest;
-     type_kind = map_kind simple_copy decl.type_kind;
+  For_copy.with_scope (fun scope ->
+    {decl with type_params = List.map (copy scope) decl.type_params;
+     type_manifest = may_map (copy scope) decl.type_manifest;
+     type_kind = map_kind (copy scope) decl.type_kind;
     }
-  in
-  cleanup_types ();
-  decl
+  )
 
 let generic_instance_declaration decl =
   let old = !current_level in
@@ -1285,26 +1280,29 @@ let generic_instance_declaration decl =
   decl
 
 let instance_class params cty =
-  let rec copy_class_type =
-    function
-      Cty_constr (path, tyl, cty) ->
-        Cty_constr (path, List.map simple_copy tyl, copy_class_type cty)
+  let rec copy_class_type scope = function
+    | Cty_constr (path, tyl, cty) ->
+        let tyl' = List.map (copy scope) tyl in
+        let cty' = copy_class_type scope cty in
+        Cty_constr (path, tyl', cty')
     | Cty_signature sign ->
         Cty_signature
-          {csig_self = copy sign.csig_self;
+          {csig_self = copy scope sign.csig_self;
            csig_vars =
-             Vars.map (function (m, v, ty) -> (m, v, copy ty)) sign.csig_vars;
+             Vars.map (function (m, v, ty) -> (m, v, copy scope ty))
+               sign.csig_vars;
            csig_concr = sign.csig_concr;
            csig_inher =
-             List.map (fun (p,tl) -> (p, List.map simple_copy tl))
+             List.map (fun (p,tl) -> (p, List.map (copy scope) tl))
                sign.csig_inher}
     | Cty_arrow (l, ty, cty) ->
-        Cty_arrow (l, copy ty, copy_class_type cty)
+        Cty_arrow (l, copy scope ty, copy_class_type scope cty)
   in
-  let params' = List.map simple_copy params in
-  let cty' = copy_class_type cty in
-  cleanup_types ();
-  (params', cty')
+  For_copy.with_scope (fun scope ->
+    let params' = List.map (copy scope) params in
+    let cty' = copy_class_type scope cty in
+    (params', cty')
+  )
 
 (**** Instantiation for types with free universal variables ****)
 
@@ -1322,14 +1320,14 @@ let delayed_copy = ref []
 
 (* Copy without sharing until there are no free univars left *)
 (* all free univars must be included in [visited]            *)
-let rec copy_sep fixed free bound visited ty =
+let rec copy_sep cleanup_scope fixed free bound visited ty =
   let ty = repr ty in
   let univars = free ty in
   if TypeSet.is_empty univars then
     if ty.level <> generic_level then ty else
     let t = newvar () in
     delayed_copy :=
-      lazy (t.desc <- Tlink (copy ty))
+      lazy (t.desc <- Tlink (copy cleanup_scope ty))
       :: !delayed_copy;
     t
   else try
@@ -1344,7 +1342,7 @@ let rec copy_sep fixed free bound visited ty =
         Tarrow _ | Ttuple _ | Tvariant _ | Tconstr _ | Tobject _ | Tpackage _ ->
           (ty,(t,bound)) :: visited
       | _ -> visited in
-    let copy_rec = copy_sep fixed free bound visited in
+    let copy_rec = copy_sep cleanup_scope fixed free bound visited in
     t.desc <-
       begin match ty.desc with
       | Tvariant row0 ->
@@ -1362,13 +1360,13 @@ let rec copy_sep fixed free bound visited ty =
           let bound = tl @ bound in
           let visited =
             List.map2 (fun ty t -> ty,(t,bound)) tl tl' @ visited in
-          Tpoly (copy_sep fixed free bound visited t1, tl')
+          Tpoly (copy_sep cleanup_scope fixed free bound visited t1, tl')
       | _ -> copy_type_desc copy_rec ty.desc
       end;
     t
   end
 
-let instance_poly ?(keep_names=false) fixed univars sch =
+let instance_poly' cleanup_scope ~keep_names fixed univars sch =
   let univars = List.map repr univars in
   let copy_var ty =
     match ty.desc with
@@ -1378,23 +1376,28 @@ let instance_poly ?(keep_names=false) fixed univars sch =
   let vars = List.map copy_var univars in
   let pairs = List.map2 (fun u v -> u, (v, [])) univars vars in
   delayed_copy := [];
-  let ty = copy_sep fixed (compute_univars sch) [] pairs sch in
+  let ty = copy_sep cleanup_scope fixed (compute_univars sch) [] pairs sch in
   List.iter Lazy.force !delayed_copy;
   delayed_copy := [];
-  cleanup_types ();
   vars, ty
 
+let instance_poly ?(keep_names=false) fixed univars sch =
+  For_copy.with_scope (fun cleanup_scope ->
+    instance_poly' cleanup_scope ~keep_names fixed univars sch
+  )
+
 let instance_label fixed lbl =
-  let ty_res = copy lbl.lbl_res in
-  let vars, ty_arg =
-    match repr lbl.lbl_arg with
-      {desc = Tpoly (ty, tl)} ->
-        instance_poly fixed tl ty
-    | _ ->
-        [], copy lbl.lbl_arg
-  in
-  cleanup_types ();
-  (vars, ty_arg, ty_res)
+  For_copy.with_scope (fun scope ->
+    let ty_res = copy scope lbl.lbl_res in
+    let vars, ty_arg =
+      match repr lbl.lbl_arg with
+        {desc = Tpoly (ty, tl)} ->
+          instance_poly' scope ~keep_names:false fixed tl ty
+      | _ ->
+          [], copy scope lbl.lbl_arg
+    in
+    (vars, ty_arg, ty_res)
+  )
 
 (**** Instantiation with parameter substitution ****)
 
@@ -1922,25 +1925,28 @@ let univar_pairs = ref []
 
 (* assumption: [ty] is fully generalized. *)
 let reify_univars ty =
-  let rec subst_univar vars ty =
+  let rec subst_univar scope vars ty =
     let ty = repr ty in
     if ty.level >= lowest_level then begin
       ty.level <- pivot_level - ty.level;
       match ty.desc with
       | Tvar name ->
-          save_desc ty ty.desc;
+          For_copy.save_desc scope ty ty.desc;
           let t = newty2 ty.level (Tunivar name) in
           vars := t :: !vars;
           ty.desc <- Tsubst t
       | _ ->
-          iter_type_expr (subst_univar vars) ty
+          iter_type_expr (subst_univar scope vars) ty
     end
   in
   let vars = ref [] in
-  subst_univar vars ty;
-  unmark_type ty;
-  let ty = copy ty in
-  cleanup_types ();
+  let ty =
+    For_copy.with_scope (fun scope ->
+      subst_univar scope vars ty;
+      unmark_type ty;
+      copy scope ty
+    )
+  in
   newty2 ty.level (Tpoly(repr ty, !vars))
 
 

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -142,7 +142,7 @@ let norm = function
 let ctype_apply_env_empty = ref (fun _ -> assert false)
 
 (* Similar to [Ctype.nondep_type_rec]. *)
-let rec typexp s ty =
+let rec typexp scope s ty =
   let ty = repr ty in
   match ty.desc with
     Tvar _ | Tunivar _ as desc ->
@@ -151,7 +151,9 @@ let rec typexp s ty =
           if s.for_saving then newpersty (norm desc)
           else newty2 ty.level desc
         in
-        save_desc ty desc; ty.desc <- Tsubst ty'; ty'
+        For_copy.save_desc scope ty desc;
+        ty.desc <- Tsubst ty';
+        ty'
       else ty
   | Tsubst ty ->
       ty
@@ -165,7 +167,7 @@ let rec typexp s ty =
 *)
   | _ ->
     let desc = ty.desc in
-    save_desc ty desc;
+    For_copy.save_desc scope ty desc;
     let tm = row_of_type ty in
     let has_fixed_row =
       not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm in
@@ -181,7 +183,7 @@ let rec typexp s ty =
         | _ -> assert false
       else match desc with
       | Tconstr (p, args, _abbrev) ->
-         let args = List.map (typexp s) args in
+         let args = List.map (typexp scope s) args in
          begin match Path.Map.find p s.types with
          | exception Not_found -> Tconstr(type_path s p, args, ref Mnil)
          | Path _ -> Tconstr(type_path s p, args, ref Mnil)
@@ -189,15 +191,18 @@ let rec typexp s ty =
             (!ctype_apply_env_empty params body args).desc
          end
       | Tpackage(p, n, tl) ->
-          Tpackage(modtype_path s p, n, List.map (typexp s) tl)
+          Tpackage(modtype_path s p, n, List.map (typexp scope s) tl)
       | Tobject (t1, name) ->
-          Tobject (typexp s t1,
-                 ref (match !name with
-                        None -> None
-                      | Some (p, tl) ->
-                         if to_subst_by_type_function s p
-                         then None
-                         else Some (type_path s p, List.map (typexp s) tl)))
+          let t1' = typexp scope s t1 in
+          let name' =
+            match !name with
+            | None -> None
+            | Some (p, tl) ->
+                if to_subst_by_type_function s p
+                then None
+                else Some (type_path s p, List.map (typexp scope s) tl)
+          in
+          Tobject (t1', ref name')
       | Tvariant row ->
           let row = row_repr row in
           let more = repr row.row_more in
@@ -216,9 +221,9 @@ let rec typexp s ty =
               let more' =
                 match more.desc with
                   Tsubst ty -> ty
-                | Tconstr _ | Tnil -> typexp s more
+                | Tconstr _ | Tnil -> typexp scope s more
                 | Tunivar _ | Tvar _ ->
-                    save_desc more more.desc;
+                    For_copy.save_desc scope more more.desc;
                     if s.for_saving then newpersty (norm more.desc) else
                     if dup && is_Tvar more then newgenty more.desc else more
                 | _ -> assert false
@@ -227,7 +232,7 @@ let rec typexp s ty =
               more.desc <- Tsubst(newgenty(Ttuple[more';ty']));
               (* Return a new copy *)
               let row =
-                copy_row (typexp s) true row (not dup) more' in
+                copy_row (typexp scope s) true row (not dup) more' in
               match row.row_name with
               | Some (p, tl) ->
                  Tvariant {row with row_name =
@@ -238,8 +243,8 @@ let rec typexp s ty =
                   Tvariant row
           end
       | Tfield(_label, kind, _t1, t2) when field_kind_repr kind = Fabsent ->
-          Tlink (typexp s t2)
-      | _ -> copy_type_desc (typexp s) desc
+          Tlink (typexp scope s t2)
+      | _ -> copy_type_desc (typexp scope s) desc
       end;
     ty'
 
@@ -247,52 +252,49 @@ let rec typexp s ty =
    Always make a copy of the type. If this is not done, type levels
    might not be correct.
 *)
-let type_expr s ty =
-  let ty' = typexp s ty in
-  cleanup_types ();
-  ty'
+let type_expr s ty = For_copy.with_scope (fun scope -> typexp scope s ty)
 
-let label_declaration s l =
+let label_declaration scope s l =
   {
     ld_id = l.ld_id;
     ld_mutable = l.ld_mutable;
-    ld_type = typexp s l.ld_type;
+    ld_type = typexp scope s l.ld_type;
     ld_loc = loc s l.ld_loc;
     ld_attributes = attrs s l.ld_attributes;
   }
 
-let constructor_arguments s = function
+let constructor_arguments scope s = function
   | Cstr_tuple l ->
-      Cstr_tuple (List.map (typexp s) l)
+      Cstr_tuple (List.map (typexp scope s) l)
   | Cstr_record l ->
-      Cstr_record (List.map (label_declaration s) l)
+      Cstr_record (List.map (label_declaration scope s) l)
 
-let constructor_declaration s c =
+let constructor_declaration scope s c =
   {
     cd_id = c.cd_id;
-    cd_args = constructor_arguments s c.cd_args;
-    cd_res = may_map (typexp s) c.cd_res;
+    cd_args = constructor_arguments scope s c.cd_args;
+    cd_res = may_map (typexp scope s) c.cd_res;
     cd_loc = loc s c.cd_loc;
     cd_attributes = attrs s c.cd_attributes;
   }
 
-let type_declaration' s decl =
-  { type_params = List.map (typexp s) decl.type_params;
+let type_declaration' scope s decl =
+  { type_params = List.map (typexp scope s) decl.type_params;
     type_arity = decl.type_arity;
     type_kind =
       begin match decl.type_kind with
         Type_abstract -> Type_abstract
       | Type_variant cstrs ->
-          Type_variant (List.map (constructor_declaration s) cstrs)
+          Type_variant (List.map (constructor_declaration scope s) cstrs)
       | Type_record(lbls, rep) ->
-          Type_record (List.map (label_declaration s) lbls, rep)
+          Type_record (List.map (label_declaration scope s) lbls, rep)
       | Type_open -> Type_open
       end;
     type_manifest =
       begin
         match decl.type_manifest with
           None -> None
-        | Some ty -> Some(typexp s ty)
+        | Some ty -> Some(typexp scope s ty)
       end;
     type_private = decl.type_private;
     type_variance = decl.type_variance;
@@ -305,92 +307,82 @@ let type_declaration' s decl =
   }
 
 let type_declaration s decl =
-  let decl = type_declaration' s decl in
-  cleanup_types ();
-  decl
+  For_copy.with_scope (fun scope -> type_declaration' scope s decl)
 
-let class_signature s sign =
-  { csig_self = typexp s sign.csig_self;
+let class_signature scope s sign =
+  { csig_self = typexp scope s sign.csig_self;
     csig_vars =
-      Vars.map (function (m, v, t) -> (m, v, typexp s t)) sign.csig_vars;
+      Vars.map (function (m, v, t) -> (m, v, typexp scope s t)) sign.csig_vars;
     csig_concr = sign.csig_concr;
     csig_inher =
-      List.map (fun (p, tl) -> (type_path s p, List.map (typexp s) tl))
+      List.map (fun (p, tl) -> (type_path s p, List.map (typexp scope s) tl))
         sign.csig_inher;
   }
 
-let rec class_type s =
-  function
-    Cty_constr (p, tyl, cty) ->
-      Cty_constr (type_path s p, List.map (typexp s) tyl, class_type s cty)
+let rec class_type scope s = function
+  | Cty_constr (p, tyl, cty) ->
+      let p' = type_path s p in
+      let tyl' = List.map (typexp scope s) tyl in
+      let cty' = class_type scope s cty in
+      Cty_constr (p', tyl', cty')
   | Cty_signature sign ->
-      Cty_signature (class_signature s sign)
+      Cty_signature (class_signature scope s sign)
   | Cty_arrow (l, ty, cty) ->
-      Cty_arrow (l, typexp s ty, class_type s cty)
+      Cty_arrow (l, typexp scope s ty, class_type scope s cty)
 
-let class_declaration' s decl =
-  { cty_params = List.map (typexp s) decl.cty_params;
+let class_declaration' scope s decl =
+  { cty_params = List.map (typexp scope s) decl.cty_params;
     cty_variance = decl.cty_variance;
-    cty_type = class_type s decl.cty_type;
+    cty_type = class_type scope s decl.cty_type;
     cty_path = type_path s decl.cty_path;
     cty_new =
       begin match decl.cty_new with
-        None    -> None
-      | Some ty -> Some (typexp s ty)
+      | None    -> None
+      | Some ty -> Some (typexp scope s ty)
       end;
     cty_loc = loc s decl.cty_loc;
     cty_attributes = attrs s decl.cty_attributes;
   }
-let class_declaration s decl =
-  let decl = class_declaration' s decl in
-  cleanup_types ();
-  decl
 
-let cltype_declaration' s decl =
-  { clty_params = List.map (typexp s) decl.clty_params;
+let class_declaration s decl =
+  For_copy.with_scope (fun scope -> class_declaration' scope s decl)
+
+let cltype_declaration' scope s decl =
+  { clty_params = List.map (typexp scope s) decl.clty_params;
     clty_variance = decl.clty_variance;
-    clty_type = class_type s decl.clty_type;
+    clty_type = class_type scope s decl.clty_type;
     clty_path = type_path s decl.clty_path;
     clty_loc = loc s decl.clty_loc;
     clty_attributes = attrs s decl.clty_attributes;
   }
 
 let cltype_declaration s decl =
-  let decl = cltype_declaration' s decl in
-  (* Do clean up even if saving: type_declaration may be recursive *)
-  cleanup_types ();
-  decl
+  For_copy.with_scope (fun scope -> cltype_declaration' scope s decl)
 
 let class_type s cty =
-  let cty = class_type s cty in
-  cleanup_types ();
-  cty
+  For_copy.with_scope (fun scope -> class_type scope s cty)
 
-let value_description' s descr =
-  { val_type = typexp s descr.val_type;
+let value_description' scope s descr =
+  { val_type = typexp scope s descr.val_type;
     val_kind = descr.val_kind;
     val_loc = loc s descr.val_loc;
     val_attributes = attrs s descr.val_attributes;
    }
 
 let value_description s descr =
-  let vd = value_description' s descr in
-  cleanup_types ();
-  vd
+  For_copy.with_scope (fun scope -> value_description' scope s descr)
 
-let extension_constructor' s ext =
+let extension_constructor' scope s ext =
   { ext_type_path = type_path s ext.ext_type_path;
-    ext_type_params = List.map (typexp s) ext.ext_type_params;
-    ext_args = constructor_arguments s ext.ext_args;
-    ext_ret_type = may_map (typexp s) ext.ext_ret_type;
+    ext_type_params = List.map (typexp scope s) ext.ext_type_params;
+    ext_args = constructor_arguments scope s ext.ext_args;
+    ext_ret_type = may_map (typexp scope s) ext.ext_ret_type;
     ext_private = ext.ext_private;
     ext_attributes = attrs s ext.ext_attributes;
     ext_loc = if s.for_saving then Location.none else ext.ext_loc; }
 
 let extension_constructor s ext =
-  let ext = extension_constructor' s ext in
-    cleanup_types ();
-    ext
+  For_copy.with_scope (fun scope -> extension_constructor' scope s ext)
 
 let rec rename_bound_idents s sg = function
     [] -> sg, s
@@ -458,32 +450,30 @@ and signature s sg =
      substitution... *)
   let (sg', s') = rename_bound_idents s [] sg in
   (* ... then apply it to each signature component in turn *)
-  let res = List.rev_map (signature_item' s') sg' in
-  cleanup_types ();
-  res
+  For_copy.with_scope (fun scope ->
+    List.rev_map (signature_item' scope s') sg'
+  )
 
 
-and signature_item' s comp =
+and signature_item' scope s comp =
   match comp with
     Sig_value(id, d, vis) ->
-      Sig_value(id, value_description' s d, vis)
+      Sig_value(id, value_description' scope s d, vis)
   | Sig_type(id, d, rs, vis) ->
-      Sig_type(id, type_declaration' s d, rs, vis)
+      Sig_type(id, type_declaration' scope s d, rs, vis)
   | Sig_typext(id, ext, es, vis) ->
-      Sig_typext(id, extension_constructor' s ext, es, vis)
+      Sig_typext(id, extension_constructor' scope s ext, es, vis)
   | Sig_module(id, pres, d, rs, vis) ->
       Sig_module(id, pres, module_declaration s d, rs, vis)
   | Sig_modtype(id, d, vis) ->
       Sig_modtype(id, modtype_declaration s d, vis)
   | Sig_class(id, d, rs, vis) ->
-      Sig_class(id, class_declaration' s d, rs, vis)
+      Sig_class(id, class_declaration' scope s d, rs, vis)
   | Sig_class_type(id, d, rs, vis) ->
-      Sig_class_type(id, cltype_declaration' s d, rs, vis)
+      Sig_class_type(id, cltype_declaration' scope s d, rs, vis)
 
 and signature_item s comp =
-  let si = signature_item' s comp in
-  cleanup_types ();
-  si
+  For_copy.with_scope (fun scope -> signature_item' scope s comp)
 
 and module_declaration s decl =
   {
@@ -512,8 +502,8 @@ let merge_path_maps f m1 m2 =
 let type_replacement s = function
   | Path p -> Path (type_path s p)
   | Type_function { params; body } ->
-     let params = List.map (typexp s) params in
-     let body = typexp s body in
+     let params = List.map (type_expr s) params in
+     let body = type_expr s body in
      Type_function { params; body }
 
 (* Composition of substitutions:

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -59,7 +59,6 @@ val signature: t -> signature -> signature
 val signature_item: t -> signature_item -> signature_item
 val modtype_declaration: t -> modtype_declaration -> modtype_declaration
 val module_declaration: t -> module_declaration -> module_declaration
-val class_signature: t -> class_signature -> class_signature
 
 (* Composition of substitutions:
      apply (compose s1 s2) x = apply s2 (apply s1 x) *)


### PR DESCRIPTION
Fixes [MPR#7929](https://caml.inria.fr/mantis/view.php?id=7929).