### PR TITLE
Don't generate Clambda constants during Cmmgen, etc.

### DIFF
--- a/.depend
+++ b/.depend
@@ -2795,7 +2795,6 @@ asmcomp/cmmgen.cmo : \
     asmcomp/compilenv.cmi \
     asmcomp/cmx_format.cmi \
     asmcomp/cmmgen_state.cmi \
-    asmcomp/cmmgen.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     asmcomp/clambda_primitives.cmi \
@@ -2822,7 +2821,6 @@ asmcomp/cmmgen.cmx : \
     asmcomp/compilenv.cmx \
     asmcomp/cmx_format.cmi \
     asmcomp/cmmgen_state.cmx \
-    asmcomp/cmmgen.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     asmcomp/clambda_primitives.cmx \

--- a/.depend
+++ b/.depend
@@ -2794,6 +2794,8 @@ asmcomp/cmmgen.cmo : \
     utils/config.cmi \
     asmcomp/compilenv.cmi \
     asmcomp/cmx_format.cmi \
+    asmcomp/cmmgen_state.cmi \
+    asmcomp/cmmgen.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     asmcomp/clambda_primitives.cmi \
@@ -2819,6 +2821,8 @@ asmcomp/cmmgen.cmx : \
     utils/config.cmx \
     asmcomp/compilenv.cmx \
     asmcomp/cmx_format.cmi \
+    asmcomp/cmmgen_state.cmx \
+    asmcomp/cmmgen.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     asmcomp/clambda_primitives.cmx \
@@ -2830,6 +2834,20 @@ asmcomp/cmmgen.cmx : \
     asmcomp/cmmgen.cmi
 asmcomp/cmmgen.cmi : \
     asmcomp/cmx_format.cmi \
+    asmcomp/cmm.cmi \
+    asmcomp/clambda.cmi
+asmcomp/cmmgen_state.cmo : \
+    utils/misc.cmi \
+    asmcomp/cmm.cmi \
+    asmcomp/clambda.cmi \
+    asmcomp/cmmgen_state.cmi
+asmcomp/cmmgen_state.cmx : \
+    utils/misc.cmx \
+    asmcomp/cmm.cmx \
+    asmcomp/clambda.cmx \
+    asmcomp/cmmgen_state.cmi
+asmcomp/cmmgen_state.cmi : \
+    utils/misc.cmi \
     asmcomp/cmm.cmi \
     asmcomp/clambda.cmi
 asmcomp/cmx_format.cmi : \

--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Working version
 - GPR#2265: Add bytecomp/opcodes.mli
   (Mark Shinwell, review by Nicolas Ojeda Bar)
 
+- GPR#2280: Don't make more Clambda constants after starting Cmmgen
+  (Mark Shinwell)
+
 ### Runtime system:
 
 - GPR#1725: Deprecate Obj.set_tag

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,9 @@ ASMCOMP=\
   asmcomp/import_approx.cmo \
   asmcomp/un_anf.cmo \
   asmcomp/afl_instrument.cmo \
-  asmcomp/strmatch.cmo asmcomp/cmmgen.cmo \
+  asmcomp/strmatch.cmo \
+  asmcomp/cmmgen_state.cmo \
+  asmcomp/cmmgen.cmo \
   asmcomp/interval.cmo \
   asmcomp/printmach.cmo asmcomp/selectgen.cmo \
   asmcomp/spacetime_profiling.cmo asmcomp/selection.cmo \

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -102,6 +102,7 @@ let (++) x f = f x
 
 let compile_fundecl ~ppf_dump fd_cmm =
   Proc.init ();
+  Cmmgen.reset ();
   Reg.reset();
   fd_cmm
   ++ Profile.record ~accumulate:true "selection" Selection.fundecl
@@ -239,8 +240,9 @@ let lambda_gen_implementation ?toplevel ~ppf_dump
     }
   in
   let clambda_and_constants =
-    clambda, [preallocated_block], []
+    clambda, [preallocated_block], Compilenv.structured_constants ()
   in
+  Compilenv.clear_structured_constants ();
   raw_clambda_dump_if ppf_dump clambda_and_constants;
   end_gen_implementation ?toplevel ~ppf_dump clambda_and_constants
 

