### PR TITLE
Proof of concept for checked cmm optimizations

### DIFF
--- a/.depend
+++ b/.depend
@@ -617,6 +617,7 @@ typing/includecore.cmx : \
 typing/includecore.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/env.cmi
@@ -2175,6 +2176,14 @@ asmcomp/cmm.cmi : \
     lambda/debuginfo.cmi \
     middle_end/backend_var.cmi \
     parsing/asttypes.cmi
+asmcomp/cmm_simplify.cmo : \
+    asmcomp/cmm.cmi \
+    asmcomp/cmm_simplify.cmi
+asmcomp/cmm_simplify.cmx : \
+    asmcomp/cmm.cmx \
+    asmcomp/cmm_simplify.cmi
+asmcomp/cmm_simplify.cmi : \
+    asmcomp/cmm.cmi
 asmcomp/cmmgen.cmo : \
     middle_end/flambda/un_anf.cmi \
     typing/types.cmi \
@@ -2193,6 +2202,7 @@ asmcomp/cmmgen.cmo : \
     file_formats/cmxs_format.cmi \
     file_formats/cmx_format.cmi \
     asmcomp/cmmgen_state.cmi \
+    asmcomp/cmm_simplify.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     middle_end/clambda_primitives.cmi \
@@ -2220,6 +2230,7 @@ asmcomp/cmmgen.cmx : \
     file_formats/cmxs_format.cmi \
     file_formats/cmx_format.cmi \
     asmcomp/cmmgen_state.cmx \
+    asmcomp/cmm_simplify.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     middle_end/clambda_primitives.cmx \

--- a/Changes
+++ b/Changes
@@ -21,8 +21,12 @@ Working version
   (Greg V, review by Sébastien Hinderer, Stephen Dolan, Damien Doligez
    and Xavier Leroy)
 
-- GPR#8547: Optimize matches that are an affine function of the input.
+- #8547: Optimize matches that are an affine function of the input.
   (Stefan Muenzel, review by Alain Frisch, Gabriel Scherer)
+
+- #????: Add proof-of-concept Cmm peephole optimizations with machine-
+  checked verification using SMT.
+  (Stefan Muenzel, review by ????)
 
 ### Compiler user-interface and warnings:
 

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ ASMCOMP=\
   asmcomp/mach.cmo asmcomp/proc.cmo \
   asmcomp/afl_instrument.cmo \
   asmcomp/strmatch.cmo \
+  asmcomp/cmm_simplify.cmo \
   asmcomp/cmmgen_state.cmo \
   asmcomp/cmmgen.cmo \
   asmcomp/interval.cmo \

--- a/asmcomp/cmm_opt_smt/cmm_simplify.smt2
+++ b/asmcomp/cmm_opt_smt/cmm_simplify.smt2
@@ -101,7 +101,7 @@
     (case XOR (ocaml-xor x y))
   ))
 
-  
+
 
 (push 1)
 (echo "verifying nested-compare")
@@ -238,5 +238,3 @@
    #b0000000000000000000000000000000000000000000000000000000000000001)))
 (check-sat)
 (pop 1)
-
-

