### PR TITLE
Consistently use @raise tags in Stdlib docs

### DIFF
--- a/Changes
+++ b/Changes
@@ -509,6 +509,9 @@ OCaml 4.11
 
 ### Manual and documentation:
 
+- #8644: fix formatting comment about @raise in stdlib's mli files
+  (Élie Brami, review by David Allsopp)
+
 - #9141: beginning of the ocamltest reference manual
   (Sébastien Hinderer, review by Gabriel Scherer and Thomas Refis)
 
@@ -1484,9 +1487,6 @@ OCaml 4.09.0 (19 September 2019)
    review by Gabriel Scherer, reports by Alexey Solovyev and Jonathan French)
 
 ### Manual and documentation:
-
-- #8644: fix formatting comment about @raise in stdlib's mli files
-  (Élie Brami, review by David Allsopp)
 
 - #7584, #8538: Document .cmt* files in the "overview" of ocaml{c,opt}
   (Oxana Kostikova, rewiew by Florian Angeletti)

--- a/Changes
+++ b/Changes
@@ -1485,6 +1485,9 @@ OCaml 4.09.0 (19 September 2019)
 
 ### Manual and documentation:
 
+- #8644: fix formatting comment about @raise in stdlib's mli files
+  (Élie Brami, review by David Allsopp)
+
 - #7584, #8538: Document .cmt* files in the "overview" of ocaml{c,opt}
   (Oxana Kostikova, rewiew by Florian Angeletti)
 

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -26,16 +26,14 @@ external get : 'a array -> int -> 'a = "%array_safe_get"
    The first element has number 0.
    The last element has number [Array.length a - 1].
    You can also write [a.(n)] instead of [Array.get a n].
-
-   Raise [Invalid_argument]
+   @raise Invalid_argument
    if [n] is outside the range 0 to [(Array.length a - 1)]. *)
 
 external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
 (** [Array.set a n x] modifies array [a] in place, replacing
    element number [n] with [x].
    You can also write [a.(n) <- x] instead of [Array.set a n x].
-
-   Raise [Invalid_argument]
+   @raise Invalid_argument
    if [n] is outside the range 0 to [Array.length a - 1]. *)
 
 external make : int -> 'a -> 'a array = "caml_make_vect"
@@ -46,8 +44,7 @@ external make : int -> 'a -> 'a array = "caml_make_vect"
    Consequently, if [x] is mutable, it is shared among all elements
    of the array, and modifying [x] through one of the array entries
    will modify all other entries at the same time.
-
-   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
    If the value of [x] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2].*)
 
@@ -69,8 +66,7 @@ val init : int -> (int -> 'a) -> 'a array
    with element number [i] initialized to the result of [f i].
    In other terms, [Array.init n f] tabulates the results of [f]
    applied to the integers [0] to [n-1].
-
-   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
    If the return type of [f] is [float], then the maximum
    size is only [Sys.max_array_length / 2].*)
 
@@ -81,8 +77,7 @@ val make_matrix : int -> int -> 'a -> 'a array array
    are initially physically equal to [e].
    The element ([x,y]) of a matrix [m] is accessed
    with the notation [m.(x).(y)].
-
-   Raise [Invalid_argument] if [dimx] or [dimy] is negative or
+   @raise Invalid_argument if [dimx] or [dimy] is negative or
    greater than {!Sys.max_array_length}.
    If the value of [e] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2]. *)
@@ -94,8 +89,7 @@ val create_matrix : int -> int -> 'a -> 'a array array
 val append : 'a array -> 'a array -> 'a array
 (** [Array.append v1 v2] returns a fresh array containing the
    concatenation of the arrays [v1] and [v2].
-
-   Raise [Invalid_argument] if
+   @raise Invalid_argument if
    [Array.length v1 + Array.length v2 > Sys.max_array_length]. *)
 
 val concat : 'a array list -> 'a array
@@ -105,8 +99,7 @@ val sub : 'a array -> int -> int -> 'a array
 (** [Array.sub a start len] returns a fresh array of length [len],
    containing the elements number [start] to [start + len - 1]
    of array [a].
-
-   Raise [Invalid_argument] if [start] and [len] do not
+   @raise Invalid_argument if [start] and [len] do not
    designate a valid subarray of [a]; that is, if
    [start < 0], or [len < 0], or [start + len > Array.length a]. *)
 
@@ -117,8 +110,7 @@ val copy : 'a array -> 'a array
 val fill : 'a array -> int -> int -> 'a -> unit
 (** [Array.fill a ofs len x] modifies the array [a] in place,
    storing [x] in elements number [ofs] to [ofs + len - 1].
-
-   Raise [Invalid_argument] if [ofs] and [len] do not
+   @raise Invalid_argument if [ofs] and [len] do not
    designate a valid subarray of [a]. *)
 
 val blit : 'a array -> int -> 'a array -> int -> int -> unit
@@ -127,8 +119,7 @@ val blit : 'a array -> int -> 'a array -> int -> int -> unit
    starting at element number [o2]. It works correctly even if
    [v1] and [v2] are the same array, and the source and
    destination chunks overlap.
-
-   Raise [Invalid_argument] if [o1] and [len] do not
+   @raise Invalid_argument if [o1] and [len] do not
    designate a valid subarray of [v1], or if [o2] and [len] do not
    designate a valid subarray of [v2]. *)
 
@@ -138,8 +129,7 @@ val to_list : 'a array -> 'a list
 val of_list : 'a list -> 'a array
 (** [Array.of_list l] returns a fresh array containing the elements
    of [l].
-
-   Raise [Invalid_argument] if the length of [l] is greater than
+   @raise Invalid_argument if the length of [l] is greater than
    [Sys.max_array_length].*)
 
 
@@ -183,14 +173,14 @@ val fold_right : ('b -> 'a -> 'a) -> 'b array -> 'a -> 'a
 val iter2 : ('a -> 'b -> unit) -> 'a array -> 'b array -> unit
 (** [Array.iter2 f a b] applies function [f] to all the elements of [a]
    and [b].
-   Raise [Invalid_argument] if the arrays are not the same size.
+   @raise Invalid_argument if the arrays are not the same size.
    @since 4.03.0 *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
 (** [Array.map2 f a b] applies function [f] to all the elements of [a]
    and [b], and builds an array with the results returned by [f]:
    [[| f a.(0) b.(0); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
-   Raise [Invalid_argument] if the arrays are not the same size.
+   @raise Invalid_argument if the arrays are not the same size.
    @since 4.03.0 *)
 
 
@@ -211,12 +201,12 @@ val exists : ('a -> bool) -> 'a array -> bool
 
 val for_all2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!Array.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays have different lengths.
+   @raise Invalid_argument if the two arrays have different lengths.
    @since 4.11.0 *)
 
 val exists2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!Array.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays have different lengths.
+   @raise Invalid_argument if the two arrays have different lengths.
    @since 4.11.0 *)
 
 val mem : 'a -> 'a array -> bool

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -204,12 +204,12 @@ val for_all : f:('a -> bool) -> 'a array -> bool
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!ArrayLabels.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays have different lengths.
+   @raise Invalid_argument if the two arrays have different lengths.
    @since 4.11.0 *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!ArrayLabels.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays have different lengths.
+   @raise Invalid_argument if the two arrays have different lengths.
    @since 4.11.0 *)
 
 val mem : 'a -> set:'a array -> bool

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -310,7 +310,7 @@ module Genarray :
      Bigarray [a].  The first dimension corresponds to [n = 0];
      the second dimension corresponds to [n = 1]; the last dimension,
      to [n = Genarray.num_dims a - 1].
-   @raise Invalid_argument if [n] is less than 0 or greater or equal than
+     @raise Invalid_argument if [n] is less than 0 or greater or equal than
      [Genarray.num_dims a]. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
@@ -347,7 +347,7 @@ module Genarray :
      and strictly less than the corresponding dimensions of [a].
      If [a] has Fortran layout, the coordinates must be greater or equal
      than 1 and less or equal than the corresponding dimensions of [a].
-   @raise Invalid_argument if the array [a] does not have exactly [N]
+     @raise Invalid_argument if the array [a] does not have exactly [N]
      dimensions, or if the coordinates are outside the array bounds.
 
      If [N > 3], alternate syntax is provided: you can write
@@ -389,7 +389,7 @@ module Genarray :
      array [a].
 
      [Genarray.sub_left] applies only to Bigarrays in C layout.
-   @raise Invalid_argument if [ofs] and [len] do not designate
+     @raise Invalid_argument if [ofs] and [len] do not designate
      a valid sub-array of [a], that is, if [ofs < 0], or [len < 0],
      or [ofs + len > Genarray.nth_dim a 0]. *)
 
@@ -409,7 +409,7 @@ module Genarray :
      array [a].
 
      [Genarray.sub_right] applies only to Bigarrays in Fortran layout.
-   @raise Invalid_argument if [ofs] and [len] do not designate
+     @raise Invalid_argument if [ofs] and [len] do not designate
      a valid sub-array of [a], that is, if [ofs < 1], or [len < 0],
      or [ofs + len > Genarray.nth_dim a (Genarray.num_dims a - 1)]. *)
 
@@ -428,7 +428,7 @@ module Genarray :
      the original array share the same storage space.
 
      [Genarray.slice_left] applies only to Bigarrays in C layout.
-   @raise Invalid_argument if [M >= N], or if [[|i1; ... ; iM|]]
+     @raise Invalid_argument if [M >= N], or if [[|i1; ... ; iM|]]
      is outside the bounds of [a]. *)
 
   external slice_right:
@@ -446,7 +446,7 @@ module Genarray :
      the original array share the same storage space.
 
      [Genarray.slice_right] applies only to Bigarrays in Fortran layout.
-   @raise Invalid_argument if [M >= N], or if [[|i1; ... ; iM|]]
+     @raise Invalid_argument if [M >= N], or if [[|i1; ... ; iM|]]
      is outside the bounds of [a]. *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -347,14 +347,16 @@ module Genarray :
      and strictly less than the corresponding dimensions of [a].
      If [a] has Fortran layout, the coordinates must be greater or equal
      than 1 and less or equal than the corresponding dimensions of [a].
-     @raise Invalid_argument if the array [a] does not have exactly [N]
-     dimensions, or if the coordinates are outside the array bounds.
 
      If [N > 3], alternate syntax is provided: you can write
      [a.{i1, i2, ..., iN}] instead of [Genarray.get a [|i1; ...; iN|]].
      (The syntax [a.{...}] with one, two or three coordinates is
      reserved for accessing one-, two- and three-dimensional arrays
-     as described below.) *)
+     as described below.)
+
+     @raise Invalid_argument if the array [a] does not have exactly [N]
+     dimensions, or if the coordinates are outside the array bounds.
+  *)
 
   external set: ('a, 'b, 'c) t -> int array -> 'a -> unit
     = "caml_ba_set_generic"

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -310,7 +310,7 @@ module Genarray :
      Bigarray [a].  The first dimension corresponds to [n = 0];
      the second dimension corresponds to [n = 1]; the last dimension,
      to [n = Genarray.num_dims a - 1].
-     Raise [Invalid_argument] if [n] is less than 0 or greater or equal than
+   @raise Invalid_argument if [n] is less than 0 or greater or equal than
      [Genarray.num_dims a]. *)
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
@@ -347,7 +347,7 @@ module Genarray :
      and strictly less than the corresponding dimensions of [a].
      If [a] has Fortran layout, the coordinates must be greater or equal
      than 1 and less or equal than the corresponding dimensions of [a].
-     Raise [Invalid_argument] if the array [a] does not have exactly [N]
+   @raise Invalid_argument if the array [a] does not have exactly [N]
      dimensions, or if the coordinates are outside the array bounds.
 
      If [N > 3], alternate syntax is provided: you can write
@@ -389,7 +389,7 @@ module Genarray :
      array [a].
 
      [Genarray.sub_left] applies only to Bigarrays in C layout.
-     Raise [Invalid_argument] if [ofs] and [len] do not designate
+   @raise Invalid_argument if [ofs] and [len] do not designate
      a valid sub-array of [a], that is, if [ofs < 0], or [len < 0],
      or [ofs + len > Genarray.nth_dim a 0]. *)
 
@@ -409,7 +409,7 @@ module Genarray :
      array [a].
 
      [Genarray.sub_right] applies only to Bigarrays in Fortran layout.
-     Raise [Invalid_argument] if [ofs] and [len] do not designate
+   @raise Invalid_argument if [ofs] and [len] do not designate
      a valid sub-array of [a], that is, if [ofs < 1], or [len < 0],
      or [ofs + len > Genarray.nth_dim a (Genarray.num_dims a - 1)]. *)
 
@@ -428,7 +428,7 @@ module Genarray :
      the original array share the same storage space.
 
      [Genarray.slice_left] applies only to Bigarrays in C layout.
-     Raise [Invalid_argument] if [M >= N], or if [[|i1; ... ; iM|]]
+   @raise Invalid_argument if [M >= N], or if [[|i1; ... ; iM|]]
      is outside the bounds of [a]. *)
 
   external slice_right:
@@ -446,7 +446,7 @@ module Genarray :
      the original array share the same storage space.
 
      [Genarray.slice_right] applies only to Bigarrays in Fortran layout.
-     Raise [Invalid_argument] if [M >= N], or if [[|i1; ... ; iM|]]
+   @raise Invalid_argument if [M >= N], or if [[|i1; ... ; iM|]]
      is outside the bounds of [a]. *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
