### PR TITLE
Fix exception handler addresses for Thumb-2 

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,8 +57,9 @@ Working version
 - #2229: Env: remove prefix_idents cache
   (Thomas Refis, review by Frédéric Bour and Gabriel Scherer)
 
-- #2237: Reorder linearisation of Trywith to avoid a call instruction
-  (Vincent Laviron and Greta Yorsh, additional review by Mark Shinwell)
+- #2237, #8582: Reorder linearisation of Trywith to avoid a call instruction
+  (Vincent Laviron and Greta Yorsh, additional review by Mark Shinwell;
+  fix in #8582 by Mark Shinwell, Xavier Leroy and Anil Madhavapeddy)
 
 - #2265: Add bytecomp/opcodes.mli
   (Mark Shinwell, review by Nicolas Ojeda Bar)

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -354,8 +354,11 @@ let emit_literals() =
   end;
   if !offset_literals <> [] then begin
     (* Additions using the pc register read a value 4 or 8 bytes greater than
-       the instruction's address, depending on the thumb setting *)
-    let offset = if !thumb then 4 else 8 in
+       the instruction's address, depending on the Thumb setting.  However in
+       Thumb mode we must follow interworking conventions and ensure that the
+       bottom bit of the pc value is set when reloaded from the trap frame.
+       Hence "3" not "4". *)
+    let offset = if !thumb then 3 else 8 in
     `	.align	2\n`;
     List.iter
       (fun { lbl; dst; src; } ->


### PR DESCRIPTION
The addresses of Thumb-2 exception handlers are computed incorrectly following #2237.

Fixes #8578 