--- a/asmcomp/cmm_opt_smt/cmm_simplify.smt2
+++ b/asmcomp/cmm_opt_smt/cmm_simplify.smt2
@@ -1,0 +1,242 @@
+;**************************************************************************
+;*                                                                        *
+;*                                 OCaml                                  *
+;*                                                                        *
+;*                  Stefan Muenzel, Jane Street Asia                      *
+;*                                                                        *
+;*   Copyright 2019 Jane Street Group LLC                                 *
+;*                                                                        *
+;*   All rights reserved.  This file is distributed under the terms of    *
+;*   the GNU Lesser General Public License version 2.1, with the          *
+;*   special exception on linking described in the file LICENSE.          *
+;*                                                                        *
+;**************************************************************************
+
+
+(define-sort ocaml-int () (_ BitVec 64))
+
+(declare-datatypes () ((CMP EQ NE LT GT LE GE)))
+
+(declare-datatypes () ((ILOG AND OR XOR)))
+
+(define-fun ocaml-lsl ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvshl x y))
+
+(define-fun ocaml-lsr ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvlshr x y))
+
+(define-fun ocaml-or ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvor x y))
+
+(define-fun ocaml-and ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvand x y))
+
+(define-fun ocaml-xor ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvxor x y))
+
+(define-fun ocaml-asr ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvashr x y))
+
+(define-fun ocaml-has-tag ((x ocaml-int)) bool
+  (= (ocaml-and x #x0000000000000001) #x0000000000000001))
+
+(define-fun ocaml-highest-bits-same ((x ocaml-int)) bool
+  (= ((_ extract 63 63) x) ((_ extract 62 62) x)))
+
+(define-fun ocaml-lsr-1 ((x ocaml-int)) ocaml-int
+  (ocaml-lsr x #x0000000000000001))
+
+(define-fun ocaml-addi ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvadd x y))
+
+(define-fun ocaml-subi ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (bvsub x y))
+
+(define-fun ocaml-tagi ((x ocaml-int)) ocaml-int
+  (bvadd (ocaml-lsl x #x0000000000000001) #x0000000000000001))
+
+(define-fun ocaml-untagi ((x ocaml-int)) ocaml-int
+  (ocaml-asr x #x0000000000000001))
+
+(define-fun ocaml-to-int-untagged ((x ocaml-int)) Int
+  (+ (if (= ((_ extract 63 63) x) #b1) -16 0)
+  (bv2int ((_ extract 62 0) x))))
+
+(define-fun ocaml-cmp-eq ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (if (= x y) #x0000000000000001 #x0000000000000000))
+
+(define-fun ocaml-cmp-ne ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (if (not (= x y)) #x0000000000000001 #x0000000000000000))
+
+(define-fun ocaml-cmp-lt ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (if (bvslt x y)
+    #x0000000000000001 #x0000000000000000))
+
+(define-fun ocaml-cmp-gt ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (if (bvsgt x y)
+    #x0000000000000001 #x0000000000000000))
+
+(define-fun ocaml-cmp-le ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (if (bvsle x y)
+    #x0000000000000001 #x0000000000000000))
+
+(define-fun ocaml-cmp-ge ((x ocaml-int) (y ocaml-int)) ocaml-int
+  (if (bvsge x y)
+    #x0000000000000001 #x0000000000000000))
+
+(define-fun ocaml-cmp ((cmp CMP) (x ocaml-int) (y ocaml-int)) ocaml-int
+  (match cmp
+    (case EQ (ocaml-cmp-eq x y))
+    (case NE (ocaml-cmp-ne x y))
+    (case LT (ocaml-cmp-lt x y))
+    (case GT (ocaml-cmp-gt x y))
+    (case LE (ocaml-cmp-le x y))
+    (case GE (ocaml-cmp-ge x y))
+    ))
+
+(define-fun ocaml-ilog ((ilog ILOG) (x ocaml-int) (y ocaml-int)) ocaml-int
+  (match ilog
+    (case AND (ocaml-and x y))
+    (case OR  (ocaml-or x y))
+    (case XOR (ocaml-xor x y))
+  ))
+
+  
+
+(push 1)
+(echo "verifying nested-compare")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(declare-const cmp_outer CMP)
+(declare-const cmp_inner CMP)
+(assert-not
+ (=
+  (ocaml-cmp cmp_outer
+   (ocaml-addi
+    (ocaml-lsl (ocaml-cmp cmp_inner left right)
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   #b0000000000000000000000000000000000000000000000000000000000000001)
+  (ocaml-cmp cmp_outer (ocaml-cmp cmp_inner left right)
+   #b0000000000000000000000000000000000000000000000000000000000000000)))
+(check-sat)
+(pop 1)
+
+
+(push 1)
+(echo "verifying nested-equal-one")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(declare-const cmp_inner CMP)
+(assert-not
+ (=
+  (ocaml-cmp EQ (ocaml-cmp cmp_inner left right)
+   #b0000000000000000000000000000000000000000000000000000000000000001)
+  (ocaml-cmp cmp_inner left right)))
+(check-sat)
+(pop 1)
+
+
+(push 1)
+(echo "verifying nested-equal-three-tagged")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(declare-const cmp_inner CMP)
+(assert-not
+ (=
+  (ocaml-cmp EQ
+   (ocaml-addi
+    (ocaml-lsl (ocaml-cmp cmp_inner left right)
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   #b0000000000000000000000000000000000000000000000000000000000000011)
+  (ocaml-cmp cmp_inner left right)))
+(check-sat)
+(pop 1)
+
+
+(push 1)
+(echo "verifying nested-nequal-zero")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(declare-const cmp_inner CMP)
+(assert-not
+ (=
+  (ocaml-cmp NE (ocaml-cmp cmp_inner left right)
+   #b0000000000000000000000000000000000000000000000000000000000000000)
+  (ocaml-cmp cmp_inner left right)))
+(check-sat)
+(pop 1)
+
+
+(push 1)
+(echo "verifying tag-and")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(assert-not
+ (=
+  (ocaml-and
+   (ocaml-addi
+    (ocaml-lsl left
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   (ocaml-addi
+    (ocaml-lsl right
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    #b0000000000000000000000000000000000000000000000000000000000000001))
+  (ocaml-addi
+   (ocaml-lsl (ocaml-and left right)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   #b0000000000000000000000000000000000000000000000000000000000000001)))
+(check-sat)
+(pop 1)
+
+
+(push 1)
+(echo "verifying tag-or")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(assert-not
+ (=
+  (ocaml-or
+   (ocaml-addi
+    (ocaml-lsl left
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   (ocaml-addi
+    (ocaml-lsl right
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    #b0000000000000000000000000000000000000000000000000000000000000001))
+  (ocaml-addi
+   (ocaml-lsl (ocaml-or left right)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   #b0000000000000000000000000000000000000000000000000000000000000001)))
+(check-sat)
+(pop 1)
+
+
+(push 1)
+(echo "verifying tag-xor")
+(declare-const right ocaml-int)
+(declare-const left ocaml-int)
+(assert-not
+ (=
+  (ocaml-or
+   (ocaml-xor
+    (ocaml-addi
+     (ocaml-lsl left
+      #b0000000000000000000000000000000000000000000000000000000000000001)
+     #b0000000000000000000000000000000000000000000000000000000000000001)
+    (ocaml-addi
+     (ocaml-lsl right
+      #b0000000000000000000000000000000000000000000000000000000000000001)
+     #b0000000000000000000000000000000000000000000000000000000000000001))
+   #b0000000000000000000000000000000000000000000000000000000000000001)
+  (ocaml-addi
+   (ocaml-lsl (ocaml-xor left right)
+    #b0000000000000000000000000000000000000000000000000000000000000001)
+   #b0000000000000000000000000000000000000000000000000000000000000001)))
+(check-sat)
+(pop 1)
+
+

--- a/asmcomp/cmm_simplify.ml
+++ b/asmcomp/cmm_simplify.ml
@@ -15,152 +15,125 @@ open Cmm
 
 let rec reduce_cmm = function
   | Cop
-      ( Ccmpi cmp_outer,
-        [ Cop
-            ( Caddi,
-              [ Cop
-                  ( Clsl,
-                    [ Cop (Ccmpi cmp_inner, [ left; right ], dbg)
-                    ; Cconst_int (1, _)
-                    ],
-                    _ )
-              ; Cconst_int (1, _)
-              ],
-              _ )
-        ; Cconst_int (1, _)
-        ],
-        _ ) ->
+      ( Ccmpi cmp_outer
+      , [ Cop
+            ( Caddi
+            , [ Cop
+                  ( Clsl
+                  , [ Cop (Ccmpi cmp_inner, [left; right], dbg)
+                    ; Cconst_int (1, _) ]
+                  , _ )
+              ; Cconst_int (1, _) ]
+            , _ )
+        ; Cconst_int (1, _) ]
+      , _ ) ->
       (* nested-compare
          Size: (4 ops, 9 heads) in -> (2 ops, 5 heads) out *)
       Cop
-        ( Ccmpi cmp_outer,
-          [ Cop (Ccmpi cmp_inner, [ left; right ], dbg); Cconst_int (0, dbg) ],
-          dbg )
+        ( Ccmpi cmp_outer
+        , [Cop (Ccmpi cmp_inner, [left; right], dbg); Cconst_int (0, dbg)]
+        , dbg )
       |> reduce_cmm
   | Cop
-      ( Ccmpi Ceq,
-        [ Cop (Ccmpi cmp_inner, [ left; right ], dbg); Cconst_int (1, _) ],
-        _ ) ->
+      ( Ccmpi Ceq
+      , [Cop (Ccmpi cmp_inner, [left; right], dbg); Cconst_int (1, _)]
+      , _ ) ->
       (* nested-equal-one
          Size: (2 ops, 5 heads) in -> (1 ops, 3 heads) out *)
-      Cop (Ccmpi cmp_inner, [ left; right ], dbg) |> reduce_cmm
+      Cop (Ccmpi cmp_inner, [left; right], dbg) |> reduce_cmm
   | Cop
-      ( Ccmpi Ceq,
-        [ Cop
-            ( Caddi,
-              [ Cop
-                  ( Clsl,
-                    [ Cop (Ccmpi cmp_inner, [ left; right ], dbg)
-                    ; Cconst_int (1, _)
-                    ],
-                    _ )
-              ; Cconst_int (1, _)
-              ],
-              _ )
-        ; Cconst_int (3, _)
-        ],
-        _ ) ->
+      ( Ccmpi Ceq
+      , [ Cop
+            ( Caddi
+            , [ Cop
+                  ( Clsl
+                  , [ Cop (Ccmpi cmp_inner, [left; right], dbg)
+                    ; Cconst_int (1, _) ]
+                  , _ )
+              ; Cconst_int (1, _) ]
+            , _ )
+        ; Cconst_int (3, _) ]
+      , _ ) ->
       (* nested-equal-three-tagged
          Size: (4 ops, 9 heads) in -> (1 ops, 3 heads) out *)
-      Cop (Ccmpi cmp_inner, [ left; right ], dbg) |> reduce_cmm
+      Cop (Ccmpi cmp_inner, [left; right], dbg) |> reduce_cmm
   | Cop
-      ( Ccmpi Cne,
-        [ Cop (Ccmpi cmp_inner, [ left; right ], dbg); Cconst_int (0, _) ],
-        _ ) ->
+      ( Ccmpi Cne
+      , [Cop (Ccmpi cmp_inner, [left; right], dbg); Cconst_int (0, _)]
+      , _ ) ->
       (* nested-nequal-zero
          Size: (2 ops, 5 heads) in -> (1 ops, 3 heads) out *)
-      Cop (Ccmpi cmp_inner, [ left; right ], dbg) |> reduce_cmm
+      Cop (Ccmpi cmp_inner, [left; right], dbg) |> reduce_cmm
   | Cop
-      ( Cand,
-        [ Cop
-            ( Caddi,
-              [ Cop (Clsl, [ left; Cconst_int (1, _) ], _)
-              ; Cconst_int (1, _)
-              ],
-              _ )
+      ( Cand
+      , [ Cop
+            ( Caddi
+            , [Cop (Clsl, [left; Cconst_int (1, _)], _); Cconst_int (1, _)]
+            , _ )
         ; Cop
-            ( Caddi,
-              [ Cop (Clsl, [ right; Cconst_int (1, _) ], _)
-              ; Cconst_int (1, _)
-              ],
-              _ )
-        ],
-        dbg_op ) ->
+            ( Caddi
+            , [Cop (Clsl, [right; Cconst_int (1, _)], _); Cconst_int (1, _)]
+            , _ ) ]
+      , dbg_op ) ->
       (* tag-and
          Size: (5 ops, 11 heads) in -> (3 ops, 7 heads) out *)
       Cop
-        ( Caddi,
-          [ Cop
-              ( Clsl,
-                [ Cop (Cand, [ left; right ], dbg_op);
-                  Cconst_int (1, dbg_op)
-                ],
-                dbg_op );
-            Cconst_int (1, dbg_op)
-          ],
-          dbg_op )
+        ( Caddi
+        , [ Cop
+              ( Clsl
+              , [Cop (Cand, [left; right], dbg_op); Cconst_int (1, dbg_op)]
+              , dbg_op )
+          ; Cconst_int (1, dbg_op) ]
+        , dbg_op )
       |> reduce_cmm
   | Cop
-      ( Cor,
-        [ Cop
-            ( Caddi,
-              [ Cop (Clsl, [ left; Cconst_int (1, _) ], _)
-              ; Cconst_int (1, _)
-              ],
-              _ )
+      ( Cor
+      , [ Cop
+            ( Caddi
+            , [Cop (Clsl, [left; Cconst_int (1, _)], _); Cconst_int (1, _)]
+            , _ )
         ; Cop
-            ( Caddi,
-              [ Cop (Clsl, [ right; Cconst_int (1, _) ], _)
-              ; Cconst_int (1, _)
-              ],
-              _ )
-        ],
-        dbg_op ) ->
+            ( Caddi
+            , [Cop (Clsl, [right; Cconst_int (1, _)], _); Cconst_int (1, _)]
+            , _ ) ]
+      , dbg_op ) ->
       (* tag-or
          Size: (5 ops, 11 heads) in -> (3 ops, 7 heads) out *)
       Cop
-        ( Caddi,
-          [ Cop
-              ( Clsl,
-                [ Cop (Cor, [ left; right ], dbg_op); Cconst_int (1, dbg_op) ],
-                dbg_op );
-            Cconst_int (1, dbg_op)
-          ],
-          dbg_op )
+        ( Caddi
+        , [ Cop
+              ( Clsl
+              , [Cop (Cor, [left; right], dbg_op); Cconst_int (1, dbg_op)]
+              , dbg_op )
+          ; Cconst_int (1, dbg_op) ]
+        , dbg_op )
       |> reduce_cmm
   | Cop
-      ( Cor,
-        [ Cop
-            ( Cxor,
-              [ Cop
-                  ( Caddi,
-                    [ Cop (Clsl, [ left; Cconst_int (1, _) ], _)
-                    ; Cconst_int (1, _)
-                    ],
-                    _ )
+      ( Cor
+      , [ Cop
+            ( Cxor
+            , [ Cop
+                  ( Caddi
+                  , [ Cop (Clsl, [left; Cconst_int (1, _)], _)
+                    ; Cconst_int (1, _) ]
+                  , _ )
               ; Cop
-                  ( Caddi,
-                    [ Cop (Clsl, [ right; Cconst_int (1, _) ], _)
-                    ; Cconst_int (1, _)
-                    ],
-                    _ )
-              ],
-              dbg_xor )
-        ; Cconst_int (1, _)
-        ],
-        _ ) ->
+                  ( Caddi
+                  , [ Cop (Clsl, [right; Cconst_int (1, _)], _)
+                    ; Cconst_int (1, _) ]
+                  , _ ) ]
+            , dbg_xor )
+        ; Cconst_int (1, _) ]
+      , _ ) ->
       (* tag-xor
          Size: (6 ops, 13 heads) in -> (3 ops, 7 heads) out *)
       Cop
-        ( Caddi,
-          [ Cop
-              ( Clsl,
-                [ Cop (Cxor, [ left; right ], dbg_xor);
-                  Cconst_int (1, dbg_xor)
-                ],
-                dbg_xor );
-            Cconst_int (1, dbg_xor)
-          ],
-          dbg_xor )
+        ( Caddi
+        , [ Cop
+              ( Clsl
+              , [Cop (Cxor, [left; right], dbg_xor); Cconst_int (1, dbg_xor)]
+              , dbg_xor )
+          ; Cconst_int (1, dbg_xor) ]
+        , dbg_xor )
       |> reduce_cmm
   | other -> other

--- a/asmcomp/cmm_simplify.ml
+++ b/asmcomp/cmm_simplify.ml
@@ -1,0 +1,166 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Stefan Muenzel, Jane Street Asia                      *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+open Cmm
+
+let rec reduce_cmm = function
+  | Cop
+      ( Ccmpi cmp_outer,
+        [ Cop
+            ( Caddi,
+              [ Cop
+                  ( Clsl,
+                    [ Cop (Ccmpi cmp_inner, [ left; right ], dbg)
+                    ; Cconst_int (1, _)
+                    ],
+                    _ )
+              ; Cconst_int (1, _)
+              ],
+              _ )
+        ; Cconst_int (1, _)
+        ],
+        _ ) ->
+      (* nested-compare
+         Size: (4 ops, 9 heads) in -> (2 ops, 5 heads) out *)
+      Cop
+        ( Ccmpi cmp_outer,
+          [ Cop (Ccmpi cmp_inner, [ left; right ], dbg); Cconst_int (0, dbg) ],
+          dbg )
+      |> reduce_cmm
+  | Cop
+      ( Ccmpi Ceq,
+        [ Cop (Ccmpi cmp_inner, [ left; right ], dbg); Cconst_int (1, _) ],
+        _ ) ->
+      (* nested-equal-one
+         Size: (2 ops, 5 heads) in -> (1 ops, 3 heads) out *)
+      Cop (Ccmpi cmp_inner, [ left; right ], dbg) |> reduce_cmm
+  | Cop
+      ( Ccmpi Ceq,
+        [ Cop
+            ( Caddi,
+              [ Cop
+                  ( Clsl,
+                    [ Cop (Ccmpi cmp_inner, [ left; right ], dbg)
+                    ; Cconst_int (1, _)
+                    ],
+                    _ )
+              ; Cconst_int (1, _)
+              ],
+              _ )
+        ; Cconst_int (3, _)
+        ],
+        _ ) ->
+      (* nested-equal-three-tagged
+         Size: (4 ops, 9 heads) in -> (1 ops, 3 heads) out *)
+      Cop (Ccmpi cmp_inner, [ left; right ], dbg) |> reduce_cmm
+  | Cop
+      ( Ccmpi Cne,
+        [ Cop (Ccmpi cmp_inner, [ left; right ], dbg); Cconst_int (0, _) ],
+        _ ) ->
+      (* nested-nequal-zero
+         Size: (2 ops, 5 heads) in -> (1 ops, 3 heads) out *)
+      Cop (Ccmpi cmp_inner, [ left; right ], dbg) |> reduce_cmm
+  | Cop
+      ( Cand,
+        [ Cop
+            ( Caddi,
+              [ Cop (Clsl, [ left; Cconst_int (1, _) ], _)
+              ; Cconst_int (1, _)
+              ],
+              _ )
+        ; Cop
+            ( Caddi,
+              [ Cop (Clsl, [ right; Cconst_int (1, _) ], _)
+              ; Cconst_int (1, _)
+              ],
+              _ )
+        ],
+        dbg_op ) ->
+      (* tag-and
+         Size: (5 ops, 11 heads) in -> (3 ops, 7 heads) out *)
+      Cop
+        ( Caddi,
+          [ Cop
+              ( Clsl,
+                [ Cop (Cand, [ left; right ], dbg_op);
+                  Cconst_int (1, dbg_op)
+                ],
+                dbg_op );
+            Cconst_int (1, dbg_op)
+          ],
+          dbg_op )
+      |> reduce_cmm
+  | Cop
+      ( Cor,
+        [ Cop
+            ( Caddi,
+              [ Cop (Clsl, [ left; Cconst_int (1, _) ], _)
+              ; Cconst_int (1, _)
+              ],
+              _ )
+        ; Cop
+            ( Caddi,
+              [ Cop (Clsl, [ right; Cconst_int (1, _) ], _)
+              ; Cconst_int (1, _)
+              ],
+              _ )
+        ],
+        dbg_op ) ->
+      (* tag-or
+         Size: (5 ops, 11 heads) in -> (3 ops, 7 heads) out *)
+      Cop
+        ( Caddi,
+          [ Cop
+              ( Clsl,
+                [ Cop (Cor, [ left; right ], dbg_op); Cconst_int (1, dbg_op) ],
+                dbg_op );
+            Cconst_int (1, dbg_op)
+          ],
+          dbg_op )
+      |> reduce_cmm
+  | Cop
+      ( Cor,
+        [ Cop
+            ( Cxor,
+              [ Cop
+                  ( Caddi,
+                    [ Cop (Clsl, [ left; Cconst_int (1, _) ], _)
+                    ; Cconst_int (1, _)
+                    ],
+                    _ )
+              ; Cop
+                  ( Caddi,
+                    [ Cop (Clsl, [ right; Cconst_int (1, _) ], _)
+                    ; Cconst_int (1, _)
+                    ],
+                    _ )
+              ],
+              dbg_xor )
+        ; Cconst_int (1, _)
+        ],
+        _ ) ->
+      (* tag-xor
+         Size: (6 ops, 13 heads) in -> (3 ops, 7 heads) out *)
+      Cop
+        ( Caddi,
+          [ Cop
+              ( Clsl,
+                [ Cop (Cxor, [ left; right ], dbg_xor);
+                  Cconst_int (1, dbg_xor)
+                ],
+                dbg_xor );
+            Cconst_int (1, dbg_xor)
+          ],
+          dbg_xor )
+      |> reduce_cmm
+  | other -> other

--- a/asmcomp/cmm_simplify.mli
+++ b/asmcomp/cmm_simplify.mli
@@ -1,0 +1,15 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Stefan Muenzel, Jane Street Asia                      *)
+(*                                                                        *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val reduce_cmm : Cmm.expression -> Cmm.expression

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -582,7 +582,8 @@ let test_bool dbg cmm =
         Cconst_int (0, dbg)
       else
         Cconst_int (1, dbg)
-  | c -> Cop(Ccmpi Cne, [c; Cconst_int (1, dbg)], dbg)
+  | c ->
+      Cmm_simplify.reduce_cmm (Cop(Ccmpi Cne, [c; Cconst_int (1, dbg)], dbg))
 
 (* Float *)
 


### PR DESCRIPTION
As a follow up to #8583, this is a proof-of-concept for machine verifiable Cmm optimizations.
The optimizations are created using a small DSL, see https://github.com/smuenzel/ocaml-pverify/blob/master/src/schemes.ml
From that DSL, we generate both cmm_simplify.ml and cmm_simplify.smt2, ensuring that we're actually verifying the code that's executed. 

I think there are still a lot of outstanding questions. Heres' some of them:

- Where should we apply the optimizations? Right now, I've just sprinkled them in cmmgen, where I think they could apply
- Should we attempt to add the tooling to the compiler distribution? It's pretty hacky right now, and it's relying on a bunch of stuff not available in the compiler distribution (Core, ocamlformat for the output)
- Should the smt file be automatically checked, or just be available in the code for manual checking?