### PR TITLE
MPR#7548 Add an example of using the printf function to the manual

### DIFF
--- a/Changes
+++ b/Changes
@@ -466,7 +466,7 @@ OCaml 4.08.0
 ### Manual and documentation:
 
 - MPR#7548: printf example in the tutorial part of the manual
- (Kostikova Oxana, rewiew by Gabriel Scherer, Florian Angeletti, 
+ (Kostikova Oxana, rewiew by Gabriel Scherer, Florian Angeletti,
  Marcello Seri and Armaël Guéneau)
 
 - MPR#7546, GPR#2020: preambles and introduction for compiler-libs.

--- a/Changes
+++ b/Changes
@@ -465,6 +465,10 @@ OCaml 4.08.0
 
 ### Manual and documentation:
 
+- MPR#7548: printf example in the tutorial part of the manual
+ (Kostikova Oxana, rewiew by Gabriel Scherer, Florian Angeletti, 
+ Marcello Seri and Armaël Guéneau)
+
 - MPR#7546, GPR#2020: preambles and introduction for compiler-libs.
   (Florian Angeletti, review by Daniel Bünzli, Perry E. Metzger
   and Gabriel Scherer)

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -686,8 +686,8 @@ output more concisely.
 It follows the behavior of the "printf" function from the C standard library.
 The "printf" function takes a format string that describes the desired output
 as a text interspered with specifiers (for instance "%d", "%f").
-Next, the specifiers are substituted by the corresponding arguments in the
-format string:
+Next, the specifiers are substituted by the following arguments in their order
+of apparition in the format string:
 \begin{caml_example}{toplevel}
 Printf.printf "%i + %i is an integer value, %F * %F is a float, %S\n"
 3 2 4.5 1. "this is a string";;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -697,15 +697,6 @@ the format specifier, the compiler will display an error message:
 \begin{caml_example}{toplevel}[error]
 Printf.printf "Float value: %F" 42;;
 \end{caml_example}
-Associated with this feature is the need to explicitly indicate that the
-string is a format string in order to pass it to the "printf" function.
-\begin{caml_example*}{toplevel}
-let str : _ format =
-    "%i is an integer value, %F is a float, %S\n";;
-\end{caml_example*}
-\begin{caml_example}{toplevel}
-Printf.printf str 3 4.5 "string value";;
-\end{caml_example}
 "fprintf" function is like "printf" except that it takes an output channel as
 the first argument.
 \begin{caml_example}{toplevel}
@@ -758,6 +749,16 @@ let print_expr ppf expr =
   in print 0 ppf expr;;
 print_expr stdout e; print_newline ();;
 print_expr stdout (deriv e "x"); print_newline ();;
+\end{caml_example}
+
+Associated with typechecking feature is the need to explicitly indicate that the
+string is a format string in order to pass it to the "printf" function.
+\begin{caml_example*}{toplevel}
+let str : _ format =
+    "%i is an integer value, %F is a float, %S\n";;
+\end{caml_example*}
+\begin{caml_example}{toplevel}
+Printf.printf str 3 4.5 "string value";;
 \end{caml_example}
 
 %%%%%%%%%%% Should be moved to the camlp4 documentation.

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -677,6 +677,36 @@ print_expr e; print_newline ();;
 print_expr (deriv e "x"); print_newline ();;
 \end{caml_example}
 
+There is a "printf" function in "Printf" module that allows you to make
+formatted output more concisely. It models the behavior of the "printf"
+function from the C standard library.
+The "printf" function takes a format string that describes the output values and
+their format, and arguments for output that correspond to the formatting
+directives in the format string.
+\begin{caml_eval}
+open Printf;;
+\end{caml_eval}
+\begin{caml_example}{toplevel}
+printf "%i + %i is an integer value, %F * %F is a float, \"%s\"\n"
+3 2 4.5 1. "this is a string";;
+\end{caml_example}
+The printf function in the OCaml language performs type checking of arguments.
+For example, if you pass it an argument of a type that does not correspond to
+the format specifier, the compiler will display an error message:
+\begin{caml_example}{toplevel}[error]
+printf "Float value: %F" 42;;
+\end{caml_example}
+Associated with this feature is the need to explicitly indicate that the
+string is a format string in order to pass it to the "printf" function.
+\begin{caml_example*}{toplevel}
+let str : ('a, 'b, 'c) format =
+    "%i is an integer value, %F is a float, \"%s\"\n";;
+\end{caml_example*}
+\begin{caml_example}{toplevel}
+printf str 3 4.5 "string value";;
+\end{caml_example}
+
+
 %%%%%%%%%%% Should be moved to the camlp4 documentation.
 %% Parsing (transforming concrete syntax into abstract syntax) is usually
 %% more delicate. OCaml offers several tools to help write parsers:

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -691,7 +691,7 @@ directives in the format string.
 Printf.printf "%i + %i is an integer value, %F * %F is a float, %S\n"
 3 2 4.5 1. "this is a string";;
 \end{caml_example}
-OCaml type system checks that the type of the arguments and the specifiers are
+The OCaml type system checks that the type of the arguments and the specifiers are
 compatible. If you pass it an argument of a type that does not correspond to
 the format specifier, the compiler will display an error message:
 \begin{caml_example}{toplevel}[error]
@@ -707,7 +707,18 @@ let str : _ format =
 Printf.printf str 3 4.5 "string value";;
 \end{caml_example}
 "fprintf" function is like "printf" except that it takes an output channel as
-the first argument. Here is how to rewrite the pretty-printer using "fprintf":
+the first argument.
+\begin{caml_example}{toplevel}
+let output_int ppf n = Printf.fprintf ppf "%d" n
+let output_option printer ppf = function
+  | None -> Printf.fprintf ppf "None"
+  | Some v -> Printf.fprintf ppf "Some(%a)" printer v
+let () = Printf.fprintf stdout
+  "The current setting is %a"
+  (output_option output_int) (Some 3);
+print_newline ();;
+\end{caml_example}
+Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}
 let print_expr ppf expr =
   let open_paren prec op_prec output =

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -697,7 +697,7 @@ the format specifier, the compiler will display an error message:
 \begin{caml_example}{toplevel}[error]
 Printf.printf "Float value: %F" 42;;
 \end{caml_example}
-"fprintf" function is like "printf" except that it takes an output channel as
+The "fprintf" function is like "printf" except that it takes an output channel as
 the first argument. The "%a" specifier can be useful to define custom printer
 (for custom types). For instance, we can create a printing template that converts
 an integer argument to signed decimal:
@@ -705,9 +705,10 @@ an integer argument to signed decimal:
 let pp_int ppf n = Printf.fprintf ppf "%d" n;;
 Printf.printf "Outputting an integer using a custom printer: %a " pp_int 42;;
 \end{caml_example}
-The printing template is itself a composable printer. It is also possible
-to create a more complex printer, for example for the optional types:
-"'a" type into a printer for "'a option":
+The advantage of those printers based on the "%a" specifier is that they can be
+composed together to create more complex printers step by step.
+We can define a combinator that can turn a printer for "'a" type into a printer
+for "'a optional":
 \begin{caml_example}{toplevel}
 let pp_option printer ppf = function
   | None -> Printf.fprintf ppf "None"
@@ -718,9 +719,8 @@ Printf.fprintf stdout
   (pp_option pp_int) None
 ;;
 \end{caml_example}
-We need to also provide a printer as argument. The function "pp_option"
-processes the argument depending on its value by printing "None" or using
-the provided printer.
+If the value of its argument its "None", the printer returned by pp_option
+printer prints "None" otherwise it uses the provided printer to print "Some ".
 
 Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}
