### PR TITLE
Widen the test for configure regeneration in Travis

### DIFF
--- a/autogen
+++ b/autogen
@@ -18,7 +18,11 @@ autoconf --force --warnings=all,error
 # http://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=a197431414088a417b407b9b20583b2e8f7363bd
 # in the GNU autoconf repo), and some don't, so ensure its effects are
 # removed for CI consistency...
-sed -i -e '/^runstatedir/d' \
-       -e '/-runstatedir /,+8d' \
-       -e '/--runstatedir=DIR/d' \
-       -e 's/ runstatedir//' configure
+# POSIX Notes
+#  - sed -i without a backup file is not portable, hence configure.tmp
+sed -e '/^runstatedir/d' \
+    -e '/-runstatedir /,+8d' \
+    -e '/--runstatedir=DIR/d' \
+    -e 's/ runstatedir//' configure > configure.tmp
+mv -f configure.tmp configure
+chmod +x configure

--- a/autogen
+++ b/autogen
@@ -20,8 +20,9 @@ autoconf --force --warnings=all,error
 # removed for CI consistency...
 # POSIX Notes
 #  - sed -i without a backup file is not portable, hence configure.tmp
+#  - GNU sed's /../,+8d becomes /../{N;..;d;} (and the last ; is important)
 sed -e '/^runstatedir/d' \
-    -e '/-runstatedir /,+8d' \
+    -e '/-runstatedir /{N;N;N;N;N;N;N;N;d;}' \
     -e '/--runstatedir=DIR/d' \
     -e 's/ runstatedir//' configure > configure.tmp
 mv -f configure.tmp configure

--- a/autogen
+++ b/autogen
@@ -13,7 +13,7 @@
 #*                                                                        *
 #**************************************************************************
 
-autoconf -W all,error
+autoconf --force --warnings=all,error
 # Some distros have the 2013 --runstatedir patch to autoconf (see
 # http://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=a197431414088a417b407b9b20583b2e8f7363bd
 # in the GNU autoconf repo), and some don't, so ensure its effects are

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -37,13 +37,20 @@ else
   FETCH_HEAD=$TRAVIS_COMMIT
 fi
 
-if [[ $TRAVIS_COMMIT != $(git rev-parse FETCH_HEAD) ]] ; then
-  echo "WARNING! Travis TRAVIS_COMMIT and FETCH_HEAD do not agree!"
-  if git cat-file -e $TRAVIS_COMMIT 2> /dev/null ; then
-    echo "TRAVIS_COMMIT exists, so going with it"
-  else
-    echo "TRAVIS_COMMIT does not exist; setting to FETCH_HEAD"
-    TRAVIS_COMMIT=$FETCH_HEAD
+if [[ $TRAVIS_EVENT_TYPE = 'push' ]] ; then
+  if ! git cat-file -e $TRAVIS_COMMIT 2> /dev/null ; then
+    echo 'TRAVIS_COMMIT does not exist - CI failure'
+    exit 1
+  fi
+else
+  if [[ $TRAVIS_COMMIT != $(git rev-parse FETCH_HEAD) ]] ; then
+    echo "WARNING! Travis TRAVIS_COMMIT and FETCH_HEAD do not agree!"
+    if git cat-file -e $TRAVIS_COMMIT 2> /dev/null ; then
+      echo "TRAVIS_COMMIT exists, so going with it"
+    else
+      echo "TRAVIS_COMMIT does not exist; setting to FETCH_HEAD"
+      TRAVIS_COMMIT=$FETCH_HEAD
+    fi
   fi
 fi
 

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -223,14 +223,15 @@ CheckTypoTree () {
     else
       echo "NOT checking $1: $path (typo.prune)"
     fi
-    if [[ $path = 'configure' || $path = 'configure.ac' ]] ; then
-      touch CHECK_CONFIGURE
-    fi
+    case "$path" in
+      configure|configure.ac|VERSION|tools/ci/travis/travis-ci.sh)
+        touch CHECK_CONFIGURE;;
+    esac
   done)
   rm -f tmp-index
   if [ -e CHECK_CONFIGURE ] ; then
     rm -f CHECK_CONFIGURE
-    echo "configure or configure.ac altered in $1"
+    echo "configure generation altered in $1"
     echo "Verifying that configure.ac generates configure"
     git checkout "$1"
     mv configure configure.ref

--- a/tools/release-checklist
+++ b/tools/release-checklist
@@ -110,7 +110,8 @@ make tests
 # for production releases: check and change the Changes header
 #  (remove "next version" and add a date)
 # Update ocaml-variants.opam file to depend on the new version of ocaml.
-git add VERSION Changes ocaml-variants.opam
+./autogen
+git add VERSION Changes ocaml-variants.opam configure
 git commit -m "last commit before tagging $VERSION"
 # update VERSION with the new release; for example,
 #   4.07.0+dev9-2018-06-26 => 4.07.0+rc2
@@ -123,7 +124,8 @@ git tag -m "release $VERSION" $VERSION
 #   4.08.0 => 4.08.1+dev0
 # for testing candidates, use N+dev(D+2) instead; for example,
 #   4.07.0+rc2 => 4.07.0+dev10-2018-06-26
-git commit -m "increment version number after tagging $VERSION" VERSION
+./autogen
+git commit -m "increment version number after tagging $VERSION" VERSION configure
 git push
 git push --tags
 ```


### PR DESCRIPTION
`configure` depends on `VERSION` and should be generated whenever the compiler version is bumped.

@damiendoligez - I think it's OK that this configure could be updated in the "last commit"/"first commit" commits, therefore?

With this PR, the Travis branch build of trunk would have (correctly) failed after 4.09 was branched.

I've also fixed an innocuous error message displayed in the `check-typo` job of Travis branch builds - GitHub makes the diff look much more drastic than it is (comment inline)

cc @avsm