### PR TITLE
Position [Lprologue] correctly

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,11 @@ Working version
 - #2291: Add [Compute_ranges] pass
   (Mark Shinwell, review by Vincent Laviron)
 
+- #2292: Add [Proc.frame_required] and [Proc.prologue_required].
+  Move tail recursion label creation to [Linearize].  Correctly position
+  [Lprologue] relative to [Iname_for_debugger] operations.
+  (Mark Shinwell, review by Vincent Laviron)
+
 - #2308: More debugging information on [Cmm] terms
   (Mark Shinwell, review by Stephen Dolan)
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -73,9 +73,6 @@ let stack_offset = ref 0
 
 (* Layout of the stack frame *)
 
-let frame_required () =
-  fp || !contains_calls || num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
-
 let frame_size () =                     (* includes return address *)
   if frame_required() then begin
     let sz =
@@ -486,6 +483,7 @@ let emit_instr fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
+    assert (Proc.prologue_required ());
     if fp then begin
       I.push rbp;
       cfi_adjust_cfa_offset 8;
@@ -498,8 +496,7 @@ let emit_instr fallthrough i =
         I.sub (int n) rsp;
         cfi_adjust_cfa_offset n;
       end;
-    end;
-    def_label !tailrec_entry_point
+    end
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
       if src.loc <> dst.loc then
@@ -898,7 +895,7 @@ let all_functions = ref []
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -377,6 +377,12 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  fp || !contains_calls || num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -381,7 +381,7 @@ let frame_required () =
   fp || !contains_calls || num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
 
 let prologue_required () =
-  !Clflags.gprofile || frame_required ()
+  frame_required ()
 
 (* Calling the assembler *)
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -439,6 +439,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> 0
     | Lprologue ->
+      assert (Proc.prologue_required ());
       let n = frame_size() in
       let num_instrs =
         if n > 0 then begin
@@ -928,7 +929,7 @@ let rec emit_all ninstr fallthrough i =
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   float_literals := [];
   gotrel_literals := [];
   symbol_literals := [];

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -352,7 +352,7 @@ let frame_required () =
     || num_stack_slots.(2) > 0
 
 let prologue_required () =
-  !Clflags.gprofile || frame_required ()
+  frame_required ()
 
 (* Calling the assembler *)
 

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -345,6 +345,15 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  !contains_calls
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+    || num_stack_slots.(2) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -566,14 +566,14 @@ let emit_instr i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
+      assert (Proc.prologue_required ());
       let n = frame_size() in
       if n > 0 then
         emit_stack_adjustment (-n);
       if !contains_calls then begin
         cfi_offset ~reg:30 (* return address *) ~offset:(-8);
         `	str	x30, [sp, #{emit_int (n-8)}]\n`
-      end;
-      `{emit_label !tailrec_entry_point}:\n`;
+      end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -896,7 +896,7 @@ let rec emit_all i =
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   float_literals := [];
   stack_offset := 0;
   call_gc_sites := [];

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -254,6 +254,14 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  !contains_calls
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -260,7 +260,7 @@ let frame_required () =
     || num_stack_slots.(1) > 0
 
 let prologue_required () =
-  !Clflags.gprofile || frame_required ()
+  frame_required ()
 
 (* Calling the assembler *)
 

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -473,12 +473,12 @@ let emit_instr fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
+    assert (Proc.prologue_required ());
     let n = frame_size() - 4 in
     if n > 0 then  begin
       I.sub (int n) esp;
       cfi_adjust_cfa_offset n;
     end;
-    def_label !tailrec_entry_point
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
       if src.loc <> dst.loc then begin
@@ -887,7 +887,7 @@ let rec emit_all fallthrough i =
 let fundecl fundecl =
   function_name := fundecl.fun_name;
   fastcode_flag := fundecl.fun_fast;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -242,7 +242,12 @@ let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
 let frame_required () =
-  num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
+  let frame_size_at_top_of_function =
+    (* cf. [frame_size] in emit.mlp. *)
+    Misc.align (4*num_stack_slots.(0) + 8*num_stack_slots.(1) + 4)
+      stack_alignment
+  in
+  frame_size_at_top_of_function > 4
 
 let prologue_required () =
   !Clflags.gprofile || frame_required ()

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -241,6 +241,12 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -250,7 +250,7 @@ let frame_required () =
   frame_size_at_top_of_function > 4
 
 let prologue_required () =
