### PR TITLE
Harden ocamltest

### DIFF
--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -1,22 +1,21 @@
 run_unix.$(O): run_unix.c run.h ../runtime/caml/misc.h \
- ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
- run_common.h
+  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+  run_common.h
 run_stubs.$(O): run_stubs.c run.h ../runtime/caml/misc.h \
- ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
- ../runtime/caml/mlvalues.h ../runtime/caml/misc.h \
- ../runtime/caml/memory.h ../runtime/caml/gc.h ../runtime/caml/mlvalues.h \
- ../runtime/caml/major_gc.h ../runtime/caml/freelist.h \
- ../runtime/caml/minor_gc.h ../runtime/caml/address_class.h \
- ../runtime/caml/io.h ../runtime/caml/osdeps.h ../runtime/caml/memory.h
+  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+  ../runtime/caml/mlvalues.h ../runtime/caml/memory.h \
+  ../runtime/caml/gc.h ../runtime/caml/major_gc.h \
+  ../runtime/caml/freelist.h ../runtime/caml/minor_gc.h \
+  ../runtime/caml/address_class.h ../runtime/caml/io.h \
+  ../runtime/caml/osdeps.h
 ocamltest_stdlib_stubs.$(O): ocamltest_stdlib_stubs.c \
- ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
- ../runtime/caml/mlvalues.h ../runtime/caml/config.h \
- ../runtime/caml/misc.h ../runtime/caml/memory.h ../runtime/caml/gc.h \
- ../runtime/caml/mlvalues.h ../runtime/caml/major_gc.h \
- ../runtime/caml/freelist.h ../runtime/caml/minor_gc.h \
- ../runtime/caml/address_class.h ../runtime/caml/alloc.h \
- ../runtime/caml/signals.h ../runtime/caml/osdeps.h \
- ../runtime/caml/memory.h
+  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+  ../runtime/caml/mlvalues.h ../runtime/caml/misc.h \
+  ../runtime/caml/memory.h ../runtime/caml/gc.h \
+  ../runtime/caml/major_gc.h ../runtime/caml/freelist.h \
+  ../runtime/caml/minor_gc.h ../runtime/caml/address_class.h \
+  ../runtime/caml/alloc.h ../runtime/caml/signals.h \
+  ../runtime/caml/osdeps.h
 actions.cmo : \
     result.cmi \
     environments.cmi \
@@ -83,10 +82,12 @@ builtin_variables.cmi : \
     variables.cmi
 environments.cmo : \
     variables.cmi \
+    tsl_lexer.cmi \
     ocamltest_stdlib.cmi \
     environments.cmi
 environments.cmx : \
     variables.cmx \
+    tsl_lexer.cmx \
     ocamltest_stdlib.cmx \
     environments.cmi
 environments.cmi : \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -96,13 +96,13 @@ core := \
   run_command.mli run_command.ml \
   filecompare.mli filecompare.ml \
   variables.mli variables.ml \
-  environments.mli environments.ml \
   result.mli result.ml \
   actions.mli actions.ml \
   tests.mli tests.ml \
   tsl_ast.mli tsl_ast.ml \
   tsl_parser.mly \
   tsl_lexer.mli tsl_lexer.mll \
+  environments.mli environments.ml \
   tsl_semantics.mli tsl_semantics.ml \
   builtin_variables.mli builtin_variables.ml \
   actions_helpers.mli actions_helpers.ml \

--- a/ocamltest/tsl_lexer.mli
+++ b/ocamltest/tsl_lexer.mli
@@ -16,3 +16,5 @@
 (* Interface to the Tsl_lexer module *)
 
 val token : Lexing.lexbuf -> Tsl_parser.token
+val modifier :
+    Lexing.lexbuf -> string * [`Remove | `Add of string | `Append of string]

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -13,7 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Lexer definitions for the Tests Specification Language *)
+(* Lexer definitions for the Tests Specification Language and for
+   response files *)
 
 {
 open Tsl_parser
@@ -114,3 +115,14 @@ and comment = parse
     {
       comment lexbuf
     }
+
+(* Parse one line of a response file (for scripts and hooks) *)
+and modifier = parse
+  | '-' (identchar* as variable)
+    { variable, `Remove }
+  | (identchar* as variable) "=\"" (_* as str) '"'
+    { variable, `Add str }
+  | (identchar* as variable) "+=\"" (_* as str) '"'
+    { variable, `Append str }
+  | _
+    { failwith "syntax error in script response file" }

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -87,7 +87,7 @@ default:
 all:
 	@rm -f $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) legacy-without-report
-	@$(MAKE) $(NO_PRINT) new-without-report
+	-@$(MAKE) $(NO_PRINT) new-without-report
 	@$(MAKE) $(NO_PRINT) report
 
 .PHONY: legacy


### PR DESCRIPTION
Three problems here:
1. When a script or hook writes an incorrect response file, `ocamltest` fails with an uncaught exception.
2. When a `+` character appears in the value of a variable, the parsing of the script response file fails.
3. When `ocamltest` fails, we get a `make` error and the report is not produced.

The first two are fixed by using an `ocamllex` parser and catching the syntax error. The error is reported as a test failure with an appropriate error message.

The third is fixed by the second commit (in `testsuite/Makefile` ignore ocamltest errors if the report is going to run, the tool will report them as unexpected errors). This one will help us track down the mysterious random errors we are getting on Inria's CI.
