### PR TITLE
Add strace support to ocamltest

### DIFF
--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -21,14 +21,17 @@ ocamltest_stdlib_stubs.$(O): ocamltest_stdlib_stubs.c \
  ../runtime/caml/alloc.h ../runtime/caml/signals.h \
  ../runtime/caml/osdeps.h ../runtime/caml/memory.h
 actions.cmo : \
+    variables.cmi \
     result.cmi \
     environments.cmi \
     actions.cmi
 actions.cmx : \
+    variables.cmx \
     result.cmx \
     environments.cmx \
     actions.cmi
 actions.cmi : \
+    variables.cmi \
     result.cmi \
     environments.cmi
 actions_helpers.cmo : \

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -36,6 +36,7 @@ actions.cmi : \
     environments.cmi
 actions_helpers.cmo : \
     variables.cmi \
+    strace.cmi \
     run_command.cmi \
     result.cmi \
     ocamltest_stdlib.cmi \
@@ -47,6 +48,7 @@ actions_helpers.cmo : \
     actions_helpers.cmi
 actions_helpers.cmx : \
     variables.cmx \
+    strace.cmx \
     run_command.cmx \
     result.cmx \
     ocamltest_stdlib.cmx \
@@ -391,6 +393,14 @@ run_command.cmx : \
     ocamltest_stdlib.cmx \
     run_command.cmi
 run_command.cmi :
+strace.cmo : \
+    variables.cmi \
+    strace.cmi
+strace.cmx : \
+    variables.cmx \
+    strace.cmi
+strace.cmi : \
+    variables.cmi
 tests.cmo : \
     result.cmi \
     actions.cmi \

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -36,6 +36,7 @@ actions_helpers.cmo : \
     run_command.cmi \
     result.cmi \
     ocamltest_stdlib.cmi \
+    modifier_parser.cmi \
     filecompare.cmi \
     environments.cmi \
     builtin_variables.cmi \
@@ -46,6 +47,7 @@ actions_helpers.cmx : \
     run_command.cmx \
     result.cmx \
     ocamltest_stdlib.cmx \
+    modifier_parser.cmx \
     filecompare.cmx \
     environments.cmx \
     builtin_variables.cmx \
@@ -86,12 +88,10 @@ builtin_variables.cmi : \
     variables.cmi
 environments.cmo : \
     variables.cmi \
-    tsl_lexer.cmi \
     ocamltest_stdlib.cmi \
     environments.cmi
 environments.cmx : \
     variables.cmx \
-    tsl_lexer.cmx \
     ocamltest_stdlib.cmx \
     environments.cmi
 environments.cmi : \
@@ -132,6 +132,20 @@ main.cmx : \
     actions.cmx \
     main.cmi
 main.cmi :
+modifier_parser.cmo : \
+    variables.cmi \
+    tsl_lexer.cmi \
+    ocamltest_stdlib.cmi \
+    environments.cmi \
+    modifier_parser.cmi
+modifier_parser.cmx : \
+    variables.cmx \
+    tsl_lexer.cmx \
+    ocamltest_stdlib.cmx \
+    environments.cmx \
+    modifier_parser.cmi
+modifier_parser.cmi : \
+    environments.cmi
 ocaml_actions.cmo : \
     result.cmi \
     ocamltest_stdlib.cmi \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -100,6 +100,7 @@ core := \
   result.mli result.ml \
   actions.mli actions.ml \
   tests.mli tests.ml \
+  strace.mli strace.ml \
   tsl_ast.mli tsl_ast.ml \
   tsl_parser.mly \
   tsl_lexer.mli tsl_lexer.mll \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -96,13 +96,14 @@ core := \
   run_command.mli run_command.ml \
   filecompare.mli filecompare.ml \
   variables.mli variables.ml \
+  environments.mli environments.ml \
   result.mli result.ml \
   actions.mli actions.ml \
   tests.mli tests.ml \
   tsl_ast.mli tsl_ast.ml \
   tsl_parser.mly \
   tsl_lexer.mli tsl_lexer.mll \
-  environments.mli environments.ml \
+  modifier_parser.mli modifier_parser.ml \
   tsl_semantics.mli tsl_semantics.ml \
   builtin_variables.mli builtin_variables.ml \
   actions_helpers.mli actions_helpers.ml \

--- a/ocamltest/actions.ml
+++ b/ocamltest/actions.ml
@@ -23,7 +23,7 @@ type t = {
   mutable hook : code option
 }
 
-let action_name a = a.name
+let name a = a.name
 
 let make n c = { name = n; body = c; hook = None }
 

