### PR TITLE
Add labels around call sites (+ some background on DWARF call site support)

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -490,6 +490,23 @@ let emit_profile () =
     I.pop r10
   end
 
+(* Emission of labels immediately prior to and after calls, used for DWARF
+   call site support. *)
+
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
+let maybe_add_label_before_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    _label (emit_label call_labels.before)
+  end
+
+(* This function should not be called if [record_frame] is going to be used,
+   since the latter defines the same label as this function. *)
+let maybe_add_label_after_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    _label (emit_label call_labels.after)
+  end
+
 (* Output the assembly code for an instruction *)
 
 (* Name of current function *)
@@ -545,40 +562,54 @@ let emit_instr fallthrough i =
   | Lop(Iconst_symbol s) ->
       add_used_symbol s;
       load_symbol_addr s (res i 0)
-  | Lop(Icall_ind { label_after; }) ->
+  | Lop(Icall_ind { call_labels; }) ->
+      maybe_add_label_before_call ~call_labels;
       I.call (arg i 0);
-      record_frame i.live false i.dbg ~label:label_after
-  | Lop(Icall_imm { func; label_after; }) ->
+      record_frame i.live false i.dbg ~label:call_labels.after
+  | Lop(Icall_imm { func; call_labels; }) ->
       add_used_symbol func;
+      maybe_add_label_before_call ~call_labels;
       emit_call func;
-      record_frame i.live false i.dbg ~label:label_after
-  | Lop(Itailcall_ind { label_after; }) ->
+      record_frame i.live false i.dbg ~label:call_labels.after
+  | Lop(Itailcall_ind { call_labels; }) ->
       output_epilogue begin fun () ->
+        maybe_add_label_before_call ~call_labels;
         I.jmp (arg i 0);
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
+          record_frame Reg.Set.empty false i.dbg ~label:call_labels.after
+        end else begin
+          maybe_add_label_after_call ~call_labels
         end
       end
-  | Lop(Itailcall_imm { func; label_after; }) ->
+  | Lop(Itailcall_imm { func; call_labels; }) ->
       begin
         if func = !function_name then
-          I.jmp (label !tailrec_entry_point)
+          maybe_add_label_before_call ~call_labels;
+          I.jmp (label !tailrec_entry_point);
+          if not Config.spacetime then begin
+            maybe_add_label_after_call ~call_labels
+          end
         else begin
           output_epilogue begin fun () ->
             add_used_symbol func;
-            emit_jump func
+            maybe_add_label_before_call ~call_labels;
+            emit_jump func;
+            if not Config.spacetime then begin
+              maybe_add_label_after_call ~call_labels
+            end
           end
         end
       end;
       if Config.spacetime then begin
-        record_frame Reg.Set.empty false i.dbg ~label:label_after
+        record_frame Reg.Set.empty false i.dbg ~label:call_labels.after
       end
-  | Lop(Iextcall { func; alloc; label_after; }) ->
+  | Lop(Iextcall { func; alloc; call_labels; }) ->
       add_used_symbol func;
       if alloc then begin
         load_symbol_addr func rax;
+        maybe_add_label_before_call ~call_labels;
         emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:label_after;
+        record_frame i.live false i.dbg ~label:call_labels.after;
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
              This comes from:
@@ -591,9 +622,12 @@ let emit_instr fallthrough i =
           I.mov (mem64 QWORD 0 R11) r15
         end
       end else begin
+        maybe_add_label_before_call ~call_labels;
         emit_call func;
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
+          record_frame Reg.Set.empty false i.dbg ~label:call_labels.after
+        end else begin
+          maybe_add_label_after_call ~call_labels
         end
       end
   | Lop(Istackoffset n) ->

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -582,23 +582,20 @@ let emit_instr fallthrough i =
         end
       end
   | Lop(Itailcall_imm { func; call_labels; }) ->
