### PR TITLE
Custom Exception Handlers at toplevel

### DIFF
--- a/Changes
+++ b/Changes
@@ -167,8 +167,9 @@ Working version
 
 ### Bug fixes:
 
-- #7156: make top level use custom printers if they are available
-  (Andrew Litteken, report by Martin Jambon, review by )
+- #7156, #8594: make top level use custom printers if they are available
+  (Andrew Litteken, report by Martin Jambon, review by Nicolás Ojeda Bär,
+   Thomas Refis, Armaël Guéneau, Gabriel Scherer, David Allsopp)
 - #3249: ocamlmklib should reject .cmxa files
   (Xavier Leroy)
 - #7937, #2287: fix uncaught Unify exception when looking for type

--- a/Changes
+++ b/Changes
@@ -161,6 +161,9 @@ Working version
 
 ### Bug fixes:
 
+- #7156: Create Mechanism so that OCaml Top Level uses custom printers 
+  if they are available
+  (Andrew Litteken, report by Martin Jambon, review by )
 - #3249: ocamlmklib should reject .cmxa files
   (Xavier Leroy)
 - #7937, #2287: fix uncaught Unify exception when looking for type

--- a/Changes
+++ b/Changes
@@ -161,8 +161,7 @@ Working version
 
 ### Bug fixes:
 
-- #7156: Create Mechanism so that OCaml Top Level uses custom printers 
-  if they are available
+- #7156: make top level use custom printers if they are available
   (Andrew Litteken, report by Martin Jambon, review by )
 - #3249: ocamlmklib should reject .cmxa files
   (Xavier Leroy)

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -69,6 +69,11 @@ let to_string x =
               constructor ^ (fields x) in
   conv !printers
 
+let to_string_opt x =
+  match !printers with
+      [] -> None
+    | _ -> Some (to_string x)
+
 let print fct arg =
   try
     fct arg

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -43,36 +43,38 @@ let fields x =
   | 2 -> sprintf "(%s)" (field x 1)
   | _ -> sprintf "(%s%s)" (field x 1) (other_fields x 2)
 
-let to_string x =
+let use_printers x =
   let rec conv = function
     | hd :: tl ->
         (match try hd x with _ -> None with
-        | Some s -> s
+        | Some s -> Some s
         | None -> conv tl)
-    | [] ->
-        match x with
-        | Out_of_memory -> "Out of memory"
-        | Stack_overflow -> "Stack overflow"
-        | Match_failure(file, line, char) ->
-            sprintf locfmt file line char (char+5) "Pattern matching failed"
-        | Assert_failure(file, line, char) ->
-            sprintf locfmt file line char (char+6) "Assertion failed"
-        | Undefined_recursive_module(file, line, char) ->
-            sprintf locfmt file line char (char+6) "Undefined recursive module"
-        | _ ->
-            let x = Obj.repr x in
-            if Obj.tag x <> 0 then
-              (Obj.magic (Obj.field x 0) : string)
-            else
-              let constructor =
-                (Obj.magic (Obj.field (Obj.field x 0) 0) : string) in
-              constructor ^ (fields x) in
+    | [] -> None in
   conv !printers
 
-let to_string_opt x =
-  match !printers with
-      [] -> None
-    | _ -> Some (to_string x)
+let to_string_default x =
+  match x with
+  | Out_of_memory -> "Out of memory"
+  | Stack_overflow -> "Stack overflow"
+  | Match_failure(file, line, char) ->
+      sprintf locfmt file line char (char+5) "Pattern matching failed"
+  | Assert_failure(file, line, char) ->
+      sprintf locfmt file line char (char+6) "Assertion failed"
+  | Undefined_recursive_module(file, line, char) ->
+      sprintf locfmt file line char (char+6) "Undefined recursive module"
+  | _ ->
+      let x = Obj.repr x in
+      if Obj.tag x <> 0 then
+        (Obj.magic (Obj.field x 0) : string)
+      else
+        let constructor =
+          (Obj.magic (Obj.field (Obj.field x 0) 0) : string) in
+        constructor ^ (fields x)
+
+let to_string e =
+  match use_printers e with
+  | Some s -> s
+  | None -> to_string_default e
 
 let print fct arg =
   try

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -46,8 +46,9 @@ let fields x =
 let use_printers x =
   let rec conv = function
     | hd :: tl ->
-        let result = (try hd x with _ -> None) in
-        if result <> None then result else conv tl
+        (match hd x with
+         | None | exception _ -> conv tl
+         | Some s -> Some s)
     | [] -> None in
   conv !printers
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -46,14 +46,12 @@ let fields x =
 let use_printers x =
   let rec conv = function
     | hd :: tl ->
