### PR TITLE
Fix Mach printer

### DIFF
--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -220,7 +220,8 @@ let rec instr ppf i =
             fprintf ppf "@ and";
             aux t
       in
-      aux handlers
+      aux handlers;
+      fprintf ppf "@;<0 -2>endcatch@]"
   | Iexit i ->
       fprintf ppf "exit(%d)" i
   | Itrywith(body, handler) ->


### PR DESCRIPTION
Fix the printing for catch handlers by closing the printing box (and adding an `endcatch` closing word, similarly to switch and trywith).