### PR TITLE
Improved error message for illegal permutations

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,9 @@ Working version
 - #2314: Remove support for gprof profiling.
   (Mark Shinwell, review by Xavier Clerc and Stephen Dolan)
 
+- #3819, more explanations and tests for illegal permutation
+  (Florian Angeletti)
+
 ### Compiler distribution build system:
 
 - #8514: Use boot/ocamlc.opt for building, if available.

--- a/Changes
+++ b/Changes
@@ -27,8 +27,8 @@ Working version
 - #2314: Remove support for gprof profiling.
   (Mark Shinwell, review by Xavier Clerc and Stephen Dolan)
 
-- #3819, more explanations and tests for illegal permutation
-  (Florian Angeletti)
+- #3819, #8546 more explanations and tests for illegal permutation
+  (Florian Angeletti, review by Gabriel Scherer)
 
 ### Compiler distribution build system:
 

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -1,0 +1,635 @@
+(* TEST
+* expect
+*)
+class type ct = object end
+module type s = sig type a val one:int type b class two:ct type c type exn+=Three type d end
+module type c12 = sig type a class two:ct type b val one:int type c type exn+=Three type d end
+module type c123 = sig type a type exn+=Three type b class two:ct type c val one:int type d end
+
+module type expected = sig module type x = s end
+
+module A: expected = struct module type x = c12 end
+[%%expect {|
+class type ct = object  end
+module type s =
+  sig
+    type a
+    val one : int
+    type b
+    class two : ct
+    type c
+    type exn += Three
+    type d
+  end
+module type c12 =
+  sig
+    type a
+    class two : ct
+    type b
+    val one : int
+    type c
+    type exn += Three
+    type d
+  end
+module type c123 =
+  sig
+    type a
+    type exn += Three
+    type b
+    class two : ct
+    type c
+    val one : int
+    type d
+  end
+module type expected = sig module type x = s end
+Line 8, characters 21-51:
+8 | module A: expected = struct module type x = c12 end
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = c12 end
+       is not included in
+         expected
+       Module type declarations do not match:
+         module type x = c12
+       does not match
+         module type x = s
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the class "two" and the value "one" are swapped.
+|}]
+
+module B: expected = struct module type x = c123 end
+[%%expect {|
+Line 1, characters 21-52:
+1 | module B: expected = struct module type x = c123 end
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = c123 end
+       is not included in
+         expected
+       Module type declarations do not match:
+         module type x = c123
+       does not match
+         module type x = s
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the extension constructor "Three" and the value "one" are swapped.
+|}]
+
+
+module Far: sig
+  module type x = sig
+    val a:int
+    val b: int
+    val c: int
+    val d: int
+    val e:int
+  end
+end = struct
+  module type x = sig
+    val a:int
+    val b:int
+    val e:int
+    val d:int
+    val c:int
+  end
+end
+[%%expect {|
+Line 9, characters 6-114:
+ 9 | ......struct
+10 |   module type x = sig
+11 |     val a:int
+12 |     val b:int
+13 |     val e:int
+14 |     val d:int
+15 |     val c:int
+16 |   end
+17 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module type x =
+             sig
+               val a : int
+               val b : int
+               val e : int
+               val d : int
+               val c : int
+             end
+         end
+       is not included in
+         sig
+           module type x =
+             sig
+               val a : int
+               val b : int
+               val c : int
+               val d : int
+               val e : int
+             end
+         end
+       Module type declarations do not match:
+         module type x =
+           sig
+             val a : int
+             val b : int
+             val e : int
+             val d : int
+             val c : int
+           end
+       does not match
+         module type x =
+           sig
+             val a : int
+             val b : int
+             val c : int
+             val d : int
+             val e : int
+           end
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the value "e" and the value "c" are swapped.
+|}]
+
+module Confusing: sig
+  module type x= sig
+    class x:ct
+    val x:int
+  end
+end = struct
+  module type x= sig
+    val x:int
+    class x:ct
+  end
+end
+[%%expect {|
+Line 6, characters 6-72:
+ 6 | ......struct
+ 7 |   module type x= sig
+ 8 |     val x:int
+ 9 |     class x:ct
+10 |   end
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = sig val x : int class x : ct end end
+       is not included in
+         sig module type x = sig class x : ct val x : int end end
+       Module type declarations do not match:
+         module type x = sig val x : int class x : ct end
+       does not match
+         module type x = sig class x : ct val x : int end
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the value "x" and the class "x" are swapped.
+|}]
+
+module MT: sig
+  module type a = sig
+    module type b = sig
+      val x:int
+      val y:int
+    end
+  end
+end = struct
+  module type a = sig
+    module type b = sig
+      val y:int
+      val x:int
+    end
+  end
+end
+[%%expect {|
+Line 8, characters 6-108:
+ 8 | ......struct
+ 9 |   module type a = sig
+10 |     module type b = sig
+11 |       val y:int
+12 |       val x:int
+13 |     end
+14 |   end
+15 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module type a =
+             sig module type b = sig val y : int val x : int end end
+         end
+       is not included in
+         sig
+           module type a =
+             sig module type b = sig val x : int val y : int end end
+         end
+       Module type declarations do not match:
+         module type a =
+           sig module type b = sig val y : int val x : int end end
+       does not match
+         module type a =
+           sig module type b = sig val x : int val y : int end end
+       At position module type a = <here>
+       Modules do not match:
+         sig module type b = sig val y : int val x : int end end
+       is not included in
+         sig module type b = sig val x : int val y : int end end
+       At position module type a = <here>
+       Module type declarations do not match:
+         module type b = sig val y : int val x : int end
+       does not match
+         module type b = sig val x : int val y : int end
+       At position module type a = sig module type b = <here> end
+       Illegal permutation of structure fields:
+         the value "y" and the value "x" are swapped.
+|}]
+
+class type ct = object end
+module Classes: sig
+  module type x = sig
+    class a: ct
+    class b: ct
+  end
+end = struct
+  module type x = sig
+    class b: ct
+    class a: ct
+  end
+end
+[%%expect{|
+class type ct = object  end
+Line 7, characters 6-76:
+ 7 | ......struct
+ 8 |   module type x = sig
+ 9 |     class b: ct
+10 |     class a: ct
+11 |   end
+12 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = sig class b : ct class a : ct end end
+       is not included in
+         sig module type x = sig class a : ct class b : ct end end
+       Module type declarations do not match:
+         module type x = sig class b : ct class a : ct end
+       does not match
+         module type x = sig class a : ct class b : ct end
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the class "b" and the class "a" are swapped.
+|}]
+
+module Ext: sig
+  module type x = sig
+    type exn+=A
+    type exn+=B
+  end
+end = struct
+  module type x = sig
+    type exn+=B
+    type exn+=A
+  end
+end
+[%%expect{|
+Line 6, characters 6-76:
+ 6 | ......struct
+ 7 |   module type x = sig
+ 8 |     type exn+=B
+ 9 |     type exn+=A
+10 |   end
+11 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = sig type exn += B type exn += A end end
+       is not included in
+         sig module type x = sig type exn += A type exn += B end end
+       Module type declarations do not match:
+         module type x = sig type exn += B type exn += A end
+       does not match
+         module type x = sig type exn += A type exn += B end
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the extension constructor "B"
+         and the extension constructor "A" are swapped.
+|}]
+
+
+module type w = sig
+  module One:s
+  module Two:s
+end
+
+module type w21 = sig
+  module Two:s
+  module One:s
+end
+
+module type wOne21 = sig
+  module One:c12
+  module Two:s
+end
+
+module C: sig module type x = w end = struct module type x = w21 end
+[%%expect {|
+module type w = sig module One : s module Two : s end
+module type w21 = sig module Two : s module One : s end
+module type wOne21 = sig module One : c12 module Two : s end
+Line 16, characters 38-68:
+16 | module C: sig module type x = w end = struct module type x = w21 end
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = w21 end
+       is not included in
+         sig module type x = w end
+       Module type declarations do not match:
+         module type x = w21
+       does not match
+         module type x = w
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         the module "Two" and the module "One" are swapped.
+|}]
+
+module D: sig module type x = w end = struct module type x = wOne21 end
+[%%expect {|
+Line 1, characters 38-71:
+1 | module D: sig module type x = w end = struct module type x = wOne21 end
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = wOne21 end
+       is not included in
+         sig module type x = w end
+       Module type declarations do not match:
+         module type x = wOne21
+       does not match
+         module type x = w
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         in module One,
+         the class "two" and the value "one" are swapped.
+|}]
+
+module F1: sig module type x = functor(X:s) -> s end =
+struct
+  module type x = functor(X:c12) -> s
+end
+[%%expect {|
+Line 2, characters 0-48:
+2 | struct
+3 |   module type x = functor(X:c12) -> s
+4 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = functor (X : c12) -> s end
+       is not included in
+         sig module type x = functor (X : s) -> s end
+       Module type declarations do not match:
+         module type x = functor (X : c12) -> s
+       does not match
+         module type x = functor (X : s) -> s
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         at position functor (X : <here>) -> ...,
+         the class "two" and the value "one" are swapped.
+|}]
+
+module F2: sig module type x = functor(X:s) -> s end =
+struct
+  module type x = functor(X:s) -> c12
+end
+[%%expect {|
+Line 2, characters 0-48:
+2 | struct
+3 |   module type x = functor(X:s) -> c12
+4 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type x = functor (X : s) -> c12 end
+       is not included in
+         sig module type x = functor (X : s) -> s end
+       Module type declarations do not match:
+         module type x = functor (X : s) -> c12
+       does not match
+         module type x = functor (X : s) -> s
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         at position functor (X) -> <here>,
+         the class "two" and the value "one" are swapped.
+|}]
+
+module Nested: sig
+  module type x = sig
+    module A: sig
+      module B: sig
+        module C: functor(X:sig end)(Y:sig end)
+          (Z:
+           sig
+             module D: sig
+               module E: sig
+                 module F:functor(X:sig end)
+                   (Arg:sig
+                      val one:int
+                      val two:int
+                    end) -> sig end
+               end
+             end
+           end)
+          -> sig end
+      end
+    end
+  end
+end=struct
+  module type x = sig
+    module A: sig
+      module B: sig
+        module C: functor(X:sig end)(Y:sig end)
+          (Z:
+           sig
+             module D: sig
+               module E: sig
+                 module F:functor(X:sig end)
+                   (Arg:sig
+                      val two:int
+                      val one:int
+                    end) -> sig end
+               end
+             end
+           end)
+          -> sig end
+      end
+    end
+  end
+end
+[%%expect {|
+Line 22, characters 4-481:
+22 | ....struct
+23 |   module type x = sig
+24 |     module A: sig
+25 |       module B: sig
+26 |         module C: functor(X:sig end)(Y:sig end)
+...
+40 |       end
+41 |     end
+42 |   end
+43 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           module type x =
+             sig
+               module A :
+                 sig
+                   module B :
+                     sig
+                       module C :
+                         functor
+                           (X : sig  end) (Y : sig  end) (Z : sig
+                                                                module D :
+                                                                  sig
+                                                                    module E :
+                                                                    sig
+                                                                    module F :
+                                                                    functor
+                                                                    (X :
+                                                                    sig
+
+                                                                    end) (Arg :
+                                                                    sig
+                                                                    val two :
+                                                                    int
+                                                                    val one :
+                                                                    int
+                                                                    end) ->
+                                                                    sig  end
+                                                                    end
+                                                                  end
+                                                              end) ->
+                           sig  end
+                     end
+                 end
+             end
+         end
+       is not included in
+         sig
+           module type x =
+             sig
+               module A :
+                 sig
+                   module B :
+                     sig
+                       module C :
+                         functor
+                           (X : sig  end) (Y : sig  end) (Z : sig
+                                                                module D :
+                                                                  sig
+                                                                    module E :
+                                                                    sig
+                                                                    module F :
+                                                                    functor
+                                                                    (X :
+                                                                    sig
+
+                                                                    end) (Arg :
+                                                                    sig
+                                                                    val one :
+                                                                    int
+                                                                    val two :
+                                                                    int
+                                                                    end) ->
+                                                                    sig  end
+                                                                    end
+                                                                  end
+                                                              end) ->
+                           sig  end
+                     end
+                 end
+             end
+         end
+       Module type declarations do not match:
+         module type x =
+           sig
+             module A :
+               sig
+                 module B :
+                   sig
+                     module C :
+                       functor
+                         (X : sig  end) (Y : sig  end) (Z : sig
+                                                              module D :
+                                                                sig
+                                                                  module E :
+                                                                    sig
+                                                                    module F :
+                                                                    functor
+                                                                    (X :
+                                                                    sig
+
+                                                                    end) (Arg :
+                                                                    sig
+                                                                    val two :
+                                                                    int
+                                                                    val one :
+                                                                    int
+                                                                    end) ->
+                                                                    sig  end
+                                                                    end
+                                                                end
+                                                            end) ->
+                         sig  end
+                   end
+               end
+           end
+       does not match
+         module type x =
+           sig
+             module A :
+               sig
+                 module B :
+                   sig
+                     module C :
+                       functor
+                         (X : sig  end) (Y : sig  end) (Z : sig
+                                                              module D :
+                                                                sig
+                                                                  module E :
+                                                                    sig
+                                                                    module F :
+                                                                    functor
+                                                                    (X :
+                                                                    sig
+
+                                                                    end) (Arg :
+                                                                    sig
+                                                                    val one :
+                                                                    int
+                                                                    val two :
+                                                                    int
+                                                                    end) ->
+                                                                    sig  end
+                                                                    end
+                                                                end
+                                                            end) ->
+                         sig  end
+                   end
+               end
+           end
+       At position module type x = <here>
+       Illegal permutation of structure fields:
+         at position
+           module A :
+             sig
+               module B :
+                 sig
+                   module C(X)(Y)(Z :
+                     sig
+                       module D :
+                         sig
+                           module E : sig module F(X)(Arg : <here>) : ... end
+                         end
+                     end) : ...
+                 end
+             end,
+         the value "two" and the value "one" are swapped.
+|}]
+

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -55,8 +55,10 @@ Error: Signature mismatch:
        does not match
          module type x = s
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         the class "two" and the value "one" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the class "two" and the value "one" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module B: expected = struct module type x = c123 end
@@ -74,8 +76,11 @@ Error: Signature mismatch:
        does not match
          module type x = s
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         the extension constructor "Three" and the value "one" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the extension constructor "Three"
+         and the value "one" are not in the same order
+         in the expected and actual module types.
 |}]
 
 
