### PR TITLE
Replace caml_int_compare and caml_float_compare with primitives

### DIFF
--- a/Changes
+++ b/Changes
@@ -242,6 +242,9 @@ Working version
 - #9305: Avoid polymorphic compare in Ident
   (Leo White, review by Xavier Leroy and Gabriel Scherer)
 
+- #2324: Replace caml_int_compare and caml_float_compare with primitives.
+  (Greta Yorsh, review by Stephen Dolan and Vincent Laviron)
+
 ### Build system:
 
 - #9250: Add --disable-ocamltest to configure and disable building for

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1371,6 +1371,7 @@ let simplif_primitive_32bits :
   | Pbintcomp(Pint64, Lambda.Cgt) -> Pccall (default_prim "caml_greaterthan")
   | Pbintcomp(Pint64, Lambda.Cle) -> Pccall (default_prim "caml_lessequal")
   | Pbintcomp(Pint64, Lambda.Cge) -> Pccall (default_prim "caml_greaterequal")
+  | Pcompare_bints Pint64 -> Pccall (default_prim "caml_int64_compare")
   | Pbigarrayref(_unsafe, n, Pbigarray_int64, _layout) ->
       Pccall (default_prim ("caml_ba_get_" ^ Int.to_string n))
   | Pbigarrayset(_unsafe, n, Pbigarray_int64, _layout) ->

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -276,16 +276,14 @@ let mk_not dbg cmm =
 
 let mk_compare_ints dbg a1 a2 =
   match (a1,a2) with
-  | Cconst_int (c1, _), Cconst_int (c2, _) -> begin
-      if c1 = c2 then int_const dbg 0
-      else if c1 < c2 then int_const dbg (-1)
-      else int_const dbg 1
-    end
-  | Cconst_natint (c1, _), Cconst_natint (c2, _) -> begin
-      if c1 = c2 then int_const dbg 0
-      else if c1 < c2 then int_const dbg (-1)
-      else int_const dbg 1
-    end
+  | Cconst_int (c1, _), Cconst_int (c2, _) ->
+     int_const dbg (Int.compare c1 c2)
+  | Cconst_natint (c1, _), Cconst_natint (c2, _) ->
+     int_const dbg (Nativeint.compare c1 c2)
+  | Cconst_int (c1, _), Cconst_natint (c2, _) ->
+     int_const dbg Nativeint.(compare (of_int c1) c2)
+  | Cconst_natint (c1, _), Cconst_int (c2, _) ->
+     int_const dbg Nativeint.(compare c1 (of_int c2))
   | a1, a2 -> begin
       let op1 = Cop(Ccmpi(Cgt), [a1; a2], dbg) in
       let op2 = Cop(Ccmpi(Clt), [a1; a2], dbg) in

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -274,6 +274,24 @@ let mk_not dbg cmm =
       Cop(Csubi, [Cconst_int (4, dbg); c], dbg)
 
 
+let mk_compare_ints dbg a1 a2 =
+  match (a1,a2) with
+  | Cconst_int (c1, _), Cconst_int (c2, _) -> begin
+      if c1 = c2 then int_const dbg 0
+      else if c1 < c2 then int_const dbg (-1)
+      else int_const dbg 1
+    end
+  | Cconst_natint (c1, _), Cconst_natint (c2, _) -> begin
+      if c1 = c2 then int_const dbg 0
+      else if c1 < c2 then int_const dbg (-1)
+      else int_const dbg 1
+    end
+  | a1, a2 -> begin
+      let op1 = Cop(Ccmpi(Cgt), [a1; a2], dbg) in
+      let op2 = Cop(Ccmpi(Clt), [a1; a2], dbg) in
+      tag_int(sub_int op1 op2 dbg) dbg
+    end
+
 let create_loop body dbg =
   let cont = Lambda.next_raise_count () in
   let call_cont = Cexit (cont, []) in

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -153,6 +153,9 @@ val mk_if_then_else :
 (** Boolean negation *)
 val mk_not : Debuginfo.t -> expression -> expression
 
