### PR TITLE
Apply Cmm peephole optimizations to the final results of expressions

### DIFF
--- a/Changes
+++ b/Changes
@@ -794,6 +794,9 @@ OCaml 4.09.0 (19 September 2019):
 - #8735: unbox across static handlers
   (Alain Frisch, review by Vincent Laviron and Gabriel Scherer)
 
+- #8554: Optimize boolean tests that are hidden behind lets
+  (Stefan Muenzel, review by ????)
+
 ### Compiler user-interface and warnings:
 
 * #2276: Remove support for compiler plugins and hooks (also adds

--- a/Changes
+++ b/Changes
@@ -794,7 +794,7 @@ OCaml 4.09.0 (19 September 2019):
 - #8735: unbox across static handlers
   (Alain Frisch, review by Vincent Laviron and Gabriel Scherer)
 
-- #8554: Optimize boolean tests that are hidden behind lets
+- #8554: Apply Cmm peephole optimizations to the final results of expressions.
   (Stefan Muenzel, review by ????)
 
 ### Compiler user-interface and warnings:

--- a/Changes
+++ b/Changes
@@ -795,7 +795,7 @@ OCaml 4.09.0 (19 September 2019):
   (Alain Frisch, review by Vincent Laviron and Gabriel Scherer)
 
 - #8554: Apply Cmm peephole optimizations to the final results of expressions.
-  (Stefan Muenzel, review by ????)
+  (Stefan Muenzel, Vincent Laviron, review by ????)
 
 ### Compiler user-interface and warnings:
 

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -281,6 +281,19 @@ let rec map_tail f = function
   | Cop _ as c ->
       f c
 
+let rec map_single_tail f = function
+  | Clet (id, exp, body) ->
+      let result = map_single_tail f body in
+      Clet (id, exp, result)
+  | Cphantom_let (var, defining_expr, body) ->
+      let result = map_single_tail f body in
+      Cphantom_let (var, defining_expr, result)
+  | Csequence (s1, s2) ->
+      let result = map_single_tail f s2 in
+      Csequence (s1, result)
+  | body ->
+      f body
+
 let map_shallow f = function
   | Clet (id, e1, e2) ->
       Clet (id, f e1, f e2)
@@ -315,3 +328,4 @@ let map_shallow f = function
   | Cvar _
     as c ->
       c
+

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -281,6 +281,30 @@ let rec map_tail f = function
   | Cop _ as c ->
       f c
 
+let lift_phantom_lets f exp =
+  let rec lift exp lifted_rev depth =
+    let next_depth = depth + 1 in
+    match exp with
+    | Cop (op, args, dbg) when depth < 4 ->
+      let lifted_rev, args =
+        List.fold_left (fun (lifted_rev, args) arg ->
+            let lifted_rev, arg = lift arg lifted_rev next_depth in
+            lifted_rev, arg :: args)
+          ([], [])
+          (List.rev args)
+      in
+      lifted_rev, Cop (op, args, dbg)
+    | Cphantom_let (var, defining_expr, body) ->
+      lift body ((var, defining_expr) :: lifted_rev) depth
+    | _ -> lifted_rev, exp
+  in
+  let lifted_rev, exp = lift exp [] 0 in
+  let exp = f exp in
+  List.fold_left (fun exp (var, defining_expr) ->
+      Cphantom_let (var, defining_expr, exp))
+    exp
+    lifted_rev
+
 let rec map_single_tail f = function
   | Clet (id, exp, body) ->
       let result = map_single_tail f body in
@@ -292,7 +316,12 @@ let rec map_single_tail f = function
       let result = map_single_tail f s2 in
       Csequence (s1, result)
   | body ->
-      f body
+      lift_phantom_lets f body
+
+let map_single_tail2 f exp1 exp2 =
+  map_single_tail (fun exp2 ->
+      map_single_tail (fun exp1 -> f exp1 exp2) exp1)
+    exp2
 
 let map_shallow f = function
   | Clet (id, e1, e2) ->
@@ -328,4 +357,3 @@ let map_shallow f = function
   | Cvar _
     as c ->
       c
-

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -282,6 +282,11 @@ let rec map_tail f = function
       f c
 
 let lift_phantom_lets f exp =
+  (* Unbounded exploration would be linear in the size of the expression,
+     which can lead to a translation pass that becomes quadratic in the size
+     of the original program. Limiting to a fixed depth prevents this problem,
+     and it happens that no existing optimisation looks deeper than 4 nested
+     operations, so no optimisation is lost because of this restriction. *)
   let rec lift exp lifted_rev depth =
     let next_depth = depth + 1 in
     match exp with

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -237,5 +237,12 @@ val map_single_tail : (expression -> expression) -> expression -> expression
     more than one result expression, meaning the transformation will be
     applied exactly once *)
 