@@ -149,8 +154,10 @@ Error: Signature mismatch:
              val e : int
            end
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         the value "e" and the value "c" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the value "e" and the value "c" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module Confusing: sig
@@ -182,8 +189,10 @@ Error: Signature mismatch:
        does not match
          module type x = sig class x : ct val x : int end
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         the value "x" and the class "x" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the value "x" and the class "x" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module MT: sig
@@ -239,8 +248,10 @@ Error: Signature mismatch:
        does not match
          module type b = sig val x : int val y : int end
        At position module type a = sig module type b = <here> end
-       Illegal permutation of structure fields:
-         the value "y" and the value "x" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the value "y" and the value "x" are not in the same order
+         in the expected and actual module types.
 |}]
 
 class type ct = object end
@@ -274,8 +285,10 @@ Error: Signature mismatch:
        does not match
          module type x = sig class a : ct class b : ct end
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         the class "b" and the class "a" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the class "b" and the class "a" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module Ext: sig
@@ -307,9 +320,11 @@ Error: Signature mismatch:
        does not match
          module type x = sig type exn += A type exn += B end
        At position module type x = <here>
-       Illegal permutation of structure fields:
+       Illegal permutation of runtime components in a module type.
+         For example,
          the extension constructor "B"
-         and the extension constructor "A" are swapped.
+         and the extension constructor "A" are not in the same order
+         in the expected and actual module types.
 |}]
 
 
