### PR TITLE
Statistical memory profiling, part 1: blocks allocated in the major heap

### DIFF
--- a/Changes
+++ b/Changes
@@ -180,6 +180,12 @@ Working version
    or young values.
    (Jacques-Henri Jourdan, review by Gabriel Scherer and Stephen Dolan)
 
+- #8634: Statistical memory profiling provided by the Gc.Memprof
+   module.
+   Incomplete version: it only samples objects allocated in the major
+   heap.
+   (Jacques-Henri Jourdan, review by Stephen Dolan)
+
 ### Other libraries:
 
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -1,21 +1,23 @@
 run_unix.$(O): run_unix.c run.h ../runtime/caml/misc.h \
-  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
-  run_common.h
+ ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+ run_common.h
 run_stubs.$(O): run_stubs.c run.h ../runtime/caml/misc.h \
-  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
-  ../runtime/caml/mlvalues.h ../runtime/caml/memory.h \
-  ../runtime/caml/gc.h ../runtime/caml/major_gc.h \
-  ../runtime/caml/freelist.h ../runtime/caml/minor_gc.h \
-  ../runtime/caml/address_class.h ../runtime/caml/io.h \
-  ../runtime/caml/osdeps.h
+ ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+ ../runtime/caml/mlvalues.h ../runtime/caml/misc.h \
+ ../runtime/caml/memory.h ../runtime/caml/gc.h ../runtime/caml/mlvalues.h \
+ ../runtime/caml/major_gc.h ../runtime/caml/freelist.h \
+ ../runtime/caml/minor_gc.h ../runtime/caml/address_class.h \
+ ../runtime/caml/memprof.h ../runtime/caml/io.h ../runtime/caml/osdeps.h \
+ ../runtime/caml/memory.h
 ocamltest_stdlib_stubs.$(O): ocamltest_stdlib_stubs.c \
-  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
-  ../runtime/caml/mlvalues.h ../runtime/caml/misc.h \
-  ../runtime/caml/memory.h ../runtime/caml/gc.h \
-  ../runtime/caml/major_gc.h ../runtime/caml/freelist.h \
-  ../runtime/caml/minor_gc.h ../runtime/caml/address_class.h \
-  ../runtime/caml/alloc.h ../runtime/caml/signals.h \
-  ../runtime/caml/osdeps.h
+ ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
+ ../runtime/caml/mlvalues.h ../runtime/caml/config.h \
+ ../runtime/caml/misc.h ../runtime/caml/memory.h ../runtime/caml/gc.h \
+ ../runtime/caml/mlvalues.h ../runtime/caml/major_gc.h \
+ ../runtime/caml/freelist.h ../runtime/caml/minor_gc.h \
+ ../runtime/caml/address_class.h ../runtime/caml/memprof.h \
+ ../runtime/caml/alloc.h ../runtime/caml/signals.h \
+ ../runtime/caml/osdeps.h ../runtime/caml/memory.h
 actions.cmo : \
     result.cmi \
     environments.cmi \

--- a/otherlibs/systhreads/.depend
+++ b/otherlibs/systhreads/.depend
@@ -7,11 +7,12 @@ st_stubs_b.$(O): st_stubs.c ../../runtime/caml/alloc.h \
  ../../runtime/caml/io.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/misc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/printexc.h \
- ../../runtime/caml/roots.h ../../runtime/caml/memory.h \
- ../../runtime/caml/signals.h ../../runtime/caml/stacks.h \
- ../../runtime/caml/sys.h threads.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/misc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/printexc.h ../../runtime/caml/roots.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/stacks.h ../../runtime/caml/sys.h \
+ ../../runtime/caml/memprof.h threads.h
 st_stubs_n.$(O): st_stubs.c ../../runtime/caml/alloc.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
@@ -21,11 +22,12 @@ st_stubs_n.$(O): st_stubs.c ../../runtime/caml/alloc.h \
  ../../runtime/caml/io.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/misc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/printexc.h \
- ../../runtime/caml/roots.h ../../runtime/caml/memory.h \
- ../../runtime/caml/signals.h ../../runtime/caml/stack.h \
- ../../runtime/caml/sys.h threads.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/misc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/printexc.h ../../runtime/caml/roots.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/stack.h ../../runtime/caml/sys.h \
+ ../../runtime/caml/memprof.h threads.h
 condition.cmo : \
     mutex.cmi \
     condition.cmi

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -33,6 +33,7 @@
 #include "caml/stacks.h"
 #endif
 #include "caml/sys.h"
+#include "caml/memprof.h"
 #include "threads.h"
 
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
@@ -98,6 +99,7 @@ struct caml_thread_struct {
   int backtrace_pos;         /* Saved caml_backtrace_pos */
   backtrace_slot * backtrace_buffer; /* Saved caml_backtrace_buffer */
   value backtrace_last_exn;  /* Saved caml_backtrace_last_exn (root) */
+  int memprof_suspended;     /* Saved caml_memprof_suspended */
 };
 
 typedef struct caml_thread_struct * caml_thread_t;
@@ -195,6 +197,7 @@ static inline void caml_thread_save_runtime_state(void)
   curr_thread->backtrace_pos = caml_backtrace_pos;
   curr_thread->backtrace_buffer = caml_backtrace_buffer;
   curr_thread->backtrace_last_exn = caml_backtrace_last_exn;
+  curr_thread->memprof_suspended = caml_memprof_suspended;
 }
 
 static inline void caml_thread_restore_runtime_state(void)
@@ -224,6 +227,7 @@ static inline void caml_thread_restore_runtime_state(void)
   caml_backtrace_pos = curr_thread->backtrace_pos;
   caml_backtrace_buffer = curr_thread->backtrace_buffer;
   caml_backtrace_last_exn = curr_thread->backtrace_last_exn;
+  caml_memprof_set_suspended(curr_thread->memprof_suspended);
 }
 
 /* Hooks for caml_enter_blocking_section and caml_leave_blocking_section */
@@ -376,6 +380,7 @@ static caml_thread_t caml_thread_new_info(void)
   th->backtrace_pos = 0;
   th->backtrace_buffer = NULL;
   th->backtrace_last_exn = Val_unit;
+  th->memprof_suspended = 0;
   return th;
 }
 

--- a/otherlibs/unix/.depend
+++ b/otherlibs/unix/.depend
@@ -36,16 +36,18 @@ chdir.o: chdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/signals.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 chmod.o: chmod.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/signals.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 chown.o: chown.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
@@ -80,8 +82,8 @@ cstringv.o: cstringv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/osdeps.h \
- ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 dup2.o: dup2.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
  unixsupport.h
