### PR TITLE
[hashtbl] Restore ongoing traversal status after filter_map_inplace

### DIFF
--- a/Changes
+++ b/Changes
@@ -472,6 +472,9 @@ Working version
   off.
   (Jacques Garrigue, report by Francois Pottier, review by Leo White)
 
+- #8746: Hashtbl: Restore ongoing traversal status after filter_map_inplace
+  (Mehdi Bouaziz, review by Alain Frisch)
+
 - #8747, #9709: incorrect principality warning on functional updates of records
   (Jacques Garrigue, report and review by Thomas Refis)
 

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -196,7 +196,8 @@ let filter_map_inplace f h =
   try
     for i = 0 to Array.length d - 1 do
       filter_map_inplace_bucket f h i Empty h.data.(i)
-    done
+    done;
+    if not old_trav then flip_ongoing_traversal h
   with exn when not old_trav ->
     flip_ongoing_traversal h;
     raise exn

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 538, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 539, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", lin
 Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 538, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 539, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.force_lazy_block.(fun) in file "camlinternalLazy.ml", line 35, characters 56-63
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -274,6 +274,12 @@ let () =
   let h = Hashtbl.create 16 in
   for i = 1 to 1000 do Hashtbl.add h i (i * 2) done;
   Printf.printf "%i elements\n" (Hashtbl.length h);
+  let () =
+    (* Check that filter_map_inplace of nothing changes nothing *)
+    let marshaled_before = Marshal.to_string h [Marshal.No_sharing] in
+    Hashtbl.filter_map_inplace (fun _k v -> Some v) h;
+    let marshaled_after = Marshal.to_string h [Marshal.No_sharing] in
+    assert (marshaled_before = marshaled_after) in
   Hashtbl.filter_map_inplace (fun k v ->
       if k mod 100 = 0 then ((*Hashtbl.add h v v;*) Some (v / 100)) else None)
     h;


### PR DESCRIPTION
Unlike `iter` and `fold`, `filter_map_inplace` forgot to restore the ongoing traversal status, leading to unoptimized `resize` afterwards.

Running `filter_map_inplace` with the identity-like function should change nothing.