@@ -346,8 +361,10 @@ Error: Signature mismatch:
        does not match
          module type x = w
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         the module "Two" and the module "One" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example,
+         the module "Two" and the module "One" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module D: sig module type x = w end = struct module type x = wOne21 end
@@ -365,9 +382,10 @@ Error: Signature mismatch:
        does not match
          module type x = w
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         in module One,
-         the class "two" and the value "one" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example, in module One,
+         the class "two" and the value "one" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module F1: sig module type x = functor(X:s) -> s end =
@@ -389,9 +407,10 @@ Error: Signature mismatch:
        does not match
          module type x = functor (X : s) -> s
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         at position functor (X : <here>) -> ...,
-         the class "two" and the value "one" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example, at position functor (X : <here>) -> ...,
+         the class "two" and the value "one" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module F2: sig module type x = functor(X:s) -> s end =
@@ -413,9 +432,10 @@ Error: Signature mismatch:
        does not match
          module type x = functor (X : s) -> s
        At position module type x = <here>
-       Illegal permutation of structure fields:
-         at position functor (X) -> <here>,
-         the class "two" and the value "one" are swapped.
+       Illegal permutation of runtime components in a module type.
+         For example, at position functor (X) -> <here>,
+         the class "two" and the value "one" are not in the same order
+         in the expected and actual module types.
 |}]
 
 module Nested: sig
