### PR TITLE
Simplif: fix the local-function optimization on Tupled functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,9 @@ Working version
   dummy Lpushtrap generated in linearize
   (Greta Yorsh and Vincent Laviron, review by Xavier Leroy)
 
+- #8707: Simplif: more regular treatment of Tupled and Curried functions
+  (Gabriel Scherer, review by Leo White and Alain Frisch)
+
 ### Runtime system:
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.


### PR DESCRIPTION
This is a fix of #8705 proposed for trunk: instead of disabling the
problematic behavior (the Tupled case) as proposed in #8706, we
propose an auxiliary function to correctly determine whether an
application is exact, and use it there and also for existing Simplif
transformations.

As a side-benefit, the other Simplif optimizations are also improved
(thanks to a suggestion of Alain Frisch for constant blocks). For
example, the following beta-redex was not reduced by Simplif before
this patch, due to the fact that its arguments are constant:

  (fun (x,y) -> x + y) (1, 2)