+(** Integer comparison that returns int not bool *)
+val mk_compare_ints : Debuginfo.t -> expression -> expression -> expression
+
 (** Loop construction (while true do expr done).
     Used to be represented as Cloop. *)
 val create_loop : expression -> Debuginfo.t -> expression

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -930,7 +930,8 @@ and transl_prim_2 env p arg1 arg2 dbg =
          To detect if the operand is NaN, we use the property:
          for all x, NaN is not equal to x, even if x is NaN.
          Therefore, op3 is 0 if and only if a1 is NaN,
-         and op4 is 0 if and only if a2 is NaN. *)
+         and op4 is 0 if and only if a2 is NaN.
+         See also caml_float_compare_unboxed in runtime/floats.c  *)
       tag_int (add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg) dbg
   | Pisout ->
       transl_isout (transl env arg1) (transl env arg2) dbg

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -277,7 +277,6 @@ let unbox_number dbg bn arg =
   | Boxed_integer (bi, _) ->
     unbox_int dbg bi arg
 
-
 (* Auxiliary functions for optimizing "let" of boxed numbers (floats and
    boxed integers *)
 
@@ -543,6 +542,7 @@ let rec transl env e =
          | Psetfield (_, _, _) | Psetfield_computed (_, _)
          | Pfloatfield _ | Psetfloatfield (_, _) | Pduprecord (_, _)
          | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _ | Poffsetint _
+         | Pcompare_ints | Pcompare_floats | Pcompare_bints _
          | Poffsetref _ | Pfloatcomp _ | Parraylength _
          | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _
          | Pbintofint _ | Pintofbint _ | Pcvtbint (_, _) | Pnegbint _
@@ -841,6 +841,7 @@ and transl_prim_1 env p arg dbg =
     | Pmakeblock (_, _, _) | Psetfield (_, _, _) | Psetfield_computed (_, _)
     | Psetfloatfield (_, _) | Pduprecord (_, _) | Pccall _ | Pdivint _
     | Pmodint _ | Pintcomp _ | Pfloatcomp _ | Pmakearray (_, _)
+    | Pcompare_ints | Pcompare_floats | Pcompare_bints _
     | Pduparray (_, _) | Parrayrefu _ | Parraysetu _
     | Parrayrefs _ | Parraysets _ | Paddbint _ | Psubbint _ | Pmulbint _
     | Pdivbint _ | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _
@@ -907,6 +908,30 @@ and transl_prim_2 env p arg1 arg2 dbg =
       asr_int_caml (transl env arg1) (transl env arg2) dbg
   | Pintcomp cmp ->
       int_comp_caml cmp (transl env arg1) (transl env arg2) dbg
+  | Pcompare_ints ->
+      (* Compare directly on tagged ints *)
+      mk_compare_ints dbg (transl env arg1) (transl env arg2)
+  | Pcompare_bints bi ->
+      let a1 = transl_unbox_int dbg env bi arg1 in
+      let a2 = transl_unbox_int dbg env bi arg2 in
+      mk_compare_ints dbg a1 a2
+  | Pcompare_floats ->
+      let a1 = transl_unbox_float dbg env arg1 in
+      let a2 = transl_unbox_float dbg env arg2 in
+      let op1 = Cop(Ccmpf(CFgt), [a1; a2], dbg) in
+      let op2 = Cop(Ccmpf(CFlt), [a1; a2], dbg) in
+      let op3 = Cop(Ccmpf(CFeq), [a1; a1], dbg) in
+      let op4 = Cop(Ccmpf(CFeq), [a2; a2], dbg) in
+      (* If both operands a1 and a2 are not NaN, then op3 = op4 = 1,
+         and the result is op1 - op2.
+         If at least one of the operands is NaN,
+         then op1 = op2 = 0, and the result is op3 - op4,
+         which orders NaN before other values.
+         To detect if the operand is NaN, we use the property:
+         for all x, NaN is not equal to x, even if x is NaN.
+         Therefore, op3 is 0 if and only if a1 is NaN,
+         and op4 is 0 if and only if a2 is NaN. *)
+      tag_int (add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg) dbg
   | Pisout ->
       transl_isout (transl env arg1) (transl env arg2) dbg
   (* Float operations *)
@@ -1063,6 +1088,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Pbswap16 | Pint_as_pointer | Popaque | Pread_symbol _ | Pmakeblock (_, _, _)
   | Pfield _ | Psetfield (_, _, _) | Pfloatfield _ | Psetfloatfield (_, _)
   | Pduprecord (_, _) | Pccall _ | Praise _ | Pdivint _ | Pmodint _ | Pintcomp _
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints _
   | Poffsetint _ | Poffsetref _ | Pfloatcomp _ | Pmakearray (_, _)
   | Pduparray (_, _) | Parraylength _ | Parrayrefu _ | Parrayrefs _
   | Pbintofint _ | Pintofbint _ | Pcvtbint (_, _) | Pnegbint _ | Paddbint _

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -118,6 +118,7 @@ let preserve_tailcall_for_prim = function
   | Pasrint | Pintcomp _ | Poffsetint _ | Poffsetref _ | Pintoffloat
   | Pfloatofint | Pnegfloat | Pabsfloat | Paddfloat | Psubfloat | Pmulfloat
   | Pdivfloat | Pfloatcomp _ | Pstringlength | Pstringrefu  | Pstringrefs
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
   | Parrayrefs _ | Parraysets _ | Pisint | Pisout | Pbintofint _ | Pintofbint _
@@ -389,6 +390,9 @@ let comp_primitive p args =
     Pgetglobal id -> Kgetglobal id
   | Psetglobal id -> Ksetglobal id
   | Pintcomp cmp -> Kintcomp cmp
+  | Pcompare_ints -> Kccall("caml_int_compare", 2)
+  | Pcompare_floats -> Kccall("caml_float_compare", 2)
+  | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
   | Pfield n -> Kgetfield n
   | Pfield_computed -> Kgetvectitem
   | Psetfield(n, _ptr, _init) -> Ksetfield n

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -71,6 +71,7 @@ type primitive =
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
   | Pintcomp of integer_comparison
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints of boxed_integer
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -76,6 +76,8 @@ type primitive =
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
   | Pintcomp of integer_comparison
+  (* Comparions that return int (not bool like above) for ordering *)
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints of boxed_integer
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -218,6 +218,9 @@ let primitive ppf = function
   | Plsrint -> fprintf ppf "lsr"
   | Pasrint -> fprintf ppf "asr"
   | Pintcomp(cmp) -> integer_comparison ppf cmp
+  | Pcompare_ints -> fprintf ppf "compare_ints"
+  | Pcompare_floats -> fprintf ppf "compare_floats"
+  | Pcompare_bints bi -> fprintf ppf "compare_bints %s" (boxed_integer_name bi)
   | Poffsetint n -> fprintf ppf "%i+" n
   | Poffsetref n -> fprintf ppf "+:=%i"n
   | Pintoffloat -> fprintf ppf "int_of_float"
@@ -377,6 +380,9 @@ let name_of_primitive = function
   | Plsrint -> "Plsrint"
   | Pasrint -> "Pasrint"
   | Pintcomp _ -> "Pintcomp"
+  | Pcompare_ints -> "Pcompare_ints"
+  | Pcompare_floats -> "Pcompare_floats"
+  | Pcompare_bints _ -> "Pcompare"
   | Poffsetint _ -> "Poffsetint"
   | Poffsetref _ -> "Poffsetref"
   | Pintoffloat -> "Pintoffloat"

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -489,10 +489,6 @@ let specialize_primitive env ty ~has_constant_constructor prim =
     end
   | _ -> None
 
-let unboxed_compare name native_repr =
-  Primitive.make ~name ~alloc:false ~native_name:(name^"_unboxed")
-    ~native_repr_args:[native_repr;native_repr] ~native_repr_res:Untagged_int
-
 let caml_equal =
   Primitive.simple ~name:"caml_equal" ~arity:2 ~alloc:true
 let caml_string_equal =
@@ -531,21 +527,10 @@ let caml_bytes_greaterthan =
   Primitive.simple ~name:"caml_bytes_greaterthan" ~arity:2 ~alloc: false
 let caml_compare =
   Primitive.simple ~name:"caml_compare" ~arity:2 ~alloc:true
-let caml_int_compare =
-  (* Not unboxed since the comparison is done directly on tagged int *)
-  Primitive.simple ~name:"caml_int_compare" ~arity:2 ~alloc:false
-let caml_float_compare =
-  unboxed_compare "caml_float_compare" Unboxed_float
 let caml_string_compare =
   Primitive.simple ~name:"caml_string_compare" ~arity:2 ~alloc:false
 let caml_bytes_compare =
   Primitive.simple ~name:"caml_bytes_compare" ~arity:2 ~alloc:false
-let caml_nativeint_compare =
-  unboxed_compare "caml_nativeint_compare" (Unboxed_integer Pnativeint)
-let caml_int32_compare =
-  unboxed_compare "caml_int32_compare" (Unboxed_integer Pint32)
-let caml_int64_compare =
-  unboxed_compare "caml_int64_compare" (Unboxed_integer Pint64)
 
 let comparison_primitive comparison comparison_kind =
   match comparison, comparison_kind with
@@ -598,13 +583,13 @@ let comparison_primitive comparison comparison_kind =
   | Greater_than, Compare_int32s -> Pbintcomp(Pint32, Cgt)
   | Greater_than, Compare_int64s -> Pbintcomp(Pint64, Cgt)
   | Compare, Compare_generic -> Pccall caml_compare
-  | Compare, Compare_ints -> Pccall caml_int_compare
-  | Compare, Compare_floats -> Pccall caml_float_compare
+  | Compare, Compare_ints -> Pcompare_ints
+  | Compare, Compare_floats -> Pcompare_floats
   | Compare, Compare_strings -> Pccall caml_string_compare
   | Compare, Compare_bytes -> Pccall caml_bytes_compare
-  | Compare, Compare_nativeints -> Pccall caml_nativeint_compare
-  | Compare, Compare_int32s -> Pccall caml_int32_compare
-  | Compare, Compare_int64s -> Pccall caml_int64_compare
+  | Compare, Compare_nativeints -> Pcompare_bints Pnativeint
+  | Compare, Compare_int32s -> Pcompare_bints Pint32
+  | Compare, Compare_int64s -> Pcompare_bints Pint64
 
 let lambda_of_loc kind loc =
   let loc_start = loc.Location.loc_start in
@@ -759,6 +744,7 @@ let lambda_primitive_needs_event_after = function
   | Parrayrefs _ | Parraysets _ | Pbintofint _ | Pcvtbint _ | Pnegbint _
   | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _
   | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _ | Pbintcomp _
+  | Pcompare_bints _
   | Pbigarrayref _ | Pbigarrayset _ | Pbigarraydim _ | Pstring_load_16 _
   | Pstring_load_32 _ | Pstring_load_64 _ | Pbytes_load_16 _ | Pbytes_load_32 _
   | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_64 _
@@ -772,6 +758,7 @@ let lambda_primitive_needs_event_after = function
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
   | Pasrint | Pintcomp _ | Poffsetint _ | Poffsetref _ | Pintoffloat
+  | Pcompare_ints | Pcompare_floats
   | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint | Pisout

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -53,6 +53,7 @@ type primitive =
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
   | Pintcomp of integer_comparison
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints of boxed_integer
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -53,6 +53,7 @@ type primitive =
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
   | Pintcomp of integer_comparison
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints of boxed_integer
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -54,6 +54,9 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Plsrint -> Plsrint
   | Pasrint -> Pasrint
   | Pintcomp comp -> Pintcomp comp
+  | Pcompare_ints -> Pcompare_ints
+  | Pcompare_floats -> Pcompare_floats
+  | Pcompare_bints bi -> Pcompare_bints bi
   | Poffsetint offset -> Poffsetint offset
   | Poffsetref offset -> Poffsetref offset
   | Pintoffloat -> Pintoffloat

--- a/middle_end/flambda/simplify_boxed_integer_ops.ml
+++ b/middle_end/flambda/simplify_boxed_integer_ops.ml
@@ -79,6 +79,8 @@ end) : Simplify_boxed_integer_ops_intf.S with type t := I.t = struct
     | Pxorbint kind when equal_kind kind I.kind -> eval I.logxor
     | Pbintcomp (kind, c) when equal_kind kind I.kind ->
       S.const_integer_comparison_expr expr c n1 n2
