### PR TITLE
Fix parallel build on Cygwin

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,10 @@ Working version
 
 ### Compiler distribution build system:
 
+- #2267: merge generation of header programs, also fixing parallel build on
+  Cygwin.
+  (David Allsopp, review by Sébastien Hinderer)
+
 - #8514: Use boot/ocamlc.opt for building, if available.
   (Stephen Dolan, review by Gabriel Scherer)
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -230,6 +230,19 @@ MAX_TESTSUITE_DIR_RETRIES=@max_testsuite_dir_retries@
 FLAT_FLOAT_ARRAY=@flat_float_array@
 AWK=@AWK@
 
+
+### Native command to build ocamlrun.exe
+
+ifeq "$(TOOLCHAIN)" "msvc"
+  MERGEMANIFESTEXE=test ! -f $(1).manifest \
+          || mt -nologo -outputresource:$(1) -manifest $(1).manifest \
+          && rm -f $(1).manifest
+  MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(OUTPUTEXE)$(1) $(2) \
+    /link /subsystem:console $(OC_LDFLAGS) && ($(MERGEMANIFESTEXE))
+else
+  MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(OC_LDFLAGS) $(OUTPUTEXE)$(1) $(2)
+endif # ifeq "$(TOOLCHAIN)" "msvc"
+
 # The following variables were defined only in the config/Makefile.* files.
 # They were not defined by the configure script used on Unix systems,
 # so we also make sure to provide them only under Windows
@@ -252,18 +265,4 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
   #   (see ocamlmklibconfig.ml in tools/Makefile)
   FLEXLINK_FLAGS=@flexlink_flags@
   FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
-
-  ### Native command to build ocamlrun.exe
-
-  ifeq "$(TOOLCHAIN)" "mingw"
-    MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(OC_LDFLAGS) $(OUTPUTEXE)$(1) $(2)
-  endif # ifeq "$(TOOLCHAIN)" "mingw"
-
-  ifeq "$(TOOLCHAIN)" "msvc"
-    MERGEMANIFESTEXE=test ! -f $(1).manifest \
-	           || mt -nologo -outputresource:$(1) -manifest $(1).manifest \
-	           && rm -f $(1).manifest
-    MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(OUTPUTEXE)$(1) $(2) \
-      /link /subsystem:console $(OC_LDFLAGS) && ($(MERGEMANIFESTEXE))
-  endif # ifeq "$(TOOLCHAIN)" "msvc"
 endif # ifeq "$(UNIX_OR_WIN32)" "win32"

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -120,9 +120,13 @@ installopt-default:
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.$(A)
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
-HEADERPROGRAM = header.c
+HEADERPROGRAM = header
+HEADER_PATH = $(BINDIR)/
+HEADER_TARGET_PATH = $(TARGET_BINDIR)/
 else # Windows
-HEADERPROGRAM = headernt.c
+HEADERPROGRAM = headernt
+HEADER_PATH =
+HEADER_TARGET_PATH =
 endif
 
 CAMLHEADERS =\
@@ -130,73 +134,61 @@ CAMLHEADERS =\
   camlheaderd target_camlheaderd \
   camlheaderi target_camlheaderi
 
+# The % in pattern rules must always match something, hence the slightly strange
+# patterns and $(subst ...) since `camlheader%:` wouldn't match `camlheader`
 ifeq "$(HASHBANGSCRIPTS)" "true"
-$(CAMLHEADERS): $(ROOTDIR)/Makefile.config
-	for suff in '' d i; do \
-	  echo '#!$(BINDIR)/ocamlrun'$$suff > camlheader$$suff && \
-	  echo '#!$(TARGET_BINDIR)/ocamlrun'$$suff >target_camlheader$$suff; \
-	done && \
-	echo '#!' | tr -d '\012' > camlheader_ur;
+camlhead%: $(ROOTDIR)/Makefile.config Makefile
+	echo '#!$(BINDIR)/ocamlrun$(subst er,,$*)' > $@
+
+target_%: $(ROOTDIR)/Makefile.config Makefile
+	echo '#!$(TARGET_BINDIR)/ocamlrun$(subst camlheader,,$*)' > $@
+
+camlheader_ur: Makefile
+	echo '#!' | tr -d '\012' > $@
+
 else # Hashbang scripts not supported
 
-$(CAMLHEADERS): $(HEADERPROGRAM) $(ROOTDIR)/Makefile.config
+$(CAMLHEADERS): $(HEADERPROGRAM).c $(ROOTDIR)/Makefile.config Makefile
 
