### PR TITLE
arm64.S: use 32-bit loads to access caml_backtrace_active

### DIFF
--- a/Changes
+++ b/Changes
@@ -581,6 +581,9 @@ OCaml 4.08.0
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
+- #8567, #8569: on ARM64, use 32-bit loads to access caml_backtrace_active
+  (Xavier Leroy, review by Mark Shinwell and Greta Yorsh)
+
 ### Tools
 
 - #2182: Split Emacs caml-mode as an independent project.

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -59,6 +59,10 @@
         ADDRGLOBAL(TMP2,symb); \
         str     reg, [TMP2]
 
+#define LOADGLOBAL32(reg,symb) \
+        ADDRGLOBAL(TMP2,symb); \
+        ldrsw   reg, [TMP2]
+
 #else
 
 #define ADDRGLOBAL(reg,symb) \
@@ -72,6 +76,10 @@
 #define STOREGLOBAL(reg,symb) \
         adrp    TMP2, symb; \
         str     reg, [TMP2, #:lo12:symb]
+
+#define LOADGLOBAL32(reg,symb) \
+        adrp    TMP2, symb; \
+        ldrsw   reg, [TMP2, #:lo12:symb]
 
 #endif
 
@@ -416,7 +424,7 @@ caml_start_program:
 caml_raise_exn:
         CFI_STARTPROC
     /* Test if backtrace is active */
-        LOADGLOBAL(TMP, caml_backtrace_active)
+        LOADGLOBAL32(TMP, caml_backtrace_active)
         cbnz     TMP, 2f
 1:  /* Cut stack at current trap handler */
         mov     sp, TRAP_PTR
@@ -450,7 +458,7 @@ caml_raise_exception:
         LOADGLOBAL(ALLOC_PTR, caml_young_ptr)
         LOADGLOBAL(ALLOC_LIMIT, caml_young_limit)
     /* Test if backtrace is active */
-        LOADGLOBAL(TMP, caml_backtrace_active)
+        LOADGLOBAL32(TMP, caml_backtrace_active)
         cbnz    TMP, 2f
 1:  /* Cut stack at current trap handler */
         mov     sp, TRAP_PTR


### PR DESCRIPTION
`caml_backtrace_active` is declared with type `int32_t`, so it is
incorrect to access it with a 64-bit `ldr` instruction.
Either a link-time error occurs, as in issue #8567,
or the wrong value may be loaded.

This commit uses ~~`ldrsh`~~ `ldrsw` instructions (32-bit signed loads) to
access `caml_backtrace_active`.
