### PR TITLE
Don't call `git ls-files` on every invocation of make

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -229,6 +229,10 @@ installation, the following targets may be of use:
 
 `make -C testsuite parallel`:: see link:testsuite/HACKING.adoc[]
 
+Additionally, there are some developer specific targets in link:Makefile.dev[].
+These targets are automatically available when working in a Git clone of the
+repository, but are not available from a tarball.
+
 === Bootstrapping
 
 The OCaml compiler is bootstrapped. This means that

--- a/Makefile
+++ b/Makefile
@@ -1267,34 +1267,9 @@ partialclean::
 
 beforedepend:: bytecomp/opcodes.ml bytecomp/opcodes.mli
 
-# Testing the parser -- see parsing/HACKING.adoc
-
-SOURCE_FILES=$(shell git ls-files '*.ml' '*.mli' | grep -v boot/menhir/parser)
-
-AST_FILES=$(addsuffix .ast,$(SOURCE_FILES))
-
-build-all-asts: $(AST_FILES)
-
-CAMLC_DPARSETREE := \
-	$(CAMLRUN) ./ocamlc -nostdlib -nopervasives \
-	  -stop-after parsing -dparsetree
-
-%.ml.ast: %.ml ocamlc
-	$(CAMLC_DPARSETREE) $< 2> $@ || exit 0
-# `|| exit 0` : some source files will fail to parse
-# (for example, they are meant as toplevel scripts
-# rather than source files, or are parse-error tests),
-# we ignore the failure in that case
-
-%.mli.ast: %.mli ocamlc
-	$(CAMLC_DPARSETREE) $< 2> $@ || exit 0
-
-.PHONY: list-all-asts
-list-all-asts:
-	@for f in $(AST_FILES); do echo "'$$f'"; done
-
-partialclean::
-	rm -f $(AST_FILES)
+ifneq "$(wildcard .git)" ""
+include Makefile.dev
+endif
 
 # Default rules
 

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -13,7 +13,7 @@
 #*                                                                        *
 #**************************************************************************
 
-# Developer-only rules
+# Developer-only rules, included in Makefile when a Git repository is detected.
 
 # Testing the parser -- see parsing/HACKING.adoc
 

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -21,7 +21,10 @@ SOURCE_FILES=$(shell git ls-files '*.ml' '*.mli' | grep -v boot/menhir/parser)
 
 AST_FILES=$(addsuffix .ast,$(SOURCE_FILES))
 
-build-all-asts: $(AST_FILES)
+build-all-asts:
+# Recursive invocation ensures that `git ls-files` is not executed on every
+# invocation of make
+	@$(MAKE) --no-print-directory $(AST_FILES)
 
 CAMLC_DPARSETREE := \
 	$(CAMLRUN) ./ocamlc -nostdlib -nopervasives \

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -1,0 +1,45 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*            Gabriel Scherer, projet Parsifal, INRIA Saclay              *
+#*                                                                        *
+#*   Copyright 2018 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# Developer-only rules
+
+# Testing the parser -- see parsing/HACKING.adoc
+
+SOURCE_FILES=$(shell git ls-files '*.ml' '*.mli' | grep -v boot/menhir/parser)
+
+AST_FILES=$(addsuffix .ast,$(SOURCE_FILES))
+
+build-all-asts: $(AST_FILES)
+
+CAMLC_DPARSETREE := \
+	$(CAMLRUN) ./ocamlc -nostdlib -nopervasives \
+	  -stop-after parsing -dparsetree
+
+%.ml.ast: %.ml ocamlc
+	$(CAMLC_DPARSETREE) $< 2> $@ || exit 0
+# `|| exit 0` : some source files will fail to parse
+# (for example, they are meant as toplevel scripts
+# rather than source files, or are parse-error tests),
+# we ignore the failure in that case
+
+%.mli.ast: %.mli ocamlc
+	$(CAMLC_DPARSETREE) $< 2> $@ || exit 0
+
+.PHONY: list-all-asts
+list-all-asts:
+	@for f in $(AST_FILES); do echo "'$$f'"; done
+
+partialclean::
+	rm -f $(AST_FILES)


### PR DESCRIPTION
This is a more permanently solution than that proposed in https://github.com/ocaml/ocaml/issues/8742#issuecomment-502471968.

An alternative way would be to fall-back to using `find` instead of `git ls-files` if the `.git` directory/file is not present (i.e. the build tree is from a tarball), but that introduces an unnecessary maintenance overhead. With this change, any bugs in the process should only affect developers who are building the `*.ast` files.

A fix will be wanted on 4.08 and 4.09.