+val map_single_tail2 :
+  (expression -> expression -> expression) ->
+  expression -> expression -> expression
+(** Analog of [map_single_tail] for binary functions.
+    Assumes that the second argument is meant to be evaluated before
+    the first one, and preserves this evaluation order. *)
+
 val map_shallow: (expression -> expression) -> expression -> expression
   (** Apply the transformation to each immediate sub-expression. *)

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -230,5 +230,12 @@ val map_tail: (expression -> expression) -> expression -> expression
       Same disclaimer as for [iter_shallow_tail] about the notion
       of "tail" sub-expression. *)
 
+val map_single_tail : (expression -> expression) -> expression -> expression
+(** Apply the transformation to an expression, trying to push it
+    to the innermost sub-expression that can produce the final result.
+    This function will not recurse into any expression that contain
+    more than one result expression, meaning the transformation will be
+    applied exactly once *)
+
 val map_shallow: (expression -> expression) -> expression -> expression
   (** Apply the transformation to each immediate sub-expression. *)

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -205,10 +205,12 @@ let ignore_low_bit_int =
     )
 
 (* removes the 1-bit sign-extension left by untag_int (tag_int c) *)
-let ignore_high_bit_int = function
-    Cop(Casr,
-        [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) -> c
-  | c -> c
+let ignore_high_bit_int =
+  map_single_tail (function
+      | Cop(Casr,
+            [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) -> c
+      | c -> c
+  )
 
 let lsr_int c1 c2 dbg =
   map_single_tail (function

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -128,7 +128,7 @@ let rec add_const_aux c n dbg =
 and add_const c n dbg =
   if n = 0 then c
   else
-    map_single_tail (fun c -> add_const_aux c n dbg) c
+    c |> map_single_tail (fun c -> add_const_aux c n dbg)
 
 let incr_int c dbg = add_const c 1 dbg
 let decr_int c dbg = add_const c (-1) dbg
@@ -144,8 +144,9 @@ let rec add_int_aux c1 c2 dbg =
   | (_, _) ->
       Cop(Caddi, [c1; c2], dbg)
 and add_int c1 c2 dbg =
-  map_single_tail
-    (fun c1 -> map_single_tail (fun c2 -> add_int_aux c1 c2 dbg) c2) c1
+  c1 |> map_single_tail @@ fun c1 ->
+  c2 |> map_single_tail @@ fun c2 ->
+  add_int_aux c1 c2 dbg
 
 let rec sub_int_aux c1 c2 dbg =
   match (c1, c2) with
@@ -158,8 +159,9 @@ let rec sub_int_aux c1 c2 dbg =
   | (c1, c2) ->
       Cop(Csubi, [c1; c2], dbg)
 and sub_int c1 c2 dbg =
-  map_single_tail
-    (fun c1 -> map_single_tail (fun c2 -> sub_int_aux c1 c2 dbg) c2) c1
+  c1 |> map_single_tail @@ fun c1 ->
+  c2 |> map_single_tail @@ fun c2 ->
+  sub_int_aux c1 c2 dbg
 
 let rec lsl_int_aux c1 c2 dbg =
   match (c1, c2) with
@@ -172,8 +174,9 @@ let rec lsl_int_aux c1 c2 dbg =
   | (_, _) ->
       Cop(Clsl, [c1; c2], dbg)
 and lsl_int c1 c2 dbg =
-  map_single_tail
-    (fun c1 -> map_single_tail (fun c2 -> lsl_int_aux c1 c2 dbg) c2) c1
+  c1 |> map_single_tail @@ fun c1 ->
+  c2 |> map_single_tail @@ fun c2 ->
+  lsl_int_aux c1 c2 dbg
 
 let is_power2 n = n = 1 lsl Misc.log2 n
 
@@ -196,12 +199,12 @@ let rec mul_int_aux c1 c2 dbg =
   | (c1, c2) ->
       Cop(Cmuli, [c1; c2], dbg)
 and mul_int c1 c2 dbg =
-  map_single_tail
-    (fun c1 -> map_single_tail (fun c2 -> mul_int_aux c1 c2 dbg) c2) c1
+  c1 |> map_single_tail @@ fun c1 ->
+  c2 |> map_single_tail @@ fun c2 ->
+  mul_int_aux c1 c2 dbg
 
 let ignore_low_bit_int =
-  map_single_tail
-    (function
+  map_single_tail (function
       | Cop(Caddi,
             [(Cop(Clsl, [_; Cconst_int (n, _)], _) as c); Cconst_int (1, _)], _)
           when n > 0
@@ -217,30 +220,27 @@ let ignore_high_bit_int = function
   | c -> c
 
 let lsr_int c1 c2 dbg =
-  map_single_tail
-    (function
+  c2 |> map_single_tail (function
       | Cconst_int (0, _) ->
           c1
       | Cconst_int (n, _) when n > 0 ->
           Cop(Clsr, [ignore_low_bit_int c1; c2], dbg)
       | c2 ->
           Cop(Clsr, [c1; c2], dbg)
-    ) c2
+    )
 
 let asr_int c1 c2 dbg =
-  map_single_tail
-    (function
+  c2 |> map_single_tail (function
       | Cconst_int (0, _) ->
           c1
       | Cconst_int (n, _) when n > 0 ->
           Cop(Casr, [ignore_low_bit_int c1; c2], dbg)
       | c2 ->
           Cop(Casr, [c1; c2], dbg)
-    ) c2
+    )
 
 let tag_int i dbg =
-  map_single_tail
-    (function
+  i |>  map_single_tail (function
       | Cconst_int (n, _) ->
           int_const dbg n
       | Cop(Casr, [c; Cconst_int (n, _)], _) when n > 0 ->
@@ -249,11 +249,10 @@ let tag_int i dbg =
             dbg)
       | c ->
           incr_int (lsl_int c (Cconst_int (1, dbg)) dbg) dbg
-    ) i
+    )
 
 let untag_int i dbg =
-  map_single_tail
-    (function
+  i |> map_single_tail (function
       | Cconst_int (n, _) -> Cconst_int(n asr 1, dbg)
       | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1,_)], _); Cconst_int (1,_)],_) ->
           c
@@ -266,45 +265,42 @@ let untag_int i dbg =
       | Cop(Cor, [c; Cconst_int (1, _)], _) ->
           Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
       | c -> Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
-    ) i
+    )
 
 let mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot =
-  map_single_tail
-    (function
+  cond |> map_single_tail (function
       | Cconst_int (0, _) -> ifnot
       | Cconst_int (1, _) -> ifso
       | cond ->
           Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg)
-    ) cond
+    )
 
 let mk_not dbg cmm =
-  map_single_tail
-    (function
+  cmm |> map_single_tail (function
       | Cop(Caddi,
             [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], dbg') ->
         begin
           match c with
           | Cop(Ccmpi cmp, [c1; c2], dbg'') ->
               tag_int
-                (Cop(Ccmpi (negate_integer_comparison cmp), [c1; c2], dbg'')) dbg'
+                (Cop(Ccmpi(negate_integer_comparison cmp), [c1;c2], dbg'')) dbg'
           | Cop(Ccmpa cmp, [c1; c2], dbg'') ->
               tag_int
-                (Cop(Ccmpa (negate_integer_comparison cmp), [c1; c2], dbg'')) dbg'
+                (Cop(Ccmpa(negate_integer_comparison cmp), [c1;c2], dbg'')) dbg'
           | Cop(Ccmpf cmp, [c1; c2], dbg'') ->
               tag_int
-                (Cop(Ccmpf (negate_float_comparison cmp), [c1; c2], dbg'')) dbg'
+                (Cop(Ccmpf(negate_float_comparison cmp), [c1;c2], dbg'')) dbg'
           | _ ->
             (* 0 -> 3, 1 -> 1 *)
             Cop(Csubi,
-              [Cconst_int (3, dbg); Cop(Clsl, [c; Cconst_int (1, dbg)], dbg)], dbg)
+              [Cconst_int(3,dbg); Cop(Clsl,[c; Cconst_int (1,dbg)], dbg)], dbg)
         end
       | Cconst_int (3, _) -> Cconst_int (1, dbg)
       | Cconst_int (1, _) -> Cconst_int (3, dbg)
       | c ->
           (* 1 -> 3, 3 -> 1 *)
           Cop(Csubi, [Cconst_int (4, dbg); c], dbg)
-    ) cmm
-
+    )
 
 let create_loop body dbg =
   let cont = Lambda.next_raise_count () in
@@ -460,8 +456,9 @@ let rec div_int_aux c1 c2 is_safe dbg =
                       raise_symbol dbg "caml_exn_Division_by_zero",
                       dbg)))
 and div_int c1 c2 is_safe dbg =
-  map_single_tail
-    (fun c1 -> map_single_tail (fun c2 -> div_int_aux c1 c2 is_safe dbg) c2) c1
+  c1 |> map_single_tail @@ fun c1 ->
+  c2 |> map_single_tail @@ fun c2 ->
+  div_int_aux c1 c2 is_safe dbg
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
@@ -504,8 +501,9 @@ let mod_int c1 c2 is_safe dbg =
                       dbg)))
 
 let mod_int c1 c2 is_safe dbg =
