### PR TITLE
Add .size directive in runtime assembly functions

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -67,7 +67,6 @@
 
 #if defined(SYS_linux) || defined(SYS_gnu)
 #define ENDFUNCTION(name) \
-        .type name,@function; \
         .size name, . - name
 #else
 #define ENDFUNCTION(name)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -65,6 +65,14 @@
 
 #endif
 
+#if defined(SYS_linux) || defined(SYS_gnu)
+#define ENDFUNCTION(name) \
+        .type name,@function; \
+        .size name, . - name
+#else
+#define ENDFUNCTION(name)
+#endif
+
 #ifdef ASM_CFI_SUPPORTED
 #define CFI_STARTPROC .cfi_startproc
 #define CFI_ENDPROC .cfi_endproc
@@ -388,6 +396,7 @@ LBL(caml_call_gc):
     /* Return to caller */
         ret
 CFI_ENDPROC
+ENDFUNCTION(G(caml_call_gc))
 
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
@@ -406,6 +415,7 @@ LBL(100):
         LEAVE_FUNCTION
         jmp     LBL(caml_alloc1)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_alloc1))
 
 FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
@@ -424,6 +434,7 @@ LBL(101):
         LEAVE_FUNCTION
         jmp     LBL(caml_alloc2)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_alloc2))
 
 FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
@@ -442,6 +453,7 @@ LBL(102):
         LEAVE_FUNCTION
         jmp     LBL(caml_alloc3)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
@@ -470,6 +482,7 @@ LBL(103):
         popq    %rax; CFI_ADJUST(-8)       /* recover desired size */
         jmp     LBL(caml_allocN)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_allocN))
 
 /* Reset the allocation pointer and invoke the GC */
 
@@ -520,6 +533,7 @@ LBL(caml_c_call):
        reserved the stack space if needed (cf. amd64/proc.ml) */
         jmp    *%rax
 CFI_ENDPROC
+ENDFUNCTION(G(caml_c_call))
 
 /* Start the OCaml program */
 
@@ -595,6 +609,7 @@ LBL(108):
         orq     $2, %rax
         jmp     LBL(109)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_start_program))
 
 /* Raise an exception from OCaml */
 
@@ -626,6 +641,7 @@ LBL(110):
         popq    %r14
         ret
 CFI_ENDPROC
+ENDFUNCTION(G(caml_raise_exn))
 
 /* Raise an exception from C */
 
@@ -658,6 +674,7 @@ LBL(112):
         LOAD_VAR(caml_young_ptr,%r15) /* Reload alloc ptr */
         ret
 CFI_ENDPROC
+ENDFUNCTION(G(caml_raise_exception))
 
 /* Raise a Stack_overflow exception on return from segv_handler()
    (in runtime/signals_nat.c).  On entry, the stack is full, so we
@@ -670,6 +687,7 @@ FUNCTION(G(caml_stack_overflow))
         movq    %r14, %rsp            /* cut the stack */
         popq    %r14                  /* recover previous exn handler */
         ret                           /* jump to handler's code */
+ENDFUNCTION(G(caml_stack_overflow))
 
 /* Callback from C to OCaml */
 
@@ -683,6 +701,7 @@ CFI_STARTPROC
         movq    0(%rbx), %r12      /* code pointer */
         jmp     LBL(caml_start_program)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_callback_exn))
 
 FUNCTION(G(caml_callback2_exn))
 CFI_STARTPROC
@@ -695,6 +714,7 @@ CFI_STARTPROC
         LEA_VAR(caml_apply2, %r12) /* code pointer */
         jmp     LBL(caml_start_program)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_callback2_exn))
 
 FUNCTION(G(caml_callback3_exn))
 CFI_STARTPROC
@@ -708,12 +728,14 @@ CFI_STARTPROC
         LEA_VAR(caml_apply3, %r12) /* code pointer */
         jmp     LBL(caml_start_program)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_callback3_exn))
 
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
         LEA_VAR(caml_array_bound_error, %rax)
         jmp     LBL(caml_c_call)
 CFI_ENDPROC
+ENDFUNCTION(G(caml_ml_array_bound_error))
 
         .globl  G(caml_system__code_end)
 G(caml_system__code_end):

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -49,6 +49,14 @@
         .align FUNCTION_ALIGN; \
         G(name):
 
