### PR TITLE
Memprof support for unmarshalled data

### DIFF
--- a/Changes
+++ b/Changes
@@ -106,9 +106,8 @@ Working version
 
 - #8634: Statistical memory profiling provided by the Gc.Memprof
    module.
-   Incomplete version: does not sample
-     - objects allocated in the minor heap in native mode,
-     - objects allocated by de-marshalling.
+   Incomplete version: does not sample objects allocated in the minor
+   heap in native mode
    (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer and
     Damien Doligez)
 

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -4,18 +4,20 @@ run_unix.$(O): run_unix.c run.h ../runtime/caml/misc.h \
 run_stubs.$(O): run_stubs.c run.h ../runtime/caml/misc.h \
  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
  ../runtime/caml/mlvalues.h ../runtime/caml/misc.h \
- ../runtime/caml/memory.h ../runtime/caml/gc.h ../runtime/caml/mlvalues.h \
- ../runtime/caml/major_gc.h ../runtime/caml/freelist.h \
- ../runtime/caml/minor_gc.h ../runtime/caml/address_class.h \
- ../runtime/caml/memprof.h ../runtime/caml/io.h ../runtime/caml/osdeps.h \
- ../runtime/caml/memory.h
+ ../runtime/caml/domain_state.h ../runtime/caml/mlvalues.h \
+ ../runtime/caml/domain_state.tbl ../runtime/caml/memory.h \
+ ../runtime/caml/gc.h ../runtime/caml/major_gc.h \
+ ../runtime/caml/freelist.h ../runtime/caml/minor_gc.h \
+ ../runtime/caml/address_class.h ../runtime/caml/domain.h \
+ ../runtime/caml/io.h ../runtime/caml/osdeps.h ../runtime/caml/memory.h
 ocamltest_stdlib_stubs.$(O): ocamltest_stdlib_stubs.c \
  ../runtime/caml/config.h ../runtime/caml/m.h ../runtime/caml/s.h \
  ../runtime/caml/mlvalues.h ../runtime/caml/config.h \
- ../runtime/caml/misc.h ../runtime/caml/memory.h ../runtime/caml/gc.h \
- ../runtime/caml/mlvalues.h ../runtime/caml/major_gc.h \
+ ../runtime/caml/misc.h ../runtime/caml/domain_state.h \
+ ../runtime/caml/mlvalues.h ../runtime/caml/domain_state.tbl \
+ ../runtime/caml/memory.h ../runtime/caml/gc.h ../runtime/caml/major_gc.h \
  ../runtime/caml/freelist.h ../runtime/caml/minor_gc.h \
- ../runtime/caml/address_class.h ../runtime/caml/memprof.h \
+ ../runtime/caml/address_class.h ../runtime/caml/domain.h \
  ../runtime/caml/alloc.h ../runtime/caml/signals.h \
  ../runtime/caml/osdeps.h ../runtime/caml/memory.h
 actions.cmo : \

--- a/otherlibs/raw_spacetime_lib/.depend
+++ b/otherlibs/raw_spacetime_lib/.depend
@@ -1,13 +1,14 @@
 spacetime_offline.$(O): spacetime_offline.c ../../runtime/caml/alloc.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/config.h \
  ../../runtime/caml/fail.h ../../runtime/caml/gc.h \
  ../../runtime/caml/intext.h ../../runtime/caml/io.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/roots.h \
  ../../runtime/caml/memory.h ../../runtime/caml/signals.h \

--- a/otherlibs/str/.depend
+++ b/otherlibs/str/.depend
@@ -1,8 +1,10 @@
 strstubs.$(O): strstubs.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/fail.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/fail.h
 str.cmo : \
     str.cmi
 str.cmx : \

--- a/otherlibs/systhreads/.depend
+++ b/otherlibs/systhreads/.depend
@@ -1,33 +1,37 @@
 st_stubs_b.$(O): st_stubs.c ../../runtime/caml/alloc.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/backtrace.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/backtrace.h \
  ../../runtime/caml/exec.h ../../runtime/caml/callback.h \
- ../../runtime/caml/custom.h ../../runtime/caml/fail.h \
- ../../runtime/caml/io.h ../../runtime/caml/memory.h \
- ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
- ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
- ../../runtime/caml/misc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/printexc.h ../../runtime/caml/roots.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h \
- ../../runtime/caml/stacks.h ../../runtime/caml/sys.h \
- ../../runtime/caml/memprof.h threads.h
+ ../../runtime/caml/custom.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/io.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/printexc.h \
+ ../../runtime/caml/roots.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/stacks.h \
+ ../../runtime/caml/sys.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/roots.h threads.h
 st_stubs_n.$(O): st_stubs.c ../../runtime/caml/alloc.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/backtrace.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/backtrace.h \
  ../../runtime/caml/exec.h ../../runtime/caml/callback.h \
- ../../runtime/caml/custom.h ../../runtime/caml/fail.h \
- ../../runtime/caml/io.h ../../runtime/caml/memory.h \
- ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
- ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
- ../../runtime/caml/misc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/printexc.h ../../runtime/caml/roots.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h \
- ../../runtime/caml/stack.h ../../runtime/caml/sys.h \
- ../../runtime/caml/memprof.h threads.h
+ ../../runtime/caml/custom.h ../../runtime/caml/domain.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/io.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/printexc.h \
+ ../../runtime/caml/roots.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/signals.h ../../runtime/caml/stack.h \
+ ../../runtime/caml/sys.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/roots.h threads.h
 condition.cmo : \
     mutex.cmi \
     condition.cmi

--- a/otherlibs/unix/.depend
+++ b/otherlibs/unix/.depend
@@ -1,516 +1,673 @@
 accept.o: accept.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 access.o: access.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/signals.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 addrofstr.o: addrofstr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 alarm.o: alarm.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 bind.o: bind.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 channels.o: channels.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h ../../runtime/caml/io.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h \
- socketaddr.h ../../runtime/caml/misc.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/io.h \
+ ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 chdir.o: chdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 chmod.o: chmod.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 chown.o: chown.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 chroot.o: chroot.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 close.o: close.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h
 closedir.o: closedir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 connect.o: connect.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h \
  socketaddr.h ../../runtime/caml/misc.h
 cst2constr.o: cst2constr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/fail.h ../../runtime/caml/mlvalues.h cst2constr.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/fail.h \