-  map_single_tail
-    (fun c1 -> map_single_tail (fun c2 -> mod_int c1 c2 is_safe dbg) c2) c1
+  c1 |> map_single_tail @@ fun c1 ->
+  c2 |> map_single_tail @@ fun c2 ->
+  mod_int c1 c2 is_safe dbg
 
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)
@@ -542,7 +540,7 @@ let safe_mod_bi is_safe =
 let test_bool dbg cmm =
   map_single_tail
     (function
-      | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
+      | Cop(Caddi,[Cop(Clsl,[c; Cconst_int (1,_)], _); Cconst_int (1,_)], _) ->
           c
       | Cconst_int (n, dbg) ->
           if n = 1 then

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -111,7 +111,7 @@ let add_no_overflow n x c dbg =
   let d = n + x in
   if d = 0 then c else Cop(Caddi, [c; Cconst_int (d, dbg)], dbg)
 
-let rec add_const c n dbg =
+let rec add_const_aux c n dbg =
   if n = 0 then c
   else match c with
   | Cconst_int (x, _) when Misc.no_overflow_add x n -> Cconst_int (x + n, dbg)
@@ -126,11 +126,15 @@ let rec add_const c n dbg =
   | Cop(Csubi, [c; Cconst_int (x, _)], _) when Misc.no_overflow_sub n x ->
       add_const c (n - x) dbg
   | c -> Cop(Caddi, [c; Cconst_int (n, dbg)], dbg)
+and add_const c n dbg =
+  if n = 0 then c
+  else
+    map_single_tail (fun c -> add_const_aux c n dbg) c
 
 let incr_int c dbg = add_const c 1 dbg
 let decr_int c dbg = add_const c (-1) dbg
 
-let rec add_int c1 c2 dbg =
+let rec add_int_aux c1 c2 dbg =
   match (c1, c2) with
   | (Cconst_int (n, _), c) | (c, Cconst_int (n, _)) ->
       add_const c n dbg
@@ -140,8 +144,11 @@ let rec add_int c1 c2 dbg =
       add_const (add_int c1 c2 dbg) n2 dbg
   | (_, _) ->
       Cop(Caddi, [c1; c2], dbg)
+and add_int c1 c2 dbg =
+  map_single_tail
+    (fun c1 -> map_single_tail (fun c2 -> add_int_aux c1 c2 dbg) c2) c1
 
-let rec sub_int c1 c2 dbg =
+let rec sub_int_aux c1 c2 dbg =
   match (c1, c2) with
   | (c1, Cconst_int (n2, _)) when n2 <> min_int ->
       add_const c1 (-n2) dbg
@@ -151,8 +158,11 @@ let rec sub_int c1 c2 dbg =
       add_const (sub_int c1 c2 dbg) n1 dbg
   | (c1, c2) ->
       Cop(Csubi, [c1; c2], dbg)
+and sub_int c1 c2 dbg =
+  map_single_tail
+    (fun c1 -> map_single_tail (fun c2 -> sub_int_aux c1 c2 dbg) c2) c1
 
-let rec lsl_int c1 c2 dbg =
+let rec lsl_int_aux c1 c2 dbg =
   match (c1, c2) with
   | (Cop(Clsl, [c; Cconst_int (n1, _)], _), Cconst_int (n2, _))
     when n1 > 0 && n2 > 0 && n1 + n2 < size_int * 8 ->
@@ -162,12 +172,15 @@ let rec lsl_int c1 c2 dbg =
       add_const (lsl_int c1 c2 dbg) (n1 lsl n2) dbg
   | (_, _) ->
       Cop(Clsl, [c1; c2], dbg)
+and lsl_int c1 c2 dbg =
+  map_single_tail
+    (fun c1 -> map_single_tail (fun c2 -> lsl_int_aux c1 c2 dbg) c2) c1
 
 let is_power2 n = n = 1 lsl Misc.log2 n
 
 and mult_power2 c n dbg = lsl_int c (Cconst_int (Misc.log2 n, dbg)) dbg
 
-let rec mul_int c1 c2 dbg =
+let rec mul_int_aux c1 c2 dbg =
   match (c1, c2) with
   | (c, Cconst_int (0, _)) | (Cconst_int (0, _), c) ->
       Csequence (c, Cconst_int (0, dbg))
@@ -183,15 +196,20 @@ let rec mul_int c1 c2 dbg =
       add_const (mul_int c (Cconst_int (k, dbg)) dbg) (n * k) dbg
   | (c1, c2) ->
       Cop(Cmuli, [c1; c2], dbg)
+and mul_int c1 c2 dbg =
+  map_single_tail
+    (fun c1 -> map_single_tail (fun c2 -> mul_int_aux c1 c2 dbg) c2) c1
 
-
-let ignore_low_bit_int = function
-    Cop(Caddi,
-        [(Cop(Clsl, [_; Cconst_int (n, _)], _) as c); Cconst_int (1, _)], _)
-      when n > 0
-      -> c
-  | Cop(Cor, [c; Cconst_int (1, _)], _) -> c
-  | c -> c
+let ignore_low_bit_int =
+  map_single_tail
+    (function
+      | Cop(Caddi,
+            [(Cop(Clsl, [_; Cconst_int (n, _)], _) as c); Cconst_int (1, _)], _)
+          when n > 0
+          -> c
+      | Cop(Cor, [c; Cconst_int (1, _)], _) -> c
+      | c -> c
+    )
 
 (* removes the 1-bit sign-extension left by untag_int (tag_int c) *)
 let ignore_high_bit_int = function
@@ -200,78 +218,93 @@ let ignore_high_bit_int = function
   | c -> c
 
 let lsr_int c1 c2 dbg =
-  match c2 with
-    Cconst_int (0, _) ->
-      c1
-  | Cconst_int (n, _) when n > 0 ->
-      Cop(Clsr, [ignore_low_bit_int c1; c2], dbg)
-  | _ ->
-      Cop(Clsr, [c1; c2], dbg)
+  map_single_tail
+    (function
+      | Cconst_int (0, _) ->
+          c1
+      | Cconst_int (n, _) when n > 0 ->
+          Cop(Clsr, [ignore_low_bit_int c1; c2], dbg)
+      | _ ->
+          Cop(Clsr, [c1; c2], dbg)
+    ) c2
 
 let asr_int c1 c2 dbg =
-  match c2 with
-    Cconst_int (0, _) ->
-      c1
-  | Cconst_int (n, _) when n > 0 ->
-      Cop(Casr, [ignore_low_bit_int c1; c2], dbg)
-  | _ ->
-      Cop(Casr, [c1; c2], dbg)
+  map_single_tail
+    (function
+      | Cconst_int (0, _) ->
+          c1
+      | Cconst_int (n, _) when n > 0 ->
+          Cop(Casr, [ignore_low_bit_int c1; c2], dbg)
+      | _ ->
+          Cop(Casr, [c1; c2], dbg)
+    ) c2
 
 let tag_int i dbg =
-  match i with
-    Cconst_int (n, _) ->
-      int_const dbg n
-  | Cop(Casr, [c; Cconst_int (n, _)], _) when n > 0 ->
-      Cop(Cor,
-        [asr_int c (Cconst_int (n - 1, dbg)) dbg; Cconst_int (1, dbg)],
-        dbg)
-  | c ->
-      incr_int (lsl_int c (Cconst_int (1, dbg)) dbg) dbg
+  map_single_tail
+    (function
+      | Cconst_int (n, _) ->
+          int_const dbg n
+      | Cop(Casr, [c; Cconst_int (n, _)], _) when n > 0 ->
+          Cop(Cor,
+            [asr_int c (Cconst_int (n - 1, dbg)) dbg; Cconst_int (1, dbg)],
+            dbg)
+      | c ->
+          incr_int (lsl_int c (Cconst_int (1, dbg)) dbg) dbg
+    ) i
 
 let untag_int i dbg =
-  match i with
-    Cconst_int (n, _) -> Cconst_int(n asr 1, dbg)
-  | Cop(Cor, [Cop(Casr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
-    when n > 0 && n < size_int * 8 ->
-      Cop(Casr, [c; Cconst_int (n+1, dbg)], dbg)
-  | Cop(Cor, [Cop(Clsr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
-    when n > 0 && n < size_int * 8 ->
-      Cop(Clsr, [c; Cconst_int (n+1, dbg)], dbg)
-  | c -> asr_int c (Cconst_int (1, dbg)) dbg
+  map_single_tail
+    (function
+      | Cconst_int (n, _) -> Cconst_int(n asr 1, dbg)
+      | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1,_)], _); Cconst_int (1,_)],_) ->
+          c
+      | Cop(Cor, [Cop(Casr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
+        when n > 0 && n < size_int * 8 ->
+          Cop(Casr, [c; Cconst_int (n+1, dbg)], dbg)
+      | Cop(Cor, [Cop(Clsr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
+        when n > 0 && n < size_int * 8 ->
+          Cop(Clsr, [c; Cconst_int (n+1, dbg)], dbg)
+      | Cop(Cor, [c; Cconst_int (1, _)], _) ->
+          Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
+      | c -> Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
+    ) i
 
 let mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot =
-  match cond with
-  | Cconst_int (0, _) -> ifnot
-  | Cconst_int (1, _) -> ifso
-  | _ ->
-    Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg)
+  map_single_tail
+    (function
+      | Cconst_int (0, _) -> ifnot
+      | Cconst_int (1, _) -> ifso
+      | _ ->
+          Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg)
+    ) cond
 
 let mk_not dbg cmm =
-  match cmm with
-  | Cop(Caddi,
-        [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], dbg') ->
-    begin
-      match c with
-      | Cop(Ccmpi cmp, [c1; c2], dbg'') ->
-          tag_int
-            (Cop(Ccmpi (negate_integer_comparison cmp), [c1; c2], dbg'')) dbg'
-      | Cop(Ccmpa cmp, [c1; c2], dbg'') ->
-          tag_int
-            (Cop(Ccmpa (negate_integer_comparison cmp), [c1; c2], dbg'')) dbg'
-      | Cop(Ccmpf cmp, [c1; c2], dbg'') ->
-          tag_int
-            (Cop(Ccmpf (negate_float_comparison cmp), [c1; c2], dbg'')) dbg'
-      | _ ->
-        (* 0 -> 3, 1 -> 1 *)
-        Cop(Csubi,
-            [Cconst_int (3, dbg); Cop(Clsl, [c; Cconst_int (1, dbg)], dbg)],
-            dbg)
-    end
-  | Cconst_int (3, _) -> Cconst_int (1, dbg)
-  | Cconst_int (1, _) -> Cconst_int (3, dbg)
-  | c ->
-      (* 1 -> 3, 3 -> 1 *)
-      Cop(Csubi, [Cconst_int (4, dbg); c], dbg)
+  map_single_tail
+    (function
+      | Cop(Caddi,
+            [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], dbg') ->
+        begin
+          match c with
+          | Cop(Ccmpi cmp, [c1; c2], dbg'') ->
+              tag_int
+                (Cop(Ccmpi (negate_integer_comparison cmp), [c1; c2], dbg'')) dbg'
+          | Cop(Ccmpa cmp, [c1; c2], dbg'') ->
+              tag_int
+                (Cop(Ccmpa (negate_integer_comparison cmp), [c1; c2], dbg'')) dbg'
+          | Cop(Ccmpf cmp, [c1; c2], dbg'') ->
+              tag_int
+                (Cop(Ccmpf (negate_float_comparison cmp), [c1; c2], dbg'')) dbg'
+          | _ ->
+            (* 0 -> 3, 1 -> 1 *)
+            Cop(Csubi,
+              [Cconst_int (3, dbg); Cop(Clsl, [c; Cconst_int (1, dbg)], dbg)], dbg)
+        end
+      | Cconst_int (3, _) -> Cconst_int (1, dbg)
+      | Cconst_int (1, _) -> Cconst_int (3, dbg)
+      | c ->
+          (* 1 -> 3, 3 -> 1 *)
+          Cop(Csubi, [Cconst_int (4, dbg); c], dbg)
+    ) cmm
 
 
 let create_loop body dbg =
@@ -372,7 +405,7 @@ let validate d m p =
 let raise_symbol dbg symb =
   Cop(Craise Lambda.Raise_regular, [Cconst_symbol (symb, dbg)], dbg)
 
-let rec div_int c1 c2 is_safe dbg =
+let rec div_int_aux c1 c2 is_safe dbg =
   match (c1, c2) with
     (c1, Cconst_int (0, _)) ->
       Csequence(c1, raise_symbol dbg "caml_exn_Division_by_zero")
@@ -427,6 +460,9 @@ let rec div_int c1 c2 is_safe dbg =
                       dbg,
                       raise_symbol dbg "caml_exn_Division_by_zero",
                       dbg)))
+and div_int c1 c2 is_safe dbg =
+  map_single_tail
+    (fun c1 -> map_single_tail (fun c2 -> div_int_aux c1 c2 is_safe dbg) c2) c1
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
@@ -468,6 +504,10 @@ let mod_int c1 c2 is_safe dbg =
                       raise_symbol dbg "caml_exn_Division_by_zero",
                       dbg)))
 
+let mod_int c1 c2 is_safe dbg =
+  map_single_tail
+    (fun c1 -> map_single_tail (fun c2 -> mod_int c1 c2 is_safe dbg) c2) c1
+
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)
 
@@ -500,20 +540,18 @@ let safe_mod_bi is_safe =
 
 (* Bool *)
 
-let rec test_bool dbg cmm =
-  match cmm with
-  | Clet (id, exp, body) ->
-      Clet (id, exp, test_bool dbg body)
-  | Cphantom_let (var, defining_expr, body) ->
-      Cphantom_let (var, defining_expr, test_bool dbg body)
-  | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
-      c
-  | Cconst_int (n, dbg) ->
-      if n = 1 then
-        Cconst_int (0, dbg)
-      else
-        Cconst_int (1, dbg)
-  | c -> Cop(Ccmpi Cne, [c; Cconst_int (1, dbg)], dbg)
+let test_bool dbg cmm =
+  map_single_tail
+    (function
+      | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
+          c
+      | Cconst_int (n, dbg) ->
+          if n = 1 then
+            Cconst_int (0, dbg)
+          else
+            Cconst_int (1, dbg)
+      | c -> Cop(Ccmpi Cne, [c; Cconst_int (1, dbg)], dbg)
+    ) cmm
 
 (* Float *)
 

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -245,17 +245,13 @@ let tag_int i dbg =
 let untag_int i dbg =
   map_single_tail (function
       | Cconst_int (n, _) -> Cconst_int(n asr 1, dbg)
-      | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1,_)], _); Cconst_int (1,_)],_) ->
-          c
       | Cop(Cor, [Cop(Casr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
         when n > 0 && n < size_int * 8 ->
           Cop(Casr, [c; Cconst_int (n+1, dbg)], dbg)
       | Cop(Cor, [Cop(Clsr, [c; Cconst_int (n, _)], _); Cconst_int (1, _)], _)
         when n > 0 && n < size_int * 8 ->
           Cop(Clsr, [c; Cconst_int (n+1, dbg)], dbg)
-      | Cop(Cor, [c; Cconst_int (1, _)], _) ->
-          Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
-      | c -> Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
+      | c -> asr_int c (Cconst_int (1, dbg)) dbg
     ) i
 
 let mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot =

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -144,9 +144,7 @@ let rec add_int_aux c1 c2 dbg =
   | (_, _) ->
       Cop(Caddi, [c1; c2], dbg)
 and add_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  add_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> add_int_aux c1 c2 dbg) c1 c2
 
 let rec sub_int_aux c1 c2 dbg =
   match (c1, c2) with
@@ -159,9 +157,7 @@ let rec sub_int_aux c1 c2 dbg =
   | (c1, c2) ->
       Cop(Csubi, [c1; c2], dbg)
 and sub_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  sub_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> sub_int_aux c1 c2 dbg) c1 c2
 
 let rec lsl_int_aux c1 c2 dbg =
   match (c1, c2) with
