### PR TITLE
try to pass on CFLAGS and LDFLAGS more thoroughly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -644,6 +644,11 @@ AS_CASE([$CC,$host],
 )
 
 
+# Respect LDFLAGS and CFLAGS
+common_cflags="$common_cflags $CFLAGS"
+oc_ldflags="$oc_ldflags $LDFLAGS"
+
+
 ## Program to use to install files
 AC_PROG_INSTALL
 


### PR DESCRIPTION
This change was made because OpenBSD needs ``LDFLAGS`` with ``-Wl,-znotext``.
With this change sometimes the ``CFLAGS`` will be passed twice to ``cc`` while building OCaml.