--- a/ocamltest/actions.ml
+++ b/ocamltest/actions.ml
@@ -25,6 +25,8 @@ type t = {
 
 let name a = a.name
 
+let action_name = Variables.make ("action_name", "Name of the current action")
+
 let make n c = { name = n; body = c; hook = None }
 
 let update action code = { action with body = code }
@@ -61,6 +63,7 @@ let run log env action =
   let code = match action.hook with
     | None -> action.body
     | Some code -> code in
+  let env = Environments.add action_name action.name env in
   code log env
 
 module ActionSet = Set.Make
@@ -68,3 +71,5 @@ module ActionSet = Set.Make
   type nonrec t = t
   let compare = compare
 end)
+
+let _ = Variables.register_variable action_name

--- a/ocamltest/actions.mli
+++ b/ocamltest/actions.mli
@@ -19,7 +19,7 @@ type code = out_channel -> Environments.t -> Result.t * Environments.t
 
 type t
 
-val action_name : t -> string
+val name : t -> string
 
 val update : t -> code -> t
 

--- a/ocamltest/actions.mli
+++ b/ocamltest/actions.mli
@@ -21,6 +21,8 @@ type t
 
 val name : t -> string
 
+val action_name : Variables.t
+
 val update : t -> code -> t
 
 val make : string -> code -> t

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -205,7 +205,7 @@ let run_script log env =
     log scriptenv in
   let final_value =
     if Result.is_pass result then begin
-      match Environments.modifiers_of_file response_file with
+      match Modifier_parser.modifiers_of_file response_file with
       | modifiers ->
         let modified_env = Environments.apply_modifiers newenv modifiers in
         (result, modified_env)
@@ -248,7 +248,7 @@ let run_hook hook_name log input_env =
   } in let exit_status = run settings in
   let final_value = match exit_status with
     | 0 ->
-      begin match Environments.modifiers_of_file response_file with
+      begin match Modifier_parser.modifiers_of_file response_file with
       | modifiers ->
         let modified_env = Environments.apply_modifiers hookenv modifiers in
         (Result.pass, modified_env)

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -97,13 +97,29 @@ let run_cmd
     ?(stderr_variable=Builtin_variables.stderr)
     ?(append=false)
     ?(timeout=0)
-    log env cmd
+    log env original_cmd
   =
   let log_redirection std filename =
     if filename<>"" then
     begin
       Printf.fprintf log "  Redirecting %s to %s \n%!" std filename
     end in
+  let cmd =
+    if (Environments.lookup_as_bool Strace.strace env) = Some true then
+    begin
+      let action_name = Environments.safe_lookup Actions.action_name env in
+      let test_build_directory = test_build_directory env in
+      let strace_logfile_name = Strace.get_logfile_name action_name in
+      let strace_logfile =
+        Filename.make_path [test_build_directory; strace_logfile_name]
+      in
+      let strace_flags = Environments.safe_lookup Strace.strace_flags env in
+      let strace_cmd =
+        ["strace -f -o"; strace_logfile; strace_flags]
+      in
+      strace_cmd @ original_cmd
+    end else original_cmd
+  in
   let lst = List.concat (List.map String.words cmd) in
   let quoted_lst =
     if Sys.os_type="Win32"

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -142,26 +142,3 @@ let rec apply_modifier environment = function
   | Remove variable -> remove variable environment
 and apply_modifiers environment modifiers =
   List.fold_left apply_modifier environment modifiers
