### PR TITLE
Functorize Consistbl (with some background info on Compilation_unit.t)

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,9 @@ Working version
   [Misc.Stdlib.List]
   (Mark Shinwell, review by Alain Frisch and Stephen Dolan)
 
+- GPR#2286: Functorise [Consistbl]
+  (Mark Shinwell, review by Gabriel Radanne)
+
 ### Runtime system:
 
 - GPR#1725: Deprecate Obj.set_tag

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -159,6 +159,8 @@ let scan_file obj_name tolink =
 
 (* Consistency check between interfaces *)
 
+module Consistbl = Consistbl.Make (Misc.Stdlib.String)
+
 let crc_interfaces = Consistbl.create ()
 let interfaces = ref ([] : string list)
 let implementations_defined = ref ([] : (string * string) list)

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -119,7 +119,7 @@ exception Load_failed
 
 let check_consistency ppf filename cu =
   try Env.import_crcs ~source:filename cu.cu_imports
-  with Consistbl.Inconsistency(name, user, auth) ->
+  with Persistent_env.Consistbl.Inconsistency(name, user, auth) ->
     fprintf ppf "@[<hv 0>The files %s@ and %s@ \
                  disagree over interface %s@]@."
             user auth name;

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -257,7 +257,7 @@ val crc_of_unit: modname -> Digest.t
 (* Return the set of compilation units imported, with their CRC *)
 val imports: unit -> crcs
 
-(* may raise Consistbl.Inconsistency *)
+(* may raise Persistent_env.Consistbl.Inconsistency *)
 val import_crcs: source:string -> crcs -> unit
 
 (* [is_imported_opaque md] returns true if [md] is an opaque imported module  *)

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -19,6 +19,8 @@
 open Misc
 open Cmi_format
 
+module Consistbl = Consistbl.Make (Misc.Stdlib.String)
+
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 type error =

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -16,6 +16,10 @@
 
 open Misc
 
+module Consistbl : module type of struct
+  include Consistbl.Make (Misc.Stdlib.String)
+end
+
 type error =
   | Illegal_renaming of modname * modname * filepath
   | Inconsistent_import of modname * filepath * filepath

--- a/utils/consistbl.ml
+++ b/utils/consistbl.ml
@@ -17,52 +17,73 @@
 
 open Misc
 
-type t = (modname, Digest.t * filepath) Hashtbl.t
+module Make (Module_name : sig
+  type t
+  module Set : Set.S with type elt = t
+  module Map : Map.S with type key = t
+  module Tbl : Hashtbl.S with type key = t
+  val compare : t -> t -> int
+end) = struct
+  type t = (Digest.t * filepath) Module_name.Tbl.t
 
-let create () = Hashtbl.create 13
+  let create () = Module_name.Tbl.create 13
 
-let clear = Hashtbl.clear
+  let clear = Module_name.Tbl.clear
 
-exception Inconsistency of modname * filepath * filepath
+  exception Inconsistency of Module_name.t * filepath * filepath
 
-exception Not_available of modname
+  exception Not_available of Module_name.t
 
-let check tbl name crc source =
-  try
-    let (old_crc, old_source) = Hashtbl.find tbl name in
-    if crc <> old_crc then raise(Inconsistency(name, source, old_source))
-  with Not_found ->
-    Hashtbl.add tbl name (crc, source)
+  let check tbl name crc source =
+    try
+      let (old_crc, old_source) = Module_name.Tbl.find tbl name in
+      if crc <> old_crc then raise(Inconsistency(name, source, old_source))
+    with Not_found ->
+      Module_name.Tbl.add tbl name (crc, source)
 
-let check_noadd tbl name crc source =
-  try
-    let (old_crc, old_source) = Hashtbl.find tbl name in
-    if crc <> old_crc then raise(Inconsistency(name, source, old_source))
-  with Not_found ->
-    raise (Not_available name)
+  let check_noadd tbl name crc source =
+    try
+      let (old_crc, old_source) = Module_name.Tbl.find tbl name in
+      if crc <> old_crc then raise(Inconsistency(name, source, old_source))
+    with Not_found ->
+      raise (Not_available name)
 