@@ -174,9 +170,7 @@ let rec lsl_int_aux c1 c2 dbg =
   | (_, _) ->
       Cop(Clsl, [c1; c2], dbg)
 and lsl_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  lsl_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> lsl_int_aux c1 c2 dbg) c1 c2
 
 let is_power2 n = n = 1 lsl Misc.log2 n
 
@@ -199,9 +193,7 @@ let rec mul_int_aux c1 c2 dbg =
   | (c1, c2) ->
       Cop(Cmuli, [c1; c2], dbg)
 and mul_int c1 c2 dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  mul_int_aux c1 c2 dbg
+  map_single_tail2 (fun c1 c2 -> mul_int_aux c1 c2 dbg) c1 c2
 
 let ignore_low_bit_int =
   map_single_tail (function
@@ -456,9 +448,7 @@ let rec div_int_aux c1 c2 is_safe dbg =
                       raise_symbol dbg "caml_exn_Division_by_zero",
                       dbg)))
 and div_int c1 c2 is_safe dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  div_int_aux c1 c2 is_safe dbg
+  map_single_tail2 (fun c1 c2 -> div_int_aux c1 c2 is_safe dbg) c1 c2
 
 let mod_int c1 c2 is_safe dbg =
   match (c1, c2) with
@@ -501,9 +491,7 @@ let mod_int c1 c2 is_safe dbg =
                       dbg)))
 
 let mod_int c1 c2 is_safe dbg =
