### PR TITLE
Propagate environments further in Selectgen

### DIFF
--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -263,15 +263,15 @@ method! mark_c_tailcall =
 
 (* Deal with register constraints *)
 
-method! insert_op_debug op dbg rs rd =
+method! insert_op_debug env op dbg rs rd =
   try
     let (rsrc, rdst) = pseudoregs_for_operation op rs rd in
-    self#insert_moves rs rsrc;
-    self#insert_debug (Iop op) dbg rsrc rdst;
-    self#insert_moves rdst rd;
+    self#insert_moves env rs rsrc;
+    self#insert_debug env (Iop op) dbg rsrc rdst;
+    self#insert_moves env rdst rd;
     rd
   with Use_default ->
-    super#insert_op_debug op dbg rs rd
+    super#insert_op_debug env op dbg rs rd
 
 end
 

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -304,15 +304,15 @@ method! select_condition = function
 
 (* Deal with some register constraints *)
 
-method! insert_op_debug op dbg rs rd =
+method! insert_op_debug env op dbg rs rd =
   try
     let (rsrc, rdst) = pseudoregs_for_operation op rs rd in
-    self#insert_moves rs rsrc;
-    self#insert_debug (Iop op) dbg rsrc rdst;
-    self#insert_moves rdst rd;
+    self#insert_moves env rs rsrc;
+    self#insert_debug env (Iop op) dbg rsrc rdst;
+    self#insert_moves env rdst rd;
     rd
   with Use_default ->
-    super#insert_op_debug op dbg rs rd
+    super#insert_op_debug env op dbg rs rd
 
 end
 

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -270,18 +270,18 @@ method select_floatarith regular_op reversed_op mem_op mem_rev_op args =
 
 (* Deal with register constraints *)
 
-method! insert_op_debug op dbg rs rd =
+method! insert_op_debug env op dbg rs rd =
   try
     let (rsrc, rdst, move_res) = pseudoregs_for_operation op rs rd in
-    self#insert_moves rs rsrc;
-    self#insert_debug (Iop op) dbg rsrc rdst;
+    self#insert_moves env rs rsrc;
+    self#insert_debug env (Iop op) dbg rsrc rdst;
     if move_res then begin
-      self#insert_moves rdst rd;
+      self#insert_moves env rdst rd;
       rd
     end else
       rdst
   with Use_default ->
-    super#insert_op_debug op dbg rs rd
+    super#insert_op_debug env op dbg rs rd
 
 (* Selection of push instructions for external calls *)
 
@@ -312,13 +312,13 @@ method! emit_extcall_args env args =
   let rec emit_pushes = function
   | [] ->
       if sz2 > sz1 then
-        self#insert (Iop (Istackoffset (sz2 - sz1))) [||] [||]
+        self#insert env (Iop (Istackoffset (sz2 - sz1))) [||] [||]
   | e :: el ->
       emit_pushes el;
       let (op, arg) = self#select_push e in
       match self#emit_expr env arg with
       | None -> ()
-      | Some r -> self#insert (Iop op) r [||] in
+      | Some r -> self#insert env (Iop op) r [||] in
   emit_pushes args;
   ([||], sz2)
 

--- a/asmcomp/s390x/selection.ml
+++ b/asmcomp/s390x/selection.ml
@@ -105,15 +105,15 @@ method select_logical op lo hi = function
       (Iintop op, args)
 
 
-method! insert_op_debug op dbg rs rd =
+method! insert_op_debug env op dbg rs rd =
   try
     let (rsrc, rdst) = pseudoregs_for_operation op rs rd in
-    self#insert_moves rs rsrc;
-    self#insert_debug (Iop op) dbg rsrc rdst;
-    self#insert_moves rdst rd;
+    self#insert_moves env rs rsrc;
+    self#insert_debug env (Iop op) dbg rsrc rdst;
+    self#insert_moves env rdst rd;
     rd
   with Use_default ->
-    super#insert_op_debug op dbg rs rd
+    super#insert_op_debug env op dbg rs rd
 
 end
 

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -138,7 +138,7 @@ let name_regs id rv =
 (* "Join" two instruction sequences, making sure they return their results
    in the same registers. *)
 