+ cst2constr.h
 cstringv.o: cstringv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 dup2.o: dup2.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 dup.o: dup.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 envir.o: envir.c ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h
 errmsg.o: errmsg.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h
 execv.o: execv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execve.o: execve.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execvp.o: execvp.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 exit.o: exit.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 fchmod.o: fchmod.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h
 fchown.o: fchown.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h
 fcntl.o: fcntl.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h unixsupport.h
 fork.o: fork.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/debugger.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/debugger.h \
  unixsupport.h
 fsync.o: fsync.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h
 ftruncate.o: ftruncate.c ../../runtime/caml/fail.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/io.h ../../runtime/caml/signals.h unixsupport.h
 getaddrinfo.o: getaddrinfo.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/misc.h ../../runtime/caml/signals.h unixsupport.h \
  cst2constr.h socketaddr.h
 getcwd.o: getcwd.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h unixsupport.h
+ ../../runtime/caml/domain.h unixsupport.h
 getegid.o: getegid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 geteuid.o: geteuid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 getgid.o: getgid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 getgr.o: getgr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/fail.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/alloc.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 getgroups.o: getgroups.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 gethost.o: gethost.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 gethostname.o: gethostname.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 getlogin.o: getlogin.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 getnameinfo.o: getnameinfo.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 getpeername.o: getpeername.c ../../runtime/caml/fail.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/mlvalues.h \
  unixsupport.h socketaddr.h ../../runtime/caml/misc.h
 getpid.o: getpid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 getppid.o: getppid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 getproto.o: getproto.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 getpw.o: getpw.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/fail.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/fail.h unixsupport.h
 getserv.o: getserv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 getsockname.o: getsockname.c ../../runtime/caml/fail.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/mlvalues.h \
  unixsupport.h socketaddr.h ../../runtime/caml/misc.h
 gettimeofday.o: gettimeofday.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 getuid.o: getuid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 gmtime.o: gmtime.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 initgroups.o: initgroups.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 isatty.o: isatty.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 itimer.o: itimer.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 kill.o: kill.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/fail.h ../../runtime/caml/mlvalues.h unixsupport.h \
- ../../runtime/caml/signals.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/fail.h \
+ unixsupport.h ../../runtime/caml/signals.h
 link.o: link.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 listen.o: listen.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h unixsupport.h
 lockf.o: lockf.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h
 lseek.o: lseek.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/io.h ../../runtime/caml/signals.h unixsupport.h
 mkdir.o: mkdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 mkfifo.o: mkfifo.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 mmap_ba.o: mmap_ba.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/bigarray.h ../../runtime/caml/custom.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/misc.h
+ ../../runtime/caml/domain.h ../../runtime/caml/misc.h
 mmap.o: mmap.c ../../runtime/caml/bigarray.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/fail.h ../../runtime/caml/io.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h \
  ../../runtime/caml/sys.h unixsupport.h
 nice.o: nice.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 open.o: open.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/misc.h \
  ../../runtime/caml/signals.h unixsupport.h
 opendir.o: opendir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 pipe.o: pipe.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 putenv.o: putenv.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 read.o: read.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 readdir.o: readdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/fail.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/fail.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h unixsupport.h
 readlink.o: readlink.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
  ../../runtime/caml/signals.h unixsupport.h
 rename.o: rename.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 rewinddir.o: rewinddir.c ../../runtime/caml/fail.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/mlvalues.h \
  unixsupport.h
 rmdir.o: rmdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 select.o: select.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 sendrecv.o: sendrecv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 setgid.o: setgid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 setgroups.o: setgroups.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 setsid.o: setsid.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h unixsupport.h
 setuid.o: setuid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 shutdown.o: shutdown.c ../../runtime/caml/fail.h \
  ../../runtime/caml/misc.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/mlvalues.h ../../runtime/caml/domain_state.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/mlvalues.h \
  unixsupport.h
 signals.o: signals.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/signals.h unixsupport.h
 sleep.o: sleep.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h
 socketaddr.o: socketaddr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 socket.o: socket.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h unixsupport.h
 socketpair.o: socketpair.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 sockopt.o: sockopt.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h unixsupport.h \
  socketaddr.h ../../runtime/caml/misc.h
 stat.o: stat.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
  ../../runtime/caml/io.h unixsupport.h cst2constr.h nanosecond_stat.h
 strofaddr.o: strofaddr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 symlink.o: symlink.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 termios.o: termios.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 time.o: time.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 times.o: times.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h unixsupport.h
 truncate.o: truncate.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h ../../runtime/caml/signals.h \
  ../../runtime/caml/io.h unixsupport.h
 umask.o: umask.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 unixsupport.o: unixsupport.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/callback.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h unixsupport.h cst2constr.h
 unlink.o: unlink.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 utimes.o: utimes.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 wait.o: wait.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 write.o: write.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 unix.cmo : \
     unix.cmi

--- a/otherlibs/win32unix/.depend
+++ b/otherlibs/win32unix/.depend
@@ -1,453 +1,565 @@
 accept.$(O): accept.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h unixsupport.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
  socketaddr.h ../../runtime/caml/misc.h
 bind.$(O): bind.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h socketaddr.h ../../runtime/caml/misc.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 channels.$(O): channels.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/io.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  unixsupport.h
 close.$(O): close.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h \
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h \
  ../../runtime/caml/io.h
 close_on.$(O): close_on.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 connect.$(O): connect.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h \
- socketaddr.h ../../runtime/caml/misc.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h socketaddr.h ../../runtime/caml/misc.h
 createprocess.$(O): createprocess.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  unixsupport.h ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h
 dup.$(O): dup.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 dup2.$(O): dup2.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 errmsg.$(O): errmsg.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  unixsupport.h
 envir.$(O): envir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h
 getpeername.$(O): getpeername.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h \
- socketaddr.h ../../runtime/caml/misc.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 getpid.$(O): getpid.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 getsockname.$(O): getsockname.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h \
- socketaddr.h ../../runtime/caml/misc.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h socketaddr.h \
+ ../../runtime/caml/misc.h
 gettimeofday.$(O): gettimeofday.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 isatty.$(O): isatty.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
- ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
- ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h unixsupport.h
-link.$(O): link.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
- ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/fail.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/domain.h unixsupport.h
+link.$(O): link.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
+ ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/fail.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
+ ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
+ ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 listen.$(O): listen.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 lockf.$(O): lockf.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h unixsupport.h ../../runtime/caml/signals.h
 lseek.$(O): lseek.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 nonblock.$(O): nonblock.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h
 mkdir.$(O): mkdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
- ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h unixsupport.h
 mmap.$(O): mmap.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/bigarray.h ../../runtime/caml/fail.h \
  ../../runtime/caml/io.h ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/signals.h ../../runtime/caml/sys.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  unixsupport.h
 open.$(O): open.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/memory.h unixsupport.h
 pipe.$(O): pipe.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h unixsupport.h
 read.$(O): read.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 readlink.$(O): readlink.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 rename.$(O): rename.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h \
- ../../runtime/caml/gc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/osdeps.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain.h ../../runtime/caml/memory.h unixsupport.h
 select.$(O): select.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/fail.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/fail.h \
  ../../runtime/caml/signals.h winworker.h unixsupport.h windbug.h \
  winlist.h
 sendrecv.$(O): sendrecv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h unixsupport.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h \
  socketaddr.h ../../runtime/caml/misc.h
 shutdown.$(O): shutdown.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 sleep.$(O): sleep.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h
 socket.$(O): socket.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h unixsupport.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 sockopt.$(O): sockopt.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h unixsupport.h \
  socketaddr.h ../../runtime/caml/misc.h
 startup.$(O): startup.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
- ../../runtime/caml/s.h ../../runtime/caml/misc.h winworker.h \
- unixsupport.h windbug.h
+ ../../runtime/caml/s.h ../../runtime/caml/misc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl winworker.h unixsupport.h windbug.h
 stat.$(O): stat.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h \
  ../unix/cst2constr.h
 symlink.$(O): symlink.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 system.$(O): system.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/signals.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 times.$(O): times.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 truncate.$(O): truncate.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h ../../runtime/caml/signals.h \
  ../../runtime/caml/io.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 unixsupport.$(O): unixsupport.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/callback.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/callback.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h ../../runtime/caml/custom.h unixsupport.h \
  ../unix/cst2constr.h
 windir.$(O): windir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/alloc.h ../../runtime/caml/fail.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 winwait.$(O): winwait.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/signals.h unixsupport.h
 write.$(O): write.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h
 winlist.$(O): winlist.c winlist.h
 winworker.$(O): winworker.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h winworker.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/signals.h winworker.h \
  unixsupport.h winlist.h windbug.h
 windbug.$(O): windbug.c windbug.h
 utimes.$(O): utimes.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/mlvalues.h ../../runtime/caml/memory.h \
  ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 access.$(O): access.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h ../../runtime/caml/signals.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/signals.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 addrofstr.$(O): addrofstr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/fail.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 chdir.$(O): chdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 chmod.$(O): chmod.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 cst2constr.$(O): cst2constr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/fail.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/fail.h \
  ../unix/cst2constr.h
 cstringv.$(O): cstringv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execv.$(O): execv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execve.$(O): execve.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 execvp.$(O): execvp.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 exit.$(O): exit.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl unixsupport.h
 getaddrinfo.$(O): getaddrinfo.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/misc.h ../../runtime/caml/signals.h unixsupport.h \
  ../unix/cst2constr.h socketaddr.h
 getcwd.$(O): getcwd.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h unixsupport.h
+ ../../runtime/caml/domain.h unixsupport.h
 gethost.$(O): gethost.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 gethostname.$(O): gethostname.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h
 getnameinfo.$(O): getnameinfo.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 getproto.$(O): getproto.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 getserv.$(O): getserv.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 gmtime.$(O): gmtime.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/fail.h ../../runtime/caml/memory.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/fail.h ../../runtime/caml/memory.h \
+ ../../runtime/caml/compatibility.h ../../runtime/caml/domain.h \
+ unixsupport.h
 mmap_ba.$(O): mmap_ba.c ../../runtime/caml/alloc.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/bigarray.h ../../runtime/caml/custom.h \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/misc.h
+ ../../runtime/caml/domain.h ../../runtime/caml/misc.h
 putenv.$(O): putenv.c ../../runtime/caml/fail.h ../../runtime/caml/misc.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/domain_state.tbl \
  ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
  ../../runtime/caml/major_gc.h ../../runtime/caml/freelist.h \
  ../../runtime/caml/minor_gc.h ../../runtime/caml/address_class.h \
- ../../runtime/caml/memprof.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain.h ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/osdeps.h ../../runtime/caml/memory.h unixsupport.h
 rmdir.$(O): rmdir.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 socketaddr.$(O): socketaddr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
- ../../runtime/caml/memory.h unixsupport.h socketaddr.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ ../../runtime/caml/memory.h ../../runtime/caml/compatibility.h \
+ ../../runtime/caml/domain.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 strofaddr.$(O): strofaddr.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
  ../../runtime/caml/fail.h unixsupport.h socketaddr.h \
  ../../runtime/caml/misc.h
 time.$(O): time.c ../../runtime/caml/mlvalues.h ../../runtime/caml/config.h \
  ../../runtime/caml/m.h ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/alloc.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/alloc.h \
+ unixsupport.h
 unlink.$(O): unlink.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/memory.h ../../runtime/caml/gc.h \
- ../../runtime/caml/mlvalues.h ../../runtime/caml/major_gc.h \
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/memory.h \
+ ../../runtime/caml/gc.h ../../runtime/caml/major_gc.h \
  ../../runtime/caml/freelist.h ../../runtime/caml/minor_gc.h \
- ../../runtime/caml/address_class.h ../../runtime/caml/memprof.h \
+ ../../runtime/caml/address_class.h ../../runtime/caml/domain.h \
  ../../runtime/caml/signals.h ../../runtime/caml/osdeps.h \
  ../../runtime/caml/memory.h unixsupport.h
 fsync.$(O): fsync.c ../../runtime/caml/mlvalues.h \
  ../../runtime/caml/config.h ../../runtime/caml/m.h \
  ../../runtime/caml/s.h ../../runtime/caml/misc.h \
