### PR TITLE
Fix alignment detection for long integers on 32-bits platforms

### DIFF
--- a/Changes
+++ b/Changes
@@ -710,6 +710,9 @@ OCaml 4.08.0
 - GPR#8528: get rid of the direct call to the C preprocessor in the testsuite
   (Sébastien Hinderer, review by David Allsopp)
 
+- Issue #7938, PR #8532: Fix alignment detection for ints on 32-bits platforms
+  (Sébastien Hinderer, review by Xavier Leroy)
+
 * GPR#8533: Remove some unused configure tests
   (Stephen Dolan, review by David Allsopp and Sébastien Hinderer)
 

--- a/configure
+++ b/configure
@@ -13267,19 +13267,20 @@ _ACEOF
 
 
 if ! $arch64; then :
-  if test x"$ac_cv_alignof_double" = "x8" ; then :
-  if test "$target_cpu" != "i686" ; then :
+  case $target_cpu in #(
+  i686) :
+     ;; #(
+  *) :
+    if test "$ac_cv_alignof_double" -gt 4; then :
   $as_echo "#define ARCH_ALIGN_DOUBLE 1" >>confdefs.h
 
 fi
-fi
-  if test x"$ac_cv_alignof_long" = "x8" ; then :
-  $as_echo "#define ARCH_ALIGN_INT64 1" >>confdefs.h
-
+    if test "$ac_cv_alignof_long" -gt 4; then :
+  $as_echo "#define ARCH_ALIGN_LONG 1" >>confdefs.h
 
 fi
-
-
+     ;;
+esac
 fi
 
 # Shared library support

--- a/configure.ac
+++ b/configure.ac
@@ -705,14 +705,13 @@ AC_CHECK_ALIGNOF([double])
 AC_CHECK_ALIGNOF([long])
 
 AS_IF([! $arch64],
-  [AS_IF([test x"$ac_cv_alignof_double" = "x8" ],
-    [AS_IF([test "$target_cpu" != "i686" ],
-      [AC_DEFINE([ARCH_ALIGN_DOUBLE], [1])])])
-  AS_IF([test x"$ac_cv_alignof_long" = "x8" ],
-    [AC_DEFINE([ARCH_ALIGN_INT64], [1])]
-  )
-  ]
-)
+  [AS_CASE([$target_cpu],
+    [i686], [],
+    [AS_IF([test "$ac_cv_alignof_double" -gt 4],
+      [AC_DEFINE([ARCH_ALIGN_DOUBLE], [1])])
+    AS_IF([test "$ac_cv_alignof_long" -gt 4],
+      [AC_DEFINE([ARCH_ALIGN_LONG], [1])])
+    ])])
 
 # Shared library support
 


### PR DESCRIPTION
This should fix Issue #7938.