-      begin
-        if func = !function_name then
+      if func = !function_name then begin
+        maybe_add_label_before_call ~call_labels;
+        I.jmp (label !tailrec_entry_point);
+        if not Config.spacetime then begin
+          maybe_add_label_after_call ~call_labels
+        end
+      end else begin
+        output_epilogue (fun () ->
+          add_used_symbol func;
           maybe_add_label_before_call ~call_labels;
-          I.jmp (label !tailrec_entry_point);
+          emit_jump func;
           if not Config.spacetime then begin
             maybe_add_label_after_call ~call_labels
-          end
-        else begin
-          output_epilogue begin fun () ->
-            add_used_symbol func;
-            maybe_add_label_before_call ~call_labels;
-            emit_jump func;
-            if not Config.spacetime then begin
-              maybe_add_label_after_call ~call_labels
-            end
-          end
-        end
+          end)
       end;
       if Config.spacetime then begin
         record_frame Reg.Set.empty false i.dbg ~label:call_labels.after

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -443,6 +443,23 @@ let emit_load_handler_address handler =
   `	add	lr, pc, lr\n`;
   2
 
+(* Emission of labels immediately prior to and after calls, used for DWARF
+   call site support. *)
+
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
+let maybe_add_label_before_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.before}:\n`
+  end
+
+(* This function should not be called if [record_frame] is going to be used,
+   since the latter defines the same label as this function. *)
+let maybe_add_label_after_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.after}:\n`
+  end
+
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -534,40 +551,58 @@ let emit_instr i =
         end; 1
     | Lop(Iconst_symbol s) ->
         emit_load_symbol_addr i.res.(0) s
-    | Lop(Icall_ind { label_after; }) ->
+    | Lop(Icall_ind { call_labels; }) ->
         if !arch >= ARMv5 then begin
+          maybe_add_label_before_call ~call_labels;
           `	blx	{emit_reg i.arg.(0)}\n`;
-          `{record_frame i.live false i.dbg ~label:label_after}\n`; 1
+          `{record_frame i.live false i.dbg ~label:call_labels.after}\n`; 1
         end else begin
           `	mov	lr, pc\n`;
+          maybe_add_label_before_call ~call_labels;
           `	bx	{emit_reg i.arg.(0)}\n`;
-          `{record_frame i.live false i.dbg ~label:label_after}\n`; 2
+          `{record_frame i.live false i.dbg ~label:call_labels.after}\n`; 2
         end
