### PR TITLE
Add a non-regression test for #7865

### DIFF
--- a/testsuite/tests/typing-objects/ocamltests
+++ b/testsuite/tests/typing-objects/ocamltests
@@ -10,4 +10,5 @@ pr6123_bad.ml
 pr6383.ml
 pr6907_bad.ml
 self_cannot_be_closed.ml
+self_cannot_escape_pr7865.ml
 Tests.ml

--- a/testsuite/tests/typing-objects/self_cannot_escape_pr7865.ml
+++ b/testsuite/tests/typing-objects/self_cannot_escape_pr7865.ml
@@ -1,0 +1,21 @@
+(* TEST
+   * expect
+*)
+
+class c =
+object (o)
+  method foo = o
+end;;
+[%%expect {|
+class c : object ('a) method foo : 'a end
+|}]
+
+class d =
+object (o) inherit c
+  method bar = fun () ->
+    let o = List.fold_right (fun _ o -> o#foo) [] o in
+    let o = match () with () -> o in o
+end;;
+[%%expect {|
+class d : object ('a) method bar : unit -> 'a method foo : 'a end
+|}]


### PR DESCRIPTION
#7865 reports a typing problem that appeared in 4.07.0, where correct code was rejected with "Self type cannot escape its class".

@trefis [points out](https://github.com/ocaml/ocaml/issues/7865#issuecomment-473078977) that #1735 seems to have fixed the problem in trunk.  This PR adds a test to ensure that the problem doesn't recur, so that we can close the issue.