### PR TITLE
String.copy was copying the string twice

### DIFF
--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -42,7 +42,7 @@ let make n c =
 let init n f =
   B.init n f |> bts
 let copy s =
-  B.copy (bos s) |> bts
+  bts (bos s)
 let sub s ofs len =
   B.sub (bos s) ofs len |> bts
 let fill =


### PR DESCRIPTION
I know there is a deprecation warning on this function.
But, when working with a shared memory (like the one provided in ocamlnet),
being able to copy a string out of the shared memory might still be necessary in some cases.