### PR TITLE
Use a more compact format for debug info

### DIFF
--- a/Changes
+++ b/Changes
@@ -110,6 +110,9 @@ Working version
   the new hook caml_fatal_error_hook.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
+- #8637, #8805: Record debug info for each allocation
+  (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez)
+
 - #8713: Introduce a state table in the runtime to contain the global variables
    which must be duplicated for each domain in the multicore runtime.
    (KC Sivaramakrishnan and Stephen Dolan, compatibility header hacking by
@@ -241,7 +244,6 @@ OCaml 4.09.0
 
 - #8787, #8788: avoid integer overflow in caml_output_value_to_bytes
   (Jeremy Yallop, report by Marcello Seri)
-
 
 - #2075, #7729: rename _T macro used to support Unicode in the (Windows) runtime
   in order to avoid compiler warning

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -239,7 +239,7 @@ let addressing addr typ i n =
 
 (* Record live pointers at call points -- see Emitaux *)
 
-let record_frame_label ?label live raise_ dbg =
+let record_frame_label ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -258,11 +258,11 @@ let record_frame_label ?label live raise_ dbg =
     )
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   lbl
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
+let record_frame ?label live dbg =
+  let lbl = record_frame_label ?label live dbg in
   def_label lbl
 
 (* Spacetime instrumentation *)
@@ -327,7 +327,7 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg ~spacetime =
   if !Clflags.debug || Config.spacetime then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label Reg.Set.empty (Dbg_other dbg) in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error; bd_frame = lbl_frame;
         bd_spacetime = spacetime; } :: !bound_error_sites;
@@ -562,16 +562,16 @@ let emit_instr fallthrough i =
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind { label_after; }) ->
       I.call (arg i 0);
-      record_frame i.live false i.dbg ~label:label_after
+      record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
       add_used_symbol func;
       emit_call func;
-      record_frame i.live false i.dbg ~label:label_after
+      record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Itailcall_ind { label_after; }) ->
       output_epilogue begin fun () ->
         I.jmp (arg i 0);
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
+          record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
         end
       end
   | Lop(Itailcall_imm { func; label_after; }) ->
@@ -586,14 +586,14 @@ let emit_instr fallthrough i =
         end
       end;
       if Config.spacetime then begin
-        record_frame Reg.Set.empty false i.dbg ~label:label_after
+        record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
       end
   | Lop(Iextcall { func; alloc; label_after; }) ->
       add_used_symbol func;
       if alloc then begin
         load_symbol_addr func rax;
         emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:label_after;
+        record_frame i.live (Dbg_other i.dbg) ~label:label_after;
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
              This comes from:
@@ -607,7 +607,7 @@ let emit_instr fallthrough i =
       end else begin
         emit_call func;
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
+          record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
         end
       end
   | Lop(Istackoffset n) ->
@@ -657,7 +657,7 @@ let emit_instr fallthrough i =
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; }) ->
-      if !fastcode_flag then begin
+    if !fastcode_flag then begin
         let lbl_redo = new_label() in
         def_label lbl_redo;
         I.sub (int n) r15;
@@ -668,7 +668,7 @@ let emit_instr fallthrough i =
           else i.dbg
         in
         let lbl_frame =
-          record_frame_label ?label:label_after_call_gc i.live false dbg
+          record_frame_label ?label:label_after_call_gc i.live (Dbg_other dbg)
         in
         I.jb (label lbl_call_gc);
         I.lea (mem64 NONE 8 R15) (res i 0);
@@ -696,8 +696,8 @@ let emit_instr fallthrough i =
             emit_call "caml_allocN"
         end;
         let label =
-          record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+          record_frame_label ?label:label_after_call_gc i.live
+            (Dbg_other i.dbg)
         in
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)
@@ -898,10 +898,10 @@ let emit_instr fallthrough i =
       | Lambda.Raise_regular ->
           I.mov (int 0) (domain_field Domainstate.Domain_backtrace_pos);
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_reraise ->
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_notrace ->
           I.mov (domain_field Domainstate.Domain_exception_pointer) rsp;
           I.pop (domain_field Domainstate.Domain_exception_pointer);
@@ -1103,6 +1103,7 @@ let end_assembly() =
   emit_frames
     { efa_code_label = (fun l -> D.qword (ConstLabel (emit_label l)));
       efa_data_label = (fun l -> D.qword (ConstLabel (emit_label l)));
+      efa_8 = (fun n -> D.byte (const n));
       efa_16 = (fun n -> D.word (const n));
       efa_32 = (fun n -> D.long (const_32 n));
       efa_word = (fun n -> D.qword (const n));
@@ -1125,6 +1126,9 @@ let end_assembly() =
       efa_def_label = (fun l -> _label (emit_label l));
       efa_string = (fun s -> D.bytes (s ^ "\000"))
     };
