### PR TITLE
adding Jeremy Yallop to the list of Approvers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -48,6 +48,7 @@ Nicolás Ojeda Bär <n.oje.bar@gmail.com>
 
 Gabriel Radanne <Drup>
 Vincent Laviron <lthls@github>
+Jeremy Yallop <yallop>
 
 
 ### Remembering naming preferences for contributors


### PR DESCRIPTION
(PRs to the compiler, to be merged, must have been approved by someone with approval power, that is either a maintainer or someone from the Approvers list.)