### PR TITLE
Add Asm_section, Asm_symbol, Target_system, etc.

### DIFF
--- a/.depend
+++ b/.depend
@@ -1911,10 +1911,12 @@ asmcomp/afl_instrument.cmi : \
     asmcomp/cmm.cmi
 asmcomp/arch.cmo : \
     utils/config.cmi \
-    utils/clflags.cmi
+    utils/clflags.cmi \
+    asmcomp/backend_sym.cmi
 asmcomp/arch.cmx : \
     utils/config.cmx \
-    utils/clflags.cmx
+    utils/clflags.cmx \
+    asmcomp/backend_sym.cmx
 asmcomp/asmgen.cmo : \
     middle_end/flambda/un_anf.cmi \
     lambda/translmod.cmi \
@@ -1951,6 +1953,7 @@ asmcomp/asmgen.cmo : \
     asmcomp/deadcode.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
+    middle_end/compilation_unit.cmi \
     asmcomp/comballoc.cmi \
     asmcomp/coloring.cmi \
     asmcomp/cmmgen.cmi \
@@ -1960,6 +1963,7 @@ asmcomp/asmgen.cmo : \
     middle_end/clambda.cmi \
     asmcomp/CSE.cmo \
     middle_end/flambda/build_export_info.cmi \
+    asmcomp/backend_compilation_unit.cmi \
     asmcomp/debug/available_regs.cmi \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmx : \
@@ -1998,6 +2002,7 @@ asmcomp/asmgen.cmx : \
     asmcomp/deadcode.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \
+    middle_end/compilation_unit.cmx \
     asmcomp/comballoc.cmx \
     asmcomp/coloring.cmx \
     asmcomp/cmmgen.cmx \
@@ -2007,6 +2012,7 @@ asmcomp/asmgen.cmx : \
     middle_end/clambda.cmx \
     asmcomp/CSE.cmx \
     middle_end/flambda/build_export_info.cmx \
+    asmcomp/backend_compilation_unit.cmx \
     asmcomp/debug/available_regs.cmx \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : \
@@ -2058,6 +2064,7 @@ asmcomp/asmlink.cmo : \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi \
+    asmcomp/backend_compilation_unit.cmi \
     asmcomp/asmgen.cmi \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : \
@@ -2076,6 +2083,7 @@ asmcomp/asmlink.cmx : \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     utils/ccomp.cmx \
+    asmcomp/backend_compilation_unit.cmx \
     asmcomp/asmgen.cmx \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmi : \
@@ -2128,6 +2136,30 @@ asmcomp/asmpackager.cmx : \
 asmcomp/asmpackager.cmi : \
     typing/env.cmi \
     middle_end/backend_intf.cmi
+asmcomp/backend_compilation_unit.cmo : \
+    utils/identifiable.cmi \
+    middle_end/compilation_unit.cmi \
+    asmcomp/backend_compilation_unit.cmi
+asmcomp/backend_compilation_unit.cmx : \
+    utils/identifiable.cmx \
+    middle_end/compilation_unit.cmx \
+    asmcomp/backend_compilation_unit.cmi
+asmcomp/backend_compilation_unit.cmi : \
+    utils/identifiable.cmi \
+    middle_end/compilation_unit.cmi
+asmcomp/backend_sym.cmo : \
+    asmcomp/object_file.cmi \
+    utils/misc.cmi \
+    middle_end/compilenv.cmi \
+    asmcomp/backend_sym.cmi
+asmcomp/backend_sym.cmx : \
+    asmcomp/object_file.cmx \
+    utils/misc.cmx \
+    middle_end/compilenv.cmx \
+    asmcomp/backend_sym.cmi
+asmcomp/backend_sym.cmi : \
+    utils/misc.cmi \
+    asmcomp/backend_compilation_unit.cmi
 asmcomp/branch_relaxation.cmo : \
     utils/misc.cmi \
     asmcomp/mach.cmi \
@@ -2292,16 +2324,19 @@ asmcomp/emit.cmo : \
     asmcomp/x86_ast.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
+    asmcomp/object_file.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/linearize.cmi \
     asmcomp/emitaux.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
-    middle_end/compilenv.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     asmcomp/branch_relaxation.cmi \
+    asmcomp/backend_sym.cmi \
+    asmcomp/asm_target/asm_symbol.cmi \
+    asmcomp/asm_target/asm_section.cmi \
     asmcomp/arch.cmo \
     asmcomp/emit.cmi
 asmcomp/emit.cmx : \
@@ -2312,26 +2347,31 @@ asmcomp/emit.cmx : \
     asmcomp/x86_ast.cmi \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
+    asmcomp/object_file.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/linearize.cmx \
     asmcomp/emitaux.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
-    middle_end/compilenv.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     asmcomp/branch_relaxation.cmx \
+    asmcomp/backend_sym.cmx \
+    asmcomp/asm_target/asm_symbol.cmx \
+    asmcomp/asm_target/asm_section.cmx \
     asmcomp/arch.cmx \
     asmcomp/emit.cmi
 asmcomp/emit.cmi : \
     asmcomp/linearize.cmi \
-    asmcomp/cmm.cmi
+    asmcomp/cmm.cmi \
+    asmcomp/backend_compilation_unit.cmi
 asmcomp/emitaux.cmo : \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
+    asmcomp/asm_target/asm_symbol.cmi \
     asmcomp/arch.cmo \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
@@ -2339,10 +2379,12 @@ asmcomp/emitaux.cmx : \
     utils/config.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
+    asmcomp/asm_target/asm_symbol.cmx \
     asmcomp/arch.cmx \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmi : \
-    lambda/debuginfo.cmi
+    lambda/debuginfo.cmi \
+    asmcomp/asm_target/asm_symbol.cmi
 asmcomp/interf.cmo : \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
@@ -2449,6 +2491,14 @@ asmcomp/mach.cmi : \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \
     asmcomp/arch.cmo
+asmcomp/object_file.cmo : \
+    utils/identifiable.cmi \
+    asmcomp/object_file.cmi
+asmcomp/object_file.cmx : \
+    utils/identifiable.cmx \
+    asmcomp/object_file.cmi
+asmcomp/object_file.cmi : \
+    utils/identifiable.cmi
 asmcomp/printcmm.cmo : \
     utils/targetint.cmi \
     lambda/lambda.cmi \
@@ -2652,6 +2702,7 @@ asmcomp/selection.cmo : \
     utils/config.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
+    asmcomp/backend_sym.cmi \
     asmcomp/arch.cmo \
     asmcomp/selection.cmi
 asmcomp/selection.cmx : \
@@ -2662,6 +2713,7 @@ asmcomp/selection.cmx : \
     utils/config.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
+    asmcomp/backend_sym.cmx \
     asmcomp/arch.cmx \
     asmcomp/selection.cmi
 asmcomp/selection.cmi : \
@@ -2747,6 +2799,17 @@ asmcomp/strmatch.cmi : \
     parsing/location.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi
+asmcomp/target_system.cmo : \
+    utils/targetint.cmi \
+    utils/misc.cmi \
+    utils/config.cmi \
+    asmcomp/target_system.cmi
+asmcomp/target_system.cmx : \
+    utils/targetint.cmx \
+    utils/misc.cmx \
+    utils/config.cmx \
+    asmcomp/target_system.cmi
+asmcomp/target_system.cmi :
 asmcomp/x86_ast.cmi :
 asmcomp/x86_dsl.cmo : \
     asmcomp/x86_proc.cmi \
@@ -5479,6 +5542,39 @@ asmcomp/debug/reg_with_debug_info.cmx : \
 asmcomp/debug/reg_with_debug_info.cmi : \
     asmcomp/reg.cmi \
     middle_end/backend_var.cmi
+asmcomp/asm_target/asm_section.cmo : \
+    asmcomp/target_system.cmi \
+    utils/misc.cmi \
+    utils/identifiable.cmi \
+    asmcomp/asm_target/asm_section.cmi
+asmcomp/asm_target/asm_section.cmx : \
+    asmcomp/target_system.cmx \
+    utils/misc.cmx \
+    utils/identifiable.cmx \
+    asmcomp/asm_target/asm_section.cmi
+asmcomp/asm_target/asm_section.cmi : \
+    utils/identifiable.cmi
+asmcomp/asm_target/asm_symbol.cmo : \
+    asmcomp/target_system.cmi \
+    asmcomp/object_file.cmi \
+    utils/misc.cmi \
+    utils/identifiable.cmi \
+    asmcomp/backend_sym.cmi \
+    asmcomp/asm_target/asm_section.cmi \
+    asmcomp/asm_target/asm_symbol.cmi
+asmcomp/asm_target/asm_symbol.cmx : \
+    asmcomp/target_system.cmx \
+    asmcomp/object_file.cmx \
+    utils/misc.cmx \
+    utils/identifiable.cmx \
+    asmcomp/backend_sym.cmx \
+    asmcomp/asm_target/asm_section.cmx \
+    asmcomp/asm_target/asm_symbol.cmi
+asmcomp/asm_target/asm_symbol.cmi : \
+    asmcomp/object_file.cmi \
+    utils/identifiable.cmi \
+    asmcomp/backend_sym.cmi \
+    asmcomp/asm_target/asm_section.cmi
 driver/compenv.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \

--- a/Changes
+++ b/Changes
@@ -131,6 +131,10 @@ Working version
 - #7878, #8542: Replaced TypedtreeIter with tast_iterator
   (Isaac "Izzy" Avram, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #8581: Add Asm_section, Asm_symbol, Target_system, Backend_compilation_unit
+  and placeholder version of Backend_sym
+  (Mark Shinwell)
+
 - #8598: Replace "not is_nonexpansive" by "maybe_expansive".
   (Thomas Refis, review by David Allsopp, Florian Angeletti, Gabriel Radanne,
    Gabriel Scherer and Xavier Leroy)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ARCHES=amd64 i386 arm arm64 power s390x
 INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
         -I lambda -I middle_end -I middle_end/closure \
         -I middle_end/flambda -I middle_end/flambda/base_types \
-        -I asmcomp -I asmcomp/debug \
+        -I asmcomp -I asmcomp/asm_target -I asmcomp/debug \
         -I driver -I toplevel
 
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
@@ -152,6 +152,12 @@ ARCH_SPECIFIC_ASMCOMP=$(INTEL_ASM)
 endif
 
 ASMCOMP=\
+  asmcomp/object_file.cmo \
+  asmcomp/backend_compilation_unit.cmo \
+  asmcomp/backend_sym.cmo \
+  asmcomp/target_system.cmo \
+  asmcomp/asm_target/asm_section.cmo \
+  asmcomp/asm_target/asm_symbol.cmo \
   $(ARCH_SPECIFIC_ASMCOMP) \
   asmcomp/arch.cmo \
   asmcomp/cmm.cmo asmcomp/printcmm.cmo \
@@ -646,6 +652,9 @@ endif
 	$(INSTALL_DATA) \
 	    asmcomp/*.cmi \
 	    "$(INSTALL_COMPLIBDIR)"
+	$(INSTALL_DATA) \
+	    asmcomp/asm_target/*.cmi \
+	    "$(INSTALL_COMPLIBDIR)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	    middle_end/*.cmt middle_end/*.cmti \
@@ -667,6 +676,10 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	    asmcomp/*.cmt asmcomp/*.cmti \
 	    asmcomp/*.mli \
+	    "$(INSTALL_COMPLIBDIR)"
+	$(INSTALL_DATA) \
+	    asmcomp/asm_target/*.cmt asmcomp/asm_target/*.cmti \
+	    asmcomp/asm_target/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
 endif
 	$(INSTALL_DATA) \
@@ -707,7 +720,7 @@ installoptopt:
 	$(INSTALL_DATA) \
 	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
 	   file_formats/*.cmx \
-	   lambda/*.cmx \
+	   lambda/*.cmx asmcomp/asm_target/*.cmx asmcomp/debug/*.cmx \
 	   driver/*.cmx asmcomp/*.cmx middle_end/*.cmx \
            middle_end/closure/*.cmx \
            middle_end/flambda/*.cmx \
@@ -1310,7 +1323,7 @@ partialclean::
 partialclean::
 	for d in utils parsing typing bytecomp asmcomp middle_end file_formats \
            lambda middle_end/closure middle_end/flambda \
-           middle_end/flambda/base_types asmcomp/debug \
+           middle_end/flambda/base_types asmcomp/debug asmcomp/asm_target \
            driver toplevel tools; do \
 	  rm -f $$d/*.cm[ioxt] $$d/*.cmti $$d/*.annot $$d/*.$(S) \
 	    $$d/*.$(O) $$d/*.$(SO); \
@@ -1320,7 +1333,7 @@ partialclean::
 depend: beforedepend
 	(for d in utils parsing typing bytecomp asmcomp middle_end \
          lambda file_formats middle_end/closure middle_end/flambda \
-         middle_end/flambda/base_types asmcomp/debug \
+         middle_end/flambda/base_types asmcomp/debug asmcomp/asm_target \
          driver toplevel; \
          do $(CAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) $$d/*.mli $$d/*.ml || exit; \
          done) > .depend

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -26,7 +26,7 @@ let command_line_options =
 open Format
 
 type addressing_mode =
-    Ibased of string * int              (* symbol + displ *)
+    Ibased of Backend_sym.t * int       (* symbol + displ *)
   | Iindexed of int                     (* reg + displ *)
   | Iindexed2 of int                    (* reg + reg + displ *)
   | Iscaled of int * int                (* reg * scale + displ *)
@@ -87,9 +87,9 @@ let num_args_addressing = function
 let print_addressing printreg addr ppf arg =
   match addr with
   | Ibased(s, 0) ->
-      fprintf ppf "\"%s\"" s
+      fprintf ppf "\"%a\"" Backend_sym.print s
   | Ibased(s, n) ->
-      fprintf ppf "\"%s\" + %i" s n
+      fprintf ppf "\"%a\" + %i" Backend_sym.print s n
   | Iindexed n ->
       let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
       fprintf ppf "%a%s" printreg arg.(0) idx

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -27,7 +27,10 @@ open Emitaux
 open X86_ast
 open X86_proc
 open X86_dsl
-module String = Misc.Stdlib.String
+
+module AS = Asm_section
+module S = Asm_symbol
+open Asm_symbol.Names
 
 (* [Branch_relaxation] is not used in this file, but is required by
    emit.mlp files for certain other targets; the reference here ensures
@@ -94,28 +97,37 @@ let slot_offset loc cl =
 
 (* Symbols *)
 
-let symbol_prefix = if system = S_macosx then "_" else ""
-
-let emit_symbol s = string_of_symbol symbol_prefix s
+let emit_symbol ?reloc s = Asm_symbol.to_escaped_string ?reloc s
 
 (* Record symbols used and defined - at the end generate extern for those
    used but not defined *)
 
-let symbols_defined = ref String.Set.empty
-let symbols_used = ref String.Set.empty
+let symbols_defined = ref S.Set.empty
+let symbols_used = ref S.Set.empty
 
-let add_def_symbol s = symbols_defined := String.Set.add s !symbols_defined
-let add_used_symbol s = symbols_used := String.Set.add s !symbols_used
+let add_def_symbol s = symbols_defined := S.Set.add s !symbols_defined
+let add_used_symbol s = symbols_used := S.Set.add s !symbols_used
 
-let imp_table = Hashtbl.create 16
+let emit_global_symbol compilation_unit kind base_name =
+  let backend_sym = Backend_sym.create ~compilation_unit ~base_name kind in
+  let sym = S.create backend_sym in
+  add_def_symbol sym;
+  D.global (emit_symbol sym);
+  _label (emit_symbol sym)
 
-let reset_imp_table () = Hashtbl.clear imp_table
+let imp_table = S.Tbl.create 16
+
+let reset_imp_table () = S.Tbl.clear imp_table
 
 let get_imp_symbol s =
-  match Hashtbl.find imp_table s with
+  match S.Tbl.find imp_table s with
   | exception Not_found ->
-      let imps = "__caml_imp_" ^ s in
-      Hashtbl.add imp_table s imps;
+      let imps_name = "__caml_imp_%s" ^ (S.to_string ~without_prefix:() s) in
+      let imps =
+        S.of_external_name AS.Data Object_file.current_compilation_unit
+          imps_name
+      in
+      S.Tbl.add imp_table s imps;
       imps
   | imps -> imps
 
@@ -127,7 +139,7 @@ let emit_imp_table () =
   D.data();
   D.comment "relocation table start";
   D.align 8;
-  Hashtbl.iter f imp_table;
+  S.Tbl.iter f imp_table;
   D.comment "relocation table end"
 
 let mem__imp s =
@@ -137,7 +149,7 @@ let mem__imp s =
 let rel_plt s =
   if windows && !Clflags.dlcode then mem__imp s
   else
-    sym (if use_plt then emit_symbol s ^ "@PLT" else emit_symbol s)
+    sym (if use_plt then emit_symbol s ~reloc:"@PLT" else emit_symbol s)
 
 let emit_call s = I.call (rel_plt s)
 
@@ -148,7 +160,7 @@ let load_symbol_addr s arg =
     if windows then begin
       (* I.mov (mem__imp s) arg (\* mov __caml_imp_foo(%rip), ... *\) *)
       I.mov (sym (emit_symbol s)) arg (* movabsq $foo, ... *)
-    end else I.mov (mem64_rip QWORD (emit_symbol s ^ "@GOTPCREL")) arg
+    end else I.mov (mem64_rip QWORD (emit_symbol s ~reloc:"@GOTPCREL")) arg
   else if !Clflags.pic_code then
     I.lea (mem64_rip NONE (emit_symbol s)) arg
   else
@@ -216,6 +228,7 @@ let res32 i n = emit_subreg reg_low_32_name DWORD i.res.(n)
 let addressing addr typ i n =
   match addr with
   | Ibased(s, ofs) ->
+      let s = S.create s in
       add_used_symbol s;
       mem64_rip typ (emit_symbol s) ~ofs
   | Iindexed d ->
@@ -292,11 +305,11 @@ let emit_call_gc gc =
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
   begin match gc.gc_size with
-  | 16 -> emit_call "caml_call_gc1"
-  | 24 -> emit_call "caml_call_gc2"
-  | 32 -> emit_call "caml_call_gc3"
+  | 16 -> emit_call caml_call_gc1
+  | 24 -> emit_call caml_call_gc2
+  | 32 -> emit_call caml_call_gc3
   | n ->  I.add (int n) r15;
-          emit_call "caml_call_gc"
+          emit_call caml_call_gc
   end;
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
@@ -336,14 +349,14 @@ let emit_call_bound_error bd =
   | Some (node_ptr, index) ->
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
-  emit_call "caml_ml_array_bound_error";
+  emit_call caml_ml_array_bound_error;
   def_label bd.bd_frame
 
 let emit_call_bound_errors () =
   List.iter emit_call_bound_error !bound_error_sites;
   if !bound_error_call > 0 then begin
     def_label !bound_error_call;
-    emit_call "caml_ml_array_bound_error"
+    emit_call caml_ml_array_bound_error
   end
 
 (* Names for instructions *)
@@ -471,17 +484,8 @@ let emit_float_constant f lbl =
   _label (emit_label lbl);
   D.qword (Const f)
 
-let emit_global_label s =
-  let lbl = Compilenv.make_symbol (Some s) in
-  add_def_symbol lbl;
-  let lbl = emit_symbol lbl in
-  D.global lbl;
-  _label lbl
-
 (* Output the assembly code for an instruction *)
 
-(* Name of current function *)
-let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
@@ -530,12 +534,14 @@ let emit_instr fallthrough i =
           I.movsd (mem64_rip NONE (emit_label lbl)) (res i 0)
       end
   | Lop(Iconst_symbol s) ->
+      let s = S.create s in
       add_used_symbol s;
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind { label_after; }) ->
       I.call (arg i 0);
       record_frame i.live false i.dbg ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
+      let func = S.create func in
       add_used_symbol func;
       emit_call func;
       record_frame i.live false i.dbg ~label:label_after
@@ -547,24 +553,24 @@ let emit_instr fallthrough i =
         end
       end
   | Lop(Itailcall_imm { func; label_after; }) ->
-      begin
-        if func = !function_name then
-          I.jmp (label !tailrec_entry_point)
-        else begin
-          output_epilogue begin fun () ->
-            add_used_symbol func;
-            emit_jump func
-          end
+      let func = S.create func in
+      if S.equal func (get_current_function ()) then begin
+        I.jmp (label !tailrec_entry_point)
+      end else begin
+        output_epilogue begin fun () ->
+          add_used_symbol func;
+          emit_jump func
         end
       end;
       if Config.spacetime then begin
         record_frame Reg.Set.empty false i.dbg ~label:label_after
       end
   | Lop(Iextcall { func; alloc; label_after; }) ->
+      let func = S.create func in
       add_used_symbol func;
       if alloc then begin
         load_symbol_addr func rax;
-        emit_call "caml_c_call";
+        emit_call caml_c_call;
         record_frame i.live false i.dbg ~label:label_after;
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
@@ -574,7 +580,7 @@ let emit_instr fallthrough i =
              If we do the same for Win64, we probably need to change
              amd64nt.asm accordingly.
           *)
-          load_symbol_addr "caml_young_ptr" r11;
+          load_symbol_addr caml_young_ptr r11;
           I.mov (mem64 QWORD 0 R11) r15
         end
       end else begin
@@ -645,13 +651,13 @@ let emit_instr fallthrough i =
           if spacetime_node_hole_ptr_is_in_rax then begin
             I.push rax
           end;
-          load_symbol_addr "caml_young_limit" rax;
+          load_symbol_addr caml_young_limit rax;
           I.cmp (mem64 QWORD 0 RAX) r15;
           if spacetime_node_hole_ptr_is_in_rax then begin
             I.pop rax  (* this does not affect the flags *)
           end
         end else
-          I.cmp (mem64_rip QWORD (emit_symbol "caml_young_limit")) r15;
+          I.cmp (mem64_rip QWORD (emit_symbol caml_young_limit)) r15;
         let lbl_call_gc = new_label() in
         let dbg =
           if not Config.spacetime then Debuginfo.none
@@ -678,12 +684,12 @@ let emit_instr fallthrough i =
             ~index:spacetime_index;
         end;
         begin match n with
-        | 16 -> emit_call "caml_alloc1"
-        | 24 -> emit_call "caml_alloc2"
-        | 32 -> emit_call "caml_alloc3"
+        | 16 -> emit_call caml_alloc1
+        | 24 -> emit_call caml_alloc2
+        | 32 -> emit_call caml_alloc3
         | _  ->
             I.mov (int n) rax;
-            emit_call "caml_allocN"
+            emit_call caml_allocN
         end;
         let label =
           record_frame_label ?label:label_after_call_gc i.live false
@@ -737,9 +743,9 @@ let emit_instr fallthrough i =
       (* We have i.arg.(0) = i.res.(0) *)
       instr_for_intop op (int n) (res i 0)
   | Lop(Inegf) ->
-      I.xorpd (mem64_rip OWORD (emit_symbol "caml_negf_mask")) (res i 0)
+      I.xorpd (mem64_rip OWORD (emit_symbol caml_negf_mask)) (res i 0)
   | Lop(Iabsf) ->
-      I.andpd (mem64_rip OWORD (emit_symbol "caml_absf_mask")) (res i 0)
+      I.andpd (mem64_rip OWORD (emit_symbol caml_absf_mask)) (res i 0)
   | Lop(Iaddf | Isubf | Imulf | Idivf as floatop) ->
       instr_for_floatop floatop (arg i 1) (res i 0)
   | Lop(Ifloatofint) ->
@@ -881,7 +887,7 @@ let emit_instr fallthrough i =
          trie is [caml_stash_backtrace], and it does not. *)
       begin match k with
       | Cmm.Raise_withtrace ->
-          emit_call "caml_raise_exn";
+          emit_call caml_raise_exn;
           record_frame Reg.Set.empty true i.dbg
       | Cmm.Raise_notrace ->
           I.mov r14 rsp;
@@ -902,7 +908,8 @@ let all_functions = ref []
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  set_current_function fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
@@ -912,15 +919,15 @@ let fundecl fundecl =
   all_functions := fundecl :: !all_functions;
   D.text ();
   D.align 16;
-  add_def_symbol fundecl.fun_name;
+  add_def_symbol fun_name;
   if system = S_macosx
   && not !Clflags.output_c_object
-  && is_generic_function fundecl.fun_name
+  && S.is_generic_function fun_name
   then (* PR#4690 *)
-    D.private_extern (emit_symbol fundecl.fun_name)
+    D.private_extern (emit_symbol fun_name)
   else
-    D.global (emit_symbol fundecl.fun_name);
-  D.label (emit_symbol fundecl.fun_name);
+    D.global (emit_symbol fun_name);
+  D.label (emit_symbol fun_name);
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
   emit_all true fundecl.fun_body;
@@ -936,26 +943,30 @@ let fundecl fundecl =
   cfi_endproc ();
   begin match system with
   | S_gnu | S_linux ->
-      D.type_ (emit_symbol fundecl.fun_name) "@function";
-      D.size (emit_symbol fundecl.fun_name)
+      D.type_ (emit_symbol fun_name) "@function";
+      D.size (emit_symbol fun_name)
         (ConstSub (
             ConstThis,
-            ConstLabel (emit_symbol fundecl.fun_name)))
+            ConstLabel (emit_symbol fun_name)))
   | _ -> ()
   end
 
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> D.global (emit_symbol s)
-  | Cdefine_symbol s -> add_def_symbol s; _label (emit_symbol s)
+  | Cglobal_symbol s -> D.global (emit_symbol (S.create s))
+  | Cdefine_symbol s ->
+    let s = S.create s in
+    add_def_symbol s; _label (emit_symbol s)
   | Cint8 n -> D.byte (const n)
   | Cint16 n -> D.word (const n)
   | Cint32 n -> D.long (const_nat n)
   | Cint n -> D.qword (const_nat n)
   | Csingle f -> D.long  (Const (Int64.of_int32 (Int32.bits_of_float f)))
   | Cdouble f -> D.qword (Const (Int64.bits_of_float f))
-  | Csymbol_address s -> add_used_symbol s; D.qword (ConstLabel (emit_symbol s))
+  | Csymbol_address s ->
+    let s = S.create s in
+    add_used_symbol s; D.qword (ConstLabel (emit_symbol s))
   | Cstring s -> D.bytes s
   | Cskip n -> if n > 0 then D.space n
   | Calign n -> D.align n
@@ -966,7 +977,7 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly comp_unit =
   X86_proc.reset_asm_code ();
   reset_debug_info();                   (* PR#5603 *)
   reset_imp_table();
@@ -999,33 +1010,33 @@ let begin_assembly() =
     | _ -> D.section [".rodata.cst8"] (Some "a") ["@progbits"]
     end;
     D.align 16;
-    _label (emit_symbol "caml_negf_mask");
+    _label (emit_symbol caml_negf_mask);
     D.qword (Const 0x8000000000000000L);
     D.qword (Const 0L);
     D.align 16;
-    _label (emit_symbol "caml_absf_mask");
+    _label (emit_symbol caml_absf_mask);
     D.qword (Const 0x7FFFFFFFFFFFFFFFL);
     D.qword (Const 0xFFFFFFFFFFFFFFFFL);
   end;
 
   D.data ();
-  emit_global_label "data_begin";
+  emit_global_symbol comp_unit Data "data_begin";
 
   D.text ();
-  emit_global_label "code_begin";
+  emit_global_symbol comp_unit Text "code_begin";
   if system = S_macosx then I.nop (); (* PR#4690 *)
   ()
 
-let emit_spacetime_shapes () =
+let emit_spacetime_shapes comp_unit =
   D.data ();
   D.align 8;
-  emit_global_label "spacetime_shapes";
+  emit_global_symbol comp_unit Data "spacetime_shapes";
   List.iter (fun fundecl ->
       (* CR-someday mshinwell: some of this should be platform independent *)
       begin match fundecl.fun_spacetime_shape with
       | None -> ()
       | Some shape ->
-        let funsym = emit_symbol fundecl.fun_name in
+        let funsym = emit_symbol (S.create fundecl.fun_name) in
         D.comment ("Shape for " ^ funsym ^ ":");
         D.qword (ConstLabel funsym);
         List.iter (fun (part_of_shape, label) ->
@@ -1039,6 +1050,7 @@ let emit_spacetime_shapes () =
             D.qword (ConstLabel (emit_label label));
             begin match part_of_shape with
             | Direct_call_point { callee; } ->
+              let callee = S.create callee in
               D.qword (ConstLabel (emit_symbol callee))
             | Indirect_call_point -> ()
             | Allocation_point -> ()
@@ -1050,7 +1062,7 @@ let emit_spacetime_shapes () =
   D.qword (Const 0L);
   D.comment "End of Spacetime shapes."
 
-let end_assembly() =
+let end_assembly comp_unit =
   if !float_constants <> [] then begin
     begin match system with
     | S_macosx -> D.section ["__TEXT";"__literal8"] None ["8byte_literals"]
@@ -1065,17 +1077,17 @@ let end_assembly() =
   if system = S_macosx then I.nop ();
   (* suppress "ld warning: atom sorting error" *)
 
-  emit_global_label "code_end";
+  emit_global_symbol comp_unit Text "code_end";
 
   emit_imp_table();
 
   D.data ();
   D.qword (const 0);  (* PR#6329 *)
-  emit_global_label "data_end";
+  emit_global_symbol comp_unit Data "data_end";
   D.qword (const 0);
 
   D.align 8;                            (* PR#7591 *)
-  emit_global_label "frametable";
+  emit_global_symbol comp_unit Data "frametable";
 
   let setcnt = ref 0 in
   emit_frames
@@ -1105,7 +1117,7 @@ let end_assembly() =
     };
 
   if Config.spacetime then begin
-    emit_spacetime_shapes ()
+    emit_spacetime_shapes comp_unit
   end;
 
   if system = S_linux then
@@ -1114,13 +1126,13 @@ let end_assembly() =
 
   if system = S_win64 then begin
     D.comment "External functions";
-    String.Set.iter
+    S.Set.iter
       (fun s ->
-         if not (String.Set.mem s !symbols_defined) then
+         if not (S.Set.mem s !symbols_defined) then
            D.extrn (emit_symbol s) NEAR)
       !symbols_used;
-    symbols_used := String.Set.empty;
-    symbols_defined := String.Set.empty;
+    symbols_used := S.Set.empty;
+    symbols_defined := S.Set.empty;
   end;
 
   let asm =

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -147,9 +147,9 @@ let mem__imp s =
   mem64_rip QWORD (emit_symbol imp_s)
 
 let rel_plt s =
-  if windows && !Clflags.dlcode then mem__imp s
+  if Target_system.windows () && !Clflags.dlcode then mem__imp s
   else
-    sym (if use_plt then emit_symbol s ~reloc:"@PLT" else emit_symbol s)
+    sym (if use_plt () then emit_symbol s ~reloc:"@PLT" else emit_symbol s)
 
 let emit_call s = I.call (rel_plt s)
 
@@ -157,7 +157,7 @@ let emit_jump s = I.jmp (rel_plt s)
 
 let load_symbol_addr s arg =
   if !Clflags.dlcode then
-    if windows then begin
+    if Target_system.windows () then begin
       (* I.mov (mem__imp s) arg (\* mov __caml_imp_foo(%rip), ... *\) *)
       I.mov (sym (emit_symbol s)) arg (* movabsq $foo, ... *)
     end else I.mov (mem64_rip QWORD (emit_symbol s ~reloc:"@GOTPCREL")) arg
@@ -169,8 +169,9 @@ let load_symbol_addr s arg =
 (* Output a label *)
 
 let emit_label lbl =
-  match system with
-  | S_macosx | S_win64 -> "L" ^ Int.to_string lbl
+  match Target_system.architecture (), Target_system.system () with
+  | _, MacOS_like
+  | X86_64, Windows Native -> "L" ^ Int.to_string lbl
   | _ -> ".L" ^ Int.to_string lbl
 
 let label s = sym (emit_label s)
@@ -572,7 +573,7 @@ let emit_instr fallthrough i =
         load_symbol_addr func rax;
         emit_call caml_c_call;
         record_frame i.live false i.dbg ~label:label_after;
-        if system <> S_win64 then begin
+        if not (Target_system.win64 ()) then begin
           (* TODO: investigate why such a diff.
              This comes from:
             http://caml.inria.fr/cgi-bin/viewvc.cgi?view=revision&revision=12664
@@ -847,9 +848,12 @@ let emit_instr fallthrough i =
       I.add (reg tmp2) (reg tmp1);
       I.jmp (reg tmp1);
 
-      begin match system with
-      | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-      | S_macosx | S_win64 -> () (* with LLVM/OS X and MASM, use the text segment *)
+      begin match Target_system.architecture (), Target_system.system () with
+      | X86_64, Windows MinGW
+      | _, Windows Cygwin -> D.section [".rdata"] (Some "dr") []
+      | _, MacOS_like
+      | X86_64, Windows Native ->
+          () (* with LLVM/OS X and MASM, use the text segment *)
       | _ -> D.section [".rodata"] None []
       end;
       D.align 4;
@@ -920,7 +924,7 @@ let fundecl fundecl =
   D.text ();
   D.align 16;
   add_def_symbol fun_name;
-  if system = S_macosx
+  if Target_system.macos_like ()
   && not !Clflags.output_c_object
   && S.is_generic_function fun_name
   then (* PR#4690 *)
@@ -941,8 +945,8 @@ let fundecl fundecl =
     end;
   end;
   cfi_endproc ();
-  begin match system with
-  | S_gnu | S_linux ->
+  begin match Target_system.system () with
+  | Linux | GNU ->
       D.type_ (emit_symbol fun_name) "@function";
       D.size (emit_symbol fun_name)
         (ConstSub (
@@ -983,30 +987,32 @@ let begin_assembly comp_unit =
   reset_imp_table();
   float_constants := [];
   all_functions := [];
-  if system = S_win64 then begin
-    D.extrn "caml_young_ptr" QWORD;
-    D.extrn "caml_young_limit" QWORD;
-    D.extrn "caml_exception_pointer" QWORD;
-    D.extrn "caml_call_gc" NEAR;
-    D.extrn "caml_call_gc1" NEAR;
-    D.extrn "caml_call_gc2" NEAR;
-    D.extrn "caml_call_gc3" NEAR;
-    D.extrn "caml_c_call" NEAR;
-    D.extrn "caml_allocN" NEAR;
-    D.extrn "caml_alloc1" NEAR;
-    D.extrn "caml_alloc2" NEAR;
-    D.extrn "caml_alloc3" NEAR;
-    D.extrn "caml_ml_array_bound_error" NEAR;
-    D.extrn "caml_raise_exn" NEAR;
+  if Target_system.win64 () then begin
+    D.extrn caml_young_ptr QWORD;
+    D.extrn caml_young_limit QWORD;
+    D.extrn caml_exception_pointer QWORD;
+    D.extrn caml_call_gc NEAR;
+    D.extrn caml_call_gc1 NEAR;
+    D.extrn caml_call_gc2 NEAR;
+    D.extrn caml_call_gc3 NEAR;
+    D.extrn caml_c_call NEAR;
+    D.extrn caml_allocN NEAR;
+    D.extrn caml_alloc1 NEAR;
+    D.extrn caml_alloc2 NEAR;
+    D.extrn caml_alloc3 NEAR;
+    D.extrn caml_ml_array_bound_error NEAR;
+    D.extrn caml_raise_exn NEAR;
   end;
 
 
   if !Clflags.dlcode || Arch.win64 then begin
     (* from amd64.S; could emit these constants on demand *)
-    begin match system with
-    | S_macosx -> D.section ["__TEXT";"__literal16"] None ["16byte_literals"]
-    | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
-    | S_win64 -> D.data ()
+    begin match Target_system.architecture (), Target_system.system () with
+    | _, MacOS_like ->
+        D.section ["__TEXT";"__literal16"] None ["16byte_literals"]
+    | X86_64, Windows MinGW
+    | _, Windows Cygwin -> D.section [".rdata"] (Some "dr") []
+    | X86_64, Windows Native -> D.data ()
     | _ -> D.section [".rodata.cst8"] (Some "a") ["@progbits"]
     end;
     D.align 16;

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -26,6 +26,9 @@ open Mach
 open Linearize
 open Emitaux
 
+module S = Asm_symbol
+open Asm_symbol.Names
+
 (* Tradeoff between code size and code speed *)
 
 let fastcode_flag = ref true
@@ -37,17 +40,27 @@ let emit_label lbl =
 
 (* Symbols *)
 
-let emit_symbol s =
-  Emitaux.emit_symbol '$' s
+let emit_symbol ?reloc s =
+  Emitaux.emit_symbol ?reloc s
+
+let emit_global_symbol0 compilation_unit kind base_name =
+  let backend_sym = Backend_sym.create ~compilation_unit ~base_name kind in
+  let sym = S.create backend_sym in
+  `	.globl	{emit_symbol sym}\n`;
+  `{emit_symbol sym}:\n`;
+  sym
+
+let emit_global_symbol compilation_unit kind base_name =
+  ignore ((emit_global_symbol0 compilation_unit kind base_name) : S.t)
 
 let emit_call s =
   if !Clflags.dlcode || !Clflags.pic_code
-  then `bl	{emit_symbol s}(PLT)`
+  then `bl	{emit_symbol s ~reloc:"(PLT)"}`
   else `bl	{emit_symbol s}`
 
 let emit_jump s =
   if !Clflags.dlcode || !Clflags.pic_code
-  then `b	{emit_symbol s}(PLT)`
+  then `b	{emit_symbol s ~reloc:"(PLT)"}`
   else `b	{emit_symbol s}`
 
 (* Output a pseudo-register *)
@@ -133,7 +146,7 @@ type gc_call =
 let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
-  `{emit_label gc.gc_lbl}:	{emit_call "caml_call_gc"}\n`;
+  `{emit_label gc.gc_lbl}:	{emit_call caml_call_gc}\n`;
   `{emit_label gc.gc_frame_lbl}:	b	{emit_label gc.gc_return_lbl}\n`
 
 (* Record calls to caml_ml_array_bound_error.
@@ -159,7 +172,7 @@ let bound_error_label ?label dbg =
   end
 
 let emit_call_bound_error bd =
-  `{emit_label bd.bd_lbl}:	{emit_call "caml_ml_array_bound_error"}\n`;
+  `{emit_label bd.bd_lbl}:	{emit_call caml_ml_array_bound_error}\n`;
   `{emit_label bd.bd_frame_lbl}:\n`
 
 (* Negate a comparison *)
@@ -272,8 +285,6 @@ let output_epilogue f =
   end else
     f ()
 
-(* Name of current function *)
-let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 (* Pending floating-point literals *)
@@ -281,7 +292,7 @@ let float_literals = ref ([] : (int64 * label) list)
 (* Pending relative references to the global offset table *)
 let gotrel_literals = ref ([] : (label * label) list)
 (* Pending symbol literals *)
-let symbol_literals = ref ([] : (string * label) list)
+let symbol_literals = ref (S.Map.empty : label S.Map.t)
 (* Total space (in words) occupied by pending literals *)
 let size_literals = ref 0
 
@@ -313,11 +324,11 @@ let gotrel_literal l =
 (* Label a symbol literal *)
 let symbol_literal s =
   try
-    List.assoc s !symbol_literals
+    S.Map.find s !symbol_literals
   with Not_found ->
     let lbl = new_label() in
     size_literals := !size_literals + 1;
-    symbol_literals := (s, lbl) :: !symbol_literals;
+    symbol_literals := S.Map.add s lbl !symbol_literals;
     lbl
 
 (* Add an offset computation *)
@@ -337,7 +348,7 @@ let emit_literals() =
       !float_literals;
     float_literals := []
   end;
-  if !symbol_literals <> [] then begin
+  if not (S.Map.is_empty !symbol_literals) then begin
     let offset = if !thumb then 4 else 8 in
     let suffix = if !Clflags.pic_code then "(GOT)" else "" in
     `	.align	2\n`;
@@ -345,12 +356,12 @@ let emit_literals() =
       (fun (l, lbl) ->
         `{emit_label lbl}:	.word	_GLOBAL_OFFSET_TABLE_-({emit_label l}+{emit_int offset})\n`)
       !gotrel_literals;
-    List.iter
-      (fun (s, lbl) ->
+    S.Map.iter
+      (fun s lbl ->
         `{emit_label lbl}:	.word	{emit_symbol s}{emit_string suffix}\n`)
       !symbol_literals;
     gotrel_literals := [];
-    symbol_literals := []
+    symbol_literals := S.Map.empty
   end;
   if !offset_literals <> [] then begin
     (* Additions using the pc register read a value 4 or 8 bytes greater than
@@ -522,7 +533,7 @@ let emit_instr i =
             `	fconstd	{emit_reg i.res.(0)}, #{emit_int imm8}\n`
         end; 1
     | Lop(Iconst_symbol s) ->
-        emit_load_symbol_addr i.res.(0) s
+        emit_load_symbol_addr i.res.(0) (S.create s)
     | Lop(Icall_ind { label_after; }) ->
         if !arch >= ARMv5 then begin
           `	blx	{emit_reg i.arg.(0)}\n`;
@@ -533,7 +544,7 @@ let emit_instr i =
           `{record_frame i.live false i.dbg ~label:label_after}\n`; 2
         end
     | Lop(Icall_imm { func; label_after; }) ->
-        `	{emit_call func}\n`;
+        `	{emit_call (S.create func)}\n`;
         `{record_frame i.live false i.dbg ~label:label_after}\n`; 1
     | Lop(Itailcall_ind { label_after = _; }) ->
         output_epilogue begin fun () ->
@@ -542,7 +553,8 @@ let emit_instr i =
           `	bx	{emit_reg i.arg.(0)}\n`; 2
         end
     | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then begin
+        let func = S.create func in
+        if S.equal func (get_current_function ()) then begin
           `	b	{emit_label !tailrec_entry_point}\n`; 1
         end else begin
           output_epilogue begin fun () ->
@@ -552,10 +564,11 @@ let emit_instr i =
           end
         end
     | Lop(Iextcall { func; alloc = false; }) ->
-        `	{emit_call func}\n`; 1
+        `	{emit_call (S.create func)}\n`; 1
     | Lop(Iextcall { func; alloc = true; label_after; }) ->
+        let func = S.create func in
         let ninstr = emit_load_symbol_addr (phys_reg 7 (* r7 *)) func in
-        `	{emit_call "caml_c_call"}\n`;
+        `	{emit_call caml_c_call}\n`;
         `{record_frame i.live false i.dbg ~label:label_after}\n`;
         1 + ninstr
     | Lop(Istackoffset n) ->
@@ -652,11 +665,11 @@ let emit_instr i =
         end else begin
           let ninstr =
             begin match n with
-               8 -> `	{emit_call "caml_alloc1"}\n`; 1
-            | 12 -> `	{emit_call "caml_alloc2"}\n`; 1
-            | 16 -> `	{emit_call "caml_alloc3"}\n`; 1
+               8 -> `	{emit_call caml_alloc1}\n`; 1
+            | 12 -> `	{emit_call caml_alloc2}\n`; 1
+            | 16 -> `	{emit_call caml_alloc3}\n`; 1
             |  _ -> let ninstr = emit_intconst (phys_reg 7) (Int32.of_int n) in
-                    `	{emit_call "caml_allocN"}\n`; 1 + ninstr
+                    `	{emit_call caml_allocN}\n`; 1 + ninstr
             end in
           `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, alloc_ptr, #4\n`;
           1 + ninstr
@@ -882,7 +895,7 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
-          `	{emit_call "caml_raise_exn"}\n`;
+          `	{emit_call caml_raise_exn}\n`;
           `{record_frame Reg.Set.empty true i.dbg}\n`; 1
         | Cmm.Raise_notrace ->
           `	mov	sp, trap_ptr\n`;
@@ -933,24 +946,25 @@ let rec emit_all ninstr fallthrough i =
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  set_current_function fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   float_literals := [];
   gotrel_literals := [];
-  symbol_literals := [];
+  symbol_literals := S.Map.empty;
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];
   `	.text\n`;
   `	.align	2\n`;
-  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  `	.globl	{emit_symbol fun_name}\n`;
   if !arch > ARMv6 && !thumb then
     `	.thumb\n`
   else
     `	.arm\n`;
-  `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
-  `{emit_symbol fundecl.fun_name}:\n`;
+  `	.type	{emit_symbol fun_name}, %function\n`;
+  `{emit_symbol fun_name}:\n`;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc();
   emit_all 0 true fundecl.fun_body;
@@ -958,21 +972,21 @@ let fundecl fundecl =
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_call_bound_error !bound_error_sites;
   cfi_endproc();
-  `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
-  `	.size	{emit_symbol fundecl.fun_name}, .-{emit_symbol fundecl.fun_name}\n`
+  `	.type	{emit_symbol fun_name}, %function\n`;
+  `	.size	{emit_symbol fun_name}, .-{emit_symbol fun_name}\n`
 
 (* Emission of data *)
 
 let emit_item = function
-    Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
-  | Cdefine_symbol s -> `{emit_symbol s}:\n`
+    Cglobal_symbol s -> `	.globl	{emit_symbol (S.create s)}\n`;
+  | Cdefine_symbol s -> `{emit_symbol (S.create s)}:\n`
   | Cint8 n -> `	.byte	{emit_int n}\n`
   | Cint16 n -> `	.short	{emit_int n}\n`
   | Cint32 n -> `	.long	{emit_int32 (Nativeint.to_int32 n)}\n`
   | Cint n -> `	.long	{emit_int32 (Nativeint.to_int32 n)}\n`
   | Csingle f -> emit_float32_directive ".long" (Int32.bits_of_float f)
   | Cdouble f -> emit_float64_split_directive ".long" (Int64.bits_of_float f)
-  | Csymbol_address s -> `	.word	{emit_symbol s}\n`
+  | Csymbol_address s -> `	.word	{emit_symbol (S.create s)}\n`
   | Cstring s -> emit_string_directive "	.ascii  " s
   | Cskip n -> if n > 0 then `	.space	{emit_int n}\n`
   | Calign n -> `	.align	{emit_int(Misc.log2 n)}\n`
@@ -983,7 +997,7 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly comp_unit =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
   `	.syntax	unified\n`;
@@ -1005,29 +1019,19 @@ let begin_assembly() =
   `trap_ptr	.req	r8\n`;
   `alloc_ptr	.req	r10\n`;
   `alloc_limit	.req	r11\n`;
-  let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   `	.data\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
-  `{emit_symbol lbl_begin}:\n`;
-  let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
+  emit_global_symbol comp_unit Data "data_begin";
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
-  `{emit_symbol lbl_begin}:\n`
+  emit_global_symbol comp_unit Text "code_begin"
 
-let end_assembly () =
-  let lbl_end = Compilenv.make_symbol (Some "code_end") in
+let end_assembly comp_unit =
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_end}\n`;
-  `{emit_symbol lbl_end}:\n`;
-  let lbl_end = Compilenv.make_symbol (Some "data_end") in
+  emit_global_symbol comp_unit Text "code_end";
   `	.data\n`;
   `	.long 0\n`;  (* PR#6329 *)
-  `	.globl	{emit_symbol lbl_end}\n`;
-  `{emit_symbol lbl_end}:\n`;
+  emit_global_symbol comp_unit Data "data_end";
   `	.long	0\n`;
-  let lbl = Compilenv.make_symbol (Some "frametable") in
-  `	.globl	{emit_symbol lbl}\n`;
-  `{emit_symbol lbl}:\n`;
+  let frametable_sym = emit_global_symbol0 comp_unit Data "frametable" in
   emit_frames
     { efa_code_label = (fun lbl ->
                        `	.type	{emit_label lbl}, %function\n`;
@@ -1043,8 +1047,8 @@ let end_assembly () =
                            `	.word	{emit_label lbl} - . + {emit_int32 ofs}\n`);
       efa_def_label = (fun lbl -> `{emit_label lbl}:\n`);
       efa_string = (fun s -> emit_string_directive "	.asciz	" s) };
-  `	.type	{emit_symbol lbl}, %object\n`;
-  `	.size	{emit_symbol lbl}, .-{emit_symbol lbl}\n`;
+  `	.type	{emit_symbol frametable_sym}, %object\n`;
+  `	.size	{emit_symbol frametable_sym}, .-{emit_symbol frametable_sym}\n`;
   begin match Config.system with
     "linux_eabihf" | "linux_eabi" | "netbsd" ->
       (* Mark stack as non-executable *)

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -25,7 +25,7 @@ let command_line_options = []
 
 type addressing_mode =
   | Iindexed of int                     (* reg + displ *)
-  | Ibased of string * int              (* global var + displ *)
+  | Ibased of Backend_sym.t * int       (* global var + displ *)
 
 (* We do not support the reg + shifted reg addressing mode, because
    what we really need is reg + shifted reg + displ,
@@ -101,9 +101,9 @@ let print_addressing printreg addr ppf arg =
       printreg ppf arg.(0);
       if n <> 0 then fprintf ppf " + %i" n
   | Ibased(s, 0) ->
-      fprintf ppf "\"%s\"" s
+      fprintf ppf "\"%a\"" Backend_sym.print s
   | Ibased(s, n) ->
-      fprintf ppf "\"%s\" + %i" s n
+      fprintf ppf "\"%a\" + %i" Backend_sym.print s n
 
 let print_specific_operation printreg op ppf arg =
   match op with

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -27,6 +27,9 @@ open Mach
 open Linearize
 open Emitaux
 
+module S = Asm_symbol
+open Asm_symbol.Names
+
 (* Tradeoff between code size and code speed *)
 
 let fastcode_flag = ref true
@@ -46,8 +49,18 @@ let emit_label lbl =
 
 (* Symbols *)
 
-let emit_symbol s =
-  Emitaux.emit_symbol '$' s
+let emit_symbol s : unit =
+  Emitaux.emit_symbol s
+
+let emit_global_symbol0 compilation_unit kind base_name =
+  let backend_sym = Backend_sym.create ~compilation_unit ~base_name kind in
+  let sym = S.create backend_sym in
+  `	.globl	{emit_symbol sym}\n`;
+  `{emit_symbol sym}:\n`;
+  sym
+
+let emit_global_symbol compilation_unit kind base_name =
+  ignore ((emit_global_symbol0 compilation_unit kind base_name) : S.t)
 
 (* Output a pseudo-register *)
 
@@ -104,7 +117,7 @@ let emit_stack r =
 (* Output an addressing mode *)
 
 let emit_symbol_offset s ofs =
-  emit_symbol s;
+  emit_symbol (S.create s);
   if ofs > 0 then `+{emit_int ofs}`
   else if ofs < 0 then `-{emit_int (-ofs)}`
   else ()
@@ -153,7 +166,7 @@ type gc_call =
 let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
-  `{emit_label gc.gc_lbl}:	bl	{emit_symbol "caml_call_gc"}\n`;
+  `{emit_label gc.gc_lbl}:	bl	{emit_symbol caml_call_gc}\n`;
   `{emit_label gc.gc_frame_lbl}:	b	{emit_label gc.gc_return_lbl}\n`
 
 (* Record calls to caml_ml_array_bound_error.
@@ -179,7 +192,7 @@ let bound_error_label ?label dbg =
   end
 
 let emit_call_bound_error bd =
-  `{emit_label bd.bd_lbl}:	bl	{emit_symbol "caml_ml_array_bound_error"}\n`;
+  `{emit_label bd.bd_lbl}:	bl	{emit_symbol caml_ml_array_bound_error}\n`;
   `{emit_label bd.bd_frame_lbl}:\n`
 
 (* Names of various instructions *)
@@ -294,8 +307,6 @@ let output_epilogue f =
   (* reset CFA back because function body may continue *)
   if n > 0 then cfi_adjust_cfa_offset n
 
-(* Name of current function *)
-let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 (* Pending floating-point literals *)
@@ -438,7 +449,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Icall_imm _) -> 1
     | Lop (Itailcall_ind _) -> epilogue_size ()
     | Lop (Itailcall_imm { func; _ }) ->
-      if func = !function_name then 1 else epilogue_size ()
+      let func = S.create func in
+      if S.equal func (get_current_function ()) then 1 else epilogue_size ()
     | Lop (Iextcall { alloc = false; }) -> 1
     | Lop (Iextcall { alloc = true; }) -> 3
     | Lop (Istackoffset _) -> 2
@@ -553,11 +565,11 @@ let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
         gc_frame_lbl = lbl_frame } :: !call_gc_sites
   end else begin
     begin match n with
-    | 16 -> `	bl	{emit_symbol "caml_alloc1"}\n`
-    | 24 -> `	bl	{emit_symbol "caml_alloc2"}\n`
-    | 32 -> `	bl	{emit_symbol "caml_alloc3"}\n`
+    | 16 -> `	bl	{emit_symbol caml_alloc1}\n`
+    | 24 -> `	bl	{emit_symbol caml_alloc2}\n`
+    | 32 -> `	bl	{emit_symbol caml_alloc3}\n`
     | _  -> emit_intconst reg_x15 (Nativeint.of_int n);
-            `	bl	{emit_symbol "caml_allocN"}\n`
+            `	bl	{emit_symbol caml_allocN}\n`
     end;
     `{emit_label lbl_frame}:	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`
   end
@@ -605,25 +617,26 @@ let emit_instr i =
           `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_tmp1}, #:lo12:{emit_label lbl}]\n`
         end
     | Lop(Iconst_symbol s) ->
-        emit_load_symbol_addr i.res.(0) s
+        emit_load_symbol_addr i.res.(0) (S.create s)
     | Lop(Icall_ind { label_after; }) ->
         `	blr	{emit_reg i.arg.(0)}\n`;
         `{record_frame i.live false i.dbg ~label:label_after}\n`
     | Lop(Icall_imm { func; label_after; }) ->
-        `	bl	{emit_symbol func}\n`;
+        `	bl	{emit_symbol (S.create func)}\n`;
         `{record_frame i.live false i.dbg ~label:label_after}\n`
     | Lop(Itailcall_ind { label_after = _; }) ->
         output_epilogue (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
     | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then
+        let func = S.create func in
+        if S.equal func (get_current_function ()) then
           `	b	{emit_label !tailrec_entry_point}\n`
         else
           output_epilogue (fun () -> `	b	{emit_symbol func}\n`)
     | Lop(Iextcall { func; alloc = false; label_after = _; }) ->
-        `	bl	{emit_symbol func}\n`
+        `	bl	{emit_symbol (S.create func)}\n`
     | Lop(Iextcall { func; alloc = true; label_after; }) ->
-        emit_load_symbol_addr reg_x15 func;
-        `	bl	{emit_symbol "caml_c_call"}\n`;
+        emit_load_symbol_addr reg_x15 (S.create func);
+        `	bl	{emit_symbol caml_c_call}\n`;
         `{record_frame i.live false i.dbg ~label:label_after}\n`
     | Lop(Istackoffset n) ->
         assert (n mod 16 = 0);
@@ -880,7 +893,7 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
-          `	bl	{emit_symbol "caml_raise_exn"}\n`;
+          `	bl	{emit_symbol caml_raise_exn}\n`;
           `{record_frame Reg.Set.empty true i.dbg}\n`
         | Cmm.Raise_notrace ->
           `	mov	sp, {emit_reg reg_trap_ptr}\n`;
@@ -897,7 +910,8 @@ let rec emit_all i =
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  set_current_function fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   float_literals := [];
@@ -906,9 +920,9 @@ let fundecl fundecl =
   bound_error_sites := [];
   `	.text\n`;
   `	.align	3\n`;
-  `	.globl	{emit_symbol fundecl.fun_name}\n`;
-  `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
-  `{emit_symbol fundecl.fun_name}:\n`;
+  `	.globl	{emit_symbol fun_name}\n`;
+  `	.type	{emit_symbol fun_name}, %function\n`;
+  `{emit_symbol fun_name}:\n`;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc();
   let num_call_gc, num_check_bound =
@@ -925,15 +939,16 @@ let fundecl fundecl =
   assert (List.length !call_gc_sites = num_call_gc);
   assert (List.length !bound_error_sites = num_check_bound);
   cfi_endproc();
-  `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
-  `	.size	{emit_symbol fundecl.fun_name}, .-{emit_symbol fundecl.fun_name}\n`;
+  `	.type	{emit_symbol fun_name}, %function\n`;
+  `	.size	{emit_symbol fun_name}, .-{emit_symbol fun_name}\n`;
   emit_literals()
 
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+  | Cglobal_symbol s -> `	.globl	{emit_symbol (S.create s)}\n`;
   | Cdefine_symbol s ->
+    let s = S.create s in
     if !Clflags.dlcode then begin
       (* GOT relocations against non-global symbols don't seem to work
          properly: GOT entries are not created for the symbols and the
@@ -948,7 +963,7 @@ let emit_item = function
   | Cint n -> `	.quad	{emit_nativeint n}\n`
   | Csingle f -> emit_float32_directive ".long" (Int32.bits_of_float f)
   | Cdouble f -> emit_float64_directive ".quad" (Int64.bits_of_float f)
-  | Csymbol_address s -> `	.quad	{emit_symbol s}\n`
+  | Csymbol_address s -> `	.quad	{emit_symbol (S.create s)}\n`
   | Cstring s -> emit_string_directive "	.ascii  " s
   | Cskip n -> if n > 0 then `	.space	{emit_int n}\n`
   | Calign n -> `	.align	{emit_int(Misc.log2 n)}\n`
@@ -960,33 +975,23 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly comp_unit =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
-  let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   `	.data\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
-  `{emit_symbol lbl_begin}:\n`;
-  let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
+  emit_global_symbol comp_unit Data "data_begin";
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
-  `{emit_symbol lbl_begin}:\n`
+  emit_global_symbol comp_unit Text "code_begin"
 
-let end_assembly () =
-  let lbl_end = Compilenv.make_symbol (Some "code_end") in
+let end_assembly comp_unit =
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_end}\n`;
-  `{emit_symbol lbl_end}:\n`;
-  let lbl_end = Compilenv.make_symbol (Some "data_end") in
+  emit_global_symbol comp_unit Text "code_end";
   `	.data\n`;
   `	.quad	0\n`;  (* PR#6329 *)
-  `	.globl	{emit_symbol lbl_end}\n`;
-  `{emit_symbol lbl_end}:\n`;
+  emit_global_symbol comp_unit Data "data_end";
   `	.quad	0\n`;
   `	.align	3\n`;  (* #7887 *)
-  let lbl = Compilenv.make_symbol (Some "frametable") in
-  `	.globl	{emit_symbol lbl}\n`;
-  `{emit_symbol lbl}:\n`;
+  let frametable_sym = emit_global_symbol0 comp_unit Data "frametable" in
   emit_frames
     { efa_code_label = (fun lbl ->
                        `	.type	{emit_label lbl}, %function\n`;
@@ -1002,8 +1007,8 @@ let end_assembly () =
                            `	.long	{emit_label lbl} - . + {emit_int32 ofs}\n`);
       efa_def_label = (fun lbl -> `{emit_label lbl}:\n`);
       efa_string = (fun s -> emit_string_directive "	.asciz	" s) };
-  `	.type	{emit_symbol lbl}, %object\n`;
-  `	.size	{emit_symbol lbl}, .-{emit_symbol lbl}\n`;
+  `	.type	{emit_symbol frametable_sym}, %object\n`;
+  `	.size	{emit_symbol frametable_sym}, .-{emit_symbol frametable_sym}\n`;
   begin match Config.system with
   | "linux" ->
       (* Mark stack as non-executable *)

--- a/asmcomp/asm_target/asm_section.ml
+++ b/asmcomp/asm_target/asm_section.ml
@@ -1,0 +1,144 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Text
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
+
+let all_sections_in_order () =
+  [ Text;
+    Data;
+    Read_only_data;
+    Eight_byte_literals;
+    Sixteen_byte_literals;
+    Jump_tables;
+  ]
+
+let section_is_text = function
+  | Text
+  | Jump_tables -> true
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals -> false
+
+type derived_system =
+  | Linux
+  | MinGW_32
+  | MinGW_64
+  | Win32
+  | Win64
+  | Cygwin
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+let derived_system () =
+  match Target_system.system (), Target_system.machine_width () with
+  | Linux, _ -> Linux
+  | Windows Cygwin, _ -> Cygwin
+  | Windows MinGW, Thirty_two -> MinGW_32
+  | Windows MinGW, Sixty_four -> MinGW_64
+  | Windows Native, Thirty_two -> Win32
+  | Windows Native, Sixty_four -> Win64
+  | MacOS_like, _ -> MacOS_like
+  | FreeBSD, _ -> FreeBSD
+  | NetBSD, _ -> NetBSD
+  | OpenBSD, _ -> OpenBSD
+  | Generic_BSD, _ -> Generic_BSD
+  | Solaris, _ -> Solaris
+  | Dragonfly, _ -> Dragonfly
+  | GNU, _ -> GNU
+  | BeOS, _ -> BeOS
+  | Unknown, _ -> Unknown
+
+type flags_for_section = {
+  names : string list;
+  flags : string option;
+  args : string list;
+}
+
+let flags t =
+  let text () = [".text"], None, [] in
+  let data () = [".data"], None, [] in
+  let rodata () = [".rodata"], None, [] in
+  let system = derived_system () in
+  let names, flags, args =
+    match t, Target_system.architecture (), system with
+    | Text, _, _ -> text ()
+    | Data, _, _ -> data ()
+    | (Eight_byte_literals | Sixteen_byte_literals), (ARM | AArch64 | Z), _
+    | (Eight_byte_literals | Sixteen_byte_literals), _, Solaris ->
+      rodata ()
+    | Sixteen_byte_literals, _, MacOS_like ->
+      ["__TEXT"; "__literal16"], None, ["16byte_literals"]
+    | Sixteen_byte_literals, _, (MinGW_64 | Cygwin) ->
+      [".rdata"], Some "dr", []
+    | Sixteen_byte_literals, _, (MinGW_32 | Win32 | Win64) -> data ()
+    | Sixteen_byte_literals, _, _ -> [".rodata.cst8"], Some "a", ["@progbits"]
+    | Eight_byte_literals, _, MacOS_like ->
+      ["__TEXT"; "__literal8"], None, ["8byte_literals"]
+    | Eight_byte_literals, _, (MinGW_64 | Cygwin) -> [".rdata"], Some "dr", []
+    | Eight_byte_literals, _, (MinGW_32 | Win32 | Win64) -> data ()
+    | Eight_byte_literals, _, _ -> [".rodata.cst8"], Some "a", ["@progbits"]
+    | Jump_tables, _, (MinGW_64 | Cygwin) -> [".rdata"], Some "dr", []
+    | Jump_tables, _, (MinGW_32 | Win32) -> data ()
+    | Jump_tables, _, (MacOS_like | Win64) ->
+      text () (* with LLVM/OS X and MASM, use the text segment *)
+    | Jump_tables, _, _ -> [".rodata"], None, []
+    | Read_only_data, _, (MinGW_32 | Win32) -> data ()
+    | Read_only_data, _, (MinGW_64 | Cygwin) -> [".rdata"], Some "dr", []
+    | Read_only_data, _, _ -> rodata ()
+  in
+  { names; flags; args; }
+
+let to_string t =
+  let { names; flags = _; args = _; } = flags t in
+  String.concat " " names
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let print ppf t =
+    let str =
+      match t with
+      | Text -> "Text"
+      | Data -> "Data"
+      | Read_only_data -> "Read_only_data"
+      | Eight_byte_literals -> "Eight_byte_literals"
+      | Sixteen_byte_literals -> "Sixteen_byte_literals"
+      | Jump_tables -> "Jump_tables"
+    in
+    Format.pp_print_string ppf str
+
+  let output chan t =
+    Format.fprintf (Format.formatter_of_out_channel chan) "%a" print t
+
+  let compare t1 t2 = Stdlib.compare t1 t2
+  let equal t1 t2 = Stdlib.compare t1 t2 = 0
+  let hash t = Hashtbl.hash t
+end)

--- a/asmcomp/asm_target/asm_section.mli
+++ b/asmcomp/asm_target/asm_section.mli
@@ -1,0 +1,60 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Representation of object file sections. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The linker may share constants in [Eight_byte_literals] and
+    [Sixteen_byte_literals] sections. *)
+type t =
+  | Text
+    (** The code section. *)
+  | Data
+    (** The read/write data section. *)
+  | Read_only_data
+    (** The read-only data section. *)
+  | Eight_byte_literals
+    (** A section containing eight-byte constants (for example unboxed floating
+        point numbers). *)
+  | Sixteen_byte_literals
+    (** A section containing sixteen-byte numeric constants. *)
+  | Jump_tables
+    (** A section containing the code of jump tables. *)
+
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
+
+(** Concise description of values of type [t] for error messages, etc. *)
+val to_string : t -> string
+
+(** All sections that this code knows about. *)
+val all_sections_in_order : unit -> t list
+
+(** [section_is_text] returns [true] if the section holds code. *)
+val section_is_text : t -> bool
+
+(** Details about a specific section, used for assembly emission. *)
+type flags_for_section = private {
+  names : string list;
+  (** The name of the section.  Some section names have multiple constituent
+      parts. *)
+  flags : string option;
+  (** Target-dependent flags for the section. *)
+  args : string list;
+  (** Target-dependent arguments for the section. *)
+}
+
+(** The necessary information for an assembler's ".section" directive. *)
+val flags : t -> flags_for_section

--- a/asmcomp/asm_target/asm_symbol.ml
+++ b/asmcomp/asm_target/asm_symbol.ml
@@ -1,0 +1,189 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Fabrice Le Fessant, projet Gallium, INRIA Rocquencourt        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t = {
+  section : Asm_section.t;
+  object_file : Object_file.t;
+  name : string;
+  never_add_prefix : bool;
+}
+
+let create backend_sym =
+  let section = Asm_section.Data in
+  let object_file = Object_file.current_compilation_unit in
+  let name = Backend_sym.name_for_asm_symbol backend_sym in
+  if String.length name <= 0 then begin
+    Misc.fatal_errorf "[Backend_sym] returned an empty name for %a"
+      Backend_sym.print backend_sym
+  end;
+  { section;
+    object_file;
+    name;
+    never_add_prefix = false;
+  }
+
+let of_external_name ?no_prefix section object_file name =
+  if String.length name <= 0 then begin
+    Misc.fatal_error "[Asm_symbol.of_external_name] with empty symbol name"
+  end;
+  let never_add_prefix = Option.is_some no_prefix in
+  { section;
+    object_file;
+    name;
+    never_add_prefix;
+  }
+
+let add_prefix t section object_file ~prefix =
+  { section;
+    object_file;
+    name = prefix ^ t.name;
+    never_add_prefix = t.never_add_prefix;
+  }
+
+let symbol_prefix t =
+  if t.never_add_prefix then ""
+  else
+    match Target_system.architecture () with
+    | IA32 ->
+      begin match Target_system.system () with
+      | Linux
+      | FreeBSD
+      | NetBSD
+      | OpenBSD
+      | Generic_BSD
+      | Solaris
+      | BeOS
+      | GNU
+      | Dragonfly -> ""
+      | Windows Cygwin
+      | Windows MinGW
+      | Windows Native
+      | Unknown
+      | MacOS_like -> "_"
+      end
+    | X86_64 ->
+      begin match Target_system.system () with
+      | Linux
+      | Windows Cygwin
+      | Windows MinGW
+      | FreeBSD
+      | NetBSD
+      | OpenBSD
+      | Generic_BSD
+      | Solaris
+      | BeOS
+      | GNU
+      | Dragonfly
+      | Windows Native
+      | Unknown -> ""
+      | MacOS_like -> "_"
+      end
+    | ARM
+    | AArch64 -> "$"
+    | POWER
+    | Z -> "."
+
+let escape name =
+  let spec = ref false in
+  for i = 0 to String.length name - 1 do
+    match String.unsafe_get name i with
+    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
+    | _ -> spec := true;
+  done;
+  if not !spec then begin
+    name
+  end else begin
+    let b = Buffer.create (String.length name + 10) in
+    String.iter
+      (function
+        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
+        | c -> Printf.bprintf b "$%02x" (Char.code c)
+      )
+      name;
+    Buffer.contents b
+  end
+
+let to_escaped_string ?(reloc = "") t =
+  (* The prefix and relocation must not be escaped! *)
+  (symbol_prefix t) ^ (escape t.name) ^ reloc
+
+let to_string ?without_prefix t =
+  let symbol_prefix =
+    match without_prefix with
+    | None -> symbol_prefix t
+    | Some () -> ""
+  in
+  symbol_prefix ^ t.name
+
+let is_generic_function t =
+  List.exists (fun prefix -> Misc.Stdlib.String.is_prefix t.name ~prefix)
+    ["caml_apply"; "caml_curry"; "caml_send"; "caml_tuplify"]
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare { section = _section1; object_file = _object_file1;
+                name = name1; never_add_prefix = never_add_prefix1;
+              }
+              { section = _section2; object_file = _object_file2;
+                name = name2; never_add_prefix = never_add_prefix2;
+              } =
+    let c = String.compare name1 name2 in
+    if c <> 0 then c
+    else
+      Stdlib.compare never_add_prefix1 never_add_prefix2
+
+  let equal t1 t2 = (compare t1 t2 = 0)
+
+  let hash { section = _; object_file = _; name; never_add_prefix; } =
+    Hashtbl.hash (name, never_add_prefix)
+
+  let print ppf t = Format.pp_print_string ppf (to_string t)
+  let output chan t = print (Format.formatter_of_out_channel chan) t
+end)
+
+module Names = struct
+  let runtime = Object_file.runtime_and_external_libs
+  let runtime_data name = of_external_name Data runtime name
+  let runtime_text name = of_external_name Text runtime name
+
+  let caml_young_ptr = runtime_data "caml_young_ptr"
+  let caml_young_limit = runtime_data "caml_young_limit"
+  let caml_exception_pointer = runtime_data "caml_exception_pointer"
+
+  let caml_call_gc = runtime_text "caml_call_gc"
+  let caml_call_gc1 = runtime_text "caml_call_gc1"
+  let caml_call_gc2 = runtime_text "caml_call_gc2"
+  let caml_call_gc3 = runtime_text "caml_call_gc3"
+  let caml_c_call = runtime_text "caml_c_call"
+  let caml_alloc1 = runtime_text "caml_alloc1"
+  let caml_alloc2 = runtime_text "caml_alloc2"
+  let caml_alloc3 = runtime_text "caml_alloc3"
+  let caml_allocN = runtime_text "caml_allocN"
+  let caml_ml_array_bound_error = runtime_text "caml_ml_array_bound_error"
+  let caml_raise_exn = runtime_text "caml_raise_exn"
+
+  let caml_negf_mask =
+    of_external_name Eight_byte_literals Object_file.current_compilation_unit
+      "caml_negf_mask"
+
+  let caml_absf_mask =
+    of_external_name Eight_byte_literals Object_file.current_compilation_unit
+      "caml_absf_mask"
+end

--- a/asmcomp/asm_target/asm_symbol.mli
+++ b/asmcomp/asm_target/asm_symbol.mli
@@ -1,0 +1,101 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Symbols in the assembly stream.  Unlike labels, symbols are named entities
+    that are potentially accessible from outside an object file; they may
+    also be seen when an object file is examined (e.g. via objdump).
+
+    [Asm_symbol]s are defined within sections and tied to a particular
+    object file.  This enables certain checks to be performed when
+    constructions involving symbols are built (e.g. in [Asm_directives]).
+    [Asm_symbol]s may point anywhere, unlike [Backend_sym]s, where those
+    of [Data] kind must point at correctly-structured OCaml values.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The type of symbols. *)
+type t
+
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
+
+(** Create an assembly symbol from a backend symbol. *)
+val create : Backend_sym.t -> t
+
+(** Create an assembly symbol given its (unescaped) name, the section within
+    which it is defined and the object file within which it is defined. Unless
+    [no_prefix] is specified, the name will be prefixed with any required symbol
+    prefix for the target system's assembler. No OCaml-specific conventions
+    (such as prefixing with "caml") will be applied to the name.
+*)
+val of_external_name
+   : ?no_prefix:unit
+  -> Asm_section.t
+  -> Object_file.t
+  -> string
+  -> t
+
+(** Take an existing symbol and add a prefix to its name component (i.e. the
+    part after any target-specific symbol prefix as determined inside this
+    module). The [object_file] and section must be specified as they often
+    change during a prefixing. *)
+val add_prefix : t -> Asm_section.t -> Object_file.t -> prefix:string -> t
+
+(** Convert a symbol to the corresponding textual form, suitable for direct
+    emission into an assembly file.  This may be useful e.g. when emitting
+    an instruction referencing a symbol.
+
+    The optional [reloc] parameter will be appended to the encoded symbol (with
+    no escaping applied to [reloc]) if provided. *)
+val to_escaped_string : ?reloc:string -> t -> string
+
+(** Convert a symbol to the corresponding textual form, as required for
+    passing to e.g. a C library function (such as [dlsym]) that takes symbol
+    names.  This is like [encode], except that it doesn't take relocation
+    information, and does not escape the symbol.
+
+    If [without_prefix] is specified, any target-specific symbol prefix will be
+    elided.
+*)
+val to_string : ?without_prefix:unit -> t -> string
+
+(** Detection of functions that can be duplicated between a DLL and the main
+    program (PR#4690). *)
+val is_generic_function : t -> bool
+
+(** The names of various predefined symbols, for convenience. *)
+module Names : sig
+  (** Global variables in the OCaml runtime accessed by OCaml code. *)
+  val caml_young_ptr : t
+  val caml_young_limit : t
+  val caml_exception_pointer : t
+
+  (** Entry points to the OCaml runtime from OCaml code. *)
+  val caml_call_gc : t
+  val caml_call_gc1 : t
+  val caml_call_gc2 : t
+  val caml_call_gc3 : t
+  val caml_c_call : t
+  val caml_allocN : t
+  val caml_alloc1 : t
+  val caml_alloc2 : t
+  val caml_alloc3 : t
+  val caml_ml_array_bound_error : t
+  val caml_raise_exn : t
+
+  (** Symbols defined (where necessary) in each OCaml compilation unit. *)
+  val caml_negf_mask : t
+  val caml_absf_mask : t
+end

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -173,7 +173,11 @@ let set_export_info (ulambda, prealloc, structured_constants, export) =
 
 let end_gen_implementation ?toplevel ~ppf_dump
     (clambda:clambda_and_constants) =
-  Emit.begin_assembly ();
+  let comp_unit =
+    Backend_compilation_unit.compilation_unit
+      (Compilation_unit.get_current_exn ())
+  in
+  Emit.begin_assembly comp_unit;
   clambda
   ++ Profile.record "cmm" (Cmmgen.compunit ~ppf_dump)
   ++ Profile.record "compile_phrases" (List.iter (compile_phrase ~ppf_dump))
@@ -191,7 +195,7 @@ let end_gen_implementation ?toplevel ~ppf_dump
        (List.filter (fun s -> s <> "" && s.[0] <> '%')
           (List.map Primitive.native_name !Translmod.primitive_declarations))
     );
-  Emit.end_assembly ()
+  Emit.end_assembly comp_unit
 
 let flambda_gen_implementation ?toplevel ~backend ~ppf_dump
     (program:Flambda.program) =

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -227,7 +227,7 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
   Location.input_name := "caml_startup"; (* set name of "current" input *)
   Compilenv.reset "_startup";
   (* set the name of the "current" compunit *)
-  Emit.begin_assembly ();
+  Emit.begin_assembly Backend_compilation_unit.startup;
   let name_list =
     List.flatten (List.map (fun (info,_,_) -> info.ui_defines) units_list) in
   compile_phrase (Cmmgen.entry_point name_list);
@@ -248,13 +248,13 @@ let make_startup_file ~ppf_dump units_list ~crc_interfaces =
   end;
   if !Clflags.output_complete_object then
     force_linking_of_startup ~ppf_dump;
-  Emit.end_assembly ()
+  Emit.end_assembly Backend_compilation_unit.startup
 
 let make_shared_startup_file ~ppf_dump units =
   let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
   Location.input_name := "caml_startup";
   Compilenv.reset "_shared_startup";
-  Emit.begin_assembly ();
+  Emit.begin_assembly Backend_compilation_unit.shared_startup;
   List.iter compile_phrase
     (Cmmgen.generic_functions true (List.map fst units));
   compile_phrase (Cmmgen.plugin_header units);
@@ -265,7 +265,7 @@ let make_shared_startup_file ~ppf_dump units =
     force_linking_of_startup ~ppf_dump;
   (* this is to force a reference to all units, otherwise the linker
      might drop some of them (in case of libraries) *)
-  Emit.end_assembly ()
+  Emit.end_assembly Backend_compilation_unit.shared_startup
 
 let call_linker_shared file_list output_name =
   if not (Ccomp.call_linker Ccomp.Dll output_name file_list "")

--- a/asmcomp/backend_compilation_unit.ml
+++ b/asmcomp/backend_compilation_unit.ml
@@ -1,0 +1,67 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Compilation_unit of Compilation_unit.t
+  | Startup
+  | Shared_startup
+  | Runtime_and_external_libs
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Compilation_unit comp_unit1, Compilation_unit comp_unit2 ->
+      Compilation_unit.compare comp_unit1 comp_unit2
+    | Startup, Startup -> 0
+    | Shared_startup, Shared_startup -> 0
+    | Runtime_and_external_libs, Runtime_and_external_libs -> 0
+    | Compilation_unit _, _ -> -1
+    | Startup, (Compilation_unit _) -> 1
+    | Startup, _ -> -1
+    | Shared_startup, (Compilation_unit _ | Startup) -> 1
+    | Shared_startup, _ -> -1
+    | Runtime_and_external_libs,
+        (Compilation_unit _ | Startup | Shared_startup) -> 1
+
+  let equal t1 t2 = compare t1 t2 = 0
+
+  let hash t =
+    match t with
+    | Compilation_unit comp_unit ->
+      Hashtbl.hash (0, Compilation_unit.hash comp_unit)
+    | Startup -> Hashtbl.hash 1
+    | Shared_startup -> Hashtbl.hash 2
+    | Runtime_and_external_libs -> Hashtbl.hash 3
+
+  let print ppf t =
+    match t with
+    | Compilation_unit comp_unit ->
+      Format.fprintf ppf "@[<hov 1>(Compilation_unit %a)@]"
+        Compilation_unit.print comp_unit
+    | Startup -> Format.pp_print_string ppf "Startup"
+    | Shared_startup -> Format.pp_print_string ppf "Shared_startup"
+    | Runtime_and_external_libs ->
+      Format.pp_print_string ppf "Runtime_and_external_libs"
+
+  let output chan t = print (Format.formatter_of_out_channel chan) t
+end)
+
+let compilation_unit comp_unit = Compilation_unit comp_unit
+let startup = Startup
+let shared_startup = Shared_startup
+let runtime_and_external_libs = Runtime_and_external_libs

--- a/asmcomp/backend_compilation_unit.mli
+++ b/asmcomp/backend_compilation_unit.mli
@@ -1,0 +1,43 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Like [Compilation_unit], but also corresponds to units derived entirely
+    from Cmm code (and not having any OCaml source file), such as the startup
+    and shared startup files.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The type of backend compilation units. *)
+type t = private
+  | Compilation_unit of Compilation_unit.t
+  | Startup
+  | Shared_startup
+  | Runtime_and_external_libs
+
+(** Printing, comparison, sets, maps, etc. *)
+include Identifiable.S with type t := t
+
+(** Create a backend compilation unit from a middle-end compilation unit. *)
+val compilation_unit : Compilation_unit.t -> t
+
+(** The backend compilation unit for an executable's startup file. *)
+val startup : t
+
+(** The backend compilation unit for a shared library's startup file. *)
+val shared_startup : t
+
+(** The backend compilation unit for code external to that produced by the
+    OCaml compiler, such as the runtime, and the system C library. *)
+val runtime_and_external_libs : t

--- a/asmcomp/backend_sym.ml
+++ b/asmcomp/backend_sym.ml
@@ -1,0 +1,139 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include Misc.Stdlib.String
+
+type kind = Text | Data
+
+let create ?compilation_unit ~base_name _kind =
+  ignore compilation_unit;
+  Compilenv.make_symbol (Some base_name)
+
+(* This is deliberately not exposed in the .mli.  (Add things to [Names],
+   below, instead.) *)
+let of_external_name _object_file name _kind = name
+
+let add_suffix t new_suffix = t ^ new_suffix
+
+let add_suffixes t new_suffixes =
+  List.fold_left (fun t new_suffix -> add_suffix t new_suffix) t new_suffixes
+
+let add_int_suffix t new_suffix = add_suffix t (string_of_int new_suffix)
+
+let name_for_asm_symbol t = t
+
+module Names = struct
+  let runtime_or_external kind name =
+    of_external_name Object_file.runtime_and_external_libs name kind
+  let startup kind name = of_external_name Object_file.startup name kind
+
+  let atan = runtime_or_external Text "atan"
+  let atan2 = runtime_or_external Text "atan2"
+  let cos = runtime_or_external Text "cos"
+  let log = runtime_or_external Text "log"
+  let log10 = runtime_or_external Text "log10"
+  let sin = runtime_or_external Text "sin"
+  let sqrt = runtime_or_external Text "sqrt"
+  let tan = runtime_or_external Text "tan"
+
+  let __aeabi_idivmod = runtime_or_external Text "__aeabi_idivmod"
+  let __aeabi_idiv = runtime_or_external Text "__aeabi_idiv"
+  let __aeabi_dadd = runtime_or_external Text "__aeabi_dadd"
+  let __aeabi_dsub = runtime_or_external Text "__aeabi_dsub"
+  let __aeabi_dmul = runtime_or_external Text "__aeabi_dmul"
+  let __aeabi_ddiv = runtime_or_external Text "__aeabi_ddiv"
+  let __aeabi_i2d = runtime_or_external Text "__aeabi_i2d"
+  let __aeabi_d2iz = runtime_or_external Text "__aeabi_d2iz"
+  let __aeabi_dcmpeq = runtime_or_external Text "__aeabi_dcmpeq"
+  let __aeabi_dcmplt = runtime_or_external Text "__aeabi_dcmplt"
+  let __aeabi_dcmple = runtime_or_external Text "__aeabi_dcmple"
+  let __aeabi_dcmpgt = runtime_or_external Text "__aeabi_dcmpgt"
+  let __aeabi_dcmpge = runtime_or_external Text "__aeabi_dcmpge"
+  let __aeabi_f2d = runtime_or_external Text "__aeabi_f2d"
+  let __aeabi_d2f = runtime_or_external Text "__aeabi_d2f"
+
+  let caml_exception_pointer = runtime_or_external Data "caml_exception_pointer"
+  let caml_backtrace_pos = runtime_or_external Data "caml_backtrace_pos"
+  let caml_exn_Division_by_zero = startup Data "caml_exn_Division_by_zero"
+
+  let caml_nativeint_ops = runtime_or_external Data "caml_nativeint_ops"
+  let caml_int32_ops = runtime_or_external Data "caml_int32_ops"
+  let caml_int64_ops = runtime_or_external Data "caml_int64_ops"
+
+  let caml_curry_n n = add_int_suffix (startup Text "caml_curry") n
+
+  let caml_curry_m_to_n m n =
+    add_suffixes (startup Text "caml_curry")
+      [string_of_int m; "_"; string_of_int n]
+
+  let caml_curry_m_to_n_app m n =
+    add_suffixes (startup Text "caml_curry")
+      [string_of_int m; "_"; string_of_int n; "_app"]
+
+  let caml_tuplify n = add_int_suffix (startup Text "caml_tuplify") n
+  let caml_apply n = add_int_suffix (startup Text "caml_apply") n
+  let caml_send n = add_int_suffix (startup Text "caml_send") n
+
+  let caml_ba_get n = add_int_suffix (runtime_or_external Text "caml_ba_get_") n
+  let caml_ba_set n = add_int_suffix (runtime_or_external Text "caml_ba_set_") n
+
+  let caml_call_gc = runtime_or_external Text "caml_call_gc"
+  let caml_modify = runtime_or_external Text "caml_modify" 
+  let caml_initialize = runtime_or_external Text "caml_initialize"
+  let caml_get_public_method = runtime_or_external Text "caml_get_public_method"
+  let caml_alloc = runtime_or_external Text "caml_alloc"
+  let caml_ml_array_bound_error =
+    runtime_or_external Text "caml_ml_array_bound_error"
+  let caml_raise_exn = runtime_or_external Text "caml_raise_exn"
+  let caml_make_array = runtime_or_external Text "caml_make_array"
+  let caml_bswap16_direct = runtime_or_external Text "caml_bswap16_direct"
+
+  type bswap_arg = Int32 | Int64 | Nativeint
+
+  let caml_direct_bswap ty =
+    let ty =
+      match ty with
+      | Int32 -> "int32"
+      | Int64 -> "int64"
+      | Nativeint -> "nativeint"
+    in
+    runtime_or_external Text (Printf.sprintf "caml_%s_direct_bswap" ty)
+
+  let caml_alloc_dummy = runtime_or_external Text "caml_alloc_dummy"
+  let caml_alloc_dummy_float = runtime_or_external Text "caml_alloc_dummy_float"
+  let caml_update_dummy = runtime_or_external Text "caml_update_dummy"
+  let caml_program = startup Text "caml_program"
+  let caml_startup = runtime_or_external Text "caml_startup"
+  let caml_globals_inited = runtime_or_external Data "caml_globals_inited"
+  let caml_globals = startup Data "caml_globals"
+  let caml_plugin_header = startup Data "caml_plugin_header"
+  let caml_globals_map = startup Data "caml_globals_map"
+  let caml_code_segments = startup Data "caml_code_segments"
+  let caml_data_segments = startup Data "caml_data_segments"
+  let caml_frametable = startup Data "caml_frametable"
+
+  let caml_afl_area_ptr = runtime_or_external Data "caml_afl_area_ptr"
+  let caml_afl_prev_loc = runtime_or_external Data "caml_afl_prev_loc"
+  let caml_setup_afl = runtime_or_external Text "caml_setup_afl"
+
+  let caml_spacetime_shapes = startup Data "caml_spacetime_shapes"
+  let caml_spacetime_allocate_node =
+    runtime_or_external Text "caml_spacetime_allocate_node"
+  let caml_spacetime_indirect_node_hole_ptr =
+    runtime_or_external Text "caml_spacetime_indirect_node_hole_ptr"
+  let caml_spacetime_generate_profinfo =
+    runtime_or_external Text "caml_spacetime_generate_profinfo"
+end

--- a/asmcomp/backend_sym.mli
+++ b/asmcomp/backend_sym.mli
@@ -1,0 +1,147 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2018--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This is a temporary placeholder for a module whose description is as
+    follows:
+
+    Names of object file symbols (including OCaml-specific, but not
+    target-specific, mangling conventions) together with knowledge about
+    whether such symbols refer to code or data.
+
+    Since we need to represent symbols that live in the startup files and
+    external libraries, in addition to those within normal OCaml compilation
+    units (i.e. those arising from OCaml source files), object file symbols
+    are tied to [Backend_compilation_unit]s rather than [Compilation_unit]s.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+include module type of struct include Misc.Stdlib.String end
+
+type kind = Text | Data
+
+(** At present, only the [base_name] is used. *)
+val create
+   : ?compilation_unit:Backend_compilation_unit.t
+  -> base_name:string
+  -> kind
+  -> t
+
+(** The mangled name of the symbol, for the use of [Asm_symbol] only. *)
+val name_for_asm_symbol : t -> string
+
+(** Symbols either defined in the runtime or defined in (shared) startup
+    files with standard names.
+
+    This does include target-specific functions.  The alternative would be
+    to expose the function in the .ml file called [of_external_name]---but that
+    is deliberately not done to try to avoid erroneous construction of
+    symbol names from plain text.
+*)
+module Names : sig
+  (** Global variables in the OCaml runtime accessed by OCaml code. *)
+  val caml_exception_pointer : t
+  val caml_backtrace_pos : t
+  val caml_exn_Division_by_zero : t
+  val caml_nativeint_ops : t
+  val caml_int32_ops : t
+  val caml_int64_ops : t
+  val caml_globals_inited : t
+
+  (** Entry points to the OCaml runtime from OCaml code. *)
+  val caml_call_gc : t
+  val caml_modify : t
+  val caml_initialize : t
+  val caml_get_public_method : t
+  val caml_alloc : t
+  val caml_ml_array_bound_error : t
+  val caml_raise_exn : t
+  val caml_make_array : t
+  val caml_bswap16_direct : t
+
+  type bswap_arg = Int32 | Int64 | Nativeint
+  val caml_direct_bswap : bswap_arg -> t
+
+  val caml_alloc_dummy : t
+  val caml_alloc_dummy_float : t
+  val caml_update_dummy : t
+
+  (** Bigarrays. *)
+  val caml_ba_get : int -> t
+  val caml_ba_set : int -> t
+
+  (** AFL instrumentation. *)
+  val caml_afl_area_ptr : t
+  val caml_afl_prev_loc : t
+  val caml_setup_afl : t
+
+  (** Entry points to the Spacetime runtime from OCaml code. *)
+  val caml_spacetime_allocate_node : t
+  val caml_spacetime_indirect_node_hole_ptr : t
+  val caml_spacetime_generate_profinfo : t
+
+  (** Main OCaml entry point related functions. *)
+  val caml_program : t
+  val caml_startup : t
+
+  (** Header of a dynamically-loaded library. *)
+  val caml_plugin_header : t
+
+  (** Various veneers generated in [Cmmgen]. *)
+  val caml_send : int -> t
+  val caml_curry_n : int -> t
+  val caml_curry_m_to_n : int -> int -> t
+  val caml_curry_m_to_n_app : int -> int -> t
+  val caml_tuplify : int -> t
+  val caml_apply : int -> t
+
+  (** Master table of globals. *)
+  val caml_globals : t
+  val caml_globals_map : t
+
+  (** Master table of module data and code segments. *)
+  val caml_code_segments : t
+  val caml_data_segments : t
+
+  (** Standard OCaml auxiliary data structures. *)
+  val caml_frametable : t
+  val caml_spacetime_shapes : t
+
+  (** Maths functions from the C library. *)
+  val atan : t
+  val atan2 : t
+  val cos : t
+  val log : t
+  val log10 : t
+  val sin : t
+  val sqrt : t
+  val tan : t
+
+  (** ARM EABI-specific functions. *)
+  val __aeabi_idivmod : t
+  val __aeabi_idiv : t
+  val __aeabi_dadd : t
+  val __aeabi_dsub : t
+  val __aeabi_dmul : t
+  val __aeabi_ddiv : t
+  val __aeabi_i2d : t
+  val __aeabi_d2iz : t
+  val __aeabi_dcmpeq : t
+  val __aeabi_dcmplt : t
+  val __aeabi_dcmple : t
+  val __aeabi_dcmpgt : t
+  val __aeabi_dcmpge : t
+  val __aeabi_f2d : t
+  val __aeabi_d2f : t
+end

--- a/asmcomp/emit.mli
+++ b/asmcomp/emit.mli
@@ -17,5 +17,5 @@
 
 val fundecl: Linearize.fundecl -> unit
 val data: Cmm.data_item list -> unit
-val begin_assembly: unit -> unit
-val end_assembly: unit -> unit
+val begin_assembly: Backend_compilation_unit.t -> unit
+val end_assembly: Backend_compilation_unit.t -> unit

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -30,15 +30,8 @@ let emit_printf fmt =
 
 let emit_int32 n = emit_printf "0x%lx" n
 
-let emit_symbol esc s =
-  for i = 0 to String.length s - 1 do
-    let c = s.[i] in
-    match c with
-      'A'..'Z' | 'a'..'z' | '0'..'9' | '_' ->
-        output_char !output_channel c
-    | _ ->
-        Printf.fprintf !output_channel "%c%02x" esc (Char.code c)
-  done
+let emit_symbol ?reloc s =
+  output_string !output_channel (Asm_symbol.to_escaped_string ?reloc s)
 
 let emit_string_literal s =
   let last_was_escape = ref false in
@@ -219,18 +212,6 @@ let emit_frames a =
   Hashtbl.iter emit_filename filenames;
   frame_descriptors := []
 
-(* Detection of functions that can be duplicated between a DLL and
-   the main program (PR#4690) *)
-
-let isprefix s1 s2 =
-  String.length s1 <= String.length s2
-  && String.sub s2 0 (String.length s1) = s1
-
-let is_generic_function name =
-  List.exists
-    (fun p -> isprefix p name)
-    ["caml_apply"; "caml_curry"; "caml_send"; "caml_tuplify"]
-
 (* CFI directives *)
 
 let is_cfi_enabled () =
@@ -313,3 +294,13 @@ let reset () =
 
 let binary_backend_available = ref false
 let create_asm_file = ref true
+
+let current_function = ref None
+
+let set_current_function sym =
+  current_function := Some sym
+
+let get_current_function () =
+  match !current_function with
+  | Some sym -> sym
+  | None -> Misc.fatal_error "[Emitaux.set_current_function] not called"

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -20,7 +20,7 @@ val emit_string: string -> unit
 val emit_int: int -> unit
 val emit_nativeint: nativeint -> unit
 val emit_int32: int32 -> unit
-val emit_symbol: char -> string -> unit
+val emit_symbol: ?reloc:string -> Asm_symbol.t -> unit
 val emit_printf: ('a, out_channel, unit) format -> 'a
 val emit_char: char -> unit
 val emit_string_literal: string -> unit
@@ -29,6 +29,9 @@ val emit_bytes_directive: string -> string -> unit
 val emit_float64_directive: string -> int64 -> unit
 val emit_float64_split_directive: string -> int64 -> unit
 val emit_float32_directive: string -> int32 -> unit
+
+val set_current_function : Asm_symbol.t -> unit
+val get_current_function : unit -> Asm_symbol.t
 
 val reset : unit -> unit
 val reset_debug_info: unit -> unit
@@ -58,8 +61,6 @@ type emit_frame_actions =
     efa_string: string -> unit }
 
 val emit_frames: emit_frame_actions -> unit
-
-val is_generic_function: string -> bool
 
 val cfi_startproc : unit -> unit
 val cfi_endproc : unit -> unit

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -24,7 +24,10 @@ open Reg
 open Mach
 open Linearize
 open Emitaux
-module String = Misc.Stdlib.String
+
+module AS = Asm_section
+module S = Asm_symbol
+open Asm_symbol.Names
 
 open X86_ast
 open X86_proc
@@ -78,26 +81,15 @@ let slot_offset loc cl =
 (* Record symbols used and defined - at the end generate extern for those
    used but not defined *)
 
-let symbols_defined = ref String.Set.empty
-let symbols_used = ref String.Set.empty
+let symbols_defined = ref S.Set.empty
+let symbols_used = ref S.Set.empty
 
-let add_def_symbol s = symbols_defined := String.Set.add s !symbols_defined
-let add_used_symbol s = symbols_used := String.Set.add s !symbols_used
+let add_def_symbol s = symbols_defined := S.Set.add s !symbols_defined
+let add_used_symbol s = symbols_used := S.Set.add s !symbols_used
 
 let trap_frame_size = Misc.align 8 stack_alignment
 
-(* Prefixing of symbols with "_" *)
-
-let symbol_prefix =
-  match system with
-  | S_linux_elf -> ""
-  | S_bsd_elf -> ""
-  | S_solaris -> ""
-  | S_beos -> ""
-  | S_gnu -> ""
-  | _ -> "_" (* win32 & others *)
-
-let emit_symbol s = string_of_symbol symbol_prefix s
+let emit_symbol s = Asm_symbol.to_escaped_string s
 
 let immsym s = sym (emit_symbol s)
 
@@ -137,10 +129,14 @@ let register_name r =
 
 let sym32 ?ofs s = mem_sym ?ofs DWORD (emit_symbol s)
 
+let caml_extra_params =
+  S.of_external_name AS.Data Object_file.runtime_and_external_libs
+    "caml_extra_params"
+
 let reg = function
   | { loc = Reg r } -> register_name r
   | { loc = Stack(Incoming n | Outgoing n) } when n < 0 ->
-      sym32 "caml_extra_params" ~ofs:(n + 64)
+      sym32 caml_extra_params ~ofs:(n + 64)
   | { loc = Stack s; typ = Float } as r ->
       let ofs = slot_offset s (register_class r) in
       mem32 REAL8 ofs RSP
@@ -176,6 +172,7 @@ let arg32 i n = reg32 i.arg.(n)
 let addressing addr typ i n =
   match addr with
   | Ibased(s, ofs) ->
+      let s = S.create s in
       add_used_symbol s;
       mem_sym typ (emit_symbol s) ~ofs
   | Iindexed d ->
@@ -227,7 +224,7 @@ let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
   def_label gc.gc_lbl;
-  emit_call "caml_call_gc";
+  emit_call caml_call_gc;
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
 
@@ -256,14 +253,14 @@ let bound_error_label ?label dbg =
 
 let emit_call_bound_error bd =
   def_label bd.bd_lbl;
-  emit_call "caml_ml_array_bound_error";
+  emit_call caml_ml_array_bound_error;
   def_label bd.bd_frame
 
 let emit_call_bound_errors () =
   List.iter emit_call_bound_error !bound_error_sites;
   if !bound_error_call > 0 then begin
     def_label !bound_error_call;
-    emit_call "caml_ml_array_bound_error"
+    emit_call caml_ml_array_bound_error
   end
 
 (* Names for instructions *)
@@ -420,7 +417,8 @@ let emit_float_test cmp arg lbl =
 
 (* Emit a Ifloatspecial instruction *)
 
-let emit_floatspecial = function
+let emit_floatspecial sym =
+  match S.to_string ~without_prefix:() sym with
   | "atan"  -> I.fld1 (); I.fpatan ()
   | "atan2" -> I.fpatan ()
   | "cos"   -> I.fcos ()
@@ -454,17 +452,16 @@ let emit_float_constant cst lbl =
   _label (emit_label lbl);
   emit_float64_split_directive cst
 
-let emit_global_label s =
-  let lbl = Compilenv.make_symbol (Some s) in
-  add_def_symbol lbl;
-  let lbl = emit_symbol lbl in
-  D.global lbl;
-  _label lbl
+let emit_global_symbol compilation_unit kind base_name =
+  let backend_sym = Backend_sym.create ~compilation_unit ~base_name kind in
+  let sym = S.create backend_sym in
+  add_def_symbol sym;
+  let escaped_sym = S.to_escaped_string sym in
+  D.global escaped_sym;
+  _label escaped_sym
 
 (* Output the assembly code for an instruction *)
 
-(* Name of current function *)
-let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
@@ -516,12 +513,14 @@ let emit_instr fallthrough i =
           I.fld (mem_sym REAL8 (emit_label lbl))
       end
   | Lop(Iconst_symbol s) ->
+      let s = S.create s in
       add_used_symbol s;
       I.mov (immsym s) (reg i.res.(0))
   | Lop(Icall_ind { label_after; }) ->
       I.call (reg i.arg.(0));
       record_frame i.live false i.dbg ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
+      let func = S.create func in
       add_used_symbol func;
       emit_call func;
       record_frame i.live false i.dbg ~label:label_after
@@ -530,19 +529,21 @@ let emit_instr fallthrough i =
         I.jmp (reg i.arg.(0))
       end
   | Lop(Itailcall_imm { func; label_after = _; }) ->
-      if func = !function_name then
+      let func = S.create func in
+      if S.equal func (get_current_function ()) then begin
         I.jmp (label !tailrec_entry_point)
-      else begin
+      end else begin
         output_epilogue begin fun () ->
           add_used_symbol func;
           I.jmp (immsym func)
         end
       end
   | Lop(Iextcall { func; alloc; label_after; }) ->
+      let func = S.create func in
       add_used_symbol func;
       if alloc then begin
         I.mov (immsym func) eax;
-        emit_call "caml_c_call";
+        emit_call caml_c_call;
         record_frame i.live false i.dbg ~label:label_after
       end else begin
         emit_call func
@@ -598,13 +599,13 @@ let emit_instr fallthrough i =
       if !fastcode_flag then begin
         let lbl_redo = new_label() in
         def_label lbl_redo;
-        I.mov (sym32 "caml_young_ptr") eax;
+        I.mov (sym32 caml_young_ptr) eax;
         I.sub (int n) eax;
-        I.cmp (sym32 "caml_young_limit") eax;
+        I.cmp (sym32 caml_young_limit) eax;
         let lbl_call_gc = new_label() in
         let lbl_frame = record_frame_label i.live false Debuginfo.none in
         I.jb (label lbl_call_gc);
-        I.mov eax (sym32 "caml_young_ptr");
+        I.mov eax (sym32 caml_young_ptr);
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0));
         call_gc_sites :=
           { gc_lbl = lbl_call_gc;
@@ -612,12 +613,12 @@ let emit_instr fallthrough i =
             gc_frame = lbl_frame } :: !call_gc_sites
       end else begin
         begin match n with
-          8  -> emit_call "caml_alloc1"
-        | 12 -> emit_call "caml_alloc2"
-        | 16 -> emit_call "caml_alloc3"
+          8  -> emit_call caml_alloc1
+        | 12 -> emit_call caml_alloc2
+        | 16 -> emit_call caml_alloc3
         | _  ->
             I.mov (int n) eax;
-            emit_call "caml_allocN"
+            emit_call caml_allocN
         end;
         let label =
           record_frame_label ?label:label_after_call_gc i.live false
@@ -719,6 +720,7 @@ let emit_instr fallthrough i =
   | Lop(Ispecific(Istore_int(n, addr, _))) ->
       I.mov (nat n) (addressing addr DWORD i 0)
   | Lop(Ispecific(Istore_symbol(s, addr, _))) ->
+      let s = S.create s in
       add_used_symbol s;
       I.mov (immsym s) (addressing addr DWORD i 0)
   | Lop(Ispecific(Ioffset_loc(n, addr))) ->
@@ -754,6 +756,7 @@ let emit_instr fallthrough i =
       cfi_adjust_cfa_offset 4;
       stack_offset := !stack_offset + 4
   | Lop(Ispecific(Ipush_symbol s)) ->
+      let s = S.create s in
       add_used_symbol s;
       I.push (immsym s);
       cfi_adjust_cfa_offset 4;
@@ -781,7 +784,7 @@ let emit_instr fallthrough i =
       (* Fix-up for binary instrs whose args were swapped *)
       if Array.length i.arg = 2 && is_tos i.arg.(1) then
         I.fxch st1;
-      emit_floatspecial s
+      emit_floatspecial (S.create s)
   | Lop (Iname_for_debugger _) -> ()
   | Lreloadretaddr ->
       ()
@@ -850,23 +853,23 @@ let emit_instr fallthrough i =
       I.push (label lbl_handler);
       if trap_frame_size > 8 then
         I.sub (int (trap_frame_size - 8)) esp;
-      I.push (sym32 "caml_exception_pointer");
+      I.push (sym32 caml_exception_pointer);
       cfi_adjust_cfa_offset trap_frame_size;
-      I.mov esp (sym32 "caml_exception_pointer");
+      I.mov esp (sym32 caml_exception_pointer);
       stack_offset := !stack_offset + trap_frame_size
   | Lpoptrap ->
-      I.pop (sym32 "caml_exception_pointer");
+      I.pop (sym32 caml_exception_pointer);
       I.add (int (trap_frame_size - 4)) esp;
       cfi_adjust_cfa_offset (-trap_frame_size);
       stack_offset := !stack_offset - trap_frame_size
   | Lraise k  ->
       begin match k with
       | Cmm.Raise_withtrace ->
-          emit_call "caml_raise_exn";
+          emit_call caml_raise_exn;
           record_frame Reg.Set.empty true i.dbg
       | Cmm.Raise_notrace ->
-          I.mov (sym32 "caml_exception_pointer") esp;
-          I.pop (sym32 "caml_exception_pointer");
+          I.mov (sym32 caml_exception_pointer) esp;
+          I.pop (sym32 caml_exception_pointer);
           if trap_frame_size > 8 then
             I.add (int (trap_frame_size - 8)) esp;
           I.pop ebx;
@@ -885,7 +888,8 @@ let rec emit_all fallthrough i =
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  set_current_function fun_name;
   fastcode_flag := fundecl.fun_fast;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
@@ -893,10 +897,10 @@ let fundecl fundecl =
   bound_error_sites := [];
   bound_error_call := 0;
   D.text ();
-  add_def_symbol fundecl.fun_name;
+  add_def_symbol fun_name;
   D.align (if system = S_win32 then 4 else 16);
-  D.global (emit_symbol fundecl.fun_name);
-  D.label (emit_symbol fundecl.fun_name);
+  D.global (emit_symbol fun_name);
+  D.label (emit_symbol fun_name);
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
   emit_all true fundecl.fun_body;
@@ -905,11 +909,11 @@ let fundecl fundecl =
   cfi_endproc ();
   begin match system with
   | S_linux_elf | S_bsd_elf | S_gnu ->
-      D.type_ (emit_symbol fundecl.fun_name) "@function";
-      D.size (emit_symbol fundecl.fun_name)
+      D.type_ (emit_symbol fun_name) "@function";
+      D.size (emit_symbol fun_name)
         (ConstSub (
             ConstThis,
-            ConstLabel (emit_symbol fundecl.fun_name)))
+            ConstLabel (emit_symbol fun_name)))
   | _ -> ()
   end
 
@@ -917,15 +921,19 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> D.global (emit_symbol s)
-  | Cdefine_symbol s -> add_def_symbol s; _label (emit_symbol s)
+  | Cglobal_symbol s -> D.global (emit_symbol (S.create s))
+  | Cdefine_symbol s ->
+      let s = S.create s in
+      add_def_symbol s; _label (emit_symbol s)
   | Cint8 n -> D.byte (const n)
   | Cint16 n -> D.word (const n)
   | Cint32 n -> D.long (const_nat n)
   | Cint n -> D.long (const_nat n)
   | Csingle f -> D.long (Const (Int64.of_int32 (Int32.bits_of_float f)))
   | Cdouble f -> emit_float64_split_directive (Int64.bits_of_float f)
-  | Csymbol_address s -> add_used_symbol s; D.long (ConstLabel (emit_symbol s))
+  | Csymbol_address s ->
+      let s = S.create s in
+      add_used_symbol s; D.long (ConstLabel (emit_symbol s))
   | Cstring s -> D.bytes s
   | Cskip n -> if n > 0 then D.space n
   | Calign n -> D.align n
@@ -936,34 +944,35 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly comp_unit =
   X86_proc.reset_asm_code ();
   reset_debug_info();                   (* PR#5603 *)
   float_constants := [];
   if system = S_win32 then begin
     D.mode386 ();
     D.model "FLAT";
-    D.extrn "_caml_young_ptr" DWORD;
-    D.extrn "_caml_young_limit" DWORD;
-    D.extrn "_caml_exception_pointer" DWORD;
-    D.extrn "_caml_extra_params" DWORD;
-    D.extrn "_caml_call_gc" PROC;
-    D.extrn "_caml_c_call" PROC;
-    D.extrn "_caml_allocN" PROC;
-    D.extrn "_caml_alloc1" PROC;
-    D.extrn "_caml_alloc2" PROC;
-    D.extrn "_caml_alloc3" PROC;
-    D.extrn "_caml_ml_array_bound_error" PROC;
-    D.extrn "_caml_raise_exn" PROC;
+    let extrn sym kind = D.extrn (S.to_escaped_string sym) kind in
+    extrn caml_young_ptr DWORD;
+    extrn caml_young_limit DWORD;
+    extrn caml_exception_pointer DWORD;
+    extrn caml_extra_params DWORD;
+    extrn caml_call_gc PROC;
+    extrn caml_c_call PROC;
+    extrn caml_allocN PROC;
+    extrn caml_alloc1 PROC;
+    extrn caml_alloc2 PROC;
+    extrn caml_alloc3 PROC;
+    extrn caml_ml_array_bound_error PROC;
+    extrn caml_raise_exn PROC;
   end;
 
   D.data ();
-  emit_global_label "data_begin";
+  emit_global_symbol comp_unit Data "data_begin";
 
   D.text ();
-  emit_global_label "code_begin"
+  emit_global_symbol comp_unit Text "code_begin"
 
-let end_assembly() =
+let end_assembly comp_unit =
   if !float_constants <> [] then begin
     D.data ();
     List.iter (fun (cst,lbl) -> emit_float_constant cst lbl) !float_constants
@@ -971,14 +980,14 @@ let end_assembly() =
 
   D.text ();
 
-  emit_global_label "code_end";
+  emit_global_symbol comp_unit Text "code_end";
 
   D.data ();
   D.long (const 0);  (* PR#6329 *)
-  emit_global_label "data_end";
+  emit_global_symbol comp_unit Data "data_end";
   D.long (const 0);
 
-  emit_global_label "frametable";
+  emit_global_symbol comp_unit Data "frametable";
 
   emit_frames
     { efa_code_label = (fun l -> D.long (ConstLabel (emit_label l)));
@@ -1002,13 +1011,13 @@ let end_assembly() =
 
   if system = S_win32 then begin
     D.comment "External functions";
-    String.Set.iter
+    S.Set.iter
       (fun s ->
-         if not (String.Set.mem s !symbols_defined) then
+         if not (S.Set.mem s !symbols_defined) then
            D.extrn (emit_symbol s) PROC)
       !symbols_used;
-    symbols_used := String.Set.empty;
-    symbols_defined := String.Set.empty;
+    symbols_used := S.Set.empty;
+    symbols_defined := S.Set.empty;
   end;
 
   let asm =

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -21,10 +21,12 @@ open Proc
 open Cmm
 open Mach
 
+module S = Backend_sym
+
 (* Auxiliary for recognizing addressing modes *)
 
 type addressing_expr =
-    Asymbol of string
+    Asymbol of S.t
   | Alinear of expression
   | Aadd of expression * expression
   | Ascale of expression * int
@@ -77,7 +79,8 @@ let rec select_addr exp =
    If you update this list, you may need to update [is_simple_expr] and/or
    [effects_of], below. *)
 let inline_float_ops =
-  ["atan"; "atan2"; "cos"; "log"; "log10"; "sin"; "sqrt"; "tan"]
+  let open S.Names in
+  S.Set.of_list [atan; atan2; cos; log; log10; sin; sqrt; tan]
 
 (* Estimate number of float temporaries needed to evaluate expression
    (Ershov's algorithm) *)
@@ -90,7 +93,7 @@ let rec float_needs = function
       let n2 = float_needs arg2 in
       if n1 = n2 then 1 + n1 else if n1 > n2 then n1 else n2
   | Cop(Cextcall(fn, _ty_res, _alloc, _label), args, _dbg)
-    when !fast_math && List.mem fn inline_float_ops ->
+    when !fast_math && S.Set.mem fn inline_float_ops ->
       begin match args with
         [arg] -> float_needs arg
       | [arg1; arg2] -> max (float_needs arg2 + 1) (float_needs arg1)
@@ -163,7 +166,7 @@ method is_immediate (_n : int) = true
 method! is_simple_expr e =
   match e with
   | Cop(Cextcall(fn, _, _alloc, _), args, _)
-    when !fast_math && List.mem fn inline_float_ops ->
+    when !fast_math && S.Set.mem fn inline_float_ops ->
       (* inlined float ops are simple if their arguments are *)
       List.for_all self#is_simple_expr args
   | _ ->
@@ -172,7 +175,7 @@ method! is_simple_expr e =
 method! effects_of e =
   match e with
   | Cop(Cextcall(fn, _, _, _), args, _)
-    when !fast_math && List.mem fn inline_float_ops ->
+    when !fast_math && S.Set.mem fn inline_float_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | _ ->
       super#effects_of e
@@ -238,7 +241,7 @@ method! select_operation op args dbg =
       end
   (* Recognize inlined floating point operations *)
   | Cextcall(fn, _ty_res, false, _label)
-    when !fast_math && List.mem fn inline_float_ops ->
+    when !fast_math && S.Set.mem fn inline_float_ops ->
       (Ispecific(Ifloatspecial fn), args)
   (* i386 does not support immediate operands for multiply high signed *)
   | Cmulhi ->

--- a/asmcomp/object_file.ml
+++ b/asmcomp/object_file.ml
@@ -1,0 +1,49 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Current_compilation_unit
+  | Another_compilation_unit
+  | Startup
+  | Shared_startup
+  | Runtime_and_external_libs
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 = Stdlib.compare t1 t2
+  let equal t1 t2 = compare t1 t2 = 0
+  let hash t = Hashtbl.hash t
+
+  let print ppf t =
+    match t with
+    | Current_compilation_unit ->
+      Format.pp_print_string ppf "Current_compilation_unit"
+    | Another_compilation_unit ->
+      Format.pp_print_string ppf "Another_compilation_unit"
+    | Startup -> Format.pp_print_string ppf "Startup"
+    | Shared_startup -> Format.pp_print_string ppf "Shared_startup"
+    | Runtime_and_external_libs ->
+      Format.pp_print_string ppf "Runtime_and_external_libs"
+
+  let output chan t = print (Format.formatter_of_out_channel chan) t
+end)
+
+let current_compilation_unit = Current_compilation_unit
+let another_compilation_unit = Another_compilation_unit
+let startup = Startup
+let shared_startup = Shared_startup
+let runtime_and_external_libs = Runtime_and_external_libs

--- a/asmcomp/object_file.mli
+++ b/asmcomp/object_file.mli
@@ -1,0 +1,52 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** A description as to where, amongst the various (shared) object files
+    involved in building a particular program, some entity (typically a
+    symbol) is defined.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The type of object file descriptions. *)
+type t
+
+(** Printing, comparison, sets, maps, etc.
+
+    When generating code for an object file [(o1 : t)] and emitting a symbol
+    reference to another object file [(o2 : t)], that symbol reference will
+    be to an undefined symbol (until such time as relocated by the linker in
+    the presence of both object files) iff [not (equal o1 o2)].
+*)
+include Identifiable.S with type t := t
+
+(** The object file that holds code and data for the current OCaml compilation
+    unit.  (When packing, there may be more than one object file for a given
+    compilation unit.  However during any one run of the compiler there is
+    only one; that is the one referred to here.) *)
+val current_compilation_unit : t
+
+(** The group of object files that hold code and data for OCaml compilation
+    units apart from the current one. *)
+val another_compilation_unit : t
+
+(** The object file holding startup code for an executable. *)
+val startup : t
+
+(** The object file holding startup code for a shared library. *)
+val shared_startup : t
+
+(** The group of object files holding non-OCaml external definitions, for
+    example code and data in the runtime, or in other libraries. *)
+val runtime_and_external_libs : t

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -59,7 +59,7 @@ let spacetime_node_hole_pointer_is_live_before = function
 (* Addressing modes *)
 
 type addressing_mode =
-    Ibased of string * int              (* symbol + displ *)
+    Ibased of Backend_sym.t * int       (* symbol + displ *)
   | Iindexed of int                     (* reg + displ *)
   | Iindexed2                           (* reg + reg *)
 
@@ -103,7 +103,7 @@ let print_addressing printreg addr ppf arg =
   match addr with
   | Ibased(s, n) ->
       let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
-      fprintf ppf "\"%s\"%s" s idx
+      fprintf ppf "\"%a\"%s" Backend_sym.print s idx
   | Iindexed n ->
       let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
       fprintf ppf "%a%s" printreg arg.(0) idx

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -24,6 +24,9 @@ open Mach
 open Linearize
 open Emitaux
 
+module S = Asm_symbol
+open S.Names
+
 (* Reserved space at bottom of stack *)
 
 let reserved_stack_space =
@@ -71,9 +74,17 @@ let (trap_size, trap_handler_offset, trap_previous_offset) =
   | ELF64v1 -> (32, 56, 64)
   | ELF64v2 -> (32, 40, 48)
 
-(* Output a symbol *)
+(* Symbols *)
 
-let emit_symbol s = Emitaux.emit_symbol '.' s
+let emit_symbol ?reloc s =
+  Emitaux.emit_symbol ?reloc s
+
+let emit_global_symbol compilation_unit kind base_name =
+  let backend_sym = Backend_sym.create ~compilation_unit ~base_name kind in
+  let sym = S.create backend_sym in
+  `	.globl	{emit_symbol sym}\n`;
+  `	.type	{emit_symbol sym}, @object\n`;
+  `{emit_symbol sym}:\n`
 
 (* Output a label *)
 
@@ -170,7 +181,7 @@ let is_native_immediate n =
 (* Record TOC entries *)
 
 type tocentry =
-  | TocSym of string
+  | TocSym of S.t
   | TocLabel of int
   | TocInt of nativeint
   | TocFloat of int64
@@ -227,6 +238,7 @@ let valid_offset instr ofs =
 let emit_load_store instr addressing_mode addr n arg =
   match addressing_mode with
   | Ibased(s, d) ->
+      let s = S.create s in
       begin match abi with
       | ELF32 ->
         `	addis	11, 0, {emit_upper emit_symbol_offset (s,d)}\n`;
@@ -278,7 +290,7 @@ let emit_free_frame () =
 let emit_call s =
   match abi with
   | ELF32 when !Clflags.dlcode || !Clflags.pic_code ->
-    `	bl	{emit_symbol s}@plt\n`
+    `	bl	{emit_symbol s ~reloc:"@plt"}\n`
   | _ ->
     `	bl	{emit_symbol s}\n`
 
@@ -388,8 +400,6 @@ let name_for_specific = function
   | Imultsubf -> "fmsub"
   | _ -> Misc.fatal_error "Emit.Ispecific"
 
-(* Name of current function *)
-let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
@@ -500,7 +510,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Icall_imm _) -> size 1 3 3
     | Lop(Itailcall_ind _) -> size 5 7 6
     | Lop(Itailcall_imm { func; _ }) ->
-        if func = !function_name
+        if S.equal (S.create func) (get_current_function ())
         then 1
         else size 4 (7 + tocload_size()) (6 + tocload_size())
     | Lop(Iextcall { alloc = true; _ }) ->
@@ -633,6 +643,7 @@ let emit_instr i =
           end
         end
     | Lop(Iconst_symbol s) ->
+        let s = S.create s in
         begin match abi with
         | ELF32 ->
           `	addis	{emit_reg i.res.(0)}, 0, {emit_upper emit_symbol s}\n`;
@@ -661,6 +672,7 @@ let emit_instr i =
           emit_reload_toc()
         end
     | Lop(Icall_imm { func; label_after; }) ->
+        let func = S.create func in
         begin match abi with
         | ELF32 ->
             emit_call func;
@@ -707,9 +719,10 @@ let emit_instr i =
         emit_free_frame();
         `	bctr\n`
     | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then
+        let func = S.create func in
+        if S.equal func (get_current_function ()) then begin
           `	b	{emit_label !tailrec_entry_point}\n`
-        else begin
+        end else begin
           begin match abi with
           | ELF32 ->
             ()
@@ -735,6 +748,7 @@ let emit_instr i =
           end
         end
     | Lop(Iextcall { func; alloc; }) ->
+        let func = S.create func in
         if not alloc then begin
           emit_call func;
           emit_call_nop()
@@ -743,11 +757,11 @@ let emit_instr i =
           | ELF32 ->
             `	addis	28, 0, {emit_upper emit_symbol func}\n`;
             `	addi	28, 28, {emit_lower emit_symbol func}\n`;
-            emit_call "caml_c_call";
+            emit_call caml_c_call;
             record_frame i.live false i.dbg
           | ELF64v1 | ELF64v2 ->
             emit_tocload emit_gpr 28 (TocSym func);
-            emit_call "caml_c_call";
+            emit_call caml_c_call;
             record_frame i.live false i.dbg;
             `	nop\n`
         end
@@ -1005,7 +1019,7 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
-            emit_call "caml_raise_exn";
+            emit_call caml_raise_exn;
             record_frame Reg.Set.empty true i.dbg;
             emit_call_nop()
         | Cmm.Raise_notrace ->
@@ -1027,7 +1041,8 @@ let rec emit_all i =
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  set_current_function fun_name;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_labels := IntMap.empty;
@@ -1036,29 +1051,29 @@ let fundecl fundecl =
   begin match abi with
   | ELF32 ->
     emit_string code_space;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
-    `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
+    `	.globl	{emit_symbol fun_name}\n`;
+    `	.type	{emit_symbol fun_name}, @function\n`;
     `	.align	2\n`;
-    `{emit_symbol fundecl.fun_name}:\n`
+    `{emit_symbol fun_name}:\n`
   | ELF64v1 ->
     emit_string function_descr_space;
     `	.align 3\n`;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
-    `	.type   {emit_symbol fundecl.fun_name}, @function\n`;
-    `{emit_symbol fundecl.fun_name}:\n`;
-    `	.quad .L.{emit_symbol fundecl.fun_name}, .TOC.@tocbase\n`;
+    `	.globl	{emit_symbol fun_name}\n`;
+    `	.type   {emit_symbol fun_name}, @function\n`;
+    `{emit_symbol fun_name}:\n`;
+    `	.quad .L.{emit_symbol fun_name}, .TOC.@tocbase\n`;
     emit_string code_space;
     `	.align  2\n`;
-    `.L.{emit_symbol fundecl.fun_name}:\n`
+    `.L.{emit_symbol fun_name}:\n`
   | ELF64v2 ->
     emit_string code_space;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
-    `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
+    `	.globl	{emit_symbol fun_name}\n`;
+    `	.type	{emit_symbol fun_name}, @function\n`;
     `	.align	2\n`;
-    `{emit_symbol fundecl.fun_name}:\n`;
+    `{emit_symbol fun_name}:\n`;
     `0:	addis	2, 12, (.TOC. - 0b)@ha\n`;
     `	addi	2, 2, (.TOC. - 0b)@l\n`;
-    `	.localentry {emit_symbol fundecl.fun_name}, . - 0b\n`
+    `	.localentry {emit_symbol fun_name}, . - 0b\n`
   end;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc();
@@ -1088,11 +1103,11 @@ let fundecl fundecl =
       delta_lbl_list;
     match abi with
     | ELF32 ->
-      `	b	{emit_symbol "caml_call_gc"}\n`
+      `	b	{emit_symbol caml_call_gc}\n`
     | ELF64v1 ->
       `	std	2, 40(1)\n`;
              (* save our TOC, will be restored by caml_call_gc *)
-      emit_tocload emit_gpr 11 (TocSym "caml_call_gc");
+      emit_tocload emit_gpr 11 (TocSym caml_call_gc);
       `	ld	0, 0(11)\n`;
       `	mtctr	0\n`;
       `	ld	2, 8(11)\n`;
@@ -1100,16 +1115,16 @@ let fundecl fundecl =
     | ELF64v2 ->
       `	std	2, 24(1)\n`;
              (* save our TOC, will be restored by caml_call_gc *)
-      emit_tocload emit_gpr 12 (TocSym "caml_call_gc");
+      emit_tocload emit_gpr 12 (TocSym caml_call_gc);
       `	mtctr	12\n`;
       `	bctr\n`
   end;
   cfi_endproc();
   begin match abi with
   | ELF32 | ELF64v2 ->
-    `	.size	{emit_symbol fundecl.fun_name}, . - {emit_symbol fundecl.fun_name}\n`
+    `	.size	{emit_symbol fun_name}, . - {emit_symbol fun_name}\n`
   | ELF64v1 ->
-    `	.size	{emit_symbol fundecl.fun_name}, . - .L.{emit_symbol fundecl.fun_name}\n`
+    `	.size	{emit_symbol fun_name}, . - .L.{emit_symbol fun_name}\n`
   end;
   (* Emit the numeric literals *)
   if !float_literals <> [] then begin
@@ -1140,9 +1155,9 @@ let declare_global_data s =
 
 let emit_item = function
     Cglobal_symbol s ->
-      declare_global_data s
+      declare_global_data (S.create s)
   | Cdefine_symbol s ->
-      `{emit_symbol s}:\n`;
+      `{emit_symbol (S.create s)}:\n`;
   | Cint8 n ->
       `	.byte	{emit_int n}\n`
   | Cint16 n ->
@@ -1158,7 +1173,7 @@ let emit_item = function
       then emit_float64_directive ".quad" (Int64.bits_of_float f)
       else emit_float64_split_directive ".long" (Int64.bits_of_float f)
   | Csymbol_address s ->
-      `	{emit_string datag}	{emit_symbol s}\n`
+      `	{emit_string datag}	{emit_symbol (S.create s)}\n`
   | Cstring s ->
       emit_bytes_directive "	.byte	" s
   | Cskip n ->
@@ -1173,7 +1188,7 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly comp_unit =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
   begin match abi with
@@ -1182,42 +1197,33 @@ let begin_assembly() =
   end;
   Hashtbl.clear tocref_entries;
   (* Emit the beginning of the segments *)
-  let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   emit_string data_space;
-  declare_global_data lbl_begin;
-  `{emit_symbol lbl_begin}:\n`;
-  let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
+  emit_global_symbol comp_unit Data "data_begin";
   emit_string function_descr_space;
   (* For the ELF64v1 ABI, we must make sure that the .opd and .data
      sections are in different pages.  .opd comes after .data,
      so aligning .opd is enough.  To save space, we do it only
      for the startup file, not for every OCaml compilation unit. *)
-  let c = Compilenv.current_unit_name() in
-  if abi = ELF64v1 && (c = "_startup" || c = "_shared_startup") then begin
+  if abi = ELF64v1
+    && Backend_compilation_unit.equal comp_unit Backend_compilation_unit.startup
+  then begin
     `	.p2align	12\n`
   end;
-  declare_global_data lbl_begin;
-  `{emit_symbol lbl_begin}:\n`
+  emit_global_symbol comp_unit Text "code_begin"
 
-let end_assembly() =
+let end_assembly comp_unit =
   (* Emit the end of the segments *)
   emit_string function_descr_space;
-  let lbl_end = Compilenv.make_symbol (Some "code_end") in
-  declare_global_data lbl_end;
-  `{emit_symbol lbl_end}:\n`;
+  emit_global_symbol comp_unit Text "code_end";
   if abi <> ELF64v1 then `	.long	0\n`;
   emit_string data_space;
-  let lbl_end = Compilenv.make_symbol (Some "data_end") in
-  declare_global_data lbl_end;
   `	{emit_string datag}	0\n`;  (* PR#6329 *)
-  `{emit_symbol lbl_end}:\n`;
+  emit_global_symbol comp_unit Data "data_end";
   `	{emit_string datag}	0\n`;
   (* Emit the frame descriptors *)
   emit_string data_space;  (* not rodata_space because it contains relocations *)
   if ppc64 then `	.align  3\n`;   (* #7887 *)
-  let lbl = Compilenv.make_symbol (Some "frametable") in
-  declare_global_data lbl;
-  `{emit_symbol lbl}:\n`;
+  emit_global_symbol comp_unit Data "frametable";
   emit_frames
     { efa_code_label =
          (fun l -> `	{emit_string datag}	{emit_label l}\n`);

--- a/asmcomp/power/selection.ml
+++ b/asmcomp/power/selection.ml
@@ -22,7 +22,7 @@ open Mach
 (* Recognition of addressing modes *)
 
 type addressing_expr =
-    Asymbol of string
+    Asymbol of Backend_sym.t
   | Alinear of expression
   | Aadd of expression * expression
 

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -25,6 +25,9 @@ open Mach
 open Linearize
 open Emitaux
 
+module S = Asm_symbol
+open Asm_symbol.Names
+
 (* Layout of the stack.  The stack is kept 8-aligned. *)
 
 let stack_offset = ref 0
@@ -48,13 +51,21 @@ let slot_offset loc cls =
 
 (* Output a symbol *)
 
-let emit_symbol s = Emitaux.emit_symbol '.' s
+let emit_symbol ?reloc s =
+  Emitaux.emit_symbol ?reloc s
+
+let emit_global_symbol compilation_unit kind base_name =
+  let backend_sym = Backend_sym.create ~compilation_unit ~base_name kind in
+  let sym = S.create backend_sym in
+  `	.globl	{emit_symbol sym}\n`;
+  `	.type	{emit_symbol sym}, @object\n`;
+  `{emit_symbol sym}:\n`
 
 (* Output function call *)
 
 let emit_call s =
   if !pic_code then
-   `	brasl	%r14, {emit_symbol s}@PLT\n`
+   `	brasl	%r14, {emit_symbol s ~reloc:"@PLT"}\n`
   else
    `	brasl	%r14, {emit_symbol s}\n`
 
@@ -104,7 +115,7 @@ let emit_stack r =
 
 let emit_load_symbol_addr reg s =
   if !pic_code then
-  `	lgrl	{emit_reg reg}, {emit_symbol s}@GOTENT\n`
+  `	lgrl	{emit_reg reg}, {emit_symbol s ~reloc:"@GOTENT"}\n`
   else
   `	larl	{emit_reg reg}, {emit_symbol s}\n`
 
@@ -197,7 +208,7 @@ type gc_call =
 let call_gc_sites = ref ([] : gc_call list)
 
 let emit_call_gc gc =
-  `{emit_label gc.gc_lbl}:`; emit_call "caml_call_gc";
+  `{emit_label gc.gc_lbl}:`; emit_call caml_call_gc;
   `{emit_label gc.gc_frame_lbl}:	brcl	15, {emit_label gc.gc_return_lbl}\n`
 
 (* Record calls to caml_ml_array_bound_error, emitted out of line. *)
@@ -222,13 +233,13 @@ let bound_error_label ?label dbg =
  end
 
 let emit_call_bound_error bd =
-  `{emit_label bd.bd_lbl}:`; emit_call "caml_ml_array_bound_error";
+  `{emit_label bd.bd_lbl}:`; emit_call caml_ml_array_bound_error;
   `{emit_label bd.bd_frame}:\n`
 
 let emit_call_bound_errors () =
   List.iter emit_call_bound_error !bound_error_sites;
   if !bound_error_call > 0 then begin
-    `{emit_label !bound_error_call}:`; emit_call "caml_ml_array_bound_error";
+    `{emit_label !bound_error_call}:`; emit_call caml_ml_array_bound_error;
   end
 
 (* Record floating-point and large integer literals *)
@@ -296,8 +307,6 @@ let name_for_specific = function
     Imultaddf -> "madbr"
   | Imultsubf -> "msdbr"
 
-(* Name of current function *)
-let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
@@ -348,13 +357,13 @@ let emit_instr i =
         `	larl	%r1, {emit_label lbl}\n`;
         `	ld	{emit_reg i.res.(0)}, 0(%r1)\n`
      | Lop(Iconst_symbol s) ->
-        emit_load_symbol_addr i.res.(0) s
+        emit_load_symbol_addr i.res.(0) (S.create s)
     | Lop(Icall_ind { label_after; }) ->
         `	basr	%r14, {emit_reg i.arg.(0)}\n`;
         `{record_frame i.live false i.dbg ~label:label_after}\n`
 
     | Lop(Icall_imm { func; label_after; }) ->
-        emit_call func;
+        emit_call (S.create func);
         `{record_frame i.live false i.dbg ~label:label_after}\n`
     | Lop(Itailcall_ind { label_after = _; }) ->
         let n = frame_size() in
@@ -363,24 +372,25 @@ let emit_instr i =
         emit_stack_adjust (-n);
         `	br	{emit_reg i.arg.(0)}\n`
     | Lop(Itailcall_imm { func; label_after = _; }) ->
-        if func = !function_name then
+        let func = S.create func in
+        if S.equal func (get_current_function ()) then begin
           `	brcl	15, {emit_label !tailrec_entry_point}\n`
-        else begin
+        end else begin
           let n = frame_size() in
           if !contains_calls then
             `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
           emit_stack_adjust (-n);
           if !pic_code then
-            `	brcl	15, {emit_symbol func}@PLT\n`
+            `	brcl	15, {emit_symbol func ~reloc:"@PLT"}\n`
           else
             `	brcl	15, {emit_symbol func}\n`
         end
-
      | Lop(Iextcall { func; alloc; label_after; }) ->
+        let func = S.create func in
         if not alloc then emit_call func
         else begin
           emit_load_symbol_addr reg_r7 func;
-          emit_call "caml_c_call";
+          emit_call caml_c_call;
           `{record_frame i.live false i.dbg ~label:label_after}\n`
         end
 
@@ -625,7 +635,7 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
-          emit_call "caml_raise_exn";
+          emit_call caml_raise_exn;
           `{record_frame Reg.Set.empty true i.dbg}\n`
         | Cmm.Raise_notrace ->
           `	lg	%r1, 0(%r13)\n`;
@@ -648,7 +658,8 @@ let rec emit_all i =
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
-  function_name := fundecl.fun_name;
+  let fun_name = S.create fundecl.fun_name in
+  set_current_function fun_name;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
@@ -656,12 +667,12 @@ let fundecl fundecl =
   bound_error_call := 0;
   float_literals := [];
   int_literals := [];
-  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  `	.globl	{emit_symbol fun_name}\n`;
   emit_debug_info fundecl.fun_dbg;
-  `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
+  `	.type	{emit_symbol fun_name}, @function\n`;
   emit_string code_space;
   `	.align	8\n`;
-  `{emit_symbol fundecl.fun_name}:\n`;
+  `{emit_symbol fun_name}:\n`;
   emit_all fundecl.fun_body;
   (* Emit the glue code to call the GC *)
   List.iter emit_call_gc !call_gc_sites;
@@ -690,9 +701,9 @@ let declare_global_data s =
 
 let emit_item = function
     Cglobal_symbol s ->
-      declare_global_data s
+      declare_global_data (S.create s)
   | Cdefine_symbol s ->
-      `{emit_symbol s}:\n`;
+      `{emit_symbol (S.create s)}:\n`;
   | Cint8 n ->
       `	.byte	{emit_int n}\n`
   | Cint16 n ->
@@ -706,7 +717,7 @@ let emit_item = function
   | Cdouble f ->
       emit_float64_directive ".quad" (Int64.bits_of_float f)
   | Csymbol_address s ->
-      `	.quad	{emit_symbol s}\n`
+      `	.quad	{emit_symbol (S.create s)}\n`
   | Cstring s ->
       emit_bytes_directive "	.byte	" s
   | Cskip n ->
@@ -722,40 +733,30 @@ let data l =
 
 (* Beginning / end of an assembly file *)
 
-let begin_assembly() =
+let begin_assembly comp_unit =
   reset_debug_info();
   `	.file	\"\"\n`;  (* PR#7037 *)
   (* Emit the beginning of the segments *)
-  let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   emit_string data_space;
   `	.align	8\n`;
-  declare_global_data lbl_begin;
-  `{emit_symbol lbl_begin}:\n`;
-  let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
+  emit_global_symbol comp_unit Data "data_begin";
   emit_string code_space;
-  declare_global_data lbl_begin;
-  `{emit_symbol lbl_begin}:\n`
+  emit_global_symbol comp_unit Text "code_begin"
 
-let end_assembly() =
+let end_assembly comp_unit =
   (* Emit the end of the segments *)
   emit_string code_space;
-  let lbl_end = Compilenv.make_symbol (Some "code_end") in
-  declare_global_data lbl_end;
-  `{emit_symbol lbl_end}:\n`;
+  emit_global_symbol comp_unit Text "code_end";
   `	.long	0\n`;
   emit_string data_space;
   `	.align	8\n`;
-  let lbl_end = Compilenv.make_symbol (Some "data_end") in
-  declare_global_data lbl_end;
   `	.quad	0\n`;  (* PR#6329 *)
-  `{emit_symbol lbl_end}:\n`;
+  emit_global_symbol comp_unit Data "data_end";
   `	.quad	0\n`;
   (* Emit the frame descriptors *)
   emit_string data_space;  (* not rodata because relocations inside *)
   `	.align	8\n`;
-  let lbl = Compilenv.make_symbol (Some "frametable") in
-  declare_global_data lbl;
-  `{emit_symbol lbl}:\n`;
+  emit_global_symbol comp_unit Data "frametable";
   emit_frames
     { efa_code_label = (fun l -> `	.quad	{emit_label l}\n`);
       efa_data_label = (fun l -> `	.quad	{emit_label l}\n`);

--- a/asmcomp/target_system.ml
+++ b/asmcomp/target_system.ml
@@ -1,0 +1,204 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2017--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type elf_abi =
+  | ARM_GNU_EABI
+  | ARM_GNU_EABI_hard_float
+  | AArch64
+  | IA32
+  | POWER_ELF32
+  | POWER_ELF64v1
+  | POWER_ELF64v2
+  | X86_64
+  | Z
+
+type object_file_format_and_abi =
+  | A_out
+  | ELF of elf_abi
+  | Mach_O
+  | PE
+  | Unknown
+
+type windows_system =
+  | Cygwin
+  | MinGW
+  | Native
+
+type system =
+  | Linux
+  | Windows of windows_system
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+(* Some references remain to Solaris in the configure script, although it
+   appears that [Config.system] never gets set to "solaris" any more. *)
+let (_ : system) = Solaris
+
+type architecture =
+  | IA32
+  | X86_64
+  | ARM
+  | AArch64
+  | POWER
+  | Z
+
+type assembler =
+  | GAS_like
+  | MacOS
+  | MASM
+
+type machine_width =
+  | Thirty_two
+  | Sixty_four
+
+let architecture () =
+  match Config.architecture with
+  | "i386" -> IA32
+  | "amd64" -> X86_64
+  | "arm" -> ARM
+  | "arm64" -> AArch64
+  | "power" -> POWER
+  | "s390x" -> Z
+  | arch -> Misc.fatal_errorf "Unknown architecture `%s'" arch
+
+let system_and_object_file_format_and_abi ()
+      : system * object_file_format_and_abi =
+  match architecture (), Config.model, Config.system with
+  | IA32, _, "linux_aout" -> Linux, A_out
+  | IA32, _, "linux_elf" -> Linux, ELF IA32
+  | IA32, _, "bsd_aout" -> Generic_BSD, A_out
+  | IA32, _, "bsd_elf" -> Generic_BSD, ELF IA32
+  | IA32, _, "beos" -> BeOS, ELF IA32
+  | IA32, _, "cygwin" -> Windows Cygwin, PE
+  | (X86_64 | IA32), _, "macosx" -> MacOS_like, Mach_O
+  | IA32, _, "gnu" -> GNU, ELF IA32
+  | IA32, _, "mingw" -> Windows MinGW, PE
+  | IA32, _, "win32" -> Windows Native, PE
+  | POWER, "ppc64le", "elf" -> Linux, ELF POWER_ELF64v2
+  | POWER, "ppc64", "elf" -> Linux, ELF POWER_ELF64v1
+  | POWER, "ppc", "elf" -> Linux, ELF POWER_ELF32
+  | POWER, "ppc", "netbsd" -> NetBSD, ELF POWER_ELF32
+  | POWER, "ppc", "bsd_elf" -> OpenBSD, ELF POWER_ELF32
+  | Z, _, "elf" -> Linux, ELF Z
+  | ARM, _, "linux_eabihf" -> Linux, ELF ARM_GNU_EABI_hard_float
+  | ARM, _, "linux_eabi" -> Linux, ELF ARM_GNU_EABI
+  | ARM, _, "bsd" -> OpenBSD, ELF ARM_GNU_EABI
+  | X86_64, _, "linux" -> Linux, ELF X86_64
+  | X86_64, _, "gnu" -> GNU, ELF X86_64
+  | X86_64, _, "dragonfly" -> Dragonfly, ELF X86_64
+  | X86_64, _, "freebsd" -> FreeBSD, ELF X86_64
+  | X86_64, _, "netbsd" -> NetBSD, ELF X86_64
+  | X86_64, _, "openbsd" -> OpenBSD, ELF X86_64
+  | X86_64, _, "darwin" -> MacOS_like, Mach_O
+  | X86_64, _, "mingw" -> Windows MinGW, PE
+  | AArch64, _, "linux" -> Linux, ELF AArch64
+  | X86_64, _, "cygwin" -> Windows Cygwin, PE
+  | X86_64, _, "win64" -> Windows Native, PE
+  | _, _, "unknown" -> Unknown, Unknown
+  | _, _, _ ->
+    Misc.fatal_errorf "Cannot determine system type (model %s, system %s): \
+        ensure `target_system.ml' matches `configure'"
+      Config.model Config.system
+
+let system () =
+  fst (system_and_object_file_format_and_abi ())
+
+let object_file_format_and_abi () =
+  snd (system_and_object_file_format_and_abi ())
+
+let string_of_architecture arch =
+  match arch with
+  | IA32 -> "IA32"
+  | X86_64 -> "X86_64"
+  | ARM -> "ARM"
+  | AArch64 -> "AArch64"
+  | POWER -> "POWER"
+  | Z -> "Z"
+
+let linux () =
+  match system () with
+  | Linux -> true
+  | Windows _
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> false
+
+let windows () =
+  match system () with
+  | Windows _ -> true
+  | Linux
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> false
+
+let assembler () =
+  match system () with
+  | Windows Native -> MASM
+  | MacOS_like -> MacOS
+  | Linux
+  | Windows _
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | GNU
+  | Dragonfly
+  | BeOS
+  | Unknown -> GAS_like
+
+let machine_width () =
+  match Targetint.size with
+  | 32 -> Thirty_two
+  | 64 -> Sixty_four
+  | bits -> Misc.fatal_errorf "Unknown machine width: %d" bits
+
+let win32 () =
+  match system (), machine_width () with
+  | Windows Native, Thirty_two -> true
+  | _, _ -> false
+
+let win64 () =
+  match system (), machine_width () with
+  | Windows Native, Sixty_four -> true
+  | _, _ -> false
+
+let macos_like () =
+  match system () with
+  | MacOS_like -> true
+  | _ -> false

--- a/asmcomp/target_system.ml
+++ b/asmcomp/target_system.ml
@@ -202,3 +202,8 @@ let macos_like () =
   match system () with
   | MacOS_like -> true
   | _ -> false
+
+let solaris () =
+  match system () with
+  | Solaris -> true
+  | _ -> false

--- a/asmcomp/target_system.mli
+++ b/asmcomp/target_system.mli
@@ -82,6 +82,9 @@ val linux : unit -> bool
 (** Whether the target system is a Windows platform. *)
 val windows : unit -> bool
 
+(** Whether the target system is a Solaris platform. *)
+val solaris : unit -> bool
+
 (** Whether the target system is a Windows 32-bit native platform (not
     MinGW or Cygwin). *)
 val win32 : unit -> bool

--- a/asmcomp/target_system.mli
+++ b/asmcomp/target_system.mli
@@ -1,0 +1,107 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2017--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Types corresponding to the compiler's target machine. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type elf_abi = private
+  | ARM_GNU_EABI
+  | ARM_GNU_EABI_hard_float
+  | AArch64
+  | IA32
+  | POWER_ELF32
+  | POWER_ELF64v1
+  | POWER_ELF64v2
+  | X86_64
+  | Z
+
+type object_file_format_and_abi = private
+  | A_out
+  | ELF of elf_abi
+  | Mach_O
+  | PE
+  | Unknown
+
+type windows_system = private
+  | Cygwin
+  | MinGW
+  | Native
+
+type system = private
+  | Linux
+  | Windows of windows_system
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+type architecture = private
+  | IA32
+  | X86_64
+  | ARM
+  | AArch64
+  | POWER
+  | Z
+
+type assembler = private
+  | GAS_like
+  | MacOS
+  | MASM
+
+type machine_width =
+  | Thirty_two
+  | Sixty_four
+
+(** The target system of the OCaml compiler. *)
+val system : unit -> system
+
+(** The target object file format and ABI of the OCaml compiler. *)
+val object_file_format_and_abi : unit -> object_file_format_and_abi
+
+(** Whether the target system is a Linux platform. *)
+val linux : unit -> bool
+
+(** Whether the target system is a Windows platform. *)
+val windows : unit -> bool
+
+(** Whether the target system is a Windows 32-bit native platform (not
+    MinGW or Cygwin). *)
+val win32 : unit -> bool
+
+(** Whether the target system is a Windows 64-bit native platform (not
+    MinGW or Cygwin). *)
+val win64 : unit -> bool
+
+(** Whether the target system is Mac OS X, macOS, or some other system
+    running a Darwin kernel and associated userland tools. *)
+val macos_like : unit -> bool
+
+(** The architecture of the target system. *)
+val architecture : unit -> architecture
+
+(** Convert an architecture to a string. *)
+val string_of_architecture : architecture -> string
+
+(** The assembler being used. *)
+val assembler : unit -> assembler
+
+(** The natural machine width of the target system. *)
+val machine_width : unit -> machine_width

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -76,10 +76,10 @@ module D : sig
   val cfi_startproc: unit -> unit
   val comment: string -> unit
   val data: unit -> unit
-  val extrn: string -> data_type -> unit
+  val extrn: Asm_symbol.t -> data_type -> unit
   val file: file_num:int -> file_name:string -> unit
-  val global: string -> unit
-  val indirect_symbol: string -> unit
+  val global: Asm_symbol.t -> unit
+  val indirect_symbol: Asm_symbol.t -> unit
   val label: ?typ:data_type -> string -> unit
   val loc: file_num:int -> line:int -> col:int -> unit
   val long: constant -> unit

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -185,7 +185,7 @@ let print_instr b = function
   | MOV ((Imm n as arg1), (Reg64 _ as arg2))
     when not (n <= 0x7FFF_FFFFL && n >= -0x8000_0000L) ->
       i2 b "movabsq" arg1 arg2
-  | MOV ((Sym _ as arg1), (Reg64 _ as arg2)) when windows ->
+  | MOV ((Sym _ as arg1), (Reg64 _ as arg2)) when Target_system.windows () ->
       i2 b "movabsq" arg1 arg2
   | MOV (arg1, arg2) -> i2_s b "mov" arg1 arg2
   | MOVAPD (arg1, arg2) -> i2 b "movapd" arg1 arg2
@@ -245,11 +245,11 @@ let print_line b = function
 
   | Align (_data,n) ->
       (* MacOSX assembler interprets the integer n as a 2^n alignment *)
-      let n = if system = S_macosx then Misc.log2 n else n in
+      let n = if Target_system.macos_like () then Misc.log2 n else n in
       bprintf b "\t.align\t%d" n
   | Byte n -> bprintf b "\t.byte\t%a" cst n
   | Bytes s ->
-      if system = S_solaris then buf_bytes_directive b ".byte" s
+      if Target_system.solaris () then buf_bytes_directive b ".byte" s
       else bprintf b "\t.ascii\t\"%s\"" (string_of_string_literal s)
   | Comment s -> bprintf b "\t\t\t\t/* %s */" s
   | Global s -> bprintf b "\t.globl\t%s" s;
@@ -269,10 +269,10 @@ let print_line b = function
       | _ -> bprintf b ",%s" (String.concat "," args)
       end
   | Space n ->
-      if system = S_solaris then bprintf b "\t.zero\t%d" n
+      if Target_system.solaris () then bprintf b "\t.zero\t%d" n
       else bprintf b "\t.space\t%d" n
   | Word n ->
-      if system = S_solaris then bprintf b "\t.value\t%a" cst n
+      if Target_system.solaris () then bprintf b "\t.value\t%a" cst n
       else bprintf b "\t.word\t%a" cst n
 
   (* gas only *)

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -77,25 +77,6 @@ let string_of_string_literal s =
   done;
   Buffer.contents b
 
-let string_of_symbol prefix s =
-  let spec = ref false in
-  for i = 0 to String.length s - 1 do
-    match String.unsafe_get s i with
-    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '_' -> ()
-    | _ -> spec := true;
-  done;
-  if not !spec then if prefix = "" then s else prefix ^ s
-  else
-    let b = Buffer.create (String.length s + 10) in
-    Buffer.add_string b prefix;
-    String.iter
-      (function
-        | ('A'..'Z' | 'a'..'z' | '0'..'9' | '_') as c -> Buffer.add_char b c
-        | c -> Printf.bprintf b "$%02x" (Char.code c)
-      )
-      s;
-    Buffer.contents b
-
 let buf_bytes_directive b directive s =
   let pos = ref 0 in
   for i = 0 to String.length s - 1 do

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -28,7 +28,6 @@ val string_of_reg64: reg64 -> string
 val string_of_registerf: registerf -> string
 val string_of_string_literal: string -> string
 val string_of_condition: condition -> string
-val string_of_symbol: (*prefix*) string -> string -> string
 val string_of_rounding: rounding -> string
 val buf_bytes_directive:
   Buffer.t -> (*directive*) string -> (*data*)string -> unit

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -53,35 +53,11 @@ val assemble_file: (*infile*) string -> (*outfile*) string -> (*retcode*) int
     the input file is ignored). Otherwise, the source asm file with an
     external assembler. *)
 