+
+  let frametable = Compilenv.make_symbol (Some "frametable") in
+  D.size frametable (ConstSub (ConstThis, ConstLabel frametable));
 
   if Config.spacetime then begin
     emit_spacetime_shapes ()

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -105,26 +105,29 @@ let emit_float32_directive directive x =
 
 (* Record live pointers at call points *)
 
+type frame_debuginfo =
+  | Dbg_raise of Debuginfo.t
+  | Dbg_other of Debuginfo.t
+
 type frame_descr =
   { fd_lbl: int;                        (* Return address *)
     fd_frame_size: int;                 (* Size of stack frame *)
     fd_live_offset: int list;           (* Offsets/regs of live addresses *)
-    fd_raise: bool;                     (* Is frame for a raise? *)
-    fd_debuginfo: Debuginfo.t }         (* Location, if any *)
+    fd_debuginfo: frame_debuginfo }     (* Location, if any *)
 
 let frame_descriptors = ref([] : frame_descr list)
 
-let record_frame_descr ~label ~frame_size ~live_offset ~raise_frame debuginfo =
+let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
   frame_descriptors :=
     { fd_lbl = label;
       fd_frame_size = frame_size;
       fd_live_offset = List.sort_uniq (-) live_offset;
-      fd_raise = raise_frame;
       fd_debuginfo = debuginfo } :: !frame_descriptors
 
 type emit_frame_actions =
   { efa_code_label: int -> unit;
     efa_data_label: int -> unit;
+    efa_8: int -> unit;
     efa_16: int -> unit;
     efa_32: int32 -> unit;
     efa_word: int -> unit;
@@ -155,64 +158,73 @@ let emit_frames a =
     end)
   in
   let debuginfos = Label_table.create 7 in
-  let rec label_debuginfos rs rdbg =
+  let label_debuginfos rs dbg =
+    let rdbg = List.rev dbg in
     let key = (rs, rdbg) in
-    try fst (Label_table.find debuginfos key)
+    try Label_table.find debuginfos key
     with Not_found ->
       let lbl = Cmm.new_label () in
-      let next =
-        match rdbg with
-        | [] -> assert false
-        | _ :: [] -> None
-        | _ :: ((_ :: _) as rdbg') -> Some (label_debuginfos false rdbg')
-      in
-      Label_table.add debuginfos key (lbl, next);
+      Label_table.add debuginfos key lbl;
       lbl
   in
-  let emit_debuginfo_label rs rdbg =
-    a.efa_data_label (label_debuginfos rs rdbg)
-  in
   let emit_frame fd =
+    assert (fd.fd_frame_size land 3 = 0);
+    let flags =
+      match fd.fd_debuginfo with
+      | Dbg_other d | Dbg_raise d ->
+        if Debuginfo.is_none d then 0 else 1
+    in
     a.efa_code_label fd.fd_lbl;
-    a.efa_16 (if Debuginfo.is_none fd.fd_debuginfo
-              then fd.fd_frame_size
-              else fd.fd_frame_size + 1);
+    a.efa_16 (fd.fd_frame_size + flags);
     a.efa_16 (List.length fd.fd_live_offset);
     List.iter a.efa_16 fd.fd_live_offset;
-    a.efa_align Arch.size_addr;
-    match List.rev fd.fd_debuginfo with
-    | [] -> ()
-    | _ :: _ as rdbg -> emit_debuginfo_label fd.fd_raise rdbg
+    begin match fd.fd_debuginfo with
+    | _ when flags = 0 ->
+      ()
+    | Dbg_other dbg ->
+      a.efa_align 4;
+      a.efa_label_rel (label_debuginfos false dbg) Int32.zero
+    | Dbg_raise dbg ->
+      a.efa_align 4;
+      a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    end;
+    a.efa_align Arch.size_addr
   in
   let emit_filename name lbl =
     a.efa_def_label lbl;
     a.efa_string name;
     a.efa_align Arch.size_addr
   in
-  let pack_info fd_raise d =
+  let pack_info fd_raise d has_next =
     let line = min 0xFFFFF d.Debuginfo.dinfo_line
     and char_start = min 0xFF d.Debuginfo.dinfo_char_start
     and char_end = min 0x3FF d.Debuginfo.dinfo_char_end
-    and kind = if fd_raise then 1 else 0 in
+    and kind = if fd_raise then 1 else 0
+    and has_next = if has_next then 1 else 0 in
     Int64.(add (shift_left (of_int line) 44)
              (add (shift_left (of_int char_start) 36)
                 (add (shift_left (of_int char_end) 26)
-                   (of_int kind))))
+                   (add (shift_left (of_int kind) 1)
+                      (of_int has_next)))))
   in
