### PR TITLE
Reduce executable size under "-nodynlink" by using hidden symbols

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ Working version
 
 - #7557, #1726: multi-indices for extended indexing operators
   (Florian Angeletti, review by Gabriel Radanne)
+### Code generation and optimizations:
+
+- #8689: Declare global symbols as "hidden" or "private_extern"
+  when using -nodynlink
+  (Mark Shinwell, Stephen Dolan)
 
 ### Internal/compiler-libs changes:
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -40,6 +40,12 @@ let emit_label lbl =
 let emit_symbol s =
   Emitaux.emit_symbol '$' s
 
+let declare_global_symbol sym =
+  `	.globl	{emit_symbol sym}\n`;
+  if not !Clflags.dlcode then begin
+    `	.hidden	{emit_symbol sym}\n`
+  end
+
 let emit_call s =
   if !Clflags.dlcode || !Clflags.pic_code
   then `bl	{emit_symbol s}(PLT)`
@@ -944,7 +950,7 @@ let fundecl fundecl =
   bound_error_sites := [];
   `	.text\n`;
   `	.align	2\n`;
-  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  declare_global_symbol fundecl.fun_name;
   if !arch > ARMv6 && !thumb then
     `	.thumb\n`
   else
@@ -964,7 +970,7 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let emit_item = function
-    Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+    Cglobal_symbol s -> declare_global_symbol s
   | Cdefine_symbol s -> `{emit_symbol s}:\n`
   | Cint8 n -> `	.byte	{emit_int n}\n`
   | Cint16 n -> `	.short	{emit_int n}\n`
