### PR TITLE
Fix Cygwin ports

### DIFF
--- a/Changes
+++ b/Changes
@@ -578,6 +578,10 @@ OCaml 4.08.0
   then encoding is UTF-8 with code page fallback.
   (Nicolás Ojeda Bär, review by Sébastien Hinderer and David Allsopp)
 
+- GPR#2266: ensure Cygwin ports configure with `EXE=.exe`, or the compiler is
+  unable to find the camlheader files (subtle regression of GPR#2139/2041)
+  (David Allsopp, report and review by Sébastien Hinderer)
+
 ### Internal/compiler-libs changes:
 
 - MPR#7918, GPR#1703, GPR#1944, GPR#2213, GPR#2257: Add the module

--- a/configure
+++ b/configure
@@ -12316,7 +12316,6 @@ esac
 case $host in #(
   *-*-mingw32|*-pc-windows) :
     unix_or_win32="win32"
-    exeext=".exe"
     unixlib="win32unix"
     graphlib="win32graph"
     cc_profile='' ;; #(
@@ -12325,6 +12324,12 @@ case $host in #(
   unixlib="unix"
   graphlib="graph"
   cc_profile='-pg' ;;
+esac
+case $host in #(
+  *-*-cygwin*|*-*-mingw32|*-pc-windows) :
+    exeext=".exe" ;; #(
+  *) :
+    exeext='' ;;
 esac
 
 otherlibraries="dynlink"

--- a/configure.ac
+++ b/configure.ac
@@ -414,7 +414,6 @@ AS_CASE([$host],
 AS_CASE([$host],
   [*-*-mingw32|*-pc-windows],
     [unix_or_win32="win32"
-    exeext=".exe"
     unixlib="win32unix"
     graphlib="win32graph"
     cc_profile=''],
@@ -422,6 +421,10 @@ AS_CASE([$host],
   unixlib="unix"
   graphlib="graph"
   cc_profile='-pg'])
+AS_CASE([$host],
+  [*-*-cygwin*|*-*-mingw32|*-pc-windows],
+    [exeext=".exe"],
+  [exeext=''])
 
 otherlibraries="dynlink"
 AS_IF([test x"$enable_unix_lib" != "xno"],


### PR DESCRIPTION
Cygwin should have `EXE=.exe` in `Makefile.config` (it did with the old configure system).

This causes a strange chain of events leading to a broken compiler: because of how Cygwin handles `.exe`, the `camlheader` programs end up with a `.exe` extension (NB this is Cygwin **only** - the native Windows builds remain correct, with no `.exe` extension on the camlheader programs). This causes a problem with #2041 since `Sys.file_exists "camlheader"` will be true on Cygwin if `camlheader.exe` exists and is execuable but `Sys.readdir` will not contain `camlheader` and so the programs built by the Cygwin builds of `ocamlc` will be headerless.

This is manifesting itself in testsuite failures - it obviously doesn't affect the build, because bytecode images are never executed directly.

cc @shindere