### PR TITLE
Restore support for bytecode target XLC/AIX/Power

### DIFF
--- a/Changes
+++ b/Changes
@@ -704,6 +704,9 @@ OCaml 4.08.0
 - MPR#7919, GPR#2311: Fix assembler detection in configure
   (Sébastien Hinderer, review by David Allsopp)
 
+- GPR#2295: Restore support for bytecode target XLC/AIX/Power
+  (Konstantin Romanov, review by Sébastien Hinderer and David Allsopp)
+
 ### Internal/compiler-libs changes:
 
 - MPR#7918, GPR#1703, GPR#1944, GPR#2213, GPR#2257: Add the module

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -183,6 +183,14 @@ On a 64-bit POWER architecture host running Linux, OCaml only operates in a
 * For AIX 4.3 with the IBM compiler `xlc`:
 
     ./configure -cc "xlc_r -D_AIX43 -Wl,-bexpall,-brtl -qmaxmem=8192"
+
+* For AIX 7.x with the IBM compiler `xlc`:
+
+    ./configure CC=xlc
++
+By default, build is 32-bit. For 64-bit build, please set environment variable `OBJECT_MODE=64`
+  for _both_ `configure` and `make world` phases. Note, if this variable is set for only one phase,
+  your build will break (`ocamlrun` segfaults).
 +
 If something goes wrong during the automatic configuration, or if the generated
 files cause errors later on, then look at the template files:

--- a/configure
+++ b/configure
@@ -12436,6 +12436,9 @@ $as_echo "$ocaml_cv_cc_vendor" >&6; }
 ## Determine which flags to use for the C compiler
 
 case $ocaml_cv_cc_vendor in #(
+  xlc-*) :
+    outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i" ;; #(
+  # all warnings enabled
   msvc-*) :
     outputobj=-Fo; CPP="cl -nologo -EP"; gcc_warnings="" ;; #(
   *) :
@@ -12506,6 +12509,9 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+  xlc-*) :
+    common_cflags="-O5 -qtune=balanced -qnoipa -qinline $CFLAGS";
+      internal_cflags="$gcc_warnings" ;; #(
   *) :
     common_cflags="-O" ;;
 esac ;;
@@ -12622,7 +12628,11 @@ fi
 fi ;; #(
   *,x86_64-*-linux*) :
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
-
+ ;; #(
+  xlc*,powerpc-ibm-aix*) :
+    mkexe="$mkexe "
+     oc_ldflags="-brtl -bexpfull"
+    $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   *) :
      ;;
@@ -13391,6 +13401,14 @@ if test x"$enable_shared" != "xno"; then :
     mksharedlib="$flexlink"
       mkmaindll="$flexlink -maindll"
       shared_libraries_supported=true ;; #(
+  powerpc-ibm-aix*) :
+    case $CC in #(
+  xlc*) :
+    mksharedlib="$CC -qmkshrobj -G"
+                shared_libraries_supported=true ;; #(
+  *) :
+     ;;
+esac ;; #(
   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
@@ -14733,8 +14751,12 @@ fi
 
 
 ## -fdebug-prefix-map support by the C compiler
-case $host in #(
-  *-*-mingw32|*-pc-windows) :
+case $CC,$host in #(
+  *,*-*-mingw32) :
+    cc_has_debug_prefix_map=false ;; #(
+  *,*-pc-windows) :
+    cc_has_debug_prefix_map=false ;; #(
+  xlc*,powerpc-ibm-aix*) :
     cc_has_debug_prefix_map=false ;; #(
   *) :
 

--- a/configure.ac
+++ b/configure.ac
@@ -478,6 +478,8 @@ OCAML_CC_VENDOR
 ## Determine which flags to use for the C compiler
 
 AS_CASE([$ocaml_cv_cc_vendor],
+  [xlc-*],
+    [outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i"], # all warnings enabled
   [msvc-*],
     [outputobj=-Fo; CPP="cl -nologo -EP"; gcc_warnings=""],
   [outputobj='-o $(EMPTY)'; AS_CASE([AC_PACKAGE_VERSION],
@@ -540,6 +542,9 @@ AS_CASE([$host],
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+    [xlc-*],
+      [common_cflags="-O5 -qtune=balanced -qnoipa -qinline $CFLAGS";
+      internal_cflags="$gcc_warnings"],
     [common_cflags="-O"])])
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
@@ -620,7 +625,11 @@ AS_CASE([$CC,$host],
       iflexdir="-I\"$flexdir\""
       mkexedebugflag="-link -g"])],
   [*,x86_64-*-linux*],
-    AC_DEFINE([HAS_ARCH_CODE32], [1])
+    AC_DEFINE([HAS_ARCH_CODE32], [1]),
+  [xlc*,powerpc-ibm-aix*],
+    [mkexe="$mkexe "
+     oc_ldflags="-brtl -bexpfull"
+    AC_DEFINE([HAS_ARCH_CODE32], [1])],
 )
 
 
@@ -734,6 +743,11 @@ AS_IF([test x"$enable_shared" != "xno"],
       [mksharedlib="$flexlink"
       mkmaindll="$flexlink -maindll"
       shared_libraries_supported=true],
+    [powerpc-ibm-aix*],
+      [AS_CASE([$CC],
+               [xlc*],
+               [mksharedlib="$CC -qmkshrobj -G"
+                shared_libraries_supported=true])],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
@@ -1325,8 +1339,10 @@ AC_CHECK_HEADER([sys/mman.h],
 AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE])])
 
 ## -fdebug-prefix-map support by the C compiler
-AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows], [cc_has_debug_prefix_map=false],
+AS_CASE([$CC,$host],
+  [*,*-*-mingw32], [cc_has_debug_prefix_map=false],
+  [*,*-pc-windows], [cc_has_debug_prefix_map=false],
+  [xlc*,powerpc-ibm-aix*], [cc_has_debug_prefix_map=false],
   [OCAML_CC_HAS_DEBUG_PREFIX_MAP])
 
 ## Does stat support nanosecond precision


### PR DESCRIPTION
This patch restores support for bytecode target using `IBM XLC` compiler on `AIX`. Both 64-bit and 32-bit builds work. The functionality was affected during transition to `autoconf` - PR #2139.

Original `xlc` PR - #1130.