+    | Pcompare_bints kind when equal_kind kind I.kind ->
+      S.const_int_expr expr (I.compare n1 n2)
     | _ -> expr, A.value_unknown Other, C.Benefit.zero
 
   let simplify_binop_int (p : Clambda_primitives.primitive)

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -150,7 +150,7 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
          let a = f 1
          let b = f 1
          let c = a, a
-         let d = a, a
+         let d = b, b
 
        If [Share_constants] is run before [f] is completely inlined (assuming
        [f] always generates the same result; effects of [f] aren't in fact
@@ -194,12 +194,14 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
       | Plsrint when shift_precond -> S.const_int_expr expr (x lsr y)
       | Pasrint when shift_precond -> S.const_int_expr expr (x asr y)
       | Pintcomp cmp -> S.const_integer_comparison_expr expr cmp x y
+      | Pcompare_ints -> S.const_int_expr expr (compare x y)
       | Pisout -> S.const_bool_expr expr (y > x || y < 0)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [Value_char x; Value_char y] ->
       begin match p with
       | Pintcomp cmp -> S.const_integer_comparison_expr expr cmp x y
+      | Pcompare_ints -> S.const_int_expr expr (Char.compare x y)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [Value_constptr x] ->
@@ -225,6 +227,7 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
       | Pmulfloat -> S.const_float_expr expr (n1 *. n2)
       | Pdivfloat -> S.const_float_expr expr (n1 /. n2)
       | Pfloatcomp c  -> S.const_float_comparison_expr expr c n1 n2
+      | Pcompare_floats -> S.const_int_expr expr (Float.compare n1 n2)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [A.Value_boxed_int(A.Nativeint, n)] ->

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -123,6 +123,9 @@ let pidentity = "Pidentity"
 let pignore = "Pignore"
 let pint_as_pointer = "Pint_as_pointer"
 let pintcomp = "Pintcomp"
+let pcompare_ints = "Pcompare_ints"
+let pcompare_floats = "Pcompare_floats"
+let pcompare_bints = "Pcompare_bints"
 let pintofbint = "Pintofbint"
 let pintoffloat = "Pintoffloat"
 let pisint = "Pisint"
@@ -222,6 +225,9 @@ let pidentity_arg = "Pidentity_arg"
 let pignore_arg = "Pignore_arg"
 let pint_as_pointer_arg = "Pint_as_pointer_arg"
 let pintcomp_arg = "Pintcomp_arg"
+let pcompare_ints_arg = "Pcompare_ints_arg"
+let pcompare_floats_arg = "Pcompare_floats_arg"
+let pcompare_bints_arg = "Pcompare_bints_arg"
 let pintofbint_arg = "Pintofbint_arg"
 let pintoffloat_arg = "Pintoffloat_arg"
 let pisint_arg = "Pisint_arg"
@@ -337,6 +343,9 @@ let of_primitive : Lambda.primitive -> string = function
   | Plsrint -> plsrint
   | Pasrint -> pasrint
   | Pintcomp _ -> pintcomp
+  | Pcompare_ints -> pcompare_ints
+  | Pcompare_floats -> pcompare_floats
+  | Pcompare_bints _ -> pcompare_bints
   | Poffsetint _ -> poffsetint
   | Poffsetref _ -> poffsetref
   | Pintoffloat -> pintoffloat
@@ -440,6 +449,9 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Plsrint -> plsrint_arg
   | Pasrint -> pasrint_arg
   | Pintcomp _ -> pintcomp_arg
+  | Pcompare_ints -> pcompare_ints_arg
+  | Pcompare_floats -> pcompare_floats_arg
+  | Pcompare_bints _ -> pcompare_bints_arg
   | Poffsetint _ -> poffsetint_arg
   | Poffsetref _ -> poffsetref_arg
   | Pintoffloat -> pintoffloat_arg

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -120,6 +120,9 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Plsrint -> fprintf ppf "lsr"
   | Pasrint -> fprintf ppf "asr"
   | Pintcomp(cmp) -> Printlambda.integer_comparison ppf cmp
+  | Pcompare_ints -> fprintf ppf "compare_ints"
+  | Pcompare_floats -> fprintf ppf "compare_floats"
+  | Pcompare_bints bi -> fprintf ppf "compare_bints %s" (boxed_integer_name bi)
   | Poffsetint n -> fprintf ppf "%i+" n
   | Poffsetref n -> fprintf ppf "+:=%i"n
   | Pintoffloat -> fprintf ppf "int_of_float"

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -47,6 +47,8 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Plsrint
   | Pasrint
   | Pintcomp _ -> No_effects, No_coeffects
+  | Pcompare_ints | Pcompare_floats | Pcompare_bints _
+    -> No_effects, No_coeffects
   | Pdivbint { is_safe = Unsafe }
   | Pmodbint { is_safe = Unsafe }
   | Pdivint Unsafe

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -982,7 +982,8 @@ intnat caml_float_compare_unboxed(double f, double g)
   /* This branchless implementation is from GPR#164.
      Note that [f == f] if and only if f is not NaN.
      We expand each subresult of the expression to
-     avoid sign-extension on 64bit. GPR#2250. */
+     avoid sign-extension on 64bit. GPR#2250.
+     See also translation of Pcompare_floats in asmcomp/cmmgen.ml  */
   intnat res =
     (intnat)(f > g) - (intnat)(f < g) + (intnat)(f == f) - (intnat)(g == g);
   return res;

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -1,16 +1,16 @@
 (setglobal Comparison_table!
   (let
     (gen_cmp = (function x y : int (caml_compare x y))
-     int_cmp = (function x[int] y[int] : int (caml_int_compare x y))
-     bool_cmp = (function x y : int (caml_int_compare x y))
-     intlike_cmp = (function x y : int (caml_int_compare x y))
-     float_cmp = (function x[float] y[float] : int (caml_float_compare x y))
+     int_cmp = (function x[int] y[int] : int (compare_ints x y))
+     bool_cmp = (function x y : int (compare_ints x y))
+     intlike_cmp = (function x y : int (compare_ints x y))
+     float_cmp = (function x[float] y[float] : int (compare_floats x y))
      string_cmp = (function x y : int (caml_string_compare x y))
-     int32_cmp = (function x[int32] y[int32] : int (caml_int32_compare x y))
-     int64_cmp = (function x[int64] y[int64] : int (caml_int64_compare x y))
+     int32_cmp = (function x[int32] y[int32] : int (compare_bints int32 x y))
+     int64_cmp = (function x[int64] y[int64] : int (compare_bints int64 x y))
      nativeint_cmp =
        (function x[nativeint] y[nativeint] : int
-         (caml_nativeint_compare x y))
+         (compare_bints nativeint x y))
      gen_eq = (function x y (caml_equal x y))
      int_eq = (function x[int] y[int] (== x y))
      bool_eq = (function x y (== x y))
@@ -66,16 +66,18 @@
      int64_ge = (function x[int64] y[int64] (Int64.>= x y))
      nativeint_ge = (function x[nativeint] y[nativeint] (Nativeint.>= x y))
      eta_gen_cmp = (function prim prim stub (caml_compare prim prim))
-     eta_int_cmp = (function prim prim stub (caml_int_compare prim prim))
-     eta_bool_cmp = (function prim prim stub (caml_int_compare prim prim))
-     eta_intlike_cmp = (function prim prim stub (caml_int_compare prim prim))
-     eta_float_cmp = (function prim prim stub (caml_float_compare prim prim))
+     eta_int_cmp = (function prim prim stub (compare_ints prim prim))
+     eta_bool_cmp = (function prim prim stub (compare_ints prim prim))
+     eta_intlike_cmp = (function prim prim stub (compare_ints prim prim))
+     eta_float_cmp = (function prim prim stub (compare_floats prim prim))
      eta_string_cmp =
        (function prim prim stub (caml_string_compare prim prim))
-     eta_int32_cmp = (function prim prim stub (caml_int32_compare prim prim))
-     eta_int64_cmp = (function prim prim stub (caml_int64_compare prim prim))
+     eta_int32_cmp =
+       (function prim prim stub (compare_bints int32 prim prim))
+     eta_int64_cmp =
+       (function prim prim stub (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function prim prim stub (caml_nativeint_compare prim prim))
+       (function prim prim stub (compare_bints nativeint prim prim))
      eta_gen_eq = (function prim prim stub (caml_equal prim prim))
      eta_int_eq = (function prim prim stub (== prim prim))
      eta_bool_eq = (function prim prim stub (== prim prim))

--- a/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -8,7 +8,7 @@
           (function prim prim prim stub (array.set[int] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[int] prim prim prim))
-          (function prim prim stub (caml_int_compare prim prim))
+          (function prim prim stub (compare_ints prim prim))
           (function prim prim stub (== prim prim))
           (function prim prim stub (!= prim prim))
           (function prim prim stub (< prim prim))
@@ -22,7 +22,7 @@
           (function prim prim prim stub (array.set[float] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[float] prim prim prim))
-          (function prim prim stub (caml_float_compare prim prim))
+          (function prim prim stub (compare_floats prim prim))
           (function prim prim stub (==. prim prim))
           (function prim prim stub (!=. prim prim))
           (function prim prim stub (<. prim prim))
@@ -50,7 +50,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_int32_compare prim prim))
+          (function prim prim stub (compare_bints int32 prim prim))
           (function prim prim stub (Int32.== prim prim))
           (function prim prim stub (Int32.!= prim prim))
           (function prim prim stub (Int32.< prim prim))
@@ -64,7 +64,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_int64_compare prim prim))
+          (function prim prim stub (compare_bints int64 prim prim))
           (function prim prim stub (Int64.== prim prim))
           (function prim prim stub (Int64.!= prim prim))
           (function prim prim stub (Int64.< prim prim))