-  c1 |> map_single_tail @@ fun c1 ->
-  c2 |> map_single_tail @@ fun c2 ->
-  mod_int c1 c2 is_safe dbg
+  map_single_tail2 (fun c1 c2 -> mod_int c1 c2 is_safe dbg) c1 c2
 
 (* Division or modulo on boxed integers.  The overflow case min_int / -1
    can occur, in which case we force x / -1 = -x and x mod -1 = 0. (PR#5513). *)

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -500,8 +500,12 @@ let safe_mod_bi is_safe =
 
 (* Bool *)
 
-let test_bool dbg cmm =
+let rec test_bool dbg cmm =
   match cmm with
+  | Clet (id, exp, body) ->
+      Clet (id, exp, test_bool dbg body)
+  | Cphantom_let (var, defining_expr, body) ->
+      Cphantom_let (var, defining_expr, test_bool dbg body)
   | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], _) ->
       c
   | Cconst_int (n, dbg) ->

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -127,8 +127,7 @@ let rec add_const_aux c n dbg =
   | c -> Cop(Caddi, [c; Cconst_int (n, dbg)], dbg)
 and add_const c n dbg =
   if n = 0 then c
-  else
-    c |> map_single_tail (fun c -> add_const_aux c n dbg)
+  else map_single_tail (fun c -> add_const_aux c n dbg) c
 
 let incr_int c dbg = add_const c 1 dbg
 let decr_int c dbg = add_const c (-1) dbg
