### PR TITLE
Print end line and valid end character for multi-lines locations

### DIFF
--- a/Changes
+++ b/Changes
@@ -154,6 +154,9 @@ Working version
   (Jules Aguillon, with help from Armaël Guéneau,
    review by Gabriel Scherer and Florian Angeletti)
 
+- GPR#8541: Correctly print multi-lines locations
+  (Louis Roché, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 - #7584, #8538: Document .cmt* files in the "overview" of ocaml{c,opt}

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -190,9 +190,10 @@ let print_loc ppf loc =
     if loc.loc_start.pos_fname = "" then !input_name
     else loc.loc_start.pos_fname
   in
-  let line = loc.loc_start.pos_lnum in
+  let startline = loc.loc_start.pos_lnum in
+  let endline = loc.loc_end.pos_lnum in
   let startchar = loc.loc_start.pos_cnum - loc.loc_start.pos_bol in
-  let endchar = loc.loc_end.pos_cnum - loc.loc_start.pos_bol in
+  let endchar = loc.loc_end.pos_cnum - loc.loc_end.pos_bol in
 
   let first = ref true in
   let capitalize s =
@@ -210,8 +211,13 @@ let print_loc ppf loc =
      existing setup of editors that parse locations in error messages (e.g.
      Emacs). *)
   comma ();
-  Format.fprintf ppf "%s %i" (capitalize "line")
-    (if line_valid line then line else 1);
+  let startline = if line_valid startline then startline else 1 in
+  let endline = if line_valid endline then endline else startline in
+  begin if startline = endline then
+    Format.fprintf ppf "%s %i" (capitalize "line") startline
+  else
+    Format.fprintf ppf "%s %i-%i" (capitalize "lines") startline endline
+  end;
 
   if chars_valid ~startchar ~endchar then (
     comma ();

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -63,7 +63,7 @@ end = struct
 end
 and B: sig val value: unit end = struct let value = A.f () end
 [%%expect {|
-Line 4, characters 6-72:
+Lines 4-7, characters 6-3:
 4 | ......struct
 5 |   module F(X:sig end) = struct end
 6 |   let f () = B.value
@@ -93,7 +93,7 @@ module F(X: sig module type t module M: t end) = struct
   and B: sig val value: unit end = struct let value  = A.f () end
 end
 [%%expect {|
-Line 5, characters 8-62:
+Lines 5-8, characters 8-5:
 5 | ........struct
 6 |     module M = X.M
 7 |     let f () = B.value

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -42,7 +42,7 @@ File "morematch.ml", line 456, characters 2-7:
 456 | | _,_,Y -> 5
         ^^^^^
 Warning 11: this match case is unused.
-File "morematch.ml", line 1050, characters 8-65:
+File "morematch.ml", lines 1050-1053, characters 8-10:
 1050 | ........function
 1051 |   | A (`A|`C) -> 0
 1052 |   | B (`B,`D) -> 1

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -1,4 +1,4 @@
-File "robustmatch.ml", line 33, characters 6-122:
+File "robustmatch.ml", lines 33-37, characters 6-23:
 33 | ......match t1, t2, x with
 34 |       | AB, AB, A -> ()
 35 |       | MAB, _, A -> ()
@@ -7,42 +7,42 @@ File "robustmatch.ml", line 33, characters 6-122:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
-File "robustmatch.ml", line 54, characters 4-73:
+File "robustmatch.ml", lines 54-56, characters 4-27:
 54 | ....match r1, r2, a with
 55 |     | R1, _, 0 -> ()
 56 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 1)
-File "robustmatch.ml", line 64, characters 4-73:
+File "robustmatch.ml", lines 64-66, characters 4-27:
 64 | ....match r1, r2, a with
 65 |     | R1, _, A -> ()
 66 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
-File "robustmatch.ml", line 69, characters 4-73:
+File "robustmatch.ml", lines 69-71, characters 4-20:
 69 | ....match r1, r2, a with
 70 |     | _, R2, "coucou" -> ()
 71 |     | R1, _, A -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
-File "robustmatch.ml", line 74, characters 4-73:
+File "robustmatch.ml", lines 74-76, characters 4-20:
 74 | ....match r1, r2, a with
 75 |     | _, R2, "coucou" -> ()
 76 |     | R1, _, _ -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, "")
-File "robustmatch.ml", line 85, characters 4-66:
+File "robustmatch.ml", lines 85-87, characters 4-20:
 85 | ....match r1, r2, a with
 86 |     | R1, _, A -> ()
 87 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
-File "robustmatch.ml", line 90, characters 4-87:
+File "robustmatch.ml", lines 90-93, characters 4-20:
 90 | ....match r1, r2, a with
 91 |     | R1, _, A -> ()
 92 |     | _, R2, X -> ()
@@ -50,35 +50,35 @@ File "robustmatch.ml", line 90, characters 4-87:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
-File "robustmatch.ml", line 96, characters 4-66:
+File "robustmatch.ml", lines 96-98, characters 4-20:
 96 | ....match r1, r2, a with
 97 |     | R1, _, _ -> ()
 98 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
-File "robustmatch.ml", line 107, characters 4-66:
+File "robustmatch.ml", lines 107-109, characters 4-20:
 107 | ....match r1, r2, a with
 108 |     | R1, _, A -> ()
 109 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
-File "robustmatch.ml", line 129, characters 4-66:
+File "robustmatch.ml", lines 129-131, characters 4-20:
 129 | ....match r1, r2, a with
 130 |     | R1, _, A -> ()
 131 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
-File "robustmatch.ml", line 151, characters 4-66:
+File "robustmatch.ml", lines 151-153, characters 4-20:
 151 | ....match r1, r2, a with
 152 |     | R1, _, A -> ()
 153 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
-File "robustmatch.ml", line 156, characters 4-87:
+File "robustmatch.ml", lines 156-159, characters 4-20:
 156 | ....match r1, r2, a with
 157 |     | R1, _, A -> ()
 158 |     | _, R2, X -> ()
@@ -86,21 +86,21 @@ File "robustmatch.ml", line 156, characters 4-87:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
-File "robustmatch.ml", line 162, characters 4-66:
+File "robustmatch.ml", lines 162-164, characters 4-20:
 162 | ....match r1, r2, a with
 163 |     | R1, _, _ -> ()
 164 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
-File "robustmatch.ml", line 167, characters 4-66:
+File "robustmatch.ml", lines 167-169, characters 4-20:
 167 | ....match r1, r2, a with
 168 |     | R1, _, C -> ()
 169 |     | _, R2, Y -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, A)
-File "robustmatch.ml", line 176, characters 4-90:
+File "robustmatch.ml", lines 176-179, characters 4-20:
 176 | ....match r1, r2, a with
 177 |     | _, R1, 0 -> ()
 178 |     | R2, _, [||] -> ()
@@ -108,14 +108,14 @@ File "robustmatch.ml", line 176, characters 4-90:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
-File "robustmatch.ml", line 182, characters 4-69:
+File "robustmatch.ml", lines 182-184, characters 4-23:
 182 | ....match r1, r2, a with
 183 |     | R1, _, _ -> ()
 184 |     | _, R2, [||] -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
-File "robustmatch.ml", line 187, characters 4-90:
+File "robustmatch.ml", lines 187-190, characters 4-20:
 187 | ....match r1, r2, a with
 188 |     | _, R2, [||] -> ()
 189 |     | R1, _, 0 -> ()
@@ -123,70 +123,70 @@ File "robustmatch.ml", line 187, characters 4-90:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
-File "robustmatch.ml", line 200, characters 4-89:
+File "robustmatch.ml", lines 200-203, characters 4-19:
 200 | ....match r1, r2, a with
 201 |     | _, R2, [||] -> ()
 202 |     | R1, _, 0 -> ()
 203 |     | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
-File "robustmatch.ml", line 210, characters 4-75:
+File "robustmatch.ml", lines 210-212, characters 4-27:
 210 | ....match r1, r2, a with
 211 |     | R1, _, 'c' -> ()
 212 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 'a')
-File "robustmatch.ml", line 219, characters 4-74:
+File "robustmatch.ml", lines 219-221, characters 4-27:
 219 | ....match r1, r2, a with
 220 |     | R1, _, `A -> ()
 221 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, `B)