@@ -615,7 +635,8 @@ Error: Signature mismatch:
                end
            end
        At position module type x = <here>
-       Illegal permutation of structure fields:
+       Illegal permutation of runtime components in a module type.
+         For example,
          at position
            module A :
              sig
@@ -630,6 +651,6 @@ Error: Signature mismatch:
                      end) : ...
                  end
              end,
-         the value "two" and the value "one" are swapped.
+         the value "two" and the value "one" are not in the same order
+         in the expected and actual module types.
 |}]
-

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -2,6 +2,7 @@ aliases.ml
 applicative_functor_type.ml
 firstclass.ml
 generative.ml
+illegal_permutation.ml
 nondep.ml
 nondep_private_abbrev.ml
 normalize_path.ml

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -28,7 +28,7 @@ type symptom =
         * extension_constructor * Includecore.type_mismatch
   | Module_types of module_type * module_type
   | Modtype_infos of Ident.t * modtype_declaration * modtype_declaration
-  | Modtype_permutation
+  | Modtype_permutation of Types.module_type * Typedtree.module_coercion
   | Interface_mismatch of string * string
   | Class_type_declarations of
       Ident.t * class_type_declaration * class_type_declaration *
@@ -520,10 +520,10 @@ and check_modtype_equiv ~loc env ~mark cxt mty1 mty2 =
      modtypes ~loc env ~mark:(negate_mark mark) cxt Subst.identity mty2 mty1)
   with
     (Tcoerce_none, Tcoerce_none) -> ()
