### PR TITLE
Fix #8558: use Strict bindings when simplifying Lstaticraise

### DIFF
--- a/Changes
+++ b/Changes
@@ -536,7 +536,7 @@ OCaml 4.08.0
 - #1917: comballoc: ensure object allocation order is preserved
   (Stephen Dolan)
 
-- #6242, #2143: optimize some local functions
+- #6242, #2143, #8558, #8559: optimize some local functions
   (Alain Frisch, review by Gabriel Scherer)
 
 - #2082: New options [-insn-sched] and [-no-insn-sched] to control

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -282,7 +282,7 @@ let simplify_exits lam =
             xs ys Ident.Map.empty
         in
         List.fold_right2
-          (fun (y, kind) l r -> Llet (Alias, kind, y, l, r))
+          (fun (y, kind) l r -> Llet (Strict, kind, y, l, r))
           ys ls (Lambda.rename env handler)
       with
       | Not_found -> Lstaticraise (i,ls)

--- a/testsuite/tests/basic/localfunction.ml
+++ b/testsuite/tests/basic/localfunction.ml
@@ -21,3 +21,12 @@ let () =
   Printf.printf "%i\n%!" !r;
   assert(x1 -. x0 = x2 -. x1)
      (* check that we did not allocated anything between x1 and x2 *)
+
+
+let () =
+  (* #8558 *)
+  let f () = () in
+  let r = ref 0 in
+  let g () = f (incr r) in
+  g ();
+  assert (!r = 1)


### PR DESCRIPTION
See discussion on #8558.

When eliminating `Lstaticraise` in Simpl.simplify_exits, arguments were always bound as `Alias`.  But nothing really prevented those argument to have side-effects.  This could be the case for e.g. the use of Lstaticraise for compiling exception cases in pattern matching, although in that case those staticraise would cross a try...with and would not be simplified away.  Now, with the new simplification pass that eliminates local functions, one could have arguments with side-effects for Lstaticraise which will be eliminated by simplify_exits, and so we need to be more careful before using Alias.