- ../../runtime/caml/signals.h ../../runtime/caml/mlvalues.h unixsupport.h
+ ../../runtime/caml/domain_state.h ../../runtime/caml/mlvalues.h \
+ ../../runtime/caml/domain_state.tbl ../../runtime/caml/signals.h \
+ unixsupport.h
 unix.cmo : \
     unix.cmi
 unix.cmx : \

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -2,50 +2,48 @@ afl_b.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_b.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_b.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_b.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_b.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_b.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_b.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_b.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_b.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/interp.h caml/instruct.h \
- caml/fix_code.h caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 clambda_checks_b.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -53,194 +51,189 @@ compact_b.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_b.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_b.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_b.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/fail.h \
- caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
- caml/mlvalues.h caml/stacks.h caml/sys.h
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
 domain_b.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_b.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_b.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_b.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_b.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_b.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_b.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_b.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_b.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_b.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_b.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stacks.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
+ caml/startup_aux.h
 globroots_b.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_b.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_b.$(O): instrtrace.c
 intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_b.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h caml/jumptbl.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_b.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_b.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_b.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_b.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_b.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_b.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_b.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_b.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_b.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_b.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_b.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_b.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_b.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_b.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -248,40 +241,40 @@ printexc_b.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_b.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_b.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_b.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_b.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_b.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_b.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_b.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -290,30 +283,30 @@ spacetime_nat_b.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_b.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_b.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_b.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/dynlink.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_b.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -321,95 +314,91 @@ startup_byt_b.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_b.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_b.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_b.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_b.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_b.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_b.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_bd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_bd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_bd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_bd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_bd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_bd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_bd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_bd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_bd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/interp.h caml/instruct.h \
- caml/fix_code.h caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 clambda_checks_bd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -417,199 +406,194 @@ compact_bd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h 
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_bd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_bd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_bd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/fail.h \
- caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
- caml/mlvalues.h caml/stacks.h caml/sys.h
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
 domain_bd.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_bd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_bd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_bd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_bd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_bd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_bd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_bd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_bd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_bd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_bd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stacks.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
+ caml/startup_aux.h
 globroots_bd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_bd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_bd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/instruct.h caml/misc.h caml/mlvalues.h \
  caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/startup_aux.h
+ caml/domain.h caml/startup_aux.h
 intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_bd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h
 ints_bd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_bd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_bd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_bd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_bd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_bd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_bd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_bd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_bd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_bd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_bd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_bd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_bd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -617,40 +601,40 @@ printexc_bd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_bd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_bd.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_bd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_bd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_bd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_bd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_bd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -659,30 +643,30 @@ spacetime_nat_bd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_bd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_bd.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_bd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/dynlink.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_bd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -690,95 +674,91 @@ startup_byt_bd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h 
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_bd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_bd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_bd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_bd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_bd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_bd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_bi.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_bi.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_bi.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_bi.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_bi.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_bi.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_bi.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_bi.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_bi.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/interp.h caml/instruct.h \
- caml/fix_code.h caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 clambda_checks_bi.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -786,194 +766,189 @@ compact_bi.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h 
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_bi.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_bi.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_bi.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/fail.h \
- caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
- caml/mlvalues.h caml/stacks.h caml/sys.h
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
 domain_bi.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_bi.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_bi.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_bi.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_bi.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_bi.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_bi.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_bi.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_bi.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_bi.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_bi.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stacks.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
+ caml/startup_aux.h
 globroots_bi.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_bi.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_bi.$(O): instrtrace.c
 intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_bi.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h caml/jumptbl.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_bi.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_bi.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_bi.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_bi.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_bi.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_bi.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bi.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_bi.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_bi.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_bi.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_bi.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_bi.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_bi.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_bi.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -981,40 +956,40 @@ printexc_bi.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_bi.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_bi.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_bi.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_bi.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_bi.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_bi.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_bi.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -1023,30 +998,30 @@ spacetime_nat_bi.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_bi.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_bi.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_bi.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/dynlink.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_bi.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -1054,95 +1029,91 @@ startup_byt_bi.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h 
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_bi.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_bi.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_bi.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_bi.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_bi.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_bi.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_bpic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_bpic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_bpic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_bpic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_bpic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_bpic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_bpic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_bpic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_bpic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/interp.h caml/instruct.h \
- caml/fix_code.h caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 clambda_checks_bpic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -1150,194 +1121,189 @@ compact_bpic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_bpic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_bpic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_bpic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/fail.h \
- caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
- caml/mlvalues.h caml/stacks.h caml/sys.h
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
 domain_bpic.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_bpic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_bpic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_bpic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_bpic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_bpic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_bpic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_bpic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_bpic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_bpic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_bpic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stacks.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
+ caml/startup_aux.h
 globroots_bpic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_bpic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_bpic.$(O): instrtrace.c
 intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_bpic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h caml/jumptbl.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_bpic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_bpic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_bpic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_bpic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_bpic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_bpic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_bpic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_bpic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_bpic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_bpic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_bpic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_bpic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_bpic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_bpic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -1345,40 +1311,40 @@ printexc_bpic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_bpic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_bpic.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_bpic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_bpic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_bpic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_bpic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_bpic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -1387,30 +1353,30 @@ spacetime_nat_bpic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_bpic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_bpic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_bpic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/dynlink.h caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/dynlink.h \
+ caml/osdeps.h caml/memory.h caml/startup_aux.h
 startup_byt_bpic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -1418,94 +1384,90 @@ startup_byt_bpic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_bpic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_bpic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_bpic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_bpic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_bpic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_bpic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_n.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_n.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_n.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_n.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_n.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_n.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_n.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_n.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_n.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
 clambda_checks_n.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -1513,192 +1475,187 @@ compact_n.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_n.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_n.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_n.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 domain_n.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_n.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_n.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_n.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_n.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_n.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_n.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_n.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_n.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_n.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_n.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stack.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
 globroots_n.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_n.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_n.$(O): instrtrace.c
 intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_n.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h caml/jumptbl.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_n.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_n.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_n.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_n.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_n.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_n.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_n.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_n.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_n.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_n.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_n.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_n.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_n.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_n.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -1706,40 +1663,40 @@ printexc_n.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_n.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_n.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_n.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_n.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_n.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_n.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_n.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -1748,30 +1705,30 @@ spacetime_nat_n.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_n.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_n.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_n.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