@@ -1007,26 +1013,26 @@ let begin_assembly() =
   `alloc_limit	.req	r11\n`;
   let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   `	.data\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
+  declare_global_symbol lbl_begin;
   `{emit_symbol lbl_begin}:\n`;
   let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
+  declare_global_symbol lbl_begin;
   `{emit_symbol lbl_begin}:\n`
 
 let end_assembly () =
   let lbl_end = Compilenv.make_symbol (Some "code_end") in
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_end}\n`;
+  declare_global_symbol lbl_end;
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
   `	.long 0\n`;  (* PR#6329 *)
-  `	.globl	{emit_symbol lbl_end}\n`;
+  declare_global_symbol lbl_end;
   `{emit_symbol lbl_end}:\n`;
   `	.long	0\n`;
   let lbl = Compilenv.make_symbol (Some "frametable") in
-  `	.globl	{emit_symbol lbl}\n`;
+  declare_global_symbol lbl;
   `{emit_symbol lbl}:\n`;
   emit_frames
     { efa_code_label = (fun lbl ->

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -49,6 +49,12 @@ let emit_label lbl =
 let emit_symbol s =
   Emitaux.emit_symbol '$' s
 
+let declare_global_symbol sym =
+  `	.globl	{emit_symbol sym}\n`;
+  if not !Clflags.dlcode then begin
+    `	.hidden	{emit_symbol sym}\n`
+  end
+
 (* Output a pseudo-register *)
 
 let emit_reg = function
@@ -906,7 +912,7 @@ let fundecl fundecl =
   bound_error_sites := [];
   `	.text\n`;
   `	.align	3\n`;
-  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  declare_global_symbol fundecl.fun_name;
   `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
   emit_debug_info fundecl.fun_dbg;
@@ -932,7 +938,7 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let emit_item = function
-  | Cglobal_symbol s -> `	.globl	{emit_symbol s}\n`;
+  | Cglobal_symbol s -> declare_global_symbol s
   | Cdefine_symbol s ->
     if !Clflags.dlcode then begin
       (* GOT relocations against non-global symbols don't seem to work
@@ -965,27 +971,27 @@ let begin_assembly() =
   `	.file	\"\"\n`;  (* PR#7037 *)
   let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
   `	.data\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
+  declare_global_symbol lbl_begin;
   `{emit_symbol lbl_begin}:\n`;
   let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_begin}\n`;
+  declare_global_symbol lbl_begin;
   `{emit_symbol lbl_begin}:\n`
 
 let end_assembly () =
   let lbl_end = Compilenv.make_symbol (Some "code_end") in
   `	.text\n`;
-  `	.globl	{emit_symbol lbl_end}\n`;
+  declare_global_symbol lbl_end;
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
   `	.quad	0\n`;  (* PR#6329 *)
-  `	.globl	{emit_symbol lbl_end}\n`;
+  declare_global_symbol lbl_end;
   `{emit_symbol lbl_end}:\n`;
   `	.quad	0\n`;
   `	.align	3\n`;  (* #7887 *)
   let lbl = Compilenv.make_symbol (Some "frametable") in
-  `	.globl	{emit_symbol lbl}\n`;
+  declare_global_symbol lbl;
   `{emit_symbol lbl}:\n`;
   emit_frames
     { efa_code_label = (fun lbl ->

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -71,9 +71,15 @@ let (trap_size, trap_handler_offset, trap_previous_offset) =
   | ELF64v1 -> (32, 56, 64)
   | ELF64v2 -> (32, 40, 48)
 
-(* Output a symbol *)
+(* Symbols *)
 
 let emit_symbol s = Emitaux.emit_symbol '.' s
+
+let declare_global_symbol sym =
+  `	.globl	{emit_symbol sym}\n`;
+  if not !Clflags.dlcode then begin
+    `	.hidden	{emit_symbol sym}\n`
+  end
 
 (* Output a label *)
 
@@ -1036,14 +1042,14 @@ let fundecl fundecl =
   begin match abi with
   | ELF32 ->
     emit_string code_space;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
+    declare_global_symbol fundecl.fun_name;
     `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
     `	.align	2\n`;
     `{emit_symbol fundecl.fun_name}:\n`
   | ELF64v1 ->
     emit_string function_descr_space;
     `	.align 3\n`;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
+    declare_global_symbol fundecl.fun_name;
     `	.type   {emit_symbol fundecl.fun_name}, @function\n`;
     `{emit_symbol fundecl.fun_name}:\n`;
     `	.quad .L.{emit_symbol fundecl.fun_name}, .TOC.@tocbase\n`;
@@ -1052,7 +1058,7 @@ let fundecl fundecl =
     `.L.{emit_symbol fundecl.fun_name}:\n`
   | ELF64v2 ->
     emit_string code_space;
-    `	.globl	{emit_symbol fundecl.fun_name}\n`;
+    declare_global_symbol fundecl.fun_name;
     `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
     `	.align	2\n`;
     `{emit_symbol fundecl.fun_name}:\n`;
@@ -1135,7 +1141,7 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let declare_global_data s =
-  `	.globl	{emit_symbol s}\n`;
+  declare_global_symbol s;
   `	.type	{emit_symbol s}, @object\n`
 
 let emit_item = function

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -46,9 +46,15 @@ let slot_offset loc cls =
   | Incoming n -> frame_size() + n
   | Outgoing n -> n
 
-(* Output a symbol *)
+(* Symbols *)
 
 let emit_symbol s = Emitaux.emit_symbol '.' s
+
+let declare_global_symbol sym =
+  `	.globl	{emit_symbol sym}\n`;
+  if not !Clflags.dlcode then begin
+    `	.hidden	{emit_symbol sym}\n`
+  end
 
 (* Output function call *)
 
@@ -656,7 +662,7 @@ let fundecl fundecl =
   bound_error_call := 0;
   float_literals := [];
   int_literals := [];
-  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  declare_global_symbol fundecl.fun_name;
   emit_debug_info fundecl.fun_dbg;
   `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
   emit_string code_space;
@@ -685,7 +691,7 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let declare_global_data s =
-  `	.globl	{emit_symbol s}\n`;
+  declare_global_symbol s;
   `	.type	{emit_symbol s}, @object\n`
 
 let emit_item = function

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -209,6 +209,7 @@ type asm_line =
   | Cfi_endproc
   | Cfi_startproc
   | File of int * string (* (file_num, file_name) *)
+  | Hidden of string
   | Indirect_symbol of string
   | Loc of int * int * int (* (file_num, line, col) *)
   | Private_extern of string

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -88,7 +88,13 @@ module D = struct
   let data () = section [ ".data" ] None []
   let extrn s ptr = directive (External (s, ptr))
   let file ~file_num ~file_name = directive (File (file_num, file_name))
-  let global s = directive (Global s)
+  let global s =
+    directive (Global s);
+    if not !Clflags.dlcode then begin
+      match system with
+      | S_macosx -> directive (Private_extern s)
+      | _ -> directive (Hidden s)
+    end
   let indirect_symbol s = directive (Indirect_symbol s)
   let label ?(typ = NONE) s = directive (NewLabel (s, typ))
   let loc ~file_num ~line ~col = directive (Loc (file_num, line, col))

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -282,6 +282,7 @@ let print_line b = function
   | File (file_num, file_name) ->
       bprintf b "\t.file\t%d\t\"%s\""
         file_num (X86_proc.string_of_string_literal file_name)
+  | Hidden s -> bprintf b "\t.hidden\t%s" s;
   | Indirect_symbol s -> bprintf b "\t.indirect_symbol %s" s
   | Loc (file_num, line, col) ->
       (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)

--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -240,6 +240,7 @@ let print_line b = function
   | Cfi_endproc
   | Cfi_startproc
   | File _
+  | Hidden _
   | Indirect_symbol _
   | Loc _
   | Private_extern _


### PR DESCRIPTION
This small patch produces significant reductions in executable size when using `-nodynlink`, which is a useful option for many production deployments.  At present, large amounts of space are wasted by the dynamic symbol table and the dynamic string table, which are near-duplicates of the normal symbol and string tables.  These tables are required for operations such as `dlsym`, but because `-nodynlink` has been specified, we're not supporting those anyway.  They are also required for self-introspection operations using the same set of calls, but I'm going to claim that the semantics of `-nodynlink` should be such that these (unusual) scenarios are also ruled out.

With this in mind, we can use the ELF "`hidden`" and the Mach-O "`private_extern`" symbol visibility modifiers to have global symbols converted to local ("static", in Mach-O terminology) after the linker has performed relocations, before the executable file has been written.  This causes the dynamic symbol and string tables to be very substantially shrunk in size.  Since these tables are mapped into memory, to support the various querying scenarios described above, the required memory mappings of the executables are also correspondingly reduced.

Here are some results on real-world executables:
```
┌──────────┬──────────┬───────────────────┐
│ old size │ new size │ reduction in size │
├──────────┼──────────┼───────────────────┤
│   1075Mb │    841Mb │               22% │
│    924Mb │    715Mb │               23% │
│    740Mb │    567Mb │               23% │
└──────────┴──────────┴───────────────────┘
```
Aside 1: You can see why we're interested in working on dead code elimination...

Aside 2: I'm planning to propose using my `Asm_directives` work to centralise handling of assembler directives; this would mean that the logic to determine whether to use "hidden", etc. would naturally live in a single place.  (In much the same way as this patch exploits the existing x86 DSL to do likewise for the `amd64` and `i386` backends.)

@xavierleroy Are you happy with this?  I will need to manually test on the various platforms---I've only checked x86-64 Linux and macOS so far---but would like approval in principle first.