-  | (_c1, _c2) ->
+  | (c1, _c2) ->
       (* Format.eprintf "@[c1 = %a@ c2 = %a@]@."
         print_coercion _c1 print_coercion _c2; *)
-      raise(Error [cxt, env, Modtype_permutation])
+      raise(Error [cxt, env, Modtype_permutation (mty1, c1)])
 
 (* Simplified inclusion check between module types (for Env) *)
 
@@ -587,7 +587,151 @@ let show_locs ppf (loc1, loc2) =
   show_loc "Expected declaration" ppf loc2;
   show_loc "Actual declaration" ppf loc1
 
-let include_err ppf = function
+let path_of_context = function
+    Module id :: rem ->
+      let rec subm path = function
+        | [] -> path
+        | Module id :: rem -> subm (Path.Pdot (path, Ident.name id)) rem
+        | _ -> assert false
+      in subm (Path.Pident id) rem
+  | _ -> assert false
+
+
+let rec context ppf = function
+    Module id :: rem ->
+      fprintf ppf "@[<2>module %a%a@]" Printtyp.ident id args rem
+  | Modtype id :: rem ->
+      fprintf ppf "@[<2>module type %a =@ %a@]"
+        Printtyp.ident id context_mty rem
+  | Body x :: rem ->
+      fprintf ppf "functor (%s) ->@ %a" (argname x) context_mty rem
+  | Arg x :: rem ->
+      fprintf ppf "functor (%a : %a) -> ..." Printtyp.ident x context_mty rem
+  | [] ->
+      fprintf ppf "<here>"
+and context_mty ppf = function
+    (Module _ | Modtype _) :: _ as rem ->
+      fprintf ppf "@[<2>sig@ %a@;<1 -2>end@]" context rem
+  | cxt -> context ppf cxt
+and args ppf = function
+    Body x :: rem ->
+      fprintf ppf "(%s)%a" (argname x) args rem
+  | Arg x :: rem ->
+      fprintf ppf "(%a :@ %a) : ..." Printtyp.ident x context_mty rem
+  | cxt ->
+      fprintf ppf " :@ %a" context_mty cxt
+and argname x =
+  let s = Ident.name x in
+  if s = "*" then "" else s
+
+let alt_context ppf cxt =
+  if cxt = [] then () else
+  if List.for_all (function Module _ -> true | _ -> false) cxt then
+    fprintf ppf "in module %a,@ " Printtyp.path (path_of_context cxt)
+  else
+    fprintf ppf "@[<hv 2>at position@ %a,@]@ " context cxt
+
+let context ppf cxt =
+  if cxt = [] then () else
+  if List.for_all (function Module _ -> true | _ -> false) cxt then
+    fprintf ppf "In module %a:@ " Printtyp.path (path_of_context cxt)
+  else
+    fprintf ppf "@[<hv 2>At position@ %a@]@ " context cxt
+
+
+module Illegal_permutation = struct
+  (** Extraction of information in case of illegal permutation
+      in a module type *)
+
+  (** When examining coercions, we only have runtime component indices,
+      we use thus a limited version of {!pos}. *)
+  type coerce_pos =
+    | Item of int
+    | InArg
+    | InBody
+
+  let either f x g y = match f x with
+    | None -> g y
+    | Some _ as x -> x
+
+  (** We extract a lone transposition from a full tree of permutations. *)
+  let rec transposition path = function
+    | Tcoerce_structure(c,_) ->
+        either
+          (not_fixpoint path 0) c
+          (first_non_id path 0) c
+    | Tcoerce_functor(arg,res) ->
+        either
+          (transposition (InArg::path)) arg
+          (transposition (InBody::path)) res
+    | Tcoerce_none -> None
+    | Tcoerce_alias _ | Tcoerce_primitive _ ->
+        (* these coercions are not inversible, and raise an error earlier when
+           checking for module type equivalence *)
+        assert false
+  (* we search the first point which is not invariant at the current level *)
+  and not_fixpoint path pos = function
+    | [] -> None
+    | (n, _) :: q when n = pos -> not_fixpoint path (pos+1) q
+    | (n,_) :: _ -> Some(List.rev path, pos, n)
+  (* we search the first item with a non-identity inner coercion *)
+  and first_non_id path pos = function
+    | [] -> None
+    | (_,Tcoerce_none) :: q -> first_non_id path (pos + 1) q
+    | (_,c) :: q ->
+        either
+          (transposition (Item pos :: path)) c
+          (first_non_id path (pos + 1)) q
+
+  let transposition c = match transposition [] c with
+    | None -> raise Not_found
+    | Some x -> x
+
+  let rec runtime_item k = function
+    | [] -> raise Not_found
+    | item :: q when is_runtime_component item ->
+        if k = 0 then item else runtime_item (k-1) q
+    | _ :: q -> runtime_item k q
+
+  (* Find module type at position [path] and convert the [coerce_pos] path to
+     a [pos] path *)
+  let rec find env ctx path mt = match mt, path with
+    | (Mty_ident p | Mty_alias p), _ ->
+        begin match (Env.find_modtype p env).mtd_type with
+        | None -> raise Not_found
+        | Some mt -> find env ctx path mt
+        end
+    | Mty_signature s , [] -> List.rev ctx, s
+    | Mty_signature s, Item k :: q ->
+        begin match runtime_item k s with
+        | Sig_module (id, _, md,_,_) -> find env (Module id :: ctx) q md.md_type
+        | _ -> raise Not_found
+        end
+    | Mty_functor(x,Some mt,_), InArg :: q -> find env (Arg x :: ctx) q mt
+    | Mty_functor(x,_,mt), InBody :: q -> find env (Body x :: ctx) q mt
+    | _ -> raise Not_found
+
+  let find env path mt = find env [] path mt
+  let item mt k = item_ident_name (runtime_item k mt)
+
+  let pp_item ppf (id,_,kind) =
+    Format.fprintf ppf "%s %S" (kind_of_field_desc kind) (Ident.name id)
+
+  let pp env ppf (mty,c) =
+    try
+      let p, k, l = transposition c in
+      let ctx, mt = find env p mty in
+      fprintf ppf
+        "@[<hv 2>Illegal permutation of structure fields:@ %a@[the %a@ \
+         and the %a are swapped@]@]."
+        alt_context ctx pp_item (item mt k) pp_item (item mt l)
+    with Not_found -> (* this should not happen *)
+      fprintf ppf "Illegal permutation of structure fields."
+
+end
+
+
+let include_err env ppf = function
   | Missing_field (id, loc, kind) ->
       fprintf ppf "The %s `%a' is required but not provided"
         kind Printtyp.ident id;
