### PR TITLE
type_let: be more careful generalizing parts of the pattern

### DIFF
--- a/Changes
+++ b/Changes
@@ -494,6 +494,9 @@ OCaml 4.08.0
   already existed, but used to be triggered even when e was not an application.)
   (Nicolás Ojeda Bär, review by Alain Frisch and Jacques Garrigue)
 
+- GPR#2317: type_let: be more careful generalizing parts of the pattern
+  (Thomas Refis and Leo White, review by Jacques Garrigue)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -33,7 +33,7 @@ let {id} = id { id };;
 [%%expect {|
 type id = { id : 'a. 'a -> 'a; }
 val id : 'a -> 'a = <fun>
-val id : '_weak1 -> '_weak1 = <fun>
+val id : 'a -> 'a = <fun>
 |}];;
 
 let px = {pv = []};;
@@ -1554,7 +1554,7 @@ let x = f 3;;
 [%%expect{|
 type (+'a, -'b) foo = private int
 val f : int -> ('a, 'a) foo = <fun>
-val x : ('_weak2, '_weak2) foo = 3
+val x : ('_weak1, '_weak1) foo = 3
 |}]
 
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -27,6 +27,15 @@ type pty = { pv : 'a. 'a list; }
 |}];;
 
 
+type id = { id : 'a. 'a -> 'a };;
+let id x = x;;
+let {id} = id { id };;
+[%%expect {|
+type id = { id : 'a. 'a -> 'a; }
+val id : 'a -> 'a = <fun>
+val id : '_weak1 -> '_weak1 = <fun>
+|}];;
+
 let px = {pv = []};;
 [%%expect {|
 val px : pty = {pv = []}
@@ -1545,7 +1554,7 @@ let x = f 3;;
 [%%expect{|
 type (+'a, -'b) foo = private int
 val f : int -> ('a, 'a) foo = <fun>
-val x : ('_weak1, '_weak1) foo = 3
+val x : ('_weak2, '_weak2) foo = 3
 |}]
 
 


### PR DESCRIPTION
This fixes a bug noticed when trying to build merlin on 4.08: bindings to polymorphic record fields introduced by `let`s of expansive expressions are not polymorphic anymore (they were in 4.07).
See the example added by the first commit.

In #1748, we removed some calls to `generalize` from `type_pat`, assuming that they were needed only for the check that followed in the next few lines. Indeed, the variables would get generalized later from `type_cases`, so there is no need to generalize then and there.

However, in the case of a let, since we're first typing the pattern and then the expression, we might end up calling `generalize_expansive` on that binding before calling `generalize`, which will then do nothing.

The issue could be fix by reintroducing the call to `generalize` in `type_pat`, but that felt a bit weird. Also, it didn't answer the question: why is `generalize_expansive` called on the type of the pattern variable? Question which can also be read as: "*why is `generalize_expansive` called on every subpattern?*".

As a result, the patch proposed here ends up "cleaning up" the generalization story inside `type_let` in a way that is very similar to #1745 (the subtleties come from the fact that the binding might be recursive).

And then some tests (the first two real tests of `testsuite/tests/typing-warnings/application.ml`) started failing, because the toplevel/expect_test has some special handling of `let _ =`, and so some plumbing was added to make sure the type which is printed is still generic (search for "`if toplevel`").