### PR TITLE
Optimise Switch code generation on booleans

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,11 @@ Working version
 - #8677: Use unsigned comparisons in amd64 and i386 emitter of Lcondbranch3.
   (Greta Yorsh, review by Xavier Leroy)
 
+### Code generation and optimizations:
+
+- #8672: Optimise Switch code generation on booleans.
+  (Stephen Dolan, review by Pierre Chambart, Gabriel Scherer and Luc Maranget)
+
 ### Runtime system:
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -268,6 +268,8 @@ type lambda =
   | Lstaticraise of int * lambda list
   | Lstaticcatch of lambda * (int * (Ident.t * value_kind) list) * lambda
   | Ltrywith of lambda * Ident.t * lambda
+(* Lifthenelse (e, t, f) evaluates t if e evaluates to 0, and
+   evaluates f if e evaluates to any other value *)
   | Lifthenelse of lambda * lambda * lambda
   | Lsequence of lambda * lambda
   | Lwhile of lambda * lambda

--- a/lambda/switch.ml
+++ b/lambda/switch.ml
@@ -659,8 +659,8 @@ let rec pkey chan  = function
           and right = {s with cases=right} in
 
           if i=1 && (lim+ctx.off)=1 && get_low cases 0+ctx.off=0 then
-            make_if_ne
-              ctx.arg 0
+            Arg.make_if
+              ctx.arg
               (c_test ctx right) (c_test ctx left)
           else if less_tests cright cleft then
             make_if_lt


### PR DESCRIPTION

This patch optimises Switch to avoid introducing an extra comparison when matching on booleans (or other types with two constant constructors). If the value being matched is known to be 0 or 1, we need not do a further comparison with 0 before dispatching.

There was already a special case to detect branches that distinguish constructor 0 from other constructors (these are compiled as a comparison against 0, rather than the usual less-than comparison). Here, this special case is extended to detect the case when there is only one other constructor, with value 1.

An example of matching on a boolean is this function:

```ocaml
let f x =
  match x = 27 with
  | true -> 7
  | false -> 77
```

Currently, it is compiled to this `Lambda`:
```
(function x/81[int] : int
  (let (*match*/153 = (== x/81 27)) (if (!= *match*/153 0) 7 77)))
```

With this patch, the `!= 0` is removed, and it becomes:

```
(function x/82[int] : int
  (let (*match*/154 = (== x/82 27)) (if *match*/154 7 77)))
```

This doesn't make much difference for the non-Flambda compilation pipeline. With Flambda enabled, the resulting Cmm is much simpler. Instead of:

```
(function camlMatchtest__f_5 (x/158: val)
   (if (!= (+ (<< (== x/158 55) 1) 1) 1) 15 155))
```

we get:

```
(function camlMatchtest__f_5 (x/158: val)
 (if (== x/158 55) 15 155))
```

This translates into smaller code:

```
camlMatchtest__f_5:
        cmpq    $55, %rax
        sete    %al
        movzbq  %al, %rax
        leaq    1(%rax,%rax), %rax
        cmpq    $1, %rax
        je      .L100
        movq    $15, %rax
        ret
        .align  4
.L100:
        movq    $155, %rax
        ret
```

vs.

```
camlMatchtest__f_5:
        cmpq    $55, %rax
        jne     .L100
        movq    $15, %rax
        ret
        .align  4
.L100:
        movq    $155, %rax
        ret
```

I haven't found a significant speed difference, but this seems worthwhile for the code size reduction alone.
