### PR TITLE
Enable SSE2 for i686 mingw32

### DIFF
--- a/Changes
+++ b/Changes
@@ -153,6 +153,10 @@ Working version
 - #8607: Remove obsolete macros for pre-2002 MSVC support
   (Stephen Dolan, review by Nicolás Ojeda Bär and David Allsopp)
 
+- #8627: Require SSE2 for 32-bit mingw port to generate correct code
+  for caml_round with GCC 7.4.
+  (David Allsopp, review by ???)
+
 ### Standard library:
 
 - #2262: take precision (.<n>) and flags ('+' and ' ') into account

--- a/configure
+++ b/configure
@@ -12415,6 +12415,14 @@ esac
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
 
+# Enable SSE2 on x86 mingw to avoid using 80-bit registers.
+case $host in #(
+  i686-*-mingw32) :
+    internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
+  *) :
+     ;;
+esac
+
 # Use 64-bit file offset if possible
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -547,6 +547,11 @@ AS_CASE([$host],
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
 
+# Enable SSE2 on x86 mingw to avoid using 80-bit registers.
+AS_CASE([$host],
+  [i686-*-mingw32],
+    [internal_cflags="$internal_cflags -mfpmath=sse -msse2"])
+
 # Use 64-bit file offset if possible
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS


### PR DESCRIPTION
The eagle-eyed amongst us may have noticed that AppVeyor has been failing all builds since this morning. AppVeyor updated the Cygwin installation in the Windows workers (see the [April 17 update](https://www.appveyor.com/updates/2019/04/14/) and in particular https://github.com/appveyor/ci/issues/2898#issuecomment-484355112).

This bumped mingw-w64 gcc from 6.4 to 7.4, and with `-O` that's causing "incorrect" code to be generated for `caml_round` such that `caml_round(0.5) == 0.0` and not the `1.0` required for the C99 emulation.

A sledgehammer is to specify `-ffloat-store` for i686 mingw32. A rock hammer is to accept that Windows 8+ requires an SSE2 processor, and Windows 7 dropped support for non-SSE2 processors last year, which is what this PR does.