### PR TITLE
Use atomic bigarray accesses whenever possible

### DIFF
--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -627,66 +627,84 @@ CAMLprim value caml_ba_get_generic(value vb, value vind)
 
 CAMLprim value caml_ba_uint8_get16(value vb, value vind)
 {
+  void *addr;
   intnat res;
   unsigned char b1, b2;
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 1) caml_array_bound_error();
-  b1 = ((unsigned char*) b->data)[idx];
-  b2 = ((unsigned char*) b->data)[idx+1];
+  addr = &((unsigned char *) b->data)[idx];
+  if (!((size_t) addr & 0x1)) { /* aligned access */
+    res = *((uint16_t *) addr);
+  } else { /* unaligned access */
+    b1 = ((unsigned char*) b->data)[idx];
+    b2 = ((unsigned char*) b->data)[idx+1];
 #ifdef ARCH_BIG_ENDIAN
-  res = b1 << 8 | b2;
+    res = b1 << 8 | b2;
 #else
-  res = b2 << 8 | b1;
+    res = b2 << 8 | b1;
 #endif
+  }
   return Val_int(res);
 }
 
 CAMLprim value caml_ba_uint8_get32(value vb, value vind)
 {
+  void *addr;
   uint32_t res;
   unsigned char b1, b2, b3, b4;
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 3) caml_array_bound_error();
-  b1 = ((unsigned char*) b->data)[idx];
-  b2 = ((unsigned char*) b->data)[idx+1];
-  b3 = ((unsigned char*) b->data)[idx+2];
-  b4 = ((unsigned char*) b->data)[idx+3];
+  addr = &((unsigned char *) b->data)[idx];
+  if (!((size_t) addr & 0x3)) { /* aligned access */
+    res = *((uint32_t *) addr);
+  } else { /* unaligned access */
+    b1 = ((unsigned char*) b->data)[idx];
+    b2 = ((unsigned char*) b->data)[idx+1];
+    b3 = ((unsigned char*) b->data)[idx+2];
+    b4 = ((unsigned char*) b->data)[idx+3];
 #ifdef ARCH_BIG_ENDIAN
-  res = b1 << 24 | b2 << 16 | b3 << 8 | b4;
+    res = b1 << 24 | b2 << 16 | b3 << 8 | b4;
 #else
-  res = b4 << 24 | b3 << 16 | b2 << 8 | b1;
+    res = b4 << 24 | b3 << 16 | b2 << 8 | b1;
 #endif
+  }
   return caml_copy_int32(res);
 }
 
 CAMLprim value caml_ba_uint8_get64(value vb, value vind)
 {
+  void *addr;
   uint64_t res;
   unsigned char b1, b2, b3, b4, b5, b6, b7, b8;
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 7) caml_array_bound_error();
-  b1 = ((unsigned char*) b->data)[idx];
-  b2 = ((unsigned char*) b->data)[idx+1];
-  b3 = ((unsigned char*) b->data)[idx+2];
-  b4 = ((unsigned char*) b->data)[idx+3];
-  b5 = ((unsigned char*) b->data)[idx+4];
-  b6 = ((unsigned char*) b->data)[idx+5];
-  b7 = ((unsigned char*) b->data)[idx+6];
-  b8 = ((unsigned char*) b->data)[idx+7];
+  addr = &((unsigned char *) b->data)[idx];
+  if (!((size_t) addr & 0x7)) { /* aligned access */
+    res = *((uint64_t *) addr);
+  } else { /* unaligned access */
+    b1 = ((unsigned char*) b->data)[idx];
+    b2 = ((unsigned char*) b->data)[idx+1];
+    b3 = ((unsigned char*) b->data)[idx+2];
+    b4 = ((unsigned char*) b->data)[idx+3];
+    b5 = ((unsigned char*) b->data)[idx+4];
+    b6 = ((unsigned char*) b->data)[idx+5];
+    b7 = ((unsigned char*) b->data)[idx+6];
+    b8 = ((unsigned char*) b->data)[idx+7];
 #ifdef ARCH_BIG_ENDIAN
-  res = (uint64_t) b1 << 56 | (uint64_t) b2 << 48
-        | (uint64_t) b3 << 40 | (uint64_t) b4 << 32
-        | (uint64_t) b5 << 24 | (uint64_t) b6 << 16
-        | (uint64_t) b7 << 8 | (uint64_t) b8;
+    res = (uint64_t) b1 << 56 | (uint64_t) b2 << 48
+          | (uint64_t) b3 << 40 | (uint64_t) b4 << 32
+          | (uint64_t) b5 << 24 | (uint64_t) b6 << 16
+          | (uint64_t) b7 << 8 | (uint64_t) b8;
 #else
-  res = (uint64_t) b8 << 56 | (uint64_t) b7 << 48
-        | (uint64_t) b6 << 40 | (uint64_t) b5 << 32
-        | (uint64_t) b4 << 24 | (uint64_t) b3 << 16
-        | (uint64_t) b2 << 8 | (uint64_t) b1;
+    res = (uint64_t) b8 << 56 | (uint64_t) b7 << 48
+          | (uint64_t) b6 << 40 | (uint64_t) b5 << 32
+          | (uint64_t) b4 << 24 | (uint64_t) b3 << 16
+          | (uint64_t) b2 << 8 | (uint64_t) b1;
 #endif
+  }
   return caml_copy_int64(res);
 }
 
