### PR TITLE
Drop dependency utils/config.ml ← Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ endif
 
 # The configuration file
 
-utils/config.ml: utils/config.mlp Makefile.config utils/Makefile Makefile
+utils/config.ml: utils/config.mlp Makefile.config utils/Makefile
 	$(MAKE) -C utils config.ml
 
 ifeq "$(UNIX_OR_WIN32)" "unix"


### PR DESCRIPTION
This addresses @gasche's comment in https://github.com/ocaml/ocaml/commit/11c3df41ed19a5dc729b4309dd616801dce2cf5f#r30438301.

At the time the comment was written, I would have had the same opinion as in https://github.com/ocaml/ocaml/pull/8626#issuecomment-484483522, but the addition of Dune files means @trefis refactored the generation of `utils/config.ml` and the root recipe in  https://github.com/ocaml/ocaml/commit/e292cb97c5101b20bcc46d0cd5f2cf00dc8e02d5 is now clearly trivial, so removing the dependency makes sense to me.