@@ -904,23 +904,27 @@ external genarray_of_array3 :
 
 val array0_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array0.t
 (** Return the zero-dimensional Bigarray corresponding to the given
-   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
+   generic Bigarray.
+   @raise Invalid_argument if the generic Bigarray
    does not have exactly zero dimension.
    @since 4.05.0 *)
 
 val array1_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array1.t
 (** Return the one-dimensional Bigarray corresponding to the given
-   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
+   generic Bigarray.
+   @raise Invalid_argument if the generic Bigarray
    does not have exactly one dimension. *)
 
 val array2_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array2.t
 (** Return the two-dimensional Bigarray corresponding to the given
-   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
+   generic Bigarray.
+   @raise Invalid_argument if the generic Bigarray
    does not have exactly two dimensions. *)
 
 val array3_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array3.t
 (** Return the three-dimensional Bigarray corresponding to the given
-   generic Bigarray.  Raise [Invalid_argument] if the generic Bigarray
+   generic Bigarray.
+   @raise Invalid_argument if the generic Bigarray
    does not have exactly three dimensions. *)
 
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -50,7 +50,7 @@ val to_bytes : t -> bytes
 val sub : t -> int -> int -> string
 (** [Buffer.sub b off len] returns a copy of [len] bytes from the
     current contents of the buffer [b], starting at offset [off].
-   @raise Invalid_argument if [srcoff] and [len] do not designate a valid
+    @raise Invalid_argument if [srcoff] and [len] do not designate a valid
     range of [b]. *)
 
 val blit : t -> int -> bytes -> int -> int -> unit
@@ -65,7 +65,7 @@ val blit : t -> int -> bytes -> int -> int -> unit
 
 val nth : t -> int -> char
 (** Get the n-th character of the buffer.
-   @raise Invalid_argument if
+    @raise Invalid_argument if
     index out of bounds *)
 
 val length : t -> int
@@ -154,7 +154,7 @@ val output_buffer : out_channel -> t -> unit
 val truncate : t -> int -> unit
 (** [truncate b len] truncates the length of [b] to [len]
   Note: the internal byte sequence is not shortened.
-   @raise Invalid_argument if [len < 0] or [len > length b].
+  @raise Invalid_argument if [len < 0] or [len > length b].
   @since 4.05.0 *)
 
 (** {1 Iterators} *)

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -50,23 +50,22 @@ val to_bytes : t -> bytes
 val sub : t -> int -> int -> string
 (** [Buffer.sub b off len] returns a copy of [len] bytes from the
     current contents of the buffer [b], starting at offset [off].
-
-    Raise [Invalid_argument] if [srcoff] and [len] do not designate a valid
+   @raise Invalid_argument if [srcoff] and [len] do not designate a valid
     range of [b]. *)
 
 val blit : t -> int -> bytes -> int -> int -> unit
 (** [Buffer.blit src srcoff dst dstoff len] copies [len] characters from
    the current contents of the buffer [src], starting at offset [srcoff]
    to [dst], starting at character [dstoff].
-
-   Raise [Invalid_argument] if [srcoff] and [len] do not designate a valid
+   @raise Invalid_argument if [srcoff] and [len] do not designate a valid
    range of [src], or if [dstoff] and [len] do not designate a valid
    range of [dst].
    @since 3.11.2
 *)
 
 val nth : t -> int -> char
-(** Get the n-th character of the buffer. Raise [Invalid_argument] if
+(** Get the n-th character of the buffer.
+   @raise Invalid_argument if
     index out of bounds *)
 
 val length : t -> int
@@ -134,7 +133,7 @@ val add_substitute : t -> (string -> string) -> string -> unit
    matching parentheses or curly brackets.
    An escaped [$] character is a [$] that immediately follows a backslash
    character; it then stands for a plain [$].
-   Raise [Not_found] if the closing character of a parenthesized variable
+   @raise Not_found if the closing character of a parenthesized variable
    cannot be found. *)
 
 val add_buffer : t -> t -> unit
@@ -144,7 +143,7 @@ val add_buffer : t -> t -> unit
 val add_channel : t -> in_channel -> int -> unit
 (** [add_channel b ic n] reads at most [n] characters from the
    input channel [ic] and stores them at the end of buffer [b].
-   Raise [End_of_file] if the channel contains fewer than [n]
+   @raise End_of_file if the channel contains fewer than [n]
    characters. In this case, the characters are still added to
    the buffer, so as to avoid loss of data. *)
 