-    | Lop(Icall_imm { func; label_after; }) ->
+    | Lop(Icall_imm { func; call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
         `	{emit_call func}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`; 1
-    | Lop(Itailcall_ind { label_after = _; }) ->
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`; 1
+    | Lop(Itailcall_ind { call_labels; }) ->
         output_epilogue begin fun () ->
-          if !contains_calls then
-            `	ldr	lr, [sp, #{emit_int (-4)}]\n`;
-          `	bx	{emit_reg i.arg.(0)}\n`; 2
+          if !contains_calls then begin
+            `	ldr	lr, [sp, #{emit_int (-4)}]\n`
+          end;
+          maybe_add_label_before_call ~call_labels;
+          `	bx	{emit_reg i.arg.(0)}\n`;
+          maybe_add_label_after_call ~call_labels;
+          2
         end
-    | Lop(Itailcall_imm { func; label_after = _; }) ->
+    | Lop(Itailcall_imm { func; call_labels; }) ->
         if func = !function_name then begin
-          `	b	{emit_label !tailrec_entry_point}\n`; 1
+          maybe_add_label_before_call ~call_labels;
+          `	b	{emit_label !tailrec_entry_point}\n`;
+          maybe_add_label_after_call ~call_labels;
+          1
         end else begin
           output_epilogue begin fun () ->
-            if !contains_calls then
-              `	ldr	lr, [sp, #{emit_int (-4)}]\n`;
-            `	{emit_jump func}\n`; 2
+            if !contains_calls then begin
+              `	ldr	lr, [sp, #{emit_int (-4)}]\n`
+            end;
+            maybe_add_label_before_call ~call_labels;
+            `	{emit_jump func}\n`;
+            maybe_add_label_after_call ~call_labels;
+            2
           end
         end
-    | Lop(Iextcall { func; alloc = false; }) ->
-        `	{emit_call func}\n`; 1
-    | Lop(Iextcall { func; alloc = true; label_after; }) ->
+    | Lop(Iextcall { func; alloc = false; call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
+        `	{emit_call func}\n`;
+        maybe_add_label_after_call ~call_labels;
+        1
+    | Lop(Iextcall { func; alloc = true; call_labels; }) ->
         let ninstr = emit_load_symbol_addr (phys_reg 7 (* r7 *)) func in
+        maybe_add_label_before_call ~call_labels;
         `	{emit_call "caml_c_call"}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`;
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`;
         1 + ninstr
     | Lop(Istackoffset n) ->
         assert (n mod 8 = 0);

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -179,7 +179,12 @@ method select_shift_arith op dbg arithop arithrevop args =
       end
 
 method private iextcall (func, alloc) =
-  Iextcall { func; alloc; label_after = Cmm.new_label (); }
+  let call_labels =
+    { before = Cmm.new_label ();
+      after = Cmm.new_label ();
+    }
+  in
+  Iextcall { func; alloc; call_labels; }
 
 method! select_operation op args dbg =
   match (op, args) with

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -570,6 +570,23 @@ let emit_profile() = ()   (* TODO *)
   | _ -> ()
 *)
 
+(* Emission of labels immediately prior to and after calls, used for DWARF
+   call site support. *)
+
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
+let maybe_add_label_before_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.before}:\n`
+  end
+
+(* This function should not be called if [record_frame] is going to be used,
+   since the latter defines the same label as this function. *)
+let maybe_add_label_after_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.after}:\n`
+  end
+
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -615,25 +632,39 @@ let emit_instr i =
         end
     | Lop(Iconst_symbol s) ->
         emit_load_symbol_addr i.res.(0) s
-    | Lop(Icall_ind { label_after; }) ->
+    | Lop(Icall_ind { call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
         `	blr	{emit_reg i.arg.(0)}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
-    | Lop(Icall_imm { func; label_after; }) ->
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+    | Lop(Icall_imm { func; call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
         `	bl	{emit_symbol func}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
-    | Lop(Itailcall_ind { label_after = _; }) ->
-        output_epilogue (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
-    | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then
-          `	b	{emit_label !tailrec_entry_point}\n`
-        else
-          output_epilogue (fun () -> `	b	{emit_symbol func}\n`)
-    | Lop(Iextcall { func; alloc = false; label_after = _; }) ->
-        `	bl	{emit_symbol func}\n`
-    | Lop(Iextcall { func; alloc = true; label_after; }) ->
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+    | Lop(Itailcall_ind { call_labels; }) ->
+        output_epilogue (fun () ->
+          maybe_add_label_before_call ~call_labels;
+          `	br	{emit_reg i.arg.(0)}\n`;
+          maybe_add_label_after_call ~call_labels)
+    | Lop(Itailcall_imm { func; call_labels; }) ->
+        if func = !function_name then begin
+          maybe_add_label_before_call ~call_labels;
+          `	b	{emit_label !tailrec_entry_point}\n`;
+          maybe_add_label_after_call ~call_labels
+        end else begin
+          output_epilogue (fun () ->
+            maybe_add_label_before_call ~call_labels;
+            `	b	{emit_symbol func}\n`;
+            maybe_add_label_after_call ~call_labels)
+        end
+    | Lop(Iextcall { func; alloc = false; call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
+        `	bl	{emit_symbol func}\n`;
+        maybe_add_label_after_call ~call_labels
+    | Lop(Iextcall { func; alloc = true; call_labels; }) ->
         emit_load_symbol_addr reg_x15 func;
+        maybe_add_label_before_call ~call_labels;
         `	bl	{emit_symbol "caml_c_call"}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
     | Lop(Istackoffset n) ->
         assert (n mod 16 = 0);
         emit_stack_adjustment (-n);

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -461,6 +461,23 @@ let emit_global_label s =
   D.global lbl;
   _label lbl
 
+(* Emission of labels immediately prior to and after calls, used for DWARF
+   call site support. *)
+
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
+let maybe_add_label_before_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    _label (emit_label call_labels.before)
+  end
+
+(* This function should not be called if [record_frame] is going to be used,
+   since the latter defines the same label as this function. *)
+let maybe_add_label_after_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    _label (emit_label call_labels.after)
+  end
+
 (* Output the assembly code for an instruction *)
 
 (* Name of current function *)
@@ -537,34 +554,45 @@ let emit_instr fallthrough i =
   | Lop(Iconst_symbol s) ->
       add_used_symbol s;
       I.mov (immsym s) (reg i.res.(0))
-  | Lop(Icall_ind { label_after; }) ->
+  | Lop(Icall_ind { call_labels; }) ->
+      maybe_add_label_before_call ~call_labels;
       I.call (reg i.arg.(0));
-      record_frame i.live false i.dbg ~label:label_after
-  | Lop(Icall_imm { func; label_after; }) ->
+      record_frame i.live false i.dbg ~label:call_labels.after
+  | Lop(Icall_imm { func; call_labels; }) ->
       add_used_symbol func;
+      maybe_add_label_before_call ~call_labels;
       emit_call func;
-      record_frame i.live false i.dbg ~label:label_after
-  | Lop(Itailcall_ind { label_after = _; }) ->
+      record_frame i.live false i.dbg ~label:call_labels.after
+  | Lop(Itailcall_ind { call_labels; }) ->
       output_epilogue begin fun () ->
-        I.jmp (reg i.arg.(0))
+        maybe_add_label_before_call ~call_labels;
+        I.jmp (reg i.arg.(0));
+        maybe_add_label_after_call ~call_labels
       end
-  | Lop(Itailcall_imm { func; label_after = _; }) ->
-      if func = !function_name then
-        I.jmp (label !tailrec_entry_point)
-      else begin
+  | Lop(Itailcall_imm { func; call_labels; }) ->
+      if func = !function_name then begin
+        maybe_add_label_before_call ~call_labels;
+        I.jmp (label !tailrec_entry_point);
+        maybe_add_label_after_call ~call_labels
+      end else begin
         output_epilogue begin fun () ->
           add_used_symbol func;
-          I.jmp (immsym func)
+          maybe_add_label_before_call ~call_labels;
+          I.jmp (immsym func);
+          maybe_add_label_after_call ~call_labels
         end
       end
-  | Lop(Iextcall { func; alloc; label_after; }) ->
+  | Lop(Iextcall { func; alloc; call_labels; }) ->
       add_used_symbol func;
       if alloc then begin
         I.mov (immsym func) eax;
+        maybe_add_label_before_call ~call_labels;
         emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:label_after
+        record_frame i.live false i.dbg ~label:call_labels.after
       end else begin
-        emit_call func
+        maybe_add_label_before_call ~call_labels;
+        emit_call func;
+        maybe_add_label_after_call ~call_labels
       end
   | Lop(Istackoffset n) ->
       if n < 0

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -39,6 +39,11 @@ type test =
   | Ioddtest
   | Ieventest
 
+type call_labels = {
+  before : label;
+  after : label;
+}
+
 type operation =
     Imove
   | Ispill
@@ -46,11 +51,11 @@ type operation =
   | Iconst_int of nativeint
   | Iconst_float of int64
   | Iconst_symbol of string
-  | Icall_ind of { label_after : label; }
-  | Icall_imm of { func : string; label_after : label; }
-  | Itailcall_ind of { label_after : label; }
-  | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Icall_ind of { call_labels : call_labels; }
+  | Icall_imm of { func : string; call_labels : call_labels; }
+  | Itailcall_ind of { call_labels : call_labels; }
+  | Itailcall_imm of { func : string; call_labels : call_labels; }
+  | Iextcall of { func : string; alloc : bool; call_labels : call_labels; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -46,6 +46,11 @@ type test =
   | Ioddtest
   | Ieventest
 
+type call_labels = {
+  before : label;
+  after : label;
+}
+
 type operation =
     Imove
   | Ispill
@@ -53,11 +58,11 @@ type operation =
   | Iconst_int of nativeint
   | Iconst_float of int64
   | Iconst_symbol of string
-  | Icall_ind of { label_after : label; }
-  | Icall_imm of { func : string; label_after : label; }
-  | Itailcall_ind of { label_after : label; }
-  | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Icall_ind of { call_labels : call_labels; }
+  | Icall_imm of { func : string; call_labels : call_labels; }
+  | Itailcall_ind of { call_labels : call_labels; }
+  | Itailcall_imm of { func : string; call_labels : call_labels; }
+  | Iextcall of { func : string; alloc : bool; call_labels : call_labels; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -539,6 +539,23 @@ let emit_profile () =
       `	bl	{emit_symbol "caml_after_mcount"}\n`;
       `	mtlr	0\n`
 
+(* Emission of labels immediately prior to and after calls, used for DWARF
+   call site support. *)
+
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
+let maybe_add_label_before_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.before}:\n`
+  end
+
+(* This function should not be called if [record_frame] is going to be used,
+   since the latter defines the same label as this function. *)
+let maybe_add_label_after_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.after}:\n`
+  end
+
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -631,31 +648,35 @@ let emit_instr i =
         | ELF64v1 | ELF64v2 ->
           emit_tocload emit_reg i.res.(0) (TocSym s)
         end
-    | Lop(Icall_ind { label_after; }) ->
+    | Lop(Icall_ind { call_labels; }) ->
         begin match abi with
         | ELF32 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`;
+          maybe_add_label_before_call ~call_labels;
           `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:label_after
+          record_frame i.live false i.dbg ~label:call_labels.after
         | ELF64v1 ->
           `	ld	0, 0({emit_reg i.arg.(0)})\n`;  (* code pointer *)
           `	mtctr	0\n`;
           `	ld	2, 8({emit_reg i.arg.(0)})\n`;  (* TOC for callee *)
+          maybe_add_label_before_call ~call_labels;
           `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:label_after;
+          record_frame i.live false i.dbg ~label:call_labels.after;
           emit_reload_toc()
         | ELF64v2 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`;
           `	mr	12, {emit_reg i.arg.(0)}\n`;  (* addr of fn in r12 *)
+          maybe_add_label_before_call ~call_labels;
           `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:label_after;
+          record_frame i.live false i.dbg ~label:call_labels.after;
           emit_reload_toc()
         end
-    | Lop(Icall_imm { func; label_after; }) ->
+    | Lop(Icall_imm { func; call_labels; }) ->
         begin match abi with
         | ELF32 ->
+            maybe_add_label_before_call ~call_labels;
             emit_call func;
-            record_frame i.live false i.dbg ~label:label_after
+            record_frame i.live false i.dbg ~label:call_labels.after
         | ELF64v1 | ELF64v2 ->
         (* For PPC64, we cannot just emit a "bl s; nop" sequence, because
            of the following scenario:
@@ -674,12 +695,13 @@ let emit_instr i =
                 by the linker, but this is harmless.
                 Cost: 3 instructions if same TOC, 7 if different TOC.
            Let's try option 2. *)
+            maybe_add_label_before_call ~call_labels;
             emit_call func;
-            record_frame i.live false i.dbg ~label:label_after;
+            record_frame i.live false i.dbg ~label:call_labels.after;
             `	nop\n`;
             emit_reload_toc()
         end
-    | Lop(Itailcall_ind { label_after = _; }) ->
+    | Lop(Itailcall_ind { call_labels; }) ->
         begin match abi with
         | ELF32 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`
@@ -696,11 +718,15 @@ let emit_instr i =
           `	mtlr	11\n`
         end;
         emit_free_frame();
-        `	bctr\n`
-    | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then
-          `	b	{emit_label !tailrec_entry_point}\n`
-        else begin
+        maybe_add_label_before_call ~call_labels;
+        `	bctr\n`;
+        maybe_add_label_after_call ~call_labels
+    | Lop(Itailcall_imm { func; call_labels; }) ->
+        if func = !function_name then begin
+          maybe_add_label_before_call ~call_labels;
+          `	b	{emit_label !tailrec_entry_point}\n`;
+          maybe_add_label_after_call ~call_labels
+        end else begin
           begin match abi with
           | ELF32 ->
             ()
@@ -718,26 +744,32 @@ let emit_instr i =
             `	mtlr	11\n`
           end;
           emit_free_frame();
+          maybe_add_label_before_call ~call_labels;
           begin match abi with
           | ELF32 ->
             `	b	{emit_symbol func}\n`
           | ELF64v1 | ELF64v2 ->
             `	bctr\n`
-          end
+          end;
+          maybe_add_label_after_call ~call_labels
         end
-    | Lop(Iextcall { func; alloc; }) ->
+    | Lop(Iextcall { func; alloc; call_labels; }) ->
         if not alloc then begin
+          maybe_add_label_before_call ~call_labels;
           emit_call func;
+          maybe_add_label_after_call ~call_labels;
           emit_call_nop()
         end else begin
           match abi with
           | ELF32 ->
             `	addis	28, 0, {emit_upper emit_symbol func}\n`;
             `	addi	28, 28, {emit_lower emit_symbol func}\n`;
+            maybe_add_label_before_call ~call_labels;
             emit_call "caml_c_call";
             record_frame i.live false i.dbg
           | ELF64v1 | ELF64v2 ->
             emit_tocload emit_gpr 28 (TocSym func);
+            maybe_add_label_before_call ~call_labels;
             emit_call "caml_c_call";
             record_frame i.live false i.dbg;
             `	nop\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -301,6 +301,23 @@ let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
+(* Emission of labels immediately prior to and after calls, used for DWARF
+   call site support. *)
+
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
+let maybe_add_label_before_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.before}:\n`
+  end
+
+(* This function should not be called if [record_frame] is going to be used,
+   since the latter defines the same label as this function. *)
+let maybe_add_label_after_call ~call_labels =
+  if supports_dwarf_call_sites () then begin
+    `{emit_label call_labels.after}:\n`
+  end
+
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -349,39 +366,54 @@ let emit_instr i =
         `	ld	{emit_reg i.res.(0)}, 0(%r1)\n`
      | Lop(Iconst_symbol s) ->
         emit_load_symbol_addr i.res.(0) s
-    | Lop(Icall_ind { label_after; }) ->
+    | Lop(Icall_ind { call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
         `	basr	%r14, {emit_reg i.arg.(0)}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
 
-    | Lop(Icall_imm { func; label_after; }) ->
+    | Lop(Icall_imm { func; call_labels; }) ->
+        maybe_add_label_before_call ~call_labels;
         emit_call func;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
-    | Lop(Itailcall_ind { label_after = _; }) ->
+        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+    | Lop(Itailcall_ind { call_labels; }) ->
         let n = frame_size() in
-        if !contains_calls then
-          `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
+        if !contains_calls then begin
+          `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`
+        end;
         emit_stack_adjust (-n);
-        `	br	{emit_reg i.arg.(0)}\n`
-    | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then
-          `	brcl	15, {emit_label !tailrec_entry_point}\n`
-        else begin
+        maybe_add_label_before_call ~call_labels;
+        `	br	{emit_reg i.arg.(0)}\n`;
+        maybe_add_label_after_call ~call_labels
+    | Lop(Itailcall_imm { func; call_labels; }) ->
+        if func = !function_name then begin
+          maybe_add_label_before_call ~call_labels;
+          `	brcl	15, {emit_label !tailrec_entry_point}\n`;
+          maybe_add_label_after_call ~call_labels
+        end else begin
           let n = frame_size() in
-          if !contains_calls then
-            `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
+          if !contains_calls then begin
+            `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`
+          end;
           emit_stack_adjust (-n);
-          if !pic_code then
+          maybe_add_label_before_call ~call_labels;
+          if !pic_code then begin
             `	brcl	15, {emit_symbol func}@PLT\n`
-          else
+          end else begin
             `	brcl	15, {emit_symbol func}\n`
+          end;
+          maybe_add_label_after_call ~call_labels
         end
 
-     | Lop(Iextcall { func; alloc; label_after; }) ->
-        if not alloc then emit_call func
-        else begin
+     | Lop(Iextcall { func; alloc; call_labels; }) ->
+        if not alloc then begin
+          maybe_add_label_before_call ~call_labels;
+          emit_call func;
+          maybe_add_label_after_call ~call_labels
+        end else begin
           emit_load_symbol_addr reg_r7 func;
+          maybe_add_label_before_call ~call_labels;
           emit_call "caml_c_call";
-          `{record_frame i.live false i.dbg ~label:label_after}\n`
+          `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
         end
 
      | Lop(Istackoffset n) ->

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -412,21 +412,32 @@ method select_checkbound () =
   Icheckbound { spacetime_index = 0; label_after_error = None; }
 method select_checkbound_extra_args () = []
 
+method private new_call_labels () : Mach.call_labels =
+  { before = Cmm.new_label ();
+    after = Cmm.new_label ();
+  }
+
 method select_operation op args _dbg =
   match (op, args) with
   | (Capply _, Cconst_symbol func :: rem) ->
-    let label_after = Cmm.new_label () in
-    (Icall_imm { func; label_after; }, rem)
+    let call_labels = self#new_call_labels () in
+    (Icall_imm { func; call_labels; }, rem)
   | (Capply _, _) ->
-    let label_after = Cmm.new_label () in
-    (Icall_ind { label_after; }, args)
+    let call_labels = self#new_call_labels () in
+    (Icall_ind { call_labels; }, args)
   | (Cextcall(func, _ty, alloc, label_after), _) ->
-    let label_after =
-      match label_after with
-      | None -> Cmm.new_label ()
-      | Some label_after -> label_after
+    let call_labels : Mach.call_labels =
+      let before = Cmm.new_label () in
+      let after =
+        match label_after with
+        | None -> Cmm.new_label ()
+        | Some label_after -> label_after
+      in
+      { before;
+        after;
+      }
     in
-    Iextcall { func; alloc; label_after; }, args
+    Iextcall { func; alloc; call_labels; }, args
   | (Cload (chunk, _mut), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
       (Iload(chunk, addr), [eloc])
@@ -1051,12 +1062,12 @@ method emit_tail (env:environment) exp =
       | Some(simple_args, env) ->
           let (new_op, new_args) = self#select_operation op simple_args dbg in
           match new_op with
-            Icall_ind { label_after; } ->
+            Icall_ind { call_labels; } ->
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let (loc_arg, stack_ofs) = Proc.loc_arguments rarg in
               if stack_ofs = 0 then begin
-                let call = Iop (Itailcall_ind { label_after; }) in
+                let call = Iop (Itailcall_ind { call_labels; }) in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| r1.(0) |]
                 in
@@ -1077,11 +1088,11 @@ method emit_tail (env:environment) exp =
                 self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
                 self#insert env Ireturn loc_res [||]
               end
-          | Icall_imm { func; label_after; } ->
+          | Icall_imm { func; call_labels; } ->
               let r1 = self#emit_tuple env new_args in
               let (loc_arg, stack_ofs) = Proc.loc_arguments r1 in
               if stack_ofs = 0 then begin
-                let call = Iop (Itailcall_imm { func; label_after; }) in
+                let call = Iop (Itailcall_imm { func; call_labels; }) in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| |]
                 in
@@ -1089,7 +1100,7 @@ method emit_tail (env:environment) exp =
                 self#maybe_emit_spacetime_move env ~spacetime_reg;
                 self#insert_debug env call dbg loc_arg [||];
               end else if func = !current_function_name then begin
-                let call = Iop (Itailcall_imm { func; label_after; }) in
+                let call = Iop (Itailcall_imm { func; call_labels; }) in
                 let loc_arg' = Proc.loc_parameters r1 in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| |]


### PR DESCRIPTION
This pull request generalises the existing support in the `Mach` language for "labels immediately after call sites" to "labels immediately before and after call sites".  Such labels are required to emit DWARF information that describes the position of call sites.  (This is a DWARF-4 GNU extension adopted as standard in DWARF-5.)

Emitting comprehensive DWARF information for all call sites enables many more variables to be available and/or printed properly in the debugger than would otherwise be the case.  This behaviour relies on the debugger being able to answer the following question.  Suppose we are in some function that has associated with it a stack frame (known as the "current frame").  There is a previous (older) frame immediately above us on the stack which can be discovered by unwinding.  The question is whether that previous frame corresponds to the caller of the function.  (It might not because there may have been one or more tail calls in the middle.)  gdb can provide various answers to this question, one of which is "definitely yes", if the DWARF information is comprehensive enough.  This requires the compilier to describe all call sites that might be involved in such stack frame relations and to say whether or not they are tail calls.  The OCaml compiler, after the DWARF patches, emits sufficient information for gdb to be able to do this.

This has two implications that are very useful in practice:

- Known arguments (e.g. the constant `None`) at call sites, which will be inferrable by an enhanced version of `Available_regs` to be presented shortly, can be described.  This means that if the parameter becomes unavailable in the callee, it can often still be recovered, as gdb will look at the DWARF information associated with the call site if the answer to the above question is "definitely yes".  (Support for this particular kind of argument recovery was what the DWARF call site support was originally intended for.  It is associated with the term "entry values" in gdb terminology.)

- We can sometimes, in a callee, find the OCaml types of its arguments even if the types of the parameters of the callee are polymorphic.  (The OCaml types are required to print values properly.) 
 This is done by examining the DWARF information for the relevant call site, on the condition that the answer to the above question is "definitely yes".  The idea is that at the call site of a polymorphic function, the type(s) of the function's polymorphic argument(s) are more likely to be monomorphic.  This support is rudimentary at present (and could probably be confused by polymorphic recursion), but it is sufficient for a fair number of invocations of polymorphic functions such as `List.map` to have their arguments printed correctly.  Improving the support for type recovery would likely only involve changes in `libmonda`, not the compiler.

@stedolan Could you take a first pass of review please?  patdiff is probably helpful for this one.  There is some duplication for the "`maybe_...`" functions as you will see, but that will go away in the future when `Asm_directives` arrives.  Likewise, the condition as to whether certain of the labels should be enabled cannot yet be wired through, as the pull request that adds new command-line flags for debugging information output control has not yet been presented.

I added a couple of `begin` and `end` pairs in one-line conditionals to improve code clarity.  I've made mistakes in the emitters in the past due to confusion relating to these.

Call sites produced in the emitter (e.g. `caml_call_gc`) will not currently have the necessary labels nor the necessary data structures associated with them to obtain a list of all such call sites that have been inserted during emission.  This will be dealt with in a future pull request.