### PR TITLE
Statmemprof optimisation 1/3: optimise call stack collection

### DIFF
--- a/Changes
+++ b/Changes
@@ -45,6 +45,9 @@ Working version
    OCaml callback when called from C.
    (Jacques-Henri Jourdan, review by Stephen Dolan and Gabriel Scherer)
 
+- #8731: Statmemprof optimisations.
+   (Stephen Dolan, review by ??)
+
 ### Standard library:
 
 - #8657: Optimization in [Array.make] when initializing with unboxed

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -351,9 +351,12 @@ CAMLprim value caml_get_exception_backtrace(value unit)
 CAMLprim value caml_get_current_callstack(value max_frames_value) {
   CAMLparam1(max_frames_value);
   CAMLlocal1(res);
+  caml_callstack stk;
 
-  res = caml_alloc(caml_current_callstack_size(Long_val(max_frames_value)), 0);
-  caml_current_callstack_write(res);
+  caml_collect_current_callstack(Long_val(max_frames_value), &stk);
+  res = caml_alloc(stk.length, 0);
+  caml_write_callstack(&stk, res);
+  caml_free_callstack(&stk);
 
   CAMLreturn(res);
 }

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -95,8 +95,10 @@ typedef struct {
 extern frame_descr ** caml_frame_descriptors;
 extern uintnat caml_frame_descriptors_mask;
 
+#define Hash_retaddr_mask(addr, mask) \
+  (((uintnat)(addr) >> 3) & (mask))
 #define Hash_retaddr(addr) \
-  (((uintnat)(addr) >> 3) & caml_frame_descriptors_mask)
+  Hash_retaddr_mask(addr, caml_frame_descriptors_mask)
 
 extern void caml_init_frame_descriptors(void);
 extern void caml_register_frametable(intnat *);
@@ -116,8 +118,6 @@ extern value * caml_globals[];
 extern char caml_globals_map[];
 extern intnat caml_globals_inited;
 extern intnat * caml_frametable[];
-
-CAMLextern frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -189,7 +189,8 @@ enum ml_alloc_kind {
    make sure the postponed queue will be handled fully at some
    point. */
 static value do_callback(tag_t tag, uintnat wosize, uintnat occurrences,
-                         caml_callstack* callstack, enum ml_alloc_kind cb_kind) {
+                         caml_callstack* callstack, enum ml_alloc_kind cb_kind)
+{
   CAMLparam0();
   CAMLlocal2(sample_info, vcallstack);
   value res; /* Not a root, can be an exception result. */


### PR DESCRIPTION
This is the first of a series of 3 PRs that do some performance optimisation for statmemprof. I've been testing with the following short program, which is a bit of a worst-case example:

```
let samples = ref 0

let rec recur n f = match n with 0 -> f () | n -> recur (n-1) f + 1

let () =
  Gc.Memprof.start { sampling_rate = 0.01; callstack_size = 10;
                     callback = fun _ -> incr samples; None };

  for i = 1 to 10_000_000 do
    let d = recur 20 (fun () ->
      Array.make 20 0 |> ignore; ref 42 |> Sys.opaque_identity |> ignore; 0) in
    assert (d = 20)
  done;

  Printf.printf "%d\n" !samples
```

On trunk, this program gets about 2.2x slower with statmemprof, compared to the execution time with the `Gc.Memprof` line commented out. (The good news is that this is a fairly contrived program, doing nothing but allocation, and even on this program the overhead goes to zero with a sufficiently low parameter).

The overhead is roughly halved with these three patches, with this PR removing about 20% of it.

The major optimisation here, in the first commit, is to avoid traversing the stack twice when collecting a callstack. The previous implementation of callstack collection walked the stack once to work out the length of the callstack, then again to collect the actual data. This is a false economy: the extra copy introduced by first collecting the stack into a too-large buffer is cheaper than the second stack walk.

This simplifies some code in `memprof.c`: we no longer need to have seperate codepaths for collecting callstacks on major and minor allocations, because the intermediate buffer is not under the control of the GC.

The second commit in this PR is a minor refactoring of caml_next_frame_descriptor, to make it a `static` function and to pass `caml_frame_descriptors` and `caml_frame_descriptors_mask` in local variables rather than reloading them from globals for each callstack entry. This is not because access to globals is especially slow: it is because previously, the C compiler was unable to prove that these globals were not modified during the loop, and so could not cache their values. Now it can cache these values in registers.