@@ -155,7 +154,7 @@ val output_buffer : out_channel -> t -> unit
 val truncate : t -> int -> unit
 (** [truncate b len] truncates the length of [b] to [len]
   Note: the internal byte sequence is not shortened.
-  Raise [Invalid_argument] if [len < 0] or [len > length b].
+   @raise Invalid_argument if [len < 0] or [len > length b].
   @since 4.05.0 *)
 
 (** {1 Iterators} *)

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -137,7 +137,7 @@ val concat : bytes -> bytes list -> bytes
 
 val cat : bytes -> bytes -> bytes
 (** [cat s1 s2] concatenates [s1] and [s2] and returns the result
-    as new byte sequence.
+    as a new byte sequence.
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -47,28 +47,28 @@ external length : bytes -> int = "%bytes_length"
 
 external get : bytes -> int -> char = "%bytes_safe_get"
 (** [get s n] returns the byte at index [n] in argument [s].
-   @raise Invalid_argument if [n] is not a valid index in [s]. *)
+    @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 external set : bytes -> int -> char -> unit = "%bytes_safe_set"
 (** [set s n c] modifies [s] in place, replacing the byte at index [n]
     with [c].
-   @raise Invalid_argument if [n] is not a valid index in [s]. *)
+    @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 external create : int -> bytes = "caml_create_bytes"
 (** [create n] returns a new byte sequence of length [n]. The
     sequence is uninitialized and contains arbitrary bytes.
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val make : int -> char -> bytes
 (** [make n c] returns a new byte sequence of length [n], filled with
     the byte [c].
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> bytes
 (** [Bytes.init n f] returns a fresh byte sequence of length [n], with
     character [i] initialized to the result of [f i] (in increasing
     index order).
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val empty : bytes
 (** A byte sequence of size 0. *)
@@ -89,7 +89,7 @@ val sub : bytes -> int -> int -> bytes
 (** [sub s start len] returns a new byte sequence of length [len],
     containing the subsequence of [s] that starts at position [start]
     and has length [len].
-   @raise Invalid_argument if [start] and [len] do not designate a
+    @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val sub_string : bytes -> int -> int -> string
@@ -101,13 +101,13 @@ val extend : bytes -> int -> int -> bytes
     [right] uninitialized bytes appended to it. If [left] or [right]
     is negative, then bytes are removed (instead of appended) from
     the corresponding side of [s].
-   @raise Invalid_argument if the result length is negative or
+    @raise Invalid_argument if the result length is negative or
     longer than {!Sys.max_string_length} bytes. *)
 
 val fill : bytes -> int -> int -> char -> unit
 (** [fill s start len c] modifies [s] in place, replacing [len]
     characters with [c], starting at [start].
-   @raise Invalid_argument if [start] and [len] do not designate a
+    @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val blit : bytes -> int -> bytes -> int -> int -> unit
@@ -116,7 +116,7 @@ val blit : bytes -> int -> bytes -> int -> int -> unit
     index [dstoff]. It works correctly even if [src] and [dst] are the
     same byte sequence, and the source and destination intervals
     overlap.
-   @raise Invalid_argument if [srcoff] and [len] do not
+    @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
@@ -124,7 +124,7 @@ val blit_string : string -> int -> bytes -> int -> int -> unit
 (** [blit_string src srcoff dst dstoff len] copies [len] bytes from
     string [src], starting at index [srcoff], to byte sequence [dst],
     starting at index [dstoff].
-   @raise Invalid_argument if [srcoff] and [len] do not
+    @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
@@ -132,13 +132,13 @@ val concat : bytes -> bytes list -> bytes
 (** [concat sep sl] concatenates the list of byte sequences [sl],
     inserting the separator byte sequence [sep] between each, and
     returns the result as a new byte sequence.
-   @raise Invalid_argument if the result is longer than
+    @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val cat : bytes -> bytes -> bytes
 (** [cat s1 s2] concatenates [s1] and [s2] and returns the result
-     as new byte sequence.
-   @raise Invalid_argument if the result is longer than
+    as new byte sequence.
+    @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val iter : (char -> unit) -> bytes -> unit
@@ -171,13 +171,13 @@ val escaped : bytes -> bytes
     by escape sequences, following the lexical conventions of OCaml.
     All characters outside the ASCII printable range (32..126) are
     escaped, as well as backslash and double-quote.
-   @raise Invalid_argument if the result is longer than
+    @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val index : bytes -> char -> int
 (** [index s c] returns the index of the first occurrence of byte [c]
     in [s].
-   @raise Not_found if [c] does not occur in [s]. *)
+    @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: bytes -> char -> int option
 (** [index_opt s c] returns the index of the first occurrence of byte [c]
@@ -187,7 +187,7 @@ val index_opt: bytes -> char -> int option
 val rindex : bytes -> char -> int
 (** [rindex s c] returns the index of the last occurrence of byte [c]
     in [s].
-   @raise Not_found if [c] does not occur in [s]. *)
+    @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: bytes -> char -> int option
 (** [rindex_opt s c] returns the index of the last occurrence of byte [c]
@@ -198,30 +198,30 @@ val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
-   @raise Not_found if [c] does not occur in [s] after position [i]. *)
+    @raise Invalid_argument if [i] is not a valid position in [s].
+    @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from_opt s i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i] or [None] if [c] does not occur in [s]
     after position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
+    @raise Invalid_argument if [i] is not a valid position in [s].
     @since 4.05 *)
 
 val rindex_from : bytes -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
     byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
-   @raise Invalid_argument if [i+1] is not a valid position in [s].
-   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
+    @raise Invalid_argument if [i+1] is not a valid position in [s].
+    @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
 (** [rindex_from_opt s i c] returns the index of the last occurrence
     of byte [c] in [s] before position [i+1] or [None] if [c] does not
     occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
-   @raise Invalid_argument if [i+1] is not a valid position in [s].
+    @raise Invalid_argument if [i+1] is not a valid position in [s].
     @since 4.05 *)
 
 val contains : bytes -> char -> bool
@@ -231,12 +231,12 @@ val contains_from : bytes -> int -> char -> bool
 (** [contains_from s start c] tests if byte [c] appears in [s] after
     position [start].  [contains s c] is equivalent to [contains_from
     s 0 c].
-   @raise Invalid_argument if [start] is not a valid position in [s]. *)
+    @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : bytes -> int -> char -> bool
 (** [rcontains_from s stop c] tests if byte [c] appears in [s] before
     position [stop+1].
-   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
+    @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)
 
 val uppercase : bytes -> bytes

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -47,33 +47,28 @@ external length : bytes -> int = "%bytes_length"
 
 external get : bytes -> int -> char = "%bytes_safe_get"
 (** [get s n] returns the byte at index [n] in argument [s].
-
-    Raise [Invalid_argument] if [n] is not a valid index in [s]. *)
+   @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 external set : bytes -> int -> char -> unit = "%bytes_safe_set"
 (** [set s n c] modifies [s] in place, replacing the byte at index [n]
     with [c].
-
-    Raise [Invalid_argument] if [n] is not a valid index in [s]. *)
+   @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 external create : int -> bytes = "caml_create_bytes"
 (** [create n] returns a new byte sequence of length [n]. The
     sequence is uninitialized and contains arbitrary bytes.
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val make : int -> char -> bytes
 (** [make n c] returns a new byte sequence of length [n], filled with
     the byte [c].
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> bytes
 (** [Bytes.init n f] returns a fresh byte sequence of length [n], with
     character [i] initialized to the result of [f i] (in increasing
     index order).
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val empty : bytes
 (** A byte sequence of size 0. *)
@@ -94,8 +89,7 @@ val sub : bytes -> int -> int -> bytes
 (** [sub s start len] returns a new byte sequence of length [len],
     containing the subsequence of [s] that starts at position [start]
     and has length [len].
-
-    Raise [Invalid_argument] if [start] and [len] do not designate a
+   @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val sub_string : bytes -> int -> int -> string
@@ -107,15 +101,13 @@ val extend : bytes -> int -> int -> bytes
     [right] uninitialized bytes appended to it. If [left] or [right]
     is negative, then bytes are removed (instead of appended) from
     the corresponding side of [s].
-
-    Raise [Invalid_argument] if the result length is negative or
+   @raise Invalid_argument if the result length is negative or
     longer than {!Sys.max_string_length} bytes. *)
 
 val fill : bytes -> int -> int -> char -> unit
 (** [fill s start len c] modifies [s] in place, replacing [len]
     characters with [c], starting at [start].
-
-    Raise [Invalid_argument] if [start] and [len] do not designate a
+   @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val blit : bytes -> int -> bytes -> int -> int -> unit
@@ -124,8 +116,7 @@ val blit : bytes -> int -> bytes -> int -> int -> unit
     index [dstoff]. It works correctly even if [src] and [dst] are the
     same byte sequence, and the source and destination intervals
     overlap.
-
-    Raise [Invalid_argument] if [srcoff] and [len] do not
+   @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
@@ -133,8 +124,7 @@ val blit_string : string -> int -> bytes -> int -> int -> unit
 (** [blit_string src srcoff dst dstoff len] copies [len] bytes from
     string [src], starting at index [srcoff], to byte sequence [dst],
     starting at index [dstoff].
-
-    Raise [Invalid_argument] if [srcoff] and [len] do not
+   @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
@@ -142,15 +132,13 @@ val concat : bytes -> bytes list -> bytes
 (** [concat sep sl] concatenates the list of byte sequences [sl],
     inserting the separator byte sequence [sep] between each, and
     returns the result as a new byte sequence.
-
-    Raise [Invalid_argument] if the result is longer than
+   @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val cat : bytes -> bytes -> bytes
 (** [cat s1 s2] concatenates [s1] and [s2] and returns the result
      as new byte sequence.
-
-    Raise [Invalid_argument] if the result is longer than
+   @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val iter : (char -> unit) -> bytes -> unit
@@ -183,15 +171,13 @@ val escaped : bytes -> bytes
     by escape sequences, following the lexical conventions of OCaml.
     All characters outside the ASCII printable range (32..126) are
     escaped, as well as backslash and double-quote.
-
-    Raise [Invalid_argument] if the result is longer than
+   @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val index : bytes -> char -> int
 (** [index s c] returns the index of the first occurrence of byte [c]
     in [s].
-
-    Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: bytes -> char -> int option
 (** [index_opt s c] returns the index of the first occurrence of byte [c]
@@ -201,8 +187,7 @@ val index_opt: bytes -> char -> int option
 val rindex : bytes -> char -> int
 (** [rindex s c] returns the index of the last occurrence of byte [c]
     in [s].
-
-    Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: bytes -> char -> int option
 (** [rindex_opt s c] returns the index of the last occurrence of byte [c]
@@ -213,34 +198,30 @@ val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
-
-    Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+   @raise Invalid_argument if [i] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from_opt s i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i] or [None] if [c] does not occur in [s]
     after position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
-
-    Raise [Invalid_argument] if [i] is not a valid position in [s].
+   @raise Invalid_argument if [i] is not a valid position in [s].
     @since 4.05 *)
 
 val rindex_from : bytes -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
     byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
-
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
 (** [rindex_from_opt s i c] returns the index of the last occurrence
     of byte [c] in [s] before position [i+1] or [None] if [c] does not
     occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
-
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
     @since 4.05 *)
 
 val contains : bytes -> char -> bool
@@ -250,14 +231,12 @@ val contains_from : bytes -> int -> char -> bool
 (** [contains_from s start c] tests if byte [c] appears in [s] after
     position [start].  [contains s c] is equivalent to [contains_from
     s 0 c].
-
-    Raise [Invalid_argument] if [start] is not a valid position in [s]. *)
+   @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : bytes -> int -> char -> bool
 (** [rcontains_from s stop c] tests if byte [c] appears in [s] before
     position [stop+1].
-
-    Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
+   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)
 
 val uppercase : bytes -> bytes

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -31,33 +31,28 @@ external length : bytes -> int = "%bytes_length"
 
 external get : bytes -> int -> char = "%bytes_safe_get"
 (** [get s n] returns the byte at index [n] in argument [s].
-
-    Raise [Invalid_argument] if [n] is not a valid index in [s]. *)
+   @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 
 external set : bytes -> int -> char -> unit = "%bytes_safe_set"
 (** [set s n c] modifies [s] in place, replacing the byte at index [n]
     with [c].
-
-    Raise [Invalid_argument] if [n] is not a valid index in [s]. *)
+   @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 external create : int -> bytes = "caml_create_bytes"
 (** [create n] returns a new byte sequence of length [n]. The
     sequence is uninitialized and contains arbitrary bytes.
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val make : int -> char -> bytes
 (** [make n c] returns a new byte sequence of length [n], filled with
     the byte [c].
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> f:(int -> char) -> bytes
 (** [init n f] returns a fresh byte sequence of length [n],
     with character [i] initialized to the result of [f i].
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val empty : bytes
 (** A byte sequence of size 0. *)
@@ -78,8 +73,7 @@ val sub : bytes -> pos:int -> len:int -> bytes
 (** [sub s start len] returns a new byte sequence of length [len],
     containing the subsequence of [s] that starts at position [start]
     and has length [len].
-
-    Raise [Invalid_argument] if [start] and [len] do not designate a
+   @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val sub_string : bytes -> pos:int -> len:int -> string
@@ -91,16 +85,14 @@ val extend : bytes -> left:int -> right:int -> bytes
     [right] uninitialized bytes appended to it. If [left] or [right]
     is negative, then bytes are removed (instead of appended) from
     the corresponding side of [s].
-
-    Raise [Invalid_argument] if the result length is negative or
+   @raise Invalid_argument if the result length is negative or
     longer than {!Sys.max_string_length} bytes.
     @since 4.05.0 *)
 
 val fill : bytes -> pos:int -> len:int -> char -> unit
 (** [fill s start len c] modifies [s] in place, replacing [len]
     characters with [c], starting at [start].
-
-    Raise [Invalid_argument] if [start] and [len] do not designate a
+   @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val blit :
@@ -111,8 +103,7 @@ val blit :
     index [dstoff]. It works correctly even if [src] and [dst] are the
     same byte sequence, and the source and destination intervals
     overlap.
-
-    Raise [Invalid_argument] if [srcoff] and [len] do not
+   @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
@@ -122,8 +113,7 @@ val blit_string :
 (** [blit src srcoff dst dstoff len] copies [len] bytes from string
     [src], starting at index [srcoff], to byte sequence [dst],
     starting at index [dstoff].
-
-    Raise [Invalid_argument] if [srcoff] and [len] do not
+   @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst].
     @since 4.05.0 *)
@@ -136,8 +126,7 @@ val concat : sep:bytes -> bytes list -> bytes
 val cat : bytes -> bytes -> bytes
 (** [cat s1 s2] concatenates [s1] and [s2] and returns the result
      as new byte sequence.
-
-    Raise [Invalid_argument] if the result is longer than
+   @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.
     @since 4.05.0 *)
 
@@ -173,8 +162,7 @@ val escaped : bytes -> bytes
 val index : bytes -> char -> int
 (** [index s c] returns the index of the first occurrence of byte [c]
     in [s].
-
-    Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: bytes -> char -> int option
 (** [index_opt s c] returns the index of the first occurrence of byte [c]
@@ -184,8 +172,7 @@ val index_opt: bytes -> char -> int option
 val rindex : bytes -> char -> int
 (** [rindex s c] returns the index of the last occurrence of byte [c]
     in [s].
-
-    Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: bytes -> char -> int option
 (** [rindex_opt s c] returns the index of the last occurrence of byte [c]
@@ -196,34 +183,30 @@ val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
-
-    Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+   @raise Invalid_argument if [i] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from _opts i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i] or [None] if [c] does not occur in [s]
     after position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
-
-    Raise [Invalid_argument] if [i] is not a valid position in [s].
+   @raise Invalid_argument if [i] is not a valid position in [s].
     @since 4.05 *)
 
 val rindex_from : bytes -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
     byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
-
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
 (** [rindex_from_opt s i c] returns the index of the last occurrence
     of byte [c] in [s] before position [i+1] or [None] if [c] does not
     occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
-
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
     @since 4.05 *)
 
 val contains : bytes -> char -> bool
@@ -233,14 +216,12 @@ val contains_from : bytes -> int -> char -> bool
 (** [contains_from s start c] tests if byte [c] appears in [s] after
     position [start].  [contains s c] is equivalent to [contains_from
     s 0 c].
-
-    Raise [Invalid_argument] if [start] is not a valid position in [s]. *)
+   @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : bytes -> int -> char -> bool
 (** [rcontains_from s stop c] tests if byte [c] appears in [s] before
     position [stop+1].
-
-    Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
+   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)
 
 val uppercase : bytes -> bytes

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -31,28 +31,28 @@ external length : bytes -> int = "%bytes_length"
 
 external get : bytes -> int -> char = "%bytes_safe_get"
 (** [get s n] returns the byte at index [n] in argument [s].
-   @raise Invalid_argument if [n] is not a valid index in [s]. *)
+    @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 
 external set : bytes -> int -> char -> unit = "%bytes_safe_set"
 (** [set s n c] modifies [s] in place, replacing the byte at index [n]
     with [c].
-   @raise Invalid_argument if [n] is not a valid index in [s]. *)
+    @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
 external create : int -> bytes = "caml_create_bytes"
 (** [create n] returns a new byte sequence of length [n]. The
     sequence is uninitialized and contains arbitrary bytes.
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val make : int -> char -> bytes
 (** [make n c] returns a new byte sequence of length [n], filled with
     the byte [c].
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> f:(int -> char) -> bytes
 (** [init n f] returns a fresh byte sequence of length [n],
     with character [i] initialized to the result of [f i].
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val empty : bytes
 (** A byte sequence of size 0. *)
@@ -73,7 +73,7 @@ val sub : bytes -> pos:int -> len:int -> bytes
 (** [sub s start len] returns a new byte sequence of length [len],
     containing the subsequence of [s] that starts at position [start]
     and has length [len].
-   @raise Invalid_argument if [start] and [len] do not designate a
+    @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val sub_string : bytes -> pos:int -> len:int -> string
@@ -85,14 +85,14 @@ val extend : bytes -> left:int -> right:int -> bytes
     [right] uninitialized bytes appended to it. If [left] or [right]
     is negative, then bytes are removed (instead of appended) from
     the corresponding side of [s].
-   @raise Invalid_argument if the result length is negative or
+    @raise Invalid_argument if the result length is negative or
     longer than {!Sys.max_string_length} bytes.
     @since 4.05.0 *)
 
 val fill : bytes -> pos:int -> len:int -> char -> unit
 (** [fill s start len c] modifies [s] in place, replacing [len]
     characters with [c], starting at [start].
-   @raise Invalid_argument if [start] and [len] do not designate a
+    @raise Invalid_argument if [start] and [len] do not designate a
     valid range of [s]. *)
 
 val blit :
@@ -103,7 +103,7 @@ val blit :
     index [dstoff]. It works correctly even if [src] and [dst] are the
     same byte sequence, and the source and destination intervals
     overlap.
-   @raise Invalid_argument if [srcoff] and [len] do not
+    @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
@@ -113,7 +113,7 @@ val blit_string :
 (** [blit src srcoff dst dstoff len] copies [len] bytes from string
     [src], starting at index [srcoff], to byte sequence [dst],
     starting at index [dstoff].
-   @raise Invalid_argument if [srcoff] and [len] do not
+    @raise Invalid_argument if [srcoff] and [len] do not
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst].
     @since 4.05.0 *)
@@ -125,8 +125,8 @@ val concat : sep:bytes -> bytes list -> bytes
 
 val cat : bytes -> bytes -> bytes
 (** [cat s1 s2] concatenates [s1] and [s2] and returns the result
-     as new byte sequence.
-   @raise Invalid_argument if the result is longer than
+    as new byte sequence.
+    @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.
     @since 4.05.0 *)
 
@@ -162,7 +162,7 @@ val escaped : bytes -> bytes
 val index : bytes -> char -> int
 (** [index s c] returns the index of the first occurrence of byte [c]
     in [s].
-   @raise Not_found if [c] does not occur in [s]. *)
+    @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: bytes -> char -> int option
 (** [index_opt s c] returns the index of the first occurrence of byte [c]
@@ -172,7 +172,7 @@ val index_opt: bytes -> char -> int option
 val rindex : bytes -> char -> int
 (** [rindex s c] returns the index of the last occurrence of byte [c]
     in [s].
-   @raise Not_found if [c] does not occur in [s]. *)
+    @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: bytes -> char -> int option
 (** [rindex_opt s c] returns the index of the last occurrence of byte [c]
@@ -183,30 +183,30 @@ val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
-   @raise Not_found if [c] does not occur in [s] after position [i]. *)
+    @raise Invalid_argument if [i] is not a valid position in [s].
+    @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from _opts i c] returns the index of the first occurrence of
     byte [c] in [s] after position [i] or [None] if [c] does not occur in [s]
     after position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
+    @raise Invalid_argument if [i] is not a valid position in [s].
     @since 4.05 *)
 
 val rindex_from : bytes -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
     byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
-   @raise Invalid_argument if [i+1] is not a valid position in [s].
-   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
+    @raise Invalid_argument if [i+1] is not a valid position in [s].
+    @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
 (** [rindex_from_opt s i c] returns the index of the last occurrence
     of byte [c] in [s] before position [i+1] or [None] if [c] does not
     occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
-   @raise Invalid_argument if [i+1] is not a valid position in [s].
+    @raise Invalid_argument if [i+1] is not a valid position in [s].
     @since 4.05 *)
 
 val contains : bytes -> char -> bool
@@ -216,12 +216,12 @@ val contains_from : bytes -> int -> char -> bool
 (** [contains_from s start c] tests if byte [c] appears in [s] after
     position [start].  [contains s c] is equivalent to [contains_from
     s 0 c].
-   @raise Invalid_argument if [start] is not a valid position in [s]. *)
+    @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : bytes -> int -> char -> bool
 (** [rcontains_from s stop c] tests if byte [c] appears in [s] before
     position [stop+1].
-   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
+    @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)
 
 val uppercase : bytes -> bytes

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -20,7 +20,7 @@ external code : char -> int = "%identity"
 
 val chr : int -> char
 (** Return the character with the given ASCII code.
-   Raise [Invalid_argument "Char.chr"] if the argument is
+   @raise Invalid_argument if the argument is
    outside the range 0--255. *)
 
 val escaped : char -> string

--- a/stdlib/digest.mli
+++ b/stdlib/digest.mli
@@ -74,11 +74,11 @@ val input : in_channel -> t
 
 val to_hex : t -> string
 (** Return the printable hexadecimal representation of the given digest.
-    Raise [Invalid_argument] if the argument is not exactly 16 bytes.
+   @raise Invalid_argument if the argument is not exactly 16 bytes.
  *)
 
 val from_hex : string -> t
 (** Convert a hexadecimal representation back into the corresponding digest.
-   Raise [Invalid_argument] if the argument is not exactly 32 hexadecimal
+   @raise Invalid_argument if the argument is not exactly 32 hexadecimal
    characters.
    @since 4.00.0 *)

--- a/stdlib/digest.mli
+++ b/stdlib/digest.mli
@@ -74,11 +74,11 @@ val input : in_channel -> t
 
 val to_hex : t -> string
 (** Return the printable hexadecimal representation of the given digest.
-   @raise Invalid_argument if the argument is not exactly 16 bytes.
+    @raise Invalid_argument if the argument is not exactly 16 bytes.
  *)
 
 val from_hex : string -> t
 (** Convert a hexadecimal representation back into the corresponding digest.
-   @raise Invalid_argument if the argument is not exactly 32 hexadecimal
+    @raise Invalid_argument if the argument is not exactly 32 hexadecimal
    characters.
    @since 4.00.0 *)

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -135,7 +135,7 @@ val temp_file : ?temp_dir: string -> string -> string -> string
    (readable and writable only by the file owner).  The file is
    guaranteed to be different from any other file that existed when
    [temp_file] was called.
-   Raise [Sys_error] if the file could not be created.
+   @raise Sys_error if the file could not be created.
    @before 3.11.2 no ?temp_dir optional argument
 *)
 
@@ -221,6 +221,5 @@ val quote_command :
     if any are quoted using {!Filename.quote}, then concatenated.
     Under Win32, additional quoting is performed as required by the
     [cmd.exe] shell that is called by {!Sys.command}.
-
-    Raise [Failure] if the command cannot be escaped on the current platform.
+   @raise Failure if the command cannot be escaped on the current platform.
 *)

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -221,5 +221,5 @@ val quote_command :
     if any are quoted using {!Filename.quote}, then concatenated.
     Under Win32, additional quoting is performed as required by the
     [cmd.exe] shell that is called by {!Sys.command}.
-   @raise Failure if the command cannot be escaped on the current platform.
+    @raise Failure if the command cannot be escaped on the current platform.
 *)

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -398,45 +398,45 @@ module Array : sig
 
   val get : t -> int -> float
   (** [get a n] returns the element number [n] of floatarray [a].
-   @raise Invalid_argument if [n] is outside the range 0 to
+      @raise Invalid_argument if [n] is outside the range 0 to
       [(length a - 1)]. *)
 
   val set : t -> int -> float -> unit
   (** [set a n x] modifies floatarray [a] in place, replacing element
       number [n] with [x].
-   @raise Invalid_argument if [n] is outside the range 0 to
+      @raise Invalid_argument if [n] is outside the range 0 to
       [(length a - 1)]. *)
 
   val make : int -> float -> t
   (** [make n x] returns a fresh floatarray of length [n], initialized with [x].
-   @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
+      @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
   val create : int -> t
   (** [create n] returns a fresh floatarray of length [n],
       with uninitialized data.
-   @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
+      @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
   val init : int -> (int -> float) -> t
   (** [init n f] returns a fresh floatarray of length [n],
-     with element number [i] initialized to the result of [f i].
-     In other terms, [init n f] tabulates the results of [f]
-     applied to the integers [0] to [n-1].
-   @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
+      with element number [i] initialized to the result of [f i].
+      In other terms, [init n f] tabulates the results of [f]
+      applied to the integers [0] to [n-1].
+      @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
   val append : t -> t -> t
   (** [append v1 v2] returns a fresh floatarray containing the
-     concatenation of the floatarrays [v1] and [v2].
-   @raise Invalid_argument if
-     [length v1 + length v2 > Sys.max_floatarray_length]. *)
+      concatenation of the floatarrays [v1] and [v2].
+      @raise Invalid_argument if
+      [length v1 + length v2 > Sys.max_floatarray_length]. *)
 
   val concat : t list -> t
   (** Same as {!append}, but concatenates a list of floatarrays. *)
 
   val sub : t -> int -> int -> t
   (** [sub a start len] returns a fresh floatarray of length [len],
-     containing the elements number [start] to [start + len - 1]
-     of floatarray [a].
-   @raise Invalid_argument if [start] and [len] do not
+      containing the elements number [start] to [start + len - 1]
+      of floatarray [a].
+      @raise Invalid_argument if [start] and [len] do not
      designate a valid subarray of [a]; that is, if
      [start < 0], or [len < 0], or [start + len > length a]. *)
 
@@ -446,8 +446,8 @@ module Array : sig
 
   val fill : t -> int -> int -> float -> unit
   (** [fill a ofs len x] modifies the floatarray [a] in place,
-     storing [x] in elements number [ofs] to [ofs + len - 1].
-   @raise Invalid_argument if [ofs] and [len] do not
+      storing [x] in elements number [ofs] to [ofs + len - 1].
+      @raise Invalid_argument if [ofs] and [len] do not
      designate a valid subarray of [a]. *)
 
   val blit : t -> int -> t -> int -> int -> unit
@@ -456,7 +456,7 @@ module Array : sig
       starting at element number [o2]. It works correctly even if
       [v1] and [v2] are the same floatarray, and the source and
       destination chunks overlap.
-   @raise Invalid_argument if [o1] and [len] do not
+      @raise Invalid_argument if [o1] and [len] do not
       designate a valid subarray of [v1], or if [o2] and [len] do not
       designate a valid subarray of [v2]. *)
 
@@ -466,7 +466,7 @@ module Array : sig
   val of_list : float list -> t
   (** [of_list l] returns a fresh floatarray containing the elements
       of [l].
-   @raise Invalid_argument if the length of [l] is greater than
+      @raise Invalid_argument if the length of [l] is greater than
       [Sys.max_floatarray_length].*)
 
   (** {2 Iterators} *)
@@ -505,13 +505,13 @@ module Array : sig
   val iter2 : (float -> float -> unit) -> t -> t -> unit
   (** [Array.iter2 f a b] applies function [f] to all the elements of [a]
       and [b].
-   @raise Invalid_argument if the floatarrays are not the same size. *)
+      @raise Invalid_argument if the floatarrays are not the same size. *)
 
   val map2 : (float -> float -> float) -> t -> t -> t
   (** [map2 f a b] applies function [f] to all the elements of [a]
       and [b], and builds a floatarray with the results returned by [f]:
       [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
-   @raise Invalid_argument if the floatarrays are not the same size. *)
+      @raise Invalid_argument if the floatarrays are not the same size. *)
 
   (** {2 Array scanning} *)
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -398,41 +398,35 @@ module Array : sig
 
   val get : t -> int -> float
   (** [get a n] returns the element number [n] of floatarray [a].
-
-      Raise [Invalid_argument] if [n] is outside the range 0 to
+   @raise Invalid_argument if [n] is outside the range 0 to
       [(length a - 1)]. *)
 
   val set : t -> int -> float -> unit
   (** [set a n x] modifies floatarray [a] in place, replacing element
       number [n] with [x].
-
-      Raise [Invalid_argument] if [n] is outside the range 0 to
+   @raise Invalid_argument if [n] is outside the range 0 to
       [(length a - 1)]. *)
 
   val make : int -> float -> t
   (** [make n x] returns a fresh floatarray of length [n], initialized with [x].
-
-      Raise [Invalid_argument] if [n < 0] or [n > Sys.max_floatarray_length]. *)
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
   val create : int -> t
   (** [create n] returns a fresh floatarray of length [n],
       with uninitialized data.
-
-      Raise [Invalid_argument] if [n < 0] or [n > Sys.max_floatarray_length]. *)
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
   val init : int -> (int -> float) -> t
   (** [init n f] returns a fresh floatarray of length [n],
      with element number [i] initialized to the result of [f i].
      In other terms, [init n f] tabulates the results of [f]
      applied to the integers [0] to [n-1].
-
-     Raise [Invalid_argument] if [n < 0] or [n > Sys.max_floatarray_length]. *)
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_floatarray_length]. *)
 
   val append : t -> t -> t
   (** [append v1 v2] returns a fresh floatarray containing the
      concatenation of the floatarrays [v1] and [v2].
-
-     Raise [Invalid_argument] if
+   @raise Invalid_argument if
      [length v1 + length v2 > Sys.max_floatarray_length]. *)
 
   val concat : t list -> t
@@ -442,8 +436,7 @@ module Array : sig
   (** [sub a start len] returns a fresh floatarray of length [len],
      containing the elements number [start] to [start + len - 1]
      of floatarray [a].
-
-     Raise [Invalid_argument] if [start] and [len] do not
+   @raise Invalid_argument if [start] and [len] do not
      designate a valid subarray of [a]; that is, if
      [start < 0], or [len < 0], or [start + len > length a]. *)
 
@@ -454,8 +447,7 @@ module Array : sig
   val fill : t -> int -> int -> float -> unit
   (** [fill a ofs len x] modifies the floatarray [a] in place,
      storing [x] in elements number [ofs] to [ofs + len - 1].
-
-     Raise [Invalid_argument] if [ofs] and [len] do not
+   @raise Invalid_argument if [ofs] and [len] do not
      designate a valid subarray of [a]. *)
 
   val blit : t -> int -> t -> int -> int -> unit
@@ -464,8 +456,7 @@ module Array : sig
       starting at element number [o2]. It works correctly even if
       [v1] and [v2] are the same floatarray, and the source and
       destination chunks overlap.
-
-      Raise [Invalid_argument] if [o1] and [len] do not
+   @raise Invalid_argument if [o1] and [len] do not
       designate a valid subarray of [v1], or if [o2] and [len] do not
       designate a valid subarray of [v2]. *)
 
@@ -475,8 +466,7 @@ module Array : sig
   val of_list : float list -> t
   (** [of_list l] returns a fresh floatarray containing the elements
       of [l].
-
-      Raise [Invalid_argument] if the length of [l] is greater than
+   @raise Invalid_argument if the length of [l] is greater than
       [Sys.max_floatarray_length].*)
 
   (** {2 Iterators} *)
@@ -515,13 +505,13 @@ module Array : sig
   val iter2 : (float -> float -> unit) -> t -> t -> unit
   (** [Array.iter2 f a b] applies function [f] to all the elements of [a]
       and [b].
-      Raise [Invalid_argument] if the floatarrays are not the same size. *)
+   @raise Invalid_argument if the floatarrays are not the same size. *)
 
   val map2 : (float -> float -> float) -> t -> t -> t
   (** [map2 f a b] applies function [f] to all the elements of [a]
       and [b], and builds a floatarray with the results returned by [f]:
       [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
-      Raise [Invalid_argument] if the floatarrays are not the same size. *)
+   @raise Invalid_argument if the floatarrays are not the same size. *)
 
   (** {2 Array scanning} *)
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -437,8 +437,8 @@ module Array : sig
       containing the elements number [start] to [start + len - 1]
       of floatarray [a].
       @raise Invalid_argument if [start] and [len] do not
-     designate a valid subarray of [a]; that is, if
-     [start < 0], or [len < 0], or [start + len > length a]. *)
+      designate a valid subarray of [a]; that is, if
+      [start < 0], or [len < 0], or [start + len > length a]. *)
 
   val copy : t -> t
   (** [copy a] returns a copy of [a], that is, a fresh floatarray
@@ -448,7 +448,7 @@ module Array : sig
   (** [fill a ofs len x] modifies the floatarray [a] in place,
       storing [x] in elements number [ofs] to [ofs + len - 1].
       @raise Invalid_argument if [ofs] and [len] do not
-     designate a valid subarray of [a]. *)
+      designate a valid subarray of [a]. *)
 
   val blit : t -> int -> t -> int -> int -> unit
   (** [blit v1 o1 v2 o2 len] copies [len] elements

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -157,7 +157,7 @@ external of_string : string -> float = "caml_float_of_string"
     and is ignored.
     Depending on the execution platforms, other representations of
     floating-point numbers can be accepted, but should not be relied upon.
-    Raise [Failure "float_of_string"] if the given string is not a valid
+    @raise Failure if the given string is not a valid
     representation of a float. *)
 
 val of_string_opt: string -> float option

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -308,7 +308,7 @@ external get_minor_free : unit -> int = "caml_get_minor_free"
 external get_bucket : int -> int = "caml_get_major_bucket" [@@noalloc]
 (** [get_bucket n] returns the current size of the [n]-th future bucket
     of the GC smoothing system. The unit is one millionth of a full GC.
-    Raise [Invalid_argument] if [n] is negative, return 0 if n is larger
+   @raise Invalid_argument if [n] is negative, return 0 if n is larger
     than the smoothing window.
 
     @since 4.03.0 *)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -308,7 +308,7 @@ external get_minor_free : unit -> int = "caml_get_minor_free"
 external get_bucket : int -> int = "caml_get_major_bucket" [@@noalloc]
 (** [get_bucket n] returns the current size of the [n]-th future bucket
     of the GC smoothing system. The unit is one millionth of a full GC.
-   @raise Invalid_argument if [n] is negative, return 0 if n is larger
+    @raise Invalid_argument if [n] is negative, return 0 if n is larger
     than the smoothing window.
 
     @since 4.03.0 *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -56,7 +56,8 @@ external mul : int32 -> int32 -> int32 = "%int32_mul"
 (** Multiplication. *)
 
 external div : int32 -> int32 -> int32 = "%int32_div"
-(** Integer division.  Raise [Division_by_zero] if the second
+(** Integer division.
+   @raise Division_by_zero if the second
    argument is zero.  This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}. *)
 
@@ -167,7 +168,7 @@ external of_string : string -> int32 = "caml_int32_of_string"
 
    The [_] (underscore) character can appear anywhere in the string
    and is ignored.
-   Raise [Failure "Int32.of_string"] if the given string is not
+   @raise Failure if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int32]. *)
 

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -56,10 +56,10 @@ external mul : int32 -> int32 -> int32 = "%int32_mul"
 (** Multiplication. *)
 
 external div : int32 -> int32 -> int32 = "%int32_div"
-(** Integer division.
+(** Integer division. This division rounds the real quotient of
+   its arguments towards zero, as specified for {!Stdlib.(/)}.
    @raise Division_by_zero if the second
-   argument is zero.  This division rounds the real quotient of
-   its arguments towards zero, as specified for {!Stdlib.(/)}. *)
+   argument is zero.  *)
 
 val unsigned_div : int32 -> int32 -> int32
 (** Same as {!div}, except that arguments and result are interpreted as {e

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -56,7 +56,8 @@ external mul : int64 -> int64 -> int64 = "%int64_mul"
 (** Multiplication. *)
 
 external div : int64 -> int64 -> int64 = "%int64_div"
-(** Integer division.  Raise [Division_by_zero] if the second
+(** Integer division.
+   @raise Division_by_zero if the second
    argument is zero.  This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}. *)
 
@@ -187,7 +188,7 @@ external of_string : string -> int64 = "caml_int64_of_string"
 
    The [_] (underscore) character can appear anywhere in the string
    and is ignored.
-   Raise [Failure "Int64.of_string"] if the given string is not
+   @raise Failure if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int64]. *)
 

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -71,10 +71,11 @@ val force_val : 'a t -> 'a
 (** [force_val x] forces the suspension [x] and returns its
     result.  If [x] has already been forced, [force_val x]
     returns the same value again without recomputing it.
-    @raise Undefined if the forcing of [x] tries to force [x] itself
-    recursively.
+
     If the computation of [x] raises an exception, it is unspecified
     whether [force_val x] raises the same exception or {!Undefined}.
+    @raise Undefined if the forcing of [x] tries to force [x] itself
+    recursively.
 *)
 
 val from_fun : (unit -> 'a) -> 'a t

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -63,7 +63,7 @@ external force : 'a t -> 'a = "%lazy_force"
    If [x] has already been forced, [Lazy.force x] returns the
    same value again without recomputing it.  If it raised an exception,
    the same exception is raised again.
-   Raise {!Undefined} if the forcing of [x] tries to force [x] itself
+   @raise Undefined if the forcing of [x] tries to force [x] itself
    recursively.
 *)
 
@@ -71,7 +71,7 @@ val force_val : 'a t -> 'a
 (** [force_val x] forces the suspension [x] and returns its
     result.  If [x] has already been forced, [force_val x]
     returns the same value again without recomputing it.
-    Raise {!Undefined} if the forcing of [x] tries to force [x] itself
+    @raise Undefined if the forcing of [x] tries to force [x] itself
     recursively.
     If the computation of [x] raises an exception, it is unspecified
     whether [force_val x] raises the same exception or {!Undefined}.

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -169,13 +169,13 @@ val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
 val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths. *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths.  Not tail-recursive. *)
 
 val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
@@ -186,13 +186,13 @@ val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
 (** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths. *)
 
 val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
 (** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths.  Not tail-recursive. *)
 
 
@@ -213,12 +213,12 @@ val exists : ('a -> bool) -> 'a list -> bool
 
 val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths. *)
 
 val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.exists}, but for a two-argument predicate.
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths. *)
 
 val mem : 'a -> 'a list -> bool
@@ -236,7 +236,7 @@ val memq : 'a -> 'a list -> bool
 val find : ('a -> bool) -> 'a list -> 'a
 (** [find p l] returns the first element of the list [l]
    that satisfies the predicate [p].
-   @raise [Not_found] if there is no value that satisfies [p] in the
+   @raise Not_found if there is no value that satisfies [p] in the
    list [l]. *)
 
 val find_opt: ('a -> bool) -> 'a list -> 'a option
@@ -283,7 +283,7 @@ val assoc : 'a -> ('a * 'b) list -> 'b
    pairs [l]. That is,
    [assoc a [ ...; (a,b); ...] = b]
    if [(a,b)] is the leftmost binding of [a] in list [l].
-   @raise [Not_found] if there is no value associated with [a] in the
+   @raise Not_found if there is no value associated with [a] in the
    list [l]. *)
 
 val assoc_opt: 'a -> ('a * 'b) list -> 'b option
@@ -335,7 +335,7 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
-   @raise [Invalid_argument] if the two lists
+   @raise Invalid_argument if the two lists
    have different lengths.  Not tail-recursive. *)
 
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -53,7 +53,7 @@ val cons : 'a -> 'a list -> 'a list
 
 val hd : 'a list -> 'a
 (** Return the first element of the given list.
-   @raise Failure if the list is empty. *)
+    @raise Failure if the list is empty. *)
 
 val tl : 'a list -> 'a list
 (** Return the given list without its first element.

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -52,24 +52,24 @@ val cons : 'a -> 'a list -> 'a list
 *)
 
 val hd : 'a list -> 'a
-(** Return the first element of the given list. Raise
-   [Failure "hd"] if the list is empty. *)
+(** Return the first element of the given list.
+   @raise Failure ["hd"] if the list is empty. *)
 
 val tl : 'a list -> 'a list
-(** Return the given list without its first element. Raise
-    [Failure "tl"] if the list is empty. *)
+(** Return the given list without its first element.
+    @raise Failure ["tl"] if the list is empty. *)
 
 val nth: 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
-   Raise [Failure "nth"] if the list is too short.
-   Raise [Invalid_argument "List.nth"] if [n] is negative. *)
+   @raise Failure ["nth"] if the list is too short.
+   @raise Invalid_argument ["List.nth"] if [n] is negative. *)
 
 val nth_opt: 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
-    Raise [Invalid_argument "List.nth"] if [n] is negative.
+    @raise Invalid_argument ["List.nth"] if [n] is negative.
     @since 4.05
 *)
 
@@ -169,13 +169,13 @@ val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
 val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
-   Raise [Invalid_argument] if the two lists are determined
+   @raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
-   Raise [Invalid_argument] if the two lists are determined
+   @raise [Invalid_argument] if the two lists are determined
    to have different lengths.  Not tail-recursive. *)
 
 val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
@@ -186,13 +186,13 @@ val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
 (** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
-   Raise [Invalid_argument] if the two lists are determined
+   @raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
 (** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
-   Raise [Invalid_argument] if the two lists are determined
+   @raise [Invalid_argument] if the two lists are determined
    to have different lengths.  Not tail-recursive. *)
 
 
@@ -213,12 +213,12 @@ val exists : ('a -> bool) -> 'a list -> bool
 
 val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists are determined
+   @raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists are determined
+   @raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val mem : 'a -> 'a list -> bool
@@ -236,7 +236,7 @@ val memq : 'a -> 'a list -> bool
 val find : ('a -> bool) -> 'a list -> 'a
 (** [find p l] returns the first element of the list [l]
    that satisfies the predicate [p].
-   Raise [Not_found] if there is no value that satisfies [p] in the
+   @raise [Not_found] if there is no value that satisfies [p] in the
    list [l]. *)
 
 val find_opt: ('a -> bool) -> 'a list -> 'a option
@@ -283,7 +283,7 @@ val assoc : 'a -> ('a * 'b) list -> 'b
    pairs [l]. That is,
    [assoc a [ ...; (a,b); ...] = b]
    if [(a,b)] is the leftmost binding of [a] in list [l].
-   Raise [Not_found] if there is no value associated with [a] in the
+   @raise [Not_found] if there is no value associated with [a] in the
    list [l]. *)
 
 val assoc_opt: 'a -> ('a * 'b) list -> 'b option
@@ -335,7 +335,7 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
-   Raise [Invalid_argument] if the two lists
+   @raise [Invalid_argument] if the two lists
    have different lengths.  Not tail-recursive. *)
 
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -53,23 +53,23 @@ val cons : 'a -> 'a list -> 'a list
 
 val hd : 'a list -> 'a
 (** Return the first element of the given list.
-   @raise Failure ["hd"] if the list is empty. *)
+   @raise Failure if the list is empty. *)
 
 val tl : 'a list -> 'a list
 (** Return the given list without its first element.
-    @raise Failure ["tl"] if the list is empty. *)
+    @raise Failure if the list is empty. *)
 
 val nth: 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
-   @raise Failure ["nth"] if the list is too short.
-   @raise Invalid_argument ["List.nth"] if [n] is negative. *)
+   @raise Failure if the list is too short.
+   @raise Invalid_argument if [n] is negative. *)
 
 val nth_opt: 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
-    @raise Invalid_argument ["List.nth"] if [n] is negative.
+    @raise Invalid_argument if [n] is negative.
     @since 4.05
 *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -14,7 +14,8 @@
 (**************************************************************************)
 
 type 'a t = 'a list = [] | (::) of 'a * 'a list (**)
-(** An alias for the type of lists. *)
+(** An alias for the type of lists.
+ *)
 
 (** List operations.
 
@@ -36,14 +37,17 @@ type 'a t = 'a list = [] | (::) of 'a * 'a list (**)
       open StdLabels
 
       let seq len = List.init ~f:(function i -> i) ~len
-   ]} *)
+   ]}
+ *)
 
 val length : 'a list -> int
