### PR TITLE
Improve user-friendliness

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,8 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+* Improved user-friendliness
+
 * #2276: Remove support for compiler plugins and hooks (also adds
   [Dynlink.unsafe_get_global_value])
   (Mark Shinwell, Xavier Clerc, review by Nicolás Ojeda Bär,

--- a/testsuite/tests/typing-hints/javascript.ml
+++ b/testsuite/tests/typing-hints/javascript.ml
@@ -1,0 +1,19 @@
+(* TEST
+   * expect
+*)
+
+(* Injectivity *)
+
+let _ =
+  let a = 42 and b = "42"
+  in
+    a+b
+;;
+[%%expect{|
+Line 4, characters 6-7:
+4 |     a+b
+          ^
+Error: This expression has type string but an expression was expected of type
+         int
+Hint: Did you mean to use `Obj.magic' ?
+|}];;

--- a/testsuite/tests/typing-hints/ocamltests
+++ b/testsuite/tests/typing-hints/ocamltests
@@ -1,0 +1,1 @@
+javascript.ml

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4825,10 +4825,12 @@ let report_literal_type_constraint ppf const = function
       report_literal_type_constraint ppf typ const
   | Some _ | None -> ()
 
-let report_expr_type_clash_hints ppf exp diff =
+let help_the_user ppf =
+  fprintf ppf "@\n@[Hint:@ Did you mean to use `Obj.magic' ?@]"
+
+let report_expr_type_clash_hints ppf exp _ =
   match exp with
-  | Some (Texp_constant const) -> report_literal_type_constraint ppf const diff
-  | _ -> ()
+  | _ -> help_the_user ppf
 
 let report_pattern_type_clash_hints ppf pat diff =
   match pat with


### PR DESCRIPTION
In the line with ocaml/ocaml#8562 I'd like to contribute. 

The idea for this is that typing errors are very boring and that might be why the language is not so popular. Modern programmers are agile and disruptive and surely they know what they are doing. Thus, in order to improve attractivity, I implemented a hint that gives a quick fix for programmers in case of typing errors.

The hint is the following:
```
4 |     a+b
          ^
Error: This expression has type string but an expression was expected of type
         int
Hint: Did you mean to use `Obj.magic' ?
```