### PR TITLE
Dynlink: run _shared_startup only once per plugin

### DIFF
--- a/Changes
+++ b/Changes
@@ -276,8 +276,8 @@ OCaml 4.08.0
 - GPR#2038: Deprecate vm threads
   (Jérémie Dimino)
 
-* PR#4208, PR#4229, PR#4839, PR#6462, PR#6957, PR#6950, GPR#1063, GPR#2176:
-  Make (nat)dynlink sound
+* PR#4208, PR#4229, PR#4839, PR#6462, PR#6957, PR#6950, GPR#1063, GPR#2176,
+  GPR#2297: Make (nat)dynlink sound.
   (Mark Shinwell, Leo White, Nicolás Ojeda Bär, Pierre Chambart)
 
 - GPR#2263: Delete the deprecated Bigarray.*.map_file functions in

--- a/otherlibs/dynlink/dynlink.ml
+++ b/otherlibs/dynlink/dynlink.ml
@@ -89,6 +89,8 @@ module Bytecode = struct
       init
       !default_crcs
 
+  let run_shared_startup _ = ()
+
   let run (ic, file_name, file_digest) ~unit_header ~priv =
     let open Misc in
     let old_state = Symtable.current_state () in

--- a/otherlibs/dynlink/dynlink_common.ml
+++ b/otherlibs/dynlink/dynlink_common.ml
@@ -339,6 +339,7 @@ module Make (P : Dynlink_platform_intf.S) = struct
     | handle, units ->
       try
         global_state := check filename units !global_state ~priv;
+        P.run_shared_startup handle;
         List.iter
           (fun unit_header ->
              P.run handle ~unit_header ~priv;

--- a/otherlibs/dynlink/dynlink_platform_intf.ml
+++ b/otherlibs/dynlink/dynlink_platform_intf.ml
@@ -60,6 +60,7 @@ module type S = sig
     -> priv:bool
     -> handle * (Unit_header.t list)
 
+  val run_shared_startup : handle -> unit
   val run : handle -> unit_header:Unit_header.t -> priv:bool -> unit
 
   val finish : handle -> unit

--- a/otherlibs/dynlink/natdynlink.ml
+++ b/otherlibs/dynlink/natdynlink.ml
@@ -76,8 +76,10 @@ module Native = struct
       init
       (ndl_getmap ())
 
+  let run_shared_startup handle =
+    ndl_run handle "_shared_startup"
+
   let run handle ~unit_header ~priv:_ =
-    ndl_run handle "_shared_startup";
     List.iter (fun cu ->
         try ndl_run handle cu
         with exn -> raise (DT.Error (Library's_module_initializers_failed exn)))


### PR DESCRIPTION
This fixes a bug with #1063, which mistakenly runs the `_shared_startup` code for each unit in the `.cmxs` being loaded. This caused huge slowdowns when dynlinking a plugin with many units, and maybe worse.

This should go in 4.08.

@mshinwell @lpw25 