### PR TITLE
fix #7829: pointer comparisons in assertions

### DIFF
--- a/Changes
+++ b/Changes
@@ -586,6 +586,9 @@ OCaml 4.08.0
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
+- #7829, #8585: Fix assertions in debug mode for 32-bit platforms
+  (Damien Doligez, review by David Allsopp)
+
 - #8567, #8569: on ARM64, use 32-bit loads to access caml_backtrace_active
   (Xavier Leroy, review by Mark Shinwell and Greta Yorsh)
 

--- a/Changes
+++ b/Changes
@@ -586,8 +586,8 @@ OCaml 4.08.0
   no-naked-pointers
   (Sam Goldman, review by Gabriel Scherer, David Allsopp, Stephen Dolan)
 
-- #7829, #8585: Fix assertions in debug mode for 32-bit platforms
-  (Damien Doligez, review by David Allsopp)
+- #7829, #8585: Fix pointer comparisons in freelist.c (for 32-bit platforms)
+  (David Allsopp and Damien Doligez)
 
 - #8567, #8569: on ARM64, use 32-bit loads to access caml_backtrace_active
   (Xavier Leroy, review by Mark Shinwell and Greta Yorsh)

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -90,7 +90,8 @@ static void fl_check (void)
         CAMLassert (Next (flp[flp_found]) == cur);
         ++ flp_found;
       }else{
-        CAMLassert (beyond == Val_NULL || cur >= Next (beyond));
+        CAMLassert (beyond == Val_NULL
+                    || Bp_val (cur) >= Bp_val (Next (beyond)));
       }
     }
     if (cur == caml_fl_merge) merge_found = 1;
@@ -460,13 +461,13 @@ header_t *caml_fl_merge_block (value bp)
   cur = Next (prev);
   /* The sweep code makes sure that this is the right place to insert
      this block: */
-  CAMLassert (prev < bp || prev == Fl_head);
-  CAMLassert (cur > bp || cur == Val_NULL);
+  CAMLassert (Bp_val (prev) < Bp_val (bp) || prev == Fl_head);
+  CAMLassert (Bp_val (cur) > Bp_val (bp) || cur == Val_NULL);
 
   if (policy == Policy_first_fit) truncate_flp (prev);
 
   /* If [last_fragment] and [bp] are adjacent, merge them. */
-  if (last_fragment == Hp_bp (bp)){
+  if (last_fragment == Hp_val (bp)){
     mlsize_t bp_whsz = Whsize_val (bp);
     if (bp_whsz <= Max_wosize){
       hd = Make_header (bp_whsz, 0, Caml_white);
@@ -556,13 +557,13 @@ void caml_fl_add_blocks (value bp)
     prev = Fl_head;
     cur = Next (prev);
     while (cur != Val_NULL && cur < bp){
-      CAMLassert (prev < bp || prev == Fl_head);
+      CAMLassert (Bp_val (prev) < Bp_val (bp) || prev == Fl_head);
       /* XXX TODO: extend flp on the fly */
       prev = cur;
       cur = Next (prev);
     }
-    CAMLassert (prev < bp || prev == Fl_head);
-    CAMLassert (cur > bp || cur == Val_NULL);
+    CAMLassert (Bp_val (prev) < Bp_val (bp) || prev == Fl_head);
+    CAMLassert (Bp_val (cur) > Bp_val (bp) || cur == Val_NULL);
     Next (Field (bp, 1)) = cur;
     Next (prev) = bp;
     /* When inserting blocks between [caml_fl_merge] and [caml_gc_sweep_hp],

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -418,9 +418,10 @@ static void truncate_flp (value changed)
     flp_size = 0;
     beyond = Val_NULL;
   }else{
-    while (flp_size > 0 && Next (flp[flp_size - 1]) >= changed)
+    while (flp_size > 0
+           && Bp_val (Next (flp[flp_size - 1])) >= Bp_val (changed))
       -- flp_size;
-    if (beyond >= changed) beyond = Val_NULL;
+    if (Bp_val (beyond) >= Bp_val (changed)) beyond = Val_NULL;
   }
 }
 
@@ -543,7 +544,7 @@ void caml_fl_add_blocks (value bp)
     cur = Field(cur, 0);
   } while (cur != Val_NULL);
 
-  if (bp > fl_last){
+  if (Bp_val (bp) > Bp_val (fl_last)){
     Next (fl_last) = bp;
     if (fl_last == caml_fl_merge && (char *) bp < caml_gc_sweep_hp){
       caml_fl_merge = Field (bp, 1);
@@ -556,7 +557,7 @@ void caml_fl_add_blocks (value bp)
 
     prev = Fl_head;
     cur = Next (prev);
-    while (cur != Val_NULL && cur < bp){
+    while (cur != Val_NULL && Bp_val (cur) < Bp_val (bp)){
       CAMLassert (Bp_val (prev) < Bp_val (bp) || prev == Fl_head);
       /* XXX TODO: extend flp on the fly */
       prev = cur;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -60,7 +60,7 @@ extern uintnat caml_custom_major_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
 
-#define Next(hp) ((hp) + Whsize_hp (hp))
+#define Next(hp) ((header_t *)(hp) + Whsize_hp (hp))
 
 #ifdef DEBUG
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -788,7 +788,7 @@ CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
 {
   char *raw_mem;
   uintnat aligned_mem;
-  CAMLassert (modulo < Page_size);
+  CAMLassert (0 <= modulo && modulo < Page_size);
   raw_mem = (char *) caml_stat_alloc_noexc(sz + Page_size);
   if (raw_mem == NULL) return NULL;
   *b = raw_mem;


### PR DESCRIPTION
This is a replacement for #1311 and a fix for #7829. When comparing values in debug assertions, cast them to pointers to make sure we don't get into trouble with the sign bit.

Note, this is only relevant on some 32-bit machines, the most important being our Travis CI x86 worker.