@@ -775,85 +793,103 @@ CAMLprim value caml_ba_set_generic(value vb, value vind, value newval)
 
 CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)
 {
+  void *addr;
   unsigned char b1, b2;
   intnat val;
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 1) caml_array_bound_error();
   val = Long_val(newval);
+  addr = &((unsigned char *) b->data)[idx];
+  if (!((size_t) addr & 0x1)) { /* aligned access */
+    *((uint16_t *) addr) = val;
+  } else { /* unaligned access */
 #ifdef ARCH_BIG_ENDIAN
-  b1 = 0xFF & val >> 8;
-  b2 = 0xFF & val;
+    b1 = 0xFF & val >> 8;
+    b2 = 0xFF & val;
 #else
-  b2 = 0xFF & val >> 8;
-  b1 = 0xFF & val;
+    b2 = 0xFF & val >> 8;
+    b1 = 0xFF & val;
 #endif
-  ((unsigned char*) b->data)[idx] = b1;
-  ((unsigned char*) b->data)[idx+1] = b2;
+    ((unsigned char*) b->data)[idx] = b1;
+    ((unsigned char*) b->data)[idx+1] = b2;
+  }
   return Val_unit;
 }
 
 CAMLprim value caml_ba_uint8_set32(value vb, value vind, value newval)
 {
+  void *addr;
   unsigned char b1, b2, b3, b4;
   intnat idx = Long_val(vind);
   intnat val;
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 3) caml_array_bound_error();
   val = Int32_val(newval);
+  addr = &((unsigned char *) b->data)[idx];
+  if (!((size_t) addr & 0x3)) { /* aligned access */
+    *((uint32_t *) addr) = val;
+  } else { /* unaligned access */
 #ifdef ARCH_BIG_ENDIAN
-  b1 = 0xFF & val >> 24;
-  b2 = 0xFF & val >> 16;
-  b3 = 0xFF & val >> 8;
-  b4 = 0xFF & val;
+    b1 = 0xFF & val >> 24;
+    b2 = 0xFF & val >> 16;
+    b3 = 0xFF & val >> 8;
+    b4 = 0xFF & val;
 #else
-  b4 = 0xFF & val >> 24;
-  b3 = 0xFF & val >> 16;
-  b2 = 0xFF & val >> 8;
-  b1 = 0xFF & val;
+    b4 = 0xFF & val >> 24;
+    b3 = 0xFF & val >> 16;
+    b2 = 0xFF & val >> 8;
+    b1 = 0xFF & val;
 #endif
-  ((unsigned char*) b->data)[idx] = b1;
-  ((unsigned char*) b->data)[idx+1] = b2;
-  ((unsigned char*) b->data)[idx+2] = b3;
-  ((unsigned char*) b->data)[idx+3] = b4;
+    ((unsigned char*) b->data)[idx] = b1;
+    ((unsigned char*) b->data)[idx+1] = b2;
+    ((unsigned char*) b->data)[idx+2] = b3;
+    ((unsigned char*) b->data)[idx+3] = b4;
+  }
   return Val_unit;
 }
 
 CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
 {
+  void *addr;
   unsigned char b1, b2, b3, b4, b5, b6, b7, b8;
   intnat idx = Long_val(vind);
   int64_t val;
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 7) caml_array_bound_error();
+  addr = &((unsigned char *) b->data)[idx];
   val = Int64_val(newval);
