### PR TITLE
Expose Persistent_env.Error and catch it from the debugger

### DIFF
--- a/Changes
+++ b/Changes
@@ -43,8 +43,8 @@ Working version
 - #1973: fix compilation of catches with multiple handlers
   (Vincent Laviron)
 
-- #2228: refactoring the handling of .cmi files by moving it from
-  Env to a new module Persistent_env
+- #2228, #8545: refactoring the handling of .cmi files
+  by moving the logic from Env to a new module Persistent_env
   (Gabriel Scherer, review by Jérémie Dimino and Thomas Refis)
 
 - #2229: Env: remove prefix_idents cache

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -239,6 +239,11 @@ let main () =
       Env.report_error err_formatter e;
       eprintf "@]@.";
       exit 2
+  | Persistent_env.Error e ->
+      eprintf "Debugger [version %s] environment error:@ @[@;" Config.version;
+      Persistent_env.report_error err_formatter e;
+      eprintf "@]@.";
+      exit 2
   | Cmi_format.Error e ->
       eprintf "Debugger [version %s] environment error:@ @[@;" Config.version;
       Cmi_format.report_error err_formatter e;

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -199,6 +199,10 @@ let speclist = [
 let function_placeholder () =
   raise Not_found
 
+let report report_error error =
+  eprintf "Debugger [version %s] environment error:@ @[@;%a@]@.;"
+    Config.version report_error error
+
 let main () =
   Callback.register "Debugger.function_placeholder" function_placeholder;
   try
@@ -232,22 +236,13 @@ let main () =
     kill_program ();
     exit 0
   with
-    Toplevel ->
-      exit 2
-  | Env.Error e ->
-      eprintf "Debugger [version %s] environment error:@ @[@;" Config.version;
-      Env.report_error err_formatter e;
-      eprintf "@]@.";
+  | Toplevel ->
       exit 2
   | Persistent_env.Error e ->
-      eprintf "Debugger [version %s] environment error:@ @[@;" Config.version;
-      Persistent_env.report_error err_formatter e;
-      eprintf "@]@.";
+      report Persistent_env.report_error e;
       exit 2
   | Cmi_format.Error e ->
-      eprintf "Debugger [version %s] environment error:@ @[@;" Config.version;
-      Cmi_format.report_error err_formatter e;
-      eprintf "@]@.";
+      report Cmi_format.report_error e;
       exit 2
 
 let _ =

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -26,6 +26,10 @@ type error =
   | Need_recursive_types of modname
   | Depend_on_unsafe_string_unit of modname
 
+exception Error of error
+
+val report_error: Format.formatter -> error -> unit
+
 module Persistent_signature : sig
   type t =
     { filename : string; (** Name of the file containing the signature. *)


### PR DESCRIPTION
The debugger reimplements its own error-reporting logic without using
the reporter-registration mechanism of the compiler, so it needs to be
adapted after the split between `Env` and `Persistent_env` in #2228.

(Interestingly, this forced me to expose the `Error of error`
exception in the Persistent_signature, which was not the case
before. It was probably a mistake to not expose an exception value
that can be raised by (correctly-written) consumers of the module.)

I noticed the issue while inspecting a testsuite failure (#8544).

Before this patch:

```
$ cat tests/tool-debugger/find-artifacts/_ocamltest/tests/tool-debugger/find-artifacts/debuggee/ocamlc.byte/debuggee.byte.output
Loading program... done.
Breakpoint: 1
10   <|b|>print x;
Uncaught exception: Persistent_env.Error(_)
```

After:
```
$ cat tests/tool-debugger/find-artifacts/_ocamltest/tests/tool-debugger/find-artifacts/debuggee/ocamlc.byte/debuggee.byte.output
Loading program... done.
Breakpoint: 1
10   <|b|>print x;
Debugger [version 4.09.0+dev0-2019-01-18] environment error:
 The files /usr/local/lib/ocaml/stdlib.cmi
 and [...]_ocamltest/tests/tool-debugger/find-artifacts/debuggee/ocamlc.byte/out/blah.cmi
 make inconsistent assumptions over interface Stdlib
```