### PR TITLE
Eliminate dead `ICatch` handlers

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,9 @@ Working version
   each function in a separate named text section on supported targets.
   (Greta Yorsh, review by Pierre Chambart)
 
+- #2321: Eliminate dead ICatch handlers
+  (Greta Yorsh, review by Pierre Chambart and Vincent Laviron)
+
 ### Runtime system:
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -107,10 +107,18 @@ let rec deadcode i =
           live_exits
           used_handlers
     in
+    let rec patch_next body next_final =
+      let next =
+        match body.next.desc with
+        | Iend -> next_final
+        | _ -> patch_next body.next next_final
+      in
+      { body with next; }
+    in
     let i =
       match used_handlers with
       | [] -> (* Simplify catch without handlers *)
-        { i with desc = body'.i.desc; next = s.i }
+        patch_next body'.i s.i
       | _ ->
         let handlers = List.map (fun (n,h) -> (n,h.i)) used_handlers in
         { i with desc = Icatch(rec_flag, handlers, body'.i); next = s.i }

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -18,16 +18,12 @@
 
 open Mach
 
-module IntSet = Set.Make(
-  struct
-    type t = int
-    let compare (x:t) y = compare x y
-  end)
+module Int = Identifiable.Make (Numbers.Int)
 
 type d = {
   i : instruction;   (* optimized instruction *)
   regs : Reg.Set.t;  (* a set of registers live "before" instruction [i] *)
-  exits : IntSet.t;  (* indexes of Iexit instructions "live before" [i] *)
+  exits : Int.Set.t;  (* indexes of Iexit instructions "live before" [i] *)
 }
 
 let rec deadcode i =
@@ -39,12 +35,12 @@ let rec deadcode i =
   in
   match i.desc with
   | Iend | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) | Iraise _ ->
-    let regs = Reg.add_set_array i.live arg in
-    { i; regs; exits = IntSet.empty; }
+      let regs = Reg.add_set_array i.live arg in
+      { i; regs; exits = Int.Set.empty; }
   | Iop op ->
       let s = deadcode i.next in
       if Proc.op_is_pure op                     (* no side effects *)
-      && Reg.disjoint_set_array s.regs i.res (* results are not used after *)
+      && Reg.disjoint_set_array s.regs i.res   (* results are not used after *)
       && not (Proc.regs_are_volatile arg)      (* no stack-like hard reg *)
       && not (Proc.regs_are_volatile i.res)    (*            is involved *)
       then begin
@@ -62,8 +58,8 @@ let rec deadcode i =
       let s = deadcode i.next in
       { i = {i with desc = Iifthenelse(test, ifso'.i, ifnot'.i); next = s.i};
         regs = Reg.add_set_array i.live arg;
-        exits = IntSet.union s.exits
-                  (IntSet.union ifso'.exits ifnot'.exits);
+        exits = Int.Set.union s.exits
+                  (Int.Set.union ifso'.exits ifnot'.exits);
       }
   | Iswitch(index, cases) ->
       let dc = Array.map deadcode cases in
@@ -72,65 +68,40 @@ let rec deadcode i =
       { i = {i with desc = Iswitch(index, cases'); next = s.i};
         regs = Reg.add_set_array i.live arg;
         exits = Array.fold_left
-                  (fun acc c -> IntSet.union acc c.exits) s.exits dc;
+                  (fun acc c -> Int.Set.union acc c.exits) s.exits dc;
       }
   | Icatch(rec_flag, handlers, body) ->
     let body' = deadcode body in
     let s = deadcode i.next in
-    let (handlers', h_exits) =
-      List.split
-        (List.map (fun (nfail, handler) ->
-           let handler' = deadcode handler in
-           ((nfail, handler'.i), handler'.exits))
-           handlers)
+    let handlers' = Int.Map.map deadcode (Int.Map.of_list handlers) in
+    let rec add_live exit (live_exits, used_handlers) =
+      if Int.Set.mem exit live_exits then
+        (live_exits, used_handlers)
+      else
+        let live_exits = Int.Set.add exit live_exits in
+        match Int.Map.find_opt exit handlers' with
+        | None -> (live_exits, used_handlers)
+        | Some handler ->
+            Int.Set.fold add_live handler.exits
+              (live_exits, (exit, handler.i) :: used_handlers)
     in
-    (* Remove unused handlers.
-       We deal with three disjoint sets of "nfail" indexes:
-       dead handler indexes = B \setminus A
-       used handler indexes = A \intersect B
-       live exit indexes = A \setminus B
-       where
-       B = indexes of handlers in this Icatch,
-       A = indexes used in Iexit instructions that are
-       in scope of the handlers of this Icatch (scope depends on rec_flag).
-    *)
-    let h_exits = List.fold_left (fun acc e -> IntSet.union acc e)
-                    IntSet.empty h_exits in
-    let all_exits = IntSet.union body'.exits h_exits in
-    let exits_in_scope =
-      match rec_flag with
-      | Cmm.Recursive -> all_exits
-        (* Indexes mentioned in Iexit instructions in body and handlers. *)
-      | Cmm.Nonrecursive -> body'.exits
-        (* Icatch body is allowed to Iexit to it's own hanlders
-           or handlers of an enclosing Icatch that are not shadowed
-           by the current Icatch.
-           A handler cannot Iexit to itself or other handlers in this Icatch.
-           Thus, all Iexits in handlers refer to an enclosing Icatch. *)
+    let live_exits, used_handlers =
+      Int.Set.fold add_live body'.exits (s.exits, [])
     in
-    (* A handler is "used" if and only if its index is in exits_in_scope .*)
-    let used_handlers =
-      List.filter (fun (n,_)-> IntSet.mem n exits_in_scope) handlers' in
-    let used_handler_indexes =
-      IntSet.of_list (fst (List.split used_handlers)) in
-    (* Exits that do not have a used handler with the same index
-       are referring to a handler in an enclosing catch.
-       They are added to "live before" exits of instruction [i] *)
-    let live_exits = IntSet.diff all_exits used_handler_indexes in
     { i = {i with desc = Icatch(rec_flag, used_handlers, body'.i); next = s.i};
       regs = i.live;
-      exits = IntSet.union s.exits live_exits;
+      exits = live_exits;
     }
   | Iexit nfail ->
-      { i;  regs = i.live; exits = IntSet.singleton nfail; }
+      { i;  regs = i.live; exits = Int.Set.singleton nfail; }
   | Itrywith(body, handler) ->
       let body' = deadcode body in
       let handler' = deadcode handler in
       let s = deadcode i.next in
       { i = {i with desc = Itrywith(body'.i, handler'.i); next = s.i};
         regs = i.live;
-        exits = IntSet.union s.exits
-                  (IntSet.union body'.exits handler'.exits);
+        exits = Int.Set.union s.exits
+                  (Int.Set.union body'.exits handler'.exits);
       }
 
 let fundecl f =

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -18,8 +18,17 @@
 
 open Mach
 
-(* [deadcode i] returns a pair of an optimized instruction [i']
-   and a set of registers live "before" instruction [i]. *)
+module IntSet = Set.Make(
+  struct
+    type t = int
+    let compare (x:t) y = compare x y
+  end)
+
+type d = {
+  i : instruction;   (* optimized instruction *)
+  regs : Reg.Set.t;  (* a set of registers live "before" instruction [i] *)
+  exits : IntSet.t;  (* indexes of Iexit instructions "live before" [i] *)
+}
 
 let rec deadcode i =
   let arg =
@@ -30,48 +39,100 @@ let rec deadcode i =
   in
   match i.desc with
   | Iend | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) | Iraise _ ->
-      (i, Reg.add_set_array i.live arg)
+    let regs = Reg.add_set_array i.live arg in
+    { i; regs; exits = IntSet.empty; }
   | Iop op ->
-      let (s, before) = deadcode i.next in
+      let s = deadcode i.next in
       if Proc.op_is_pure op                     (* no side effects *)
-      && Reg.disjoint_set_array before i.res    (* results are not used after *)
+      && Reg.disjoint_set_array s.regs i.res (* results are not used after *)
       && not (Proc.regs_are_volatile arg)      (* no stack-like hard reg *)
       && not (Proc.regs_are_volatile i.res)    (*            is involved *)
       then begin
         assert (Array.length i.res > 0);  (* sanity check *)
-        (s, before)
+        s
       end else begin
-        ({i with next = s}, Reg.add_set_array i.live arg)
+        { i = {i with next = s.i};
+          regs = Reg.add_set_array i.live arg;
+          exits = s.exits;
+        }
       end
   | Iifthenelse(test, ifso, ifnot) ->
-      let (ifso', _) = deadcode ifso in
-      let (ifnot', _) = deadcode ifnot in
-      let (s, _) = deadcode i.next in
-      ({i with desc = Iifthenelse(test, ifso', ifnot'); next = s},
-       Reg.add_set_array i.live arg)
+      let ifso' = deadcode ifso in
+      let ifnot' = deadcode ifnot in
+      let s = deadcode i.next in
+      { i = {i with desc = Iifthenelse(test, ifso'.i, ifnot'.i); next = s.i};
+        regs = Reg.add_set_array i.live arg;
+        exits = IntSet.union s.exits
+                  (IntSet.union ifso'.exits ifnot'.exits);
+      }
   | Iswitch(index, cases) ->
-      let cases' = Array.map (fun c -> fst (deadcode c)) cases in
-      let (s, _) = deadcode i.next in
-      ({i with desc = Iswitch(index, cases'); next = s},
-       Reg.add_set_array i.live arg)
+      let dc = Array.map deadcode cases in
+      let cases' = Array.map (fun c -> c.i) dc in
+      let s = deadcode i.next in
+      { i = {i with desc = Iswitch(index, cases'); next = s.i};
+        regs = Reg.add_set_array i.live arg;
+        exits = Array.fold_left
+                  (fun acc c -> IntSet.union acc c.exits) s.exits dc;
+      }
   | Icatch(rec_flag, handlers, body) ->
-      let (body', _) = deadcode body in
-      let handlers' =
-        List.map (fun (nfail, handler) ->
-            let (handler', _) = deadcode handler in
-            nfail, handler')
-          handlers
-      in
-      let (s, _) = deadcode i.next in
-      ({i with desc = Icatch(rec_flag, handlers', body'); next = s}, i.live)
-  | Iexit _nfail ->
-      (i, i.live)
+    let body' = deadcode body in
+    let s = deadcode i.next in
+    let (handlers', h_exits) =
+      List.split
+        (List.map (fun (nfail, handler) ->
+           let handler' = deadcode handler in
+           ((nfail, handler'.i), handler'.exits))
+           handlers)
+    in
+    (* Remove unused handlers.
+       We deal with three disjoint sets of "nfail" indexes:
+       dead handler indexes = B \setminus A
+       used handler indexes = A \intersect B
+       live exit indexes = A \setminus B
+       where
+       B = indexes of handlers in this Icatch,
+       A = indexes used in Iexit instructions that are
+       in scope of the handlers of this Icatch (scope depends on rec_flag).
+    *)
+    let h_exits = List.fold_left (fun acc e -> IntSet.union acc e)
+                    IntSet.empty h_exits in
+    let all_exits = IntSet.union body'.exits h_exits in
+    let exits_in_scope =
+      match rec_flag with
+      | Cmm.Recursive -> all_exits
+        (* Indexes mentioned in Iexit instructions in body and handlers. *)
+      | Cmm.Nonrecursive -> body'.exits
+        (* Icatch body is allowed to Iexit to it's own hanlders
+           or handlers of an enclosing Icatch that are not shadowed
+           by the current Icatch.
+           A handler cannot Iexit to itself or other handlers in this Icatch.
+           Thus, all Iexits in handlers refer to an enclosing Icatch. *)
+    in
+    (* A handler is "used" if and only if its index is in exits_in_scope .*)
+    let used_handlers =
+      List.filter (fun (n,_)-> IntSet.mem n exits_in_scope) handlers' in
+    let used_handler_indexes =
+      IntSet.of_list (fst (List.split used_handlers)) in
+    (* Exits that do not have a used handler with the same index
+       are referring to a handler in an enclosing catch.
+       They are added to "live before" exits of instruction [i] *)
+    let live_exits = IntSet.diff all_exits used_handler_indexes in
+    { i = {i with desc = Icatch(rec_flag, used_handlers, body'.i); next = s.i};
+      regs = i.live;
+      exits = IntSet.union s.exits live_exits;
+    }
+  | Iexit nfail ->
+      { i;  regs = i.live; exits = IntSet.singleton nfail; }
   | Itrywith(body, handler) ->
-      let (body', _) = deadcode body in
-      let (handler', _) = deadcode handler in
-      let (s, _) = deadcode i.next in
-      ({i with desc = Itrywith(body', handler'); next = s}, i.live)
+      let body' = deadcode body in
+      let handler' = deadcode handler in
+      let s = deadcode i.next in
+      { i = {i with desc = Itrywith(body'.i, handler'.i); next = s.i};
+        regs = i.live;
+        exits = IntSet.union s.exits
+                  (IntSet.union body'.exits handler'.exits);
+      }
 
 let fundecl f =
-  let (new_body, _) = deadcode f.fun_body in
-  {f with fun_body = new_body}
+  let new_body = deadcode f.fun_body in
+  {f with fun_body = new_body.i}

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -699,9 +699,15 @@ let run_codegen log env =
       compiler_output
       env
   in
+  let output = Filename.make_path
+                 [test_build_directory;
+                  (Filename.make_filename
+                     (Filename.chop_extension testfile) "output")] in
+  let env = Environments.add Builtin_variables.output output env in
   let commandline =
   [
     Ocaml_commands.ocamlrun_codegen ocamlsrcdir;
+    flags env;
     "-S " ^ testfile
   ] in
   let expected_exit_status = 0 in

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -686,6 +686,7 @@ let finalise_codegen_msvc ocamlsrcdir test_basename log env =
 let run_codegen log env =
   let ocamlsrcdir = Ocaml_directories.srcdir () in
   let testfile = Actions_helpers.testfile env in
+  let testfile_basename = Filename.chop_extension testfile in
   let what = Printf.sprintf "Running codegen on %s" testfile in
   Printf.fprintf log "%s\n%!" what;
   let test_build_directory =
@@ -699,10 +700,8 @@ let run_codegen log env =
       compiler_output
       env
   in
-  let output = Filename.make_path
-                 [test_build_directory;
-                  (Filename.make_filename
-                     (Filename.chop_extension testfile) "output")] in
+  let output_file = Filename.make_filename testfile_basename "output" in
+  let output = Filename.make_path [test_build_directory; output_file] in
   let env = Environments.add Builtin_variables.output output env in
   let commandline =
   [
@@ -720,7 +719,6 @@ let run_codegen log env =
       log env commandline in
   if exit_status=expected_exit_status
   then begin
-    let testfile_basename = Filename.chop_extension testfile in
     let finalise =
        if Ocamltest_config.ccomptype="msvc"
       then finalise_codegen_msvc

--- a/testsuite/tests/asmgen/catch-rec-deadhandler.cmm
+++ b/testsuite/tests/asmgen/catch-rec-deadhandler.cmm
@@ -1,0 +1,17 @@
+(* TEST
+flags = "-dlive"
+files = "main.c"
+arguments = "-DUNIT_INT -DFUN=catch_rec_deadhandler main.c"
+* asmgen
+** run
+*** check-program-output
+*)
+
+(function "catch_rec_deadhandler" ()
+  (let x
+    (catch
+      (exit one)
+     with (one) 1
+     and (two) (exit three)
+     and (three) 3)
+    x))

--- a/testsuite/tests/asmgen/catch-rec-deadhandler.reference
+++ b/testsuite/tests/asmgen/catch-rec-deadhandler.reference
@@ -1,0 +1,6 @@
+  catch rec
+    exit(1)
+  with(1)
+  catch rec
+    exit(1)
+  with(1)

--- a/testsuite/tests/asmgen/catch-rec-deadhandler.run
+++ b/testsuite/tests/asmgen/catch-rec-deadhandler.run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec > "${output}" 2>&1
+
+grep -E "catch |with\(|and\(|exit\(" "${compiler_output}"

--- a/testsuite/tests/asmgen/ocamltests
+++ b/testsuite/tests/asmgen/ocamltests
@@ -4,6 +4,7 @@ catch-try.cmm
 catch-float.cmm
 catch-multiple.cmm
 catch-try-float.cmm
+catch-rec-deadhandler.cmm
 checkbound.cmm
 even-odd-spill.cmm
 even-odd-spill-float.cmm

--- a/testsuite/tests/asmgen/quicksort.cmm
+++ b/testsuite/tests/asmgen/quicksort.cmm
@@ -27,16 +27,16 @@ arguments = "-DSORT -DFUN=quicksort main.c"
         (while (< i j)
           (catch
               (while 1
-                (if (>= i hi) exit [])
-                (if (> (addraref a i) pivot) exit [])
+                (if (>= i hi) (exit n25) [])
+                (if (> (addraref a i) pivot) (exit n25) [])
                 (assign i (+ i 1)))
-           with [])
+           with (n25) [])
           (catch
               (while 1
-                (if (<= j lo) exit [])
-                (if (< (addraref a j) pivot) exit [])
+                (if (<= j lo) (exit n35) [])
+                (if (< (addraref a j) pivot) (exit n35) [])
                 (assign j (- j 1)))
-           with [])
+           with (n35) [])
           (if (< i j)
               (let temp (addraref a i)
                    (addraset a i (addraref a j))

--- a/testsuite/tests/asmgen/quicksort2.cmm
+++ b/testsuite/tests/asmgen/quicksort2.cmm
@@ -30,16 +30,16 @@ arguments = "-DSORT -DFUN=quicksort main.c"
         (while (< i j)
           (catch
             (while 1
-              (if (>= i hi) exit [])
-              (if (> (app cmp (intaref a i) pivot int) 0) exit [])
+              (if (>= i hi) (exit n25) [])
+              (if (> (app cmp (intaref a i) pivot int) 0) (exit n25) [])
               (assign i (+ i 1)))
-            with [])
+            with (n25) [])
           (catch
             (while 1
-              (if (<= j lo) exit [])
-              (if (< (app cmp (intaref a j) pivot int) 0) exit [])
+              (if (<= j lo) (exit n35) [])
+              (if (< (app cmp (intaref a j) pivot int) 0) (exit n35) [])
               (assign j (- j 1)))
-           with [])
+           with (n35) [])
           (if (< i j)
               (let temp (intaref a i)
                    (intaset a i (intaref a j))

--- a/testsuite/tests/asmgen/tagged-quicksort.cmm
+++ b/testsuite/tests/asmgen/tagged-quicksort.cmm
@@ -27,16 +27,16 @@ arguments = "-DSORT -DFUN=quicksort main.c"
         (while (< i j)
           (catch
               (while 1
-                (if (>= i hi) exit [])
-                (if (> (addraref a (>>s i 1)) pivot) exit [])
+                (if (>= i hi) (exit n25) [])
+                (if (> (addraref a (>>s i 1)) pivot) (exit n25) [])
                 (assign i (+ i 2)))
-           with [])
+           with (n25) [])
           (catch
               (while 1
-                (if (<= j lo) exit [])
-                (if (< (addraref a (>>s j 1)) pivot) exit [])
+                (if (<= j lo) (exit n35) [])
+                (if (< (addraref a (>>s j 1)) pivot) (exit n35) [])
                 (assign j (- j 2)))
-           with [])
+           with (n35) [])
           (if (< i j)
               (let temp (addraref a (>>s i 1))
                    (addraset a (>>s i 1) (addraref a (>>s j 1)))


### PR DESCRIPTION
This is an improvement of `deadcode` pass.
This PR detects dead handlers by propagating information about `Iexit` instructions that appear inside an instruction `i` and refer to handlers outside of `i`, using correct scoping rules depending on whether  `Icatch` is recursive or not. The function `deadcode` was refactored to return a record instead of a pair.

Here is a common and simple example that resulted in dead code before this PR:
```
type t = A | B

let bar t (x:float) (y:float) = match t with
  | A -> x < y
  | B -> x > y

let foo t x y = not (bar t x y)
```

Generated assembly (amd64, compiled with flambda) with dead code in blocks L107 and L106:
```
camlTest1__foo_22:
        .cfi_startproc
.L113:
        cmpq    $1, %rax
        je      .L110
        movsd   (%rdi), %xmm0
        movsd   (%rbx), %xmm1
        comisd  %xmm0, %xmm1
        ja      .L112
        movq    $1, %rax
        jmp     .L111
        .align  4
.L112:
        xorq    %rax, %rax
.L111:
        leaq    1(%rax,%rax), %rax
        ret
        .align  4
.L110:
        movsd   (%rdi), %xmm0
        movsd   (%rbx), %xmm1
        comisd  %xmm1, %xmm0
        ja      .L109
        movq    $1, %rax
        jmp     .L108
        .align  4
.L109:
        xorq    %rax, %rax
.L108:
        leaq    1(%rax,%rax), %rax
        ret
        .align  4
.L107:
        movq    $3, %rax
        ret
        .align  4
.L106:
        movq    $1, %rax
        ret
```