-ifeq "$(UNIX_OR_WIN32)" "unix"
-$(CAMLHEADERS):
-	for suff in '' d i; do \
-	  $(CC) $(OC_CFLAGS) $(OC_CPPFLAGS) $(OC_LDFLAGS) \
-	            -DRUNTIME_NAME='"$(BINDIR)/ocamlrun'$$suff'"' \
-	            header.c $(OUTPUTEXE)tmpheader$(EXE) && \
-	  strip tmpheader$(EXE) && \
-	  mv tmpheader$(EXE) camlheader$$suff && \
-	  $(CC) $(OC_CFLAGS) $(OC_CPPFLAGS) $(OC_LDFLAGS) \
-	            -DRUNTIME_NAME='"$(TARGET_BINDIR)/ocamlrun'$$suff'"' \
-	            header.c $(OUTPUTEXE)tmpheader$(EXE) && \
-	  strip tmpheader$(EXE) && \
-	  mv tmpheader$(EXE) target_camlheader$$suff; \
-	done && \
-	cp camlheader camlheader_ur
+# $@.exe is deleted to ensure no Cygwin .exe mangling takes place
+camlhead%: tmphead%.exe
+	rm -f $@.exe
+	mv $< $@
 
-else # Windows
+# Again, pattern weirdness here means that the dot is always present so that
+# tmpheader.exe matches.
+tmpheader%exe: $(HEADERPROGRAM)%$(O)
+	$(call MKEXE_BOOT,$@,$^ $(EXTRALIBS))
+# FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
+ifneq "$(UNIX_OR_WIN32)" "win32"
+	strip $@
+endif
 
-# TODO: see whether there is a way to further merge the rules below
-# with those above
-
-camlheader: headernt.c
+$(HEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
 	$(CC) -c $(OC_CFLAGS) $(OC_CPPFLAGS) \
-	          -DRUNTIME_NAME='"ocamlrun"' $(OUTPUTOBJ)headernt.$(O) $<
-	$(MKEXE) -o tmpheader.exe headernt.$(O) $(EXTRALIBS)
-	rm -f camlheader.exe
-	mv tmpheader.exe camlheader
-
-target_camlheader: camlheader
-	cp camlheader target_camlheader
+	      -DRUNTIME_NAME='"$(HEADER_PATH)ocamlrun$(subst .,,$*)"' \
+	      $(OUTPUTOBJ)$@ $^
 
 camlheader_ur: camlheader
-	cp camlheader camlheader_ur
+	cp camlheader $@
 
-camlheaderd: headernt.c
+ifeq "$(UNIX_OR_WIN32)" "unix"
+tmptargetcamlheader%exe: $(HEADERPROGRAM)%$(O)
+	$(call MKEXE_BOOT,$@,$^ $(EXTRALIBS))
+	strip $@
+
+$(TARGETHEADERPROGRAM)%$(O): $(HEADERPROGRAM).c
 	$(CC) -c $(OC_CFLAGS) $(OC_CPPFLAGS) \
-	          -DRUNTIME_NAME='"ocamlrund"' $(OUTPUTOBJ)headerntd.$(O) $<
-	$(MKEXE) -o tmpheaderd.exe headerntd.$(O) $(EXTRALIBS)
-	mv tmpheaderd.exe camlheaderd
+	      -DRUNTIME_NAME='"$(HEADER_TARGET_PATH)ocamlrun$(subst .,,$*)"' \
+	      $(OUTPUTOBJ)$@ $^
 
-target_camlheaderd: camlheaderd
-	cp camlheaderd target_camlheaderd
-
-camlheaderi: headernt.c
-	$(CC) -c $(OC_CFLAGS) $(OC_CPPFLAGS) \
-	          -DRUNTIME_NAME='"ocamlruni"' $(OUTPUTOBJ)headernti.$(O) $<
-	$(MKEXE) -o tmpheaderi.exe headernti.$(O) $(EXTRALIBS)
-	mv tmpheaderi.exe camlheaderi
-
-target_camlheaderi: camlheaderi
-	cp camlheaderi target_camlheaderi
-
-# TODO: do not call flexlink to build tmpheader.exe (we don't need
-# the export table)
-
-endif # ifeq "$(UNIX_OR_WIN32)" "unix"
+target_%: tmptarget%.exe
+	rm -f $@.exe
+	mv $< $@
+else
+target_%: %
+	cp $< $@
+endif
 
 endif # ifeq "$(HASHBANGSCRIPTS)" "true"
 


### PR DESCRIPTION
The Unix and Cygwin build instructions in `stdlib/Makefile` are incorrect. They appear to have been written on the assumption that:

```make
foo bar: baz
	command
```

means that `foo` and `bar` are generated by a single command, which is incorrect as that really defines two separate recipies. On Unix, with `#!` scripts, this just means that the headers are generated more times than necessary but for Cygwin it means that the `for` loop which was there is called multiple times and unsurprisingly in parallel those calls interfere with each other.

Unusually, the native Windows build instructions were better, so my approach has been to merge them both (there was a `TODO` note to this effect already)

I have also fixed a note that the build should not be done using `flexlink` - this has been done by formally promoting `MKEXE_BOOT` to the entire build system (it means "do `MKEXE`, but don't use `flexlink`"). At some point I may come up with a better name, I had simply started this fix until I realised that #2266 was the minimum 4.08 required fix and the lack of parallelism on Cygwin is annoying (at least, possibly uniquely, for me...)

The diff is very awkward to read - I'd recommend simply reviewing my resulting code in `stdlib/Makefile` as though there were nothing there before.