### PR TITLE
Improve object system

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2030,7 +2030,10 @@ let rec transl env e =
           Cop(Capply typ_val, cargs, dbg)
       in
       bind "obj" (transl env obj) (fun obj ->
-        match kind, args with
+        Cifthenelse(
+        Cop(Ccmpi Ceq, [get_tag obj dbg; Cconst_int (Obj.custom_tag, dbg)], dbg),
+        dbg, Cop(Cextcall("caml_null_access", typ_val, true, None), [obj], dbg),
+        dbg, (match kind, args with
           Self, _ ->
             bind "met" (lookup_label obj (transl env met) dbg)
               (call_met obj args)
@@ -2040,7 +2043,7 @@ let rec transl env e =
               (List.map (transl env) args) dbg
         | _ ->
             bind "met" (lookup_tag obj (transl env met) dbg)
-              (call_met obj args))
+              (call_met obj args)),dbg))
   | Ulet(str, kind, id, exp, body) ->
       transl_let env str kind id exp body
   | Uphantom_let (var, defining_expr, body) ->

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -222,6 +222,17 @@ let char_of_int n =
 
 external ignore : 'a -> unit = "%ignore"
 
+external make_nulls : unit -> < .. > * < .. > * < .. > =
+  "caml_make_nulls"
+let (null, undefined, nothing) = make_nulls ()
+
+let (//) a b =
+  if a == null then b
+  else if a == undefined then
+    raise (Failure "Object is undefined")
+  else if a == nothing then nothing
+  else a
+
 (* Pair operations *)
 
 external fst : 'a * 'b -> 'a = "%field0"

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -687,6 +687,10 @@ external ignore : 'a -> unit = "%ignore"
    compiler warning; writing [ignore(f x)] instead
    avoids the warning. *)
 
+val null : < .. >
+val undefined : < .. >
+val nothing : < .. >
+val (//) : (< .. > as 'a) -> 'a -> 'a
 
 (** {1 String conversion functions} *)
 


### PR DESCRIPTION
Despite forming 20% of the language (by letter), the OCaml object system remains sorely underused. This PR establishes why, and proposes a fix.

As the data below shows, this is a simple case of a missing feature. Unlike most other languages supporting advanced object models, OCaml has no notion of `null` values. This is a glaring omission of a feature of great familiarity to programmers, whose [worth is measured in billions of dollars](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare).

Consider the relationship between language adoption and the presence of `null` values:

![nulls](https://user-images.githubusercontent.com/79765/55310421-57e52100-5458-11e9-9127-4576d20bd8b5.png)

*(source: GitHub statistics collated by [Ben Frederickson](https://www.benfrederickson.com/ranking-programming-languages-by-github-users/))*

There is a a clear link between a language's ranking and the presence of `null` values: languages with [more `null` values are ranked higher](https://en.wikipedia.org/wiki/Rank%E2%80%93nullity_theorem). Accordingly, this patch extends OCaml with *three* `null` values. By extrapolating the data shown above, I estimate that this will result in 30-35% of GitHub users switching to OCaml.

## Syntax and semantics

Three new values are added as predefined identifiers, which may take any object type:

  - `null`: for objects which are not present.
  - `undefined`: for objects which are not defined.
  - `nothing`: for objects which are not.

Any attempt to invoke methods on one of these values will yield an appropriate exception:

```
# null#go;;
Exception: Failure "Object is null".
# undefined#go;;
Exception: Failure "Object is undefined".
# nothing#go;;
Exception: Not_found.
```

## Equality comparisons

The `null` value is, of course, equal to itself:
```
# null = null;;
- : bool = true
```

**For compatibility** with IEEE754 `NaN`, `undefined` is *not* equal to itself:
```
# undefined = undefined;;
- : bool = false
```

**For compatibility** with JavaScript, `undefined` *is* equal to `null`:
```
# null = undefined;;
- : bool = true
# undefined = null;;
- : bool = true
```

The case of `nothing` is trickier. Is nothing equal to nothing? If something were equal to nothing, would that make nothing something? Must everything be something or can anything be nothing?

This patch resolves this philosophical conundrum with an equitable compromise: `nothing` is equal to `nothing`, except on Tuesdays.

## Null coalescing operator

This patch also adds the [Null-coalescing operator](https://en.wikipedia.org/wiki/Null_coalescing_operator), which allows a default to be supplied in case an object might be `null`.

```
# let default = object method print = print_endline "default" end;;
val default : < print : unit > = <obj>
# let a = object method print = print_endline "a" end;;
val default : < print : unit > = <obj>
#   List.iter (fun x -> (x // default)#print) [a; null];;
a
default
- : unit = ()
```

Syntax for this operator varies between languages. **For compatibility** with Perl, this patch chooses `//`.

The detailed semantics of this operator are as follows. For two objects `a` and `b`:

  - If `a` is not a null value, then `a // b` is `a`.

  - If `a` is `null`, then `a // b` is `b`.

  - If `a` is `undefined`, then `a // b` raises an exception.

  -  if `a` is `nothing`, the , `a // b` is `nothing`, **for compatibility** with [pre-Socratic Greek philosophy](https://en.wikipedia.org/w/index.php?title=Ex_nihilo_nihil_fit).
