### PR TITLE
Generate DWARF information

### DIFF
--- a/asmcomp/debug/dwarf/dwarf.ml
+++ b/asmcomp/debug/dwarf/dwarf.ml
@@ -1,0 +1,125 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+
+type t = {
+  state : DS.t;
+  mutable emitted : bool;
+}
+
+(* CR mshinwell: On OS X 10.11 (El Capitan), dwarfdump doesn't seem to be able
+   to read our 64-bit DWARF output. *)
+
+let create ~sourcefile ~prefix_name ~cmt_file_digest ~objfiles =
+  begin match !Clflags.gdwarf_format with
+  | Thirty_two -> Dwarf_format.set Thirty_two
+  | Sixty_four -> Dwarf_format.set Sixty_four
+  end;
+  let dwarf_version =
+    match !Clflags.gdwarf_version with
+    | Four -> Dwarf_version.four
+    | Five -> Dwarf_version.five
+  in
+  let start_of_code_symbol =
+    Dwarf_name_laundry.mangle_symbol Text (
+      Symbol.of_global_linkage (Compilation_unit.get_current_exn ())
+        (Linkage_name.create "code_begin"))
+  in
+  let end_of_code_symbol =
+    Dwarf_name_laundry.mangle_symbol Text (
+      Symbol.of_global_linkage (Compilation_unit.get_current_exn ())
+        (Linkage_name.create "code_end"))
+  in
+  let address_table = Address_table.create () in
+  let debug_loc_table = Debug_loc_table.create () in
+  let debug_ranges_table = Debug_ranges_table.create () in
+  let location_list_table = Location_list_table.create () in
+  let range_list_table = Range_list_table.create () in
+  let compilation_unit_proto_die =
+    Dwarf_compilation_unit.compile_unit_proto_die ~sourcefile ~prefix_name
+      ~cmt_file_digest ~objfiles ~start_of_code_symbol ~end_of_code_symbol
+      address_table location_list_table range_list_table
+  in
+  let value_type_proto_die =
+    Proto_die.create ~parent:(Some compilation_unit_proto_die)
+      ~tag:Base_type
+      ~attribute_values:[
+        DAH.create_name Dwarf_name_laundry.ocaml_value_type_name;
+        DAH.create_encoding ~encoding:Encoding_attribute.signed;
+        DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
+      ]
+      ()
+  in
+  let naked_float_type_proto_die =
+    Proto_die.create ~parent:(Some compilation_unit_proto_die)
+      ~tag:Base_type
+      ~attribute_values:[
+        DAH.create_name Dwarf_name_laundry.ocaml_naked_float_type_name;
+        DAH.create_encoding ~encoding:Encoding_attribute.float;
+        DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
+      ]
+      ()
+  in
+  let compilation_unit_header_label = Asm_label.create (DWARF Debug_info) in
+  let state =
+    DS.create ~compilation_unit_header_label
+      ~compilation_unit_proto_die
+      ~value_type_proto_die ~naked_float_type_proto_die
+      ~start_of_code_symbol ~end_of_code_symbol
+      address_table debug_loc_table debug_ranges_table
+      location_list_table range_list_table dwarf_version
+  in
+  { state;
+    emitted = false;
+  }
+
+let dwarf_for_fundecl t (result : Debug_passes.result) =
+  if Clflags.debug_thing Debug_dwarf_functions then begin
+    Dwarf_concrete_instances.for_fundecl t.state result
+  end
+
+let dwarf_for_toplevel_constants t constants =
+  if Clflags.debug_thing Debug_dwarf_vars then begin
+    Dwarf_toplevel_values.dwarf_for_toplevel_constants t.state constants
+  end
+
+let dwarf_for_closure_top_level_module_block t ~module_block_sym
+      ~module_block_var =
+  if Clflags.debug_thing Debug_dwarf_vars then begin
+    Dwarf_toplevel_values.dwarf_for_closure_top_level_module_block t.state
+        ~module_block_sym ~module_block_var
+  end
+
+let emit t =
+  if t.emitted then begin
+    Misc.fatal_error "Cannot call [Dwarf.emit] more than once on a given \
+      value of type [Dwarf.t]"
+  end;
+  t.emitted <- true;
+  Dwarf_world.emit
+    ~compilation_unit_proto_die:(DS.compilation_unit_proto_die t.state)
+    ~start_of_code_symbol:(DS.start_of_code_symbol t.state)
+    ~end_of_code_symbol:(DS.end_of_code_symbol t.state)
+    ~compilation_unit_header_label:(DS.compilation_unit_header_label t.state)
+    ~address_table:(DS.address_table t.state)
+    ~debug_loc_table:(DS.debug_loc_table t.state)
+    ~debug_ranges_table:(DS.debug_ranges_table t.state)
+    ~location_list_table:(DS.location_list_table t.state)
+    ~range_list_table:(DS.range_list_table t.state)
+
+let emit t = Profile.record "emit_dwarf" emit t

--- a/asmcomp/debug/dwarf/dwarf.mli
+++ b/asmcomp/debug/dwarf/dwarf.mli
@@ -1,0 +1,52 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Generation and emission of DWARF debugging information for OCaml
+    compilation units. *)
+
+type t
+
+(** Create a value of type [t], which holds all state necessary to emit
+    DWARF debugging information for a single compilation unit.
+    The names of certain parameters line up with the code in [Asmgen].
+    The current [Compilation_unit] must have been set before calling this
+    function. *)
+val create
+   : sourcefile:string
+  -> prefix_name:string
+  -> cmt_file_digest:Digest.t option
+  -> objfiles:string list
+  -> t
+
+(** Generate DWARF for the given function. *)
+val dwarf_for_fundecl : t -> Debug_passes.result -> unit
+
+(** Generate DWARF for Flambda [Let_symbol] bindings. *)
+val dwarf_for_toplevel_constants
+   : t
+  -> Clambda.preallocated_constant list
+  -> unit
+
+(** For dealing with [Closure]'s top level module blocks.  The symbol for
+    the module block and the corresponding variable must be provided. *)
+val dwarf_for_closure_top_level_module_block
+   : t
+  -> module_block_sym:Backend_sym.t
+  -> module_block_var:Backend_var.t
+  -> unit
+
+(** Write the DWARF information to the assembly file.  This should only be
+    called once all (in)constants and function declarations have been passed
+    to the above functions. *)
+val emit : t -> unit

--- a/asmcomp/debug/dwarf/dwarf_abstract_instances.ml
+++ b/asmcomp/debug/dwarf/dwarf_abstract_instances.ml
@@ -1,0 +1,79 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+
+let attributes fun_dbg =
+  let function_name = Debuginfo.Function.name fun_dbg in
+  let is_visible_externally =
+    Debuginfo.Function.is_visible_externally fun_dbg
+  in
+  [ DAH.create_name function_name;
+    DAH.create_external ~is_visible_externally;
+  ]
+
+let add state fun_dbg =
+  let module_path = Debuginfo.Function.module_path fun_dbg in
+  let parent = Dwarf_modules.dwarf state ~module_path in
+  let abstract_instance_proto_die =
+    (* DWARF-5 specification section 3.3.8.1, page 82. *)
+    Proto_die.create ~parent:(Some parent)
+      ~tag:Subprogram
+      ~attribute_values:((attributes fun_dbg) @ [
+        (* We assume every function might potentially be inlined (and possibly
+           in the future), so we choose [DW_INL_inlined] as the most appropriate
+           setting for [DW_AT_inline], even if it doesn't seem exactly
+           correct.  We must set something here to ensure that the subprogram
+           is marked as an abstract instance root. *)
+        DAH.create_inline Inlined;
+      ])
+      ()
+  in
+  let id = Debuginfo.Function.id fun_dbg in
+  let abstract_instance_proto_die_symbol =
+    Dwarf_name_laundry.abstract_instance_root_die_name id
+  in
+  Proto_die.set_name abstract_instance_proto_die
+    abstract_instance_proto_die_symbol;
+  Debuginfo.Function.Id.Tbl.add (DS.function_abstract_instances state) id
+    (abstract_instance_proto_die, abstract_instance_proto_die_symbol);
+  abstract_instance_proto_die, abstract_instance_proto_die_symbol
+
+let find_or_add state fun_dbg =
+  let id = Debuginfo.Function.id fun_dbg in
+  match
+    Debuginfo.Function.Id.Tbl.find (DS.function_abstract_instances state) id
+  with
+  | exception Not_found -> add state fun_dbg
+  | existing_instance -> existing_instance
+
+let find_maybe_in_another_unit_or_add state fun_dbg =
+  if not (Debuginfo.Function.dwarf_die_present fun_dbg) then
+    None
+  else
+    let id = Debuginfo.Function.id fun_dbg in
+    let dbg_comp_unit = Debuginfo.Function.Id.compilation_unit id in
+    let this_comp_unit = Compilation_unit.get_current_exn () in
+    if Compilation_unit.equal dbg_comp_unit this_comp_unit then
+      let _abstract_instance_proto_die, abstract_instance_proto_die_symbol =
+        find_or_add state fun_dbg
+      in
+      Some abstract_instance_proto_die_symbol
+    else if DS.can_reference_dies_across_units state then
+      Some (Dwarf_name_laundry.abstract_instance_root_die_name id)
+    else
+      None

--- a/asmcomp/debug/dwarf/dwarf_abstract_instances.mli
+++ b/asmcomp/debug/dwarf/dwarf_abstract_instances.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Management of DWARF "abstract instances" for functions. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val attributes
+   : Debuginfo.Function.t
+  -> Dwarf_attribute_values.Attribute_value.t list
+
+val find_or_add
+   : Dwarf_state.t
+  -> Debuginfo.Function.t
+  -> Proto_die.t * Asm_symbol.t
+
+val find_maybe_in_another_unit_or_add
+   : Dwarf_state.t
+  -> Debuginfo.Function.t
+  -> Asm_symbol.t option