+ caml/memory.h caml/startup_aux.h
 startup_byt_n.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -1779,94 +1736,90 @@ startup_byt_n.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_n.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_n.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_n.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_n.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_n.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_n.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_nd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_nd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_nd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_nd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_nd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_nd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_nd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_nd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_nd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
 clambda_checks_nd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -1874,197 +1827,192 @@ compact_nd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h 
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_nd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_nd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_nd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 domain_nd.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_nd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_nd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_nd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_nd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_nd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_nd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_nd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_nd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_nd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_nd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stack.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
 globroots_nd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_nd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_nd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/instruct.h caml/misc.h caml/mlvalues.h \
  caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/startup_aux.h
+ caml/domain.h caml/startup_aux.h
 intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_nd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h
 ints_nd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_nd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_nd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_nd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_nd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_nd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_nd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_nd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_nd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_nd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_nd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_nd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_nd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_nd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -2072,40 +2020,40 @@ printexc_nd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_nd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_nd.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_nd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_nd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_nd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_nd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_nd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -2114,30 +2062,30 @@ spacetime_nat_nd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_nd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_nd.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_nd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
+ caml/memory.h caml/startup_aux.h
 startup_byt_nd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -2145,94 +2093,90 @@ startup_byt_nd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h 
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_nd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_nd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_nd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_nd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_nd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_nd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_ni.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_ni.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_ni.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_ni.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_ni.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_ni.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_ni.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_ni.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_ni.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
 clambda_checks_ni.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -2240,192 +2184,187 @@ compact_ni.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h 
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_ni.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_ni.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_ni.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 domain_ni.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_ni.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_ni.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_ni.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_ni.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_ni.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_ni.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_ni.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_ni.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_ni.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_ni.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stack.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
 globroots_ni.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_ni.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_ni.$(O): instrtrace.c
 intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_ni.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h caml/jumptbl.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_ni.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_ni.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_ni.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_ni.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_ni.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_ni.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_ni.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_ni.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_ni.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_ni.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_ni.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_ni.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_ni.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_ni.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -2433,40 +2372,40 @@ printexc_ni.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_ni.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_ni.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_ni.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_ni.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_ni.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_ni.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_ni.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -2475,30 +2414,30 @@ spacetime_nat_ni.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_ni.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_ni.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_ni.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
+ caml/memory.h caml/startup_aux.h
 startup_byt_ni.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -2506,94 +2445,90 @@ startup_byt_ni.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h 
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_ni.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_ni.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_ni.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_ni.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_ni.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_ni.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
 afl_npic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 alloc_npic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h
 array_npic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_npic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/backtrace.h \
- caml/exec.h caml/backtrace_prim.h caml/backtrace.h caml/fail.h \
- caml/debugger.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
 backtrace_byt_npic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
  caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/startup.h caml/exec.h caml/stacks.h caml/memory.h caml/sys.h \
- caml/backtrace.h caml/fail.h caml/backtrace_prim.h caml/backtrace.h \
- caml/debugger.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
+ caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
+ caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
+backtrace_npic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
 backtrace_nat_npic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
  caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/stack.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
 bigarray_npic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
  caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
 callback_npic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
 clambda_checks_npic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl
@@ -2601,192 +2536,187 @@ compact_npic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h \
- caml/compact.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
 compare_npic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
 custom_npic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/signals.h
+ caml/domain.h caml/mlvalues.h caml/signals.h
 debugger_npic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 domain_npic.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 dynlink_npic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/prims.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
 dynlink_nat_npic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/stack.h caml/callback.h caml/alloc.h caml/intext.h \
- caml/io.h caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h \
- caml/hooks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
 extern_npic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail_byt_npic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 fail_nat_npic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/printexc.h \
- caml/signals.h caml/stack.h caml/roots.h caml/memory.h caml/callback.h
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 finalise_npic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
 fix_code_npic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats_npic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist_npic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/gc.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl_npic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/stack.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
 globroots_npic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
  caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
 hash_npic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/hash.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
 instrtrace_npic.$(O): instrtrace.c
 intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp_npic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
  caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h \
- caml/memory.h caml/startup_aux.h caml/jumptbl.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
+ caml/startup_aux.h caml/jumptbl.h
 ints_npic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h
+ caml/domain.h caml/misc.h caml/mlvalues.h
 io_npic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
 lexing_npic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
 main_npic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h
+ caml/domain.h
 major_gc_npic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/freelist.h \
- caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 md5_npic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/mlvalues.h caml/io.h caml/reverse.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
 memory_npic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h \
- caml/memprof.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
 memprof_npic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/weak.h \
- caml/memory.h caml/stack.h caml/misc.h
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
 meta_npic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/config.h \
  caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h caml/io.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
- caml/memory.h caml/debugger.h caml/backtrace_prim.h caml/backtrace.h \
- caml/exec.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/debugger.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h
 minor_gc_npic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_npic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/osdeps.h \
- caml/memory.h caml/version.h
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
 obj_npic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/prims.h caml/spacetime.h caml/io.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/spacetime.h caml/io.h caml/stack.h
 parsing_npic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
  caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/alloc.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
 prims_npic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
  caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
  caml/prims.h
@@ -2794,40 +2724,40 @@ printexc_npic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
  caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/memprof.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
 roots_byt_npic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_npic.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/globroots.h caml/memory.h caml/major_gc.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
+signals_byt_npic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ caml/finalise.h caml/roots.h
 signals_npic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h \
- caml/memprof.h caml/finalise.h caml/roots.h
-signals_byt_npic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h caml/finalise.h caml/roots.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
 signals_nat_npic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/signals_machdep.h signals_osdep.h caml/stack.h caml/spacetime.h \
- caml/io.h caml/stack.h caml/memprof.h caml/finalise.h caml/roots.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
+ signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
+ caml/memprof.h caml/roots.h caml/finalise.h
 spacetime_byt_npic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/mlvalues.h
@@ -2836,30 +2766,30 @@ spacetime_nat_npic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
  caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/roots.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 spacetime_snapshot_npic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/signals.h caml/stack.h caml/sys.h \
- caml/spacetime.h caml/stack.h
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
+ caml/stack.h
 stacks_npic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h
+ caml/address_class.h caml/domain.h
 startup_aux_npic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/callback.h caml/major_gc.h \
