### PR TITLE
Buffer.add_channel_full : Buffer.t -> input_channel -> int

### DIFF
--- a/Changes
+++ b/Changes
@@ -130,6 +130,9 @@ Working version
   (Damien Doligez, reports by John Whitington and Alain Frisch,
    review by Jeremy Yallop and Gabriel Scherer)
 
+- #8600: `Buffer.add_channel_full : Buffer.t -> input_channel -> int`
+  (Gabriel Scherer, review by David Allsopp)
+
 ### Other libraries:
 
 - #7903, #2306: Make Thread.delay interruptible by signals again

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -148,6 +148,14 @@ val add_channel : t -> in_channel -> int -> unit
    characters. In this case, the characters are still added to
    the buffer, so as to avoid loss of data. *)
 
+val add_channel_full : t -> in_channel -> int
+(** [add_channel_full b ic] reads all the available characters from
+   the input channel [ic] and stores them at the end of buffer [b].
+   Returns the number of characters read.
+
+   @since 4.09
+*)
+
 val output_buffer : out_channel -> t -> unit
 (** [output_buffer oc b] writes the current contents of buffer [b]
    on the output channel [oc]. *)

--- a/testsuite/tests/lib-buffer/test.reference
+++ b/testsuite/tests/lib-buffer/test.reference
@@ -7,3 +7,4 @@ Buffer reset: zero passed
 Buffer add_utf_8_uchar: test against spec passed
 Buffer add_utf_16be_uchar: test against spec passed
 Buffer add_utf_16le_uchar: test against spec passed
+testing Buffer.add_channel_full with 0 < buffer_size<= 13, 0 <= offset <= 13, 0 <= data_size <= 13


### PR DESCRIPTION
[add_channel b ic] reads all the available characters from
the input channel [ic] and stores them at the end of buffer [b].
Returns the number of characters read.

A test is added for this new function. The test fails if the `resize`
action is removed from the function implementation.

This is a spinoff from #8599.