@@ -212,27 +211,27 @@ let ignore_high_bit_int = function
   | c -> c
 
 let lsr_int c1 c2 dbg =
-  c2 |> map_single_tail (function
+  map_single_tail (function
       | Cconst_int (0, _) ->
           c1
       | Cconst_int (n, _) when n > 0 ->
           Cop(Clsr, [ignore_low_bit_int c1; c2], dbg)
       | c2 ->
           Cop(Clsr, [c1; c2], dbg)
-    )
+    ) c2
 
 let asr_int c1 c2 dbg =
-  c2 |> map_single_tail (function
+  map_single_tail (function
       | Cconst_int (0, _) ->
           c1
       | Cconst_int (n, _) when n > 0 ->
           Cop(Casr, [ignore_low_bit_int c1; c2], dbg)
       | c2 ->
           Cop(Casr, [c1; c2], dbg)
-    )
+    ) c2
 
 let tag_int i dbg =
-  i |>  map_single_tail (function
+  map_single_tail (function
       | Cconst_int (n, _) ->
           int_const dbg n
       | Cop(Casr, [c; Cconst_int (n, _)], _) when n > 0 ->
@@ -241,10 +240,10 @@ let tag_int i dbg =
             dbg)
       | c ->
           incr_int (lsl_int c (Cconst_int (1, dbg)) dbg) dbg
-    )
+    ) i
 
 let untag_int i dbg =