-let set tbl name crc source = Hashtbl.add tbl name (crc, source)
+  let set tbl name crc source = Module_name.Tbl.add tbl name (crc, source)
 
-let source tbl name = snd (Hashtbl.find tbl name)
+  let source tbl name = snd (Module_name.Tbl.find tbl name)
 
-let extract l tbl =
-  let l = List.sort_uniq String.compare l in
-  List.fold_left
-    (fun assc name ->
-       try
-         let (crc, _) = Hashtbl.find tbl name in
-           (name, Some crc) :: assc
-       with Not_found ->
-         (name, None) :: assc)
-    [] l
+  let extract l tbl =
+    let l = List.sort_uniq Module_name.compare l in
+    List.fold_left
+      (fun assc name ->
+         try
+           let (crc, _) = Module_name.Tbl.find tbl name in
+             (name, Some crc) :: assc
+         with Not_found ->
+           (name, None) :: assc)
+      [] l
 
-let filter p tbl =
-  let to_remove = ref [] in
-  Hashtbl.iter
-    (fun name _ ->
-      if not (p name) then to_remove := name :: !to_remove)
-    tbl;
-  List.iter
-    (fun name ->
-       while Hashtbl.mem tbl name do Hashtbl.remove tbl name done)
-    !to_remove
+  let extract_map mod_names tbl =
+    Module_name.Set.fold
+      (fun name result ->
+         try
+           let (crc, _) = Module_name.Tbl.find tbl name in
+           Module_name.Map.add name (Some crc) result
+         with Not_found ->
+           Module_name.Map.add name None result)
+      mod_names
+      Module_name.Map.empty
+
+  let filter p tbl =
+    let to_remove = ref [] in
+    Module_name.Tbl.iter
+      (fun name _ ->
+        if not (p name) then to_remove := name :: !to_remove)
+      tbl;
+    List.iter
+      (fun name ->
+         while Module_name.Tbl.mem tbl name do
+           Module_name.Tbl.remove tbl name
+         done)
+      !to_remove
+end

--- a/utils/consistbl.mli
+++ b/utils/consistbl.mli
@@ -22,48 +22,60 @@
 
 open Misc
 
-type t
+module Make (Module_name : sig
+  type t
+  module Set : Set.S with type elt = t
+  module Map : Map.S with type key = t
+  module Tbl : Hashtbl.S with type key = t
+  val compare : t -> t -> int
+end) : sig
+  type t
 
-val create: unit -> t
+  val create: unit -> t
 
-val clear: t -> unit
+  val clear: t -> unit
 
-val check: t -> modname -> Digest.t -> filepath -> unit
-      (* [check tbl name crc source]
-           checks consistency of ([name], [crc]) with infos previously
-           stored in [tbl].  If no CRC was previously associated with
-           [name], record ([name], [crc]) in [tbl].
-           [source] is the name of the file from which the information
-           comes from.  This is used for error reporting. *)
+  val check: t -> Module_name.t -> Digest.t -> filepath -> unit
+        (* [check tbl name crc source]
+             checks consistency of ([name], [crc]) with infos previously
+             stored in [tbl].  If no CRC was previously associated with
+             [name], record ([name], [crc]) in [tbl].
+             [source] is the name of the file from which the information
+             comes from.  This is used for error reporting. *)
 
-val check_noadd: t -> modname -> Digest.t -> filepath -> unit
-      (* Same as [check], but raise [Not_available] if no CRC was previously
-           associated with [name]. *)
+  val check_noadd: t -> Module_name.t -> Digest.t -> filepath -> unit
+        (* Same as [check], but raise [Not_available] if no CRC was previously
+             associated with [name]. *)
 
-val set: t -> modname -> Digest.t -> filepath -> unit
-      (* [set tbl name crc source] forcefully associates [name] with
-         [crc] in [tbl], even if [name] already had a different CRC
-         associated with [name] in [tbl]. *)
+  val set: t -> Module_name.t -> Digest.t -> filepath -> unit
+        (* [set tbl name crc source] forcefully associates [name] with
+           [crc] in [tbl], even if [name] already had a different CRC
+           associated with [name] in [tbl]. *)
 
