### PR TITLE
fix the -runtime-variant option for bytecode

### DIFF
--- a/Changes
+++ b/Changes
@@ -125,6 +125,9 @@ OCaml 4.09.0
 - #3819, #8546 more explanations and tests for illegal permutation
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #8537: fix the -runtime-variant option for bytecode
+  (Damien Doligez, review by David Allsopp)
+
 - #8541: Correctly print multi-lines locations
   (Louis Roché, review by Gabriel Scherer)
 

--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ flexlink: flexdll/Makefile
 	cd stdlib && cp stdlib.cma std_exit.cmo *.cmi ../boot
 	$(MAKE) -C flexdll MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
 	  CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
-	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" \
+	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -nostdlib -I ../boot" \
 	  flexlink.exe
 	$(MAKE) -C runtime clean
 	$(MAKE) partialclean
@@ -513,7 +513,8 @@ flexlink.opt:
 	mv flexlink.exe flexlink && \
 	($(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
 	           OCAML_CONFIG_FILE=../Makefile.config \
-	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe || \
+	           OCAMLOPT="../ocamlopt.opt -nostdlib -I ../stdlib" \
+	           flexlink.exe || \
 	 (mv flexlink flexlink.exe && false)) && \
 	mv flexlink.exe flexlink.opt && \
 	mv flexlink flexlink.exe

--- a/Makefile
+++ b/Makefile
@@ -498,8 +498,9 @@ flexdll: flexdll/Makefile flexlink
 flexlink: flexdll/Makefile
 	$(MAKE) -C runtime BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
-	$(MAKE) -C stdlib COMPILER=../boot/ocamlc stdlib.cma std_exit.cmo
-	cd stdlib && cp stdlib.cma std_exit.cmo *.cmi ../boot
+	$(MAKE) -C stdlib COMPILER=../boot/ocamlc \
+	                  $(filter-out *.cmi,$(LIBFILES))
+	cd stdlib && cp $(LIBFILES) ../boot/
 	$(MAKE) -C flexdll MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
 	  CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
 	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -nostdlib -I ../boot" \
@@ -524,8 +525,7 @@ INSTALL_FLEXDLLDIR=$(INSTALL_LIBDIR)/flexdll
 
 .PHONY: install-flexdll
 install-flexdll:
-	cat stdlib/camlheader flexdll/flexlink.exe > \
-	  "$(INSTALL_BINDIR)/flexlink.exe"
+	$(INSTALL_PROG) flexdll/flexlink.exe "$(INSTALL_BINDIR)/flexlink$(EXE)"
 ifneq "$(filter-out mingw,$(TOOLCHAIN))" ""
 	$(INSTALL_DATA) flexdll/default$(filter-out _i386,_$(ARCH)).manifest \
     "$(INSTALL_BINDIR)/"

--- a/bytecomp/bytelink.mli
+++ b/bytecomp/bytelink.mli
@@ -34,6 +34,7 @@ type error =
   | File_exists of filepath
   | Cannot_open_dll of filepath
   | Required_module_unavailable of modname
+  | Camlheader of string * filepath
 
 exception Error of error
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -101,12 +101,12 @@ endif
 
 ifeq "$(RUNTIMED)" "true"
 install::
-	$(INSTALL_DATA) target_camlheaderd "$(INSTALL_LIBDIR)"
+	$(INSTALL_DATA) target_camlheaderd "$(INSTALL_LIBDIR)/camlheaderd"
 endif
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	$(INSTALL_DATA) target_camlheaderi "$(INSTALL_LIBDIR)"
+	$(INSTALL_DATA) target_camlheaderi "$(INSTALL_LIBDIR)/camlheaderi"
 endif
 
 .PHONY: installopt


### PR DESCRIPTION
The `-runtime-variant` option has been broken since 4.03.0 because the `camlheaderd` and `camlheaderi` files are installed under the wrong names. The first commit fixes this problem.

The failure is silent and a bytecode file is produced that has the executable flag but doesn't work because the header is missing. The second commit adds some error handling for this case (in particular when the user specifies a runtime variant that doesn't exist).

Note: the first bug was introduced by myself in commit 0225ca01e39289ce1801fb09cd011cdbfb542b8d
