### PR TITLE
Use same cflags and cppflags for ocamlc -c and ocamlopt -c (#7678)

### DIFF
--- a/Changes
+++ b/Changes
@@ -209,6 +209,11 @@ Working version
   building shared libraries like `-output-obj`.
   (Florian Angeletti, review by Nicolás Ojeda Bär)
 
+* #7678, #8631: ocamlc -c and ocamlopt -c pass same switches to the C
+  compiler when compiling .c files (in particular, this means ocamlopt
+  passes -fPIC on systems requiring it for shared library support).
+  (David Allsopp, report by Daniel Bünzli, review by Sébastien Hinderer)
+
 - #9074: reworded error message for non-regular structural types
   (Florian Angeletti, review by Jacques Garrigue and Leo White,
    report by Chas Emerick)

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -193,8 +193,10 @@ NATDYNLINK=@natdynlink@
 NATDYNLINKOPTS=@natdynlinkopts@
 SYSLIB=@syslib@
 MKLIB=@mklib@
-OCAMLOPT_CFLAGS=@ocamlopt_cflags@
-OCAMLOPT_CPPFLAGS=@ocamlopt_cppflags@
+# #7678: ocamlopt uses these only to compile .c files, and the behaviour for the
+#        two drivers should be identical.
+OCAMLOPT_CFLAGS=@ocamlc_cflags@
+OCAMLOPT_CPPFLAGS=@ocamlc_cppflags@
 NATIVECCLIBS=@nativecclibs@
 SYSTHREAD_SUPPORT=@systhread_support@
 PACKLD=@PACKLD@

--- a/configure
+++ b/configure
@@ -804,8 +804,6 @@ AR
 shebangscripts
 long_shebang
 iflexdir
-ocamlopt_cppflags
-ocamlopt_cflags
 ocamlc_cppflags
 ocamlc_cflags
 nativecclibs
@@ -2748,8 +2746,6 @@ internal_cflags=""
 internal_cppflags=""
 ocamlc_cflags=""
 ocamlc_cppflags=""
-ocamlopt_cflags=""
-ocamlopt_cppflags=""
 oc_ldflags=""
 with_sharedlibs=true
 ostype="Unix"
@@ -2806,8 +2802,6 @@ VERSION=4.11.0+dev0-2019-10-18
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-
-
 
 
 
@@ -16886,8 +16880,6 @@ oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
 ocamlc_cflags="$common_cflags $sharedlib_cflags"
 ocamlc_cppflags="$common_cppflags"
-ocamlopt_cflags="$common_cflags"
-ocamlopt_cppflags="$common_cppflags"
 cclibs="$cclibs $mathlib"
 
 case $host in #(

--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,6 @@ internal_cflags=""
 internal_cppflags=""
 ocamlc_cflags=""
 ocamlc_cppflags=""
-ocamlopt_cflags=""
-ocamlopt_cppflags=""
 oc_ldflags=""
 with_sharedlibs=true
 ostype="Unix"
@@ -108,8 +106,6 @@ AC_SUBST([bytecclibs])
 AC_SUBST([nativecclibs])
 AC_SUBST([ocamlc_cflags])
 AC_SUBST([ocamlc_cppflags])
-AC_SUBST([ocamlopt_cflags])
-AC_SUBST([ocamlopt_cppflags])
 AC_SUBST([iflexdir])
 AC_SUBST([long_shebang])
 AC_SUBST([shebangscripts])
@@ -1788,8 +1784,6 @@ oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"
 ocamlc_cflags="$common_cflags $sharedlib_cflags"
 ocamlc_cppflags="$common_cppflags"
-ocamlopt_cflags="$common_cflags"
-ocamlopt_cppflags="$common_cppflags"
 cclibs="$cclibs $mathlib"
 
 AS_CASE([$host],

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -89,11 +89,12 @@ let compile_file ?output ?(opt="") ?stable_name name =
          (match !Clflags.c_compiler with
           | Some cc -> cc
           | None ->
-              let (cflags, cppflags) =
-                  if !Clflags.native_code
-                  then (Config.ocamlopt_cflags, Config.ocamlopt_cppflags)
-                  else (Config.ocamlc_cflags, Config.ocamlc_cppflags) in
-              (String.concat " " [Config.c_compiler; cflags; cppflags]))
+              (* #7678: ocamlopt only calls the C compiler to process .c files
+                 from the command line, and the behaviour between
+                 ocamlc/ocamlopt should be identical. *)
+              (String.concat " " [Config.c_compiler;
+                                  Config.ocamlc_cflags;
+                                  Config.ocamlc_cppflags]))
          debug_prefix_map
          (match output with
           | None -> ""

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -51,10 +51,14 @@ val ocamlc_cppflags : string
 (** The flags ocamlc should pass to the C preprocessor *)
 
 val ocamlopt_cflags : string
-(** The flags ocamlopt should pass to the C compiler *)
+  [@@ocaml.deprecated "Use ocamlc_cflags instead."]
+(** @deprecated {!ocamlc_cflags} should be used instead.
+    The flags ocamlopt should pass to the C compiler *)
 
 val ocamlopt_cppflags : string
-(** The flags ocamlopt should pass to the C preprocessor *)
+  [@@ocaml.deprecated "Use ocamlc_cppflags instead."]
+(** @deprecated {!ocamlc_cppflags} should be used instead.
+    The flags ocamlopt should pass to the C preprocessor *)
 
 val bytecomp_c_libraries: string
 (** The C libraries to link with custom runtimes *)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -35,7 +35,9 @@ let c_has_debug_prefix_map = %%CC_HAS_DEBUG_PREFIX_MAP%%
 let as_has_debug_prefix_map = %%AS_HAS_DEBUG_PREFIX_MAP%%
 let ocamlc_cflags = "%%OCAMLC_CFLAGS%%"
 let ocamlc_cppflags = "%%OCAMLC_CPPFLAGS%%"
-let ocamlopt_cflags = "%%OCAMLOPT_CFLAGS%%"
+(* #7678: ocamlopt uses these only to compile .c files, and the behaviour for
+          the two drivers should be identical. *)
+let ocamlopt_cflags = "%%OCAMLC_CFLAGS%%"
 let ocamlopt_cppflags = "%%OCAMLOPT_CPPFLAGS%%"
 let bytecomp_c_libraries = "%%BYTECCLIBS%%"
 (* bytecomp_c_compiler and native_c_compiler have been supported for a


### PR DESCRIPTION
`Config.ocamlopt_cflags` and `Config.ocamlopt_cppflags` were solely used by the driver when compiling .c files passed on the command line. The behaviour of this should be the same as for `ocamlc -c` and the
inclusion of `-fPIC` in `ocamlc_cflags` only on some systems causes problems for `ocamlmklib` which behaves as though the two drivers compile C files identically.

This PR eliminates the separate settings in `configure.ac` and deprecates the old variables in `Config`.

Closes #7678