### PR TITLE
optimize some buffer operations (implements #6148)

### DIFF
--- a/Changes
+++ b/Changes
@@ -126,6 +126,10 @@ Working version
   in printf %F
   (Pierre Roux, review by Gabriel Scherer)
 
+- #6148, #8596: optimize some buffer operations
+  (Damien Doligez, reports by John Whitington and Alain Frisch,
+   review by Jeremy Yallop and Gabriel Scherer)
+
 ### Other libraries:
 
 - #7903, #2306: Make Thread.delay interruptible by signals again

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -72,7 +72,8 @@ let resize b more =
      this tricky function that is slow anyway. *)
   Bytes.blit b.buffer 0 new_buffer 0 b.position;
   b.buffer <- new_buffer;
-  b.length <- !new_len
+  b.length <- !new_len;
+  assert (b.position + more <= b.length)
 
 let add_char b c =
   let pos = b.position in
@@ -277,6 +278,7 @@ let truncate b len =
 
 let to_seq b =
   let rec aux i () =
+    (* Note that b.position is not a constant and cannot be lifted out of aux *)
     if i >= b.position then Seq.Nil
     else
       let x = Bytes.unsafe_get b.buffer i in
@@ -286,6 +288,7 @@ let to_seq b =
 
 let to_seqi b =
   let rec aux i () =
+    (* Note that b.position is not a constant and cannot be lifted out of aux *)
     if i >= b.position then Seq.Nil
     else
       let x = Bytes.unsafe_get b.buffer i in

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -279,7 +279,7 @@ let to_seq b =
   let rec aux i () =
     if i >= b.position then Seq.Nil
     else
-      let x = Bytes.get b.buffer i in
+      let x = Bytes.unsafe_get b.buffer i in
       Seq.Cons (x, aux (i+1))
   in
   aux 0
@@ -288,7 +288,7 @@ let to_seqi b =
   let rec aux i () =
     if i >= b.position then Seq.Nil
     else
-      let x = Bytes.get b.buffer i in
+      let x = Bytes.unsafe_get b.buffer i in
       Seq.Cons ((i,x), aux (i+1))
   in
   aux 0

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -163,7 +163,7 @@ let add_substring b s offset len =
   then invalid_arg "Buffer.add_substring/add_subbytes";
   let new_position = b.position + len in
   if new_position > b.length then resize b len;
-  Bytes.blit_string s offset b.buffer b.position len;
+  Bytes.unsafe_blit_string s offset b.buffer b.position len;
   b.position <- new_position
 
 let add_subbytes b s offset len =
@@ -173,7 +173,7 @@ let add_string b s =
   let len = String.length s in
   let new_position = b.position + len in
   if new_position > b.length then resize b len;
-  Bytes.blit_string s 0 b.buffer b.position len;
+  Bytes.unsafe_blit_string s 0 b.buffer b.position len;
   b.position <- new_position
 
 let add_bytes b s = add_string b (Bytes.unsafe_to_string s)

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -669,7 +669,8 @@ external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
 external unsafe_blit :
   bytes -> int -> bytes -> int -> int -> unit
   = "caml_blit_bytes" [@@noalloc]
-external unsafe_blit_string : string -> int -> bytes -> int -> int -> unit
-                     = "caml_blit_string" [@@noalloc]
+external unsafe_blit_string :
+  string -> int -> bytes -> int -> int -> unit
+  = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
   bytes -> int -> int -> char -> unit = "caml_fill_bytes" [@@noalloc]

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -669,5 +669,7 @@ external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
 external unsafe_blit :
   bytes -> int -> bytes -> int -> int -> unit
   = "caml_blit_bytes" [@@noalloc]
+external unsafe_blit_string : string -> int -> bytes -> int -> int -> unit
+                     = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
   bytes -> int -> int -> char -> unit = "caml_fill_bytes" [@@noalloc]

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -513,8 +513,9 @@ external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
 external unsafe_blit :
   src:bytes -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int ->
     unit = "caml_blit_bytes" [@@noalloc]
-external unsafe_blit_string : string -> int -> bytes -> int -> int -> unit
-                     = "caml_blit_string" [@@noalloc]
+external unsafe_blit_string :
+  src:string -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int -> unit
+  = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
   bytes -> pos:int -> len:int -> char -> unit = "caml_fill_bytes" [@@noalloc]
 val unsafe_to_string : bytes -> string

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -513,6 +513,8 @@ external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
 external unsafe_blit :
   src:bytes -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int ->
     unit = "caml_blit_bytes" [@@noalloc]
+external unsafe_blit_string : string -> int -> bytes -> int -> int -> unit
+                     = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
   bytes -> pos:int -> len:int -> char -> unit = "caml_fill_bytes" [@@noalloc]
 val unsafe_to_string : bytes -> string


### PR DESCRIPTION
`Buffer.add_string` and `Buffer.add_substring` are the two remaining functions from #6148 that were not optimized when we switched to safe strings.
