### PR TITLE
Update issue numbers in comments after Mantis -> Github migration.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1665,7 +1665,7 @@ OCaml 4.06.0 (3 Nov 2017):
 
 ### Type system
 
-- MPR#248, GPR#1225: unique names for weak type variables
+- MPR#2642, GPR#1225: unique names for weak type variables
     # ref [];;
     - : '_weak1 list ref = {contents = []}
   (Florian Angeletti, review by Frédéric Bour, Jacques Garrigue,
@@ -1682,7 +1682,7 @@ OCaml 4.06.0 (3 Nov 2017):
 
 ### Standard library:
 
-- MPR#1771, MPR#7309, GPR#1026: Add update to maps. Allows to update a
+- MPR#8223, MPR#7309, GPR#1026: Add update to maps. Allows to update a
   binding in a map or create a new binding if the key had no binding
     val update: key -> ('a option -> 'a option) -> 'a t -> 'a t
   (Sébastien Briais, review by Daniel Bünzli, Alain Frisch and
@@ -1938,7 +1938,7 @@ OCaml 4.06.0 (3 Nov 2017):
 
 ### Tools:
 
-- MPR#1956, GPR#973: tools/check-symbol-names checks for globally
+- MPR#8395, GPR#973: tools/check-symbol-names checks for globally
   linked names not namespaced with caml_
   (Stephen Dolan)
 
@@ -2398,7 +2398,7 @@ OCaml 4.05.0 (13 Jul 2017):
 
 ### Runtime system:
 
-- MPR#385, GPR#953: Add caml_startup_exn
+- MPR#2784, GPR#953: Add caml_startup_exn
   (Mark Shinwell)
 
 - MPR#7423, GPR#946: expose new exception-raising functions
@@ -3750,7 +3750,7 @@ OCaml 4.03.0 (25 Apr 2016):
   caml_fill_bytes and caml_create_bytes for migration
   (Hongbo Zhang, review by Damien Doligez, Alain Frisch, and Hugo Heuzard)
 
-- PR#3612, PR#92: allow allocating custom block with finalizers
+- PR#3612, PR#2429: allow allocating custom block with finalizers
   in the minor heap.
   (Pierre Chambart)
 
@@ -3800,7 +3800,7 @@ OCaml 4.03.0 (25 Apr 2016):
 
 ### Standard library:
 
-- PR#1460, GPR#230: Array.map2, Array.iter2
+- PR#7848, GPR#230: Array.map2, Array.iter2
   (John Christopher McAlpine)
 
 - PR#5197, GPR#63: Arg: allow flags such as --flag=arg as well as --flag arg
@@ -5758,7 +5758,7 @@ Installation procedure:
       ocamlbytecomp.cma/.cmxa   modules for ocamlc and ocaml
       ocamloptcomp.cma/.cmxa    modules specific to ocamlopt
       ocamltoplevel.cma         modules specific to ocaml
-   (PR#1804, PR#4653, frequently-asked feature).
+   (PR#8255, PR#4653, frequently-asked feature).
 * Some .cmi for toplevel internals that used to be installed in
   `ocamlc -where` are now to be found in  `ocamlc -where`/compiler-libs.
   Add "-I +compiler-libs" where needed.
@@ -5770,7 +5770,7 @@ Installation procedure:
 
 Bug Fixes:
 
-- PR#1643: functions of the Lazy module whose named started with 'lazy_' have
+- PR#8109: functions of the Lazy module whose named started with 'lazy_' have
   been deprecated, and new ones without the prefix added
 - PR#3571: in Bigarrays, call msync() before unmapping to commit changes
 - PR#4292: various documentation problems
@@ -5919,12 +5919,12 @@ Bug Fixes:
 - crash when using OCAMLRUNPARAM=a=X with invalid X (reported in private)
 
 Feature wishes:
-- PR#352: new option "-stdin" to make ocaml read stdin as a script
-- PR#1164: better error message when mixing -a and .cmxa
-- PR#1284: documentation: remove restriction on mixed streams
-- PR#1496: allow configuring LIBDIR, BINDIR, and MANDIR relative to $(PREFIX)
-- PR#1835: add Digest.from_hex
-- PR#1898: toplevel: add option to suppress continuation prompts
+- PR#2757: new option "-stdin" to make ocaml read stdin as a script
+- PR#3358: better error message when mixing -a and .cmxa
+- PR#3492: documentation: remove restriction on mixed streams
+- PR#7971: allow configuring LIBDIR, BINDIR, and MANDIR relative to $(PREFIX)
+- PR#8285: add Digest.from_hex
+- PR#8341: toplevel: add option to suppress continuation prompts
 - PR#4278: configure: option to disable "graph" library
 - PR#4444: new String.trim function, removing leading and trailing whistespace
 - PR#4549: make Filename.dirname/basename POSIX compliant
@@ -6258,8 +6258,8 @@ Bug fixes:
 - Various build problems with ocamlbuild under Windows with msvc
 
 Feature wishes:
-- PR#9: (tentative implementation) make ocamldebug use #linenum annotations
-- PR#123, PR#4477: custom exception printers
+- PR#2337: (tentative implementation) make ocamldebug use #linenum annotations
+- PR#2464, PR#4477: custom exception printers
 - PR#3456: Obj.double_field and Obj.set_double_field functions
 - PR#4003: destination directory can be given to Filename.[open_]temp_file
 - PR#4647: Buffer.blit function
@@ -6459,7 +6459,7 @@ Objective Caml 3.10.2 (29 Feb 2008):
 ------------------------------------
 
 Bug fixes:
-- PR#1217 (partial) Typo in ocamldep man page
+- PR#3410 (partial) Typo in ocamldep man page
 - PR#3952 (partial) ocamlopt: allocation problems on ARM
 - PR#4339 (continued) ocamlopt: problems on HPPA
 - PR#4455 str.mli not installed under Windows

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -302,7 +302,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
     | Link_object(file_name, _) when file_name = exec_name ->
       raise (Error (Wrong_object_name exec_name));
     | _ -> ()) tolink;
-  Misc.remove_file exec_name; (* avoid permission problems, cf PR#1911 *)
+  Misc.remove_file exec_name; (* avoid permission problems, cf PR#8354 *)
   let outchan =
     open_out_gen [Open_wronly; Open_trunc; Open_creat; Open_binary]
                  0o777 exec_name in

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -1346,7 +1346,7 @@ let transl_toplevel_item item =
         (transl_extension_constructor item.str_env None ext.tyexn_constructor)
   | Tstr_module {mb_id=id; mb_presence=Mp_present; mb_expr=modl} ->
       (* we need to use the unique name for the module because of issues
-         with "open" (PR#1672) *)
+         with "open" (PR#8133) *)
       set_toplevel_unique_name id;
       let lam = transl_module Tcoerce_none (Some(Pident id)) modl in
       toploop_setvalue id lam

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -38,7 +38,7 @@ let init_path ?(dir="") () =
 (* Return the initial environment in which compilation proceeds. *)
 
 (* Note: do not do init_path() in initial_env, this breaks
-   toplevel initialization (PR#1775) *)
+   toplevel initialization (PR#8227) *)
 
 let initial_env () =
   Ident.reinit();

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -462,7 +462,7 @@ static void caml_thread_reinitialize(void)
 
 CAMLprim value caml_thread_initialize(value unit)   /* ML */
 {
-  /* Protect against repeated initialization (PR#1325) */
+  /* Protect against repeated initialization (PR#3532) */
   if (curr_thread != NULL) return Val_unit;
   /* OS-specific initialization */
   st_initialize();

--- a/otherlibs/unix/open.c
+++ b/otherlibs/unix/open.c
@@ -74,7 +74,7 @@ CAMLprim value unix_open(value path, value flags, value perm)
   if (cloexec) cv_flags |= O_CLOEXEC;
 #endif
   p = caml_stat_strdup(String_val(path));
-  /* open on a named FIFO can block (PR#1533) */
+  /* open on a named FIFO can block (PR#8005) */
   caml_enter_blocking_section();
   fd = open(p, cv_flags, Int_val(perm));
   caml_leave_blocking_section();

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -241,7 +241,7 @@ void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise)
     return;
 
   if (caml_backtrace_pos >= BACKTRACE_BUFFER_SIZE) return;
-  /* testing the code region is needed: PR#1554 */
+  /* testing the code region is needed: PR#8026 */
   if (find_debug_info(pc) != NULL)
     caml_backtrace_buffer[caml_backtrace_pos++] = pc;
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -100,7 +100,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   res = caml_interprete(local_callback_code, sizeof(local_callback_code));
   caml_release_bytecode(local_callback_code, sizeof(local_callback_code));
 #endif /*LOCAL_CALLBACK_BYTECODE*/
-  if (Is_exception_result(res)) caml_extern_sp += narg + 4; /* PR#1228 */
+  if (Is_exception_result(res)) caml_extern_sp += narg + 4; /* PR#3419 */
   return res;
 }
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -153,13 +153,13 @@ CAMLprim value caml_obj_truncate (value v, value newsize)
   mlsize_t wosize = Wosize_hd (hd);
   mlsize_t i;
 
-  if (tag == Double_array_tag) new_wosize *= Double_wosize;  /* PR#156 */
+  if (tag == Double_array_tag) new_wosize *= Double_wosize;  /* PR#2520 */
 
   if (new_wosize <= 0 || new_wosize > wosize){
     caml_invalid_argument ("Obj.truncate");
   }
   if (new_wosize == wosize) return Val_unit;
-  /* PR#61: since we're about to lose our references to the elements
+  /* PR#2400: since we're about to lose our references to the elements
      beyond new_wosize in v, erase them explicitly so that the GC
      can darken them as appropriate. */
   if (tag < No_scan_tag) {

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -196,7 +196,7 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
   p = caml_stat_strdup_to_os(String_val(path));
   flags |= caml_convert_flag_list(vflags, sys_open_flags);
   perm = Int_val(vperm);
-  /* open on a named FIFO can block (PR#1533) */
+  /* open on a named FIFO can block (PR#8005) */
   caml_enter_blocking_section();
   fd = open_os(p, flags, perm);
   /* fcntl on a fd can block (PR#5069)*/

--- a/testsuite/tests/basic-more/morematch.ml
+++ b/testsuite/tests/basic-more/morematch.ml
@@ -1022,7 +1022,7 @@ test "maf" maf (`TConstr []) 5 ;
 test "maf" maf (`TVariant []) 6
 ;;
 
-(* PR#1310
+(* PR#3517
   Using ``get_args'' in place or an ad-hoc ``matcher'' function for tuples.
   Has made the compiler [3.05] to fail.
 *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -836,7 +836,7 @@ val f :
   (< p : int * 'c > as 'c) -> unit = <fun>
 |}];;
 
-(* PR#1374 *)
+(* PR#3643 *)
 
 type 'a t= [`A of 'a];;
 class c = object (self)
@@ -884,7 +884,7 @@ type ('a, 'b) list_visitor = < caseCons : 'b -> 'b list -> 'a; caseNil : 'a >
 type 'b alist = < visit : 'a. ('a, 'b) list_visitor -> 'a >
 |}];;
 
-(* PR#1607 *)
+(* PR#8074 *)
 class type ct = object ('s)
   method fold : ('b -> 's -> 'b) -> 'b -> 'b
 end
@@ -894,7 +894,7 @@ class type ct = object ('a) method fold : ('b -> 'a -> 'b) -> 'b -> 'b end
 type t = { f : 'a 'b. ('b -> (#ct as 'a) -> 'b) -> 'b; }
 |}];;
 
-(* PR#1663 *)
+(* PR#8124 *)
 type t = u and u = t;;
 [%%expect {|
 Line 1, characters 0-10:
@@ -904,7 +904,7 @@ Error: The definition of t contains a cycle:
        u
 |}];;
 
-(* PR#1731 *)
+(* PR#8188 *)
 class ['t] a = object constraint 't = [> `A of 't a] end
 type t = [ `A of t a ];;
 [%%expect {|
@@ -966,7 +966,7 @@ Line 1, characters 0-24:
 Error: In the definition of v, type 'a list u should be 'a u
 |}];;
 
-(* PR#1744: Ctype.matches *)
+(* PR#8198: Ctype.matches *)
 type 'a t = 'a
 type 'a u = A of 'a t;;
 [%%expect {|
@@ -999,7 +999,7 @@ Error: The definition of a contains a cycle:
        [> `B of ('a, 'b) b as 'b ] as 'a
 |}];;
 
-(* PR#1917: expanding may change original in Ctype.unify2 *)
+(* PR#8359: expanding may change original in Ctype.unify2 *)
 (* Note: since 3.11, the abbreviations are not used when printing
    a type where they occur recursively inside. *)
 class type ['a, 'b] a = object


### PR DESCRIPTION
This renumbers comments of the form `PR#nnnn` and `MPR#nnnn` (but not `GPR#nnnn`) according to the table in https://gist.github.com/nojb/47d6fea4bba4edc2654941fd8fe4fbd5, so that source code references to issues can be followed after the Mantis -> Github migration.

Thanks @nojb for doing the migration and making this table!