### PR TITLE
Replace "not is_nonexpansive" by "maybe_expansive"

### DIFF
--- a/Changes
+++ b/Changes
@@ -106,6 +106,10 @@ Working version
 - #7878, #8542: Replaced TypedtreeIter with tast_iterator
   (Isaac "Izzy" Avram, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #8598: Replace "not is_nonexpansive" by "maybe_expansive".
+  (Thomas Refis, review by David Allsopp, Florian Angeletti, Gabriel Radanne,
+   Gabriel Scherer and Xavier Leroy)
+
 ### Runtime system:
 
 - #1725, #2279: Deprecate Obj.set_tag and Obj.truncate

--- a/testsuite/tests/typing-misc/is_expansive.ml
+++ b/testsuite/tests/typing-misc/is_expansive.ml
@@ -8,5 +8,5 @@ match [] with x -> (fun x -> x);;
 
 match [] with x -> (fun x -> x) | _ -> .;;
 [%%expect{|
-- : '_weak1 -> '_weak1 = <fun>
+- : 'a -> 'a = <fun>
 |}];;

--- a/testsuite/tests/typing-misc/is_expansive.ml
+++ b/testsuite/tests/typing-misc/is_expansive.ml
@@ -1,0 +1,12 @@
+(* TEST
+   * expect *)
+
+match [] with x -> (fun x -> x);;
+[%%expect{|
+- : 'a -> 'a = <fun>
+|}];;
+
+match [] with x -> (fun x -> x) | _ -> .;;
+[%%expect{|
+- : '_weak1 -> '_weak1 = <fun>
+|}];;

--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -2,6 +2,7 @@ constraints.ml
 disambiguate_principality.ml
 exotic_unifications.ml
 inside_out.ml
+is_expansive.ml
 labels.ml
 occur_check.ml
 pat_type_sharing.ml

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1866,7 +1866,22 @@ let rec is_nonexpansive exp =
                          ("%raise" | "%reraise" | "%raise_notrace")}}) },
       [Nolabel, Some e]) ->
      is_nonexpansive e
-  | _ -> false
+  | Texp_array (_ :: _)
+  | Texp_apply _
+  | Texp_unreachable
+  | Texp_try _
+  | Texp_setfield _
+  | Texp_while _
+  | Texp_for _
+  | Texp_send _
+  | Texp_new _
+  | Texp_instvar _
+  | Texp_setinstvar _
+  | Texp_override _
+  | Texp_letexception _
+  | Texp_letop _
+  | Texp_extension_constructor _ ->
+    false
 
 and is_nonexpansive_mod mexp =
   match mexp.mod_desc with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1829,8 +1829,7 @@ let rec is_nonexpansive exp =
   | Texp_ifthenelse(_cond, ifso, ifnot) ->
       is_nonexpansive ifso && is_nonexpansive_opt ifnot
   | Texp_sequence (_e1, e2) -> is_nonexpansive e2  (* PR#4354 *)
-  | Texp_new (_, _, cl_decl) when Ctype.class_type_arity cl_decl.cty_type > 0 ->
-      true
+  | Texp_new (_, _, cl_decl) -> Ctype.class_type_arity cl_decl.cty_type > 0
   (* Note: nonexpansive only means no _observable_ side effects *)
   | Texp_lazy e -> is_nonexpansive e
   | Texp_object ({cstr_fields=fields; cstr_type = { csig_vars=vars}}, _) ->
@@ -1874,7 +1873,6 @@ let rec is_nonexpansive exp =
   | Texp_while _
   | Texp_for _
   | Texp_send _
-  | Texp_new _
   | Texp_instvar _
   | Texp_setinstvar _
   | Texp_override _

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1782,13 +1782,14 @@ let rec final_subexpression sexp =
 
 let rec is_nonexpansive exp =
   match exp.exp_desc with
-    Texp_ident(_,_,_) -> true
-  | Texp_constant _ -> true
-  | Texp_unreachable -> true
+  | Texp_ident _
+  | Texp_constant _
+  | Texp_unreachable
+  | Texp_function _
+  | Texp_array [] -> true
   | Texp_let(_rec_flag, pat_exp_list, body) ->
       List.for_all (fun vb -> is_nonexpansive vb.vb_expr) pat_exp_list &&
       is_nonexpansive body
-  | Texp_function _ -> true
   | Texp_apply(e, (_,None)::el) ->
       is_nonexpansive e && List.for_all is_nonexpansive_opt (List.map snd el)
   | Texp_match(e, cases, _) ->
@@ -1825,7 +1826,6 @@ let rec is_nonexpansive exp =
         fields
       && is_nonexpansive_opt extended_expression
   | Texp_field(exp, _, _) -> is_nonexpansive exp
-  | Texp_array [] -> true
   | Texp_ifthenelse(_cond, ifso, ifnot) ->
       is_nonexpansive ifso && is_nonexpansive_opt ifnot
   | Texp_sequence (_e1, e2) -> is_nonexpansive e2  (* PR#4354 *)
@@ -1885,7 +1885,7 @@ let rec is_nonexpansive exp =
 
 and is_nonexpansive_mod mexp =
   match mexp.mod_desc with
-  | Tmod_ident _ -> true
+  | Tmod_ident _
   | Tmod_functor _ -> true
   | Tmod_unpack (e, _) -> is_nonexpansive e
   | Tmod_constraint (m, _, _, _) -> is_nonexpansive_mod m
@@ -1918,7 +1918,7 @@ and is_nonexpansive_mod mexp =
   | Tmod_apply _ -> false
 
 and is_nonexpansive_opt = function
-    None -> true
+  | None -> true
   | Some e -> is_nonexpansive e
 
 let maybe_expansive e = not (is_nonexpansive e)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1784,6 +1784,7 @@ let rec is_nonexpansive exp =
   match exp.exp_desc with
     Texp_ident(_,_,_) -> true
   | Texp_constant _ -> true
+  | Texp_unreachable -> true
   | Texp_let(_rec_flag, pat_exp_list, body) ->
       List.for_all (fun vb -> is_nonexpansive vb.vb_expr) pat_exp_list &&
       is_nonexpansive body
@@ -1868,7 +1869,6 @@ let rec is_nonexpansive exp =
      is_nonexpansive e
   | Texp_array (_ :: _)
   | Texp_apply _
-  | Texp_unreachable
   | Texp_try _
   | Texp_setfield _
   | Texp_while _


### PR DESCRIPTION
I find double negations harder to read.

Also, I took the opportunity to make the function non-fragile, as this has proved to be a source of bugs in the past (see #2166 and #2167 for instance).
In the process, I noticed that `Texp_unreachable` was deemed expansive, which seems wrong to me, so I changed that.