@@ -731,7 +731,7 @@ let pp_expr ppf expr =
     if prec > op_prec then Printf.fprintf output "%s" ")" in
   let rec print prec ppf expr =
       match expr with
-        Const c -> Printf.fprintf ppf "%F" c
+      | Const c -> Printf.fprintf ppf "%F" c
       | Var v -> Printf.fprintf ppf "%s" v
       | Sum(f, g) ->
           open_paren prec 0 ppf;
@@ -754,8 +754,8 @@ pp_expr stdout e; print_newline ();;
 pp_expr stdout (deriv e "x"); print_newline ();;
 \end{caml_example}
 
-Associated with typechecking feature is the need to explicitly indicate that the
-string is a format string in order to pass it to the "printf" function.
+Due to the way that format string are build, storing a format string requires
+an explicit type annotation:
 \begin{caml_example*}{toplevel}
 let str : _ format =
     "%i is an integer value, %F is a float, %S\n";;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -712,17 +712,15 @@ to create a more complex printer, for example for the optional types:
 let pp_option printer ppf = function
   | None -> Printf.fprintf ppf "None"
   | Some v -> Printf.fprintf ppf "Some(%a)" printer v;;
-Printf.fprintf stdout "The current setting is %a"
-  (pp_option pp_int) (Some 3);
-print_newline();;
-Printf.fprintf stdout "There is only %a"
-  (pp_option pp_int) (None);
-print_newline();;
+Printf.fprintf stdout
+  "The current setting is %a. \nThere is only %a\n"
+  (pp_option pp_int) (Some 3)
+  (pp_option pp_int) None
+;;
 \end{caml_example}