+  if (!((size_t) addr & 0x7)) { /* aligned access */
+    *((uint64_t *) addr) = val;
+  } else { /* unaligned access */
 #ifdef ARCH_BIG_ENDIAN
-  b1 = 0xFF & val >> 56;
-  b2 = 0xFF & val >> 48;
-  b3 = 0xFF & val >> 40;
-  b4 = 0xFF & val >> 32;
-  b5 = 0xFF & val >> 24;
-  b6 = 0xFF & val >> 16;
-  b7 = 0xFF & val >> 8;
-  b8 = 0xFF & val;
+    b1 = 0xFF & val >> 56;
+    b2 = 0xFF & val >> 48;
+    b3 = 0xFF & val >> 40;
+    b4 = 0xFF & val >> 32;
+    b5 = 0xFF & val >> 24;
+    b6 = 0xFF & val >> 16;
+    b7 = 0xFF & val >> 8;
+    b8 = 0xFF & val;
 #else
-  b8 = 0xFF & val >> 56;
-  b7 = 0xFF & val >> 48;
-  b6 = 0xFF & val >> 40;
-  b5 = 0xFF & val >> 32;
-  b4 = 0xFF & val >> 24;
-  b3 = 0xFF & val >> 16;
-  b2 = 0xFF & val >> 8;
-  b1 = 0xFF & val;
+    b8 = 0xFF & val >> 56;
+    b7 = 0xFF & val >> 48;
+    b6 = 0xFF & val >> 40;
+    b5 = 0xFF & val >> 32;
+    b4 = 0xFF & val >> 24;
+    b3 = 0xFF & val >> 16;
+    b2 = 0xFF & val >> 8;
+    b1 = 0xFF & val;
 #endif
-  ((unsigned char*) b->data)[idx] = b1;
-  ((unsigned char*) b->data)[idx+1] = b2;
-  ((unsigned char*) b->data)[idx+2] = b3;
-  ((unsigned char*) b->data)[idx+3] = b4;
-  ((unsigned char*) b->data)[idx+4] = b5;
-  ((unsigned char*) b->data)[idx+5] = b6;
-  ((unsigned char*) b->data)[idx+6] = b7;
-  ((unsigned char*) b->data)[idx+7] = b8;
+    ((unsigned char*) b->data)[idx] = b1;
+    ((unsigned char*) b->data)[idx+1] = b2;
+    ((unsigned char*) b->data)[idx+2] = b3;
+    ((unsigned char*) b->data)[idx+3] = b4;
+    ((unsigned char*) b->data)[idx+4] = b5;
+    ((unsigned char*) b->data)[idx+5] = b6;
+    ((unsigned char*) b->data)[idx+6] = b7;
+    ((unsigned char*) b->data)[idx+7] = b8;
+  }
   return Val_unit;
 }
 

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -629,7 +629,9 @@ CAMLprim value caml_ba_uint8_get16(value vb, value vind)
 {
   void *addr;
   intnat res;
+#ifdef ARCH_ALIGN_INT16
   unsigned char b1, b2;
+#endif
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 1) caml_array_bound_error();
@@ -656,7 +658,9 @@ CAMLprim value caml_ba_uint8_get32(value vb, value vind)
 {
   void *addr;
   uint32_t res;
+#ifdef ARCH_ALIGN_INT32
   unsigned char b1, b2, b3, b4;
+#endif
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 3) caml_array_bound_error();
@@ -685,7 +689,9 @@ CAMLprim value caml_ba_uint8_get64(value vb, value vind)
 {
   void *addr;
   uint64_t res;
+#ifdef ARCH_ALIGN_INT64
   unsigned char b1, b2, b3, b4, b5, b6, b7, b8;
+#endif
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 7) caml_array_bound_error();
@@ -806,7 +812,9 @@ CAMLprim value caml_ba_set_generic(value vb, value vind, value newval)
 CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)
 {
   void *addr;
+#ifdef ARCH_ALIGN_INT16
   unsigned char b1, b2;
+#endif
   intnat val;
   intnat idx = Long_val(vind);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
@@ -836,7 +844,9 @@ CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)
 CAMLprim value caml_ba_uint8_set32(value vb, value vind, value newval)
 {
   void *addr;
+#ifdef ARCH_ALIGN_INT32
   unsigned char b1, b2, b3, b4;
+#endif
   intnat idx = Long_val(vind);
   intnat val;
   struct caml_ba_array * b = Caml_ba_array_val(vb);
@@ -872,7 +882,9 @@ CAMLprim value caml_ba_uint8_set32(value vb, value vind, value newval)
 CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
 {
   void *addr;
+#ifdef ARCH_ALIGN_INT64
   unsigned char b1, b2, b3, b4, b5, b6, b7, b8;
+#endif
   intnat idx = Long_val(vind);
   int64_t val;
   struct caml_ba_array * b = Caml_ba_array_val(vb);

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -634,6 +634,7 @@ CAMLprim value caml_ba_uint8_get16(value vb, value vind)
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 1) caml_array_bound_error();
   addr = &((unsigned char *) b->data)[idx];
+#ifdef ARCH_ALIGN_INT16
   if (!((size_t) addr & 0x1)) { /* aligned access */
     res = *((uint16_t *) addr);
   } else { /* unaligned access */
@@ -643,8 +644,11 @@ CAMLprim value caml_ba_uint8_get16(value vb, value vind)
     res = b1 << 8 | b2;
 #else
     res = b2 << 8 | b1;
-#endif
+#endif /* ARCH_BIG_ENDIAN */
   }
+#else
+  res = *((uint16_t *) addr);
+#endif /* ARCH_ALIGN_INT16 */
   return Val_int(res);
 }
 
