### PR TITLE
Fix --with-pic in configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -917,7 +917,7 @@ OCaml 4.08.0
   Damien Doligez)
 
 - #8632: Correctly propagate flags for --with-pic in configure.
-  (David Allsopp, review by ??)
+  (David Allsopp, review by Sébastien Hinderer and Damien Doligez)
 
 - #8673: restore SpaceTime and libunwind support in configure script
   (Sébastien Hinderer, review by Damien Doligez)

--- a/Changes
+++ b/Changes
@@ -916,6 +916,9 @@ OCaml 4.08.0
   (Sébastien Hinderer, review by David Allsopp, Gabriel Scherer and
   Damien Doligez)
 
+- #8632: Correctly propagate flags for --with-pic in configure.
+  (David Allsopp, review by ??)
+
 - #8673: restore SpaceTime and libunwind support in configure script
   (Sébastien Hinderer, review by Damien Doligez)
 

--- a/configure
+++ b/configure
@@ -13743,6 +13743,16 @@ esac ;; #(
      ;;
 esac
 
+if test "$with_pic"; then :
+  fpic=true
+  $as_echo "#define CAML_WITH_FPIC 1" >>confdefs.h
+
+  internal_cflags="$internal_cflags $sharedlib_cflags"
+  default_aspp="$default_aspp $sharedlib_cflags"
+else
+  fpic=false
+fi
+
 if test -z "$AS"; then :
   AS="$default_as"
 fi
@@ -16467,18 +16477,6 @@ _ACEOF
 if $profinfo; then :
   $as_echo "#define WITH_PROFINFO 1" >>confdefs.h
 
-fi
-
-## PIC
-
-if test "$with_pic"; then :
-  fpic=true
-  $as_echo "#define CAML_WITH_FPIC 1" >>confdefs.h
-
-  internal_cflags="$internal_cflags $sharedlib_cflags"
-  ASPP="$ASPP $sharedlib_cflags"
-else
-  fpic=false
 fi
 
 if test x"$enable_installing_bytecode_programs" = "xno"; then :

--- a/configure
+++ b/configure
@@ -16475,8 +16475,8 @@ if test "$with_pic"; then :
   fpic=true
   $as_echo "#define CAML_WITH_FPIC 1" >>confdefs.h
 
-  common_cflags="$common_cflags $sharedlib_cflags"
-  aspp="$aspp $sharedlib_cflags"
+  internal_cflags="$internal_cflags $sharedlib_cflags"
+  ASPP="$ASPP $sharedlib_cflags"
 else
   fpic=false
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1584,8 +1584,8 @@ AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
 AS_IF([test "$with_pic"],
   [fpic=true
   AC_DEFINE([CAML_WITH_FPIC])
-  common_cflags="$common_cflags $sharedlib_cflags"
-  aspp="$aspp $sharedlib_cflags"],
+  internal_cflags="$internal_cflags $sharedlib_cflags"
+  ASPP="$ASPP $sharedlib_cflags"],
   [fpic=false])
 
 AS_IF([test x"$enable_installing_bytecode_programs" = "xno"],

--- a/configure.ac
+++ b/configure.ac
@@ -986,6 +986,13 @@ AS_CASE(["$arch,$system"],
       [clang-*], [default_aspp="${toolpref}clang -c -Wno-trigraphs"],
       [default_aspp="${toolpref}gcc -c"])])
 
+AS_IF([test "$with_pic"],
+  [fpic=true
+  AC_DEFINE([CAML_WITH_FPIC])
+  internal_cflags="$internal_cflags $sharedlib_cflags"
+  default_aspp="$default_aspp $sharedlib_cflags"],
+  [fpic=false])
+
 AS_IF([test -z "$AS"], [AS="$default_as"])
 
 AS_IF([test -z "$ASPP"], [ASPP="$default_aspp"])
@@ -1578,15 +1585,6 @@ AS_IF([test x"$enable_spacetime" != "xyes" ],
 
 AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
 AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])
-
-## PIC
-
-AS_IF([test "$with_pic"],
-  [fpic=true
-  AC_DEFINE([CAML_WITH_FPIC])
-  internal_cflags="$internal_cflags $sharedlib_cflags"
-  ASPP="$ASPP $sharedlib_cflags"],
-  [fpic=false])
 
 AS_IF([test x"$enable_installing_bytecode_programs" = "xno"],
   [install_bytecode_programs=false],


### PR DESCRIPTION
@dbuenzli noted in https://github.com/ocaml/ocaml/issues/7678#issuecomment-485027549 that specifying `--with-pic` causes `-fPIC` to appear twice when using `ocamlc -c`. While fixing that PR, I noticed two problems with the logic for `--with-pic`:

- It should be updating `$internal_cflags`, not `$common_cflags` (which is what Daniel noticed)
- `aspp` is not used anywhere - I think it should be updating `ASPP`, although I also wonder if it should in fact update `default_aspp` (which would require `ASPP` to be defined later. @shindere - if the user provides `ASPP`, do we expect that to have absolutely everything which is required? If so, then I should amend this to set `default_aspp` instead. As it stands, if the user says `./configure ASPP=foo --with-pic` then `Makefile.config` will have `ASPP=foo -fPIC`.