### PR TITLE
No need to call [caml_initialize] in [caml_make_vect], since we make sure the initial value is not in the minor heap

### DIFF
--- a/Changes
+++ b/Changes
@@ -170,6 +170,10 @@ Working version
   (Damien Doligez, reports by John Whitington and Alain Frisch,
    review by Jeremy Yallop and Gabriel Scherer)
 
+- #8657: Optimization in [Array.make] when initializing with unboxed
+   or young values.
+   (Jacques-Henri Jourda, review by Gabriel Scherer)
+
 ### Other libraries:
 
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -316,19 +316,19 @@ CAMLprim value caml_make_vect(value len, value init)
       for (i = 0; i < size; i++) Field(res, i) = init;
     }
     else if (size > Max_wosize) caml_invalid_argument("Array.make");
-    else if (Is_block(init) && Is_young(init)) {
-      /* We don't want to create so many major-to-minor references,
-         so [init] is moved to the major heap by doing a minor GC. */
-      CAML_INSTR_INT ("force_minor/make_vect@", 1);
-      caml_request_minor_gc ();
-      caml_gc_dispatch ();
-      res = caml_alloc_shr(size, 0);
-      for (i = 0; i < size; i++) Field(res, i) = init;
-      res = caml_check_urgent_gc (res);
-    }
     else {
+      if (Is_block(init) && Is_young(init)) {
+        /* We don't want to create so many major-to-minor references,
+           so [init] is moved to the major heap by doing a minor GC. */
+        CAML_INSTR_INT ("force_minor/make_vect@", 1);
+        caml_request_minor_gc ();
+        caml_gc_dispatch ();
+      }
+      CAMLassert(!(Is_block(init) && Is_young(init)));
       res = caml_alloc_shr(size, 0);
-      for (i = 0; i < size; i++) caml_initialize(&Field(res, i), init);
+      /* We now know that [init] is not in the minor heap, so there is
+         no need to call [caml_initialize]. */
+      for (i = 0; i < size; i++) Field(res, i) = init;
       res = caml_check_urgent_gc (res);
     }
   }


### PR DESCRIPTION
On the following micro-benchmark, this gives a x2.2 performance improvement on my machine:

```
let bench () =
  let t1 = Sys.time () in
  for i = 0 to 5000000 do
    ignore (Array.make 300 1)
  done;
  Sys.time () -. t1

let () =
  for i = 0 to 10 do
    let t1 = bench () in
    Printf.printf "%f\n%!" t1;
  done
```

Moreover, I would argue the code of `caml_make_vect` becomes simpler, since it somewhat factorizes the case where `init` is young or not.