### PR TITLE
#8610: toplevel printing, consistent deduplicated name for types

### DIFF
--- a/Changes
+++ b/Changes
@@ -173,6 +173,10 @@ Working version
 - GPR#2296: Fix parsing of hexadecimal floats with underscores in the exponent.
   (Hugo Heuzard and Xavier Leroy, review by Gabriel Scherer)
 
+- #8610, #8613: toplevel printing, consistent deduplicated name for types
+  (Florian Angeletti, review by Thomas Refis and Gabriel Scherer,
+   reported by Xavier Clerc)
+
 OCaml 4.08.0
 ------------
 

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -42,5 +42,5 @@ type float
 
 0.;;
 [%%expect {|
-- : float = 0.
+- : float/2 = 0.
 |}];;

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -6,14 +6,10 @@ type 'a x = private [> `x] as 'a;;
 [%%expect {|
 Line 1:
 Error: Type declarations do not match:
-         type 'a x = private [> `x ] constraint 'a = 'a x/2
+         type 'a x = private [> `x ] constraint 'a = 'a x
        is not included in
          type 'a x
        Their constraints differ.
-       File "_none_", line 1:
-         Definition of type x/1
-       Line 1, characters 0-32:
-         Definition of type x/2
 |}, Principal{|
 Line 1:
 Error: Type declarations do not match:

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -1,0 +1,46 @@
+(* TEST
+   * expect
+*)
+
+type 'a x = private [> `x] as 'a;;
+[%%expect {|
+Line 1:
+Error: Type declarations do not match:
+         type 'a x = private [> `x ] constraint 'a = 'a x/2
+       is not included in
+         type 'a x
+       Their constraints differ.
+       File "_none_", line 1:
+         Definition of type x/1
+       Line 1, characters 0-32:
+         Definition of type x/2
+|}, Principal{|
+Line 1:
+Error: Type declarations do not match:
+         type 'a x = private 'a constraint 'a = [> `x ]
+       is not included in
+         type 'a x
+       Their constraints differ.
+|}];;
+
+
+type int;;
+[%%expect {|
+type int
+|}];;
+
+let x = 0;;
+[%%expect {|
+val x : int/2 = 0
+|}];;
+
+
+type float;;
+[%%expect {|
+type float
+|}];;
+
+0.;;
+[%%expect {|
+- : float = 0.
+|}];;

--- a/testsuite/tests/printing-types/ocamltests
+++ b/testsuite/tests/printing-types/ocamltests
@@ -1,1 +1,2 @@
+disambiguation.ml
 pr248.ml

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -54,8 +54,8 @@ type t = D
 Line 2, characters 25-26:
 2 | let f: t -> t = fun D -> x;;
                              ^
-Error: This expression has type t/1 but an expression was expected of type
-         t/2
+Error: This expression has type t/2 but an expression was expected of type
+         t/1
        Line 1, characters 0-10:
          Definition of type t/1
        Line 1, characters 0-10:

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1524,13 +1524,16 @@ let protect_rec_items items =
       | _ -> [] in
   List.iter Naming_context.add_protected (get_ids Trec_first items)
 
+let stop_type_group env =
+  Naming_context.reset_protected ();
+  set_printing_env env
+
 let still_in_type_group env' in_type_group item =
   match in_type_group, recursive_sigitem item with
-    true, Some (_,Trec_next,_) -> true
+  | true, Some (_,Trec_next,_) -> true
   | _, Some (_, (Trec_not | Trec_first),_) ->
-      Naming_context.reset_protected ();
-      set_printing_env env'; true
-  | _ -> Naming_context.reset_protected (); set_printing_env env'; false
+      stop_type_group env' ; true
+  | _ -> stop_type_group env'; false
 
 let rec tree_of_modtype ?(ellipsis=false) = function
   | Mty_ident p ->
@@ -1624,7 +1627,7 @@ let print_items showval env x =
   reset_naming_context ();
   Conflicts.reset ();
   let rec print showval in_type_group env = function
-  | [] -> []
+  | [] -> stop_type_group env; []
   | item :: rem as items ->
       let in_type_group = still_in_type_group env in_type_group item in
       let (sg, rem) = filter_rem_sig item rem in

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1557,7 +1557,7 @@ and tree_of_signature sg =
   wrap_env (fun env -> env) (tree_of_signature_rec !printing_env false) sg
 
 and tree_of_signature_rec env' in_type_group = function
-    [] -> []
+    [] -> stop_type_group env'; []
   | item :: rem as items ->
       let in_type_group = still_in_type_group env' in_type_group item in
       let (sg, rem) = filter_rem_sig item rem in

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -205,6 +205,8 @@ let set namespace x = map.(Namespace.id namespace) <- x
 let protected = ref S.empty
 let add_protected id = protected := S.add (Ident.name id) !protected
 let reset_protected () = protected := S.empty
+let with_hidden id f =
+  protect_refs [ R(protected,S.add (Ident.name id) !protected)] f
 
 let pervasives_name namespace name =
   if not !enabled then Out_name.create name else
@@ -2045,4 +2047,7 @@ let tree_of_modtype = tree_of_modtype ~ellipsis:false
 let type_expansion ty ppf ty' =
   type_expansion ppf (trees_of_type_expansion (ty,ty'))
 let tree_of_type_declaration id td rs =
-  wrap_env (hide [id]) (fun () -> tree_of_type_declaration id td rs) ()
+  Naming_context.with_hidden id ( (* for disambiguation *)
+    wrap_env (hide [id]) (* for short-path *)
+      (fun () -> tree_of_type_declaration id td rs)
+  )


### PR DESCRIPTION
This PR fixes the final state of `Printtyp.print_items`. Without this fix, a final type declaration in a phrase is not registered in the environment before the next call to `Printtyp.print_items`. 

This make the disambiguation of type name inconsistent between

```OCaml
type int
type u ;;
0;;
```
> _ : int/2

and
```OCaml
type float;;
0.;;
```
> _ : float

With this PR, the two examples are rendered in the same way

```OCaml
type float;;
0.;;
```
> _ : float/2

