### PR TITLE
Clean up int literal hint

### DIFF
--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -217,7 +217,7 @@ Line 3, characters 13-14:
                  ^
 Error: This expression has type int but an expression was expected of type
          float
-       Hint: Did you mean `1.'?
+  Hint: Did you mean `1.'?
 |}];;
 
 module Ill_typed_3 = struct

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -24,7 +24,7 @@ Line 3, characters 8-9:
             ^
 Error: This expression has type int but an expression was expected of type
          float
-       Hint: Did you mean `1.'?
+  Hint: Did you mean `1.'?
 Line 4, characters 2-4:
 4 | 2 in
       ^^

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -9,7 +9,7 @@ Line 1, characters 19-20:
                        ^
 Error: This expression has type int but an expression was expected of type
          int32
-       Hint: Did you mean `1l'?
+  Hint: Did you mean `1l'?
 |}]
 
 let _ : int32 * int32 = 42l, 43;;
@@ -19,7 +19,7 @@ Line 1, characters 29-31:
                                  ^^
 Error: This expression has type int but an expression was expected of type
          int32
-       Hint: Did you mean `43l'?
+  Hint: Did you mean `43l'?
 |}]
 
 let _ : int32 * nativeint = 42l, 43;;
@@ -29,7 +29,7 @@ Line 1, characters 33-35:
                                      ^^
 Error: This expression has type int but an expression was expected of type
          nativeint
-       Hint: Did you mean `43n'?
+  Hint: Did you mean `43n'?
 |}]
 
 let _ = min 6L 7;;
@@ -39,7 +39,7 @@ Line 1, characters 15-16:
                    ^
 Error: This expression has type int but an expression was expected of type
          int64
-       Hint: Did you mean `7L'?
+  Hint: Did you mean `7L'?
 |}]
 
 let _ : float = 123;;
@@ -49,7 +49,7 @@ Line 1, characters 16-19:
                     ^^^
 Error: This expression has type int but an expression was expected of type
          float
-       Hint: Did you mean `123.'?
+  Hint: Did you mean `123.'?
 |}]
 
 (* no hint *)
@@ -74,7 +74,7 @@ Line 2, characters 4-5:
         ^
 Error: This pattern matches values of type int
        but a pattern was expected which matches values of type int32
-       Hint: Did you mean `0l'?
+  Hint: Did you mean `0l'?
 |}, Principal{|
 Line 2, characters 4-5:
 2 |   | 0 -> 0l
@@ -92,7 +92,7 @@ Line 2, characters 9-10:
              ^
 Error: This pattern matches values of type int
        but a pattern was expected which matches values of type int64
-       Hint: Did you mean `2L'?
+  Hint: Did you mean `2L'?
 |}]
 
 (* symmetric *)
@@ -103,7 +103,7 @@ Line 1, characters 16-18:
                     ^^
 Error: This expression has type int64 but an expression was expected of type
          int32
-       Hint: Did you mean `1l'?
+  Hint: Did you mean `1l'?
 |}]
 let _ : float = 1L;;
 [%%expect{|
@@ -112,7 +112,7 @@ Line 1, characters 16-18:
                     ^^
 Error: This expression has type int64 but an expression was expected of type
          float
-       Hint: Did you mean `1.'?
+  Hint: Did you mean `1.'?
 |}]
 let _ : int64 = 1n;;
 [%%expect{|
@@ -121,7 +121,7 @@ Line 1, characters 16-18:
                     ^^
 Error: This expression has type nativeint
        but an expression was expected of type int64
-       Hint: Did you mean `1L'?
+  Hint: Did you mean `1L'?
 |}]
 let _ : nativeint = 1l;;
 [%%expect{|
@@ -130,7 +130,7 @@ Line 1, characters 20-22:
                         ^^
 Error: This expression has type int32 but an expression was expected of type
          nativeint
-       Hint: Did you mean `1n'?
+  Hint: Did you mean `1n'?
 |}]
 
 (* not implemented *)

--- a/testsuite/tests/typing-core-bugs/int_operator_hint.ml
+++ b/testsuite/tests/typing-core-bugs/int_operator_hint.ml
@@ -75,5 +75,5 @@ Line 1, characters 8-9:
             ^
 Error: This expression has type int but an expression was expected of type
          float
