### PR TITLE
make alldepend

### DIFF
--- a/.depend
+++ b/.depend
@@ -5479,6 +5479,30 @@ asmcomp/debug/reg_with_debug_info.cmx : \
 asmcomp/debug/reg_with_debug_info.cmi : \
     asmcomp/reg.cmi \
     middle_end/backend_var.cmi
+driver/compdynlink.cmi :
+driver/compdynlink_common.cmo : \
+    driver/compdynlink_types.cmi \
+    driver/compdynlink_platform_intf.cmi \
+    driver/compdynlink_common.cmi
+driver/compdynlink_common.cmx : \
+    driver/compdynlink_types.cmx \
+    driver/compdynlink_platform_intf.cmx \
+    driver/compdynlink_common.cmi
+driver/compdynlink_common.cmi : \
+    driver/compdynlink_platform_intf.cmi
+driver/compdynlink_platform_intf.cmo : \
+    driver/compdynlink_types.cmi \
+    driver/compdynlink_platform_intf.cmi
+driver/compdynlink_platform_intf.cmx : \
+    driver/compdynlink_types.cmx \
+    driver/compdynlink_platform_intf.cmi
+driver/compdynlink_platform_intf.cmi : \
+    driver/compdynlink_types.cmi
+driver/compdynlink_types.cmo : \
+    driver/compdynlink_types.cmi
+driver/compdynlink_types.cmx : \
+    driver/compdynlink_types.cmi
+driver/compdynlink_types.cmi :
 driver/compenv.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \


### PR DESCRIPTION
If I try to `make world` on trunk right now:
```
File ".../otherlibs/dynlink/otherlibs/dynlink/dynlink_platform_intf.ml", line 44, characters 23-45:
Error: Unbound module Dynlink_types
```