### PR TITLE
Assorted Makefile tweaks

### DIFF
--- a/Changes
+++ b/Changes
@@ -192,6 +192,12 @@ Working version
 - #8515: manual, precise constraints on reexported types
   (Florian Angeletti, review by Gabriel Scherer)
 
+### Build system:
+
+- #8650: ensure that "make" variables are defined before use;
+  revise generation of config/util.ml to better quote special characters
+  (Xavier Leroy, review by David Allsopp)
+
 ### Bug fixes:
 
 - #7156, #8594: make top level use custom printers if they are available

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ opt-core: runtimeopt
 	$(MAKE) libraryopt
 
 .PHONY: opt
-opt:
+opt: checknative
 	$(MAKE) runtimeopt
 	$(MAKE) ocamlopt
 	$(MAKE) libraryopt
@@ -409,7 +409,7 @@ opt:
 
 # Native-code versions of the tools
 .PHONY: opt.opt
-opt.opt:
+opt.opt: checknative
 	$(MAKE) checkstack
 	$(MAKE) runtime
 	$(MAKE) core
@@ -464,7 +464,8 @@ world: coldstart
 
 # Compile also native code compiler and libraries, fast
 .PHONY: world.opt
-world.opt: coldstart
+world.opt: checknative
+	$(MAKE) coldstart
 	$(MAKE) opt.opt
 
 # FlexDLL sources missing error messages
@@ -1129,6 +1130,16 @@ ocamldebugger: ocamlc ocamlyacc ocamllex otherlibraries
 
 partialclean::
 	$(MAKE) -C debugger clean
+
+# Check that the native-code compiler is supported
+.PHONY: checknative
+checknative:
+ifeq "$(ARCH)" "none"
+checknative:
+	$(error The native-code compiler is not supported on this platform)
+else
+	@
+endif
 
 # Check that the stack limit is reasonable (Unix-only)
 .PHONY: checkstack

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -24,6 +24,7 @@ INSTALL_PROG ?= $(INSTALL) -m u=rwx,g=rwx,o=rx
 # as some parts of the makefiles change BINDIR, etc.
 # and expect INSTALL_BINDIR, etc. to stay in synch
 # (see `shellquote` in tools/Makefile)
+DESTDIR ?=
 INSTALL_BINDIR = $(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR = $(DESTDIR)$(LIBDIR)
 INSTALL_STUBLIBDIR = $(DESTDIR)$(STUBLIBDIR)

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -25,7 +25,7 @@ CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 CAMLC = $(BOOT_OCAMLC) -strict-sequence -nostdlib \
         -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
 CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
-COMPFLAGS = $(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
             -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS =
 YACCFLAGS = -v

--- a/man/Makefile
+++ b/man/Makefile
@@ -16,6 +16,7 @@
 ROOTDIR = ..
 include $(ROOTDIR)/Makefile.config
 
+DESTDIR ?=
 INSTALL_DIR=$(DESTDIR)$(MANDIR)/man$(PROGRAMS_MAN_SECTION)
 
 install:

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -37,18 +37,18 @@ OPTCOMPFLAGS=
 endif
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 
-# Variables to be defined by individual libraries:
-#LIBNAME=
-#CLIBNAME=
-#CMIFILES=
-#CAMLOBJS=
-#COBJS=
-#EXTRACFLAGS=
-#EXTRACAMLFLAGS=
-#LINKOPTS=
-#LDOPTS=
-#HEADERS=
+# Variables that must be defined by individual libraries:
+# LIBNAME
+# CAMLOBJS
 
+# Variables that can be defined by individual libraries,
+# but have sensible default values:
+COBJS ?=
+EXTRACFLAGS ?=
+EXTRACAMLFLAGS ?=
+LINKOPTS ?=
+LDOPTS ?=
+HEADERS ?=
 CMIFILES ?= $(CAMLOBJS:.cmo=.cmi)
 CAMLOBJS_NAT ?= $(CAMLOBJS:.cmo=.cmx)
 CLIBNAME ?= $(LIBNAME)

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -121,7 +121,7 @@ esac
 build=''
 host=''
 conffile=Makefile.config
-make=make
+make="make --warn-undefined-variables"
 instdir="$HOME/ocaml-tmp-install"
 confoptions="${OCAML_CONFIGURE_OPTIONS}"
 make_native=true
@@ -131,7 +131,9 @@ dorebase=false
 jobs=''
 
 case "${OCAML_ARCH}" in
-  bsd) make=gmake ;;
+  bsd)
+    make="gmake --warn-undefined-variables"
+  ;;
   macos) ;;
   linux)
     check_make_alldepend=true

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -29,51 +29,75 @@ else
   FLEXDLL_DIR =
 endif
 