-       Hint: Did you mean `0.'?
+  Hint: Did you mean `0.'?
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4783,10 +4783,13 @@ let type_clash_of_trace trace =
 (* Hint on type error on integer literals
    To avoid confusion, it is disabled on float literals
    and when the expected type is `int` *)
-let report_literal_type_constraint ppf expected_type const =
+let report_literal_type_constraint expected_type const =
   let hint str_val =
     let hint_suffix c =
-      fprintf ppf "@\n@[Hint: Did you mean `%s%c'?@]" str_val c
+      let txt ppf =
+        fprintf ppf "@[Hint: Did you mean `%s%c'?@]" str_val c
+      in
+      [ Location.{ txt; loc = none } ]
     in
     if Path.same expected_type Predef.path_int32 then
       hint_suffix 'l'
@@ -4797,30 +4800,30 @@ let report_literal_type_constraint ppf expected_type const =
     else if Path.same expected_type Predef.path_float then
       hint_suffix '.'
     else
-      ()
+      []
   in
   match const with
   | Const_int n -> hint (Int.to_string n)
   | Const_int32 n -> hint (Int32.to_string n)
   | Const_int64 n -> hint (Int64.to_string n)
   | Const_nativeint n -> hint (Nativeint.to_string n)
-  | _ -> ()
+  | _ -> []
 
-let report_literal_type_constraint ppf const = function
+let report_literal_type_constraint const = function
   | Some Unification_trace.
     { expected = { t = { desc = Tconstr (typ, [], _) } } } ->
-      report_literal_type_constraint ppf typ const
-  | Some _ | None -> ()
+      report_literal_type_constraint typ const
+  | Some _ | None -> []
 
-let report_expr_type_clash_hints ppf exp diff =
+let report_expr_type_clash_hints exp diff =
   match exp with
-  | Some (Texp_constant const) -> report_literal_type_constraint ppf const diff
-  | _ -> ()
+  | Some (Texp_constant const) -> report_literal_type_constraint const diff
+  | _ -> []
 
-let report_pattern_type_clash_hints ppf pat diff =
+let report_pattern_type_clash_hints pat diff =
   match pat with
-  | Some (Tpat_constant const) -> report_literal_type_constraint ppf const diff
-  | _ -> ()
+  | Some (Tpat_constant const) -> report_literal_type_constraint const diff
+  | _ -> []
 
 (* Hint when using int operators (eg. `+`)
    on other kind of integer and floats *)
@@ -4926,14 +4929,14 @@ let report_error ~loc env = function
            fprintf ppf "but is mixed here with fields of type")
   | Pattern_type_clash (trace, pat) ->
       let diff = type_clash_of_trace trace in
-      Location.error_of_printer ~loc (fun ppf () ->
+      let sub = report_pattern_type_clash_hints pat diff in
+      Location.error_of_printer ~loc ~sub (fun ppf () ->
         Printtyp.report_unification_error ppf env trace
           (function ppf ->
             fprintf ppf "This pattern matches values of type")
           (function ppf ->
             fprintf ppf "but a pattern was expected which matches values of \
                          type");
-        report_pattern_type_clash_hints ppf pat diff
       ) ()
   | Or_pattern_type_clash (id, trace) ->
       report_unification_error ~loc env trace
@@ -4955,7 +4958,11 @@ let report_error ~loc env = function
       ) ()
   | Expr_type_clash (trace, explanation, exp) ->
       let diff = type_clash_of_trace trace in
-      let sub = report_application_clash_hints diff explanation in
+      let sub = List.concat [
+          report_application_clash_hints diff explanation;
+          report_expr_type_clash_hints exp diff;
+        ]
+      in
       Location.error_of_printer ~loc ~sub (fun ppf () ->
         Printtyp.report_unification_error ppf env trace
           ~type_expected_explanation:
@@ -4964,7 +4971,6 @@ let report_error ~loc env = function
              fprintf ppf "This expression has type")
           (function ppf ->
              fprintf ppf "but an expression was expected of type");
-        report_expr_type_clash_hints ppf exp diff
       ) ()
   | Apply_non_function typ ->
       reset_and_mark_loops typ;


### PR DESCRIPTION
As @gasche pointed out [on my previous PR](https://github.com/ocaml/ocaml/pull/2307#pullrequestreview-212626005), my two previous PR need a small cleanup.

I changed `Location.report` to allow sub messages without location and print the int literal hint as a sub message.