@@ -102,16 +104,16 @@ execv.o: execv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/osdeps.h \
- ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execve.o: execve.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/osdeps.h \
- ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execvp.o: execvp.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
@@ -160,7 +162,7 @@ getcwd.o: getcwd.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- unixsupport.h
+ ../../runtime/caml/memprof.h unixsupport.h
 getegid.o: getegid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
@@ -298,7 +300,7 @@ mmap_ba.o: mmap_ba.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/misc.h
+ ../../runtime/caml/memprof.h ../../runtime/caml/misc.h
 mmap.o: mmap.c ../../runtime/caml/bigarray.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/misc.h \
@@ -327,8 +329,8 @@ putenv.o: putenv.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/osdeps.h \
- ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/memprof.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 read.o: read.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
  ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
@@ -360,8 +362,9 @@ rmdir.o: rmdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/signals.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 select.o: select.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
@@ -401,8 +404,8 @@ signals.o: signals.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h
 sleep.o: sleep.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
@@ -433,9 +436,9 @@ stat.o: stat.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/alloc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/io.h unixsupport.h \
- cst2constr.h nanosecond_stat.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/io.h unixsupport.h cst2constr.h nanosecond_stat.h
 strofaddr.o: strofaddr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
@@ -466,8 +469,9 @@ truncate.o: truncate.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/fail.h \
- ../../runtime/caml/signals.h ../../runtime/caml/io.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/io.h unixsupport.h
 umask.o: umask.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
@@ -483,24 +487,26 @@ unlink.o: unlink.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/signals.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 utimes.o: utimes.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/signals.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h unixsupport.h
 wait.o: wait.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/signals.h \
- unixsupport.h
+ ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/signals.h unixsupport.h
 write.o: write.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -1,223 +1,243 @@
 afl_b.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_b.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_b.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_b.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_b.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_b.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_b.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_b.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h caml/stacks.h caml/memory.h
 clambda_checks_b.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_b.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_b.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_b.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_b.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/sys.h
 dynlink_b.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_b.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_b.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_b.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_b.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_b.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_b.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_b.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_b.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_b.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots_b.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_b.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_b.$(O): instrtrace.c
 intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_b.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
- caml/jumptbl.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_b.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_b.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_b.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_b.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_b.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_b.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_b.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_b.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_b.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_b.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_b.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_b.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_b.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_b.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_b.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_b.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_b.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_b.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_b.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_b.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_b.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_b.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -225,291 +245,312 @@ spacetime_nat_b.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_b.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_b.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_b.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/dynlink.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_b.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_b.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_b.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_b.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_b.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_b.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_b.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_bd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_bd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_bd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_bd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_bd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_bd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_bd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_bd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h caml/stacks.h caml/memory.h
 clambda_checks_bd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_bd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_bd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_bd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_bd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/sys.h
 dynlink_bd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_bd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_bd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_bd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_bd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_bd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_bd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_bd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_bd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_bd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots_bd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_bd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_bd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/instruct.h caml/misc.h \
  caml/mlvalues.h caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/startup_aux.h
 intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_bd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h
 ints_bd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_bd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_bd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_bd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_bd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_bd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_bd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_bd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_bd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_bd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_bd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_bd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_bd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_bd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_bd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_bd.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_bd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_bd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_bd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_bd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_bd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -517,288 +558,308 @@ spacetime_nat_bd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_bd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_bd.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_bd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/dynlink.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_bd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_bd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_bd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_bd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_bd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_bd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_bd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_bi.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_bi.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_bi.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_bi.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_bi.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_bi.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_bi.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_bi.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h caml/stacks.h caml/memory.h
 clambda_checks_bi.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_bi.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_bi.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_bi.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_bi.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/sys.h
 dynlink_bi.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_bi.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_bi.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_bi.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_bi.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_bi.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_bi.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_bi.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_bi.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_bi.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots_bi.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_bi.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_bi.$(O): instrtrace.c
 intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_bi.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
- caml/jumptbl.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_bi.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_bi.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_bi.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_bi.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_bi.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_bi.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bi.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_bi.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_bi.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_bi.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_bi.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_bi.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_bi.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_bi.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_bi.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_bi.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_bi.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_bi.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_bi.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_bi.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_bi.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_bi.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -806,288 +867,308 @@ spacetime_nat_bi.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_bi.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_bi.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_bi.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/dynlink.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_bi.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_bi.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_bi.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_bi.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_bi.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_bi.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_bi.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_bpic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_bpic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_bpic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_bpic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_bpic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_bpic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_bpic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_bpic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/interp.h caml/instruct.h \
+ caml/fix_code.h caml/stacks.h caml/memory.h
 clambda_checks_bpic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_bpic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_bpic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_bpic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_bpic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/sys.h
 dynlink_bpic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_bpic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_bpic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_bpic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_bpic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_bpic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_bpic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_bpic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_bpic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_bpic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots_bpic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_bpic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_bpic.$(O): instrtrace.c
 intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_bpic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
- caml/jumptbl.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_bpic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_bpic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_bpic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_bpic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_bpic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_bpic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bpic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_bpic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_bpic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_bpic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_bpic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_bpic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_bpic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_bpic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_bpic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_bpic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_bpic.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_bpic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_bpic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_bpic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_bpic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_bpic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -1095,285 +1176,305 @@ spacetime_nat_bpic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_bpic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_bpic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_bpic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/dynlink.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_bpic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_bpic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_bpic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_bpic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_bpic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_bpic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_bpic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_n.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_n.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_n.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_n.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_n.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_n.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_n.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_n.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h
+ caml/memprof.h caml/mlvalues.h
 clambda_checks_n.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_n.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_n.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_n.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_n.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 dynlink_n.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_n.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_n.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_n.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_n.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_n.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_n.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_n.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_n.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_n.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stack.h caml/startup_aux.h
 globroots_n.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_n.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_n.$(O): instrtrace.c
 intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_n.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
- caml/jumptbl.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_n.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_n.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_n.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_n.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_n.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_n.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_n.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_n.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_n.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_n.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_n.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_n.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_n.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_n.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_n.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_n.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_n.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_n.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_n.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_n.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_n.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_n.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -1381,288 +1482,309 @@ spacetime_nat_n.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_n.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_n.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_n.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/osdeps.h \
- caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_n.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_n.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_n.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_n.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_n.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_n.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_n.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_nd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_nd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_nd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_nd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_nd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_nd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_nd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_nd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h
+ caml/memprof.h caml/mlvalues.h
 clambda_checks_nd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_nd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_nd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_nd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_nd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 dynlink_nd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_nd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_nd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_nd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_nd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_nd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_nd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_nd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_nd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_nd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stack.h caml/startup_aux.h
 globroots_nd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_nd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_nd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/instruct.h caml/misc.h \
  caml/mlvalues.h caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/startup_aux.h
 intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_nd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h
 ints_nd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_nd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_nd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_nd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_nd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_nd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_nd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_nd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_nd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_nd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_nd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_nd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_nd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_nd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_nd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_nd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_nd.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_nd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_nd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_nd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_nd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_nd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -1670,285 +1792,305 @@ spacetime_nat_nd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_nd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_nd.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_nd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/osdeps.h \
- caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_nd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_nd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_nd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_nd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_nd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_nd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_nd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_ni.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_ni.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_ni.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_ni.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_ni.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_ni.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_ni.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_ni.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h
+ caml/memprof.h caml/mlvalues.h
 clambda_checks_ni.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_ni.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_ni.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_ni.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_ni.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 dynlink_ni.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_ni.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_ni.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_ni.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_ni.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_ni.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_ni.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_ni.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_ni.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_ni.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stack.h caml/startup_aux.h
 globroots_ni.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_ni.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_ni.$(O): instrtrace.c
 intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_ni.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
- caml/jumptbl.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_ni.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_ni.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_ni.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_ni.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_ni.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_ni.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_ni.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_ni.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_ni.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_ni.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_ni.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_ni.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_ni.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_ni.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_ni.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_ni.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_ni.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_ni.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_ni.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_ni.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_ni.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_ni.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -1956,285 +2098,305 @@ spacetime_nat_ni.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_ni.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_ni.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_ni.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/osdeps.h \
- caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_ni.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_ni.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_ni.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_ni.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_ni.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_ni.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_ni.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h
 afl_npic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 alloc_npic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h
 array_npic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h \
+ caml/stack.h
 backtrace_byt_npic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/alloc.h caml/mlvalues.h \
  caml/custom.h caml/io.h caml/instruct.h caml/intext.h caml/io.h \
  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
+ caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h
 backtrace_npic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/backtrace.h caml/exec.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/fail.h
 backtrace_nat_npic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/backtrace_prim.h caml/backtrace.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/stack.h
 bigarray_npic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/mlvalues.h caml/signals.h
 callback_npic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h
+ caml/memprof.h caml/mlvalues.h
 clambda_checks_npic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h
 compact_npic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/mlvalues.h \
+ caml/roots.h caml/weak.h caml/compact.h
 compare_npic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/mlvalues.h
 custom_npic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/signals.h
 debugger_npic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h \
  caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 dynlink_npic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h \
  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_npic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+ caml/memprof.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
+ caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
+ caml/hooks.h
 extern_npic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 fail_byt_npic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stacks.h caml/memory.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/printexc.h caml/signals.h caml/stacks.h caml/memory.h
 fail_nat_npic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/printexc.h \
+ caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_npic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h
 fix_code_npic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/fix_code.h \
  caml/instruct.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/reverse.h
 floats_npic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/memprof.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h \
+ caml/memory.h
 freelist_npic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
 gc_ctrl_npic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/address_class.h caml/memprof.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/signals.h caml/stack.h caml/startup_aux.h
 globroots_npic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_npic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/custom.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/hash.h
+ caml/memprof.h caml/hash.h
 instrtrace_npic.$(O): instrtrace.c
 intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h \
  caml/fail.h caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/misc.h \
+ caml/reverse.h
 interp_npic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
- caml/jumptbl.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_npic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h
 io_npic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h
 lexing_npic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 main_npic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/sys.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 major_gc_npic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/custom.h caml/config.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 md5_npic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/memprof.h caml/mlvalues.h caml/io.h caml/reverse.h
 memory_npic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
  caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/memprof.h
+memprof_npic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/fail.h caml/alloc.h caml/callback.h \
+ caml/signals.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/minor_gc.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
+ caml/stack.h
 meta_npic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/stacks.h caml/memory.h caml/backtrace_prim.h caml/backtrace.h \
+ caml/exec.h
 minor_gc_npic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/config.h caml/fail.h caml/finalise.h \
  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/minor_gc.h caml/address_class.h caml/memprof.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
  caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
 misc_npic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/osdeps.h caml/memory.h caml/version.h
 obj_npic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
 parsing_npic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/alloc.h
+ caml/memprof.h caml/alloc.h
 prims_npic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/prims.h
 printexc_npic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
  caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h
+ caml/address_class.h caml/memprof.h
 roots_byt_npic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/memprof.h caml/globroots.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 roots_nat_npic.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/memprof.h caml/globroots.h caml/memory.h caml/major_gc.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
 signals_byt_npic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
  caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h caml/memprof.h
 signals_npic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/sys.h
 signals_nat_npic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/memprof.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
+ caml/io.h caml/stack.h caml/memprof.h
 spacetime_byt_npic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/mlvalues.h
 spacetime_nat_npic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
@@ -2242,65 +2404,65 @@ spacetime_nat_npic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
+ caml/memprof.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
+ caml/spacetime.h caml/stack.h
 spacetime_snapshot_npic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/config.h caml/custom.h caml/fail.h \
  caml/gc.h caml/gc_ctrl.h caml/intext.h caml/io.h caml/major_gc.h \
  caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/memory.h caml/signals.h caml/stack.h \
+ caml/sys.h caml/spacetime.h caml/stack.h
 stacks_npic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h
+ caml/minor_gc.h caml/address_class.h caml/memprof.h
 startup_aux_npic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/callback.h caml/major_gc.h caml/osdeps.h \
- caml/memory.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/callback.h caml/major_gc.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_npic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h caml/reverse.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/address_class.h caml/memprof.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
 startup_nat_npic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/backtrace.h caml/exec.h \
  caml/custom.h caml/debugger.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/printexc.h \
- caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/memprof.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_npic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
- caml/misc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/mlvalues.h caml/misc.h
 sys_npic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
  caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/version.h caml/callback.h caml/startup_aux.h
+ caml/address_class.h caml/memprof.h caml/signals.h caml/stacks.h \
+ caml/sys.h caml/version.h caml/callback.h caml/startup_aux.h
 unix_npic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
+ caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h \
+ caml/io.h caml/alloc.h
 weak_npic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
