### PR TITLE
Removed function caml_init_alloc_for_heap from memory.h

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -58,7 +58,6 @@ CAMLextern void caml_free_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_modify (value *, value);
 CAMLextern void caml_initialize (value *, value);
 CAMLextern value caml_check_urgent_gc (value);
-CAMLextern int caml_init_alloc_for_heap (void);
 CAMLextern char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */
 CAMLextern void caml_free_for_heap (char *mem);
 CAMLextern void caml_disown_for_heap (char *mem);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -634,9 +634,6 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
     Bsize_wsize (caml_normalize_heap_increment (major_size));
 
   caml_instr_init ();
-  if (caml_init_alloc_for_heap () != 0){
-    caml_fatal_error ("cannot initialize heap: mmap failed");
-  }
   if (caml_page_table_initialize(Bsize_wsize(minor_size) + major_heap_size)){
     caml_fatal_error ("cannot initialize page table");
   }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -239,17 +239,6 @@ int caml_page_table_remove(int kind, void * start, void * end)
   return 0;
 }
 
-
-/* Initialize the [alloc_for_heap] system.
-   This function must be called exactly once, and it must be called
-   before the first call to [alloc_for_heap].
-   It returns 0 on success and -1 on failure.
-*/
-int caml_init_alloc_for_heap (void)
-{
-  return 0;
-}
-
 /* Allocate a block of the requested size, to be passed to
    [caml_add_to_heap] later.
    [request] will be rounded up to some implementation-dependent size.


### PR DESCRIPTION
Removed the function 'caml_init_alloc_from_heap' from memory.h, as well as it's definition in memory.c, and the calling code in gc_ctrl.c. The function was unconditionally returning zero with no other functionality, as explained in issue #8709.

As expected, after removing those functions the compiler continues to compile without any errors or warnings, and passes all of the tests it did before removing the function.

```
List of skipped tests:
    tests/unboxed-primitive-args/'test.ml' with 1.1.1 (ocaml) 
    tests/lib-unix/isatty/'isatty_tty.ml' with 1 (libwin32unix) 
    tests/asmcomp/'static_float_array_flambda.ml' with 1 (flambda) 
    tests/manual-intf-c
    tests/lib-unix/win-symlink
    tests/lib-bigarray-2
    tests/lib-unix/win-stat
    tests/unwind
    tests/runtime-errors/'syserror.ml' with 2.1.1.2 (libwin32unix) 
    tests/arch-power
    tests/lib-unix/unix-execvpe/'exec.ml' with 1.1 (script) 
    tests/lib-dynlink-csharp
    tests/afl-instrumentation/'afltest.ml' with 1.1 (script) 
    tests/translprim/'module_coercion.ml' with 1.1.2 (no-flat-float-array) 
    tests/runtime-errors/'syserror.ml' with 1.1.1.2 (libwin32unix) 
    tests/warnings/'w59.ml' with 3 (flambda) 
    tests/letrec-check/'no_flat_float_array.ml' with 1 (no-flat-float-array) 
    tests/asmcomp/'unrolling_flambda.ml' with 1 (flambda) 
    tests/flambda/'specialise.ml' with 1 (flambda) 
    tests/warnings/'w55.ml' with 3 (flambda) 
    tests/typing-unboxed-types/'test_no_flat.ml' with 1 (no-flat-float-array) 
    tests/translprim/'array_spec.ml' with 1.1.2 (no-flat-float-array) 
    tests/asmcomp/'is_static_flambda.ml' with 1 (flambda) 
    tests/lib-unix/win-env
    tests/flambda/'gpr2239.ml' with 1 (flambda) 
    tests/asmcomp/'static_float_array_flambda_opaque.ml' with 1 (flambda) 
    tests/runtime-errors/'stackoverflow.ml' with 2 (libwin32unix) 
    tests/tool-caml-tex/'redirections.ml' with 1.1.2 (no-shared-libraries) 
    tests/win-unicode
    tests/typing-misc/'pr6939-no-flat-float-array.ml' with 1 (no-flat-float-array) 
    tests/asmgen/'integr.cmm' with 1 (skip) 
    tests/asmcomp/'unrolling_flambda2.ml' with 1 (flambda) 
    tests/flambda/'approx_meet.ml' with 1 (flambda) 

Summary:
  2420 tests passed
   33 tests skipped
    0 tests failed
   93 tests not started (parent test skipped or failed)
    0 unexpected errors
  2546 tests considered
make[1]: Leaving directory '/home/jflopezfernandez/Projects/ocaml/testsuite'

```