### PR TITLE
Debugging-related changes in the Mach language and passes

### DIFF
--- a/.depend
+++ b/.depend
@@ -2295,8 +2295,8 @@ asmcomp/emit.cmo : \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/linearize.cmi \
+    asmcomp/insn_debuginfo.cmi \
     asmcomp/emitaux.cmi \
-    lambda/debuginfo.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
     asmcomp/cmm.cmi \
@@ -2315,8 +2315,8 @@ asmcomp/emit.cmx : \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/linearize.cmx \
+    asmcomp/insn_debuginfo.cmx \
     asmcomp/emitaux.cmx \
-    lambda/debuginfo.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \
     asmcomp/cmm.cmx \
@@ -2343,6 +2343,20 @@ asmcomp/emitaux.cmx : \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmi : \
     lambda/debuginfo.cmi
+asmcomp/insn_debuginfo.cmo : \
+    asmcomp/debug/reg_availability_set.cmi \
+    lambda/debuginfo.cmi \
+    middle_end/backend_var.cmi \
+    asmcomp/insn_debuginfo.cmi
+asmcomp/insn_debuginfo.cmx : \
+    asmcomp/debug/reg_availability_set.cmx \
+    lambda/debuginfo.cmx \
+    middle_end/backend_var.cmx \
+    asmcomp/insn_debuginfo.cmi
+asmcomp/insn_debuginfo.cmi : \
+    asmcomp/debug/reg_availability_set.cmi \
+    lambda/debuginfo.cmi \
+    middle_end/backend_var.cmi
 asmcomp/interf.cmo : \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
@@ -2375,6 +2389,7 @@ asmcomp/linearize.cmo : \
     asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
+    asmcomp/insn_debuginfo.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
@@ -2384,6 +2399,7 @@ asmcomp/linearize.cmx : \
     asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
+    asmcomp/insn_debuginfo.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
@@ -2391,6 +2407,7 @@ asmcomp/linearize.cmx : \
 asmcomp/linearize.cmi : \
     asmcomp/reg.cmi \
     asmcomp/mach.cmi \
+    asmcomp/insn_debuginfo.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi
 asmcomp/linscan.cmo : \
@@ -2425,26 +2442,24 @@ asmcomp/liveness.cmx : \
 asmcomp/liveness.cmi : \
     asmcomp/mach.cmi
 asmcomp/mach.cmo : \
-    asmcomp/debug/reg_with_debug_info.cmi \
-    asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi \
+    asmcomp/insn_debuginfo.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \
     asmcomp/arch.cmo \
     asmcomp/mach.cmi
 asmcomp/mach.cmx : \
-    asmcomp/debug/reg_with_debug_info.cmx \
-    asmcomp/debug/reg_availability_set.cmx \
     asmcomp/reg.cmx \
+    asmcomp/insn_debuginfo.cmx \
     lambda/debuginfo.cmx \
     asmcomp/cmm.cmx \
     middle_end/backend_var.cmx \
     asmcomp/arch.cmx \
     asmcomp/mach.cmi
 asmcomp/mach.cmi : \
-    asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi \
+    asmcomp/insn_debuginfo.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \
@@ -2473,6 +2488,7 @@ asmcomp/printlinear.cmo : \
     asmcomp/printcmm.cmi \
     asmcomp/mach.cmi \
     asmcomp/linearize.cmi \
+    asmcomp/insn_debuginfo.cmi \
     lambda/debuginfo.cmi \
     asmcomp/printlinear.cmi
 asmcomp/printlinear.cmx : \
@@ -2480,6 +2496,7 @@ asmcomp/printlinear.cmx : \
     asmcomp/printcmm.cmx \
     asmcomp/mach.cmx \
     asmcomp/linearize.cmx \
+    asmcomp/insn_debuginfo.cmx \
     lambda/debuginfo.cmx \
     asmcomp/printlinear.cmi
 asmcomp/printlinear.cmi : \
@@ -2491,6 +2508,7 @@ asmcomp/printmach.cmo : \
     asmcomp/printcmm.cmi \
     asmcomp/mach.cmi \
     asmcomp/interval.cmi \
+    asmcomp/insn_debuginfo.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
@@ -2505,6 +2523,7 @@ asmcomp/printmach.cmx : \
     asmcomp/printcmm.cmx \
     asmcomp/mach.cmx \
     asmcomp/interval.cmx \
+    asmcomp/insn_debuginfo.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
@@ -5413,6 +5432,7 @@ asmcomp/debug/available_regs.cmo : \
     asmcomp/printmach.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
+    asmcomp/insn_debuginfo.cmi \
     utils/clflags.cmi \
     middle_end/backend_var.cmi \
     asmcomp/debug/available_regs.cmi
@@ -5424,6 +5444,7 @@ asmcomp/debug/available_regs.cmx : \
     asmcomp/printmach.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
+    asmcomp/insn_debuginfo.cmx \
     utils/clflags.cmx \
     middle_end/backend_var.cmx \
     asmcomp/debug/available_regs.cmi

