### PR TITLE
Fix a bug in [caml_modify_generational_global_root]

### DIFF
--- a/Changes
+++ b/Changes
@@ -160,6 +160,9 @@ Working version
   (Stephen Dolan, Xavier Leroy and David Allsopp,
    review by Xavier Leroy and Gabriel Scherer)
 
+- #8656: Fix a bug in [caml_modify_generational_global_root]
+  (Jacques-Henri Jourdan, review by ???)
+
 ### Standard library:
 
 - #2262: take precision (.<n>) and flags ('+' and ' ') into account

--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -77,6 +77,10 @@ module TestGenerational = Test(Generational)
 external young2old : unit -> unit = "gb_young2old"
 let _ = young2old (); Gc.full_major ()
 
+external static2young : int * int -> (unit -> unit) -> int = "gb_static2young"
+let _ =
+  assert (static2young (1, 1) Gc.full_major == 0x42)
+
 let _ =
   let n =
     if Array.length Sys.argv < 2 then 10000 else int_of_string Sys.argv.(1) in

--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -17,6 +17,7 @@
 #include "caml/memory.h"
 #include "caml/alloc.h"
 #include "caml/gc.h"
+#include "caml/callback.h"
 
 struct block { value header; value v; };
 
@@ -80,4 +81,33 @@ value gb_young2old(value _dummy) {
   caml_remove_generational_global_root(&root);
   root += sizeof(value);
   return Val_unit;
+}
+
+value gb_static2young(value static_value, value full_major) {
+  CAMLparam2 (static_value, full_major);
+  CAMLlocal1(v);
+  int i;
+
+  root = Val_unit;
+  caml_register_generational_global_root(&root);
+
+  /* Write a static value in the root. */
+  caml_modify_generational_global_root(&root, static_value);
+
+  /* Overwrite it with a young value. */
+  v = caml_alloc_small(1, 0);
+  Field(v, 0) = Val_long(0x42);
+  caml_modify_generational_global_root(&root, v);
+
+  /* Promote the young value */
+  caml_callback(full_major, Val_unit);
+
+  /* Fill the minor heap to make sure the old block is overwritten */
+  for(i = 0; i < 1000000; i++)
+    caml_alloc_small(1, 0);
+
+  v = Field(root, 0);
+  caml_remove_generational_global_root(&root);
+
+  CAMLreturn(v);
 }


### PR DESCRIPTION
When the old value was static (i.e., boxed, but outside of the major and the minor heaps) but the new value pointed to one of the two heaps, then the root was not re-inserted in the lists.