### PR TITLE
Ensure awk supports interval expressions for check-typo

### DIFF
--- a/tools/check-typo
+++ b/tools/check-typo
@@ -151,6 +151,18 @@ IGNORE_DIRS="
 # is faster to optimistically run check-typo on them (and maybe get
 # out in the middle) than to first check then run.
 
+TEST_AWK='BEGIN {if ("a{1}" ~ /a{1}/) exit 0}'
+if $OCAML_CT_AWK "$TEST_AWK" ; then
+  TEST_AWK='BEGIN {if ("a" ~ /a{1}/) exit 0}'
+  if $OCAML_CT_AWK --re-interval "$TEST_AWK" 2>/dev/null ; then
+    OCAML_CT_AWK="$OCAML_CT_AWK --re-interval"
+  else
+    echo "This script requires interval support in regexes ({m} notation)">&2
+    echo "Please install a version of awk (e.g. gawk) which supports this">&2
+    exit 2
+  fi
+fi
+
 EXIT_CODE=0
 ( case $# in
     0) find . $IGNORE_DIRS -type f -print;;

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -234,7 +234,6 @@ CheckTypo () {
   export OCAML_CT_CA_FLAG="--cached"
   # Work around an apparent bug in Ubuntu 12.4.5
   # See https://bugs.launchpad.net/ubuntu/+source/gawk/+bug/1647879
-  export OCAML_CT_AWK="awk --re-interval"
   rm -f check-typo-failed
   if test -z "$TRAVIS_COMMIT_RANGE"
   then CheckTypoTree $TRAVIS_COMMIT $TRAVIS_COMMIT


### PR DESCRIPTION
I got stung by this developing #2298, and had forgotten why Travis manually adds `--re-interval`. Even Ubuntu 18.10 still ships a default awk which doesn't support the required regexes for check-typo. We need the highly advanced `\*{74}` constructs to work...

This PR automates the addition of `--re-interval`, at the cost of an extra invocation to awk and improves the error message if (g)awk really doesn't support braces in regexes.

Without this PR, an incompatible awk confusingly complains that the copyright header is missing (in state `(first line)`).

cc @damiendoligez, with advice to ensure your desk has a cushion on it before your head crashes towards it...