--- a/asmcomp/clambda_primitives.mli
+++ b/asmcomp/clambda_primitives.mli
@@ -65,6 +65,9 @@ type primitive =
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   (* Array operations *)
   | Pmakearray of array_kind * mutable_flag
+  (** For [Pmakearray], the list of arguments must not be empty.  The empty
+      array should be represented by a distinguished constant in the middle
+      end. *)
   | Pduparray of array_kind * mutable_flag
   (** For [Pduparray], the argument must be an immutable array.
       The arguments of [Pduparray] give the kind and mutability of the

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -1054,6 +1054,7 @@ let rec close fenv cenv = function
       let dbg = Debuginfo.from_location loc in
       (Uprim(P.Praise k, [ulam], dbg),
        Value_unknown)
+  | Lprim (Pmakearray _, [], _loc) -> make_const_ref (Uconst_block (0, []))
   | Lprim(p, args, loc) ->
       let p = Convert_primitives.convert p in
       let dbg = Debuginfo.from_location loc in

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -15,6 +15,8 @@
 
 (* Translation from closed lambda to C-- *)
 
+[@@@ocaml.warning "-40"]
+
 open Misc
 open Arch
 open Asttypes
@@ -899,7 +901,7 @@ let transl_int_comparison cmp = cmp
 
 let transl_float_comparison cmp = cmp
 
-(* Translate structured constants *)
+(* Translate structured constants to Cmm data items *)
 
 let transl_constant = function
   | Uconst_int n ->
@@ -912,43 +914,99 @@ let transl_constant = function
   | Uconst_ref (label, _) ->
       Cconst_symbol label
 
-let transl_structured_constant cst =
-  let label = Compilenv.new_structured_constant cst ~shared:true in
-  Cconst_symbol label
+let cdefine_symbol (symb, (global : Cmmgen_state.is_global)) =
+  match global with
+  | Global -> [Cglobal_symbol symb; Cdefine_symbol symb]
+  | Local -> [Cdefine_symbol symb]
 
-(* Translate constant closures *)
+let emit_block symb is_global white_header cont =
+  (* Headers for structured constants must be marked black in case we
+     are in no-naked-pointers mode.  See [caml_darken]. *)
+  let black_header = Nativeint.logor white_header caml_black in
+  Cint black_header :: cdefine_symbol (symb, is_global) @ cont
 
-type is_global = Global | Not_global
+let rec emit_structured_constant (sym, is_global) cst cont =
+  match cst with
+  | Uconst_float s ->
+      emit_block sym is_global float_header (Cdouble s :: cont)
+  | Uconst_string s ->
+      emit_block sym is_global (string_header (String.length s))
+        (emit_string_constant s cont)
+  | Uconst_int32 n ->
+      emit_block sym is_global boxedint32_header
+        (emit_boxed_int32_constant n cont)
+  | Uconst_int64 n ->
+      emit_block sym is_global boxedint64_header
+        (emit_boxed_int64_constant n cont)
+  | Uconst_nativeint n ->
+      emit_block sym is_global boxedintnat_header
+        (emit_boxed_nativeint_constant n cont)
+  | Uconst_block (tag, csts) ->
+      let cont = List.fold_right emit_constant csts cont in
+      emit_block sym is_global (block_header tag (List.length csts)) cont
+  | Uconst_float_array fields ->
+      emit_block sym is_global (floatarray_header (List.length fields))
+        (Misc.map_end (fun f -> Cdouble f) fields cont)
+  | Uconst_closure(fundecls, lbl, fv) ->
+      Cmmgen_state.add_constant lbl (Const_closure (is_global, fundecls, fv));
+      List.iter (fun f -> Cmmgen_state.add_function f) fundecls;
+      cont
 
-type symbol_defn = string * is_global
+and emit_constant cst cont =
+  match cst with
+  | Uconst_int n | Uconst_ptr n ->
+      cint_const n
+      :: cont
+  | Uconst_ref (sym, _) ->
+      Csymbol_address sym :: cont
 
-type cmm_constant =
-  | Const_closure of symbol_defn * ufunction list * uconstant list
-  | Const_table of symbol_defn * data_item list
+and emit_string_constant s cont =
+  let n = size_int - 1 - (String.length s) mod size_int in
+  Cstring s :: Cskip n :: Cint8 n :: cont
 
-let cmm_constants =
-  ref ([] : cmm_constant list)
+and emit_boxed_int32_constant n cont =
+  let n = Nativeint.of_int32 n in
+  if size_int = 8 then
+    Csymbol_address "caml_int32_ops" :: Cint32 n :: Cint32 0n :: cont
+  else
+    Csymbol_address "caml_int32_ops" :: Cint n :: cont
 
-let add_cmm_constant c =
-  cmm_constants := c :: !cmm_constants
+and emit_boxed_nativeint_constant n cont =
+  Csymbol_address "caml_nativeint_ops" :: Cint n :: cont
+
+and emit_boxed_int64_constant n cont =
+  let lo = Int64.to_nativeint n in
+  if size_int = 8 then
+    Csymbol_address "caml_int64_ops" :: Cint lo :: cont
+  else begin
+    let hi = Int64.to_nativeint (Int64.shift_right n 32) in
+    if big_endian then
+      Csymbol_address "caml_int64_ops" :: Cint hi :: Cint lo :: cont
+    else
+      Csymbol_address "caml_int64_ops" :: Cint lo :: Cint hi :: cont
+  end
 
 (* Boxed integers *)
 
-let box_int_constant bi n =
+let box_int_constant sym bi n =
   match bi with
-    Pnativeint -> Uconst_nativeint n
-  | Pint32 -> Uconst_int32 (Nativeint.to_int32 n)
-  | Pint64 -> Uconst_int64 (Int64.of_nativeint n)
-
-let caml_nativeint_ops = "caml_nativeint_ops"
-let caml_int32_ops = "caml_int32_ops"
-let caml_int64_ops = "caml_int64_ops"
+    Pnativeint ->
+      emit_block sym Local boxedintnat_header
+        (emit_boxed_nativeint_constant n [])
+  | Pint32 ->
+      let n = Nativeint.to_int32 n in
+      emit_block sym Local boxedint32_header
+        (emit_boxed_int32_constant n [])
+  | Pint64 ->
+      let n = Int64.of_nativeint n in
+      emit_block sym Local boxedint64_header
+        (emit_boxed_int64_constant n [])
 
 let operations_boxed_int bi =
   match bi with
-    Pnativeint -> caml_nativeint_ops
-  | Pint32 -> caml_int32_ops
-  | Pint64 -> caml_int64_ops
+    Pnativeint -> "caml_nativeint_ops"
+  | Pint32 -> "caml_int32_ops"
+  | Pint64 -> "caml_int64_ops"
 
 let alloc_header_boxed_int bi =
   match bi with
@@ -958,10 +1016,16 @@ let alloc_header_boxed_int bi =
 
 let box_int dbg bi arg =
   match arg with
-    Cconst_int n ->
-      transl_structured_constant (box_int_constant bi (Nativeint.of_int n))
+  | Cconst_int n ->
+      let sym = Compilenv.new_const_symbol () in
+      let data_items = box_int_constant sym bi (Nativeint.of_int n) in
+      Cmmgen_state.add_data_items data_items;
+      Cconst_symbol sym
   | Cconst_natint n ->
-      transl_structured_constant (box_int_constant bi n)
+      let sym = Compilenv.new_const_symbol () in
+      let data_items = box_int_constant sym bi n in
+      Cmmgen_state.add_data_items data_items;
+      Cconst_symbol sym
   | _ ->
       let arg' =
         if bi = Pint32 && size_int = 8 && big_endian
@@ -982,13 +1046,13 @@ let alloc_matches_boxed_int bi ~hdr ~ops =
   match bi, hdr, ops with
   | Pnativeint, Cblockheader (hdr, _dbg), Cconst_symbol sym ->
       Nativeint.equal hdr boxedintnat_header
-        && String.equal sym caml_nativeint_ops
+        && String.equal sym "caml_nativeint_ops"
   | Pint32, Cblockheader (hdr, _dbg), Cconst_symbol sym ->
       Nativeint.equal hdr boxedint32_header
-        && String.equal sym caml_int32_ops
+        && String.equal sym "caml_int32_ops"
   | Pint64, Cblockheader (hdr, _dbg), Cconst_symbol sym ->
       Nativeint.equal hdr boxedint64_header
-        && String.equal sym caml_int64_ops
+        && String.equal sym "caml_int64_ops"
   | (Pnativeint | Pint32 | Pint64), _, _ -> false
 
 let rec unbox_int bi arg dbg =
@@ -1512,7 +1576,7 @@ let make_switch arg cases actions dbg =
       | _ -> assert false in
     let const_actions = Array.map to_data_item actions in
     let table = Compilenv.new_const_symbol () in
-    add_cmm_constant (Const_table ((table, Not_global),
+    Cmmgen_state.add_constant table (Const_table (Local,
         Array.to_list (Array.map (fun act ->
           const_actions.(act)) cases)));
     addr_array_ref (Cconst_symbol table) (tag_int arg dbg) dbg
@@ -1781,8 +1845,6 @@ let assignment_kind ptr init =
 
 (* Translate an expression *)
 
-let functions = (Queue.create() : ufunction Queue.t)
-
 let strmatch_compile =
   let module S =
     Strmatch.Make
@@ -1802,17 +1864,16 @@ let rec transl env e =
   | Uconst sc ->
       transl_constant sc
   | Uclosure(fundecls, []) ->
-      let lbl = Compilenv.new_const_symbol() in
-      add_cmm_constant (
-        Const_closure ((lbl, Not_global), fundecls, []));
-      List.iter (fun f -> Queue.add f functions) fundecls;
-      Cconst_symbol lbl
+      let sym = Compilenv.new_const_symbol() in
+      Cmmgen_state.add_constant sym (Const_closure (Local, fundecls, []));
+      List.iter (fun f -> Cmmgen_state.add_function f) fundecls;
+      Cconst_symbol sym
   | Uclosure(fundecls, clos_vars) ->
       let rec transl_fundecls pos = function
           [] ->
             List.map (transl env) clos_vars
         | f :: rem ->
-            Queue.add f functions;
+            Cmmgen_state.add_function f;
             let without_header =
               if f.arity = 1 || f.arity = 0 then
                 Cconst_symbol f.label ::
@@ -1931,7 +1992,12 @@ let rec transl env e =
           in
           transl_ccall env prim_obj_dup [arg] dbg
       | (Pmakearray _, []) ->
-          transl_structured_constant (Uconst_block(0, []))
+          let sym = Compilenv.new_const_symbol () in
+          let tag = 0 in
+          let size = 0 in
+          let data_items = emit_block sym Local (block_header tag size) [] in
+          Cmmgen_state.add_data_items data_items;
+          Cconst_symbol sym
       | (Pmakearray (kind, _), args) -> transl_make_array dbg env kind args
       | (Pbigarrayref(unsafe, _num_dims, elt_kind, layout), arg1 :: argl) ->
           let elt =
@@ -2933,92 +2999,17 @@ let transl_function ~ppf_dump f =
 (* Translate all function definitions *)
 
 let rec transl_all_functions ~ppf_dump already_translated cont =
-  try
-    let f = Queue.take functions in
-    if String.Set.mem f.label already_translated then
+  match Cmmgen_state.next_function () with
+  | None -> cont, already_translated
+  | Some f ->
+    let sym = f.label in
+    if String.Set.mem sym already_translated then
       transl_all_functions ~ppf_dump already_translated cont
     else begin
       transl_all_functions ~ppf_dump
-        (String.Set.add f.label already_translated)
+        (String.Set.add sym already_translated)
         ((f.dbg, transl_function ~ppf_dump f) :: cont)
     end
-  with Queue.Empty ->
-    cont, already_translated
-
-let cdefine_symbol (symb, global) =
-  match global with
-  | Global -> [Cglobal_symbol symb; Cdefine_symbol symb]
-  | Not_global -> [Cdefine_symbol symb]
-
-(* Emit structured constants *)
-
-let rec emit_structured_constant symb cst cont =
-  let emit_block white_header symb cont =
-    (* Headers for structured constants must be marked black in case we
-       are in no-naked-pointers mode.  See [caml_darken]. *)
-    let black_header = Nativeint.logor white_header caml_black in
-    Cint black_header :: cdefine_symbol symb @ cont
-  in
-  match cst with
-  | Uconst_float s->
-      emit_block float_header symb (Cdouble s :: cont)
-  | Uconst_string s ->
-      emit_block (string_header (String.length s)) symb
-        (emit_string_constant s cont)
-  | Uconst_int32 n ->
-      emit_block boxedint32_header symb
-        (emit_boxed_int32_constant n cont)
-  | Uconst_int64 n ->
-      emit_block boxedint64_header symb
-        (emit_boxed_int64_constant n cont)
-  | Uconst_nativeint n ->
-      emit_block boxedintnat_header symb
-        (emit_boxed_nativeint_constant n cont)
-  | Uconst_block (tag, csts) ->
-      let cont = List.fold_right emit_constant csts cont in
-      emit_block (block_header tag (List.length csts)) symb cont
-  | Uconst_float_array fields ->
-      emit_block (floatarray_header (List.length fields)) symb
-        (Misc.map_end (fun f -> Cdouble f) fields cont)
-  | Uconst_closure(fundecls, lbl, fv) ->
-      assert(lbl = fst symb);
-      add_cmm_constant (Const_closure (symb, fundecls, fv));
-      List.iter (fun f -> Queue.add f functions) fundecls;
-      cont
-
-and emit_constant cst cont =
-  match cst with
-  | Uconst_int n | Uconst_ptr n ->
-      cint_const n
-      :: cont
-  | Uconst_ref (label, _) ->
-      Csymbol_address label :: cont
-
-and emit_string_constant s cont =
-  let n = size_int - 1 - (String.length s) mod size_int in
-  Cstring s :: Cskip n :: Cint8 n :: cont
-
-and emit_boxed_int32_constant n cont =
-  let n = Nativeint.of_int32 n in
-  if size_int = 8 then
-    Csymbol_address("caml_int32_ops") :: Cint32 n :: Cint32 0n :: cont
-  else
-    Csymbol_address("caml_int32_ops") :: Cint n :: cont
-
-and emit_boxed_nativeint_constant n cont =
-  Csymbol_address("caml_nativeint_ops") :: Cint n :: cont
-
-and emit_boxed_int64_constant n cont =
-  let lo = Int64.to_nativeint n in
-  if size_int = 8 then
-    Csymbol_address("caml_int64_ops") :: Cint lo :: cont
-  else begin
-    let hi = Int64.to_nativeint (Int64.shift_right n 32) in
-    if big_endian then
-      Csymbol_address("caml_int64_ops") :: Cint hi :: Cint lo :: cont
-    else
-      Csymbol_address("caml_int64_ops") :: Cint lo :: Cint hi :: cont
-  end
 
 (* Emit constant closures *)
 
@@ -3077,39 +3068,44 @@ let emit_constant_table symb elems =
 
 (* Emit all structured constants *)
 
-let emit_constants cont (constants:Clambda.preallocated_constant list) =
+let transl_clambda_constants (constants : Clambda.preallocated_constant list)
+      cont =
   let c = ref cont in
+  let emit_clambda_constant symbol global cst =
+     let cst = emit_structured_constant (symbol, global) cst [] in
+     c := (Cdata cst) :: !c
+  in
   List.iter
-    (fun { symbol = lbl; exported; definition = cst; provenance = _; } ->
-       let global = if exported then Global else Not_global in
-       let cst = emit_structured_constant (lbl, global) cst [] in
-         c:= Cdata(cst):: !c)
+    (fun { symbol; exported; definition = cst; provenance = _; } ->
+       let global : Cmmgen_state.is_global =
+         if exported then Global else Local
+       in
+       emit_clambda_constant symbol global cst)
     constants;
-  List.iter
-    (function
-    | Const_closure (symb, fundecls, clos_vars) ->
-        c := Cdata(emit_constant_closure symb fundecls clos_vars []) :: !c
-    | Const_table (symb, elems) ->
-        c := Cdata(emit_constant_table symb elems) :: !c)
-    !cmm_constants;
-  cmm_constants := [];
   !c
 
-let emit_all_constants cont =
-  let constants = Compilenv.structured_constants () in
-  Compilenv.clear_structured_constants ();
-  emit_constants cont constants
+let emit_cmm_data_items_for_constants cont =
+  let c = ref cont in
+  String.Map.iter (fun symbol (cst : Cmmgen_state.constant) ->
+      match cst with
+      | Const_closure (global, fundecls, clos_vars) ->
+          let cmm =
+            emit_constant_closure (symbol, global) fundecls clos_vars []
+          in
+          c := (Cdata cmm) :: !c
+      | Const_table (global, elems) ->
+          c := (Cdata (emit_constant_table (symbol, global) elems)) :: !c)
+    (Cmmgen_state.constants ());
+  Cdata (Cmmgen_state.data_items ()) :: !c
 
-let transl_all_functions_and_emit_all_constants ~ppf_dump cont =
+let transl_all_functions ~ppf_dump cont =
   let rec aux already_translated cont translated_functions =
-    if Compilenv.structured_constants () = [] &&
-       Queue.is_empty functions
+    if Cmmgen_state.no_more_functions ()
     then cont, translated_functions
     else
       let translated_functions, already_translated =
         transl_all_functions ~ppf_dump already_translated translated_functions
       in
-      let cont = emit_all_constants cont in
       aux already_translated cont translated_functions
   in
   let cont, translated_functions =
@@ -3191,9 +3187,10 @@ let compunit ~ppf_dump (ulam, preallocated_blocks, constants) =
                          ]
                          else [ Reduce_code_size ];
                        fun_dbg  = Debuginfo.none }] in