@@ -657,6 +661,7 @@ CAMLprim value caml_ba_uint8_get32(value vb, value vind)
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 3) caml_array_bound_error();
   addr = &((unsigned char *) b->data)[idx];
+#ifdef ARCH_ALIGN_INT32
   if (!((size_t) addr & 0x3)) { /* aligned access */
     res = *((uint32_t *) addr);
   } else { /* unaligned access */
@@ -668,8 +673,11 @@ CAMLprim value caml_ba_uint8_get32(value vb, value vind)
     res = b1 << 24 | b2 << 16 | b3 << 8 | b4;
 #else
     res = b4 << 24 | b3 << 16 | b2 << 8 | b1;
-#endif
+#endif /* ARCH_BIG_ENDIAN */
   }
+#else
+  res = *((uint32_t *) addr);
+#endif /* ARCH_ALIGN_INT32 */
   return caml_copy_int32(res);
 }
 
@@ -682,6 +690,7 @@ CAMLprim value caml_ba_uint8_get64(value vb, value vind)
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 7) caml_array_bound_error();
   addr = &((unsigned char *) b->data)[idx];
+#ifdef ARCH_ALIGN_INT64
   if (!((size_t) addr & 0x7)) { /* aligned access */
     res = *((uint64_t *) addr);
   } else { /* unaligned access */
@@ -703,8 +712,11 @@ CAMLprim value caml_ba_uint8_get64(value vb, value vind)
           | (uint64_t) b6 << 40 | (uint64_t) b5 << 32
           | (uint64_t) b4 << 24 | (uint64_t) b3 << 16
           | (uint64_t) b2 << 8 | (uint64_t) b1;
-#endif
+#endif /* ARCH_BIG_ENDIAN */
   }
+#else
+  res = *((uint64_t *) addr);
+#endif /* ARCH_ALIGN_INT64 */
   return caml_copy_int64(res);
 }
 
