### PR TITLE
Avoid rebuilding the world when files containing primitives change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ _build
 /runtime/caml/m.h
 /runtime/caml/s.h
 /runtime/primitives
+/runtime/primitives.new
 /runtime/prims.c
 /runtime/caml/opnames.h
 /runtime/caml/version.h

--- a/Changes
+++ b/Changes
@@ -51,6 +51,9 @@ Working version
   revise generation of config/util.ml to better quote special characters
   (Xavier Leroy, review by David Allsopp)
 
+- #8690: avoid rebuilding the world when files containing primitives change.
+  (Stephen Dolan, review by ??)
+
 ### Bug fixes:
 
 - #8622: Don't generate #! headers over 127 characters.

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -239,8 +239,15 @@ ld.conf: $(ROOTDIR)/Makefile.config
 # "using sort to process pathnames, it is recommended that LC_ALL .. set to C"
 
 
-primitives : $(PRIMS)
+primitives.new : $(PRIMS)
 	./gen_primitives.sh >$@
+
+# To speed up builds, we avoid changing "primitives" when files
+# in PRIMS change but the primitives table does not
+.PHONY: maybe-update-primitives
+maybe-update-primitives: primitives.new
+	cmp primitives primitives.new || cp primitives.new primitives
+primitives: maybe-update-primitives
 
 prims.c : primitives
 	(echo '#define CAML_INTERNALS'; \


### PR DESCRIPTION
This is a small Makefile patch that we've been using on the multicore branch for a while, which makes life more pleasant when working on the runtime.

Some runtime files contain primitives. The script `runtime/gen_primitives.sh` extracts their names and produces a file called `primitives`. If this file changes, everything needs to be rebuilt because the compiler depends on the set of available primitives.

Usually, when working on the runtime, this file does not change much. However, you frequently edit files containing primitives, so `primitives` gets regenerated, and `make` does not notice that the new content is the same as the old and rebuilds everything.

This patch contains a small bit of `make` voodoo to ensure that the modification date of `primitives` is only changed if the content primitives actually changes. This works by generating the primitives table into an alternate file `primitives.new`. The `primitives` file is then overwritten with this one, but only if their contents differ.

With this patch, `touch runtime/gc_ctrl.c; make world` goes >10x faster.