### PR TITLE
Make caml_named_value return a const value*

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,9 @@ Working version
 * GPR#2240: Constify "identifier" in struct custom_operations
   (Cedric Cellier, review by Xavier Leroy)
 
+* GPR#2293: Constify "caml_named_value"
+  (Stephen Dolan, review by ??)
+
 ### Standard library:
 
 - GPR#2262: take precision (.<n>) and flags ('+' and ' ') into account

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -1440,15 +1440,15 @@ above:
 \end{verbatim}
 
 The pointer returned by "caml_named_value" is constant and can safely
-be cached in a C variable to avoid repeated name lookups. On the other
-hand, the value pointed to can change during garbage collection and
-must always be recomputed at the point of use. Here is a more
-efficient variant of "call_caml_f" above that calls "caml_named_value"
-only once:
+be cached in a C variable to avoid repeated name lookups. The value
+pointed to cannot be changed from C. However, it might change during
+garbage collection, so must always be recomputed at the point of
+use. Here is a more efficient variant of "call_caml_f" above that
+calls "caml_named_value" only once:
 \begin{verbatim}
     void call_caml_f(int arg)
     {
-        static value * closure_f = NULL;
+        static const value * closure_f = NULL;
         if (closure_f == NULL) {
             /* First time around, look up by name */
             closure_f = caml_named_value("test function");
@@ -1684,14 +1684,14 @@ Here is the C stub code for calling these functions from C:
 
 int fib(int n)
 {
-  static value * fib_closure = NULL;
+  static const value * fib_closure = NULL;
   if (fib_closure == NULL) fib_closure = caml_named_value("fib");
   return Int_val(caml_callback(*fib_closure, Val_int(n)));
 }
 
 char * format_result(int n)
 {
-  static value * format_result_closure = NULL;
+  static const value * format_result_closure = NULL;
   if (format_result_closure == NULL)
     format_result_closure = caml_named_value("format_result");
   return strdup(String_val(caml_callback(*format_result_closure, Val_int(n))));

--- a/otherlibs/graph/open.c
+++ b/otherlibs/graph/open.c
@@ -365,7 +365,7 @@ value caml_gr_sigio_handler(void)
 
 /* Processing of graphic errors */
 
-static value * graphic_failure_exn = NULL;
+static const value * graphic_failure_exn = NULL;
 
 void caml_gr_fail(const char *fmt, const char *arg)
 {

--- a/otherlibs/unix/unixsupport.c
+++ b/otherlibs/unix/unixsupport.c
@@ -253,7 +253,7 @@ int error_table[] = {
   EHOSTUNREACH, ELOOP, EOVERFLOW /*, EUNKNOWNERR */
 };
 
-static value * unix_error_exn = NULL;
+static const value * unix_error_exn = NULL;
 
 value unix_error_of_code (int errcode)
 {

--- a/otherlibs/win32graph/open.c
+++ b/otherlibs/win32graph/open.c
@@ -351,7 +351,7 @@ CAMLprim value caml_gr_sigio_handler(value unit)
 
 /* Processing of graphic errors */
 
-static value * graphic_failure_exn = NULL;
+static const value * graphic_failure_exn = NULL;
 void gr_fail(char *fmt, char *arg)
 {
   char buffer[1024];

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -265,7 +265,7 @@ int error_table[] = {
   EHOSTUNREACH, ELOOP, EOVERFLOW /*, EUNKNOWNERR */
 };
 
-static value * unix_error_exn = NULL;
+static const value * unix_error_exn = NULL;
 
 value unix_error_of_code (int errcode)
 {

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -239,7 +239,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   return Val_unit;
 }
 
-CAMLexport value * caml_named_value(char const *name)
+CAMLexport const value * caml_named_value(char const *name)
 {
   struct named_value * nv;
   for (nv = named_value_table[hash_value_name(name)];

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -225,7 +225,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
 
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
-      nv->val = val;
+      caml_modify_generational_global_root(&nv->val, val);
       return Val_unit;
     }
   }
@@ -235,7 +235,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   nv->val = val;
   nv->next = named_value_table[h];
   named_value_table[h] = nv;
-  caml_register_global_root(&nv->val);
+  caml_register_generational_global_root(&nv->val);
   return Val_unit;
 }
 

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -43,8 +43,8 @@ CAMLextern value caml_callbackN_exn (value closure, int narg, value args[]);
 #define Is_exception_result(v) (((v) & 3) == 2)
 #define Extract_exception(v) ((v) & ~3)
 
-CAMLextern value * caml_named_value (char const * name);
-typedef void (*caml_named_action) (value*, char *);
+CAMLextern const value * caml_named_value (char const * name);
+typedef void (*caml_named_action) (const value*, char *);
 CAMLextern void caml_iterate_named_values(caml_named_action f);
 
 CAMLextern void caml_main (char_os ** argv);

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -169,7 +169,7 @@ void caml_raise_sys_blocked_io(void)
    do a GC before the exception is raised (lack of stack descriptors
    for the ccall to [caml_array_bound_error]).  */
 
-static value * caml_array_bound_error_exn = NULL;
+static const value * caml_array_bound_error_exn = NULL;
 
 void caml_array_bound_error(void)
 {

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -505,7 +505,7 @@ static void intern_rec(value *dest)
         if (codeptr != NULL) {
           v = (value) codeptr;
         } else {
-          value * function_placeholder =
+          const value * function_placeholder =
             caml_named_value ("Debugger.function_placeholder");
           if (function_placeholder != NULL) {
             v = *function_placeholder;

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -110,7 +110,7 @@ CAMLexport char * caml_format_exception(value exn)
 static void default_fatal_uncaught_exception(value exn)
 {
   char * msg;
-  value * at_exit;
+  const value * at_exit;
   int saved_backtrace_active, saved_backtrace_pos;
 
   /* Build a string representation of the exception */
@@ -136,7 +136,7 @@ int caml_abort_on_uncaught_exn = 0; /* see afl.c */
 
 void caml_fatal_uncaught_exception(value exn)
 {
-  value *handle_uncaught_exception;
+  const value *handle_uncaught_exception;
 
   handle_uncaught_exception =
     caml_named_value("Printexc.handle_uncaught_exception");

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -147,7 +147,7 @@ int caml_startup_aux(int pooling)
 
 static void call_registered_value(char* name)
 {
-  value *f = caml_named_value(name);
+  const value *f = caml_named_value(name);
   if (f != NULL)
     caml_callback_exn(*f, Val_unit);
 }

--- a/testsuite/tests/embedded/cmstub.c
+++ b/testsuite/tests/embedded/cmstub.c
@@ -19,12 +19,12 @@
 
 int fib(int n)
 {
-  value * fib_closure = caml_named_value("fib");
+  const value * fib_closure = caml_named_value("fib");
   return Int_val(caml_callback(*fib_closure, Val_int(n)));
 }
 
 char * format_result(int n)
 {
-  value * format_result_closure = caml_named_value("format_result");
+  const value * format_result_closure = caml_named_value("format_result");
   return strdup(String_val(caml_callback(*format_result_closure, Val_int(n))));
 }


### PR DESCRIPTION
Values can be passed from OCaml to C by registering them under a known name using `Callback.register` and retrieving them using `caml_named_value`, which returns a `value*` that is then dereferenced.

This patch changes the return type to `const value*`, to indicate that the C code cannot use the pointer that is returned to change which value is registered. The ability to mutate the value using the raw pointer returned by `caml_named_value` is:

  - incompatible with multicore
  - never used, as far as I can tell (see below)

This patch requires minor code changes to make C stubs continue to compile cleanly (detailed below). As well as the change to the type of `caml_named_value`, this patch makes these changes where necessary in the stdlib, and updates the manual to reflect the change.

### Code changes in C stubs

There are two ways that `caml_named_value` is used in C stubs. The first is by immediately dereferencing the returned pointer:

    *caml_named_value(...)

The second is by caching the returned pointer in a static variable:

    static value* cache;
    if (!cache) cache = caml_named_value(...);
    ... *cache ...

With this patch, the second type of occurrence will cause a compiler warning ("assignment discards const qualifier", or something to that effect). This warning is non-fatal (unless compiling with `-Werror` or compiling as C++) and no undefined behaviour is triggered by ignoring it.

To avoid the warning, the declaration of `cache` must be changed to:

    static const value* cache;

This change is compatible with all versions of OCaml: it is always safe to store a `value*` in a variable of type `const value*`. So, it is not necessary to maintain two versions of C stubs to cleanly compile both before and after this patch, but C stubs will generate a warning until they're updated.

### OPAM survey

To check whether all uses of `caml_named_value` fit one of the patterns above, I downloaded the sources of the latest version of each OPAM package ([using this script](https://gist.github.com/stedolan/a472a32c35d892345e97effb7e879625)) and grepped them.

In OPAM, there are 1297 references to caml_named_value, of which 627 match the first pattern above (they dereference immediately as `*caml_named_value(...)` and are unaffected by this patch).

The remaining 670 nontrivial occurrences are spread over 173 files of C source, 8 files of C++ source, and 85 other files (mostly documentation and generated JavaScript).

I manually inspected all of the C++ source occurrences and a random sample of 10% of the C occurrences; every single one fit the second pattern above. After this patch, these occurrences will generate a warning until a `const` is added. The 8 C++ sources (in packages `irrlicht`, `lablqt` and `leveldb`) will fail to compile until `const` is added.

*Edit*: The occurrence count numbers above are all a bit too high (by ~20%), since my hacky script downloads the source of each package, despite the fact that many packages share the same source.

### Optimisation

A minor side benefit of this change is that since the registered values can no longer be modified from C code, they can be registered with `caml_register_generational_global_root` instead of `caml_register_global_root`. This means that they need no longer be scanned during minor GC. (I expect the benefit will be minimal, however: few programs register very many of these values).