- caml/address_class.h caml/mlvalues.h caml/weak.h caml/minor_gc.h \
- caml/signals.h
+ caml/address_class.h caml/memprof.h caml/mlvalues.h caml/weak.h \
+ caml/minor_gc.h caml/signals.h
 win32_npic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/address_class.h caml/memprof.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/config.h

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -22,7 +22,7 @@ include $(ROOTDIR)/Makefile.common
 
 PRIMS := $(addsuffix .c, \
   alloc array compare extern floats gc_ctrl hash intern interp ints io \
-  lexing md5 meta obj parsing signals str sys callback weak finalise \
+  lexing md5 meta memprof obj parsing signals str sys callback weak finalise \
   stacks dynlink backtrace_byt backtrace spacetime_byt afl bigarray)
 
 BYTECODE_C_SOURCES := $(addsuffix .c, \
@@ -31,7 +31,7 @@ BYTECODE_C_SOURCES := $(addsuffix .c, \
   signals_byt printexc backtrace_byt backtrace compare ints \
   floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
   lexing callback debugger weak compact finalise custom dynlink \
-  spacetime_byt afl $(UNIX_OR_WIN32) bigarray main)
+  spacetime_byt afl $(UNIX_OR_WIN32) bigarray main memprof)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
   startup_aux startup_nat main fail_nat roots_nat signals \
@@ -39,7 +39,8 @@ NATIVE_C_SOURCES := $(addsuffix .c, \
   floats str array io extern intern hash sys parsing gc_ctrl md5 obj \
   lexing $(UNIX_OR_WIN32) printexc callback weak compact finalise custom \
   globroots backtrace_nat backtrace dynlink_nat debugger meta \
-  dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray)
+  dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray \
+  memprof)
 
 # The other_files variable stores the list of files whose dependencies
 # should be computed by `make depend` although they do not need to be

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -347,3 +347,13 @@ CAMLprim value caml_get_exception_backtrace(value unit)
 
   CAMLreturn(res);
 }
+
+CAMLprim value caml_get_current_callstack(value max_frames_value) {
+  CAMLparam1(max_frames_value);
+  CAMLlocal1(res);
+
+  res = caml_alloc(caml_current_callstack_size(Long_val(max_frames_value)), 0);
+  caml_current_callstack_write(res);
+
+  CAMLreturn(res);
+}

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -26,6 +26,7 @@
 #include "gc.h"
 #include "major_gc.h"
 #include "minor_gc.h"
+#include "memprof.h"
 #endif /* CAML_INTERNALS */
 #include "misc.h"
 #include "mlvalues.h"