-We need to also provide a printer as argument. "pp_option" processes the
-argument depending on its value by printing "None" or using the provided printer.
-This approach works for more complex types like options. In such case
-we need to provide a printer for any additional type that they wrap.
+We need to also provide a printer as argument. The function "pp_option"
+processes the argument depending on its value by printing "None" or using
+the provided printer.
 
 Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -718,6 +718,16 @@ let () = Printf.fprintf stdout
   (output_option output_int) (Some 3);
 print_newline ();;
 \end{caml_example}
+In the "output_int" we create a printing template that converts an integer
+argument to signed decimal.
+"output_option" is a function that processes the argument passed to it,
+depending on its value (displays the number if it is not None using a printer
+passed as an argument).
+This approach works for more complex types, for example options. In such case
+we need to provide a printer for any additional type that they wrap.
+In this way we coustruct the composable printer that can be used with the "%a"
+specifier, calling it in the last step of an example.
+
 Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}
 let print_expr ppf expr =

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -711,13 +711,13 @@ the first argument. Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}
 let print_expr ppf expr =
   let open_paren prec op_prec output =
-    if prec > op_prec then Printf.fprintf output "%S" "(" in
+    if prec > op_prec then Printf.fprintf output "%s" "(" in
   let close_paren prec op_prec output =
-    if prec > op_prec then Printf.fprintf output "%S" ")" in
+    if prec > op_prec then Printf.fprintf output "%s" ")" in
   let rec print prec ppf expr =
       match expr with
         Const c -> Printf.fprintf ppf "%F" c
-      | Var v -> Printf.fprintf ppf "%S" v
+      | Var v -> Printf.fprintf ppf "%s" v
       | Sum(f, g) ->
           open_paren prec 0 ppf;
           Printf.fprintf ppf "%a + %a" (print 0) f (print 0) g;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -677,33 +677,32 @@ print_expr e; print_newline ();;
 print_expr (deriv e "x"); print_newline ();;
 \end{caml_example}
 
-There is a "printf" function in "Printf" module that allows you to make
-formatted output more concisely. It models the behavior of the "printf"
-function from the C standard library.
+\section{Printf formats}
+
+There is a "printf" function in "Printf" module (see chapter~\ref{c:moduleexamples})
+that allows you to make formatted output more concisely.
+It follows the behavior of the "printf" function from the C standard library.
 The "printf" function takes a format string that describes the output values and
 their format, and arguments for output that correspond to the formatting
 directives in the format string.
-\begin{caml_eval}
-open Printf;;
-\end{caml_eval}
 \begin{caml_example}{toplevel}
-printf "%i + %i is an integer value, %F * %F is a float, \"%s\"\n"
+Printf.printf "%i + %i is an integer value, %F * %F is a float, %S\n"
 3 2 4.5 1. "this is a string";;
 \end{caml_example}
-The printf function in the OCaml language performs type checking of arguments.
-For example, if you pass it an argument of a type that does not correspond to
+OCaml type system checks that the type of the arguments and the specifiers are
+compatible. If you pass it an argument of a type that does not correspond to
 the format specifier, the compiler will display an error message:
 \begin{caml_example}{toplevel}[error]
-printf "Float value: %F" 42;;
+Printf.printf "Float value: %F" 42;;
 \end{caml_example}
 Associated with this feature is the need to explicitly indicate that the
 string is a format string in order to pass it to the "printf" function.
 \begin{caml_example*}{toplevel}
