### PR TITLE
Do not emit three-operand LEA (amd64)

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -224,7 +224,7 @@ let addressing addr typ i n =
       mem64 typ d (arg64 i n)
   | Iindexed2 d ->
       mem64 typ ~base:(arg64 i n) d (arg64 i (n+1))
-  | Iscaled(2, d) ->
+  | Iscaled(2, d) when not !Clflags.optimize_for_speed ->
       mem64 typ ~base:(arg64 i n) d (arg64 i n)
   | Iscaled(scale, d) ->
       mem64 typ ~scale d (arg64 i n)

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -190,7 +190,13 @@ method! select_operation op args dbg =
       begin match self#select_addressing Word_int (Cop(op, args, dbg)) with
         (Iindexed _, _)
       | (Iindexed2 0, _) -> super#select_operation op args dbg
-      | (addr, arg) -> (Ispecific(Ilea addr), [arg])
+      | ((Iscaled _) as addr, arg) when !Clflags.optimize_for_speed ->
+        (Ispecific(Ilea addr), [arg])
+      | (addr, arg) ->
+        if !Clflags.optimize_for_speed then
+          super#select_operation op args dbg
+        else
+          (Ispecific(Ilea addr), [arg])
       end
   (* Recognize float arithmetic with memory. *)
   | Caddf ->


### PR DESCRIPTION
This PR proposes to stop emitting three-operand LEA when optimizing for speed.  This instruction has been slow on Intel CPUs since Sandybridge (2011).

Referring to previous discussions of slow LEA https://github.com/ocaml/ocaml/issues/6125#issuecomment-472988968 @xavierleroy: When comparing a 3-cycle LEA to a 2-cycle longer instruction sequence, we should also take into account the restriction on port usage of slow LEA.

Consider the attached microbenchmarks:
[test1.ml](https://github.com/ocaml/ocaml/files/2988772/test1.ml.txt) has a single slow LEA in a tight loop.
[test2.ml](https://github.com/ocaml/ocaml/files/2988773/test2.ml.txt) has two slow LEA instructions and one fast LEA in a loop.

For test1, using LEA is about 6% faster. For test2, replacement sequence is more than 20% faster than using LEA. In test2, we created contention on the single port capable of dispatching a slow LEA. This is a more realistic scenario than test1, because instructions other than LEA also complete on this port.

GCC and LLVM also avoid emitting slow LEA instructions in many cases, for example:

LLVM: Replace slow LEA instructions in X86 (May 2017)
https://reviews.llvm.org/rL303183 
https://github.com/llvm/llvm-project/blob/master/llvm/lib/Target/X86/X86FixupLEAs.cpp#L59

GCC: transform a single LEA instruction into a series of MOV and ADD instructions (Jan 2014)
https://gcc.gnu.org/ml/gcc-patches/2014-01/msg01087.html


```
┌──────────────┬────────────────┬───────┬─────────────────┬───────┬────────────────┬───────┐
│              │ test1.orig.exe │  +-   │ test1.nolea.exe │  +-   │     Difference │     % │
├──────────────┼────────────────┼───────┼─────────────────┼───────┼────────────────┼───────┤
│       cycles │ 30,059,073,646 │ 0.00% │  32,288,906,621 │ 0.00% │  2,229,832,975 │ 1.074 │
│ instructions │ 80,024,539,270 │ 0.00% │ 100,026,062,514 │ 0.00% │ 20,001,523,244 │ 1.250 │
│   task-clock │      7,196.793 │ 0.33% │       7,627.278 │ 0.47% │        430.485 │ 1.060 │
└──────────────┴────────────────┴───────┴─────────────────┴───────┴────────────────┴───────┘
┌──────────────┬─────────────────┬──────┬─────────────────┬───────┬────────────────┬───────┐
│              │  test2.orig.exe │  +-  │ test2.nolea.exe │  +-   │     Difference │     % │
├──────────────┼─────────────────┼──────┼─────────────────┼───────┼────────────────┼───────┤
│       cycles │ 120,230,139,792 │ 0.00%│  92,431,186,560 │ 0.00% │-27,798,953,232 │ 0.769 │
│ instructions │ 180,090,097,616 │ 0.00%│ 210,069,708,648 │ 0.00% │ 29,979,611,032 │ 1.166 │
│   task-clock │      28,894.978 │ 0.10%│      22,153.513 │ 0.22% │     -6,741.465 │ 0.767 │
└──────────────┴─────────────────┴──────┴─────────────────┴───────┴────────────────┴───────┘
```
For a benchmark from issue #6125, LEA is also slower:
```
┌──────────────┬────────────────┬───────┬─────────────────┬───────┬──────────────┬───────┐
│              │ lea_bench.orig │  +-   │ lea_bench.nolea │  +-   │   Difference │     % │
├──────────────┼────────────────┼───────┼─────────────────┼───────┼──────────────┼───────┤
│       cycles │  2,411,877,061 │ 0.01% │   2,284,250,171 │ 0.03% │ -127,626,890 │ 0.947 │
│ instructions │  2,879,358,120 │ 0.00% │   3,004,272,380 │ 0.00% │  124,914,260 │ 1.043 │
│   task-clock │        572.939 │ 1.01% │         474.529 │ 5.76% │      -98.411 │ 0.828 │
└──────────────┴────────────────┴───────┴─────────────────┴───────┴──────────────┴───────┘
```
Measured on Intel(R) Xeon(R) Gold 6144 CPU.

The patch is a based on https://github.com/mshinwell/ocaml/commit/a75b13e88498ba9d25e0355647baf5f76e153327.
