### PR TITLE
configure: add --disable-windows-unicode option

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,15 @@ Working version
 
 (Changes that can break existing programs are marked with a "*")
 
+### Build system:
+
+- GPR#2264, MPR#7904: the configure script now sets the Unicode handling mode
+  under Windows according to the value of the variable WINDOWS_UNICODE_MODE. If
+  WINDOWS_UNICODE_MODE is "ansi" then it is assumed to be the current code page
+  encoding. If WINDOWS_UNICODE_MODE is "compatible" or empty or not set at all,
+  then encoding is UTF-8 with code page fallback.
+  (Nicolás Ojeda Bär, review by Sébastien Hinderer and David Allsopp)
+
 ### Internal/compiler-libs changes:
 
 - GPR#1579: Add a separate types for clambda primitives

--- a/configure
+++ b/configure
@@ -673,6 +673,7 @@ CFLAGS
 LIBTOOL
 ac_ct_LD
 LD
+WINDOWS_UNICODE_MODE
 PARTIALLD
 target_os
 target_vendor
@@ -866,6 +867,7 @@ target_alias
 AS
 ASPP
 PARTIALLD
+WINDOWS_UNICODE_MODE
 CC
 CFLAGS
 LDFLAGS
@@ -1569,6 +1571,8 @@ Some influential environment variables:
   AS          which assembler to use
   ASPP        which assembler (with preprocessor) to use
   PARTIALLD   how to build partial (relocatable) object files
+  WINDOWS_UNICODE_MODE
+              how to handle Unicode under Windows: ansi, compatible
   CC          C compiler command
   CFLAGS      C compiler flags
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
@@ -3142,6 +3146,8 @@ fi
 if test "${with_reserved_header_bits+set}" = set; then :
   withval=$with_reserved_header_bits;
 fi
+
+
 
 
 # There are two configure-time string safety options,
@@ -16966,7 +16972,14 @@ fi
 case $host in #(
   *-*-mingw32|*-pc-windows) :
     max_testsuite_dir_retries=1
+    case $WINDOWS_UNICODE_MODE in #(
+  ansi) :
+    windows_unicode=0 ;; #(
+  compatible|"") :
     windows_unicode=1 ;; #(
+  *) :
+    as_fn_error $? "unexpected windows unicode mode" "$LINENO" 5 ;;
+esac ;; #(
   *) :
     max_testsuite_dir_retries=0
   windows_unicode=0 ;;

--- a/configure.ac
+++ b/configure.ac
@@ -307,6 +307,9 @@ AC_ARG_WITH([reserved-header-bits],
   [AS_HELP_STRING([--with-reserved-header-bits=BITS],
     [reserve BITS bits in block headers for profiling info])])
 
+AC_ARG_VAR([WINDOWS_UNICODE_MODE],
+  [how to handle Unicode under Windows: ansi, compatible])
+
 # There are two configure-time string safety options,
 # --(enable|disable)-force-safe-string and
 # --with-default-string=safe|unsafe that
@@ -1690,7 +1693,12 @@ AS_IF([test x"$mandir" = x'${datarootdir}/man'],
 AS_CASE([$host],
   [*-*-mingw32|*-pc-windows],
     [max_testsuite_dir_retries=1
-    windows_unicode=1],
+    AS_CASE([$WINDOWS_UNICODE_MODE],
+      [ansi],
+        [windows_unicode=0],
+      [compatible|""],
+        [windows_unicode=1],
+      [AC_MSG_ERROR([unexpected windows unicode mode])])],
   [max_testsuite_dir_retries=0
   windows_unicode=0])
 


### PR DESCRIPTION
Adds a `configure` option to disable Unicode support under Windows. See [MPR#7904](https://caml.inria.fr/mantis/view.php?id=7904).