### PR TITLE
Build system: make ocamllex silent by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -852,7 +852,7 @@ otherlibs/dynlink/dynlink.cmxa: otherlibs/dynlink/native/dynlink.ml
 # The lexer
 
 parsing/lexer.ml: parsing/lexer.mll
-	$(CAMLLEX) $<
+	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
 
 partialclean::
 	rm -f parsing/lexer.ml

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -62,3 +62,6 @@ else
   ocamlc_cmd = $(FLEXLINK_ENV) $(ocamlc)
   ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
 endif
+
+# By default, request ocamllex to be quiet
+OCAMLLEX_FLAGS ?= -q

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -103,7 +103,7 @@ depend: beforedepend
 	| sed -e 's,$(UNIXDIR)/,$$(UNIXDIR)/,' > .depend
 
 lexer.ml: lexer.mll
-	$(CAMLLEX) lexer.mll
+	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
 clean::
 	rm -f lexer.ml
 beforedepend:: lexer.ml

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -61,7 +61,7 @@ clean::
 beforedepend:: parser.ml parser.mli
 
 lexer.ml: lexer.mll
-	$(CAMLLEX) lexer.mll
+	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
 
 clean::
 	rm -f lexer.ml

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -271,7 +271,7 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 	$(OCAMLOPT_CMD) -shared -o $@ $(OCAMLPP) $(COMPFLAGS) $<
 
 .mll.ml:
-	$(OCAMLLEX) $<
+	$(OCAMLLEX) $(OCAMLLEX_FLAGS) $<
 
 .mly.ml:
 	$(OCAMLYACC) --strict -v $<
@@ -507,10 +507,10 @@ clean:
 depend:
 	$(OCAMLYACC) odoc_text_parser.mly
 	$(OCAMLYACC) odoc_parser.mly
-	$(OCAMLLEX) odoc_text_lexer.mll
-	$(OCAMLLEX) odoc_lexer.mll
-	$(OCAMLLEX) odoc_ocamlhtml.mll
-	$(OCAMLLEX) odoc_see_lexer.mll
+	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_text_lexer.mll
+	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_lexer.mll
+	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_ocamlhtml.mll
+	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_see_lexer.mll
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mll *.mly *.ml *.mli > .depend
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) -shared generators/*.ml >> .depend
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -218,7 +218,7 @@ ocamltest.opt$(EXE): $(native_modules)
 	$(ocamlyacc) $<
 
 %.ml: %.mll
-	$(ocamllex) -q $<
+	$(ocamllex) $(OCAMLLEX_FLAGS) $<
 
 %.$(O): %.c
 	$(CC) $(OC_CFLAGS) $(OC_CPPFLAGS) -c $<

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -262,9 +262,6 @@ cvt_emit: $(CVT_EMIT)
 clean::
 	if test -f cvt_emit; then mv -f cvt_emit cvt_emit.bak; else :; fi
 
-cvt_emit.ml: cvt_emit.mll
-	$(CAMLLEX) cvt_emit.mll
-
 clean::
 	rm -f cvt_emit.ml
 
@@ -298,9 +295,6 @@ DUMPOBJ= \
           opnames.cmo dumpobj.cmo
 
 $(call byte_and_opt,dumpobj,$(DUMPOBJ),)
-
-make_opcodes.ml: make_opcodes.mll
-	$(CAMLLEX) make_opcodes.mll
 
 make_opcodes: make_opcodes.ml
 	$(CAMLC) make_opcodes.ml -o $@
@@ -408,7 +402,8 @@ clean::
 
 # Common stuff
 
-.SUFFIXES:
+%.ml: %.mll
+	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
 
 %.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) - $<


### PR DESCRIPTION
The idea behind this PR is to make e.g. `make -s world.opt` completely
silent when everything works, in order to increase the visibility of
any unexpected message occurring during the build.
This will be useful for instance during CI, in particular it should
make it easier to catch undefined build variables.

The implementation is straightforward. THe `OCAMLLEX_FLAGS` variable is
defined in `Makefile.common.in` and then used consistently by all
lexing recipes.

In addition, in `tools/Makefile`, the two rules producing the lexers
from `cvt_emit.mll` and `make_opcodes.mll` have been replaced by a
pattern-rule and the useless `.SUFFIXES` target has been removed.