+FLEXLINK_FLAGS ?=
+
+# Escape special characters in the argument string.
+# There are four characters that need escaping:
+# - backslash and ampersand, which are special in the replacement text
+#   of sed's "s" command
+# - exclamation mark, which is the delimiter we use for sed's "s" command
+# - single quote, which interferes with shell quoting.  We are inside
+#   single quotes already, so the proper escape is '\''
+#   (close single quotation, insert single quote character,
+#    reopen single quotation).
+SED_ESCAPE=$(subst ','\'',$(subst !,\!,$(subst &,\&,$(subst \,\\,$1))))
+
+# Escape special characters in an OCaml string literal "..."
+# There are two: backslash and double quote.
+OCAML_ESCAPE=$(subst ",\",$(subst \,\\,$1))
+
 # SUBST generates the sed substitution for the variable *named* in $1
-# SUBST_QUOTE does the same, adding double-quotes around non-empty strings
+SUBST=-e 's!%%$1%%!$(call SED_ESCAPE,$($1))!'
+
+# SUBST_STRING does the same, for a variable that occurs between "..."
+# in config.mlp.  Thus, backslashes and double quotes must be escaped.
+SUBST_STRING=-e 's!%%$1%%!$(call SED_ESCAPE,$(call OCAML_ESCAPE,$($1)))!'
+
+# SUBST_QUOTE does the same, adding OCaml quotes around non-empty strings
 #   (see FLEXDLL_DIR which must empty if FLEXDLL_DIR is empty but an OCaml
 #    string otherwise)
-SUBST_ESCAPE=$(subst ",\\",$(subst \,\\,$(if $2,$2,$($1))))
-SUBST=-e 's|%%$1%%|$(call SUBST_ESCAPE,$1,$2)|'
-SUBST_QUOTE2=-e 's|%%$1%%|$(if $2,"$2")|'
-SUBST_QUOTE=$(call SUBST_QUOTE2,$1,$(call SUBST_ESCAPE,$1,$2))
+SUBST_QUOTE2=\
+  -e 's!%%$1%%!$(if $2,$(call SED_ESCAPE,"$(call OCAML_ESCAPE,$2)"))!'
+SUBST_QUOTE=$(call SUBST_QUOTE2,$1,$($1))
+
 FLEXLINK_LDFLAGS=$(if $(OC_LDFLAGS), -link "$(OC_LDFLAGS)")
+
 config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	sed $(call SUBST,AFL_INSTRUMENT) \
 	    $(call SUBST,ARCH) \
-	    $(call SUBST,ARCMD) \
-	    $(call SUBST,ASM) \
+	    $(call SUBST_STRING,ARCMD) \
+	    $(call SUBST_STRING,ASM) \
 	    $(call SUBST,ASM_CFI_SUPPORTED) \
-	    $(call SUBST,BYTECCLIBS) \
-	    $(call SUBST,CC) \
-	    $(call SUBST,CCOMPTYPE) \
-	    $(call SUBST,OUTPUTOBJ) \
-	    $(call SUBST,EXT_ASM) \
-	    $(call SUBST,EXT_DLL) \
-	    $(call SUBST,EXE) \
-	    $(call SUBST,EXT_LIB) \
-	    $(call SUBST,EXT_OBJ) \
+	    $(call SUBST_STRING,BYTECCLIBS) \
+	    $(call SUBST_STRING,CC) \
+	    $(call SUBST_STRING,CCOMPTYPE) \
+	    $(call SUBST_STRING,OUTPUTOBJ) \
+	    $(call SUBST_STRING,EXT_ASM) \
+	    $(call SUBST_STRING,EXT_DLL) \
+	    $(call SUBST_STRING,EXE) \
+	    $(call SUBST_STRING,EXT_LIB) \
+	    $(call SUBST_STRING,EXT_OBJ) \
 	    $(call SUBST,FLAMBDA) \
 	    $(call SUBST,WITH_FLAMBDA_INVARIANTS) \
-	    $(call SUBST,FLEXLINK_FLAGS) \
+	    $(call SUBST_STRING,FLEXLINK_FLAGS) \
 	    $(call SUBST_QUOTE,FLEXDLL_DIR) \
 	    $(call SUBST,HOST) \
-	    $(call SUBST,LIBDIR) \
+	    $(call SUBST_STRING,LIBDIR) \
 	    $(call SUBST,LIBUNWIND_AVAILABLE) \
 	    $(call SUBST,LIBUNWIND_LINK_FLAGS) \
-	    $(call SUBST,MKDLL) \
-	    $(call SUBST,MKEXE) \
-	    $(call SUBST,FLEXLINK_LDFLAGS) \
-	    $(call SUBST,MKMAINDLL) \
+	    $(call SUBST_STRING,MKDLL) \
+	    $(call SUBST_STRING,MKEXE) \
+	    $(call SUBST_STRING,FLEXLINK_LDFLAGS) \
+	    $(call SUBST_STRING,MKMAINDLL) \
 	    $(call SUBST,MODEL) \
-	    $(call SUBST,NATIVECCLIBS) \
-	    $(call SUBST,OCAMLC_CFLAGS) \
-	    $(call SUBST,OCAMLC_CPPFLAGS) \
-	    $(call SUBST,OCAMLOPT_CFLAGS) \
-	    $(call SUBST,OCAMLOPT_CPPFLAGS) \
-	    $(call SUBST,PACKLD) \
+	    $(call SUBST_STRING,NATIVECCLIBS) \
+	    $(call SUBST_STRING,OCAMLC_CFLAGS) \
+	    $(call SUBST_STRING,OCAMLC_CPPFLAGS) \
+	    $(call SUBST_STRING,OCAMLOPT_CFLAGS) \
+	    $(call SUBST_STRING,OCAMLOPT_CPPFLAGS) \
+	    $(call SUBST_STRING,PACKLD) \
 	    $(call SUBST,PROFINFO_WIDTH) \
-	    $(call SUBST,RANLIBCMD) \
+	    $(call SUBST_STRING,RANLIBCMD) \
 	    $(call SUBST,FORCE_SAFE_STRING) \
 	    $(call SUBST,DEFAULT_SAFE_STRING) \
 	    $(call SUBST,WINDOWS_UNICODE) \
@@ -89,3 +113,30 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST,CC_HAS_DEBUG_PREFIX_MAP) \
 	    $(call SUBST,AS_HAS_DEBUG_PREFIX_MAP) \
 	    $< > $@
