### PR TITLE
Remove Misc.may_map and similar

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,9 @@ Working version
   [Flambda_middle_end].  Run [Un_anf] from the middle end, not [Cmmgen].
   (Mark Shinwell, review by Pierre Chambart)
 
+- #8692: Remove Misc.may_map and similar
+  (Leo White, review by Gabriel Scherer and Thomas Refis)
+
 ### Runtime system:
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2239,7 +2239,7 @@ let rec transl env e =
       let dbg = Debuginfo.none in
       bind "switch" (transl env arg)
         (fun arg ->
-          strmatch_compile dbg arg (Misc.may_map (transl env) d)
+          strmatch_compile dbg arg (Option.map (transl env) d)
             (List.map (fun (s,act) -> s,transl env act) sw))
   | Ustaticfail (nfail, args) ->
       Cexit (nfail, List.map (transl env) args)

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -172,7 +172,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi =
            | None -> None
            | Some cmi -> Some (output_cmi temp_file_name oc cmi)
          in
-         let source_digest = Misc.may_map Digest.file sourcefile in
+         let source_digest = Option.map Digest.file sourcefile in
          let cmt = {
            cmt_modname = modname;
            cmt_annots = clear_env binary_annots;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -783,14 +783,14 @@ let shallow_map f = function
                  sw_consts = List.map (fun (n, e) -> (n, f e)) sw.sw_consts;
                  sw_numblocks = sw.sw_numblocks;
                  sw_blocks = List.map (fun (n, e) -> (n, f e)) sw.sw_blocks;
-                 sw_failaction = Misc.may_map f sw.sw_failaction;
+                 sw_failaction = Option.map f sw.sw_failaction;
                },
                loc)
   | Lstringswitch (e, sw, default, loc) ->
       Lstringswitch (
         f e,
         List.map (fun (s, e) -> (s, f e)) sw,
-        Misc.may_map f default,
+        Option.map f default,
         loc)
   | Lstaticraise (i, args) ->
       Lstaticraise (i, List.map f args)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -56,13 +56,13 @@ let rec eliminate_ref id = function
          sw_blocks =
             List.map (fun (n, e) -> (n, eliminate_ref id e)) sw.sw_blocks;
          sw_failaction =
-            Misc.may_map (eliminate_ref id) sw.sw_failaction; },
+            Option.map (eliminate_ref id) sw.sw_failaction; },
         loc)
   | Lstringswitch(e, sw, default, loc) ->
       Lstringswitch
         (eliminate_ref id e,
          List.map (fun (s, e) -> (s, eliminate_ref id e)) sw,
-         Misc.may_map (eliminate_ref id) default, loc)
+         Option.map (eliminate_ref id) default, loc)
   | Lstaticraise (i,args) ->
       Lstaticraise (i,List.map (eliminate_ref id) args)
   | Lstaticcatch(e1, i, e2) ->
@@ -254,7 +254,7 @@ let simplify_exits lam =
       let new_l = simplif l
       and new_consts =  List.map (fun (n, e) -> (n, simplif e)) sw.sw_consts
       and new_blocks =  List.map (fun (n, e) -> (n, simplif e)) sw.sw_blocks