-(** Return the length (number of elements) of the given list. *)
+(** Return the length (number of elements) of the given list.
+ *)
 
 val hd : 'a list -> 'a
-(** Return the first element of the given list. Raise
-   [Failure "hd"] if the list is empty. *)
+(** Return the first element of the given list.
+   @raise [Failure "hd"] if the list is empty.
+ *)
 
 val compare_lengths : 'a list -> 'b list -> int
 (** Compare the lengths of two lists. [compare_lengths l1 l2] is
@@ -57,60 +61,66 @@ val compare_length_with : 'a list -> len:int -> int
    equivalent to [compare (length l) n], except that
    the computation stops after at most [n] iterations on the list.
    @since 4.05.0
-*)
+ *)
 
 val cons : 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
     @since 4.05.0
-*)
+ *)
 
 val tl : 'a list -> 'a list
-(** Return the given list without its first element. Raise
-   [Failure "tl"] if the list is empty. *)
+(** Return the given list without its first element.
+   @raise [Failure "tl"] if the list is empty.
+ *)
 
 val nth : 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
-   Raise [Failure "nth"] if the list is too short.
-   Raise [Invalid_argument "List.nth"] if [n] is negative. *)
+   @raise [Failure "nth"] if the list is too short.
+   @raise [Invalid_argument "List.nth"] if [n] is negative.
+ *)
 
 val nth_opt: 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
