### PR TITLE
Don't apply local function optimisation for Tupled functions (fixes #8705)

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -882,5 +882,10 @@ let merge_inline_attributes attr1 attr2 =
     if attr1 = attr2 then Some attr1
     else None
 
+let function_is_curried func =
+  match func.kind with
+  | Curried -> true
+  | Tupled -> false
+
 let reset () =
   raise_count := 0

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -403,6 +403,8 @@ val swap_float_comparison : float_comparison -> float_comparison
 val default_function_attribute : function_attribute
 val default_stub_attribute : function_attribute
 
+val function_is_curried : lfunction -> bool
+
 (***********************)
 (* For static failures *)
 (***********************)

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -795,9 +795,7 @@ let simplify_local_functions lam =
     | Lvar id ->
         Hashtbl.remove slots id
     | Lfunction lf as lam ->
-        if Lambda.function_is_curried lf then begin
-          check_static lf
-        end;
+        check_static lf;
         Lambda.shallow_iter ~tail ~non_tail lam
     | lam ->
         Lambda.shallow_iter ~tail ~non_tail lam

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -754,7 +754,8 @@ let simplify_local_functions lam =
       -> false
   in
   let rec tail = function
-    | Llet (_str, _kind, id, Lfunction lf, cont) when enabled lf.attr ->
+    | Llet (_str, _kind, id, Lfunction lf, cont)
+      when Lambda.function_is_curried lf && enabled lf.attr ->
         let r = {nargs=List.length lf.params; scope=None} in
         Hashtbl.add slots id r;
         tail cont;
@@ -794,7 +795,9 @@ let simplify_local_functions lam =
     | Lvar id ->
         Hashtbl.remove slots id
     | Lfunction lf as lam ->
-        check_static lf;
+        if Lambda.function_is_curried lf then begin
+          check_static lf
+        end;
         Lambda.shallow_iter ~tail ~non_tail lam
     | lam ->
         Lambda.shallow_iter ~tail ~non_tail lam

--- a/testsuite/tests/local-functions/ocamltests
+++ b/testsuite/tests/local-functions/ocamltests
@@ -1,0 +1,2 @@
+tupled.ml
+tupled2.ml

--- a/testsuite/tests/local-functions/tupled.ml
+++ b/testsuite/tests/local-functions/tupled.ml
@@ -1,0 +1,11 @@
+(* TEST
+*)
+
+(* PR#8705 *)
+let () =
+  let tupled (x, y) =
+    print_string "";
+    fun z -> x, y, z
+  in
+  let a, b, c = tupled (0, 1) 2 in
+  assert (a = 0 && b = 1 && c = 2)

--- a/testsuite/tests/local-functions/tupled2.ml
+++ b/testsuite/tests/local-functions/tupled2.ml
@@ -1,0 +1,16 @@
+(* TEST
+*)
+
+(* PR#8705 *)
+
+let test x =
+  let tupled (x, y) = (); fun () -> [|x; y|] in
+  match x with
+  | None -> [| |]
+  | Some (x, y) -> tupled (x, y) ()
+
+let expected = "Hello "
+
+let result = (test (Some (expected, "World!"))).(0)
+
+let () = assert (String.equal expected result)


### PR DESCRIPTION
The local function optimisation from #2143 appears to contain a bug, as seen in #8705, which causes arguments to be passed incorrectly when the function is of `Tupled` kind.

The symptom in this particular case was the "list" argument to `mapi` containing a code pointer to one of the `caml_curry` functions.

As far as I understand it, `Tupled` functions appear from their `params` to have arity greater than one.  However in fact all of these parameters are passed within a single block; code is generated later in the compiler to project them out before binding the parameter variables themselves.  (This is made explicit on the way into Flambda, in fact, which generates the appropriate wrapper functions.)

I think the optimisation goes wrong when the arity of a function application, of a `Tupled` function, has N arguments where N is two or more.  This should be treated as an over-application, but instead, each of the N arguments get bound to the variables corresponding to the parameters.  This is wrong because those parameters, as above, should instead contain values projected from the first argument.

The following is what the optimisation did to a piece of code in Lem:
```diff
 (let
   (extended_exp_to_exp/1388 =
      (function (param/3996, param/3997, param/3998)
        (let
          (l_org/1391 =
             (apply (field 21 (global Typed_ast!)) param/3998)
           l/1392 =
             (makeblock 0 1a "extended_exp_to_exp"
               (makeblock 0 l_org/1391))
-          new_sub/1393 =
-            (function n/1394 m/1395
-              (makeblock 0 (field 1 (field 7 (global Types!)))
-                (apply (field 5 (field 1 (global Typed_ast!)))
-                  (field 1 (field 1 (global Typed_ast!)))
-                  (makeblock 0 n/1394 (makeblock 1 m/1395)))))
-          sub_fun/1396 =
-            (function (param/4000, param/4001)
-              (apply (field 0 (field 23 (global Patterns!)))
-                (apply new_sub/1393 param/4000 param/4001)))
           modify_fun/1400 =
             (function param/1405 e2/1403
               (let
                 (e/1402 =a (field 1 param/1405)
                  n/1401 =a (field 0 param/1405)
                  *match*/3999 =
                    (apply (field 43 (global Typed_ast_syntax!)) e/1402))
                 (if *match*/3999
-                  (apply sub_fun/1396
+                  (let
+                    (param/5169 =
-                    (makeblock 0 n/1401 (field 0 *match*/3999))
-                    e2/1403)
+                       (makeblock 0 n/1401 (field 0 *match*/3999)))
+                    (apply (field 0 (field 23 (global Patterns!)))
+                      (makeblock 0 (field 1 (field 7 (global Types!)))
+                        (apply (field 5 (field 1 (global Typed_ast!)))
+                          (field 1 (field 1 (global Typed_ast!)))
+                          (makeblock 0 param/5169
+                            (makeblock 1 e2/1403))))))
                   (apply (field 79 (global Typed_ast_syntax!)) l/1392
                     (makeblock 0 n/1401 e/1402) e2/1403)))))
          (apply (field 21 (global Stdlib__list!)) modify_fun/1400
            param/3997 param/3998))))
   (setfield_ptr(root-init) 55 (global Patterns!)
     extended_exp_to_exp/1388))
```
The fix takes the most straightforward approach, namely disabling this optimisation for `Tupled` functions.

I have tested a previous version of this patch (the same except for cosmetic details) on Lem but would be pleased if someone (maybe @bacam) could independently verify.

Marked as no-change-entry needed since this will presumably end up on the same branch (4.08) as the code introducing this feature.