### PR TITLE
Fix #7851 by checking type declaration coherence for recursive modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -1077,7 +1077,7 @@ OCaml 4.08.0
 
 - #7851: Module type of allows to transform a malformed module type into
   a vicious signature, breaking soundness
-  (Jacques Garrigue, review by ...)
+  (Jacques Garrigue, review by Leo White)
 
 - #7923, #2259: fix regression in FlexDLL bootstrapped build caused by
   refactoring the root Makefile for Dune in #2093)

--- a/Changes
+++ b/Changes
@@ -1075,6 +1075,10 @@ OCaml 4.08.0
 - #2231: Env: always freshen persistent signatures before using them
   (Thomas Refis and Leo White, review by Gabriel Radanne)
 
+- #7851: Module type of allows to transform a malformed module type into
+  a vicious signature, breaking soundness
+  (Jacques Garrigue, review by ...)
+
 - #7923, #2259: fix regression in FlexDLL bootstrapped build caused by
   refactoring the root Makefile for Dune in #2093)
   (David Allsopp, report by Marc Lasson)

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -13,6 +13,7 @@ pr7348.ml
 pr7726.ml
 pr7787.ml
 pr7818.ml
+pr7851.ml
 printing.ml
 recursive.ml
 Test.ml

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -311,10 +311,9 @@ module type S' =
   end
 module Asc : sig type t = int val compare : int -> int -> int end
 module Desc : sig type t = int val compare : int -> int -> int end
-module rec M1 :
-  sig
-    type t = M.t = E of (MkT(Desc).t, MkT(Desc).t) eq
-    type u = t = E of (MkT(Asc).t, MkT(Desc).t) eq
-  end
-val eq : (MkT(Asc).t, MkT(Desc).t) eq = Eq
+Line 15, characters 16-64:
+15 | module rec M1 : S' with module Term0 := Asc and module T := Desc = M1;;
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type M.t
+       The types for field E are not equal.
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -4,12 +4,10 @@
 
 (* Leo's version *)
 module F(X : sig type t end) = struct
-  module type S = sig
-    type x = X.t
-    type y = X.t
-    type t = E of x
-    type u = t = E of y
-  end
+  type x = X.t
+  type y = X.t
+  type t = E of x
+  type u = t = E of y
 end;;
 
 module M = F(struct type t end);;
@@ -18,12 +16,9 @@ module type S = module type of M;;
 [%%expect{|
 module F :
   functor (X : sig type t end) ->
-    sig
-      module type S =
-        sig type x = X.t type y = X.t type t = E of x type u = t = E of y end
-    end
-module M : sig module type S end
-module type S = sig module type S end
+    sig type x = X.t type y = X.t type t = E of x type u = t = E of y end
+module M : sig type x type y type t = E of x type u = t = E of y end
+module type S = sig type x type y type t = E of x type u = t = E of y end
 |}]
 
 module rec M1 : S with type x = int and type y = bool = M1;;
@@ -31,7 +26,8 @@ module rec M1 : S with type x = int and type y = bool = M1;;
 Line 1, characters 16-53:
 1 | module rec M1 : S with type x = int and type y = bool = M1;;
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The signature constrained by `with' has no component named x
+Error: This variant or record definition does not match that of type M1.t
+       The types for field E are not equal.
 |}]
 
 let bool_of_int x =

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -1,0 +1,83 @@
+(* TEST
+   * expect
+*)
+
+(* Leo's version *)
+module F(X : sig type t end) = struct
+  module type S = sig
+    type x = X.t
+    type y = X.t
+    type t = E of x
+    type u = t = E of y
+  end
+end;;
+
+module M = F(struct type t end);;
+
+module type S = module type of M;;
+[%%expect{|
+module F :
+  functor (X : sig type t end) ->
+    sig
+      module type S =
+        sig type x = X.t type y = X.t type t = E of x type u = t = E of y end
+    end
+module M : sig module type S end
+module type S = sig module type S end
+|}]
+
+module rec M1 : S with type x = int and type y = bool = M1;;
+[%%expect{|
+Line 1, characters 16-53:
+1 | module rec M1 : S with type x = int and type y = bool = M1;;
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The signature constrained by `with' has no component named x
+|}]
+
+let bool_of_int x =
+  let (E y : M1.u) = (E x : M1.t) in
+  y;;
+
+bool_of_int 3;;
+[%%expect{|
+Line 2, characters 28-32:
+2 |   let (E y : M1.u) = (E x : M1.t) in
+                                ^^^^
+Error: Unbound module M1
+|}]
+
+(* Also check the original version *)
+type (_,_) eq = Eq : ('a,'a) eq
+module F(X : Set.OrderedType) = struct
+type x = Set.Make(X).t and y = Set.Make(X).t
+type t = E of (x,x) eq
+type u = t = E of (x,y) eq
+end;;
+module M = F(struct type t let compare = compare end);;
+module type S = module type of M;;
+[%%expect{|
+type (_, _) eq = Eq : ('a, 'a) eq
+module F :
+  functor (X : Set.OrderedType) ->
+    sig
+      type x = Set.Make(X).t
+      and y = Set.Make(X).t
+      type t = E of (x, x) eq
+      type u = t = E of (x, y) eq
+    end
+module M :
+  sig type x and y type t = E of (x, x) eq type u = t = E of (x, y) eq end
+module type S =
+  sig type x and y type t = E of (x, x) eq type u = t = E of (x, y) eq end
+|}]
+module rec M1 : S with type x = int and type y = bool = M1;;
+let (E eq : M1.u) = (E Eq : M1.t);;
+let cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x;;
+cast eq 3;;
+[%%expect{|
+Line 1, characters 16-53:
+1 | module rec M1 : S with type x = int and type y = bool = M1;;
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type M1.t
+       The types for field E are not equal.
+|}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -249,7 +249,7 @@ and compare_records ~loc env params1 params2 n
           Some (Field_type ld1.ld_id)
       end
 
-let type_declarations ?(equality = false) ~loc env ~mark name decl1 id decl2 =
+let type_declarations ?(equality = false) ~loc env ~mark name decl1 path decl2 =
   Builtin_attributes.check_alerts_inclusion
     ~def:decl1.type_loc
     ~use:decl2.type_loc
@@ -268,7 +268,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name decl1 id decl2 =
         then None else Some Manifest
     | (None, Some ty2) ->
         let ty1 =
-          Btype.newgenty (Tconstr(Pident id, decl2.type_params, ref Mnil))
+          Btype.newgenty (Tconstr(path, decl2.type_params, ref Mnil))
         in
         if Ctype.equal env true decl1.type_params decl2.type_params then
           if Ctype.equal env false [ty1] [ty2] then None
@@ -301,7 +301,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name decl1 id decl2 =
             then Env.Positive else Env.Privatize
           in
           mark cstrs1 usage name decl1;
-          if equality then mark cstrs2 Env.Positive (Ident.name id) decl2
+          if equality then mark cstrs2 Env.Positive (Path.name path) decl2
         end;
         compare_variants ~loc env decl1.type_params
           decl2.type_params 1 cstrs1 cstrs2

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -44,7 +44,7 @@ val type_declarations:
   ?equality:bool ->
   loc:Location.t ->
   Env.t -> mark:bool -> string ->
-  type_declaration -> Ident.t -> type_declaration -> type_mismatch option
+  type_declaration -> Path.t -> type_declaration -> type_mismatch option
 
 val extension_constructors:
   loc:Location.t -> Env.t -> mark:bool -> Ident.t ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -87,7 +87,7 @@ let type_declarations ~loc env ~mark ?old_env:_ cxt subst id decl1 decl2 =
   let decl2 = Subst.type_declaration subst decl2 in
   match
     Includecore.type_declarations ~loc env ~mark
-      (Ident.name id) decl1 id decl2
+      (Ident.name id) decl1 (Path.Pident id) decl2
   with
   | None -> ()
   | Some err ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -641,7 +641,7 @@ let check_constraints env sdecl (_, decl) =
    need to check that the equation refers to a type of the same kind
    with the same constructors and labels.
 *)
