### PR TITLE
Remove unnecessary warning 64

### DIFF
--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -173,9 +173,6 @@ let file_aux ~tool_name inputfile (type a) parse_fun invariant_fun
     try
       if is_ast_file then begin
         Location.input_name := (input_value ic : string);
-        if !Clflags.unsafe then
-          Location.prerr_warning (Location.in_file !Location.input_name)
-            Warnings.Unsafe_without_parsing;
         let ast = (input_value ic : a) in
         if !Clflags.all_ppx = [] then invariant_fun ast;
         (* if all_ppx <> [], invariant_fun will be called by apply_rewriters *)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -88,7 +88,7 @@ type t =
   | Unboxable_type_in_prim_decl of string   (* 61 *)
   | Constraint_on_gadt                      (* 62 *)
   | Erroneous_printed_signature of string   (* 63 *)
-  | Unsafe_without_parsing                  (* 64 *)
+(*| Unsafe_without_parsing *)               (* 64 *)
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
 ;;
@@ -165,7 +165,6 @@ let number = function
   | Unboxable_type_in_prim_decl _ -> 61
   | Constraint_on_gadt -> 62
   | Erroneous_printed_signature _ -> 63
-  | Unsafe_without_parsing -> 64
   | Redefining_unit _ -> 65
   | Unused_open_bang _ -> 66
 ;;
@@ -617,8 +616,6 @@ let message = function
      ^ s
      ^ "\nBeware that this warning is purely informational and will not catch\n\
         all instances of erroneous printed interface."
-  | Unsafe_without_parsing ->
-     "option -unsafe used with a preprocessor returning a syntax tree"
   | Redefining_unit name ->
       Printf.sprintf
         "This type declaration is defining a new '()' constructor\n\

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -90,7 +90,7 @@ type t =
   | Unboxable_type_in_prim_decl of string   (* 61 *)
   | Constraint_on_gadt                      (* 62 *)
   | Erroneous_printed_signature of string   (* 63 *)
-  | Unsafe_without_parsing                  (* 64 *)
+(*| Unsafe_without_parsing *)               (* 64 *)
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
 ;;


### PR DESCRIPTION
This PR removes warning 64. Warning 64 triggers if you use the `-unsafe` option but pass in a marshalled AST rather than using the parser.

My understanding is that this warning exists because once upon a time `-unsafe` was implemented in the parser and so `-unsafe` would have no affect if you didn't use the parser. These days `-unsafe` is implemented in `cmmgen.ml` and so there is no problem with passing in a marshalled AST.