-    Raise [Invalid_argument "List.nth"] if [n] is negative.
+    @raise [Invalid_argument "List.nth"] if [n] is negative.
     @since 4.05
-*)
+ *)
 
 val rev : 'a list -> 'a list
-(** List reversal. *)
+(** List reversal.
+ *)
 
 val init : len:int -> f:(int -> 'a) -> 'a list
 (** [List.init len f] is [f 0; f 1; ...; f (len-1)], evaluated left to right.
-
     @raise Invalid_argument if [len < 0].
     @since 4.06.0
-*)
+ *)
 
 val append : 'a list -> 'a list -> 'a list
-(** Catenate two lists.  Same function as the infix operator [@].
-   Not tail-recursive (length of the first argument).  The [@]
-   operator is not tail-recursive either. *)
+(** Catenate two lists. Same function as the infix operator [@].
+   Not tail-recursive (length of the first argument). The [@]
+   operator is not tail-recursive either.
+ *)
 
 val rev_append : 'a list -> 'a list -> 'a list
 (** [List.rev_append l1 l2] reverses [l1] and concatenates it with [l2].
    This is equivalent to [(]{!List.rev}[ l1) @ l2], but [rev_append] is
-   tail-recursive and more efficient. *)
+   tail-recursive and more efficient.
+ *)
 
 val concat : 'a list list -> 'a list
-(** Concatenate a list of lists.  The elements of the argument are all
+(** Concatenate a list of lists. The elements of the argument are all
    concatenated together (in the same order) to give the result.
    Not tail-recursive
-   (length of the argument + length of the longest sub-list). *)
+   (length of the argument + length of the longest sub-list).
+ *)
 
 val flatten : 'a list list -> 'a list
-(** Same as [concat].  Not tail-recursive
-   (length of the argument + length of the longest sub-list). *)
+(** Same as [concat]. Not tail-recursive
+   (length of the argument + length of the longest sub-list).
+ *)
 
 
 (** {1 Iterators} *)
@@ -119,38 +129,41 @@ val flatten : 'a list list -> 'a list
 val iter : f:('a -> unit) -> 'a list -> unit
 (** [List.iter f [a1; ...; an]] applies function [f] in turn to
    [a1; ...; an]. It is equivalent to
-   [begin f a1; f a2; ...; f an; () end]. *)
+   [begin f a1; f a2; ...; f an; () end].
+ *)
 
 val iteri : f:(int -> 'a -> unit) -> 'a list -> unit
 (** Same as {!List.iter}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00.0
-*)
+ *)
 
 val map : f:('a -> 'b) -> 'a list -> 'b list
 (** [List.map f [a1; ...; an]] applies function [f] to [a1, ..., an],
    and builds the list [[f a1; ...; f an]]
-   with the results returned by [f].  Not tail-recursive. *)
+   with the results returned by [f]. Not tail-recursive.
+ *)
 
 val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!List.map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00.0
-*)
+ *)
 
 val rev_map : f:('a -> 'b) -> 'a list -> 'b list
 (** [List.rev_map f l] gives the same result as
    {!List.rev}[ (]{!List.map}[ f l)], but is tail-recursive and
-   more efficient. *)
+   more efficient.
+ *)
 
 val filter_map : f:('a -> 'b option) -> 'a list -> 'b list
 (** [filter_map f l] applies [f] to every element of [l], filters
     out the [None] elements and returns the list of the arguments of
     the [Some] elements.
     @since 4.08.0
-*)
+ *)
 
 val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
 (** [List.concat_map f l] gives the same result as
@@ -168,11 +181,13 @@ val fold_left_map :
 
 val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b list -> 'a
 (** [List.fold_left f a [b1; ...; bn]] is
-   [f (... (f (f a b1) b2) ...) bn]. *)
+   [f (... (f (f a b1) b2) ...) bn].
+ *)
 
 val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
 (** [List.fold_right f [a1; ...; an] b] is
-   [f a1 (f a2 (... (f an b) ...))].  Not tail-recursive. *)
+   [f a1 (f a2 (... (f an b) ...))]. Not tail-recursive.
+ *)
 
 
 (** {1 Iterators on two lists} *)
@@ -181,33 +196,38 @@ val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
 val iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
