### PR TITLE
Available_regs, Reg_with_debug_info, Reg_availability_set etc.

### DIFF
--- a/.depend
+++ b/.depend
@@ -2425,18 +2425,18 @@ asmcomp/liveness.cmx : \
 asmcomp/liveness.cmi : \
     asmcomp/mach.cmi
 asmcomp/mach.cmo : \
-    asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \
     asmcomp/arch.cmo \
     asmcomp/mach.cmi
 asmcomp/mach.cmx : \
-    asmcomp/debug/reg_with_debug_info.cmx \
     asmcomp/debug/reg_availability_set.cmx \
     asmcomp/reg.cmx \
+    middle_end/flambda/base_types/is_parameter.cmx \
     lambda/debuginfo.cmx \
     asmcomp/cmm.cmx \
     middle_end/backend_var.cmx \
@@ -2445,6 +2445,7 @@ asmcomp/mach.cmx : \
 asmcomp/mach.cmi : \
     asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \
@@ -2490,6 +2491,7 @@ asmcomp/printmach.cmo : \
     asmcomp/proc.cmi \
     asmcomp/printcmm.cmi \
     asmcomp/mach.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi \
     asmcomp/interval.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
@@ -2504,6 +2506,7 @@ asmcomp/printmach.cmx : \
     asmcomp/proc.cmx \
     asmcomp/printcmm.cmx \
     asmcomp/mach.cmx \
+    middle_end/flambda/base_types/is_parameter.cmx \
     asmcomp/interval.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
@@ -5328,6 +5331,16 @@ middle_end/flambda/base_types/id_types.cmx : \
     middle_end/flambda/base_types/id_types.cmi
 middle_end/flambda/base_types/id_types.cmi : \
     utils/identifiable.cmi
+middle_end/flambda/base_types/is_parameter.cmo : \
+    utils/misc.cmi \
+    utils/identifiable.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi
+middle_end/flambda/base_types/is_parameter.cmx : \
+    utils/misc.cmx \
+    utils/identifiable.cmx \
+    middle_end/flambda/base_types/is_parameter.cmi
+middle_end/flambda/base_types/is_parameter.cmi : \
+    utils/identifiable.cmi
 middle_end/flambda/base_types/mutable_variable.cmo : \
     middle_end/variable.cmi \
     utils/int_replace_polymorphic_compare.cmi \
@@ -5406,6 +5419,7 @@ middle_end/flambda/base_types/var_within_closure.cmx : \
 middle_end/flambda/base_types/var_within_closure.cmi : \
     middle_end/flambda/base_types/closure_element.cmi
 asmcomp/debug/available_regs.cmo : \
+    utils/targetint.cmi \
     asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi \
@@ -5413,10 +5427,12 @@ asmcomp/debug/available_regs.cmo : \
     asmcomp/printmach.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi \
     utils/clflags.cmi \
     middle_end/backend_var.cmi \
     asmcomp/debug/available_regs.cmi
 asmcomp/debug/available_regs.cmx : \
+    utils/targetint.cmx \
     asmcomp/debug/reg_with_debug_info.cmx \
     asmcomp/debug/reg_availability_set.cmx \
     asmcomp/reg.cmx \
@@ -5424,6 +5440,7 @@ asmcomp/debug/available_regs.cmx : \
     asmcomp/printmach.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
+    middle_end/flambda/base_types/is_parameter.cmx \
     utils/clflags.cmx \
     middle_end/backend_var.cmx \
     asmcomp/debug/available_regs.cmi
@@ -5459,25 +5476,34 @@ asmcomp/debug/compute_ranges_intf.cmx : \
     utils/identifiable.cmx
 asmcomp/debug/reg_availability_set.cmo : \
     asmcomp/debug/reg_with_debug_info.cmi \
-    middle_end/backend_var.cmi \
     asmcomp/debug/reg_availability_set.cmi
 asmcomp/debug/reg_availability_set.cmx : \
     asmcomp/debug/reg_with_debug_info.cmx \
-    middle_end/backend_var.cmx \
     asmcomp/debug/reg_availability_set.cmi
 asmcomp/debug/reg_availability_set.cmi : \
     asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/reg.cmi
 asmcomp/debug/reg_with_debug_info.cmo : \
+    utils/targetint.cmi \
     asmcomp/reg.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi \
+    utils/identifiable.cmi \
     middle_end/backend_var.cmi \
     asmcomp/debug/reg_with_debug_info.cmi
 asmcomp/debug/reg_with_debug_info.cmx : \
+    utils/targetint.cmx \
     asmcomp/reg.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/base_types/is_parameter.cmx \
+    utils/identifiable.cmx \
     middle_end/backend_var.cmx \
     asmcomp/debug/reg_with_debug_info.cmi
 asmcomp/debug/reg_with_debug_info.cmi : \
+    utils/targetint.cmi \
     asmcomp/reg.cmi \
+    middle_end/flambda/base_types/is_parameter.cmi \
+    utils/identifiable.cmi \
     middle_end/backend_var.cmi
 driver/compenv.cmo : \
     utils/warnings.cmi \

--- a/Changes
+++ b/Changes
@@ -132,6 +132,10 @@ Working version
   (Thomas Refis, review by David Allsopp, Florian Angeletti, Gabriel Radanne,
    Gabriel Scherer and Xavier Leroy)
 
+- #8614: [Available_regs] constant propagation, new implementations of
+  [Reg_with_debug_info] and [Reg_availability_set]
+  (Mark Shinwell, Greta Yorsh)
+
 ### Runtime system:
 
 - #1725, #2279: Deprecate Obj.set_tag and Obj.truncate

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,7 @@ MIDDLE_END=\
   middle_end/flambda/base_types/id_types.cmo \
   middle_end/flambda/base_types/export_id.cmo \
   middle_end/flambda/base_types/tag.cmo \
+  middle_end/flambda/base_types/is_parameter.cmo \
   middle_end/flambda/base_types/mutable_variable.cmo \
   middle_end/flambda/base_types/set_of_closures_id.cmo \
   middle_end/flambda/base_types/set_of_closures_origin.cmo \

--- a/asmcomp/debug/available_regs.mli
+++ b/asmcomp/debug/available_regs.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*            Mark Shinwell and Thomas Refis, Jane Street Europe          *)
 (*                                                                        *)
