### PR TITLE
Fix amd64 emitter of Lcondbranch3

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,7 +23,7 @@ Working version
 - #8692: Remove Misc.may_map and similar
   (Leo White, review by Gabriel Scherer and Thomas Refis)
 
-- #8677: Use unsigned comparisons in amd64 emitter of Lcondbranch3.
+- #8677: Use unsigned comparisons in amd64 and i386 emitter of Lcondbranch3.
   (Greta Yorsh, review by Xavier Leroy)
 
 ### Runtime system:

--- a/Changes
+++ b/Changes
@@ -23,6 +23,9 @@ Working version
 - #8692: Remove Misc.may_map and similar
   (Leo White, review by Gabriel Scherer and Thomas Refis)
 
+- #8677: Use unsigned comparisons in amd64 emitter of Lcondbranch3.
+  (Greta Yorsh, review by Xavier Leroy)
+
 ### Runtime system:
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -821,7 +821,7 @@ let emit_instr fallthrough i =
       end;
       begin match lbl2 with
       | None -> ()
-      | Some lbl -> I.jg (label lbl)
+      | Some lbl -> I.ja (label lbl)
       end
   | Lswitch jumptbl ->
       let lbl = emit_label (new_label()) in

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -833,7 +833,7 @@ let emit_instr fallthrough i =
       end;
       begin match lbl2 with
         None -> ()
-      | Some lbl -> I.jg (label lbl)
+      | Some lbl -> I.ja (label lbl)
       end
   | Lswitch jumptbl ->
       let lbl = new_label() in


### PR DESCRIPTION
The first two cases of Lcondbranch3 use **unsigned** comparison, while the third case uses a **signed** comparison. Is it just a typo? It happens to be correct because Lcondbranch3 can only be generated from Switch with 3 options, and therefore the argument is known statically to evaluate to { 0,1,2 }. 

This one-letter patch fixes it.

