### PR TITLE
Apply peephole optimizations to if conditions

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ Working version
   (Greg V, review by Sébastien Hinderer, Stephen Dolan, Damien Doligez
    and Xavier Leroy)
 
+- #8583: Simplify nested comparisons in if conditions
+  (Stefan Muenzel, review by ????)
+
 ### Compiler user-interface and warnings:
 
 * #2276: Remove support for compiler plugins and hooks (also adds

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -142,6 +142,7 @@ and operation =
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Ccmpi of integer_comparison
+  (** [Ccmpi] results in an untagged int: 1 (true) or 0 (false) *)
   | Caddv (* pointer addition that produces a [Val] (well-formed Caml value) *)
   | Cadda (* pointer addition that produces a [Addr] (derived heap pointer) *)
   | Ccmpa of integer_comparison
@@ -172,6 +173,8 @@ and expression =
   | Csequence of expression * expression
   | Cifthenelse of expression * Debuginfo.t * expression
       * Debuginfo.t * expression * Debuginfo.t
+  (** The [Cifthenelse] condition is an expression that results in an integer
+      that can be 0 (false) or 1 (true). It is not tagged. *)
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
       * Debuginfo.t
   | Ccatch of


### PR DESCRIPTION
If conditions sometimes end up comparing the result of a comparison with true/false, either tagged or untagged.
This PR simplifies these operations to use the result of the comparison directly. 
A instrumented version of this PR was run against a subset of the Jane Street codebase, and the three conditions checked triggered more than 9000 times each (except the third, which triggered around 600 times).