@@ -801,6 +813,7 @@ CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)
   if (idx < 0 || idx >= b->dim[0] - 1) caml_array_bound_error();
   val = Long_val(newval);
   addr = &((unsigned char *) b->data)[idx];
+#ifdef ARCH_ALIGN_INT16
   if (!((size_t) addr & 0x1)) { /* aligned access */
     *((uint16_t *) addr) = val;
   } else { /* unaligned access */
@@ -810,10 +823,13 @@ CAMLprim value caml_ba_uint8_set16(value vb, value vind, value newval)
 #else
     b2 = 0xFF & val >> 8;
     b1 = 0xFF & val;
-#endif
+#endif /* ARCH_BIG_ENDIAN */
     ((unsigned char*) b->data)[idx] = b1;
     ((unsigned char*) b->data)[idx+1] = b2;
   }
+#else
+  *((uint16_t *) addr) = val;
+#endif /* ARCH_ALIGN_INT16 */
   return Val_unit;
 }
 
@@ -827,6 +843,7 @@ CAMLprim value caml_ba_uint8_set32(value vb, value vind, value newval)
   if (idx < 0 || idx >= b->dim[0] - 3) caml_array_bound_error();
   val = Int32_val(newval);
   addr = &((unsigned char *) b->data)[idx];
+#ifdef ARCH_ALIGN_INT32
   if (!((size_t) addr & 0x3)) { /* aligned access */
     *((uint32_t *) addr) = val;
   } else { /* unaligned access */
@@ -840,12 +857,15 @@ CAMLprim value caml_ba_uint8_set32(value vb, value vind, value newval)
     b3 = 0xFF & val >> 16;
     b2 = 0xFF & val >> 8;
     b1 = 0xFF & val;
-#endif
+#endif /* ARCH_BIG_ENDIAN */
     ((unsigned char*) b->data)[idx] = b1;
     ((unsigned char*) b->data)[idx+1] = b2;
     ((unsigned char*) b->data)[idx+2] = b3;
     ((unsigned char*) b->data)[idx+3] = b4;
   }
+#else
+  *((uint32_t *) addr) = val;
+#endif /* ARCH_ALIGN_INT32 */
   return Val_unit;
 }
 
@@ -858,6 +878,7 @@ CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   if (idx < 0 || idx >= b->dim[0] - 7) caml_array_bound_error();
   addr = &((unsigned char *) b->data)[idx];
+#ifdef ARCH_ALIGN_INT64
   val = Int64_val(newval);
   if (!((size_t) addr & 0x7)) { /* aligned access */
     *((uint64_t *) addr) = val;
@@ -880,7 +901,7 @@ CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
     b3 = 0xFF & val >> 16;
     b2 = 0xFF & val >> 8;
     b1 = 0xFF & val;
-#endif
+#endif /* ARCH_BIG_ENDIAN */
     ((unsigned char*) b->data)[idx] = b1;
     ((unsigned char*) b->data)[idx+1] = b2;
     ((unsigned char*) b->data)[idx+2] = b3;
@@ -890,6 +911,9 @@ CAMLprim value caml_ba_uint8_set64(value vb, value vind, value newval)
     ((unsigned char*) b->data)[idx+6] = b7;
     ((unsigned char*) b->data)[idx+7] = b8;
   }
+#else
+  *((uint64_t *) addr) = val;
+#endif /* ARCH_ALIGN_INT64 */
   return Val_unit;
 }
 


### PR DESCRIPTION
This PR adds compile time and runtime checks to `caml_ba_uint8_{g,s}et{16,32,64}` to use atomic reads/writes whenever possible. This aids in driver development (see the corresponding [`ocaml-cstruct` issue](https://github.com/mirage/ocaml-cstruct/issues/229)) and may or may not improve performance in some cases.

This PR needs `ARCH_ALIGN_INT{16,32,64}` to be defined by the configure script, which somebody with more autoconf knowledge than me will have to do. [Mantis issue #7938](https://caml.inria.fr/mantis/view.php?id=7938) is related.

Additionally benchmarking would need to be done.