### PR TITLE
amd64: align data section to word boundary

### DIFF
--- a/Changes
+++ b/Changes
@@ -85,6 +85,10 @@ Working version
   (Gabriel Scherer and Florian Angeletti,
    review by Florian Angeletti and Gabriel Radanne)
 
+- #8751: fix bug that could result in misaligned data section when compiling to
+  native-code on amd64.  (observed with the mingw64 compiler)
+  (Nicolás Ojeda Bär, review by David Allsopp)
+
 OCaml 4.09.0
 ------------
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -962,6 +962,7 @@ let emit_item = function
 
 let data l =
   D.data ();
+  D.align 8;
   List.iter emit_item l
 
 (* Beginning / end of an assembly file *)


### PR DESCRIPTION
We came across a case where compiling with `mingw64` results in misaligned statically allocated constants in the data section. This patch fixes the issue. Incidentally, both `arm64` ([here](https://github.com/ocaml/ocaml/blob/637546168619e3a0806c79289b29839d8933e3e8/asmcomp/arm64/emit.mlp#L958)) and `power` ([here](https://github.com/ocaml/ocaml/blob/637546168619e3a0806c79289b29839d8933e3e8/asmcomp/power/emit.mlp#L1171)) explicitly align the data items to a word boundary.

Unfortunately, I haven't been able to come up with a small reproduction case. 