@@ -38,15 +39,19 @@ extern "C" {
 CAMLextern value caml_alloc_shr (mlsize_t wosize, tag_t);
 #ifdef WITH_PROFINFO
 CAMLextern value caml_alloc_shr_with_profinfo (mlsize_t, tag_t, intnat);
-CAMLextern value caml_alloc_shr_preserving_profinfo (mlsize_t, tag_t,
-                                                     header_t);
 #else
 #define caml_alloc_shr_with_profinfo(size, tag, profinfo) \
   caml_alloc_shr(size, tag)
-#define caml_alloc_shr_preserving_profinfo(size, tag, header) \
-  caml_alloc_shr(size, tag)
 #endif /* WITH_PROFINFO */
-CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
+
+/* Variant of [caml_alloc_shr] where no memprof sampling is performed. */
+CAMLextern value caml_alloc_shr_no_track (mlsize_t, tag_t);
+
+/* Variant of [caml_alloc_shr] where no memprof sampling is performed,
+   and re-using the profinfo associated with the header given in
+   parameter. */
+CAMLextern value caml_alloc_shr_for_minor_gc (mlsize_t, tag_t, header_t);
+
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_free_dependent_memory (mlsize_t bsz);

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -1,0 +1,33 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Jacques-Henri Joudan, projet Gallium, INRIA Paris          */
+/*                                                                        */
+/*   Copyright 2016 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#ifndef CAML_MEMPROF_H
+#define CAML_MEMPROF_H
+
+#ifdef CAML_INTERNALS
+
+#include "config.h"
+#include "mlvalues.h"
+
+extern void caml_memprof_track_alloc_shr(value block);
+extern void caml_memprof_handle_postponed();
+
+/* Exported only for saving and restoring in threads. */
+extern int caml_memprof_suspended;
+extern void caml_memprof_set_suspended(int new_suspended);
+
+#endif
+
+#endif /* CAML_MEMPROF_H */

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -20,8 +20,8 @@
 (
   for prim in \
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
-      lexing md5 meta obj parsing signals str sys callback weak finalise \
-      stacks dynlink backtrace_byt backtrace spacetime_byt afl bigarray
+      lexing md5 meta memprof obj parsing signals str sys callback weak \
+      finalise stacks dynlink backtrace_byt backtrace spacetime_byt afl bigarray
   do
       sed -n -e "s/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p" "$prim.c"
   done

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -629,7 +629,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
         intern_block = caml_alloc_small (wosize, String_tag);
       }
     }else{
-      intern_block = caml_alloc_shr_no_raise (wosize, String_tag);
+      intern_block = caml_alloc_shr_no_track (wosize, String_tag);
       /* do not do the urgent_gc check here because it might darken
          intern_block into gray and break the intern_color assertion below */
       if (intern_block == 0) {

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1,0 +1,315 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Jacques-Henri Joudan, projet Gallium, INRIA Paris          */
+/*                                                                        */
+/*   Copyright 2016 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+#include <math.h>
+#include <string.h>
+#include "caml/memprof.h"
+#include "caml/fail.h"
+#include "caml/alloc.h"
+#include "caml/callback.h"
+#include "caml/signals.h"
+#include "caml/memory.h"
+#include "caml/minor_gc.h"
+#include "caml/backtrace_prim.h"
+#include "caml/weak.h"
+#include "caml/stack.h"
+
+static uint32_t mt_state[624];
+static uint32_t mt_index;
+
+/* [lambda] is the mean number of samples for each allocated word (including
+   block headers). */
+static double lambda = 0;
+int caml_memprof_suspended = 0;
+static intnat callstack_size = 0;
+static value memprof_callback = Val_unit;
+
+/* Whether memprof has been initialized.  */
+static int init = 0;
+
+/**** Statistical sampling ****/
+
+static double mt_generate_uniform(void) {
+  int i;
+  uint32_t y;
+
+  /* Mersenne twister PRNG */
+  if (mt_index == 624) {
+    for(i = 0; i < 227; i++) {
+      y = (mt_state[i] & 0x80000000) + (mt_state[i+1] & 0x7fffffff);
+      mt_state[i] = mt_state[i+397] ^ (y >> 1) ^ ((-(y&1)) & 0x9908b0df);
+    }
+    for(i = 227; i < 623; i++) {
+      y = (mt_state[i] & 0x80000000) + (mt_state[i+1] & 0x7fffffff);
+      mt_state[i] = mt_state[i-227] ^ (y >> 1) ^ ((-(y&1)) & 0x9908b0df);
+    }
+    y = (mt_state[623] & 0x80000000) + (mt_state[0] & 0x7fffffff);
+    mt_state[623] = mt_state[396] ^ (y >> 1) ^ ((-(y&1)) & 0x9908b0df);
+    mt_index = 0;
+  }
+
+  y = mt_state[mt_index];
+  y = y ^ (y >> 11);
+  y = y ^ ((y << 7) & 0x9d2c5680);
+  y = y ^ ((y << 15) & 0xefc60000);
+  y = y ^ (y >> 18);
+
+  mt_index++;
+  return y*2.3283064365386962890625e-10 + /* 2^-32 */
+          1.16415321826934814453125e-10; /* 2^-33 */
+}
+
+/* C99's [lgammaf] function is not available in some compilers
+   (including MSVC). Here is our own approximate implementation of the
+   log-factorial function.
+
+   Requirement: [n] is a non-negative integer.
+
+   We use Ramanujan's formula. For n < 10^8, the absolute error is
+   less than 10^-6, which is way better than what we need.
+ */
+static double lfact(double n) {
+  static double tab[10] = {
+    0.0000000000, 0.0000000000, 0.6931471806, 1.7917594692, 3.1780538303,
+    4.7874917428, 6.5792512120, 8.5251613611, 10.6046029027, 12.8018274801 };
+  if(n < 10)
+    return tab[(int)n];
+  return n*(log(n) - 1) + (1./6)*log(((8*n + 4)*n + 1)*n + 1./34)
+       + 0.5723649429; /* log(pi)/2 */
+}
+
+#define MAX_MT_GENERATE_POISSON (1<<29)
+static double next_mt_generate_poisson;
+/* Simulate a Poisson distribution of parameter [lambda*len].  The
+   result is clipped to the interval [0..MAX_MT_GENERATE_POISSON] */
+static int32_t mt_generate_poisson(double len) {
+  double cur_lambda = lambda * len;
+  CAMLassert(cur_lambda >= 0 && cur_lambda < 1e20);
+
+  if(caml_memprof_suspended || cur_lambda == 0)
+    return 0;
+
+  if(cur_lambda < 20) {
+    /* First algorithm when [cur_lambda] is small: we proceed by
+       repeated simulations of exponential distributions. */
+
+    next_mt_generate_poisson -= cur_lambda;
+    if(next_mt_generate_poisson > 0) {
+      /* Fast path if [cur_lambda] is small: we reuse the same
+         exponential sample accross several calls to
+         [mt_generate_poisson]. */
+      return 0;
+    } else {
+      /* We use the float versions of exp/log, since these functions
+         are significantly faster, and we really don't need much
+         precision here. The entropy contained in
+         [next_mt_generate_poisson] is anyway bounded by the entropy
+         provided by [mt_generate_uniform], which is 32bits. */
+      double p = expf(-next_mt_generate_poisson);
+      int32_t k = 0;
+      do {
+        k++;
+        p *= mt_generate_uniform();
+      } while(p > 1);
+
+      /* [p] is now uniformly distributed in [0, 1] and independent
+         from other variables (including [k]). We can therefore reuse
+         [p] for reinitializing [next_mt_generate_poisson]. */
+      next_mt_generate_poisson = -logf(p);
+
+      return k;
+    }
+
+  } else {
+    /* Second algorithm when [cur_lambda] is large. Taken from: */
+    /* The Computer Generation of Poisson Random Variables
+       A. C. Atkinson Journal of the Royal Statistical Society.
+       Series C (Applied Statistics) Vol. 28, No. 1 (1979), pp. 29-35
+       "Method PA" */
+
+    double c, beta_inverse, k, log_cur_lambda;
+    log_cur_lambda = log(cur_lambda);
+    c = 0.767 - 3.36/cur_lambda;
+    beta_inverse = sqrt(0.30396355092701332623 * cur_lambda);
+                        /* ^ = 3./(PI*PI) */
+    k = log(c*beta_inverse) - cur_lambda;
+    while(1) {
+      double u, n, v, y;
+      u = mt_generate_uniform();
+      y = log(1./u-1);
+      n = floor(cur_lambda - y*beta_inverse + 0.5);
+      if(n < 0.)
+        continue;
+      v = mt_generate_uniform();
+      /* When [cur_lambda] is large, we expect [n*log_cur_lambda] and
+         [lfact(n)] to be close, while both being relatively
+         large. Hence, here, we may actually need the double precision
+         in the computation of log and lfact. */
+      if(y + log(v*u*u) < k + n*log_cur_lambda - lfact(n))
+        return n > MAX_MT_GENERATE_POISSON ? MAX_MT_GENERATE_POISSON : n;
+    }
+  }
+}
+
+/**** Interface with the OCaml code. ****/
+
+CAMLprim value caml_memprof_set(value v) {
+  CAMLparam1(v);
+  double l = Double_val(Field(v, 0));
+  intnat sz = Long_val(Field(v, 1));
+
+  if(sz < 0 || !(l >= 0.) || l > 1.)
+    caml_failwith("caml_memprof_set");
+
+  if(!init) {
+    int i;
+    init = 1;
+
+    mt_index = 624;
+    mt_state[0] = 42;
+    for(i = 1; i < 624; i++)
+      mt_state[i] = 0x6c078965 * (mt_state[i-1] ^ (mt_state[i-1] >> 30)) + i;
+
+    caml_register_generational_global_root(&memprof_callback);
+
+    next_mt_generate_poisson = -logf(mt_generate_uniform());
+  }
+
+  lambda = l;
+  callstack_size = sz;
+  caml_modify_generational_global_root(&memprof_callback, Field(v, 2));
+
+  CAMLreturn(Val_unit);
+}
+
+/* Cf. Gc.Memprof.alloc_kind */
+enum ml_alloc_kind {
+  Minor = Val_long(0),
+  Major = Val_long(1),
+  Serialized = Val_long(2)
+};
+
+static value do_callback(tag_t tag, intnat wosize, int32_t occurences,
+                         value callstack, enum ml_alloc_kind cb_kind) {
+  CAMLparam1(callstack);
+  CAMLlocal1(sample_info);
+  CAMLassert(occurences > 0);
+
+  sample_info = caml_alloc_small(5, 0);
+  Field(sample_info, 0) = Val_long(occurences);
+  Field(sample_info, 1) = cb_kind;
+  Field(sample_info, 2) = Val_long(tag);
+  Field(sample_info, 3) = Val_long(wosize);
+  Field(sample_info, 4) = callstack;
+
+  CAMLreturn(caml_callback_exn(memprof_callback, sample_info));
+}
+
+void caml_memprof_set_suspended(int new_suspended) {
+  caml_memprof_suspended = new_suspended;
+}
+
+/**** Sampling procedures ****/
+
+static value capture_callstack() {
+  value res;
+  intnat size = caml_current_callstack_size(callstack_size);
+  /* We do not use [caml_alloc] to make sure the GC will not get called. */
+  if(size == 0) return Atom (0);
+  res = caml_alloc_shr_no_track(size, 0);
+  caml_current_callstack_write(res);
+  return res;
+}
+
+struct caml_memprof_postponed_block {
+  value block;
+  value callstack;
+  int32_t occurences;
+  struct caml_memprof_postponed_block* next;
+} static *caml_memprof_postponed_head = NULL;
+
+/* When allocating in the major heap, we cannot call the callback,
+   because [caml_alloc_shr] is guaranteed not to call the GC. Hence,
+   this function determines if the block needs to be sampled, and if
+   so, it registers the block in the todo-list so that the callback
+   call is performed when possible. */
+void caml_memprof_track_alloc_shr(value block) {
+  int32_t occurences = mt_generate_poisson(Whsize_val(block));
+  CAMLassert(Is_in_heap(block));
+  if(occurences > 0) {
+    struct caml_memprof_postponed_block* pb =
+      caml_stat_alloc_noexc(sizeof(struct caml_memprof_postponed_block));
+    value callstack = capture_callstack();
+    if(pb == NULL) return;
+    pb->block = block;
+    caml_register_generational_global_root(&pb->block);
+    pb->callstack = callstack;
+    caml_register_generational_global_root(&pb->callstack);
+    pb->occurences = occurences;
+    pb->next = caml_memprof_postponed_head;
+    caml_memprof_postponed_head = pb;
+#ifndef NATIVE_CODE
+    caml_something_to_do = 1;
+#else
+    caml_young_limit = caml_young_alloc_end;
+#endif
+  }
+}
+
+void caml_memprof_handle_postponed() {
+  struct caml_memprof_postponed_block *p, *q;
+  value ephe;
+
+  if(caml_memprof_postponed_head == NULL)
+    return;
+
+  // We first reverse the list
+  p = caml_memprof_postponed_head;
+  q = caml_memprof_postponed_head->next;
+  p->next = NULL;
+  while(q != NULL) {
+    struct caml_memprof_postponed_block* next = q->next;
+    q->next = p;
+    p = q;
+    q = next;
+  }
+  caml_memprof_postponed_head = NULL;
+
+#define NEXT_P \
+  { struct caml_memprof_postponed_block* next = p->next;   \
+    caml_remove_generational_global_root(&p->callstack);   \
+    caml_remove_generational_global_root(&p->block);       \
+    caml_stat_free(p);                                     \
+    p = next; }
+
+  caml_memprof_set_suspended(1);
+  // We then do the actual iteration on postponed blocks
+  while(p != NULL) {
+    ephe = do_callback(Tag_val(p->block), Wosize_val(p->block),
+                       p->occurences, p->callstack, Major);
+    if (Is_exception_result(ephe)) {
+      caml_memprof_set_suspended(0);
+      // In the case of an exception, we just forget the entire list.
+      while(p != NULL) NEXT_P;
+      caml_raise(Extract_exception(ephe));
+    }
+    if(Is_block(ephe))
+      caml_ephemeron_set_key(Field(ephe, 0), 0, p->block);
+    NEXT_P;
+  }
+  caml_memprof_set_suspended(0);
+}

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -195,7 +195,7 @@ CAMLprim value caml_realloc_global(value size)
     for (i = actual_size; i < requested_size; i++){
       Field (new_global_data, i) = Val_long (0);
     }
-    caml_global_data = new_global_data;
+    caml_global_data = caml_check_urgent_gc(new_global_data);
   }
   return Val_unit;
 }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -196,7 +196,7 @@ void caml_oldify_one (value v, value *p)
         value field0;
 
         sz = Wosize_hd (hd);