-(** System detection *)
-
-type system =
-  (* 32 bits and 64 bits *)
-  | S_macosx
-  | S_gnu
-  | S_cygwin
-
-  (* 32 bits only *)
-  | S_solaris
-  | S_win32
-  | S_linux_elf
-  | S_bsd_elf
-  | S_beos
-  | S_mingw
-
-  (* 64 bits only *)
-  | S_win64
-  | S_linux
-  | S_mingw64
-
-  | S_unknown
-
-val system: system
-val masm: bool
-val windows:bool
+(** Whether the MASM assembler is being used. *)
+val masm : unit -> bool
 
 (** Whether calls need to go via the PLT. *)
-val use_plt : bool
+val use_plt : unit -> bool
 
 (** Support for plumbing a binary code emitter *)
 

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -22,7 +22,11 @@ let compile_file filename =
     Emitaux.output_channel := open_out out_name
   end; (* otherwise, stdout *)
   Compilenv.reset "test";
-  Emit.begin_assembly();
+  let comp_unit =
+    Backend_compilation_unit.compilation_unit
+      (Compilation_unit.get_current_exn ())
+  in
+  Emit.begin_assembly comp_unit;
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
   lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with pos_fname = filename };
@@ -33,7 +37,7 @@ let compile_file filename =
     done
   with
       End_of_file ->