+#if defined(SYS_linux_elf) || defined(SYS_bsd_elf) || defined(SYS_gnu)
+#define ENDFUNCTION(name) \
+        .type name,@function; \
+        .size name, . - name
+#else
+#define ENDFUNCTION(name)
+#endif
+
 #ifdef ASM_CFI_SUPPORTED
 #define CFI_STARTPROC .cfi_startproc
 #define CFI_ENDPROC .cfi_endproc
@@ -108,6 +116,7 @@ LBL(105):
     /* Return to caller */
         ret
         CFI_ENDPROC
+        ENDFUNCTION(caml_call_gc)
 
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
@@ -127,6 +136,7 @@ LBL(100):
         UNDO_ALIGN_STACK(12)
         jmp     G(caml_alloc1)
         CFI_ENDPROC
+        ENDFUNCTION(caml_alloc1)
 
 FUNCTION(caml_alloc2)
         CFI_STARTPROC
@@ -146,6 +156,7 @@ LBL(101):
         UNDO_ALIGN_STACK(12)
         jmp     G(caml_alloc2)
         CFI_ENDPROC
+        ENDFUNCTION(caml_alloc2)
 
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
@@ -165,6 +176,7 @@ LBL(102):
         UNDO_ALIGN_STACK(12)
         jmp     G(caml_alloc3)
         CFI_ENDPROC
+        ENDFUNCTION(caml_alloc3)
 
 FUNCTION(caml_allocN)
         CFI_STARTPROC
@@ -188,6 +200,7 @@ LBL(103):
         popl    %eax; CFI_ADJUST(-4)    /* recover desired size */
         jmp     G(caml_allocN)
         CFI_ENDPROC
+        ENDFUNCTION(caml_allocN)
 
 /* Call a C function from OCaml */
 
@@ -208,6 +221,7 @@ FUNCTION(caml_c_call)
     /* Call the function (address in %eax) */
         jmp     *%eax
         CFI_ENDPROC
+        ENDFUNCTION(caml_c_call)
 
 /* Start the OCaml program */
 
@@ -256,6 +270,7 @@ LBL(108):
         orl     $2, %eax
         jmp     LBL(109)
         CFI_ENDPROC
+        ENDFUNCTION(caml_start_program)
 
 /* Raise an exception from OCaml */
 
@@ -284,6 +299,7 @@ LBL(110):
         UNDO_ALIGN_STACK(8)
         ret
         CFI_ENDPROC
+        ENDFUNCTION(caml_raise_exn)
 
 /* Raise an exception from C */
 
@@ -310,6 +326,7 @@ LBL(112):
         UNDO_ALIGN_STACK(8)
         ret
         CFI_ENDPROC
+        ENDFUNCTION(caml_raise_exception)
 
 /* Callback from C to OCaml */
 
@@ -326,6 +343,7 @@ FUNCTION(caml_callback_exn)
         movl    0(%ebx), %esi    /* code pointer */
         jmp     LBL(106)
         CFI_ENDPROC
+        ENDFUNCTION(caml_callback_exn)
 
 FUNCTION(caml_callback2_exn)
         CFI_STARTPROC
@@ -341,6 +359,7 @@ FUNCTION(caml_callback2_exn)
         movl    $ G(caml_apply2), %esi   /* code pointer */
         jmp     LBL(106)
         CFI_ENDPROC
+        ENDFUNCTION(caml_callback2_exn)
 
 FUNCTION(caml_callback3_exn)
         CFI_STARTPROC
@@ -357,6 +376,7 @@ FUNCTION(caml_callback3_exn)
         movl    $ G(caml_apply3), %esi   /* code pointer */
         jmp     LBL(106)
         CFI_ENDPROC
+        ENDFUNCTION(caml_callback3_exn)
 
 FUNCTION(caml_ml_array_bound_error)
         CFI_STARTPROC
@@ -379,6 +399,7 @@ FUNCTION(caml_ml_array_bound_error)
     /* Branch to [caml_array_bound_error] (never returns) */
         call    G(caml_array_bound_error)
         CFI_ENDPROC
+        ENDFUNCTION(caml_ml_array_bound_error)
 
         .globl  G(caml_system__code_end)
 G(caml_system__code_end):


### PR DESCRIPTION
Function symbols such as `caml_c_call` and `caml_call_gc` show up with size 0 in ELF symbol tables, because `.size` directives are missing from assembly functions defined in `amd64.S` and `i386.S`.  This patch adds  `.size` along with missing `.type` directives, following the same syntax as in `emit.mlp`.

Note that `.size` directives are already present in `arm*.S` and `power.S` files.  For `s390x`, we do not emit `.size` directives for any functions, so I haven't added it to the runtime assembly functions either.
