### PR TITLE
Memprof sampling for blocks in the minor heap, allocated by C code.

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,9 +34,11 @@ Working version
 
 - #8634: Statistical memory profiling provided by the Gc.Memprof
    module.
-   Incomplete version: it only samples objects allocated in the major
-   heap.
-   (Jacques-Henri Jourdan, review by Stephen Dolan)
+   Incomplete version: does not sample
+     - objects allocated in the minor heap in native mode,
+     - objects allocated by de-marshalling.
+   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer and
+    Damien Doligez)
 
 ### Other libraries:
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -227,7 +227,7 @@ static inline void caml_thread_restore_runtime_state(void)
   caml_backtrace_pos = curr_thread->backtrace_pos;
   caml_backtrace_buffer = curr_thread->backtrace_buffer;
   caml_backtrace_last_exn = curr_thread->backtrace_last_exn;
-  caml_memprof_set_suspended(curr_thread->memprof_suspended);
+  caml_memprof_suspended = curr_thread->memprof_suspended;
 }
 
 /* Hooks for caml_enter_blocking_section and caml_leave_blocking_section */

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -24,9 +24,13 @@
 extern void caml_memprof_track_alloc_shr(value block);
 extern void caml_memprof_handle_postponed();
 
-/* Exported only for saving and restoring in threads. */
+extern void caml_memprof_renew_minor_sample(void);
+extern value* caml_memprof_young_trigger;
+extern void caml_memprof_track_young(tag_t tag, uintnat wosize);
+
 extern int caml_memprof_suspended;
-extern void caml_memprof_set_suspended(int new_suspended);
+
+struct caml_memprof_postponed_block *caml_memprof_postponed_head;
 
 #endif
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -37,6 +37,7 @@ CAMLextern int volatile caml_something_to_do;
 extern int volatile caml_requested_major_slice;
 extern int volatile caml_requested_minor_gc;
 
