### PR TITLE
MPR#7903: make Thread.delay interruptible again

### DIFF
--- a/Changes
+++ b/Changes
@@ -59,6 +59,9 @@ Working version
 
 ### Other libraries:
 
+- MPR#7903, GPR#2306: Make Thread.delay interruptible by signals again
+  (Xavier Leroy, review by Jacques-Henri Jourdan and Edwin Török)
+
 - GPR#2248: Unix alloc_sockaddr: Fix read of uninitialized memory for an
   unbound Unix socket. Add support for receiving abstract (Linux) socket paths.
   (Tim Cuthbertson, review by Sébastien Hinderer and Jérémie Dimino)

--- a/otherlibs/unix/sleep.c
+++ b/otherlibs/unix/sleep.c
@@ -35,26 +35,31 @@ CAMLprim value unix_sleep(value duration)
   {
     struct timespec t;
     int ret;
-    caml_enter_blocking_section();
     t.tv_sec = (time_t) d;
     t.tv_nsec = (d - t.tv_sec) * 1e9;
     do {
+      caml_enter_blocking_section();
       ret = nanosleep(&t, &t);
+      /* MPR#7903: if we were interrupted by a signal, and this signal
+         is handled in OCaml, we should run its handler now,
+         not at the end of the full sleep duration.  Leaving the blocking
+         section and re-entering it does the job. */
+      caml_leave_blocking_section();
     } while (ret == -1 && errno == EINTR);
-    caml_leave_blocking_section();
     if (ret == -1) uerror("sleep", Nothing);
   }
 #elif defined(HAS_SELECT)
   {
     struct timeval t;
     int ret;
-    caml_enter_blocking_section();
     t.tv_sec = (time_t) d;
     t.tv_usec = (d - t.tv_sec) * 1e6;
     do {
+      caml_enter_blocking_section();
       ret = select(0, NULL, NULL, NULL, &t);
+      /* MPR#7903: same comment as above */
+      caml_leave_blocking_section();
     } while (ret == -1 && errno == EINTR);
-    caml_leave_blocking_section();
     if (ret == -1) uerror("sleep", Nothing);
   }
 #else

--- a/testsuite/tests/lib-threads/delayintr.ml
+++ b/testsuite/tests/lib-threads/delayintr.ml
@@ -1,0 +1,61 @@
+(* TEST
+
+* hassysthreads
+include systhreads
+
+files = "sigint.c"
+
+** libunix (* excludes mingw32/64 and msvc32/64 *)
+
+*** setup-ocamlc.byte-build-env
+
+program = "${test_build_directory}/delayintr.byte"
+
+**** ocamlc.byte
+
+program = "sigint"
+all_modules = "sigint.c"
+
+***** ocamlc.byte
+
+program = "${test_build_directory}/delayintr.byte"
+all_modules = "delayintr.ml"
+
+****** check-ocamlc.byte-output
+******* run
+******** check-program-output
+
+*** setup-ocamlopt.byte-build-env
+
+program = "${test_build_directory}/delayintr.opt"
+
+**** ocamlopt.byte
+
+program = "sigint"
+all_modules = "sigint.c"
+
+***** ocamlopt.byte
+
+program = "${test_build_directory}/delayintr.opt"
+all_modules = "delayintr.ml"
+
+****** check-ocamlopt.byte-output
+******* run
+******** check-program-output
+
+*)
+
+(* Regression test for MPR#7903 *)
+
+let () =
+  let start = Unix.gettimeofday() in
+  let sighandler _ =
+    let now = Unix.gettimeofday() in
+    if now -. start <= 20. then begin
+      print_string "Received signal early\n"; exit 0
+    end else begin
+      print_string "Received signal late\n"; exit 2
+    end in
+  Sys.set_signal Sys.sigint (Sys.Signal_handle sighandler);
+  Thread.delay 30.;
+  print_string "No signal received\n"; exit 4

--- a/testsuite/tests/lib-threads/delayintr.reference
+++ b/testsuite/tests/lib-threads/delayintr.reference
@@ -1,0 +1,1 @@
+Received signal early

--- a/testsuite/tests/lib-threads/delayintr.run
+++ b/testsuite/tests/lib-threads/delayintr.run
@@ -1,0 +1,5 @@
+${program} > ${output} &
+pid=$!
+sleep 2
+./sigint $pid
+wait

--- a/testsuite/tests/lib-threads/ocamltests
+++ b/testsuite/tests/lib-threads/ocamltests
@@ -3,6 +3,7 @@ bank.ml
 beat.ml
 bufchan.ml
 close.ml
+delayintr.ml
 fileio.ml
 pr4466.ml
 pr5325.ml


### PR DESCRIPTION
This is a fix for https://caml.inria.fr/mantis/view.php?id=7903 .

In OCaml 4.07, Unix.sleepf and Thread.delay were changed so that they
would restart the sleep when interrupted by a signal (error EINTR).

The unintented consequence is that Thread.delay will not run
signal handlers until the full delay has expired.  If the effect
of the handler is to raise an exception, as with Sys.catch_break,
the delay is not terminated early.

(This is specific to threaded programs, where asynchronous invocation
of signal handlers is turned off and handlers are only run at the next
leave-blocking-section.  Using Unix.sleepf in a non-threaded program
doesn't show the issue.)

This commit implements a more intuitive behavior, closer to that of 4.06:
signals received during Thread.delay are handled immediately, and if
the handler returns normally, the delay is restarted with the remaining time.

A test is added in testsuite/tests/lib-threads/delayintr.ml