-File "robustmatch.ml", line 228, characters 4-89:
+File "robustmatch.ml", lines 228-230, characters 4-37:
 228 | ....match r1, r2, a with
 229 |     | R1, _, (3, "") -> ()
 230 |     | _, R2, (1, "coucou", 'a') -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
-File "robustmatch.ml", line 239, characters 4-113:
+File "robustmatch.ml", lines 239-241, characters 4-51:
 239 | ....match r1, r2, a with
 240 |     | R1, _, { x = 3; y = "" } -> ()
 241 |     | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
-File "robustmatch.ml", line 244, characters 4-113:
+File "robustmatch.ml", lines 244-246, characters 4-36:
 244 | ....match r1, r2, a with
 245 |     | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
 246 |     | _, R1, { x = 3; y = "" } -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, {a=1; b="coucou"; c='b'})
-File "robustmatch.ml", line 253, characters 4-72:
+File "robustmatch.ml", lines 253-255, characters 4-20:
 253 | ....match r1, r2, a with
 254 |     | R1, _, (3, "") -> ()
 255 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
-File "robustmatch.ml", line 263, characters 4-82:
+File "robustmatch.ml", lines 263-265, characters 4-20:
 263 | ....match r1, r2, a with
 264 |     | R1, _, { x = 3; y = "" } -> ()
 265 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
-File "robustmatch.ml", line 272, characters 4-71:
+File "robustmatch.ml", lines 272-274, characters 4-20:
 272 | ....match r1, r2, a with
 273 |     | R1, _, lazy 1 -> ()
 274 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, lazy 0)
-File "robustmatch.ml", line 281, characters 4-99:
+File "robustmatch.ml", lines 281-284, characters 4-24:
 281 | ....match r1, r2, a with
 282 |     | R1, _, () -> ()
 283 |     | _, R2, "coucou" -> ()

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -35,7 +35,7 @@ match { x = assert false } with
 | { x = None } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-70:
+Lines 1-3, characters 0-20:
 1 | match { x = assert false } with
 2 | | { x = 3 } -> ()
 3 | | { x = None } -> ()
@@ -50,7 +50,7 @@ match { x = assert false } with
 | { x = "" } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-71:
+Lines 1-3, characters 0-18:
 1 | match { x = assert false } with
 2 | | { x = None } -> ()
 3 | | { x = "" } -> ()
@@ -65,7 +65,7 @@ match { x = assert false } with
 | { x = `X } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-71:
+Lines 1-3, characters 0-18:
 1 | match { x = assert false } with
 2 | | { x = None } -> ()
 3 | | { x = `X } -> ()
@@ -80,7 +80,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-70:
+Lines 1-3, characters 0-17:
 1 | match { x = assert false } with
 2 | | { x = [||] } -> ()
 3 | | { x = 3 } -> ()
@@ -95,7 +95,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-68:
+Lines 1-3, characters 0-17:
 1 | match { x = assert false } with
 2 | | { x = `X } -> ()
 3 | | { x = 3 } -> ()
@@ -110,7 +110,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-74:
+Lines 1-3, characters 0-17:
 1 | match { x = assert false } with
 2 | | { x = `X "lol" } -> ()
 3 | | { x = 3 } -> ()