- caml/osdeps.h caml/memory.h caml/startup_aux.h
+ caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
+ caml/memory.h caml/startup_aux.h
 startup_byt_npic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
@@ -2867,44 +2797,42 @@ startup_byt_npic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.
  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h \
- caml/printexc.h caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h \
- caml/startup.h caml/startup_aux.h caml/version.h
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
+ caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
+ caml/startup_aux.h caml/version.h
 startup_nat_npic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
  caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
- caml/memory.h caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
 str_npic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/mlvalues.h \
- caml/misc.h
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
 sys_npic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/memprof.h \
- caml/domain.h caml/signals.h caml/stacks.h caml/sys.h caml/version.h \
- caml/callback.h caml/startup_aux.h
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
 unix_npic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/memprof.h caml/domain.h caml/misc.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/sys.h caml/io.h \
- caml/alloc.h
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
 weak_npic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/memprof.h caml/domain.h \
- caml/mlvalues.h caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_npic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/memprof.h caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h caml/config.h
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -149,7 +149,8 @@ intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_b.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -509,7 +510,8 @@ intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_bd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -864,7 +866,8 @@ intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_bi.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -1219,7 +1222,8 @@ intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_bpic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -1571,7 +1575,8 @@ intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_n.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -1928,7 +1933,8 @@ intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_nd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -2280,7 +2286,8 @@ intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_ni.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -2632,7 +2639,8 @@ intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h
+ caml/domain.h caml/mlvalues.h caml/misc.h caml/reverse.h caml/memprof.h \
+ caml/roots.h caml/memory.h
 interp_npic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -26,7 +26,6 @@
 #include "gc.h"
 #include "major_gc.h"
 #include "minor_gc.h"
-#include "memprof.h"
 #endif /* CAML_INTERNALS */
 #include "misc.h"
 #include "mlvalues.h"

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -28,6 +28,7 @@ extern void caml_memprof_handle_postponed();
 
 extern void caml_memprof_track_alloc_shr(value block);
 extern void caml_memprof_track_young(tag_t tag, uintnat wosize, int from_caml);
+extern void caml_memprof_track_interned(header_t* block, header_t* blockend);
 
 extern void caml_memprof_renew_minor_sample(void);
 extern value* caml_memprof_young_trigger;

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "mlvalues.h"
+#include "roots.h"
 
 extern int caml_memprof_suspended;
 
@@ -30,6 +31,8 @@ extern void caml_memprof_track_young(tag_t tag, uintnat wosize, int from_caml);
 
 extern void caml_memprof_renew_minor_sample(void);
 extern value* caml_memprof_young_trigger;
+
+extern void caml_memprof_scan_roots(scanning_action f);
 
 #endif
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -34,6 +34,7 @@
 #include "caml/mlvalues.h"
 #include "caml/misc.h"
 #include "caml/reverse.h"
+#include "caml/memprof.h"
 
 static unsigned char * intern_src;
 /* Reading pointer in block holding input data. */
@@ -659,8 +660,9 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     CAMLassert(intern_obj_table == NULL);
 }
 
-static void intern_add_to_heap(mlsize_t whsize)
+static header_t* intern_add_to_heap(mlsize_t whsize)
 {
+  header_t* res = NULL;
   /* Add new heap chunk to heap if needed */
   if (intern_extra_block != NULL) {
     /* If heap chunk not filled totally, build free block at end */
@@ -675,11 +677,32 @@ static void intern_add_to_heap(mlsize_t whsize)
     }
     caml_allocated_words +=
       Wsize_bsize ((char *) intern_dest - intern_extra_block);
-    caml_add_to_heap(intern_extra_block);
+    if(caml_add_to_heap(intern_extra_block) != 0) {
+      intern_cleanup();
+      caml_raise_out_of_memory();
+    }
+    res = (header_t*)intern_extra_block;
     intern_extra_block = NULL; // To prevent intern_cleanup freeing it
-  } else {
+  } else if(intern_block != 0) { /* [intern_block = 0] when [whsize = 0]  */
+    res = Hp_val(intern_block);
     intern_block = 0; // To prevent intern_cleanup rewriting its header
   }
+  return res;
+}
+
+static value intern_end(value res, mlsize_t whsize) {
+  header_t *block = intern_add_to_heap(whsize);
+  header_t *blockend = intern_dest;
+
+  /* Free everything */
+  intern_cleanup();
+
+  /* Memprof tracking has to be done here, because unmarshalling can
+     still fail until now. */
+  if(block != NULL)
+    caml_memprof_track_interned(block, blockend);
+
+  return caml_check_urgent_gc(res);
 }
 
 /* Parsing the header */
@@ -776,16 +799,16 @@ static value caml_input_val_core(struct channel *chan, int outside_heap)
   intern_alloc(h.whsize, h.num_objects, outside_heap);
   /* Fill it in */
   intern_rec(&res);
-  if (!outside_heap) {
-    intern_add_to_heap(h.whsize);
-  } else {
+  if (!outside_heap)
+    return intern_end(res, h.whsize);
+  else {
     caml_disown_for_heap(intern_extra_block);
     intern_extra_block = NULL;
     intern_block = 0;
+    /* Free everything */
+    intern_cleanup();
+    return caml_check_urgent_gc(res);
   }
-  /* Free everything */
-  intern_cleanup();
-  return caml_check_urgent_gc(res);
 }
 
 value caml_input_val(struct channel* chan)
@@ -835,10 +858,7 @@ CAMLexport value caml_input_val_from_bytes(value str, intnat ofs)
   intern_src = &Byte_u(str, ofs + h.header_len); /* If a GC occurred */
   /* Fill it in */
   intern_rec(&obj);
-  intern_add_to_heap(h.whsize);
-  /* Free everything */
-  intern_cleanup();
-  CAMLreturn (caml_check_urgent_gc(obj));
+  CAMLreturn (intern_end(obj, h.whsize));
 }
 
 CAMLprim value caml_input_value_from_string(value str, value ofs)
@@ -858,10 +878,7 @@ static value input_val_from_block(struct marshal_header * h)
   intern_alloc(h->whsize, h->num_objects, 0);
   /* Fill it in */
   intern_rec(&obj);