+
+# Test for the substitution functions above
+
+ALLCHARS= \
+  !"\#\$\%&'()*+,-./ \
+  0123456789:;<=>? \
+  @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ \
+  `abcdefghijklmnopqrstuvwxyz{|}~
+
+TMPFILE=testdata.tmp
+TMPSCRIPT=ocamlscript.tmp
+
+test-subst:
+	$(file >$(TMPFILE),$(ALLCHARS))
+	echo '%%ALLCHARS%%' | sed $(call SUBST,ALLCHARS) | cmp $(TMPFILE) -
+	@rm $(TMPFILE)
+	@echo "Test passed"
+
+# This test assumes there is a working OCaml in the path
+
+test-subst-string:
+	$(file >$(TMPFILE),$(ALLCHARS))
+	echo 'print_string "%%ALLCHARS%%"; print_newline();;' \
+        | sed $(call SUBST_STRING,ALLCHARS) > $(TMPSCRIPT) && \
+        ocaml $(TMPSCRIPT) | cmp $(TMPFILE) -
+	@rm $(TMPFILE) $(TMPSCRIPT)
+	@echo "Test passed"


### PR DESCRIPTION
I played with `make --warn-undefined-variables` as a way to detect make problems such as #8626.  Also, #8647 reminded me that we should fail more clearly when the native-code compiler is not supported.

This pull request proposes some tweaks to the Makefiles related to undefined make variables and to early failure.  It is best reviewed commit-per-commit:
* 00e9f36 In ./Makefile, check that native-code is supported in world.opt
* 4665451 In lex/Makefile, remove undefined and useless variable $(INCLUDE)
* 075e45a In otherlibs/Makefile.otherlibs.common, be more explicit about the default values of parameters when they are not set by the calling Makefile
* 55e7e17 In utils/Makefile, avoid using undefined function parameter `$2`; rewrite the make functions and use `{|...|}` literals in utils/config.mlp to improve the quoting of parameters that are inserted in utils/config.mlp.  This one must be reviewed by @dra27.

The next step would be to run our CI with `make --warn-undefined-variables` and find a way to grep the build log for make warnings and fail the build.  Maybe @shindere will have ideas.
 