### PR TITLE
add a new Travis CI check that 'make alldepend' is a no-op

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
       XARCH=x64
       CONFIG_ARG=--enable-dependency-generation
       MAKE_ARG=-j
+  - env: CI_KIND=check-depend
   - env: CI_KIND=changes
   - env: CI_KIND=manual
   - env: CI_KIND=check-typo

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -43,4 +43,14 @@ BEST_OCAMLC := $(call choose_best,ocamlc)
 BEST_OCAMLOPT := $(call choose_best,ocamlopt)
 BEST_OCAMLLEX := $(call choose_best,lex/ocamllex)
 
-BEST_OCAMLDEP := $(BEST_OCAMLC) -depend
+# We want to be able to compute dependencies even if the bytecode compiler
+# is not built yet, using the bootstrap compiler.
+
+# Unlike other tools, there is no risk of mixing incompatible
+# bootrap-compiler and host-compiler object files, as ocamldep only
+# produces text output.
+BEST_OCAMLDEP := $(strip $(if \
+   $(and $(wildcard $(ROOTDIR)/ocamlc.opt),$(strip \
+      $(call check_not_stale,boot/ocamlc,ocamlc.opt))), \
+    $(ROOTDIR)/ocamlc.opt -depend, \
+    $(BOOT_OCAMLC) -depend))


### PR DESCRIPTION
Parallel build breaks in the development version when we forget to run `make alldepend` after some of our changes. (The releases are safe from this issue because refreshing dependencies is part of the release process.) This is annoying¹.

The present PR adds a check that `make alldepend` is a no-op at each pull-request. The hope is that people who forgot to run `make alldepend` will get surprised by test failures, instead of random developers surprised by parallel build failures.

This test might prove too fragile in practice, if C-dependency tools have an output that varies too much from one contributor's environment to another. I propose to merge and see, backtracking if problems happen.

¹: As an example of annoyance, see the related comment where @dra27 wonders about the reasonableness of enabling parallel builds on `+trunk` opam switches: https://github.com/ocaml/opam-repository/pull/14257#issuecomment-500322943..