-  intern_add_to_heap(h->whsize);
-  /* Free internal data structures */
-  intern_cleanup();
-  return caml_check_urgent_gc(obj);
+  return (intern_end(obj, h->whsize));
 }
 
 CAMLexport value caml_input_value_from_malloc(char * data, intnat ofs)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -30,6 +30,7 @@
 #include "caml/roots.h"
 #include "caml/signals.h"
 #include "caml/weak.h"
+#include "caml/memprof.h"
 
 /* Pointers into the minor heap.
    [Caml_state->young_base]

--- a/runtime/roots_byt.c
+++ b/runtime/roots_byt.c
@@ -26,6 +26,7 @@
 #include "caml/mlvalues.h"
 #include "caml/roots.h"
 #include "caml/stacks.h"
+#include "caml/memprof.h"
 
 CAMLexport void (*caml_scan_roots_hook) (scanning_action f) = NULL;
 
@@ -56,6 +57,8 @@ void caml_oldify_local_roots (void)
   caml_scan_global_young_roots(&caml_oldify_one);
   /* Finalised values */
   caml_final_oldify_young_roots ();
+  /* Memprof */
+  caml_memprof_scan_roots (&caml_oldify_one);
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&caml_oldify_one);
 }
@@ -92,6 +95,9 @@ void caml_do_roots (scanning_action f, int do_globals)
   /* Finalised values */
   caml_final_do_roots (f);
   CAML_INSTR_TIME (tmr, "major_roots/finalised");
+  /* Memprof */
+  caml_memprof_scan_roots (f);
+  CAML_INSTR_TIME (tmr, "major_roots/memprof");
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f);
   CAML_INSTR_TIME (tmr, "major_roots/hook");

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -26,6 +26,7 @@
 #include "caml/mlvalues.h"
 #include "caml/stack.h"
 #include "caml/roots.h"
+#include "caml/memprof.h"
 #include <string.h>
 #include <stdio.h>
 
@@ -322,6 +323,8 @@ void caml_oldify_local_roots (void)
   caml_scan_global_young_roots(&caml_oldify_one);
   /* Finalised values */
   caml_final_oldify_young_roots ();
+  /* Memprof */
+  caml_memprof_scan_roots (&caml_oldify_one);
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&caml_oldify_one);
 }
@@ -418,6 +421,9 @@ void caml_do_roots (scanning_action f, int do_globals)
   /* Finalised values */
   caml_final_do_roots (f);
   CAML_INSTR_TIME (tmr, "major_roots/finalised");
+  /* Memprof */
+  caml_memprof_scan_roots (f);
+  CAML_INSTR_TIME (tmr, "major_roots/memprof");
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f);
   CAML_INSTR_TIME (tmr, "major_roots/hook");

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -124,7 +124,7 @@ module Memprof =
     type alloc_kind =
       | Minor
       | Major