--- a/Changes
+++ b/Changes
@@ -100,8 +100,12 @@ Working version
   [Lprologue] relative to [Iname_for_debugger] operations.
   (Mark Shinwell, review by Vincent Laviron)
 
+- #2303: Add [Insn_debuginfo] module.  Change the interface for
+  creating [Mach] instructions.  Do not generate empty debuginfo when
+  copying [Mach] instructions, etc.
+  (Mark Shinwell, review by Vincent Laviron)
+
 - #2308: More debugging information on [Cmm] terms
-  (Mark Shinwell, review by Stephen Dolan)
 
 - #7878, #8542: Replaced TypedtreeIter with tast_iterator
   (Isaac "Izzy" Avram, review by Gabriel Scherer and Nicolás Ojeda Bär)

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ ASMCOMP=\
   asmcomp/cmm.cmo asmcomp/printcmm.cmo \
   asmcomp/reg.cmo asmcomp/debug/reg_with_debug_info.cmo \
   asmcomp/debug/reg_availability_set.cmo \
+  asmcomp/insn_debuginfo.cmo \
   asmcomp/mach.cmo asmcomp/proc.cmo \
   asmcomp/afl_instrument.cmo \
   asmcomp/strmatch.cmo \

--- a/asmcomp/CSEgen.mli
+++ b/asmcomp/CSEgen.mli
@@ -24,7 +24,7 @@ type op_class =
   | Op_other   (* anything else that does not allocate nor store in memory *)
 
 class cse_generic : object
