### PR TITLE
Buffer trickeries

### DIFF
--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -202,6 +202,11 @@ let really_input_up_to ic buf ofs len =
 let unsafe_add_channel_up_to b ic len =
   if b.position + len > b.length then resize b len;
   let n = really_input_up_to ic b.buffer b.position len in
+  (* The assertion below may fail in weird scenario where
+     threaded/finalizer code races on the buffer; we don't
+     support these use-cases, but we want to at least
+     preserve the invariant. *)
+  assert (b.position + n <= b.length);
   b.position <- b.position + n;
   n
 


### PR DESCRIPTION
The various changes here should not make any difference for `Buffer` users, but they are the result of an extensive conversation on the correctness of `unsafe_set` usage in the module in #8596.