### PR TITLE
manual: update references to toplevel improvements

### DIFF
--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -72,14 +72,7 @@ latter is read and executed as described below.
 
 The toplevel system does not perform line editing, but it can
 easily be used in conjunction with an external line editor such as
-"ledit", "ocaml2" or "rlwrap"
-\begin{latexonly}
-(see the Caml Hump "http://caml.inria.fr/humps/index_framed_caml.html").
-\end{latexonly}
-\begin{htmlonly}
-(see the
-\ahref{http://caml.inria.fr/humps/index\_framed\_caml.html}{Caml Hump}).
-\end{htmlonly}
+"ledit", or "rlwrap". An improved toplevel, "utop", is also available.
 Another option is to use "ocaml" under Gnu Emacs, which gives the
 full editing power of Emacs (command "run-caml" from library "inf-caml").
 


### PR DESCRIPTION
This small PR replaces the reference to `ocaml2` with a reference to `utop` in the manual's short list of toplevel improvements. Similarly, the link to the Caml Hump is replaced by a link to opam.ocaml.org.
It might make sense to cherry-pick this PR to 4.08 due to the broken link.

Closes #8574 .