-        result = caml_alloc_shr_preserving_profinfo (sz, tag, hd);
+        result = caml_alloc_shr_for_minor_gc (sz, tag, hd);
         *p = result;
         field0 = Field (v, 0);
         Hd_val (v) = 0;            /* Set forward flag */
@@ -213,7 +213,7 @@ void caml_oldify_one (value v, value *p)
         }
       }else if (tag >= No_scan_tag){
         sz = Wosize_hd (hd);
-        result = caml_alloc_shr_preserving_profinfo (sz, tag, hd);
+        result = caml_alloc_shr_for_minor_gc (sz, tag, hd);
         for (i = 0; i < sz; i++) Field (result, i) = Field (v, i);
         Hd_val (v) = 0;            /* Set forward flag */
         Field (v, 0) = result;     /*  and forward pointer. */
@@ -246,7 +246,7 @@ void caml_oldify_one (value v, value *p)
             ){
           /* Do not short-circuit the pointer.  Copy as a normal block. */
           CAMLassert (Wosize_hd (hd) == 1);
-          result = caml_alloc_shr_preserving_profinfo (1, Forward_tag, hd);
+          result = caml_alloc_shr_for_minor_gc (1, Forward_tag, hd);
           *p = result;
           Hd_val (v) = 0;             /* Set (GC) forward flag */
           Field (v, 0) = result;      /*  and forward pointer. */
@@ -489,6 +489,7 @@ CAMLexport value caml_check_urgent_gc (value extra_root)
     CAML_INSTR_INT ("force_minor/check_urgent_gc@", 1);
     caml_gc_dispatch();
   }
+  caml_memprof_handle_postponed();
   CAMLreturn (extra_root);
 }
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -118,6 +118,7 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
   } else {
     res = caml_alloc_shr(sz, tg);
     for (i = 0; i < sz; i++) caml_initialize(&Field(res, i), Field(arg, i));
+    res = caml_check_urgent_gc(res);
   }
   CAMLreturn (res);
 }

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -31,6 +31,8 @@
 #include "signals_osdep.h"
 #include "caml/stack.h"
 #include "caml/spacetime.h"
+#include "caml/memprof.h"
+
 
 #ifdef HAS_STACK_OVERFLOW_DETECTION
 #include <sys/time.h>
@@ -83,6 +85,8 @@ void caml_garbage_collection(void)
     caml_spacetime_automatic_snapshot();
   }
 #endif