-        close_in ic; Emit.end_assembly();
+        close_in ic; Emit.end_assembly comp_unit;
         if !write_asm_file then close_out !Emitaux.output_channel
     | Lexcmm.Error msg ->
         close_in ic; Lexcmm.report_error lb msg

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -79,7 +79,7 @@ CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp \
                        middle_end middle_end/closure middle_end/flambda \
                        middle_end/flambda/base_types driver toplevel \
-                       file_formats lambda)
+                       file_formats lambda asmcomp asmcomp/asm_target)
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
  -safe-string -strict-formats -bin-annot $(INCLUDES)
 LINKFLAGS = $(INCLUDES)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -237,6 +237,10 @@ module Stdlib = struct
 
     let print ppf t =
       Format.pp_print_string ppf t
+
+    let is_prefix t ~prefix =
+      length prefix <= length t
+        && equal (sub t 0 (length prefix)) prefix
   end
 
   external compare : 'a -> 'a -> int = "%compare"

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -176,6 +176,9 @@ module Stdlib : sig
     val print : Format.formatter -> t -> unit
 
     val for_all : (char -> bool) -> t -> bool
+
+    (** Returns [true] iff the given string starts with [prefix]. *)
+    val is_prefix : t -> prefix:t -> bool
   end
 
   external compare : 'a -> 'a -> int = "%compare"