-   Raise [Invalid_argument] if the two lists are determined
-   to have different lengths. *)
+   @raise [Invalid_argument] if the two lists are determined
+   to have different lengths.
+ *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
-   Raise [Invalid_argument] if the two lists are determined
-   to have different lengths.  Not tail-recursive. *)
+   @raise [Invalid_argument] if the two lists are determined
+   to have different lengths. Not tail-recursive.
+ *)
 
 val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.rev_map2 f l1 l2] gives the same result as
    {!List.rev}[ (]{!List.map2}[ f l1 l2)], but is tail-recursive and
-   more efficient. *)
+   more efficient.
+ *)
 
 val fold_left2 :
   f:('a -> 'b -> 'c -> 'a) -> init:'a -> 'b list -> 'c list -> 'a
 (** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
-   Raise [Invalid_argument] if the two lists are determined
-   to have different lengths. *)
+   @raise [Invalid_argument] if the two lists are determined
+   to have different lengths.
+ *)
 
 val fold_right2 :
   f:('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> init:'c -> 'c
 (** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
-   Raise [Invalid_argument] if the two lists are determined
-   to have different lengths.  Not tail-recursive. *)
+   @raise [Invalid_argument] if the two lists are determined
+   to have different lengths. Not tail-recursive.
+ *)
 
 
 (** {1 List scanning} *)
@@ -216,30 +236,36 @@ val fold_right2 :
 val for_all : f:('a -> bool) -> 'a list -> bool
 (** [for_all p [a1; ...; an]] checks if all elements of the list
    satisfy the predicate [p]. That is, it returns
-   [(p a1) && (p a2) && ... && (p an)]. *)
+   [(p a1) && (p a2) && ... && (p an)].
+ *)
 
 val exists : f:('a -> bool) -> 'a list -> bool
 (** [exists p [a1; ...; an]] checks if at least one element of
    the list satisfies the predicate [p]. That is, it returns
-   [(p a1) || (p a2) || ... || (p an)]. *)
+   [(p a1) || (p a2) || ... || (p an)].
+ *)
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists are determined
-   to have different lengths. *)
+   @raise [Invalid_argument] if the two lists are determined
+   to have different lengths.
+ *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists are determined
-   to have different lengths. *)
+   @raise [Invalid_argument] if the two lists are determined
+   to have different lengths.
+ *)
 
 val mem : 'a -> set:'a list -> bool
 (** [mem a l] is true if and only if [a] is equal
-   to an element of [l]. *)
+   to an element of [l].
+ *)
 
 val memq : 'a -> set:'a list -> bool
 (** Same as {!List.mem}, but uses physical equality instead of structural
-   equality to compare list elements. *)
+   equality to compare list elements.
+ *)
 
 
 (** {1 List searching} *)
@@ -248,15 +274,17 @@ val memq : 'a -> set:'a list -> bool
 val find : f:('a -> bool) -> 'a list -> 'a
 (** [find p l] returns the first element of the list [l]
    that satisfies the predicate [p].
-   Raise [Not_found] if there is no value that satisfies [p] in the
-   list [l]. *)
+   @raise [Not_found] if there is no value that satisfies [p] in the
+   list [l].
+ *)
 
 val find_opt: f:('a -> bool) -> 'a list -> 'a option
 (** [find p l] returns the first element of the list [l]
    that satisfies the predicate [p].
    Returns [None] if there is no value that satisfies [p] in the
    list [l].
-   @since 4.05 *)
+   @since 4.05
+ *)
 
 val find_map: f:('a -> 'b option) -> 'a list -> 'b option
 (** [find_map f l] applies [f] to the elements of [l] in order,
@@ -267,11 +295,13 @@ val find_map: f:('a -> 'b option) -> 'a list -> 'b option
 
 val filter : f:('a -> bool) -> 'a list -> 'a list
 (** [filter p l] returns all the elements of the list [l]
-   that satisfy the predicate [p].  The order of the elements
-   in the input list is preserved.  *)
+   that satisfy the predicate [p]. The order of the elements
+   in the input list is preserved.
+ *)
 
 val find_all : f:('a -> bool) -> 'a list -> 'a list
-(** [find_all] is another name for {!List.filter}. *)
+(** [find_all] is another name for {!List.filter}.
+ *)
 
 val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
 (** Same as {!List.filter}, but the predicate is applied to the index of
@@ -285,7 +315,8 @@ val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
    [l1] is the list of all the elements of [l] that
    satisfy the predicate [p], and [l2] is the list of all the
    elements of [l] that do not satisfy [p].
-   The order of the elements in the input list is preserved. *)
+   The order of the elements in the input list is preserved.
+ *)
 
 
 (** {1 Association lists} *)
@@ -296,8 +327,9 @@ val assoc : 'a -> ('a * 'b) list -> 'b
    pairs [l]. That is,
    [assoc a [ ...; (a,b); ...] = b]
    if [(a,b)] is the leftmost binding of [a] in list [l].
-   Raise [Not_found] if there is no value associated with [a] in the
-   list [l]. *)
+   @raise [Not_found] if there is no value associated with [a] in the
+   list [l].
+ *)
 
 val assoc_opt: 'a -> ('a * 'b) list -> 'b option
 (** [assoc_opt a l] returns the value associated with key [a] in the list of
@@ -307,33 +339,39 @@ val assoc_opt: 'a -> ('a * 'b) list -> 'b option
     Returns [None] if there is no value associated with [a] in the
     list [l].
     @since 4.05
-*)
+ *)
 
 val assq : 'a -> ('a * 'b) list -> 'b
 (** Same as {!List.assoc}, but uses physical equality instead of
-   structural equality to compare keys. *)
+   structural equality to compare keys.
+ *)
 
 val assq_opt: 'a -> ('a * 'b) list -> 'b option
 (** Same as {!List.assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
-   @since 4.05.0 *)
+   @since 4.05.0
+ *)
 
 val mem_assoc : 'a -> map:('a * 'b) list -> bool
 (** Same as {!List.assoc}, but simply return true if a binding exists,
-   and false if no bindings exist for the given key. *)
+   and false if no bindings exist for the given key.
+ *)
 
 val mem_assq : 'a -> map:('a * 'b) list -> bool
 (** Same as {!List.mem_assoc}, but uses physical equality instead of
-   structural equality to compare keys. *)
+   structural equality to compare keys.
+ *)
 
 val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** [remove_assoc a l] returns the list of
    pairs [l] without the first pair with key [a], if any.
-   Not tail-recursive. *)
+   Not tail-recursive.
+ *)
 
 val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!List.remove_assoc}, but uses physical equality instead
-   of structural equality to compare keys.  Not tail-recursive. *)
+   of structural equality to compare keys. Not tail-recursive.
+ *)
 
 
 (** {1 Lists of pairs} *)
@@ -343,14 +381,15 @@ val split : ('a * 'b) list -> 'a list * 'b list
 (** Transform a list of pairs into a pair of lists:
    [split [(a1,b1); ...; (an,bn)]] is [([a1; ...; an], [b1; ...; bn])].
    Not tail-recursive.
-*)
+ *)
 
 val combine : 'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
-   Raise [Invalid_argument] if the two lists
-   have different lengths.  Not tail-recursive. *)
+   @raise [Invalid_argument] if the two lists
+   have different lengths. Not tail-recursive.
+ *)
 
 
 (** {1 Sorting} *)
@@ -358,10 +397,10 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 
 val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Sort a list in increasing order according to a comparison
-   function.  The comparison function must return 0 if its arguments
+   function. The comparison function must return 0 if its arguments
    compare as equal, a positive integer if the first is greater,
    and a negative integer if the first is smaller (see Array.sort for
-   a complete specification).  For example,
+   a complete specification). For example,
    {!Stdlib.compare} is a suitable comparison function.
    The resulting list is sorted in increasing order.
    [List.sort] is guaranteed to run in constant heap space
@@ -370,7 +409,7 @@ val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 
    The current implementation uses Merge Sort. It runs in constant
    heap space and logarithmic stack space.
-*)
+ *)
 
 val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!List.sort}, but the sorting algorithm is guaranteed to
@@ -379,15 +418,17 @@ val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 
    The current implementation uses Merge Sort. It runs in constant
    heap space and logarithmic stack space.
-*)
+ *)
 
 val fast_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!List.sort} or {!List.stable_sort}, whichever is
-    faster on typical input. *)
+    faster on typical input.
+ *)
 
 val sort_uniq : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!List.sort}, but also remove duplicates.
-    @since 4.03.0 *)
+    @since 4.03.0
+ *)
 
 val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 (** Merge two lists:
@@ -397,14 +438,16 @@ val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
     If several elements compare equal, the elements of [l1] will be
     before the elements of [l2].
     Not tail-recursive (sum of the lengths of the arguments).
-*)
+ *)
 
 (** {1 Iterators} *)
 
 val to_seq : 'a list -> 'a Seq.t
 (** Iterate on the list
-    @since 4.07 *)
+    @since 4.07
+ *)
 
 val of_seq : 'a Seq.t -> 'a list
 (** Create a list from the iterator
-    @since 4.07 *)
+    @since 4.07
+ *)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -76,8 +76,8 @@ val tl : 'a list -> 'a list
 val nth : 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
-   @raise Failure ["nth"] if the list is too short.
-   @raise Invalid_argument ["List.nth"] if [n] is negative.
+   @raise Failure if the list is too short.
+   @raise Invalid_argument if [n] is negative.
  *)
 
 val nth_opt: 'a list -> int -> 'a option

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -46,7 +46,7 @@ val length : 'a list -> int
 
 val hd : 'a list -> 'a
 (** Return the first element of the given list.
-   @raise Failure ["hd"] if the list is empty.
+   @raise Failure if the list is empty.
  *)
 
 val compare_lengths : 'a list -> 'b list -> int
@@ -70,7 +70,7 @@ val cons : 'a -> 'a list -> 'a list
 
 val tl : 'a list -> 'a list
 (** Return the given list without its first element.
-   @raise Failure ["tl"] if the list is empty.
+   @raise Failure if the list is empty.
  *)
 
 val nth : 'a list -> int -> 'a

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -84,7 +84,7 @@ val nth_opt: 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
-    @raise Invalid_argument ["List.nth"] if [n] is negative.
+    @raise Invalid_argument if [n] is negative.
     @since 4.05
  *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -46,7 +46,7 @@ val length : 'a list -> int
 
 val hd : 'a list -> 'a
 (** Return the first element of the given list.
-   @raise [Failure "hd"] if the list is empty.
+   @raise Failure ["hd"] if the list is empty.
  *)
 
 val compare_lengths : 'a list -> 'b list -> int
@@ -70,21 +70,21 @@ val cons : 'a -> 'a list -> 'a list
 
 val tl : 'a list -> 'a list
 (** Return the given list without its first element.
-   @raise [Failure "tl"] if the list is empty.
+   @raise Failure ["tl"] if the list is empty.
  *)
 
 val nth : 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
-   @raise [Failure "nth"] if the list is too short.
-   @raise [Invalid_argument "List.nth"] if [n] is negative.
+   @raise Failure ["nth"] if the list is too short.
+   @raise Invalid_argument ["List.nth"] if [n] is negative.
  *)
 
 val nth_opt: 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
-    @raise [Invalid_argument "List.nth"] if [n] is negative.
+    @raise Invalid_argument ["List.nth"] if [n] is negative.
     @since 4.05
  *)
 
@@ -196,14 +196,14 @@ val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
 val iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths. Not tail-recursive.
  *)
 
