### PR TITLE
Fix ppc64 TOC load for exception handler addresses

### DIFF
--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -200,11 +200,9 @@ let emit_toctable () =
 
 (* Emit a load from a TOC entry.
 
-   This function must not be called with any destination that resolves to
-   register r0.  A zero operand between the brackets of an "ld"
-   instruction, which this situation would cause, does not mean register
-   r0.  It means zero! *)
-
+   The [dest] should not be r0, since [dest] is used as the index register for a
+   ld instruction, but r0 reads as zero when used as an index register.
+*)
 let emit_tocload emit_dest dest entry =
   let lbl = label_for_tocref entry in
   if !big_toc || !Clflags.for_package <> None then begin

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -198,7 +198,12 @@ let emit_toctable () =
       `{emit_label lbl}:	.quad	{emit_tocentry entry}\n`)
     tocref_entries
 
-(* Emit a load from a TOC entry *)
+(* Emit a load from a TOC entry.
+
+   This function must not be called with any destination that resolves to
+   register r0.  A zero operand between the brackets of an "ld"
+   instruction, which this situation would cause, does not mean register
+   r0.  It means zero! *)
 
 let emit_tocload emit_dest dest entry =
   let lbl = label_for_tocref entry in
@@ -969,9 +974,9 @@ let emit_instr i =
         | ELF64v1 | ELF64v2 ->
           `	addi	1, 1, {emit_int (-trap_size)}\n`;
           adjust_stack_offset trap_size;
-          emit_tocload emit_gpr 0 (TocLabel lbl_handler);
-          `	std     0, {emit_int trap_handler_offset}(1)\n`;
           `	std	29, {emit_int trap_previous_offset}(1)\n`;
+          emit_tocload emit_gpr 29 (TocLabel lbl_handler);
+          `	std     29, {emit_int trap_handler_offset}(1)\n`;
           `	mr	29, 1\n`
           end
     | Lpoptrap ->

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -145,6 +145,12 @@ let arch64 = make
     "64-bit architecture"
     "non-64-bit architecture")
 
+let arch_power = make
+  "arch_power"
+  (Actions_helpers.pass_or_skip (String.equal Ocamltest_config.arch "power")
+    "Target is POWER architecture"
+    "Target is not POWER architecture")
+
 let has_symlink = make
   "has_symlink"
   (Actions_helpers.pass_or_skip (Sys.has_symlink () )
@@ -208,4 +214,5 @@ let _ =
     run;
     script;
     check_program_output;
+    arch_power;
   ]

--- a/ocamltest/builtin_actions.mli
+++ b/ocamltest/builtin_actions.mli
@@ -34,6 +34,9 @@ val not_bsd : Actions.t
 val arch32 : Actions.t
 val arch64 : Actions.t
 
+(** Whether the compiler target is POWER architecture. *)
+val arch_power : Actions.t
+
 val has_symlink : Actions.t
 
 val setup_build_env : Actions.t

--- a/testsuite/tests/arch-power/exn_raise.ml
+++ b/testsuite/tests/arch-power/exn_raise.ml
@@ -1,0 +1,19 @@
+(* TEST
+  * arch_power
+  ** native
+  *** ocamlopt.byte
+  ocamlopt_flags = "-flarge-toc"
+  **** run
+*)
+
+(* GPR#8506
+
+   This isn't guaranteed to fail even without the fix from #8506, because
+   the @ha relocation on the TOC entry for the exception handler's address
+   might be zero, in which case the linker optimises the code sequence to one
+   that will not fail.
+*)
+
+let () =
+  try failwith "foo"
+  with (Failure _) -> ()

--- a/testsuite/tests/arch-power/ocamltests
+++ b/testsuite/tests/arch-power/ocamltests
@@ -1,0 +1,1 @@
+exn_raise.ml


### PR DESCRIPTION
GPR #2237 contains a bug which was noticed by precheck failing on GPR #2268.  Interestingly, precheck only failed on the flambda build on ppc64le, but not on the non-flambda build.

The reason for the failure is a bogus exception handler address in a trap frame.  This is on ppc64le with the ELF64v2 ABI, an ABI of impressive complexity, of which I understand very little.  On this system an address amidst the code (such as that of an exception handler) is obtained by labelling the relevant code and putting a reference to that label in a special place in the data section called the "table of contents".  To load the code address at runtime, the base address of the table will be found (always in register `r2`), and a signed integer constant will be added to it.  This will then point at the slot in the table that in turn contains the code address.

The computation to load an exception handler address is therefore of the form: `r0 = *(r2 + C)`, where `r0` is a temporary that we are going to store in the trap frame, and `C` is the integer constant.  When we emit the assembly we don't have to determine what `C` is; instead, we label the slot in the table of contents and use special linker support to substitute the label reference with `C`, which can be determined at link time.

Owing to constraints on the sizes of constants that can be fitted into the relevant instructions, the computation is actually going to be split into `r0 = *(r2 + A + B)`, in certain cases.  One of these cases is when `-for-pack` is in effect (@xavierleroy perhaps you could explain why this is) and is the reason that GPR#2227 did not cause CI to fail.  At present, there are no native code packs in the compiler distribution; GPR#2268 will introduce the first one.

In order to compute `r0 = *(r2 + A + B)` we generate two instructions: `r0 = r2 + A` then `r0 = *(r0 + B)`.  The second instruction in ppc64 assembly language is of the form `ld 0, exp(0)`, with `exp` being the appropriate TOC slot label reference and relocation that I shall elide.  The linker will turn `exp` into `B`.  (For some strange reason, you elide the `r` prefix when referencing registers in written ppc64 assembly code.)

In the test case that failed, B was computed by the linker to be some negative number, let's say -16000.  Upon disassembling the test case I was surprised to see that the `ld` instruction didn't say `ld`, it said `li`, which was just loading a constant (-16000, or whatever) into `r0`.   This address was the one in the trap frame, which was obviously wrong.

This turns out to be because writing zero between the brackets of an `ld` instruction doesn't mean _register_ zero (unlike writing the number one, or two, for example).  It means zero!  Hence why `ld` had been turned into `li`.

Why didn't this fail on the non-flambda build?  The reason appears to be because, going back to the notation above, `A` was zero.  This presumably happens because the code is smaller due to less inlining without flambda.  As such, the linker actually optimised the sequence, replacing the first `add` instruction with a no-op and the second (`ld`) instruction with one that just added `B` to the contents of `r2` before dereferencing.  The strange thing here is that this optimisation appears to be invalid given the semantics of "zero between the brackets".  Our (broken) input code described a computation that loaded a constant integer into a register, but the output code miraculously loaded something via the TOC.  Magic.

The fix is not to use `r0` as the temporary.