### PR DESCRIPTION
This pull request is the third in a series of four that overhaul the types used to represent symbols throughout the compiler, in conjunction with various other refactorings, that either fell out naturally during development or were necessitated.  (The first two are #2281, which has been merged, and #2288, which should be ready soon.)  At present, the majority of symbol types are just "string", but there are a couple more (`Symbol.t` and `Linkage_name.t`) used in Flambda.

Symbols are difficult to deal with because of various layers of mangling, escaping, prefixing and suffixing---some of which is OCaml-specific and some of which is architecture- and/or OS target-specific.  In addition, the current treatment of them (especially at the boundary between the middle end and backend) is highly involved, in parts very subtle, and overly divergent between Closure and Flambda modes.  After the four parts of this series I am confident things will be much easier to understand and less error-prone.

This patch series means that we will be able to make strong checks to ensure that we are not emitting expressions involving symbols whose semantics we do not understand.  It is very easy to stray into such areas, some of which may yield surprising results, without any assembly- or link-time error messages; others may cause compile-time failures with unusual messages. 

This work also means that we should be able to track other information about symbols, for example whether they should be marked local or global, with little difficulty in the future.

This individual PR is effectively a subset of #2073 which will become obsolete or be altered to only include `Asm_directives` and `Asm_label`.  (The former is a target-independent abstraction for the emission of assembler directives which will enable a fair amount of boilerplate to be removed from the individual code emitters.)

The end state contains the following modules:
- `Symbol`: representing "middle end symbols".  These are created in the middle end and are segregated according to what they point at (lifted closures, anonymous constants, etc).  With one exception, namely function pointers for direct application, they always point at well-formed OCaml values.  Middle end symbols always correspond to an OCaml compilation unit (by which I mean a compilation unit arising from OCaml source files, not a startup or shared startup file fabricated in `Cmmgen`).

- `Backend_sym`: representing "backend symbols".  These are used from the `Cmm` language onwards and are passed into the emitters.  All OCaml-specific name mangling is encapsulated within `Backend_sym`.  Unlike middle-end symbols, backend symbols may point anywhere, although their definition point is recorded.  Since not all backend symbols arise from OCaml compilation units, they are associated with a new type `Backend_compilation_unit.t`, which is an extended version of `Compilation_unit.t`.  It can describe the locations of symbols at an approximate but adequately precise level, for example being in some OCaml compilation unit, or a startup file, or an external library.

- `Asm_symbol`: representing "assembly language symbols".  These are basically raw text that can be emitted into an assembly file.  `Asm_symbol` knows how to do target-specific (not OCaml-specific) name mangling conventions, including the application of symbol prefixes, and escaping.  Each `Asm_symbol.t` is tied to an `Object_file.t`, the latter being a simplified version of a `Backend_compilation_unit.t`.  Assembly language symbols also know which object file section they are defined in.

The `Linkage_name` module currently used in Flambda will be deleted in the fourth patch.  (The fourth patch also enables the complete removal of `Export_info_for_pack`; and I think with only a small amount of subsequent work it will be possible to completely eliminate the rewriting that currently happens when Flambda loads `.cmx` files.  This should simplify the code and make compilation go faster.)

This patch contains a skeleton implementation of `Backend_sym`, which comes along with the nearly-complete implementation of `Backend_compilation_unit`, in order that part 4 of this patch series becomes fully target-independent (no changes to the emitters).  Various places that used to directly match on strings have been changed to use the proper equality function on `Backend_sym.t` values.  (This code would actually compile without those, due to the presence of the type equality to `string` in `backend_sym.mli`, but that equality will be removed in part 4 making `Backend_sym.t` abstract.)

The `Asm_section` and `Asm_symbol` modules here incorporate the comments from the review of @damiendoligez on #2073.