### PR TITLE
Move size computations from Cmm to Selectgen

### DIFF
--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -27,11 +27,6 @@ let typ_addr = [|Addr|]
 let typ_int = [|Int|]
 let typ_float = [|Float|]
 
-let size_component = function
-  | Val | Addr -> Arch.size_addr
-  | Int -> Arch.size_int
-  | Float -> Arch.size_float
-
 (** [machtype_component]s are partially ordered as follows:
 
       Addr     Float
@@ -81,13 +76,6 @@ let ge_component comp1 comp2 =
   | (Int | Addr | Val), Float
   | Float, (Int | Addr | Val) ->
     assert false
-
-let size_machtype mty =
-  let size = ref 0 in
-  for i = 0 to Array.length mty - 1 do
-    size := !size + size_component mty.(i)
-  done;
-  !size
 
 type integer_comparison = Lambda.integer_comparison =
   | Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -55,8 +55,6 @@ val typ_addr: machtype
 val typ_int: machtype
 val typ_float: machtype
 
-val size_component: machtype_component -> int
-
 (** Least upper bound of two [machtype_component]s. *)
 val lub_component
    : machtype_component
@@ -69,8 +67,6 @@ val ge_component
    : machtype_component
   -> machtype_component
   -> bool
-
-val size_machtype: machtype -> int
 
 type integer_comparison = Lambda.integer_comparison =
   | Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -78,6 +78,18 @@ let oper_result_type = function
 (* Infer the size in bytes of the result of an expression whose evaluation
    may be deferred (cf. [emit_parts]). *)
 
+let size_component = function
+  | Val | Addr -> Arch.size_addr
+  | Int -> Arch.size_int
+  | Float -> Arch.size_float
+
+let size_machtype mty =
+  let size = ref 0 in
+  for i = 0 to Array.length mty - 1 do
+    size := !size + size_component mty.(i)
+  done;
+  !size
+
 let size_expr (env:environment) exp =
   let rec size localenv = function
       Cconst_int _ | Cconst_natint _ -> Arch.size_int


### PR DESCRIPTION
This removes a dependency to Arch in Cmm.
The dependency was interfering with @Gbury 's ongoing work on register typing.