### PR TITLE
Don't run the "test for tests" check on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ matrix:
   - env: CI_KIND=changes
   - env: CI_KIND=manual
   - env: CI_KIND=check-typo
-  - env: CI_KIND=tests
-  allow_failures:
-  - env: CI_KIND=tests
+#  - env: CI_KIND=tests
+#  allow_failures:
+#  - env: CI_KIND=tests
 addons:
   apt:
     packages:


### PR DESCRIPTION
This is a very small step in the reduction of our CI carbon footprint, but it really seems daft to be running a test which no one pays attention to. I think there's a generally good attitude post-ocamltest to asking for tests to be added to PRs where necessary, so I think this Travis job has served its purpose.