### PR TITLE
Remove some unused configure tests.

### DIFF
--- a/Changes
+++ b/Changes
@@ -707,6 +707,9 @@ OCaml 4.08.0
 - GPR#2295: Restore support for bytecode target XLC/AIX/Power
   (Konstantin Romanov, review by Sébastien Hinderer and David Allsopp)
 
+* GPR#8533: Remove some unused configure tests
+  (Stephen Dolan, review by David Allsopp and Sébastien Hinderer)
+
 ### Internal/compiler-libs changes:
 
 - MPR#7918, GPR#1703, GPR#1944, GPR#2213, GPR#2257: Add the module

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -69,7 +69,6 @@ AC_DEFUN([OCAML_SIGNAL_HANDLERS_SEMANTICS], [
     [AC_DEFINE([POSIX_SIGNALS])
       AC_MSG_NOTICE([POSIX signal handling found.])],
     [AC_MSG_NOTICE([assuming signals have the System V semantics.])
-    AC_CHECK_FUNCS([sigsetmask], [AC_DEFINE([HAS_SIGSETMASK])])
     ]
   )
 ])

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -25,7 +25,6 @@
 #define HAS_SOCKETS
 #define HAS_GETCWD
 #define HAS_UTIME
-#define HAS_DUP2
 #define HAS_GETHOSTNAME
 #define HAS_MKTIME
 #define HAS_PUTENV

--- a/configure
+++ b/configure
@@ -13863,18 +13863,6 @@ $as_echo "$as_me: POSIX signal handling found." >&6;}
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: assuming signals have the System V semantics." >&5
 $as_echo "$as_me: assuming signals have the System V semantics." >&6;}
-    for ac_func in sigsetmask
-do :
-  ac_fn_c_check_func "$LINENO" "sigsetmask" "ac_cv_func_sigsetmask"
-if test "x$ac_cv_func_sigsetmask" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SIGSETMASK 1
-_ACEOF
- $as_echo "#define HAS_SIGSETMASK 1" >>confdefs.h
-
-fi
-done
-
 
 
 fi
@@ -14233,17 +14221,6 @@ if test "x$ac_cv_func_getcwd" = xyes; then :
 fi
 
 
-ac_fn_c_check_func "$LINENO" "getpriority" "ac_cv_func_getpriority"
-if test "x$ac_cv_func_getpriority" = xyes; then :
-  ac_fn_c_check_func "$LINENO" "setpriority" "ac_cv_func_setpriority"
-if test "x$ac_cv_func_setpriority" = xyes; then :
-  $as_echo "#define HAS_GETPRIORITY 1" >>confdefs.h
-
-fi
-
-fi
-
-
 ## utime
 ## Note: this was defined in config/s-nt.h but the autoconf macros do not
 # seem to detect it properly on Windows so we hardcode the definition
@@ -14274,13 +14251,6 @@ esac
 ac_fn_c_check_func "$LINENO" "utimes" "ac_cv_func_utimes"
 if test "x$ac_cv_func_utimes" = xyes; then :
   $as_echo "#define HAS_UTIMES 1" >>confdefs.h
-
-fi
-
-
-ac_fn_c_check_func "$LINENO" "dup2" "ac_cv_func_dup2"
-if test "x$ac_cv_func_dup2" = xyes; then :
-  $as_echo "#define HAS_DUP2 1" >>confdefs.h
 
 fi
 
@@ -14423,80 +14393,6 @@ fi
 
 fi
 
-
-
-## Asynchronous I/O
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for asynchronous I/O" >&5
-$as_echo_n "checking for asynchronous I/O... " >&6; }
-if test "$cross_compiling" = yes; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <stdio.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-
-int signalled;
-
-void sigio_handler(int arg)
-{
-  signalled = 1;
-}
-
-int main(void)
-{
-#if defined(SIGIO) && defined(FASYNC) && defined(F_SETFL) && defined(F_SETOWN)
-  int p[2];
-  int ret;
-#define OUT 0
-#define IN 1
-  if (socketpair(PF_UNIX, SOCK_STREAM, 0, p) == -1) return 1;
-  signalled = 0;
-  signal(SIGIO, sigio_handler);
-  ret = fcntl(p[OUT], F_GETFL, 0);
-  fcntl(p[OUT], F_SETFL, ret | FASYNC);
-  fcntl(p[OUT], F_SETOWN, getpid());
-  switch(fork()) {
-  case -1:
-    return 1;
-  case 0:
-    close(p[OUT]);
-    write(p[IN], "x", 1);
-    sleep(1);
-    exit(0);
-  default:
-    close(p[IN]);
-    while(wait(NULL) == -1 && errno == EINTR) /*nothing*/;
-  }
-  if (signalled) return 0; else return 1;
-#else
-  return 1;
-#endif
-}
-
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-
-    $as_echo "#define HAS_ASYNC_IO 1" >>confdefs.h
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
 
 
 ## setitimer

--- a/configure.ac
+++ b/configure.ac
@@ -1114,10 +1114,6 @@ AC_CHECK_FUNC([mkfifo], [AC_DEFINE([HAS_MKFIFO])])
 
 AC_CHECK_FUNC([getcwd], [AC_DEFINE([HAS_GETCWD])])
 
