### PR TITLE
Fix stack overflow detection with systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -73,6 +73,10 @@ Working version
   (Stephen Dolan, Xavier Leroy and David Allsopp,
    review by Xavier Leroy and Gabriel Scherer)
 
+- #8670: Fix stack overflow detection with systhreads
+  (Stephen Dolan, review by Xavier Leroy, Anil Madhavapeddy, Gabriel Scherer,
+   Frédéric Bour and Guillaume Munch-Maccagnoni)
+
 * #8711: The major GC hooks are no longer allowed to interact with the
    OCaml heap.
    (Jacques-Henri Jourdan, review by Damien Doligez)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -563,6 +563,7 @@ static ST_THREAD_FUNCTION caml_thread_start(void * arg)
   st_tls_set(thread_descriptor_key, (void *) th);
   /* Acquire the global mutex */
   caml_leave_blocking_section();
+  caml_setup_stack_overflow_detection();
 #ifdef NATIVE_CODE
   /* Setup termination handler (for caml_thread_exit) */
   if (sigsetjmp(termination_buf.buf, 0) == 0) {

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -290,7 +290,7 @@
 #else
 #  define PREPARE_FOR_C_CALL
 #  define CLEANUP_AFTER_C_CALL
-#  define STACK_PROBE_SIZE 32768
+#  define STACK_PROBE_SIZE 4096
 #endif
 
 /* Registers holding arguments of C functions. */

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -132,34 +132,17 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
   CAMLparam0();
   CAMLlocal1(res);
 
-  /* Beware: the allocations below may cause finalizers to be run, and another
-     backtrace---possibly of a different length---to be stashed (for example
-     if the finalizer raises then catches an exception).  We choose to ignore
-     any such finalizer backtraces and return the original one. */
-
   if (!Caml_state->backtrace_active ||
       Caml_state->backtrace_buffer == NULL ||
       Caml_state->backtrace_pos == 0) {
     res = caml_alloc(0, 0);
   }
   else {
-    backtrace_slot saved_backtrace_buffer[BACKTRACE_BUFFER_SIZE];
-    int saved_backtrace_pos;
-    intnat i;
+    intnat i, len = Caml_state->backtrace_pos;
 
-    saved_backtrace_pos = Caml_state->backtrace_pos;
-
-    if (saved_backtrace_pos > BACKTRACE_BUFFER_SIZE) {
-      saved_backtrace_pos = BACKTRACE_BUFFER_SIZE;
-    }
-
-    memcpy(saved_backtrace_buffer, Caml_state->backtrace_buffer,
-           saved_backtrace_pos * sizeof(backtrace_slot));
-
-    res = caml_alloc(saved_backtrace_pos, 0);
-    for (i = 0; i < saved_backtrace_pos; i++) {
-      Field(res, i) = Val_backtrace_slot(saved_backtrace_buffer[i]);
-    }
+    res = caml_alloc(len, 0);
+    for (i = 0; i < len; i++)
+      Field(res, i) = Val_backtrace_slot(Caml_state->backtrace_buffer[i]);
   }
 
   CAMLreturn(res);

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -45,6 +45,7 @@ void caml_set_something_to_do (void);
 void caml_raise_in_async_callback (value exc);
 void caml_process_event(void);
 int caml_set_signal_action(int signo, int action);
+void caml_setup_stack_overflow_detection(void);
 
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);

--- a/runtime/signals_byt.c
+++ b/runtime/signals_byt.c
@@ -98,3 +98,5 @@ int caml_set_signal_action(int signo, int action)
   else
     return 0;
 }
+
+void caml_setup_stack_overflow_detection(void) {}

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -29,6 +29,7 @@
   typedef greg_t context_reg;
   #define CONTEXT_C_ARG_1 (context->uc_mcontext.gregs[REG_RDI])
   #define CONTEXT_PC (context->uc_mcontext.gregs[REG_RIP])
+  #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
   #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.gregs[REG_CR2])
 
@@ -79,6 +80,7 @@
 
   typedef unsigned long context_reg;
   #define CONTEXT_PC (context->uc_mcontext.arm_pc)
+  #define CONTEXT_SP (context->uc_mcontext.arm_sp)
   #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.arm_fp)
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.arm_r8)
   #define CONTEXT_FAULTING_ADDRESS ((char *) context->uc_mcontext.fault_address)
