### PR TITLE
Add pseudo-instruction `Ladjust_trap_depth`

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,6 +31,10 @@ Working version
 - #8672: Optimise Switch code generation on booleans.
   (Stephen Dolan, review by Pierre Chambart)
 
+- #2322: Add pseudo-instruction `Ladjust_trap_depth` to replace
+  dummy Lpushtrap generated in linearize
+  (Greta Yorsh and Vincent Laviron, review by Xavier Leroy)
+
 ### Runtime system:
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -855,6 +855,11 @@ let emit_instr fallthrough i =
       D.text ()
   | Lentertrap ->
       ()
+  | Ladjust_trap_depth { delta_traps; } ->
+      (* each trap occupies 16 bytes on the stack *)
+      let delta = 16 * delta_traps in
+      cfi_adjust_cfa_offset delta;
+      stack_offset := !stack_offset + delta
   | Lpushtrap { lbl_handler; } ->
       let load_label_addr s arg =
         if !Clflags.pic_code then

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -869,6 +869,11 @@ let emit_instr i =
         end
     | Lentertrap ->
         0
+    | Ladjust_trap_depth { delta_traps } ->
+        (* each trap occupies 8 bytes on the stack *)
+        let delta = 8 * delta_traps in
+        cfi_adjust_cfa_offset delta;
+        stack_offset := !stack_offset + delta; 0
     | Lpushtrap { lbl_handler; } ->
         let s = emit_load_handler_address lbl_handler in
         stack_offset := !stack_offset + 8;

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -495,6 +495,7 @@ module BR = Branch_relaxation.Make (struct
         + begin match lbl2 with None -> 0 | Some _ -> 1 end
     | Lswitch jumptbl -> 3 + Array.length jumptbl
     | Lentertrap -> 0
+    | Ladjust_trap_depth _ -> 0
     | Lpushtrap _ -> 4
     | Lpoptrap -> 1
     | Lraise k ->
@@ -866,6 +867,11 @@ let emit_instr i =
 *)
     | Lentertrap ->
         ()
+    | Ladjust_trap_depth { delta_traps } ->
+        (* each trap occupies 16 bytes on the stack *)
+        let delta = 16 * delta_traps in
+        cfi_adjust_cfa_offset delta;
+        stack_offset := !stack_offset + delta
     | Lpushtrap { lbl_handler; } ->
         `	adr	{emit_reg reg_tmp1}, {emit_label lbl_handler}\n`;
         stack_offset := !stack_offset + 16;

--- a/asmcomp/debug/compute_ranges.ml
+++ b/asmcomp/debug/compute_ranges.ml
@@ -456,7 +456,8 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
     | Lend -> first_insn
     | Lprologue | Lop _ | Lreloadretaddr | Lreturn | Llabel _
     | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
-    | Lentertrap | Lpushtrap _ | Lpoptrap | Lraise _ ->
+    | Lentertrap | Lpushtrap _ | Lpoptrap | Ladjust_trap_depth _
+    | Lraise _ ->
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn
       in

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -846,6 +846,10 @@ let emit_instr fallthrough i =
       D.text ()
   | Lentertrap ->
       ()
+  | Ladjust_trap_depth { delta_traps } ->
+      let delta = trap_frame_size * delta_traps in
+      cfi_adjust_cfa_offset delta;
+      stack_offset := !stack_offset + delta
   | Lpushtrap { lbl_handler; } ->
       I.push (label lbl_handler);
       if trap_frame_size > 8 then

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -128,16 +128,15 @@ let check_label n = match n.desc with
    of differences in exception trap depths.
    The argument delta is the number of trap frames (not bytes). *)
 
-let adjust_trap_depth delta_traps next =
+let rec adjust_trap_depth delta_traps next =
   (* Simplify by merging and eliminating Ladjust_trap_depth instructions
      whenever possible. *)