-  i |> map_single_tail (function
+  map_single_tail (function
       | Cconst_int (n, _) -> Cconst_int(n asr 1, dbg)
       | Cop(Caddi, [Cop(Clsl, [c; Cconst_int (1,_)], _); Cconst_int (1,_)],_) ->
           c
@@ -257,18 +256,18 @@ let untag_int i dbg =
       | Cop(Cor, [c; Cconst_int (1, _)], _) ->
           Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
       | c -> Cop(Casr, [c; Cconst_int (1, dbg)], dbg)
-    )
+    ) i
 
 let mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot =
-  cond |> map_single_tail (function
+  map_single_tail (function
       | Cconst_int (0, _) -> ifnot
       | Cconst_int (1, _) -> ifso
       | cond ->
           Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg)
-    )
+    ) cond
 
 let mk_not dbg cmm =
-  cmm |> map_single_tail (function
+  map_single_tail (function
       | Cop(Caddi,
             [Cop(Clsl, [c; Cconst_int (1, _)], _); Cconst_int (1, _)], dbg') ->
         begin
@@ -292,7 +291,7 @@ let mk_not dbg cmm =
       | c ->
           (* 1 -> 3, 3 -> 1 *)
           Cop(Csubi, [Cconst_int (4, dbg); c], dbg)
-    )
+    ) cmm
 
 let create_loop body dbg =
   let cont = Lambda.next_raise_count () in

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -112,8 +112,7 @@ let add_no_overflow n x c dbg =
   if d = 0 then c else Cop(Caddi, [c; Cconst_int (d, dbg)], dbg)
 
 let rec add_const_aux c n dbg =
-  if n = 0 then c
-  else match c with
+  match c with
   | Cconst_int (x, _) when Misc.no_overflow_add x n -> Cconst_int (x + n, dbg)
   | Cop(Caddi, [Cconst_int (x, _); c], _)
     when Misc.no_overflow_add n x ->
@@ -224,7 +223,7 @@ let lsr_int c1 c2 dbg =
           c1
       | Cconst_int (n, _) when n > 0 ->
           Cop(Clsr, [ignore_low_bit_int c1; c2], dbg)
-      | _ ->
+      | c2 ->
           Cop(Clsr, [c1; c2], dbg)
     ) c2
 
@@ -235,7 +234,7 @@ let asr_int c1 c2 dbg =
           c1
       | Cconst_int (n, _) when n > 0 ->
           Cop(Casr, [ignore_low_bit_int c1; c2], dbg)
-      | _ ->
+      | c2 ->
           Cop(Casr, [c1; c2], dbg)
     ) c2
 
@@ -274,7 +273,7 @@ let mk_if_then_else dbg cond ifso_dbg ifso ifnot_dbg ifnot =
     (function
       | Cconst_int (0, _) -> ifnot
       | Cconst_int (1, _) -> ifso
-      | _ ->
+      | cond ->
           Cifthenelse(cond, ifso_dbg, ifso, ifnot_dbg, ifnot, dbg)
     ) cond
 


### PR DESCRIPTION
test_bool in cmmgen applies some simplifications when it's looking at a previously computed (and tagged) bool. This doesn't trigger when the bool is hidden behind a let or a phantom let.
I don't have benchmarks for this, I figure the simplicity of the patch will make up for it.
I ran this patch on part of the Jane Street code base, and the new optimization (when triggered through the recursive call) takes effect 36692 times.
Inside the compiler, it's not that common:
```
Cop: asmcomp/cmmgen.ml 1130
Cop: asmcomp/cmmgen.ml 1133
Cop: asmcomp/cmmgen.ml 1136
Cop: asmcomp/spill.ml 379
Cop: middle_end/simplify_primitives.ml 258
Cop: middle_end/simplify_primitives.ml 64
Cop: middle_end/flambda_utils.ml 230
Cop: middle_end/flambda_utils.ml 229
Cop: middle_end/flambda_utils.ml 228
Cop: middle_end/simple_value_approx.ml 702
Cop: middle_end/simple_value_approx.ml 702
Cop: middle_end/simple_value_approx.ml 593
Cop: asmcomp/debug/compute_ranges.ml 110
Cop: asmcomp/debug/compute_ranges.ml 68
Cop: asmcomp/debug/compute_ranges.ml 68
Cop: middle_end/inlining_cost.ml 442
Cop: middle_end/unbox_closures.ml 29
Cop: middle_end/base_types/variable.ml 40
Cop: typing/env.ml 1878
Cop: typing/env.ml 1833
Cop: middle_end/freshening.ml 369
```