+void caml_update_young_limit(void);
 void caml_request_major_slice (void);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -625,8 +625,12 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     if (wosize <= Max_young_wosize){
       if (wosize == 0){
         intern_block = Atom (String_tag);
-      } else {
-        intern_block = caml_alloc_small (wosize, String_tag);
+      }else{
+#define Setup_for_gc
+#define Restore_after_gc
+        Alloc_small_no_track(intern_block, wosize, String_tag);
+#undef Setup_for_gc
+#undef Restore_after_gc
       }
     }else{
       intern_block = caml_alloc_shr_no_track (wosize, String_tag);

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -34,16 +34,30 @@ static uint32_t mt_index;
 /* [lambda] is the mean number of samples for each allocated word (including
    block headers). */
 static double lambda = 0;
+ /* Inverse of [lamdba]. Meaningless if lamdba = 0 */
+static double lambda_inverse = 0;
+
 int caml_memprof_suspended = 0;
 static intnat callstack_size = 0;
 static value memprof_callback = Val_unit;
+
+/* Position of the next sample in the minor heap. Equals
+   [caml_young_alloc_start] if no sampling is planned in the current
+   minor heap.
+   Invariant: [caml_memprof_young_trigger <= caml_young_ptr].
+ */
+value* caml_memprof_young_trigger;
+/* The continuous position of the next minor sample within the next
+   sampled word. Always in [0, 1[. */
+static double next_sample_frac_part;
 
 /* Whether memprof has been initialized.  */
 static int init = 0;
 
 /**** Statistical sampling ****/
 
-static double mt_generate_uniform(void) {
+static double mt_generate_uniform(void)
+{
   int i;
   uint32_t y;
 
@@ -82,7 +96,8 @@ static double mt_generate_uniform(void) {
    We use Ramanujan's formula. For n < 10^8, the absolute error is
    less than 10^-6, which is way better than what we need.
  */
-static double lfact(double n) {
+static double lfact(double n)
+{
   static double tab[10] = {
     0.0000000000, 0.0000000000, 0.6931471806, 1.7917594692, 3.1780538303,
     4.7874917428, 6.5792512120, 8.5251613611, 10.6046029027, 12.8018274801 };
@@ -96,12 +111,10 @@ static double lfact(double n) {
 static double next_mt_generate_poisson;
 /* Simulate a Poisson distribution of parameter [lambda*len].  The
    result is clipped to the interval [0..MAX_MT_GENERATE_POISSON] */
-static int32_t mt_generate_poisson(double len) {
+static int32_t mt_generate_poisson(double len)
+{
   double cur_lambda = lambda * len;
   CAMLassert(cur_lambda >= 0 && cur_lambda < 1e20);
-
-  if(caml_memprof_suspended || cur_lambda == 0)
-    return 0;
 
   if(cur_lambda < 20) {
     /* First algorithm when [cur_lambda] is small: we proceed by
@@ -167,7 +180,8 @@ static int32_t mt_generate_poisson(double len) {
 
 /**** Interface with the OCaml code. ****/
 
-CAMLprim value caml_memprof_set(value v) {
+CAMLprim value caml_memprof_set(value v)
+{
   CAMLparam1(v);
   double l = Double_val(Field(v, 0));
   intnat sz = Long_val(Field(v, 1));
@@ -190,6 +204,8 @@ CAMLprim value caml_memprof_set(value v) {
   }
 
   lambda = l;
+  lambda_inverse = 1/l;
+  caml_memprof_renew_minor_sample();
   callstack_size = sz;
   caml_modify_generational_global_root(&memprof_callback, Field(v, 2));
 
@@ -203,14 +219,14 @@ enum ml_alloc_kind {
   Serialized = Val_long(2)
 };
 
-static value do_callback(tag_t tag, intnat wosize, int32_t occurences,
+static value do_callback(tag_t tag, intnat wosize, int32_t occurrences,
                          value callstack, enum ml_alloc_kind cb_kind) {
   CAMLparam1(callstack);
   CAMLlocal1(sample_info);
-  CAMLassert(occurences > 0);
+  CAMLassert(occurrences > 0);
 
   sample_info = caml_alloc_small(5, 0);
-  Field(sample_info, 0) = Val_long(occurences);
+  Field(sample_info, 0) = Val_long(occurrences);
   Field(sample_info, 1) = cb_kind;
   Field(sample_info, 2) = Val_long(tag);
   Field(sample_info, 3) = Val_long(wosize);
@@ -219,18 +235,25 @@ static value do_callback(tag_t tag, intnat wosize, int32_t occurences,
   CAMLreturn(caml_callback_exn(memprof_callback, sample_info));
 }
 
-void caml_memprof_set_suspended(int new_suspended) {
-  caml_memprof_suspended = new_suspended;
-}
-
 /**** Sampling procedures ****/
 
-static value capture_callstack() {
+static value capture_callstack_major()
+{
   value res;
-  intnat size = caml_current_callstack_size(callstack_size);
+  intnat wosize = caml_current_callstack_size(callstack_size);
   /* We do not use [caml_alloc] to make sure the GC will not get called. */
-  if(size == 0) return Atom (0);
-  res = caml_alloc_shr_no_track(size, 0);
+  if(wosize == 0) return Atom (0);
+  res = caml_alloc_shr_no_track(wosize, 0);
+  caml_current_callstack_write(res);
+  return res;
+}
+
+static value capture_callstack_minor()
+{
+  value res;
+  intnat wosize = caml_current_callstack_size(callstack_size);
+  CAMLassert(caml_memprof_suspended); /* => no samples in the call stack. */
+  res = caml_alloc(wosize, 0);
   caml_current_callstack_write(res);
   return res;
 }
@@ -238,28 +261,33 @@ static value capture_callstack() {
 struct caml_memprof_postponed_block {
   value block;
   value callstack;
-  int32_t occurences;
+  int32_t occurrences;
   struct caml_memprof_postponed_block* next;
-} static *caml_memprof_postponed_head = NULL;
+} *caml_memprof_postponed_head = NULL;
 
 /* When allocating in the major heap, we cannot call the callback,
    because [caml_alloc_shr] is guaranteed not to call the GC. Hence,
    this function determines if the block needs to be sampled, and if
    so, it registers the block in the todo-list so that the callback
    call is performed when possible. */
-void caml_memprof_track_alloc_shr(value block) {
-  int32_t occurences = mt_generate_poisson(Whsize_val(block));
+void caml_memprof_track_alloc_shr(value block)
+{
+  int32_t occurrences;
   CAMLassert(Is_in_heap(block));
-  if(occurences > 0) {
+  /* This test also makes sure memprof is initialized. */
+  if(lambda == 0 || caml_memprof_suspended)
+    return;
+  occurrences = mt_generate_poisson(Whsize_val(block));
+  if(occurrences > 0) {
     struct caml_memprof_postponed_block* pb =
       caml_stat_alloc_noexc(sizeof(struct caml_memprof_postponed_block));
-    value callstack = capture_callstack();
+    value callstack = capture_callstack_major();
     if(pb == NULL) return;
     pb->block = block;
     caml_register_generational_global_root(&pb->block);
     pb->callstack = callstack;
     caml_register_generational_global_root(&pb->callstack);
-    pb->occurences = occurences;
+    pb->occurrences = occurrences;
     pb->next = caml_memprof_postponed_head;
     caml_memprof_postponed_head = pb;
 #ifndef NATIVE_CODE
@@ -270,14 +298,15 @@ void caml_memprof_track_alloc_shr(value block) {
   }
 }
 
-void caml_memprof_handle_postponed() {
+void caml_memprof_handle_postponed()
+{
   struct caml_memprof_postponed_block *p, *q;
   value ephe;
 
   if(caml_memprof_postponed_head == NULL)
     return;
 
-  // We first reverse the list
+  /* We first reverse the list */
   p = caml_memprof_postponed_head;
   q = caml_memprof_postponed_head->next;
   p->next = NULL;
@@ -288,6 +317,7 @@ void caml_memprof_handle_postponed() {
     q = next;
   }
   caml_memprof_postponed_head = NULL;
+  caml_update_young_limit();
 
 #define NEXT_P \
   { struct caml_memprof_postponed_block* next = p->next;   \
@@ -296,14 +326,14 @@ void caml_memprof_handle_postponed() {
     caml_stat_free(p);                                     \
     p = next; }
 
-  caml_memprof_set_suspended(1);
-  // We then do the actual iteration on postponed blocks
+  caml_memprof_suspended = 1;
+  /* We then do the actual iteration on postponed blocks */
   while(p != NULL) {
     ephe = do_callback(Tag_val(p->block), Wosize_val(p->block),
-                       p->occurences, p->callstack, Major);
+                       p->occurrences, p->callstack, Major);
     if (Is_exception_result(ephe)) {
-      caml_memprof_set_suspended(0);
-      // In the case of an exception, we just forget the entire list.
+      caml_memprof_suspended = 0;
+      /* In the case of an exception, we just forget the entire list. */
       while(p != NULL) NEXT_P;
       caml_raise(Extract_exception(ephe));
     }
@@ -311,5 +341,136 @@ void caml_memprof_handle_postponed() {
       caml_ephemeron_set_key(Field(ephe, 0), 0, p->block);
     NEXT_P;
   }
-  caml_memprof_set_suspended(0);
+  caml_memprof_suspended = 0;
+}
+
+/* Shifts the next sample in the minor heap by [n] words. Essentially,
+   this tells the sampler to ignore the next [n] words of the minor
+   heap. */
+static void shift_sample(uintnat n)
+{
+  if(caml_memprof_young_trigger - caml_young_alloc_start > n)
+    caml_memprof_young_trigger -= n;
+  else
+    caml_memprof_young_trigger = caml_young_alloc_start;
+  caml_update_young_limit();
+}
+
+/* Renew the next sample in the minor heap. This needs to be called
+   after each minor sampling and after each minor collection. In
+   practice, because we disable sampling during callbacks, this is
+   called at each sampling (including major ones). These extra calls
+   do not change the statistical properties of the sampling because of
+   the memorylessness of the exponential distribution. */
+void caml_memprof_renew_minor_sample(void)
+{
+  double exp;
+  uintnat max, exp_int;
+
+  if(lambda == 0) /* No trigger in the current minor heap. */
+    caml_memprof_young_trigger = caml_young_alloc_start;
+  else {
+    exp = - lambda_inverse * logf(mt_generate_uniform());
+    max = caml_young_ptr - caml_young_alloc_start;
+    if(exp >= (double)max) /* No trigger in the current minor heap. */
+      caml_memprof_young_trigger = caml_young_alloc_start;
+    else {
+      exp_int = (uintnat)exp;
+      /* This assertion can be false only if [max] is not exactly
+        representable as a double, which cannot happen if the size of the
+        minor heap does not reach 2^52. */
+      CAMLassert(exp_int < max);
+
+      caml_memprof_young_trigger = caml_young_ptr - exp_int;
+
+      next_sample_frac_part = exp - exp_int;
+      CAMLassert(0 <= next_sample_frac_part && next_sample_frac_part < 1);
+    }
+  }
+
+  caml_update_young_limit();
+}
+
+/* Called when exceeding the threshold for the next sample in the
+   minor heap, from the C code (the handling is different when called
+   from natively compiled OCaml code). */
+void caml_memprof_track_young(tag_t tag, uintnat wosize)
+{
+  CAMLparam0();
+  CAMLlocal2(ephe, callstack);
+  uintnat whsize = Whsize_wosize(wosize);
+  double rest;
+  int32_t occurrences;
+
+  if(caml_memprof_suspended) {
+    caml_memprof_renew_minor_sample();
+    CAMLreturn0;
+  }
+
+  /* If [lambda == 0], then [caml_memprof_young_trigger] should be
+     equal to [caml_young_alloc_start].  But this function is only
+     called with [caml_young_alloc_start <= caml_young_ptr <
+     caml_memprof_young_trigger], which is contradictory. */
+  CAMLassert(lambda > 0);
+
+  /* We need to call the callback for this sampled block. Since the
+     callback can potentially allocate, the sampled block will *not*
+     be the one pointed to by [caml_memprof_young_trigger]. Instead,
+     we remember here that we need to sample the next allocated word,
+     call the callback and use as a sample the block which will be
+     allocated right after the callback. */
+
+  /* [rest] is the size of the part of the allocated block which is
+     after the sampling point. */
+  rest = (caml_memprof_young_trigger - caml_young_ptr) - next_sample_frac_part;
+  CAMLassert(rest >= 0);
+  occurrences = mt_generate_poisson(rest) + 1;
+
+  /* Restore the minor heap in a valid state and suspend sampling for
+     calling the callback.
+     We should not call the GC before this. */
+  caml_young_ptr += whsize;
+  caml_memprof_suspended = 1;
+  caml_memprof_renew_minor_sample();
+
+  callstack = capture_callstack_minor();
+  ephe = do_callback(tag, wosize, occurrences, callstack, Minor);
+
+  caml_memprof_suspended = 0;
+  if (Is_exception_result(ephe)) caml_raise(Extract_exception(ephe));
+
+  /* We can now restore the minor heap in the state needed by
+     [Alloc_small_aux].
+     We should not call the GC after this. */
+  if(caml_young_ptr - whsize < caml_young_trigger) {
+    /* The call to [caml_gc_dispatch] may run arbitrary OCaml code via
+       finalizers. We artificially fill the ephemeron with [Val_unit]
+       so that the client code never sees the ephemeron empty before
+       the block is actually freed. */
+    if(Is_block(ephe))
+      caml_ephemeron_set_key(Field(ephe, 0), 0, Val_unit);
+
+    CAML_INSTR_INT ("force_minor/memprof@", 1);
+    caml_gc_dispatch();
+  }
+  caml_young_ptr -= whsize;
+
+  /* Make sure this block is not going to be sampled again. */
+  shift_sample(whsize);
+
+  /* Write the ephemeron if not [None]. */
+  if(Is_block(ephe)) {
+    /* Subtlety: we are actually writing the ephemeron with an invalid
+       (unitialized) block. This is correct for two reasons:
+          - The logic of [caml_ephemeron_set_key] never inspects the content of
+            the block. In only checks that the block is young.
+          - The allocation and initialization happens right after returning
+            from [caml_memprof_track_young]. Since the heap is in an invalid
+            state before that initialization, very little heap operations are
+            allowed until then.
+    */
+    caml_ephemeron_set_key(Field(ephe, 0), 0, Val_hp(caml_young_ptr));
+  }
+
+  CAMLreturn0;
 }

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -28,6 +28,7 @@
 #include "caml/mlvalues.h"
 #include "caml/printexc.h"
 #include "caml/memory.h"
+#include "caml/memprof.h"
 
 struct stringbuf {
   char * ptr;
@@ -140,6 +141,13 @@ void caml_fatal_uncaught_exception(value exn)
 
   handle_uncaught_exception =
     caml_named_value("Printexc.handle_uncaught_exception");
+
+  /* If the callback allocates, memprof could be called. In this case,
+     memprof's callback could raise an exception while
+     [handle_uncaught_exception] is running, so that the printing of
+     the exception fails. */
+  caml_memprof_suspended = 1;
+
   if (handle_uncaught_exception != NULL)
     /* [Printexc.handle_uncaught_exception] does not raise exception. */
     caml_callback2(*handle_uncaught_exception, exn, Val_bool(DEBUGGER_IN_USE));

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -74,7 +74,11 @@ extern char caml_system__code_begin, caml_system__code_end;
 
 void caml_garbage_collection(void)
 {
-  caml_young_limit = caml_young_trigger;
+  /* TEMPORARY: if we have just sampled an allocation in native mode,
+     we simply renew the sample to ignore it. Otherwise, renewing now
+     will not have any efect on the sampling distribution, because of
+     the memorylessness of the Poisson process. */
+  caml_memprof_renew_minor_sample();
   if (caml_requested_major_slice || caml_requested_minor_gc ||
       caml_young_ptr - caml_young_trigger < Max_young_whsize){
     caml_gc_dispatch ();

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -419,7 +419,7 @@ module Memprof :
         tag: int;
         (** The tag of the allocated block. *)
         size: int;
-        (** The size of the allocated block, in words (exclusing the
+        (** The size of the allocated block, in words (excluding the
             header). *)
         callstack: Printexc.raw_backtrace;
         (** The callstack for the allocation. *)
@@ -428,8 +428,10 @@ module Memprof :
 
     type 'a callback = sample_info -> (Obj.t, 'a) Ephemeron.K1.t option
     (** [callback] is the type of callbacks launch by the sampling
-       engine.  A callback returns an option over an ephemeron whose
-       key is set to the allocated block for further tracking.
+       engine. A callback returns an option over an ephemeron whose
+       key is set to the allocated block for further tracking. After
+       the callback returns, the key of the ephemeron should not be
+       read, since this would change its reachability properties.
 
        The sampling is temporarily disabled when calling the callback
        for the current thread. So it needs not be reentrant if only

--- a/testsuite/tests/statmemprof/arrays_in_major.byte.reference
+++ b/testsuite/tests/statmemprof/arrays_in_major.byte.reference
@@ -1,5 +1,5 @@
 check_nosample
-check_ephe_full
+check_ephe_full_major
 check_no_nested
 check_distrib 300 3000 1 0.000010
 check_distrib 300 3000 1 0.000100
@@ -8,6 +8,6 @@ check_distrib 300 3000 1 1.000000
 check_distrib 300 300 100000 0.100000
 check_distrib 300000 300000 30 0.100000
 check_callstack
-Raised by primitive operation at file "arrays_in_major.ml", line 133, characters 2-35
-Called from file "arrays_in_major.ml", line 139, characters 9-27
+Raised by primitive operation at file "arrays_in_major.ml", line 136, characters 2-35
+Called from file "arrays_in_major.ml", line 142, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/arrays_in_major.opt.reference
+++ b/testsuite/tests/statmemprof/arrays_in_major.opt.reference
@@ -1,5 +1,5 @@
 check_nosample
-check_ephe_full
+check_ephe_full_major
 check_no_nested
 check_distrib 300 3000 1 0.000010
 check_distrib 300 3000 1 0.000100
@@ -8,7 +8,7 @@ check_distrib 300 3000 1 1.000000
 check_distrib 300 300 100000 0.100000
 check_distrib 300000 300000 30 0.100000
 check_callstack
-Raised by primitive operation at file "arrays_in_major.ml", line 16, characters 14-28
-Called from file "arrays_in_major.ml", line 133, characters 2-35
-Called from file "arrays_in_major.ml", line 139, characters 9-27
+Raised by primitive operation at file "arrays_in_major.ml", line 17, characters 14-28
+Called from file "arrays_in_major.ml", line 136, characters 2-35
+Called from file "arrays_in_major.ml", line 142, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/arrays_in_minor.byte.reference
+++ b/testsuite/tests/statmemprof/arrays_in_minor.byte.reference
@@ -1,0 +1,13 @@
+check_nosample
+check_ephe_full_major
+check_no_nested
+check_distrib 1 250 1000 0.000010
+check_distrib 1 250 1000 0.000100
+check_distrib 1 250 1000 0.010000
+check_distrib 1 250 1000 1.000000
+check_distrib 1 1 10000000 0.010000
+check_distrib 250 250 100000 0.100000
+check_callstack
+Raised by primitive operation at file "arrays_in_minor.ml", line 142, characters 2-35
+Called from file "arrays_in_minor.ml", line 148, characters 9-27
+OK !

--- a/testsuite/tests/statmemprof/arrays_in_minor.opt.reference
+++ b/testsuite/tests/statmemprof/arrays_in_minor.opt.reference
@@ -1,0 +1,14 @@
+check_nosample
+check_ephe_full_major
+check_no_nested
+check_distrib 1 250 1000 0.000010
+check_distrib 1 250 1000 0.000100
+check_distrib 1 250 1000 0.010000
+check_distrib 1 250 1000 1.000000
+check_distrib 1 1 10000000 0.010000
+check_distrib 250 250 100000 0.100000
+check_callstack
+Raised by primitive operation at file "arrays_in_minor.ml", line 22, characters 20-34
+Called from file "arrays_in_minor.ml", line 142, characters 2-35
+Called from file "arrays_in_minor.ml", line 148, characters 9-27
+OK !

--- a/testsuite/tests/statmemprof/exception_callback.ml
+++ b/testsuite/tests/statmemprof/exception_callback.ml
@@ -1,0 +1,19 @@
+(* TEST
+   exit_status = "2"
+*)
+
+open Gc.Memprof
+
+(* We don't want to print the backtrace. We just want to make sure the
+   exception is printed.
+   This also makes sure [Printexc] is loaded, otherwise we don't use
+   its uncaught exception handler. *)
+let _ = Printexc.record_backtrace false
+
+let _ =
+  start {
+    sampling_rate = 1.;
+    callstack_size = 10;
+    callback = fun _ -> assert false
+  };
+  Array.make 200 0

--- a/testsuite/tests/statmemprof/exception_callback.reference
+++ b/testsuite/tests/statmemprof/exception_callback.reference
@@ -1,0 +1,1 @@
+Fatal error: exception File "exception_callback.ml", line 17, characters 24-30: Assertion failed

--- a/testsuite/tests/statmemprof/lists_in_minor.byte.reference
+++ b/testsuite/tests/statmemprof/lists_in_minor.byte.reference
@@ -1,0 +1,12 @@
+check_distrib 10 1000000 0.010000
+check_distrib 1000000 10 0.000010
+check_distrib 1000000 10 0.000100
+check_distrib 1000000 10 0.001000
+check_distrib 1000000 10 0.010000
+check_distrib 100000 10 0.100000
+check_distrib 100000 10 1.000000
+check_callstack
+Raised by primitive operation at file "lists_in_minor.ml", line 15, characters 11-33
+Called from file "lists_in_minor.ml", line 67, characters 2-26
+Called from file "lists_in_minor.ml", line 74, characters 2-20
+OK !

--- a/testsuite/tests/statmemprof/lists_in_minor.ml
+++ b/testsuite/tests/statmemprof/lists_in_minor.ml
@@ -1,0 +1,77 @@
+(* TEST
+   flags = "-g"
+   * bytecode
+     reference = "${test_source_directory}/lists_in_minor.byte.reference"
+*)
+
+open Gc.Memprof
+
+let[@inline never] allocate_lists len cnt =
+  let rec allocate_list accu = function
+    | 0 -> accu
+    | n -> allocate_list (n::accu) (n-1)
+  in
+  for j = 0 to cnt-1 do
+    ignore (allocate_list [] len)
+  done
+
+let check_distrib len cnt rate =
+  Printf.printf "check_distrib %d %d %f\n%!" len cnt rate;
+  let smp = ref 0 in
+  start {
+      sampling_rate = rate;
+      callstack_size = 10;
+      callback = fun info ->
+        assert (info.kind = Minor);
+        if info.tag = 0 then begin (* Exclude noise such as spurious closures. *)
+          assert (info.size = 2);
+          assert (info.n_samples > 0);
+          smp := !smp + info.n_samples
+        end;
+        None
+    };
+  allocate_lists len cnt;
+  stop ();
+
+  (* The probability distribution of the number of samples follows a
+     poisson distribution with mean tot_alloc*rate. Given that we
+     expect this quantity to be large (i.e., > 100), this distribution
+     is approximately equal to a normal distribution. We compute a
+     1e-8 confidence interval for !smp using quantiles of the normal
+     distribution, and check that we are in this confidence interval. *)
+  let tot_alloc = cnt*len*3 in
+  let mean = float tot_alloc *. rate in
+  let stddev = sqrt mean in
+  (* This assertion has probability to fail close to 1e-8. *)
+  assert (abs_float (mean -. float !smp) <= stddev *. 5.7)
+
+let () =
+  check_distrib 10 1000000 0.01;
+  check_distrib 1000000 10 0.00001;
+  check_distrib 1000000 10 0.0001;
+  check_distrib 1000000 10 0.001;
+  check_distrib 1000000 10 0.01;
+  check_distrib 100000 10 0.1;
+  check_distrib 100000 10 1.
+
+let[@inline never] check_callstack () =
+  Printf.printf "check_callstack\n%!";
+  let callstack = ref None in
+  start {
+      sampling_rate = 1.;
+      callstack_size = 10;
+      callback = fun info ->
+        if info.tag = 0 then callstack := Some info.callstack;
+        None
+    };
+  allocate_lists 1000000 1;
+  stop ();
+  match !callstack with
+  | None -> assert false
+  | Some cs -> Printexc.print_raw_backtrace stdout cs
+
+let () =
+  check_callstack ()
+
+let () =
+  Printf.printf "OK !\n"

--- a/testsuite/tests/statmemprof/ocamltests
+++ b/testsuite/tests/statmemprof/ocamltests
@@ -1,1 +1,4 @@
 arrays_in_major.ml
+arrays_in_minor.ml
+lists_in_minor.ml
+exception_callback.ml


### PR DESCRIPTION
Allocations ignored by this version
- Marshalling
- In the minor heap by natively-compiled OCaml code

Allocations potentially sampled
- In the major heap
- In the minor heap by C code and OCaml code in bytecode mode