### PR TITLE
Limit GC credit to 1.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -158,6 +158,9 @@ Working version
   (Stephen Dolan, Xavier Leroy and David Allsopp,
    review by Xavier Leroy and Gabriel Scherer)
 
+- #8667: Limit GC credit to 1.0
+  (Leo White, review by Damien Doligez)
+
 - #8670: Fix stack overflow detection with systhreads
   (Stephen Dolan, review by Xavier Leroy, Anil Madhavapeddy, Gabriel Scherer,
    Frédéric Bour and Guillaume Munch-Maccagnoni)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -752,6 +752,8 @@ void caml_major_collection_slice (intnat howmuch)
                / Caml_state->stat_heap_wsz / caml_percent_free / 2.0;
     }
     caml_major_work_credit += filt_p;
+    /* Limit work credit to 1.0 */
+    caml_major_work_credit = fmin(caml_major_work_credit, 1.0);
   }
 
   p = filt_p;


### PR DESCRIPTION
The GC credit keeps track of what proportion of the required GC work has been done by explicit calls to `Gc.major_slice`. This value currently increases without limit and even if there isn't any newly allocated stuff on the heap, which seems to cause the GC to run too slowly in some cases. For example:

```ocaml
let force = true

let major_slice n =
  if force then Gc.major_slice n
  else 0

let () =
  List.init 1000 (fun _ ->
    major_slice 10000000 |> ignore;
    List.init 10000 (fun _ ->
      Bytes.create 1000)
    |> ignore)
  |> ignore

let () =
  let credit = Gc.get_credit () in
  let stat = Gc.quick_stat () in
  Printf.eprintf "credit %d, heapsize %d\n%!" credit stat.top_heap_words
```
gives:
```
credit 13089838787, heapsize 4726784
```
when `force` is `true` and:
```
credit 0, heapsize 2605568
```
when `force` is `false`.

This PR limits the GC credit to 1.0. This makes sense since it is supposed to represent a proportion of the GC work in a cycle. With that change the above program gives:
```
credit 0, heapsize 2651136
```
when `force` is `true`.