### PR TITLE
Refactor long tuples to records in typeclass.ml

### DIFF
--- a/Changes
+++ b/Changes
@@ -125,6 +125,9 @@ Working version
 - #2308: More debugging information on [Cmm] terms
   (Mark Shinwell, review by Stephen Dolan)
 
+- #7927, #8527: Replace long tuples into records in typeclass.ml
+  (Ulugbek Abdullaev, review by David Allsopp and Gabriel Scherer)
+
 - #7878, #8542: Replaced TypedtreeIter with tast_iterator
   (Isaac "Izzy" Avram, review by Gabriel Scherer and Nicolás Ojeda Bär)
 


### PR DESCRIPTION
Addressing issue #7927. 

I refactored only four functions that take the same long tuple. (Short commits for easier reviewing) 
Those four functions are `extract_type_decls`, `merge_type_decls`, `final_env`, and `check_coercions`. 
The long tuple was replaced by a record type that I created `'a class_res`. The type's name and its fields' names should probably be changed. 

Should that type also be revealed in the interface file? Afaik, `'a class_res` is only used by those four functions internal to the `typeclass.ml`. 