-      and new_fail = Misc.may_map simplif sw.sw_failaction in
+      and new_fail = Option.map simplif sw.sw_failaction in
       Lswitch
         (new_l,
          {sw with sw_consts = new_consts ; sw_blocks = new_blocks;
@@ -263,7 +263,7 @@ let simplify_exits lam =
   | Lstringswitch(l,sw,d,loc) ->
       Lstringswitch
         (simplif l,List.map (fun (s,l) -> s,simplif l) sw,
-         Misc.may_map simplif d,loc)
+         Option.map simplif d,loc)
   | Lstaticraise (i,[]) as l ->
       begin try
         let _,handler =  Hashtbl.find subst i in
@@ -536,7 +536,7 @@ let simplify_lets lam =
       let new_l = simplif l
       and new_consts =  List.map (fun (n, e) -> (n, simplif e)) sw.sw_consts
       and new_blocks =  List.map (fun (n, e) -> (n, simplif e)) sw.sw_blocks
-      and new_fail = Misc.may_map simplif sw.sw_failaction in
+      and new_fail = Option.map simplif sw.sw_failaction in
       Lswitch
         (new_l,
          {sw with sw_consts = new_consts ; sw_blocks = new_blocks;
@@ -545,7 +545,7 @@ let simplify_lets lam =
   | Lstringswitch (l,sw,d,loc) ->
       Lstringswitch
         (simplif l,List.map (fun (s,l) -> s,simplif l) sw,
-         Misc.may_map simplif d,loc)
+         Option.map simplif d,loc)
   | Lstaticraise (i,ls) ->
       Lstaticraise (i, List.map simplif ls)
   | Lstaticcatch(l1, (i,args), l2) ->
@@ -615,13 +615,13 @@ let rec emit_tail_infos is_tail lambda =
       emit_tail_infos false lam;
       list_emit_tail_infos_fun snd is_tail sw.sw_consts;
       list_emit_tail_infos_fun snd is_tail sw.sw_blocks;
-      Misc.may  (emit_tail_infos is_tail) sw.sw_failaction
+      Option.iter  (emit_tail_infos is_tail) sw.sw_failaction
   | Lstringswitch (lam, sw, d, _) ->
       emit_tail_infos false lam;
       List.iter
         (fun (_,lam) ->  emit_tail_infos is_tail lam)
         sw ;
-      Misc.may (emit_tail_infos is_tail) d
+      Option.iter (emit_tail_infos is_tail) d
   | Lstaticraise (_, l) ->
       list_emit_tail_infos false l
   | Lstaticcatch (body, _, handler) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -644,12 +644,16 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
         in
         let args, args' =
           if List.for_all (fun (_,opt) -> opt) args then [], args
-          else args, [] in
+          else args, []
+        in
         let lam =
-          if args = [] then lam else lapply lam (List.rev_map fst args) in
-        let handle = protect "func" lam
-        and l = List.map (fun (arg, opt) -> Option.map (protect "arg") arg, opt) l
-        and id_arg = Ident.create_local "param" in
+          if args = [] then lam else lapply lam (List.rev_map fst args)
+        in
+        let handle = protect "func" lam in
+        let l =
+          List.map (fun (arg, opt) -> Option.map (protect "arg") arg, opt) l
+        in
+        let id_arg = Ident.create_local "param" in
         let body =
           match build_apply handle ((Lvar id_arg, optional)::args') l with
             Lfunction{kind = Curried; params = ids; return;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -648,7 +648,7 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
         let lam =
           if args = [] then lam else lapply lam (List.rev_map fst args) in
         let handle = protect "func" lam
-        and l = List.map (fun (arg, opt) -> may_map (protect "arg") arg, opt) l
+        and l = List.map (fun (arg, opt) -> Option.map (protect "arg") arg, opt) l
         and id_arg = Ident.create_local "param" in
         let body =
           match build_apply handle ((Lvar id_arg, optional)::args') l with
@@ -679,7 +679,7 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
         lapply lam (List.rev_map fst args)
   in
   (build_apply lam [] (List.map (fun (l, x) ->
-                                   may_map transl_exp x, Btype.is_optional l)
+                                   Option.map transl_exp x, Btype.is_optional l)
                                 sargs)
      : Lambda.lambda)
 

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -184,7 +184,7 @@ let lambda_smaller lam threshold =
             size := !size+2 ;
             lambda_size lam)
           sw ;
-        Misc.may lambda_size d
+        Option.iter lambda_size d
     | Ustaticfail (_,args) -> lambda_list_size args
     | Ucatch(_, _, body, handler) ->
         incr size; lambda_size body; lambda_size handler
@@ -627,7 +627,7 @@ let rec substitute loc ((backend, fpc) as st) sb rn ulam =
       Ustringswitch
         (substitute loc st sb rn arg,
          List.map (fun (s,act) -> s,substitute loc st sb rn act) sw,
-         Misc.may_map (substitute loc st sb rn) d)
+         Option.map (substitute loc st sb rn) d)
   | Ustaticfail (nfail, args) ->
       let nfail =
         match rn with
@@ -1116,7 +1116,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
             s,uact)
           sw in
       let ud =
-        Misc.may_map
+        Option.map
           (fun d ->
             let ud,_ = close env d in
             ud) d in
@@ -1433,7 +1433,7 @@ let collect_exported_structured_constants a =
     | Ustringswitch (u,sw,d) ->
         ulam u ;
         List.iter (fun (_,act) -> ulam act) sw ;
-        Misc.may ulam d
+        Option.iter ulam d
     | Ustaticfail (_, ul) -> List.iter ulam ul
     | Ucatch (_, _, u1, u2)
     | Utrywith (u1, _, u2)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -502,14 +502,14 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           consts = List.map aux sw.sw_consts;
           numblocks = nums sw.sw_numblocks sw.sw_blocks sw.sw_failaction;
           blocks = List.map aux sw.sw_blocks;
-          failaction = Misc.may_map (close t env) sw.sw_failaction;
+          failaction = Option.map (close t env) sw.sw_failaction;
         }))
   | Lstringswitch (arg, sw, def, _) ->
     let scrutinee = Variable.create Names.string_switch in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (String_switch (scrutinee,
         List.map (fun (s, e) -> s, close t env e) sw,
-        Misc.may_map (close t env) def))
+        Option.map (close t env) def))
   | Lstaticraise (i, args) ->
     Lift_code.lifting_helper (close_list t env args)
       ~evaluation_order:`Right_to_left

--- a/middle_end/flambda/effect_analysis.ml
+++ b/middle_end/flambda/effect_analysis.ml
@@ -37,12 +37,10 @@ let rec no_effects (flam : Flambda.t) =
     let aux (_, flam) = no_effects flam in
     List.for_all aux sw.blocks
       && List.for_all aux sw.consts
-      && Misc.Stdlib.Option.value_default no_effects sw.failaction
-        ~default:true
+      && Option.fold ~some:no_effects ~none:true sw.failaction
   | String_switch (_, sw, def) ->
     List.for_all (fun (_, lam) -> no_effects lam) sw
-      && Misc.Stdlib.Option.value_default no_effects def
-        ~default:true
+      && Option.fold ~some:no_effects ~none:true def
   | Static_catch (_, _, body, _) | Try_with (body, _, _) ->
     (* If there is a [raise] in [body], the whole [Try_with] may have an
        effect, so there is no need to test the handler. *)

--- a/middle_end/flambda/export_info_for_pack.ml
+++ b/middle_end/flambda/export_info_for_pack.ml
@@ -89,7 +89,7 @@ let import_set_of_closures units pack
       Closure_id.Map.map (import_approx_for_pack units pack)
         set_of_closures.results;
     aliased_symbol =
-      Misc.may_map
+      Option.map
         (import_symbol_for_pack units pack)
         set_of_closures.aliased_symbol;
   }

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -565,11 +565,11 @@ let rec variables_usage ?ignore_uses_as_callee ?ignore_uses_as_argument
         free_variable scrutinee;
         List.iter (fun (_, e) -> aux e) switch.consts;
         List.iter (fun (_, e) -> aux e) switch.blocks;
-        Misc.may aux switch.failaction
+        Option.iter aux switch.failaction
       | String_switch (scrutinee, cases, failaction) ->
         free_variable scrutinee;
         List.iter (fun (_, e) -> aux e) cases;
-        Misc.may aux failaction
+        Option.iter aux failaction
       | Static_raise (_, es) ->
         List.iter free_variable es
       | Static_catch (_, vars, e1, e2) ->
@@ -789,10 +789,10 @@ let iter_general ~toplevel f f_named maybe_named =
       | Switch (_, sw) ->
         List.iter (fun (_,l) -> aux l) sw.consts;
         List.iter (fun (_,l) -> aux l) sw.blocks;
-        Misc.may aux sw.failaction
+        Option.iter aux sw.failaction
       | String_switch (_, sw, def) ->
         List.iter (fun (_,l) -> aux l) sw;
-        Misc.may aux def
+        Option.iter aux def
   and aux_named (named : named) =
     f_named named;
     match named with

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -213,14 +213,14 @@ let variable_and_symbol_invariants (program : Flambda.program) =
           ignore_int n;
           loop env e)
         (consts @ blocks);
-      Misc.may (loop env) failaction
+      Option.iter (loop env) failaction
     | String_switch (arg, cases, e_opt) ->
       check_variable_is_bound env arg;
       List.iter (fun (label, case) ->
           ignore_string label;
           loop env case)
         cases;
-      Misc.may (loop env) e_opt
+      Option.iter (loop env) e_opt
     | Static_raise (static_exn, es) ->
       ignore_static_exception static_exn;
       List.iter (check_variable_is_bound env) es

--- a/middle_end/flambda/flambda_iterators.ml
+++ b/middle_end/flambda/flambda_iterators.ml
@@ -32,10 +32,10 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
   | Switch (_, sw) ->
     List.iter (fun (_,l) -> f l) sw.consts;
     List.iter (fun (_,l) -> f l) sw.blocks;
-    Misc.may f sw.failaction
+    Option.iter f sw.failaction
   | String_switch (_, sw, def) ->
     List.iter (fun (_,l) -> f l) sw;
-    Misc.may f def
+    Option.iter f def
   | Static_catch (_,_,f1,f2) ->
     f f1; f f2;
   | Try_with (f1,_,f2) ->

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -313,7 +313,7 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
   | String_switch (arg, sw, def) ->
     let arg = subst_var env arg in
     let sw = List.map (fun (s, e) -> s, to_clambda t env e) sw in
-    let def = Misc.may_map (to_clambda t env) def in
+    let def = Option.map (to_clambda t env) def in
     Ustringswitch (arg, sw, def)
   | Static_raise (static_exn, args) ->
     Ustaticfail (Static_exception.to_int static_exn,

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -286,12 +286,12 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_var arg curr;
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw.consts;
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw.blocks;
-      Misc.may (fun l -> mark_loop ~toplevel [] l) sw.failaction
+      Option.iter (fun l -> mark_loop ~toplevel [] l) sw.failaction
     | String_switch (arg,sw,def) ->
       mark_curr curr;
       mark_var arg curr;
       List.iter (fun (_,l) -> mark_loop ~toplevel [] l) sw;
-      Misc.may (fun l -> mark_loop ~toplevel [] l) def
+      Option.iter (fun l -> mark_loop ~toplevel [] l) def
     | Send { kind = _; meth; obj; args; dbg = _; } ->
       mark_curr curr;
       mark_var meth curr;

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -99,7 +99,7 @@ let lambda_smaller' lam ~than:threshold =
           size := !size + 2;
           lambda_size lam)
         sw;
-      Misc.may lambda_size def
+      Option.iter lambda_size def
     | Static_raise _ -> ()
     | Static_catch (_, _, body, handler) ->
       incr size; lambda_size body; lambda_size handler

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -60,11 +60,11 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       set := Variable.Set.add cond !set;
       List.iter (fun (_, branch) -> loop branch) consts;
       List.iter (fun (_, branch) -> loop branch) blocks;
-      Misc.may loop failaction
+      Option.iter loop failaction
     | String_switch (cond, branches, default) ->
       set := Variable.Set.add cond !set;
       List.iter (fun (_, branch) -> loop branch) branches;
-      Misc.may loop default
+      Option.iter loop default
     | Static_catch (_, _, body, handler) ->
       loop body;
       loop handler

--- a/middle_end/flambda/simple_value_approx.ml
+++ b/middle_end/flambda/simple_value_approx.ml
@@ -290,7 +290,7 @@ let value_closure ?closure_var ?set_of_closures_var ?set_of_closures_symbol
   let approx_set_of_closures =
     { descr = Value_set_of_closures value_set_of_closures;
       var = set_of_closures_var;
-      symbol = Misc.may_map (fun s -> s, None) set_of_closures_symbol;
+      symbol = Option.map (fun s -> s, None) set_of_closures_symbol;
     }
   in
   let value_closure =

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -152,7 +152,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
           ignore_string str;
           loop branch)
         branches;
-      Misc.may loop default
+      Option.iter loop default
     | Ustaticfail (static_exn, args) ->
       ignore_int static_exn;
       List.iter loop args
@@ -354,7 +354,7 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
           loop branch)
         branches;
       let_stack := [];
-      Misc.may loop default;
+      Option.iter loop default;
       let_stack := []
     | Ustaticfail (static_exn, args) ->
       ignore_int static_exn;
@@ -516,7 +516,7 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
         branches
     in
     let default =
-      Misc.may_map (substitute_let_moveable is_let_moveable env) default
+      Option.map (substitute_let_moveable is_let_moveable env) default
     in
     Ustringswitch (cond, branches, default)
   | Ustaticfail (n, args) ->
@@ -735,7 +735,7 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
       List.map (fun (s, branch) -> s, un_anf var_info env branch)
         branches
     in
-    let default = Misc.may_map (un_anf var_info env) default in
+    let default = Option.map (un_anf var_info env) default in
     Ustringswitch (cond, branches, default), Fixed
   | Ustaticfail (n, args) ->
     let args = un_anf_list var_info env args in

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -14,7 +14,6 @@
 (**************************************************************************)
 
 (** Analysis of implementation files. *)
-open Misc
 open Asttypes
 open Types
 open Typedtree
@@ -1307,7 +1306,7 @@ module Analyser =
                               xt_name = complete_name;
                               xt_args;
                               xt_ret =
-                                may_map (fun ctyp -> Odoc_env.subst_type new_env ctyp.ctyp_type) ret_type;
+                                Option.map (fun ctyp -> Odoc_env.subst_type new_env ctyp.ctyp_type) ret_type;
                               xt_type_extension = new_te;
                               xt_alias = None;
                               xt_loc = { loc_impl = Some tt_ext.ext_loc ; loc_inter = None } ;
@@ -1366,7 +1365,7 @@ module Analyser =
                   ex_info = comment_opt ;
                   ex_args;
                   ex_ret =
-                    Misc.may_map
+                    Option.map
                       (fun ctyp -> Odoc_env.subst_type new_env ctyp.ctyp_type)
                       tt_ret_type;
                   ex_alias = None ;
@@ -1729,7 +1728,7 @@ module Analyser =
            let param =
              {
                mp_name = mp_name ;
-               mp_type = Misc.may_map
+               mp_type = Option.map
                 (fun m -> Odoc_env.subst_module_type env m.mty_type) mtyp ;
                mp_type_code = mp_type_code ;
                mp_kind = mp_kind ;

--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -224,7 +224,7 @@ let subst_module_type env t =
     | Types.Mty_signature _ ->
         t
     | Types.Mty_functor (id, mt1, mt2) ->
-        Types.Mty_functor (id, Misc.may_map iter mt1, iter mt2)
+        Types.Mty_functor (id, Option.map iter mt1, iter mt2)
   in
   iter t
 

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -733,7 +733,7 @@ class man =
             (fun (p, desc_opt) ->
               bs b ".sp\n";
               bs b ("\""^p.mp_name^"\"\n");
-              Misc.may (self#man_of_module_type b m_name) p.mp_type;
+              Option.iter (self#man_of_module_type b m_name) p.mp_type;
               bs b "\n";
               (
                match desc_opt with

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -63,7 +63,7 @@ let simpl_module_type ?code t =
          | Some s -> raise (Use_code s)
         )
     | Types.Mty_functor (id, mt1, mt2) ->
-        Types.Mty_functor (id, Misc.may_map iter mt1, iter mt2)
+        Types.Mty_functor (id, Option.map iter mt1, iter mt2)
   in
   iter t
 

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -15,7 +15,6 @@
 
 (** Analysis of interface files. *)
 
-open Misc
 open Asttypes
 open Types
 
@@ -395,7 +394,7 @@ module Analyser =
             {
               vc_name = constructor_name ;
               vc_args;
-              vc_ret =  may_map (Odoc_env.subst_type env) ret_type;
+              vc_ret =  Option.map (Odoc_env.subst_type env) ret_type;
               vc_text = comment_opt
             }
           in
@@ -842,7 +841,7 @@ module Analyser =
                 {
                   xt_name = Name.concat current_module_name name ;
                   xt_args;
-                  xt_ret = may_map (Odoc_env.subst_type new_env) types_ext.ext_ret_type ;
+                  xt_ret = Option.map (Odoc_env.subst_type new_env) types_ext.ext_ret_type ;
                   xt_type_extension = new_te;
                   xt_alias = None ;
                   xt_loc = { loc_impl = None ; loc_inter = Some types_ext.Types.ext_loc} ;
@@ -887,7 +886,7 @@ module Analyser =
                 ex_name = Name.concat current_module_name name.txt ;
                 ex_info = comment_opt ;
                 ex_args;
-                ex_ret = may_map (Odoc_env.subst_type env) types_ext.ext_ret_type ;
+                ex_ret = Option.map (Odoc_env.subst_type env) types_ext.ext_ret_type ;
                 ex_alias = None ;
                 ex_loc = { loc_impl = None ; loc_inter = Some sig_item_loc } ;
                 ex_code =
@@ -1564,7 +1563,7 @@ module Analyser =
                  {
                    mp_name = Name.from_ident ident ;
                    mp_type =
-                    Misc.may_map (Odoc_env.subst_module_type env)
+                    Option.map (Odoc_env.subst_module_type env)
                       param_module_type;
                    mp_type_code = mp_type_code ;
                    mp_kind = mp_kind ;
@@ -1658,7 +1657,7 @@ module Analyser =
                let param =
                  {
                    mp_name = Name.from_ident ident ;
-                   mp_type = Misc.may_map
+                   mp_type = Option.map
                     (Odoc_env.subst_module_type env) param_module_type ;
                    mp_type_code = mp_type_code ;
                    mp_kind = mp_kind ;

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -262,7 +262,7 @@ module MT = struct
     | Pmty_signature sg -> signature ~loc ~attrs (sub.signature sub sg)
     | Pmty_functor (s, mt1, mt2) ->
         functor_ ~loc ~attrs (map_loc sub s)
-          (Misc.may_map (sub.module_type sub) mt1)
+          (Option.map (sub.module_type sub) mt1)
           (sub.module_type sub mt2)
     | Pmty_with (mt, l) ->
         with_ ~loc ~attrs (sub.module_type sub mt)
@@ -320,7 +320,7 @@ module M = struct
     | Pmod_structure str -> structure ~loc ~attrs (sub.structure sub str)
     | Pmod_functor (arg, arg_ty, body) ->
         functor_ ~loc ~attrs (map_loc sub arg)
-          (Misc.may_map (sub.module_type sub) arg_ty)
+          (Option.map (sub.module_type sub) arg_ty)
           (sub.module_expr sub body)
     | Pmod_apply (m1, m2) ->
         apply ~loc ~attrs (sub.module_expr sub m1) (sub.module_expr sub m2)

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -133,7 +133,7 @@ let add_constructor_arguments bv = function
 
 let add_constructor_decl bv pcd =
   add_constructor_arguments bv pcd.pcd_args;
-  Misc.may (add_type bv) pcd.pcd_res
+  Option.iter (add_type bv) pcd.pcd_res
 
 let add_type_declaration bv td =
   List.iter
@@ -153,7 +153,7 @@ let add_extension_constructor bv ext =
   match ext.pext_kind with
     Pext_decl(args, rty) ->
       add_constructor_arguments bv args;
-      Misc.may (add_type bv) rty
+      Option.iter (add_type bv) rty
   | Pext_rebind lid -> add bv lid
 
 let add_type_extension bv te =
@@ -284,7 +284,7 @@ and add_modtype bv mty =
   | Pmty_alias l -> add_module_path bv l
   | Pmty_signature s -> add_signature bv s
   | Pmty_functor(id, mty1, mty2) ->
-      Misc.may (add_modtype bv) mty1;
+      Option.iter (add_modtype bv) mty1;
       add_modtype (String.Map.add id.txt bound bv) mty2
   | Pmty_with(mty, cstrl) ->
       add_modtype bv mty;
@@ -398,7 +398,7 @@ and add_module_expr bv modl =
     Pmod_ident l -> add_module_path bv l
   | Pmod_structure s -> ignore (add_structure bv s)
   | Pmod_functor(id, mty, modl) ->
-      Misc.may (add_modtype bv) mty;
+      Option.iter (add_modtype bv) mty;
       add_module_expr (String.Map.add id.txt bound bv) modl
   | Pmod_apply(mod1, mod2) ->
       add_module_expr bv mod1; add_module_expr bv mod2

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -452,7 +452,7 @@ let highlight_quote ppf
         |> infer_line_numbers
         |> List.map (fun (lnum, { text; start_pos }) ->
           (text,
-           Misc.Stdlib.Option.value_default Int.to_string ~default:"" lnum,
+           Option.fold ~some:Int.to_string ~none:"" lnum,
            start_pos))
       in
     Format.fprintf ppf "@[<v>";

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1305,7 +1305,7 @@ and structure_item ctxt f x =
       let rec module_helper = function
         | {pmod_desc=Pmod_functor(s,mt,me'); pmod_attributes = []} ->
             if mt = None then pp f "()"
-            else Misc.may (pp f "(%s:%a)" s.txt (module_type ctxt)) mt;
+            else Option.iter (pp f "(%s:%a)" s.txt (module_type ctxt)) mt;
             module_helper me'
         | me -> me
       in

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -664,7 +664,7 @@ and module_type i ppf x =
       signature i ppf s;
   | Pmty_functor (s, mt1, mt2) ->
       line i ppf "Pmty_functor %a\n" fmt_string_loc s;
-      Misc.may (module_type i ppf) mt1;
+      Option.iter (module_type i ppf) mt1;
       module_type i ppf mt2;
   | Pmty_with (mt, l) ->
       line i ppf "Pmty_with\n";
@@ -767,7 +767,7 @@ and module_expr i ppf x =
       structure i ppf s;
   | Pmod_functor (s, mt, me) ->
       line i ppf "Pmod_functor %a\n" fmt_string_loc s;
-      Misc.may (module_type i ppf) mt;
+      Option.iter (module_type i ppf) mt;
       module_expr i ppf me;
   | Pmod_apply (me1, me2) ->
       line i ppf "Pmod_apply\n";

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -15,7 +15,6 @@
 
 (* Basic operations on core types *)
 
-open Misc
 open Asttypes
 open Types
 
@@ -258,7 +257,7 @@ let rec fold_row f init row =
     Tvariant row -> fold_row f result row
   | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil ->
     begin match
-      Misc.may_map (fun (_,l) -> List.fold_left f result l) row.row_name
+      Option.map (fun (_,l) -> List.fold_left f result l) row.row_name
     with
     | None -> result
     | Some result -> result
@@ -336,7 +335,7 @@ let iter_type_expr_kind f = function
       List.iter
         (fun cd ->
            iter_type_expr_cstr_args f cd.cd_args;
-           Misc.may f cd.cd_res
+           Option.iter f cd.cd_res
         )
         cstrs
   | Type_record(lbls, _) ->
@@ -360,21 +359,21 @@ let type_iterators =
     it.it_type_expr it vd.val_type
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
-    may (it.it_type_expr it) td.type_manifest;
+    Option.iter (it.it_type_expr it) td.type_manifest;
     it.it_type_kind it td.type_kind
   and it_extension_constructor it td =
     it.it_path td.ext_type_path;
     List.iter (it.it_type_expr it) td.ext_type_params;
     iter_type_expr_cstr_args (it.it_type_expr it) td.ext_args;
-    may (it.it_type_expr it) td.ext_ret_type
+    Option.iter (it.it_type_expr it) td.ext_ret_type
   and it_module_declaration it md =
     it.it_module_type it md.md_type
   and it_modtype_declaration it mtd =
-    may (it.it_module_type it) mtd.mtd_type
+    Option.iter (it.it_module_type it) mtd.mtd_type
   and it_class_declaration it cd =
     List.iter (it.it_type_expr it) cd.cty_params;
     it.it_class_type it cd.cty_type;
-    may (it.it_type_expr it) cd.cty_new;
+    Option.iter (it.it_type_expr it) cd.cty_new;
     it.it_path cd.cty_path
   and it_class_type_declaration it ctd =
     List.iter (it.it_type_expr it) ctd.clty_params;
@@ -385,7 +384,7 @@ let type_iterators =
     | Mty_alias p -> it.it_path p
     | Mty_signature sg -> it.it_signature it sg
     | Mty_functor (_, mto, mt) ->
-        may (it.it_module_type it) mto;
+        Option.iter (it.it_module_type it) mto;
         it.it_module_type it mt
   and it_class_type it = function
       Cty_constr (p, tyl, cty) ->
@@ -411,7 +410,7 @@ let type_iterators =
     | Tpackage (p, _, _) ->
         it.it_path p
     | Tvariant row ->
-        may (fun (p,_) -> it.it_path p) (row_repr row).row_name
+        Option.iter (fun (p,_) -> it.it_path p) (row_repr row).row_name
     | _ -> ()
   and it_path _p = ()
   in
@@ -570,7 +569,7 @@ let unmark_type_decl decl =
 let unmark_extension_constructor ext =
   List.iter unmark_type ext.ext_type_params;
   iter_type_expr_cstr_args unmark_type ext.ext_args;
-  Misc.may unmark_type ext.ext_ret_type
+  Option.iter unmark_type ext.ext_ret_type
 
 let unmark_class_signature sign =
   unmark_type sign.csig_self;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1269,7 +1269,7 @@ let map_kind f = function
           (fun c ->
              {c with
               cd_args = map_type_expr_cstr_args f c.cd_args;
-              cd_res = may_map f c.cd_res
+              cd_res = Option.map f c.cd_res
              })
           cl)
   | Type_record (fl, rr) ->
@@ -1283,7 +1283,7 @@ let map_kind f = function
 let instance_declaration decl =
   For_copy.with_scope (fun scope ->
     {decl with type_params = List.map (copy scope) decl.type_params;
-     type_manifest = may_map (copy scope) decl.type_manifest;
+     type_manifest = Option.map (copy scope) decl.type_manifest;
      type_kind = map_kind (copy scope) decl.type_kind;
     }
   )
@@ -4632,7 +4632,7 @@ let nondep_extension_constructor env ids ext =
           ext.ext_type_path, type_params
     in
     let args = map_type_expr_cstr_args (nondep_type_rec env ids) ext.ext_args in
-    let ret_type = may_map (nondep_type_rec env ids) ext.ext_ret_type in
+    let ret_type = Option.map (nondep_type_rec env ids) ext.ext_ret_type in
       clear_hash ();
       { ext_type_path = type_path;
         ext_type_params = type_params;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1777,7 +1777,7 @@ and components_of_module_maker {cm_env; cm_freshening_subst; cm_prefixing_subst;
           fcomp_param = param;
           (* fcomp_arg and fcomp_res must be prefixed eagerly, because
              they are interpreted in the outer environment *)
-          fcomp_arg = may_map (Subst.modtype scoping sub) ty_arg;
+          fcomp_arg = Option.map (Subst.modtype scoping sub) ty_arg;
           fcomp_res = Subst.modtype scoping sub ty_res;
           fcomp_cache = Hashtbl.create 17;
           fcomp_subst_cache = Hashtbl.create 17 })
@@ -1813,7 +1813,7 @@ and check_value_name name loc =
 
 and store_value ?check id addr decl env =
   check_value_name (Ident.name id) decl.val_loc;
-  may (fun f -> check_usage decl.val_loc id f value_declarations) check;
+  Option.iter (fun f -> check_usage decl.val_loc id f value_declarations) check;
   { env with
     values = IdTbl.add id (decl, addr) env.values;
     summary = Env_value(env.summary, id, decl) }

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -175,7 +175,7 @@ let rec nondep_mty_with_presence env va ids pres mty =
       let var_inv =
         match va with Co -> Contra | Contra -> Co | Strict -> Strict in
       let mty =
-        Mty_functor(param, Misc.may_map (nondep_mty env var_inv ids) arg,
+        Mty_functor(param, Option.map (nondep_mty env var_inv ids) arg,
                     nondep_mty
                       (Env.add_module ~arg:true param Mp_present
                          (Btype.default_mty arg) env) va ids res)
@@ -215,7 +215,7 @@ and nondep_sig env va ids sg =
   List.map (nondep_sig_item env va ids) sg
 
 and nondep_modtype_decl env ids mtd =
-  {mtd with mtd_type = Misc.may_map (nondep_mty env Strict ids) mtd.mtd_type}
+  {mtd with mtd_type = Option.map (nondep_mty env Strict ids) mtd.mtd_type}
 
 let nondep_supertype env ids = nondep_mty env Co ids
 let nondep_sig_item env ids = nondep_sig_item env Co ids

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -432,7 +432,7 @@ let rec normalize_pat q = match q.pat_desc with
         (Tpat_construct (lid, c,omega_list args))
         q.pat_type q.pat_env
   | Tpat_variant (l, arg, row) ->
-      make_pat (Tpat_variant (l, may_map (fun _ -> omega) arg, row))
+      make_pat (Tpat_variant (l, Option.map (fun _ -> omega) arg, row))
         q.pat_type q.pat_env
   | Tpat_array (args) ->
       make_pat (Tpat_array (omega_list args))  q.pat_type q.pat_env
@@ -1902,7 +1902,7 @@ module Conv = struct
           in
           mkpat (Ppat_construct(lid, arg))
       | Tpat_variant(label,p_opt,_row_desc) ->
-          let arg = Misc.may_map loop p_opt in
+          let arg = Option.map loop p_opt in
           mkpat (Ppat_variant(label, arg))
       | Tpat_record (subpatterns, _closed_flag) ->
           let fields =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1123,7 +1123,7 @@ let rec tree_of_type_decl id decl =
       List.iter
         (fun c ->
            mark_loops_constructor_arguments c.cd_args;
-           may mark_loops c.cd_res)
+           Option.iter mark_loops c.cd_res)
         cstrs
   | Type_record(l, _rep) ->
       List.iter (fun l -> mark_loops l.ld_type) l
@@ -1235,7 +1235,7 @@ let tree_of_extension_constructor id ext es =
   List.iter mark_loops ty_params;
   List.iter check_name_of_type (List.map proxy ty_params);
   mark_loops_constructor_arguments ext.ext_args;
-  may mark_loops ext.ext_ret_type;
+  Option.iter mark_loops ext.ext_ret_type;
   let type_param =
     function
     | Otyp_var (_, id) -> id
@@ -1551,7 +1551,7 @@ let rec tree_of_modtype ?(ellipsis=false) = function
                      (tree_of_modtype ~ellipsis) ty_res
       in
       Omty_functor (Ident.name param,
-                    may_map (tree_of_modtype ~ellipsis:false) ty_arg, res)
+                    Option.map (tree_of_modtype ~ellipsis:false) ty_arg, res)
   | Mty_alias p ->
       Omty_alias (tree_of_path Module p)
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -670,7 +670,7 @@ and module_type i ppf x =
       signature i ppf s;
   | Tmty_functor (s, _, mt1, mt2) ->
       line i ppf "Tmty_functor \"%a\"\n" fmt_ident s;
-      Misc.may (module_type i ppf) mt1;
+      Option.iter (module_type i ppf) mt1;
       module_type i ppf mt2;
   | Tmty_with (mt, l) ->
       line i ppf "Tmty_with\n";
@@ -770,7 +770,7 @@ and module_expr i ppf x =
       structure i ppf s;
   | Tmod_functor (s, _, mt, me) ->
       line i ppf "Tmod_functor \"%a\"\n" fmt_ident s;
-      Misc.may (module_type i ppf) mt;
+      Option.iter (module_type i ppf) mt;
       module_expr i ppf me;
   | Tmod_apply (me1, me2, _) ->
       line i ppf "Tmod_apply\n";

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -274,7 +274,7 @@ let constructor_declaration copy_scope s c =
   {
     cd_id = c.cd_id;
     cd_args = constructor_arguments copy_scope s c.cd_args;
-    cd_res = may_map (typexp copy_scope s) c.cd_res;
+    cd_res = Option.map (typexp copy_scope s) c.cd_res;
     cd_loc = loc s c.cd_loc;
     cd_attributes = attrs s c.cd_attributes;
   }
@@ -379,7 +379,7 @@ let extension_constructor' copy_scope s ext =
   { ext_type_path = type_path s ext.ext_type_path;
     ext_type_params = List.map (typexp copy_scope s) ext.ext_type_params;
     ext_args = constructor_arguments copy_scope s ext.ext_args;
-    ext_ret_type = may_map (typexp copy_scope s) ext.ext_ret_type;
+    ext_ret_type = Option.map (typexp copy_scope s) ext.ext_ret_type;
     ext_private = ext.ext_private;
     ext_attributes = attrs s ext.ext_attributes;
     ext_loc = if s.for_saving then Location.none else ext.ext_loc; }
@@ -459,7 +459,7 @@ let rec modtype scoping s = function
       Mty_signature(signature scoping s sg)
   | Mty_functor(id, arg, res) ->
       let id' = Ident.rename id in
-      Mty_functor(id', may_map (modtype scoping s) arg,
+      Mty_functor(id', Option.map (modtype scoping s) arg,
                        modtype scoping (add_module id (Pident id') s) res)
   | Mty_alias p ->
       Mty_alias (module_path s p)
@@ -504,7 +504,7 @@ and module_declaration scoping s decl =
 
 and modtype_declaration scoping s decl  =
   {
-    mtd_type = may_map (modtype scoping s) decl.mtd_type;
+    mtd_type = Option.map (modtype scoping s) decl.mtd_type;
     mtd_attributes = attrs s decl.mtd_attributes;
     mtd_loc = loc s decl.mtd_loc;
   }

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -73,8 +73,6 @@ type mapper =
 let id x = x
 let tuple2 f1 f2 (x, y) = (f1 x, f2 y)
 let tuple3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
-let opt f = function None -> None | Some x -> Some (f x)
-
 
 let structure sub {str_items; str_type; str_final_env} =
   {
@@ -90,7 +88,7 @@ let class_infos sub f x =
   }
 
 let module_type_declaration sub x =
-  let mtd_type = opt (sub.module_type sub) x.mtd_type in
+  let mtd_type = Option.map (sub.module_type sub) x.mtd_type in
   {x with mtd_type}
 
 let module_declaration sub x =
@@ -152,7 +150,7 @@ let constructor_args sub = function
 
 let constructor_decl sub cd =
   let cd_args = constructor_args sub cd.cd_args in
-  let cd_res = opt (sub.typ sub) cd.cd_res in
+  let cd_res = Option.map (sub.typ sub) cd.cd_res in
   {cd with cd_args; cd_res}
 
 let type_kind sub = function
@@ -168,7 +166,7 @@ let type_declaration sub x =
       x.typ_cstrs
   in
   let typ_kind = sub.type_kind sub x.typ_kind in
-  let typ_manifest = opt (sub.typ sub) x.typ_manifest in
+  let typ_manifest = Option.map (sub.typ sub) x.typ_manifest in
   let typ_params = List.map (tuple2 (sub.typ sub) id) x.typ_params in
   {x with typ_cstrs; typ_kind; typ_manifest; typ_params}
 
@@ -192,7 +190,7 @@ let extension_constructor sub x =
   let ext_kind =
     match x.ext_kind with
       Text_decl(ctl, cto) ->
-        Text_decl(constructor_args sub ctl, opt (sub.typ sub) cto)
+        Text_decl(constructor_args sub ctl, Option.map (sub.typ sub) cto)
     | Text_rebind _ as d -> d
   in
   {x with ext_kind}
@@ -214,7 +212,7 @@ let pat sub x =
     | Tpat_tuple l -> Tpat_tuple (List.map (sub.pat sub) l)
     | Tpat_construct (loc, cd, l) ->
         Tpat_construct (loc, cd, List.map (sub.pat sub) l)
-    | Tpat_variant (l, po, rd) -> Tpat_variant (l, opt (sub.pat sub) po, rd)
+    | Tpat_variant (l, po, rd) -> Tpat_variant (l, Option.map (sub.pat sub) po, rd)
     | Tpat_record (l, closed) ->
         Tpat_record (List.map (tuple3 id id (sub.pat sub)) l, closed)
     | Tpat_array l -> Tpat_array (List.map (sub.pat sub) l)
@@ -231,9 +229,9 @@ let expr sub x =
     | Texp_constraint cty ->
         Texp_constraint (sub.typ sub cty)
     | Texp_coerce (cty1, cty2) ->
-        Texp_coerce (opt (sub.typ sub) cty1, sub.typ sub cty2)
+        Texp_coerce (Option.map (sub.typ sub) cty1, sub.typ sub cty2)
     | Texp_newtype _ as d -> d
-    | Texp_poly cto -> Texp_poly (opt (sub.typ sub) cto)
+    | Texp_poly cto -> Texp_poly (Option.map (sub.typ sub) cto)
   in
   let exp_extra = List.map (tuple3 extra id id) x.exp_extra in
   let exp_env = sub.env sub x.exp_env in
@@ -250,7 +248,7 @@ let expr sub x =
     | Texp_apply (exp, list) ->
         Texp_apply (
           sub.expr sub exp,
-          List.map (tuple2 id (opt (sub.expr sub))) list
+          List.map (tuple2 id (Option.map (sub.expr sub))) list
         )
     | Texp_match (exp, cases, p) ->
         Texp_match (
@@ -268,7 +266,7 @@ let expr sub x =
     | Texp_construct (lid, cd, args) ->
         Texp_construct (lid, cd, List.map (sub.expr sub) args)
     | Texp_variant (l, expo) ->
-        Texp_variant (l, opt (sub.expr sub) expo)
+        Texp_variant (l, Option.map (sub.expr sub) expo)
     | Texp_record { fields; representation; extended_expression } ->
         let fields = Array.map (function
             | label, Kept t -> label, Kept t
@@ -278,7 +276,7 @@ let expr sub x =
         in
         Texp_record {
           fields; representation;
-          extended_expression = opt (sub.expr sub) extended_expression;
+          extended_expression = Option.map (sub.expr sub) extended_expression;
         }
     | Texp_field (exp, lid, ld) ->
         Texp_field (sub.expr sub exp, lid, ld)
@@ -295,7 +293,7 @@ let expr sub x =
         Texp_ifthenelse (
           sub.expr sub exp1,
           sub.expr sub exp2,
-          opt (sub.expr sub) expo
+          Option.map (sub.expr sub) expo
         )
     | Texp_sequence (exp1, exp2) ->
         Texp_sequence (
@@ -321,7 +319,7 @@ let expr sub x =
           (
             sub.expr sub exp,
             meth,
-            opt (sub.expr sub) expo
+            Option.map (sub.expr sub) expo
           )
     | Texp_new _
     | Texp_instvar _ as d -> d
@@ -438,7 +436,7 @@ let module_type sub x =
         Tmty_functor (
           id,
           s,
-          opt (sub.module_type sub) mtype1,
+          Option.map (sub.module_type sub) mtype1,
           sub.module_type sub mtype2
         )
     | Tmty_with (mtype, list) ->
@@ -489,7 +487,7 @@ let module_expr sub x =
         Tmod_functor (
           id,
           s,
-          opt (sub.module_type sub) mtype,
+          Option.map (sub.module_type sub) mtype,
           sub.module_expr sub mexpr
         )
     | Tmod_apply (mexp1, mexp2, c) ->
@@ -528,7 +526,7 @@ let class_expr sub x =
     | Tcl_constraint (cl, clty, vals, meths, concrs) ->
         Tcl_constraint (
           sub.class_expr sub cl,
-          opt (sub.class_type sub) clty,
+          Option.map (sub.class_type sub) clty,
           vals,
           meths,
           concrs
@@ -546,7 +544,7 @@ let class_expr sub x =
     | Tcl_apply (cl, args) ->
         Tcl_apply (
           sub.class_expr sub cl,
-          List.map (tuple2 id (opt (sub.expr sub))) args
+          List.map (tuple2 id (Option.map (sub.expr sub))) args
         )
     | Tcl_let (rec_flag, value_bindings, ivars, cl) ->
         let (rec_flag, value_bindings) =
@@ -691,7 +689,7 @@ let cases sub l =
 let case sub {c_lhs; c_guard; c_rhs} =
   {
     c_lhs = sub.pat sub c_lhs;
-    c_guard = opt (sub.expr sub) c_guard;
+    c_guard = Option.map (sub.expr sub) c_guard;
     c_rhs = sub.expr sub c_rhs;
   }
 

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -212,7 +212,8 @@ let pat sub x =
     | Tpat_tuple l -> Tpat_tuple (List.map (sub.pat sub) l)
     | Tpat_construct (loc, cd, l) ->
         Tpat_construct (loc, cd, List.map (sub.pat sub) l)
-    | Tpat_variant (l, po, rd) -> Tpat_variant (l, Option.map (sub.pat sub) po, rd)
+    | Tpat_variant (l, po, rd) ->
+        Tpat_variant (l, Option.map (sub.pat sub) po, rd)
     | Tpat_record (l, closed) ->
         Tpat_record (List.map (tuple3 id id (sub.pat sub)) l, closed)
     | Tpat_array l -> Tpat_array (List.map (sub.pat sub) l)

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1615,11 +1615,11 @@ let final_decl env define_class
 
   List.iter Ctype.generalize clty.cty_params;
   generalize_class_type true clty.cty_type;
-  Misc.may  Ctype.generalize clty.cty_new;
+  Option.iter  Ctype.generalize clty.cty_new;
   List.iter Ctype.generalize obj_abbr.type_params;
-  Misc.may  Ctype.generalize obj_abbr.type_manifest;
+  Option.iter  Ctype.generalize obj_abbr.type_manifest;
   List.iter Ctype.generalize cl_abbr.type_params;
-  Misc.may  Ctype.generalize cl_abbr.type_manifest;
+  Option.iter  Ctype.generalize cl_abbr.type_manifest;
 
   if not (closed_class clty) then
     raise(Error(cl.pci_loc, env, Non_generalizable_class (id, clty)));

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -522,10 +522,12 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) loc name ty
     if not !allow_modules then
       raise (Error (loc, Env.empty, Modules_not_allowed));
     module_variables := (name, loc) :: !module_variables
-  end else
+  end else begin
     (* moved to genannot *)
-    Option.iter (fun s -> Stypes.record (Stypes.An_ident (name.loc, name.txt, s)))
-        !pattern_scope;
+    Option.iter
+      (fun s -> Stypes.record (Stypes.An_ident (name.loc, name.txt, s)))
+      !pattern_scope
+  end;
   id
 
 let sort_pattern_variables vs =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -718,16 +718,16 @@ let check_well_founded env loc path to_check ty =
     in
     match ty.desc with
     | Tconstr(p, _, _) when arg_exn <> None || to_check p ->
-        if to_check p then may raise arg_exn
+        if to_check p then Option.iter raise arg_exn
         else Btype.iter_type_expr (check ty0 TypeSet.empty) ty;
         begin try
           let ty' = Ctype.try_expand_once_opt env ty in
           let ty0 = if TypeSet.is_empty parents then ty else ty0 in
           check ty0 (TypeSet.add ty parents) ty'
         with
-          Ctype.Cannot_expand -> may raise arg_exn
+          Ctype.Cannot_expand -> Option.iter raise arg_exn
         end
-    | _ -> may raise arg_exn
+    | _ -> Option.iter raise arg_exn
   in
   let snap = Btype.snapshot () in
   try Ctype.wrap_trace_gadt_instances env (check ty TypeSet.empty) ty
@@ -797,7 +797,7 @@ let check_recursion env loc path decl to_check =
           Btype.iter_type_expr (check_regular cpath args prev_exp) ty
     end in
 
-  Misc.may
+  Option.iter
     (fun body ->
       let (args, body) =
         Ctype.instance_parameterized_type
@@ -1196,7 +1196,7 @@ let transl_type_extension extend env loc styext =
   List.iter
     (fun ext ->
        Btype.iter_type_expr_cstr_args Ctype.generalize ext.ext_type.ext_args;
-       may Ctype.generalize ext.ext_type.ext_ret_type)
+       Option.iter Ctype.generalize ext.ext_type.ext_ret_type)
     constructors;
   (* Check that all type variables are closed *)
   List.iter
@@ -1250,7 +1250,7 @@ let transl_exception env sext =
   Ctype.end_def();
   (* Generalize types *)
   Btype.iter_type_expr_cstr_args Ctype.generalize ext.ext_type.ext_args;
-  may Ctype.generalize ext.ext_type.ext_ret_type;
+  Option.iter Ctype.generalize ext.ext_type.ext_ret_type;
   (* Check that all type variables are closed *)
   begin match Ctype.closed_extension_constructor ext.ext_type with
     Some ty ->

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -15,7 +15,6 @@
 
 (* Abstract syntax tree after typing *)
 
-open Misc
 open Asttypes
 open Types
 
@@ -592,7 +591,7 @@ let iter_pattern_desc f = function
   | Tpat_alias(p, _, _) -> f p
   | Tpat_tuple patl -> List.iter f patl
   | Tpat_construct(_, _, patl) -> List.iter f patl
-  | Tpat_variant(_, pat, _) -> may f pat
+  | Tpat_variant(_, pat, _) -> Option.iter f pat
   | Tpat_record (lbl_pat_list, _) ->
       List.iter (fun (_, _, pat) -> f pat) lbl_pat_list
   | Tpat_array patl -> List.iter f patl

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -313,7 +313,7 @@ let iterator_with_env env =
     );
     Btype.it_module_type = (fun self -> function
     | Mty_functor (param, mty_arg, mty_body) ->
-      may (self.Btype.it_module_type self) mty_arg;
+      Option.iter (self.Btype.it_module_type self) mty_arg;
       let env_before = !env in
       env := lazy (Env.add_module ~arg:true param Mp_present
                      (Btype.default_mty mty_arg) (Lazy.force env_before));
@@ -604,11 +604,7 @@ let merge_constraint initial_env remove_aliases loc sg constr =
             in
             fun s path -> Subst.add_type_path path replacement s
          | None ->
-            let body =
-              match tdecl.typ_type.type_manifest with
-              | None -> assert false
-              | Some x -> x
-            in
+            let body = Option.get tdecl.typ_type.type_manifest in
             let params = tdecl.typ_type.type_params in
             if params_are_constrained params
             then raise(Error(loc, initial_env,
@@ -690,7 +686,7 @@ let rec approx_modtype env smty =
   | Pmty_signature ssg ->
       Mty_signature(approx_sig env ssg)
   | Pmty_functor(param, sarg, sres) ->
-      let arg = may_map (approx_modtype env) sarg in
+      let arg = Option.map (approx_modtype env) sarg in
       let rarg = Mtype.scrape_for_functor_arg env (Btype.default_mty arg) in
       let scope = Ctype.create_scope () in
       let (id, newenv) =
@@ -816,7 +812,7 @@ and approx_sig env ssg =
 
 and approx_modtype_info env sinfo =
   {
-   mtd_type = may_map (approx_modtype env) sinfo.pmtd_type;
+   mtd_type = Option.map (approx_modtype env) sinfo.pmtd_type;
    mtd_attributes = sinfo.pmtd_attributes;
    mtd_loc = sinfo.pmtd_loc;
   }
@@ -1117,8 +1113,8 @@ and transl_modtype_aux env smty =
       mkmty (Tmty_signature sg) (Mty_signature sg.sig_type) env loc
         smty.pmty_attributes
   | Pmty_functor(param, sarg, sres) ->
-      let arg = Misc.may_map (transl_modtype_functor_arg env) sarg in
-      let ty_arg = Misc.may_map (fun m -> m.mty_type) arg in
+      let arg = Option.map (transl_modtype_functor_arg env) sarg in
+      let ty_arg = Option.map (fun m -> m.mty_type) arg in
       let scope = Ctype.create_scope () in
       let (id, newenv) =
         Env.enter_module ~scope ~arg:true
@@ -1431,10 +1427,10 @@ and transl_modtype_decl names env pmtd =
 
 and transl_modtype_decl_aux names env
     {pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc} =
-  let tmty = Misc.may_map (transl_modtype env) pmtd_type in
+  let tmty = Option.map (transl_modtype env) pmtd_type in
   let decl =
     {
-     Types.mtd_type=may_map (fun t -> t.mty_type) tmty;
+     Types.mtd_type=Option.map (fun t -> t.mty_type) tmty;
      mtd_attributes=pmtd_attributes;
      mtd_loc=pmtd_loc;
     }
@@ -1814,8 +1810,8 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
       wrap_constraint env false md (Mty_signature sg')
         Tmodtype_implicit
   | Pmod_functor(name, smty, sbody) ->
-      let mty = may_map (transl_modtype_functor_arg env) smty in
-      let ty_arg = Misc.may_map (fun m -> m.mty_type) mty in
+      let mty = Option.map (transl_modtype_functor_arg env) smty in
+      let ty_arg = Option.map (fun m -> m.mty_type) mty in
       let scope = Ctype.create_scope () in
       let (id, newenv), funct_body =
         match ty_arg with

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -96,8 +96,6 @@ let string_is_prefix sub str =
   let sublen = String.length sub in
   String.length str >= sublen && String.sub str 0 sublen = sub
 
-let map_opt f = function None -> None | Some e -> Some (f e)
-
 let rec lident_of_path = function
   | Path.Pident id -> Longident.Lident (Ident.name id)
   | Path.Pdot (p, s) -> Longident.Ldot (lident_of_path p, s)
@@ -239,7 +237,7 @@ let type_declaration sub decl =
         decl.typ_cstrs)
     ~kind:(sub.type_kind sub decl.typ_kind)
     ~priv:decl.typ_private
-    ?manifest:(map_opt (sub.typ sub) decl.typ_manifest)
+    ?manifest:(Option.map (sub.typ sub) decl.typ_manifest)
     (map_loc sub decl.typ_name)
 
 let type_kind sub tk = match tk with
@@ -259,7 +257,7 @@ let constructor_declaration sub cd =
   let attrs = sub.attributes sub cd.cd_attributes in
   Type.constructor ~loc ~attrs
     ~args:(constructor_arguments sub cd.cd_args)
-    ?res:(map_opt (sub.typ sub) cd.cd_res)
+    ?res:(Option.map (sub.typ sub) cd.cd_res)
     (map_loc sub cd.cd_name)
 
 let label_declaration sub ld =
@@ -291,7 +289,7 @@ let extension_constructor sub ext =
     (match ext.ext_kind with
       | Text_decl (args, ret) ->
           Pext_decl (constructor_arguments sub args,
-                     map_opt (sub.typ sub) ret)
+                     Option.map (sub.typ sub) ret)
       | Text_rebind (_p, lid) -> Pext_rebind (map_loc sub lid)
     )
 
@@ -345,7 +343,7 @@ let pattern sub pat =
                   )
           ))
     | Tpat_variant (label, pato, _) ->
-        Ppat_variant (label, map_opt (sub.pat sub) pato)
+        Ppat_variant (label, Option.map (sub.pat sub) pato)
     | Tpat_record (list, closed) ->
         Ppat_record (List.map (fun (lid, _, pat) ->
             map_loc sub lid, sub.pat sub pat) list, closed)
@@ -363,11 +361,11 @@ let exp_extra sub (extra, loc, attrs) sexp =
     match extra with
       Texp_coerce (cty1, cty2) ->
         Pexp_coerce (sexp,
-                     map_opt (sub.typ sub) cty1,
+                     Option.map (sub.typ sub) cty1,
                      sub.typ sub cty2)
     | Texp_constraint cty ->
         Pexp_constraint (sexp, sub.typ sub cty)
-    | Texp_poly cto -> Pexp_poly (sexp, map_opt (sub.typ sub) cto)
+    | Texp_poly cto -> Pexp_poly (sexp, Option.map (sub.typ sub) cto)
     | Texp_newtype s -> Pexp_newtype (mkloc s loc, sexp)
   in
   Exp.mk ~loc ~attrs desc
@@ -377,7 +375,7 @@ let cases sub l = List.map (sub.case sub) l
 let case sub {c_lhs; c_guard; c_rhs} =
   {
    pc_lhs = sub.pat sub c_lhs;
-   pc_guard = map_opt (sub.expr sub) c_guard;
+   pc_guard = Option.map (sub.expr sub) c_guard;
    pc_rhs = sub.expr sub c_rhs;
   }
 
@@ -438,14 +436,14 @@ let expression sub exp =
                 (Exp.tuple ~loc (List.map (sub.expr sub) args))
           ))
     | Texp_variant (label, expo) ->
-        Pexp_variant (label, map_opt (sub.expr sub) expo)
+        Pexp_variant (label, Option.map (sub.expr sub) expo)
     | Texp_record { fields; extended_expression; _ } ->
         let list = Array.fold_left (fun l -> function
             | _, Kept _ -> l
             | _, Overridden (lid, exp) -> (lid, sub.expr sub exp) :: l)
             [] fields
         in
-        Pexp_record (list, map_opt (sub.expr sub) extended_expression)
+        Pexp_record (list, Option.map (sub.expr sub) extended_expression)
     | Texp_field (exp, lid, _label) ->
         Pexp_field (sub.expr sub exp, map_loc sub lid)
     | Texp_setfield (exp1, lid, _label, exp2) ->
@@ -456,7 +454,7 @@ let expression sub exp =
     | Texp_ifthenelse (exp1, exp2, expo) ->
         Pexp_ifthenelse (sub.expr sub exp1,
           sub.expr sub exp2,
-          map_opt (sub.expr sub) expo)
+          Option.map (sub.expr sub) expo)
     | Texp_sequence (exp1, exp2) ->
         Pexp_sequence (sub.expr sub exp1, sub.expr sub exp2)
     | Texp_while (exp1, exp2) ->
@@ -527,7 +525,7 @@ let module_type_declaration sub mtd =
   let loc = sub.location sub mtd.mtd_loc in
   let attrs = sub.attributes sub mtd.mtd_attributes in
   Mtd.mk ~loc ~attrs
-    ?typ:(map_opt (sub.module_type sub) mtd.mtd_type)
+    ?typ:(Option.map (sub.module_type sub) mtd.mtd_type)
     (map_loc sub mtd.mtd_name)
 
 let signature sub sg =
@@ -612,7 +610,7 @@ let module_type sub mty =
     | Tmty_alias (_path, lid) -> Pmty_alias (map_loc sub lid)
     | Tmty_signature sg -> Pmty_signature (sub.signature sub sg)
     | Tmty_functor (_id, name, mtype1, mtype2) ->
-        Pmty_functor (name, map_opt (sub.module_type sub) mtype1,
+        Pmty_functor (name, Option.map (sub.module_type sub) mtype1,
           sub.module_type sub mtype2)
     | Tmty_with (mtype, list) ->
         Pmty_with (sub.module_type sub mtype,
@@ -644,7 +642,7 @@ let module_expr sub mexpr =
             Tmod_ident (_p, lid) -> Pmod_ident (map_loc sub lid)
           | Tmod_structure st -> Pmod_structure (sub.structure sub st)
           | Tmod_functor (_id, name, mtype, mexpr) ->
-              Pmod_functor (name, Misc.may_map (sub.module_type sub) mtype,
+              Pmod_functor (name, Option.map (sub.module_type sub) mtype,
                 sub.module_expr sub mexpr)
           | Tmod_apply (mexp1, mexp2, _) ->
               Pmod_apply (sub.module_expr sub mexp1, sub.module_expr sub mexp2)
@@ -801,7 +799,7 @@ let class_field sub cf =
   let desc = match cf.cf_desc with
       Tcf_inherit (ovf, cl, super, _vals, _meths) ->
         Pcf_inherit (ovf, sub.class_expr sub cl,
-                     map_opt (fun v -> mkloc v loc) super)
+                     Option.map (fun v -> mkloc v loc) super)
     | Tcf_constraint (cty, cty') ->
         Pcf_constraint (sub.typ sub cty, sub.typ sub cty')
     | Tcf_val (lab, mut, _, Tcfk_virtual cty, _) ->

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -182,11 +182,6 @@ module Stdlib = struct
   module Option = struct
     type 'a t = 'a option
 
-    let value_default f ~default a =
-      match a with
-      | None -> default
-      | Some a -> f a
-
     let print print_contents ppf t =
       match t with
       | None -> Format.pp_print_string ppf "None"
@@ -241,9 +236,6 @@ module Stdlib = struct
 
   external compare : 'a -> 'a -> int = "%compare"
 end
-
-let may = Option.iter
-let may_map = Option.map
 
 (* File functions *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -76,8 +76,6 @@ val list_remove: 'a -> 'a list -> 'a list
            element equal to [x] removed. *)
 val split_last: 'a list -> 'a list * 'a
         (* Return the last element and the other elements of the given list. *)
-val may: ('a -> unit) -> 'a option -> unit
-val may_map: ('a -> 'b) -> 'a option -> 'b option
 
 type ref_and_value = R : 'a ref * 'a -> ref_and_value
 
@@ -143,8 +141,6 @@ module Stdlib : sig
 
   module Option : sig
     type 'a t = 'a option
-
-    val value_default : ('a -> 'b) -> default:'b -> 'a t -> 'b
 
     val print
        : (Format.formatter -> 'a -> unit)


### PR DESCRIPTION
Now that we have an `Option` module in the stdlib we can remove some helper functions from the compiler. I grepped for matches on `Some` to try to find all the clones of `Option.map` and `Option.iter` so hopefully I got them all.