-
-let modifier_of_string str =
-  let lexbuf = Lexing.from_string str in
-  let variable_name, result = Tsl_lexer.modifier lexbuf in
-  let variable =
-    match Variables.find_variable variable_name with
-    | None -> raise (Variables.No_such_variable variable_name)
-    | Some variable -> variable
-  in
-  match result with
-  | `Remove -> Remove variable
-  | `Add value -> Add (variable, value)
-  | `Append value -> Append (variable, value)
-
-let modifiers_of_file filename =
-  let ic = open_in filename in
-  let rec modifiers_of_lines acc = match input_line_opt ic with
-    | None -> acc
-    | Some line ->
-      modifiers_of_lines ((modifier_of_string (String.trim line)) :: acc) in
-  let modifiers = modifiers_of_lines [] in
-  close_in ic;
-  List.rev modifiers

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -67,7 +67,3 @@ exception Modifiers_name_already_registered of string
 exception Modifiers_name_not_found of string
 
 val register_modifiers : string -> modifiers -> unit
-
-val modifier_of_string : string -> modifier
-
-val modifiers_of_file : string -> modifiers

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -121,7 +121,7 @@ let test_file test_filename =
   let used_tests = tests_in_trees test_trees in
   let used_actions = actions_in_tests used_tests in
   let action_names =
-    let f act names = String.Set.add (Actions.action_name act) names in
+    let f act names = String.Set.add (Actions.name act) names in
     Actions.ActionSet.fold f used_actions String.Set.empty in
   let test_dirname = Filename.dirname test_filename in
   let test_basename = Filename.basename test_filename in

--- a/ocamltest/modifier_parser.ml
+++ b/ocamltest/modifier_parser.ml
@@ -1,0 +1,41 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Parsing of modifier (response) files created by hooks and scripts *)
+
+open Ocamltest_stdlib
+
+let modifier_of_string str =
+  let lexbuf = Lexing.from_string str in
+  let variable_name, result = Tsl_lexer.modifier lexbuf in
+  let variable =
+    match Variables.find_variable variable_name with
+    | None -> raise (Variables.No_such_variable variable_name)
+    | Some variable -> variable
+  in
+  match result with
+  | `Remove -> Environments.Remove variable
+  | `Add value -> Environments.Add (variable, value)
+  | `Append value -> Environments.Append (variable, value)
+
+let modifiers_of_file filename =
+  let ic = open_in filename in
+  let rec modifiers_of_lines acc = match input_line_opt ic with
+    | None -> acc
+    | Some line ->
+      modifiers_of_lines ((modifier_of_string (String.trim line)) :: acc) in
+  let modifiers = modifiers_of_lines [] in
+  close_in ic;
+  List.rev modifiers

--- a/ocamltest/modifier_parser.mli
+++ b/ocamltest/modifier_parser.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Parsing of modifier (response) files created by hooks and scripts *)
+
+val modifier_of_string : string -> Environments.modifier
+
+val modifiers_of_file : string -> Environments.modifiers

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -21,7 +21,7 @@ let show_objects title string_of_object objects =
   List.iter print_object objects;
   exit 0
 
-let string_of_action = Actions.action_name
+let string_of_action = Actions.name
 
 let string_of_test test =
   if test.Tests.test_run_by_default

--- a/ocamltest/strace.ml
+++ b/ocamltest/strace.ml
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Implementation of the strace feature *)
+
+let strace = Variables.make ("strace", "Whether to use strace")
+let strace_flags =
+  Variables.make ("strace_flags", "Which flags to pass to strace")
+
+let (counters : (string, int) Hashtbl.t) = Hashtbl.create 10
+
+let get_logfile_name base =
+  let n = try Hashtbl.find counters base with Not_found -> 1 in
+  let filename = Printf.sprintf "strace-%s_%d.log" base n in
+  Hashtbl.add counters base (n+1);
+  filename
+
+let _ =
+  Variables.register_variable strace;
+  Variables.register_variable strace_flags

--- a/ocamltest/strace.mli
+++ b/ocamltest/strace.mli
@@ -1,0 +1,22 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Sebastien Hinderer, projet Gallium, INRIA Paris            *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Interface to the strace feature *)
+
+val strace : Variables.t
+
+val strace_flags : Variables.t
+
+val get_logfile_name : string -> string

--- a/ocamltest/tests.ml
+++ b/ocamltest/tests.ml
@@ -43,7 +43,7 @@ let lookup name =
 
 let test_of_action action =
 {
-  test_name = Actions.action_name action;
+  test_name = Actions.name action;
   test_run_by_default = false;
   test_actions = [action]
 }
@@ -55,10 +55,10 @@ let run_actions log testenv actions =
     | action::remaining_actions ->
       begin
         Printf.fprintf log "Running action %d/%d (%s)\n%!"
-          action_number total (Actions.action_name action);
+          action_number total (Actions.name action);
         let (result, env') = Actions.run log env action in
         Printf.fprintf log "Action %d/%d (%s) %s\n%!"
-          action_number total (Actions.action_name action)
+          action_number total (Actions.name action)
           (Result.string_of_result result);
         if Result.is_pass result
         then run_actions_aux (action_number+1) env' remaining_actions


### PR DESCRIPTION
This PR adds strace support to ocamltest. More precisely, if the
ocamltest `strace` variable is `true` while a command (compiler,
debugger...) is about to be run, then this command will be run under strace
and the strace results will be stored
in a per-command file in
the test build directory.

It is possible to control the flags passed to strace with the
`strace_flags` variable.

The first commits of this PR do a bit of code refactoring, the actual
implementation of the feature is in the last commit. Consequently,
this PR is best reviewed commit by commit.