-(*   Copyright 2013--2017 Jane Street Group LLC                           *)
+(*   Copyright 2013--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,7 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Available registers analysis used to determine which variables may be
-    shown in the debugger. *)
+(** Available registers analysis.  This determines which variables' values,
+    together with which constants, occupy registers at each point of a
+    function's code. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
 val fundecl : Mach.fundecl -> Mach.fundecl

--- a/asmcomp/debug/reg_availability_set.ml
+++ b/asmcomp/debug/reg_availability_set.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2017 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,100 +12,70 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
 module RD = Reg_with_debug_info
-module V = Backend_var
 
 type t =
-  | Ok of RD.Set.t
   | Unreachable
+  | Ok of RD.Availability_map.t
 
-let inter regs1 regs2 =
-  match regs1, regs2 with
-  | Unreachable, _ -> regs2
-  | _, Unreachable -> regs1
-  | Ok avail1, Ok avail2 ->
-    let result =
-      RD.Set.fold (fun reg1 result ->
-          match RD.Set.find_reg_exn avail2 (RD.reg reg1) with
-          | exception Not_found -> result
-          | reg2 ->
-            let debug_info1 = RD.debug_info reg1 in
-            let debug_info2 = RD.debug_info reg2 in
-            let debug_info =
-              match debug_info1, debug_info2 with
-              | None, None -> None
-              (* Example for this next case: the value of a mutable variable x
-                 is copied into another variable y; then there is a conditional
-                 where on one branch x is assigned and on the other branch it
-                 is not.  This means that on the former branch we have
-                 forgotten about y holding the value of x; but we have not on
-                 the latter.  At the join point we must have forgotten the
-                 information. *)
-              | None, Some _ | Some _, None -> None
-              | Some debug_info1, Some debug_info2 ->
-                if RD.Debug_info.compare debug_info1 debug_info2 = 0 then
-                  Some debug_info1
-                else
-                  None
-            in
-            let reg =
-              RD.create_with_debug_info ~reg:(RD.reg reg1)
-                ~debug_info
-            in
-            RD.Set.add reg result)
-        avail1
-        RD.Set.empty
-    in
-    Ok result
+let unreachable = Unreachable
+
+let empty = Ok RD.Availability_map.empty
+
+let create map = Ok map
+
+let canonicalise t =
+  (* Users of canonicalised sets aren't interested in what the set contains
+     for portions of dead code, so for [Unreachable], we can just return the
+     empty set. *)
+  match t with
+  | Unreachable -> RD.Canonical_availability_map.empty
+  | Ok map -> RD.Canonical_availability_map.create map
+
+let print ~print_reg:_ ppf = function
+  | Unreachable -> Format.fprintf ppf "<unreachable>"
+  | Ok map -> RD.Availability_map.print ppf map
 
 let equal t1 t2 =
   match t1, t2 with
   | Unreachable, Unreachable -> true
   | Unreachable, Ok _ | Ok _, Unreachable -> false
-  | Ok regs1, Ok regs2 -> RD.Set.equal regs1 regs2
+  | Ok regs1, Ok regs2 -> RD.Availability_map.equal regs1 regs2
 
-let canonicalise availability =
-  match availability with
+let map t ~f =
+  match t with
+  | Ok t -> Ok (f t)
   | Unreachable -> Unreachable
-  | Ok availability ->
-    let regs_by_ident = V.Tbl.create 42 in
-    RD.Set.iter (fun reg ->
-        match RD.debug_info reg with
-        | None -> ()
-        | Some debug_info ->
-          let name = RD.Debug_info.holds_value_of debug_info in
-          if not (V.persistent name) then begin
-            match V.Tbl.find regs_by_ident name with
-            | exception Not_found -> V.Tbl.add regs_by_ident name reg
-            | (reg' : RD.t) ->
-              (* We prefer registers that are assigned to the stack since
-                 they probably give longer available ranges (less likely to
-                 be clobbered). *)
-              match RD.location reg, RD.location reg' with
-              | Reg _, Stack _
-              | Reg _, Reg _
-              | Stack _, Stack _
-              | _, Unknown
-              | Unknown, _ -> ()
-              | Stack _, Reg _ ->
-                V.Tbl.remove regs_by_ident name;
-                V.Tbl.add regs_by_ident name reg
-          end)
-      availability;
-    let result =
-      V.Tbl.fold (fun _ident reg availability ->
-          RD.Set.add reg availability)
-        regs_by_ident
-        RD.Set.empty
-    in
-    Ok result
 
-let print ~print_reg ppf = function
-  | Unreachable -> Format.fprintf ppf "<unreachable>"
-  | Ok availability ->
-    Format.fprintf ppf "{%a}"
-      (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
-        (Reg_with_debug_info.print ~print_reg))
-      (RD.Set.elements availability)
+let disjoint_union regs1 regs2 =
+  match regs1, regs2 with
+  | Unreachable, _ -> regs1
+  | _, Unreachable -> regs2
+  | Ok avail1, Ok avail2 -> 
+    Ok (RD.Availability_map.disjoint_union avail1 avail2)
+
+let inter regs1 regs2 =
+  match regs1, regs2 with
+  | Unreachable, _ -> regs2
+  | _, Unreachable -> regs1
+  | Ok avail1, Ok avail2 -> Ok (RD.Availability_map.inter avail1 avail2)
+
+let find_debug_info t reg =
+  match t with
+  | Unreachable -> None
+  | Ok avail ->
+    match RD.Availability_map.find avail reg with
+    | None | Some None -> None
+    | Some debug_info -> debug_info
+
+let made_unavailable_by_clobber t ~regs_clobbered ~register_class =
+  match t with
+  | Unreachable -> Unreachable
+  | Ok map ->
+    Ok (RD.Availability_map.made_unavailable_by_clobber map ~regs_clobbered
+      ~register_class)
+
+let subset t1 t2 =
+  equal (inter t1 t2) t1

--- a/asmcomp/debug/reg_availability_set.ml
+++ b/asmcomp/debug/reg_availability_set.ml
@@ -53,7 +53,7 @@ let disjoint_union regs1 regs2 =
   match regs1, regs2 with
   | Unreachable, _ -> regs1
   | _, Unreachable -> regs2
-  | Ok avail1, Ok avail2 -> 
+  | Ok avail1, Ok avail2 ->
     Ok (RD.Availability_map.disjoint_union avail1 avail2)
 
 let inter regs1 regs2 =

--- a/asmcomp/debug/reg_availability_set.mli
+++ b/asmcomp/debug/reg_availability_set.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2017 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,26 +12,92 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Register availability sets. *)
+(** Register availability sets. This module is just a version of
+    [Reg_with_debug_info.Availability_map] (but seen more intuitively as a set,
+    as per the comment in reg_with_debug_info.mli) whose type is lifted to have
+    an additional top element. This element corresponds to availability
+    information known at any unreachable point in the generated code.
 
-type t =
-  | Ok of Reg_with_debug_info.Set.t
+    We do not use [Reg_with_debug_info.Canonical_availability_map] here. If we
+    were to do that, we would throw away availability information that we might
+    want to use later. For example, the value of some variable may occur in two
+    different registers, at some instruction. The next instruction might clobber
+    one of those registers. We would like to still remember that the value of
+    the variable is available; but we would not be guaranteed to do so were we
+    to use canonicalised maps, since only one of the registers holding the value
+    of the variable would have been recorded.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(** The type of register availability sets. *)
+type t = private
   | Unreachable
+  | Ok of Reg_with_debug_info.Availability_map.t
 
-val inter : t -> t -> t
-(** Intersection of availabilities. *)
+(** The top element. *)
+val unreachable : t
 
-val canonicalise : t -> t
-(** Return a subset of the given availability set which contains no registers
-    that are not associated with debug info (and holding values of
-    non-persistent identifiers); and where no two registers share the same
-    location. *)
+(** Create a register availability set (that is not the top element). *)
+val create : Reg_with_debug_info.Availability_map.t -> t
 
-val equal : t -> t -> bool
+(** Canonicalise the given register availability set.  The result can be
+    used for [Compute_ranges], etc.  See the documentation for
+    [Reg_with_debug_info.Canonical_availability_map] with regard to the
+    definition of "canonical". *)
+val canonicalise : t -> Reg_with_debug_info.Canonical_availability_map.t
 
+(** The functions below are lifted versions of the corresponding ones in
+    [Reg_with_debug_info.Availability_map]. *)
+
+(** Print a value of type [t] to a formatter.
+    [print_reg] should be [Printmach.reg]. *)
 val print
    : print_reg:(Format.formatter -> Reg.t -> unit)
   -> Format.formatter
   -> t
   -> unit
-(** For debugging purposes only. *)
+
+(** Test for equality.  As per [Reg_with_debug_info.Availability_map.equal]
+    this compares both the [Reg.t] and [Reg_with_debug_info.Debug_info.t option]
+    components in the [Ok] case. *)
+val equal : t -> t -> bool
+
+(** The empty set. *)
+val empty : t
+
+(** A lifted version of [Reg_with_debug_info.Availability_map.disjoint_union];
+    see the documentation of that function. *)
+val disjoint_union : t -> t -> t
+
+(** A lifted version of [Reg_with_debug_info.Availability_map.inter];
+    see the documentation of that function. *)
+val inter : t -> t -> t
+
+(** Non-strict subset inclusion, defined in terms of [inter] and [equal]. *)
+val subset : t -> t -> bool
+
+(** Map the [Reg_with_debug_info.Availability_map.t] value contained within some
+    values of type [t]. *)
+val map
+   : t
+  -> f:(Reg_with_debug_info.Availability_map.t
+    -> Reg_with_debug_info.Availability_map.t)
+  -> t
+
+(** Find the debug info component of an element of the set given the underlying
+    [Reg.t]. This function returns [None] if the supplied [t] is [Unreachable],
+    if the given register does not occur in the supplied [t], or if the
+    given register does occur but is not associated with any debug info. *)
+val find_debug_info : t -> Reg.t -> Reg_with_debug_info.Debug_info.t option
+
+(** [made_unavailable_by_clobber t ~regs_clobbered ~register_class] returns
+    the largest subset of [t] whose locations do not overlap with any
+    registers in [regs_clobbered].  (Think of [t] as a set of available
+    registers.)
+    [register_class] should always be [Proc.register_class]. *)
+val made_unavailable_by_clobber
+   : t
+  -> regs_clobbered:Reg.t array
+  -> register_class:(Reg.t -> int)
+  -> t

--- a/asmcomp/debug/reg_with_debug_info.ml
+++ b/asmcomp/debug/reg_with_debug_info.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2017 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,189 +12,399 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
 module V = Backend_var
 
+(* We unfortunately cannot depend on [Proc] here, so we can't use
+   [Proc.register_name]. *)
+let register_name r = Printf.sprintf "r%d" r
+
+let reg_printer ?print_reg ppf t =
+  match print_reg with
+  | None -> Reg.print ~register_name ppf t
+  | Some print_reg -> print_reg ppf t
+
+module Holds_value_of = struct
+  type t =
+    | Var of Backend_var.t
+    | Const_int of Targetint.t
+    | Const_naked_float of Int64.t
+    | Const_symbol of String.t
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare t1 t2 =
+      match t1, t2 with
+      | Var var1, Var var2 -> Backend_var.compare var1 var2
+      | Const_int i1, Const_int i2 -> Targetint.compare i1 i2
+      | Const_naked_float f1, Const_naked_float f2 -> Int64.compare f1 f2
+      | Const_symbol sym1, Const_symbol sym2 -> String.compare sym1 sym2
+      | Var _, _ -> -1
+      | Const_int _, Var _ -> 1
+      | Const_int _, _ -> -1
+      | Const_naked_float _, (Var _ | Const_int _) -> 1
+      | Const_naked_float _, _ -> -1
+      | Const_symbol _, _ -> 1
+
+    let equal t1 t2 =
+      compare t1 t2 = 0
+
+    let hash t =
+      match t with
+      | Var var -> Hashtbl.hash (0, Backend_var.hash var)
+      | Const_int i -> Hashtbl.hash (1, i)
+      | Const_naked_float f -> Hashtbl.hash (2, f)
+      | Const_symbol sym -> Hashtbl.hash (3, Hashtbl.hash sym)
+
+    let print ppf t =
+      match t with
+      | Var var ->
+        Format.fprintf ppf "@[(Var@ %a)@]"
+          Backend_var.print var
+      | Const_int i ->
+        Format.fprintf ppf "@[(Const_int@ %a)@]" Targetint.print i
+      | Const_naked_float f ->
+        Format.fprintf ppf "@[(Const_naked_float@ 0x%Lx)@]" f
+      | Const_symbol sym ->
+        Format.fprintf ppf "@[(Const_symbol@ %s)@]" sym
+
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end
+
 module Debug_info = struct
   type t = {
-    holds_value_of : V.t;
+    holds_value_of : Holds_value_of.t;
     part_of_value : int;
     num_parts_of_value : int;
-    which_parameter : int option;
-    provenance : unit option;
+    is_parameter : Is_parameter.t;
+    provenance : Backend_var.Provenance.t option;
   }
 
-  let compare t1 t2 =
-    let c = V.compare t1.holds_value_of t2.holds_value_of in
+  let create ~holds_value_of ~part_of_value ~num_parts_of_value
+        is_parameter ~provenance =
+    assert (num_parts_of_value >= 1);
+    assert (part_of_value >= 0 && part_of_value < num_parts_of_value);
+    { holds_value_of;
+      part_of_value;
+      num_parts_of_value;
+      is_parameter;
+      provenance;
+    }
+
+  let compare
+        { holds_value_of = holds_value_of1; part_of_value = part_of_value1;
+          num_parts_of_value = num_parts_of_value1;
+          is_parameter = is_parameter1; provenance = provenance1;
+        }
+        { holds_value_of = holds_value_of2; part_of_value = part_of_value2;
+          num_parts_of_value = num_parts_of_value2;
+          is_parameter = is_parameter2; provenance = provenance2;
+        } =
+    let c = Holds_value_of.compare holds_value_of1 holds_value_of2 in
     if c <> 0 then c
     else
-      Stdlib.compare
-        (t1.part_of_value, t1.num_parts_of_value, t1.which_parameter)
-        (t2.part_of_value, t2.num_parts_of_value, t2.which_parameter)
+      let c = Stdlib.compare part_of_value1 part_of_value2 in
+      if c <> 0 then c
+      else
+        let c = Stdlib.compare num_parts_of_value1 num_parts_of_value2 in
+        if c <> 0 then c
+        else
+          let c = Is_parameter.compare is_parameter1 is_parameter2 in
+          if c <> 0 then c
+          else
+            Option.compare Backend_var.Provenance.compare
+              provenance1 provenance2
+
+  let equal t1 t2 = (compare t1 t2 = 0)
 
   let holds_value_of t = t.holds_value_of
   let part_of_value t = t.part_of_value
   let num_parts_of_value t = t.num_parts_of_value
-  let which_parameter t = t.which_parameter
+  let is_parameter t = t.is_parameter
   let provenance t = t.provenance
 
   let print ppf t =
-    Format.fprintf ppf "%a" V.print t.holds_value_of;
+    Format.fprintf ppf "%a" Holds_value_of.print t.holds_value_of;
     if not (t.part_of_value = 0 && t.num_parts_of_value = 1) then begin
       Format.fprintf ppf "(%d/%d)" t.part_of_value t.num_parts_of_value
     end;
-    begin match t.which_parameter with
-    | None -> ()
-    | Some index -> Format.fprintf ppf "[P%d]" index
+    begin match t.is_parameter with
+    | Local -> ()
+    | Parameter { index; } -> Format.fprintf ppf "[P%d]" index
     end
 end
 
-module T = struct
-  type t = {
-    reg : Reg.t;
-    debug_info : Debug_info.t option;
-  }
-
-  module Order = struct
-    type t = Reg.t
-    let compare (t1 : t) (t2 : t) = t1.stamp - t2.stamp
-  end
-
-  let compare t1 t2 =
-    Order.compare t1.reg t2.reg
-end
-
-include T
+type t = {
+  reg : Reg.t;
+  debug_info : Debug_info.t option;
+}
 
 type reg_with_debug_info = t
 
-let create ~reg ~holds_value_of ~part_of_value ~num_parts_of_value
-      ~which_parameter ~provenance =
-  assert (num_parts_of_value >= 1);
-  assert (part_of_value >= 0 && part_of_value < num_parts_of_value);
-  assert (match which_parameter with None -> true | Some index -> index >= 0);
-  let debug_info : Debug_info.t =
-    { holds_value_of;
-      part_of_value;
-      num_parts_of_value;
-      which_parameter;
-      provenance;
-    }
-  in
-  { reg;
-    debug_info = Some debug_info;
-  }
+let print ?print_reg ppf t =
+  match t.debug_info with
+  | None -> reg_printer ?print_reg ppf t.reg
+  | Some debug_info ->
+    Format.fprintf ppf "%a(%a)"
+      (reg_printer ?print_reg) t.reg
+      Debug_info.print debug_info
 
-let create_with_debug_info ~reg ~debug_info =
+let compare { reg = reg1; debug_info = debug_info1; }
+            { reg = reg2; debug_info = debug_info2; } =
+  let c = Stdlib.compare reg1.stamp reg2.stamp in
+  if c <> 0 then c
+  else Option.compare Debug_info.compare debug_info1 debug_info2
+
+let create_with_debug_info reg debug_info =
   { reg;
     debug_info;
   }
 
-let create_without_debug_info ~reg =
-  { reg;
-    debug_info = None;
-  }
-
-let create_copying_debug_info ~reg ~debug_info_from =
-  { reg;
-    debug_info = debug_info_from.debug_info;
-  }
-
 let reg t = t.reg
 let location t = t.reg.loc
-
-let holds_pointer t =
-  match t.reg.typ with
-  | Addr | Val -> true
-  | Int | Float -> false
-
-let holds_non_pointer t = not (holds_pointer t)
-
-let assigned_to_stack t =
-  match t.reg.loc with
-  | Stack _ -> true
-  | Reg _ | Unknown -> false
-
-let regs_at_same_location (reg1 : Reg.t) (reg2 : Reg.t) ~register_class =
-  (* We need to check the register classes too: two locations both saying
-     "stack offset N" might actually be different physical locations, for
-     example if one is of class "Int" and another "Float" on amd64.
-     [register_class] will be [Proc.register_class], but cannot be here,
-     due to a circular dependency. *)
-  reg1.loc = reg2.loc
-    && register_class reg1 = register_class reg2
-
-let at_same_location t (reg : Reg.t) ~register_class =
-  regs_at_same_location t.reg reg ~register_class
-
 let debug_info t = t.debug_info
 
-let clear_debug_info t =
-  { t with debug_info = None; }
+(* We use maps to allow lookup by [Reg.t] to be fast, and to statically forbid
+   multiple [Debug_info.t option] values being associated with any given [Reg.t]
+   value.  Using maps rather than sets also simplifies the code in
+   [Available_regs]. *)
+module Availability_map = struct
+  type t = Debug_info.t option Reg.Map.t
 
-module Order_distinguishing_names_and_locations = struct
-  type nonrec t = t
+  let print ppf t =
+    (* CR-someday mshinwell: Try to pass a proper [print_reg] here, or break
+       the circular dependency so [print_reg] isn't needed. *)
+    let print_reg = None in
+    let elts ppf t =
+      Reg.Map.iter (fun reg debug_info ->
+          let rd = create_with_debug_info reg debug_info in
+          Format.fprintf ppf "@ %a" (print ?print_reg) rd)
+        t
+    in
+    Format.fprintf ppf "@[<1>{@[%a@ @]}@]" elts t
 
-  let compare t1 t2 =
-    match t1.debug_info, t2.debug_info with
-    | None, None -> 0
-    | None, Some _ -> -1
-    | Some _, None -> 1
-    | Some di1, Some di2 ->
-      let c = V.compare di1.holds_value_of di2.holds_value_of in
-      if c <> 0 then c
-      else Stdlib.compare t1.reg.loc t2.reg.loc
-end
+  let equal t1 t2 = Reg.Map.equal (Option.equal Debug_info.equal) t1 t2
 
-module Set_distinguishing_names_and_locations =
-  Set.Make (Order_distinguishing_names_and_locations)
+  let empty = Reg.Map.empty
 
-module Map_distinguishing_names_and_locations =
-  Map.Make (Order_distinguishing_names_and_locations)
+  let singleton reg debug_info = Reg.Map.singleton reg debug_info
 
-module Set = struct
-  include Set.Make (T)
+  let add_or_replace t reg debug_info = Reg.Map.add reg debug_info t
 
-  let of_array elts =
-    of_list (Array.to_list elts)
-
-  let forget_debug_info t =
-    fold (fun t acc -> Reg.Set.add (reg t) acc) t Reg.Set.empty
-
-  let without_debug_info regs =
-    Reg.Set.fold (fun reg acc -> add (create_without_debug_info ~reg) acc)
-      regs
+  let of_assoc_array arr =
+    Array.fold_left (fun t (reg, debug_info) ->
+        add_or_replace t reg debug_info)
       empty
+      arr
+
+  let mem t reg = Reg.Map.mem reg t
+
+  let find t reg =
+    match Reg.Map.find reg t with
+    | exception Not_found -> None
+    | debug_info -> Some debug_info
+
+  let keys t =
+    Reg.Set.of_list (List.map fst (Reg.Map.bindings t))
+
+  let map t ~f = Reg.Map.map f t
+
+  let filter t ~f = Reg.Map.filter (fun reg _debug_info -> f reg) t
+
+  let diff_domain t1 t2 =
+    Reg.Map.filter (fun reg _ -> not (Reg.Map.mem reg t2)) t1
+
+  let inter t1 t2 =
+    Reg.Map.merge (fun _reg debug_info_opt1 debug_info_opt2 ->
+        match debug_info_opt1, debug_info_opt2 with
+        | Some debug_info1, Some debug_info2 ->
+          (* This check ensures that, for example, when we intersect two sets
+             together (for example to handle a join point in a function's
+             code) then we correctly lose debugging information when it is not
+             valid on all paths.
+
+             For example, suppose the value of a mutable variable x is copied
+             into another variable y; then there is a conditional where on one
+             branch x is assigned and on the other branch it is not. This
+             means that on the former branch we have forgotten about y holding
+             the value of x; but we have not on the latter. At the join point
+             we must have forgotten the information. *)
+          if Option.equal Debug_info.equal debug_info1 debug_info2 then
+            Some debug_info1
+          else
+            Some None
+        | Some _debug_info, None
+        | None, Some _debug_info ->
+          (* The register only occurred in one of [t1] and [t2].  Since
+             this is intersection, we always return [None]. *)
+          None
+        | None, None -> Misc.fatal_error "Bug in [Map.merge]")
+      t1 t2
+
+  let disjoint_union t1 t2 =
+    Reg.Map.union (fun _reg _debug_info1 _debug_info2 ->
+        Misc.fatal_errorf "[Reg.t] keys in supplied availability maps are \
+          not disjoint")
+      t1 t2
 
   let made_unavailable_by_clobber t ~regs_clobbered ~register_class =
-    Reg.Set.fold (fun reg acc ->
-        let made_unavailable =
-          filter (fun reg' ->
-              regs_at_same_location reg'.reg reg ~register_class)
-            t
-        in
-        union made_unavailable acc)
-      (Reg.set_of_array regs_clobbered)
-      (* ~init:*)empty
+    let regs_clobbered = Reg.set_of_array regs_clobbered in
+    Reg.Map.filter (fun reg _debug_info ->
+        Reg.Set.exists (fun reg' ->
+            Reg.at_same_location reg' reg ~register_class)
+          regs_clobbered)
+      t
 
-  let mem_reg t (reg : Reg.t) =
-    exists (fun t -> t.reg.stamp = reg.stamp) t
-
-  let filter_reg t (reg : Reg.t) =
-    filter (fun t -> t.reg.stamp <> reg.stamp) t
-
-  (* CR-someday mshinwell: Well, it looks like we should have used a map.
-     mshinwell: Also see @chambart's suggestion on GPR#856. *)
-  let find_reg_exn t (reg : Reg.t) =
-    match elements (filter (fun t -> t.reg.stamp = reg.stamp) t) with
-    | [] -> raise Not_found
-    | [reg] -> reg
-    | _ -> assert false
+  let subset t1 t2 =
+    let regs1 = Reg.Set.of_list (List.map fst (Reg.Map.bindings t1)) in
+    let regs2 = Reg.Set.of_list (List.map fst (Reg.Map.bindings t2)) in
+    Reg.Set.subset regs1 regs2
 end
 
-let print ~print_reg ppf t =
-  match t.debug_info with
-  | None -> Format.fprintf ppf "%a" print_reg t.reg
-  | Some debug_info ->
-    Format.fprintf ppf "%a(%a)" print_reg t.reg Debug_info.print debug_info
+module Canonical_availability_map = struct
+  type t = Availability_map.t
+
+  let print = Availability_map.print
+
+  let empty = Reg.Map.empty
+
+  let create (map : Availability_map.t) =
+    let regs_by_var : reg_with_debug_info V.Tbl.t = V.Tbl.create 42 in
+    Reg.Map.iter (fun reg debug_info ->
+        let reg = create_with_debug_info reg debug_info in
+        match debug_info with
+        | None -> ()
+        | Some debug_info ->
+          match Debug_info.holds_value_of debug_info with
+          | Var name ->
+            begin match V.Tbl.find regs_by_var name with
+            | exception Not_found -> V.Tbl.add regs_by_var name reg
+            | (reg' : reg_with_debug_info) ->
+              let loc = location reg in
+              let loc' = location reg' in
+              match loc, loc' with
+              | Stack _, Reg _ ->
+                (* We prefer registers that are assigned to the stack since they
+                   probably give longer available ranges (less likely to be
+                   clobbered). Additionally, for the DWARF call site argument
+                   descriptions, we can only describe registers assigned to the
+                   stack, as all others may have been clobbered. *)
+                V.Tbl.remove regs_by_var name;
+                V.Tbl.add regs_by_var name reg
+              | Reg _, Stack _
+              | Reg _, Reg _
+              | Stack _, Stack _
+              | _, Unknown
+              | Unknown, _ ->
+                (* In all other cases, we use a stable method to determine which
+                   register to choose as the canonical one, to avoid unnecessary
+                   opening and closing of ranges (c.f. [Compute_ranges]). *)
+                let c = Stdlib.compare loc loc' in
+                if c = 0 then begin
+                  ()
+                end else if c < 0 then begin
+                  V.Tbl.remove regs_by_var name;
+                  V.Tbl.add regs_by_var name reg
+                end else begin
+                  V.Tbl.remove regs_by_var name;
+                  V.Tbl.add regs_by_var name reg'
+                end
+            end
+          | Const_int _ | Const_naked_float _ | Const_symbol _ -> ())
+      map;
+    let result =
+      V.Tbl.fold (fun _var reg result ->
+          Reg.Map.add reg.reg reg.debug_info result)
+        regs_by_var
+        Reg.Map.empty
+    in
+    if true (* !Clflags.ddebug_invariants *) then begin
+      assert (Availability_map.subset result map)
+    end;
+    result
+
+  let of_list rds =
+    let regs = Reg.Set.of_list (List.map reg rds) in
+    if Reg.Set.cardinal regs <> List.length rds then begin
+      Misc.fatal_error "More than one binding with the same [Reg.t]"
+    end;
+    let avail_map =
+      List.fold_left (fun t rd ->
+          Availability_map.add_or_replace t (reg rd) (debug_info rd))
+        Availability_map.empty
+        rds
+    in
+    create avail_map
+
+  let is_empty = Reg.Map.is_empty
+
+  let invariant t =
+    if true (* !Clflags.ddebug_invariants *) then begin
+      if not (Reg.Map.equal (Option.equal Debug_info.equal) t (create t))
+      then begin
+        Misc.fatal_errorf "Invariant broken:@ %a" print t
+      end
+    end
+
+  (* [diff] and [inter], by construction, preserve the canonical form. *)
+
+  let diff t1 t2 =
+    let t =
+      Reg.Map.filter (fun reg debug_info_t1 ->
+          let occurs_in_t2 =
+            match Reg.Map.find reg t2 with
+            | exception Not_found -> false
+            | debug_info_t2 ->
+              Option.equal Debug_info.equal debug_info_t1 debug_info_t2
+          in
+          not occurs_in_t2)
+        t1
+    in
+    invariant t;
+    t
+
+  let inter t1 t2 =
+    let t = Availability_map.inter t1 t2 in
+    invariant t;
+    t
+
+  let fold f t init =
+    Reg.Map.fold (fun reg debug_info acc ->
+        let rd = create_with_debug_info reg debug_info in
+        f rd acc)
+      t
+      init
+
+  let find_holding_value_of_variable t var =
+    let t =
+      Reg.Map.filter (fun _reg debug_info ->
+          match debug_info with
+          | None -> false
+          | Some debug_info ->
+            Holds_value_of.equal (Debug_info.holds_value_of debug_info)
+              (Var var))
+        t
+    in
+    match Reg.Map.bindings t with
+    | [] -> None
+    | [reg, debug_info] -> Some (create_with_debug_info reg debug_info)
+    | _ ->
+      invariant t;
+      assert false  (* The invariant must have been broken. *)
+end
+
+module For_compute_ranges = struct
+  type nonrec t = t
+
+  let print ppf t : unit = print ?print_reg:None ppf t
+
+  module Set = Canonical_availability_map
+
+  module Map = Map.Make (struct
+    type nonrec t = t
+    let compare = compare
+  end)
+end

--- a/asmcomp/debug/reg_with_debug_info.mli
+++ b/asmcomp/debug/reg_with_debug_info.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2016--2017 Jane Street Group LLC                           *)
+(*   Copyright 2016--2019 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,101 +12,240 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Registers equipped with information used for generating debugging
-    information. *)
+(** Registers equipped with extra data about their contents that is used
+    for generating debugging information; together with data structures
+    used for keeping track of such registers. *)
 
-module Debug_info : sig
-  type t
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
-  val compare : t -> t -> int
+(** What a particular register holds. *)
+module Holds_value_of : sig
+  type t =
+    | Var of Backend_var.t
+      (** The value of the given variable. *)
+    | Const_int of Targetint.t
+      (** The given integer constant. *)
+    | Const_naked_float of Int64.t
+      (** The floating-point constant with the given bit pattern. *)
+    | Const_symbol of String.t
+      (** The given statically-allocated constant. *)
 
-  val holds_value_of : t -> Backend_var.t
-  (** The identifier that the register holds (part of) the value of. *)
-
-  val part_of_value : t -> int
-  val num_parts_of_value : t -> int
-
-  val which_parameter : t -> int option
-  (** If the register corresponds to a function parameter, the value returned
-      is the zero-based index of said parameter; otherwise it is [None]. *)
-
-  val provenance : t -> unit option
+  include Identifiable.S with type t := t
 end
 
-type t
+module Debug_info : sig
+  (** The type of debugging information attached to a register. *)
+  type t
 
-type reg_with_debug_info = t
-
-val create
-   : reg:Reg.t
-  -> holds_value_of:Backend_var.t
-  -> part_of_value:int
-  -> num_parts_of_value:int
-  -> which_parameter:int option
-  -> provenance:unit option
-  -> t
-
-val create_with_debug_info : reg:Reg.t -> debug_info:Debug_info.t option -> t
-
-val create_without_debug_info : reg:Reg.t -> t
-
-val create_copying_debug_info : reg:Reg.t -> debug_info_from:t -> t
-
-val reg : t -> Reg.t
-val location : t -> Reg.location
-val debug_info : t -> Debug_info.t option
-
-val at_same_location : t -> Reg.t -> register_class:(Reg.t -> int) -> bool
-(** [at_same_location t reg] holds iff the register [t] corresponds to
-    the same (physical or pseudoregister) location as the register [reg],
-    which is not equipped with debugging information.
-    [register_class] should be [Proc.register_class].
-*)
-
-val holds_pointer : t -> bool
-val holds_non_pointer : t -> bool
-
-val assigned_to_stack : t -> bool
-(** [assigned_to_stack t] holds iff the location of [t] is a hard stack
-    slot. *)
-
-val clear_debug_info : t -> t
-
-module Set_distinguishing_names_and_locations
-  : Set.S with type elt = t
-
-module Map_distinguishing_names_and_locations
-  : Map.S with type key = t
-
-module Set : sig
-  include Set.S with type elt = t
-
-  val of_array : reg_with_debug_info array -> t
-
-  val mem_reg : t -> Reg.t -> bool
-
-  val find_reg_exn : t -> Reg.t -> reg_with_debug_info
-
-  val filter_reg : t -> Reg.t -> t
-
-  val forget_debug_info : t -> Reg.Set.t
-
-  val without_debug_info : Reg.Set.t -> t
-
-  val made_unavailable_by_clobber
-     : t
-    -> regs_clobbered:Reg.t array
-    -> register_class:(Reg.t -> int)
+  (** Create a value of type [t]. *)
+  val create
+     : holds_value_of:Holds_value_of.t
+    -> part_of_value:int
+    -> num_parts_of_value:int
+    -> Is_parameter.t
+    -> provenance:Backend_var.Provenance.t option
     -> t
+
+  (** Total order on values of type [t]. *)
+  val compare : t -> t -> int
+
+  (** The identifier or constant that the register holds (part of) the
+      value of. *)
+  val holds_value_of : t -> Holds_value_of.t
+
+  (** If the register holds only one part of a value (for example half of a
+      64-bit constant), then this function returns how many parts there are,
+      or unity otherwise. *)
+  val num_parts_of_value : t -> int
+
+  (** If [num_parts_of_value] is greater than zero, then this function returns
+      the zero-based index of which part of the whole value is contained within
+      the register; otherwise it returns zero. *)
+  val part_of_value : t -> int
+
+  (* CR-soon mshinwell: This doesn't seem quite right, because the provenance
+     is only relevant for the [Var] case.  Likewise [is_parameter].  We should
+     try to improve this after the initial merge. *)
+
+  (** A description as to whether the register holds the value of a function
+      parameter or local variable.  (Anonymous constants will count as
+      local variables.) *)
+  val is_parameter : t -> Is_parameter.t
+
+  (** Any provenance information, which can be used for linking back to
+      .cmt files, associated with the register.  This will be [None] except
+      in the [Var] case. *)
+  val provenance : t -> Backend_var.Provenance.t option
+end
+
+(** Maps from registers to debug info. These can also be seen as sets of
+    registers with debug info (effectively values of type [reg_with_debug_info],
+    see below) subject to the condition that within any given set, any given
+    register is associated with at most one debug info value. *)
+module Availability_map : sig
+  type t
+
+  (** Print the given map to a formatter. *)
+  val print : Format.formatter -> t -> unit
+
+  (** Equality on maps, testing both the [Reg.t] and the [Debug_info.t option]
+      components (i.e. the domain and the range). *)
+  val equal : t -> t -> bool
+
+  (** The empty map. *)
+  val empty : t
+
+  (** Create a map with a single element mapping the given register to the
+      given debugging information. *)
+  val singleton : Reg.t -> Debug_info.t option -> t
+
+  (** Add a new binding to the given map or replace any existing binding
+      of the same [Reg.t]. *)
+  val add_or_replace : t -> Reg.t -> Debug_info.t option -> t
+
+  (** Create a map from the given associative array.  An exception is raised
+      if the input contains duplicate [Reg.t] values. *)
+  val of_assoc_array : (Reg.t * (Debug_info.t option)) array -> t
+
+  (** Test whether the given map maps the given register. *)
+  val mem : t -> Reg.t -> bool
+
+  (** Locate the debugging information associated with the given register
+      in the map.  [None] being returned indicates that the register is not
+      mapped in the given map.  [Some None] indicates that the register is
+      mapped but has no associated debugging information. *)
+  val find : t -> Reg.t -> Debug_info.t option option
+
+  (** Return all registers mapped by the given map. *)
+  val keys : t -> Reg.Set.t
+
+  (** Map the range of the given map, i.e. the debugging information
+      components. *)
+  val map : t -> f:(Debug_info.t option -> Debug_info.t option) -> t
+
+  (** Keep only the bindings in the given map for which the given
+      predicate returns [true]. *)
+  val filter : t -> f:(Reg.t -> bool) -> t
+
+  (** [diff_domain t1 t2] removes bindings from [t1] whose [Reg.t] key occurs
+      in the domain of [t2].  Note that this function does not look at the
+      range (i.e. the [Debug_info.t option] values) of the maps. *)
+  val diff_domain : t -> t -> t
+
+  (** [inter t1 t2] returns those bindings that occur in both [t1] and [t2].
+      Both the [Reg.t] and [Debug_info.t option] components of a binding have
+      to be equal for such binding to be returned in the result. *)
+  val inter : t -> t -> t
+
+  (** [disjoint_union t1 t2] is the union operation on maps restricted to the
+      case where the domains of [t1] and [t2] are disjoint.  If this condition
+      is not satisfied a fatal error is raised. *)
+  val disjoint_union : t -> t -> t
+
   (** [made_unavailable_by_clobber t ~regs_clobbered ~register_class] returns
       the largest subset of [t] whose locations do not overlap with any
       registers in [regs_clobbered].  (Think of [t] as a set of available
       registers.)
       [register_class] should always be [Proc.register_class]. *)
+  val made_unavailable_by_clobber
+     : t
+    -> regs_clobbered:Reg.t array
+    -> register_class:(Reg.t -> int)
+    -> t
 end
 
+(** The type of a register with associated debugging information. Each value
+    of type [t] holds an "underlying" [Reg.t] value. By the time this module
+    is used, all such [Reg.t] values will describe hard registers or stack
+    slots, and not unallocated pseudos. *)
+type t
+
+type reg_with_debug_info = t
+
+(** Print a value of type [t] to a formatter. *)
 val print
-   : print_reg:(Format.formatter -> Reg.t -> unit)
+   : ?print_reg:(Format.formatter -> Reg.t -> unit)
   -> Format.formatter
   -> t
   -> unit
+
+(** Return the normal [Reg.t] value described by the given register with
+    debug info. *)
+val reg : t -> Reg.t
+
+(** Where the register is located (a hard register, the stack, etc). *)
+val location : t -> Reg.location
+
+(** The debugging information associated with the register. *)
+val debug_info : t -> Debug_info.t option
+
+(** Maps from registers to debug info, kept in a canonical form, guaranteeing
+    for each map that it:
+    (a) contains only registers that are associated with debug info; and
+    (b) contains at most one register that holds the value of any given
+        variable.
+
+    Registers assigned to the stack are preferred if a choice has to be
+    made to satisfy (b).
+*)
+module Canonical_availability_map : sig
+  type t
+
+  (** Print the given map to a formatter. *)
+  val print : Format.formatter -> t -> unit
+
+  (** The empty map. *)
+  val empty : t
+
+  (** Canonicalise the given register-to-debug-info map. *)
+  val create : Availability_map.t -> t
+
+  (** [of_list] will raise an exception if more than one entry in the
+      supplied list contains the same [Reg.t]. *)
+  val of_list : reg_with_debug_info list -> t
+
+  (** Returns [true] iff the supplied map does not contain any bindings. *)
+  val is_empty : t -> bool
+
+  (** Note that no "union" operations are provided.  Values of type [t]
+      form a semilattice with respect to [inter], but not a lattice also
+      with respect to [union], since the canonical form might not be
+      preserved. *)
+
+  (** [diff t1 t2] returns those bindings in [t1] that do not occur in [t2].
+      Note that both the [Reg.t] and the [Debug_info.t] components are
+      taken into account.  (This means, for example, that if [t1] contains
+      a mapping of register [r] to debug info [di1] and if [t2] contains a
+      mapping of register [r] to debug info [di2] with
+      [not (Debug_info.equal di1 di2)] then [diff t1 t2] returns [t1]
+      unchanged.) *)
+  val diff : t -> t -> t
+
+  (** [inter t1 t2] returns those bindings that occur in both [t1] and [t2].
+      As for [diff], both the [Reg.t] and the [Debug_info.t] components of
+      each binding are considered, and must match for a binding to be
+      returned in the intersection. *)
+  val inter : t -> t -> t
+
+  (** Fold over the bindings in the given map; the order is unspecified. *)
+  val fold : (reg_with_debug_info -> 'a -> 'a) -> t -> 'a -> 'a
+
+  (** Find the element of the set that holds the value of the given variable,
+      if such exists, otherwise returning [None].  (Note that by virtue of the
+      canonical form criterion, there can never be more than one variable
+      eligible to be returned from any one call to this function.) *)
+  val find_holding_value_of_variable
+     : t
+    -> Backend_var.t
+    -> reg_with_debug_info option
+end
+
+(** Convenience module for use with [Compute_ranges_intf]. *)
+module For_compute_ranges : sig
+  type nonrec t = t
+
+  val print : Format.formatter -> t -> unit
+
+  module Set = Canonical_availability_map
+  module Map : Map.S with type key = t
+end

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -61,8 +61,12 @@ type operation =
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat
   | Ispecific of Arch.specific_operation
-  | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
-      provenance : unit option; is_assignment : bool; }
+  | Iname_for_debugger of {
+      ident : Backend_var.t;
+      is_parameter : Is_parameter.t;
+      provenance : Backend_var.Provenance.t option;
+      is_assignment : bool;
+    }
 
 type instruction =
   { desc: instruction_desc;
@@ -109,7 +113,7 @@ let rec dummy_instr =
     res = [||];
     dbg = Debuginfo.none;
     live = Reg.Set.empty;
-    available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
+    available_before = Reg_availability_set.empty;
     available_across = None;
   }
 
@@ -120,20 +124,20 @@ let end_instr () =
     res = [||];
     dbg = Debuginfo.none;
     live = Reg.Set.empty;
-    available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
+    available_before = Reg_availability_set.empty;
     available_across = None;
   }
 
 let instr_cons d a r n =
   { desc = d; next = n; arg = a; res = r;
     dbg = Debuginfo.none; live = Reg.Set.empty;
-    available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
+    available_before = Reg_availability_set.empty;
     available_across = None;
   }
 
 let instr_cons_debug d a r dbg n =
   { desc = d; next = n; arg = a; res = r; dbg = dbg; live = Reg.Set.empty;
-    available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
+    available_before = Reg_availability_set.empty;
     available_across = None;
   }
 

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -71,8 +71,12 @@ type operation =
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat
   | Ispecific of Arch.specific_operation
-  | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
-      provenance : unit option; is_assignment : bool; }
+  | Iname_for_debugger of {
+      ident : Backend_var.t;
+      is_parameter : Is_parameter.t;
+      provenance : Backend_var.Provenance.t option;
+      is_assignment : bool;
+    }
     (** [Iname_for_debugger] has the following semantics:
         (a) The argument register(s) is/are deemed to contain the value of the
             given identifier.

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -23,24 +23,7 @@ open Interval
 
 module V = Backend_var
 
-let reg ppf r =
-  if not (Reg.anonymous r) then
-    fprintf ppf "%s" (Reg.name r)
-  else
-    fprintf ppf "%s"
-      (match r.typ with Val -> "V" | Addr -> "A" | Int -> "I" | Float -> "F");
-  fprintf ppf "/%i" r.stamp;
-  begin match r.loc with
-  | Unknown -> ()
-  | Reg r ->
-      fprintf ppf "[%s]" (Proc.register_name r)
-  | Stack(Local s) ->
-      fprintf ppf "[s%i]" s
-  | Stack(Incoming s) ->
-      fprintf ppf "[si%i]" s
-  | Stack(Outgoing s) ->
-      fprintf ppf "[so%i]" s
-  end
+let reg = Reg.print ~register_name:Proc.register_name
 
 let regs ppf v =
   match Array.length v with
@@ -158,12 +141,10 @@ let operation op arg ppf res =
   | Idivf -> fprintf ppf "%a /f %a" reg arg.(0) reg arg.(1)
   | Ifloatofint -> fprintf ppf "floatofint %a" reg arg.(0)
   | Iintoffloat -> fprintf ppf "intoffloat %a" reg arg.(0)
-  | Iname_for_debugger { ident; which_parameter; } ->
-    fprintf ppf "name_for_debugger %a%s=%a"
+  | Iname_for_debugger { ident; is_parameter; } ->
+    fprintf ppf "name_for_debugger %a(%a)=%a"
       V.print ident
-      (match which_parameter with
-        | None -> ""
-        | Some index -> sprintf "[P%d]" index)
+      Is_parameter.print is_parameter
       reg arg.(0)
   | Ispecific op ->
       Arch.print_specific_operation reg op ppf arg

--- a/asmcomp/reg.mli
+++ b/asmcomp/reg.mli
@@ -64,7 +64,26 @@ val inter_set_array: Set.t -> t array -> Set.t
 val disjoint_set_array: Set.t -> t array -> bool
 val set_of_array: t array -> Set.t
 
+(** Whether the register may hold a pointer value. *)
+val maybe_holds_pointer : t -> bool
+
+(** Whether the register always holds an immediate value. *)
+val always_holds_non_pointer : t -> bool
+
+(** [assigned_to_stack t] holds iff the location of [t] is a hard stack
+    slot. *)
+val assigned_to_stack : t -> bool
+
+(** [at_same_location t reg] holds iff the register [t] corresponds to
+    the same (physical or pseudoregister) location as the register [reg],
+    which is not equipped with debugging information.
+    [register_class] should be [Proc.register_class].
+*)
+val at_same_location : t -> t -> register_class:(t -> int) -> bool
+
 val reset: unit -> unit
 val all_registers: unit -> t list
 val num_registers: unit -> int
 val reinit: unit -> unit
+
+val print : register_name:(int -> string) -> Format.formatter -> t -> unit

--- a/middle_end/backend_var.ml
+++ b/middle_end/backend_var.ml
@@ -44,6 +44,19 @@ module Provenance = struct
   let module_path t = t.module_path
   let location t = t.location
   let original_ident t = t.original_ident
+
+  let compare
+        { module_path = module_path1; location = location1;
+          original_ident = original_ident1; }
+        { module_path = module_path2; location = location2;
+          original_ident = original_ident2; } =
+    let c = Path.compare module_path1 module_path2 in
+    if c <> 0 then c
+    else
+      let c = Debuginfo.compare location1 location2 in
+      if c <> 0 then c
+      else
+        Ident.compare original_ident1 original_ident2
 end
 
 module With_provenance = struct

--- a/middle_end/flambda/base_types/is_parameter.ml
+++ b/middle_end/flambda/base_types/is_parameter.ml
@@ -1,0 +1,65 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type t =
+  | Local
+  | Parameter of { index : int; }
+
+let local = Local
+
+let parameter ~index =
+  if index < 0 then begin
+    Misc.fatal_errorf "Bad parameter index %d" index
+  end;
+  Parameter { index; }
+
+let join t1 t2 =
+  match t1, t2 with
+  | Local, Local -> Local
+  | Parameter { index; }, Local
+  | Local, Parameter { index; } -> Parameter { index; }
+  | Parameter { index = index1; }, Parameter { index = index2; } ->
+    if index1 <> index2 then begin
+      Misc.fatal_error "Cannot join [Is_parameter.t] values that disagree \
+        on parameter indexes"
+    end else begin
+      Parameter { index = index1; }
+    end
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Local, Local -> 0
+    | Parameter { index = index1; }, Parameter { index = index2; } ->
+      Stdlib.compare index1 index2
+    | Local, Parameter _ -> -1
+    | Parameter _, Local -> 1
+
+  let equal t1 t2 =
+    compare t1 t2 = 0
+
+  let hash t = Hashtbl.hash t
+
+  let print ppf t =
+    match t with
+    | Local -> Format.pp_print_string ppf "local"
+    | Parameter { index; } ->
+      Format.fprintf ppf "@[(parameter@ (index %d))@]" index
+
+  let output _ _ = Misc.fatal_error "Not yet implemented"
+end)

--- a/middle_end/flambda/base_types/is_parameter.mli
+++ b/middle_end/flambda/base_types/is_parameter.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Mark Shinwell, Jane Street Europe                     *)
 (*                                                                        *)
-(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -12,45 +12,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Variables used in the backend, optionally equipped with "provenance"
-    information, used for the emission of debugging information. *)
-
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-include module type of struct include Ident end
+(** Whether a variable is a local or a function parameter. *)
 
-type backend_var = t
+type t = private
+  | Local
+  | Parameter of { index : int; }
 
-module Provenance : sig
-  type t
+val local : t
 
-  val create
-     : module_path:Path.t
-    -> location:Debuginfo.t
-    -> original_ident:Ident.t
-    -> t
+val parameter : index:int -> t
 
-  val module_path : t -> Path.t
-  val location : t -> Debuginfo.t
-  val original_ident : t -> Ident.t
+val join : t -> t -> t
 
-  val print : Format.formatter -> t -> unit
-
-  val compare : t -> t -> int
-end
-
-module With_provenance : sig
-  (** Values of type [t] should be used for variables in binding position. *)
-  type t
-
-  val print : Format.formatter -> t -> unit
-
-  val create : ?provenance:Provenance.t -> backend_var -> t
-
-  val var : t -> backend_var
-  val provenance : t -> Provenance.t option
-
-  val name : t -> string
-
-  val rename : t -> t
-end
+include Identifiable.S with type t := t

--- a/utils/targetint.ml
+++ b/utils/targetint.ml
@@ -52,6 +52,7 @@ module type S = sig
   val to_int32 : t -> int32
   val of_int64 : int64 -> t
   val to_int64 : t -> int64
+  val of_nativeint : Nativeint.t -> t
   val of_string : string -> t
   val to_string : t -> string
   val compare: t -> t -> int
@@ -83,6 +84,7 @@ module Int32 = struct
   let to_int32 x = x
   let of_int64 = Int64.to_int32
   let to_int64 = Int64.of_int32
+  let of_nativeint = Nativeint.to_int32
   let repr x = Int32 x
   let print ppf t = Format.fprintf ppf "%ld" t
 end
@@ -92,6 +94,7 @@ module Int64 = struct
   let of_int_exn = Int64.of_int
   let of_int64 x = x
   let to_int64 x = x
+  let of_nativeint = Int64.of_nativeint
   let repr x = Int64 x
   let print ppf t = Format.fprintf ppf "%Ld" t
 end

--- a/utils/targetint.mli
+++ b/utils/targetint.mli
@@ -171,6 +171,9 @@ val to_int64 : t -> int64
 (** Convert the given target integer to a
     64-bit integer (type [int64]). *)
 
+val of_nativeint : Nativeint.t -> t
+(** Convert the given native integer to a target integer. *)
+
 val of_string : string -> t
 (** Convert the given string to a target integer.
     The string is read in decimal (by default) or in hexadecimal,


### PR DESCRIPTION
This patch allows `Available_regs` to track which registers hold which constants in addition to the values of which variables.  New implementations are also provided of `Reg_with_debug_info` and `Reg_availability_set`.  These two should be read by just looking at the files rather than the diffs.

This whole area, especially the notions of canonical and non-canonical register availability sets, is rather subtle.  I think this new version of the code is a substantial improvement and it should be more obviously correct.

Some changes have been necessitated to `Compute_ranges` as a union operation is not provided on canonical availability sets.  Concerned about the correctness of this part, I wrote a specification of a proof in a [PDF document](https://github.com/ocaml/ocaml/files/3073191/rangeproof.pdf) and @gretay-js has [done the proof in z3](https://github.com/ocaml/ocaml/files/3073205/rangeproof-dot-smt2.txt).

I've tested all of this on the main `gdb-names-gpr` branch and everything appears to be ok.  It would be nice in the future to try to add some more automated testing in this area (e.g. to make sure that all variables that should be visible in the debugger are visible)---although it's probably difficult.

@lthls @chambart Please could you two look at the various pieces of this, as you were the original reviewers of these files.
