### PR TITLE
restore the error message for closing a self type

### DIFF
--- a/Changes
+++ b/Changes
@@ -662,8 +662,9 @@ OCaml 4.08.0
 * GPR#2041: add a cache for looking up files in the load path
   (Jérémie Dimino, review by Alain Frisch and David Allsopp)
 
-- GPR#2047: a new type for unification traces
-  (Florian Angeletti, review by Thomas Refis and Gabriel Scherer)
+- GPR#2047, GPR#2269: a new type for unification traces
+  (Florian Angeletti, report by Leo White (GPR#2269),
+   review by Thomas Refis and Gabriel Scherer)
 
 - GPR#2055: Add [Linearize.Lprologue].
   (Mark Shinwell, review by Pierre Chambart)

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -154,3 +154,13 @@ Here is an example of a case that is not matched:
 (`AnyOtherTag', `AnyOtherTag'')
 val f : [> `AnyOtherTag ] * [> `AnyOtherTag | `AnyOtherTag' ] -> int = <fun>
 |}]
+
+let x:(([`A] as 'a)* ([`B] as 'a)) = [`A]
+[%%expect {|
+Line 1, characters 22-32:
+1 | let x:(([`A] as 'a)* ([`B] as 'a)) = [`A]
+                          ^^^^^^^^^^
+Error: This alias is bound to type [ `B ] but is used as an instance of type
+         [ `A ]
+       These two variant types have no intersection
+|}]

--- a/testsuite/tests/typing-objects/ocamltests
+++ b/testsuite/tests/typing-objects/ocamltests
@@ -9,4 +9,5 @@ pr5858.ml
 pr6123_bad.ml
 pr6383.ml
 pr6907_bad.ml
+self_cannot_be_closed.ml
 Tests.ml

--- a/testsuite/tests/typing-objects/self_cannot_be_closed.ml
+++ b/testsuite/tests/typing-objects/self_cannot_be_closed.ml
@@ -1,0 +1,17 @@
+(* TEST
+   * expect
+ *)
+let is_empty (x : < >) = ();;
+[%%expect {|
+val is_empty : <  > -> unit = <fun>
+|}]
+
+class c = object (self) method private foo = is_empty self end;;
+[%%expect {|
+Line 1, characters 54-58:
+1 | class c = object (self) method private foo = is_empty self end;;
+                                                          ^^^^
+Error: This expression has type < .. > but an expression was expected of type
+         <  >
+       Self type cannot be unified with a closed object type
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -81,6 +81,7 @@ module Unification_trace = struct
   type obj =
     | Missing_field of position * string
     | Abstract_row of position
+    | Self_cannot_be_closed
 
   type 'a elt =
     | Diff of 'a diff
@@ -2662,7 +2663,9 @@ and unify3 env t1 t1' t2 t2' =
               if d2 = Tnil then unify env rem t2'
               else unify env (newty2 rem.level Tnil) rem
           | _      ->
-              if d1 = Tnil then
+              if f = dummy_method then
+                raise (Unify Trace.[Obj Self_cannot_be_closed])
+              else if d1 = Tnil then
                 raise (Unify Trace.[Obj(Missing_field (First, f))])
               else
                 raise (Unify Trace.[Obj(Missing_field (Second, f))])

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -45,6 +45,7 @@ module Unification_trace: sig
   type obj =
     | Missing_field of position * string
     | Abstract_row of position
+    | Self_cannot_be_closed
 
   type 'a elt =
     | Diff of 'a diff

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1875,6 +1875,8 @@ let explain_escape intro prev ctx e =
 
 
 let explain_object = function
+  | Trace.Self_cannot_be_closed ->
+      Some (dprintf "@,Self type cannot be unified with a closed object type")
   | Trace.Missing_field (pos,f) ->
       Some(dprintf "@,@[The %a object type has no method %s@]" print_pos pos f)
   | Trace.Abstract_row pos -> Some(


### PR DESCRIPTION
This PR fixes a bug in #2047 : when raising an error due to a missing field, I forgot to check for the dummy method of self type. As noticed by @lpw25 , this broke the error message for unifying the self type with a closed object type. Moreover, it made possible to leak this dummy method name with:

```OCaml
# let is_empty (x : < >) = ();;
val is_empty : <  > -> unit = <fun>
# class c = object (self) method private foo = is_empty self end;;
Line 1, characters 54-58:
1 | class c = object (self) method private foo = is_empty self end;;
                                                          ^^^^
Error: This expression has type < .. > but an expression was expected of type
         <  >
       The second object type has no method *dummy method*
```

This PR restores the correct error message

```OCaml
Error: This expression has type < .. > but an expression was expected of type
         <  >
       Self type cannot be unified with a closed object type
```
and adds a test for this case.

The second commit adds another test for a specific error that was not tested at all in the test suite. With this last commit, all explanation messages are now tested by the test suite.