-  let c2 = emit_constants c1 constants in
-  let c3 = transl_all_functions_and_emit_all_constants ~ppf_dump c2 in
-  emit_preallocated_blocks preallocated_blocks c3
+  let c2 = transl_clambda_constants constants c1 in
+  let c3 = transl_all_functions ~ppf_dump c2 in
+  let c4 = emit_preallocated_blocks preallocated_blocks c3 in
+  emit_cmm_data_items_for_constants c4
 
 (*
 CAMLprim value caml_cache_public_method (value meths, value tag, value *cache)
@@ -3620,16 +3617,21 @@ let code_segment_table namelist =
 (* Initialize a predefined exception *)
 
 let predef_exception i name =
-  let symname = "caml_exn_" ^ name in
-  let cst = Uconst_string name in
-  let label = Compilenv.new_const_symbol () in
-  let cont = emit_structured_constant (label, Not_global) cst [] in
-  Cdata(emit_structured_constant (symname, Global)
-          (Uconst_block(Obj.object_tag,
-                       [
-                         Uconst_ref(label, Some cst);
-                         Uconst_int (-i-1);
-                       ])) cont)
+  let name_sym = Compilenv.new_const_symbol () in
+  let data_items =
+    emit_block name_sym Local (string_header (String.length name))
+      (emit_string_constant name [])
+  in
+  let exn_sym = "caml_exn_" ^ name in
+  let tag = Obj.object_tag in
+  let size = 2 in
+  let fields =
+    (Csymbol_address name_sym)
+      :: (cint_const (-i - 1))
+      :: data_items
+  in
+  let data_items = emit_block exn_sym Global (block_header tag size) fields in
+  Cdata data_items
 
 (* Header for a plugin *)
 
@@ -3643,3 +3645,6 @@ let plugin_header units =
     } in
   global_data "caml_plugin_header"
     { dynu_magic = Config.cmxs_magic_number; dynu_units = List.map mk units }
