### PR TITLE
main_args: remove some redundancy in Ocamldoc_options.

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1053,10 +1053,6 @@ module type Ocamldoc_options = sig
   val _intf : string -> unit
   val _intf_suffix : string -> unit
   val _pp : string -> unit
-  val _principal : unit -> unit
-  val _rectypes : unit -> unit
-  val _safe_string : unit -> unit
-  val _short_paths : unit -> unit
   val _thread : unit -> unit
   val _v : unit -> unit
   val _verbose : unit -> unit

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -234,10 +234,6 @@ module type Ocamldoc_options = sig
   val _intf : string -> unit
   val _intf_suffix : string -> unit
   val _pp : string -> unit
-  val _principal : unit -> unit
-  val _rectypes : unit -> unit
-  val _safe_string : unit -> unit
-  val _short_paths : unit -> unit
   val _thread : unit -> unit
   val _v : unit -> unit
   val _verbose : unit -> unit


### PR DESCRIPTION
This removes declarations from the module type which are already part of `Common_options`.

Btw, I'm a bit weirded out by the fact that `Common_options` contains things like `-drawlambda` if it's also used by ocamldoc.
But whatever.