### PR TITLE
Improve doc for Hashtbl.to_seq*

### DIFF
--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -219,7 +219,10 @@ val stats : ('a, 'b) t -> statistics
 (** {1 Iterators} *)
 
 val to_seq : ('a,'b) t -> ('a * 'b) Seq.t
-(** Iterate on the whole table, in unspecified order.
+(** Iterate on the whole table.  The order in which the bindings
+    appear in the sequence is unspecified. However, if the table contains
+    several bindings for the same key, they appear in reversed order of
+    introduction, that is, the most recent binding appears first.
 
     The behavior is not defined if the hash table is modified
     during the iteration.

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -227,11 +227,11 @@ val to_seq : ('a,'b) t -> ('a * 'b) Seq.t
     @since 4.07 *)
 
 val to_seq_keys : ('a,_) t -> 'a Seq.t
-(** Iterate on 'as, in ascending order
+(** Same as [Seq.map fst (to_seq m)]
     @since 4.07 *)
 
 val to_seq_values : (_,'b) t -> 'b Seq.t
-(** Iterate on values, in ascending order of their corresponding 'a
+(** Same as [Seq.map snd (to_seq m)]
     @since 4.07 *)
 
 val add_seq : ('a,'b) t -> ('a * 'b) Seq.t -> unit


### PR DESCRIPTION
- `Hashtbl.to_seq_{keys,values}`: the doc was wrong (the ordering is unspecified, and certainly not the one currently documented).
- `Hashtbl.to_seq`: specify relative ordering of multiple bindings for the same key, following #2236.