+
+let reset () =
+  Cmmgen_state.reset ()

--- a/asmcomp/cmmgen_state.ml
+++ b/asmcomp/cmmgen_state.ml
@@ -1,0 +1,66 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                     Mark Shinwell, Jane Street Europe                  *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module S = Misc.Stdlib.String
+
+type is_global = Global | Local
+
+type constant =
+  | Const_closure of is_global * Clambda.ufunction list * Clambda.uconstant list
+  | Const_table of is_global * Cmm.data_item list
+
+type t = {
+  mutable constants : constant S.Map.t;
+  mutable data_items : Cmm.data_item list list;
+  functions : Clambda.ufunction Queue.t;
+}
+
+let empty = {
+  constants = S.Map.empty;
+  data_items = [];
+  functions = Queue.create ();
+}
+
+let state = empty
+
+let reset () =
+  state.constants <- S.Map.empty;
+  state.data_items <- [];
+  Queue.clear state.functions
+
+let add_constant sym cst =
+  state.constants <- S.Map.add sym cst state.constants
+
+let add_data_items items =
+  state.data_items <- items :: state.data_items
+
+let add_function func =
+  Queue.add func state.functions
+
+let constants () = state.constants
+
+let data_items () = List.concat (List.rev state.data_items)
+
+let next_function () =
+  match Queue.take state.functions with
+  | exception Queue.Empty -> None
+  | func -> Some func
+
+let no_more_functions () =
+  Queue.is_empty state.functions