-      | Serialized
+      | Unmarshalled
 
     type sample_info = {
         n_samples: int; kind: alloc_kind; tag: int;

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -401,12 +401,11 @@ module Memprof :
     type alloc_kind =
       | Minor
       | Major
-      | Serialized
+      | Unmarshalled
     (** Allocation kinds
         - [Minor] : the allocation took place in the minor heap.
         - [Major] : the allocation took place in the major heap.
-        - [Serialized] : the allocation happened during a
-          deserialization. *)
+        - [Unmarshalled] : the allocation happened while unmarshalling. *)
 
     type sample_info = {
         n_samples: int;

--- a/testsuite/tests/statmemprof/intern.byte.reference
+++ b/testsuite/tests/statmemprof/intern.byte.reference
@@ -1,0 +1,13 @@
+check_nosample
+check_ephe_full_major
+check_no_nested
+check_distrib 2 3000 3 0.000010
+check_distrib 2 3000 1 0.000100
+check_distrib 2 2000 1 0.010000
+check_distrib 2 2000 1 0.900000
+check_distrib 300000 300000 20 0.100000
+check_callstack
+Raised by primitive operation at file "intern.ml", line 32, characters 14-35
+Called from file "intern.ml", line 168, characters 2-25
+Called from file "intern.ml", line 174, characters 9-27
+OK !

--- a/testsuite/tests/statmemprof/intern.ml
+++ b/testsuite/tests/statmemprof/intern.ml
@@ -1,0 +1,177 @@
+(* TEST
+   flags = "-g"
+   * bytecode
+     reference = "${test_source_directory}/intern.byte.reference"
+   * native
+     reference = "${test_source_directory}/intern.opt.reference"
+     compare_programs = "false"
+*)
+
+open Gc.Memprof
+
+type t = Dummy of int (* Skip tag 0. *) | I of int | II of int * int | Cons of t
+let rec t_of_len = function
+  | len when len <= 1 -> assert false
+  | 2 -> I 1
+  | 3 -> II (2, 3)
+  | len -> Cons (t_of_len (len - 2))
+
+let marshalled_data = Hashtbl.create 17
+let[@inline never] get_marshalled_data len : t =
+  Marshal.from_string (Hashtbl.find marshalled_data len) 0
+let precompute_marshalled_data lo hi =
+  for len = lo to hi do
+    if not (Hashtbl.mem marshalled_data len) then
+      Hashtbl.add marshalled_data len (Marshal.to_string (t_of_len len) [])
+  done
+
+let root = ref []
+let[@inline never] do_intern lo hi cnt keep =
+  for j = 0 to cnt-1 do
+    for i = lo to hi do
+      root := get_marshalled_data i :: !root
+    done;
+    if not keep then root := []
+  done
+
+let check_nosample () =
+  Printf.printf "check_nosample\n%!";
+  precompute_marshalled_data 2 3000;
+  start {
+      sampling_rate = 0.;
+      callstack_size = 10;
+      callback = fun _ ->
+        Printf.printf "Callback called with sampling_rate = 0\n";
+        assert(false)
+  };
+  do_intern 2 3000 1 false
+
+let () = check_nosample ()
+
+let check_ephe_full_major () =
+  Printf.printf "check_ephe_full_major\n%!";
+  precompute_marshalled_data 2 3000;
+  let ephes = ref [] in
+  start {
+    sampling_rate = 0.01;
+    callstack_size = 10;
+    callback = fun _ ->
+      let res = Ephemeron.K1.create () in
+      ephes := res :: !ephes;
+      Some res
+  };
+  do_intern 2 3000 1 true;
+  stop ();
+  List.iter (fun e -> assert (Ephemeron.K1.check_key e)) !ephes;
+  Gc.full_major ();
+  List.iter (fun e -> assert (Ephemeron.K1.check_key e)) !ephes;
+  root := [];
+  Gc.full_major ();
+  List.iter (fun e -> assert (not (Ephemeron.K1.check_key e))) !ephes
+
+let () = check_ephe_full_major ()
+
+let check_no_nested () =
+  Printf.printf "check_no_nested\n%!";
+  precompute_marshalled_data 2 300;
+  let in_callback = ref false in
+  start {
+      (* FIXME: we should use 1. to make sure the block is sampled,
+       but the runtime does an infinite loop in native mode in this
+       case. This bug will go away when the sampling of natively
+       allocated will be correctly implemented. *)
+      sampling_rate = 0.5;
+      callstack_size = 10;
+      callback = fun _ ->
+        assert (not !in_callback);
+        in_callback := true;
+        do_intern 100 200 1 false;
+        in_callback := false;
+        None
+  };
+  do_intern 100 200 1 false;
+  stop ()
+
+let () = check_no_nested ()
+
+let check_distrib lo hi cnt rate =
+  Printf.printf "check_distrib %d %d %d %f\n%!" lo hi cnt rate;
+  precompute_marshalled_data lo hi;
+  let smp = ref 0 in
+  start {
+      sampling_rate = rate;
+      callstack_size = 10;
+      callback = fun info ->
+        (* We also allocate the list constructor in the minor heap. *)
+        if info.kind = Unmarshalled then begin
+          begin match info.tag, info.size with
+          | 1, 1 | 2, 2 | 3, 1 -> ()
+          | _ -> assert false
+          end;
+          assert (info.n_samples > 0);
+          smp := !smp + info.n_samples
+        end;
+        None
+    };
+  do_intern lo hi cnt false;
+  stop ();
+
+  (* The probability distribution of the number of samples follows a
+     binomial distribution of parameters tot_alloc and rate. Given
+     that tot_alloc*rate and tot_alloc*(1-rate) are large (i.e., >
+     100), this distribution is approximately equal to a normal
+     distribution. We compute a 1e-8 confidence interval for !smp
+     using quantiles of the normal distribution, and check that we are
+     in this confidence interval. *)
+  let tot_alloc = cnt*(lo+hi)*(hi-lo+1)/2 in
+  assert (float tot_alloc *. rate > 100. &&
+          float tot_alloc *. (1. -. rate) > 100.);
+  let mean = float tot_alloc *. rate in
+  let stddev = sqrt (float tot_alloc *. rate *. (1. -. rate)) in
+  (* This assertion has probability to fail close to 1e-8. *)
+  assert (abs_float (mean -. float !smp) <= stddev *. 5.7)
+
+let () =
+  check_distrib 2 3000 3 0.00001;
+  check_distrib 2 3000 1 0.0001;
+  check_distrib 2 2000 1 0.01;
+  check_distrib 2 2000 1 0.9;
+  check_distrib 300000 300000 20 0.1
+
+(* FIXME : in bytecode mode, the function [caml_get_current_callstack_impl],
+   which is supposed to capture the current call stack, does not have access
+   to the current value of [pc]. Therefore, depending on how the C call is
+   performed, we may miss the first call stack slot in the captured backtraces.
+   This is the reason why the reference file is different in native and
+   bytecode modes.
+
+   Note that [Printexc.get_callstack] does not suffer from this problem, because
+   this function is actually an automatically generated stub which performs th
+   C call. This is because [Printexc.get_callstack] is not declared as external
+   in the mli file. *)
+
+let[@inline never] check_callstack () =
+  Printf.printf "check_callstack\n%!";
+  precompute_marshalled_data 2 300;
+  let callstack = ref None in
+  start {
+      (* FIXME: we should use 1. to make sure the block is sampled,
+       but the runtime does an infinite loop in native mode in this
+       case. This bug will go away when the sampling of natively
+       allocated will be correctly implemented. *)
+      sampling_rate = 0.5;
+      callstack_size = 10;
+      callback = fun info ->
+        if info.kind = Unmarshalled then callstack := Some info.callstack;
+        None
+    };
+  do_intern 2 300 1 false;
+  stop ();
+  match !callstack with
+  | None -> assert false
+  | Some cs -> Printexc.print_raw_backtrace stdout cs
+
+let () = check_callstack ()
+
+let () =
+  Printf.printf "OK !\n"

--- a/testsuite/tests/statmemprof/intern.opt.reference
+++ b/testsuite/tests/statmemprof/intern.opt.reference
@@ -1,0 +1,14 @@
+check_nosample
+check_ephe_full_major
+check_no_nested
+check_distrib 2 3000 3 0.000010
+check_distrib 2 3000 1 0.000100
+check_distrib 2 2000 1 0.010000
+check_distrib 2 2000 1 0.900000
+check_distrib 300000 300000 20 0.100000
+check_callstack
+Raised by primitive operation at file "marshal.ml", line 61, characters 9-35
+Called from file "intern.ml", line 32, characters 14-35
+Called from file "intern.ml", line 168, characters 2-25
+Called from file "intern.ml", line 174, characters 9-27
+OK !

--- a/testsuite/tests/statmemprof/ocamltests
+++ b/testsuite/tests/statmemprof/ocamltests
@@ -2,3 +2,4 @@ arrays_in_major.ml
 arrays_in_minor.ml
 lists_in_minor.ml
 exception_callback.ml
+intern.ml


### PR DESCRIPTION
This PR implements memprof tracking for unmarshaled data.

This is performed by traversing the unmarshaled section after unmarshalling is complete. The reasons for not calling the memprof tracking function during unmarshaling are:
- The current code is less invasive in the intern.c code.
- In the current code, there is no performance penalty when memprof is disabled (while some code would have to be executed at every unmarshalled block otherwise)
- Benchmarking suggests that even when memprof is enabled, re-traversing the unmarshaled section is faster. Perhaps the reason in that the hot part of the re-traversing algorithm is a very tight loop.

In addition to this, this PR implements memprof's own root tracking mechanism for the postponed queue. Calling the `caml_xxx_global_root` functions turned out to be rather slow.

TODO:
- [x] Write tests