-        (match try hd x with _ -> None with
-        | Some s -> Some s
-        | None -> conv tl)
+        let result = (try hd x with _ -> None) in
+        if result <> None then result else conv tl
     | [] -> None in
   conv !printers
 
-let to_string_default x =
-  match x with
+let to_string_default = function
   | Out_of_memory -> "Out of memory"
   | Stack_overflow -> "Stack overflow"
   | Match_failure(file, line, char) ->
@@ -62,7 +60,7 @@ let to_string_default x =
       sprintf locfmt file line char (char+6) "Assertion failed"
   | Undefined_recursive_module(file, line, char) ->
       sprintf locfmt file line char (char+6) "Undefined recursive module"
-  | _ ->
+  | x ->
       let x = Obj.repr x in
       if Obj.tag x <> 0 then
         (Obj.magic (Obj.field x 0) : string)

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -103,7 +103,7 @@ val register_printer: (exn -> string option) -> unit
 
 val use_printers: exn -> string option
 (** [Printexc.use_printers e] returns [None] if there are no registered
-    printers and [Some (to_string e)] otherwise.
+    printers and [Some s] with else as the resulting string otherwise.
     @since 4.09
 *)
 

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -100,7 +100,7 @@ val register_printer: (exn -> string option) -> unit
 *)
 
 val use_printers: exn -> string option