@@ -78,7 +78,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_nativeint_compare prim prim))
+          (function prim prim stub (compare_bints nativeint prim prim))
           (function prim prim stub (Nativeint.== prim prim))
           (function prim prim stub (Nativeint.!= prim prim))
           (function prim prim stub (Nativeint.< prim prim))


### PR DESCRIPTION
Add new compiler primitives to implement comparison operations that return int (not bool) result. These operations are important for IntMap.
Instead of calls to `caml_int*_compare` and `caml_float_compare`, emit native code directly.  This enables some optimizations when arguments of compare operations are statically known constants.  There is no change to machine-specific code generation, because the new primitives are translated in `cmmgen` to existing cmm constructs.

Recently, PR #2250 @smuenzel-js   proposed to improve these C functions.  It will still be useful for bytecode and int64 on 32-bit targets.  For native code, the current PR gives better performance than PR #2250.

Benchmarking on amd64 target Intel(R) Xeon(R) Gold 6144 on two microbenchmarks:

test5.ml: Tight loop example from PR #2250
```
┌───────────────────┬─────────────────┬─────────────────┬───────┬────────────┬─────────────┬───────┐
│                   │    instructions │      Difference │     % │ clock (ms) │  Difference │     % │
├───────────────────┼─────────────────┼─────────────────┼───────┼────────────┼─────────────┼───────┤
│    test5-base.exe │ 280,092,029,458 │               0 │ 1.000 │ 29,386.268 │           0 │ 1.000 │
│  test5-pr2250.exe │ 268,091,554,395 │ -12,000,475,063 │ 0.957 │ 29,439.480 │      53.212 │ 1.002 │
│ test5-compare.exe │ 220,056,326,489 │ -60,035,702,969 │ 0.786 │ 17,720.873 │ -11,665.395 │ 0.603 │
└───────────────────┴─────────────────┴─────────────────┴───────┴────────────┴─────────────┴───────┘
```


test6.ml: IntMap loop that calls add, remove, find, and mem.
```
┌───────────────────┬────────────────┬────────────────┬───────┬────────────┬────────────┬───────┐
│                   │   instructions │     Difference │     % │ clock (ms) │ Difference │     % │
├───────────────────┼────────────────┼────────────────┼───────┼────────────┼────────────┼───────┤
│    test6-base.exe │ 72,942,680,772 │              0 │ 1.000 │ 13,188.722 │          0 │ 1.000 │
│  test6-pr2250.exe │ 72,034,245,520 │   -908,435,252 │ 0.988 │ 13,126.140 │    -62.582 │ 0.995 │
│ test6-compare.exe │ 68,470,617,181 │ -4,472,063,591 │ 0.939 │ 12,640.141 │   -548.581 │ 0.958 │
└───────────────────┴────────────────┴────────────────┴───────┴────────────┴────────────┴───────┘
```

Inria's precheck all tests pass (build # 206).