@@ -217,7 +217,7 @@ val fold_left2 :
   f:('a -> 'b -> 'c -> 'a) -> init:'a -> 'b list -> 'c list -> 'a
 (** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
@@ -225,7 +225,7 @@ val fold_right2 :
   f:('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> init:'c -> 'c
 (** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths. Not tail-recursive.
  *)
 
@@ -247,13 +247,13 @@ val exists : f:('a -> bool) -> 'a list -> bool
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.exists}, but for a two-argument predicate.
-   @raise [Invalid_argument] if the two lists are determined
+   @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
@@ -274,7 +274,7 @@ val memq : 'a -> set:'a list -> bool
 val find : f:('a -> bool) -> 'a list -> 'a
 (** [find p l] returns the first element of the list [l]
    that satisfies the predicate [p].
-   @raise [Not_found] if there is no value that satisfies [p] in the
+   @raise Not_found if there is no value that satisfies [p] in the
    list [l].
  *)
 
@@ -327,7 +327,7 @@ val assoc : 'a -> ('a * 'b) list -> 'b
    pairs [l]. That is,
    [assoc a [ ...; (a,b); ...] = b]
    if [(a,b)] is the leftmost binding of [a] in list [l].
-   @raise [Not_found] if there is no value associated with [a] in the
+   @raise Not_found if there is no value associated with [a] in the
    list [l].
  *)
 
@@ -387,7 +387,7 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
-   @raise [Invalid_argument] if the two lists
+   @raise Invalid_argument if the two lists
    have different lengths. Not tail-recursive.
  *)
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -59,7 +59,9 @@ external mul : nativeint -> nativeint -> nativeint = "%nativeint_mul"
 (** Multiplication. *)
 
 external div : nativeint -> nativeint -> nativeint = "%nativeint_div"
-(** Integer division.  Raise [Division_by_zero] if the second
+(** Integer division.
+
+   @raise Division_by_zero if the second
    argument is zero.  This division rounds the real quotient of
    its arguments towards zero, as specified for {!Stdlib.(/)}. *)
 
@@ -193,7 +195,7 @@ external of_string : string -> nativeint = "caml_nativeint_of_string"
    it is converted to the signed integer
    [Int64.min_int + input - Nativeint.max_int - 1].
 
-   Raise [Failure "Nativeint.of_string"] if the given string is not
+   @raise Failure if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [nativeint]. *)
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -59,11 +59,11 @@ external mul : nativeint -> nativeint -> nativeint = "%nativeint_mul"
 (** Multiplication. *)
 
 external div : nativeint -> nativeint -> nativeint = "%nativeint_div"
-(** Integer division.
+(** Integer division. This division rounds the real quotient of
+   its arguments towards zero, as specified for {!Stdlib.(/)}.
 
    @raise Division_by_zero if the second
-   argument is zero.  This division rounds the real quotient of
-   its arguments towards zero, as specified for {!Stdlib.(/)}. *)
+   argument is zero. *)
 
 val unsigned_div : nativeint -> nativeint -> nativeint
 (** Same as {!div}, except that arguments and result are interpreted as {e

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -314,7 +314,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
     - [c]: reads a single character. To test the current input character
       without reading it, specify a null field width, i.e. use
       specification [%0c].
-   @raise Invalid_argument, if the field width
+    - Raise [Invalid_argument], if the field width
       specification is greater than 1.
     - [C]: reads a single delimited character (delimiters and special
       escaped characters follow the lexical conventions of OCaml).
@@ -451,15 +451,12 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 
     - Raise {!Scanf.Scan_failure} if the input does not match the format.
 
-    -
-   @raise Failure if a conversion to a number is not possible.
+    - Raise [Failure] if a conversion to a number is not possible.
 
-    -
-   @raise End_of_file if the end of input is encountered while some more
+    - Raise [End_of_file] if the end of input is encountered while some more
       characters are needed to read the current conversion specification.
 
-    -
-   @raise Invalid_argument if the format string is invalid.
+    - Raise [Invalid_argument] if the format string is invalid.
 
     Note:
 

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -448,7 +448,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 (** Scanners may raise the following exceptions when the input cannot be read
     according to the format string:
 
-    - Raise [Scan_failure] if the input does not match the format.
+    - Raise {!Scanf.Scan_failure} if the input does not match the format.
 
     - Raise [Failure] if a conversion to a number is not possible.
 

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -449,7 +449,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 (** Scanners may raise the following exceptions when the input cannot be read
     according to the format string:
 
-    - Raise {!Scanf.Scan_failure} if the input does not match the format.
+    - Raise [Scan_failure] if the input does not match the format.
 
     - Raise [Failure] if a conversion to a number is not possible.
 
@@ -499,7 +499,7 @@ val bscanf_format :
 (** [bscanf_format ic fmt f] reads a format string token from the formatted
     input channel [ic], according to the given format string [fmt], and
     applies [f] to the resulting format string value.
-    Raise {!Scan_failure} if the format string value read does not have the
+    @raise Scan_failure if the format string value read does not have the
     same type as [fmt].
     @since 3.09.0
 *)
@@ -516,7 +516,7 @@ val format_from_string :
     ('a, 'b, 'c, 'd, 'e, 'f) format6 -> ('a, 'b, 'c, 'd, 'e, 'f) format6
 (** [format_from_string s fmt] converts a string argument to a format string,
     according to the given format string [fmt].
-    Raise {!Scan_failure} if [s], considered as a format string, does not
+    @raise Scan_failure if [s], considered as a format string, does not
     have the same type as [fmt].
     @since 3.10.0
 *)
@@ -530,7 +530,7 @@ val unescaped : string -> string
 
     Always return a copy of the argument, even if there is no escape sequence
     in the argument.
-    Raise {!Scan_failure} if [s] is not properly escaped (i.e. [s] has invalid
+    @raise Scan_failure if [s] is not properly escaped (i.e. [s] has invalid
     escape sequences or special characters that are not properly escaped).
     For instance, [Scanf.unescaped "\""] will fail.
     @since 4.00.0

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -313,8 +313,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
       escaped characters follow the lexical conventions of OCaml).
     - [c]: reads a single character. To test the current input character
       without reading it, specify a null field width, i.e. use
-      specification [%0c].
-    - Raise [Invalid_argument], if the field width
+      specification [%0c]. Raise [Invalid_argument], if the field width
       specification is greater than 1.
     - [C]: reads a single delimited character (delimiters and special
       escaped characters follow the lexical conventions of OCaml).

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -313,7 +313,8 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
       escaped characters follow the lexical conventions of OCaml).
     - [c]: reads a single character. To test the current input character
       without reading it, specify a null field width, i.e. use
-      specification [%0c]. Raise [Invalid_argument], if the field width
+      specification [%0c].
+   @raise Invalid_argument, if the field width
       specification is greater than 1.
     - [C]: reads a single delimited character (delimiters and special
       escaped characters follow the lexical conventions of OCaml).
@@ -450,12 +451,15 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 
     - Raise {!Scanf.Scan_failure} if the input does not match the format.
 
-    - Raise [Failure] if a conversion to a number is not possible.
+    -
+   @raise Failure if a conversion to a number is not possible.
 
-    - Raise [End_of_file] if the end of input is encountered while some more
+    -
+   @raise End_of_file if the end of input is encountered while some more
       characters are needed to read the current conversion specification.
 
-    - Raise [Invalid_argument] if the format string is invalid.
+    -
+   @raise Invalid_argument if the format string is invalid.
 
     Note:
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -361,7 +361,7 @@ external ( * ) : int -> int -> int = "%mulint"
 
 external ( / ) : int -> int -> int = "%divint"
 (** Integer division.
-   Raise [Division_by_zero] if the second argument is 0.
+   @raise Division_by_zero if the second argument is 0.
    Integer division rounds the real quotient of its arguments towards zero.
    More precisely, if [x >= 0] and [y > 0], [x / y] is the greatest integer
    less than or equal to the real quotient of [x] by [y].  Moreover,
@@ -376,7 +376,7 @@ external ( mod ) : int -> int -> int = "%modint"
    [abs(x mod y) <= abs(y) - 1].
    If [y = 0], [x mod y] raises [Division_by_zero].
    Note that [x mod y] is negative only if [x < 0].
-   Raise [Division_by_zero] if [y] is zero.
+   @raise Division_by_zero if [y] is zero.
    Left-associative operator, see {!Ocaml_operators} for more information.
 *)
 
@@ -1046,13 +1046,13 @@ val open_in_gen : open_flag list -> int -> string -> in_channel
 
 val input_char : in_channel -> char
 (** Read one character from the given input channel.
-   Raise [End_of_file] if there are no more characters to read. *)
+   @raise End_of_file if there are no more characters to read. *)
 
 val input_line : in_channel -> string
 (** Read characters from the given input channel, until a
    newline character is encountered. Return the string of
    all characters read, without the newline character at the end.
-   Raise [End_of_file] if the end of the file is reached
+   @raise End_of_file if the end of the file is reached
    at the beginning of line. *)
 
 val input : in_channel -> bytes -> int -> int -> int
@@ -1075,7 +1075,7 @@ val input : in_channel -> bytes -> int -> int -> int
 val really_input : in_channel -> bytes -> int -> int -> unit
 (** [really_input ic buf pos len] reads [len] characters from channel [ic],
    storing them in byte sequence [buf], starting at character number [pos].
-   Raise [End_of_file] if the end of file is reached before [len]
+   @raise End_of_file if the end of file is reached before [len]
    characters have been read.
    Raise [Invalid_argument "really_input"] if
    [pos] and [len] do not designate a valid range of [buf]. *)
@@ -1083,19 +1083,19 @@ val really_input : in_channel -> bytes -> int -> int -> unit
 val really_input_string : in_channel -> int -> string
 (** [really_input_string ic len] reads [len] characters from channel [ic]
    and returns them in a new string.
-   Raise [End_of_file] if the end of file is reached before [len]
+   @raise End_of_file if the end of file is reached before [len]
    characters have been read.
    @since 4.02.0 *)
 
 val input_byte : in_channel -> int
 (** Same as {!Stdlib.input_char}, but return the 8-bit integer representing
    the character.
-   Raise [End_of_file] if an end of file was reached. *)
+   @raise End_of_file if an end of file was reached. *)
 
 val input_binary_int : in_channel -> int
 (** Read an integer encoded in binary format (4 bytes, big-endian)
    from the given input channel. See {!Stdlib.output_binary_int}.
-   Raise [End_of_file] if an end of file was reached while reading the
+   @raise End_of_file if an end of file was reached while reading the
    integer. *)
 
 val input_value : in_channel -> 'a

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -682,7 +682,7 @@ external int_of_char : char -> int = "%identity"
 
 val char_of_int : int -> char
 (** Return the character with the given ASCII code.
-   Raise [Invalid_argument "char_of_int"] if the argument is
+   @raise Invalid_argument if the argument is
    outside the range 0--255. *)
 
 
@@ -958,7 +958,7 @@ val output_bytes : out_channel -> bytes -> unit
 val output : out_channel -> bytes -> int -> int -> unit
 (** [output oc buf pos len] writes [len] characters from byte sequence [buf],
    starting at offset [pos], to the given output channel [oc].
-   Raise [Invalid_argument "output"] if [pos] and [len] do not
+   @raise Invalid_argument if [pos] and [len] do not
    designate a valid range of [buf]. *)
 
 val output_substring : out_channel -> string -> int -> int -> unit
@@ -1077,7 +1077,7 @@ val really_input : in_channel -> bytes -> int -> int -> unit
    storing them in byte sequence [buf], starting at character number [pos].
    @raise End_of_file if the end of file is reached before [len]
    characters have been read.
-   Raise [Invalid_argument "really_input"] if
+   @raise Invalid_argument if
    [pos] and [len] do not designate a valid range of [buf]. *)
 
 val really_input_string : in_channel -> int -> string

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -361,12 +361,13 @@ external ( * ) : int -> int -> int = "%mulint"
 
 external ( / ) : int -> int -> int = "%divint"
 (** Integer division.
-   @raise Division_by_zero if the second argument is 0.
    Integer division rounds the real quotient of its arguments towards zero.
    More precisely, if [x >= 0] and [y > 0], [x / y] is the greatest integer
    less than or equal to the real quotient of [x] by [y].  Moreover,
    [(- x) / y = x / (- y) = - (x / y)].
    Left-associative operator, see {!Ocaml_operators} for more information.
+
+   @raise Division_by_zero if the second argument is 0.
 *)
 
 external ( mod ) : int -> int -> int = "%modint"
@@ -376,8 +377,9 @@ external ( mod ) : int -> int -> int = "%modint"
    [abs(x mod y) <= abs(y) - 1].
    If [y = 0], [x mod y] raises [Division_by_zero].
    Note that [x mod y] is negative only if [x < 0].
-   @raise Division_by_zero if [y] is zero.
    Left-associative operator, see {!Ocaml_operators} for more information.
+
+   @raise Division_by_zero if [y] is zero.
 *)
 
 val abs : int -> int