+
+  caml_memprof_handle_postponed();
 
   caml_process_pending_signals();
 }

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -105,7 +105,7 @@ CAMLexport value caml_ephemeron_create (mlsize_t len)
   for (i = 1; i < size; i++) Field (res, i) = caml_ephe_none;
   Field (res, CAML_EPHE_LINK_OFFSET) = caml_ephe_list_head;
   caml_ephe_list_head = res;
-  return res;
+  return caml_check_urgent_gc(res);
 }
 
 CAMLprim value caml_ephe_create (value len)

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -274,13 +274,22 @@ stdlib__gc.cmo : \
     stdlib__sys.cmi \
     stdlib__string.cmi \
     stdlib__printf.cmi \
+    stdlib__printexc.cmi \
+    stdlib__obj.cmi \
+    stdlib__ephemeron.cmi \
     stdlib__gc.cmi
 stdlib__gc.cmx : \
     stdlib__sys.cmx \
     stdlib__string.cmx \
     stdlib__printf.cmx \
+    stdlib__printexc.cmx \
+    stdlib__obj.cmx \
+    stdlib__ephemeron.cmx \
     stdlib__gc.cmi
-stdlib__gc.cmi :
+stdlib__gc.cmi : \
+    stdlib__printexc.cmi \
+    stdlib__obj.cmi \
+    stdlib__ephemeron.cmi
 stdlib__genlex.cmo : \
     stdlib__string.cmi \
     stdlib__stream.cmi \

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -3,9 +3,10 @@
 (*                                 OCaml                                  *)
 (*                                                                        *)
 (*             Damien Doligez, projet Para, INRIA Rocquencourt            *)
+(*             Jacques-Henri Joudan, projet Gallium, INRIA Paris          *)
 (*                                                                        *)
-(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 1996-2016 Institut National de Recherche en Informatique   *)
+(*     et en Automatique.                                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -117,3 +118,34 @@ let create_alarm f =
 
 
 let delete_alarm a = a := false
+
+module Memprof =
+  struct
+    type alloc_kind =
+      | Minor
+      | Major
+      | Serialized
+
+    type sample_info = {
+        n_samples: int; kind: alloc_kind; tag: int;
+        size: int; callstack: Printexc.raw_backtrace;
+    }
+
+    type 'a callback = sample_info -> (Obj.t, 'a) Ephemeron.K1.t option
+
+    type 'a ctrl = {
+        sampling_rate : float;
+        callstack_size : int;
+        callback : 'a callback
+    }
+
+    let stopped_ctrl = {
+        sampling_rate = 0.; callstack_size = 0;
+        callback = fun _ -> assert false
+    }
+
+    external set_ctrl : 'a ctrl -> unit = "caml_memprof_set"
+
+    let start = set_ctrl
+    let stop () = set_ctrl stopped_ctrl
+  end

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -2,10 +2,11 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*              Damien Doligez, projet Para, INRIA Rocquencourt           *)
+(*             Damien Doligez, projet Para, INRIA Rocquencourt            *)
+(*             Jacques-Henri Joudan, projet Gallium, INRIA Paris          *)
 (*                                                                        *)
-(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 1996-2016 Institut National de Recherche en Informatique   *)
+(*     et en Automatique.                                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -385,3 +386,79 @@ val create_alarm : (unit -> unit) -> alarm
 val delete_alarm : alarm -> unit
 (** [delete_alarm a] will stop the calls to the function associated
    to [a].  Calling [delete_alarm a] again has no effect. *)
+
+(** [Memprof] is an sampling engine for allocated words. The blocks
+
+    are sampled according to a Poisson process. That is, every block
+    has a probability of being sampled which is proportional to its
+    size, and large blocks can be sampled several times. The samples
+    appear using a configurable sampling rate.
+
+    This engine is typically used by a statistical memory profiler.
+ *)
+module Memprof :
+  sig
+    type alloc_kind =
+      | Minor
+      | Major
+      | Serialized
+    (** Allocation kinds
+        - [Minor] : the allocation took place in the minor heap.
+        - [Major] : the allocation took place in the major heap.
+        - [Serialized] : the allocation happened during a
+          deserialization. *)
+
+    type sample_info = {
+        n_samples: int;
+        (** The number of samples in this block. Always >= 1, it is sampled
+            according to a Poisson process, and in average equal to the
+            size of the block (including the header) multiplied by lambda
+            (the sampling rate). *)
+        kind: alloc_kind;
+        (** The kind of the allocation. *)
+        tag: int;
+        (** The tag of the allocated block. *)
+        size: int;
+        (** The size of the allocated block, in words (exclusing the
+            header). *)
+        callstack: Printexc.raw_backtrace;
+        (** The callstack for the allocation. *)
+    }
+    (** The meta data passed at each callback.  *)
+
+    type 'a callback = sample_info -> (Obj.t, 'a) Ephemeron.K1.t option
+    (** [callback] is the type of callbacks launch by the sampling
+       engine.  A callback returns an option over an ephemeron whose
+       key is set to the allocated block for further tracking.
+
+       The sampling is temporarily disabled when calling the callback
+       for the current thread. So it needs not be reentrant if only
+       one thread is running. However, if threads are used, it is
+       possible that a context switch occurs during a callback, in
+       which case reentrency has to be taken into account.
+
+       Note that when the callback kind is [Major], the callback could
+       be postponed after the actual allocation. Therefore, the
+       context of the callback is maybe slightly different than
+       expected. This should not happen if no C binding is used. *)
+
+    type 'a ctrl = {
+        sampling_rate : float;
+        (** The sampling rate in samples per word (including headers).
+            Usually, with cheap callbacks, a rate of 0.001 has no
+            visible effect on performance, and 0.01 causes the program
+            to run a few percent slower. *)
+        callstack_size : int;
+        (** The length of the callstack recorded at every sample. *)
+        callback : 'a callback
+        (** The callback to be called at every sample. *)
+    }
+    (** Control data for the sampling engine.  *)
+
+    val start : 'a ctrl -> unit
+    (** Start the sampling with the given parameters. If another
+        sampling is already running, it is stopped. *)
+
+    val stop : unit -> unit
+    (** Stop the sampling. *)
+end

--- a/testsuite/tests/statmemprof/arrays_in_major.byte.reference
+++ b/testsuite/tests/statmemprof/arrays_in_major.byte.reference
@@ -1,0 +1,13 @@
+check_nosample
+check_ephe_full
+check_no_nested
+check_distrib 300 3000 1 0.000010
+check_distrib 300 3000 1 0.000100
+check_distrib 300 3000 1 0.010000
+check_distrib 300 3000 1 1.000000
+check_distrib 300 300 100000 0.100000
+check_distrib 300000 300000 30 0.100000
+check_callstack
+Raised by primitive operation at file "arrays_in_major.ml", line 133, characters 2-35
+Called from file "arrays_in_major.ml", line 139, characters 9-27
+OK !

