### PR TITLE
Major GC hooks are no longer allowed to interact with the GC heap.

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,10 @@ Working version
   (Stephen Dolan, Xavier Leroy and David Allsopp,
    review by Xavier Leroy and Gabriel Scherer)
 
+* #8711: The major GC hooks are no longer allowed to interact with the
+   OCaml heap.
+   (Jacques-Henri Jourdan, review by xxx)
+
 ### Standard library:
 
 - #8657: Optimization in [Array.make] when initializing with unboxed

--- a/Changes
+++ b/Changes
@@ -34,7 +34,7 @@ Working version
 
 * #8711: The major GC hooks are no longer allowed to interact with the
    OCaml heap.
-   (Jacques-Henri Jourdan, review by xxx)
+   (Jacques-Henri Jourdan, review by Damien Doligez)
 
 ### Standard library:
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -72,7 +72,7 @@ extern double caml_gc_clock;
 /* [caml_major_gc_hook] is called just between the end of the mark
    phase and the beginning of the sweep phase of the major GC.
 
-   This hook is not authorized to allocate, change any heap value or
+   This hook must not allocate, change any heap value, nor
    call OCaml code. */
 CAMLextern void (*caml_major_gc_hook)(void);
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -70,7 +70,10 @@ extern double caml_major_work_credit;
 extern double caml_gc_clock;
 
 /* [caml_major_gc_hook] is called just between the end of the mark
-   phase and the beginning of the sweep phase of the major GC */
+   phase and the beginning of the sweep phase of the major GC.
+
+   This hook is not authorized to allocate, change any heap value or
+   call OCaml code. */
 CAMLextern void (*caml_major_gc_hook)(void);
 
 void caml_init_major_heap (asize_t);           /* size in bytes */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -85,9 +85,8 @@ typedef char * addr;
 extern "C" {
 #endif
 
-/* GC timing hooks. These can be assigned by the user. None of these
-   hooks are authorized to allocate, change any heap value or call
-   OCaml code.
+/* GC timing hooks. These can be assigned by the user. These hooks
+   must not allocate, change any heap value, nor call OCaml code.
 */
 typedef void (*caml_timing_hook) (void);
 extern caml_timing_hook caml_major_slice_begin_hook, caml_major_slice_end_hook;

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -85,9 +85,9 @@ typedef char * addr;
 extern "C" {
 #endif
 
-/* GC timing hooks. These can be assigned by the user.
-   [caml_minor_gc_begin_hook] must not allocate nor change any heap value.
-   The others can allocate and even call back to OCaml code.
+/* GC timing hooks. These can be assigned by the user. None of these
+   hooks are authorized to allocate, change any heap value or call
+   OCaml code.
 */
 typedef void (*caml_timing_hook) (void);
 extern caml_timing_hook caml_major_slice_begin_hook, caml_major_slice_end_hook;


### PR DESCRIPTION
As discussed in https://github.com/ocaml/ocaml/pull/8691#issuecomment-498240886 (by @stedolan):

> > BTW, the fact that the major GC is calling hooks that are allowed to allocate and execute arbitrary OCaml code (see comment in misc.h) completely kills the point of this PR. I did not know about them!
>
> > Would it be possible to add the restriction that these functions should not call an OCaml callback? Where are these functions used, in practice?
>
> I didn't know about these functions either!
>
> I think it would be possible to add this restriction. I can only find two uses of this feature: one in flow and one in Jane Street's internal code. Neither allocates, performs callbacks, or indeed calls any OCaml runtime functions at all.
>
> Since this is nominally a breaking change, I think there should be a seperate PR which just edits the comment in misc.h.