--- a/asmcomp/cmmgen_state.mli
+++ b/asmcomp/cmmgen_state.mli
@@ -3,9 +3,11 @@
 (*                                 OCaml                                  *)
 (*                                                                        *)
 (*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                     Mark Shinwell, Jane Street Europe                  *)
 (*                                                                        *)
 (*   Copyright 1996 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,30 +15,28 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Translation from closed lambda to C-- *)
+(** Mutable state used by [Cmmgen]. *)
 
-val compunit:
-  ppf_dump:Format.formatter
-  -> Clambda.ulambda
-    * Clambda.preallocated_block list
-    * Clambda.preallocated_constant list
-  -> Cmm.phrase list
-
-val apply_function: int -> Cmm.phrase
-val send_function: int -> Cmm.phrase
-val curry_function: int -> Cmm.phrase list
-val generic_functions: bool -> Cmx_format.unit_infos list -> Cmm.phrase list
-val entry_point: string list -> Cmm.phrase
-val global_table: string list -> Cmm.phrase
-val reference_symbols: string list -> Cmm.phrase
-val globals_map:
-  (string * Digest.t option * Digest.t option * string list) list -> Cmm.phrase
-val frame_table: string list -> Cmm.phrase
-val spacetime_shapes: string list -> Cmm.phrase
-val data_segment_table: string list -> Cmm.phrase
-val code_segment_table: string list -> Cmm.phrase
-val predef_exception: int -> string -> Cmm.phrase
-val plugin_header: (Cmx_format.unit_infos * Digest.t) list -> Cmm.phrase
-val black_block_header: (*tag:*)int -> (*size:*)int -> nativeint
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
 val reset : unit -> unit