--- a/testsuite/tests/statmemprof/arrays_in_major.ml
+++ b/testsuite/tests/statmemprof/arrays_in_major.ml
@@ -1,0 +1,142 @@
+(* TEST
+   flags = "-g"
+   * bytecode
+     reference = "${test_source_directory}/arrays_in_major.byte.reference"
+   * native
+     reference = "${test_source_directory}/arrays_in_major.opt.reference"
+     compare_programs = "false"
+*)
+
+open Gc.Memprof
+
+let root = ref []
+let[@inline never] allocate_arrays lo hi cnt keep =
+  for j = 0 to cnt-1 do
+    for i = lo to hi do
+      root := Array.make i 0 :: !root
+    done;
+    if not keep then root := []
+  done
+
+let check_nosample () =
+  Printf.printf "check_nosample\n%!";
+  start {
+      sampling_rate = 0.;
+      callstack_size = 10;
+      callback = fun _ ->
+        Printf.printf "Callback called with sampling_rate = 0\n";
+        assert(false)
+  };
+  allocate_arrays 300 3000 1 false
+
+let () = check_nosample ()
+
+let check_ephe_full () =
+  Printf.printf "check_ephe_full\n%!";
+  let ephes = ref [] in
+  start {
+    sampling_rate = 0.01;
+    callstack_size = 10;
+    callback = fun _ ->
+      let res = Ephemeron.K1.create () in
+      ephes := res :: !ephes;
+      Some res
+  };
+  allocate_arrays 300 3000 1 true;
+  stop ();
+  List.iter (fun e -> assert (Ephemeron.K1.check_key e)) !ephes;
+  Gc.full_major ();
+  List.iter (fun e -> assert (Ephemeron.K1.check_key e)) !ephes;
+  root := [];
+  Gc.full_major ();
+  List.iter (fun e -> assert (not (Ephemeron.K1.check_key e))) !ephes
+
+let () = check_ephe_full ()
+
+let check_no_nested () =
+  Printf.printf "check_no_nested\n%!";
+  let in_callback = ref false in
+  start {
+      sampling_rate = 1.;
+      callstack_size = 10;
+      callback = fun _ ->
+        assert (not !in_callback);
+        in_callback := true;
+        allocate_arrays 300 300 100 false;
+        in_callback := false;
+        None
+  };
+  allocate_arrays 300 300 100 false;
+  stop ()
+
+let () = check_no_nested ()
+
+let check_distrib lo hi cnt rate =
+  Printf.printf "check_distrib %d %d %d %f\n%!" lo hi cnt rate;
+  let smp = ref 0 in
+  start {
+      sampling_rate = rate;
+      callstack_size = 10;
+      callback = fun info ->
+        assert (info.kind = Major);
+        assert (info.tag = 0);
+        assert (info.size >= lo && info.size <= hi);
+        assert (info.n_samples > 0);
+        smp := !smp + info.n_samples;
+        None
+    };
+  allocate_arrays lo hi cnt false;
+  stop ();
+
+  (* The probability distribution of the number of samples follows a
+     poisson distribution with mean tot_alloc*rate. Given that we
+     expect this quantity to be large (i.e., > 100), this distribution
+     is approximately equal to a normal distribution. We compute a
+     1e-8 confidence interval for !smp using quantiles of the normal
+     distribution, and check that we are in this confidence interval. *)
+  let tot_alloc = cnt*(lo+hi+2)*(hi-lo+1)/2 in
+  let mean = float tot_alloc *. rate in
+  let stddev = sqrt mean in
+  (* This assertion has probability to fail close to 1e-8. *)
+  assert (abs_float (mean -. float !smp) <= stddev *. 5.7)
+
+let () =
+  check_distrib 300 3000 1 0.00001;
+  check_distrib 300 3000 1 0.0001;
+  check_distrib 300 3000 1 0.01;
+  check_distrib 300 3000 1 1.;
+  check_distrib 300 300 100000 0.1;
+  check_distrib 300000 300000 30 0.1
+
+(* FIXME : in bytecode mode, the function [caml_get_current_callstack_impl],
+   which is supposed to capture the current call stack, does not have access
+   to the current value of [pc]. Therefore, depending on how the C call is
+   performed, we may miss the first call stack slot in the captured backtraces.
+   This is the reason why the reference file is different in native and
+   bytecode modes.
+
+   Note that [Printexc.get_callstack] does not suffer from this problem, because
+   this function is actually an automatically generated stub which performs th
+   C call. This is because [Printexc.get_callstack] is not declared as external
+   in the mli file. *)
+
+let[@inline never] check_callstack () =
+  Printf.printf "check_callstack\n%!";
+  let callstack = ref None in
+  start {
+      sampling_rate = 1.;
+      callstack_size = 10;
+      callback = fun info ->
+        callstack := Some info.callstack;
+        None
+    };
+  allocate_arrays 300 300 100 false;
+  stop ();
+  match !callstack with
+  | None -> assert false
+  | Some cs -> Printexc.print_raw_backtrace stdout cs
+
+let () = check_callstack ()
+
+let () =
+  Printf.printf "OK !\n"

--- a/testsuite/tests/statmemprof/arrays_in_major.opt.reference
+++ b/testsuite/tests/statmemprof/arrays_in_major.opt.reference
@@ -1,0 +1,14 @@
+check_nosample
+check_ephe_full
+check_no_nested
+check_distrib 300 3000 1 0.000010
+check_distrib 300 3000 1 0.000100
+check_distrib 300 3000 1 0.010000
+check_distrib 300 3000 1 1.000000
+check_distrib 300 300 100000 0.100000
+check_distrib 300000 300000 30 0.100000
+check_callstack
+Raised by primitive operation at file "arrays_in_major.ml", line 16, characters 14-28
+Called from file "arrays_in_major.ml", line 133, characters 2-35
+Called from file "arrays_in_major.ml", line 139, characters 9-27
+OK !

--- a/testsuite/tests/statmemprof/ocamltests
+++ b/testsuite/tests/statmemprof/ocamltests
@@ -1,0 +1,1 @@
+arrays_in_major.ml


### PR DESCRIPTION
This PR is a part of #847. It contains:
- the API, consisting in the `Memprof` submodule of gc.ml/gc.mli,
- the parts of `memprof.c` which are common to all kinds of allocation sampling,
- the sampling engine for memory blocks which are allocated directly in the major heap.