-  !Clflags.gprofile || frame_required ()
+  frame_required ()
 
 (* Calling the assembler *)
 

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -55,6 +55,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_tailrec_entry_point_label : label;
   }
 
 (* Invert a test *)
@@ -313,20 +314,72 @@ let rec linear i n =
       copy_instr (Lraise k) i (discard_dead_code n)
 
 let add_prologue first_insn =
-  let insn = first_insn in
-  { desc = Lprologue;
-    next = insn;
-    arg = [| |];
-    res = [| |];
-    dbg = insn.dbg;
-    live = insn.live;
-  }
+  (* The prologue needs to come after any [Iname_for_debugger] operations that
+     refer to parameters.  (Such operations always come in a contiguous
+     block, cf. [Selectgen].) *)
+  let rec skip_naming_ops (insn : instruction) : label * instruction =
+    match insn.desc with
+    | Lop (Iname_for_debugger _) ->
+      let tailrec_entry_point_label, next = skip_naming_ops insn.next in
+      tailrec_entry_point_label, { insn with next; }
+    | _ ->
+      let tailrec_entry_point_label = Cmm.new_label () in
+      let tailrec_entry_point =
+        { desc = Llabel tailrec_entry_point_label;
+          next = insn;
+          arg = [| |];
+          res = [| |];
+          dbg = insn.dbg;
+          live = insn.live;
+        }
+      in
+      (* We expect [Lprologue] to expand to at least one instruction---as such,
+         if no prologue is required, we avoid adding the instruction here.
+         The reason is subtle: an empty expansion of [Lprologue] can cause
+         two labels, one either side of the [Lprologue], to point at the same
+         location.  This means that we lose the property (cf. [Coalesce_labels])
+         that we can check if two labels point at the same location by
+         comparing them for equality.  This causes trouble when the function
+         whose prologue is in question lands at the top of the object file
+         and we are emitting DWARF debugging information:
+           foo_code_begin:
+           foo:
+           .L1:
+           ; empty prologue
+           .L2:
+           ...
+         If we were to emit a location list entry from L1...L2, not realising
+         that they point at the same location, then the beginning and ending
+         points of the range would be both equal to each other and (relative to
+         "foo_code_begin") equal to zero.  This appears to confuse objdump,
+         which seemingly misinterprets the entry as an end-of-list entry
+         (which is encoded with two zero words), then complaining about a
+         "hole in location list" (as it ignores any remaining list entries
+         after the misinterpreted entry). *)
+      if Proc.prologue_required () then
+        let prologue =
+          { desc = Lprologue;
+            next = tailrec_entry_point;
+            arg = [| |];
+            res = [| |];
+            dbg = tailrec_entry_point.dbg;
+            live = Reg.Set.empty;  (* will not be used *)
+          }
+        in
+        tailrec_entry_point_label, prologue
+      else
+        tailrec_entry_point_label, tailrec_entry_point
+  in
+  skip_naming_ops first_insn
 
 let fundecl f =
-  let fun_body = add_prologue (linear f.Mach.fun_body end_instr) in
+  let fun_tailrec_entry_point_label, fun_body =
+    add_prologue (linear f.Mach.fun_body end_instr)
+  in
   { fun_name = f.Mach.fun_name;
     fun_body;
     fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
+    fun_tailrec_entry_point_label;
   }

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -53,6 +53,7 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_tailrec_entry_point_label : label;
   }
 
 val fundecl: Mach.fundecl -> fundecl

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -527,6 +527,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
+      assert (Proc.prologue_required ());
       let n = frame_size() in
       if n > 0 then begin
         `	addi	1, 1, {emit_int(-n)}\n`;
@@ -541,8 +542,7 @@ let emit_instr i =
         | ELF32 -> ()
         | ELF64v1 | ELF64v2 ->
           `	std	2, {emit_int(toc_save_offset())}(1)\n`