-  (* The following methods can be overridden to handle processor-specific
+  (* The following methods can be overriden to handle processor-specific
      operations. *)
 
   method class_of_operation: Mach.operation -> op_class

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -232,6 +232,7 @@ let addressing addr typ i n =
 (* Record live pointers at call points -- see Emitaux *)
 
 let record_frame_label ?label live raise_ dbg =
+  let dbg = Insn_debuginfo.dbg dbg in
   let lbl =
     match label with
     | None -> new_label()
@@ -480,7 +481,7 @@ let tailrec_entry_point = ref 0
 
 (* Emit an instruction *)
 let emit_instr fallthrough i =
-  emit_debug_info i.dbg;
+  emit_debug_info (Insn_debuginfo.dbg i.dbg);
   match i.desc with
   | Lend -> ()
   | Lprologue ->
@@ -647,7 +648,7 @@ let emit_instr fallthrough i =
           I.cmp (mem64_rip QWORD (emit_symbol "caml_young_limit")) r15;
         let lbl_call_gc = new_label() in
         let dbg =
-          if not Config.spacetime then Debuginfo.none
+          if not Config.spacetime then Insn_debuginfo.none
           else i.dbg
         in
         let lbl_frame =
@@ -679,7 +680,7 @@ let emit_instr fallthrough i =
         end;
         let label =
           record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+            Insn_debuginfo.none
         in
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -100,6 +100,7 @@ let emit_addressing addr r n =
 (* Record live pointers at call points *)
 
 let record_frame_label ?label live raise_ dbg =
+  let dbg = Insn_debuginfo.dbg dbg in
   let lbl =
     match label with
     | None -> new_label()
@@ -438,7 +439,7 @@ let emit_load_handler_address handler =
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
-    emit_debug_info i.dbg;
+    emit_debug_info (Insn_debuginfo.dbg i.dbg);
     match i.desc with
     | Lend -> 0
     | Lprologue ->

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -120,6 +120,7 @@ let emit_addressing addr r =
 (* Record live pointers at call points *)
 
 let record_frame_label ?label live raise_ dbg =
+  let dbg = Insn_debuginfo.dbg dbg in
   let lbl =
     match label with
     | None -> new_label()
@@ -562,7 +563,7 @@ let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
-    emit_debug_info i.dbg;
+    emit_debug_info (Insn_debuginfo.dbg i.dbg);
     match i.desc with
     | Lend -> ()
     | Lprologue ->

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -38,8 +38,7 @@ let rec combine i allocstate =
          let (next, totalsz) =
            combine i.next
              (Pending_alloc { reg = i.res.(0); totalsz = totalsz + sz }) in
-         (instr_cons_debug (Iop(Iintop_imm(Iadd, -sz)))
-            [| reg |] i.res i.dbg next,
+         (instr_cons_from i (Iop(Iintop_imm(Iadd, -sz))) ~arg:[| reg |] ~next,
           totalsz)
       | No_alloc | Pending_alloc _ ->
          let (next, totalsz) =
@@ -48,44 +47,46 @@ let rec combine i allocstate =
          let next =
            let offset = totalsz - sz in
            if offset = 0 then next
-           else instr_cons_debug (Iop(Iintop_imm(Iadd, offset))) i.res
-                i.res i.dbg next
+           else
+             instr_cons_from i (Iop(Iintop_imm(Iadd, offset)))
+               ~arg:i.res ~res:i.res ~next
          in
-         (instr_cons_debug (Iop(Ialloc {bytes = totalsz; spacetime_index = 0;
+         (instr_cons_from i (Iop(Ialloc {bytes = totalsz; spacetime_index = 0;
                                         label_after_call_gc = None; }))
-          i.arg i.res i.dbg next, allocated_size allocstate)
+            ~next,
+          allocated_size allocstate)
       end
   | Iop(Icall_ind _ | Icall_imm _ | Iextcall _ |
         Itailcall_ind _ | Itailcall_imm _) ->
       let newnext = combine_restart i.next in
-      (instr_cons_debug i.desc i.arg i.res i.dbg newnext,
+      (instr_cons_from i i.desc ~next:newnext,
        allocated_size allocstate)
   | Iop _ ->
       let (newnext, sz) = combine i.next allocstate in
-      (instr_cons_debug i.desc i.arg i.res i.dbg newnext, sz)
+      (instr_cons_from i i.desc ~next:newnext, sz)
   | Iifthenelse(test, ifso, ifnot) ->
       let newifso = combine_restart ifso in
       let newifnot = combine_restart ifnot in
       let newnext = combine_restart i.next in
-      (instr_cons (Iifthenelse(test, newifso, newifnot)) i.arg i.res newnext,
+      (instr_cons_from i (Iifthenelse(test, newifso, newifnot)) ~next:newnext,
        allocated_size allocstate)
   | Iswitch(table, cases) ->
       let newcases = Array.map combine_restart cases in
       let newnext = combine_restart i.next in
-      (instr_cons (Iswitch(table, newcases)) i.arg i.res newnext,
+      (instr_cons_from i (Iswitch(table, newcases)) ~next:newnext,
        allocated_size allocstate)
   | Icatch(rec_flag, handlers, body) ->
       let (newbody, sz) = combine body allocstate in
       let newhandlers =
         List.map (fun (io, handler) -> io, combine_restart handler) handlers in
       let newnext = combine_restart i.next in
-      (instr_cons (Icatch(rec_flag, newhandlers, newbody))
-         i.arg i.res newnext, sz)
+      (instr_cons_from i (Icatch(rec_flag, newhandlers, newbody)) ~next:newnext,
+       sz)
   | Itrywith(body, handler) ->
       let (newbody, sz) = combine body allocstate in
       let newhandler = combine_restart handler in
       let newnext = combine_restart i.next in
-      (instr_cons (Itrywith(newbody, newhandler)) i.arg i.res newnext, sz)
+      (instr_cons_from i (Itrywith(newbody, newhandler)) ~next:newnext, sz)
 
 and combine_restart i =
   let (newi, _) = combine i No_alloc in newi

--- a/asmcomp/debug/available_regs.ml
+++ b/asmcomp/debug/available_regs.ml
@@ -85,7 +85,7 @@ let check_invariants (instr : M.instruction) ~(avail_before : RAS.t) =
 let rec available_regs (instr : M.instruction)
       ~(avail_before : RAS.t) : RAS.t =
   check_invariants instr ~avail_before;
-  instr.available_before <- avail_before;
+  instr.dbg <- Insn_debuginfo.with_available_before instr.dbg avail_before;
   let avail_across, avail_after =
     let ok set = RAS.Ok set in
     let unreachable = RAS.Unreachable in
@@ -325,7 +325,7 @@ let rec available_regs (instr : M.instruction)
         augment_availability_at_raise avail_before;
         None, unreachable
   in
-  instr.available_across <- avail_across;
+  instr.dbg <- Insn_debuginfo.with_available_across instr.dbg avail_across;
   match instr.desc with
   | Iend -> avail_after
   | _ -> available_regs instr.next ~avail_before:avail_after

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -192,6 +192,7 @@ let addressing addr typ i n =
 (* Record live pointers at call points *)
 
 let record_frame_label ?label live raise_ dbg =
+  let dbg = Insn_debuginfo.dbg dbg in
   let lbl =
     match label with
     | None -> new_label()
@@ -469,7 +470,7 @@ let function_name = ref ""
 let tailrec_entry_point = ref 0
 
 let emit_instr fallthrough i =
-  emit_debug_info i.dbg;
+  emit_debug_info (Insn_debuginfo.dbg i.dbg);
   match i.desc with
   | Lend -> ()
   | Lprologue ->
@@ -603,7 +604,7 @@ let emit_instr fallthrough i =
         I.mov eax (sym32 "caml_young_ptr");
         I.cmp (sym32 "caml_young_limit") eax;
         let lbl_call_gc = new_label() in
-        let lbl_frame = record_frame_label i.live false Debuginfo.none in
+        let lbl_frame = record_frame_label i.live false Insn_debuginfo.none in
         I.jb (label lbl_call_gc);
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0));
         call_gc_sites :=
@@ -621,7 +622,7 @@ let emit_instr fallthrough i =
         end;
         let label =
           record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+            Insn_debuginfo.none
         in
         def_label label;
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0))

--- a/asmcomp/insn_debuginfo.ml
+++ b/asmcomp/insn_debuginfo.ml
@@ -1,0 +1,50 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = {
+  dbg: Debuginfo.t;
+  phantom_available_before: Backend_var.Set.t;
+  available_before: Reg_availability_set.t;
+  available_across: Reg_availability_set.t option;
+}
+
+let create dbg ~phantom_available_before =
+  { dbg;
+    phantom_available_before;
+    available_before = Reg_availability_set.Unreachable;
+    available_across = None;
+  }
+
+let none =
+  { dbg = Debuginfo.none;
+    phantom_available_before = Backend_var.Set.empty;
+    available_before = Reg_availability_set.Unreachable;
+    available_across = None;
+  }
+
+let dbg t = t.dbg
+let phantom_available_before t = t.phantom_available_before
+let available_before t = t.available_before
+let available_across t = t.available_across
+
+let with_available_before t available_before =
+  { t with available_before; }
+
+let with_available_across t available_across =
+  { t with available_across; }
+
+let map_available_before t ~f =
+  with_available_before t (f t.available_before)

--- a/asmcomp/insn_debuginfo.mli
+++ b/asmcomp/insn_debuginfo.mli
@@ -1,0 +1,70 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Information attached to Mach and Linearize instructions that is used
+    for the emission of debugging information. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t
+
+(** Create a debugging information structure that corresponds to some
+    particular instruction.  Values of type [t] are immutable.
+
+    The parameters are as for the documentation on [dbg] and
+    [phantom_available_before], below. *)
+val create
+   : Debuginfo.t
+  -> phantom_available_before:Backend_var.Set.t
+  -> t
+
+(** The empty debugging information structure. *)
+val none : t
+
+(** Information about the source location and the block where the instruction
+    is located. *)
+val dbg : t -> Debuginfo.t
+
+(** Which variables bound by phantom lets are available immediately prior to
+    commencement of execution of the instruction. *)
+val phantom_available_before : t -> Backend_var.Set.t
+
+(** Which registers are available (in the sense of [Available_regs])
+    immediately prior to commencement of execution of the instruction. *)
+val available_before : t -> Reg_availability_set.t
+
+(** Which registers are available (in the sense of [Available_regs])
+    during execution of the instruction.
+
+    Note that [available_across] may not be a subset of [available_before],
+    because [Reg_availability_set.canonicalise] does not preserve this
+    property.  (Example: if %rax and %rbx both hold the value of some variable
+    [x] before the instruction but %rax is not available across the instruction,
+    then the canonicalised sets for [available_before] and [available_after]
+    may not name the same register for [x].) *)
+val available_across : t -> Reg_availability_set.t option
+
+(** Set which registers are available (in the sense of [Available_regs])
+    immediately prior to commencement of execution of the instruction. *)
+val with_available_before : t -> Reg_availability_set.t -> t
+
+(** Set which registers are available (in the sense of [Available_regs])
+    during execution of the instruction. *)
+val with_available_across : t -> Reg_availability_set.t option -> t
+
+(** Change the [available_before] field according to the given function. *)
+val map_available_before
+   : t
+  -> f:(Reg_availability_set.t -> Reg_availability_set.t)
+  -> t

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -25,7 +25,7 @@ type instruction =
     mutable next: instruction;
     arg: Reg.t array;
     res: Reg.t array;
-    dbg: Debuginfo.t;
+    mutable dbg: Insn_debuginfo.t;
     live: Reg.Set.t }
 
 and instruction_desc =
@@ -80,20 +80,20 @@ let rec end_instr =
     next = end_instr;
     arg = [||];
     res = [||];
-    dbg = Debuginfo.none;
+    dbg = Insn_debuginfo.none;
     live = Reg.Set.empty }
 
 (* Cons an instruction (live, debug empty) *)
 
 let instr_cons d a r n =
   { desc = d; next = n; arg = a; res = r;
-    dbg = Debuginfo.none; live = Reg.Set.empty }
+    dbg = Insn_debuginfo.none; live = Reg.Set.empty }
 
 (* Cons a simple instruction (arg, res, live empty) *)
 
 let cons_instr d n =
   { desc = d; next = n; arg = [||]; res = [||];
-    dbg = Debuginfo.none; live = Reg.Set.empty }
+    dbg = Insn_debuginfo.none; live = Reg.Set.empty }
 
 (* Build an instruction with arg, res, dbg, live taken from
    the given Mach.instruction *)

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -22,7 +22,7 @@ type instruction =
     mutable next: instruction;
     arg: Reg.t array;
     res: Reg.t array;
