### PR TITLE
Format: set maximum offset added to a new line

### DIFF
--- a/Changes
+++ b/Changes
@@ -364,9 +364,9 @@ OCaml 4.08.0
 
 ### Standard library:
 
-- #8719: Add Format.set_max_newline_offset to set the maximum offset
+- #8719: Add Format.set_max_indent_offset to set the maximum offset
   added to a new line
-  (Guillaume Petiot, review by ...)
+  (Guillaume Petiot, review by David Allsopp)
 
 - #2128: Add Fun module: `id, const, flip, negate, protect`
   (protect is a "try_finally" combinator)

--- a/Changes
+++ b/Changes
@@ -364,6 +364,10 @@ OCaml 4.08.0
 
 ### Standard library:
 
+- #8719: Add Format.set_max_newline_offset to set the maximum offset
+  added to a new line
+  (Guillaume Petiot, review by ...)
+
 - #2128: Add Fun module: `id, const, flip, negate, protect`
   (protect is a "try_finally" combinator)
   https://caml.inria.fr/pub/docs/manual-ocaml/libref/Fun.html

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -149,6 +149,9 @@ type formatter = {
   (* Maximum value of indentation:
      no box can be opened further. *)
   mutable pp_max_indent : int;
+  (* Maximum offset added to a new line in addition to the offset of the
+     previous line. *)
+  mutable pp_max_newline_offset : int;
   (* Space remaining on the current line. *)
   mutable pp_space_left : int;
   (* Current value of indentation. *)
@@ -271,6 +274,8 @@ let break_new_line state (before, offset, after) width =
   let indent = state.pp_margin - width + offset in
   (* Don't indent more than pp_max_indent. *)
   let real_indent = min state.pp_max_indent indent in
+  let real_indent =
+    min real_indent (state.pp_current_indent + state.pp_max_newline_offset) in
   state.pp_current_indent <- real_indent;
   state.pp_space_left <- state.pp_margin - state.pp_current_indent;
   pp_output_indent state state.pp_current_indent;
@@ -795,6 +800,9 @@ let pp_set_max_indent state n =
 
 let pp_get_max_indent state () = state.pp_max_indent
 
+let pp_set_max_newline_offset state n =
+  state.pp_max_newline_offset <- n
+
 let pp_set_margin state n =
   if n >= 1 then
     let n = pp_limit n in
@@ -933,6 +941,7 @@ let pp_make_formatter f g h i j =
     pp_margin = pp_margin;
     pp_min_space_left = pp_min_space_left;
     pp_max_indent = pp_margin - pp_min_space_left;
+    pp_max_newline_offset = pp_margin - pp_min_space_left;
     pp_space_left = pp_margin;
     pp_current_indent = 0;
     pp_is_new_line = true;

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -149,9 +149,9 @@ type formatter = {
   (* Maximum value of indentation:
      no box can be opened further. *)
   mutable pp_max_indent : int;
-  (* Maximum offset added to a new line in addition to the offset of the
+  (* Maximum offset added to a new line in addition to the indentation of the
      previous line. *)
-  mutable pp_max_newline_offset : int;
+  mutable pp_max_indent_offset : int;
   (* Space remaining on the current line. *)
   mutable pp_space_left : int;
   (* Current value of indentation. *)
@@ -275,7 +275,7 @@ let break_new_line state (before, offset, after) width =
   (* Don't indent more than pp_max_indent. *)
   let real_indent = min state.pp_max_indent indent in
   let real_indent =
-    min real_indent (state.pp_current_indent + state.pp_max_newline_offset) in
+    min real_indent (state.pp_current_indent + state.pp_max_indent_offset) in
   state.pp_current_indent <- real_indent;
   state.pp_space_left <- state.pp_margin - state.pp_current_indent;
   pp_output_indent state state.pp_current_indent;
@@ -800,8 +800,7 @@ let pp_set_max_indent state n =
 
 let pp_get_max_indent state () = state.pp_max_indent
 
-let pp_set_max_newline_offset state n =
-  state.pp_max_newline_offset <- n
+let pp_set_max_indent_offset state n = state.pp_max_indent_offset <- n
 
 let pp_set_margin state n =
   if n >= 1 then
@@ -941,7 +940,7 @@ let pp_make_formatter f g h i j =
     pp_margin = pp_margin;
     pp_min_space_left = pp_min_space_left;
     pp_max_indent = pp_margin - pp_min_space_left;
-    pp_max_newline_offset = pp_margin - pp_min_space_left;
+    pp_max_indent_offset = pp_margin - pp_min_space_left;
     pp_space_left = pp_margin;
     pp_current_indent = 0;
     pp_is_new_line = true;
@@ -1129,7 +1128,7 @@ and get_margin = pp_get_margin std_formatter
 and set_max_indent = pp_set_max_indent std_formatter
 and get_max_indent = pp_get_max_indent std_formatter
 
-and set_max_newline_offset = pp_set_max_newline_offset std_formatter
+and set_max_indent_offset = pp_set_max_indent_offset std_formatter
 
 and set_geometry = pp_set_geometry std_formatter
 and safe_set_geometry = pp_safe_set_geometry std_formatter

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1129,6 +1129,8 @@ and get_margin = pp_get_margin std_formatter
 and set_max_indent = pp_set_max_indent std_formatter
 and get_max_indent = pp_get_max_indent std_formatter
 
+and set_max_newline_offset = pp_set_max_newline_offset std_formatter
+
 and set_geometry = pp_set_geometry std_formatter
 and safe_set_geometry = pp_safe_set_geometry std_formatter
 and get_geometry = pp_get_geometry std_formatter

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -455,10 +455,30 @@ val pp_get_max_indent : formatter -> unit -> int
 val get_max_indent : unit -> int
 (** Return the maximum indentation limit (in characters). *)
 
-val pp_set_max_newline_offset : formatter -> int -> unit
-val set_max_newline_offset : int -> unit
-(** Maximum offset added to a new line in addition to the offset of the
-    previous line. *)
+val pp_set_max_indent_offset : formatter -> int -> unit
+val set_max_indent_offset : int -> unit
+(** Maximum offset added to a new line in addition to the indentation of the
+    previous line.
+    As an illustration, if the following text is printed with adding 4 columns
+    of indentation for each opened parenthesis, and 6 columns of indentation
+    for braces:
+    {[
+      text (
+          text {
+                text
+          }
+      )
+    ]}
+    Setting the maximum offset to 2 with [set_max_indent_offset 2] would format
+    the previous text this way:
+    {[
+      text (
+        text (
+          text
+        )
+      )
+    ]}
+*)
 
 (** {1 Geometry }
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -455,6 +455,10 @@ val pp_get_max_indent : formatter -> unit -> int
 val get_max_indent : unit -> int
 (** Return the maximum indentation limit (in characters). *)
 
+val pp_set_max_newline_offset : formatter -> int -> unit
+(** Maximum offset added to a new line in addition to the offset of the
+    previous line. *)
+
 (** {1 Geometry }
 
 Geometric functions can be used to manipulate simultaneously the

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -456,6 +456,7 @@ val get_max_indent : unit -> int
 (** Return the maximum indentation limit (in characters). *)
 
 val pp_set_max_newline_offset : formatter -> int -> unit
+val set_max_newline_offset : int -> unit
 (** Maximum offset added to a new line in addition to the offset of the
     previous line. *)
 

--- a/testsuite/tests/lib-format/ocamltests
+++ b/testsuite/tests/lib-format/ocamltests
@@ -1,4 +1,5 @@
 pr6824.ml
+pr8719.ml
 tformat.ml
 print_if_newline.ml
 pp_print_custom_break.ml

--- a/testsuite/tests/lib-format/pr8719.ml
+++ b/testsuite/tests/lib-format/pr8719.ml
@@ -1,0 +1,54 @@
+(* TEST *)
+
+(*
+
+A test file for Format.set_max_newline_offset.
+
+*)
+
+open Format;;
+
+let set_margin n =
+  Format.set_margin n;
+  Format.set_max_indent (n - 1)
+;;
+
+let test_max_newline_offset n =
+  print_string "max_newline_offset = ";
+  print_int n;
+  print_newline ();
+  set_margin 20;
+  set_max_newline_offset n;
+  print_break 0 2;
+  open_hvbox 0;
+  begin
+    print_string "foooooooooooooooooooo";
+    print_space ();
+    print_string "foooooooooooooooooooo";
+    print_break 0 4;
+    open_hvbox 0;
+    begin
+      print_string "foooooooooooooooooooo";
+      print_space ();
+      print_string "foooooooooooooooooooo";
+      print_break 0 6;
+      open_hvbox 0;
+      begin
+        print_string "foooooooooooooooooooo";
+        print_space ();
+        print_string "foooooooooooooooooooo";
+        print_space ();
+        print_string "foooooooooooooooooooo";
+      end;
+      close_box ()
+    end;
+    close_box ()
+  end;
+  close_box ();
+  print_newline ()
+;;
+
+test_max_newline_offset 4;;
+test_max_newline_offset 3;;
+test_max_newline_offset 2;;
+test_max_newline_offset 1;;

--- a/testsuite/tests/lib-format/pr8719.ml
+++ b/testsuite/tests/lib-format/pr8719.ml
@@ -2,7 +2,7 @@
 
 (*
 
-A test file for Format.set_max_newline_offset.
+A test file for Format.set_max_indent_offset.
 
 *)
 
@@ -13,12 +13,12 @@ let set_margin n =
   Format.set_max_indent (n - 1)
 ;;
 
-let test_max_newline_offset n =
-  print_string "max_newline_offset = ";
+let test_max_indent_offset n =
+  print_string "max_indent_offset = ";
   print_int n;
   print_newline ();
   set_margin 20;
-  set_max_newline_offset n;
+  set_max_indent_offset n;
   print_break 0 2;
   open_hvbox 0;
   begin
@@ -48,7 +48,7 @@ let test_max_newline_offset n =
   print_newline ()
 ;;
 
-test_max_newline_offset 4;;
-test_max_newline_offset 3;;
-test_max_newline_offset 2;;
-test_max_newline_offset 1;;
+test_max_indent_offset 4;;
+test_max_indent_offset 3;;
+test_max_indent_offset 2;;
+test_max_indent_offset 1;;

--- a/testsuite/tests/lib-format/pr8719.reference
+++ b/testsuite/tests/lib-format/pr8719.reference
@@ -1,0 +1,36 @@
+max_newline_offset = 4
+
+  foooooooooooooooooooo
+  foooooooooooooooooooo
+      foooooooooooooooooooo
+      foooooooooooooooooooo
+          foooooooooooooooooooo
+          foooooooooooooooooooo
+          foooooooooooooooooooo
+max_newline_offset = 3
+
+  foooooooooooooooooooo
+  foooooooooooooooooooo
+     foooooooooooooooooooo
+     foooooooooooooooooooo
+        foooooooooooooooooooo
+        foooooooooooooooooooo
+        foooooooooooooooooooo
+max_newline_offset = 2
+
+  foooooooooooooooooooo
+  foooooooooooooooooooo
+    foooooooooooooooooooo
+    foooooooooooooooooooo
+      foooooooooooooooooooo
+      foooooooooooooooooooo
+      foooooooooooooooooooo
+max_newline_offset = 1
+
+ foooooooooooooooooooo
+ foooooooooooooooooooo
+  foooooooooooooooooooo
+  foooooooooooooooooooo
+   foooooooooooooooooooo
+   foooooooooooooooooooo
+   foooooooooooooooooooo

--- a/testsuite/tests/lib-format/pr8719.reference
+++ b/testsuite/tests/lib-format/pr8719.reference
@@ -1,4 +1,4 @@
-max_newline_offset = 4
+max_indent_offset = 4
 
   foooooooooooooooooooo
   foooooooooooooooooooo
@@ -7,7 +7,7 @@ max_newline_offset = 4
           foooooooooooooooooooo
           foooooooooooooooooooo
           foooooooooooooooooooo
-max_newline_offset = 3
+max_indent_offset = 3
 
   foooooooooooooooooooo
   foooooooooooooooooooo
@@ -16,7 +16,7 @@ max_newline_offset = 3
         foooooooooooooooooooo
         foooooooooooooooooooo
         foooooooooooooooooooo
-max_newline_offset = 2
+max_indent_offset = 2
 
   foooooooooooooooooooo
   foooooooooooooooooooo
@@ -25,7 +25,7 @@ max_newline_offset = 2
       foooooooooooooooooooo
       foooooooooooooooooooo
       foooooooooooooooooooo
-max_newline_offset = 1
+max_indent_offset = 1
 
  foooooooooooooooooooo
  foooooooooooooooooooo


### PR DESCRIPTION
This PR adds a function `(pp_)set_max_newline_offset` to set the maximum offset added to a new line in addition to the offset of the previous line.
This will directly be useful for `ocamlformat` (currently in the patched version of Format we use: https://github.com/ocaml-ppx/ocamlformat/pull/841/files)