### PR TITLE
Hint on type error on int literal

### DIFF
--- a/Changes
+++ b/Changes
@@ -45,6 +45,12 @@ Working version
   unbound Unix socket. Add support for receiving abstract (Linux) socket paths.
   (Tim Cuthbertson, review by Sébastien Hinderer and Jérémie Dimino)
 
+### Compiler user-interface and warnings:
+
+- GPR#2301: Hint on type error on int literal
+  (Jules Aguillon, review by Nicolás Ojeda Bär , Florian Angeletti,
+  Gabriel Scherer and Armaël Guéneau)
+
 ### Bug fixes:
 
 - MPR#7937, GPR#2287: fix uncaught Unify exception when looking for type

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -217,6 +217,7 @@ Line 3, characters 13-14:
                  ^
 Error: This expression has type int but an expression was expected of type
          float
+       Hint: Did you mean `1.'?
 |}];;
 
 module Ill_typed_3 = struct

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -24,6 +24,7 @@ Line 3, characters 8-9:
             ^
 Error: This expression has type int but an expression was expected of type
          float
+       Hint: Did you mean `1.'?
 Line 4, characters 2-4:
 4 | 2 in
       ^^

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -1,0 +1,133 @@
+(* TEST
+   * expect
+*)
+
+let _ = Int32.(add 1 2l);;
+[%%expect{|
+Line 1, characters 19-20:
+1 | let _ = Int32.(add 1 2l);;
+                       ^
+Error: This expression has type int but an expression was expected of type
+         int32
+       Hint: Did you mean `1l'?
+|}]
+
+let _ : int32 * int32 = 42l, 43;;
+[%%expect{|
+Line 1, characters 29-31:
+1 | let _ : int32 * int32 = 42l, 43;;
+                                 ^^
+Error: This expression has type int but an expression was expected of type
+         int32
+       Hint: Did you mean `43l'?
+|}]
+
+let _ : int32 * nativeint = 42l, 43;;
+[%%expect{|
+Line 1, characters 33-35:
+1 | let _ : int32 * nativeint = 42l, 43;;
+                                     ^^
+Error: This expression has type int but an expression was expected of type
+         nativeint
+       Hint: Did you mean `43n'?
+|}]
+
+let _ = min 6L 7;;
+[%%expect{|
+Line 1, characters 15-16:
+1 | let _ = min 6L 7;;
+                   ^
+Error: This expression has type int but an expression was expected of type
+         int64
+       Hint: Did you mean `7L'?
+|}]
+
+let _ : float = 123;;
+[%%expect{|
+Line 1, characters 16-19:
+1 | let _ : float = 123;;
+                    ^^^
+Error: This expression has type int but an expression was expected of type
+         float
+       Hint: Did you mean `123.'?
+|}]
+
+(* no hint *)
+let x = 0
+let _ = Int32.(add x 2l);;
+[%%expect{|
+val x : int = 0
+Line 2, characters 19-20:
+2 | let _ = Int32.(add x 2l);;
+                       ^
+Error: This expression has type int but an expression was expected of type
+         int32
+|}]
+
+(* not implemented *)
+let _ : int32 -> int32 = function
+  | 0 -> 0l
+  | x -> x
+[%%expect{|
+Line 2, characters 4-5:
+2 |   | 0 -> 0l
+        ^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type int32
+|}]
+
+(* symmetric *)
+let _ : int32 = 1L;;
+[%%expect{|
+Line 1, characters 16-18:
+1 | let _ : int32 = 1L;;
+                    ^^
+Error: This expression has type int64 but an expression was expected of type
+         int32
+       Hint: Did you mean `1l'?
+|}]
+let _ : float = 1L;;
+[%%expect{|
+Line 1, characters 16-18:
+1 | let _ : float = 1L;;
+                    ^^
+Error: This expression has type int64 but an expression was expected of type
+         float
+       Hint: Did you mean `1.'?
+|}]
+let _ : int64 = 1n;;
+[%%expect{|
+Line 1, characters 16-18:
+1 | let _ : int64 = 1n;;
+                    ^^
+Error: This expression has type nativeint
+       but an expression was expected of type int64
+       Hint: Did you mean `1L'?
+|}]
+let _ : nativeint = 1l;;
+[%%expect{|
+Line 1, characters 20-22:
+1 | let _ : nativeint = 1l;;
+                        ^^
+Error: This expression has type int32 but an expression was expected of type
+         nativeint
+       Hint: Did you mean `1n'?
+|}]
+
+(* not implemented *)
+let _ : int64 = 0.;;
+[%%expect{|
+Line 1, characters 16-18:
+1 | let _ : int64 = 0.;;
+                    ^^
+Error: This expression has type float but an expression was expected of type
+         int64
+|}]
+let _ : int = 1L;;
+[%%expect{|
+Line 1, characters 14-16:
+1 | let _ : int = 1L;;
+                  ^^
+Error: This expression has type int64 but an expression was expected of type
+         int
+|}]

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -64,7 +64,7 @@ Error: This expression has type int but an expression was expected of type
          int32
 |}]
 
-(* not implemented *)
+(* pattern *)
 let _ : int32 -> int32 = function
   | 0 -> 0l
   | x -> x
@@ -74,6 +74,25 @@ Line 2, characters 4-5:
         ^
 Error: This pattern matches values of type int
        but a pattern was expected which matches values of type int32
+       Hint: Did you mean `0l'?
+|}, Principal{|
+Line 2, characters 4-5:
+2 |   | 0 -> 0l
+        ^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type int32
+|}]
+
+let _ : int64 -> int64 = function
+  | 1L | 2 -> 3L
+  | x -> x;;
+[%%expect{|
+Line 2, characters 9-10:
+2 |   | 1L | 2 -> 3L
+             ^
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type int64
+       Hint: Did you mean `2L'?
 |}]
 
 (* symmetric *)

--- a/testsuite/tests/typing-core-bugs/ocamltests
+++ b/testsuite/tests/typing-core-bugs/ocamltests
@@ -2,3 +2,4 @@ missing_rec_hint.ml
 unit_fun_hints.ml
 type_expected_explanation.ml
 repeated_did_you_mean.ml
+const_int_hint.ml

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -135,6 +135,16 @@ module Unification_trace = struct
   let incompatible_fields name got expected =
     Incompatible_fields {name; diff={got; expected} }
 
+  let explain trace f =
+    let rec explain = function
+      | [] -> None
+      | [h] -> f ~prev:None h
+      | h :: (prev :: _ as rem) ->
+        match f ~prev:(Some prev) h with
+        | Some _ as m -> m
+        | None -> explain rem in
+    explain (List.rev trace)
+
 end
 module Trace = Unification_trace
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -70,6 +70,14 @@ module Unification_trace: sig
   (** Switch [expected] and [got] *)
   val swap: t -> t
 
+  (** [explain trace f] calls [f] on trace elements starting from the end
+      until [f ~prev elt] is [Some _], returns that
+      or [None] if the end of the trace is reached. *)
+  val explain:
+          'a elt list ->
+          (prev:'a elt option -> 'a elt -> 'b option) ->
+          'b option
+
 end
 
 exception Unify of Unification_trace.t

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1899,13 +1899,7 @@ let explanation intro prev env = function
             type_expr x type_expr y)
 
 let mismatch intro env trace =
-  let rec mismatch intro env = function
-    | [] -> None
-    | [h] -> explanation intro None env h
-    | h :: (prev :: _ as rem) -> match explanation intro (Some prev) env h with
-      | Some _ as m -> m
-      | None -> mismatch intro env rem in
-  mismatch intro env (List.rev trace)
+  Trace.explain trace (fun ~prev h -> explanation intro prev env h)
 
 let explain mis ppf =
   match mis with

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -119,7 +119,8 @@ val self_coercion : (Path.t * Location.t list ref) list ref
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Ctype.Unification_trace.t
-  | Pattern_type_clash of Ctype.Unification_trace.t
+  | Pattern_type_clash of
+      Ctype.Unification_trace.t * Typedtree.pattern_desc option
   | Or_pattern_type_clash of Ident.t * Ctype.Unification_trace.t
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -125,6 +125,7 @@ type error =
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
       Ctype.Unification_trace.t * type_forcing_context option
+      * Typedtree.expression_desc option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr
   | Label_multiply_defined of string


### PR DESCRIPTION
Add an hint on type error on int literal where expecting int32, int64 or nativeint.

Example:

```
let a = 2l
let _ = Int32.add a 3
```

Will give:

```
Line 2, characters 20-21:
2 | let _ = Int32.add a 3
                        ^
Error: This expression has type int but an expression was expected of type
         int32
       Hint: Did you mean `3l'?
```