### PR TITLE
Fix PR8701 by expanding types in lower_contravariant

### DIFF
--- a/Changes
+++ b/Changes
@@ -306,7 +306,7 @@ OCaml 4.09.0
   ocamldep. It used to turn some errors into successes
   (Jérémie Dimino)
 
-- #8701: Variance of constrained parameters causes principality issues
+- #8701, #8725: Variance of constrained parameters causes principality issues
   (Jacques Garrigue, report by Leo White)
 
 OCaml 4.08.0

--- a/Changes
+++ b/Changes
@@ -307,7 +307,7 @@ OCaml 4.09.0
   (Jérémie Dimino)
 
 - #8701, #8725: Variance of constrained parameters causes principality issues
-  (Jacques Garrigue, report by Leo White)
+  (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
 OCaml 4.08.0
 ------------

--- a/Changes
+++ b/Changes
@@ -306,6 +306,9 @@ OCaml 4.09.0
   ocamldep. It used to turn some errors into successes
   (Jérémie Dimino)
 
+- #8701: Variance of constrained parameters causes principality issues
+  (Jacques Garrigue, report by Leo White)
+
 OCaml 4.08.0
 ------------
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1734,3 +1734,22 @@ Error: The type of this class,
          object constraint 'a = '_weak2 list ref method get : 'a end,
        contains type variables that cannot be generalized
 |}]
+
+(* #8701 *)
+type 'a t = 'a constraint 'a = 'b list;;
+type 'a s = 'a list;;
+let id x = x;;
+[%%expect{|
+type 'a t = 'a constraint 'a = 'b list
+type 'a s = 'a list
+val id : 'a -> 'a = <fun>
+|}]
+
+let x : [ `Foo of _ s | `Foo of 'a t ] = id (`Foo []);;
+[%%expect{|
+val x : [ `Foo of 'a s ] = `Foo []
+|}]
+let x : [ `Foo of 'a t | `Foo of _ s ] = id (`Foo []);;
+[%%expect{|
+val x : [ `Foo of 'a list t ] = `Foo []
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -890,30 +890,38 @@ let rec lower_contravariant env var_level visited contra ty =
   in
   if must_visit then begin
     Hashtbl.add visited ty.id contra;
-    let generalize_rec = lower_contravariant env var_level visited in
+    let lower_rec = lower_contravariant env var_level visited in
     match ty.desc with
       Tvar _ -> if contra then set_level ty var_level
-    | Tconstr (path, tyl, abbrev) ->
+    | Tconstr (_, [], _) -> ()
+    | Tconstr (path, tyl, _abbrev) ->
         let variance =
           try (Env.find_type path env).type_variance
           with Not_found ->
             (* See testsuite/tests/typing-missing-cmi-2 for an example *)
             List.map (fun _ -> Variance.may_inv) tyl
         in
-        abbrev := Mnil;
-        List.iter2
-          (fun v t ->
-            if Variance.(mem May_weak v)
-            then generalize_rec true t
-            else generalize_rec contra t)
-          variance tyl
+        if List.for_all ((=) Variance.null) variance then () else
+        begin try
+          let ty = !forward_try_expand_once env ty in
+          lower_rec contra ty
+        with Cannot_expand ->
+          (* abbrev := Mnil;  Should not be needed anymore *)
+          List.iter2
+            (fun v t ->
+              if v = Variance.null then () else
+              if Variance.(mem May_weak v)
+              then lower_rec true t
+              else lower_rec contra t)
+            variance tyl
+        end
     | Tpackage (_, _, tyl) ->
-        List.iter (generalize_rec true) tyl
+        List.iter (lower_rec true) tyl
     | Tarrow (_, t1, t2, _) ->
-        generalize_rec true t1;
-        generalize_rec contra t2
+        lower_rec true t1;
+        lower_rec contra t2
     | _ ->
-        iter_type_expr (generalize_rec contra) ty
+        iter_type_expr (lower_rec contra) ty
   end
 
 let lower_contravariant env ty =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -902,10 +902,9 @@ let rec lower_contravariant env var_level visited contra ty =
             List.map (fun _ -> Variance.may_inv) tyl
         in
         if List.for_all ((=) Variance.null) variance then () else
-        begin try
-          let ty = !forward_try_expand_once env ty in
-          lower_rec contra ty
-        with Cannot_expand ->
+        begin match !forward_try_expand_once env ty with
+        | ty -> lower_rec contra ty
+        | exception Cannot_expand ->
           (* abbrev := Mnil;  Should not be needed anymore *)
           List.iter2
             (fun v t ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -905,7 +905,6 @@ let rec lower_contravariant env var_level visited contra ty =
         begin match !forward_try_expand_once env ty with
         | ty -> lower_rec contra ty
         | exception Cannot_expand ->
-          (* abbrev := Mnil;  Should not be needed anymore *)
           List.iter2
             (fun v t ->
               if v = Variance.null then () else


### PR DESCRIPTION
As noted in #8701, `Ctype.lower_contravariant` ended up lowering the levels of type variables inside constrained parameters, where it should have first tried to expand the type.
This resulted in principality issues.

This PR fixes that by expanding when needed.
This could be more optimized, but the code intends to be simple.

This fix should also go in 4.09.