-  let emit_debuginfo (rs, rdbg) (lbl,next) =
-    let d = List.hd rdbg in
+  let emit_debuginfo (rs, rdbg) lbl =
+    (* Due to inlined functions, a single debuginfo may have multiple locations.
+       These are represented sequentially in memory (innermost frame first),
+       with the low bit of the packed debuginfo being 0 on the last entry. *)
     a.efa_align Arch.size_addr;
     a.efa_def_label lbl;
-    let info = pack_info rs d in
-    a.efa_label_rel
-      (label_filename d.Debuginfo.dinfo_file)
-      (Int64.to_int32 info);
-    a.efa_32 (Int64.to_int32 (Int64.shift_right info 32));
-    begin match next with
-    | Some next -> a.efa_data_label next
-    | None -> a.efa_word 0
-    end
-  in
+    let rec emit rs d rest =
+      let info = pack_info rs d (rest <> []) in
+      a.efa_label_rel
+        (label_filename d.Debuginfo.dinfo_file)
+        (Int64.to_int32 info);
+      a.efa_32 (Int64.to_int32 (Int64.shift_right info 32));
+      match rest with
+      | [] -> ()
+      | d :: rest -> emit false d rest in
+    match rdbg with
+    | [] -> assert false
+    | d :: rest -> emit rs d rest in
   a.efa_word (List.length !frame_descriptors);
   List.iter emit_frame !frame_descriptors;
   Label_table.iter emit_debuginfo debuginfos;

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -38,17 +38,21 @@ val emit_debug_info_gen :
   (file_num:int -> file_name:string -> unit) ->
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
+type frame_debuginfo =
+  | Dbg_raise of Debuginfo.t
+  | Dbg_other of Debuginfo.t
+
 val record_frame_descr :
   label:int ->              (* Return address *)
   frame_size:int ->         (* Size of stack frame *)
   live_offset:int list ->   (* Offsets/regs of live addresses *)
-  raise_frame:bool ->       (* Is frame for a raise? *)
-  Debuginfo.t ->            (* Location, if any *)
+  frame_debuginfo ->        (* Location, if any *)
   unit
 
 type emit_frame_actions =
   { efa_code_label: int -> unit;
     efa_data_label: int -> unit;
+    efa_8: int -> unit;
     efa_16: int -> unit;
     efa_32: int32 -> unit;
     efa_word: int -> unit;

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -137,18 +137,20 @@ void caml_current_callstack_write(value trace) {
 
 debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
-  uintnat infoptr;
+  unsigned char* infoptr;
+  uint32_t debuginfo_offset;
   frame_descr * d = (frame_descr *)slot;
 
   if ((d->frame_size & 1) == 0) {
     return NULL;
   }
   /* Recover debugging info */
-  infoptr = ((uintnat) d +
-             sizeof(char *) + sizeof(short) + sizeof(short) +
-             sizeof(short) * d->num_live + sizeof(frame_descr *) - 1)
-            & -sizeof(frame_descr *);
-  return *((debuginfo*)infoptr);
+  infoptr = (unsigned char*)&d->live_ofs[d->num_live];
+  /* align to 32 bits */
+  infoptr = Align_to(infoptr, uint32_t);
+  /* read offset to debuginfo */
+  debuginfo_offset = *(uint32_t*)infoptr;
+  return (debuginfo)(infoptr + debuginfo_offset);
 }
 
 debuginfo caml_debuginfo_next(debuginfo dbg)
@@ -159,8 +161,12 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
     return NULL;
 
   infoptr = dbg;
-  infoptr += 2; /* Two packed info fields */
-  return *((debuginfo*)infoptr);
+  if ((infoptr[0] & 1) == 0)
+    /* No next debuginfo */
+    return NULL;
+  else
+    /* Next debuginfo is after the two packed info fields */
+    return (debuginfo*)(infoptr + 2);
 }
 
 /* Extract location information for the given frame descriptor */
@@ -181,17 +187,19 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   info1 = ((uint32_t *)dbg)[0];
   info2 = ((uint32_t *)dbg)[1];
   /* Format of the two info words:
-       llllllllllllllllllll aaaaaaaa bbbbbbbbbb nnnnnnnnnnnnnnnnnnnnnnnn kk
-                          44       36         26                       2  0
+       llllllllllllllllllll aaaaaaaa bbbbbbbbbb ffffffffffffffffffffffff k n
+                         44       36         26                       2  1 0
                        (32+12)    (32+4)
-     k ( 2 bits): 0 if it's a call
+     n ( 1 bit ): 0 if this is the final debuginfo
+                  1 if there's another following this one
+     k ( 1 bit ): 0 if it's a call
                   1 if it's a raise
-     n (24 bits): offset (in 4-byte words) of file name relative to dbg
+     f (24 bits): offset (in 4-byte words) of file name relative to dbg
      l (20 bits): line number
      a ( 8 bits): beginning of character range
      b (10 bits): end of character range */
   li->loc_valid = 1;