-let join opt_r1 seq1 opt_r2 seq2 =
+let join env opt_r1 seq1 opt_r2 seq2 =
   match (opt_r1, opt_r2) with
     (None, _) -> opt_r2
   | (_, None) -> opt_r1
@@ -151,24 +151,24 @@ let join opt_r1 seq1 opt_r2 seq2 =
           && Cmm.ge_component r1.(i).typ r2.(i).typ
         then begin
           r.(i) <- r1.(i);
-          seq2#insert_move r2.(i) r1.(i)
+          seq2#insert_move env r2.(i) r1.(i)
         end else if Reg.anonymous r2.(i)
           && Cmm.ge_component r2.(i).typ r1.(i).typ
         then begin
           r.(i) <- r2.(i);
-          seq1#insert_move r1.(i) r2.(i)
+          seq1#insert_move env r1.(i) r2.(i)
         end else begin
           let typ = Cmm.lub_component r1.(i).typ r2.(i).typ in
           r.(i) <- Reg.create typ;
-          seq1#insert_move r1.(i) r.(i);
-          seq2#insert_move r2.(i) r.(i)
+          seq1#insert_move env r1.(i) r.(i);
+          seq2#insert_move env r2.(i) r.(i)
         end
       done;
       Some r
 
 (* Same, for N branches *)
 
-let join_array rs =
+let join_array env rs =
   let some_res = ref None in
   for i = 0 to Array.length rs - 1 do
     let (r, _) = rs.(i) in
@@ -195,7 +195,7 @@ let join_array rs =
         let (r, s) = rs.(i) in
         match r with
           None -> ()
-        | Some r -> s#insert_moves r res
+        | Some r -> s#insert_moves env r res
       done;
       Some res
 
@@ -555,10 +555,10 @@ method regs_for tys = Reg.createv tys
 
 val mutable instr_seq = dummy_instr
 
-method insert_debug desc dbg arg res =
+method insert_debug _env desc dbg arg res =
   instr_seq <- instr_cons_debug desc arg res dbg instr_seq
 
-method insert desc arg res =
+method insert _env desc arg res =
   instr_seq <- instr_cons desc arg res instr_seq
 
 method extract_core ~end_instr =
@@ -573,13 +573,13 @@ method extract =
 
 (* Insert a sequence of moves from one pseudoreg set to another. *)
 
-method insert_move src dst =
+method insert_move env src dst =
   if src.stamp <> dst.stamp then
-    self#insert (Iop Imove) [|src|] [|dst|]
+    self#insert env (Iop Imove) [|src|] [|dst|]
 
-method insert_moves src dst =
+method insert_moves env src dst =
   for i = 0 to min (Array.length src) (Array.length dst) - 1 do
