### PR TITLE
Adding -stop-after lambda flag option in ocaml{c,opt}

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -437,7 +437,7 @@ let read_one_param ppf position name v =
     | Some pass ->
         Clflags.stop_after := Some pass;
         begin match pass with
-        | P.Parsing | P.Typing ->
+        | P.Parsing | P.Typing | P.Lambda ->
             compile_only := true
         end;
     end

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -49,9 +49,12 @@ let emit_bytecode i (bytecode, required_globals) =
     ~always:(fun () -> close_out oc)
     ~exceptionally:(fun () -> Misc.remove_file cmofile)
     (fun () ->
-       bytecode
-       |> Profile.(record ~accumulate:true generate)
-         (Emitcode.to_file oc i.module_name cmofile ~required_globals);
+       if Clflags.(should_stop_after Compiler_pass.Lambda) then () else
+       begin
+         bytecode
+         |> Profile.(record ~accumulate:true generate)
+            (Emitcode.to_file oc i.module_name cmofile ~required_globals);
+       end
     )
 
 let implementation ~source_file ~output_prefix =

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -20,11 +20,17 @@ val interface:
 val implementation:
   source_file:string -> output_prefix:string -> unit
 
-(** {2 Internal functions} **)
+(** {3 Internal functions} **)
+
+val to_lambda :
+  Compile_common.info ->
+  Typedtree.structure * Typedtree.module_coercion ->
+  Lambda.lambda * Ident.Set.t
+
 
 val to_bytecode :
   Compile_common.info ->
-  Typedtree.structure * Typedtree.module_coercion ->
+  Lambda.lambda * Ident.Set.t ->
   Instruct.instruction list * Ident.Set.t
 (** [to_bytecode info typed] takes a typechecked implementation
     and returns its bytecode.

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -60,7 +60,7 @@ module Options = Main_args.Make_bytecomp_options (struct
     | Some pass ->
         stop_after := Some pass;
         begin match pass with
-        | P.Parsing | P.Typing ->
+        | P.Parsing | P.Typing | P.Lambda ->
             compile_only := true
         end;
     end
@@ -182,7 +182,7 @@ let main () =
       match !stop_after with
       | None ->
         fatal "Please specify at most one of -pack, -a, -c, -output-obj";
-      | Some (P.Parsing | P.Typing) ->
+      | Some (P.Parsing | P.Typing | P.Lambda ) ->
           Printf.ksprintf fatal
             "Options -i and -stop-after (%s)\
              are  incompatible with -pack, -a, -output-obj"

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -77,6 +77,7 @@ let clambda_bytecode backend i program =
   end
 
 let clambda i backend typed =
+  Clflags.use_inlining_arguments_set Clflags.classic_arguments;
       typed
       |> Profile.(record transl)
         (Translmod.transl_store_implementation i.module_name)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -21,7 +21,12 @@ val implementation:
    backend:(module Backend_intf.S)
    -> source_file:string -> output_prefix:string -> unit
 
-(** {2 Internal functions} **)
+(** {4 Internal functions} **)
+
+val clambda_bytecode:
+  (module Backend_intf.S) ->
+  Compile_common.info ->
+  Lambda.program -> unit
 
 val clambda :
   Compile_common.info ->
@@ -30,6 +35,12 @@ val clambda :
 (** [clambda info typed] applies the regular compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)
+
+val flambda_bytecode:
+  Compile_common.info ->
+  (module Backend_intf.S) ->
+  Ident.Set.t ->
+  (Ident.t * int) * Lambda.lambda -> unit
 
 val flambda :
   Compile_common.info ->

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -69,7 +69,7 @@ module Options = Main_args.Make_optcomp_options (struct
     | Some pass ->
         stop_after := Some pass;
         begin match pass with
-        | P.Parsing | P.Typing ->
+        | P.Parsing | P.Typing | P.Lambda ->
             compile_only := true
         end;
     end

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -416,24 +416,28 @@ module Compiler_pass = struct
      - the manpages in man/ocaml{c,opt}.m
      - the manual manual/manual/cmds/unified-options.etex
   *)
-  type t = Parsing | Typing
+  type t = Parsing | Typing | Lambda
 
   let to_string = function
     | Parsing -> "parsing"
     | Typing -> "typing"
+    | Lambda -> "lambda"
 
   let of_string = function
     | "parsing" -> Some Parsing
     | "typing" -> Some Typing
+    | "lambda" -> Some Lambda
     | _ -> None
 
   let rank = function
     | Parsing -> 0
     | Typing -> 1
+    | Lambda -> 2
 
   let passes = [
     Parsing;
     Typing;
+    Lambda;
   ]
   let pass_names = List.map to_string passes
 end

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -232,7 +232,7 @@ val insn_sched : bool ref
 val insn_sched_default : bool
 
 module Compiler_pass : sig
-  type t = Parsing | Typing
+  type t = Parsing | Typing | Lambda
   val of_string : string -> t option
   val to_string : t -> string
   val passes : t list


### PR DESCRIPTION
Part of #6102, adding logic to stop compilation after lambdas are generated but before code is written.

Allows outputting of just lambda with ocaml compilers:
```
ocaml -dlambda -stop-after lambda script.ml

ocamlopt -dlambda -stop-after lambda script.ml
```

Required branches checking if compilation should be executed in driver/ocamlc.ml and driver/ocamlopt.ml