### PR TITLE
Shorten symbol names of anonymous functions in Flambda mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,10 @@ Working version
   iOS and other Darwin targets.
   (Mark Shinwell, review by Nicolas Ojeda Bar and Xavier Leroy)
 
+- GPR#8507: Shorten symbol names of anonymous functions in Flambda mode
+  (the directory portions are now hidden)
+  (Mark Shinwell, review by Nicolás Ojeda Bär)
+
 ### Compiler user-interface and warnings:
 
 * GPR#2276: Remove support for compiler plugins and hooks (also adds

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -299,8 +299,8 @@ let anon_fn_with_loc (loc: Location.t) =
     if startchar >= 0 then Format.fprintf ppf ",%i--%i" startchar endchar in
   if loc.Location.loc_ghost then "anon_fn"
   else
-    Format.asprintf "anon_fn[%a:%i%t]"
-      Location.print_filename file line pp_chars
+    Format.asprintf "anon_fn[%s:%i%t]"
+      (Filename.basename file) line pp_chars
 
 let of_primitive : Lambda.primitive -> string = function
   | Pidentity -> pidentity


### PR DESCRIPTION
Precheck fails on #2268 not only because of #8506 but also because of some excessively long symbol names.  These cause trouble on Windows platforms where there is a length limit on such things.  The symbol names correspond to anonymous functions, whose names for convenience are equipped with the source filename and location.  I have changed these names in this patch to strip any directory names, which should reduce problems in this area with very deeply nested directory structures and/or use of `-absname`.

In the future, the actual names of symbols won't really be relevant any more, since the DWARF information will enable debuggers and other tools to reconstruct proper names even for anonymous functions.  (Furthermore, I believe the current namespacing proposals of @lpw25 are going to yield symbols that to a first approximation are just hashes.)

I will add a Changes entry to this in due course, since this is user-visible.