-val source: t -> modname -> filepath
-      (* [source tbl name] returns the file name associated with [name]
-         if the latter has an associated CRC in [tbl].
-         Raise [Not_found] otherwise. *)
+  val source: t -> Module_name.t -> filepath
+        (* [source tbl name] returns the file name associated with [name]
+           if the latter has an associated CRC in [tbl].
+           Raise [Not_found] otherwise. *)
 
-val extract: modname list -> t -> crcs
-      (* [extract tbl names] returns an associative list mapping each string
-         in [names] to the CRC associated with it in [tbl]. If no CRC is
-         associated with a name then it is mapped to [None]. *)
+  val extract: Module_name.t list -> t -> (Module_name.t * Digest.t option) list
+        (* [extract tbl names] returns an associative list mapping each string
+           in [names] to the CRC associated with it in [tbl]. If no CRC is
+           associated with a name then it is mapped to [None]. *)
 
-val filter: (modname -> bool) -> t -> unit
-      (* [filter pred tbl] removes from [tbl] table all (name, CRC) pairs
-         such that [pred name] is [false]. *)
+  val extract_map : Module_name.Set.t -> t -> Digest.t option Module_name.Map.t
+        (* Like [extract] but with a more sophisticated type. *)
 
-exception Inconsistency of modname * filepath * filepath
-      (* Raised by [check] when a CRC mismatch is detected.
-         First string is the name of the compilation unit.
-         Second string is the source that caused the inconsistency.
-         Third string is the source that set the CRC. *)
+  val filter: (Module_name.t -> bool) -> t -> unit
+        (* [filter pred tbl] removes from [tbl] table all (name, CRC) pairs
+           such that [pred name] is [false]. *)
 
-exception Not_available of modname
-      (* Raised by [check_noadd] when a name doesn't have an associated CRC. *)
+  exception Inconsistency of Module_name.t * filepath * filepath
+        (* Raised by [check] when a CRC mismatch is detected.
+           First string is the name of the compilation unit.
+           Second string is the source that caused the inconsistency.
+           Third string is the source that set the CRC. *)
+
+  exception Not_available of Module_name.t
+        (* Raised by [check_noadd] when a name doesn't have an associated
+           CRC. *)
+end


### PR DESCRIPTION
In #2281 I mentioned a patch that provides a new version of `Compilenv`.  One of the things this does, as part of the work to transition to new types for representing middle-end symbols, is to change the types that are used to represent the slightly tricky concept of "compilation unit names".  In summary, the type `Compilation_unit.t` will be used as the identity of a compilation unit _with OCaml semantics_ (as opposed to one fabricated for a startup file in `Cmmgen`, for example).  Such an identity consists of the base name of the unit, of type `Compilation_unit.Name.t`, together with the `-for-pack` prefix (which may be empty).  The type `Compilation_unit.Name.t` is very close to the type alias `modname`, although it is equipped with various operations, and does not currently occur earlier than the middle end.

Making the distinction between `Compilation_unit.t` and `Compilation_unit.Name.t` is a good, statically-enforced way of showing the distinction between places where we know the packing prefix of a compilation unit and places where we do not.

At present, in particular, `-for-pack` is not provided when compiling interfaces and thus there are various places, for example when dealing with interface dependencies in `Asmlink` and looking up symbols from global `Ident.t` values, where `Compilation_unit.t` values are not provided.  Instead one has to start with a `Compilation_unit.Name.t`, and either work out or guess the `-for-pack` prefix (the latter in the case where the `.cmx` file is missing).

@lpw25 proposes to fix that particular nuance as part of his namespacing proposal, which would require that `-for-pack` is specified when building an `.mli` file.  That aside, these subtleties are not obvious in the existing code, but are clear in the new version.  This helps mere mortals such as myself understand what is going on.

To this end, with the advent of stronger types than `string` when dealing with dependencies in `Asmlink` and the like, it is necessary to have different versions of `Consistbl`.  This necessity will probably persist even beyond any change to mandate `-for-pack` on `.mli` files because the type checker would quite possibly still use a different type from the middle end when indexing such table.  This patch simply functorizes `Consistbl` to allow these multiple uses, along the way having the convenient side effect of replacing polymorphic equality by a more specialised version.

The diff is much smaller than it might appear; use a whitespace-aware diffing tool to review.