-      end;
-      `{emit_label !tailrec_entry_point}:\n`
+      end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -1007,7 +1007,7 @@ let rec emit_all i =
 
 let fundecl fundecl =
   function_name := fundecl.fun_name;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_label := 0;
   float_literals := [];

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -359,7 +359,7 @@ let frame_required () =
     || (!contains_calls && is_elf32)
 
 let prologue_required () =
-  !Clflags.gprofile || frame_required ()
+  frame_required ()
 
 (* Calling the assembler *)
 

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -341,6 +341,26 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+(* See [reserved_stack_space] in emit.mlp. *)
+let reserved_stack_space_required () =
+  match abi with
+  | ELF32 -> false
+  | ELF64v1 | ELF64v2 -> true
+
+let frame_required () =
+  let is_elf32 =
+    match abi with
+    | ELF32 -> true
+    | ELF64v1 | ELF64v2 -> false
+  in
+  reserved_stack_space_required ()
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+    || (!contains_calls && is_elf32)
+
+let prologue_required () =
+  !Clflags.gprofile || frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -67,6 +67,10 @@ val op_is_pure: Mach.operation -> bool
 (* Info for laying out the stack frame *)
 val num_stack_slots: int array
 val contains_calls: bool ref
+val frame_required : unit -> bool
+
+(* Function prologues *)
+val prologue_required : unit -> bool
 
 (** For a given register class, the DWARF register numbering for that class.
     Given an allocated register with location [Reg n] and class [reg_class], the

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -308,11 +308,11 @@ let emit_instr i =
     match i.desc with
       Lend -> ()
     | Lprologue ->
+      assert (Proc.prologue_required ());
       let n = frame_size() in
       emit_stack_adjust n;
       if !contains_calls then
-        `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
-      `{emit_label !tailrec_entry_point}:\n`;
+        `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -648,7 +648,7 @@ let rec emit_all i =
 
 let fundecl fundecl =
   function_name := fundecl.fun_name;
-  tailrec_entry_point := new_label();
+  tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -228,6 +228,15 @@ let op_is_pure = function
 let num_stack_slots = [| 0; 0 |]
 let contains_calls = ref false
 
+let frame_required () =
+  !contains_calls
+    || num_stack_slots.(0) > 0
+    || num_stack_slots.(1) > 0
+
+let prologue_required () =
+  (* There appears to be no gprof support on this platform. *)
+  frame_required ()
+
 (* Calling the assembler *)
 
 let assemble_file infile outfile =

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -234,7 +234,6 @@ let frame_required () =
     || num_stack_slots.(1) > 0
 
 let prologue_required () =
-  (* There appears to be no gprof support on this platform. *)
   frame_required ()
 
 (* Calling the assembler *)

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -392,6 +392,7 @@ method schedule_fundecl f =
       fun_fast = f.fun_fast;
       fun_dbg  = f.fun_dbg;
       fun_spacetime_shape = f.fun_spacetime_shape;
+      fun_tailrec_entry_point_label = f.fun_tailrec_entry_point_label;
     }
   end else
     f


### PR DESCRIPTION
It is necessary that the `Lprologue` instruction in linearized code is positioned correctly with respect to the `Iname_for_debugger` pseudooperation that assigns variable names to registers.  If this does not happen, then the user may not see values of variables that are expected to be seen (function parameters in particular...), when stepping amongst the prologue.  This produces a poor user experience.

This patch ensures that the prologue instruction goes in the correct place.  It also elides the `Lprologue` instruction entirely when it is going to expand to nothing.  The reason for this is documented in the code.  The comment refers to a pass that has not yet been presented upstream, `Coalesce_labels`, but all that is necessary to know about that pass is the following: it ensures that given two labels in the linearized code that do not compare equal, those labels do not point at the same code address.

The reason for moving the creation of the tail recursion label into `Linearize` (apart from the fact that it seems better to represent such things explicitly in intermediate languages) is because otherwise, if we elide the `Lprologue` instruction, we would fail to define the label.

@lthls Are you qualified to review this?  For the `prologue_required` calculations, the thing to look at is what the `Lprologue` clause does in the instruction emitter, and observe that the `stack_offset` variables will always be zero at that point.