### PR TITLE
configure: fix libunwind and spacetime support

### DIFF
--- a/Changes
+++ b/Changes
@@ -911,7 +911,11 @@ OCaml 4.08.0
   (Leo White, Greta Yorsh, review by Gabriel Radanne)
 
 - #8616: configure: use variables rather than arguments for a few options
-  (Sébastien Hinderer, review by David Allsopp and Gabriel Scherer)
+  (Sébastien Hinderer, review by David Allsopp, Gabriel Scherer and
+  Damien Doligez)
+
+- #8673: restore SpaceTime and libunwind support in configure script
+  (Sébastien Hinderer, review by Damien Doligez)
 
 ### Internal/compiler-libs changes:
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -251,3 +251,16 @@ int main (int argc, char *argv[]){
     [AC_MSG_RESULT([no])],
     [AC_MSG_RESULT([no assumed])])
 ])
+
+AC_DEFUN([OCAML_CHECK_LIBUNWIND], [
+  SAVED_CFLAGS="$CFLAGS"
+  SAVED_LDFLAGS="$LDFLAGS"
+  CFLAGS="$CFLAGS $libunwind_include_flags"
+  LDFLAGS="$LDFLAGS $libunwind_link_flags"
+  AC_CHECK_HEADER([libunwind.h],
+    [AC_DEFINE([HAS_LIBUNWIND])
+    libunwind_available=true],
+    [libunwind_available=false])
+  LDFLAGS="$SAVED_LDFLAGS"
+  CFLAGS="$SAVED_CFLAGS"
+])

--- a/configure
+++ b/configure
@@ -673,6 +673,8 @@ ac_ct_LD
 LD
 DEFAULT_STRING
 WINDOWS_UNICODE_MODE
+LIBUNWIND_LIB_DIR
+LIBUNWIND_INCLUDE_DIR
 DLLIBS
 PARTIALLD
 target_os
@@ -824,7 +826,6 @@ enable_instrumented_runtime
 enable_vmthreads
 enable_systhreads
 with_libunwind
-with_libunwind_include_dir
 enable_graph_lib
 enable_str_lib
 enable_unix_lib
@@ -861,6 +862,8 @@ AS
 ASPP
 PARTIALLD
 DLLIBS
+LIBUNWIND_INCLUDE_DIR
+LIBUNWIND_LIB_DIR
 WINDOWS_UNICODE_MODE
 DEFAULT_STRING
 CC
@@ -1525,9 +1528,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-libunwind        location of the libunwind package
-  --with-libunwind-include-dir
-                          location of header files for libunwind
+  --without-libunwind     disable libunwind support for Spacetime profiling
   --with-target-bindir    location of binary programs on target system
   --with-afl              use the AFL fuzzer
   --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
@@ -1545,6 +1546,10 @@ Some influential environment variables:
   PARTIALLD   how to build partial (relocatable) object files
   DLLIBS      which libraries to use (in addition to -ldl) to load dynamic
               libs
+  LIBUNWIND_INCLUDE_DIR
+              location of header files for libunwind
+  LIBUNWIND_LIB_DIR
+              location of library files for libunwind
   WINDOWS_UNICODE_MODE
               how to handle Unicode under Windows: ansi, compatible
   DEFAULT_STRING
@@ -3002,10 +3007,7 @@ fi
 
 
 
-# Check whether --with-libunwind-include-dir was given.
-if test "${with_libunwind_include_dir+set}" = set; then :
-  withval=$with_libunwind_include_dir;
-fi
+
 
 
 # Check whether --enable-graph-lib was given.
@@ -16365,19 +16367,83 @@ $as_echo_n "checking whether to use libunwind... " >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled" >&5
 $as_echo "disabled" >&6; }
 else