-let check_coherence env loc id decl =
+let check_coherence env loc dpath decl =
   match decl with
     { type_kind = (Type_variant _ | Type_record _| Type_open);
       type_manifest = Some ty } ->
@@ -659,9 +659,9 @@ let check_coherence env loc id decl =
                   ~mark:true
                   (Path.last path)
                   decl'
-                  id
+                  dpath
                   (Subst.type_declaration
-                     (Subst.add_type id path Subst.identity) decl)
+                     (Subst.add_type_path dpath path Subst.identity) decl)
             in
             if err <> None then
               raise(Error(loc, Definition_mismatch (ty, err)))
@@ -673,7 +673,7 @@ let check_coherence env loc id decl =
   | _ -> ()
 
 let check_abbrev env sdecl (id, decl) =
-  check_coherence env sdecl.ptype_loc id decl
+  check_coherence env sdecl.ptype_loc (Path.Pident id) decl
 
 (* Check that recursion is well-founded *)
 
@@ -1564,7 +1564,10 @@ let check_recmod_typedecl env loc recmod_ids path decl =
      (path, decl) is the type declaration to be checked. *)
   let to_check path = Path.exists_free recmod_ids path in
   check_well_founded_decl env loc path decl to_check;
-  check_recursion env loc path decl to_check
+  check_recursion env loc path decl to_check;
+  (* additionally check coherece, as one might build an incoherent signature,
+     and use it to build an incoherent module, cf. #7851 *)
+  check_coherence env loc path decl
 
 
 (**** Error report ****)

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -49,7 +49,7 @@ val approx_type_decl:
 val check_recmod_typedecl:
     Env.t -> Location.t -> Ident.t list -> Path.t -> type_declaration -> unit
 val check_coherence:
-    Env.t -> Location.t -> Ident.t -> type_declaration -> unit
+    Env.t -> Location.t -> Path.t -> type_declaration -> unit
 
 (* for fixed types *)
 val is_fixed_type : Parsetree.type_declaration -> bool

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -257,7 +257,7 @@ let check_type_decl env loc id row_id newdecl decl rs rem =
   in
   let env = if rs = Trec_not then env else add_rec_types env rem in
   Includemod.type_declarations ~loc env id newdecl decl;
-  Typedecl.check_coherence env loc id newdecl
+  Typedecl.check_coherence env loc (Path.Pident id) newdecl
 
 let update_rec_next rs rem =
   match rs with


### PR DESCRIPTION
I suppose that a really robust solution to #7851 would be to fully check the wellformedness of signatures, but in the mid-time a simpler solution is to check the coherence of type declarations for recursive modules.
This can be done by adding one line to `Typedecl.check_recmod_typedecl` (and also having a few related functions take a path rather than and ident).

I mark this as _consider for release_, but it is probably not as urgent as #8552; as explained in #7851, this is a very old bug, and triggering it is not so easy. Yet, if we could have it in 4.08 this would be one soundness bug less!

Since the change is a bit light-headed, it would be a good idea to test this on a large code base with many recursive modules, if this happens to exist.