@@ -632,8 +776,7 @@ let include_err ppf = function
         %a@;<1 -2>does not match@ %a@]"
       !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration id d1)
       !Oprint.out_sig_item (Printtyp.tree_of_modtype_declaration id d2)
-  | Modtype_permutation ->
-      fprintf ppf "Illegal permutation of structure fields"
+  | Modtype_permutation (mty,c) -> Illegal_permutation.pp env ppf (mty,c)
   | Interface_mismatch(impl_name, intf_name) ->
       fprintf ppf "@[The implementation %s@ does not match the interface %s:"
        impl_name intf_name
@@ -660,52 +803,9 @@ let include_err ppf = function
   | Invalid_module_alias path ->
       fprintf ppf "Module %a cannot be aliased" Printtyp.path path
 
-let rec context ppf = function
-    Module id :: rem ->
-      fprintf ppf "@[<2>module %a%a@]" Printtyp.ident id args rem
-  | Modtype id :: rem ->
-      fprintf ppf "@[<2>module type %a =@ %a@]"
-        Printtyp.ident id context_mty rem
-  | Body x :: rem ->
-      fprintf ppf "functor (%s) ->@ %a" (argname x) context_mty rem
-  | Arg x :: rem ->
-      fprintf ppf "functor (%a : %a) -> ..." Printtyp.ident x context_mty rem
-  | [] ->
-      fprintf ppf "<here>"
-and context_mty ppf = function
-    (Module _ | Modtype _) :: _ as rem ->
-      fprintf ppf "@[<2>sig@ %a@;<1 -2>end@]" context rem
-  | cxt -> context ppf cxt
-and args ppf = function
-    Body x :: rem ->
-      fprintf ppf "(%s)%a" (argname x) args rem
-  | Arg x :: rem ->
-      fprintf ppf "(%a :@ %a) : ..." Printtyp.ident x context_mty rem
-  | cxt ->
-      fprintf ppf " :@ %a" context_mty cxt
-and argname x =
-  let s = Ident.name x in
-  if s = "*" then "" else s
-
-let path_of_context = function
-    Module id :: rem ->
-      let rec subm path = function
-        | [] -> path
-        | Module id :: rem -> subm (Path.Pdot (path, Ident.name id)) rem
-        | _ -> assert false
-      in subm (Path.Pident id) rem
-  | _ -> assert false
-
-let context ppf cxt =
-  if cxt = [] then () else
-  if List.for_all (function Module _ -> true | _ -> false) cxt then
-    fprintf ppf "In module %a:@ " Printtyp.path (path_of_context cxt)
-  else
-    fprintf ppf "@[<hv 2>At position@ %a@]@ " context cxt
-
 let include_err ppf (cxt, env, err) =
   Printtyp.wrap_printing_env ~error:true env (fun () ->
-    fprintf ppf "@[<v>%a%a@]" context (List.rev cxt) include_err err)
+    fprintf ppf "@[<v>%a%a@]" context (List.rev cxt) (include_err env) err)
 
 let buffer = ref Bytes.empty
 let is_big obj =

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -722,11 +722,12 @@ module Illegal_permutation = struct
       let p, k, l = transposition c in
       let ctx, mt = find env p mty in
       fprintf ppf
