### PR TITLE
Fix assembler detection in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -646,6 +646,9 @@ OCaml 4.08.0
   unable to find the camlheader files (subtle regression of GPR#2139/2041)
   (David Allsopp, report and review by Sébastien Hinderer)
 
+- MPR#7919, GPR#2311: Fix assembler detection in configure
+  (Sébastien Hinderer, review by David Allsopp)
+
 ### Internal/compiler-libs changes:
 
 - MPR#7918, GPR#1703, GPR#1944, GPR#2213, GPR#2257: Add the module

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -73,8 +73,12 @@ AS_HAS_DEBUG_PREFIX_MAP=@as_has_debug_prefix_map@
 # our own symbols):
 OC_LDFLAGS=@oc_ldflags@
 
-### How to invoke the C preprocessor
+### How to invoke the C preprocessor through the C compiler
 CPP=@CPP@
+
+### How to invoke the C preprocessor directly, just to expand macros
+### (at the moment this is used only in one test in the testsuite)
+DIRECT_CPP=@DIRECT_CPP@
 
 ### How to invoke ranlib
 RANLIB=@RANLIB@

--- a/configure
+++ b/configure
@@ -13818,7 +13818,7 @@ case "$arch,$system" in #(
   amd64,win64) :
     default_as="ml64 -nologo -Cp -c -Fo" ;; #(
   amd64,macosx) :
-    case $ccfamily in #(
+    case $ocaml_cv_cc_vendor in #(
   clang-*) :
     default_as='clang -arch x86_64 -Wno-trigraphs -c'
         default_aspp='clang -arch x86_64 -Wno-trigraphs -c' ;; #(
@@ -13860,7 +13860,7 @@ esac ;; #(
     default_aspp="${toolpref}cc -c" ;; #(
   amd64,*|arm,*|arm64,*|i386,*|power,bsd*|power,netbsd) :
     default_as="${toolpref}as"
-    case $ccfamily in #(
+    case $ocaml_cv_cc_vendor in #(
   clang-*) :
     default_aspp="${toolpref}clang -c -Wno-trigraphs" ;; #(
   *) :

--- a/configure
+++ b/configure
@@ -643,7 +643,6 @@ DIRECT_LD
 INSTALL_DATA
 INSTALL_SCRIPT
 INSTALL_PROGRAM
-DIRECT_CPP
 CPP
 LT_SYS_LIBRARY_PATH
 OTOOL64
@@ -777,6 +776,7 @@ libext
 OBJEXT
 exeext
 ac_tool_prefix
+DIRECT_CPP
 CC
 VERSION
 CONFIGURE_ARGS
@@ -799,6 +799,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -913,6 +914,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1165,6 +1167,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1302,7 +1313,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1455,6 +1466,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -2734,6 +2746,7 @@ VERSION=4.09.0+dev0-2019-01-18
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -12199,9 +12212,23 @@ fi
    ;;
 esac
 
-# C preprocessor: we do not rely on AC_PROG_CPP because it returns
-# 'fcc -E' while we really need cpp
-if test -n "$ac_tool_prefix"; then
+# Determine how to call the C preprocessor directly.
+# Most of the time, calling the C preprocessor through the C compiler is
+# desirable and even important.
+# In some cases, though, we want to use the C preprocessor only to
+# expand macros. In such cases, it is much more convenient to be able
+# to invoke it directly rather than through the C compiler, for instance
+# because, when invoked directly, the C preprocessor does not require
+# to be invoked on a file with a '.c' extension
+# We thus figure out how to invoke the C preprocessor directly but
+# let the CPP variable untouched, except for the MSVC port where we set it
+# manually to make sure the backward compatibility is preserved
+case $host in #(
+  *-pc-windows) :
+    DIRECT_CPP="$CC -nologo -EP";
+    CPP="$DIRECT_CPP" ;; #(
+  *) :
+    if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}cpp", so it can be a program name with args.
 set dummy ${ac_tool_prefix}cpp; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -12292,12 +12319,7 @@ esac
 else
   DIRECT_CPP="$ac_cv_prog_DIRECT_CPP"
 fi