-    self#insert_move src.(i) dst.(i)
+    self#insert_move env src.(i) dst.(i)
   done
 
 (* Adjust the types of destination pseudoregs for a [Cassign] assignment.
@@ -602,37 +602,41 @@ method adjust_types src dst =
 
 (* Insert moves and stack offsets for function arguments and results *)
 
-method insert_move_args arg loc stacksize =
-  if stacksize <> 0 then self#insert (Iop(Istackoffset stacksize)) [||] [||];
-  self#insert_moves arg loc
+method insert_move_args env arg loc stacksize =
+  if stacksize <> 0 then begin
+    self#insert env (Iop(Istackoffset stacksize)) [||] [||]
+  end;
+  self#insert_moves env arg loc
 
-method insert_move_results loc res stacksize =
-  if stacksize <> 0 then self#insert(Iop(Istackoffset(-stacksize))) [||] [||];
-  self#insert_moves loc res
+method insert_move_results env loc res stacksize =
+  if stacksize <> 0 then begin
+    self#insert env (Iop(Istackoffset(-stacksize))) [||] [||]
+  end;
+  self#insert_moves env loc res
 
 (* Add an Iop opcode. Can be overridden by processor description
    to insert moves before and after the operation, i.e. for two-address
    instructions, or instructions using dedicated registers. *)
 
-method insert_op_debug op dbg rs rd =
-  self#insert_debug (Iop op) dbg rs rd;
+method insert_op_debug env op dbg rs rd =
+  self#insert_debug env (Iop op) dbg rs rd;
   rd
 
-method insert_op op rs rd =
-  self#insert_op_debug op Debuginfo.none rs rd
+method insert_op env op rs rd =
+  self#insert_op_debug env op Debuginfo.none rs rd
 
-method emit_blockheader _env n _dbg =
+method emit_blockheader env n _dbg =
   let r = self#regs_for typ_int in
-  Some(self#insert_op (Iconst_int n) [||] r)
+  Some(self#insert_op env (Iconst_int n) [||] r)
 
 method about_to_emit_call _env _insn _arg = None
 
 (* Prior to a function call, update the Spacetime node hole pointer hard
    register. *)
 
-method private maybe_emit_spacetime_move ~spacetime_reg =
+method private maybe_emit_spacetime_move env ~spacetime_reg =
   Misc.Stdlib.Option.iter (fun reg ->
-      self#insert_moves reg [| Proc.loc_spacetime_node_hole |])
+      self#insert_moves env reg [| Proc.loc_spacetime_node_hole |])
     spacetime_reg
 
 (* Add the instructions for the given expression
@@ -642,22 +646,22 @@ method emit_expr (env:environment) exp =
   match exp with
     Cconst_int n ->
       let r = self#regs_for typ_int in
-      Some(self#insert_op (Iconst_int(Nativeint.of_int n)) [||] r)
+      Some(self#insert_op env (Iconst_int(Nativeint.of_int n)) [||] r)
   | Cconst_natint n ->
       let r = self#regs_for typ_int in
-      Some(self#insert_op (Iconst_int n) [||] r)
+      Some(self#insert_op env (Iconst_int n) [||] r)
   | Cconst_float n ->
       let r = self#regs_for typ_float in
-      Some(self#insert_op (Iconst_float (Int64.bits_of_float n)) [||] r)
+      Some(self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
   | Cconst_symbol n ->
       let r = self#regs_for typ_val in
-      Some(self#insert_op (Iconst_symbol n) [||] r)
+      Some(self#insert_op env (Iconst_symbol n) [||] r)
   | Cconst_pointer n ->
       let r = self#regs_for typ_val in  (* integer as Caml value *)
-      Some(self#insert_op (Iconst_int(Nativeint.of_int n)) [||] r)
+      Some(self#insert_op env (Iconst_int(Nativeint.of_int n)) [||] r)
   | Cconst_natpointer n ->
       let r = self#regs_for typ_val in  (* integer as Caml value *)
-      Some(self#insert_op (Iconst_int n) [||] r)
+      Some(self#insert_op env (Iconst_int n) [||] r)
   | Cblockheader(n, dbg) ->
       self#emit_blockheader env n dbg
   | Cvar v ->
@@ -681,7 +685,8 @@ method emit_expr (env:environment) exp =
           Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
       begin match self#emit_expr env e1 with
         None -> None
-      | Some r1 -> self#adjust_types r1 rv; self#insert_moves r1 rv; Some [||]
+      | Some r1 ->
+          self#adjust_types r1 rv; self#insert_moves env r1 rv; Some [||]
       end
   | Ctuple [] ->
       Some [||]
@@ -696,8 +701,8 @@ method emit_expr (env:environment) exp =
         None -> None
       | Some r1 ->
           let rd = [|Proc.loc_exn_bucket|] in
-          self#insert (Iop Imove) r1 rd;
-          self#insert_debug (Iraise k) dbg rd [||];
+          self#insert env (Iop Imove) r1 rd;
+          self#insert_debug env  (Iraise k) dbg rd [||];
           None
       end
   | Cop(Ccmpf _, _, _) ->
@@ -718,11 +723,11 @@ method emit_expr (env:environment) exp =
               let spacetime_reg =
                 self#about_to_emit_call env (Iop new_op) [| r1.(0) |]
               in
-              self#insert_move_args rarg loc_arg stack_ofs;
-              self#maybe_emit_spacetime_move ~spacetime_reg;
-              self#insert_debug (Iop new_op) dbg
+              self#insert_move_args env rarg loc_arg stack_ofs;
+              self#maybe_emit_spacetime_move env ~spacetime_reg;
+              self#insert_debug env (Iop new_op) dbg
                           (Array.append [|r1.(0)|] loc_arg) loc_res;
-              self#insert_move_results loc_res rd stack_ofs;
+              self#insert_move_results env loc_res rd stack_ofs;
               Some rd
           | Icall_imm _ ->
               let r1 = self#emit_tuple env new_args in
@@ -732,22 +737,22 @@ method emit_expr (env:environment) exp =
               let spacetime_reg =
                 self#about_to_emit_call env (Iop new_op) [| |]
               in
-              self#insert_move_args r1 loc_arg stack_ofs;
-              self#maybe_emit_spacetime_move ~spacetime_reg;
-              self#insert_debug (Iop new_op) dbg loc_arg loc_res;
-              self#insert_move_results loc_res rd stack_ofs;
+              self#insert_move_args env r1 loc_arg stack_ofs;
+              self#maybe_emit_spacetime_move env ~spacetime_reg;
+              self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
+              self#insert_move_results env loc_res rd stack_ofs;
               Some rd
           | Iextcall _ ->
               let spacetime_reg =
                 self#about_to_emit_call env (Iop new_op) [| |]
               in
               let (loc_arg, stack_ofs) = self#emit_extcall_args env new_args in
-              self#maybe_emit_spacetime_move ~spacetime_reg;
+              self#maybe_emit_spacetime_move env ~spacetime_reg;
               let rd = self#regs_for ty in
               let loc_res =
-                self#insert_op_debug new_op dbg
+                self#insert_op_debug env new_op dbg
                   loc_arg (Proc.loc_external_results rd) in
-              self#insert_move_results loc_res rd stack_ofs;
+              self#insert_move_results env loc_res rd stack_ofs;
               Some rd
           | Ialloc { bytes = _; spacetime_index; label_after_call_gc; } ->
               let rd = self#regs_for typ_val in
@@ -756,13 +761,13 @@ method emit_expr (env:environment) exp =
                 Ialloc { bytes; spacetime_index; label_after_call_gc; }
               in
               let args = self#select_allocation_args env in
-              self#insert_debug (Iop op) dbg args rd;
+              self#insert_debug env (Iop op) dbg args rd;
               self#emit_stores env new_args rd;
               Some rd
           | op ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              Some (self#insert_op_debug op dbg r1 rd)
+              Some (self#insert_op_debug env op dbg r1 rd)
       end
   | Csequence(e1, e2) ->
       begin match self#emit_expr env e1 with
@@ -776,8 +781,8 @@ method emit_expr (env:environment) exp =
       | Some rarg ->
           let (rif, sif) = self#emit_sequence env eif in
           let (relse, selse) = self#emit_sequence env eelse in
-          let r = join rif sif relse selse in
-          self#insert (Iifthenelse(cond, sif#extract, selse#extract))
+          let r = join env rif sif relse selse in
+          self#insert env (Iifthenelse(cond, sif#extract, selse#extract))
                       rarg [||];
           r
       end
@@ -786,9 +791,9 @@ method emit_expr (env:environment) exp =
         None -> None
       | Some rsel ->
           let rscases = Array.map (self#emit_sequence env) ecases in
-          let r = join_array rscases in
-          self#insert (Iswitch(index,
-                               Array.map (fun (_, s) -> s#extract) rscases))
+          let r = join_array env rscases in
+          self#insert env (Iswitch(index,
+                                   Array.map (fun (_, s) -> s#extract) rscases))
                       rsel [||];
           r
       end
@@ -825,9 +830,10 @@ method emit_expr (env:environment) exp =
       in
       let l = List.map translate_one_handler handlers in
       let a = Array.of_list ((r_body, s_body) :: List.map snd l) in
-      let r = join_array a in
+      let r = join_array env a in
       let aux (nfail, (_r, s)) = (nfail, s#extract) in
-      self#insert (Icatch (rec_flag, List.map aux l, s_body#extract)) [||] [||];
+      self#insert env (Icatch (rec_flag, List.map aux l, s_body#extract))
+        [||] [||];
       r
   | Cexit (nfail,args) ->
       begin match self#emit_parts_list env args with
@@ -845,17 +851,17 @@ method emit_expr (env:environment) exp =
           let tmp_regs = Reg.createv_like src in
           (* Ccatch registers must not contain out of heap pointers *)
           Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
-          self#insert_moves src tmp_regs ;
-          self#insert_moves tmp_regs (Array.concat dest_args) ;
-          self#insert (Iexit nfail) [||] [||];
+          self#insert_moves env src tmp_regs ;
+          self#insert_moves env tmp_regs (Array.concat dest_args) ;
+          self#insert env (Iexit nfail) [||] [||];
           None
       end
   | Ctrywith(e1, v, e2) ->
       let (r1, s1) = self#emit_sequence env e1 in
       let rv = self#regs_for typ_val in
       let (r2, s2) = self#emit_sequence (env_add v rv env) e2 in
-      let r = join r1 s1 r2 s2 in
-      self#insert
+      let r = join env r1 s1 r2 s2 in
+      self#insert env
         (Itrywith(s1#extract,
                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
                              (s2#extract)))
@@ -874,7 +880,7 @@ method private bind_let (env:environment) v r1 =
   end else begin
     let rv = Reg.createv_like r1 in
     name_regs v rv;
-    self#insert_moves r1 rv;
+    self#insert_moves env r1 rv;
     env_add v rv env
   end
 
@@ -939,7 +945,7 @@ method private emit_parts (env:environment) ~effects_after exp =
           else begin
             (* Introduce a fresh temp to hold the result *)
             let tmp = Reg.createv_like r in
-            self#insert_moves r tmp;
+            self#insert_moves env r tmp;
             Some (Cvar id, env_add (VP.create id) tmp env)
           end
         end
@@ -993,7 +999,7 @@ method emit_extcall_args env args =
      required semantics of [loc_external_arguments] (see proc.mli). *)
   let args = Array.concat args in
   let arg_hard_regs = Array.concat (Array.to_list arg_hard_regs) in
-  self#insert_move_args args arg_hard_regs stack_ofs;
+  self#insert_move_args env args arg_hard_regs stack_ofs;
   arg_hard_regs, stack_ofs
 
 method emit_stores env data regs_addr =
@@ -1010,12 +1016,13 @@ method emit_stores env data regs_addr =
               for i = 0 to Array.length regs - 1 do
                 let r = regs.(i) in
                 let kind = if r.typ = Float then Double_u else Word_val in
-                self#insert (Iop(Istore(kind, !a, false)))
+                self#insert env 
+                            (Iop(Istore(kind, !a, false)))
                             (Array.append [|r|] regs_addr) [||];
                 a := Arch.offset_addressing !a (size_component r.typ)
               done
           | _ ->
-              self#insert (Iop op) (Array.append regs regs_addr) [||];
+              self#insert env (Iop op) (Array.append regs regs_addr) [||];
               a := Arch.offset_addressing !a (size_expr env e))
     data
 
@@ -1026,8 +1033,8 @@ method private emit_return (env:environment) exp =
     None -> ()
   | Some r ->
       let loc = Proc.loc_results r in
-      self#insert_moves r loc;
-      self#insert Ireturn loc [||]
+      self#insert_moves env r loc;
+      self#insert env Ireturn loc [||]
 
 method emit_tail (env:environment) exp =
   match exp with
@@ -1053,9 +1060,9 @@ method emit_tail (env:environment) exp =
                 let spacetime_reg =
                   self#about_to_emit_call env call [| r1.(0) |]
                 in
-                self#insert_moves rarg loc_arg;
-                self#maybe_emit_spacetime_move ~spacetime_reg;
-                self#insert_debug call dbg
+                self#insert_moves env rarg loc_arg;
+                self#maybe_emit_spacetime_move env ~spacetime_reg;
+                self#insert_debug env call dbg
                             (Array.append [|r1.(0)|] loc_arg) [||];
               end else begin
                 let rd = self#regs_for ty in
@@ -1063,12 +1070,12 @@ method emit_tail (env:environment) exp =
                 let spacetime_reg =
                   self#about_to_emit_call env (Iop new_op) [| r1.(0) |]
                 in
-                self#insert_move_args rarg loc_arg stack_ofs;
-                self#maybe_emit_spacetime_move ~spacetime_reg;
-                self#insert_debug (Iop new_op) dbg
+                self#insert_move_args env rarg loc_arg stack_ofs;
+                self#maybe_emit_spacetime_move env ~spacetime_reg;
+                self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
-                self#insert(Iop(Istackoffset(-stack_ofs))) [||] [||];
-                self#insert Ireturn loc_res [||]
+                self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
+                self#insert env Ireturn loc_res [||]
               end
           | Icall_imm { func; label_after; } ->
               let r1 = self#emit_tuple env new_args in
@@ -1078,29 +1085,29 @@ method emit_tail (env:environment) exp =
                 let spacetime_reg =
                   self#about_to_emit_call env call [| |]
                 in
-                self#insert_moves r1 loc_arg;
-                self#maybe_emit_spacetime_move ~spacetime_reg;
-                self#insert_debug call dbg loc_arg [||];
+                self#insert_moves env r1 loc_arg;
+                self#maybe_emit_spacetime_move env ~spacetime_reg;
+                self#insert_debug env call dbg loc_arg [||];
               end else if func = !current_function_name then begin
                 let call = Iop (Itailcall_imm { func; label_after; }) in
                 let loc_arg' = Proc.loc_parameters r1 in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| |]
                 in
-                self#insert_moves r1 loc_arg';
-                self#maybe_emit_spacetime_move ~spacetime_reg;
-                self#insert_debug call dbg loc_arg' [||];
+                self#insert_moves env r1 loc_arg';
+                self#maybe_emit_spacetime_move env ~spacetime_reg;
+                self#insert_debug env call dbg loc_arg' [||];
               end else begin
                 let rd = self#regs_for ty in
                 let loc_res = Proc.loc_results rd in
                 let spacetime_reg =
                   self#about_to_emit_call env (Iop new_op) [| |]
                 in
-                self#insert_move_args r1 loc_arg stack_ofs;
-                self#maybe_emit_spacetime_move ~spacetime_reg;
-                self#insert_debug (Iop new_op) dbg loc_arg loc_res;
-                self#insert(Iop(Istackoffset(-stack_ofs))) [||] [||];
-                self#insert Ireturn loc_res [||]
+                self#insert_move_args env r1 loc_arg stack_ofs;
+                self#maybe_emit_spacetime_move env ~spacetime_reg;
+                self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
+                self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
+                self#insert env Ireturn loc_res [||]
               end
           | _ -> Misc.fatal_error "Selection.emit_tail"
       end
@@ -1114,7 +1121,8 @@ method emit_tail (env:environment) exp =
       begin match self#emit_expr env earg with
         None -> ()
       | Some rarg ->
-          self#insert (Iifthenelse(cond, self#emit_tail_sequence env eif,
+          self#insert env
+                      (Iifthenelse(cond, self#emit_tail_sequence env eif,
                                          self#emit_tail_sequence env eelse))
                       rarg [||]
       end
@@ -1122,7 +1130,7 @@ method emit_tail (env:environment) exp =
       begin match self#emit_expr env esel with
         None -> ()
       | Some rsel ->
-          self#insert
+          self#insert env
             (Iswitch(index, Array.map (self#emit_tail_sequence env) ecases))
             rsel [||]
       end
@@ -1151,12 +1159,13 @@ method emit_tail (env:environment) exp =
             env (List.combine ids rs) in
         nfail, self#emit_tail_sequence new_env e2
       in
-      self#insert (Icatch(rec_flag, List.map aux handlers, s_body)) [||] [||]
+      self#insert env (Icatch(rec_flag, List.map aux handlers, s_body))
+        [||] [||]
   | Ctrywith(e1, v, e2) ->
       let (opt_r1, s1) = self#emit_sequence env e1 in
       let rv = self#regs_for typ_val in
       let s2 = self#emit_tail_sequence (env_add v rv env) e2 in
-      self#insert
+      self#insert env
         (Itrywith(s1#extract,
                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2))
         [||] [||];
@@ -1164,8 +1173,8 @@ method emit_tail (env:environment) exp =
         None -> ()
       | Some r1 ->
           let loc = Proc.loc_results r1 in
-          self#insert_moves r1 loc;
-          self#insert Ireturn loc [||]
+          self#insert_moves env r1 loc;
+          self#insert env Ireturn loc [||]
       end
   | _ ->
       self#emit_return env exp
@@ -1177,8 +1186,8 @@ method private emit_tail_sequence env exp =
 
 (* Insertion of the function prologue *)
 
-method insert_prologue _f ~loc_arg ~rarg ~spacetime_node_hole:_ ~env:_ =
-  self#insert_moves loc_arg rarg;
+method insert_prologue _f ~loc_arg ~rarg ~spacetime_node_hole:_ ~env =
+  self#insert_moves env loc_arg rarg;
   None
 
 (* Sequentialization of a function definition *)

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1016,7 +1016,7 @@ method emit_stores env data regs_addr =
               for i = 0 to Array.length regs - 1 do
                 let r = regs.(i) in
                 let kind = if r.typ = Float then Double_u else Word_val in
-                self#insert env 
+                self#insert env
                             (Iop(Istore(kind, !a, false)))
                             (Array.append [|r|] regs_addr) [||];
                 a := Arch.offset_addressing !a (size_component r.typ)

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -88,11 +88,12 @@ class virtual selector_generic : object
        Can be overridden if float values are stored as pairs of
        integer registers. *)
   method insert_op :
-    Mach.operation -> Reg.t array -> Reg.t array -> Reg.t array
+    environment -> Mach.operation -> Reg.t array -> Reg.t array -> Reg.t array
     (* Can be overridden to deal with 2-address instructions
        or instructions with hardwired input/output registers *)
   method insert_op_debug :
-    Mach.operation -> Debuginfo.t -> Reg.t array -> Reg.t array -> Reg.t array
+    environment -> Mach.operation -> Debuginfo.t -> Reg.t array
+      -> Reg.t array -> Reg.t array
     (* Can be overridden to deal with 2-address instructions
        or instructions with hardwired input/output registers *)
   method emit_extcall_args :
@@ -136,13 +137,17 @@ class virtual selector_generic : object
      are not always applied to "self", but ideally they should be private. *)
   method extract : Mach.instruction
   method extract_core : end_instr:Mach.instruction -> Mach.instruction
-  method insert : Mach.instruction_desc -> Reg.t array -> Reg.t array -> unit
-  method insert_debug : Mach.instruction_desc -> Debuginfo.t ->
-                                        Reg.t array -> Reg.t array -> unit
-  method insert_move : Reg.t -> Reg.t -> unit
-  method insert_move_args : Reg.t array -> Reg.t array -> int -> unit
-  method insert_move_results : Reg.t array -> Reg.t array -> int -> unit
-  method insert_moves : Reg.t array -> Reg.t array -> unit
+  method insert :
+    environment -> Mach.instruction_desc -> Reg.t array -> Reg.t array -> unit
+  method insert_debug :
+    environment -> Mach.instruction_desc -> Debuginfo.t ->
+      Reg.t array -> Reg.t array -> unit
+  method insert_move : environment -> Reg.t -> Reg.t -> unit
+  method insert_move_args :
+    environment -> Reg.t array -> Reg.t array -> int -> unit
+  method insert_move_results :
+    environment -> Reg.t array -> Reg.t array -> int -> unit
+  method insert_moves : environment -> Reg.t array -> Reg.t array -> unit
   method adjust_type : Reg.t -> Reg.t -> unit
   method adjust_types : Reg.t array -> Reg.t array -> unit
   method emit_expr :

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -348,7 +348,7 @@ class virtual instruction_selection = object (self)
       disable_instrumentation <- false;
       let node = Lazy.force !spacetime_node_ident in
       let node_reg = Selectgen.env_find node env in
-      self#insert_moves node_temp_reg node_reg
+      self#insert_moves env node_temp_reg node_reg
     end
 
   method! emit_blockheader env n dbg =
@@ -446,7 +446,7 @@ class virtual instruction_selection = object (self)
         | None -> assert false
         | Some (node_hole, reg) -> node_hole, reg
       in
-      self#insert_moves [| Proc.loc_spacetime_node_hole |] node_hole_reg;
+      self#insert_moves env [| Proc.loc_spacetime_node_hole |] node_hole_reg;
       self#emit_prologue f ~node_hole ~env;
       match !reverse_shape with
       | [] -> None


### PR DESCRIPTION
This exciting no-op pull request, which simply propagates the "`env`" parameter to more places in `Selectgen`, does not need backend-specific knowledge to review.  It will help to make some other forthcoming patches on this file more readable.