-  li->loc_is_raise = (info1 & 3) == 1;
+  li->loc_is_raise = (info1 & 2) == 2;
   li->loc_is_inlined = caml_debuginfo_next(dbg) != NULL;
   li->loc_filename = (char *) dbg + (info1 & 0x3FFFFFC);
   li->loc_lnum = info2 >> 12;

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -43,7 +43,7 @@ struct caml_loc_info {
 };
 
 /* When compiling with -g, backtrace slots have debug info associated.
- * When a call is inlined in native mode, debuginfos form a linked list.
+ * When a call is inlined in native mode, debuginfos form a sequence.
  */
 typedef void * debuginfo;
 

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -87,8 +87,18 @@ typedef struct {
   uintnat retaddr;
   unsigned short frame_size;
   unsigned short num_live;
-  unsigned short live_ofs[1];
+  unsigned short live_ofs[1 /* num_live */];
+  /*
+    If frame_size & 1, then debug info follows:
+  uint32_t debug_info_offset;
+    Debug info is stored as a relative offset to a debuginfo structure. */
 } frame_descr;
+
+/* Used to compute offsets in frame tables.
+   ty must have power-of-2 size */
+#define Align_to(p, ty) \
+  (void*)(((uintnat)(p) + sizeof(ty) - 1) & -sizeof(ty))
+
 
 /* Hash table of frame descriptors */
 

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -29,6 +29,7 @@
 #include "caml/memprof.h"
 #include <string.h>
 #include <stdio.h>
+#include <stddef.h>
 
 /* Roots registered from C functions */
 
@@ -78,14 +79,19 @@ static link* frametables_list_tail(link *list) {
 }
 
 static frame_descr * next_frame_descr(frame_descr * d) {
-  uintnat nextd;
-  nextd =
-    ((uintnat)d +
-     sizeof(char *) + sizeof(short) + sizeof(short) +
-     sizeof(short) * d->num_live + sizeof(frame_descr *) - 1)
-    & -sizeof(frame_descr *);
-  if (d->frame_size & 1) nextd += sizeof(void *); /* pointer to debuginfo */
-  return((frame_descr *) nextd);
+  unsigned char num_allocs = 0, *p;
+  CAMLassert(d->retaddr >= 4096);
+  /* Skip to end of live_ofs */
+  p = (unsigned char*)&d->live_ofs[d->num_live];
+  /* Skip debug info if present */
+  if (d->frame_size & 1) {
+    /* Align to 32 bits */
+    p = Align_to(p, uint32_t);
+    p += sizeof(uint32_t) * (d->frame_size & 2 ? num_allocs : 1);
+  }
+  /* Align to word size */
+  p = Align_to(p, void*);
+  return ((frame_descr*) p);
 }
 
 static void fill_hashtable(link *frametables) {


### PR DESCRIPTION
~~This PR generates debug info for each allocation point as well as for each call point, something that's required for generating good backtraces with statmemprof.~~

This PR optimises the size of debug info, as part of #8805 

## Debug info optimisations

The first is to use a more efficient format for inlined frames: instead of a linked-list of pairs of (debuginfo, next), the debuginfo lists for inlined frames are now represented as a contiguous list, using a spare bit in the format to indicate the end of the list. In the common case of no inlined frames, this halves the size of the debug info: instead of 8 bytes of debug info followed by 8 bytes of next pointer (all zeros), there are just 8 bytes of debug info.

The space saving from this optimisation nearly cancels out the loss above: with this change, ocamlopt.opt becomes 0.1% bigger.

## Frame table optimisations

However, the size of the debug info is less important than the size of the frame tables: the frame tables are accessed on a hot path in the GC where cache misses matter, and the debug info is not. Even with the more efficient debug info format, the frame tables get bigger: currently, only 64% of `ocamlopt.opt`'s frame tables have debug info attached. Since the debug info is an 8-byte pointer (on 64-bit machines), this means that trunk currently spends an average of 5 bytes per frame table on debug info.

So, this patch contains a second optimisation, which is to encode the debug info pointers in the frame table as a 32-bit relative offset instead of a full pointer. This means that this patch uses 4 bytes per frame table for debug info, which is a 20% saving over trunk despite adding debug info to all frames.

--- 

With both of these changes, `ocamlopt.opt` actually gets 1.5% *smaller*, despite the extra debug info.

(There remain two situations where it gets bigger though: when compiling without -g, some space is still used in the frame tables for null pointers, and on 32-bit machines relative pointers to debug info don't save any space, so the frame tables get bigger there. If these issues are considered blockers, I can have another go at the frame table format, I think there's more space to be squeezed out there if needed)