+  if test x"$with_libunwind" = "x"; then :
+  libunwind_requested=false
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: if available" >&5
+$as_echo "if available" >&6; }
+else
+  libunwind_requested=true
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: requested" >&5
+$as_echo "requested" >&6; }
+        if test x"$with_libunwind" != "xyes"; then :
+  if test x"$LIBUNWIND_INCLUDE_DIR" = "x"; then :
+  LIBUNWIND_INCLUDE_DIR="$with_libunwind/include"
+fi
+          if test x"$LIBUNWIND_LIB_DIR" = "x"; then :
+  LIBUNWIND_LIB_DIR="$with_libunwind/lib"
+fi
+
+fi
+
+fi
+      if test "$system" = "macosx"; then :
+  if test x"$LIBUNWIND_INCLUDE_DIR" != x -o \
+                     x"$LIBUNWIND_LIB_DIR" != x; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: On MacOSX, specifying paths for libunwind headers or libraries is strongly discouraged. It is recommended to rely on the defaults provided by the configure script" >&5
+$as_echo "$as_me: WARNING: On MacOSX, specifying paths for libunwind headers or libraries is strongly discouraged. It is recommended to rely on the defaults provided by the configure script" >&2;}
+fi
+fi
+
+      if test x"$LIBUNWIND_INCLUDE_DIR" != x; then :
+  libunwind_include_flags="-I$LIBUNWIND_INCLUDE_DIR"
+else
+  libunwind_include_flags=""
+fi
+
+      case "$system" in #(
+  "macosx") :
+    libunwind_link_flags="-framework System" ;; #(
+  *) :
+    libunwind_link_flags="-lunwind -lunwind-x86_64" ;;
+esac
+
+      if test x"$LIBUNWIND_LIB_DIR" != x; then :
+  libunwind_link_flags="-L$LIBUNWIND_LIB_DIR $libunwind_link_flags"
+fi
+
+
+  SAVED_CFLAGS="$CFLAGS"
+  SAVED_LDFLAGS="$LDFLAGS"
+  CFLAGS="$CFLAGS $libunwind_include_flags"
+  LDFLAGS="$LDFLAGS $libunwind_link_flags"
   ac_fn_c_check_header_mongrel "$LINENO" "libunwind.h" "ac_cv_header_libunwind_h" "$ac_includes_default"
 if test "x$ac_cv_header_libunwind_h" = xyes; then :
   $as_echo "#define HAS_LIBUNWIND 1" >>confdefs.h
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+    libunwind_available=true
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
+  libunwind_available=false
 fi
 
 
+  LDFLAGS="$SAVED_LDFLAGS"
+  CFLAGS="$SAVED_CFLAGS"
 
+
+      if $libunwind_requested && ! $libunwind_available; then :
+  as_fn_error $? "libunwind was requested but can not be found" "$LINENO" 5
+fi
+
+        # We need unwinding information at runtime, but since we use
+        # -no_compact_unwind, we also need -keep_dwarf_unwind otherwise
+        # the OS X linker will chuck away the DWARF-like (.eh_frame)
+        # information.  (Older versions of OS X don't provide this.)
+
+        if $libunwind_available && test x"$system" = "xmacosx"; then :
+  extra_flags="-Wl,-keep_dwarf_unwind"
+          mkexe="$mkexe $extra_flags"
+          mksharedlib="$mksharedlib $extra_flags"
+fi
 fi
 
 else
@@ -16393,8 +16459,6 @@ fi
 fi
 
 fi
-
-
 
 cat >>confdefs.h <<_ACEOF
 #define PROFINFO_WIDTH $profinfo_width

--- a/configure.ac
+++ b/configure.ac
@@ -225,12 +225,14 @@ AC_ARG_ENABLE([systhreads],
     [disable the Win32/POSIX threads library])])
 
 AC_ARG_WITH([libunwind],
-  [AS_HELP_STRING([--with-libunwind],
-    [location of the libunwind package])])
+  [AS_HELP_STRING([--without-libunwind],
+    [disable libunwind support for Spacetime profiling])])
 
