### PR TITLE
Add Set.union_list to Identifiable

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Working version
 - GPR#2265: Add bytecomp/opcodes.mli
   (Mark Shinwell, review by Nicolas Ojeda Bar)
 
+- GPR#2285: Add [Set.union_list] in [Identifiable]
+  (Mark Shinwell)
+
 ### Runtime system:
 
 - GPR#1725: Deprecate Obj.set_tag

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -35,6 +35,7 @@ module type Set = sig
   val to_string : t -> string
   val of_list : elt list -> t
   val map : (elt -> elt) -> t -> t
+  val union_list : t list -> t
 end
 
 module type Map = sig
@@ -202,6 +203,11 @@ module Make_set (T : Thing) = struct
     | t :: q -> List.fold_left (fun acc e -> add e acc) (singleton t) q
 
   let map f s = of_list (List.map f (elements s))
+
+  let rec union_list ts =
+    match ts with
+    | [] -> empty
+    | t::ts -> union t (union_list ts)
 end
 
 module Make_tbl (T : Thing) = struct

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -44,6 +44,7 @@ module type Set = sig
   val to_string : t -> string
   val of_list : elt list -> t
   val map : (elt -> elt) -> t -> t
+  val union_list : t list -> t
 end
 
 module type Map = sig


### PR DESCRIPTION
The title of this pull request says it all.  For current purposes there will be no need for this function to be tail recursive.