-AC_CHECK_FUNC([getpriority],
-  [AC_CHECK_FUNC([setpriority],
-    [AC_DEFINE([HAS_GETPRIORITY])])])
-
 ## utime
 ## Note: this was defined in config/s-nt.h but the autoconf macros do not
 # seem to detect it properly on Windows so we hardcode the definition
@@ -1129,8 +1125,6 @@ AS_CASE([$host],
       [AC_CHECK_FUNC([utime], [AC_DEFINE([HAS_UTIME])])])])])
 
 AC_CHECK_FUNC([utimes], [AC_DEFINE([HAS_UTIMES])])
-
-AC_CHECK_FUNC([dup2], [AC_DEFINE([HAS_DUP2])])
 
 AC_CHECK_FUNC([fchmod],
   [AC_CHECK_FUNC([fchown], [AC_DEFINE([HAS_FCHMOD])])])
@@ -1186,64 +1180,6 @@ AC_CHECK_HEADER([termios.h],
       [AC_CHECK_FUNC([tcsendbreak],
         [AC_CHECK_FUNC([tcflush],
           [AC_CHECK_FUNC([tcflow], [AC_DEFINE([HAS_TERMIOS])])])])])])])
-
-## Asynchronous I/O
-
-AC_MSG_CHECKING([for asynchronous I/O])
-AC_RUN_IFELSE(
-  [AC_LANG_SOURCE([[
-#include <stdio.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-
-int signalled;
-
-void sigio_handler(int arg)
-{
-  signalled = 1;
-}
-
-int main(void)
-{
-#if defined(SIGIO) && defined(FASYNC) && defined(F_SETFL) && defined(F_SETOWN)
-  int p[2];
-  int ret;
-#define OUT 0
-#define IN 1
-  if (socketpair(PF_UNIX, SOCK_STREAM, 0, p) == -1) return 1;
-  signalled = 0;
-  signal(SIGIO, sigio_handler);
-  ret = fcntl(p[OUT], F_GETFL, 0);
-  fcntl(p[OUT], F_SETFL, ret | FASYNC);
-  fcntl(p[OUT], F_SETOWN, getpid());
-  switch(fork()) {
-  case -1:
-    return 1;
-  case 0:
-    close(p[OUT]);
-    write(p[IN], "x", 1);
-    sleep(1);
-    exit(0);
-  default:
-    close(p[IN]);
-    while(wait(NULL) == -1 && errno == EINTR) /*nothing*/;
-  }
-  if (signalled) return 0; else return 1;
-#else
-  return 1;
-#endif
-}
-  ]])],
-  [
-    AC_DEFINE([HAS_ASYNC_IO])
-    AC_MSG_RESULT([yes])
-  ],
-  [AC_MSG_RESULT([no])],
-  [AC_MSG_RESULT([no])]
-)
 
 ## setitimer
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -37,10 +37,6 @@
    undefined if signal handlers have the System V semantics: the signal
    resets the behavior to default. */
 
-#undef HAS_SIGSETMASK
-
-/* Define HAS_SIGSETMASK if you have sigsetmask(), as in BSD. */
-
 #undef SUPPORT_DYNAMIC_LINKING
 
 /* Define SUPPORT_DYNAMIC_LINKING if dynamic loading of C stub code
@@ -110,20 +106,11 @@
 
 /* Define HAS_GETCWD if the library provides the getcwd() function. */
 
-#undef HAS_GETPRIORITY
-
-/* Define HAS_GETPRIORITY if the library provides getpriority() and
-   setpriority(). Otherwise, we'll use nice(). */
-
 #undef HAS_UTIME
 #undef HAS_UTIMES
 
 /* Define HAS_UTIME if you have /usr/include/utime.h and the library
    provides utime(). Define HAS_UTIMES if the library provides utimes(). */
-
-#undef HAS_DUP2
-
-/* Define HAS_DUP2 if you have dup2(). */
 
 #undef HAS_FCHMOD
 
@@ -172,12 +159,6 @@
 
 /* Define HAS_TERMIOS if you have /usr/include/termios.h and it is
    Posix-compliant. */
-
-#undef HAS_ASYNC_IO
-
-/* Define HAS_ASYNC_IO if BSD-style asynchronous I/O are supported
-   (the process can request to be sent a SIGIO signal when a descriptor
-   is ready for reading). */
 
 #undef HAS_SETITIMER
 


### PR DESCRIPTION
Removes a few tests that are no longer needed by the build, but still done by configure.

  - `HAS_ASYNC_IO` - was only used by Graphics, so not needed after #2318
  - `HAS_DUP2` - last use removed by #650
  - `HAS_GETPRIORITY` - last use removed by 7ae8be59fa3a47a3fae0b306bafdb4b13881d7c0
  - `HAS_SIGSETMASK` - last use removed by 51c55b222826b2251c358ce73f2262972ce0cf48

(the HAS_ASYNC_IO test was particularly slow, so this speeds up configure a bit)