--- a/asmcomp/debug/dwarf/dwarf_call_sites.ml
+++ b/asmcomp/debug/dwarf/dwarf_call_sites.ml
@@ -1,0 +1,513 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+module L = Linearize
+module SLDL = Simple_location_description_lang
+module V = Backend_var
+
+let add_call_site_argument state ~call_site_die ~is_tail ~arg_index
+      ~(arg : Reg.t) ~stack_offset (insn : L.instruction) =
+  let param_location =
+    let offset_from_cfa_in_bytes =
+      match arg.loc with
+      | Stack stack_loc ->
+        Dwarf_reg_locations.offset_from_cfa_in_bytes arg stack_loc ~stack_offset
+      | Reg _ -> None
+      | Unknown ->
+        Misc.fatal_errorf "Register without location: %a"
+          Printmach.reg arg
+    in
+    let param_location =
+      Dwarf_reg_locations.reg_location_description arg ~offset_from_cfa_in_bytes
+        ~need_rvalue:false
+    in
+    match param_location with
+    | None -> []
+    | Some param_location ->
+      let param_location =
+        Single_location_description.of_simple_location_description
+          param_location
+      in
+      [DAH.create_single_location_description param_location]
+  in
+  let arg_location, type_attribute =
+    (* The reason we call [Reg_availability_set.canonicalise] from
+       [Available_ranges] vars, rather than traversing each function's
+       code and rewriting all of the availability sets first, is so that
+       we don't lose information (in particular that a particular hard
+       register before a call contains the value of a certain variable)
+       that we may need here.  (Specifically for the call to
+       [Reg_availability_set.find_all_holding_value_of].) *)
+    let available_before = Insn_debuginfo.available_before insn.dbg in
+    match Reg_availability_set.find_reg_opt available_before arg with
+    | None -> [], []
+    | Some rd ->
+      match Reg_with_debug_info.debug_info rd with
+      | None -> [], []
+      | Some debug_info ->
+        let holds_value_of =
+          Reg_with_debug_info.Debug_info.holds_value_of debug_info
+        in
+        let create_location_description arg_location =
+          let arg_location =
+            Single_location_description.of_simple_location_description
+              arg_location
+          in
+          [DAH.create_single_call_value_location_description arg_location;
+          ]
+        in
+        match holds_value_of with
+        | Var holds_value_of ->
+          let type_attribute =
+            match Reg_with_debug_info.Debug_info.provenance debug_info with
+            | None -> []
+            | Some provenance ->
+              let type_die =
+                (* CR mshinwell: This should reuse DIEs which were created
+                   previously to describe these vars.  Also, shouldn't these
+                   DIEs be parented higher up? *)
+                Dwarf_variables_and_parameters.normal_type_for_var
+                  ~parent:(Some call_site_die)
+                  (Some (Backend_var.Provenance.ident_for_type provenance))
+                  (Backend_var.Provenance.is_parameter provenance)
+              in
+              [DAH.create_type_from_reference
+                ~proto_die_reference:(Proto_die.reference type_die)
+              ]
+          in
+          let arg_location =
+            if is_tail then begin
+              (* If this is a tail call site, no arguments of the call will be
+                 available with certainty in the callee, since any argument we
+                 describe in DWARF (see comment below) will be on the
+                 stack---and our stack frame may have been overwritten by the
+                 time such argument is queried in the debugger. *)
+              []
+            end else begin
+              let everywhere_holding_var =
+                Reg_availability_set.find_all_holding_value_of
+                  available_before (Var holds_value_of)
+              in
+              (* Only registers spilled at the time of the call will be
+                 available with certainty (in the caller's frame) during the
+                 execution of the callee. *)
+              let on_stack =
+                Misc.Stdlib.List.filter_map (fun rd ->
+                    let reg = Reg_with_debug_info.reg rd in
+                    match reg.loc with
+                    | Stack stack_loc ->
+                      Some (reg,
+                        Dwarf_reg_locations.offset_from_cfa_in_bytes reg
+                          stack_loc ~stack_offset)
+                    | Reg _ -> None
+                    | Unknown ->
+                      Misc.fatal_errorf "Register without location: %a"
+                        Printmach.reg reg)
+                  everywhere_holding_var
+              in
+              match on_stack with
+              | [] -> []
+              | (reg, offset_from_cfa_in_bytes) :: _ ->
+                let arg_location_rvalue =
+                  Dwarf_reg_locations.reg_location_description reg
+                    ~offset_from_cfa_in_bytes ~need_rvalue:true
+                in
+                match arg_location_rvalue with
+                | None -> []
+                | Some arg_location_rvalue ->
+                  create_location_description arg_location_rvalue
+            end
+          in
+          arg_location, type_attribute
+        | Const_int i ->
+          let arg_location =
+            create_location_description
+              (SLDL.compile (SLDL.of_rvalue (SLDL.Rvalue.signed_int_const i)))
+          in
+          let type_attribute =
+            [ DAH.create_type ~proto_die:(DS.value_type_proto_die state)
+            ]
+          in
+          arg_location, type_attribute
+        | Const_naked_float f ->
+          (* CR mshinwell: This shouldn't happen at the moment *)
+          let arg_location =
+            create_location_description
+              (SLDL.compile (SLDL.of_rvalue (SLDL.Rvalue.float_const f)))
+          in
+          let type_attribute =
+            [ DAH.create_type ~proto_die:(DS.naked_float_type_proto_die state)
+            ]
+          in
+          arg_location, type_attribute
+        | Const_symbol symbol ->
+          let symbol = Asm_symbol.create symbol in
+          let arg_location =
+            create_location_description
+              (SLDL.compile (SLDL.of_rvalue (SLDL.Rvalue.const_symbol symbol)))
+          in
+          let type_attribute =
+            (* CR-someday mshinwell: Work out what we need to do in order to
+               know whether a given symbol, in another compilation unit, has
+               a DWARF DIE. *)
+            match DS.type_die_for_lifted_constant state symbol with
+            | None ->
+              (* In this case the debugger will have to print the value using
+                 only the contents of the heap, and not the OCaml type. *)
+              (* CR mshinwell: Except that it seems to use the type from the
+                 parameter -- see above *)
+              [ DAH.create_type ~proto_die:(DS.value_type_proto_die state)
+              ]
+            | Some type_die ->
+              (* This case may arise where the defining expression of a
+                 variable was lifted, but an occurrence of the variable as one
+                 of the call site arguments was substituted out.  Despite the
+                 substitution, we can still retrieve the OCaml type. *)
+              [ DAH.create_type ~proto_die:type_die
+              ]
+          in
+          arg_location, type_attribute
+  in
+  let tag : Dwarf_tag.t =
+    match !Clflags.gdwarf_version with
+    | Four -> Dwarf_4 GNU_call_site_parameter
+    | Five -> Call_site_parameter
+  in
+  (* We don't give the name of the parameter since it is
+     complicated to calculate (and there is currently insufficient
+     information to perform the calculation if the function is in
+     a different compilation unit). *)
+  Proto_die.create_ignore ~sort_priority:arg_index
+    ~parent:(Some call_site_die)
+    ~tag
+    ~attribute_values:(arg_location @ param_location @ type_attribute)
+    ()
+
+let add_call_site state ~scope_proto_dies ~function_proto_die
+      ~stack_offset ~is_tail ~args ~(call_labels : Mach.call_labels)
+      (insn : L.instruction) attrs =
+  let dbg = Insn_debuginfo.dbg insn.dbg in
+  let block_die =
+    Dwarf_lexical_blocks_and_inlined_frames.find_scope_die_from_debuginfo dbg
+      ~function_proto_die ~scope_proto_dies
+  in
+  match block_die with
+  | None ->
+    Misc.fatal_errorf "No lexical block DIE found for debuginfo (the block \
+        should always exist since this debuginfo came from a [Linearize] \
+        instruction, not a [Backend_var]):@ %a"
+      Debuginfo.print dbg
+  | Some block_die ->
+    let position_attrs =
+      match Debuginfo.position dbg with
+      | None -> []
+      | Some code_range ->
+        if not (Debuginfo.Code_range.is_none code_range) then begin
+          (* These are DWARF-5 attributes, but should be fine in DWARF-4
+             output.  They are also needed for polymorphic function type
+             recovery. *)
+          let file_name = Debuginfo.Code_range.file code_range in
+          [ DAH.create_call_file (Emitaux.file_num_for ~file_name);
+            DAH.create_call_line (Debuginfo.Code_range.line code_range);
+            DAH.create_call_column (Debuginfo.Code_range.char_start code_range);
+          ]
+        end else begin
+          []
+        end
+    in
+    let call_site_die =
+      let dwarf_5_only =
+        match !Clflags.gdwarf_version with
+        | Four -> [
+            DAH.create_low_pc (Asm_label.create_int Text call_labels.after);
+          ]
+        | Five -> [
+            DAH.create_call_pc (Asm_label.create_int Text call_labels.before);
+            DAH.create_call_return_pc (
+              Asm_label.create_int Text call_labels.after);
+          ]
+      in
+      let tag : Dwarf_tag.t =
+        match !Clflags.gdwarf_version with
+        | Four -> Dwarf_4 GNU_call_site
+        | Five -> Call_site
+      in
+      Proto_die.create ~parent:(Some block_die)
+        ~tag
+        ~attribute_values:(attrs @ position_attrs @ dwarf_5_only @ [
+          DAH.create_call_tail_call ~is_tail;
+        ])
+        ()
+    in
+    (* CR-someday mshinwell: For the moment, don't generate argument
+       information if one or more of the arguments is split across registers.
+       This could be improved in the future. *)
+    let no_split_args =
+      Array.for_all (fun (arg : Reg.t) ->
+          match arg.part with
+          | None -> true
+          | Some _ -> false)
+        args
+    in
+    if no_split_args then begin
+      Array.iteri (fun arg_index arg ->
+          add_call_site_argument state ~call_site_die ~is_tail ~arg_index ~arg
+            ~stack_offset insn)
+        args
+    end
+
+type direct_callee =
+  | Ocaml of Asm_symbol.t * Debuginfo.Function.t
+  | External of Asm_symbol.t * Linkage_name.t
+
+let call_target_for_direct_callee state (callee : direct_callee) =
+  (* If we cannot reference DIEs across compilation units, then we treat direct
+     calls to OCaml functions in other compilation units as if they were to an
+     external function, fabricating our own subprogram DIE for each such
+     function and providing the "low PC" and "entry PC" value that GDB looks for
+     (or may look for in the future). See
+     gdb/dwarf2read.c:read_call_site_scope. *)
+  let callee =
+    match callee with
+    | Ocaml (callee_symbol, callee_dbg)
+        when (not (DS.can_reference_dies_across_units state))
+          && (not (Compilation_unit.equal
+            (Asm_symbol.compilation_unit callee_symbol)
+            (Compilation_unit.get_current_exn ()))) ->
+      let linkage_name =
+        (* See comment about linkage names in dwarf_concrete_instances.ml. *)
+        Linkage_name.create (
+          Debuginfo.Function.name_with_module_path callee_dbg)
+      in
+      External (callee_symbol, linkage_name)
+    | _ -> callee
+  in
+  let die_symbol =
+    match callee with
+    | Ocaml (_callee_symbol, callee_dbg) ->
+      if not (Debuginfo.Function.dwarf_die_present callee_dbg) then None
+      else
+        let id = Debuginfo.Function.id callee_dbg in
+        Some (Dwarf_name_laundry.concrete_instance_die_name id)
+    | External (callee, _linkage_name) ->
+      match
+        Asm_symbol.Tbl.find (DS.die_symbols_for_external_declarations state)
+          callee
+      with
+      | exception Not_found ->
+        (* CR-someday mshinwell: dedup DIEs for runtime, "caml_curry", etc.
+           functions across compilation units (maybe only generate the DIEs
+           when compiling the startup file)? *)
+        let linkage_name = Asm_symbol.linkage_name callee in
+        let callee_die =
+          Proto_die.create ~parent:(Some (DS.compilation_unit_proto_die state))
+            ~tag:Subprogram
+            ~attribute_values:[
+              DAH.create_declaration ();
+              (* We use the linkage name rather than the actual symbol address
+                 [of the target function] because dsymutil helpfully
+                 replaces such symbol references, when they refer to other
+                 compilation units, with zeros.
+                 Unlike the [DW_AT_linkage_names] used on concrete symbols, we
+                 have to emit a linkage name consisting of the actual
+                 object file symbol here (rather than the OCaml path to the
+                 function in question), since those are what the GDB minsyms
+                 lookup code uses.  (Such code is called when resolving call
+                 site chains.) *)
+              DAH.create_linkage_name linkage_name;
+            ]
+            ()
+        in
+        let die_symbol =
+          Dwarf_name_laundry.external_declaration_die_name callee
+            (Compilation_unit.get_current_exn ())
+        in
+        Proto_die.set_name callee_die die_symbol;
+        Asm_symbol.Tbl.add (DS.die_symbols_for_external_declarations state)
+          callee die_symbol;
+        Some die_symbol
+      | die_symbol -> Some die_symbol
+  in
+  match die_symbol with
+  | None -> []
+  | Some die_symbol -> [DAH.create_call_origin ~die_symbol]
+
+let call_target_for_indirect_callee ~(callee : Reg.t) ~stack_offset =
+  let offset_from_cfa_in_bytes, clobbered_by_call =
+    match callee.loc with
+    | Stack stack_loc ->
+      let offset_from_cfa_in_bytes =
+        Dwarf_reg_locations.offset_from_cfa_in_bytes callee stack_loc
+          ~stack_offset
+      in
+      offset_from_cfa_in_bytes, false
+    | Reg _ -> None, true
+    | Unknown ->
+      Misc.fatal_errorf "Register without location: %a" Printmach.reg callee
+  in
+  let simple_location_desc =
+    Dwarf_reg_locations.reg_location_description callee
+      ~offset_from_cfa_in_bytes ~need_rvalue:false
+  in
+  match simple_location_desc with
+  | None -> []
+  | Some simple_location_desc ->
+    let location_desc =
+      Single_location_description.of_simple_location_description
+        simple_location_desc
+    in
+    (* It seems unlikely that we won't be calling through a [Reg], but we
+       support the stack case (yielding [DW_AT_call_target] rather than the
+       "clobbered" variant) for completeness. *)
+    if clobbered_by_call then
+      [DAH.create_call_target_clobbered location_desc] 
+    else
+      [DAH.create_call_target location_desc] 
+
+let dwarf state ~scope_proto_dies (fundecl : L.fundecl)
+      ~external_calls_generated_during_emit ~function_symbol
+      ~function_proto_die =
+  let found_self_tail_calls = ref false in
+  let add_call_site =
+    add_call_site ~scope_proto_dies ~function_proto_die
+  in
+  let add_indirect_ocaml_call ~stack_offset ~callee ~args ~call_labels insn =
+    add_call_site state ~stack_offset ~is_tail:false ~args ~call_labels insn
+      (call_target_for_indirect_callee ~callee ~stack_offset)
+  in
+  let add_direct_ocaml_call ~stack_offset ~callee ~callee_dbg ~args
+        ~call_labels insn =
+    match callee_dbg with
+    | None -> ()
+    | Some callee_dbg ->
+      add_call_site state ~stack_offset ~is_tail:false ~args ~call_labels insn
+        (call_target_for_direct_callee state (Ocaml (callee, callee_dbg)))
+  in
+  let add_indirect_ocaml_tail_call ~stack_offset ~callee ~args ~call_labels
+        insn =
+    add_call_site state ~stack_offset ~is_tail:true ~args ~call_labels insn
+      (call_target_for_indirect_callee ~callee ~stack_offset)
+  in
+  let add_direct_ocaml_tail_call ~stack_offset ~callee ~callee_dbg
+        ~args ~call_labels insn =
+    match callee_dbg with
+    | None -> ()
+    | Some callee_dbg ->
+      (* DWARF-5 spec section 3.4, page 89, lines 19--22: [DW_TAG_call_site]s
+         are not to be generated for self tail calls (called "tail recursion
+         calls" in the spec). *)
+      if Asm_symbol.equal callee function_symbol
+        && not !Clflags.gdwarf_self_tail_calls
+      then begin
+        found_self_tail_calls := true
+      end else begin
+        add_call_site state ~stack_offset ~is_tail:true ~args ~call_labels insn
+          (call_target_for_direct_callee state (Ocaml (callee, callee_dbg)))
+      end
+  in
+  let add_external_call ~stack_offset ~callee ~args ~call_labels insn =
+    let linkage_name = Asm_symbol.linkage_name callee in
+    add_call_site state ~stack_offset ~is_tail:false ~args ~call_labels insn
+      (call_target_for_direct_callee state (External (callee, linkage_name)))
+  in
+  let rec traverse_insns (insn : L.instruction) ~stack_offset =
+    match insn.desc with
+    | Lend -> stack_offset
+    | Lop op ->
+      let stack_offset =
+        match op with
+        | Icall_ind { call_labels; } ->
+          let args = Array.sub insn.arg 1 (Array.length insn.arg - 1) in
+          add_indirect_ocaml_call ~stack_offset
+            ~callee:insn.arg.(0) ~args ~call_labels insn;
+          stack_offset
+        | Icall_imm { func = callee; callee_dbg; call_labels; _ } ->
+          let callee = Asm_symbol.create callee in
+          add_direct_ocaml_call ~stack_offset ~callee
+            ~callee_dbg ~args:insn.arg ~call_labels insn;
+          stack_offset
+        | Itailcall_ind { call_labels; } ->
+          let args = Array.sub insn.arg 1 (Array.length insn.arg - 1) in
+          add_indirect_ocaml_tail_call ~stack_offset
+            ~callee:insn.arg.(0) ~args ~call_labels insn;
+          stack_offset
+        | Itailcall_imm { func = callee; callee_dbg; call_labels; _ } ->
+          let callee = Asm_symbol.create callee in
+          add_direct_ocaml_tail_call ~stack_offset
+            ~callee ~callee_dbg ~args:insn.arg ~call_labels insn;
+          stack_offset
+        | Iextcall { func = callee; alloc = _; call_labels; } ->
+          let callee = Asm_symbol.create callee in
+          add_external_call ~stack_offset
+            ~callee ~args:insn.arg ~call_labels insn;
+          stack_offset
+        | Imove
+        | Ispill
+        | Ireload
+        | Iconst_int _
+        | Iconst_float _
+        | Iconst_symbol _
+        | Iload _
+        | Istore _
+        | Ialloc _
+        | Iintop _
+        | Iintop_imm _
+        | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
+        | Ifloatofint | Iintoffloat
+        | Ispecific _
+        | Iname_for_debugger _ -> stack_offset
+        | Istackoffset delta -> stack_offset + delta
+      in
+      traverse_insns insn.next ~stack_offset
+    | Lprologue
+    | Lreloadretaddr
+    | Lreturn
+    | Llabel _
+    | Lbranch _
+    | Lcondbranch _
+    | Lcondbranch3 _
+    | Lswitch _
+    | Lsetuptrap _
+    | Lraise _ -> traverse_insns insn.next ~stack_offset
+    | Lpushtrap ->
+      traverse_insns insn.next
+        ~stack_offset:(stack_offset + Proc.trap_frame_size_in_bytes)
+    | Lpoptrap ->
+      traverse_insns insn.next
+        ~stack_offset:(stack_offset - Proc.trap_frame_size_in_bytes)
+  in
+  let (_stack_offset : int) =
+    traverse_insns fundecl.fun_body ~stack_offset:Proc.initial_stack_offset
+  in
+  List.iter (fun ({ callee; call_labels; call_dbg; }
+        : Emitaux.external_call_generated_during_emit) ->
+      (* We omit [DW_tag_call_site_parameter] for these calls.  As such the
+         [available_before] information and the stack offset is irrelevant
+         here. *)
+      let dbg =
+        Insn_debuginfo.create call_dbg ~phantom_available_before:V.Set.empty
+      in
+      let fake_insn : L.instruction =
+        { L.end_instr with
+          dbg;
+        }
+      in
+      add_external_call ~stack_offset:0 ~callee ~args:[| |] ~call_labels
+        fake_insn)
+    external_calls_generated_during_emit;
+  !found_self_tail_calls

--- a/asmcomp/debug/dwarf/dwarf_call_sites.mli
+++ b/asmcomp/debug/dwarf/dwarf_call_sites.mli
@@ -1,0 +1,27 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Generation of descriptions of function call sites in DWARF. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val dwarf
+   : Dwarf_state.t
+  -> scope_proto_dies:Proto_die.t Debuginfo.Block.Map.t
+  -> Linearize.fundecl
+  -> external_calls_generated_during_emit
+       : Emitaux.external_call_generated_during_emit list
+  -> function_symbol:Asm_symbol.t
+  -> function_proto_die:Proto_die.t
+  -> bool

--- a/asmcomp/debug/dwarf/dwarf_compilation_unit.ml
+++ b/asmcomp/debug/dwarf/dwarf_compilation_unit.ml
@@ -1,0 +1,97 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module String = Misc.Stdlib.String
+
+let compile_unit_proto_die ~sourcefile ~prefix_name ~cmt_file_digest ~objfiles
+      ~start_of_code_symbol ~end_of_code_symbol
+      address_table location_list_table range_list_table =
+  let unit_name =
+    Compilation_unit.get_persistent_ident (Compilation_unit.get_current_exn ())
+  in
+  let cwd = Sys.getcwd () in
+  let source_directory_path, source_filename =
+    if Filename.is_relative sourcefile then cwd, sourcefile
+    else Filename.dirname sourcefile, Filename.basename sourcefile
+  in
+  let prefix_name =
+    if Filename.is_relative prefix_name then Filename.concat cwd prefix_name
+    else prefix_name
+  in
+  let source_directory_path =
+    Location.rewrite_absolute_path source_directory_path
+  in
+  let prefix_name = Location.rewrite_absolute_path prefix_name in
+  let linker_dir_names =
+    List.map (fun objfile ->
+        let dir = Filename.dirname objfile in
+        if Filename.is_relative objfile then Filename.concat cwd dir
+        else dir)
+      objfiles
+  in
+  let linker_dirs =
+    match linker_dir_names with
+    | [] -> []
+    | linker_dir_names ->
+      let linker_dir_names =
+        String.Set.map Location.rewrite_absolute_path
+          (String.Set.of_list linker_dir_names)
+      in
+      [ DAH.create_ocaml_linker_dirs linker_dir_names ]
+  in
+  (* CR mshinwell: Use [Build_path_prefix_map]. *)
+  let debug_line_label = Asm_label.for_section (DWARF Debug_line) in
+  let addr_base = Address_table.base_addr address_table in
+  let loclists_base = Location_list_table.base_addr location_list_table in
+  let rnglists_base = Range_list_table.base_addr range_list_table in
+  let config_digest = Config.digest_static_configuration_values () in
+  let dwarf_5_only =
+    match !Clflags.gdwarf_version with
+    | Four -> []
+    | Five -> [
+      DAH.create_addr_base addr_base;
+      DAH.create_loclists_base loclists_base;
+      DAH.create_rnglists_base rnglists_base;
+    ]
+  in
+  let cmt_file_digest =
+    match cmt_file_digest with
+    | None -> []
+    | Some cmt_file_digest -> [DAH.create_ocaml_cmt_file_digest cmt_file_digest]
+  in
+  let attribute_values =
+    [ DAH.create_name source_filename;
+      DAH.create_comp_dir source_directory_path;
+      (* The [OCaml] attribute value here is only defined in DWARF-5, but
+         it doesn't mean anything else in DWARF-4, so we always emit it.
+         This saves special-case logic in gdb based on the producer name. *)
+      DAH.create_language OCaml;
+      DAH.create_producer "ocamlopt";
+      DAH.create_ocaml_unit_name unit_name;
+      DAH.create_ocaml_compiler_version Sys.ocaml_version;
+      DAH.create_ocaml_config_digest config_digest;
+      DAH.create_ocaml_prefix_name prefix_name;
+      DAH.create_low_pc_from_symbol start_of_code_symbol;
+      DAH.create_high_pc_from_symbol ~low_pc:start_of_code_symbol
+        end_of_code_symbol;
+      DAH.create_stmt_list ~debug_line_label;
+    ] @ cmt_file_digest @ linker_dirs @ dwarf_5_only
+  in
+  Proto_die.create ~parent:None
+    ~tag:Compile_unit
+    ~attribute_values
+    ()

--- a/asmcomp/debug/dwarf/dwarf_compilation_unit.mli
+++ b/asmcomp/debug/dwarf/dwarf_compilation_unit.mli
@@ -1,0 +1,29 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Construction of DWARF "compile_unit" DIEs and associated entities. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val compile_unit_proto_die
+   : sourcefile:string
+  -> prefix_name:string
+  -> cmt_file_digest:Digest.t option
+  -> objfiles:string list
+  -> start_of_code_symbol:Asm_symbol.t
+  -> end_of_code_symbol:Asm_symbol.t
+  -> Address_table.t
+  -> Location_list_table.t
+  -> Range_list_table.t
+  -> Proto_die.t

--- a/asmcomp/debug/dwarf/dwarf_concrete_instances.ml
+++ b/asmcomp/debug/dwarf/dwarf_concrete_instances.ml
@@ -1,0 +1,98 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+
+(* CR mshinwell: Function names are not being disambiguated
+   (e.g. Ctype.unify) *)
+
+let for_fundecl state (result : Debug_passes.result) =
+  let available_ranges_vars = result.available_ranges_vars in
+  let fundecl = result.fundecl in
+  let lexical_block_ranges = result.lexical_block_ranges in
+  let external_calls_generated_during_emit =
+    result.external_calls_generated_during_emit
+  in
+  let symbol = Asm_symbol.create fundecl.fun_name in
+  (* Our "linkage names" in DWARF are in fact normal OCaml qualified paths.
+     This is done, instead of using the actual symbol names, because there
+     appears to be a presumption in GDB that demangled names can be deduced
+     from mangled names.  This is not the case, reliably, using the current
+     OCaml mangling scheme.  Since fully-qualified name should be unique across
+     a whole program anyway it doesn't seem that there is any real downside
+     to using such names as the linkage names. *)
+  let linkage_name =
+    Linkage_name.create (
+      Debuginfo.Function.name_with_module_path fundecl.fun_dbg)
+  in
+  let start_of_function = DAH.create_low_pc_from_symbol symbol in
+  let end_of_function =
+    DAH.create_high_pc ~low_pc:symbol
+      (Asm_label.create_int Text result.end_of_function_label)
+  in
+  let _abstract_instance_proto_die, abstract_instance_die_symbol =
+    Dwarf_abstract_instances.find_or_add state fundecl.fun_dbg
+  in
+  let module_path = Debuginfo.Function.module_path fundecl.fun_dbg in
+  let parent = Dwarf_modules.dwarf state ~module_path in
+  let concrete_instance_proto_die =
+    Proto_die.create ~parent:(Some parent)
+      ~tag:Subprogram
+      ~attribute_values:[
+        start_of_function;
+        end_of_function;
+        DAH.create_entry_pc_from_symbol symbol;
+        DAH.create_abstract_origin ~die_symbol:abstract_instance_die_symbol;
+        DAH.create_linkage_name linkage_name;
+      ]
+      ()
+  in
+  Proto_die.set_name concrete_instance_proto_die
+    (Dwarf_name_laundry.concrete_instance_die_name
+      (Debuginfo.Function.id fundecl.fun_dbg));
+  if Clflags.debug_thing Debug_dwarf_scopes then begin
+    let scope_proto_dies =
+      Profile.record "dwarf_lexical_blocks_and_inlined_frames"
+        (fun () ->
+          Dwarf_lexical_blocks_and_inlined_frames.dwarf state fundecl
+            lexical_block_ranges ~function_proto_die:concrete_instance_proto_die)
+        ~accumulate:true
+        ()
+    in
+    if Clflags.debug_thing Debug_dwarf_vars then begin
+      Profile.record "dwarf_variables_and_parameters" (fun () ->
+          Dwarf_variables_and_parameters.dwarf state fundecl
+            ~function_proto_die:concrete_instance_proto_die
+            ~scope_proto_dies available_ranges_vars)
+        ~accumulate:true
+        ();
+      if (DS.supports_call_sites state) then begin
+        let found_self_tail_calls =
+          Profile.record "dwarf_call_sites" (fun () ->
+              Dwarf_call_sites.dwarf state ~scope_proto_dies fundecl
+                ~external_calls_generated_during_emit ~function_symbol:symbol
+                ~function_proto_die:concrete_instance_proto_die)
+            ~accumulate:true
+            ()
+        in
+        if not found_self_tail_calls then begin
+          Proto_die.add_or_replace_attribute_value concrete_instance_proto_die
+            (DAH.create_call_all_calls ())
+        end
+      end
+    end
+  end

--- a/asmcomp/debug/dwarf/dwarf_concrete_instances.mli
+++ b/asmcomp/debug/dwarf/dwarf_concrete_instances.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Emission of DWARF information for concrete (i.e. non-inlined) instances of
+    functions. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val for_fundecl : Dwarf_state.t -> Debug_passes.result -> unit

--- a/asmcomp/debug/dwarf/dwarf_lexical_blocks_and_inlined_frames.ml
+++ b/asmcomp/debug/dwarf/dwarf_lexical_blocks_and_inlined_frames.ml
@@ -1,0 +1,233 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+module L = Linearize
+module LB = Lexical_block_ranges
+
+let find_scope_die_from_debuginfo dbg ~function_proto_die ~scope_proto_dies =
+  let innermost_block = Debuginfo.innermost_block dbg in
+  match Debuginfo.Current_block.to_block innermost_block with
+  | Toplevel -> Some function_proto_die
+  | Block block ->
+    let module B = Debuginfo.Block in
+    match B.Map.find block scope_proto_dies with
+    | exception Not_found -> None
+    | proto_die -> Some proto_die
+
+let create_range_list_and_summarise state (_fundecl : L.fundecl) range =
+  LB.Range.fold range
+    ~init:([], Range_list.create (), Address_index.Pair.Set.empty)
+    ~f:(fun (dwarf_4_range_list_entries, range_list, summary) subrange ->
+      let start_pos = LB.Subrange.start_pos subrange in
+      let start_pos_offset = LB.Subrange.start_pos_offset subrange in
+      let end_pos = LB.Subrange.end_pos subrange in
+      let end_pos_offset = LB.Subrange.end_pos_offset subrange in
+      let start_inclusive =
+        Address_table.add (DS.address_table state)
+          (Asm_label.create_int Text start_pos)
+          ~adjustment:start_pos_offset
+          ~start_of_code_symbol:(DS.start_of_code_symbol state)
+      in
+      let end_exclusive =
+        Address_table.add (DS.address_table state)
+          (Asm_label.create_int Text end_pos)
+          ~adjustment:end_pos_offset
+          ~start_of_code_symbol:(DS.start_of_code_symbol state)
+      in
+      let range_list_entry : Range_list_entry.entry =
+        (* DWARF-5 spec page 54 line 1. *)
+        Startx_endx {
+          start_inclusive;
+          end_exclusive;
+          payload = ();
+        }
+      in
+      let range_list_entry =
+        Range_list_entry.create range_list_entry
+          ~start_of_code_symbol:(DS.start_of_code_symbol state)
+      in
+      (* We still use the [Range_list] when emitting DWARF-4 (even though
+         it is a DWARF-5 structure) for the purposes of de-duplicating
+         ranges. *)
+      let range_list = Range_list.add range_list range_list_entry in
+      let summary =
+        Address_index.Pair.Set.add (start_inclusive, end_exclusive) summary
+      in
+      let dwarf_4_range_list_entries =
+        match !Clflags.gdwarf_version with
+        | Four ->
+          let range_list_entry =
+            Dwarf_4_range_list_entry.create_range_list_entry
+              ~start_of_code_symbol:(DS.start_of_code_symbol state)
+              ~first_address_when_in_scope:(Asm_label.create_int Text start_pos)
+              ~first_address_when_not_in_scope:
+                (Asm_label.create_int Text end_pos)
+              ~first_address_when_not_in_scope_offset:(Some end_pos_offset)
+          in
+          range_list_entry :: dwarf_4_range_list_entries
+        | Five -> dwarf_4_range_list_entries
+      in
+      dwarf_4_range_list_entries, range_list, summary)
+
+(* "Summaries", sets of pairs of the starting and ending points of ranges,
+   are used to dedup entries in the range list table.  We do this for range
+   lists but not yet for location lists since deduping entries in the latter
+   would involve comparing DWARF location descriptions. *)
+module All_summaries = Identifiable.Make (struct
+  include Address_index.Pair.Set
+  let hash t = Hashtbl.hash (elements t)
+end)
+
+let die_for_lexical_block parent range_list_attribute =
+  Proto_die.create ~parent:(Some parent)
+    ~tag:Lexical_block
+    ~attribute_values:[
+      range_list_attribute;
+    ]
+    ()
+
+let die_for_inlined_frame state parent call_site range range_list_attribute =
+  let fun_dbg = Debuginfo.Call_site.fun_dbg call_site in
+  let abstract_instance_symbol =
+    Dwarf_abstract_instances.find_maybe_in_another_unit_or_add state fun_dbg
+  in
+  let entry_pc =
+    (* CR-someday mshinwell: The "entry PC" is supposed to be the address of the
+       "temporally first" instruction of the inlined function. We assume here
+       that we don't do transformations which might cause the first instruction
+       of the inlined function to not be the one at the lowest address amongst
+       all instructions of the inlined function. If this assumption is wrong the
+       most likely outcome seems to be breakpoints being slightly in the wrong
+       place, although still in the correct function. Making this completely
+       accurate will necessitate more tracking of instruction ordering from
+       earlier in the compiler. *)
+    match LB.Range.lowest_address range with
+    | None -> []
+    | Some lowest_address -> [
+        DAH.create_entry_pc (Asm_label.create_int Text lowest_address);
+      ]
+  in
+  (* Note that with Flambda, this DIE may not be in the scope of the referenced
+     abstract instance DIE, as inline expansions may be made out of the scope of
+     the function declaration. *)
+  let abstract_instance =
+    match abstract_instance_symbol with
+    | None ->
+      (* If the abstract instance DIE cannot be referenced, reconstitute as much
+         of its attributes as we can and put them directly into the DIE for the
+         inlined frame, making use of DWARF-5 spec page 85, line 30 onwards. *)
+      Dwarf_abstract_instances.attributes fun_dbg
+    | Some abstract_instance_symbol ->
+      (* This appears to be the source of a bogus error from "dwarfdump
+         --verify" on macOS:
+
+         error: <address>: DIE has tag Unknown DW_TAG constant: 0x4109 has
+         DW_AT_abstract_origin that points to DIE <address> with incompatible
+         tag TAG_subprogram
+
+         The error seems to be bogus because:
+
+         (a) 0x4109 is DW_TAG_GNU_call_site which has no DW_AT_abstract_origin
+             attribute (it does in a child, but not in itself); and
+
+         (b) When DW_AT_abstract_origin is used to reference an abstract
+             instance then it is expected that the tags of the referring and
+             referred-to DIEs differ. DWARF-5 spec page 85, lines 4--8.
+
+         Since this complaint does not appear during a normal build process we
+         do not attempt to work around it. *)
+      [DAH.create_abstract_origin ~die_symbol:abstract_instance_symbol]
+  in
+  let code_range = Debuginfo.Call_site.position call_site in
+  let file_name = Debuginfo.Code_range.file code_range in
+  Proto_die.create ~parent:(Some parent)
+    ~tag:Inlined_subroutine
+    ~attribute_values:(entry_pc @ abstract_instance @ [
+      range_list_attribute;
+      DAH.create_call_file (Emitaux.file_num_for ~file_name);
+      DAH.create_call_line (Debuginfo.Code_range.line code_range);
+      DAH.create_call_column (Debuginfo.Code_range.char_start code_range);
+    ])
+    ()
+
+let dwarf state (fundecl : L.fundecl) lexical_block_ranges ~function_proto_die =
+  let module B = Debuginfo.Block in
+  let all_blocks = LB.all_indexes lexical_block_ranges in
+  let scope_proto_dies, _all_summaries =
+    B.Set.fold (fun block (scope_proto_dies, all_summaries) ->
+        let rec create_up_to_root block scope_proto_dies all_summaries =
+          match B.Map.find block scope_proto_dies with
+          | proto_die ->
+            proto_die, scope_proto_dies, all_summaries
+          | exception Not_found ->
+            let parent, scope_proto_dies, all_summaries =
+              match B.parent block with
+              | None ->
+                function_proto_die, scope_proto_dies, all_summaries
+              | Some parent ->
+                create_up_to_root parent scope_proto_dies all_summaries
+            in
+            let range = LB.find lexical_block_ranges block in
+            let range_list_attribute, all_summaries =
+              let dwarf_4_range_list_entries, range_list, summary =
+                create_range_list_and_summarise state fundecl range
+              in
+              match All_summaries.Map.find summary all_summaries with
+              | exception Not_found ->
+                let range_list_index =
+                  Range_list_table.add (DS.range_list_table state) range_list
+                in
+                let range_list_attribute =
+                  match !Clflags.gdwarf_version with
+                  | Four ->
+                    let range_list =
+                      Dwarf_4_range_list.create
+                        ~range_list_entries:dwarf_4_range_list_entries
+                    in
+                    Debug_ranges_table.insert (DS.debug_ranges_table state)
+                      ~range_list
+                  | Five ->
+                    DAH.create_ranges range_list_index
+                in
+                let all_summaries =
+                  All_summaries.Map.add summary range_list_attribute
+                    all_summaries
+                in
+                range_list_attribute, all_summaries
+              | range_list_attribute ->
+                range_list_attribute, all_summaries
+            in
+            let proto_die =
+              match B.frame_classification block with
+              | Lexical_scope_only ->
+                die_for_lexical_block parent range_list_attribute
+              | Inlined_frame call_site ->
+                die_for_inlined_frame state parent call_site range
+                  range_list_attribute
+            in
+            let scope_proto_dies = B.Map.add block proto_die scope_proto_dies in
+            proto_die, scope_proto_dies, all_summaries
+        in
+        let _proto_die, scope_proto_dies, all_summaries =
+          create_up_to_root block scope_proto_dies all_summaries
+        in
+        scope_proto_dies, all_summaries)
+      all_blocks
+      (B.Map.empty, All_summaries.Map.empty)
+  in
+  scope_proto_dies

--- a/asmcomp/debug/dwarf/dwarf_lexical_blocks_and_inlined_frames.mli
+++ b/asmcomp/debug/dwarf/dwarf_lexical_blocks_and_inlined_frames.mli
@@ -1,0 +1,31 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Generation of descriptions of lexical blocks and inlined frames in
+    DWARF. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val find_scope_die_from_debuginfo
+   : Debuginfo.t
+  -> function_proto_die:Proto_die.t
+  -> scope_proto_dies:Proto_die.t Debuginfo.Block.Map.t
+  -> Proto_die.t option
+
+val dwarf
+   : Dwarf_state.t
+  -> Linearize.fundecl
+  -> Lexical_block_ranges.t
+  -> function_proto_die:Proto_die.t
+  -> Proto_die.t Debuginfo.Block.Map.t

--- a/asmcomp/debug/dwarf/dwarf_modules.ml
+++ b/asmcomp/debug/dwarf/dwarf_modules.ml
@@ -1,0 +1,53 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+
+let proto_die_for_module state ~module_path ~get_parent ~module_name =
+  match DS.find_die_for_module_path state ~module_path with
+  | None ->
+    (* We don't give information about the code range for the module
+       initialiser in this DIE.  The reason is that the standard says nothing
+       about the treatment of local variables, etc., for such initialisers.
+       Furthermore, we would not want such variables being in scope in the
+       debugger whenever we are inside a function from the module. *)
+    let proto_die =
+      Proto_die.create ~parent:(Some (get_parent ()))
+        ~tag:Module
+        ~attribute_values:[
+          DAH.create_name module_name;
+        ]
+        ()
+    in
+    DS.record_die_for_module_path state ~module_path proto_die;
+    proto_die
+  | Some proto_die -> proto_die
+
+let dwarf state ~(module_path : Path.t) =
+  let rec create_up_to_root ~(module_path : Path.t) =
+    match module_path with
+    | Pident module_name ->
+      let module_name = Ident.name module_name in
+      proto_die_for_module state ~module_path ~module_name
+        ~get_parent:(fun () -> DS.compilation_unit_proto_die state)
+    | Pdot (module_path_prefix, module_name, _) ->
+      proto_die_for_module state ~module_path ~module_name
+        ~get_parent:(fun () ->
+          create_up_to_root ~module_path:module_path_prefix)
+    | Papply _ -> Misc.fatal_error "[Papply] should not occur here"
+  in
+  create_up_to_root ~module_path

--- a/asmcomp/debug/dwarf/dwarf_modules.mli
+++ b/asmcomp/debug/dwarf/dwarf_modules.mli
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Create DWARF structures representing OCaml modules. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* CR mshinwell: improve function name *)
+val dwarf
+   : Dwarf_state.t
+  -> module_path:Path.t
+  -> Proto_die.t

--- a/asmcomp/debug/dwarf/dwarf_name_laundry.ml
+++ b/asmcomp/debug/dwarf/dwarf_name_laundry.ml
@@ -1,0 +1,96 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Mark Shinwell and Thomas Refis, Jane Street Europe          *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+let base_type_die_name_for_var compilation_unit var
+      (is_parameter : Is_parameter.t) =
+  let var_name = Backend_var.name var in
+  assert (try ignore (String.index var_name ' '); false
+      with Not_found -> true);
+  let stamp = Backend_var.stamp var in
+  let is_parameter =
+    match is_parameter with
+    | Local -> ""
+    | Parameter { index; } -> Printf.sprintf " %d" index
+  in
+  Printf.sprintf "__ocaml %s %s %d%s"
+    (Compilation_unit.string_for_printing compilation_unit)
+    var_name stamp
+    is_parameter
+
+type split_base_type_die_name_result = {
+  compilation_unit : string;
+  ident_name : string;
+  ident_stamp : int;
+  is_parameter : Is_parameter.t;
+}
+
+let split_base_type_die_name name =
+  match String.split_on_char ' ' name with
+  | "__ocaml"::compilation_unit::ident_name::ident_stamp::rest ->
+    let ident_stamp = int_of_string ident_stamp in
+    let is_parameter =
+      match rest with
+      | [index] -> Is_parameter.parameter ~index:(int_of_string index)
+      | _ -> Is_parameter.local
+    in
+    Some { compilation_unit; ident_name; ident_stamp; is_parameter; }
+  | _ -> None
+
+let abstract_instance_root_die_name id =
+  let compilation_unit = Debuginfo.Function.Id.compilation_unit id in
+  let name =
+    Format.asprintf "caml__abstract_instance_%s"
+      (Debuginfo.Function.Id.to_string_for_dwarf_die_name id)
+  in
+  Asm_symbol.of_external_name (DWARF Debug_info) compilation_unit name
+
+let concrete_instance_die_name id =
+  let compilation_unit = Debuginfo.Function.Id.compilation_unit id in
+  let name =
+    Format.asprintf "caml__concrete_instance_%s"
+      (Debuginfo.Function.Id.to_string_for_dwarf_die_name id)
+  in
+  Asm_symbol.of_external_name (DWARF Debug_info) compilation_unit name
+
+let external_declaration_die_name sym compilation_unit =
+  let compilation_unit_str =
+    Compilation_unit.string_for_printing compilation_unit
+  in
+  Asm_symbol.prefix sym (DWARF Debug_info) compilation_unit
+    ~prefix:("camlDIE__" ^ compilation_unit_str ^ "__")
+
+let ocaml_value_type_name = "__ocaml_value"
+
+let ocaml_naked_float_type_name = "__ocaml_naked_float"
+
+let mangle_symbol section symbol =
+  let unit_name =
+    Linkage_name.to_string (Compilation_unit.get_linkage_name (
+      Symbol.compilation_unit symbol))
+  in
+  let symbol' =
+    Compilenv.concat_symbol unit_name
+      (Linkage_name.to_string (Symbol.label symbol))
+  in
+  Asm_symbol.of_external_name section (Symbol.compilation_unit symbol) symbol'
+
+let linker_dir_sep = '\001'
+
+let mangle_linker_dirs dirs =
+  String.concat (Printf.sprintf "%c" linker_dir_sep) dirs
+
+let demangle_linker_dirs mangled_dirs =
+  String.split_on_char linker_dir_sep mangled_dirs

--- a/asmcomp/debug/dwarf/dwarf_name_laundry.mli
+++ b/asmcomp/debug/dwarf/dwarf_name_laundry.mli
@@ -1,0 +1,61 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            Mark Shinwell and Thomas Refis, Jane Street Europe          *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** The name laundry: where names get (de)mangled.
+    (This functionality is used by the debugger support library as well as
+    the compiler.) *)
+
+(** The name of the DWARF debugging information entry corresponding to the
+    type of some identifier. *)
+val base_type_die_name_for_var
+   : Compilation_unit.t
+  -> Backend_var.t
+  -> Is_parameter.t
+  -> string
+
+(** The symbol for the DWARF debugging information entry corresponding to the
+    abstract instance root for the function with the given ID. *)
+val abstract_instance_root_die_name : Debuginfo.Function.Id.t -> Asm_symbol.t
+
+(** The symbol for the DWARF debugging information entry corresponding to the
+    concrete (non-inlined) instance for the function with the given ID. *)
+val concrete_instance_die_name : Debuginfo.Function.Id.t -> Asm_symbol.t
+
+(** The symbol for an incomplete non-defining declaration DIE for an
+    external function. *)
+val external_declaration_die_name
+   : Asm_symbol.t
+  -> Compilation_unit.t
+  -> Asm_symbol.t
+
+val ocaml_value_type_name : string
+
+val ocaml_naked_float_type_name : string
+
+type split_base_type_die_name_result = private {
+  compilation_unit : string;
+  ident_name : string;
+  ident_stamp : int;
+  is_parameter : Is_parameter.t;
+}
+
+(** The inverse of [base_type_die_name_for_var]. *)
+val split_base_type_die_name : string -> split_base_type_die_name_result option
+
+(* CR mshinwell: rename? *)
+val mangle_symbol : Asm_section.t -> Symbol.t -> Asm_symbol.t
+
+val mangle_linker_dirs : string list -> string
+
+val demangle_linker_dirs : string -> string list

--- a/asmcomp/debug/dwarf/dwarf_reg_locations.ml
+++ b/asmcomp/debug/dwarf/dwarf_reg_locations.ml
@@ -1,0 +1,87 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module SLDL = Simple_location_description_lang
+
+let reg_location_description (reg : Reg.t) ~offset_from_cfa_in_bytes
+      ~need_rvalue =
+  let module SLD = Simple_location_description in
+  (* CR-someday mshinwell: Implement support for values split across
+     registers. *)
+  if Misc.Stdlib.Option.is_some reg.part then
+    None
+  else
+    match reg.loc with
+    | Unknown ->
+      Misc.fatal_errorf "Register without location: %a" Printmach.reg reg
+    | Reg n ->
+      let dwarf_reg_number =
+        let reg_class = Proc.register_class reg in
+        let first_available_reg = Proc.first_available_register.(reg_class) in
+        let num_hard_regs = Proc.num_available_registers.(reg_class) in
+        let n = n - first_available_reg in
+        (* This [None] case isn't an error to cover situations such as found
+           in the i386 backend where [num_available_registers] does not extend
+           to the end of the register arrays (in that case for the x87 top of
+           stack register). *)
+        if n < 0 || n >= num_hard_regs then None
+        else Some (Proc.dwarf_register_numbers ~reg_class).(n)
+      in
+      begin match dwarf_reg_number with
+      | None -> None
+      | Some dwarf_reg_number ->
+        let location_description =
+          if not need_rvalue then
+            SLDL.compile (SLDL.of_lvalue (
+              SLDL.Lvalue.in_register ~dwarf_reg_number))
+          else
+            SLDL.compile (SLDL.of_rvalue (
+              SLDL.Rvalue.in_register ~dwarf_reg_number))
+        in
+        Some location_description
+      end
+    | Stack _ ->
+      match offset_from_cfa_in_bytes with
+      | None ->
+        Misc.fatal_errorf "Register %a assigned to stack but no offset \
+            from CFA provided"
+          Printmach.reg reg
+      | Some offset_from_cfa_in_bytes ->
+        if offset_from_cfa_in_bytes mod Arch.size_addr <> 0 then begin
+          Misc.fatal_errorf "Dwarf.location_list_entry: misaligned stack \
+              slot at offset %d (reg %a)"
+            offset_from_cfa_in_bytes
+            Printmach.reg reg
+        end;
+        (* CR-soon mshinwell: use [offset_in_bytes] instead *)
+        let offset_in_words =
+          Targetint.of_int_exn (offset_from_cfa_in_bytes / Arch.size_addr)
+        in
+        if not need_rvalue then
+          Some (SLDL.compile (SLDL.of_lvalue (
+            SLDL.Lvalue.in_stack_slot ~offset_in_words)))
+        else
+          Some (SLDL.compile (SLDL.of_rvalue (
+            SLDL.Rvalue.in_stack_slot ~offset_in_words)))
+
+(* CR mshinwell: Share with [Available_ranges_vars]. *)
+let offset_from_cfa_in_bytes reg stack_loc ~stack_offset =
+  let frame_size = Proc.frame_size ~stack_offset in
+  let slot_offset =
+    Proc.slot_offset stack_loc ~reg_class:(Proc.register_class reg)
+      ~stack_offset
+  in
+  Some (frame_size - slot_offset)

--- a/asmcomp/debug/dwarf/dwarf_reg_locations.mli
+++ b/asmcomp/debug/dwarf/dwarf_reg_locations.mli
@@ -1,0 +1,29 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Construction of DWARF location descriptions for registers. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val reg_location_description
+   : Reg.t
+  -> offset_from_cfa_in_bytes:int option
+  -> need_rvalue:bool
+  -> Simple_location_description.t option
+
+val offset_from_cfa_in_bytes
+   : Reg.t
+  -> Reg.stack_location
+  -> stack_offset:int
+  -> int option

--- a/asmcomp/debug/dwarf/dwarf_state.ml
+++ b/asmcomp/debug/dwarf/dwarf_state.ml
@@ -1,0 +1,108 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module V = Backend_var
+
+type t = {
+  compilation_unit_header_label : Asm_label.t;
+  compilation_unit_proto_die : Proto_die.t;
+  value_type_proto_die : Proto_die.t;
+  naked_float_type_proto_die : Proto_die.t;
+  address_table : Address_table.t;
+  debug_loc_table : Debug_loc_table.t;
+  debug_ranges_table : Debug_ranges_table.t;
+  location_list_table : Location_list_table.t;
+  range_list_table : Range_list_table.t;
+  start_of_code_symbol : Asm_symbol.t;
+  end_of_code_symbol : Asm_symbol.t;
+  mutable rvalue_dies_required_for : V.Set.t;
+  function_abstract_instances :
+    (Proto_die.t * Asm_symbol.t) Debuginfo.Function.Id.Tbl.t;
+  die_symbols_for_external_declarations : Asm_symbol.t Asm_symbol.Tbl.t;
+  supports_call_sites : bool;
+  can_reference_dies_across_units : bool;
+  dwarf_version : Dwarf_version.t;
+  type_dies_for_lifted_constants : Proto_die.t Asm_symbol.Tbl.t;
+  module_path_dies : Proto_die.t Path.Tbl.t;
+}
+
+let can_reference_dies_across_units () =
+  (* We don't know how to do this on macOS yet.  See comments in the
+     implementation of [Asm_directives.offset_into_dwarf_section_symbol]. *)
+  not (Target_system.macos_like ())
+
+let create ~compilation_unit_header_label ~compilation_unit_proto_die
+      ~value_type_proto_die ~naked_float_type_proto_die
+      ~start_of_code_symbol ~end_of_code_symbol
+      address_table debug_loc_table debug_ranges_table location_list_table
+      range_list_table dwarf_version =
+  { compilation_unit_header_label;
+    compilation_unit_proto_die;
+    value_type_proto_die;
+    naked_float_type_proto_die;
+    address_table;
+    debug_loc_table;
+    debug_ranges_table;
+    location_list_table;
+    range_list_table;
+    start_of_code_symbol;
+    end_of_code_symbol;
+    rvalue_dies_required_for = V.Set.empty;
+    function_abstract_instances = Debuginfo.Function.Id.Tbl.create 42;
+    die_symbols_for_external_declarations = Asm_symbol.Tbl.create 42;
+    supports_call_sites = Clflags.debug_thing Debug_dwarf_call_sites;
+    can_reference_dies_across_units = can_reference_dies_across_units ();
+    dwarf_version;
+    type_dies_for_lifted_constants = Asm_symbol.Tbl.create 42;
+    module_path_dies = Path.Tbl.create 42;
+  }
+
+let compilation_unit_header_label t = t.compilation_unit_header_label
+let compilation_unit_proto_die t = t.compilation_unit_proto_die
+let value_type_proto_die t = t.value_type_proto_die
+let naked_float_type_proto_die t = t.naked_float_type_proto_die
+let address_table t = t.address_table
+let debug_loc_table t = t.debug_loc_table
+let debug_ranges_table t = t.debug_ranges_table
+let location_list_table t = t.location_list_table
+let range_list_table t = t.range_list_table
+let start_of_code_symbol t = t.start_of_code_symbol
+let end_of_code_symbol t = t.end_of_code_symbol
+let rvalue_dies_required_for t = t.rvalue_dies_required_for
+let set_rvalue_dies_required_for t rvalue_dies_required_for =
+  t.rvalue_dies_required_for <- rvalue_dies_required_for
+let function_abstract_instances t = t.function_abstract_instances
+let die_symbols_for_external_declarations t =
+  t.die_symbols_for_external_declarations
+let supports_call_sites t = t.supports_call_sites
+let can_reference_dies_across_units t = t.can_reference_dies_across_units
+let dwarf_version t = t.dwarf_version
+
+let record_type_die_for_lifted_constant t symbol proto_die =
+  Asm_symbol.Tbl.replace t.type_dies_for_lifted_constants symbol proto_die
+
+let type_die_for_lifted_constant t symbol =
+  match Asm_symbol.Tbl.find t.type_dies_for_lifted_constants symbol with
+  | exception Not_found -> None
+  | proto_die -> Some proto_die
+
+let find_die_for_module_path t ~module_path =
+  match Path.Tbl.find t.module_path_dies module_path with
+  | exception Not_found -> None
+  | proto_die -> Some proto_die
+
+let record_die_for_module_path t ~module_path proto_die =
+  Path.Tbl.replace t.module_path_dies module_path proto_die

--- a/asmcomp/debug/dwarf/dwarf_state.mli
+++ b/asmcomp/debug/dwarf/dwarf_state.mli
@@ -1,0 +1,94 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** State that is shared amongst the various dwarf_* modules. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+val create
+   : compilation_unit_header_label:Asm_label.t
+  -> compilation_unit_proto_die:Proto_die.t
+  -> value_type_proto_die:Proto_die.t
+  -> naked_float_type_proto_die:Proto_die.t
+  -> start_of_code_symbol:Asm_symbol.t
+  -> end_of_code_symbol:Asm_symbol.t
+  -> Address_table.t
+  -> Debug_loc_table.t
+  -> Debug_ranges_table.t
+  -> Location_list_table.t
+  -> Range_list_table.t
+  -> Dwarf_version.t
+  -> t
+
+val compilation_unit_header_label : t -> Asm_label.t
+
+val compilation_unit_proto_die : t -> Proto_die.t
+
+val value_type_proto_die : t -> Proto_die.t
+
+val naked_float_type_proto_die : t -> Proto_die.t
+
+val address_table : t -> Address_table.t
+
+val debug_loc_table : t -> Debug_loc_table.t
+
+val debug_ranges_table : t -> Debug_ranges_table.t
+
+val location_list_table : t -> Location_list_table.t
+
+val range_list_table : t -> Range_list_table.t
+
+val start_of_code_symbol : t -> Asm_symbol.t
+
+val end_of_code_symbol : t -> Asm_symbol.t
+
+val rvalue_dies_required_for : t -> Backend_var.Set.t
+
+val set_rvalue_dies_required_for : t -> Backend_var.Set.t -> unit
+
+val function_abstract_instances
+   : t
+  -> (Proto_die.t * Asm_symbol.t) Debuginfo.Function.Id.Tbl.t
+
+val die_symbols_for_external_declarations : t -> Asm_symbol.t Asm_symbol.Tbl.t
+
+val supports_call_sites : t -> bool
+
+val can_reference_dies_across_units : t -> bool
+
+val dwarf_version : t -> Dwarf_version.t
+
+val record_type_die_for_lifted_constant
+   : t
+  -> Asm_symbol.t
+  -> Proto_die.t
+  -> unit
+
+val type_die_for_lifted_constant
+   : t
+  -> Asm_symbol.t
+  -> Proto_die.t option
+
+val find_die_for_module_path
+   : t
+  -> module_path:Path.t
+  -> Proto_die.t option
+
+val record_die_for_module_path
+   : t
+  -> module_path:Path.t
+  -> Proto_die.t
+  -> unit

--- a/asmcomp/debug/dwarf/dwarf_toplevel_values.ml
+++ b/asmcomp/debug/dwarf/dwarf_toplevel_values.ml
@@ -1,0 +1,133 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+module SLDL = Simple_location_description_lang
+
+let dwarf_for_toplevel_constant state
+      (provenance : Clambda.usymbol_provenance option) ~symbol
+      (const : Clambda.preallocated_constant) =
+  let symbol = Asm_symbol.create symbol in
+  let common_attributes =
+    [ DAH.create_const_value_from_symbol ~symbol;
+      (* Mark everything as "external" so gdb puts the constants in its
+         list of "global symbols". *)
+      DAH.create_external ~is_visible_externally:true;
+    ]
+  in
+  let vars_and_module_path =
+    match provenance with
+    | None -> None
+    | Some provenance ->
+      Some (provenance.idents_for_types, provenance.module_path)
+  in
+  match vars_and_module_path with
+  | None ->
+    (* No name is provided, so the debugger should hide this constant
+       definition from the user; but it can still be referenced from
+       elsewhere in the DWARF information. *)
+    let type_attributes =
+      match const.definition with
+      | Uconst_float _
+      | Uconst_int32 _
+      | Uconst_int64 _
+      | Uconst_nativeint _
+      | Uconst_block _
+      | Uconst_float_array _ 
+      | Uconst_string _
+      | Uconst_closure _ ->
+        (* The best we can do here, since we haven't got a source-level
+           variable (and hence no OCaml type), is to have the debugger print
+           the constant based only on what is found in the heap. *)
+        let type_die = DS.value_type_proto_die state in
+        [ DAH.create_type_from_reference
+            ~proto_die_reference:(Proto_die.reference type_die)
+        ]
+    in
+    Proto_die.create_ignore
+      ~parent:(Some (DS.compilation_unit_proto_die state))
+      ~tag:Constant
+      ~attribute_values:(common_attributes @ type_attributes)
+      ()
+  | Some (vars, module_path) ->
+    (* Give each variable bound to this symbol the same definition for the
+       moment. *)
+    let parent = Some (Dwarf_modules.dwarf state ~module_path) in
+    List.iter (fun var ->
+        let name =
+          let path = Printtyp.string_of_path module_path in
+          let name = Backend_var.name var in
+          path ^ "." ^ name
+        in
+        let type_proto_die =
+          Dwarf_variables_and_parameters.normal_type_for_var
+            ~parent
+            (Some (Compilation_unit.get_current_exn (), var))
+            Is_parameter.local
+        in
+        (* The type DIE is noted down so that, when we find a call site one
+           of whose arguments contains [symbol], we can link to it. *)
+        DS.record_type_die_for_lifted_constant state symbol type_proto_die;
+        Proto_die.create_ignore
+          ~parent
+          ~tag:Constant
+          ~attribute_values:(common_attributes @ [
+            DAH.create_name name;
+            DAH.create_type ~proto_die:type_proto_die;
+          ])
+          ())
+      vars
+
+let dwarf_for_toplevel_constants state constants =
+  List.iter (fun (constant : Clambda.preallocated_constant) ->
+      match constant.definition with
+      | Uconst_closure _ ->
+        (* Function declarations are emitted separately.  There's no more
+           information that we require in a toplevel constant closure. *)
+        ()
+      | _ ->
+        dwarf_for_toplevel_constant state constant.provenance
+          ~symbol:constant.symbol constant)
+    constants
+
+let dwarf_for_closure_top_level_module_block state ~module_block_sym
+      ~module_block_var =
+  assert (not Config.flambda);
+  let name = Backend_var.name module_block_var in
+  let type_proto_die =
+    Dwarf_variables_and_parameters.normal_type_for_var
+      ~parent:(Some (DS.compilation_unit_proto_die state))
+      (Some (Compilation_unit.get_current_exn (), module_block_var))
+      Is_parameter.local
+  in
+  let single_location_description =
+    let symbol = Asm_symbol.create module_block_sym in
+    let lang =
+      SLDL.Lvalue_without_address.of_rvalue (SLDL.Rvalue.const_symbol symbol)
+    in
+    Single_location_description.of_simple_location_description
+      (SLDL.compile (SLDL.of_lvalue_without_address lang))
+  in
+  Proto_die.create_ignore ~parent:(Some (DS.compilation_unit_proto_die state))
+    ~tag:Variable
+    ~attribute_values:[
+      DAH.create_name name;
+      DAH.create_type ~proto_die:type_proto_die;
+      DAH.create_single_location_description single_location_description;
+      DAH.create_external ~is_visible_externally:true;
+    ]
+    ()

--- a/asmcomp/debug/dwarf/dwarf_toplevel_values.mli
+++ b/asmcomp/debug/dwarf/dwarf_toplevel_values.mli
@@ -1,0 +1,33 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Emission of DWARF information relating to lifted (statically allocated)
+    constants. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** For dealing with constants lifted by [Closure]; and Flambda's [Let_symbol]
+    bindings. *)
+val dwarf_for_toplevel_constants
+   : Dwarf_state.t
+  -> Clambda.preallocated_constant list
+  -> unit
+
+(** For dealing with [Closure]'s top level module blocks.  The symbol for
+    the module block and the corresponding variable must be provided. *)
+val dwarf_for_closure_top_level_module_block
+   : Dwarf_state.t
+  -> module_block_sym:Backend_sym.t
+  -> module_block_var:Backend_var.t
+  -> unit

--- a/asmcomp/debug/dwarf/dwarf_variables_and_parameters.ml
+++ b/asmcomp/debug/dwarf/dwarf_variables_and_parameters.ml
@@ -1,0 +1,927 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module ARV = Available_ranges_all_vars
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+module L = Linearize
+module SLDL = Simple_location_description_lang
+module V = Backend_var
+
+type var_uniqueness = {
+  name_is_unique : bool;
+  position_is_unique_given_name_is_unique : bool;
+}
+
+module Var_name_and_code_range = struct
+  type t = string * (Debuginfo.Code_range.t option)
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare (name1, range_opt1) (name2, range_opt2) =
+      let c = String.compare name1 name2 in
+      if c <> 0 then c
+      else
+        match range_opt1, range_opt2 with
+        | None, None -> 0
+        | None, Some _ -> -1
+        | Some _, None -> 1
+        | Some range1, Some range2 ->
+          Debuginfo.Code_range.compare range1 range2
+
+    let equal t1 t2 = (compare t1 t2 = 0)
+
+    let hash (name, range_opt) =
+      match range_opt with
+      | None -> Hashtbl.hash (name, None)
+      | Some range ->
+        Hashtbl.hash (name, Some (Debuginfo.Code_range.hash range))
+
+    let print _ _ = Misc.fatal_error "Not yet implemented"
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end
+
+type is_variable_phantom = Non_phantom | Phantom
+
+type proto_dies_for_var = {
+  is_variable_phantom : is_variable_phantom;
+  value_die_lvalue : Proto_die.reference;
+  value_die_rvalue : Proto_die.reference;
+  type_die : Proto_die.reference;
+}
+
+let arch_size_addr = Targetint.of_int_exn Arch.size_addr
+
+(* Note: this function only works for static (toplevel) variables because we
+   assume they all occur in a single compilation unit (namely the startup
+   one). *)
+let calculate_var_uniqueness ~available_ranges_vars =
+  let module String = Misc.Stdlib.String in
+  let by_name = String.Tbl.create 42 in
+  let by_position = Var_name_and_code_range.Tbl.create 42 in
+  let update_uniqueness var pos ~module_path =
+    let name = Backend_var.name_for_debugger var in
+    let name =
+      match module_path with
+      | None -> name
+      | Some module_path -> Format.asprintf "%a.%s" Path.print module_path name
+    in
+    begin match String.Tbl.find by_name name with
+    | exception Not_found ->
+      String.Tbl.add by_name name (Backend_var.Set.singleton var)
+    | vars ->
+      String.Tbl.replace by_name name (Backend_var.Set.add var vars)
+    end;
+    begin match Var_name_and_code_range.Tbl.find by_position (name, pos) with
+    | exception Not_found ->
+      Var_name_and_code_range.Tbl.add by_position (name, pos)
+        (Backend_var.Set.singleton var)
+    | vars ->
+      Var_name_and_code_range.Tbl.replace by_position (name, pos)
+        (Backend_var.Set.add var vars)
+    end
+  in
+  let result = Backend_var.Tbl.create 42 in
+  ARV.iter available_ranges_vars
+    ~f:(fun var range ->
+      let range_info = ARV.Range.info range in
+      let provenance = ARV.Range_info.provenance range_info in
+      let module_path =
+        (* The startup function may contain phantom let bindings for
+           static identifiers that have various different (sub)module paths. *)
+        match provenance with
+        | None -> None
+        | Some provenance ->
+          if not (V.Provenance.is_static provenance) then None
+          else Some (V.Provenance.module_path provenance)
+      in
+      let dbg = ARV.Range_info.debuginfo range_info in
+      let pos = Debuginfo.position dbg in
+      update_uniqueness var pos ~module_path;
+      Backend_var.Tbl.replace result var
+        { name_is_unique = false;
+          position_is_unique_given_name_is_unique = false;
+        });
+  String.Tbl.iter (fun _name vars ->
+      match Backend_var.Set.get_singleton vars with
+      | None -> ()
+      | Some var ->
+        let var_uniqueness = Backend_var.Tbl.find result var in
+        Backend_var.Tbl.replace result var
+          { var_uniqueness with
+            name_is_unique = true;
+          })
+    by_name;
+  (* Note that [by_position] isn't of type [_ Debuginfo.Code_range.Map.t].
+     The reason that the [Backend_var.t] is included in the key is because we
+     need to make a judgement as to whether two variables have the same
+     position _given also that they have the same name_.  (See the
+     computations in [dwarf_for_variable], below.) *)
+  Var_name_and_code_range.Tbl.iter (fun _var_and_pos vars ->
+      match Backend_var.Set.get_singleton vars with
+      | None -> ()
+      | Some var ->
+        let var_uniqueness = Backend_var.Tbl.find result var in
+        Backend_var.Tbl.replace result var
+          { var_uniqueness with
+            position_is_unique_given_name_is_unique = true;
+          })
+    by_position;
+  result
+
+let proto_dies_for_variable var ~proto_dies_for_vars =
+  match Backend_var.Tbl.find proto_dies_for_vars var with
+  | exception Not_found -> None
+  | result -> Some result
+
+let normal_type_for_var ?reference ~parent ident_for_type is_parameter =
+  let name_attribute =
+    match ident_for_type with
+    | None -> []
+    | Some (compilation_unit, var) ->
+      let name =
+        Dwarf_name_laundry.base_type_die_name_for_var compilation_unit var
+          is_parameter
+      in
+      [DAH.create_name name]
+  in
+  (* CR mshinwell: This should not create duplicates when the name is
+     missing *)
+  Proto_die.create ?reference
+    ~parent
+    ~tag:Base_type
+    ~attribute_values:(name_attribute @ [
+      DAH.create_encoding ~encoding:Encoding_attribute.signed;
+      DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
+    ])
+    ()
+
+let type_die_reference_for_var var ~proto_dies_for_vars =
+  match proto_dies_for_variable var ~proto_dies_for_vars with
+  | None -> None
+  | Some dies -> Some dies.type_die
+
+(* Build a new DWARF type for [var].  Each variable has its
+   own type, which is basically its stamped name, and is nothing to do with
+   its inferred OCaml type.  The inferred type may be recovered by the
+   debugger by extracting the stamped name and then using that as a key
+   for lookup into the .cmt file for the appropriate module.
+
+   We emit the parameter index into the type if the variable in question
+   is a function parameter.  This is used in the debugger support library.
+   It would be nice not to have to have this hack, but it avoids changes
+   in the main gdb code to pass parameter indexes to the printing function.
+   It is arguably more robust, too.
+*)
+(* CR mshinwell: Add proper type for [ident_for_type] *)
+let construct_type_of_value_description state ~parent ident_for_type
+      ~(phantom_defining_expr : ARV.Range_info.phantom_defining_expr)
+      is_parameter ~proto_dies_for_vars ~reference =
+  let normal_case () =
+    let (_ : Proto_die.t) =
+      normal_type_for_var ~reference ~parent ident_for_type is_parameter
+    in
+    ()
+  in
+  let name_attribute =
+    match ident_for_type with
+    | None -> []
+    | Some (compilation_unit, var) ->
+      let name =
+        Dwarf_name_laundry.base_type_die_name_for_var compilation_unit var
+          is_parameter
+      in
+      [DAH.create_name name]
+  in
+  match phantom_defining_expr with
+  | Non_phantom -> normal_case ()
+  | Phantom defining_expr ->
+    match defining_expr with
+    | Iphantom_const_int _
+    | Iphantom_const_symbol _
+    | Iphantom_read_symbol_field _ -> normal_case ()
+    | Iphantom_var var ->
+      let type_attribute_value =
+        match type_die_reference_for_var var ~proto_dies_for_vars with
+        | None ->
+          (* This (and other similar cases below) guard against the case where
+             a variable referenced in the defining expression of a phantom
+             variable doesn't have any available range. *)
+          DAH.create_type ~proto_die:(DS.value_type_proto_die state)
+        | Some target_type ->
+          DAH.create_type_from_reference ~proto_die_reference:target_type
+      in
+      let _proto_die : Proto_die.t =
+        Proto_die.create ~reference
+          ~parent
+          ~tag:Typedef
+          ~attribute_values:(name_attribute @ [
+            type_attribute_value;
+          ])
+          ()
+      in
+      ()
+    | Iphantom_read_field { var = _; field = _; } ->
+      (* We cannot dereference an implicit pointer when evaluating a DWARF
+         location expression, which means we must restrict ourselves to 
+         projections from non-phantom identifiers. *)
+      normal_case ()
+    | Iphantom_offset_var { var = _; offset_in_words = _; } ->
+      (* The same applies here as for [Iphantom_read_var_field] above, but we
+         never generate this for phantom identifiers at present (it is only
+         used for offsetting a closure environment variable). *)
+      normal_case ()
+    | Iphantom_block { tag = _; fields; } ->
+      (* The block will be described as a composite location expression
+         pointed at by an implicit pointer.  The corresponding type is
+         a pointer type whose target type is a structure type; the members of
+         the structure correspond to the fields of the block (plus the
+         header).  We don't use DWARF array types as we need to describe a
+         different type for each field. *)
+      let struct_type_die =
+        Proto_die.create ~parent
+          ~tag:Structure_type
+          ~attribute_values:[
+            DAH.create_name "<block>";
+            DAH.create_byte_size_exn
+              ~byte_size:((1 + List.length fields) * Arch.size_addr);
+          ]
+          ()
+      in
+      List.iteri (fun index field ->
+          let name = string_of_int (index - 1) in
+          let type_attribute =
+            match field with
+            | None ->
+              DAH.create_type ~proto_die:(DS.value_type_proto_die state)
+            | Some var ->
+              (* It's ok if [var] is a phantom identifier, since we will
+                 be building a composite location expression to describe the
+                 structure, and implicit pointers are permitted there.  (That
+                 is to say, the problem for [Iphantom_read_var_field] above
+                 does not exist here). *)
+              match type_die_reference_for_var var ~proto_dies_for_vars with
+              | None ->
+                DAH.create_type ~proto_die:(DS.value_type_proto_die state)
+              | Some proto_die_reference ->
+                DAH.create_type_from_reference ~proto_die_reference
+          in
+          Proto_die.create_ignore ~sort_priority:index
+            ~parent:(Some struct_type_die)
+            ~tag:Member
+            ~attribute_values:(type_attribute :: name_attribute @ [
+              DAH.create_name name;
+              DAH.create_bit_size (Int64.of_int (Arch.size_addr * 8));
+              DAH.create_data_member_location
+                ~byte_offset:(Int64.of_int (index * Arch.size_addr));
+            ])
+            ())
+        (None :: fields);  (* "None" is for the GC header. *)
+      let _pointer_to_struct_type_die : Proto_die.t =
+        Proto_die.create ~reference ~parent
+          ~tag:Pointer_type
+          ~attribute_values:(name_attribute @ [
+            DAH.create_type ~proto_die:struct_type_die;
+          ])
+          ()
+      in
+      ()
+
+let is_variable_phantom var ~proto_dies_for_vars =
+  match proto_dies_for_variable var ~proto_dies_for_vars with
+  | None -> None
+  | Some { is_variable_phantom; _ } -> Some is_variable_phantom
+
+let die_location_of_variable_lvalue state var ~proto_dies_for_vars =
+  (* We may need to reference the locations of other values in order to
+     describe the location of some particular value.  This is done by using
+     the "call" functionality of DWARF location descriptions.
+     (DWARF-4 specification section 2.5.1.5, page 24.)  This avoids any need
+     to transitively resolve phantom lets (to constants, symbols or
+     non-phantom variables) in the compiler. *)
+  match proto_dies_for_variable var ~proto_dies_for_vars with
+  | None -> None
+  | Some { value_die_lvalue; _; } ->
+    let location =
+      SLDL.Lvalue.location_from_another_die
+        ~die_label:value_die_lvalue
+        ~compilation_unit_header_label:(DS.compilation_unit_header_label state)
+    in
+    Some location
+
+let die_location_of_variable_rvalue state var ~proto_dies_for_vars =
+  match proto_dies_for_variable var ~proto_dies_for_vars with
+  | None -> None
+  | Some { value_die_rvalue; _; } ->
+    DS.set_rvalue_dies_required_for state
+      (V.Set.add var (DS.rvalue_dies_required_for state));
+    let location =
+      SLDL.Rvalue.location_from_another_die
+        ~die_label:value_die_rvalue
+        ~compilation_unit_header_label:(DS.compilation_unit_header_label state)
+    in
+    Some location
+
+type location_description =
+  | Simple of Simple_location_description.t
+  | Composite of Composite_location_description.t
+
+let reg_location_description reg ~offset_from_cfa_in_bytes
+      ~need_rvalue : location_description option =
+  match
+    Dwarf_reg_locations.reg_location_description reg
+      ~offset_from_cfa_in_bytes ~need_rvalue
+  with
+  | None -> None
+  | Some simple_loc_desc -> Some (Simple simple_loc_desc)
+
+(* Phantom-let-bound variables are always immutable, so we don't actually
+   need lvalue (in the sense of the [SLDL] module) descriptions for them.
+   (For example, we'll never need to watchpoint them.)  However, to be
+   consistent with normal variables, we always emit lvalue descriptions (and
+   emit rvalue descriptions only when required). *)
+let phantom_var_location_description state
+      ~(defining_expr : Mach.phantom_defining_expr) ~need_rvalue
+      ~proto_dies_for_vars ~parent
+      : location_description option =
+  let module SLD = Simple_location_description in
+  let lvalue lvalue = Some (Simple (SLDL.compile (SLDL.of_lvalue lvalue))) in
+  let lvalue_without_address lvalue =
+    Some (Simple (SLDL.compile (SLDL.of_lvalue_without_address lvalue)))
+  in
+  let rvalue rvalue = Some (Simple (SLDL.compile (SLDL.of_rvalue rvalue))) in
+  match defining_expr with
+  | Iphantom_const_int i ->
+    let i = SLDL.Rvalue.signed_int_const i in
+    if need_rvalue then rvalue i
+    else lvalue_without_address (SLDL.Lvalue_without_address.of_rvalue i)
+  | Iphantom_const_symbol symbol ->
+    let symbol = SLDL.Rvalue.const_symbol (Asm_symbol.create symbol) in
+    if need_rvalue then rvalue symbol
+    else lvalue_without_address (SLDL.Lvalue_without_address.of_rvalue symbol)
+  | Iphantom_read_symbol_field { sym; field; } ->
+    let symbol = Asm_symbol.create sym in
+    (* CR-soon mshinwell: Fix [field] to be of type [Targetint.t] *)
+    let field = Targetint.of_int field in
+    if need_rvalue then rvalue (SLDL.Rvalue.read_symbol_field symbol ~field)
+    else lvalue (SLDL.Lvalue.in_symbol_field symbol ~field)
+  | Iphantom_var var ->
+    (* mshinwell: What happens if [var] isn't available at some point
+       just due to the location list?  Should we push zero on the stack
+       first?  Or can we detect the stack is empty?  Or does gdb just abort
+       evaluation of the whole thing if the location list doesn't match?
+       mshinwell: The answer seems to be that you get an error saying
+       that you tried to pop something from an empty stack.  What we do
+       now is to wrap the location description in a composite location
+       description (with only one piece), which then causes gdb to
+       correctly detect unavailability. *)
+    (* CR-someday mshinwell: consider DWARF extension to avoid this?
+       The problem is worse for the read-field/read-var cases below,
+       since I think the (e.g.) dereferencing needs to be inside the piece
+       delimiters, exposing us to an error.  At the moment this should just
+       get caught by the exception handler in libmonda, but even still, a
+       better solution would be desirable.  Follow-up: actually it doesn't
+       get that far---the error is thrown even before the value printer
+       is called. *)
+    if need_rvalue then
+      begin match
+        die_location_of_variable_rvalue state var ~proto_dies_for_vars
+      with
+      | None -> None
+      | Some rvalue ->
+        let location = SLDL.compile (SLDL.of_rvalue rvalue) in
+        let composite =
+          Composite_location_description.
+            pieces_of_simple_location_descriptions
+              [location, arch_size_addr]
+        in
+        Some (Composite composite)
+      end
+    else
+      begin match
+        die_location_of_variable_lvalue state var ~proto_dies_for_vars
+      with
+      | None -> None
+      | Some lvalue ->
+        let location = SLDL.compile (SLDL.of_lvalue lvalue) in
+        let composite =
+          Composite_location_description.
+            pieces_of_simple_location_descriptions
+              [location, arch_size_addr]
+        in
+        Some (Composite composite)
+      end
+  | Iphantom_read_field { var; field; } ->
+    begin match is_variable_phantom var ~proto_dies_for_vars with
+    | None | Some Phantom ->
+      (* For the moment, show this field access as unavailable, since we
+         cannot "DW_OP_deref" a value built up with implicit pointers. *)
+      None
+    | Some Non_phantom ->
+      match die_location_of_variable_rvalue state var ~proto_dies_for_vars with
+      | None -> None
+      | Some block ->
+        let field = Targetint.of_int_exn field in
+        if need_rvalue then
+          let read_field =
+            SLDL.compile (SLDL.of_rvalue (SLDL.Rvalue.read_field ~block ~field))
+          in
+          let composite =
+            Composite_location_description.
+              pieces_of_simple_location_descriptions
+                [read_field, arch_size_addr]
+          in
+          Some (Composite composite)
+        else
+          lvalue (SLDL.Lvalue.read_field ~block ~field)
+    end
+  | Iphantom_offset_var { var; offset_in_words; } ->
+    begin match
+      die_location_of_variable_lvalue state var ~proto_dies_for_vars
+    with
+    | None -> None
+    | Some location ->
+      let offset_in_words = Targetint.of_int_exn offset_in_words in
+      if need_rvalue then None
+      else lvalue (SLDL.Lvalue.offset_pointer location ~offset_in_words)
+    end
+  | Iphantom_block { tag; fields; } ->
+    (* A phantom block construction: instead of the block existing in the
+       target program's address space, it is going to be conjured up in the
+       *debugger's* address space using instructions described in DWARF.
+       References between such blocks do not use normal pointers in the
+       target's address space---instead they use "implicit pointers"
+       (requires GNU DWARF extensions prior to DWARF-5). *)
+    (* CR-someday mshinwell: use a cache to dedup the CLDs *)
+    let header =
+      SLDL.compile (SLDL.of_rvalue (SLDL.Rvalue.signed_int_const (
+        Targetint.of_int64 (Int64.of_nativeint (
+          Cmmgen.black_block_header tag (List.length fields))))))
+    in
+    let header_size = arch_size_addr in
+    let field_size = arch_size_addr in
+    let fields =
+      List.map (fun var ->
+          let simple_location_description =
+            match var with
+            | None ->
+              (* This element of the block isn't accessible. *)
+              []
+            | Some ident ->
+              match
+                die_location_of_variable_rvalue state ident
+                  ~proto_dies_for_vars
+              with
+              | None -> []
+              | Some rvalue -> SLDL.compile (SLDL.of_rvalue rvalue)
+          in
+          simple_location_description, field_size)
+        fields
+    in
+    let composite_location_description =
+      Composite_location_description.pieces_of_simple_location_descriptions
+        ((header, header_size) :: fields)
+    in
+    let proto_die =
+      Proto_die.create ~parent
+        ~tag:Variable
+        ~attribute_values:[
+          DAH.create_composite_location_description
+            composite_location_description;
+        ]
+        ()
+    in
+    let offset_in_bytes = Targetint.zero in
+    let die_label = Proto_die.reference proto_die in
+    let version = DS.dwarf_version state in
+    if need_rvalue then
+      rvalue (SLDL.Rvalue.implicit_pointer ~offset_in_bytes ~die_label version)
+    else
+      lvalue_without_address (SLDL.Lvalue_without_address.implicit_pointer
+        ~offset_in_bytes ~die_label version)
+
+let single_location_description state (_fundecl : L.fundecl) ~parent ~subrange
+      ~proto_dies_for_vars ~need_rvalue =
+  let location_description =
+    match ARV.Subrange.info subrange with
+    | Non_phantom { reg; offset_from_cfa_in_bytes; } ->
+      reg_location_description reg ~offset_from_cfa_in_bytes ~need_rvalue
+    | Phantom defining_expr ->
+      phantom_var_location_description state ~defining_expr
+        ~need_rvalue ~proto_dies_for_vars ~parent
+  in
+  match location_description with
+  | None -> None
+  | Some (Simple simple) ->
+    Some (Single_location_description.of_simple_location_description simple)
+  | Some (Composite composite) ->
+    Some (Single_location_description.of_composite_location_description
+      composite)
+
+let single_phantom_location_description state ~parent ~proto_dies_for_vars
+      ~need_rvalue defining_expr =
+  let location_description =
+    phantom_var_location_description state ~defining_expr
+      ~need_rvalue ~proto_dies_for_vars ~parent
+  in
+  match location_description with
+  | None -> None
+  | Some (Simple simple) ->
+    Some (Single_location_description.of_simple_location_description simple)
+  | Some (Composite composite) ->
+    Some (Single_location_description.of_composite_location_description
+      composite)
+
+type location_list_entry =
+  | Dwarf_4 of Dwarf_4_location_list_entry.t
+  | Dwarf_5 of Location_list_entry.t
+
+let location_list_entry state ~subrange single_location_description
+      : location_list_entry =
+  let start_pos =
+    Asm_label.create_int Text (ARV.Subrange.start_pos subrange)
+  in
+  let start_pos_offset = ARV.Subrange.start_pos_offset subrange in
+  let end_pos =
+    Asm_label.create_int Text (ARV.Subrange.end_pos subrange)
+  in
+  let end_pos_offset = ARV.Subrange.end_pos_offset subrange in
+  match !Clflags.gdwarf_version with
+  | Four ->
+    let location_list_entry =
+      Dwarf_4_location_list_entry.create_location_list_entry
+        ~start_of_code_symbol:(DS.start_of_code_symbol state)
+        ~first_address_when_in_scope:start_pos
+        ~first_address_when_in_scope_offset:(Some start_pos_offset)
+        ~first_address_when_not_in_scope:end_pos
+        ~first_address_when_not_in_scope_offset:(Some end_pos_offset)
+        ~single_location_description
+    in
+    Dwarf_4 location_list_entry
+  | Five ->
+    let start_inclusive =
+      Address_table.add (DS.address_table state) start_pos
+        ~adjustment:start_pos_offset
+        ~start_of_code_symbol:(DS.start_of_code_symbol state)
+    in
+    let end_exclusive =
+      Address_table.add (DS.address_table state) end_pos
+        ~adjustment:end_pos_offset
+        ~start_of_code_symbol:(DS.start_of_code_symbol state)
+    in
+    let loc_desc =
+      Counted_location_description.create single_location_description
+    in
+    let location_list_entry : Location_list_entry.entry =
+      (* DWARF-5 spec page 45 line 1. *)
+      Startx_endx {
+        start_inclusive;
+        end_exclusive;
+        payload = loc_desc;
+      }
+    in
+    Dwarf_5 (Location_list_entry.create location_list_entry
+      ~start_of_code_symbol:(DS.start_of_code_symbol state))
+
+let dwarf_for_variable state (fundecl : L.fundecl) ~function_proto_die
+      ~scope_proto_dies ~uniqueness_by_var ~proto_dies_for_vars
+      ~need_rvalue (var : Backend_var.t) ~phantom:_ ~hidden ~ident_for_type
+      ~range =
+  let range_info = ARV.Range.info range in
+  let provenance = ARV.Range_info.provenance range_info in
+  let var_is_a_parameter_of_fundecl_itself =
+    match ARV.Range_info.is_parameter range_info with
+    | Local -> false
+    | Parameter _ -> true
+  in
+  let is_static =
+    match provenance with
+    | None -> false
+    | Some provenance -> V.Provenance.is_static provenance
+  in
+  let phantom_defining_expr = ARV.Range_info.phantom_defining_expr range_info in
+  let (parent_proto_die : Proto_die.t), hidden =
+    if var_is_a_parameter_of_fundecl_itself then
+      function_proto_die, hidden
+    else if is_static then
+      begin match provenance with
+      | None -> DS.compilation_unit_proto_die state, hidden
+      | Some provenance ->
+        let module_path = V.Provenance.module_path provenance in
+        Dwarf_modules.dwarf state ~module_path, hidden
+      end
+    else
+      (* Local variables need to be children of "lexical blocks", which in turn
+         are children of the function.  It is important to generate accurate
+         lexical block information to avoid large numbers of variables, many
+         of which may be out of scope, being visible in the debugger at the
+         same time. *)
+      match provenance with
+      | None ->
+        (* Any variable without provenance gets hidden. *)
+        function_proto_die, true
+      | Some provenance ->
+        let dbg = Backend_var.Provenance.debuginfo provenance in
+        let block_die =
+          Dwarf_lexical_blocks_and_inlined_frames.find_scope_die_from_debuginfo
+            dbg ~function_proto_die ~scope_proto_dies
+        in
+        match block_die with
+        | Some block_die -> block_die, hidden
+        | None ->
+          (* There are be no instructions marked with the block in which
+             [var] was defined.  For the moment, just hide [var]. *)
+          function_proto_die, true
+  in
+  let location_attribute_value, location_list_in_debug_loc_table =
+    if is_static then begin
+      (* The location of a static (toplevel) variable is invariant under changes
+         to the program counter. As such a location list is not needed. *)
+      (* CR-someday mshinwell: In the future we should work out how to make
+         static variables be properly scoped with respect to the
+         interleaving function definitions.  Then, we would use the actual
+         calculated subranges here.  This work requires not only changes in
+         the OCaml middle end but also a determination as to whether GDB can
+         support the necessary scoping. *)
+      match phantom_defining_expr with
+      | Non_phantom -> [], None  (* Should have been caught below. *)
+      | Phantom defining_expr ->
+        if not (Mach.phantom_defining_expr_definitely_static defining_expr)
+        then begin
+          Misc.fatal_errorf "Variable %a bound by phantom let has defining \
+              expression that might not be invariant under changes to the \
+              program counter: %a"
+            V.print var
+            Printmach.phantom_defining_expr defining_expr
+        end;
+        let single_location_description =
+          single_phantom_location_description state
+            ~parent:(Some (DS.compilation_unit_proto_die state))
+            ~proto_dies_for_vars ~need_rvalue defining_expr
+        in
+        match single_location_description with
+        | None -> [], None
+        | Some single_location_description ->
+          [DAH.create_single_location_description single_location_description;
+           DAH.create_external ~is_visible_externally:true;
+          ], None
+    end else begin
+      (* Build a location list that identifies where the value of [var] may be
+         found at runtime, indexed by program counter range. The representations
+         of location lists (and range lists, used below to describe lexical
+         blocks) changed completely between DWARF-4 and DWARF-5. *)
+      let dwarf_4_location_list_entries, location_list =
+        ARV.Range.fold range
+          ~init:([], Location_list.create ())
+          ~f:(fun (dwarf_4_location_list_entries, location_list) subrange ->
+            let single_location_description =
+              single_location_description state fundecl
+                ~parent:(Some function_proto_die)
+                ~subrange ~proto_dies_for_vars ~need_rvalue
+            in
+            match single_location_description with
+            | None -> dwarf_4_location_list_entries, location_list
+            | Some single_location_description ->
+              let location_list_entry =
+                location_list_entry state ~subrange single_location_description
+              in
+              match location_list_entry with
+              | Dwarf_4 location_list_entry ->
+                let dwarf_4_location_list_entries =
+                  location_list_entry :: dwarf_4_location_list_entries
+                in
+                dwarf_4_location_list_entries, location_list
+              | Dwarf_5 location_list_entry ->
+                let location_list =
+                  Location_list.add location_list location_list_entry
+                in
+                dwarf_4_location_list_entries, location_list)
+      in
+      match !Clflags.gdwarf_version with
+      | Four ->
+        let location_list_entries = dwarf_4_location_list_entries in
+        let location_list =
+          Dwarf_4_location_list.create ~location_list_entries
+        in
+        [Debug_loc_table.attribute_to_reference_location_list location_list],
+          Some location_list
+      | Five ->
+        let location_list_index =
+          Location_list_table.add (DS.location_list_table state) location_list
+        in
+        [DAH.create_location location_list_index], None
+    end
+  in
+  let is_parameter =
+    let is_parameter_from_provenance =
+      match provenance with
+      | None -> Is_parameter.local
+      | Some provenance -> Backend_var.Provenance.is_parameter provenance
+    in
+    (* The two inputs here correspond to:
+       1. The normal case of parameters of function declarations, which are
+          identified in [Selectgen].
+       2. Parameters of inlined functions, which have to be tagged much
+          earlier, on [let]-bindings when inlining is performed. *)
+    Is_parameter.join (ARV.Range_info.is_parameter range_info)
+      is_parameter_from_provenance
+  in
+  let type_and_name_attributes =
+    match type_die_reference_for_var var ~proto_dies_for_vars with
+    | None -> []
+    | Some reference ->
+      let name_is_unique, position_is_unique_given_name_is_unique =
+        match Backend_var.Tbl.find uniqueness_by_var var with
+        | exception Not_found ->
+          Misc.fatal_errorf "No uniqueness information for %a"
+            Backend_var.print var
+        | { name_is_unique; position_is_unique_given_name_is_unique; } ->
+          name_is_unique, position_is_unique_given_name_is_unique
+      in
+      let name_for_var =
+        if name_is_unique then begin
+          Backend_var.name_for_debugger var
+        end else if position_is_unique_given_name_is_unique then begin
+          match provenance with
+          | None -> Backend_var.unique_name_for_debugger var
+          | Some provenance ->
+            let dbg = Backend_var.Provenance.debuginfo provenance in
+            match Debuginfo.position dbg with
+            | None -> Backend_var.unique_name_for_debugger var
+            | Some position ->
+              Format.asprintf "%s[%a]"
+                (Backend_var.name_for_debugger var)
+                Debuginfo.Code_range.print_compact_without_dirname position
+        end else begin
+          Backend_var.unique_name_for_debugger var
+        end
+      in
+      (* CR-someday mshinwell: This should be tidied up.  It's only correct by
+         virtue of the fact we do the closure-env ones second below. *)
+      (* CR mshinwell: re-check this CR-someday *)
+      let type_attribute =
+        if not need_rvalue then begin
+          construct_type_of_value_description state
+            ~parent:(Some (DS.compilation_unit_proto_die state))
+            ident_for_type is_parameter ~phantom_defining_expr
+            ~proto_dies_for_vars ~reference
+        end;
+        [DAH.create_type_from_reference ~proto_die_reference:reference;
+        ]
+      in
+      let name_attribute =
+        if hidden || need_rvalue then []
+        else [DAH.create_name name_for_var]
+      in
+      name_attribute @ type_attribute
+  in
+  let tag : Dwarf_tag.t =
+    match is_parameter with
+    | Parameter _index ->
+      (* The lvalue DIE is the "normal" one for variables and parameters; it
+         is the one that is marked with a name, for example.  To avoid
+         erroneous display of, or confusion around, rvalue DIEs we always
+         mark them as variables not parameters. *)
+      if need_rvalue then Variable
+      else Formal_parameter
+    | Local -> Variable
+  in
+  let reference =
+    match proto_dies_for_variable var ~proto_dies_for_vars with
+    | None -> None
+    | Some proto_dies ->
+      if need_rvalue then Some proto_dies.value_die_rvalue
+      else Some proto_dies.value_die_lvalue
+  in
+  let sort_priority =
+    match is_parameter with
+    | Local -> None
+    | Parameter { index; } ->
+      (* Ensure that parameters appear in the correct order in the debugger. *)
+      if need_rvalue then None
+      else Some index
+  in
+  Proto_die.create_ignore ?reference
+    ?sort_priority
+    ?location_list_in_debug_loc_table
+    ~parent:(Some parent_proto_die)
+    ~tag
+    ~attribute_values:(type_and_name_attributes @ location_attribute_value)
+    ()
+
+(* This function covers local variables, parameters, variables in closures
+   and other "fun_var"s in the current mutually-recursive set.  (The last
+   two cases are handled by the explicit addition of phantom lets way back
+   in [Flambda_to_clambda].)  Phantom variables are also covered. *)
+let iterate_over_variable_like_things state ~available_ranges_vars
+      ~rvalues_only ~f =
+  ARV.iter available_ranges_vars ~f:(fun var range ->
+    let should_process =
+      (not rvalues_only)
+        || V.Set.mem var (DS.rvalue_dies_required_for state)
+    in
+    if should_process then begin
+      let range_info = ARV.Range.info range in
+      let provenance = ARV.Range_info.provenance range_info in
+      let phantom : is_variable_phantom =
+        match ARV.Range_info.phantom_defining_expr range_info with
+        | Non_phantom ->
+          begin match provenance with
+          | None -> ()
+          | Some provenance ->
+            if V.Provenance.is_static provenance then begin
+              Misc.fatal_errorf "Variable %a marked as static, but it is not \
+                  bound by a phantom let"
+                V.print var
+            end
+          end;
+          Non_phantom
+        | Phantom _ -> Phantom
+      in
+      (* There are two variables in play here:
+         1. [var] is the "real" variable that is used for obtaining a value
+            at runtime in the debugger.
+         2. [ident_for_type] is the corresponding identifier with the stamp
+            as in the typed tree together with its original compilation unit.
+            This is the one used for lookup in .cmt files to retrieve a type.
+         We cannot conflate these since the multiple [vars] that might
+         be associated with a given [ident_for_type] (due to inlining) may
+         not all have the same value. *)
+      (* CR-someday mshinwell: Introduce some flag on Backend_var.t to mark
+         identifiers that were generated internally (or vice-versa)?  We
+         should probably also hide certain internally-generated identifiers
+         that appear in .cmt files but did not come from the source code. *)
+      let hidden = Backend_var.is_internal var in
+      let ident_for_type =
+        match provenance with
+        | None ->
+          (* In this case the variable won't be given a name in the DWARF,
+             so as not to appear in the debugger; but we still need to emit
+             a DIE for it, as it may be referenced as part of some chain of
+             phantom lets. *)
+          let in_startup_file =
+            (* The startup file is generated from Cmm code and is therefore
+               not expected to link back to any .cmt file via identifier
+               names and stamps. *)
+            Compilation_unit.equal (Compilation_unit.get_current_exn ())
+              Compilation_unit.startup
+          in
+          if (not hidden) && (not in_startup_file) then begin
+            Misc.fatal_errorf "Variable %a is not hidden, but has no \
+                provenance\n%!"
+              Backend_var.print var
+          end;
+          None
+        | Some provenance ->
+          Some (Backend_var.Provenance.ident_for_type provenance)
+      in
+      f var ~phantom ~hidden ~ident_for_type ~range
+    end)
+
+let dwarf state fundecl ~function_proto_die ~scope_proto_dies
+      available_ranges_vars =
+  let proto_dies_for_vars = Backend_var.Tbl.create 42 in
+  let uniqueness_by_var =
+    calculate_var_uniqueness ~available_ranges_vars
+  in
+  iterate_over_variable_like_things state ~available_ranges_vars
+    ~rvalues_only:false
+    ~f:(fun var ~phantom ~hidden:_ ~ident_for_type:_ ~range:_ ->
+      let value_die_lvalue = Proto_die.create_reference () in
+      let value_die_rvalue = Proto_die.create_reference () in
+      let type_die = Proto_die.create_reference () in
+      assert (not (Backend_var.Tbl.mem proto_dies_for_vars var));
+      Backend_var.Tbl.add proto_dies_for_vars var
+        { is_variable_phantom = phantom;
+          value_die_lvalue;
+          value_die_rvalue;
+          type_die;
+        });
+  DS.set_rvalue_dies_required_for state V.Set.empty;
+  (* CR-someday mshinwell: Consider changing [need_rvalue] to use a variant
+     type "lvalue or rvalue". *)
+  iterate_over_variable_like_things state ~available_ranges_vars
+    ~rvalues_only:false
+    ~f:(dwarf_for_variable state fundecl ~function_proto_die
+      ~scope_proto_dies ~uniqueness_by_var ~proto_dies_for_vars
+      ~need_rvalue:false);
+  iterate_over_variable_like_things state ~available_ranges_vars
+    ~rvalues_only:true
+    ~f:(dwarf_for_variable state fundecl ~function_proto_die
+      ~scope_proto_dies ~uniqueness_by_var ~proto_dies_for_vars
+      ~need_rvalue:true)

--- a/asmcomp/debug/dwarf/dwarf_variables_and_parameters.mli
+++ b/asmcomp/debug/dwarf/dwarf_variables_and_parameters.mli
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Handling of DWARF descriptions of variables and function parameters. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+val normal_type_for_var
+   : ?reference:Proto_die.reference
+  -> parent:Proto_die.t option
+  -> (Compilation_unit.t * Ident.t) option
+  -> Is_parameter.t
+  -> Proto_die.t
+
+val dwarf
+   : Dwarf_state.t
+  -> Linearize.fundecl
+  -> function_proto_die:Proto_die.t
+  -> scope_proto_dies:Proto_die.t Debuginfo.Block.Map.t
+  -> Available_ranges_all_vars.t
+  -> unit


### PR DESCRIPTION
The code in this pull request is the magic that generates DWARF debugging information from the output of the backend and the various debugging analysis passes.  It receives information about variable availability and contents; an approximation of the lexical block structure of the program including any inlined-out frames; descriptions of statically-allocated constants; and the linearised code of the program itself.  In effect, this is a compiler within a compiler.

The DWARF output generated is comprehensive and could potentially be used for purposes other than debugging (such as program analysis).  Remarkably, the output is compatible with GNU toolchains on Linux as well as the LLVM-based toolchain on the latest version of macOS (Mojave), although gdb rather than lldb should be used as the debugger.

It turns out that, by virtue of the optimisations performed by the OCaml compiler and the calling conventions used at runtime, the "phantom let" support and the recent DWARF support for describing call sites both play particularly important roles in achieving a good user experience in the debugger.

This pull request is missing many dependencies at present (to be provided by other GPRs whose upstreaming is in progress) and will no doubt require a certain amount of explanation.  I am posting it now so that @bschommer in particular can have a high-level overview of what is going on; this may be useful when reviewing the pull requests for the `dwarf_high` and `dwarf_low` libraries.