-        "@[<hv 2>Illegal permutation of structure fields:@ %a@[the %a@ \
-         and the %a are swapped@]@]."
+        "@[<hv 2>Illegal permutation of runtime components in a module type.@ \
+         @[For example,@ %a@[the %a@ and the %a are not in the same order@ \
+         in the expected and actual module types.@]@]"
         alt_context ctx pp_item (item mt k) pp_item (item mt l)
     with Not_found -> (* this should not happen *)
-      fprintf ppf "Illegal permutation of structure fields."
+      fprintf ppf "Illegal permutation of runtime components in a module type."
 
 end
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -64,7 +64,7 @@ type symptom =
         * extension_constructor * Includecore.type_mismatch
   | Module_types of module_type * module_type
   | Modtype_infos of Ident.t * modtype_declaration * modtype_declaration
-  | Modtype_permutation
+  | Modtype_permutation of Types.module_type * Typedtree.module_coercion
   | Interface_mismatch of string * string
   | Class_type_declarations of
       Ident.t * class_type_declaration * class_type_declaration *


### PR DESCRIPTION

This PR supplements the error message for illegal permutations of runtime components in module types

```OCaml
module M: sig
  module type x = sig val x: int class y : object end end
end = struct
  module type x = sig class y: object end val x : int end
end
```
> At position module type x = <here>
Illegal permutation of structure fields

with an example of two swapped runtime components:

> Illegal permutation of structure fields:
the class "y" and the value "x" are swapped.

This illustrative transposition is chosen to increase the number of fixed points in the coercing permutation (following the traditional decomposition of permutation). Thus applying the suggested swap may yield a new error message, but this chain of error messages should be finite.
(The alternative of displaying the whole cycle decomposition seemed a bit too noisy and hard to decipher for users.)

This PR comes with few new tests for illegal permutations.

Closes #3819