### PR TITLE
Remove LACKS_SANE_NAN and LACKS_VCSPRINTF.

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,9 @@ Working version
 * #2293: Constify "caml_named_value"
   (Stephen Dolan, review by Xavier Leroy)
 
+- #8607: Remove obsolete macros for pre-2002 MSVC support
+  (Stephen Dolan, review by Nicolás Ojeda Bär and David Allsopp)
+
 ### Standard library:
 
 - #2262: take precision (.<n>) and flags ('+' and ' ') into account

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -37,7 +37,3 @@
 #define HAS_NICE
 #define SUPPORT_DYNAMIC_LINKING
 #define HAS_EXECVPE
-#if defined(_MSC_VER) && _MSC_VER < 1300
-#define LACKS_SANE_NAN
-#define LACKS_VSCPRINTF
-#endif

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -39,11 +39,6 @@
 
 #include "s.h"
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
-#define LACKS_SANE_NAN
-#define LACKS_VSCPRINTF
-#endif
-
 #ifdef BOOTSTRAPPING_FLEXLINK
 #undef SUPPORT_DYNAMIC_LINKING
 #endif

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -23,10 +23,6 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 
-#if defined(LACKS_SANE_NAN) && !defined(isnan)
-#define isnan _isnan
-#endif
-
 /* Structural comparison on trees. */
 
 struct compare_item { value * v1, * v2; mlsize_t count; };
@@ -208,19 +204,8 @@ static intnat do_compare_val(struct compare_stack* stk,
     case Double_tag: {
       double d1 = Double_val(v1);
       double d2 = Double_val(v2);
-#ifdef LACKS_SANE_NAN
-      if (isnan(d2)) {
-        if (! total) return UNORDERED;
-        if (isnan(d1)) break;
-        return GREATER;
-      } else if (isnan(d1)) {
-        if (! total) return UNORDERED;
-        return LESS;
-      }
-#endif
       if (d1 < d2) return LESS;
       if (d1 > d2) return GREATER;
-#ifndef LACKS_SANE_NAN
       if (d1 != d2) {
         if (! total) return UNORDERED;
         /* One or both of d1 and d2 is NaN.  Order according to the
@@ -229,7 +214,6 @@ static intnat do_compare_val(struct compare_stack* stk,
         if (d2 == d2) return LESS;    /* d2 is not NaN, d1 is NaN */
         /* d1 and d2 are both NaN, thus equal: continue comparison */
       }
-#endif
       break;
     }
     case Double_array_tag: {
@@ -240,26 +224,14 @@ static intnat do_compare_val(struct compare_stack* stk,
       for (i = 0; i < sz1; i++) {
         double d1 = Double_flat_field(v1, i);
         double d2 = Double_flat_field(v2, i);
-  #ifdef LACKS_SANE_NAN
-        if (isnan(d2)) {
-          if (! total) return UNORDERED;
-          if (isnan(d1)) break;
-          return GREATER;
-        } else if (isnan(d1)) {
-          if (! total) return UNORDERED;
-          return LESS;
-        }
-  #endif
         if (d1 < d2) return LESS;
         if (d1 > d2) return GREATER;
-  #ifndef LACKS_SANE_NAN
         if (d1 != d2) {
           if (! total) return UNORDERED;
           /* See comment for Double_tag case */
           if (d1 == d1) return GREATER;
           if (d2 == d2) return LESS;
         }
-  #endif
       }
       break;
     }

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -965,33 +965,6 @@ CAMLprim value caml_signbit_float(value f)
   return caml_signbit(Double_val(f));
 }
 
-#ifdef LACKS_SANE_NAN
-
-CAMLprim value caml_neq_float(value vf, value vg)
-{
-  double f = Double_val(vf);
-  double g = Double_val(vg);
-  return Val_bool(isnan(f) || isnan(g) || f != g);
-}
-
-#define DEFINE_NAN_CMP(op) (value vf, value vg) \
-{ \
-  double f = Double_val(vf); \
-  double g = Double_val(vg); \
-  return Val_bool(!isnan(f) && !isnan(g) && f op g); \
-}
-
-intnat caml_float_compare_unboxed(double f, double g)
-{
-  /* Insane => nan == everything && nan < everything && nan > everything */
-  if (isnan(f) && isnan(g)) return 0;
-  if (!isnan(g) && f < g) return -1;
-  if (f != g) return 1;
-  return 0;
-}
-
-#else
-
 CAMLprim value caml_neq_float(value f, value g)
 {
   return Val_bool(Double_val(f) != Double_val(g));
@@ -1014,8 +987,6 @@ intnat caml_float_compare_unboxed(double f, double g)
     (intnat)(f > g) - (intnat)(f < g) + (intnat)(f == f) - (intnat)(g == g);
   return res;
 }
-
-#endif
 
 CAMLprim value caml_eq_float DEFINE_NAN_CMP(==)
 CAMLprim value caml_le_float DEFINE_NAN_CMP(<=)

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -676,26 +676,6 @@ wchar_t * caml_executable_name(void)
 
 /* snprintf emulation */
 
-#ifdef LACKS_VSCPRINTF
-/* No _vscprintf until Visual Studio .NET 2002 and sadly no version number
-   in the CRT headers until Visual Studio 2005 so forced to predicate this
-   on the compiler version instead */
-int _vscprintf(const char * format, va_list args)
-{
-  int n;
-  int sz = 5;
-  char* buf = (char*)malloc(sz);
-  n = _vsnprintf(buf, sz, format, args);
-  while (n < 0 || n > sz) {
-    sz += 512;
-    buf = (char*)realloc(buf, sz);
-    n = _vsnprintf(buf, sz, format, args);
-  }
-  free(buf);
-  return n;
-}
-#endif
-
 #if defined(_WIN32) && !defined(_UCRT)
 int caml_snprintf(char * buf, size_t size, const char * format, ...)
 {


### PR DESCRIPTION
These were present only for MSVC 2002, which is no longer supported (I think? @dra27 ?)