+
+type is_global = Global | Local
+
+type constant =
+  | Const_closure of is_global * Clambda.ufunction list * Clambda.uconstant list
+  | Const_table of is_global * Cmm.data_item list
+
+val add_constant : Misc.Stdlib.String.t -> constant -> unit
+
+val add_data_items : Cmm.data_item list -> unit
+
+val add_function : Clambda.ufunction -> unit
+
+val constants : unit -> constant Misc.Stdlib.String.Map.t
+
+val data_items : unit -> Cmm.data_item list
+
+val next_function : unit -> Clambda.ufunction option
+
+val no_more_functions : unit -> bool


### PR DESCRIPTION
This patch is a prerequisite of a forthcoming patch that improves the types used to represent symbols (names of statically-allocated entities) throughout the middle end and backend.  This in turn is needed for the `Asm_directives` layer on which the DWARF support is based.

I think a good general principle, when writing a pass that operates on some particular IR, is to avoid generating constructs from previous IRs and sending them back through part of the current pass.  Instead, it is better to refactor the current pass so that the constructs you want can be generated directly in your current language.

This patch changes `Cmmgen` to follow this principle for constants.  The reason this is necessary is because, with the forthcoming patch, it is not always possible to construct a value of the type that describes middle-end symbols (such as will appear in `Clambda`) during `Cmmgen`.  I would rather not get into the details here, but in summary, this relates to the fact that during `Cmmgen` we may be generating code (e.g. for a startup file) that does not stem from an OCaml compilation unit.

There are a couple of other related changes that I thought reasonable to include with this patch, since our workflow management becomes difficult if there are just too many pull requests.  One of them passes the list of constants, for the classic Closure mode, through from `Asmgen` rather than reading the `Compilenv` global state in `Cmmgen`; this is consistent with what Flambda does.  The other pulls the global state from `Cmmgen`, much of which is to do with constants, into a separate file.  Warning 40 is suppressed to increase code legibility (e.g. with `Local` and `Global`) and reduce proliferation of "`open`".

@lthls Could you please look at this?  (Some amount of this is just moving code upwards in `cmmgen.ml`; you might want to diff that separately.)