-AC_ARG_WITH([libunwind-include-dir],
-  [AS_HELP_STRING([--with-libunwind-include-dir],
-    [location of header files for libunwind])])
+AC_ARG_VAR([LIBUNWIND_INCLUDE_DIR],
+  [location of header files for libunwind])
+
+AC_ARG_VAR([LIBUNWIND_LIB_DIR],
+  [location of library files for libunwind])
 
 AC_ARG_ENABLE([graph-lib], [],
   [AC_MSG_ERROR([The graphics library is no longer distributed with OCaml \
@@ -1520,11 +1522,52 @@ AS_IF([test x"$enable_spacetime" != "xyes" ],
     AC_MSG_CHECKING([whether to use libunwind])
     AS_IF([test x"$with_libunwind" = "xno"],
       [AC_MSG_RESULT([disabled])],
-      [AC_CHECK_HEADER([libunwind.h],
-        [AC_DEFINE([HAS_LIBUNWIND])
-        AC_MSG_RESULT([yes])],
-        [AC_MSG_RESULT([no])])
-      ])
+      [AS_IF([test x"$with_libunwind" = "x"],
+        [libunwind_requested=false
+        AC_MSG_RESULT([if available])],
+        [libunwind_requested=true
+        AC_MSG_RESULT([requested])
+        AS_IF([test x"$with_libunwind" != "xyes"],
+          [AS_IF([test x"$LIBUNWIND_INCLUDE_DIR" = "x"],
+            [LIBUNWIND_INCLUDE_DIR="$with_libunwind/include"])
+          AS_IF([test x"$LIBUNWIND_LIB_DIR" = "x"],
+            [LIBUNWIND_LIB_DIR="$with_libunwind/lib"])
+          ])
+        ])
+      AS_IF([test "$system" = "macosx"],
+        [AS_IF([test x"$LIBUNWIND_INCLUDE_DIR" != x -o \
+                     x"$LIBUNWIND_LIB_DIR" != x],
+          [AC_MSG_WARN(m4_normalize([
+            On MacOSX, specifying paths for libunwind headers or libraries
+            is strongly discouraged.  It is recommended to rely on the
+            defaults provided by the configure script
+          ]))])])
+
+      AS_IF([test x"$LIBUNWIND_INCLUDE_DIR" != x],
+        [libunwind_include_flags="-I$LIBUNWIND_INCLUDE_DIR"],
+        [libunwind_include_flags=""])
+
+      AS_CASE(["$system"],
+        ["macosx"], [libunwind_link_flags="-framework System"],
+        [libunwind_link_flags="-lunwind -lunwind-x86_64"])
+
+      AS_IF([test x"$LIBUNWIND_LIB_DIR" != x],
+        [libunwind_link_flags="-L$LIBUNWIND_LIB_DIR $libunwind_link_flags"])
+
+      OCAML_CHECK_LIBUNWIND
+
+      AS_IF([$libunwind_requested && ! $libunwind_available],
+        [AC_MSG_ERROR([libunwind was requested but can not be found])])
+
+        # We need unwinding information at runtime, but since we use
+        # -no_compact_unwind, we also need -keep_dwarf_unwind otherwise
+        # the OS X linker will chuck away the DWARF-like (.eh_frame)
+        # information.  (Older versions of OS X don't provide this.)
+
+        AS_IF([$libunwind_available && test x"$system" = "xmacosx"],
+          [extra_flags="-Wl,-keep_dwarf_unwind"
+          mkexe="$mkexe $extra_flags"
+          mksharedlib="$mksharedlib $extra_flags"])])
     ],
     [AS_IF([test x"$enable_spacetime" = "xyes"],
       [AC_MSG_RESULT([requested but not supported])
@@ -1532,8 +1575,6 @@ AS_IF([test x"$enable_spacetime" != "xyes" ],
       [AC_MSG_RESULT([no])])
     ])
   ])
-
-
 
 AC_DEFINE_UNQUOTED([PROFINFO_WIDTH], [$profinfo_width])
 AS_IF([$profinfo], [AC_DEFINE([WITH_PROFINFO])])

--- a/runtime/caml/m.h.in
+++ b/runtime/caml/m.h.in
@@ -78,6 +78,9 @@
 
 #undef PROFINFO_WIDTH
 
+#undef WITH_SPACETIME
+#undef ENABLE_CALL_COUNTS
+
 #undef NONSTANDARD_DIV_MOD
 
 /* Leave NONSTANDARD_DIV_MOD undefined if the C operators / and % implement

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -253,6 +253,8 @@
 
 #undef HUGE_PAGE_SIZE
 
+#undef HAS_LIBUNWIND
+
 #undef HAS_BROKEN_PRINTF
 
 #undef HAS_STRERROR


### PR DESCRIPTION
Since the switch to autoconf in #2139, it was not possible to
enable SpaceTime profiling any longer.

This PR restores the support for both SpaceTime and libunwind.

The MacOSX-specific unwind test works again, too.