### PR TITLE
Add String.{Set,Map} ?

### DIFF
--- a/otherlibs/dynlink/dynlink_common.ml
+++ b/otherlibs/dynlink/dynlink_common.ml
@@ -22,10 +22,8 @@
 module String = struct
   include String
 
-  module Set = Set.Make (String)
-
   module Map = struct
-    include Map.Make (String)
+    include Map
 
     let keys t =
       fold (fun key _data keys -> Set.add key keys) t Set.empty

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -44,11 +44,11 @@ P=stdlib__
 OBJS=camlinternalFormatBasics.cmo stdlib.cmo $(OTHERS)
 OTHERS= $(P)pervasives.cmo $(P)seq.cmo $(P)option.cmo $(P)result.cmo \
   $(P)bool.cmo $(P)char.cmo $(P)uchar.cmo $(P)sys.cmo $(P)list.cmo \
-  $(P)bytes.cmo $(P)string.cmo $(P)unit.cmo \
+  $(P)set.cmo $(P)map.cmo $(P)bytes.cmo $(P)string.cmo $(P)unit.cmo \
   $(P)marshal.cmo $(P)obj.cmo $(P)array.cmo $(P)float.cmo \
   $(P)int.cmo $(P)int32.cmo $(P)int64.cmo $(P)nativeint.cmo \
   $(P)lexing.cmo $(P)parsing.cmo \
-  $(P)set.cmo $(P)map.cmo $(P)stack.cmo $(P)queue.cmo \
+  $(P)stack.cmo $(P)queue.cmo \
   camlinternalLazy.cmo $(P)lazy.cmo $(P)stream.cmo \
   $(P)buffer.cmo camlinternalFormat.cmo $(P)printf.cmo \
   $(P)arg.cmo $(P)printexc.cmo $(P)fun.cmo $(P)gc.cmo \

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -224,6 +224,11 @@ let capitalize s =
 let uncapitalize s =
   B.uncapitalize (bos s) |> bts
 
+(** {1 Sets and maps} *)
+
+module Set = Set.Make (struct type t = string let compare = compare end)
+module Map = Map.Make (struct type t = string let compare = compare end)
+
 (** {1 Iterators} *)
 
 let to_seq s = bos s |> B.to_seq

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -333,6 +333,11 @@ val split_on_char: char -> string -> string list
     @since 4.04.0
 *)
 
+(** {1 Sets and maps} *)
+
+module Set : Set.S with type elt = t
+module Map : Map.S with type key = t
+
 (** {1 Iterators} *)
 
 val to_seq : t -> char Seq.t

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -228,8 +228,6 @@ module Stdlib = struct
 
   module String = struct
     include String
-    module Set = Set.Make(String)
-    module Map = Map.Make(String)
     module Tbl = Hashtbl.Make(struct
       include String
       let hash = Hashtbl.hash

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -164,8 +164,6 @@ module Stdlib : sig
 
   module String : sig
     include module type of String
-    module Set : Set.S with type elt = string
-    module Map : Map.S with type key = string
     module Tbl : Hashtbl.S with type key = string
 
     val for_all : (char -> bool) -> t -> bool


### PR DESCRIPTION
Opinions? One downside is that it breaks the idiom
```ocaml
module String = struct
  include String
  module Set = Set.Make (String)
end
```
which may be quite widespread.