### PR TITLE
List prefix functions for Misc.Stdlib.List

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,11 +25,11 @@ Working version
   (Mark Shinwell, review by Nicolas Ojeda Bar)
 
 - GPR#2280: Don't make more Clambda constants after starting Cmmgen
-  (Mark Shinwell)
+  (Mark Shinwell, review by Vincent Laviron)
 
 - GPR#2283: Add [is_prefix] and [find_and_chop_longest_common_prefix] to
   [Misc.Stdlib.List]
-  (Mark Shinwell)
+  (Mark Shinwell, review by Alain Frisch and Stephen Dolan)
 
 ### Runtime system:
 

--- a/Changes
+++ b/Changes
@@ -27,6 +27,10 @@ Working version
 - GPR#2280: Don't make more Clambda constants after starting Cmmgen
   (Mark Shinwell)
 
+- GPR#2283: Add [is_prefix] and [find_and_chop_longest_common_prefix] to
+  [Misc.Stdlib.List]
+  (Mark Shinwell)
+
 ### Runtime system:
 
 - GPR#1725: Deprecate Obj.set_tag

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -150,6 +150,45 @@ module Stdlib = struct
           | t::q -> aux (n-1) (t::acc) q
       in
       aux n [] l
+
+    let rec is_prefix ~equal t ~of_ =
+      match t, of_ with
+      | [], [] -> true
+      | _::_, [] -> false
+      | [], _::_ -> true
+      | x1::t, x2::of_ ->
+        if equal x1 x2 then is_prefix ~equal t ~of_
+        else false
+
+    type 'a longest_common_prefix_result = {
+      longest_common_prefix : 'a list;
+      first_without_longest_common_prefix : 'a list;
+      second_without_longest_common_prefix : 'a list;
+    }
+
+    let find_and_chop_longest_common_prefix ~equal ~first ~second =
+      let rec find_prefix ~longest_common_prefix_rev l1 l2 =
+        match l1, l2 with
+        | [], []
+        | [], _::_
+        | _::_, [] ->
+          let longest_common_prefix = List.rev longest_common_prefix_rev in
+          { longest_common_prefix;
+            first_without_longest_common_prefix = l1;
+            second_without_longest_common_prefix = l2;
+          }
+        | elt1::l1_tail, elt2::l2_tail ->
+          if equal elt1 elt2 then
+            let longest_common_prefix_rev = elt1 :: longest_common_prefix_rev in
+            find_prefix ~longest_common_prefix_rev l1_tail l2_tail
+          else
+            let longest_common_prefix = List.rev longest_common_prefix_rev in
+            { longest_common_prefix;
+              first_without_longest_common_prefix = l1;
+              second_without_longest_common_prefix = l2;
+            }
+      in
+      find_prefix ~longest_common_prefix_rev:[] first second
   end
 
   module Option = struct

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -156,9 +156,7 @@ module Stdlib = struct
       | [], [] -> true
       | _::_, [] -> false
       | [], _::_ -> true
-      | x1::t, x2::of_ ->
-        if equal x1 x2 then is_prefix ~equal t ~of_
-        else false
+      | x1::t, x2::of_ -> equal x1 x2 && is_prefix ~equal t ~of_
 
     type 'a longest_common_prefix_result = {
       longest_common_prefix : 'a list;
@@ -169,24 +167,14 @@ module Stdlib = struct
     let find_and_chop_longest_common_prefix ~equal ~first ~second =
       let rec find_prefix ~longest_common_prefix_rev l1 l2 =
         match l1, l2 with
-        | [], []
-        | [], _::_
-        | _::_, [] ->
-          let longest_common_prefix = List.rev longest_common_prefix_rev in
-          { longest_common_prefix;
+        | elt1 :: l1, elt2 :: l2 when equal elt1 elt2 ->
+          let longest_common_prefix_rev = elt1 :: longest_common_prefix_rev in
+          find_prefix ~longest_common_prefix_rev l1 l2
+        | l1, l2 ->
+          { longest_common_prefix = List.rev longest_common_prefix_rev;
             first_without_longest_common_prefix = l1;
             second_without_longest_common_prefix = l2;
           }
-        | elt1::l1_tail, elt2::l2_tail ->
-          if equal elt1 elt2 then
-            let longest_common_prefix_rev = elt1 :: longest_common_prefix_rev in
-            find_prefix ~longest_common_prefix_rev l1_tail l2_tail
-          else
-            let longest_common_prefix = List.rev longest_common_prefix_rev in
-            { longest_common_prefix;
-              first_without_longest_common_prefix = l1;
-              second_without_longest_common_prefix = l2;
-            }
       in
       find_prefix ~longest_common_prefix_rev:[] first second
   end

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -117,13 +117,13 @@ module Stdlib : sig
         the [n] first elements of [l] and [after] the remaining ones.
         If [l] has less than [n] elements, raises Invalid_argument. *)
 
-    (** Returns [true] iff the given list, with respect to the given equality
-        function on list members, is a prefix of the list [of_]. *)
     val is_prefix
        : equal:('a -> 'a -> bool)
       -> 'a list
       -> of_:'a list
       -> bool
+    (** Returns [true] iff the given list, with respect to the given equality
+        function on list members, is a prefix of the list [of_]. *)
 
     type 'a longest_common_prefix_result = private {
       longest_common_prefix : 'a list;
@@ -131,14 +131,14 @@ module Stdlib : sig
       second_without_longest_common_prefix : 'a list;
     }
 
-    (** Returns the longest list that, with respect to the provided equality
-        function, is a prefix of both of the given lists.  The input lists,
-        each with such longest common prefix removed, are also returned. *)
     val find_and_chop_longest_common_prefix
        : equal:('a -> 'a -> bool)
       -> first:'a list
       -> second:'a list
       -> 'a longest_common_prefix_result
+    (** Returns the longest list that, with respect to the provided equality
+        function, is a prefix of both of the given lists.  The input lists,
+        each with such longest common prefix removed, are also returned. *)
   end
 
   module Option : sig

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -116,6 +116,29 @@ module Stdlib : sig
     (** [split_at n l] returns the pair [before, after] where [before] is
         the [n] first elements of [l] and [after] the remaining ones.
         If [l] has less than [n] elements, raises Invalid_argument. *)
+
+    (** Returns [true] iff the given list, with respect to the given equality
+        function on list members, is a prefix of the list [of_]. *)
+    val is_prefix
+       : equal:('a -> 'a -> bool)
+      -> 'a list
+      -> of_:'a list
+      -> bool
+
+    type 'a longest_common_prefix_result = private {
+      longest_common_prefix : 'a list;
+      first_without_longest_common_prefix : 'a list;
+      second_without_longest_common_prefix : 'a list;
+    }
+
+    (** Returns the longest list that, with respect to the provided equality
+        function, is a prefix of both of the given lists.  The input lists,
+        each with such longest common prefix removed, are also returned. *)
+    val find_and_chop_longest_common_prefix
+       : equal:('a -> 'a -> bool)
+      -> first:'a list
+      -> second:'a list
+      -> 'a longest_common_prefix_result
   end
 
   module Option : sig


### PR DESCRIPTION
The work to improve the types of symbols requires some more prefix-related functions on lists, as presented here.  I don't think we have anywhere to put unit tests for such things at present.  These have been tested in the toplevel, which I think will suffice, nonetheless.