### PR TITLE
manual: fix cross-reference test

### DIFF
--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -20,7 +20,7 @@ check-cross-references: cross-reference-checker
 	  -auxfile $(MANUAL)/texstuff/manual.aux \
 	  $(TOPDIR)/utils/warnings.ml \
 	  $(TOPDIR)/driver/main_args.ml \
-	  $(TOPDIR)/bytecomp/translmod.ml
+	  $(TOPDIR)/lambda/translmod.ml
 
 .PHONY: check-stdlib
 check-stdlib:


### PR DESCRIPTION
This PR fixes the manual cross-reference test after the middle end reorganisation.