### PR TITLE
Add bytecomp/opcodes.mli

### DIFF
--- a/.depend
+++ b/.depend
@@ -547,7 +547,6 @@ typing/env.cmo : \
     utils/load_path.cmi \
     typing/ident.cmi \
     typing/datarepr.cmi \
-    utils/config.cmi \
     typing/cmi_format.cmi \
     utils/clflags.cmi \
     parsing/builtin_attributes.cmi \
@@ -567,7 +566,6 @@ typing/env.cmx : \
     utils/load_path.cmx \
     typing/ident.cmx \
     typing/datarepr.cmx \
-    utils/config.cmx \
     typing/cmi_format.cmx \
     utils/clflags.cmx \
     parsing/builtin_attributes.cmx \
@@ -824,6 +822,7 @@ typing/persistent_env.cmo : \
     utils/warnings.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     utils/consistbl.cmi \
     utils/config.cmi \
     typing/cmi_format.cmi \
@@ -833,6 +832,7 @@ typing/persistent_env.cmx : \
     utils/warnings.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/load_path.cmx \
     utils/consistbl.cmx \
     utils/config.cmx \
     typing/cmi_format.cmx \
@@ -1692,7 +1692,7 @@ bytecomp/bytelibrarian.cmi :
 bytecomp/bytelink.cmo : \
     utils/warnings.cmi \
     bytecomp/symtable.cmi \
-    bytecomp/opcodes.cmo \
+    bytecomp/opcodes.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
     utils/load_path.cmi \
@@ -1793,7 +1793,7 @@ bytecomp/dll.cmi :
 bytecomp/emitcode.cmo : \
     bytecomp/translmod.cmi \
     typing/primitive.cmi \
-    bytecomp/opcodes.cmo \
+    bytecomp/opcodes.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
     bytecomp/lambda.cmi \
@@ -1935,8 +1935,11 @@ bytecomp/meta.cmx : \
     bytecomp/meta.cmi
 bytecomp/meta.cmi : \
     bytecomp/instruct.cmi
-bytecomp/opcodes.cmo :
-bytecomp/opcodes.cmx :
+bytecomp/opcodes.cmo : \
+    bytecomp/opcodes.cmi
+bytecomp/opcodes.cmx : \
+    bytecomp/opcodes.cmi
+bytecomp/opcodes.cmi :
 bytecomp/printinstr.cmo : \
     bytecomp/printlambda.cmi \
     parsing/location.cmi \
@@ -1982,6 +1985,7 @@ bytecomp/runtimedef.cmi :
 bytecomp/simplif.cmo : \
     utils/warnings.cmi \
     typing/stypes.cmi \
+    typing/primitive.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
     bytecomp/lambda.cmi \
@@ -1993,6 +1997,7 @@ bytecomp/simplif.cmo : \
 bytecomp/simplif.cmx : \
     utils/warnings.cmx \
     typing/stypes.cmx \
+    typing/primitive.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
     bytecomp/lambda.cmx \
@@ -6011,7 +6016,7 @@ toplevel/topdirs.cmo : \
     typing/predef.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
-    bytecomp/opcodes.cmo \
+    bytecomp/opcodes.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
     parsing/longident.cmi \
@@ -6222,7 +6227,7 @@ driver/compdynlink.cmx : \
     driver/compdynlink.cmi
 driver/compdynlink.cmo : \
     bytecomp/symtable.cmi \
-    bytecomp/opcodes.cmo \
+    bytecomp/opcodes.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
     typing/ident.cmi \

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ _build
 
 /bytecomp/runtimedef.ml
 /bytecomp/opcodes.ml
+/bytecomp/opcodes.mli
 
 /debugger/lexer.ml
 /debugger/parser.ml

--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ Working version
 - GPR#2229: Env: remove prefix_idents cache
   (Thomas Refis, review by Frédéric Bour and Gabriel Scherer)
 
+- GPR#2265: Add bytecomp/opcodes.mli
+  (Mark Shinwell, review by Nicolas Ojeda Bar)
+
 ### Runtime system:
 
 - GPR#1725: Deprecate Obj.set_tag

--- a/Makefile
+++ b/Makefile
@@ -1279,13 +1279,17 @@ toplevel/opttoploop.cmx: otherlibs/dynlink/dynlink.cmxa
 bytecomp/opcodes.ml: runtime/caml/instruct.h tools/make_opcodes
 	runtime/ocamlrun tools/make_opcodes -opcodes < $< > $@
 
+bytecomp/opcodes.mli: runtime/caml/instruct.h tools/make_opcodes
+	runtime/ocamlrun tools/make_opcodes -opcodes-mli < $< > $@
+
 tools/make_opcodes: tools/make_opcodes.mll
 	$(MAKE) -C tools make_opcodes
 
 partialclean::
 	rm -f bytecomp/opcodes.ml