-(** [Printexc.use_printers e] returns [None] if there are no registered 
+(** [Printexc.use_printers e] returns [None] if there are no registered
     printers and [Some (to_string e)] otherwise.*)
 
 (** {1 Raw backtraces} *)

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -22,6 +22,11 @@ val to_string: exn -> string
 (** [Printexc.to_string e] returns a string representation of
    the exception [e]. *)
 
+val to_string_opt: exn -> string option
+(** [Printexc.to_string_opt e] returns a string option containing None if
+  there are no registered printers and Some s for a representation if there
+  are registered printers. *)
+
 val print: ('a -> 'b) -> 'a -> 'b
 (** [Printexc.print fn x] applies [fn] to [x] and returns the result.
    If the evaluation of [fn x] raises any exception, the

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -22,10 +22,9 @@ val to_string: exn -> string
 (** [Printexc.to_string e] returns a string representation of
    the exception [e]. *)
 
-val to_string_opt: exn -> string option
-(** [Printexc.to_string_opt e] returns a string option containing None if
-  there are no registered printers and Some s for a representation if there
-  are registered printers. *)
+val to_string_default: exn -> string
+(** [Printexc.to_string_opt e] returns a string that would be generated
+    without registered printers of exception [e] *)
 
 val print: ('a -> 'b) -> 'a -> 'b
 (** [Printexc.print fn x] applies [fn] to [x] and returns the result.
@@ -99,6 +98,10 @@ val register_printer: (exn -> string option) -> unit
     the backtrace if it has itself raised an exception before.
     @since 3.11.2
 *)
+
+val use_printers: exn -> string option
+(** [Printexc.use_printers e] returns [None] if there are no registered 
+    printers and [Some (to_string e)] otherwise.*)
 
 (** {1 Raw backtraces} *)
 

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -23,8 +23,10 @@ val to_string: exn -> string
    the exception [e]. *)
 
 val to_string_default: exn -> string
-(** [Printexc.to_string_opt e] returns a string that would be generated
-    without registered printers of exception [e] *)
+(** [Printexc.to_string_default e] returns a string representation of the
+    exception [e], ignoring all registered exception printers.
+    @since 4.09
+*)
 
 val print: ('a -> 'b) -> 'a -> 'b
 (** [Printexc.print fn x] applies [fn] to [x] and returns the result.
@@ -101,7 +103,9 @@ val register_printer: (exn -> string option) -> unit
 
 val use_printers: exn -> string option
 (** [Printexc.use_printers e] returns [None] if there are no registered
-    printers and [Some (to_string e)] otherwise.*)
+    printers and [Some (to_string e)] otherwise.
+    @since 4.09
+*)
 
 (** {1 Raw backtraces} *)
 

--- a/testsuite/tests/tool-toplevel/ocamltests
+++ b/testsuite/tests/tool-toplevel/ocamltests
@@ -5,3 +5,4 @@ pr7751.ml
 strings.ml
 tracing.ml
 error_highlighting.ml
+uncaught_exceptions.ml

--- a/testsuite/tests/tool-toplevel/uncaught_exceptions.ml
+++ b/testsuite/tests/tool-toplevel/uncaught_exceptions.ml
@@ -1,0 +1,39 @@
+(* TEST
+   * expect
+*)
+
+(* PR#8594 *)
+Printexc.register_printer (fun e -> 
+  match e with 
+    | Division_by_zero -> Some "A division by zero is undefined"
+    | _ -> None);;
+Printexc.register_printer (fun e -> 
+  match e with 
+    | Exit -> Some "Catching an exit"
+    | _ -> None);;
+raise Not_found;;
+[%%expect{|
+- : unit = ()
+- : unit = ()
+Exception: Not_found.
+|}];;
+
+raise Exit;;
+[%%expect{|
+Exception: Catching an exit
+|}];;
+
+exception Foo of string;;
+[%%expect {|
+exception Foo of string
+|}];;
+
+raise (Foo "bar");;
+[%%expect {|
+Exception: Foo "bar".
+|}];;
+
+raise Division_by_zero;;
+[%%expect {|
+Exception: A division by zero is undefined
+|}];;

--- a/testsuite/tests/tool-toplevel/uncaught_exceptions.ml
+++ b/testsuite/tests/tool-toplevel/uncaught_exceptions.ml
@@ -3,12 +3,12 @@
 *)
 
 (* PR#8594 *)
-Printexc.register_printer (fun e -> 
-  match e with 
+Printexc.register_printer (fun e ->
+  match e with
     | Division_by_zero -> Some "A division by zero is undefined"
     | _ -> None);;
-Printexc.register_printer (fun e -> 
-  match e with 
+Printexc.register_printer (fun e ->
+  match e with
     | Exit -> Some "Catching an exit"
     | _ -> None);;
 raise Not_found;;

--- a/testsuite/tests/tool-toplevel/uncaught_exceptions.ml
+++ b/testsuite/tests/tool-toplevel/uncaught_exceptions.ml
@@ -7,14 +7,20 @@ Printexc.register_printer (fun e ->
   match e with
     | Division_by_zero -> Some "A division by zero is undefined"
     | _ -> None);;
+[%%expect{|
+- : unit = ()
+|}];;
+
 Printexc.register_printer (fun e ->
   match e with
     | Exit -> Some "Catching an exit"
     | _ -> None);;
-raise Not_found;;
 [%%expect{|
 - : unit = ()
-- : unit = ()
+|}];;
+
+raise Not_found;;
+[%%expect{|
 Exception: Not_found.
 |}];;
 

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -717,7 +717,9 @@ let print_out_exception ppf exn outv =
   | Out_of_memory -> fprintf ppf "Out of memory during evaluation.@."
   | Stack_overflow ->
       fprintf ppf "Stack overflow during evaluation (looping recursion?).@."
-  | _ -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
+  | _ -> match Printexc.to_string_opt exn with
+        None -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
+      | Some s -> fprintf ppf "@[Exception:@ %s.@]@." s
 
 let rec print_items ppf =
   function

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -717,8 +717,8 @@ let print_out_exception ppf exn outv =
   | Out_of_memory -> fprintf ppf "Out of memory during evaluation.@."
   | Stack_overflow ->
       fprintf ppf "Stack overflow during evaluation (looping recursion?).@."
-  | _ -> match Printexc.to_string_opt exn with
-        None -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
+  | _ -> match Printexc.use_printers exn with
+      | None -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
       | Some s -> fprintf ppf "@[Exception:@ %s.@]@." s
 
 let rec print_items ppf =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -718,8 +718,8 @@ let print_out_exception ppf exn outv =
   | Stack_overflow ->
       fprintf ppf "Stack overflow during evaluation (looping recursion?).@."
   | _ -> match Printexc.use_printers exn with
-      | None -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
-      | Some s -> fprintf ppf "@[Exception:@ %s@]@." s
+        | None -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
+        | Some s -> fprintf ppf "@[Exception:@ %s@]@." s
 
 let rec print_items ppf =
   function

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -719,7 +719,7 @@ let print_out_exception ppf exn outv =
       fprintf ppf "Stack overflow during evaluation (looping recursion?).@."
   | _ -> match Printexc.use_printers exn with
       | None -> fprintf ppf "@[Exception:@ %a.@]@." !out_value outv
-      | Some s -> fprintf ppf "@[Exception:@ %s.@]@." s
+      | Some s -> fprintf ppf "@[Exception:@ %s@]@." s
 
 let rec print_items ppf =
   function


### PR DESCRIPTION
This is in response to issue [#7156](https://github.com/ocaml/ocaml/issues/7156) where the OCaml Top-level level does not use any custom printers if they are registered.

There is a new function in `Printexc.ml` called `to_string_opt` that returns an option that is None where there are no printers registers, and Some string when there are printers that have been registered to resolve the Exception.

The addition involved adding to the `print_out_exception` function found in `types/oprint.ml`.  For all Exceptions excluding Interrupts and Out of Memory errors, the result of the new function `Printexc.to_string_opt` is called against the exception.  If None is returned, the previous method is used, if Some is returned then the string generated from the printers is used.

Closes [#7156](https://github.com/ocaml/ocaml/issues/7156)