--- a/stdlib/stream.mli
+++ b/stdlib/stream.mli
@@ -67,7 +67,8 @@ val iter : ('a -> unit) -> 'a t -> unit
 
 val next : 'a t -> 'a
 (** Return the first element of the stream and remove it from the
-   stream. Raise {!Stream.Failure} if the stream is empty. *)
+   stream.
+   @raise Stream.Failure if the stream is empty. *)
 
 val empty : 'a t -> unit
 (** Return [()] if the stream is empty, else raise {!Stream.Failure}. *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -81,8 +81,8 @@ val init : int -> (int -> char) -> string
 (** [String.init n f] returns a string of length [n], with character
     [i] initialized to the result of [f i] (called in increasing
     index order).
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
 
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
     @since 4.02.0
 *)
 
@@ -114,7 +114,7 @@ val blit : string -> int -> bytes -> int -> int -> unit
 val concat : string -> string list -> string
 (** [String.concat sep sl] concatenates the list of strings [sl],
     inserting the separator string [sep] between each.
-   @raise Invalid_argument if the result is longer than
+    @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val iter : (char -> unit) -> string -> unit
@@ -157,7 +157,7 @@ val escaped : string -> string
 
     If there is no special character in the argument that needs
     escaping, return the original string itself, not a copy.
-   @raise Invalid_argument if the result is longer than
+    @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
@@ -199,7 +199,7 @@ val index_from_opt: string -> int -> char -> int option
     or [None] if [c] does not occur in [s] after position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
+    @raise Invalid_argument if [i] is not a valid position in [s].
 
     @since 4.05
 *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -52,8 +52,7 @@ external length : string -> int = "%string_length"
 external get : string -> int -> char = "%string_safe_get"
 (** [String.get s n] returns the character at index [n] in string [s].
    You can also write [s.[n]] instead of [String.get s n].
-
-   Raise [Invalid_argument] if [n] not a valid index in [s]. *)
+   @raise Invalid_argument if [n] not a valid index in [s]. *)
 
 
 external set : bytes -> int -> char -> unit = "%string_safe_set"
@@ -61,8 +60,7 @@ external set : bytes -> int -> char -> unit = "%string_safe_set"
 (** [String.set s n c] modifies byte sequence [s] in place,
    replacing the byte at index [n] with [c].
    You can also write [s.[n] <- c] instead of [String.set s n c].
-
-   Raise [Invalid_argument] if [n] is not a valid index in [s].
+   @raise Invalid_argument if [n] is not a valid index in [s].
 
    @deprecated This is a deprecated alias of {!Bytes.set}.[ ] *)
 
@@ -70,23 +68,20 @@ external create : int -> bytes = "caml_create_string"
   [@@ocaml.deprecated "Use Bytes.create instead."]
 (** [String.create n] returns a fresh byte sequence of length [n].
    The sequence is uninitialized and contains arbitrary bytes.
-
-   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
 
    @deprecated This is a deprecated alias of {!Bytes.create}.[ ] *)
 
 val make : int -> char -> string
 (** [String.make n c] returns a fresh string of length [n],
    filled with the character [c].
-
-   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> string
 (** [String.init n f] returns a string of length [n], with character
     [i] initialized to the result of [f i] (called in increasing
     index order).
-
-    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
 
     @since 4.02.0
 *)
@@ -101,16 +96,14 @@ val sub : string -> int -> int -> string
 (** [String.sub s start len] returns a fresh string of length [len],
    containing the substring of [s] that starts at position [start] and
    has length [len].
-
-   Raise [Invalid_argument] if [start] and [len] do not
+   @raise Invalid_argument if [start] and [len] do not
    designate a valid substring of [s]. *)
 
 val fill : bytes -> int -> int -> char -> unit
   [@@ocaml.deprecated "Use Bytes.fill instead."]
 (** [String.fill s start len c] modifies byte sequence [s] in place,
    replacing [len] bytes with [c], starting at [start].
-
-   Raise [Invalid_argument] if [start] and [len] do not
+   @raise Invalid_argument if [start] and [len] do not
    designate a valid range of [s].
 
    @deprecated This is a deprecated alias of {!Bytes.fill}.[ ] *)
@@ -121,8 +114,7 @@ val blit : string -> int -> bytes -> int -> int -> unit
 val concat : string -> string list -> string
 (** [String.concat sep sl] concatenates the list of strings [sl],
     inserting the separator string [sep] between each.
-
-    Raise [Invalid_argument] if the result is longer than
+   @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 val iter : (char -> unit) -> string -> unit
@@ -165,8 +157,7 @@ val escaped : string -> string
 
     If there is no special character in the argument that needs
     escaping, return the original string itself, not a copy.
-
-    Raise [Invalid_argument] if the result is longer than
+   @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
@@ -176,8 +167,7 @@ val escaped : string -> string
 val index : string -> char -> int
 (** [String.index s c] returns the index of the first
    occurrence of character [c] in string [s].
-
-   Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: string -> char -> int option
 (** [String.index_opt s c] returns the index of the first
@@ -188,8 +178,7 @@ val index_opt: string -> char -> int option
 val rindex : string -> char -> int
 (** [String.rindex s c] returns the index of the last
    occurrence of character [c] in string [s].
-
-   Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: string -> char -> int option
 (** [String.rindex_opt s c] returns the index of the last occurrence
@@ -201,9 +190,8 @@ val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the index of the
    first occurrence of character [c] in string [s] after position [i].
    [String.index s c] is equivalent to [String.index_from s 0 c].
-
-   Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+   @raise Invalid_argument if [i] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
 (** [String.index_from_opt s i c] returns the index of the
@@ -211,7 +199,7 @@ val index_from_opt: string -> int -> char -> int option
     or [None] if [c] does not occur in [s] after position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
-    Raise [Invalid_argument] if [i] is not a valid position in [s].
+   @raise Invalid_argument if [i] is not a valid position in [s].
 
     @since 4.05
 *)
@@ -221,9 +209,8 @@ val rindex_from : string -> int -> char -> int
    last occurrence of character [c] in string [s] before position [i+1].
    [String.rindex s c] is equivalent to
    [String.rindex_from s (String.length s - 1) c].
-
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
 (** [String.rindex_from_opt s i c] returns the index of the
@@ -232,8 +219,7 @@ val rindex_from_opt: string -> int -> char -> int option
 
    [String.rindex_opt s c] is equivalent to
    [String.rindex_from_opt s (String.length s - 1) c].
-
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
 
     @since 4.05
 *)
@@ -247,14 +233,12 @@ val contains_from : string -> int -> char -> bool
    appears in [s] after position [start].
    [String.contains s c] is equivalent to
    [String.contains_from s 0 c].
-
-   Raise [Invalid_argument] if [start] is not a valid position in [s]. *)
+   @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : string -> int -> char -> bool
 (** [String.rcontains_from s stop c] tests if character [c]
    appears in [s] before position [stop+1].
-
-   Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
+   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
    position in [s]. *)
 
 val uppercase : string -> string

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -166,7 +166,7 @@ val index_from_opt: string -> int -> char -> int option
     or [None] if [c] does not occur in [s] after position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
+    @raise Invalid_argument if [i] is not a valid position in [s].
 
     @since 4.05
 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -30,16 +30,14 @@ external length : string -> int = "%string_length"
 external get : string -> int -> char = "%string_safe_get"
 (** [String.get s n] returns the character at index [n] in string [s].
    You can also write [s.[n]] instead of [String.get s n].
-
-   Raise [Invalid_argument] if [n] not a valid index in [s]. *)
+   @raise Invalid_argument if [n] not a valid index in [s]. *)
 
 external set : bytes -> int -> char -> unit = "%string_safe_set"
   [@@ocaml.deprecated "Use BytesLabels.set instead."]
 (** [String.set s n c] modifies byte sequence [s] in place,
    replacing the byte at index [n] with [c].
    You can also write [s.[n] <- c] instead of [String.set s n c].
-
-   Raise [Invalid_argument] if [n] is not a valid index in [s].
+   @raise Invalid_argument if [n] is not a valid index in [s].
 
    @deprecated This is a deprecated alias of {!BytesLabels.set}. *)
 
@@ -47,22 +45,19 @@ external create : int -> bytes = "caml_create_string"
   [@@ocaml.deprecated "Use BytesLabels.create instead."]
 (** [String.create n] returns a fresh byte sequence of length [n].
    The sequence is uninitialized and contains arbitrary bytes.
-
-   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
 
    @deprecated This is a deprecated alias of {!BytesLabels.create}. *)
 
 val make : int -> char -> string
 (** [String.make n c] returns a fresh string of length [n],
    filled with the character [c].
-
-   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> f:(int -> char) -> string
 (** [init n f] returns a string of length [n],
     with character [i] initialized to the result of [f i].
-
-   Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
    @since 4.02.0 *)
 
 val copy : string -> string  [@@ocaml.deprecated]
@@ -72,16 +67,14 @@ val sub : string -> pos:int -> len:int -> string
 (** [String.sub s start len] returns a fresh string of length [len],
    containing the substring of [s] that starts at position [start] and
    has length [len].
-
-   Raise [Invalid_argument] if [start] and [len] do not
+   @raise Invalid_argument if [start] and [len] do not
    designate a valid substring of [s]. *)
 
 val fill : bytes -> pos:int -> len:int -> char -> unit
   [@@ocaml.deprecated "Use BytesLabels.fill instead."]
 (** [String.fill s start len c] modifies byte sequence [s] in place,
    replacing [len] bytes by [c], starting at [start].
-
-   Raise [Invalid_argument] if [start] and [len] do not
+   @raise Invalid_argument if [start] and [len] do not
    designate a valid substring of [s].
 
    @deprecated This is a deprecated alias of {!BytesLabels.fill}. *)
@@ -92,8 +85,7 @@ val blit :
 (** [String.blit src srcoff dst dstoff len] copies [len] bytes
    from the string [src], starting at index [srcoff],
    to byte sequence [dst], starting at character number [dstoff].
-
-   Raise [Invalid_argument] if [srcoff] and [len] do not
+   @raise Invalid_argument if [srcoff] and [len] do not
    designate a valid range of [src], or if [dstoff] and [len]
    do not designate a valid range of [dst]. *)
 
@@ -142,8 +134,7 @@ val escaped : string -> string
 val index : string -> char -> int
 (** [String.index s c] returns the index of the first
    occurrence of character [c] in string [s].
-
-   Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: string -> char -> int option
 (** [String.index_opt s c] returns the index of the first
@@ -154,8 +145,7 @@ val index_opt: string -> char -> int option
 val rindex : string -> char -> int
 (** [String.rindex s c] returns the index of the last
    occurrence of character [c] in string [s].
-
-   Raise [Not_found] if [c] does not occur in [s]. *)
+   @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: string -> char -> int option
 (** [String.rindex_opt s c] returns the index of the last occurrence
@@ -167,9 +157,8 @@ val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the index of the
    first occurrence of character [c] in string [s] after position [i].
    [String.index s c] is equivalent to [String.index_from s 0 c].
-
-   Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+   @raise Invalid_argument if [i] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
 (** [String.index_from_opt s i c] returns the index of the
@@ -177,7 +166,7 @@ val index_from_opt: string -> int -> char -> int option
     or [None] if [c] does not occur in [s] after position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
-    Raise [Invalid_argument] if [i] is not a valid position in [s].
+   @raise Invalid_argument if [i] is not a valid position in [s].
 
     @since 4.05
 *)
@@ -187,9 +176,8 @@ val rindex_from : string -> int -> char -> int
    last occurrence of character [c] in string [s] before position [i+1].
    [String.rindex s c] is equivalent to
    [String.rindex_from s (String.length s - 1) c].
-
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
+   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
 (** [String.rindex_from_opt s i c] returns the index of the
@@ -198,8 +186,7 @@ val rindex_from_opt: string -> int -> char -> int option
 
    [String.rindex_opt s c] is equivalent to
    [String.rindex_from_opt s (String.length s - 1) c].
-
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   @raise Invalid_argument if [i+1] is not a valid position in [s].
 
     @since 4.05
 *)
@@ -213,14 +200,12 @@ val contains_from : string -> int -> char -> bool
    appears in [s] after position [start].
    [String.contains s c] is equivalent to
    [String.contains_from s 0 c].
-
-   Raise [Invalid_argument] if [start] is not a valid position in [s]. *)
+   @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : string -> int -> char -> bool
 (** [String.rcontains_from s stop c] tests if character [c]
    appears in [s] before position [stop+1].
-
-   Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
+   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
    position in [s]. *)
 
 val uppercase : string -> string

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -38,7 +38,7 @@ external file_exists : string -> bool = "caml_sys_file_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"
 (** Returns [true] if the given name refers to a directory,
     [false] if it refers to another kind of file.
-   @raise Sys_error if no file exists with the given name.
+    @raise Sys_error if no file exists with the given name.
     @since 3.10.0
 *)
 

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -38,7 +38,7 @@ external file_exists : string -> bool = "caml_sys_file_exists"
 external is_directory : string -> bool = "caml_sys_is_directory"
 (** Returns [true] if the given name refers to a directory,
     [false] if it refers to another kind of file.
-    Raise [Sys_error] if no file exists with the given name.
+   @raise Sys_error if no file exists with the given name.
     @since 3.10.0
 *)
 
@@ -57,7 +57,8 @@ external rename : string -> string -> unit = "caml_sys_rename"
 
 external getenv : string -> string = "caml_sys_getenv"
 (** Return the value associated to a variable in the process
-   environment. Raise [Not_found] if the variable is unbound. *)
+   environment.
+   @raise Not_found if the variable is unbound. *)
 
 val getenv_opt: string -> string option
 (** Return the value associated to a variable in the process

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -39,7 +39,8 @@ type 'a t
 
 val create : int -> 'a t
 (** [Weak.create n] returns a new weak array of length [n].
-   All the pointers are initially empty.  Raise [Invalid_argument]
+   All the pointers are initially empty.
+   @raise Invalid_argument
    if [n] is not comprised between zero and
    {!Obj.Ephemeron.max_ephe_length} (limits included).*)
 
@@ -142,7 +143,7 @@ module type S = sig
 
   val find : t -> data -> data
     (** [find t x] returns an instance of [x] found in [t].
-        Raise [Not_found] if there is no such element. *)
+   @raise Not_found if there is no such element. *)
 
   val find_opt: t -> data -> data option
     (** [find_opt t x] returns an instance of [x] found in [t]

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -144,7 +144,7 @@ module type S = sig
 
   val find : t -> data -> data
     (** [find t x] returns an instance of [x] found in [t].
-   @raise Not_found if there is no such element. *)
+        @raise Not_found if there is no such element. *)
 
   val find_opt: t -> data -> data option
     (** [find_opt t x] returns an instance of [x] found in [t]

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -52,13 +52,13 @@ val set : 'a t -> int -> 'a option -> unit
 (** [Weak.set ar n (Some el)] sets the [n]th cell of [ar] to be a
    (full) pointer to [el]; [Weak.set ar n None] sets the [n]th
    cell of [ar] to empty.
-   Raise [Invalid_argument "Weak.set"] if [n] is not in the range
+   @raise Invalid_argument if [n] is not in the range
    0 to {!Weak.length}[ a - 1].*)
 
 val get : 'a t -> int -> 'a option
 (** [Weak.get ar n] returns None if the [n]th cell of [ar] is
    empty, [Some x] (where [x] is the value) if it is full.
-   Raise [Invalid_argument "Weak.get"] if [n] is not in the range
+   @raise Invalid_argument if [n] is not in the range
    0 to {!Weak.length}[ a - 1].*)
 
 val get_copy : 'a t -> int -> 'a option
@@ -69,7 +69,7 @@ val get_copy : 'a t -> int -> 'a option
    difference with [get] is that [get_copy] does not prevent
    the incremental GC from erasing the value in its current cycle
    ([get] may delay the erasure to the next GC cycle).
-   Raise [Invalid_argument "Weak.get"] if [n] is not in the range
+   @raise Invalid_argument if [n] is not in the range
    0 to {!Weak.length}[ a - 1].
 
    If the element is a custom block it is not copied.
@@ -84,14 +84,15 @@ val check : 'a t -> int -> bool
 
 val fill : 'a t -> int -> int -> 'a option -> unit
 (** [Weak.fill ar ofs len el] sets to [el] all pointers of [ar] from
-   [ofs] to [ofs + len - 1].  Raise [Invalid_argument "Weak.fill"]
+   [ofs] to [ofs + len - 1].
+   @raise Invalid_argument
    if [ofs] and [len] do not designate a valid subarray of [a].*)
 
 val blit : 'a t -> int -> 'a t -> int -> int -> unit
 (** [Weak.blit ar1 off1 ar2 off2 len] copies [len] weak pointers
    from [ar1] (starting at [off1]) to [ar2] (starting at [off2]).
    It works correctly even if [ar1] and [ar2] are the same.
-   Raise [Invalid_argument "Weak.blit"] if [off1] and [len] do
+   @raise Invalid_argument if [off1] and [len] do
    not designate a valid subarray of [ar1], or if [off2] and [len]
    do not designate a valid subarray of [ar2].*)
 


### PR DESCRIPTION
All comment have the same shape
`(**
   comment
 *)`
Use of @raise tags when it was in text.
Do you think it worth ask for ocamldoc autodetect exception and try to detect which value cause error (by scanning code like if match ... with structure ?)