### PR TITLE
Bigarray mmap leak

### DIFF
--- a/Changes
+++ b/Changes
@@ -578,6 +578,9 @@ OCaml 4.08.0
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
+- #8568: Fix a memory leak in mmapped bigarrays
+  (Damien Doligez, review by Xavier Leroy and Jérémie Dimino)
+
 ### Tools
 
 - #2182: Split Emacs caml-mode as an independent project.

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -29,7 +29,7 @@ CAMLextern void caml_ba_unmap_file(void * addr, uintnat len);
 static void caml_ba_mapped_finalize(value v)
 {
   struct caml_ba_array * b = Caml_ba_array_val(v);
-  CAMLassert(b->flags & CAML_BA_MANAGED_MASK == CAML_BA_MAPPED_FILE);
+  CAMLassert((b->flags & CAML_BA_MANAGED_MASK) == CAML_BA_MAPPED_FILE);
   if (b->proxy == NULL) {
     caml_ba_unmap_file(b->data, caml_ba_byte_size(b));
   } else {

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -937,7 +937,7 @@ static void caml_ba_update_proxy(struct caml_ba_array * b1,
 CAMLprim value caml_ba_slice(value vb, value vind)
 {
   CAMLparam2 (vb, vind);
-  #define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
+  #define b (Caml_ba_array_val(vb))
   CAMLlocal1 (res);
   intnat index[CAML_BA_MAX_NUM_DIMS];
   int num_inds, i;
@@ -983,7 +983,7 @@ CAMLprim value caml_ba_change_layout(value vb, value vlayout)
 {
   CAMLparam2 (vb, vlayout);
   CAMLlocal1 (res);
-  #define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
+  #define b (Caml_ba_array_val(vb))
   /* if the layout is different, change the flags and reverse the dimensions */
   if (Caml_ba_layout_val(vlayout) != (b->flags & CAML_BA_LAYOUT_MASK)) {
     /* change the flags to reflect the new layout */
@@ -1010,7 +1010,7 @@ CAMLprim value caml_ba_sub(value vb, value vofs, value vlen)
 {
   CAMLparam3 (vb, vofs, vlen);
   CAMLlocal1 (res);
-  #define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
+  #define b (Caml_ba_array_val(vb))
   intnat ofs = Long_val(vofs);
   intnat len = Long_val(vlen);
   int i, changed_dim;
@@ -1190,7 +1190,7 @@ CAMLprim value caml_ba_reshape(value vb, value vdim)
 {
   CAMLparam2 (vb, vdim);
   CAMLlocal1 (res);
-#define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
+#define b (Caml_ba_array_val(vb))
   intnat dim[CAML_BA_MAX_NUM_DIMS];
   mlsize_t num_dims;
   uintnat num_elts;

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -162,6 +162,7 @@ CAMLexport void caml_ba_finalize(value v)
     break;
   case CAML_BA_MAPPED_FILE:
     /* Bigarrays for mapped files use a different finalization method */
+    /* fallthrough */
   default:
     CAMLassert(0);
   }

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -969,6 +969,8 @@ CAMLprim value caml_ba_slice(value vb, value vind)
     offset * caml_ba_element_size[b->flags & CAML_BA_KIND_MASK];
   /* Allocate an OCaml bigarray to hold the result */
   res = caml_ba_alloc(b->flags, b->num_dims - num_inds, sub_data, sub_dims);
+  /* Copy the finalization function from the original array (PR#8568) */
+  Custom_ops_val(res) = Custom_ops_val(vb);
   /* Create or update proxy in case of managed bigarray */
   caml_ba_update_proxy(b, Caml_ba_array_val(res));
   /* Return result */
@@ -994,6 +996,8 @@ CAMLprim value caml_ba_change_layout(value vb, value vlayout)
     unsigned int i;
     for(i = 0; i < b->num_dims; i++) new_dim[i] = b->dim[b->num_dims - i - 1];
     res = caml_ba_alloc(flags, b->num_dims, b->data, new_dim);
+    /* Copy the finalization function from the original array (PR#8568) */
+    Custom_ops_val(res) = Custom_ops_val(vb);
     caml_ba_update_proxy(b, Caml_ba_array_val(res));
     CAMLreturn(res);
   } else {
@@ -1037,6 +1041,8 @@ CAMLprim value caml_ba_sub(value vb, value vofs, value vlen)
     ofs * mul * caml_ba_element_size[b->flags & CAML_BA_KIND_MASK];
   /* Allocate an OCaml bigarray to hold the result */
   res = caml_ba_alloc(b->flags, b->num_dims, sub_data, b->dim);
+  /* Copy the finalization function from the original array (PR#8568) */
+  Custom_ops_val(res) = Custom_ops_val(vb);
   /* Doctor the changed dimension */
   Caml_ba_array_val(res)->dim[changed_dim] = len;
   /* Create or update proxy in case of managed bigarray */
@@ -1212,6 +1218,8 @@ CAMLprim value caml_ba_reshape(value vb, value vdim)
     caml_invalid_argument("Bigarray.reshape: size mismatch");
   /* Create bigarray with same data and new dimensions */
   res = caml_ba_alloc(b->flags, num_dims, b->data, dim);
+  /* Copy the finalization function from the original array (PR#8568) */
+  Custom_ops_val(res) = Custom_ops_val(vb);
   /* Create or update proxy in case of managed bigarray */
   caml_ba_update_proxy(b, Caml_ba_array_val(res));
   /* Return result */


### PR DESCRIPTION
When a  bigarray is allocated with `Unix.mmap_file` then passed to `slice`, `change_layout`, `reshape` or `sub`, a new bigarray is allocated that shares the data. But this allocation is done in `bigarray.c` with the normal allocation function, using the same flags as the original array, in particular the `CAML_BA_MAPPED_FILE` flag. The normal allocation function sets the finalization function to `caml_ba_finalize`, which doesn't expect a mapped bigarray, and in this case does nothing (in normal mode) or asserts false (in debug mode).

This results in a leak of memory (the proxy block) and address space (the mmapped file) and possibly other system resources.

The solution is to copy the `custom_ops` pointer from the original array, ensuring that the proper finalization function is called.

I tried to come up with a test but the leak is quite slow on 64-bit machines so I couldn't get a clean crash.
