### PR TITLE
Make sure build variables are defined

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -267,4 +267,7 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
   #   (see ocamlmklibconfig.ml in tools/Makefile)
   FLEXLINK_FLAGS=@flexlink_flags@
   FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
+else # ifeq "$(UNIX_OR_WIN32)" "win32"
+  # On Unix, make sure FLEXLINK is defined but empty
+  FLEXLINK =
 endif # ifeq "$(UNIX_OR_WIN32)" "win32"

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -50,6 +50,9 @@ SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
 
 include $(TOPDIR)/Makefile.config
 
+# Make sure USE_RUNTIME is defined
+USE_RUNTIME ?=
+
 ifneq ($(USE_RUNTIME),)
 #Check USE_RUNTIME value
 ifeq ($(findstring $(USE_RUNTIME),d i),)

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -39,6 +39,7 @@ ifeq "$(UNIX_OR_WIN32)" "unix"
   else # Non-cygwin Unix
     find := find
   endif
+  FLEXLINK_ENV =
 else # Windows
   find := /usr/bin/find
   FLEXDLL_SUBMODULE_PRESENT := $(wildcard ../flexdll/Makefile)
@@ -268,7 +269,7 @@ promote:
 
 .PHONY: lib
 lib:
-	@cd lib && $(MAKE) -s BASEDIR=$(BASEDIR)
+	@$(MAKE) -s -C lib
 
 .PHONY: tools
 tools:
@@ -276,7 +277,7 @@ tools:
 
 .PHONY: clean
 clean:
-	@cd lib && $(MAKE) BASEDIR=$(BASEDIR) clean
+	@$(MAKE) -C lib clean
 	@cd tools && $(MAKE) BASEDIR=$(BASEDIR) clean
 	@for file in `$(FIND) interactive tests -name Makefile`; do \
 	  (cd `dirname $$file` && $(MAKE) BASEDIR=$(BASEDIR) clean); \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -66,8 +66,6 @@ endif
 default:
 	@echo "Available targets:"
 	@echo "  all             launch all tests"
-	@echo "  legacy          launch legacy tests"
-	@echo "  new             launch new (ocamltest based) tests"
 	@echo "  all-foo         launch all tests beginning with foo"
 	@echo "  parallel        launch all tests using GNU parallel"
 	@echo "  parallel-foo    launch all tests beginning with foo using \
@@ -86,26 +84,6 @@ default:
 
 .PHONY: all
 all:
-	@rm -f $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) legacy-without-report
-	@$(MAKE) $(NO_PRINT) new-without-report
-	@$(MAKE) $(NO_PRINT) report
-
-.PHONY: legacy
-legacy:
-	@rm -f $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) legacy-without-report
-	@$(MAKE) $(NO_PRINT) report
-
-.PHONY: legacy-without-report
-legacy-without-report: lib tools
-	@for dir in tests/*; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir LEGACY=y; \
-	done 2>&1 | tee -a $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) retries
-
-.PHONY: new
-new:
 	@rm -f $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) new-without-report
 	@$(MAKE) $(NO_PRINT) report
@@ -209,21 +187,17 @@ one: lib tools
 
 .PHONY: exec-one
 exec-one:
-	@if [ ! -f $(DIR)/Makefile -a ! -f $(DIR)/ocamltests ]; then \
+	@if [ -f $(DIR)/ocamltests ]; then \
+	  echo "Running tests from '$$DIR' ..."; \
+	  $(MAKE) exec-ocamltest DIR=$(DIR) \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR_CYGPATH)" \
+	    OCAMLTESTFLAGS=""; \
+	else \
 	  for dir in $(DIR)/*; do \
 	    if [ -d $$dir ]; then \
 	      $(MAKE) exec-one DIR=$$dir; \
 	    fi; \
 	  done; \
-	elif [ -f $(DIR)/Makefile ]; then \
-	  echo "Running tests from '$$DIR' ..."; \
-	  cd $(DIR) && \
-	  $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) || echo '=> unexpected error'; \
-	elif [ -f $(DIR)/ocamltests ] && [ -z $(LEGACY) ] ; then \
-	  echo "Running tests from '$$DIR' ..."; \
-	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR_CYGPATH)" \
-	    OCAMLTESTFLAGS=""; \
 	fi
 
 .PHONY: exec-ocamltest

--- a/testsuite/lib/Makefile
+++ b/testsuite/lib/Makefile
@@ -13,25 +13,38 @@
 #*                                                                        *
 #**************************************************************************
 
-.PHONY: compile
-compile: compile-targets
+TOPDIR = ../..
+COMPFLAGS ?=
+RUNTIME_VARIANT ?=
 
-.PHONY: promote
-promote: defaultpromote
+include $(TOPDIR)/Makefile.tools
 
-.PHONY: clean
-clean: defaultclean
+libraries := testing.cmi testing.cma lib.cmo
 
-include ../makefiles/Makefile.common
+# If the native compiler is enabled, then also compile testing.cmxa
+ifneq "$(ARCH)" "none"
+libraries += testing.cmxa
+endif
 
-.PHONY: compile-targets
-compile-targets: testing.cmi testing.cma lib.cmo
-	@if $(BYTECODE_ONLY); then : ; else \
-	  $(MAKE) testing.cmxa; \
-	fi
+all: $(libraries)
 
 testing.cma: testing.cmo
-	$(OCAMLC) -a -linkall $(ADD_COMPFLAGS) -o $@ $<
+	$(OCAMLC) -a -linkall -o $@ $<
 
 testing.cmxa: testing.cmx
-	$(OCAMLOPT) -a -linkall $(ADD_COMPFLAGS) -o $@ $<
+	$(OCAMLOPT) -a -linkall -o $@ $<
+
+testing.cmo : testing.cmi
+
+%.cmi: %.mli
+	$(OCAMLC) -c $<
+
+%.cmo: %.ml
+	$(OCAMLC) -c $<
+
+%.cmx: %.ml
+	$(OCAMLOPT) -c $<
+
+.PHONY: clean
+clean:
+	rm -f *.cm* *.$(O) *.$(A)

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -12,73 +12,87 @@
 #*                                                                        *
 #**************************************************************************
 
-BASEDIR = ..
+TOPDIR = ../..
 
-ROOTDIR = ../..
+COMPILERLIBSDIR = $(TOPDIR)/compilerlibs
 
-include $(ROOTDIR)/Makefile.config
+RUNTIME_VARIANT ?=
+ASPPFLAGS ?=
+
+include $(TOPDIR)/Makefile.tools
+
 expect_MAIN=expect_test
 expect_PROG=$(expect_MAIN)$(EXE)
-expect_COMPFLAGS=-I $(OTOPDIR)/parsing -I $(OTOPDIR)/utils \
-          -I $(OTOPDIR)/driver -I $(OTOPDIR)/typing -I $(OTOPDIR)/toplevel
-expect_LIBRARIES := $(addprefix $(ROOTDIR)/compilerlibs/,\
+expect_DIRS = parsing utils driver typing toplevel
+expect_OCAMLFLAGS = $(addprefix -I $(TOPDIR)/,$(expect_DIRS))
+expect_LIBS := $(addprefix $(COMPILERLIBSDIR)/,\
   ocamlcommon ocamlbytecomp ocamltoplevel)
 
-codegen_INCLUDES=\
-  -I $(OTOPDIR)/parsing \
-  -I $(OTOPDIR)/utils \
-  -I $(OTOPDIR)/typing \
-  -I $(OTOPDIR)/middle_end \
-  -I $(OTOPDIR)/bytecomp \
-  -I $(OTOPDIR)/lambda \
-  -I $(OTOPDIR)/asmcomp
+codegen_PROG = codegen$(EXE)
+codegen_DIRS = parsing utils typing middle_end bytecomp lambda asmcomp
+codegen_OCAMLFLAGS = $(addprefix -I $(TOPDIR)/, $(codegen_DIRS)) -w +40 -g
 
-codegen_OTHEROBJECTS=\
-  $(OTOPDIR)/compilerlibs/ocamlcommon.cma \
-  $(OTOPDIR)/compilerlibs/ocamloptcomp.cma
+codegen_LIBS = $(addprefix $(COMPILERLIBSDIR)/,\
+  ocamlcommon ocamloptcomp)
 
-codegen_OBJECTS=parsecmmaux.cmo parsecmm.cmo lexcmm.cmo codegen_main.cmo
+codegen_OBJECTS = $(addsuffix .cmo,\
+  parsecmmaux parsecmm lexcmm codegen_main)
 
-codegen_ADD_COMPFLAGS=$(codegen_INCLUDES) -w -40 -g
-
-targets := $(expect_PROG)
+tools := $(expect_PROG)
 
 ifneq "$(ARCH)" "none"
-targets += codegen
+tools += $(codegen_PROG)
 ifneq "$(CCOMPTYPE)-$(ARCH)" "msvc-amd64"
 # The asmgen tests are not ported to MSVC64 yet
 # so do not compile any arch-specific module
-targets += asmgen_$(ARCH).$(O)
+tools += asmgen_$(ARCH).$(O)
 endif
 endif
 
-all: $(targets)
+all: $(tools)
 
-$(expect_PROG): $(expect_LIBRARIES:=.cma) $(expect_MAIN).cmo
-	@$(OCAMLC) -linkall -o $@ $^
+$(expect_PROG): $(expect_LIBS:=.cma) $(expect_MAIN).cmo
+	$(OCAMLC) -linkall -o $@ $^
 
-include $(BASEDIR)/makefiles/Makefile.common
+$(expect_PROG): COMPFLAGS = $(expect_OCAMLFLAGS)
 
-.PHONY: clean
-clean: defaultclean
-	rm -f $(expect_PROG)
-	rm -f codegen parsecmm.ml parsecmm.mli lexcmm.ml
-
-expect_test.cmo: COMPFLAGS=$(expect_COMPFLAGS)
-
-$(codegen_OBJECTS): ADD_COMPFLAGS = $(codegen_ADD_COMPFLAGS)
+$(codegen_PROG): COMPFLAGS = $(codegen_OCAMLFLAGS)
 
 codegen_main.cmo: parsecmm.cmo
 
-codegen: $(codegen_OBJECTS)
-	@$(OCAMLC) $(LINKFLAGS) -o $@ $(codegen_OTHEROBJECTS) $^
+$(codegen_PROG): $(codegen_OBJECTS)
+	$(OCAMLC) -o $@ $(codegen_LIBS:=.cma) $^
 
 parsecmm.mli parsecmm.ml: parsecmm.mly
-	@$(OCAMLYACC) -q parsecmm.mly
+	$(OCAMLYACC) -q parsecmm.mly
 
 lexcmm.ml: lexcmm.mll
-	@$(OCAMLLEX) -q lexcmm.mll
+	$(OCAMLLEX) -q lexcmm.mll
+
+parsecmmaux.cmo: parsecmmaux.cmi
+
+lexcmm.cmo: lexcmm.cmi
+
+parsecmm.cmo: parsecmm.cmi
 
 asmgen_i386.obj: asmgen_i386nt.asm
 	@set -o pipefail ; \
 	$(ASM) $@ $^ | tail -n +2
+
+%.cmi: %.mli
+	$(OCAMLC) -c $<
+
+%.cmo: %.ml
+	$(OCAMLC) -c $<
+
+%.cmx: %.ml
+	$(OCAMLOPT) -c $<
+
+%.$(O): %.S
+	$(ASPP) $(ASPPFLAGS) -DSYS_$(SYSTEM) -DMODEL_$(MODEL) -o $@ $<
+
+.PHONY: clean
+clean:
+	rm -f *.cm* *.$(O)
+	rm -f $(tools)
+	rm -f parsecmm.ml parsecmm.mli lexcmm.ml

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -25,7 +25,7 @@ let compile_file filename =
   Emit.begin_assembly();
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
-  lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with pos_fname = filename };
+  lb.Lexing.lex_curr_p <- Lexing.{ lb.lex_curr_p with pos_fname = filename };
   try
     while true do
       Asmgen.compile_phrase ~ppf_dump:Format.std_formatter

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -242,25 +242,32 @@ expr:
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, $5, $6, debuginfo ()) }
   | LPAREN VAL expr expr RPAREN
-      { Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+      { let open Asttypes in
+        Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
           debuginfo ()) }
   | LPAREN ADDRAREF expr expr RPAREN
-      { Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+      { let open Asttypes in
+        Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
           Debuginfo.none) }
   | LPAREN INTAREF expr expr RPAREN
-      { Cop(Cload (Word_int, Mutable), [access_array $3 $4 Arch.size_int],
+      { let open Asttypes in
+        Cop(Cload (Word_int, Mutable), [access_array $3 $4 Arch.size_int],
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
-      { Cop(Cload (Double_u, Mutable), [access_array $3 $4 Arch.size_float],
+      { let open Asttypes in
+        Cop(Cload (Double_u, Mutable), [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
-      { Cop(Cstore (Word_val, Assignment),
+      { let open Lambda in
+        Cop(Cstore (Word_val, Assignment),
             [access_array $3 $4 Arch.size_addr; $5], Debuginfo.none) }
   | LPAREN INTASET expr expr expr RPAREN
-      { Cop(Cstore (Word_int, Assignment),
+      { let open Lambda in
+        Cop(Cstore (Word_int, Assignment),
             [access_array $3 $4 Arch.size_int; $5], Debuginfo.none) }
   | LPAREN FLOATASET expr expr expr RPAREN
-      { Cop(Cstore (Double_u, Assignment),
+      { let open Lambda in
+        Cop(Cstore (Double_u, Assignment),
             [access_array $3 $4 Arch.size_float; $5], Debuginfo.none) }
 ;
 exprlist:
@@ -293,14 +300,14 @@ chunk:
   | VAL                         { Word_val }
 ;
 unaryop:
-    LOAD chunk                  { Cload ($2, Mutable) }
+    LOAD chunk                  { Cload ($2, Asttypes.Mutable) }
   | FLOATOFINT                  { Cfloatofint }
   | INTOFFLOAT                  { Cintoffloat }
   | RAISE                       { Craise $1 }
   | ABSF                        { Cabsf }
 ;
 binaryop:
-    STORE chunk                 { Cstore ($2, Assignment) }
+    STORE chunk                 { Cstore ($2, Lambda.Assignment) }
   | ADDI                        { Caddi }
   | SUBI                        { Csubi }
   | STAR                        { Cmuli }

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -121,7 +121,7 @@ esac
 build=''
 host=''
 conffile=Makefile.config
-make="make --warn-undefined-variables"
+make=make
 instdir="$HOME/ocaml-tmp-install"
 confoptions="${OCAML_CONFIGURE_OPTIONS}"
 make_native=true
@@ -132,7 +132,7 @@ jobs=''
 
 case "${OCAML_ARCH}" in
   bsd)
-    make="gmake --warn-undefined-variables"
+    make=gmake
   ;;
   macos) ;;
   linux)
@@ -218,11 +218,7 @@ done
 # Tell gcc to use only ASCII in its diagnostic outputs.
 export LC_ALL=C
 
-$make -s distclean || :
-
-# `make distclean` does not clean the files from previous versions that
-# are not produced by the current version, so use `git clean` in addition.
-git clean -f -d -x
+git clean -q -f -d -x
 
 if $flambda; then
   confoptions="$confoptions --enable-flambda --enable-flambda-invariants"
@@ -231,10 +227,10 @@ fi
 eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
 
 if $make_native; then
-  $make $jobs world.opt
-  if $check_make_alldepend; then $make alldepend; fi
+  $make $jobs --warn-undefined-variables world.opt
+  if $check_make_alldepend; then $make --warn-undefined-variables alldepend; fi
 else
-  $make $jobs world
+  $make $jobs --warn-undefined-variables world
 fi
 if $dorebase; then
     # temporary solution to the cygwin fork problem
@@ -242,11 +238,11 @@ if $dorebase; then
     rebase -b 0x7cd20000 otherlibs/unix/dllunix.so
     rebase -b 0x7cdc0000 otherlibs/systhreads/dllthreads.so
 fi
-$make install
+$make --warn-undefined-variables install
 
 rm -rf "$instdir"
 cd testsuite
 if test -n "$jobs" && test -x /usr/bin/parallel
-then PARALLEL="$jobs $PARALLEL" $make parallel
-else $make all
+then PARALLEL="$jobs $PARALLEL" $make --warn-undefined-variables parallel
+else $make --warn-undefined-variables all
 fi


### PR DESCRIPTION
Cc @xavierleroy and @dra27

This PR is a follow-up to #8650. Its purpose is to make sure that
running the testsuite with make's `--warn-undefined-variables` does not
trigger any warning.

The PR is probably best reviewed commit by commit, here are explanations
on each of the three commits.

The first commit:

- Defines flexdll-related variables on Unix, in Makefile.config.in

- Defines `USE_RUNTIME` in Makefile.tools

- Defines `FLEXLINK_ENV` on Unix, in the main Makefile of the testsuite

- Slightly simplifies this file

- Rewrites the makefiles in testsuite/lib and testsuite/tools so that
  they do not need to include makefiles/Makefile.common any longer

Two remarks about this last point:

1. It could seem a better option to fix Makefile.common rather than to do
all this rewriting, but this file is actually almost not used any longer
so the idea was to eliminate the dependency so that it can then be
removed.

2. The former makefile mentionned warning 40 but that warning was
actually not passed to ocamlc. Rewriting the makefile in a correct way
lead to the warning being passed, which in turn revealed problems in
testsuite/tools/codegen_main.ml and testsuite/tools/parsecmm.mly,
which this commit addresses, too.

The second commit removes the ability to run legacy testss: this looks
as a reasonable choice because we don't have such tests any longer and
that part of the build system was triggering an undefined variable
warning about the LEGACY variable.

Finally, the third commit slightly improves Inria's main CI script: we
stop calling make distclean at the beginning of the script and rely on
git clean to make sure the repository is in a clean state and make this
command quiet. Moreover the `--warn-undefined-variables` option is added
explicitly to some invocations of make.

After this PR, Inria's CI does not yet report any undefined variable as
an error, because doing so in a proper way will require a bit of
refactoring work in the CI scripts, which will be performed in a
distinct, future PR.

However, it could be verified by grepping the logs of prechek build
#261 that, with this PR, no undefined variable warning is triggered
on any architecture by the usual build procedure, which includes running
the testsuite.

An expected side effect of the above-mentionned refactoring work is that
the absence of undefined variables should become verifiable during the
bootstrap test, too.