-
-case $host in #(
-  *-pc-windows) :
-    CPP="$CC -nologo -EP" ;; #(
-  *) :
-    CPP=$DIRECT_CPP ;;
+ ;;
 esac
 
 # Libraries to build depending on the host

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,7 @@ AC_SUBST([CC])
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+AC_SUBST([DIRECT_CPP])
 AC_SUBST([ac_tool_prefix])
 AC_SUBST([exeext])
 AC_SUBST([OBJEXT])
@@ -403,12 +404,22 @@ AS_CASE([$host],
     mklib="rm -f \$(1) && ${AR} rc \$(1) \$(2) && ${RANLIB} \$(1)"
   ])
 
-# C preprocessor: we do not rely on AC_PROG_CPP because it returns
-# 'fcc -E' while we really need cpp
-AC_CHECK_TOOL([DIRECT_CPP],[cpp])
+# Determine how to call the C preprocessor directly.
+# Most of the time, calling the C preprocessor through the C compiler is
+# desirable and even important.
+# In some cases, though, we want to use the C preprocessor only to
+# expand macros. In such cases, it is much more convenient to be able
+# to invoke it directly rather than through the C compiler, for instance
+# because, when invoked directly, the C preprocessor does not require
+# to be invoked on a file with a '.c' extension
+# We thus figure out how to invoke the C preprocessor directly but
+# let the CPP variable untouched, except for the MSVC port where we set it
+# manually to make sure the backward compatibility is preserved
 AS_CASE([$host],
-  [*-pc-windows], [CPP="$CC -nologo -EP"],
-  [CPP=$DIRECT_CPP])
+  [*-pc-windows],
+    [DIRECT_CPP="$CC -nologo -EP";
+    CPP="$DIRECT_CPP"],
+  [AC_CHECK_TOOL([DIRECT_CPP],[cpp])])
 
 # Libraries to build depending on the host
 

--- a/configure.ac
+++ b/configure.ac
@@ -945,7 +945,7 @@ AS_CASE(["$arch,$system"],
   [amd64,win64],
     [default_as="ml64 -nologo -Cp -c -Fo"],
   [amd64,macosx],
-    [AS_CASE([$ccfamily],
+    [AS_CASE([$ocaml_cv_cc_vendor],
       [clang-*],
         [default_as='clang -arch x86_64 -Wno-trigraphs -c'
         default_aspp='clang -arch x86_64 -Wno-trigraphs -c'],
@@ -982,7 +982,7 @@ AS_CASE(["$arch,$system"],
     default_aspp="${toolpref}cc -c"],
   [amd64,*|arm,*|arm64,*|i386,*|power,bsd*|power,netbsd],
     [default_as="${toolpref}as"
-    AS_CASE([$ccfamily],
+    AS_CASE([$ocaml_cv_cc_vendor],
       [clang-*], [default_aspp="${toolpref}clang -c -Wno-trigraphs"],
       [default_aspp="${toolpref}gcc -c"])])
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -52,7 +52,7 @@ else
 endif
 
 ifeq "$(TOOLCHAIN)" "msvc"
-CPP := $(CPP) 2> nul
+DIRECT_CPP := $(DIRECT_CPP) 2> nul
 CSC := csc
 ifeq "$(HOST)" "i686-pc-windows"
 CSCFLAGS := /platform:x86
@@ -232,7 +232,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	  -e 's|@@SYSTHREADS@@|$(systhreads)|' \
 	  -e 's|@@STR@@|$(str)|' \
 	  -e 's|@@SYSTEM@@|$(SYSTEM)|' \
-	  -e 's|@@CPP@@|$(CPP)|' \
+	  -e 's|@@CPP@@|$(DIRECT_CPP)|' \
 	  -e 's|@@OCAMLCDEFAULTFLAGS@@|$(ocamlcdefaultflags)|' \
 	  -e 's|@@OCAMLOPTDEFAULTFLAGS@@|$(ocamloptdefaultflags)|' \
 	  -e 's|@@OCAMLSRCDIR@@|$(ocamlsrcdir)|' \


### PR DESCRIPTION
This PR fixes the detection of the assembler program on some platforms,
amnong which Mac OS. It thus fixes MPR#7919.

The PR also makes sure the CPP build variable is dealt with properly,
which should also be helpful for GPR##2295

See precheck build #216(https://ci.inria.fr/ocaml/job/precheck/216).

(Should be cherry-picked to 4.08.)