### PR TITLE
Fix Thread sanitizer after GPR#8691.

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -152,6 +152,7 @@ static void st_masterlock_release(st_masterlock * m)
   pthread_cond_signal(&m->is_free);
 }
 
+CAMLno_tsan  /* This can be called for reading [waiters] without locking. */
 static INLINE int st_masterlock_waiters(st_masterlock * m)
 {
   return m->waiters;

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -434,6 +434,15 @@ extern void caml_instr_atexit (void);
 
 #endif /* CAML_INSTR */
 
+/* Macro used to deactivate thread sanitizer on some functions. */
+#define CAMLno_tsan
+#if defined(__has_feature)
+#  if __has_feature(thread_sanitizer)
+#    undef CAMLno_tsan
+#    define CAMLno_tsan __attribute__((no_sanitize("thread")))
+#  endif
+#endif
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -102,6 +102,8 @@ void caml_process_pending_signals(void)
   }
 }
 
+CAMLno_tsan /* When called from [caml_record_signal], these memory
+               accesses may not be synchronized. */
 void caml_set_something_to_do(void)
 {
   caml_something_to_do = 1;
@@ -121,11 +123,11 @@ void caml_set_something_to_do(void)
        in caml_garbage_collection
 */
 
-void caml_record_signal(int signal_number)
+CAMLno_tsan void caml_record_signal(int signal_number)
 {
-  caml_set_something_to_do();
   caml_pending_signals[signal_number] = 1;
   signals_are_pending = 1;
+  caml_set_something_to_do();
 }
 
 /* Management of blocking sections. */
@@ -158,6 +160,7 @@ CAMLexport void (*caml_leave_blocking_section_hook)(void) =
 CAMLexport int (*caml_try_leave_blocking_section_hook)(void) =
    caml_try_leave_blocking_section_default;
 
+CAMLno_tsan /* The read of [caml_something_to_do] is no synchronized. */
 CAMLexport void caml_enter_blocking_section(void)
 {
   while (1){

--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -179,8 +179,7 @@ $make -s distclean || :
 set_config_var OC_CFLAGS "-O1 \
 -fno-strict-aliasing -fwrapv -fno-omit-frame-pointer \
 -Wall -Werror \
--fsanitize=thread \
--fsanitize-blacklist=$(pwd)/tools/ci/inria/tsan-suppr.txt"
+-fsanitize=thread"
 
 # Build the system
 make $jobs world.opt

--- a/tools/ci/inria/tsan-suppr.txt
+++ b/tools/ci/inria/tsan-suppr.txt
@@ -1,6 +1,0 @@
-# The treatment of pending signals involves unsynchronized accesses
-fun:caml_record_signal
-fun:caml_process_pending_signals
-fun:caml_leave_blocking_section
-# st_masterlock_waiters polls m->waiters without locking
-fun:st_masterlock_waiters


### PR DESCRIPTION
GPR#8691 refactored the signal/async callback system, and introduced
new data races to `caml_something_to_do` and friends. These data races
morally already existed and are "benign", in the sense that they can
only cause more checks for async callbacks.

The corresponding functions are now marked with a special attribute for
whitelisting them. We do no longer use -fsanitize-blacklist, which
seemed to fail preventing warnings (???).