-  let delta_traps, next  =
-    match next.desc with
-    | Ladjust_trap_depth { delta_traps = k } -> delta_traps + k, next.next
-    | _ -> delta_traps, next
-  in
-  if delta_traps = 0 then next
-  else cons_instr (Ladjust_trap_depth { delta_traps }) next
+  match next.desc with
+  | Ladjust_trap_depth { delta_traps = k } ->
+    adjust_trap_depth (delta_traps + k) next.next
+  | _ ->
+    if delta_traps = 0 then next
+    else cons_instr (Ladjust_trap_depth { delta_traps }) next
 
 (* Discard all instructions up to the next label.
    This function is to be called before adding a non-terminating

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -40,6 +40,7 @@ and instruction_desc =
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
   | Lentertrap
+  | Ladjust_trap_depth of { delta_traps : int; }
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Cmm.raise_kind
@@ -129,9 +130,9 @@ let rec discard_dead_code n =
   match n.desc with
     Lend -> n
   | Llabel _ -> n
-(* Do not discard Lpoptrap/Lpushtrap or Istackoffset instructions,
+  (* Do not discard Lpoptrap/Lpushtrap or Istackoffset instructions,
    as this may cause a stack imbalance later during assembler generation. *)
-  | Lpoptrap | Lpushtrap _ -> n
+  | Lpoptrap | Lpushtrap _ | Ladjust_trap_depth _ -> n
   | Lop(Istackoffset _) -> n
   | _ -> discard_dead_code n.next
 
@@ -277,19 +278,9 @@ let rec linear i n =
       n3
   | Iexit nfail ->
       let lbl, t = find_exit_label_try_depth nfail in
-      (* We need to re-insert dummy pushtrap (which won't be executed),
-         so as to preserve stack offset during assembler generation.
-         It would make sense to have a special pseudo-instruction
-         only to inform the later pass about this stack offset
-         (corresponding to N traps).
-       *)
-      let lbl_dummy = lbl in
-      let rec loop i tt =
-        if t = tt then i
-        else
-          loop (cons_instr (Lpushtrap { lbl_handler = lbl_dummy; }) i) (tt - 1)
-      in
-      let n1 = loop (linear i.Mach.next n) !try_depth in
+      assert (i.Mach.next.desc = Iend);
+      let delta_traps = !try_depth - t in
+      let n1 = cons_instr (Ladjust_trap_depth { delta_traps }) n in
       let rec loop i tt =
         if t = tt then i
         else loop (cons_instr Lpoptrap i) (tt - 1)

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -126,10 +126,10 @@ let check_label n = match n.desc with
 (* Add pseudo-instruction Ladjust_trap_depth in front of a continuation
    to notify assembler generation about updates to the stack as a result
    of differences in exception trap depths.
-   The argument the delta in the number of trap frames (not bytes). *)
+   The argument delta is the number of trap frames (not bytes). *)
 
 let adjust_trap_depth delta_traps next =
-  (* Simplify by merging and liminate Ladjust_trap_depth instructions
+  (* Simplify by merging and eliminating Ladjust_trap_depth instructions
      whenever possible. *)
   let delta_traps, next  =
     match next.desc with

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -122,20 +122,48 @@ let check_label n = match n.desc with
   | Llabel lbl -> lbl
   | _ -> -1
 
+
+(* Add pseudo-instruction Ladjust_trap_depth in front of a continuation
+   to notify assembler generation about updates to the stack as a result
+   of differences in exception trap depths.
+   The argument the delta in the number of trap frames (not bytes). *)
+
+let adjust_trap_depth delta_traps next =
+  (* Simplify by merging and liminate Ladjust_trap_depth instructions
+     whenever possible. *)
+  let delta_traps, next  =
+    match next.desc with
+    | Ladjust_trap_depth { delta_traps = k } -> delta_traps + k, next.next
+    | _ -> delta_traps, next
+  in
+  if delta_traps = 0 then next
+  else cons_instr (Ladjust_trap_depth { delta_traps }) next
+
 (* Discard all instructions up to the next label.
    This function is to be called before adding a non-terminating
    instruction. *)
 
 let rec discard_dead_code n =
+  let adjust trap_depth =
+    adjust_trap_depth trap_depth (discard_dead_code n.next)
+  in
   match n.desc with
     Lend -> n
   | Llabel _ -> n
     (* Do not discard Lpoptrap/Lpushtrap/Ladjust_trap_depth
        or Istackoffset instructions, as this may cause a stack imbalance
-       later during assembler generation.
-       However, it's ok to eliminate dead instructions after them.*)
-  | Lpoptrap | Lpushtrap _ | Ladjust_trap_depth _
+       later during assembler generation. Replace them
+       with pseudo-instruction Ladjust_trap_depth with the corresponding
+       stack offset and eliminate dead instructions after them. *)
+  | Lpoptrap -> adjust (-1)
+  | Lpushtrap _ -> adjust (+1)
+  | Ladjust_trap_depth { delta_traps } -> adjust delta_traps
   | Lop(Istackoffset _) ->
+    (* This dead instruction cannot be replaced by Ladjust_trap_depth,
+       because the units don't match: the argument of Istackoffset is in bytes,
+       whereas the argument of Ladjust_trap_depth is in trap frames,
+       and the size of trap frames is machine-dependant and therefore not
+       available here.  *)
     { n with next = discard_dead_code n.next; }
   | _ -> discard_dead_code n.next
 
@@ -283,7 +311,7 @@ let rec linear i n =
       let lbl, t = find_exit_label_try_depth nfail in
       assert (i.Mach.next.desc = Iend);
       let delta_traps = !try_depth - t in
-      let n1 = cons_instr (Ladjust_trap_depth { delta_traps }) n in
+      let n1 = adjust_trap_depth delta_traps n in
       let rec loop i tt =
         if t = tt then i
         else loop (cons_instr Lpoptrap i) (tt - 1)

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -130,10 +130,13 @@ let rec discard_dead_code n =
   match n.desc with
     Lend -> n
   | Llabel _ -> n
-  (* Do not discard Lpoptrap/Lpushtrap or Istackoffset instructions,
-   as this may cause a stack imbalance later during assembler generation. *)
-  | Lpoptrap | Lpushtrap _ | Ladjust_trap_depth _ -> n
-  | Lop(Istackoffset _) -> n
+    (* Do not discard Lpoptrap/Lpushtrap/Ladjust_trap_depth
+       or Istackoffset instructions, as this may cause a stack imbalance
+       later during assembler generation.
+       However, it's ok to eliminate dead instructions after them.*)
+  | Lpoptrap | Lpushtrap _ | Ladjust_trap_depth _
+  | Lop(Istackoffset _) ->
+    { n with next = discard_dead_code n.next; }
   | _ -> discard_dead_code n.next
 
 (*

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -37,6 +37,7 @@ and instruction_desc =
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
   | Lentertrap
+  | Ladjust_trap_depth of { delta_traps : int; }
   | Lpushtrap of { lbl_handler : label; }
   | Lpoptrap
   | Lraise of Cmm.raise_kind

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -535,6 +535,7 @@ module BR = Branch_relaxation.Make (struct
         + (if lbl2 = None then 0 else 1)
     | Lswitch _ -> size 7 (5 + tocload_size()) (5 + tocload_size())
     | Lentertrap -> size 0 (tocload_size()) (tocload_size())
+    | Ladjust_trap_depth _ -> 0
     | Lpushtrap _ -> size 5 (4 + tocload_size()) (4 + tocload_size())
     | Lpoptrap -> 2
     | Lraise _ -> 6
@@ -981,6 +982,8 @@ let emit_instr i =
         | ELF32 -> ()
         | ELF64v1 | ELF64v2 -> emit_reload_toc()
         end
+    | Ladjust_trap_depth { delta_traps } ->
+        adjust_stack_offset (trap_size * delta_traps)
     | Lpushtrap { lbl_handler; } ->
         begin match abi with
         | ELF32 ->

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -61,6 +61,8 @@ let instr ppf i =
       fprintf ppf "@,endswitch"
   | Lentertrap ->
       fprintf ppf "enter trap"
+  | Ladjust_trap_depth { delta_traps } ->
+      fprintf ppf "adjust trap depth by %d traps" delta_traps
   | Lpushtrap { lbl_handler; } ->
       fprintf ppf "push trap %a" label lbl_handler
   | Lpoptrap ->

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -611,6 +611,11 @@ let emit_instr i =
         emit_string code_space
     | Lentertrap ->
         ()
+    | Ladjust_trap_depth { delta_traps } ->
+        (* each trap occupies 16 bytes on the stack *)
+        let delta = 16 * delta_traps in
+        emit_stack_adjust delta;
+        stack_offset := !stack_offset + delta
     | Lpushtrap { lbl_handler; } ->
         stack_offset := !stack_offset + 16;
         emit_stack_adjust 16;


### PR DESCRIPTION
`Ladjust_trap_depth` replaces dummy `Lpushtrap` generated in `linearize` of `Iexit` to notify assembler generation about updates to the stack. `Ladjust_trap_depth` is used to keep the virtual stack pointer in sync and emit dwarf information, without emitting any assembly instructions. It therefore avoids generating dead code. 

There was already a comment in `linearize.ml` saying that this should be done.

This PR is based on #1482 @lthls. This PR also includes a more aggressive version of discard_dead_code in linearize, to eliminate dead code that results from Iexit at the end a try-with block, a common situation in large programs. This change along with #2321 eliminate 99% of dead code at the level of compliation unit found in our benchmarks.

This PR passes all tests in Inria's precheck (build # 218).

Here is an example program:
```
let r = ref 0

let bar t =
  ignore (Sys.opaque_identity ( 2 * t + 7));
  Printf.printf "%d\n" t

let foo t =
  match bar t with
  | () ->
    r := 3
  | exception exn ->
    r := 7;
    raise exn
```

Generated assembly (amd64, compiled with flambda) with dead code after the first "jmp .LL104"

```
camlTest5__foo_43:
        .cfi_startproc
        subq    $8, %rsp
        .cfi_adjust_cfa_offset 8
.L106:
        .cfi_adjust_cfa_offset 16
        subq    $16, %rsp
        movq    %r14, (%rsp)
        leaq    .L105(%rip), %r14
        movq    %r14, 8(%rsp)
        movq    %rsp, %r14
        call    camlTest5__bar_15@PLT
.L103:
        popq    %r14
        .cfi_adjust_cfa_offset -8
        addq    $8, %rsp
        .cfi_adjust_cfa_offset -8
        jmp     .L104
        .cfi_adjust_cfa_offset 16
        subq    $16, %rsp
        movq    %r14, (%rsp)
        leaq    .L104(%rip), %r14
        movq    %r14, 8(%rsp)
        movq    %rsp, %r14
        popq    %r14
        .cfi_adjust_cfa_offset -8
        addq    $8, %rsp
        .cfi_adjust_cfa_offset -8
        jmp     .L104
        .align  4
.L105:
        movq    camlTest5__Pmakeblock_71@GOTPCREL(%rip), %rbx
        movq    (%rbx), %rbx
        movq    $15, (%rbx)
        movq    %r14, %rsp
        popq    %r14
        popq    %r11
        jmp     *%r11
        .align  4
.L104:
        movq    camlTest5__Pmakeblock_71@GOTPCREL(%rip), %rax
        movq    (%rax), %rax
        movq    $7, (%rax)
        movq    $1, %rax
        addq    $8, %rsp
        .cfi_adjust_cfa_offset -8
        ret

```