### PR TITLE
Fix stdlib build

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -129,6 +129,8 @@ HEADER_PATH =
 HEADER_TARGET_PATH =
 endif
 
+TARGETHEADERPROGRAM = target_$(HEADERPROGRAM)
+
 CAMLHEADERS =\
   camlheader target_camlheader camlheader_ur \
   camlheaderd target_camlheaderd \
@@ -173,7 +175,7 @@ camlheader_ur: camlheader
 	cp camlheader $@
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
-tmptargetcamlheader%exe: $(HEADERPROGRAM)%$(O)
+tmptargetcamlheader%exe: $(TARGETHEADERPROGRAM)%$(O)
 	$(call MKEXE_BOOT,$@,$^ $(EXTRALIBS))
 	strip $@
 


### PR DESCRIPTION
PR#2267 and in particular commit 278e5abbc0 has introduced the use
of the `TARGETHEADERPROGRAM` variable which is actually never defined.

This confuses make on system where hashbbang scripts are not supported,
because it introduces a rule saying that each file whose name ends with
"o" (or "obj") (no matter whether there is a dot before or not)
can be build from either `header.c` or `headernt.c`.

Combined with make's implicit rules, this leads to make trying to
update files like `.depend`, `Makefile.common` and `Makefile.config`
as soon as the source of the header program is more recent than they are.

Similarly, since `Makefile`itself is declared as a prerequisite,
make also tries to rebuild it whenever the source file for the header
program is newer.

This PR fixes this by removing `Makefile`of the lists of
prerequisites and protecting the rule that uses `TARGETHEADERPROGRAM`
so that it is used only when the variable is non-empty.