@@ -98,6 +100,7 @@
 
   typedef unsigned long context_reg;
   #define CONTEXT_PC (context->uc_mcontext.pc)
+  #define CONTEXT_SP (context->uc_mcontext.sp)
   #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.regs[26])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.regs[27])
   #define CONTEXT_FAULTING_ADDRESS ((char *) context->uc_mcontext.fault_address)
@@ -117,6 +120,7 @@
 
   typedef unsigned long context_reg;
   #define CONTEXT_PC (context->uc_mcontext.mc_gpregs.gp_elr)
+  #define CONTEXT_SP (context->uc_mcontext.mc_gpregs.gp_sp)
   #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.mc_gpregs.gp_x[26])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.mc_gpregs.gp_x[27])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
@@ -138,6 +142,7 @@
   typedef greg_t context_reg;
   #define CONTEXT_PC (context->uc_mcontext.gregs[REG_RIP])
   #define CONTEXT_C_ARG_1 (context->uc_mcontext.gregs[REG_RDI])
+  #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
@@ -154,6 +159,7 @@
 
  #define CONTEXT_PC (context->sc_rip)
  #define CONTEXT_C_ARG_1 (context->sc_rdi)
+ #define CONTEXT_SP (context->sc_rsp)
  #define CONTEXT_YOUNG_PTR (context->sc_r15)
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
@@ -171,6 +177,7 @@
 
  #define CONTEXT_PC (_UC_MACHINE_PC(context))
  #define CONTEXT_C_ARG_1 (context->uc_mcontext.gregs[REG_RDI])
+ #define CONTEXT_SP (_UC_MACHINE_SP(context))
  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
@@ -186,6 +193,8 @@
      sigact.sa_flags = 0
 
   #define CONTEXT_FAULTING_ADDRESS ((char *) context.cr2)
+  #define CONTEXT_PC (context.eip)
+  #define CONTEXT_SP (context.esp)
 
 /****************** I386, BSD_ELF */
 
@@ -206,8 +215,10 @@
 
  #if defined (__NetBSD__)
   #define CONTEXT_PC (_UC_MACHINE_PC(context))
+  #define CONTEXT_SP (_UC_MACHINE_SP(context))
  #else
   #define CONTEXT_PC (context->sc_eip)
+  #define CONTEXT_SP (context->sc_esp)
  #endif
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
@@ -247,6 +258,7 @@
 
   #define CONTEXT_STATE (((ucontext_t *)context)->uc_mcontext->CONTEXT_REG(ss))
   #define CONTEXT_PC (CONTEXT_STATE.CONTEXT_REG(eip))
+  #define CONTEXT_SP (CONTEXT_STATE.CONTEXT_REG(esp))
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
 /****************** I386, Solaris x86 */


### PR DESCRIPTION
Stack overflow detection doesn't work properly with systhreads, as shown by #7490. A fix was proposed a while ago in #1062, but stalled. This PR implements a simpler approach.

Instead of trying to work out the stack dimensions by querying OS interfaces, this patch defines a stack overflow as a SIGSEGV that happens on an address that's between the top of the stack and the current stack pointer (or slightly past the stack pointer, to handle some edge cases around function prologues).

There are a couple of changes:

  - calls to getrlimit are removed from the signal handler, inspecting the stack pointer instead.

  - all systhreads now reinitialise the sigaltstack (but not the signal handler) on startup. ~~POSIX says you should have to do the former but not the latter, on Linux it seems you need both~~ (this is nonsense, I was testing it badly. Reinitialising sigaltstack and leaving the handler alone suffices). All threads share the same sigaltstack - they won't collide unless there's a segfault in C code, in which case all bets are already off.

  - the stack probe limit on amd64 was lowered from 32k to 4k. Linux adds a 4k guard page at the end of thread stacks to catch overflow, but beyond that is free space. It is quite common (i.e. happened regularly in testing) for that space to be used by some other allocation. So, a stack probe of 32k from the current stack pointer has false positives: it crosses the guard page and touches some random bit of memory. A 4k probe cannot have false positives: it either lies in the stack or in the guard page.

  - `caml_get_exception_raw_backtrace` no longer allocates an 8K array on the stack. (This is an independent change, in a seperate commit. Including it here makes it safe to call `Printexc.print_backtrace` from a `Stack_overflow` handler).

This has so far only been tested on Linux amd64, but I've added CONTEXT_SP support for other platforms. Hopefully it will work everywhere?