-    dbg: Debuginfo.t;
+    mutable dbg: Insn_debuginfo.t;
     live: Reg.Set.t }
 
 and instruction_desc =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -304,6 +304,7 @@ let adjust_stack_offset delta =
 (* Record live pointers at call points *)
 
 let record_frame ?label live raise_ dbg =
+  let dbg = Insn_debuginfo.dbg dbg in
   let lbl =
     match label with
     | None -> new_label()
@@ -523,7 +524,7 @@ end)
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
-    emit_debug_info i.dbg;
+    emit_debug_info (Insn_debuginfo.dbg i.dbg);
     match i.desc with
     | Lend -> ()
     | Lprologue ->
@@ -761,7 +762,7 @@ let emit_instr i =
         `	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`;
         `	bltl	{emit_label !call_gc_label}\n`;
         (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live false Debuginfo.none
+        record_frame i.live false Insn_debuginfo.none
     | Lop(Ispecific(Ialloc_far { bytes = n; label_after_call_gc; })) ->
         if !call_gc_label = 0 then begin
           match label_after_call_gc with
@@ -774,7 +775,7 @@ let emit_instr i =
         `	bge	{emit_label lbl}\n`;
         `	bl	{emit_label !call_gc_label}\n`;
         (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live false Debuginfo.none;
+        record_frame i.live false Insn_debuginfo.none;
         `{emit_label lbl}:	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`
     | Lop(Iintop Isub) ->               (* subfc has swapped arguments *)
         `	subfc	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -68,8 +68,9 @@ let instr ppf i =
   | Lraise k ->
       fprintf ppf "%a %a" Printcmm.raise_kind k reg i.arg.(0)
   end;
-  if not (Debuginfo.is_none i.dbg) then
-    fprintf ppf " %s" (Debuginfo.to_string i.dbg)
+  let dbg = Insn_debuginfo.dbg i.dbg in
+  if not (Debuginfo.is_none dbg) then
+    fprintf ppf " %s" (Debuginfo.to_string dbg)
 
 let rec all_instr ppf i =
   match i.desc with

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -174,9 +174,11 @@ let rec instr ppf i =
     if Array.length i.arg > 0 then fprintf ppf "@ +@ %a" regs i.arg;
     fprintf ppf "}@]@,";
     if !Clflags.dump_avail then begin
+      let available_before = Insn_debuginfo.available_before i.dbg in
+      let available_across = Insn_debuginfo.available_across i.dbg in
       let module RAS = Reg_availability_set in
-      fprintf ppf "@[<1>AB={%a}" (RAS.print ~print_reg:reg) i.available_before;
-      begin match i.available_across with
+      fprintf ppf "@[<1>AB={%a}" (RAS.print ~print_reg:reg) available_before;
+      begin match available_across with
       | None -> ()
       | Some available_across ->
         fprintf ppf ",AA={%a}" (RAS.print ~print_reg:reg) available_across
@@ -229,8 +231,9 @@ let rec instr ppf i =
   | Iraise k ->
       fprintf ppf "%a %a" Printcmm.raise_kind k reg i.arg.(0)
   end;
-  if not (Debuginfo.is_none i.dbg) then
-    fprintf ppf "%s" (Debuginfo.to_string i.dbg);
+  let dbg = Insn_debuginfo.dbg i.dbg in
+  if not (Debuginfo.is_none dbg) then
+    fprintf ppf "%s" (Debuginfo.to_string dbg);
   begin match i.next.desc with
     Iend -> ()
   | _ -> fprintf ppf "@,%a" instr i.next

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -163,6 +163,7 @@ let emit_set_comp cmp res =
 (* Record live pointers at call points *)
 
 let record_frame_label ?label live raise_ dbg =
+  let dbg = Insn_debuginfo.dbg dbg in
   let lbl =
     match label with
     | None -> new_label()
@@ -304,7 +305,7 @@ let tailrec_entry_point = ref 0
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
-    emit_debug_info i.dbg;
+    emit_debug_info (Insn_debuginfo.dbg i.dbg);
     match i.desc with
       Lend -> ()
     | Lprologue ->

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -560,7 +560,7 @@ method insert_debug _env desc dbg arg res =
     instr_cons_debug ~phantom_available_before:(Exactly Backend_var.Set.empty)
       desc arg res dbg instr_seq
 
-method insert desc _env arg res =
+method insert _env desc arg res =
   instr_seq <-
     instr_cons_debug ~phantom_available_before:(Exactly Backend_var.Set.empty)
       desc arg res Debuginfo.none instr_seq

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -121,7 +121,8 @@ let destroyed_at_fork = ref ([] : (instruction * Reg.Set.t) list)
 
 let add_reloads regset i =
   Reg.Set.fold
-    (fun r i -> instr_cons (Iop Ireload) [|spill_reg r|] [|r|] i)
+    (fun r i ->
+      instr_cons_from i (Iop Ireload) ~arg:[|spill_reg r|] ~res:[|r|] ~next:i)
     regset i
 
 let reload_at_exit = ref []
@@ -146,7 +147,7 @@ let rec reload i before =
       (* All regs live across must be spilled *)
       let (new_next, finally) = reload i.next i.live in
       (add_reloads (Reg.inter_set_array before i.arg)
-                   (instr_cons_debug i.desc i.arg i.res i.dbg new_next),
+                   (instr_cons_from i i.desc ~next:new_next),
        finally)
   | Iop op ->
       let new_before =
@@ -160,7 +161,7 @@ let rec reload i before =
         Reg.diff_set_array (Reg.diff_set_array new_before i.arg) i.res in
       let (new_next, finally) = reload i.next after in
       (add_reloads (Reg.inter_set_array new_before i.arg)
-                   (instr_cons_debug i.desc i.arg i.res i.dbg new_next),
+                   (instr_cons_from i i.desc ~next:new_next),
        finally)
   | Iifthenelse(test, ifso, ifnot) ->
       let at_fork = Reg.diff_set_array before i.arg in
@@ -173,8 +174,9 @@ let rec reload i before =
       let (new_next, finally) =
         reload i.next (Reg.Set.union after_ifso after_ifnot) in
       let new_i =
-        instr_cons (Iifthenelse(test, new_ifso, new_ifnot))
-        i.arg i.res new_next in
+        instr_cons_from i (Iifthenelse(test, new_ifso, new_ifnot))
+          ~next:new_next
+      in
       destroyed_at_fork := (new_i, at_fork) :: !destroyed_at_fork;
       (add_reloads (Reg.inter_set_array before i.arg) new_i,
        finally)
@@ -195,8 +197,8 @@ let rec reload i before =
       current_date := !date_join;
       let (new_next, finally) = reload i.next !after_cases in
       (add_reloads (Reg.inter_set_array before i.arg)
-                   (instr_cons (Iswitch(index, new_cases))
-                               i.arg i.res new_next),
+                   (instr_cons_from i (Iswitch(index, new_cases))
+                     ~next:new_next),
        finally)
   | Icatch(rec_flag, handlers, body) ->
       let new_sets = List.map
@@ -231,8 +233,8 @@ let rec reload i before =
       let new_handlers = List.map2
           (fun (nfail, _) (new_handler, _) -> nfail, new_handler)
           handlers res in
-      (instr_cons
-         (Icatch(rec_flag, new_handlers, new_body)) i.arg i.res new_next,
+      (instr_cons_from i (Icatch(rec_flag, new_handlers, new_body))
+         ~next:new_next,
        finally)
   | Iexit nfail ->
       let set = find_reload_at_exit nfail in
@@ -248,7 +250,7 @@ let rec reload i before =
       let (new_handler, after_handler) = reload handler before_handler in
       let (new_next, finally) =
         reload i.next (Reg.Set.union after_body after_handler) in
-      (instr_cons (Itrywith(new_body, new_handler)) i.arg i.res new_next,
+      (instr_cons_from i (Itrywith(new_body, new_handler)) ~next:new_next,
        finally)
   | Iraise _ ->
       (add_reloads (Reg.inter_set_array before i.arg) i, Reg.Set.empty)
@@ -286,9 +288,23 @@ and inside_arm = ref false
 and inside_catch = ref false
 
 let add_spills regset i =
-  Reg.Set.fold
-    (fun r i -> instr_cons (Iop Ispill) [|r|] [|spill_reg r|] i)
-    regset i
+  let regset = Reg.Set.elements regset in
+  (* Skip over any [Iname_for_debugger] operations so that we don't put a
+     spill between a move into a register and the operation naming that
+     register.  (Such a situation would cause the spilled register to be
+     unnamed). *)
+  let rec add_spills i =
+    match i.desc with
+    | Iop (Iname_for_debugger _) ->
+      let next = add_spills i.next in
+      { i with next; }
+    | _ ->
+      List.fold_left (fun i r ->
+          instr_cons_from i (Iop Ispill) ~arg:[|r|] ~res:[|spill_reg r|]
+            ~next:i)
+        i regset
+  in
+  add_spills i
 
 let rec spill i finally =
   match i.desc with
@@ -299,7 +315,7 @@ let rec spill i finally =
   | Iop Ireload ->
       let (new_next, after) = spill i.next finally in
       let before1 = Reg.diff_set_array after i.res in
-      (instr_cons i.desc i.arg i.res new_next,
+      (instr_cons_from i i.desc ~next:new_next,
        Reg.add_set_array before1 i.res)
   | Iop _ ->
       let (new_next, after) = spill i.next finally in
@@ -311,8 +327,8 @@ let rec spill i finally =
             Reg.Set.union before1 !spill_at_raise
         | _ ->
             before1 in
-      (instr_cons_debug i.desc i.arg i.res i.dbg
-                  (add_spills (Reg.inter_set_array after i.res) new_next),
+      (instr_cons_from i i.desc
+         ~next:(add_spills (Reg.inter_set_array after i.res) new_next),
        before)
   | Iifthenelse(test, ifso, ifnot) ->
       let (new_next, at_join) = spill i.next finally in
@@ -321,8 +337,8 @@ let rec spill i finally =
       if
         !inside_loop || !inside_arm || !inside_catch
       then
-        (instr_cons (Iifthenelse(test, new_ifso, new_ifnot))
-                     i.arg i.res new_next,
+        (instr_cons_from i (Iifthenelse(test, new_ifso, new_ifnot))
+          ~next:new_next,
          Reg.Set.union before_ifso before_ifnot)
       else begin
         let destroyed = List.assq i !destroyed_at_fork in
@@ -330,10 +346,10 @@ let rec spill i finally =
           Reg.Set.diff (Reg.Set.diff before_ifso before_ifnot) destroyed
         and spill_ifnot_branch =
           Reg.Set.diff (Reg.Set.diff before_ifnot before_ifso) destroyed in
-        (instr_cons
+        (instr_cons_from i
             (Iifthenelse(test, add_spills spill_ifso_branch new_ifso,
                                add_spills spill_ifnot_branch new_ifnot))
-            i.arg i.res new_next,
+            ~next:new_next,
          Reg.Set.diff (Reg.Set.diff (Reg.Set.union before_ifso before_ifnot)
                                     spill_ifso_branch)
                        spill_ifnot_branch)
@@ -351,7 +367,7 @@ let rec spill i finally =
             new_c)
           cases in
       inside_arm := saved_inside_arm ;
-      (instr_cons (Iswitch(index, new_cases)) i.arg i.res new_next,
+      (instr_cons_from i (Iswitch(index, new_cases)) ~next:new_next,
        !before)
   | Icatch(rec_flag, handlers, body) ->
       let (new_next, at_join) = spill i.next finally in
@@ -391,8 +407,8 @@ let rec spill i finally =
       let new_handlers = List.map2
           (fun (nfail, _) (handler, _) -> nfail, handler)
           handlers res in
-      (instr_cons (Icatch(rec_flag, new_handlers, new_body))
-         i.arg i.res new_next,
+      (instr_cons_from i (Icatch(rec_flag, new_handlers, new_body))
+         ~next:new_next,
        before)
   | Iexit nfail ->
       (i, find_spill_at_exit nfail)
@@ -403,7 +419,7 @@ let rec spill i finally =
       spill_at_raise := before_handler;
       let (new_body, before_body) = spill body at_join in
       spill_at_raise := saved_spill_at_raise;
-      (instr_cons (Itrywith(new_body, new_handler)) i.arg i.res new_next,
+      (instr_cons_from i (Itrywith(new_body, new_handler)) ~next:new_next,
        before_body)
   | Iraise _ ->
       (i, !spill_at_raise)
@@ -432,4 +448,5 @@ let fundecl f =
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_phantom_lets = f.fun_phantom_lets;
   }

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -288,7 +288,6 @@ and inside_arm = ref false
 and inside_catch = ref false
 
 let add_spills regset i =
-  let regset = Reg.Set.elements regset in
   (* Skip over any [Iname_for_debugger] operations so that we don't put a
      spill between a move into a register and the operation naming that
      register.  (Such a situation would cause the spilled register to be
@@ -299,10 +298,11 @@ let add_spills regset i =
       let next = add_spills i.next in
       { i with next; }
     | _ ->
-      List.fold_left (fun i r ->
+      Reg.Set.fold
+        (fun r i ->
           instr_cons_from i (Iop Ispill) ~arg:[|r|] ~res:[|spill_reg r|]
             ~next:i)
-        i regset
+        regset i
   in
   add_spills i
 

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -126,7 +126,8 @@ let rec rename i sub =
     Iend ->
       (i, sub)
   | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
-      (instr_cons_debug i.desc (subst_regs i.arg sub) [||] i.dbg i.next,
+      (instr_cons_from i i.desc ~arg:(subst_regs i.arg sub) ~res:[||]
+         ~next:i.next,
        None)
   | Iop Ireload when i.res.(0).loc = Unknown ->
       begin match sub with
@@ -136,29 +137,31 @@ let rec rename i sub =
           let newr = Reg.clone i.res.(0) in
           let (new_next, sub_next) =
             rename i.next (Some(Reg.Map.add oldr newr s)) in
-          (instr_cons i.desc i.arg [|newr|] new_next,
+          (instr_cons_from i i.desc ~res:[|newr|] ~next:new_next,
            sub_next)
       end
   | Iop _ ->
       let (new_next, sub_next) = rename i.next sub in
-      (instr_cons_debug i.desc (subst_regs i.arg sub) (subst_regs i.res sub)
-                        i.dbg new_next,
+      (instr_cons_from i i.desc
+        ~arg:(subst_regs i.arg sub) ~res:(subst_regs i.res sub)
+        ~next:new_next,
        sub_next)
   | Iifthenelse(tst, ifso, ifnot) ->
       let (new_ifso, sub_ifso) = rename ifso sub in
       let (new_ifnot, sub_ifnot) = rename ifnot sub in
       let (new_next, sub_next) =
         rename i.next (merge_substs sub_ifso sub_ifnot i.next) in
-      (instr_cons (Iifthenelse(tst, new_ifso, new_ifnot))
-                  (subst_regs i.arg sub) [||] new_next,
+      (instr_cons_from i (Iifthenelse(tst, new_ifso, new_ifnot))
+         ~arg:(subst_regs i.arg sub) ~res:[||] ~next:new_next,
        sub_next)
   | Iswitch(index, cases) ->
       let new_sub_cases = Array.map (fun c -> rename c sub) cases in
       let sub_merge =
         merge_subst_array (Array.map (fun (_n, s) -> s) new_sub_cases) i.next in
       let (new_next, sub_next) = rename i.next sub_merge in
-      (instr_cons (Iswitch(index, Array.map (fun (n, _s) -> n) new_sub_cases))
-                  (subst_regs i.arg sub) [||] new_next,
+      (instr_cons_from i
+         (Iswitch(index, Array.map (fun (n, _s) -> n) new_sub_cases))
+         ~arg:(subst_regs i.arg sub) ~res:[||] ~next:new_next,
        sub_next)
   | Icatch(rec_flag, handlers, body) ->
       let new_subst = List.map (fun (nfail, _) -> nfail, ref None)
@@ -177,8 +180,8 @@ let rec rename i sub =
       let (new_next, sub_next) = rename i.next merged_subst in
       let new_handlers = List.map2 (fun (nfail, _) (handler, _) ->
           (nfail, handler)) handlers res in
-      (instr_cons
-         (Icatch(rec_flag, new_handlers, new_body)) [||] [||] new_next,
+      (instr_cons_from i (Icatch(rec_flag, new_handlers, new_body))
+         ~arg:[||] ~res:[||] ~next:new_next,
        sub_next)
   | Iexit nfail ->
       let r = find_exit_subst nfail in
@@ -189,10 +192,12 @@ let rec rename i sub =
       let (new_handler, sub_handler) = rename handler sub in
       let (new_next, sub_next) =
         rename i.next (merge_substs sub_body sub_handler i.next) in
-      (instr_cons (Itrywith(new_body, new_handler)) [||] [||] new_next,
+      (instr_cons_from i (Itrywith(new_body, new_handler))
+         ~arg:[||] ~res:[||] ~next:new_next,
        sub_next)
   | Iraise k ->
-      (instr_cons_debug (Iraise k) (subst_regs i.arg sub) [||] i.dbg i.next,
+      (instr_cons_from i (Iraise k)
+         ~arg:(subst_regs i.arg sub) ~res:[||] ~next:i.next,
        None)
 
 (* Second pass: replace registers by their final representatives *)
@@ -220,4 +225,5 @@ let fundecl f =
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_phantom_lets = f.fun_phantom_lets;
   }


### PR DESCRIPTION
This pull request contains the changes necessary to the Mach language and its associated passes for gdb support.  I'm fairly pleased with these changes insofar as they have, in the end, worked out to be fairly modest in scale.

The main thing here is the introduction of a new type, `Insn_debuginfo.t`, which is used all the way through to the emitters as a replacement for `Debuginfo.t` on instructions.  It encapsulates the existing `Debuginfo.t` structure together with various register and variable availability sets.  The introduction of this type means that the `Mach.instruction` type goes back to looking very nearly how it used to, save that the `dbg` field is mutable.

The interface for creating Mach instructions has been reworked a little.  I think the new version provides an improvement in readability.  It also incorporates the new types; and, crucially, _stops creating instructions that have empty debugging information fields_.  (The forthcoming patch to `Selectgen` will contain a few changes to ensure this property holds when we first create Mach code.)

In the new world, we need every instruction to have non-empty debugging information, as far as is reasonably possible.  The reason is that we track an approximation to lexical scopes right through from the `Lambda` code.  The scope information is contained within an enhanced `Debuginfo.t` type (to be presented in due course) and is used to assign instructions to DWARF lexical blocks, which are nested possibly-discontiguous ranges of code.  In turn, these lexical blocks affect the visibility of local variables in the debugger.

This visibility control is important since, in OCaml programs, the entirety of a function often contains a large number of variables.  If they all appear at all program points within such function in the debugger, with of course many of them showing as unavailable, it becomes unmanageable.

If a given instruction lacks debugging information, it will be assigned to the toplevel lexical block of the enclosing function, which means that when the user lands on that instruction in the debugger local variables may suddenly become invisible.

The changes to the Mach passes themselves are straightforward; with one exception, these are just coping with the interface change.

The exception relates to the insertion of spill instructions.  As noted in the code, we need to ensure that spill instructions do not get positioned in the wrong place relative to the `Iname_for_debugger` pseudooperation.  It is straightforward to ensure this.

Apart from that, there is the introduction of a field to carry phantom let information on function declarations; correction of one spelling mistake; and I think that's all.  There are probably some "dangling" references to things not yet merged in some of the comments, but those will resolve themselves once the remainder of the gdb support is in.

@chambart @lthls Could you take a look at this in the first instance?