+	rm -f bytecomp/opcodes.mli
 
-beforedepend:: bytecomp/opcodes.ml
+beforedepend:: bytecomp/opcodes.ml bytecomp/opcodes.mli
 
 # Testing the parser -- see parsing/HACKING.adoc
 

--- a/Makefile
+++ b/Makefile
@@ -1279,8 +1279,8 @@ toplevel/opttoploop.cmx: otherlibs/dynlink/dynlink.cmxa
 bytecomp/opcodes.ml: runtime/caml/instruct.h tools/make_opcodes
 	runtime/ocamlrun tools/make_opcodes -opcodes < $< > $@
 
-bytecomp/opcodes.mli: runtime/caml/instruct.h tools/make_opcodes
-	runtime/ocamlrun tools/make_opcodes -opcodes-mli < $< > $@
+bytecomp/opcodes.mli: bytecomp/opcodes.ml
+	$(CAMLC) -i $< > $@
 
 tools/make_opcodes: tools/make_opcodes.mll
 	$(MAKE) -C tools make_opcodes

--- a/tools/make_opcodes.mll
+++ b/tools/make_opcodes.mll
@@ -27,6 +27,7 @@ and opnames = parse
 {
   let print_opnames = ref false
   let print_opcodes = ref false
+  let print_opcodes_mli = ref false
 
   open Printf
 
@@ -35,16 +36,22 @@ and opnames = parse
       [
         "-opnames", Arg.Set print_opnames, " Dump opcode names";
         "-opcodes", Arg.Set print_opcodes, " Dump opcode numbers";
+        "-opcodes-mli", Arg.Set print_opcodes_mli,
+          " Produce the .mli for opcodes.ml";
       ]
     in
     Arg.parse (Arg.align spec) ignore "Extract opcode info from instruct.h";
     let lexbuf = Lexing.from_channel stdin in
     let id, opnames = find_enum lexbuf in
-    if !print_opnames then begin
-      printf "let names_of_%s = [|\n" id;
-      List.iter (fun s -> printf "  %S;\n" s) opnames;
-      printf "|]\n"
-    end;
-    if !print_opcodes then
-      List.iteri (fun i op -> printf "let op%s = %i\n" op i) opnames
+    if !print_opcodes_mli then begin
+      List.iteri (fun i op -> printf "val op%s : int\n" op) opnames
+    end else begin
+      if !print_opnames then begin
+        printf "let names_of_%s = [|\n" id;
+        List.iter (fun s -> printf "  %S;\n" s) opnames;
+        printf "|]\n"
+      end;
+      if !print_opcodes then
+        List.iteri (fun i op -> printf "let op%s = %i\n" op i) opnames
+    end
 }

--- a/tools/make_opcodes.mll
+++ b/tools/make_opcodes.mll
@@ -27,7 +27,6 @@ and opnames = parse
 {
   let print_opnames = ref false
   let print_opcodes = ref false
-  let print_opcodes_mli = ref false
 
   open Printf
 
@@ -36,22 +35,16 @@ and opnames = parse
       [
         "-opnames", Arg.Set print_opnames, " Dump opcode names";
         "-opcodes", Arg.Set print_opcodes, " Dump opcode numbers";
-        "-opcodes-mli", Arg.Set print_opcodes_mli,
-          " Produce the .mli for opcodes.ml";
       ]
     in
     Arg.parse (Arg.align spec) ignore "Extract opcode info from instruct.h";
     let lexbuf = Lexing.from_channel stdin in
     let id, opnames = find_enum lexbuf in
-    if !print_opcodes_mli then begin
-      List.iteri (fun i op -> printf "val op%s : int\n" op) opnames
-    end else begin
-      if !print_opnames then begin
-        printf "let names_of_%s = [|\n" id;
-        List.iter (fun s -> printf "  %S;\n" s) opnames;
-        printf "|]\n"
-      end;
-      if !print_opcodes then
-        List.iteri (fun i op -> printf "let op%s = %i\n" op i) opnames
-    end
+    if !print_opnames then begin
+      printf "let names_of_%s = [|\n" id;
+      List.iter (fun s -> printf "  %S;\n" s) opnames;
+      printf "|]\n"
+    end;
+    if !print_opcodes then
+      List.iteri (fun i op -> printf "let op%s = %i\n" op i) opnames
 }


### PR DESCRIPTION
This pull request adds a .mli file for `bytecomp/opcodes.mli`.

This is needed to simplify a patch I will post shortly to improve the packing mechanism used to build the various `Dynlink` libraries.  (It will mean that every `.ml` file from compilerlibs that `Dynlink` depends on has a corresponding `.mli` file.)

In turn, that patch is needed for another patch I am preparing that overhauls the types used to represent various kinds of object file symbols throughout the compiler, which is in turn needed for `Asm_directives`, which is in turn needed for the gdb support.