-let str : ('a, 'b, 'c) format =
-    "%i is an integer value, %F is a float, \"%s\"\n";;
+let str : _ format =
+    "%i is an integer value, %F is a float, %S\n";;
 \end{caml_example*}
 \begin{caml_example}{toplevel}
-printf str 3 4.5 "string value";;
+Printf.printf str 3 4.5 "string value";;
 \end{caml_example}
 
 

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -679,8 +679,10 @@ print_expr (deriv e "x"); print_newline ();;
 
 \section{Printf formats}
 
-There is a "printf" function in "Printf" module (see chapter~\ref{c:moduleexamples})
-that allows you to make formatted output more concisely.
+There is a "printf" function in
+\href{https://caml.inria.fr/pub/docs/manual-ocaml/libref/Printf.html}{Printf}
+module (see chapter~\ref{c:moduleexamples}) that allows you to make formatted
+output more concisely.
 It follows the behavior of the "printf" function from the C standard library.
 The "printf" function takes a format string that describes the output values and
 their format, and arguments for output that correspond to the formatting

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -700,18 +700,18 @@ Printf.printf "Float value: %F" 42;;
 "fprintf" function is like "printf" except that it takes an output channel as
 the first argument.
 \begin{caml_example}{toplevel}
-let output_int ppf n = Printf.fprintf ppf "%d" n
-let output_option printer ppf = function
+let pp_int ppf n = Printf.fprintf ppf "%d" n
+let pp_option printer ppf = function
   | None -> Printf.fprintf ppf "None"
   | Some v -> Printf.fprintf ppf "Some(%a)" printer v
 let () = Printf.fprintf stdout
   "The current setting is %a"
-  (output_option output_int) (Some 3);
+  (pp_option pp_int) (Some 3);
 print_newline ();;
 \end{caml_example}
-In the "output_int" we create a printing template that converts an integer
+In the "pp_int" we create a printing template that converts an integer
 argument to signed decimal.
-"output_option" is a function that processes the argument passed to it,
+"pp_option" is a function that processes the argument passed to it,
 depending on its value (displays the number if it is not None using a printer
 passed as an argument).
 This approach works for more complex types, for example options. In such case

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -684,9 +684,10 @@ There is a "printf" function in
 module (see chapter~\ref{c:moduleexamples}) that allows you to make formatted
 output more concisely.
 It follows the behavior of the "printf" function from the C standard library.
-The "printf" function takes a format string that describes the output values and
-their format, and arguments for output that correspond to the formatting
-directives in the format string.
+The "printf" function takes a format string that describes the desired output
+as a text interspered with specifiers (for instance "%d", "%f").
+Next, the specifiers are substituted by the corresponding arguments in the
+format string:
 \begin{caml_example}{toplevel}
 Printf.printf "%i + %i is an integer value, %F * %F is a float, %S\n"
 3 2 4.5 1. "this is a string";;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -698,23 +698,24 @@ the format specifier, the compiler will display an error message:
 Printf.printf "Float value: %F" 42;;
 \end{caml_example}
 "fprintf" function is like "printf" except that it takes an output channel as
-the first argument.
+the first argument. The "%a" specifier can be useful to define custom printer
+(for custom types). For instance, a custom printer for ints:
 \begin{caml_example}{toplevel}
-let pp_int ppf n = Printf.fprintf ppf "%d" n
+let pp_int ppf n = Printf.fprintf ppf "%d" n;;
+Printf.printf "Outputting an integer using a custom printer: %a " pp_int 42;;
+\end{caml_example}
+We can create a combinator that transforms a printer for
+"'a" type into a printer for "'a option":
+\begin{caml_example}{toplevel}
 let pp_option printer ppf = function
   | None -> Printf.fprintf ppf "None"
   | Some v -> Printf.fprintf ppf "Some(%a)" printer v
 let () = Printf.fprintf stdout
   "The current setting is %a"
   (pp_option pp_int) (Some 3);
-print_newline ();;
+print_newline();;
 \end{caml_example}
-In the "pp_int" we create a printing template that converts an integer
-argument to signed decimal.
-"pp_option" is a function that processes the argument passed to it,
-depending on its value (displays the number if it is not None using a printer
-passed as an argument).
-This approach works for more complex types, for example options. In such case
+This approach works for more complex types like options. In such case
 we need to provide a printer for any additional type that they wrap.
 In this way we construct the composable printer that can be used with the "%a"
 specifier, calling it in the last step of an example.

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -699,26 +699,30 @@ Printf.printf "Float value: %F" 42;;
 \end{caml_example}
 "fprintf" function is like "printf" except that it takes an output channel as
 the first argument. The "%a" specifier can be useful to define custom printer
-(for custom types). For instance, a custom printer for ints:
+(for custom types). For instance, we can create a printing template that converts
+an integer argument to signed decimal:
 \begin{caml_example}{toplevel}
 let pp_int ppf n = Printf.fprintf ppf "%d" n;;
 Printf.printf "Outputting an integer using a custom printer: %a " pp_int 42;;
 \end{caml_example}
-We can create a combinator that transforms a printer for
+The printing template is itself a composable printer. It is also possible
+to create a more complex printer, for example for the optional types:
 "'a" type into a printer for "'a option":
 \begin{caml_example}{toplevel}
 let pp_option printer ppf = function
   | None -> Printf.fprintf ppf "None"
-  | Some v -> Printf.fprintf ppf "Some(%a)" printer v
-let () = Printf.fprintf stdout
-  "The current setting is %a"
+  | Some v -> Printf.fprintf ppf "Some(%a)" printer v;;
+Printf.fprintf stdout "The current setting is %a"
   (pp_option pp_int) (Some 3);
 print_newline();;
+Printf.fprintf stdout "There is only %a"
+  (pp_option pp_int) (None);
+print_newline();;
 \end{caml_example}
+We need to also provide a printer as argument. "pp_option" processes the
+argument depending on its value by printing "None" or using the provided printer.
 This approach works for more complex types like options. In such case
 we need to provide a printer for any additional type that they wrap.
-In this way we construct the composable printer that can be used with the "%a"
-specifier, calling it in the last step of an example.
 
 Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -706,7 +706,38 @@ let str : _ format =
 \begin{caml_example}{toplevel}
 Printf.printf str 3 4.5 "string value";;
 \end{caml_example}
-
+"fprintf" function is like "printf" except that it takes an output channel as
+the first argument. Here is how to rewrite the pretty-printer using "fprintf":
+\begin{caml_example}{toplevel}
+let print_expr ppf expr =
+  let open_paren prec op_prec output =
+    if prec > op_prec then Printf.fprintf output "%S" "(" in
+  let close_paren prec op_prec output =
+    if prec > op_prec then Printf.fprintf output "%S" ")" in
+  let rec print prec ppf expr =
+      match expr with
+        Const c -> Printf.fprintf ppf "%F" c
+      | Var v -> Printf.fprintf ppf "%S" v
+      | Sum(f, g) ->
+          open_paren prec 0 ppf;
+          Printf.fprintf ppf "%a + %a" (print 0) f (print 0) g;
+          close_paren prec 0 ppf
+      | Diff(f, g) ->
+          open_paren prec 0 ppf;
+          Printf.fprintf ppf "%a - %a" (print 0) f (print 1) g;
+          close_paren prec 0 ppf
+      | Prod(f, g) ->
+          open_paren prec 2 ppf;
+          Printf.fprintf ppf "%a * %a" (print 2) f (print 2) g;
+          close_paren prec 2 ppf
+      | Quot(f, g) ->
+          open_paren prec 2 ppf;
+          Printf.fprintf ppf "%a / %a" (print 2) f (print 3) g;
+          close_paren prec 2 ppf
+  in print 0 ppf expr;;
+print_expr stdout e; print_newline ();;
+print_expr stdout (deriv e "x"); print_newline ();;
+\end{caml_example}
 
 %%%%%%%%%%% Should be moved to the camlp4 documentation.
 %% Parsing (transforming concrete syntax into abstract syntax) is usually

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -716,12 +716,12 @@ depending on its value (displays the number if it is not None using a printer
 passed as an argument).
 This approach works for more complex types, for example options. In such case
 we need to provide a printer for any additional type that they wrap.
-In this way we coustruct the composable printer that can be used with the "%a"
+In this way we construct the composable printer that can be used with the "%a"
 specifier, calling it in the last step of an example.
 
 Here is how to rewrite the pretty-printer using "fprintf":
 \begin{caml_example}{toplevel}
-let print_expr ppf expr =
+let pp_expr ppf expr =
   let open_paren prec op_prec output =
     if prec > op_prec then Printf.fprintf output "%s" "(" in
   let close_paren prec op_prec output =
@@ -747,8 +747,8 @@ let print_expr ppf expr =
           Printf.fprintf ppf "%a / %a" (print 2) f (print 3) g;
           close_paren prec 2 ppf
   in print 0 ppf expr;;
-print_expr stdout e; print_newline ();;
-print_expr stdout (deriv e "x"); print_newline ();;
+pp_expr stdout e; print_newline ();;
+pp_expr stdout (deriv e "x"); print_newline ();;
 \end{caml_example}
 
 Associated with typechecking feature is the need to explicitly indicate that the


### PR DESCRIPTION
Added a description and examples of using the printf function to the manual section "1.8 Pretty-printing", closing the [MPR#7548](https://caml.inria.fr/mantis/view.php?id=7548).