### PR TITLE
Improve depend from scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1074,6 +1074,9 @@ parsing/parser.ml: boot/menhir/parser.ml parsing/parser.mly \
 parsing/parser.mli: boot/menhir/parser.mli
 	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@
 
+beforedepend:: parsing/camlinternalMenhirLib.ml \
+  parsing/camlinternalMenhirLib.mli \
+	parsing/parser.ml parsing/parser.mli
 
 partialclean:: partialclean-menhir
 

--- a/Makefile
+++ b/Makefile
@@ -1021,7 +1021,7 @@ partialclean::
 # The lexer and parser generators
 
 .PHONY: ocamllex
-ocamllex: ocamlyacc ocamlc
+ocamllex: ocamlyacc
 	$(MAKE) -C lex all
 
 .PHONY: ocamllex.opt

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -184,7 +184,7 @@ ocamldep := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/boot/ocamlc -depend
 depflags := -slash
 depincludes :=
 
-ocamllex := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/lex/ocamllex
+ocamllex := $(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/boot/ocamllex
 
 ocamlyacc := $(ROOTDIR)/yacc/ocamlyacc
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -260,6 +260,9 @@ clean: partialclean
 	      $(LOCAL_SRC)/*.ml $(LOCAL_SRC)/*.mli $(LOCAL_SRC)/Makefile \
 	      $(LOCAL_SRC)/.depend byte/dynlink.mli native/dynlink.mli
 
+.PHONY: beforedepend
+beforedepend: dynlink_platform_intf.mli
+
 .PHONY: depend
 ifeq "$(TOOLCHAIN)" "msvc"
 depend:
@@ -269,15 +272,14 @@ DEPEND_DUMMY_FILES=\
   native/dynlink_compilerlibs.ml \
   byte/dynlink_compilerlibs.mli \
   byte/dynlink.mli \
-  native/dynlink.mli \
-  dynlink_platform_intf.mli
+  native/dynlink.mli
 
-depend:
+depend: beforedepend
 	touch $(DEPEND_DUMMY_FILES)
 	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
-    -I byte -bytecode *.mli *.ml byte/dynlink.ml > .depend
+	  -I byte -bytecode *.mli *.ml byte/dynlink.ml > .depend
 	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
-    -I native -native *.ml native/dynlink.ml >> .depend
+	  -I native -native *.ml native/dynlink.ml >> .depend
 	rm -f $(DEPEND_DUMMY_FILES)
 endif
 


### PR DESCRIPTION
This is a follow-up to the (temporarily paused) #8753 which makes it easier to run `alldepend` from a tree that has not been built yet. One commit fixes a bug in the `dynlink/Makefile` depend rule, the other removes an unnecessary dependency (`ocamlc`) to shorten the required build steps before alldepend can run correctly (the important dependencies are `coldstart` (or some subset of it), `ocamllex` and `ocamlyacc`).

Yesterday I committed incorrect `.depend` files that broke the parallel build. This was due to the `dynlink/Makefile` bug mentioned above.