@@ -126,7 +126,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line 1, characters 0-95:
+Lines 1-4, characters 0-17:
 1 | match { x = assert false } with
 2 | | { x = (2., "") } -> ()
 3 | | { x = None } -> ()

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -115,7 +115,7 @@ module A = struct
   end
 end
 [%%expect{|
-Line 3, characters 4-56:
+Lines 3-6, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |       let x = T
@@ -135,7 +135,7 @@ module A = struct
   let g = y
 end
 [%%expect{|
-Line 3, characters 4-40:
+Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -290,7 +290,7 @@ let ill_typed_5 =
     x + y + z
   );;
 [%%expect{|
-Line 3, characters 9-44:
+Lines 3-5, characters 9-14:
 3 | .........x = 1
 4 |     and+ y = 2
 5 |     and+ z = 3...
@@ -320,7 +320,7 @@ let ill_typed_6 =
     x + y + z
   );;
 [%%expect{|
-Line 3, characters 9-29:
+Lines 3-4, characters 9-14:
 3 | .........x = 1
 4 |     and+ y = 2
 Error: These bindings have type int * int but bindings were expected of type
@@ -512,7 +512,7 @@ let indexed_monad4 =
       return (first ^ second)
   );;
 [%%expect{|
-Line 6, characters 4-55:
+Lines 6-7, characters 4-29:
 6 | ....let* second = read in
 7 |       return (first ^ second)
 Error: This expression has type

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -172,7 +172,7 @@ let rec x =
   done
 and y = x; ();;
 [%%expect{|
-Line 2, characters 2-52:
+Lines 2-4, characters 2-6:
 2 | ..for i = 0 to 1 do
 3 |     let z = y in ignore z
 4 |   done
@@ -185,7 +185,7 @@ let rec x =
   done
 and y = 10;;
 [%%expect{|
-Line 2, characters 2-33:
+Lines 2-4, characters 2-6:
 2 | ..for i = 0 to y do
 3 |     ()
 4 |   done
@@ -198,7 +198,7 @@ let rec x =
   done
 and y = 0;;
 [%%expect{|
-Line 2, characters 2-34:
+Lines 2-4, characters 2-6:
 2 | ..for i = y to 10 do
 3 |     ()
 4 |   done
@@ -211,7 +211,7 @@ let rec x =
   done
 and y = x; ();;
 [%%expect{|
-Line 2, characters 2-49:
+Lines 2-4, characters 2-6:
 2 | ..while false do
 3 |     let y = x in ignore y
 4 |   done
@@ -224,7 +224,7 @@ let rec x =
   done
 and y = false;;
 [%%expect{|
-Line 2, characters 2-26:
+Lines 2-4, characters 2-6:
 2 | ..while y do
 3 |     ()
 4 |   done
@@ -237,7 +237,7 @@ let rec x =
   done
 and y = false;;
 [%%expect{|
-Line 2, characters 2-45:
+Lines 2-4, characters 2-6:
 2 | ..while y do
 3 |     let y = x in ignore y
 4 |   done
@@ -320,7 +320,7 @@ let rec x =
 and y = match x with
   z -> ("y", z);;
 [%%expect{|
-Line 2, characters 2-85:
+Lines 2-4, characters 2-30:
 2 | ..match let _ = y in raise Not_found with
 3 |     _ -> "x"
 4 |   | exception Not_found -> "z"
@@ -346,7 +346,7 @@ let rec wrong =
   and y = ref wrong
   in ref ("foo" ^ ! ! !x);;
 [%%expect{|
-Line 10, characters 2-65:
+Lines 10-12, characters 2-25:
 10 | ..let rec x = ref y
 11 |   and y = ref wrong
 12 |   in ref ("foo" ^ ! ! !x)..

--- a/testsuite/tests/letrec-check/extension_constructor.ml
+++ b/testsuite/tests/letrec-check/extension_constructor.ml
@@ -18,7 +18,7 @@ let rec x =
 and (m : (module T)) =
   (module (struct exception A of int end) : T);;
 [%%expect{|
-Line 2, characters 2-36:
+Lines 2-3, characters 2-8:
 2 | ..let module M = (val m) in
 3 |   M.A 42
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-check/modules.ml
+++ b/testsuite/tests/letrec-check/modules.ml
@@ -37,7 +37,7 @@ let rec x =
     module N = struct let y = x end
   end in M.N.y;;
 [%%expect{|
-Line 2, characters 2-74:
+Lines 2-4, characters 2-14:
 2 | ..let module M = struct
 3 |     module N = struct let y = x end
 4 |   end in M.N.y..

--- a/testsuite/tests/letrec-check/pr7706.ocaml.reference
+++ b/testsuite/tests/letrec-check/pr7706.ocaml.reference
@@ -1,4 +1,4 @@
-Line 5, characters 2-67:
+Lines 5-6, characters 2-3:
 5 | ..let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
 6 |   y..
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-check/unboxed.ml
+++ b/testsuite/tests/letrec-check/unboxed.ml
@@ -59,7 +59,7 @@ let rec a =
 [%%expect{|
 type a = { a : b; } [@@unboxed]
 and b = X of a | Y
-Line 5, characters 2-75:
+Lines 5-9, characters 2-10:
 5 | ..{a=
 6 |     (if Sys.opaque_identity true then
 7 |        X a
@@ -99,7 +99,7 @@ let rec d =
 [%%expect{|
 type d = D of e [@@unboxed]
 and e = V of d | W
-Line 5, characters 2-72:
+Lines 5-9, characters 2-9:
 5 | ..D
 6 |     (if Sys.opaque_identity true then
 7 |        V d

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -16,7 +16,7 @@ let test_match_exhaustiveness () =
 ;;
 
 [%%expect{|
-Line 8, characters 4-83:
+Lines 8-11, characters 4-16:
  8 | ....match None with
  9 |     | exception e -> ()
 10 |     | Some false -> ()
@@ -35,7 +35,7 @@ let test_match_exhaustiveness_nest1 () =
 ;;
 
 [%%expect{|
-Line 2, characters 4-73:
+Lines 2-4, characters 4-30:
 2 | ....match None with
 3 |     | Some false -> ()
 4 |     | None | exception _ -> ()
@@ -53,7 +53,7 @@ let test_match_exhaustiveness_nest2 () =
 ;;
 
 [%%expect{|
-Line 2, characters 4-73:
+Lines 2-4, characters 4-16:
 2 | ....match None with
 3 |     | Some false | exception _ -> ()
 4 |     | None -> ()
@@ -72,7 +72,7 @@ let test_match_exhaustiveness_full () =
 ;;
 
 [%%expect{|
-Line 2, characters 4-111:
+Lines 2-5, characters 4-30:
 2 | ....match None with
 3 |     | exception e -> ()
 4 |     | Some false | exception _ -> ()

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -33,7 +33,7 @@ Line 2, characters 8-9:
 2 | let x = (1
             ^
   This '(' might be unmatched
-Line 2, characters 8-17:
+Lines 2-4, characters 8-2:
 2 | ........(1
 3 |   +
 4 | 2)...
@@ -60,7 +60,7 @@ File "error_highlighting_use3.ml", line 1, characters 8-9:
 1 | let x = (1
             ^
   This '(' might be unmatched
-File "error_highlighting_use4.ml", line 1, characters 8-17:
+File "error_highlighting_use4.ml", lines 1-3, characters 8-2:
 1 | ........(1
 2 |   +
 3 | 2)...

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -322,7 +322,7 @@ let f = function
   | [] -> 2
 ;;
 [%%expect {|
-Line 1, characters 8-60:
+Lines 1-4, characters 8-11:
 1 | ........function
 2 |   | [Foo] -> 1
 3 |   | _::_::_ -> 3

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -12,7 +12,7 @@ let fbool (type t) (x : t) (tag : t ty) =
 ;;
 [%%expect{|
 type 'a ty = Int : int ty | Bool : bool ty
-Line 6, characters 2-30:
+Lines 6-7, characters 2-13:
 6 | ..match tag with
 7 |   | Bool -> x
 Warning 8: this pattern-matching is not exhaustive.
@@ -28,7 +28,7 @@ let fint (type t) (x : t) (tag : t ty) =
   | Int -> x > 0
 ;;
 [%%expect{|
-Line 2, characters 2-33:
+Lines 2-3, characters 2-16:
 2 | ..match tag with
 3 |   | Int -> x > 0
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -240,7 +240,7 @@ let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Line 3, characters 4-57:
+Lines 3-4, characters 4-30:
 3 | ....IntLit, ((3 : a) as x)
 4 |   | BoolLit, ((true : a) as x)............
 Error: The variable x on the left-hand side of this or-pattern has type
@@ -551,7 +551,7 @@ let extract_merged_annotated (type a) (t2 : a t2) : a =
 
 
 [%%expect{|
-Line 3, characters 4-20:
+Lines 3-4, characters 4-10:
 3 | ....Int x
 4 |   | Bool x.....
 Error: The variable x on the left-hand side of this or-pattern has type
@@ -575,7 +575,7 @@ let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
 ;;
 
 [%%expect{|
-Line 3, characters 4-26:
+Lines 3-4, characters 4-10:
 3 | ....Int (x : a)
 4 |   | Bool x.....
 Error: The variable x on the left-hand side of this or-pattern has type
@@ -731,7 +731,7 @@ let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
   | _, _, _ -> ()
 ;;
 [%%expect{|
-Line 3, characters 4-108:
+Lines 3-4, characters 4-65:
 3 | ....IntLit,  ({ contents = true } as x), _
 4 |   | BoolLit,  _,                        ({ contents = true} as x)............
 Error: The variable x on the left-hand side of this or-pattern has type

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -13,7 +13,7 @@ struct
     | Two, Two -> "four"
 end;;
 [%%expect{|
-Line 7, characters 43-100:
+Lines 7-9, characters 43-24:
 7 | ...........................................function
 8 |     | One, One -> "two"
 9 |     | Two, Two -> "four"

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -27,7 +27,7 @@ type (_, _, _) binop =
     Eq : ('a, 'a, bool) binop
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
-Line 12, characters 2-195:
+Lines 12-16, characters 2-36:
 12 | ..match bop, x, y with
 13 |   | Eq, Bool x, Bool y -> Bool (if x then y else not y)
 14 |   | Leq, Int x, Int y -> Bool (x <= y)

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -12,7 +12,7 @@ module F(S : sig type 'a t end) = struct
     | A, B -> "f A B"
 end;;
 [%%expect{|
-Line 7, characters 47-84:
+Lines 7-8, characters 47-21:
 7 | ...............................................match l, r with
 8 |     | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.
@@ -39,7 +39,7 @@ module F(S : sig type 'a t end) = struct
     | A, B -> "f A B"
 end;;
 [%%expect{|
-Line 10, characters 15-52:
+Lines 10-11, characters 15-21:
 10 | ...............match l, r with
 11 |     | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -37,7 +37,7 @@ module F(T:sig type 'a t end) = struct
     object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
 end;; (* fail *)
 [%%expect{|
-Line 2, characters 2-86:
+Lines 2-3, characters 2-67:
 2 | ..class ['a] c x =
 3 |     object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
 Error: In this definition, a type variable cannot be deduced

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -25,7 +25,7 @@ let () = print_endline (f M.eq) ;;
 [%%expect{|
 type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig type s = private [> `A ] val eq : (s, [ `A | `B ]) t end
-Line 16, characters 39-64:
+Lines 16-17, characters 39-16:
 16 | .......................................function
 17 |   | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.
@@ -55,7 +55,7 @@ module N :
     type s = private < a : int; .. >
     val eq : (s, < a : int; b : bool >) t
   end
-Line 12, characters 49-74:
+Lines 12-13, characters 49-16:
 12 | .................................................function
 13 |   | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -21,7 +21,7 @@ let x = N.f A;;
 
 [%%expect{|
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
-Line 8, characters 52-74:
+Lines 8-9, characters 52-13:
 8 | ....................................................function
 9 |    | B s -> s
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -14,7 +14,7 @@ type _ t =
   | String : string -> string t
   | Same : 'l t -> 'l t
 val f : int t -> int = <fun>
-Line 4, characters 0-97:
+Lines 4-5, characters 0-77:
 4 | type 'a tt = 'a t =
 5 |   Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt..
 Error: This variant or record definition does not match that of type 'a t

--- a/testsuite/tests/typing-gadts/pr7260.ml
+++ b/testsuite/tests/typing-gadts/pr7260.ml
@@ -19,7 +19,7 @@ class foo =
 type bar = < bar : unit >
 type _ ty = Int : int ty
 type dyn = Dyn : 'a ty -> dyn
-Line 7, characters 0-108:
+Lines 7-12, characters 0-5:
  7 | class foo =
  8 |   object (this)
  9 |     method foo (Dyn ty) =

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -15,7 +15,7 @@ module Y = struct
     | A : 'a * 'b * ('b -> unit) -> t
 end;; (* should fail *)
 [%%expect{|
-Line 2, characters 2-54:
+Lines 2-3, characters 2-37:
 2 | ..type t = X.t =
 3 |     | A : 'a * 'b * ('b -> unit) -> t
 Error: This variant or record definition does not match that of type X.t

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -103,13 +103,13 @@ module Nonexhaustive =
   end
 ;;
 [%%expect{|
-Line 11, characters 6-34:
+Lines 11-12, characters 6-19:
 11 | ......function
 12 |         | C2 x -> x
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C1 _
-Line 24, characters 6-77:
+Lines 24-26, characters 6-30:
 24 | ......function
 25 |         | Foo _ , Foo _ -> true
 26 |         | Bar _, Bar _ -> true
@@ -260,7 +260,7 @@ module PR6801 = struct
     | String s -> print_endline s (* warn : Any *)
 end;;
 [%%expect{|
-Line 8, characters 4-50:
+Lines 8-9, characters 4-33:
 8 | ....match x with
 9 |     | String s -> print_endline s.................
 Warning 8: this pattern-matching is not exhaustive.
@@ -687,7 +687,7 @@ let f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
 ;; (* fail *)
 [%%expect{|
 type (_, _) eq = Eq : ('a, 'a) eq
-Line 3, characters 4-90:
+Lines 3-4, characters 4-15:
 3 | ....f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
 4 |   fun Eq o -> o
 Error: The universal type variable 'b cannot be generalized:
@@ -813,7 +813,7 @@ Error: This expression has type [> `A of a ]
 let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
   fun Eq o -> o ;; (* fail *)
 [%%expect{|
-Line 1, characters 4-84:
+Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
 Error: This definition has type
@@ -915,7 +915,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
   | TA, D z -> z
 ;; (* warn *)
 [%%expect{|
-Line 2, characters 2-153:
+Lines 2-8, characters 2-16:
 2 | ..match x, y with
 3 |   | _, A z -> z
 4 |   | _, B z -> if z then 1 else 2
@@ -979,7 +979,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 ;; (* ok *)
 [%%expect{|
 type ('a, 'b) pair = { left : 'a; right : 'b; }
-Line 4, characters 2-244:
+Lines 4-10, characters 2-29:
  4 | ..match {left=x; right=y} with
  5 |   | {left=_; right=A z} -> z
  6 |   | {left=_; right=B z} -> if z then 1 else 2

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -56,7 +56,7 @@ let check : type s . s t * s -> bool = function
 ;;
 [%%expect{|
 type _ t = IntLit : int t | BoolLit : bool t
-Line 5, characters 39-99:
+Lines 5-7, characters 39-23:
 5 | .......................................function
 6 |   | BoolLit, false -> false
 7 |   | IntLit , 6 -> false
@@ -74,7 +74,7 @@ let check : type s . (s t, s) pair -> bool = function
 ;;
 [%%expect{|
 type ('a, 'b) pair = { fst : 'a; snd : 'b; }
-Line 3, characters 45-134:
+Lines 3-5, characters 45-38:
 3 | .............................................function
 4 |   | {fst = BoolLit; snd = false} -> false
 5 |   | {fst = IntLit ; snd =  6} -> false

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -131,7 +131,7 @@ module D : sig type t [@@immediate] end = struct
   type t = string
 end;;
 [%%expect{|
-Line 1, characters 42-70:
+Lines 1-3, characters 42-3:
 1 | ..........................................struct
 2 |   type t = string
 3 | end..

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -494,7 +494,7 @@ let t = function
     x := B
 ;;
 [%%expect{|
-Line 1, characters 8-70:
+Lines 1-3, characters 8-10:
 1 | ........function
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
@@ -507,7 +507,7 @@ Line 3, characters 9-10:
 3 |     x := B
              ^
 Warning 18: this type-based constructor disambiguation is not principal.
-Line 1, characters 8-70:
+Lines 1-3, characters 8-10:
 1 | ........function
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -12,7 +12,7 @@ module M = struct
   end
 end;;
 [%%expect{|
-Line 5, characters 8-52:
+Lines 5-8, characters 8-5:
 5 | ........struct
 6 |     type t = B
 7 |     let f B = ()
@@ -67,7 +67,7 @@ module K = struct
 end;;
 
 [%%expect{|
-Line 4, characters 4-70:
+Lines 4-7, characters 4-7:
 4 | ....struct
 5 |       module type s
 6 |       module A(X:s) =struct end
@@ -99,7 +99,7 @@ module L = struct
     end
 end;;
       [%%expect {|
-Line 4, characters 4-77:
+Lines 4-7, characters 4-7:
 4 | ....struct
 5 |       module T = struct type t end
 6 |       type t = A of T.t
@@ -187,7 +187,7 @@ end;;
 
 
 [%%expect{|
-Line 4, characters 2-105:
+Lines 4-7, characters 2-5:
 4 | ..struct
 5 |     class a = object method c = let module X = struct type t end in () end
 6 |     class b = a
@@ -219,7 +219,7 @@ module R = struct
 end;;
 
 [%%expect{|
-Line 4, characters 2-65:
+Lines 4-7, characters 2-5:
 4 | ..struct
 5 |     class type a = object end
 6 |     class type b = a
@@ -266,7 +266,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 8, characters 6-141:
+Lines 8-15, characters 6-3:
  8 | ......struct
  9 |   type t
 10 |   class type a = object method m:t end
@@ -343,7 +343,7 @@ type t = A
 type t = B
 type t = C
 type t = D
-Line 5, characters 44-72:
+Lines 5-7, characters 44-3:
 5 | ............................................struct
 6 |   let f A B C = D
 7 | end..

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -10,7 +10,7 @@ end;;
 
 [%%expect{|
 type t = int
-Line 3, characters 0-31:
+Lines 3-5, characters 0-3:
 3 | struct
 4 |   type t = [`T of t]
 5 | end..

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -20,7 +20,7 @@ else `Right ()) xs
 val partition_map :
   ('a -> [< `Left of 'b | `Right of 'c ]) -> 'a list -> 'b list * 'c list =
   <fun>
-Line 12, characters 35-96:
+Lines 12-13, characters 35-18:
 12 | ...................................partition_map (fun x -> if x then `Left ()
 13 | else `Right ()) xs
 Error: This expression has type unit list * unit list
@@ -57,7 +57,7 @@ let a b =
 end
 ;;
 [%%expect{|
-Line 8, characters 6-348:
+Lines 8-27, characters 6-3:
  8 | ......struct
  9 |   type t = [
 10 |     | `A of int

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -39,7 +39,7 @@ Line 7, characters 34-35:
                                       ^
 Error: This expression has type M/2.t but an expression was expected of type
          M/1.t
-       Line 4, characters 2-41:
+       Lines 4-6, characters 2-5:
          Definition of module M/1
        Line 1, characters 0-32:
          Definition of module M/2

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -11,7 +11,7 @@ end = struct
  let f = function A | B -> 0
 end;;
 [%%expect{|
-Line 3, characters 6-61:
+Lines 3-6, characters 6-3:
 3 | ......struct
 4 |  type t = A | B
 5 |  let f = function A | B -> 0

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -180,7 +180,7 @@ end = struct
   type t += E of int
 end;;
 [%%expect{|
-Line 3, characters 6-37:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t += E of int
 5 | end..

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -102,7 +102,7 @@ end = struct
   end
 end
 [%%expect {|
-Line 9, characters 6-114:
+Lines 9-17, characters 6-3:
  9 | ......struct
 10 |   module type x = sig
 11 |     val a:int
@@ -172,7 +172,7 @@ end = struct
   end
 end
 [%%expect {|
-Line 6, characters 6-72:
+Lines 6-11, characters 6-3:
  6 | ......struct
  7 |   module type x= sig
  8 |     val x:int
@@ -211,7 +211,7 @@ end = struct
   end
 end
 [%%expect {|
-Line 8, characters 6-108:
+Lines 8-15, characters 6-3:
  8 | ......struct
  9 |   module type a = sig
 10 |     module type b = sig
@@ -268,7 +268,7 @@ end = struct
 end
 [%%expect{|
 class type ct = object  end
-Line 7, characters 6-76:
+Lines 7-12, characters 6-3:
  7 | ......struct
  8 |   module type x = sig
  9 |     class b: ct
@@ -303,7 +303,7 @@ end = struct
   end
 end
 [%%expect{|
-Line 6, characters 6-76:
+Lines 6-11, characters 6-3:
  6 | ......struct
  7 |   module type x = sig
  8 |     type exn+=B
@@ -393,7 +393,7 @@ struct
   module type x = functor(X:c12) -> s
 end
 [%%expect {|
-Line 2, characters 0-48:
+Lines 2-4, characters 0-3:
 2 | struct
 3 |   module type x = functor(X:c12) -> s
 4 | end
@@ -418,7 +418,7 @@ struct
   module type x = functor(X:s) -> c12
 end
 [%%expect {|
-Line 2, characters 0-48:
+Lines 2-4, characters 0-3:
 2 | struct
 3 |   module type x = functor(X:s) -> c12
 4 | end
@@ -482,7 +482,7 @@ end=struct
   end
 end
 [%%expect {|
-Line 22, characters 4-481:
+Lines 22-43, characters 4-3:
 22 | ....struct
 23 |   module type x = sig
 24 |     module A: sig

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -99,7 +99,7 @@ end = struct
   type s = t
 end;;
 [%%expect{|
-Line 3, characters 6-29:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type s = t
 5 | end..

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -10,7 +10,7 @@ end = struct
   let f = function A | B -> 0
 end;;
 [%%expect{|
-Line 4, characters 6-63:
+Lines 4-7, characters 6-3:
 4 | ......struct
 5 |   type t = A | B
 6 |   let f = function A | B -> 0

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -108,7 +108,7 @@ module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
   module Id2 = Id
 end;;
 [%%expect{|
-Line 2, characters 57-107:
+Lines 2-5, characters 57-3:
 2 | .........................................................struct
 3 |   module Id = T'.T.Id
 4 |   module Id2 = Id

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -1,4 +1,4 @@
-File "pr3968_bad.ml", line 20, characters 0-165:
+File "pr3968_bad.ml", lines 20-29, characters 0-3:
 20 | object
 21 |   val l = e1
 22 |   val r = e2

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -95,7 +95,7 @@ class ref x_init = object
   method set y = x <- y
 end;;
 [%%expect{|
-Line 1, characters 0-95:
+Lines 1-5, characters 0-3:
 1 | class ref x_init = object
 2 |   val mutable x = x_init
 3 |   method get = x

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -31,7 +31,7 @@ end and d () = object
   inherit ['a] c ()
 end;;
 [%%expect{|
-Line 3, characters 4-45:
+Lines 3-5, characters 4-3:
 3 | ....and d () = object
 4 |   inherit ['a] c ()
 5 | end..
@@ -88,7 +88,7 @@ class x () = object
   method virtual f : int
 end;;
 [%%expect{|
-Line 1, characters 0-48:
+Lines 1-3, characters 0-3:
 1 | class x () = object
 2 |   method virtual f : int
 3 | end..
@@ -116,7 +116,7 @@ class ['a] c () = object
   method f x = (x : bool c)
 end;;
 [%%expect{|
-Line 1, characters 0-78:
+Lines 1-4, characters 0-3:
 1 | class ['a] c () = object
 2 |   constraint 'a = int
 3 |   method f x = (x : bool c)
@@ -162,7 +162,7 @@ class ['a] c () = object
   method f = (x : 'a)
 end;;
 [%%expect{|
-Line 1, characters 0-50:
+Lines 1-3, characters 0-3:
 1 | class ['a] c () = object
 2 |   method f = (x : 'a)
 3 | end..
@@ -618,7 +618,7 @@ class virtual ['a] matrix (sz, init : int * 'a) = object
   method add (mtx : 'a matrix) = (mtx#m.(0).(0) : 'a)
 end;;
 [%%expect{|
-Line 1, characters 0-153:
+Lines 1-4, characters 0-3:
 1 | class virtual ['a] matrix (sz, init : int * 'a) = object
 2 |   val m = Array.make_matrix sz sz init
 3 |   method add (mtx : 'a matrix) = (mtx#m.(0).(0) : 'a)
@@ -667,7 +667,7 @@ end : sig
   val f : #c -> #c
 end);;
 [%%expect{|
-Line 1, characters 12-43:
+Lines 1-3, characters 12-3:
 1 | ............struct
 2 |   let f (x : #c) = x
 3 | end......

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -139,7 +139,7 @@ class leading_up_to = object(self : 'a)
     end
 end;;
 [%%expect{|
-Line 4, characters 4-65:
+Lines 4-7, characters 4-7:
 4 | ....object
 5 |       inherit child1 self
 6 |       inherit child2
@@ -162,7 +162,7 @@ class assertion_failure = object(self : 'a)
     end
 end;;
 [%%expect{|
-Line 4, characters 4-129:
+Lines 4-10, characters 4-7:
  4 | ....object
  5 |       inherit child1 self
  6 |       inherit child2

--- a/testsuite/tests/typing-objects/pr5619_bad.ml
+++ b/testsuite/tests/typing-objects/pr5619_bad.ml
@@ -40,7 +40,7 @@ class foo: foo_t =
   end
 ;;
 [%%expect{|
-Line 2, characters 2-156:
+Lines 2-8, characters 2-5:
 2 | ..object(self)
 3 |     method foo = "foo"
 4 |     method cast: type a. a name -> a =

--- a/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pervasives_leitmotiv.compilers.reference
@@ -2,7 +2,7 @@ File "pervasives_leitmotiv.ml", line 1:
 Warning 63: The printed interface differs from the inferred interface.
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
-File "pervasives_leitmotiv.ml", line 10, characters 0-45:
+File "pervasives_leitmotiv.ml", lines 10-12, characters 0-3:
   Definition of module Stdlib/1
 File "_none_", line 1:
   Definition of module Stdlib/2

--- a/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
+++ b/testsuite/tests/typing-ocamlc-i/pr7402.compilers.reference
@@ -2,9 +2,9 @@ File "pr7402.ml", line 1:
 Warning 63: The printed interface differs from the inferred interface.
 The inferred interface contained items which could not be printed
 properly due to name collisions between identifiers.
-File "pr7402.ml", line 14, characters 0-39:
+File "pr7402.ml", lines 14-16, characters 0-5:
   Definition of module M/1
-File "pr7402.ml", line 8, characters 0-70:
+File "pr7402.ml", lines 8-11, characters 0-3:
   Definition of module M/2
 Beware that this warning is purely informational and will not catch
 all instances of erroneous printed interface.

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -54,7 +54,7 @@ let _ = f (object
 [%%expect {|
 class type t_a = object method f : 'a -> int end
 val f : t_a -> int = <fun>
-Line 5, characters 10-42:
+Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -47,7 +47,7 @@ match px with
 | {pv=true::_} -> "bool"
 ;;
 [%%expect {|
-Line 1, characters 0-77:
+Lines 1-4, characters 0-24:
 1 | match px with
 2 | | {pv=[]} -> "OK"
 3 | | {pv=5::_} -> "int"
@@ -64,7 +64,7 @@ match px with
 | {pv=5::_} -> "int"
 ;;
 [%%expect {|
-Line 1, characters 0-77:
+Lines 1-4, characters 0-20:
 1 | match px with
 2 | | {pv=[]} -> "OK"
 3 | | {pv=true::_} -> "bool"
@@ -555,7 +555,7 @@ class id4 () = object
 end
 ;;
 [%%expect {|
-Line 4, characters 12-79:
+Lines 4-7, characters 12-17:
 4 | ............x =
 5 |     match r with
 6 |       None -> r <- Some x; x
@@ -1222,7 +1222,7 @@ let f5 x =
 let f6 x =
   (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
 [%%expect {|
-Line 2, characters 2-88:
+Lines 2-3, characters 2-47:
 2 | ..(x : <m:'a. (<p:int;..> as 'a) -> int>
 3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)..
 Error: Type < m : 'a. (< p : int; .. > as 'a) -> int > is not a subtype of

--- a/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
@@ -37,7 +37,7 @@ let f x =
   | _::_ -> (x :> [`A | `C] Element.t)
 ;;
 [%%expect{|
-Line 4, characters 2-54:
+Lines 4-5, characters 2-38:
 4 | ..match [] with
 5 |   | _::_ -> (x :> [`A | `C] Element.t)
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-recmod/t12bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t12bad.compilers.reference
@@ -1,4 +1,4 @@
-File "t12bad.ml", line 11, characters 4-101:
+File "t12bad.ml", lines 11-15, characters 4-7:
 11 | ....sig
 12 |       class ['a] c : 'a -> object
 13 |         method map : ('a -> 'b) -> 'b M.c

--- a/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
+++ b/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
@@ -1,4 +1,4 @@
-File "b_bad.ml", line 13, characters 29-66:
+File "b_bad.ml", lines 13-14, characters 29-28:
 13 | .............................function
 14 |     A.X s -> print_endline s
 Error (warning 8): this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -47,7 +47,7 @@ module type S0 = sig
   and M2 : sig type t = int end
 end with type M.t = int
 [%%expect {|
-Line 1, characters 17-115:
+Lines 1-4, characters 17-23:
 1 | .................sig
 2 |   module rec M : sig type t = M2.t end
 3 |   and M2 : sig type t = int end
@@ -162,7 +162,7 @@ module type S = sig
 end with type 'a t2 := 'a t * bool
 [%%expect {|
 type 'a t constraint 'a = 'b list
-Line 2, characters 16-142:
+Lines 2-6, characters 16-34:
 2 | ................sig
 3 |   type 'a t2 constraint 'a = 'b list
 4 |   type 'a mylist = 'a list
@@ -267,7 +267,7 @@ module type S = sig
   module A = M
 end with type M.t := float
 [%%expect {|
-Line 1, characters 16-89:
+Lines 1-4, characters 16-26:
 1 | ................sig
 2 |   module M : sig type t end
 3 |   module A = M
@@ -329,7 +329,7 @@ module type S3 = sig
 end with type M2.t := int
 [%%expect {|
 module Id : functor (X : sig type t end) -> sig type t = X.t end
-Line 2, characters 17-120:
+Lines 2-5, characters 17-25:
 2 | .................sig
 3 |   module rec M : sig type t = A of Id(M2).t end
 4 |   and M2 : sig type t end
@@ -372,7 +372,7 @@ module type S = sig
   module Alias = M
 end with module M.N := A
 [%%expect {|
-Line 1, characters 16-159:
+Lines 1-10, characters 16-24:
  1 | ................sig
  2 |   module M : sig
  3 |     module N : sig

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -111,7 +111,7 @@ end = struct
   type t = A of string [@@ocaml.unboxed]
 end;;
 [%%expect{|
-Line 3, characters 6-57:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t = A of string [@@ocaml.unboxed]
 5 | end..
@@ -134,7 +134,7 @@ end = struct
   type t = A of string
 end;;
 [%%expect{|
-Line 3, characters 6-39:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t = A of string
 5 | end..
@@ -157,7 +157,7 @@ end = struct
   type t = { f : string } [@@ocaml.unboxed]
 end;;
 [%%expect{|
-Line 3, characters 6-60:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t = { f : string } [@@ocaml.unboxed]
 5 | end..
@@ -180,7 +180,7 @@ end = struct
   type t = { f : string }
 end;;
 [%%expect{|
-Line 3, characters 6-42:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t = { f : string }
 5 | end..
@@ -203,7 +203,7 @@ end = struct
   type t = A of { f : string } [@@ocaml.unboxed]
 end;;
 [%%expect{|
-Line 3, characters 6-65:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t = A of { f : string } [@@ocaml.unboxed]
 5 | end..
@@ -226,7 +226,7 @@ end = struct
   type t = A of { f : string }
 end;;
 [%%expect{|
-Line 3, characters 6-47:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type t = A of { f : string }
 5 | end..
@@ -292,7 +292,7 @@ end = struct
   type u = { f1 : t; f2 : t }
 end;;
 [%%expect{|
-Line 4, characters 6-86:
+Lines 4-7, characters 6-3:
 4 | ......struct
 5 |   type t = A of float [@@ocaml.unboxed]
 6 |   type u = { f1 : t; f2 : t }

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -106,7 +106,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-70:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : int -> (int [@untagged]) = "f" "f_nat"
 5 | end..
@@ -128,7 +128,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-70:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : (int [@untagged]) -> int = "f" "f_nat"
 5 | end..
@@ -150,7 +150,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-73:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : float -> (float [@unboxed]) = "f" "f_nat"
 5 | end..
@@ -172,7 +172,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-73:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : (float [@unboxed]) -> float = "f" "f_nat"
 5 | end..
@@ -196,7 +196,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-56:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : int -> int = "f" "f_nat"
 5 | end..
@@ -218,7 +218,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-56:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : int -> int = "a" "a_nat"
 5 | end..
@@ -240,7 +240,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-60:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : float -> float = "f" "f_nat"
 5 | end..
@@ -262,7 +262,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line 3, characters 6-60:
+Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   external f : float -> float = "a" "a_nat"
 5 | end..

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -197,7 +197,7 @@ let ambiguous__first_orpat = function
   | _ -> ()
 ;;
 [%%expect {|
-Line 2, characters 4-101:
+Lines 2-3, characters 4-58:
 2 | ....`A ((`B (Some x, _) | `B (_, Some x)),
 3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -215,7 +215,7 @@ let ambiguous__second_orpat = function
   | _ -> ()
 ;;
 [%%expect {|
-Line 2, characters 4-101:
+Lines 2-3, characters 4-42:
 2 | ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
 3 |         (`C (Some y, _) | `C (_, Some y))).................
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -308,7 +308,7 @@ let ambiguous__amoi a = match a with
 | X _|Y _|Z _ -> 1
 ;;
 [%%expect {|
-Line 2, characters 2-35:
+Lines 2-3, characters 2-17:
 2 | ..X (Z x,Y (y,0))
 3 | | X (Z y,Y (x,_))
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -328,7 +328,7 @@ let ambiguous__module_variable x b =  match x with
   | _ -> 2
 ;;
 [%%expect {|
-Line 2, characters 4-49:
+Lines 2-3, characters 4-24:
 2 | ....(module M:S),_,(1,_)
 3 |   | _,(module M:S),(_,1)...................
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -365,7 +365,7 @@ Line 2, characters 4-5:
         ^
 Warning 41: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
-Line 1, characters 41-137:
+Lines 1-3, characters 41-10:
 1 | .........................................function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -8,7 +8,7 @@ let f = function
     None, None -> 1
   | Some _, Some _ -> 2;;
 [%%expect {|
-Line 1, characters 8-60:
+Lines 1-3, characters 8-23:
 1 | ........function
 2 |     None, None -> 1
 3 |   | Some _, Some _ -> 2..
@@ -38,7 +38,7 @@ let f : type a b c d e f g.
    (*| _ -> _ *)
 ;;
 [%%expect {|
-Line 4, characters 1-82:
+Lines 4-5, characters 1-38:
 4 | .function A, A, A, A, A, A, A, _, U, U -> 1
 5 |    | _, _, _, _, _, _, _, G, _, _ -> 1
 Warning 8: this pattern-matching is not exhaustive.
@@ -358,7 +358,7 @@ let f = function
   | Some x when x <= 0 -> ()
 ;;
 [%%expect {|
-Line 1, characters 8-88:
+Lines 1-4, characters 8-28:
 1 | ........function
 2 |   | None -> ()
 3 |   | Some x when x > 0 -> ()

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -23,7 +23,7 @@ module B: sig val f: fpclass -> fpclass end =
   end
     ;;
 [%%expect {|
-Line 2, characters 2-38:
+Lines 2-4, characters 2-5:
 2 | ..struct
 3 |     let f A = FP_normal
 4 |   end

--- a/testsuite/tests/warnings/w04.compilers.reference
+++ b/testsuite/tests/warnings/w04.compilers.reference
@@ -1,4 +1,4 @@
-File "w04.ml", line 21, characters 10-40:
+File "w04.ml", lines 21-23, characters 10-8:
 21 | ..........match x with
 22 | | A -> 0
 23 | | _ -> 1

--- a/testsuite/tests/warnings/w04_failure.compilers.reference
+++ b/testsuite/tests/warnings/w04_failure.compilers.reference
@@ -1,18 +1,18 @@
-File "w04_failure.ml", line 20, characters 2-78:
+File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
 21 |   | AB, _, A -> ()
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
-File "w04_failure.ml", line 20, characters 2-78:
+File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
 21 |   | AB, _, A -> ()
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type ab.
-File "w04_failure.ml", line 20, characters 2-78:
+File "w04_failure.ml", lines 20-23, characters 2-17:
 20 | ..match r1, r2, t with
 21 |   | AB, _, A -> ()
 22 |   | _, XY, X -> ()

--- a/testsuite/tests/warnings/w32.compilers.reference
+++ b/testsuite/tests/warnings/w32.compilers.reference
@@ -46,7 +46,7 @@ File "w32.ml", line 59, characters 22-23:
 59 |   and[@warning "+32"] k x = x
                            ^
 Warning 32: unused value k.
-File "w32.ml", line 52, characters 0-174:
+File "w32.ml", lines 52-60, characters 0-3:
 52 | module M = struct
 53 |   [@@@warning "-32"]
 54 |   let f x = x


### PR DESCRIPTION
When a location is related to multiple lines of code, it is printed
incorrectly. More specifically, the end character is actually an
offset between the beginning and the end of the location.

This commit changes the format of the locations when they cover
multiple lines. It adds the end line and the end character is now a
proper column rather than an offset. It doesn't affect locations
related to a single line.

The old format was:

```
Line STARTLINE, characters STARTCHAR-OFFSET
```

The new format is:

```
Lines STARTLINE-ENDLINE, characters STARTCHAR-ENDCHAR
```

The new format has been chosen so that emacs doesn't need any
change. I unfortunately don't have a vim with enough configuration
to check if it is affected.