### PR TITLE
Ensure frame table is 8-aligned on ARM64 and PPC64

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,7 +10,8 @@ Working version
   (Mark Shinwell, review by Nicolas Ojeda Bar and Xavier Leroy)
 
 - #7887: ensure frame table is 8-aligned on ARM64 and PPC64
-  (Xavier Leroy, report by Mark Hayden)
+  (Xavier Leroy, report by Mark Hayden, review by Mark Shinwell
+   and Gabriel Scherer)
 
 - #8507: Shorten symbol names of anonymous functions in Flambda mode
   (the directory portions are now hidden)

--- a/Changes
+++ b/Changes
@@ -9,6 +9,9 @@ Working version
   iOS and other Darwin targets.
   (Mark Shinwell, review by Nicolas Ojeda Bar and Xavier Leroy)
 
+- #7887: ensure frame table is 8-aligned on ARM64 and PPC64
+  (Xavier Leroy, report by Mark Hayden)
+
 - #8507: Shorten symbol names of anonymous functions in Flambda mode
   (the directory portions are now hidden)
   (Mark Shinwell, review by Nicolás Ojeda Bär)

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -979,7 +979,8 @@ let end_assembly () =
   `	.quad	0\n`;  (* PR#6329 *)
   `	.globl	{emit_symbol lbl_end}\n`;
   `{emit_symbol lbl_end}:\n`;
-  `	.long	0\n`;
+  `	.quad	0\n`;
+  `	.align	3\n`;  (* #7887 *)
   let lbl = Compilenv.make_symbol (Some "frametable") in
   `	.globl	{emit_symbol lbl}\n`;
   `{emit_symbol lbl}:\n`;

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -1177,6 +1177,7 @@ let end_assembly() =
   `	{emit_string datag}	0\n`;
   (* Emit the frame descriptors *)
   emit_string data_space;  (* not rodata_space because it contains relocations *)
+  if ppc64 then `	.align  3\n`;   (* #7887 *)
   let lbl = Compilenv.make_symbol (Some "frametable") in
   declare_global_data lbl;
   `{emit_symbol lbl}:\n`;


### PR DESCRIPTION
This fixes issue #7887.

On AMD64 the frame table was not properly 8-aligned, causing possibly slower accesses and definitely some linker warnings.   This was reported in #7591 and fixed in 7077b6057 .

#7887 reports that a similar issue exists on ARM64.

This PR fixes the ARM64 code generator, and for good measure it also adds explicit realignment to the PPC64 code generator, although there was probably no issue there to begin with.

CI precheck is happy on the interested architectures (ARM64, PPC64).

