### PR TITLE
[matching.ml cleanup] introductory changes

### DIFF
--- a/lambda/.ocamlformat
+++ b/lambda/.ocamlformat
@@ -1,0 +1,5 @@
+profile=conventional
+if-then-else=k-r
+indicate-multiline-delimiters=closing-on-separate-line
+break-cases=all
+disable=true

--- a/lambda/.ocamlformat-enable
+++ b/lambda/.ocamlformat-enable
@@ -1,0 +1,1 @@
+matching.ml

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -559,7 +559,15 @@ let up_ok (ps,act_p) l =
      - aliases are removed and replaced by bindings in actions.
    However or-patterns are simplified differently,
      - aliases are not removed
-     - or-patterns (_|p) are changed into _
+     - or-patterns: (_|p) are changed into _
+                    (p|_) are left unchanged
+       This difference is observable in situations like:
+         {v
+             # match lazy (print_int 3; 3) with _ | lazy 2 -> ();;
+             - : unit = ()
+             # match lazy (print_int 3; 3) with lazy 2 | _ -> ();;
+             3- : unit = ()
+         v}
 *)
 
 exception Var of pattern

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2681,13 +2681,15 @@ let rec comp_match_handlers comp_fun partial ctx arg first_match next_matchs =
                 | Unused ->
                     c_rec (Lstaticcatch (body,(i,[]),lambda_unit))
                       total_rem  rem
-            end in
-   try
-      let first_lam,total = comp_fun Partial ctx arg first_match in
-      c_rec first_lam total rem
-   with Unused -> match next_matchs with
-   | [] -> raise Unused
-   | (_,x)::xs ->  comp_match_handlers comp_fun partial ctx arg x xs
+            end
+      in
+      try
+        let first_lam,total = comp_fun Partial ctx arg first_match in
+        c_rec first_lam total rem
+      with Unused ->
+        match next_matchs with
+        | [] -> raise Unused
+        | (_,x)::xs ->  comp_match_handlers comp_fun partial ctx arg x xs
 
 (* To find reasonable names for variables *)
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -644,18 +644,20 @@ let half_simplify_cases args cls =
 
 let rec what_is_cases cases =
   match cases with
-  | ({ pat_desc = Tpat_any } :: _, _) :: rem -> what_is_cases rem
-  | ( { pat_desc = Tpat_var _ | Tpat_or (_, _, _) | Tpat_alias (_, _, _) } :: _,
-      _ )
-    :: _ ->
-      assert false (* applies to simplified matchings only *)
-  | (p :: _, _) :: _ -> p
   | [] -> omega
-  | _ -> assert false
+  | ([], _) :: _ -> assert false
+  | (p :: _, _) :: rem -> (
+      match p.pat_desc with
+      | Tpat_any -> what_is_cases rem
+      | Tpat_var _
+      | Tpat_or (_, _, _)
+      | Tpat_alias (_, _, _) ->
+          (* applies to simplified matchings only *)
+          assert false
+      | _ -> p
+    )
 
 (* A few operations on default environments *)
-let as_matrix cases = get_mins le_pats (List.map (fun (ps, _) -> ps) cases)
-
 let cons_default matrix raise_num default =
   match matrix with
   | [] -> default
@@ -869,6 +871,8 @@ let insert_or_append p ps act ors no =
   attempt [] ors
 
 (* Reconstruct default information from half_compiled  pm list *)
+
+let as_matrix cases = get_mins le_pats (List.map (fun (ps, _) -> ps) cases)
 
 let rec rebuild_matrix pmh =
   match pmh with

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -180,7 +180,7 @@ let specialize_default matcher env =
         let rem = make_rec rem in
         match specialize_matrix matcher pss with
         | [] -> rem
-        | [] :: _ -> ([ [] ], i) :: rem
+        | [] :: _ -> [ ([ [] ], i) ]
         | pss -> (pss, i) :: rem
       )
   in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1199,6 +1199,8 @@ and precompile_var args cls def k =
   match args with
   | [] -> assert false
   | _ :: (((Lvar v as av), _) as arg) :: rargs -> (
+      (* We will use the name of the head column of the submatrix
+         we compile, and this is the *second* column of our argument. *)
       match cls with
       | [ _ ] ->
           (* as split as it can *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -664,20 +664,41 @@ let cons_default matrix raise_num default =
   | _ -> (matrix, raise_num) :: default
 
 let default_compat p def =
-  List.fold_right
-    (fun (pss, i) r ->
-      let qss =
-        List.fold_right
-          (fun qs r ->
-            match qs with
-            | q :: rem when may_compat p q -> rem :: r
-            | _ -> r)
-          pss []
-      in
-      match qss with
-      | [] -> r
-      | _ -> (qss, i) :: r)
-    def []
+  let specialize_row qs =
+    match qs with
+    | q :: rem when may_compat p q -> Some rem
+    | _ -> None
+  in
+  List.filter_map
+    (fun (pss, i) ->
+      match List.filter_map specialize_row pss with
+      | [] -> None
+      | qss -> Some (qss, i))
+    def
+
+let rec optim_default = function
+  | [] -> []
+  | ([] :: _, i) :: _ -> [ ([ [] ], i) ]
+  | (pss, i) :: rem -> (pss, i) :: optim_default rem
+
+let other_default_compat p def =
+  let compat_matcher q rem =
+    if may_compat p q then
+      rem
+    else
+      raise NoMatch
+  in
+  specialize_default compat_matcher def
+
+let same_def (m1, i1) (m2, i2) =
+  i1 = i2 && List.for_all2 MayCompat.compats m1 m2
+
+let default_compat p def =
+  let v1 = default_compat p def in
+  let v2 = other_default_compat p def in
+  let v1_optim = optim_default v1 in
+  assert (List.for_all2 same_def v1_optim v2);
+  v1
 
 (* Or-pattern expansion, variables are a complication w.r.t. the article *)
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -24,7 +24,6 @@ open Parmatch
 open Printf
 open Printpat
 
-
 let dbg = false
 
 (*  See Peyton-Jones, ``The Implementation of functional programming
@@ -42,9 +41,12 @@ let dbg = false
    returns true when they may have a common instance.
 *)
 
-module MayCompat =
-  Parmatch.Compat (struct let equal = Types.may_equal_constr end)
+module MayCompat = Parmatch.Compat (struct
+  let equal = Types.may_equal_constr
+end)
+
 let may_compat = MayCompat.compat
+
 and may_compats = MayCompat.compats
 
 (*
@@ -56,71 +58,73 @@ and may_compats = MayCompat.compats
      - Jump summaries: mapping from exit numbers to contexts
 *)
 
-
 let string_of_lam lam =
-  Printlambda.lambda Format.str_formatter lam ;
+  Printlambda.lambda Format.str_formatter lam;
   Format.flush_str_formatter ()
 
-let all_record_args lbls = match lbls with
-| (_,{lbl_all=lbl_all},_)::_ ->
-    let t =
-      Array.map
-        (fun lbl -> mknoloc (Longident.Lident "?temp?"), lbl,omega)
-        lbl_all in
-    List.iter
-      (fun ((_, lbl,_) as x) ->  t.(lbl.lbl_pos) <- x)
-      lbls ;
-    Array.to_list t
-|  _ -> fatal_error "Parmatch.all_record_args"
+let all_record_args lbls =
+  match lbls with
+  | (_, { lbl_all }, _) :: _ ->
+      let t =
+        Array.map
+          (fun lbl -> (mknoloc (Longident.Lident "?temp?"), lbl, omega))
+          lbl_all
+      in
+      List.iter (fun ((_, lbl, _) as x) -> t.(lbl.lbl_pos) <- x) lbls;
+      Array.to_list t
+  | _ -> fatal_error "Parmatch.all_record_args"
 
 type matrix = pattern list list
 
-let add_omega_column pss = List.map (fun ps -> omega::ps) pss
+let add_omega_column pss = List.map (fun ps -> omega :: ps) pss
 
-type ctx = {left:pattern list ; right:pattern list}
+type ctx = { left : pattern list; right : pattern list }
 
 let pretty_ctx ctx =
   List.iter
-    (fun {left=left ; right=right} ->
+    (fun { left; right } ->
       Format.eprintf "LEFT:%a RIGHT:%a\n" pretty_line left pretty_line right)
     ctx
 
-let le_ctx c1 c2 =
-  le_pats c1.left c2.left &&
-  le_pats c1.right c2.right
+let le_ctx c1 c2 = le_pats c1.left c2.left && le_pats c1.right c2.right
 
-let lshift {left=left ; right=right} = match right with
-| x::xs -> {left=x::left ; right=xs}
-| _ ->  assert false
+let lshift { left; right } =
+  match right with
+  | x :: xs -> { left = x :: left; right = xs }
+  | _ -> assert false
 
-let lforget {left=left ; right=right} = match right with
-| _::xs -> {left=omega::left ; right=xs}
-|  _ -> assert false
+let lforget { left; right } =
+  match right with
+  | _ :: xs -> { left = omega :: left; right = xs }
+  | _ -> assert false
 
 let ctx_lshift ctx =
   if List.length ctx < !Clflags.match_context_rows then
     List.map lshift ctx
-  else (* Context pruning *) begin
+  else
+    (* Context pruning *)
     get_mins le_ctx (List.map lforget ctx)
-  end
 
-let  rshift {left=left ; right=right} = match left with
-| p::ps -> {left=ps ; right=p::right}
-| _ -> assert false
+let rshift { left; right } =
+  match left with
+  | p :: ps -> { left = ps; right = p :: right }
+  | _ -> assert false
 
 let ctx_rshift ctx = List.map rshift ctx
 
 let rec rev_split_at n ps =
-  if n <= 0 then [],ps
-  else match ps with
-  | p::rem ->
-    let left,right = rev_split_at (n-1) rem in
-    p::left,right
-  | _ -> assert false
+  if n <= 0 then
+    ([], ps)
+  else
+    match ps with
+    | p :: rem ->
+        let left, right = rev_split_at (n - 1) rem in
+        (p :: left, right)
+    | _ -> assert false
 
-let  rshift_num n {left=left ; right=right} =
-  let shifted,left = rev_split_at n left in
-  {left=left ; right = shifted@right}
+let rshift_num n { left; right } =
+  let shifted, left = rev_split_at n left in
+  { left; right = shifted @ right }
 
 let ctx_rshift_num n ctx = List.map (rshift_num n) ctx
 
@@ -128,145 +132,155 @@ let ctx_rshift_num n ctx = List.map (rshift_num n) ctx
   All mutable fields are replaced by '_', since side-effects in
   guards can alter these fields *)
 
-let combine {left=left ; right=right} = match left with
-| p::ps -> {left=ps ; right=set_args_erase_mutable p right}
-| _ -> assert false
+let combine { left; right } =
+  match left with
+  | p :: ps -> { left = ps; right = set_args_erase_mutable p right }
+  | _ -> assert false
 
 let ctx_combine ctx = List.map combine ctx
 
 let ncols = function
   | [] -> 0
-  | ps::_ -> List.length ps
-
+  | ps :: _ -> List.length ps
 
 exception NoMatch
+
 exception OrPat
 
 let filter_matrix matcher pss =
-
   let rec filter_rec = function
-    | (p::ps)::rem ->
-        begin match p.pat_desc with
-        | Tpat_alias (p,_,_) ->
-            filter_rec ((p::ps)::rem)
-        | Tpat_var _ ->
-            filter_rec ((omega::ps)::rem)
-        | _ ->
-            begin
-              let rem = filter_rec rem in
-              try
-                matcher p ps::rem
-              with
-              | NoMatch -> rem
-              | OrPat   ->
+    | (p :: ps) :: rem -> (
+        match p.pat_desc with
+        | Tpat_alias (p, _, _) -> filter_rec ((p :: ps) :: rem)
+        | Tpat_var _ -> filter_rec ((omega :: ps) :: rem)
+        | _ -> (
+            let rem = filter_rec rem in
+            try matcher p ps :: rem with
+            | NoMatch -> rem
+            | OrPat -> (
                 match p.pat_desc with
-                | Tpat_or (p1,p2,_) -> filter_rec [(p1::ps) ;(p2::ps)]@rem
+                | Tpat_or (p1, p2, _) ->
+                    filter_rec [ p1 :: ps; p2 :: ps ] @ rem
                 | _ -> assert false
-            end
-        end
+              )
+          )
+      )
     | [] -> []
     | _ ->
-        pretty_matrix Format.err_formatter pss ;
-        fatal_error "Matching.filter_matrix" in
+        pretty_matrix Format.err_formatter pss;
+        fatal_error "Matching.filter_matrix"
+  in
   filter_rec pss
 
 let make_default matcher env =
   let rec make_rec = function
     | [] -> []
-    | ([[]],i)::_ -> [[[]],i]
-    | (pss,i)::rem ->
+    | ([ [] ], i) :: _ -> [ ([ [] ], i) ]
+    | (pss, i) :: rem -> (
         let rem = make_rec rem in
         match filter_matrix matcher pss with
         | [] -> rem
-        | ([]::_) -> ([[]],i)::rem
-        | pss -> (pss,i)::rem in
+        | [] :: _ -> ([ [] ], i) :: rem
+        | pss -> (pss, i) :: rem
+      )
+  in
   make_rec env
 
 let ctx_matcher p =
   let p = normalize_pat p in
   match p.pat_desc with
-  | Tpat_construct (_, cstr,omegas) ->
-      (fun q rem -> match q.pat_desc with
-      | Tpat_construct (_, cstr',args)
-(* NB:  may_constr_equal considers (potential) constructor rebinding *)
-        when Types.may_equal_constr cstr cstr' ->
-          p,args@rem
-      | Tpat_any -> p,omegas @ rem
-      | _ -> raise NoMatch)
-  | Tpat_constant cst ->
-      (fun q rem -> match q.pat_desc with
-      | Tpat_constant cst' when const_compare cst cst' = 0 ->
-          p,rem
-      | Tpat_any -> p,rem
-      | _ -> raise NoMatch)
-  | Tpat_variant (lab,Some omega,_) ->
-      (fun q rem -> match q.pat_desc with
-      | Tpat_variant (lab',Some arg,_) when lab=lab' ->
-          p,arg::rem
-      | Tpat_any -> p,omega::rem
-      | _ -> raise NoMatch)
-  | Tpat_variant (lab,None,_) ->
-      (fun q rem -> match q.pat_desc with
-      | Tpat_variant (lab',None,_) when lab=lab' ->
-          p,rem
-      | Tpat_any -> p,rem
-      | _ -> raise NoMatch)
-  | Tpat_array omegas ->
+  | Tpat_construct (_, cstr, omegas) -> (
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_construct (_, cstr', args)
+        (* NB:  may_constr_equal considers (potential) constructor rebinding *)
+          when Types.may_equal_constr cstr cstr' ->
+            (p, args @ rem)
+        | Tpat_any -> (p, omegas @ rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_constant cst -> (
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_constant cst' when const_compare cst cst' = 0 -> (p, rem)
+        | Tpat_any -> (p, rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_variant (lab, Some omega, _) -> (
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_variant (lab', Some arg, _) when lab = lab' -> (p, arg :: rem)
+        | Tpat_any -> (p, omega :: rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_variant (lab, None, _) -> (
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_variant (lab', None, _) when lab = lab' -> (p, rem)
+        | Tpat_any -> (p, rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_array omegas -> (
       let len = List.length omegas in
-      (fun q rem -> match q.pat_desc with
-      | Tpat_array args when List.length args = len -> p,args @ rem
-      | Tpat_any -> p, omegas @ rem
-      | _ -> raise NoMatch)
-  | Tpat_tuple omegas ->
-      let len = List.length omegas  in
-      (fun q rem -> match q.pat_desc with
-      | Tpat_tuple args when List.length args = len -> p,args @ rem
-      | Tpat_any -> p, omegas @ rem
-      | _ -> raise NoMatch)
-  | Tpat_record (((_, lbl, _) :: _) as l,_) -> (* Records are normalized *)
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_array args when List.length args = len -> (p, args @ rem)
+        | Tpat_any -> (p, omegas @ rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_tuple omegas -> (
+      let len = List.length omegas in
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_tuple args when List.length args = len -> (p, args @ rem)
+        | Tpat_any -> (p, omegas @ rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_record (((_, lbl, _) :: _ as l), _) -> (
+      (* Records are normalized *)
       let len = Array.length lbl.lbl_all in
-      (fun q rem -> match q.pat_desc with
-      | Tpat_record (((_, lbl', _) :: _) as l',_)
-        when Array.length lbl'.lbl_all = len ->
-          let l' = all_record_args l' in
-          p, List.fold_right (fun (_, _,p) r -> p::r) l' rem
-      | Tpat_any -> p,List.fold_right (fun (_, _,p) r -> p::r) l rem
-      | _ -> raise NoMatch)
-  | Tpat_lazy omega ->
-      (fun q rem -> match q.pat_desc with
-      | Tpat_lazy arg -> p, (arg::rem)
-      | Tpat_any      -> p, (omega::rem)
-      | _             -> raise NoMatch)
- | _ -> fatal_error "Matching.ctx_matcher"
-
-
-
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_record (((_, lbl', _) :: _ as l'), _)
+          when Array.length lbl'.lbl_all = len ->
+            let l' = all_record_args l' in
+            (p, List.fold_right (fun (_, _, p) r -> p :: r) l' rem)
+        | Tpat_any -> (p, List.fold_right (fun (_, _, p) r -> p :: r) l rem)
+        | _ -> raise NoMatch
+    )
+  | Tpat_lazy omega -> (
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_lazy arg -> (p, arg :: rem)
+        | Tpat_any -> (p, omega :: rem)
+        | _ -> raise NoMatch
+    )
+  | _ -> fatal_error "Matching.ctx_matcher"
 
 let filter_ctx q ctx =
-
   let matcher = ctx_matcher q in
-
   let rec filter_rec = function
-    | ({right=p::ps} as l)::rem ->
-        begin match p.pat_desc with
-        | Tpat_or (p1,p2,_) ->
-            filter_rec ({l with right=p1::ps}::{l with right=p2::ps}::rem)
-        | Tpat_alias (p,_,_) ->
-            filter_rec ({l with right=p::ps}::rem)
-        | Tpat_var _ ->
-            filter_rec ({l with right=omega::ps}::rem)
-        | _ ->
-            begin let rem = filter_rec rem in
+    | ({ right = p :: ps } as l) :: rem -> (
+        match p.pat_desc with
+        | Tpat_or (p1, p2, _) ->
+            filter_rec
+              ({ l with right = p1 :: ps }
+              :: { l with right = p2 :: ps }
+              :: rem
+              )
+        | Tpat_alias (p, _, _) -> filter_rec ({ l with right = p :: ps } :: rem)
+        | Tpat_var _ -> filter_rec ({ l with right = omega :: ps } :: rem)
+        | _ -> (
+            let rem = filter_rec rem in
             try
               let to_left, right = matcher p ps in
-              {left=to_left::l.left ; right=right}::rem
-            with
-            | NoMatch -> rem
-            end
-        end
+              { left = to_left :: l.left; right } :: rem
+            with NoMatch -> rem
+          )
+      )
     | [] -> []
-    | _ ->  fatal_error "Matching.filter_ctx" in
-
+    | _ -> fatal_error "Matching.filter_ctx"
+  in
   filter_rec ctx
 
 let select_columns pss ctx =
@@ -274,189 +288,183 @@ let select_columns pss ctx =
   List.fold_right
     (fun ps r ->
       List.fold_right
-        (fun {left=left ; right=right} r ->
+        (fun { left; right } r ->
           let transfer, right = rev_split_at n right in
-          try
-            {left = lubs transfer ps @ left ; right=right}::r
-          with
-          | Empty -> r)
+          try { left = lubs transfer ps @ left; right } :: r with Empty -> r)
         ctx r)
     pss []
 
 let ctx_lub p ctx =
   List.fold_right
-    (fun {left=left ; right=right} r ->
+    (fun { left; right } r ->
       match right with
-      | q::rem ->
-          begin try
-            {left=left ; right = lub p q::rem}::r
-          with
-          | Empty -> r
-          end
+      | q :: rem -> (
+          try { left; right = lub p q :: rem } :: r with Empty -> r
+        )
       | _ -> fatal_error "Matching.ctx_lub")
     ctx []
 
 let ctx_match ctx pss =
   List.exists
-    (fun {right=qs} ->  List.exists (fun ps -> may_compats qs ps)  pss)
+    (fun { right = qs } -> List.exists (fun ps -> may_compats qs ps) pss)
     ctx
 
 type jumps = (int * ctx list) list
 
-let pretty_jumps (env : jumps) = match env with
-| [] -> ()
-| _ ->
-    List.iter
-      (fun (i,ctx) ->
-        Printf.fprintf stderr "jump for %d\n" i ;
-        pretty_ctx ctx)
-      env
-
+let pretty_jumps (env : jumps) =
+  match env with
+  | [] -> ()
+  | _ ->
+      List.iter
+        (fun (i, ctx) ->
+          Printf.fprintf stderr "jump for %d\n" i;
+          pretty_ctx ctx)
+        env
 
 let rec jumps_extract i = function
-  | [] -> [],[]
-  | (j,pss) as x::rem as all ->
-      if i=j then pss,rem
-      else if j < i then [],all
+  | [] -> ([], [])
+  | ((j, pss) as x) :: rem as all ->
+      if i = j then
+        (pss, rem)
+      else if j < i then
+        ([], all)
       else
-        let r,rem = jumps_extract i rem in
-        r,(x::rem)
+        let r, rem = jumps_extract i rem in
+        (r, x :: rem)
 
 let rec jumps_remove i = function
   | [] -> []
-  | (j,_)::rem when i=j -> rem
-  | x::rem -> x::jumps_remove i rem
+  | (j, _) :: rem when i = j -> rem
+  | x :: rem -> x :: jumps_remove i rem
 
 let jumps_empty = []
+
 and jumps_is_empty = function
-  |  [] -> true
-  |  _ -> false
+  | [] -> true
+  | _ -> false
 
 let jumps_singleton i = function
-  | []  -> []
-  | ctx ->  [i,ctx]
+  | [] -> []
+  | ctx -> [ (i, ctx) ]
 
-let jumps_add i pss jumps = match pss with
-| [] -> jumps
-| _  ->
-    let rec add = function
-      | [] -> [i,pss]
-      | (j,qss) as x::rem as all ->
-          if j > i then x::add rem
-      else if j < i then (i,pss)::all
-      else (i,(get_mins le_ctx (pss@qss)))::rem in
-    add jumps
+let jumps_add i pss jumps =
+  match pss with
+  | [] -> jumps
+  | _ ->
+      let rec add = function
+        | [] -> [ (i, pss) ]
+        | ((j, qss) as x) :: rem as all ->
+            if j > i then
+              x :: add rem
+            else if j < i then
+              (i, pss) :: all
+            else
+              (i, get_mins le_ctx (pss @ qss)) :: rem
+      in
+      add jumps
 
-
-let rec jumps_union (env1:(int*ctx list)list) env2 = match env1,env2 with
-| [],_ -> env2
-| _,[] -> env1
-| ((i1,pss1) as x1::rem1), ((i2,pss2) as x2::rem2) ->
-    if i1=i2 then
-      (i1,get_mins le_ctx (pss1@pss2))::jumps_union rem1 rem2
-    else if i1 > i2 then
-      x1::jumps_union rem1 env2
-    else
-      x2::jumps_union env1 rem2
-
+let rec jumps_union (env1 : (int * ctx list) list) env2 =
+  match (env1, env2) with
+  | [], _ -> env2
+  | _, [] -> env1
+  | ((i1, pss1) as x1) :: rem1, ((i2, pss2) as x2) :: rem2 ->
+      if i1 = i2 then
+        (i1, get_mins le_ctx (pss1 @ pss2)) :: jumps_union rem1 rem2
+      else if i1 > i2 then
+        x1 :: jumps_union rem1 env2
+      else
+        x2 :: jumps_union env1 rem2
 
 let rec merge = function
-  | env1::env2::rem ->  jumps_union env1 env2::merge rem
+  | env1 :: env2 :: rem -> jumps_union env1 env2 :: merge rem
   | envs -> envs
 
-let rec jumps_unions envs = match envs with
+let rec jumps_unions envs =
+  match envs with
   | [] -> []
-  | [env] -> env
+  | [ env ] -> env
   | _ -> jumps_unions (merge envs)
 
-let jumps_map f env =
-  List.map
-    (fun (i,pss) -> i,f pss)
-    env
+let jumps_map f env = List.map (fun (i, pss) -> (i, f pss)) env
 
 (* Pattern matching before any compilation *)
 
-type pattern_matching =
-  { mutable cases : (pattern list * lambda) list;
-    args : (lambda * let_kind) list ;
-    default : (matrix * int) list}
+type pattern_matching = {
+  mutable cases : (pattern list * lambda) list;
+  args : (lambda * let_kind) list;
+  default : (matrix * int) list
+}
 
 (* Pattern matching after application of both the or-pat rule and the
    mixture rule *)
 
-type pm_or_compiled =
-  {body : pattern_matching ;
-   handlers :
-     (matrix * int * (Ident.t * Lambda.value_kind) list * pattern_matching)
-       list;
-   or_matrix : matrix ; }
+type pm_or_compiled = {
+  body : pattern_matching;
+  handlers :
+    (matrix * int * (Ident.t * Lambda.value_kind) list * pattern_matching) list;
+  or_matrix : matrix
+}
 
 type pm_half_compiled =
   | PmOr of pm_or_compiled
   | PmVar of pm_var_compiled
   | Pm of pattern_matching
 
-and pm_var_compiled =
-    {inside : pm_half_compiled ; var_arg : lambda ; }
+and pm_var_compiled = { inside : pm_half_compiled; var_arg : lambda }
 
 (* Only used inside the various split functions, we only keep [me] when we're
    done splitting / precompiling. *)
-type pm_half_compiled_info =
-    {me : pm_half_compiled ;
-     matrix : matrix ;
-     (* the matrix matched by [me]. Is used to extend the list of reachable trap
+type pm_half_compiled_info = {
+  me : pm_half_compiled;
+  matrix : matrix;
+  (* the matrix matched by [me]. Is used to extend the list of reachable trap
         handlers (aka "default environments") when returning from recursive
         calls. *)
-     top_default : (matrix * int) list ; }
+  top_default : (matrix * int) list
+}
 
 let pretty_cases cases =
   List.iter
-    (fun (ps,_l) ->
-      List.iter
-        (fun p -> Format.eprintf " %a%!" top_pretty p)
-        ps ;
+    (fun (ps, _l) ->
+      List.iter (fun p -> Format.eprintf " %a%!" top_pretty p) ps;
       Format.eprintf "\n")
     cases
 
 let pretty_def def =
-  Format.eprintf "+++++ Defaults +++++\n" ;
+  Format.eprintf "+++++ Defaults +++++\n";
   List.iter
-    (fun (pss,i) -> Format.eprintf "Matrix for %d\n%a" i pretty_matrix pss)
-    def ;
+    (fun (pss, i) -> Format.eprintf "Matrix for %d\n%a" i pretty_matrix pss)
+    def;
   Format.eprintf "+++++++++++++++++++++\n"
 
 let pretty_pm pm =
-  pretty_cases pm.cases ;
-  if pm.default <> [] then
-    pretty_def pm.default
-
+  pretty_cases pm.cases;
+  if pm.default <> [] then pretty_def pm.default
 
 let rec pretty_precompiled = function
   | Pm pm ->
-      Format.eprintf "++++ PM ++++\n" ;
+      Format.eprintf "++++ PM ++++\n";
       pretty_pm pm
   | PmVar x ->
-      Format.eprintf "++++ VAR ++++\n" ;
+      Format.eprintf "++++ VAR ++++\n";
       pretty_precompiled x.inside
   | PmOr x ->
-      Format.eprintf "++++ OR ++++\n" ;
-      pretty_pm x.body ;
-      pretty_matrix Format.err_formatter x.or_matrix ;
+      Format.eprintf "++++ OR ++++\n";
+      pretty_pm x.body;
+      pretty_matrix Format.err_formatter x.or_matrix;
       List.iter
-        (fun (_,i,_,pm) ->
-          eprintf "++ Handler %d ++\n" i ;
+        (fun (_, i, _, pm) ->
+          eprintf "++ Handler %d ++\n" i;
           pretty_pm pm)
         x.handlers
 
 let pretty_precompiled_res first nexts =
-  pretty_precompiled first ;
+  pretty_precompiled first;
   List.iter
     (fun (e, pmh) ->
-      eprintf "** DEFAULT %d **\n" e ;
+      eprintf "** DEFAULT %d **\n" e;
       pretty_precompiled pmh)
     nexts
-
-
 
 (* Identifying some semantically equivalent lambda-expressions,
    Our goal here is also to
@@ -469,87 +477,90 @@ let pretty_precompiled_res first nexts =
    in case action sharing is present.
 *)
 
+module StoreExp = Switch.Store (struct
+  type t = lambda
 
-module StoreExp =
-  Switch.Store
-    (struct
-      type t = lambda
-      type key = lambda
-      let compare_key = Stdlib.compare
-      let make_key = Lambda.make_key
-    end)
+  type key = lambda
 
+  let compare_key = Stdlib.compare
 
-let make_exit i = Lstaticraise (i,[])
+  let make_key = Lambda.make_key
+end)
+
+let make_exit i = Lstaticraise (i, [])
 
 (* Introduce a catch, if worth it *)
-let make_catch d k = match d with
-| Lstaticraise (_,[]) -> k d
-| _ ->
-    let e = next_raise_count () in
-    Lstaticcatch (k (make_exit e),(e,[]),d)
+let make_catch d k =
+  match d with
+  | Lstaticraise (_, []) -> k d
+  | _ ->
+      let e = next_raise_count () in
+      Lstaticcatch (k (make_exit e), (e, []), d)
 
 (* Introduce a catch, if worth it, delayed version *)
 let rec as_simple_exit = function
-  | Lstaticraise (i,[]) -> Some i
-  | Llet (Alias,_k,_,_,e) -> as_simple_exit e
+  | Lstaticraise (i, []) -> Some i
+  | Llet (Alias, _k, _, _, e) -> as_simple_exit e
   | _ -> None
 
-
-let make_catch_delayed handler = match as_simple_exit handler with
-| Some i -> i,(fun act -> act)
-| None ->
-    let i = next_raise_count () in
-(*
+let make_catch_delayed handler =
+  match as_simple_exit handler with
+  | Some i -> (i, fun act -> act)
+  | None -> (
+      let i = next_raise_count () in
+      (*
     Printf.eprintf "SHARE LAMBDA: %i\n%s\n" i (string_of_lam handler);
 *)
-    i,
-    (fun body -> match body with
-    | Lstaticraise (j,_) ->
-        if i=j then handler else body
-    | _ -> Lstaticcatch (body,(i,[]),handler))
-
+      ( i,
+        fun body ->
+          match body with
+          | Lstaticraise (j, _) ->
+              if i = j then
+                handler
+              else
+                body
+          | _ -> Lstaticcatch (body, (i, []), handler) )
+    )
 
 let raw_action l =
-  match make_key l with | Some l -> l | None -> l
+  match make_key l with
+  | Some l -> l
+  | None -> l
 
-
-let tr_raw act = match make_key act with
-| Some act -> act
-| None -> raise Exit
+let tr_raw act =
+  match make_key act with
+  | Some act -> act
+  | None -> raise Exit
 
 let same_actions = function
   | [] -> None
-  | [_,act] -> Some act
-  | (_,act0) :: rem ->
+  | [ (_, act) ] -> Some act
+  | (_, act0) :: rem -> (
       try
         let raw_act0 = tr_raw act0 in
         let rec s_rec = function
           | [] -> Some act0
-          | (_,act)::rem ->
+          | (_, act) :: rem ->
               if raw_act0 = tr_raw act then
                 s_rec rem
               else
-                None in
+                None
+        in
         s_rec rem
-      with
-      | Exit -> None
-
+      with Exit -> None
+    )
 
 (* Test for swapping two clauses *)
 
 let up_ok_action act1 act2 =
   try
-    let raw1 = tr_raw act1
-    and raw2 = tr_raw act2 in
+    let raw1 = tr_raw act1 and raw2 = tr_raw act2 in
     raw1 = raw2
-  with
-  | Exit -> false
+  with Exit -> false
 
-let up_ok (ps,act_p) l =
+let up_ok (ps, act_p) l =
   List.for_all
-    (fun (qs,act_q) ->
-      up_ok_action act_p act_q || not (may_compats ps qs))
+    (fun (qs, act_q) -> up_ok_action act_p act_q || not (may_compats ps qs))
     l
 
 (*
@@ -574,107 +585,102 @@ exception Var of pattern
 let simplify_or p =
   let rec simpl_rec p =
     match p.pat_desc with
-    | Tpat_any | Tpat_var _ -> raise (Var p)
-    | Tpat_alias (q,id,s) ->
-        begin try
-          {p with pat_desc = Tpat_alias (simpl_rec q,id,s)}
-        with
-        | Var q' -> raise (Var {p with pat_desc = Tpat_alias (q', id, s)})
-        end
-    | Tpat_or (p1,p2,o) ->
+    | Tpat_any
+    | Tpat_var _ ->
+        raise (Var p)
+    | Tpat_alias (q, id, s) -> (
+        try { p with pat_desc = Tpat_alias (simpl_rec q, id, s) }
+        with Var q' ->
+          raise (Var { p with pat_desc = Tpat_alias (q', id, s) })
+      )
+    | Tpat_or (p1, p2, o) -> (
         let q1 = simpl_rec p1 in
-        begin try
+        try
           let q2 = simpl_rec p2 in
-          {p with pat_desc = Tpat_or (q1, q2, o)}
-        with
-        | Var q2 -> raise (Var {p with pat_desc = Tpat_or (q1, q2, o)})
-        end
-    | Tpat_record (lbls,closed) ->
+          { p with pat_desc = Tpat_or (q1, q2, o) }
+        with Var q2 -> raise (Var { p with pat_desc = Tpat_or (q1, q2, o) })
+      )
+    | Tpat_record (lbls, closed) ->
         let all_lbls = all_record_args lbls in
-        {p with pat_desc = Tpat_record (all_lbls, closed)}
+        { p with pat_desc = Tpat_record (all_lbls, closed) }
     | _ -> p
   in
-  try
-    simpl_rec p
-  with
-  | Var p -> p
+  try simpl_rec p with Var p -> p
 
-let simplify_cases args cls = match args with
-| [] -> assert false
-| (arg,_)::_ ->
-    let rec simplify = function
-      | [] -> []
-      | ((pat :: patl, action) as cl) :: rem ->
-          begin match pat.pat_desc with
-          | Tpat_var (id, _) ->
-              let k = Typeopt.value_kind pat.pat_env pat.pat_type in
-              (omega :: patl, bind_with_value_kind Alias (id, k) arg action) ::
-              simplify rem
-          | Tpat_any ->
-              cl :: simplify rem
-          | Tpat_alias(p, id,_) ->
-              let k = Typeopt.value_kind pat.pat_env pat.pat_type in
-              simplify ((p :: patl,
-                         bind_with_value_kind Alias (id, k) arg action) :: rem)
-          | Tpat_record ([],_) ->
-              (omega :: patl, action)::
-              simplify rem
-          | Tpat_record (lbls, closed) ->
-              let all_lbls = all_record_args lbls in
-              let full_pat =
-                {pat with pat_desc=Tpat_record (all_lbls, closed)} in
-              (full_pat::patl,action)::
-              simplify rem
-          | Tpat_or _ ->
-              let pat_simple  = simplify_or pat in
-              begin match pat_simple.pat_desc with
-              | Tpat_or _ ->
-                  (pat_simple :: patl, action) ::
-                  simplify rem
-              | _ ->
-                  simplify ((pat_simple::patl,action) :: rem)
-              end
-          | _ -> cl :: simplify rem
-          end
-      | _ -> assert false in
-
-    simplify cls
-
-
+let simplify_cases args cls =
+  match args with
+  | [] -> assert false
+  | (arg, _) :: _ ->
+      let rec simplify = function
+        | [] -> []
+        | ((pat :: patl, action) as cl) :: rem -> (
+            match pat.pat_desc with
+            | Tpat_var (id, _) ->
+                let k = Typeopt.value_kind pat.pat_env pat.pat_type in
+                (omega :: patl, bind_with_value_kind Alias (id, k) arg action)
+                :: simplify rem
+            | Tpat_any -> cl :: simplify rem
+            | Tpat_alias (p, id, _) ->
+                let k = Typeopt.value_kind pat.pat_env pat.pat_type in
+                simplify
+                  ((p :: patl, bind_with_value_kind Alias (id, k) arg action)
+                  :: rem
+                  )
+            | Tpat_record ([], _) -> (omega :: patl, action) :: simplify rem
+            | Tpat_record (lbls, closed) ->
+                let all_lbls = all_record_args lbls in
+                let full_pat =
+                  { pat with pat_desc = Tpat_record (all_lbls, closed) }
+                in
+                (full_pat :: patl, action) :: simplify rem
+            | Tpat_or _ -> (
+                let pat_simple = simplify_or pat in
+                match pat_simple.pat_desc with
+                | Tpat_or _ -> (pat_simple :: patl, action) :: simplify rem
+                | _ -> simplify ((pat_simple :: patl, action) :: rem)
+              )
+            | _ -> cl :: simplify rem
+          )
+        | _ -> assert false
+      in
+      simplify cls
 
 (* Once matchings are simplified one can easily find
    their nature *)
 
-let rec what_is_cases cases = match cases with
-| ({pat_desc=Tpat_any} :: _, _) :: rem -> what_is_cases rem
-| (({pat_desc=(Tpat_var _|Tpat_or (_,_,_)|Tpat_alias (_,_,_))}::_),_)::_
-  -> assert false (* applies to simplified matchings only *)
-| (p::_,_)::_ -> p
-| [] -> omega
-| _ -> assert false
-
-
+let rec what_is_cases cases =
+  match cases with
+  | ({ pat_desc = Tpat_any } :: _, _) :: rem -> what_is_cases rem
+  | ( { pat_desc = Tpat_var _ | Tpat_or (_, _, _) | Tpat_alias (_, _, _) } :: _,
+      _ )
+    :: _ ->
+      assert false (* applies to simplified matchings only *)
+  | (p :: _, _) :: _ -> p
+  | [] -> omega
+  | _ -> assert false
 
 (* A few operations on default environments *)
-let as_matrix cases = get_mins le_pats (List.map (fun (ps,_) -> ps) cases)
+let as_matrix cases = get_mins le_pats (List.map (fun (ps, _) -> ps) cases)
 
 let cons_default matrix raise_num default =
   match matrix with
   | [] -> default
-  | _ -> (matrix,raise_num)::default
+  | _ -> (matrix, raise_num) :: default
 
 let default_compat p def =
   List.fold_right
-    (fun (pss,i) r ->
+    (fun (pss, i) r ->
       let qss =
         List.fold_right
-          (fun qs r -> match qs with
-            | q::rem when may_compat p q -> rem::r
+          (fun qs r ->
+            match qs with
+            | q :: rem when may_compat p q -> rem :: r
             | _ -> r)
-          pss [] in
+          pss []
+      in
       match qss with
       | [] -> r
-      | _  -> (qss,i)::r)
+      | _ -> (qss, i) :: r)
     def []
 
 (* Or-pattern expansion, variables are a complication w.r.t. the article *)
@@ -683,128 +689,128 @@ exception Cannot_flatten
 
 let mk_alpha_env arg aliases ids =
   List.map
-    (fun id -> id,
-      if List.mem id aliases then
-        match arg with
-        | Some v -> v
-        | _      -> raise Cannot_flatten
-      else
-        Ident.create_local (Ident.name id))
+    (fun id ->
+      ( id,
+        if List.mem id aliases then
+          match arg with
+          | Some v -> v
+          | _ -> raise Cannot_flatten
+        else
+          Ident.create_local (Ident.name id) ))
     ids
 
 let rec explode_or_pat arg patl mk_action rem vars aliases = function
-  | {pat_desc = Tpat_or (p1,p2,_)} ->
-      explode_or_pat
-        arg patl mk_action
+  | { pat_desc = Tpat_or (p1, p2, _) } ->
+      explode_or_pat arg patl mk_action
         (explode_or_pat arg patl mk_action rem vars aliases p2)
         vars aliases p1
-  | {pat_desc = Tpat_alias (p,id, _)} ->
-      explode_or_pat arg patl mk_action rem vars (id::aliases) p
-  | {pat_desc = Tpat_var (x, _)} ->
-      let env = mk_alpha_env arg (x::aliases) vars in
-      (omega::patl,mk_action (List.map snd env))::rem
+  | { pat_desc = Tpat_alias (p, id, _) } ->
+      explode_or_pat arg patl mk_action rem vars (id :: aliases) p
+  | { pat_desc = Tpat_var (x, _) } ->
+      let env = mk_alpha_env arg (x :: aliases) vars in
+      (omega :: patl, mk_action (List.map snd env)) :: rem
   | p ->
       let env = mk_alpha_env arg aliases vars in
-      (alpha_pat env p::patl,mk_action (List.map snd env))::rem
+      (alpha_pat env p :: patl, mk_action (List.map snd env)) :: rem
 
-let pm_free_variables {cases=cases} =
+let pm_free_variables { cases } =
   List.fold_right
-    (fun (_,act) r -> Ident.Set.union (free_variables act) r)
+    (fun (_, act) r -> Ident.Set.union (free_variables act) r)
     cases Ident.Set.empty
-
 
 (* Basic grouping predicates *)
 let pat_as_constr = function
-  | {pat_desc=Tpat_construct (_, cstr,_)} -> cstr
+  | { pat_desc = Tpat_construct (_, cstr, _) } -> cstr
   | _ -> fatal_error "Matching.pat_as_constr"
 
 let group_const_int = function
-  | {pat_desc= Tpat_constant Const_int _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_int _) } -> true
+  | _ -> false
 
 let group_const_char = function
-  | {pat_desc= Tpat_constant Const_char _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_char _) } -> true
+  | _ -> false
 
 let group_const_string = function
-  | {pat_desc= Tpat_constant Const_string _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_string _) } -> true
+  | _ -> false
 
 let group_const_float = function
-  | {pat_desc= Tpat_constant Const_float _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_float _) } -> true
+  | _ -> false
 
 let group_const_int32 = function
-  | {pat_desc= Tpat_constant Const_int32 _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_int32 _) } -> true
+  | _ -> false
 
 let group_const_int64 = function
-  | {pat_desc= Tpat_constant Const_int64 _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_int64 _) } -> true
+  | _ -> false
 
 let group_const_nativeint = function
-  | {pat_desc= Tpat_constant Const_nativeint _ } -> true
-  | _                                      -> false
+  | { pat_desc = Tpat_constant (Const_nativeint _) } -> true
+  | _ -> false
 
 and group_constructor = function
-  | {pat_desc = Tpat_construct (_,_,_)} -> true
+  | { pat_desc = Tpat_construct (_, _, _) } -> true
   | _ -> false
 
 and group_variant = function
-  | {pat_desc = Tpat_variant (_, _, _)} -> true
+  | { pat_desc = Tpat_variant (_, _, _) } -> true
   | _ -> false
 
 and group_var = function
-  | {pat_desc=Tpat_any} -> true
+  | { pat_desc = Tpat_any } -> true
   | _ -> false
 
 and group_tuple = function
-  | {pat_desc = (Tpat_tuple _|Tpat_any)} -> true
+  | { pat_desc = Tpat_tuple _ | Tpat_any } -> true
   | _ -> false
 
 and group_record = function
-  | {pat_desc = (Tpat_record _|Tpat_any)} -> true
+  | { pat_desc = Tpat_record _ | Tpat_any } -> true
   | _ -> false
 
 and group_array = function
-  | {pat_desc=Tpat_array _} -> true
+  | { pat_desc = Tpat_array _ } -> true
   | _ -> false
 
 and group_lazy = function
-  | {pat_desc = Tpat_lazy _} -> true
+  | { pat_desc = Tpat_lazy _ } -> true
   | _ -> false
 
-let get_group p = match p.pat_desc with
-| Tpat_any -> group_var
-| Tpat_constant Const_int _ -> group_const_int
-| Tpat_constant Const_char _ -> group_const_char
-| Tpat_constant Const_string _ -> group_const_string
-| Tpat_constant Const_float _ -> group_const_float
-| Tpat_constant Const_int32 _ -> group_const_int32
-| Tpat_constant Const_int64 _ -> group_const_int64
-| Tpat_constant Const_nativeint _ -> group_const_nativeint
-| Tpat_construct _ -> group_constructor
-| Tpat_tuple _ -> group_tuple
-| Tpat_record _ -> group_record
-| Tpat_array _ -> group_array
-| Tpat_variant (_,_,_) -> group_variant
-| Tpat_lazy _ -> group_lazy
-|  _ -> fatal_error "Matching.get_group"
+let get_group p =
+  match p.pat_desc with
+  | Tpat_any -> group_var
+  | Tpat_constant (Const_int _) -> group_const_int
+  | Tpat_constant (Const_char _) -> group_const_char
+  | Tpat_constant (Const_string _) -> group_const_string
+  | Tpat_constant (Const_float _) -> group_const_float
+  | Tpat_constant (Const_int32 _) -> group_const_int32
+  | Tpat_constant (Const_int64 _) -> group_const_int64
+  | Tpat_constant (Const_nativeint _) -> group_const_nativeint
+  | Tpat_construct _ -> group_constructor
+  | Tpat_tuple _ -> group_tuple
+  | Tpat_record _ -> group_record
+  | Tpat_array _ -> group_array
+  | Tpat_variant (_, _, _) -> group_variant
+  | Tpat_lazy _ -> group_lazy
+  | _ -> fatal_error "Matching.get_group"
 
-
-
-let is_or p = match p.pat_desc with
-| Tpat_or _ -> true
-| _ -> false
+let is_or p =
+  match p.pat_desc with
+  | Tpat_or _ -> true
+  | _ -> false
 
 (* Conditions for appending to the Or matrix *)
 let conda p q = not (may_compat p q)
-and condb act ps qs =  not (is_guarded act) && Parmatch.le_pats qs ps
+
+and condb act ps qs = (not (is_guarded act)) && Parmatch.le_pats qs ps
 
 let or_ok p ps l =
   List.for_all
     (function
-      | ({pat_desc=Tpat_or _} as q::qs,act) ->
+      | ({ pat_desc = Tpat_or _ } as q) :: qs, act ->
           conda p q || condb act ps qs
       | _ -> true)
     l
@@ -813,68 +819,79 @@ let or_ok p ps l =
 
 let equiv_pat p q = le_pat p q && le_pat q p
 
-let rec get_equiv p l = match l with
-  | (q::_,_) as cl::rem ->
+let rec get_equiv p l =
+  match l with
+  | ((q :: _, _) as cl) :: rem ->
       if equiv_pat p q then
-        let others,rem = get_equiv p rem in
-        cl::others,rem
+        let others, rem = get_equiv p rem in
+        (cl :: others, rem)
       else
-        [],l
-  | _ -> [],l
-
+        ([], l)
+  | _ -> ([], l)
 
 let insert_or_append p ps act ors no =
   let rec attempt seen = function
-    | (q::qs,act_q) as cl::rem ->
-        if is_or q then begin
+    | ((q :: qs, act_q) as cl) :: rem ->
+        if is_or q then
           if may_compat p q then
             if
-              Typedtree.pat_bound_idents p = [] &&
-              Typedtree.pat_bound_idents q = [] &&
-              equiv_pat p q
-            then (* attempt insert, for equivalent orpats with no variables *)
+              Typedtree.pat_bound_idents p = []
+              && Typedtree.pat_bound_idents q = []
+              && equiv_pat p q
+            then
+              (* attempt insert, for equivalent orpats with no variables *)
               let _, not_e = get_equiv q rem in
               if
-                or_ok p ps not_e && (* check append condition for head of O *)
-                List.for_all        (* check insert condition for tail of O *)
-                  (fun cl -> match cl with
-                  | (q::_,_) -> not (may_compat p q)
-                  | _        -> assert false)
-                  seen
-              then (* insert *)
-                List.rev_append seen ((p::ps,act)::cl::rem), no
-              else (* fail to insert or append *)
-                ors,(p::ps,act)::no
-            else if condb act_q ps qs then (* check condition (b) for append *)
-              attempt (cl::seen) rem
+                or_ok p ps not_e
+                && (* check append condition for head of O *)
+                   List.for_all (* check insert condition for tail of O *)
+                     (fun cl ->
+                       match cl with
+                       | q :: _, _ -> not (may_compat p q)
+                       | _ -> assert false)
+                     seen
+              then
+                (* insert *)
+                (List.rev_append seen ((p :: ps, act) :: cl :: rem), no)
+              else
+                (* fail to insert or append *)
+                (ors, (p :: ps, act) :: no)
+            else if condb act_q ps qs then
+              (* check condition (b) for append *)
+              attempt (cl :: seen) rem
             else
-              ors,(p::ps,act)::no
-          else (* p # q, go on with append/insert *)
-            attempt (cl::seen) rem
-        end else (* q is not an or-pat, go on with append/insert *)
-          attempt (cl::seen) rem
-    | _  -> (* [] in fact *)
-        (p::ps,act)::ors,no in (* success in appending *)
+              (ors, (p :: ps, act) :: no)
+          else
+            (* p # q, go on with append/insert *)
+            attempt (cl :: seen) rem
+        else
+          (* q is not an or-pat, go on with append/insert *)
+          attempt (cl :: seen) rem
+    | _ ->
+        (* [] in fact *)
+        ((p :: ps, act) :: ors, no)
+  in
+  (* success in appending *)
   attempt [] ors
 
 (* Reconstruct default information from half_compiled  pm list *)
 
-let rec rebuild_matrix pmh = match pmh with
+let rec rebuild_matrix pmh =
+  match pmh with
   | Pm pm -> as_matrix pm.cases
-  | PmOr {or_matrix=m} -> m
-  | PmVar x -> add_omega_column  (rebuild_matrix x.inside)
+  | PmOr { or_matrix = m } -> m
+  | PmVar x -> add_omega_column (rebuild_matrix x.inside)
 
-let rec rebuild_default nexts def = match nexts with
-| [] -> def
-| (e, pmh)::rem ->
-    (add_omega_column (rebuild_matrix pmh), e)::
-    rebuild_default rem def
+let rec rebuild_default nexts def =
+  match nexts with
+  | [] -> def
+  | (e, pmh) :: rem ->
+      (add_omega_column (rebuild_matrix pmh), e) :: rebuild_default rem def
 
 let rebuild_nexts arg nexts k =
   List.fold_right
-    (fun (e, pm) k -> (e, PmVar {inside=pm ; var_arg=arg})::k)
+    (fun (e, pm) k -> (e, PmVar { inside = pm; var_arg = arg }) :: k)
     nexts k
-
 
 (*
   Split a matching.
@@ -896,322 +913,332 @@ let rebuild_nexts arg nexts k =
 
 *)
 
-
 let rec split_or argo cls args def =
-
   let cls = simplify_cases args cls in
-
   let rec do_split before ors no = function
-    | [] ->
-        cons_next
-          (List.rev before) (List.rev ors) (List.rev no)
-    | ((p::ps,act) as cl)::rem ->
+    | [] -> cons_next (List.rev before) (List.rev ors) (List.rev no)
+    | ((p :: ps, act) as cl) :: rem ->
         if up_ok cl no then
           if is_or p then
             let ors, no = insert_or_append p ps act ors no in
             do_split before ors no rem
-          else begin
-            if up_ok cl ors then
-              do_split (cl::before) ors no rem
-            else if or_ok p ps ors then
-              do_split before (cl::ors) no rem
-            else
-              do_split before ors (cl::no) rem
-          end
+          else if up_ok cl ors then
+            do_split (cl :: before) ors no rem
+          else if or_ok p ps ors then
+            do_split before (cl :: ors) no rem
+          else
+            do_split before ors (cl :: no) rem
         else
-          do_split before ors (cl::no) rem
+          do_split before ors (cl :: no) rem
     | _ -> assert false
-
   and cons_next yes yesor = function
-    | [] ->
-        precompile_or argo yes yesor args def []
+    | [] -> precompile_or argo yes yesor args def []
     | rem ->
-        let {me=next ; matrix=matrix ; top_default=def},nexts =
-          do_split [] [] [] rem in
+        let { me = next; matrix; top_default = def }, nexts =
+          do_split [] [] [] rem
+        in
         let idef = next_raise_count () in
-        precompile_or
-          argo yes yesor args
+        precompile_or argo yes yesor args
           (cons_default matrix idef def)
-          ((idef,next)::nexts) in
-
+          ((idef, next) :: nexts)
+  in
   do_split [] [] [] cls
 
 (* Ultra-naive splitting, close to semantics, used for extension,
    as potential rebind prevents any kind of optimisation *)
-
 and split_naive cls args def k =
-
   let rec split_exc cstr0 yes = function
     | [] ->
         let yes = List.rev yes in
-        { me = Pm {cases=yes; args=args; default=def;} ;
-          matrix = as_matrix yes ;
-          top_default=def},
-        k
-    | (p::_,_ as cl)::rem ->
+        ( { me = Pm { cases = yes; args; default = def };
+            matrix = as_matrix yes;
+            top_default = def
+          },
+          k )
+    | ((p :: _, _) as cl) :: rem ->
         if group_constructor p then
           let cstr = pat_as_constr p in
-          if cstr = cstr0 then split_exc cstr0 (cl::yes) rem
+          if cstr = cstr0 then
+            split_exc cstr0 (cl :: yes) rem
           else
             let yes = List.rev yes in
-            let {me=next ; matrix=matrix ; top_default=def}, nexts =
-              split_exc cstr [cl] rem in
+            let { me = next; matrix; top_default = def }, nexts =
+              split_exc cstr [ cl ] rem
+            in
             let idef = next_raise_count () in
             let def = cons_default matrix idef def in
-            { me = Pm {cases=yes; args=args; default=def} ;
-              matrix = as_matrix yes ;
-              top_default = def; },
-            (idef,next)::nexts
+            ( { me = Pm { cases = yes; args; default = def };
+                matrix = as_matrix yes;
+                top_default = def
+              },
+              (idef, next) :: nexts )
         else
           let yes = List.rev yes in
-          let {me=next ; matrix=matrix ; top_default=def}, nexts =
-              split_noexc [cl] rem in
-            let idef = next_raise_count () in
-            let def = cons_default matrix idef def in
-            { me = Pm {cases=yes; args=args; default=def} ;
-              matrix = as_matrix yes ;
-              top_default = def; },
-            (idef,next)::nexts
+          let { me = next; matrix; top_default = def }, nexts =
+            split_noexc [ cl ] rem
+          in
+          let idef = next_raise_count () in
+          let def = cons_default matrix idef def in
+          ( { me = Pm { cases = yes; args; default = def };
+              matrix = as_matrix yes;
+              top_default = def
+            },
+            (idef, next) :: nexts )
     | _ -> assert false
-
   and split_noexc yes = function
     | [] -> precompile_var args (List.rev yes) def k
-    | (p::_,_ as cl)::rem ->
+    | ((p :: _, _) as cl) :: rem ->
         if group_constructor p then
-          let yes= List.rev yes in
-          let {me=next; matrix=matrix; top_default=def;},nexts =
-            split_exc (pat_as_constr p) [cl] rem in
+          let yes = List.rev yes in
+          let { me = next; matrix; top_default = def }, nexts =
+            split_exc (pat_as_constr p) [ cl ] rem
+          in
           let idef = next_raise_count () in
-          precompile_var
-            args yes
+          precompile_var args yes
             (cons_default matrix idef def)
-            ((idef,next)::nexts)
-        else split_noexc (cl::yes) rem
-    | _ -> assert false in
-
+            ((idef, next) :: nexts)
+        else
+          split_noexc (cl :: yes) rem
+    | _ -> assert false
+  in
   match cls with
   | [] -> assert false
-  | (p::_,_ as cl)::rem ->
+  | ((p :: _, _) as cl) :: rem ->
       if group_constructor p then
-        split_exc (pat_as_constr p) [cl] rem
+        split_exc (pat_as_constr p) [ cl ] rem
       else
-        split_noexc [cl] rem
+        split_noexc [ cl ] rem
   | _ -> assert false
 
 and split_constr cls args def k =
   let ex_pat = what_is_cases cls in
   match ex_pat.pat_desc with
   | Tpat_any -> precompile_var args cls def k
-  | Tpat_construct (_,{cstr_tag=Cstr_extension _},_) ->
+  | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
       split_naive cls args def k
-  | _ ->
-
+  | _ -> (
       let group = get_group ex_pat in
-
       let rec split_ex yes no = function
-        | [] ->
+        | [] -> (
             let yes = List.rev yes and no = List.rev no in
-            begin match no with
+            match no with
             | [] ->
-                {me = Pm {cases=yes ; args=args ; default=def} ;
-                  matrix = as_matrix yes ;
-                  top_default = def},
-                k
-            | cl::rem ->
-                begin match yes with
+                ( { me = Pm { cases = yes; args; default = def };
+                    matrix = as_matrix yes;
+                    top_default = def
+                  },
+                  k )
+            | cl :: rem -> (
+                match yes with
                 | [] ->
                     (* Could not success in raising up a constr matching up *)
-                    split_noex [cl] [] rem
+                    split_noex [ cl ] [] rem
                 | _ ->
-                    let {me=next ; matrix=matrix ; top_default=def}, nexts =
-                      split_noex [cl] [] rem in
+                    let { me = next; matrix; top_default = def }, nexts =
+                      split_noex [ cl ] [] rem
+                    in
                     let idef = next_raise_count () in
                     let def = cons_default matrix idef def in
-                    {me = Pm {cases=yes ; args=args ; default=def} ;
-                      matrix = as_matrix yes ;
-                      top_default = def },
-                    (idef, next)::nexts
-                end
-            end
-        | (p::_,_) as cl::rem ->
+                    ( { me = Pm { cases = yes; args; default = def };
+                        matrix = as_matrix yes;
+                        top_default = def
+                      },
+                      (idef, next) :: nexts )
+              )
+          )
+        | ((p :: _, _) as cl) :: rem ->
             if group p && up_ok cl no then
-              split_ex (cl::yes) no rem
+              split_ex (cl :: yes) no rem
             else
-              split_ex yes (cl::no) rem
+              split_ex yes (cl :: no) rem
         | _ -> assert false
-
       and split_noex yes no = function
-        | [] ->
+        | [] -> (
             let yes = List.rev yes and no = List.rev no in
-            begin match no with
+            match no with
             | [] -> precompile_var args yes def k
-            | cl::rem ->
-                let {me=next ; matrix=matrix ; top_default=def}, nexts =
-                  split_ex [cl] [] rem in
+            | cl :: rem ->
+                let { me = next; matrix; top_default = def }, nexts =
+                  split_ex [ cl ] [] rem
+                in
                 let idef = next_raise_count () in
-                precompile_var
-                  args yes
+                precompile_var args yes
                   (cons_default matrix idef def)
-                  ((idef,next)::nexts)
-            end
-        | [ps,_ as cl]
-            when List.for_all group_var ps && yes <> [] ->
-       (* This enables an extra division in some frequent cases :
+                  ((idef, next) :: nexts)
+          )
+        | [ ((ps, _) as cl) ] when List.for_all group_var ps && yes <> [] ->
+            (* This enables an extra division in some frequent cases :
           last row is made of variables only *)
-              split_noex yes (cl::no) []
-        | (p::_,_) as cl::rem ->
-            if not (group p) && up_ok cl no then
-              split_noex (cl::yes) no rem
+            split_noex yes (cl :: no) []
+        | ((p :: _, _) as cl) :: rem ->
+            if (not (group p)) && up_ok cl no then
+              split_noex (cl :: yes) no rem
             else
-              split_noex yes (cl::no) rem
-        | _ -> assert false in
-
+              split_noex yes (cl :: no) rem
+        | _ -> assert false
+      in
       match cls with
-      | ((p::_,_) as cl)::rem ->
-          if group p then split_ex [cl] [] rem
-          else split_noex [cl] [] rem
-      | _ ->  assert false
+      | ((p :: _, _) as cl) :: rem ->
+          if group p then
+            split_ex [ cl ] [] rem
+          else
+            split_noex [ cl ] [] rem
+      | _ -> assert false
+    )
 
-and precompile_var  args cls def k = match args with
-| []  -> assert false
-| _::((Lvar v as av,_) as arg)::rargs ->
-    begin match cls with
-    | [_] -> (* as split as it can *)
-        dont_precompile_var args cls def k
-    | _ ->
-(* Precompile *)
-        let var_cls =
-          List.map
-            (fun (ps,act) -> match ps with
-            | _::ps -> ps,act | _     -> assert false)
-            cls
-        and var_def = make_default (fun _ rem -> rem) def in
-        let {me=first ; matrix=matrix}, nexts =
-          split_or (Some v) var_cls (arg::rargs) var_def in
-
-(* Compute top information *)
-        match nexts with
-        | [] -> (* If you need *)
-            dont_precompile_var args cls def k
-        | _  ->
-            let rfirst =
-              {me = PmVar {inside=first ; var_arg = av} ;
-                matrix = add_omega_column matrix ;
-                top_default = rebuild_default nexts def ; }
-            and rnexts = rebuild_nexts av nexts k in
-            rfirst, rnexts
-    end
-|  _ ->
-    dont_precompile_var args cls def k
+and precompile_var args cls def k =
+  match args with
+  | [] -> assert false
+  | _ :: (((Lvar v as av), _) as arg) :: rargs -> (
+      match cls with
+      | [ _ ] ->
+          (* as split as it can *)
+          dont_precompile_var args cls def k
+      | _ -> (
+          (* Precompile *)
+          let var_cls =
+            List.map
+              (fun (ps, act) ->
+                match ps with
+                | _ :: ps -> (ps, act)
+                | _ -> assert false)
+              cls
+          and var_def = make_default (fun _ rem -> rem) def in
+          let { me = first; matrix }, nexts =
+            split_or (Some v) var_cls (arg :: rargs) var_def
+          in
+          (* Compute top information *)
+          match nexts with
+          | [] ->
+              (* If you need *)
+              dont_precompile_var args cls def k
+          | _ ->
+              let rfirst =
+                { me = PmVar { inside = first; var_arg = av };
+                  matrix = add_omega_column matrix;
+                  top_default = rebuild_default nexts def
+                }
+              and rnexts = rebuild_nexts av nexts k in
+              (rfirst, rnexts)
+        )
+    )
+  | _ -> dont_precompile_var args cls def k
 
 and dont_precompile_var args cls def k =
-  {me =  Pm {cases = cls ; args = args ; default = def } ;
-    matrix=as_matrix cls ;
-    top_default=def},k
+  ( { me = Pm { cases = cls; args; default = def };
+      matrix = as_matrix cls;
+      top_default = def
+    },
+    k )
 
-and precompile_or argo cls ors args def k = match ors with
-| [] -> split_constr cls args def k
-| _  ->
-    let rec do_cases = function
-      | ({pat_desc=Tpat_or _} as orp::patl, action)::rem ->
-          let others,rem = get_equiv orp rem in
-          let orpm =
-            {cases =
-              (patl, action)::
-              List.map
-                (function
-                  | (_::ps,action) -> ps,action
-                  | _ -> assert false)
-                others ;
-              args = (match args with _::r -> r | _ -> assert false) ;
-             default = default_compat orp def} in
-          let pm_fv = pm_free_variables orpm in
-          let vars =
-            Typedtree.pat_bound_idents_full orp
-            |> List.filter (fun (id, _, _) -> Ident.Set.mem id pm_fv)
-            |> List.map (fun (id,_,ty) -> id,Typeopt.value_kind orp.pat_env ty)
-          in
-          let or_num = next_raise_count () in
-          let new_patl = Parmatch.omega_list patl in
-
-          let mk_new_action vs =
-            Lstaticraise
-              (or_num, List.map (fun v -> Lvar v) vs) in
-
-          let body,handlers = do_cases rem in
-          explode_or_pat
-            argo new_patl mk_new_action body (List.map fst vars) [] orp,
-          let mat = [[orp]] in
-          ((mat, or_num, vars , orpm):: handlers)
-      | cl::rem ->
-          let new_ord,new_to_catch = do_cases rem in
-          cl::new_ord,new_to_catch
-      | [] -> [],[] in
-
-    let end_body, handlers = do_cases ors in
-    let matrix = as_matrix (cls@ors)
-    and body = {cases=cls@end_body ; args=args ; default=def} in
-    {me = PmOr {body=body ; handlers=handlers ; or_matrix=matrix} ;
-      matrix=matrix ;
-      top_default=def},
-    k
+and precompile_or argo cls ors args def k =
+  match ors with
+  | [] -> split_constr cls args def k
+  | _ ->
+      let rec do_cases = function
+        | (({ pat_desc = Tpat_or _ } as orp) :: patl, action) :: rem ->
+            let others, rem = get_equiv orp rem in
+            let orpm =
+              { cases =
+                  (patl, action)
+                  :: List.map
+                       (function
+                         | _ :: ps, action -> (ps, action)
+                         | _ -> assert false)
+                       others;
+                args =
+                  ( match args with
+                  | _ :: r -> r
+                  | _ -> assert false
+                  );
+                default = default_compat orp def
+              }
+            in
+            let pm_fv = pm_free_variables orpm in
+            let vars =
+              Typedtree.pat_bound_idents_full orp
+              |> List.filter (fun (id, _, _) -> Ident.Set.mem id pm_fv)
+              |> List.map (fun (id, _, ty) ->
+                     (id, Typeopt.value_kind orp.pat_env ty))
+            in
+            let or_num = next_raise_count () in
+            let new_patl = Parmatch.omega_list patl in
+            let mk_new_action vs =
+              Lstaticraise (or_num, List.map (fun v -> Lvar v) vs)
+            in
+            let body, handlers = do_cases rem in
+            ( explode_or_pat argo new_patl mk_new_action body
+                (List.map fst vars) [] orp,
+              let mat = [ [ orp ] ] in
+              (mat, or_num, vars, orpm) :: handlers )
+        | cl :: rem ->
+            let new_ord, new_to_catch = do_cases rem in
+            (cl :: new_ord, new_to_catch)
+        | [] -> ([], [])
+      in
+      let end_body, handlers = do_cases ors in
+      let matrix = as_matrix (cls @ ors)
+      and body = { cases = cls @ end_body; args; default = def } in
+      ( { me = PmOr { body; handlers; or_matrix = matrix };
+          matrix;
+          top_default = def
+        },
+        k )
 
 let split_precompile argo pm =
-  let {me=next}, nexts = split_or argo pm.cases pm.args pm.default  in
-  if dbg && (nexts <> [] || (match next with PmOr _ -> true | _ -> false))
-  then begin
-    Format.eprintf "** SPLIT **\n" ;
-    pretty_pm pm ;
-    pretty_precompiled_res  next nexts
-  end ;
-  next, nexts
-
+  let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
+  if
+    dbg
+    && (nexts <> []
+       ||
+       match next with
+       | PmOr _ -> true
+       | _ -> false
+       )
+  then (
+    Format.eprintf "** SPLIT **\n";
+    pretty_pm pm;
+    pretty_precompiled_res next nexts
+  );
+  (next, nexts)
 
 (* General divide functions *)
 
-let add_line patl_action pm = pm.cases <- patl_action :: pm.cases; pm
+let add_line patl_action pm =
+  pm.cases <- patl_action :: pm.cases;
+  pm
 
-type cell =
-  {pm : pattern_matching ;
-  ctx : ctx list ;
-  pat : pattern}
+type cell = { pm : pattern_matching; ctx : ctx list; pat : pattern }
 
 let add make_matching_fun division eq_key key patl_action args =
   try
-    let (_,cell) = List.find (fun (k,_) -> eq_key key k) division in
+    let _, cell = List.find (fun (k, _) -> eq_key key k) division in
     cell.pm.cases <- patl_action :: cell.pm.cases;
     division
   with Not_found ->
     let cell = make_matching_fun args in
-    cell.pm.cases <- [patl_action] ;
+    cell.pm.cases <- [ patl_action ];
     (key, cell) :: division
 
-
 let divide make eq_key get_key get_args ctx pm =
-
   let rec divide_rec = function
-    | (p::patl,action) :: rem ->
+    | (p :: patl, action) :: rem ->
         let this_match = divide_rec rem in
-        add
-          (make p pm.default ctx)
-          this_match eq_key (get_key p) (get_args p patl,action) pm.args
-    | _ -> [] in
-
+        add (make p pm.default ctx) this_match eq_key (get_key p)
+          (get_args p patl, action)
+          pm.args
+    | _ -> []
+  in
   divide_rec pm.cases
-
 
 let divide_line make_ctx make get_args pat ctx pm =
   let rec divide_rec = function
-    | (p::patl,action) :: rem ->
+    | (p :: patl, action) :: rem ->
         let this_match = divide_rec rem in
         add_line (get_args p patl, action) this_match
-    | _ -> make pm.default pm.args in
-
-  {pm = divide_rec pm.cases ;
-  ctx=make_ctx ctx ;
-  pat=pat}
-
-
+    | _ -> make pm.default pm.args
+  in
+  { pm = divide_rec pm.cases; ctx = make_ctx ctx; pat }
 
 (* Then come various functions,
    There is one set of functions per matching style
@@ -1229,66 +1256,59 @@ let divide_line make_ctx make get_args pat ctx pm =
    new  ``pattern_matching'' records.
 *)
 
-
-
-let rec matcher_const cst p rem = match p.pat_desc with
-| Tpat_or (p1,p2,_) ->
-    begin try
-      matcher_const cst p1 rem with
-    | NoMatch -> matcher_const cst p2 rem
-    end
-| Tpat_constant c1 when const_compare c1 cst = 0 -> rem
-| Tpat_any    -> rem
-| _ -> raise NoMatch
+let rec matcher_const cst p rem =
+  match p.pat_desc with
+  | Tpat_or (p1, p2, _) -> (
+      try matcher_const cst p1 rem with NoMatch -> matcher_const cst p2 rem
+    )
+  | Tpat_constant c1 when const_compare c1 cst = 0 -> rem
+  | Tpat_any -> rem
+  | _ -> raise NoMatch
 
 let get_key_constant caller = function
-  | {pat_desc= Tpat_constant cst} -> cst
+  | { pat_desc = Tpat_constant cst } -> cst
   | p ->
-      Format.eprintf "BAD: %s" caller ;
-      pretty_pat p ;
+      Format.eprintf "BAD: %s" caller;
+      pretty_pat p;
       assert false
 
 let get_args_constant _ rem = rem
 
 let make_constant_matching p def ctx = function
-    [] -> fatal_error "Matching.make_constant_matching"
-  | (_ :: argl) ->
-      let def =
-        make_default
-          (matcher_const (get_key_constant "make" p)) def
-      and ctx =
-        filter_ctx p  ctx in
-      {pm = {cases = []; args = argl ; default = def} ;
-        ctx = ctx ;
-        pat = normalize_pat p}
-
-
-
+  | [] -> fatal_error "Matching.make_constant_matching"
+  | _ :: argl ->
+      let def = make_default (matcher_const (get_key_constant "make" p)) def
+      and ctx = filter_ctx p ctx in
+      { pm = { cases = []; args = argl; default = def };
+        ctx;
+        pat = normalize_pat p
+      }
 
 let divide_constant ctx m =
-  divide
-    make_constant_matching
-    (fun c d -> const_compare c d = 0) (get_key_constant "divide")
-    get_args_constant
-    ctx m
+  divide make_constant_matching
+    (fun c d -> const_compare c d = 0)
+    (get_key_constant "divide")
+    get_args_constant ctx m
 
 (* Matching against a constructor *)
 
-
 let make_field_args loc binding_kind arg first_pos last_pos argl =
   let rec make_args pos =
-    if pos > last_pos
-    then argl
-    else (Lprim(Pfield pos, [arg], loc), binding_kind) :: make_args (pos + 1)
-  in make_args first_pos
+    if pos > last_pos then
+      argl
+    else
+      (Lprim (Pfield pos, [ arg ], loc), binding_kind) :: make_args (pos + 1)
+  in
+  make_args first_pos
 
 let get_key_constr = function
-  | {pat_desc=Tpat_construct (_, cstr,_)} -> cstr.cstr_tag
+  | { pat_desc = Tpat_construct (_, cstr, _) } -> cstr.cstr_tag
   | _ -> assert false
 
-let get_args_constr p rem = match p with
-| {pat_desc=Tpat_construct (_, _, args)} -> args @ rem
-| _ -> assert false
+let get_args_constr p rem =
+  match p with
+  | { pat_desc = Tpat_construct (_, _, args) } -> args @ rem
+  | _ -> assert false
 
 (* NB: matcher_constr applies to default matrices.
 
@@ -1297,143 +1317,161 @@ let get_args_constr p rem = match p with
        This comparison is performed by Types.may_equal_constr.
 *)
 
-let matcher_constr cstr = match cstr.cstr_arity with
-| 0 ->
-    let rec matcher_rec q rem = match q.pat_desc with
-    | Tpat_or (p1,p2,_) ->
-        begin
-          try matcher_rec p1 rem
-          with NoMatch -> matcher_rec p2 rem
-        end
-    | Tpat_construct (_, cstr',[])
-      when Types.may_equal_constr cstr cstr' -> rem
-    | Tpat_any -> rem
-    | _ -> raise NoMatch in
-    matcher_rec
-| 1 ->
-    let rec matcher_rec q rem = match q.pat_desc with
-    | Tpat_or (p1,p2,_) ->
-       (* if both sides of the or-pattern match the head constructor,
+let matcher_constr cstr =
+  match cstr.cstr_arity with
+  | 0 ->
+      let rec matcher_rec q rem =
+        match q.pat_desc with
+        | Tpat_or (p1, p2, _) -> (
+            try matcher_rec p1 rem with NoMatch -> matcher_rec p2 rem
+          )
+        | Tpat_construct (_, cstr', []) when Types.may_equal_constr cstr cstr'
+          ->
+            rem
+        | Tpat_any -> rem
+        | _ -> raise NoMatch
+      in
+      matcher_rec
+  | 1 ->
+      let rec matcher_rec q rem =
+        match q.pat_desc with
+        | Tpat_or (p1, p2, _) -> (
+            (* if both sides of the or-pattern match the head constructor,
             (K p1 | K p2) :: rem
           return (p1 | p2) :: rem *)
-        let r1 = try Some (matcher_rec p1 rem) with NoMatch -> None
-        and r2 = try Some (matcher_rec p2 rem) with NoMatch -> None in
-        begin match r1,r2 with
-        | None, None -> raise NoMatch
-        | Some r1, None -> r1
-        | None, Some r2 -> r2
-        | Some (a1::_), Some (a2::_) ->
-            {a1 with
-             pat_loc = Location.none ;
-             pat_desc = Tpat_or (a1, a2, None)}::
-            rem
-        | _, _ -> assert false
-        end
-    | Tpat_construct (_, cstr', [arg])
-      when Types.may_equal_constr cstr cstr' -> arg::rem
-    | Tpat_any -> omega::rem
-    | _ -> raise NoMatch in
-    matcher_rec
-| _ ->
-    fun q rem -> match q.pat_desc with
-    | Tpat_or (_,_,_) ->
-       (* we cannot preserve the or-pattern as in the arity-1 case,
+            let r1 = try Some (matcher_rec p1 rem) with NoMatch -> None
+            and r2 = try Some (matcher_rec p2 rem) with NoMatch -> None in
+            match (r1, r2) with
+            | None, None -> raise NoMatch
+            | Some r1, None -> r1
+            | None, Some r2 -> r2
+            | Some (a1 :: _), Some (a2 :: _) ->
+                { a1 with
+                  pat_loc = Location.none;
+                  pat_desc = Tpat_or (a1, a2, None)
+                }
+                :: rem
+            | _, _ -> assert false
+          )
+        | Tpat_construct (_, cstr', [ arg ])
+          when Types.may_equal_constr cstr cstr' ->
+            arg :: rem
+        | Tpat_any -> omega :: rem
+        | _ -> raise NoMatch
+      in
+      matcher_rec
+  | _ -> (
+      fun q rem ->
+        match q.pat_desc with
+        | Tpat_or (_, _, _) ->
+            (* we cannot preserve the or-pattern as in the arity-1 case,
           because we cannot express
             (K (p1, .., pn) | K (q1, .. qn))
           as (p1 .. pn | q1 .. qn) *)
-       raise OrPat
-    | Tpat_construct (_,cstr',args)
-      when  Types.may_equal_constr cstr cstr' -> args @ rem
-    | Tpat_any -> Parmatch.omegas cstr.cstr_arity @ rem
-    | _        -> raise NoMatch
+            raise OrPat
+        | Tpat_construct (_, cstr', args)
+          when Types.may_equal_constr cstr cstr' ->
+            args @ rem
+        | Tpat_any -> Parmatch.omegas cstr.cstr_arity @ rem
+        | _ -> raise NoMatch
+    )
 
 let make_constr_matching p def ctx = function
-    [] -> fatal_error "Matching.make_constr_matching"
-  | ((arg, _mut) :: argl) ->
+  | [] -> fatal_error "Matching.make_constr_matching"
+  | (arg, _mut) :: argl ->
       let cstr = pat_as_constr p in
       let newargs =
         if cstr.cstr_inlined <> None then
           (arg, Alias) :: argl
-        else match cstr.cstr_tag with
-          Cstr_constant _ | Cstr_block _ ->
-            make_field_args p.pat_loc Alias arg 0 (cstr.cstr_arity - 1) argl
-        | Cstr_unboxed -> (arg, Alias) :: argl
-        | Cstr_extension _ ->
-            make_field_args p.pat_loc Alias arg 1 cstr.cstr_arity argl in
-      {pm=
-        {cases = []; args = newargs;
-          default = make_default (matcher_constr cstr) def} ;
-        ctx =  filter_ctx p ctx ;
-        pat=normalize_pat p}
-
+        else
+          match cstr.cstr_tag with
+          | Cstr_constant _
+          | Cstr_block _ ->
+              make_field_args p.pat_loc Alias arg 0 (cstr.cstr_arity - 1) argl
+          | Cstr_unboxed -> (arg, Alias) :: argl
+          | Cstr_extension _ ->
+              make_field_args p.pat_loc Alias arg 1 cstr.cstr_arity argl
+      in
+      { pm =
+          { cases = [];
+            args = newargs;
+            default = make_default (matcher_constr cstr) def
+          };
+        ctx = filter_ctx p ctx;
+        pat = normalize_pat p
+      }
 
 let divide_constructor ctx pm =
-  divide
-    make_constr_matching
-    (=) get_key_constr get_args_constr
-    ctx pm
+  divide make_constr_matching ( = ) get_key_constr get_args_constr ctx pm
 
 (* Matching against a variant *)
 
-let rec matcher_variant_const lab p rem = match p.pat_desc with
-| Tpat_or (p1, p2, _) ->
-    begin
-      try
-        matcher_variant_const lab p1 rem
-      with
-      | NoMatch -> matcher_variant_const lab p2 rem
-    end
-| Tpat_variant (lab1,_,_) when lab1=lab -> rem
-| Tpat_any -> rem
-| _   -> raise NoMatch
-
+let rec matcher_variant_const lab p rem =
+  match p.pat_desc with
+  | Tpat_or (p1, p2, _) -> (
+      try matcher_variant_const lab p1 rem
+      with NoMatch -> matcher_variant_const lab p2 rem
+    )
+  | Tpat_variant (lab1, _, _) when lab1 = lab -> rem
+  | Tpat_any -> rem
+  | _ -> raise NoMatch
 
 let make_variant_matching_constant p lab def ctx = function
-    [] -> fatal_error "Matching.make_variant_matching_constant"
-  | (_ :: argl) ->
+  | [] -> fatal_error "Matching.make_variant_matching_constant"
+  | _ :: argl ->
       let def = make_default (matcher_variant_const lab) def
       and ctx = filter_ctx p ctx in
-      {pm={ cases = []; args = argl ; default=def} ;
-        ctx=ctx ;
-        pat = normalize_pat p}
+      { pm = { cases = []; args = argl; default = def };
+        ctx;
+        pat = normalize_pat p
+      }
 
-let matcher_variant_nonconst lab p rem = match p.pat_desc with
-| Tpat_or (_,_,_) -> raise OrPat
-| Tpat_variant (lab1,Some arg,_) when lab1=lab -> arg::rem
-| Tpat_any -> omega::rem
-| _   -> raise NoMatch
-
+let matcher_variant_nonconst lab p rem =
+  match p.pat_desc with
+  | Tpat_or (_, _, _) -> raise OrPat
+  | Tpat_variant (lab1, Some arg, _) when lab1 = lab -> arg :: rem
+  | Tpat_any -> omega :: rem
+  | _ -> raise NoMatch
 
 let make_variant_matching_nonconst p lab def ctx = function
-    [] -> fatal_error "Matching.make_variant_matching_nonconst"
-  | ((arg, _mut) :: argl) ->
+  | [] -> fatal_error "Matching.make_variant_matching_nonconst"
+  | (arg, _mut) :: argl ->
       let def = make_default (matcher_variant_nonconst lab) def
       and ctx = filter_ctx p ctx in
-      {pm=
-        {cases = []; args = (Lprim(Pfield 1, [arg], p.pat_loc), Alias) :: argl;
-          default=def} ;
-        ctx=ctx ;
-        pat = normalize_pat p}
+      { pm =
+          { cases = [];
+            args = (Lprim (Pfield 1, [ arg ], p.pat_loc), Alias) :: argl;
+            default = def
+          };
+        ctx;
+        pat = normalize_pat p
+      }
 
-let divide_variant row ctx {cases = cl; args = al; default=def} =
+let divide_variant row ctx { cases = cl; args = al; default = def } =
   let row = Btype.row_repr row in
   let rec divide = function
-      ({pat_desc = Tpat_variant(lab, pato, _)} as p:: patl, action) :: rem ->
+    | (({ pat_desc = Tpat_variant (lab, pato, _) } as p) :: patl, action)
+      :: rem -> (
         let variants = divide rem in
-        if try Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
-        with Not_found -> true
+        if
+          try Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
+          with Not_found -> true
         then
           variants
-        else begin
+        else
           let tag = Btype.hash_variant lab in
           match pato with
-            None ->
-              add (make_variant_matching_constant p lab def ctx) variants
-                (=) (Cstr_constant tag) (patl, action) al
+          | None ->
+              add
+                (make_variant_matching_constant p lab def ctx)
+                variants ( = ) (Cstr_constant tag) (patl, action) al
           | Some pat ->
-              add (make_variant_matching_nonconst p lab def ctx) variants
-                (=) (Cstr_block tag) (pat :: patl, action) al
-        end
+              add
+                (make_variant_matching_nonconst p lab def ctx)
+                variants ( = ) (Cstr_block tag)
+                (pat :: patl, action)
+                al
+      )
     | _ -> []
   in
   divide cl
@@ -1446,58 +1484,57 @@ let divide_variant row ctx {cases = cl; args = al; default=def} =
 
 let get_args_var _ rem = rem
 
-
 let make_var_matching def = function
-  | [] ->  fatal_error "Matching.make_var_matching"
-  | _::argl ->
-      {cases=[] ;
-        args = argl ;
-        default= make_default get_args_var def}
+  | [] -> fatal_error "Matching.make_var_matching"
+  | _ :: argl ->
+      { cases = []; args = argl; default = make_default get_args_var def }
 
 let divide_var ctx pm =
   divide_line ctx_lshift make_var_matching get_args_var omega ctx pm
 
 (* Matching and forcing a lazy value *)
 
-let get_arg_lazy p rem = match p with
-| {pat_desc = Tpat_any} -> omega :: rem
-| {pat_desc = Tpat_lazy arg} -> arg :: rem
-| _ ->  assert false
+let get_arg_lazy p rem =
+  match p with
+  | { pat_desc = Tpat_any } -> omega :: rem
+  | { pat_desc = Tpat_lazy arg } -> arg :: rem
+  | _ -> assert false
 
-let matcher_lazy p rem = match p.pat_desc with
-| Tpat_or (_,_,_)     -> raise OrPat
-| Tpat_any
-| Tpat_var _          -> omega :: rem
-| Tpat_lazy arg       -> arg :: rem
-| _                   -> raise NoMatch
+let matcher_lazy p rem =
+  match p.pat_desc with
+  | Tpat_or (_, _, _) -> raise OrPat
+  | Tpat_any
+  | Tpat_var _ ->
+      omega :: rem
+  | Tpat_lazy arg -> arg :: rem
+  | _ -> raise NoMatch
 
 (* Inlining the tag tests before calling the primitive that works on
    lazy blocks. This is also used in translcore.ml.
    No other call than Obj.tag when the value has been forced before.
 *)
 
-let prim_obj_tag =
-  Primitive.simple ~name:"caml_obj_tag" ~arity:1 ~alloc:false
+let prim_obj_tag = Primitive.simple ~name:"caml_obj_tag" ~arity:1 ~alloc:false
 
 let get_mod_field modname field =
-  lazy (
-    let mod_ident = Ident.create_persistent modname in
-    let env = Env.add_persistent_structure mod_ident Env.initial_safe_string in
-    match Env.open_pers_signature modname env with
-    | exception Not_found -> fatal_error ("Module "^modname^" unavailable.")
-    | env -> begin
-        match Env.lookup_value (Longident.Lident field) env with
-        | exception Not_found ->
-            fatal_error ("Primitive "^modname^"."^field^" not found.")
-        | (path, _) -> transl_value_path Location.none env path
-      end
-  )
+  lazy
+    (let mod_ident = Ident.create_persistent modname in
+     let env =
+       Env.add_persistent_structure mod_ident Env.initial_safe_string
+     in
+     match Env.open_pers_signature modname env with
+     | exception Not_found ->
+         fatal_error ("Module " ^ modname ^ " unavailable.")
+     | env -> (
+         match Env.lookup_value (Longident.Lident field) env with
+         | exception Not_found ->
+             fatal_error ("Primitive " ^ modname ^ "." ^ field ^ " not found.")
+         | path, _ -> transl_value_path Location.none env path
+       ))
 
-let code_force_lazy_block =
-  get_mod_field "CamlinternalLazy" "force_lazy_block"
-let code_force_lazy =
-  get_mod_field "CamlinternalLazy" "force"
-;;
+let code_force_lazy_block = get_mod_field "CamlinternalLazy" "force_lazy_block"
+
+let code_force_lazy = get_mod_field "CamlinternalLazy" "force"
 
 (* inline_lazy_force inlines the beginning of the code of Lazy.force. When
    the value argument is tagged as:
@@ -1514,49 +1551,73 @@ let inline_lazy_force_cond arg loc =
   let varg = Lvar idarg in
   let tag = Ident.create_local "tag" in
   let force_fun = Lazy.force code_force_lazy_block in
-  Llet(Strict, Pgenval, idarg, arg,
-       Llet(Alias, Pgenval, tag, Lprim(Pccall prim_obj_tag, [varg], loc),
-            Lifthenelse(
-              (* if (tag == Obj.forward_tag) then varg.(0) else ... *)
-              Lprim(Pintcomp Ceq,
-                    [Lvar tag; Lconst(Const_base(Const_int Obj.forward_tag))],
-                    loc),
-              Lprim(Pfield 0, [varg], loc),
-              Lifthenelse(
-                (* ... if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
-                Lprim(Pintcomp Ceq,
-                      [Lvar tag; Lconst(Const_base(Const_int Obj.lazy_tag))],
-                      loc),
-                Lapply{ap_should_be_tailcall=false;
-                       ap_loc=loc;
-                       ap_func=force_fun;
-                       ap_args=[varg];
-                       ap_inlined=Default_inline;
-                       ap_specialised=Default_specialise},
-                (* ... arg *)
-                  varg))))
+  Llet
+    ( Strict,
+      Pgenval,
+      idarg,
+      arg,
+      Llet
+        ( Alias,
+          Pgenval,
+          tag,
+          Lprim (Pccall prim_obj_tag, [ varg ], loc),
+          Lifthenelse
+            ( (* if (tag == Obj.forward_tag) then varg.(0) else ... *)
+              Lprim
+                ( Pintcomp Ceq,
+                  [ Lvar tag; Lconst (Const_base (Const_int Obj.forward_tag)) ],
+                  loc ),
+              Lprim (Pfield 0, [ varg ], loc),
+              Lifthenelse
+                ( (* ... if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
+                  Lprim
+                    ( Pintcomp Ceq,
+                      [ Lvar tag; Lconst (Const_base (Const_int Obj.lazy_tag)) ],
+                      loc ),
+                  Lapply
+                    { ap_should_be_tailcall = false;
+                      ap_loc = loc;
+                      ap_func = force_fun;
+                      ap_args = [ varg ];
+                      ap_inlined = Default_inline;
+                      ap_specialised = Default_specialise
+                    },
+                  (* ... arg *)
+                  varg ) ) ) )
 
 let inline_lazy_force_switch arg loc =
   let idarg = Ident.create_local "lzarg" in
   let varg = Lvar idarg in
   let force_fun = Lazy.force code_force_lazy_block in
-  Llet(Strict, Pgenval, idarg, arg,
-       Lifthenelse(
-         Lprim(Pisint, [varg], loc), varg,
-         (Lswitch
-            (varg,
-             { sw_numconsts = 0; sw_consts = [];
-               sw_numblocks = 256;  (* PR#6033 - tag ranges from 0 to 255 *)
-               sw_blocks =
-                 [ (Obj.forward_tag, Lprim(Pfield 0, [varg], loc));
-                   (Obj.lazy_tag,
-                    Lapply{ap_should_be_tailcall=false;
-                           ap_loc=loc;
-                           ap_func=force_fun;
-                           ap_args=[varg];
-                           ap_inlined=Default_inline;
-                           ap_specialised=Default_specialise}) ];
-               sw_failaction = Some varg }, loc ))))
+  Llet
+    ( Strict,
+      Pgenval,
+      idarg,
+      arg,
+      Lifthenelse
+        ( Lprim (Pisint, [ varg ], loc),
+          varg,
+          Lswitch
+            ( varg,
+              { sw_numconsts = 0;
+                sw_consts = [];
+                sw_numblocks = 256;
+                (* PR#6033 - tag ranges from 0 to 255 *)
+                sw_blocks =
+                  [ (Obj.forward_tag, Lprim (Pfield 0, [ varg ], loc));
+                    ( Obj.lazy_tag,
+                      Lapply
+                        { ap_should_be_tailcall = false;
+                          ap_loc = loc;
+                          ap_func = force_fun;
+                          ap_args = [ varg ];
+                          ap_inlined = Default_inline;
+                          ap_specialised = Default_specialise
+                        } )
+                  ];
+                sw_failaction = Some varg
+              },
+              loc ) ) )
 
 let inline_lazy_force arg loc =
   if !Clflags.afl_instrument then
@@ -1564,166 +1625,172 @@ let inline_lazy_force arg loc =
        so that the GC forwarding optimisation is not visible in the
        instrumentation output.
        (see https://github.com/stedolan/crowbar/issues/14) *)
-    Lapply{ap_should_be_tailcall = false;
-           ap_loc=loc;
-           ap_func=Lazy.force code_force_lazy;
-           ap_args=[arg];
-           ap_inlined=Default_inline;
-           ap_specialised=Default_specialise}
+    Lapply
+      { ap_should_be_tailcall = false;
+        ap_loc = loc;
+        ap_func = Lazy.force code_force_lazy;
+        ap_args = [ arg ];
+        ap_inlined = Default_inline;
+        ap_specialised = Default_specialise
+      }
+  else if !Clflags.native_code then
+    (* Lswitch generates compact and efficient native code *)
+    inline_lazy_force_switch arg loc
   else
-    if !Clflags.native_code then
-      (* Lswitch generates compact and efficient native code *)
-      inline_lazy_force_switch arg loc
-    else
-      (* generating bytecode: Lswitch would generate too many rather big
+    (* generating bytecode: Lswitch would generate too many rather big
          tables (~ 250 elts); conditionals are better *)
-      inline_lazy_force_cond arg loc
+    inline_lazy_force_cond arg loc
 
 let make_lazy_matching def = function
-    [] -> fatal_error "Matching.make_lazy_matching"
-  | (arg,_mut) :: argl ->
+  | [] -> fatal_error "Matching.make_lazy_matching"
+  | (arg, _mut) :: argl ->
       { cases = [];
-        args =
-          (inline_lazy_force arg Location.none, Strict) :: argl;
-        default = make_default matcher_lazy def }
+        args = (inline_lazy_force arg Location.none, Strict) :: argl;
+        default = make_default matcher_lazy def
+      }
 
 let divide_lazy p ctx pm =
-  divide_line
-    (filter_ctx p)
-    make_lazy_matching
-    get_arg_lazy
-    p ctx pm
+  divide_line (filter_ctx p) make_lazy_matching get_arg_lazy p ctx pm
 
 (* Matching against a tuple pattern *)
 
+let get_args_tuple arity p rem =
+  match p with
+  | { pat_desc = Tpat_any } -> omegas arity @ rem
+  | { pat_desc = Tpat_tuple args } -> args @ rem
+  | _ -> assert false
 
-let get_args_tuple arity p rem = match p with
-| {pat_desc = Tpat_any} -> omegas arity @ rem
-| {pat_desc = Tpat_tuple args} ->
-    args @ rem
-| _ ->  assert false
-
-let matcher_tuple arity p rem = match p.pat_desc with
-| Tpat_or (_,_,_)     -> raise OrPat
-| Tpat_any
-| Tpat_var _ -> omegas arity @ rem
-| Tpat_tuple args when List.length args = arity -> args @ rem
-| _ ->  raise NoMatch
+let matcher_tuple arity p rem =
+  match p.pat_desc with
+  | Tpat_or (_, _, _) -> raise OrPat
+  | Tpat_any
+  | Tpat_var _ ->
+      omegas arity @ rem
+  | Tpat_tuple args when List.length args = arity -> args @ rem
+  | _ -> raise NoMatch
 
 let make_tuple_matching loc arity def = function
-    [] -> fatal_error "Matching.make_tuple_matching"
+  | [] -> fatal_error "Matching.make_tuple_matching"
   | (arg, _mut) :: argl ->
       let rec make_args pos =
-        if pos >= arity
-        then argl
-        else (Lprim(Pfield pos, [arg], loc), Alias) :: make_args (pos + 1) in
-      {cases = []; args = make_args 0 ;
-        default=make_default (matcher_tuple arity) def}
-
+        if pos >= arity then
+          argl
+        else
+          (Lprim (Pfield pos, [ arg ], loc), Alias) :: make_args (pos + 1)
+      in
+      { cases = [];
+        args = make_args 0;
+        default = make_default (matcher_tuple arity) def
+      }
 
 let divide_tuple arity p ctx pm =
-  divide_line
-    (filter_ctx p)
+  divide_line (filter_ctx p)
     (make_tuple_matching p.pat_loc arity)
-    (get_args_tuple  arity) p ctx pm
+    (get_args_tuple arity) p ctx pm
 
 (* Matching against a record pattern *)
-
 
 let record_matching_line num_fields lbl_pat_list =
   let patv = Array.make num_fields omega in
   List.iter (fun (_, lbl, pat) -> patv.(lbl.lbl_pos) <- pat) lbl_pat_list;
   Array.to_list patv
 
-let get_args_record num_fields p rem = match p with
-| {pat_desc=Tpat_any} ->
-    record_matching_line num_fields [] @ rem
-| {pat_desc=Tpat_record (lbl_pat_list,_)} ->
-    record_matching_line num_fields lbl_pat_list @ rem
-| _ -> assert false
+let get_args_record num_fields p rem =
+  match p with
+  | { pat_desc = Tpat_any } -> record_matching_line num_fields [] @ rem
+  | { pat_desc = Tpat_record (lbl_pat_list, _) } ->
+      record_matching_line num_fields lbl_pat_list @ rem
+  | _ -> assert false
 
-let matcher_record num_fields p rem = match p.pat_desc with
-| Tpat_or (_,_,_) -> raise OrPat
-| Tpat_any
-| Tpat_var _      ->
-  record_matching_line num_fields [] @ rem
-| Tpat_record ([], _) when num_fields = 0 -> rem
-| Tpat_record ((_, lbl, _) :: _ as lbl_pat_list, _)
-  when Array.length lbl.lbl_all = num_fields ->
-    record_matching_line num_fields lbl_pat_list @ rem
-| _ -> raise NoMatch
+let matcher_record num_fields p rem =
+  match p.pat_desc with
+  | Tpat_or (_, _, _) -> raise OrPat
+  | Tpat_any
+  | Tpat_var _ ->
+      record_matching_line num_fields [] @ rem
+  | Tpat_record ([], _) when num_fields = 0 -> rem
+  | Tpat_record (((_, lbl, _) :: _ as lbl_pat_list), _)
+    when Array.length lbl.lbl_all = num_fields ->
+      record_matching_line num_fields lbl_pat_list @ rem
+  | _ -> raise NoMatch
 
 let make_record_matching loc all_labels def = function
-    [] -> fatal_error "Matching.make_record_matching"
-  | ((arg, _mut) :: argl) ->
+  | [] -> fatal_error "Matching.make_record_matching"
+  | (arg, _mut) :: argl ->
       let rec make_args pos =
-        if pos >= Array.length all_labels then argl else begin
+        if pos >= Array.length all_labels then
+          argl
+        else
           let lbl = all_labels.(pos) in
           let access =
             match lbl.lbl_repres with
-            | Record_regular | Record_inlined _ ->
-              Lprim (Pfield lbl.lbl_pos, [arg], loc)
+            | Record_regular
+            | Record_inlined _ ->
+                Lprim (Pfield lbl.lbl_pos, [ arg ], loc)
             | Record_unboxed _ -> arg
-            | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [arg], loc)
-            | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1), [arg], loc)
+            | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
+            | Record_extension _ ->
+                Lprim (Pfield (lbl.lbl_pos + 1), [ arg ], loc)
           in
           let str =
             match lbl.lbl_mut with
-              Immutable -> Alias
-            | Mutable -> StrictOpt in
-          (access, str) :: make_args(pos + 1)
-        end in
+            | Immutable -> Alias
+            | Mutable -> StrictOpt
+          in
+          (access, str) :: make_args (pos + 1)
+      in
       let nfields = Array.length all_labels in
-      let def= make_default (matcher_record nfields) def in
-      {cases = []; args = make_args 0 ; default = def}
-
+      let def = make_default (matcher_record nfields) def in
+      { cases = []; args = make_args 0; default = def }
 
 let divide_record all_labels p ctx pm =
   let get_args = get_args_record (Array.length all_labels) in
-  divide_line
-    (filter_ctx p)
+  divide_line (filter_ctx p)
     (make_record_matching p.pat_loc all_labels)
-    get_args
-    p ctx pm
+    get_args p ctx pm
 
 (* Matching against an array pattern *)
 
 let get_key_array = function
-  | {pat_desc=Tpat_array patl} -> List.length patl
+  | { pat_desc = Tpat_array patl } -> List.length patl
   | _ -> assert false
 
-let get_args_array p rem = match p with
-| {pat_desc=Tpat_array patl} -> patl@rem
-| _ -> assert false
+let get_args_array p rem =
+  match p with
+  | { pat_desc = Tpat_array patl } -> patl @ rem
+  | _ -> assert false
 
-let matcher_array len p rem = match p.pat_desc with
-| Tpat_or (_,_,_) -> raise OrPat
-| Tpat_array args when List.length args=len -> args @ rem
-| Tpat_any -> Parmatch.omegas len @ rem
-| _ -> raise NoMatch
+let matcher_array len p rem =
+  match p.pat_desc with
+  | Tpat_or (_, _, _) -> raise OrPat
+  | Tpat_array args when List.length args = len -> args @ rem
+  | Tpat_any -> Parmatch.omegas len @ rem
+  | _ -> raise NoMatch
 
 let make_array_matching kind p def ctx = function
   | [] -> fatal_error "Matching.make_array_matching"
-  | ((arg, _mut) :: argl) ->
+  | (arg, _mut) :: argl ->
       let len = get_key_array p in
       let rec make_args pos =
-        if pos >= len
-        then argl
-        else (Lprim(Parrayrefu kind,
-                    [arg; Lconst(Const_base(Const_int pos))],
-                    p.pat_loc),
-              StrictOpt) :: make_args (pos + 1) in
+        if pos >= len then
+          argl
+        else
+          ( Lprim
+              ( Parrayrefu kind,
+                [ arg; Lconst (Const_base (Const_int pos)) ],
+                p.pat_loc ),
+            StrictOpt )
+          :: make_args (pos + 1)
+      in
       let def = make_default (matcher_array len) def
       and ctx = filter_ctx p ctx in
-      {pm={cases = []; args = make_args 0 ; default = def} ;
-        ctx=ctx ;
-        pat = normalize_pat p}
+      { pm = { cases = []; args = make_args 0; default = def };
+        ctx;
+        pat = normalize_pat p
+      }
 
 let divide_array kind ctx pm =
-  divide
-    (make_array_matching kind)
-    (=) get_key_array get_args_array ctx pm
-
+  divide (make_array_matching kind) ( = ) get_key_array get_args_array ctx pm
 
 (*
    Specific string test sequence
@@ -1742,73 +1809,68 @@ let divide_array kind ctx pm =
 let strings_test_threshold = 8
 
 let prim_string_notequal =
-  Pccall(Primitive.simple
-           ~name:"caml_string_notequal"
-           ~arity:2
-           ~alloc:false)
+  Pccall (Primitive.simple ~name:"caml_string_notequal" ~arity:2 ~alloc:false)
 
 let prim_string_compare =
-  Pccall(Primitive.simple
-           ~name:"caml_string_compare"
-           ~arity:2
-           ~alloc:false)
+  Pccall (Primitive.simple ~name:"caml_string_compare" ~arity:2 ~alloc:false)
 
-let bind_sw arg k = match arg with
-| Lvar _ -> k arg
-| _ ->
-    let id = Ident.create_local "switch" in
-    Llet (Strict,Pgenval,id,arg,k (Lvar id))
-
+let bind_sw arg k =
+  match arg with
+  | Lvar _ -> k arg
+  | _ ->
+      let id = Ident.create_local "switch" in
+      Llet (Strict, Pgenval, id, arg, k (Lvar id))
 
 (* Sequential equality tests *)
 
 let make_string_test_sequence loc arg sw d =
-  let d,sw = match d with
-  | None ->
-      begin match sw with
-      | (_,d)::sw -> d,sw
-      | [] -> assert false
-      end
-  | Some d -> d,sw in
-  bind_sw arg
-    (fun arg ->
+  let d, sw =
+    match d with
+    | None -> (
+        match sw with
+        | (_, d) :: sw -> (d, sw)
+        | [] -> assert false
+      )
+    | Some d -> (d, sw)
+  in
+  bind_sw arg (fun arg ->
       List.fold_right
-        (fun (s,lam) k ->
+        (fun (s, lam) k ->
           Lifthenelse
-            (Lprim
-               (prim_string_notequal,
-                [arg; Lconst (Const_immstring s)], loc),
-             k,lam))
+            ( Lprim
+                (prim_string_notequal, [ arg; Lconst (Const_immstring s) ], loc),
+              k,
+              lam ))
         sw d)
 
-let rec split k xs = match xs with
-| [] -> assert false
-| x0::xs ->
-    if k <= 1 then [],x0,xs
-    else
-      let xs,y0,ys = split (k-2) xs in
-      x0::xs,y0,ys
+let rec split k xs =
+  match xs with
+  | [] -> assert false
+  | x0 :: xs ->
+      if k <= 1 then
+        ([], x0, xs)
+      else
+        let xs, y0, ys = split (k - 2) xs in
+        (x0 :: xs, y0, ys)
 
-let zero_lam  = Lconst (Const_base (Const_int 0))
+let zero_lam = Lconst (Const_base (Const_int 0))
 
 let tree_way_test loc arg lt eq gt =
   Lifthenelse
-    (Lprim (Pintcomp Clt,[arg;zero_lam], loc),lt,
-     Lifthenelse(Lprim (Pintcomp Clt,[zero_lam;arg], loc),gt,eq))
+    ( Lprim (Pintcomp Clt, [ arg; zero_lam ], loc),
+      lt,
+      Lifthenelse (Lprim (Pintcomp Clt, [ zero_lam; arg ], loc), gt, eq) )
 
 (* Dichotomic tree *)
 
-
 let rec do_make_string_test_tree loc arg sw delta d =
   let len = List.length sw in
-  if len <= strings_test_threshold+delta then
+  if len <= strings_test_threshold + delta then
     make_string_test_sequence loc arg sw d
   else
-    let lt,(s,act),gt = split len sw in
+    let lt, (s, act), gt = split len sw in
     bind_sw
-      (Lprim
-         (prim_string_compare,
-          [arg; Lconst (Const_immstring s)], loc))
+      (Lprim (prim_string_compare, [ arg; Lconst (Const_immstring s) ], loc))
       (fun r ->
         tree_way_test loc r
           (do_make_string_test_tree loc arg lt delta d)
@@ -1816,15 +1878,13 @@ let rec do_make_string_test_tree loc arg sw delta d =
           (do_make_string_test_tree loc arg gt delta d))
 
 (* Entry point *)
-let expand_stringswitch loc arg sw d = match d with
-| None ->
-    bind_sw arg
-      (fun arg -> do_make_string_test_tree loc arg sw 0 None)
-| Some e ->
-    bind_sw arg
-      (fun arg ->
-        make_catch e
-          (fun d -> do_make_string_test_tree loc arg sw 1 (Some d)))
+let expand_stringswitch loc arg sw d =
+  match d with
+  | None -> bind_sw arg (fun arg -> do_make_string_test_tree loc arg sw 0 None)
+  | Some e ->
+      bind_sw arg (fun arg ->
+          make_catch e (fun d ->
+              do_make_string_test_tree loc arg sw 1 (Some d)))
 
 (**********************)
 (* Generic test trees *)
@@ -1835,702 +1895,750 @@ let expand_stringswitch loc arg sw d = match d with
 (* Add handler, if shared *)
 let handle_shared () =
   let hs = ref (fun x -> x) in
-  let handle_shared act = match act with
-  | Switch.Single act -> act
-  | Switch.Shared act ->
-      let i,h = make_catch_delayed act in
-      let ohs = !hs in
-      hs := (fun act -> h (ohs act)) ;
-      make_exit i in
-  hs,handle_shared
-
+  let handle_shared act =
+    match act with
+    | Switch.Single act -> act
+    | Switch.Shared act ->
+        let i, h = make_catch_delayed act in
+        let ohs = !hs in
+        (hs := fun act -> h (ohs act));
+        make_exit i
+  in
+  (hs, handle_shared)
 
 let share_actions_tree sw d =
   let store = StoreExp.mk_store () in
-(* Default action is always shared *)
+  (* Default action is always shared *)
   let d =
     match d with
     | None -> None
-    | Some d -> Some (store.Switch.act_store_shared () d) in
-(* Store all other actions *)
+    | Some d -> Some (store.Switch.act_store_shared () d)
+  in
+  (* Store all other actions *)
   let sw =
-    List.map  (fun (cst,act) -> cst,store.Switch.act_store () act) sw in
-
-(* Retrieve all actions, including potential default *)
+    List.map (fun (cst, act) -> (cst, store.Switch.act_store () act)) sw
+  in
+  (* Retrieve all actions, including potential default *)
   let acts = store.Switch.act_get_shared () in
-
-(* Array of actual actions *)
-  let hs,handle_shared = handle_shared () in
+  (* Array of actual actions *)
+  let hs, handle_shared = handle_shared () in
   let acts = Array.map handle_shared acts in
-
-(* Reconstruct default and switch list *)
-  let d = match d with
-  | None -> None
-  | Some d -> Some (acts.(d)) in
-  let sw = List.map (fun (cst,j) -> cst,acts.(j)) sw in
-  !hs,sw,d
+  (* Reconstruct default and switch list *)
+  let d =
+    match d with
+    | None -> None
+    | Some d -> Some acts.(d)
+  in
+  let sw = List.map (fun (cst, j) -> (cst, acts.(j))) sw in
+  (!hs, sw, d)
 
 (* Note: dichotomic search requires sorted input with no duplicates *)
-let rec uniq_lambda_list sw = match sw with
-  | []|[_] -> sw
-  | (c1,_ as p1)::((c2,_)::sw2 as sw1) ->
-      if const_compare c1 c2 = 0 then uniq_lambda_list (p1::sw2)
-      else p1::uniq_lambda_list sw1
+let rec uniq_lambda_list sw =
+  match sw with
+  | []
+  | [ _ ] ->
+      sw
+  | ((c1, _) as p1) :: ((c2, _) :: sw2 as sw1) ->
+      if const_compare c1 c2 = 0 then
+        uniq_lambda_list (p1 :: sw2)
+      else
+        p1 :: uniq_lambda_list sw1
 
 let sort_lambda_list l =
-  let l =
-    List.stable_sort (fun (x,_) (y,_) -> const_compare x y) l in
+  let l = List.stable_sort (fun (x, _) (y, _) -> const_compare x y) l in
   uniq_lambda_list l
 
 let rec cut n l =
-  if n = 0 then [],l
-  else match l with
-    [] -> raise (Invalid_argument "cut")
-  | a::l -> let l1,l2 = cut (n-1) l in a::l1, l2
+  if n = 0 then
+    ([], l)
+  else
+    match l with
+    | [] -> raise (Invalid_argument "cut")
+    | a :: l ->
+        let l1, l2 = cut (n - 1) l in
+        (a :: l1, l2)
 
 let rec do_tests_fail loc fail tst arg = function
   | [] -> fail
-  | (c, act)::rem ->
+  | (c, act) :: rem ->
       Lifthenelse
-        (Lprim (tst, [arg ; Lconst (Const_base c)], loc),
-         do_tests_fail loc fail tst arg rem,
-         act)
+        ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
+          do_tests_fail loc fail tst arg rem,
+          act )
 
 let rec do_tests_nofail loc tst arg = function
   | [] -> fatal_error "Matching.do_tests_nofail"
-  | [_,act] -> act
-  | (c,act)::rem ->
+  | [ (_, act) ] -> act
+  | (c, act) :: rem ->
       Lifthenelse
-        (Lprim (tst, [arg ; Lconst (Const_base c)], loc),
-         do_tests_nofail loc tst arg rem,
-         act)
+        ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
+          do_tests_nofail loc tst arg rem,
+          act )
 
 let make_test_sequence loc fail tst lt_tst arg const_lambda_list =
   let const_lambda_list = sort_lambda_list const_lambda_list in
-  let hs,const_lambda_list,fail =
-    share_actions_tree const_lambda_list fail in
-
+  let hs, const_lambda_list, fail =
+    share_actions_tree const_lambda_list fail
+  in
   let rec make_test_sequence const_lambda_list =
     if List.length const_lambda_list >= 4 && lt_tst <> Pignore then
       split_sequence const_lambda_list
-    else match fail with
-    | None -> do_tests_nofail loc tst arg const_lambda_list
-    | Some fail -> do_tests_fail loc fail tst arg const_lambda_list
-
+    else
+      match fail with
+      | None -> do_tests_nofail loc tst arg const_lambda_list
+      | Some fail -> do_tests_fail loc fail tst arg const_lambda_list
   and split_sequence const_lambda_list =
     let list1, list2 =
-      cut (List.length const_lambda_list / 2) const_lambda_list in
-    Lifthenelse(Lprim(lt_tst,
-                      [arg; Lconst(Const_base (fst(List.hd list2)))],
-                      loc),
-                make_test_sequence list1, make_test_sequence list2)
+      cut (List.length const_lambda_list / 2) const_lambda_list
+    in
+    Lifthenelse
+      ( Lprim (lt_tst, [ arg; Lconst (Const_base (fst (List.hd list2))) ], loc),
+        make_test_sequence list1,
+        make_test_sequence list2 )
   in
   hs (make_test_sequence const_lambda_list)
-
 
 module SArg = struct
   type primitive = Lambda.primitive
 
   let eqint = Pintcomp Ceq
+
   let neint = Pintcomp Cne
+
   let leint = Pintcomp Cle
+
   let ltint = Pintcomp Clt
+
   let geint = Pintcomp Cge
+
   let gtint = Pintcomp Cgt
 
   type act = Lambda.lambda
 
-  let make_prim p args = Lprim (p,args,Location.none)
-  let make_offset arg n = match n with
-  | 0 -> arg
-  | _ -> Lprim (Poffsetint n,[arg],Location.none)
+  let make_prim p args = Lprim (p, args, Location.none)
+
+  let make_offset arg n =
+    match n with
+    | 0 -> arg
+    | _ -> Lprim (Poffsetint n, [ arg ], Location.none)
 
   let bind arg body =
-    let newvar,newarg = match arg with
-    | Lvar v -> v,arg
-    | _      ->
-        let newvar = Ident.create_local "switcher" in
-        newvar,Lvar newvar in
+    let newvar, newarg =
+      match arg with
+      | Lvar v -> (v, arg)
+      | _ ->
+          let newvar = Ident.create_local "switcher" in
+          (newvar, Lvar newvar)
+    in
     bind Alias newvar arg (body newarg)
+
   let make_const i = Lconst (Const_base (Const_int i))
-  let make_isout h arg = Lprim (Pisout, [h ; arg],Location.none)
-  let make_isin h arg = Lprim (Pnot,[make_isout h arg],Location.none)
+
+  let make_isout h arg = Lprim (Pisout, [ h; arg ], Location.none)
+
+  let make_isin h arg = Lprim (Pnot, [ make_isout h arg ], Location.none)
+
   let make_if cond ifso ifnot = Lifthenelse (cond, ifso, ifnot)
+
   let make_switch loc arg cases acts =
     let l = ref [] in
-    for i = Array.length cases-1 downto 0 do
-      l := (i,acts.(cases.(i))) ::  !l
-    done ;
-    Lswitch(arg,
-            {sw_numconsts = Array.length cases ; sw_consts = !l ;
-             sw_numblocks = 0 ; sw_blocks =  []  ;
-             sw_failaction = None}, loc)
-  let make_catch  = make_catch_delayed
-  let make_exit = make_exit
+    for i = Array.length cases - 1 downto 0 do
+      l := (i, acts.(cases.(i))) :: !l
+    done;
+    Lswitch
+      ( arg,
+        { sw_numconsts = Array.length cases;
+          sw_consts = !l;
+          sw_numblocks = 0;
+          sw_blocks = [];
+          sw_failaction = None
+        },
+        loc )
 
+  let make_catch = make_catch_delayed
+
+  let make_exit = make_exit
 end
 
 (* Action sharing for Lswitch argument *)
 let share_actions_sw sw =
-(* Attempt sharing on all actions *)
+  (* Attempt sharing on all actions *)
   let store = StoreExp.mk_store () in
-  let fail = match sw.sw_failaction with
-  | None -> None
-  | Some fail ->
-      (* Fail is translated to exit, whatever happens *)
-      Some (store.Switch.act_store_shared () fail) in
+  let fail =
+    match sw.sw_failaction with
+    | None -> None
+    | Some fail ->
+        (* Fail is translated to exit, whatever happens *)
+        Some (store.Switch.act_store_shared () fail)
+  in
   let consts =
-    List.map
-      (fun (i,e) -> i,store.Switch.act_store () e)
-      sw.sw_consts
+    List.map (fun (i, e) -> (i, store.Switch.act_store () e)) sw.sw_consts
   and blocks =
-    List.map
-      (fun (i,e) -> i,store.Switch.act_store () e)
-      sw.sw_blocks in
+    List.map (fun (i, e) -> (i, store.Switch.act_store () e)) sw.sw_blocks
+  in
   let acts = store.Switch.act_get_shared () in
-  let hs,handle_shared = handle_shared () in
+  let hs, handle_shared = handle_shared () in
   let acts = Array.map handle_shared acts in
-  let fail = match fail with
-  | None -> None
-  | Some fail -> Some (acts.(fail)) in
-  !hs,
-  { sw with
-    sw_consts = List.map (fun (i,j) -> i,acts.(j)) consts ;
-    sw_blocks = List.map (fun (i,j) -> i,acts.(j)) blocks ;
-    sw_failaction = fail; }
+  let fail =
+    match fail with
+    | None -> None
+    | Some fail -> Some acts.(fail)
+  in
+  ( !hs,
+    { sw with
+      sw_consts = List.map (fun (i, j) -> (i, acts.(j))) consts;
+      sw_blocks = List.map (fun (i, j) -> (i, acts.(j))) blocks;
+      sw_failaction = fail
+    } )
 
 (* Reintroduce fail action in switch argument,
    for the sake of avoiding carrying over huge switches *)
 
-let reintroduce_fail sw = match sw.sw_failaction with
-| None ->
-    let t = Hashtbl.create 17 in
-    let seen (_,l) = match as_simple_exit l with
-    | Some i ->
-        let old = try Hashtbl.find t i with Not_found -> 0 in
-        Hashtbl.replace t i (old+1)
-    | None -> () in
-    List.iter seen sw.sw_consts ;
-    List.iter seen sw.sw_blocks ;
-    let i_max = ref (-1)
-    and max = ref (-1) in
-    Hashtbl.iter
-      (fun i c ->
-        if c > !max then begin
-          i_max := i ;
-          max := c
-        end) t ;
-    if !max >= 3 then
-      let default = !i_max in
-      let remove =
-        List.filter
-          (fun (_,lam) -> match as_simple_exit lam with
-          | Some j -> j <> default
-          | None -> true) in
-      {sw with
-       sw_consts = remove sw.sw_consts ;
-       sw_blocks = remove sw.sw_blocks ;
-       sw_failaction = Some (make_exit default)}
-    else sw
-| Some _ -> sw
+let reintroduce_fail sw =
+  match sw.sw_failaction with
+  | None ->
+      let t = Hashtbl.create 17 in
+      let seen (_, l) =
+        match as_simple_exit l with
+        | Some i ->
+            let old = try Hashtbl.find t i with Not_found -> 0 in
+            Hashtbl.replace t i (old + 1)
+        | None -> ()
+      in
+      List.iter seen sw.sw_consts;
+      List.iter seen sw.sw_blocks;
+      let i_max = ref (-1) and max = ref (-1) in
+      Hashtbl.iter
+        (fun i c ->
+          if c > !max then (
+            i_max := i;
+            max := c
+          ))
+        t;
+      if !max >= 3 then
+        let default = !i_max in
+        let remove =
+          List.filter (fun (_, lam) ->
+              match as_simple_exit lam with
+              | Some j -> j <> default
+              | None -> true)
+        in
+        { sw with
+          sw_consts = remove sw.sw_consts;
+          sw_blocks = remove sw.sw_blocks;
+          sw_failaction = Some (make_exit default)
+        }
+      else
+        sw
+  | Some _ -> sw
 
-
-module Switcher = Switch.Make(SArg)
+module Switcher = Switch.Make (SArg)
 open Switch
 
 let rec last def = function
   | [] -> def
-  | [x,_] -> x
-  | _::rem -> last def rem
+  | [ (x, _) ] -> x
+  | _ :: rem -> last def rem
 
-let get_edges low high l = match l with
-| [] -> low, high
-| (x,_)::_ -> x, last high l
-
+let get_edges low high l =
+  match l with
+  | [] -> (low, high)
+  | (x, _) :: _ -> (x, last high l)
 
 let as_interval_canfail fail low high l =
   let store = StoreExp.mk_store () in
-
   let do_store _tag act =
-
-    let i =  store.act_store () act in
-(*
+    let i = store.act_store () act in
+    (*
     eprintf "STORE [%s] %i %s\n" tag i (string_of_lam act) ;
 *)
-    i in
-
+    i
+  in
   let rec nofail_rec cur_low cur_high cur_act = function
     | [] ->
         if cur_high = high then
-          [cur_low,cur_high,cur_act]
+          [ (cur_low, cur_high, cur_act) ]
         else
-          [(cur_low,cur_high,cur_act) ; (cur_high+1,high, 0)]
-    | ((i,act_i)::rem) as all ->
+          [ (cur_low, cur_high, cur_act); (cur_high + 1, high, 0) ]
+    | (i, act_i) :: rem as all ->
         let act_index = do_store "NO" act_i in
-        if cur_high+1= i then
-          if act_index=cur_act then
+        if cur_high + 1 = i then
+          if act_index = cur_act then
             nofail_rec cur_low i cur_act rem
-          else if act_index=0 then
-            (cur_low,i-1, cur_act)::fail_rec i i rem
+          else if act_index = 0 then
+            (cur_low, i - 1, cur_act) :: fail_rec i i rem
           else
-            (cur_low, i-1, cur_act)::nofail_rec i i act_index rem
+            (cur_low, i - 1, cur_act) :: nofail_rec i i act_index rem
         else if act_index = 0 then
-          (cur_low, cur_high, cur_act)::
-          fail_rec (cur_high+1) (cur_high+1) all
+          (cur_low, cur_high, cur_act)
+          :: fail_rec (cur_high + 1) (cur_high + 1) all
         else
-          (cur_low, cur_high, cur_act)::
-          (cur_high+1,i-1,0)::
-          nofail_rec i i act_index rem
-
+          (cur_low, cur_high, cur_act)
+          :: (cur_high + 1, i - 1, 0)
+          :: nofail_rec i i act_index rem
   and fail_rec cur_low cur_high = function
-    | [] -> [(cur_low, cur_high, 0)]
-    | (i,act_i)::rem ->
+    | [] -> [ (cur_low, cur_high, 0) ]
+    | (i, act_i) :: rem ->
         let index = do_store "YES" act_i in
-        if index=0 then fail_rec cur_low i rem
+        if index = 0 then
+          fail_rec cur_low i rem
         else
-          (cur_low,i-1,0)::
-          nofail_rec i i index rem in
-
+          (cur_low, i - 1, 0) :: nofail_rec i i index rem
+  in
   let init_rec = function
-    | [] -> [low,high,0]
-    | (i,act_i)::rem ->
+    | [] -> [ (low, high, 0) ]
+    | (i, act_i) :: rem ->
         let index = do_store "INIT" act_i in
-        if index=0 then
+        if index = 0 then
           fail_rec low i rem
+        else if low < i then
+          (low, i - 1, 0) :: nofail_rec i i index rem
         else
-          if low < i then
-            (low,i-1,0)::nofail_rec i i index rem
-          else
-            nofail_rec i i index rem in
+          nofail_rec i i index rem
+  in
+  assert (do_store "FAIL" fail = 0);
 
-  assert (do_store "FAIL" fail = 0) ; (* fail has action index 0 *)
+  (* fail has action index 0 *)
   let r = init_rec l in
-  Array.of_list r,  store
+  (Array.of_list r, store)
 
 let as_interval_nofail l =
   let store = StoreExp.mk_store () in
   let rec some_hole = function
-    | []|[_] -> false
-    | (i,_)::((j,_)::_ as rem) ->
-        j > i+1 || some_hole rem in
+    | []
+    | [ _ ] ->
+        false
+    | (i, _) :: ((j, _) :: _ as rem) -> j > i + 1 || some_hole rem
+  in
   let rec i_rec cur_low cur_high cur_act = function
-    | [] ->
-        [cur_low, cur_high, cur_act]
-    | (i,act)::rem ->
+    | [] -> [ (cur_low, cur_high, cur_act) ]
+    | (i, act) :: rem ->
         let act_index = store.act_store () act in
         if act_index = cur_act then
           i_rec cur_low i cur_act rem
         else
-          (cur_low, cur_high, cur_act)::
-          i_rec i i act_index rem in
-  let inters = match l with
-  | (i,act)::rem ->
-      let act_index =
-        (* In case there is some hole and that a switch is emitted,
+          (cur_low, cur_high, cur_act) :: i_rec i i act_index rem
+  in
+  let inters =
+    match l with
+    | (i, act) :: rem ->
+        let act_index =
+          (* In case there is some hole and that a switch is emitted,
            action 0 will be used as the action of unreachable
            cases (cf. switch.ml, make_switch).
            Hence, this action will be shared *)
-        if some_hole rem then
-          store.act_store_shared () act
-        else
-          store.act_store () act in
-      assert (act_index = 0) ;
-      i_rec i i act_index rem
-  | _ -> assert false in
-
-  Array.of_list inters, store
-
+          if some_hole rem then
+            store.act_store_shared () act
+          else
+            store.act_store () act
+        in
+        assert (act_index = 0);
+        i_rec i i act_index rem
+    | _ -> assert false
+  in
+  (Array.of_list inters, store)
 
 let sort_int_lambda_list l =
   List.sort
-    (fun (i1,_) (i2,_) ->
-      if i1 < i2 then -1
-      else if i2 < i1 then 1
-      else 0)
+    (fun (i1, _) (i2, _) ->
+      if i1 < i2 then
+        -1
+      else if i2 < i1 then
+        1
+      else
+        0)
     l
 
 let as_interval fail low high l =
   let l = sort_int_lambda_list l in
-  get_edges low high l,
-  (match fail with
-  | None -> as_interval_nofail l
-  | Some act -> as_interval_canfail act low high l)
+  ( get_edges low high l,
+    match fail with
+    | None -> as_interval_nofail l
+    | Some act -> as_interval_canfail act low high l )
 
 let call_switcher loc fail arg low high int_lambda_list =
-  let edges, (cases, actions) =
-    as_interval fail low high int_lambda_list in
+  let edges, (cases, actions) = as_interval fail low high int_lambda_list in
   Switcher.zyva loc edges arg cases actions
-
 
 let rec list_as_pat = function
   | [] -> fatal_error "Matching.list_as_pat"
-  | [pat] -> pat
-  | pat::rem ->
-      {pat with pat_desc = Tpat_or (pat,list_as_pat rem,None)}
-
+  | [ pat ] -> pat
+  | pat :: rem -> { pat with pat_desc = Tpat_or (pat, list_as_pat rem, None) }
 
 let complete_pats_constrs = function
-  | p::_ as pats ->
-      List.map
-        (pat_of_constr p)
+  | p :: _ as pats ->
+      List.map (pat_of_constr p)
         (complete_constrs p (List.map get_key_constr pats))
   | _ -> assert false
-
 
 (*
      Following two ``failaction'' function compute n, the trap handler
     to jump to in case of failure of elementary tests
 *)
 
-let mk_failaction_neg partial ctx def = match partial with
-| Partial ->
-    begin match def with
-    | (_,idef)::_ ->
-        Some (Lstaticraise (idef,[])),jumps_singleton idef ctx
-    | [] ->
-       (* Act as Total, this means
+let mk_failaction_neg partial ctx def =
+  match partial with
+  | Partial -> (
+      match def with
+      | (_, idef) :: _ ->
+          (Some (Lstaticraise (idef, [])), jumps_singleton idef ctx)
+      | [] ->
+          (* Act as Total, this means
           If no appropriate default matrix exists,
           then this switch cannot fail *)
-        None, jumps_empty
-    end
-| Total ->
-    None, jumps_empty
-
-
+          (None, jumps_empty)
+    )
+  | Total -> (None, jumps_empty)
 
 (* In line with the article and simpler than before *)
-let mk_failaction_pos partial seen ctx defs  =
-  if dbg then begin
-    Format.eprintf "**POS**\n" ;
-    pretty_def defs ;
+let mk_failaction_pos partial seen ctx defs =
+  if dbg then (
+    Format.eprintf "**POS**\n";
+    pretty_def defs;
     ()
-  end ;
-  let rec scan_def env to_test defs = match to_test,defs with
-  | ([],_)|(_,[]) ->
-      List.fold_left
-        (fun  (klist,jumps) (pats,i)->
-          let action = Lstaticraise (i,[]) in
-          let klist =
-            List.fold_right
-              (fun pat r -> (get_key_constr pat,action)::r)
-              pats klist
-          and jumps =
-            jumps_add i (ctx_lub (list_as_pat pats) ctx) jumps in
-          klist,jumps)
-        ([],jumps_empty) env
-  | _,(pss,idef)::rem ->
-      let now, later =
-        List.partition
-          (fun (_p,p_ctx) -> ctx_match p_ctx pss) to_test in
-      match now with
-      | [] -> scan_def env to_test rem
-      | _  -> scan_def ((List.map fst now,idef)::env) later rem in
-
+  );
+  let rec scan_def env to_test defs =
+    match (to_test, defs) with
+    | [], _
+    | _, [] ->
+        List.fold_left
+          (fun (klist, jumps) (pats, i) ->
+            let action = Lstaticraise (i, []) in
+            let klist =
+              List.fold_right
+                (fun pat r -> (get_key_constr pat, action) :: r)
+                pats klist
+            and jumps = jumps_add i (ctx_lub (list_as_pat pats) ctx) jumps in
+            (klist, jumps))
+          ([], jumps_empty) env
+    | _, (pss, idef) :: rem -> (
+        let now, later =
+          List.partition (fun (_p, p_ctx) -> ctx_match p_ctx pss) to_test
+        in
+        match now with
+        | [] -> scan_def env to_test rem
+        | _ -> scan_def ((List.map fst now, idef) :: env) later rem
+      )
+  in
   let fail_pats = complete_pats_constrs seen in
-  if List.length fail_pats < !Clflags.match_context_rows then begin
-    let fail,jmps =
-      scan_def
-        []
-        (List.map
-           (fun pat -> pat, ctx_lub pat ctx)
-           fail_pats)
-        defs in
-    if dbg then begin
+  if List.length fail_pats < !Clflags.match_context_rows then (
+    let fail, jmps =
+      scan_def [] (List.map (fun pat -> (pat, ctx_lub pat ctx)) fail_pats) defs
+    in
+    if dbg then (
       eprintf "POSITIVE JUMPS [%i]:\n" (List.length fail_pats);
       pretty_jumps jmps
-    end ;
-    None,fail,jmps
-  end else begin (* Too many non-matched constructors -> reduced information *)
-    if dbg then eprintf "POS->NEG!!!\n%!" ;
-    let fail,jumps =  mk_failaction_neg partial ctx defs in
+    );
+    (None, fail, jmps)
+  ) else (
+    (* Too many non-matched constructors -> reduced information *)
+    if dbg then eprintf "POS->NEG!!!\n%!";
+    let fail, jumps = mk_failaction_neg partial ctx defs in
     if dbg then
       eprintf "FAIL: %s\n"
-        (match fail with
+        ( match fail with
         | None -> "<none>"
-        | Some lam -> string_of_lam lam) ;
-    fail,[],jumps
-  end
+        | Some lam -> string_of_lam lam
+        );
+    (fail, [], jumps)
+  )
 
 let combine_constant loc arg cst partial ctx def
     (const_lambda_list, total, _pats) =
-  let fail, local_jumps =
-    mk_failaction_neg partial ctx def in
+  let fail, local_jumps = mk_failaction_neg partial ctx def in
   let lambda1 =
     match cst with
     | Const_int _ ->
         let int_lambda_list =
-          List.map (function Const_int n, l -> n,l | _ -> assert false)
-            const_lambda_list in
+          List.map
+            (function
+              | Const_int n, l -> (n, l)
+              | _ -> assert false)
+            const_lambda_list
+        in
         call_switcher loc fail arg min_int max_int int_lambda_list
     | Const_char _ ->
         let int_lambda_list =
-          List.map (function Const_char c, l -> (Char.code c, l)
-            | _ -> assert false)
-            const_lambda_list in
+          List.map
+            (function
+              | Const_char c, l -> (Char.code c, l)
+              | _ -> assert false)
+            const_lambda_list
+        in
         call_switcher loc fail arg 0 255 int_lambda_list
     | Const_string _ ->
-(* Note as the bytecode compiler may resort to dichotomic search,
+        (* Note as the bytecode compiler may resort to dichotomic search,
    the clauses of stringswitch  are sorted with duplicates removed.
    This partly applies to the native code compiler, which requires
    no duplicates *)
         let const_lambda_list = sort_lambda_list const_lambda_list in
         let sw =
           List.map
-            (fun (c,act) -> match c with
-            | Const_string (s,_) -> s,act
-            | _ -> assert false)
-            const_lambda_list in
-        let hs,sw,fail = share_actions_tree sw fail in
-        hs (Lstringswitch (arg,sw,fail,loc))
+            (fun (c, act) ->
+              match c with
+              | Const_string (s, _) -> (s, act)
+              | _ -> assert false)
+            const_lambda_list
+        in
+        let hs, sw, fail = share_actions_tree sw fail in
+        hs (Lstringswitch (arg, sw, fail, loc))
     | Const_float _ ->
-        make_test_sequence loc
-          fail
-          (Pfloatcomp CFneq) (Pfloatcomp CFlt)
-          arg const_lambda_list
+        make_test_sequence loc fail (Pfloatcomp CFneq) (Pfloatcomp CFlt) arg
+          const_lambda_list
     | Const_int32 _ ->
-        make_test_sequence loc
-          fail
-          (Pbintcomp(Pint32, Cne)) (Pbintcomp(Pint32, Clt))
+        make_test_sequence loc fail
+          (Pbintcomp (Pint32, Cne))
+          (Pbintcomp (Pint32, Clt))
           arg const_lambda_list
     | Const_int64 _ ->
-        make_test_sequence loc
-          fail
-          (Pbintcomp(Pint64, Cne)) (Pbintcomp(Pint64, Clt))
+        make_test_sequence loc fail
+          (Pbintcomp (Pint64, Cne))
+          (Pbintcomp (Pint64, Clt))
           arg const_lambda_list
     | Const_nativeint _ ->
-        make_test_sequence loc
-          fail
-          (Pbintcomp(Pnativeint, Cne)) (Pbintcomp(Pnativeint, Clt))
+        make_test_sequence loc fail
+          (Pbintcomp (Pnativeint, Cne))
+          (Pbintcomp (Pnativeint, Clt))
           arg const_lambda_list
-  in lambda1,jumps_union local_jumps total
-
-
+  in
+  (lambda1, jumps_union local_jumps total)
 
 let split_cases tag_lambda_list =
   let rec split_rec = function
-      [] -> ([], [])
-    | (cstr, act) :: rem ->
-        let (consts, nonconsts) = split_rec rem in
+    | [] -> ([], [])
+    | (cstr, act) :: rem -> (
+        let consts, nonconsts = split_rec rem in
         match cstr with
-          Cstr_constant n -> ((n, act) :: consts, nonconsts)
-        | Cstr_block n    -> (consts, (n, act) :: nonconsts)
-        | Cstr_unboxed    -> (consts, (0, act) :: nonconsts)
-        | Cstr_extension _ -> assert false in
+        | Cstr_constant n -> ((n, act) :: consts, nonconsts)
+        | Cstr_block n -> (consts, (n, act) :: nonconsts)
+        | Cstr_unboxed -> (consts, (0, act) :: nonconsts)
+        | Cstr_extension _ -> assert false
+      )
+  in
   let const, nonconst = split_rec tag_lambda_list in
-  sort_int_lambda_list const,
-  sort_int_lambda_list nonconst
+  (sort_int_lambda_list const, sort_int_lambda_list nonconst)
 
 let split_extension_cases tag_lambda_list =
   let rec split_rec = function
-      [] -> ([], [])
-    | (cstr, act) :: rem ->
-        let (consts, nonconsts) = split_rec rem in
+    | [] -> ([], [])
+    | (cstr, act) :: rem -> (
+        let consts, nonconsts = split_rec rem in
         match cstr with
-          Cstr_extension(path, true) -> ((path, act) :: consts, nonconsts)
-        | Cstr_extension(path, false) -> (consts, (path, act) :: nonconsts)
-        | _ -> assert false in
+        | Cstr_extension (path, true) -> ((path, act) :: consts, nonconsts)
+        | Cstr_extension (path, false) -> (consts, (path, act) :: nonconsts)
+        | _ -> assert false
+      )
+  in
   split_rec tag_lambda_list
-
 
 let combine_constructor loc arg ex_pat cstr partial ctx def
     (tag_lambda_list, total1, pats) =
-  if cstr.cstr_consts < 0 then begin
+  if cstr.cstr_consts < 0 then
     (* Special cases for extensions *)
-    let fail, local_jumps =
-      mk_failaction_neg partial ctx def in
+    let fail, local_jumps = mk_failaction_neg partial ctx def in
     let lambda1 =
       let consts, nonconsts = split_extension_cases tag_lambda_list in
       let default, consts, nonconsts =
         match fail with
-        | None ->
-            begin match consts, nonconsts with
-            | _, (_, act)::rem -> act, consts, rem
-            | (_, act)::rem, _ -> act, rem, nonconsts
+        | None -> (
+            match (consts, nonconsts) with
+            | _, (_, act) :: rem -> (act, consts, rem)
+            | (_, act) :: rem, _ -> (act, rem, nonconsts)
             | _ -> assert false
-            end
-        | Some fail -> fail, consts, nonconsts in
+          )
+        | Some fail -> (fail, consts, nonconsts)
+      in
       let nonconst_lambda =
         match nonconsts with
-          [] -> default
+        | [] -> default
         | _ ->
             let tag = Ident.create_local "tag" in
             let tests =
               List.fold_right
                 (fun (path, act) rem ->
-                   let ext = transl_extension_path loc ex_pat.pat_env path in
-                   Lifthenelse(Lprim(Pintcomp Ceq, [Lvar tag; ext], loc),
-                               act, rem))
-                nonconsts
-                default
+                  let ext = transl_extension_path loc ex_pat.pat_env path in
+                  Lifthenelse
+                    (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
+                nonconsts default
             in
-              Llet(Alias, Pgenval,tag, Lprim(Pfield 0, [arg], loc), tests)
+            Llet (Alias, Pgenval, tag, Lprim (Pfield 0, [ arg ], loc), tests)
       in
-        List.fold_right
-          (fun (path, act) rem ->
-             let ext = transl_extension_path loc ex_pat.pat_env path in
-             Lifthenelse(Lprim(Pintcomp Ceq, [arg; ext], loc),
-                         act, rem))
-          consts
-          nonconst_lambda
+      List.fold_right
+        (fun (path, act) rem ->
+          let ext = transl_extension_path loc ex_pat.pat_env path in
+          Lifthenelse (Lprim (Pintcomp Ceq, [ arg; ext ], loc), act, rem))
+        consts nonconst_lambda
     in
-    lambda1, jumps_union local_jumps total1
-  end else begin
+    (lambda1, jumps_union local_jumps total1)
+  else
     (* Regular concrete type *)
     let ncases = List.length tag_lambda_list
-    and nconstrs =  cstr.cstr_consts + cstr.cstr_nonconsts in
+    and nconstrs = cstr.cstr_consts + cstr.cstr_nonconsts in
     let sig_complete = ncases = nconstrs in
-    let fail_opt,fails,local_jumps =
-      if sig_complete then None,[],jumps_empty
+    let fail_opt, fails, local_jumps =
+      if sig_complete then
+        (None, [], jumps_empty)
       else
-        mk_failaction_pos partial pats ctx def in
-
+        mk_failaction_pos partial pats ctx def
+    in
     let tag_lambda_list = fails @ tag_lambda_list in
-    let (consts, nonconsts) = split_cases tag_lambda_list in
+    let consts, nonconsts = split_cases tag_lambda_list in
     let lambda1 =
-      match fail_opt,same_actions tag_lambda_list with
-      | None,Some act -> act (* Identical actions, no failure *)
-      | _ ->
-          match
-            (cstr.cstr_consts, cstr.cstr_nonconsts, consts, nonconsts)
-          with
-          | (1, 1, [0, act1], [0, act2]) ->
-           (* Typically, match on lists, will avoid isint primitive in that
+      match (fail_opt, same_actions tag_lambda_list) with
+      | None, Some act -> act (* Identical actions, no failure *)
+      | _ -> (
+          match (cstr.cstr_consts, cstr.cstr_nonconsts, consts, nonconsts) with
+          | 1, 1, [ (0, act1) ], [ (0, act2) ] ->
+              (* Typically, match on lists, will avoid isint primitive in that
               case *)
-              Lifthenelse(arg, act2, act1)
-          | (n,0,_,[])  -> (* The type defines constant constructors only *)
-              call_switcher loc fail_opt arg 0 (n-1) consts
-          | (n, _, _, _) ->
-              let act0  =
+              Lifthenelse (arg, act2, act1)
+          | n, 0, _, [] ->
+              (* The type defines constant constructors only *)
+              call_switcher loc fail_opt arg 0 (n - 1) consts
+          | n, _, _, _ -> (
+              let act0 =
                 (* = Some act when all non-const constructors match to act *)
-                match fail_opt,nonconsts with
-                | Some a,[] -> Some a
-                | Some _,_ ->
+                match (fail_opt, nonconsts) with
+                | Some a, [] -> Some a
+                | Some _, _ ->
                     if List.length nonconsts = cstr.cstr_nonconsts then
                       same_actions nonconsts
-                    else None
-                | None,_ -> same_actions nonconsts in
+                    else
+                      None
+                | None, _ -> same_actions nonconsts
+              in
               match act0 with
               | Some act ->
                   Lifthenelse
-                    (Lprim (Pisint, [arg], loc),
-                     call_switcher loc
-                       fail_opt arg
-                       0 (n-1) consts,
-                     act)
-(* Emit a switch, as bytecode implements this sophisticated instruction *)
+                    ( Lprim (Pisint, [ arg ], loc),
+                      call_switcher loc fail_opt arg 0 (n - 1) consts,
+                      act )
+              (* Emit a switch, as bytecode implements this sophisticated instruction *)
               | None ->
                   let sw =
-                    {sw_numconsts = cstr.cstr_consts; sw_consts = consts;
-                     sw_numblocks = cstr.cstr_nonconsts; sw_blocks = nonconsts;
-                     sw_failaction = fail_opt} in
-                  let hs,sw = share_actions_sw sw in
+                    { sw_numconsts = cstr.cstr_consts;
+                      sw_consts = consts;
+                      sw_numblocks = cstr.cstr_nonconsts;
+                      sw_blocks = nonconsts;
+                      sw_failaction = fail_opt
+                    }
+                  in
+                  let hs, sw = share_actions_sw sw in
                   let sw = reintroduce_fail sw in
-                  hs (Lswitch (arg,sw,loc)) in
-    lambda1, jumps_union local_jumps total1
-  end
+                  hs (Lswitch (arg, sw, loc))
+            )
+        )
+    in
+    (lambda1, jumps_union local_jumps total1)
 
 let make_test_sequence_variant_constant fail arg int_lambda_list =
-  let _, (cases, actions) =
-    as_interval fail min_int max_int int_lambda_list in
+  let _, (cases, actions) = as_interval fail min_int max_int int_lambda_list in
   Switcher.test_sequence arg cases actions
 
 let call_switcher_variant_constant loc fail arg int_lambda_list =
   call_switcher loc fail arg min_int max_int int_lambda_list
 
-
 let call_switcher_variant_constr loc fail arg int_lambda_list =
   let v = Ident.create_local "variant" in
-  Llet(Alias, Pgenval, v, Lprim(Pfield 0, [arg], loc),
-       call_switcher loc
-         fail (Lvar v) min_int max_int int_lambda_list)
+  Llet
+    ( Alias,
+      Pgenval,
+      v,
+      Lprim (Pfield 0, [ arg ], loc),
+      call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
 
-let combine_variant loc row arg partial ctx def
-                    (tag_lambda_list, total1, _pats) =
+let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
+    =
   let row = Btype.row_repr row in
   let num_constr = ref 0 in
   if row.row_closed then
     List.iter
       (fun (_, f) ->
         match Btype.row_field_repr f with
-          Rabsent | Reither(true, _::_, _, _) -> ()
+        | Rabsent
+        | Reither (true, _ :: _, _, _) ->
+            ()
         | _ -> incr num_constr)
       row.row_fields
   else
     num_constr := max_int;
   let test_int_or_block arg if_int if_block =
-    Lifthenelse(Lprim (Pisint, [arg], loc), if_int, if_block) in
-  let sig_complete =  List.length tag_lambda_list = !num_constr
+    Lifthenelse (Lprim (Pisint, [ arg ], loc), if_int, if_block)
+  in
+  let sig_complete = List.length tag_lambda_list = !num_constr
   and one_action = same_actions tag_lambda_list in
   let fail, local_jumps =
     if
-      sig_complete  || (match partial with Total -> true | _ -> false)
+      sig_complete
+      ||
+      match partial with
+      | Total -> true
+      | _ -> false
     then
-      None, jumps_empty
+      (None, jumps_empty)
     else
-      mk_failaction_neg partial ctx def in
-  let (consts, nonconsts) = split_cases tag_lambda_list in
-  let lambda1 = match fail, one_action with
-  | None, Some act -> act
-  | _,_ ->
-      match (consts, nonconsts) with
-      | ([_, act1], [_, act2]) when fail=None ->
-          test_int_or_block arg act1 act2
-      | (_, []) -> (* One can compare integers and pointers *)
-          make_test_sequence_variant_constant fail arg consts
-      | ([], _) ->
-          let lam = call_switcher_variant_constr loc
-              fail arg nonconsts in
-          (* One must not dereference integers *)
-          begin match fail with
-          | None -> lam
-          | Some fail -> test_int_or_block arg fail lam
-          end
-      | (_, _) ->
-          let lam_const =
-            call_switcher_variant_constant loc
-              fail arg consts
-          and lam_nonconst =
-            call_switcher_variant_constr loc
-              fail arg nonconsts in
-          test_int_or_block arg lam_const lam_nonconst
+      mk_failaction_neg partial ctx def
   in
-  lambda1, jumps_union local_jumps total1
+  let consts, nonconsts = split_cases tag_lambda_list in
+  let lambda1 =
+    match (fail, one_action) with
+    | None, Some act -> act
+    | _, _ -> (
+        match (consts, nonconsts) with
+        | [ (_, act1) ], [ (_, act2) ] when fail = None ->
+            test_int_or_block arg act1 act2
+        | _, [] ->
+            (* One can compare integers and pointers *)
+            make_test_sequence_variant_constant fail arg consts
+        | [], _ -> (
+            let lam = call_switcher_variant_constr loc fail arg nonconsts in
+            (* One must not dereference integers *)
+            match fail with
+            | None -> lam
+            | Some fail -> test_int_or_block arg fail lam
+          )
+        | _, _ ->
+            let lam_const = call_switcher_variant_constant loc fail arg consts
+            and lam_nonconst =
+              call_switcher_variant_constr loc fail arg nonconsts
+            in
+            test_int_or_block arg lam_const lam_nonconst
+      )
+  in
+  (lambda1, jumps_union local_jumps total1)
 
-
-let combine_array loc arg kind partial ctx def
-    (len_lambda_list, total1, _pats)  =
-  let fail, local_jumps = mk_failaction_neg partial  ctx def in
+let combine_array loc arg kind partial ctx def (len_lambda_list, total1, _pats)
+    =
+  let fail, local_jumps = mk_failaction_neg partial ctx def in
   let lambda1 =
     let newvar = Ident.create_local "len" in
     let switch =
-      call_switcher loc
-        fail (Lvar newvar)
-        0 max_int len_lambda_list in
-    bind
-      Alias newvar (Lprim(Parraylength kind, [arg], loc)) switch in
-  lambda1, jumps_union local_jumps total1
+      call_switcher loc fail (Lvar newvar) 0 max_int len_lambda_list
+    in
+    bind Alias newvar (Lprim (Parraylength kind, [ arg ], loc)) switch
+  in
+  (lambda1, jumps_union local_jumps total1)
 
 (* Insertion of debugging events *)
 
 let rec event_branch repr lam =
-  begin match lam, repr with
-    (_, None) ->
-      lam
-  | (Levent(lam', ev), Some r) ->
+  match (lam, repr) with
+  | _, None -> lam
+  | Levent (lam', ev), Some r ->
       incr r;
-      Levent(lam', {lev_loc = ev.lev_loc;
-                    lev_kind = ev.lev_kind;
-                    lev_repr = repr;
-                    lev_env = ev.lev_env})
-  | (Llet(str, k, id, lam, body), _) ->
-      Llet(str, k, id, lam, event_branch repr body)
-  | Lstaticraise _,_ -> lam
-  | (_, Some _) ->
-      Printlambda.lambda Format.str_formatter lam ;
-      fatal_error
-        ("Matching.event_branch: "^Format.flush_str_formatter ())
-  end
-
+      Levent
+        ( lam',
+          { lev_loc = ev.lev_loc;
+            lev_kind = ev.lev_kind;
+            lev_repr = repr;
+            lev_env = ev.lev_env
+          } )
+  | Llet (str, k, id, lam, body), _ ->
+      Llet (str, k, id, lam, event_branch repr body)
+  | Lstaticraise _, _ -> lam
+  | _, Some _ ->
+      Printlambda.lambda Format.str_formatter lam;
+      fatal_error ("Matching.event_branch: " ^ Format.flush_str_formatter ())
 
 (*
    This exception is raised when the compiler cannot produce code
@@ -2549,172 +2657,171 @@ let rec event_branch repr lam =
 exception Unused
 
 let compile_list compile_fun division =
-
   let rec c_rec totals = function
-  | [] -> [], jumps_unions totals, []
-  | (key, cell) :: rem ->
-      begin match cell.ctx with
-      | [] -> c_rec totals rem
-      | _  ->
-          try
-            let (lambda1, total1) = compile_fun cell.ctx cell.pm in
-            let c_rem, total, new_pats =
-              c_rec
-                (jumps_map ctx_combine total1::totals) rem in
-            ((key,lambda1)::c_rem), total, (cell.pat::new_pats)
-          with
-          | Unused -> c_rec totals rem
-      end in
+    | [] -> ([], jumps_unions totals, [])
+    | (key, cell) :: rem -> (
+        match cell.ctx with
+        | [] -> c_rec totals rem
+        | _ -> (
+            try
+              let lambda1, total1 = compile_fun cell.ctx cell.pm in
+              let c_rem, total, new_pats =
+                c_rec (jumps_map ctx_combine total1 :: totals) rem
+              in
+              ((key, lambda1) :: c_rem, total, cell.pat :: new_pats)
+            with Unused -> c_rec totals rem
+          )
+      )
+  in
   c_rec [] division
-
 
 let compile_orhandlers compile_fun lambda1 total1 ctx to_catch =
   let rec do_rec r total_r = function
-    | [] -> r,total_r
-    | (mat,i,vars,pm)::rem ->
-        begin try
+    | [] -> (r, total_r)
+    | (mat, i, vars, pm) :: rem -> (
+        try
           let ctx = select_columns mat ctx in
-          let handler_i, total_i =
-            compile_fun ctx pm in
+          let handler_i, total_i = compile_fun ctx pm in
           match raw_action r with
-          | Lstaticraise (j,args) ->
-              if i=j then
-                List.fold_right2 (bind_with_value_kind Alias)
-                  vars args handler_i,
-                jumps_map (ctx_rshift_num (ncols mat)) total_i
+          | Lstaticraise (j, args) ->
+              if i = j then
+                ( List.fold_right2
+                    (bind_with_value_kind Alias)
+                    vars args handler_i,
+                  jumps_map (ctx_rshift_num (ncols mat)) total_i )
               else
                 do_rec r total_r rem
           | _ ->
               do_rec
-                (Lstaticcatch (r,(i,vars), handler_i))
-                (jumps_union
-                   (jumps_remove i total_r)
+                (Lstaticcatch (r, (i, vars), handler_i))
+                (jumps_union (jumps_remove i total_r)
                    (jumps_map (ctx_rshift_num (ncols mat)) total_i))
-              rem
-        with
-        | Unused ->
-            do_rec (Lstaticcatch (r, (i,vars), lambda_unit)) total_r rem
-        end in
+                rem
+        with Unused ->
+          do_rec (Lstaticcatch (r, (i, vars), lambda_unit)) total_r rem
+      )
+  in
   do_rec lambda1 total1 to_catch
-
 
 let compile_test compile_fun partial divide combine ctx to_match =
   let division = divide ctx to_match in
   let c_div = compile_list compile_fun division in
   match c_div with
-  | [],_,_ ->
-     begin match mk_failaction_neg partial ctx to_match.default with
-     | None,_ -> raise Unused
-     | Some l,total -> l,total
-     end
-  | _ ->
-      combine ctx to_match.default c_div
+  | [], _, _ -> (
+      match mk_failaction_neg partial ctx to_match.default with
+      | None, _ -> raise Unused
+      | Some l, total -> (l, total)
+    )
+  | _ -> combine ctx to_match.default c_div
 
 (* Attempt to avoid some useless bindings by lowering them *)
 
 (* Approximation of v present in lam *)
 let rec approx_present v = function
   | Lconst _ -> false
-  | Lstaticraise (_,args) ->
+  | Lstaticraise (_, args) ->
       List.exists (fun lam -> approx_present v lam) args
-  | Lprim (_,args,_) ->
-      List.exists (fun lam -> approx_present v lam) args
-  | Llet (Alias, _k, _, l1, l2) ->
-      approx_present v l1 || approx_present v l2
+  | Lprim (_, args, _) -> List.exists (fun lam -> approx_present v lam) args
+  | Llet (Alias, _k, _, l1, l2) -> approx_present v l1 || approx_present v l2
   | Lvar vv -> Ident.same v vv
   | _ -> true
 
-let rec lower_bind v arg lam = match lam with
-| Lifthenelse (cond, ifso, ifnot) ->
-    let pcond = approx_present v cond
-    and pso = approx_present v ifso
-    and pnot = approx_present v ifnot in
-    begin match pcond, pso, pnot with
-    | false, false, false -> lam
-    | false, true, false ->
-        Lifthenelse (cond, lower_bind v arg ifso, ifnot)
-    | false, false, true ->
-        Lifthenelse (cond, ifso, lower_bind v arg ifnot)
-    | _,_,_ -> bind Alias v arg lam
-    end
-| Lswitch (ls,({sw_consts=[i,act] ; sw_blocks = []} as sw), loc)
+let rec lower_bind v arg lam =
+  match lam with
+  | Lifthenelse (cond, ifso, ifnot) -> (
+      let pcond = approx_present v cond
+      and pso = approx_present v ifso
+      and pnot = approx_present v ifnot in
+      match (pcond, pso, pnot) with
+      | false, false, false -> lam
+      | false, true, false -> Lifthenelse (cond, lower_bind v arg ifso, ifnot)
+      | false, false, true -> Lifthenelse (cond, ifso, lower_bind v arg ifnot)
+      | _, _, _ -> bind Alias v arg lam
+    )
+  | Lswitch (ls, ({ sw_consts = [ (i, act) ]; sw_blocks = [] } as sw), loc)
     when not (approx_present v ls) ->
-      Lswitch (ls, {sw with sw_consts = [i,lower_bind v arg act]}, loc)
-| Lswitch (ls,({sw_consts=[] ; sw_blocks = [i,act]} as sw), loc)
+      Lswitch (ls, { sw with sw_consts = [ (i, lower_bind v arg act) ] }, loc)
+  | Lswitch (ls, ({ sw_consts = []; sw_blocks = [ (i, act) ] } as sw), loc)
     when not (approx_present v ls) ->
-      Lswitch (ls, {sw with sw_blocks = [i,lower_bind v arg act]}, loc)
-| Llet (Alias, k, vv, lv, l) ->
-    if approx_present v lv then
-      bind Alias v arg lam
-    else
-      Llet (Alias, k, vv, lv, lower_bind v arg l)
-| _ ->
-    bind Alias v arg lam
+      Lswitch (ls, { sw with sw_blocks = [ (i, lower_bind v arg act) ] }, loc)
+  | Llet (Alias, k, vv, lv, l) ->
+      if approx_present v lv then
+        bind Alias v arg lam
+      else
+        Llet (Alias, k, vv, lv, lower_bind v arg l)
+  | _ -> bind Alias v arg lam
 
-let bind_check str v arg lam = match str,arg with
-| _, Lvar _ ->bind str v arg lam
-| Alias,_ -> lower_bind v arg lam
-| _,_     -> bind str v arg lam
+let bind_check str v arg lam =
+  match (str, arg) with
+  | _, Lvar _ -> bind str v arg lam
+  | Alias, _ -> lower_bind v arg lam
+  | _, _ -> bind str v arg lam
 
-let comp_exit ctx m = match m.default with
-| (_,i)::_ -> Lstaticraise (i,[]), jumps_singleton i ctx
-| _        -> fatal_error "Matching.comp_exit"
-
-
+let comp_exit ctx m =
+  match m.default with
+  | (_, i) :: _ -> (Lstaticraise (i, []), jumps_singleton i ctx)
+  | _ -> fatal_error "Matching.comp_exit"
 
 let rec comp_match_handlers comp_fun partial ctx arg first_match next_matchs =
   match next_matchs with
   | [] -> comp_fun partial ctx arg first_match
-  | rem ->
+  | rem -> (
       let rec c_rec body total_body = function
-        | [] -> body, total_body
+        | [] -> (body, total_body)
         (* Hum, -1 means never taken
         | (-1,pm)::rem -> c_rec body total_body rem *)
-        | (i,pm)::rem ->
-            let ctx_i,total_rem = jumps_extract i total_body in
-            begin match ctx_i with
+        | (i, pm) :: rem -> (
+            let ctx_i, total_rem = jumps_extract i total_body in
+            match ctx_i with
             | [] -> c_rec body total_body rem
-            | _ ->
+            | _ -> (
                 try
-                  let li,total_i =
+                  let li, total_i =
                     comp_fun
-                      (match rem with [] -> partial | _ -> Partial)
-                      ctx_i arg pm in
+                      ( match rem with
+                      | [] -> partial
+                      | _ -> Partial
+                      )
+                      ctx_i arg pm
+                  in
                   c_rec
-                    (Lstaticcatch (body,(i,[]),li))
+                    (Lstaticcatch (body, (i, []), li))
                     (jumps_union total_i total_rem)
                     rem
-                with
-                | Unused ->
-                    c_rec (Lstaticcatch (body,(i,[]),lambda_unit))
-                      total_rem  rem
-            end
+                with Unused ->
+                  c_rec
+                    (Lstaticcatch (body, (i, []), lambda_unit))
+                    total_rem rem
+              )
+          )
       in
       try
-        let first_lam,total = comp_fun Partial ctx arg first_match in
+        let first_lam, total = comp_fun Partial ctx arg first_match in
         c_rec first_lam total rem
-      with Unused ->
+      with Unused -> (
         match next_matchs with
         | [] -> raise Unused
-        | (_,x)::xs ->  comp_match_handlers comp_fun partial ctx arg x xs
+        | (_, x) :: xs -> comp_match_handlers comp_fun partial ctx arg x xs
+      )
+    )
 
 (* To find reasonable names for variables *)
 
 let rec name_pattern default = function
-    (pat :: _, _) :: rem ->
-      begin match pat.pat_desc with
-        Tpat_var (id, _) -> id
-      | Tpat_alias(_, id, _) -> id
+  | (pat :: _, _) :: rem -> (
+      match pat.pat_desc with
+      | Tpat_var (id, _) -> id
+      | Tpat_alias (_, id, _) -> id
       | _ -> name_pattern default rem
-      end
+    )
   | _ -> Ident.create_local default
 
-let arg_to_var arg cls = match arg with
-| Lvar v -> v,arg
-| _ ->
-    let v = name_pattern "*match*" cls in
-    v,Lvar v
-
+let arg_to_var arg cls =
+  match arg with
+  | Lvar v -> (v, arg)
+  | _ ->
+      let v = name_pattern "*match*" cls in
+      (v, Lvar v)
 
 (*
   The main compilation function.
@@ -2727,99 +2834,108 @@ let arg_to_var arg cls = match arg with
    Output: a lambda term, a jump summary {..., exit number -> context, .. }
 *)
 
-let rec compile_match repr partial ctx m = match m with
-| { cases = []; args = [] } -> comp_exit ctx m
-| { cases = ([], action) :: rem } ->
-    if is_guarded action then begin
-      let (lambda, total) =
-        compile_match None partial ctx { m with cases = rem } in
-      event_branch repr (patch_guarded lambda action), total
-    end else
-      (event_branch repr action, jumps_empty)
-| { args = (arg, str)::argl } ->
-    let v,newarg = arg_to_var arg m.cases in
-    let first_match,rem =
-      split_precompile (Some v)
-        { m with args = (newarg, Alias) :: argl } in
-    let (lam, total) =
-      comp_match_handlers
-        ((if dbg then do_compile_matching_pr else do_compile_matching) repr)
-        partial ctx newarg first_match rem in
-    bind_check str v arg lam, total
-| _ -> assert false
-
+let rec compile_match repr partial ctx m =
+  match m with
+  | { cases = []; args = [] } -> comp_exit ctx m
+  | { cases = ([], action) :: rem } ->
+      if is_guarded action then
+        let lambda, total =
+          compile_match None partial ctx { m with cases = rem }
+        in
+        (event_branch repr (patch_guarded lambda action), total)
+      else
+        (event_branch repr action, jumps_empty)
+  | { args = (arg, str) :: argl } ->
+      let v, newarg = arg_to_var arg m.cases in
+      let first_match, rem =
+        split_precompile (Some v) { m with args = (newarg, Alias) :: argl }
+      in
+      let lam, total =
+        comp_match_handlers
+          (( if dbg then
+             do_compile_matching_pr
+           else
+             do_compile_matching
+           )
+             repr)
+          partial ctx newarg first_match rem
+      in
+      (bind_check str v arg lam, total)
+  | _ -> assert false
 
 (* verbose version of do_compile_matching, for debug *)
-
 and do_compile_matching_pr repr partial ctx arg x =
   Format.eprintf "COMPILE: %s\nMATCH\n"
-    (match partial with Partial -> "Partial" | Total -> "Total") ;
-  pretty_precompiled x ;
-  Format.eprintf "CTX\n" ;
-  pretty_ctx ctx ;
-  let (_, jumps) as r =  do_compile_matching repr partial ctx arg x in
-  Format.eprintf "JUMPS\n" ;
-  pretty_jumps jumps ;
+    ( match partial with
+    | Partial -> "Partial"
+    | Total -> "Total"
+    );
+  pretty_precompiled x;
+  Format.eprintf "CTX\n";
+  pretty_ctx ctx;
+  let ((_, jumps) as r) = do_compile_matching repr partial ctx arg x in
+  Format.eprintf "JUMPS\n";
+  pretty_jumps jumps;
   r
 
-and do_compile_matching repr partial ctx arg pmh = match pmh with
-| Pm pm ->
-  let pat = what_is_cases pm.cases in
-  begin match pat.pat_desc with
-  | Tpat_any ->
-      compile_no_test
-        divide_var ctx_rshift repr partial ctx pm
-  | Tpat_tuple patl ->
-      compile_no_test
-        (divide_tuple (List.length patl) (normalize_pat pat)) ctx_combine
-        repr partial ctx pm
-  | Tpat_record ((_, lbl,_)::_,_) ->
-      compile_no_test
-        (divide_record lbl.lbl_all (normalize_pat pat))
-        ctx_combine repr partial ctx pm
-  | Tpat_constant cst ->
-      compile_test
-        (compile_match repr partial) partial
-        divide_constant
-        (combine_constant pat.pat_loc arg cst partial)
-        ctx pm
-  | Tpat_construct (_, cstr, _) ->
-      compile_test
-        (compile_match repr partial) partial
-        divide_constructor
-        (combine_constructor pat.pat_loc arg pat cstr partial)
-        ctx pm
-  | Tpat_array _ ->
-      let kind = Typeopt.array_pattern_kind pat in
-      compile_test (compile_match repr partial) partial
-        (divide_array kind) (combine_array pat.pat_loc arg kind partial)
-        ctx pm
-  | Tpat_lazy _ ->
-      compile_no_test
-        (divide_lazy (normalize_pat pat))
-        ctx_combine repr partial ctx pm
-  | Tpat_variant(_, _, row) ->
-      compile_test (compile_match repr partial) partial
-        (divide_variant !row)
-        (combine_variant pat.pat_loc !row arg partial)
-        ctx pm
-  | _ -> assert false
-  end
-| PmVar {inside=pmh ; var_arg=arg} ->
-    let lam, total =
-      do_compile_matching repr partial (ctx_lshift ctx) arg pmh in
-    lam, jumps_map ctx_rshift total
-| PmOr {body=body ; handlers=handlers} ->
-    let lam, total = compile_match repr partial ctx body in
-    compile_orhandlers (compile_match repr partial) lam total ctx handlers
+and do_compile_matching repr partial ctx arg pmh =
+  match pmh with
+  | Pm pm -> (
+      let pat = what_is_cases pm.cases in
+      match pat.pat_desc with
+      | Tpat_any -> compile_no_test divide_var ctx_rshift repr partial ctx pm
+      | Tpat_tuple patl ->
+          compile_no_test
+            (divide_tuple (List.length patl) (normalize_pat pat))
+            ctx_combine repr partial ctx pm
+      | Tpat_record ((_, lbl, _) :: _, _) ->
+          compile_no_test
+            (divide_record lbl.lbl_all (normalize_pat pat))
+            ctx_combine repr partial ctx pm
+      | Tpat_constant cst ->
+          compile_test
+            (compile_match repr partial)
+            partial divide_constant
+            (combine_constant pat.pat_loc arg cst partial)
+            ctx pm
+      | Tpat_construct (_, cstr, _) ->
+          compile_test
+            (compile_match repr partial)
+            partial divide_constructor
+            (combine_constructor pat.pat_loc arg pat cstr partial)
+            ctx pm
+      | Tpat_array _ ->
+          let kind = Typeopt.array_pattern_kind pat in
+          compile_test
+            (compile_match repr partial)
+            partial (divide_array kind)
+            (combine_array pat.pat_loc arg kind partial)
+            ctx pm
+      | Tpat_lazy _ ->
+          compile_no_test
+            (divide_lazy (normalize_pat pat))
+            ctx_combine repr partial ctx pm
+      | Tpat_variant (_, _, row) ->
+          compile_test
+            (compile_match repr partial)
+            partial (divide_variant !row)
+            (combine_variant pat.pat_loc !row arg partial)
+            ctx pm
+      | _ -> assert false
+    )
+  | PmVar { inside = pmh; var_arg = arg } ->
+      let lam, total =
+        do_compile_matching repr partial (ctx_lshift ctx) arg pmh
+      in
+      (lam, jumps_map ctx_rshift total)
+  | PmOr { body; handlers } ->
+      let lam, total = compile_match repr partial ctx body in
+      compile_orhandlers (compile_match repr partial) lam total ctx handlers
 
 and compile_no_test divide up_ctx repr partial ctx to_match =
-  let {pm=this_match ; ctx=this_ctx } = divide ctx to_match in
-  let lambda,total = compile_match repr partial this_ctx this_match in
-  lambda, jumps_map up_ctx total
-
-
-
+  let { pm = this_match; ctx = this_ctx } = divide ctx to_match in
+  let lambda, total = compile_match repr partial this_ctx this_match in
+  (lambda, jumps_map up_ctx total)
 
 (* The entry points *)
 
@@ -2843,48 +2959,66 @@ LM:
 
 let find_in_pat pred =
   let rec find_rec p =
-    pred p.pat_desc ||
-    begin match p.pat_desc with
-    | Tpat_alias (p,_,_) | Tpat_variant (_,Some p,_) | Tpat_lazy p ->
+    pred p.pat_desc
+    ||
+    match p.pat_desc with
+    | Tpat_alias (p, _, _)
+    | Tpat_variant (_, Some p, _)
+    | Tpat_lazy p ->
         find_rec p
-    | Tpat_tuple ps|Tpat_construct (_,_,ps) | Tpat_array ps ->
+    | Tpat_tuple ps
+    | Tpat_construct (_, _, ps)
+    | Tpat_array ps ->
         List.exists find_rec ps
-    | Tpat_record (lpats,_) ->
-        List.exists
-          (fun (_, _, p) -> find_rec p)
-          lpats
-    | Tpat_or (p,q,_) ->
-        find_rec p || find_rec q
-    | Tpat_constant _ | Tpat_var _
-    | Tpat_any | Tpat_variant (_,None,_) -> false
+    | Tpat_record (lpats, _) -> List.exists (fun (_, _, p) -> find_rec p) lpats
+    | Tpat_or (p, q, _) -> find_rec p || find_rec q
+    | Tpat_constant _
+    | Tpat_var _
+    | Tpat_any
+    | Tpat_variant (_, None, _) ->
+        false
     | Tpat_exception _ -> assert false
-  end in
+  in
   find_rec
 
 let is_lazy_pat = function
   | Tpat_lazy _ -> true
-  | Tpat_alias _ | Tpat_variant _ | Tpat_record _
-  | Tpat_tuple _|Tpat_construct _ | Tpat_array _
-  | Tpat_or _ | Tpat_constant _ | Tpat_var _ | Tpat_any
-      -> false
+  | Tpat_alias _
+  | Tpat_variant _
+  | Tpat_record _
+  | Tpat_tuple _
+  | Tpat_construct _
+  | Tpat_array _
+  | Tpat_or _
+  | Tpat_constant _
+  | Tpat_var _
+  | Tpat_any ->
+      false
   | Tpat_exception _ -> assert false
 
 let is_lazy p = find_in_pat is_lazy_pat p
 
-let have_mutable_field p = match p with
-| Tpat_record (lps,_) ->
-    List.exists
-      (fun (_,lbl,_) ->
-        match lbl.Types.lbl_mut with
-        | Mutable -> true
-        | Immutable -> false)
-      lps
-| Tpat_alias _ | Tpat_variant _ | Tpat_lazy _
-| Tpat_tuple _|Tpat_construct _ | Tpat_array _
-| Tpat_or _
-| Tpat_constant _ | Tpat_var _ | Tpat_any
-  -> false
-| Tpat_exception _ -> assert false
+let have_mutable_field p =
+  match p with
+  | Tpat_record (lps, _) ->
+      List.exists
+        (fun (_, lbl, _) ->
+          match lbl.Types.lbl_mut with
+          | Mutable -> true
+          | Immutable -> false)
+        lps
+  | Tpat_alias _
+  | Tpat_variant _
+  | Tpat_lazy _
+  | Tpat_tuple _
+  | Tpat_construct _
+  | Tpat_array _
+  | Tpat_or _
+  | Tpat_constant _
+  | Tpat_var _
+  | Tpat_any ->
+      false
+  | Tpat_exception _ -> assert false
 
 let is_mutable p = find_in_pat have_mutable_field p
 
@@ -2897,65 +3031,81 @@ let check_partial is_mutable is_lazy pat_act_list = function
   | Partial -> Partial
   | Total ->
       if
-        pat_act_list = [] ||  (* allow empty case list *)
-        List.exists
-          (fun (pats, lam) ->
-            is_mutable pats && (is_guarded lam || is_lazy pats))
-          pat_act_list
-      then Partial
-      else Total
+        pat_act_list = []
+        || (* allow empty case list *)
+           List.exists
+             (fun (pats, lam) ->
+               is_mutable pats && (is_guarded lam || is_lazy pats))
+             pat_act_list
+      then
+        Partial
+      else
+        Total
 
 let check_partial_list =
   check_partial (List.exists is_mutable) (List.exists is_lazy)
+
 let check_partial = check_partial is_mutable is_lazy
 
 (* have toplevel handler when appropriate *)
 
-let start_ctx n = [{left=[] ; right = omegas n}]
+let start_ctx n = [ { left = []; right = omegas n } ]
 
 let check_total total lambda i handler_fun =
   if jumps_is_empty total then
     lambda
-  else begin
-    Lstaticcatch(lambda, (i,[]), handler_fun())
-  end
+  else
+    Lstaticcatch (lambda, (i, []), handler_fun ())
 
 let compile_matching repr handler_fun arg pat_act_list partial =
   let partial = check_partial pat_act_list partial in
   match partial with
-  | Partial ->
+  | Partial -> (
       let raise_num = next_raise_count () in
       let pm =
-        { cases = List.map (fun (pat, act) -> ([pat], act)) pat_act_list;
-          args = [arg, Strict] ;
-          default = [[[omega]],raise_num]} in
-      begin try
-        let (lambda, total) = compile_match repr partial (start_ctx 1) pm in
+        { cases = List.map (fun (pat, act) -> ([ pat ], act)) pat_act_list;
+          args = [ (arg, Strict) ];
+          default = [ ([ [ omega ] ], raise_num) ]
+        }
+      in
+      try
+        let lambda, total = compile_match repr partial (start_ctx 1) pm in
         check_total total lambda raise_num handler_fun
-      with
-      | Unused -> assert false (* ; handler_fun() *)
-      end
+      with Unused -> assert false
+      (* ; handler_fun() *)
+    )
   | Total ->
       let pm =
-        { cases = List.map (fun (pat, act) -> ([pat], act)) pat_act_list;
-          args = [arg, Strict] ;
-          default = []} in
-      let (lambda, total) = compile_match repr partial (start_ctx 1) pm in
-      assert (jumps_is_empty total) ;
+        { cases = List.map (fun (pat, act) -> ([ pat ], act)) pat_act_list;
+          args = [ (arg, Strict) ];
+          default = []
+        }
+      in
+      let lambda, total = compile_match repr partial (start_ctx 1) pm in
+      assert (jumps_is_empty total);
       lambda
-
 
 let partial_function loc () =
   let slot =
-    transl_extension_path loc
-      Env.initial_safe_string Predef.path_match_failure
+    transl_extension_path loc Env.initial_safe_string Predef.path_match_failure
   in
-  let (fname, line, char) = Location.get_pos_info loc.Location.loc_start in
-  Lprim(Praise Raise_regular, [Lprim(Pmakeblock(0, Immutable, None),
-          [slot; Lconst(Const_block(0,
-                   [Const_base(Const_string (fname, None));
-                    Const_base(Const_int line);
-                    Const_base(Const_int char)]))], loc)], loc)
+  let fname, line, char = Location.get_pos_info loc.Location.loc_start in
+  Lprim
+    ( Praise Raise_regular,
+      [ Lprim
+          ( Pmakeblock (0, Immutable, None),
+            [ slot;
+              Lconst
+                (Const_block
+                   ( 0,
+                     [ Const_base (Const_string (fname, None));
+                       Const_base (Const_int line);
+                       Const_base (Const_int char)
+                     ] ))
+            ],
+            loc )
+      ],
+      loc )
 
 let for_function loc repr param pat_act_list partial =
   compile_matching repr (partial_function loc) param pat_act_list partial
@@ -2963,12 +3113,11 @@ let for_function loc repr param pat_act_list partial =
 (* In the following two cases, exhaustiveness info is not available! *)
 let for_trywith param pat_act_list =
   compile_matching None
-    (fun () -> Lprim(Praise Raise_reraise, [param], Location.none))
+    (fun () -> Lprim (Praise Raise_reraise, [ param ], Location.none))
     param pat_act_list Partial
 
 let simple_for_let loc param pat body =
-  compile_matching None (partial_function loc) param [pat, body] Partial
-
+  compile_matching None (partial_function loc) param [ (pat, body) ] Partial
 
 (* Optimize binding of immediate tuples
 
@@ -3028,7 +3177,7 @@ let rec map_return f = function
   | Ltrywith (l1, id, l2) -> Ltrywith (map_return f l1, id, map_return f l2)
   | Lstaticcatch (l1, b, l2) ->
       Lstaticcatch (map_return f l1, b, map_return f l2)
-  | Lstaticraise _ | Lprim(Praise _, _, _) as l -> l
+  | (Lstaticraise _ | Lprim (Praise _, _, _)) as l -> l
   | l -> f l
 
 (* The 'opt' reference indicates if the optimization is worthy.
@@ -3047,22 +3196,22 @@ let rec map_return f = function
 *)
 
 let assign_pat opt nraise catch_ids loc pat lam =
-  let rec collect acc pat lam = match pat.pat_desc, lam with
-  | Tpat_tuple patl, Lprim(Pmakeblock _, lams, _) ->
-      opt := true;
-      List.fold_left2 collect acc patl lams
-  | Tpat_tuple patl, Lconst(Const_block(_, scl)) ->
-      opt := true;
-      let collect_const acc pat sc = collect acc pat (Lconst sc) in
-      List.fold_left2 collect_const acc patl scl
-  | _ ->
-    (* pattern idents will be bound in staticcatch (let body), so we
+  let rec collect acc pat lam =
+    match (pat.pat_desc, lam) with
+    | Tpat_tuple patl, Lprim (Pmakeblock _, lams, _) ->
+        opt := true;
+        List.fold_left2 collect acc patl lams
+    | Tpat_tuple patl, Lconst (Const_block (_, scl)) ->
+        opt := true;
+        let collect_const acc pat sc = collect acc pat (Lconst sc) in
+        List.fold_left2 collect_const acc patl scl
+    | _ ->
+        (* pattern idents will be bound in staticcatch (let body), so we
        refresh them here to guarantee binders  uniqueness *)
-    let pat_ids = pat_bound_idents pat in
-    let fresh_ids = List.map (fun id -> id, Ident.rename id) pat_ids in
-    (fresh_ids, alpha_pat fresh_ids pat, lam) :: acc
+        let pat_ids = pat_bound_idents pat in
+        let fresh_ids = List.map (fun id -> (id, Ident.rename id)) pat_ids in
+        (fresh_ids, alpha_pat fresh_ids pat, lam) :: acc
   in
-
   (* sublets were accumulated by 'collect' with the leftmost tuple
      pattern at the bottom of the list; to respect right-to-left
      evaluation order for tuples, we must evaluate sublets
@@ -3075,7 +3224,7 @@ let assign_pat opt nraise catch_ids loc pat lam =
     let add_ids acc (ids, _pat, _lam) = List.fold_left add acc ids in
     let tbl = List.fold_left add_ids Ident.empty rev_sublets in
     let fresh_var id = Lvar (Ident.find_same id tbl) in
-    Lstaticraise(nraise, List.map fresh_var catch_ids)
+    Lstaticraise (nraise, List.map fresh_var catch_ids)
   in
   let push_sublet code (_ids, pat, lam) = simple_for_let loc lam pat code in
   List.fold_left push_sublet exit rev_sublets
@@ -3085,23 +3234,26 @@ let for_let loc param pat body =
   | Tpat_any ->
       (* This eliminates a useless variable (and stack slot in bytecode)
          for "let _ = ...". See #6865. *)
-      Lsequence(param, body)
+      Lsequence (param, body)
   | Tpat_var (id, _) ->
       (* fast path, and keep track of simple bindings to unboxable numbers *)
       let k = Typeopt.value_kind pat.pat_env pat.pat_type in
-      Llet(Strict, k, id, param, body)
+      Llet (Strict, k, id, param, body)
   | _ ->
       let opt = ref false in
       let nraise = next_raise_count () in
       let catch_ids = pat_bound_idents_full pat in
       let ids_with_kinds =
-        List.map (fun (id, _, typ) -> id, Typeopt.value_kind pat.pat_env typ)
+        List.map
+          (fun (id, _, typ) -> (id, Typeopt.value_kind pat.pat_env typ))
           catch_ids
       in
       let ids = List.map (fun (id, _, _) -> id) catch_ids in
       let bind = map_return (assign_pat opt nraise ids loc pat) param in
-      if !opt then Lstaticcatch(bind, (nraise, ids_with_kinds), body)
-      else simple_for_let loc param pat body
+      if !opt then
+        Lstaticcatch (bind, (nraise, ids_with_kinds), body)
+      else
+        simple_for_let loc param pat body
 
 (* Handling of tupled functions and matchings *)
 
@@ -3109,152 +3261,158 @@ let for_let loc param pat body =
 let for_tupled_function loc paraml pats_act_list partial =
   let partial = check_partial_list pats_act_list partial in
   let raise_num = next_raise_count () in
-  let omegas = [List.map (fun _ -> omega) paraml] in
+  let omegas = [ List.map (fun _ -> omega) paraml ] in
   let pm =
     { cases = pats_act_list;
-      args = List.map (fun id -> (Lvar id, Strict)) paraml ;
-      default = [omegas,raise_num]
-    } in
+      args = List.map (fun id -> (Lvar id, Strict)) paraml;
+      default = [ (omegas, raise_num) ]
+    }
+  in
   try
-    let (lambda, total) = compile_match None partial
-        (start_ctx (List.length paraml)) pm in
+    let lambda, total =
+      compile_match None partial (start_ctx (List.length paraml)) pm
+    in
     check_total total lambda raise_num (partial_function loc)
-  with
-  | Unused -> partial_function loc ()
+  with Unused -> partial_function loc ()
 
+let flatten_pattern size p =
+  match p.pat_desc with
+  | Tpat_tuple args -> args
+  | Tpat_any -> omegas size
+  | _ -> raise Cannot_flatten
 
-
-let flatten_pattern size p = match p.pat_desc with
-| Tpat_tuple args -> args
-| Tpat_any -> omegas size
-| _ -> raise Cannot_flatten
-
-let rec flatten_pat_line size p k = match p.pat_desc with
-| Tpat_any ->  omegas size::k
-| Tpat_tuple args -> args::k
-| Tpat_or (p1,p2,_) ->  flatten_pat_line size p1 (flatten_pat_line size p2 k)
-| Tpat_alias (p,_,_) -> (* Note: if this 'as' pat is here, then this is a
+let rec flatten_pat_line size p k =
+  match p.pat_desc with
+  | Tpat_any -> omegas size :: k
+  | Tpat_tuple args -> args :: k
+  | Tpat_or (p1, p2, _) ->
+      flatten_pat_line size p1 (flatten_pat_line size p2 k)
+  | Tpat_alias (p, _, _) ->
+      (* Note: if this 'as' pat is here, then this is a
                            useless binding, solves PR#3780 *)
-    flatten_pat_line size p k
-| _ -> fatal_error "Matching.flatten_pat_line"
+      flatten_pat_line size p k
+  | _ -> fatal_error "Matching.flatten_pat_line"
 
 let flatten_cases size cases =
   List.map
-    (fun (ps,action) -> match ps with
-    | [p] -> flatten_pattern size p,action
-    | _ -> fatal_error "Matching.flatten_case")
+    (fun (ps, action) ->
+      match ps with
+      | [ p ] -> (flatten_pattern size p, action)
+      | _ -> fatal_error "Matching.flatten_case")
     cases
 
 let flatten_matrix size pss =
   List.fold_right
-    (fun ps r -> match ps with
-    | [p] -> flatten_pat_line size p r
-    | _   -> fatal_error "Matching.flatten_matrix")
+    (fun ps r ->
+      match ps with
+      | [ p ] -> flatten_pat_line size p r
+      | _ -> fatal_error "Matching.flatten_matrix")
     pss []
 
 let flatten_def size def =
-  List.map
-    (fun (pss,i) -> flatten_matrix size pss,i)
-    def
+  List.map (fun (pss, i) -> (flatten_matrix size pss, i)) def
 
 let flatten_pm size args pm =
-    {args = args ; cases = flatten_cases size pm.cases ;
-     default = flatten_def size pm.default}
+  { args;
+    cases = flatten_cases size pm.cases;
+    default = flatten_def size pm.default
+  }
 
-
-let flatten_precompiled size args  pmh = match pmh with
-| Pm pm -> Pm (flatten_pm size args pm)
-| PmOr {body=b ; handlers=hs ; or_matrix=m} ->
-    PmOr
-      {body=flatten_pm size args b ;
-       handlers=
-         List.map
-          (fun (mat,i,vars,pm) -> flatten_matrix size mat,i,vars,pm)
-          hs ;
-       or_matrix=flatten_matrix size m ;}
-| PmVar _ -> assert false
+let flatten_precompiled size args pmh =
+  match pmh with
+  | Pm pm -> Pm (flatten_pm size args pm)
+  | PmOr { body = b; handlers = hs; or_matrix = m } ->
+      PmOr
+        { body = flatten_pm size args b;
+          handlers =
+            List.map
+              (fun (mat, i, vars, pm) ->
+                (flatten_matrix size mat, i, vars, pm))
+              hs;
+          or_matrix = flatten_matrix size m
+        }
+  | PmVar _ -> assert false
 
 (*
    compiled_flattened is a ``comp_fun'' argument to comp_match_handlers.
    Hence it needs a fourth argument, which it ignores
 *)
 
-let compile_flattened repr partial ctx _ pmh = match pmh with
-| Pm pm -> compile_match repr partial ctx pm
-| PmOr {body=b ; handlers=hs} ->
-    let lam, total = compile_match repr partial ctx b in
-    compile_orhandlers (compile_match repr partial) lam total ctx hs
-| PmVar _ -> assert false
+let compile_flattened repr partial ctx _ pmh =
+  match pmh with
+  | Pm pm -> compile_match repr partial ctx pm
+  | PmOr { body = b; handlers = hs } ->
+      let lam, total = compile_match repr partial ctx b in
+      compile_orhandlers (compile_match repr partial) lam total ctx hs
+  | PmVar _ -> assert false
 
 let do_for_multiple_match loc paraml pat_act_list partial =
   let repr = None in
   let partial = check_partial pat_act_list partial in
-  let raise_num,pm1 =
+  let raise_num, pm1 =
     let raise_num, default =
       match partial with
       | Partial ->
-        let raise_num = next_raise_count () in
-        raise_num, [ [[omega]], raise_num ]
-      | Total ->
-        -1, []
+          let raise_num = next_raise_count () in
+          (raise_num, [ ([ [ omega ] ], raise_num) ])
+      | Total -> (-1, [])
     in
-    raise_num,
-    { cases = List.map (fun (pat, act) -> ([pat], act)) pat_act_list;
-      args = [Lprim(Pmakeblock(0, Immutable, None), paraml, loc), Strict];
-      default }
+    ( raise_num,
+      { cases = List.map (fun (pat, act) -> ([ pat ], act)) pat_act_list;
+        args =
+          [ (Lprim (Pmakeblock (0, Immutable, None), paraml, loc), Strict) ];
+        default
+      } )
   in
-
   try
     try
-(* Once for checking that compilation is possible *)
+      (* Once for checking that compilation is possible *)
       let next, nexts = split_precompile None pm1 in
-
       let size = List.length paraml
       and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
-      let args =  List.map (fun id -> Lvar id, Alias) idl in
-
+      let args = List.map (fun id -> (Lvar id, Alias)) idl in
       let flat_next = flatten_precompiled size args next
       and flat_nexts =
-        List.map
-          (fun (e,pm) ->  e,flatten_precompiled size args pm)
-          nexts in
-
+        List.map (fun (e, pm) -> (e, flatten_precompiled size args pm)) nexts
+      in
       let lam, total =
-        comp_match_handlers
-          (compile_flattened repr)
-          partial (start_ctx size) () flat_next flat_nexts in
+        comp_match_handlers (compile_flattened repr) partial (start_ctx size)
+          () flat_next flat_nexts
+      in
       List.fold_right2 (bind Strict) idl paraml
-        (match partial with
-        | Partial ->
-            check_total total lam raise_num (partial_function loc)
+        ( match partial with
+        | Partial -> check_total total lam raise_num (partial_function loc)
         | Total ->
-            assert (jumps_is_empty total) ;
-            lam)
-    with Cannot_flatten ->
-      let (lambda, total) = compile_match None partial (start_ctx 1) pm1 in
-      begin match partial with
-      | Partial ->
-          check_total total lambda raise_num (partial_function loc)
+            assert (jumps_is_empty total);
+            lam
+        )
+    with Cannot_flatten -> (
+      let lambda, total = compile_match None partial (start_ctx 1) pm1 in
+      match partial with
+      | Partial -> check_total total lambda raise_num (partial_function loc)
       | Total ->
-          assert (jumps_is_empty total) ;
+          assert (jumps_is_empty total);
           lambda
-      end
-  with Unused ->
-    assert false (* ; partial_function loc () *)
+    )
+  with Unused -> assert false
+
+(* ; partial_function loc () *)
 
 (* PR#4828: Believe it or not, the 'paraml' argument below
    may not be side effect free. *)
 
-let param_to_var param = match param with
-| Lvar v -> v,None
-| _ -> Ident.create_local "*match*",Some param
+let param_to_var param =
+  match param with
+  | Lvar v -> (v, None)
+  | _ -> (Ident.create_local "*match*", Some param)
 
-let bind_opt (v,eo) k = match eo with
-| None -> k
-| Some e ->  Lambda.bind Strict v e k
+let bind_opt (v, eo) k =
+  match eo with
+  | None -> k
+  | Some e -> Lambda.bind Strict v e k
 
 let for_multiple_match loc paraml pat_act_list partial =
   let v_paraml = List.map param_to_var paraml in
-  let paraml = List.map (fun (v,_) -> Lvar v) v_paraml in
+  let paraml = List.map (fun (v, _) -> Lvar v) v_paraml in
   List.fold_right bind_opt v_paraml
     (do_for_multiple_match loc paraml pat_act_list partial)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -405,9 +405,14 @@ type pm_half_compiled =
 and pm_var_compiled =
     {inside : pm_half_compiled ; var_arg : lambda ; }
 
+(* Only used inside the various split functions, we only keep [me] when we're
+   done splitting / precompiling. *)
 type pm_half_compiled_info =
     {me : pm_half_compiled ;
      matrix : matrix ;
+     (* the matrix matched by [me]. Is used to extend the list of reachable trap
+        handlers (aka "default environments") when returning from recursive
+        calls. *)
      top_default : (matrix * int) list ; }
 
 let pretty_cases cases =

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -478,6 +478,11 @@ end
 type pattern_matching = {
   mutable cases : (pattern list * lambda) list;
   args : (lambda * let_kind) list;
+      (** args are not just Ident.t in at least the following cases:
+        - when matching the arguments of a constructor,
+          direct field projections are used (make_field_args)
+        - with lazy patterns args can be of the form [Lazy.force ...]
+          (inline_lazy_force). *)
   default : (matrix * int) list
 }
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3171,18 +3171,19 @@ let do_for_multiple_match loc paraml pat_act_list partial =
   let repr = None in
   let partial = check_partial pat_act_list partial in
   let raise_num,pm1 =
-    match partial with
-    | Partial ->
+    let raise_num, default =
+      match partial with
+      | Partial ->
         let raise_num = next_raise_count () in
-        raise_num,
-        { cases = List.map (fun (pat, act) -> ([pat], act)) pat_act_list;
-          args = [Lprim(Pmakeblock(0, Immutable, None), paraml, loc), Strict];
-          default = [[[omega]],raise_num] }
-    | _ ->
-        -1,
-        { cases = List.map (fun (pat, act) -> ([pat], act)) pat_act_list;
-          args = [Lprim(Pmakeblock(0, Immutable, None), paraml, loc), Strict];
-          default = [] } in
+        raise_num, [ [[omega]], raise_num ]
+      | Total ->
+        -1, []
+    in
+    raise_num,
+    { cases = List.map (fun (pat, act) -> ([pat], act)) pat_act_list;
+      args = [Lprim(Pmakeblock(0, Immutable, None), paraml, loc), Strict];
+      default }
+  in
 
   try
     try

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -97,14 +97,8 @@ let lforget {left=left ; right=right} = match right with
 | _::xs -> {left=omega::left ; right=xs}
 |  _ -> assert false
 
-let rec small_enough n = function
-  | [] -> true
-  | _::rem ->
-      if n <= 0 then false
-      else small_enough (n-1) rem
-
 let ctx_lshift ctx =
-  if small_enough (!Clflags.match_context_rows - 1) ctx then
+  if List.length ctx < !Clflags.match_context_rows then
     List.map lshift ctx
   else (* Context pruning *) begin
     get_mins le_ctx (List.map lforget ctx)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -985,17 +985,13 @@ let rec split_or argo cls args def =
     | ((p :: ps, act) as cl) :: rem ->
         if not (safe_before cl rev_no) then
           do_split rev_before rev_ors (cl :: rev_no) rem
-        else if is_or p then
-          let ors, no =
+        else if (not (is_or p)) && safe_before cl rev_ors then
+          do_split (cl :: rev_before) rev_ors rev_no rem
+        else
+          let rev_ors, rev_no =
             Or_matrix.insert_or_append (p, ps, act) rev_ors rev_no
           in
-          do_split rev_before ors no rem
-        else if safe_before cl rev_ors then
-          do_split (cl :: rev_before) rev_ors rev_no rem
-        else if Or_matrix.safe_below_or_matrix rev_ors (p, ps) then
-          do_split rev_before (cl :: rev_ors) rev_no rem
-        else
-          do_split rev_before rev_ors (cl :: rev_no) rem
+          do_split rev_before rev_ors rev_no rem
     | _ -> assert false
   and cons_next yes yesor = function
     | [] -> precompile_or argo yes yesor args def []

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -993,16 +993,18 @@ let rec split_or argo cls args def =
           in
           do_split rev_before rev_ors rev_no rem
     | _ -> assert false
-  and cons_next yes yesor = function
-    | [] -> precompile_or argo yes yesor args def []
-    | rem ->
-        let { me = next; matrix; top_default = def }, nexts =
-          do_split [] [] [] rem
-        in
-        let idef = next_raise_count () in
-        precompile_or argo yes yesor args
-          (cons_default matrix idef def)
-          ((idef, next) :: nexts)
+  and cons_next yes yesor no =
+    let def, nexts =
+      match no with
+      | [] -> (def, [])
+      | _ ->
+          let { me = next; matrix; top_default = def }, nexts =
+            do_split [] [] [] no
+          in
+          let idef = next_raise_count () in
+          (cons_default matrix idef def, (idef, next) :: nexts)
+    in
+    precompile_or argo yes yesor args def nexts
   in
   do_split [] [] [] cls
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -897,11 +897,11 @@ let safe_below_or_matrix l (q, qs) =
 
 let equiv_pat p q = le_pat p q && le_pat q p
 
-let rec get_equiv p l =
+let rec extract_equiv_head p l =
   match l with
   | ((q :: _, _) as cl) :: rem ->
       if equiv_pat p q then
-        let others, rem = get_equiv p rem in
+        let others, rem = extract_equiv_head p rem in
         (cl :: others, rem)
       else
         ([], l)
@@ -918,7 +918,7 @@ let insert_or_append p ps act ors no =
               && equiv_pat p q
             then
               (* attempt insert, for equivalent orpats with no variables *)
-              let _, not_e = get_equiv q rem in
+              let _, not_e = extract_equiv_head q rem in
               if
                 safe_below_or_matrix not_e (p, ps)
                 && (* check append condition for head of O *)
@@ -1217,7 +1217,7 @@ and precompile_or argo cls ors args def k =
   | _ ->
       let rec do_cases = function
         | (({ pat_desc = Tpat_or _ } as orp) :: patl, action) :: rem ->
-            let others, rem = get_equiv orp rem in
+            let others, rem = extract_equiv_head orp rem in
             let orpm =
               { cases =
                   (patl, action)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -486,9 +486,6 @@ type pattern_matching = {
   default : (matrix * int) list
 }
 
-(* Pattern matching after application of both the or-pat rule and the
-   mixture rule *)
-
 type handler = {
   provenance : matrix;
   exit : int;
@@ -501,6 +498,9 @@ type pm_or_compiled = {
   handlers : handler list;
   or_matrix : matrix
 }
+
+(* Pattern matching after application of both the or-pat rule and the
+   mixture rule *)
 
 type pm_half_compiled =
   | PmOr of pm_or_compiled

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1203,7 +1203,9 @@ and precompile_var args cls def k =
             List.map
               (fun (ps, act) ->
                 match ps with
-                | _ :: ps -> (ps, act)
+                | p :: ps ->
+                    assert (group_var p);
+                    (ps, act)
                 | _ -> assert false)
               cls
           and var_def = default_pop_column def in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -110,16 +110,16 @@ let  rshift {left=left ; right=right} = match left with
 
 let ctx_rshift ctx = List.map rshift ctx
 
-let rec nchars n ps =
+let rec rev_split_at n ps =
   if n <= 0 then [],ps
   else match ps with
   | p::rem ->
-    let chars, cdrs = nchars (n-1) rem in
-    p::chars,cdrs
+    let left,right = rev_split_at (n-1) rem in
+    p::left,right
   | _ -> assert false
 
 let  rshift_num n {left=left ; right=right} =
-  let shifted,left = nchars n left in
+  let shifted,left = rev_split_at n left in
   {left=left ; right = shifted@right}
 
 let ctx_rshift_num n ctx = List.map (rshift_num n) ctx
@@ -275,7 +275,7 @@ let select_columns pss ctx =
     (fun ps r ->
       List.fold_right
         (fun {left=left ; right=right} r ->
-          let transfer, right = nchars n right in
+          let transfer, right = rev_split_at n right in
           try
             {left = lubs transfer ps @ left ; right=right}::r
           with

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1317,7 +1317,7 @@ and precompile_or argo cls ors args def k =
     },
     k )
 
-let split_precompile argo pm =
+let split_and_precompile argo pm =
   let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
   if
     dbg
@@ -2983,7 +2983,7 @@ let rec compile_match repr partial ctx m =
   | { args = (arg, str) :: argl } ->
       let v, newarg = arg_to_var arg m.cases in
       let first_match, rem =
-        split_precompile (Some v) { m with args = (newarg, Alias) :: argl }
+        split_and_precompile (Some v) { m with args = (newarg, Alias) :: argl }
       in
       let lam, total =
         comp_match_handlers
@@ -3500,7 +3500,7 @@ let do_for_multiple_match loc paraml pat_act_list partial =
   try
     try
       (* Once for checking that compilation is possible *)
-      let next, nexts = split_precompile None pm1 in
+      let next, nexts = split_and_precompile None pm1 in
       let size = List.length paraml
       and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
       let args = List.map (fun id -> (Lvar id, Alias)) idl in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -664,24 +664,6 @@ let cons_default matrix raise_num default =
   | _ -> (matrix, raise_num) :: default
 
 let default_compat p def =
-  let specialize_row qs =
-    match qs with
-    | q :: rem when may_compat p q -> Some rem
-    | _ -> None
-  in
-  List.filter_map
-    (fun (pss, i) ->
-      match List.filter_map specialize_row pss with
-      | [] -> None
-      | qss -> Some (qss, i))
-    def
-
-let rec optim_default = function
-  | [] -> []
-  | ([] :: _, i) :: _ -> [ ([ [] ], i) ]
-  | (pss, i) :: rem -> (pss, i) :: optim_default rem
-
-let other_default_compat p def =
   let compat_matcher q rem =
     if may_compat p q then
       rem
@@ -689,16 +671,6 @@ let other_default_compat p def =
       raise NoMatch
   in
   specialize_default compat_matcher def
-
-let same_def (m1, i1) (m2, i2) =
-  i1 = i2 && List.for_all2 MayCompat.compats m1 m2
-
-let default_compat p def =
-  let v1 = default_compat p def in
-  let v2 = other_default_compat p def in
-  let v1_optim = optim_default v1 in
-  assert (List.for_all2 same_def v1_optim v2);
-  v1
 
 (* Or-pattern expansion, variables are a complication w.r.t. the article *)
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -524,36 +524,28 @@ let raw_action l =
   | Some l -> l
   | None -> l
 
-let tr_raw act =
-  match make_key act with
-  | Some act -> act
-  | None -> raise Exit
-
 let same_actions = function
   | [] -> None
   | [ (_, act) ] -> Some act
   | (_, act0) :: rem -> (
-      try
-        let raw_act0 = tr_raw act0 in
-        let rec s_rec = function
-          | [] -> Some act0
-          | (_, act) :: rem ->
-              if raw_act0 = tr_raw act then
-                s_rec rem
-              else
-                None
-        in
-        s_rec rem
-      with Exit -> None
+      match make_key act0 with
+      | None -> None
+      | key0_opt ->
+          let same_act (_, act) = make_key act = key0_opt in
+          if List.for_all same_act rem then
+            Some act0
+          else
+            None
     )
 
 (* Test for swapping two clauses *)
 
 let up_ok_action act1 act2 =
-  try
-    let raw1 = tr_raw act1 and raw2 = tr_raw act2 in
-    raw1 = raw2
-  with Exit -> false
+  match (make_key act1, make_key act2) with
+  | Some key1, Some key2 -> key1 = key2
+  | None, _
+  | _, None ->
+      false
 
 let up_ok (ps, act_p) l =
   List.for_all

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -312,14 +312,11 @@ let ctx_match ctx pss =
 type jumps = (int * ctx list) list
 
 let pretty_jumps (env : jumps) =
-  match env with
-  | [] -> ()
-  | _ ->
-      List.iter
-        (fun (i, ctx) ->
-          Printf.fprintf stderr "jump for %d\n" i;
-          pretty_ctx ctx)
-        env
+  List.iter
+    (fun (i, ctx) ->
+      Printf.fprintf stderr "jump for %d\n" i;
+      pretty_ctx ctx)
+    env
 
 let rec jumps_extract i = function
   | [] -> ([], [])

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -928,15 +928,11 @@ module Or_matrix = struct
     in
     let rec attempt seen = function
       (* invariant: the new clause is safe to append at the end of
-       'seen' (but maybe not rem yet) *)
+         [seen] (but maybe not [rem] yet) *)
       | [] -> ((p :: ps, act) :: rev_ors, rev_no)
       | ([], _act) :: _ -> assert false
       | ((q :: qs, act_q) as cl) :: rem ->
-          if not (is_or q) then
-            (* q is not an or-pat, continue *)
-            attempt (cl :: seen) rem
-          else if disjoint p q then
-            (* p # q, continue *)
+          if (not (is_or q)) || disjoint p q then
             attempt (cl :: seen) rem
           else if
             Typedtree.pat_bound_idents p = []

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -275,9 +275,9 @@ let select_columns pss ctx =
     (fun ps r ->
       List.fold_right
         (fun {left=left ; right=right} r ->
-          let transfert, right = nchars n right in
+          let transfer, right = nchars n right in
           try
-            {left = lubs transfert ps @ left ; right=right}::r
+            {left = lubs transfer ps @ left ; right=right}::r
           with
           | Empty -> r)
         ctx r)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2091,16 +2091,6 @@ let sort_lambda_list l =
   let l = List.stable_sort (fun (x, _) (y, _) -> const_compare x y) l in
   uniq_lambda_list l
 
-let rec cut n l =
-  if n = 0 then
-    ([], l)
-  else
-    match l with
-    | [] -> raise (Invalid_argument "cut")
-    | a :: l ->
-        let l1, l2 = cut (n - 1) l in
-        (a :: l1, l2)
-
 let rec do_tests_fail loc fail tst arg = function
   | [] -> fail
   | (c, act) :: rem ->
@@ -2132,7 +2122,7 @@ let make_test_sequence loc fail tst lt_tst arg const_lambda_list =
       | Some fail -> do_tests_fail loc fail tst arg const_lambda_list
   and split_sequence const_lambda_list =
     let list1, list2 =
-      cut (List.length const_lambda_list / 2) const_lambda_list
+      rev_split_at (List.length const_lambda_list / 2) const_lambda_list
     in
     Lifthenelse
       ( Lprim (lt_tst, [ arg; Lconst (Const_base (fst (List.hd list2))) ], loc),

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -656,8 +656,9 @@ let safe_before (ps, act_p) l =
 
    However or-patterns are only half-simplified,
      - aliases under or-patterns are kept
-     - or-patterns whose left-hand-side is simplifiable
-       are removed: (_|p) is changed into _
+     - or-patterns whose right-hand-side is subsumed by their lhs
+       are simplified to their lhs.
+       For instance: [(_ :: _ | 1 :: _)] is changed into [_ :: _]
      - or-patterns whose left-hand-side is not simplified
        are preserved: (p|q) is changed into (simpl(p)|simpl(q))
          {v

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -865,16 +865,32 @@ let is_or p =
   | Tpat_or _ -> true
   | _ -> false
 
+(* Splitting a matrix uses an or-matrix that contains or-patterns
+   (at the head of some of its rows).
+
+   The property that we want to maintain for the rows of the
+   or-matrix is that if the row p::ps is before q::qs and p is an
+   or-pattern, and v::vs matches p but not ps, then we don't need to
+   try q::qs. This is necessary because the compilation of the
+   or-pattern p will exit to a sub-matrix and never come back.
+
+   For this to hold, (p::ps) and (q::qs) must satisfy one of:
+   - disjointness: p and q are not compatible
+   - ordering: if p and q are compatible, ps is more general than qs
+     (this only works if the row p::ps is not guarded; otherwise the
+      guard could fail and q::qs should still be tried)
+*)
+
 (* Conditions for appending to the Or matrix *)
-let conda p q = not (may_compat p q)
+let disjoint p q = not (may_compat p q)
 
-and condb act ps qs = (not (is_guarded act)) && Parmatch.le_pats qs ps
+let safe_below (ps, act) qs = (not (is_guarded act)) && Parmatch.le_pats ps qs
 
-let or_ok p ps l =
+let safe_below_or_matrix l (q, qs) =
   List.for_all
     (function
-      | ({ pat_desc = Tpat_or _ } as q) :: qs, act ->
-          conda p q || condb act ps qs
+      | ({ pat_desc = Tpat_or _ } as p) :: ps, act_p ->
+          disjoint p q || safe_below (ps, act_p) qs
       | _ -> true)
     l
 
@@ -905,12 +921,12 @@ let insert_or_append p ps act ors no =
               (* attempt insert, for equivalent orpats with no variables *)
               let _, not_e = get_equiv q rem in
               if
-                or_ok p ps not_e
+                safe_below_or_matrix not_e (p, ps)
                 && (* check append condition for head of O *)
                    List.for_all (* check insert condition for tail of O *)
                      (fun cl ->
                        match cl with
-                       | q :: _, _ -> not (may_compat p q)
+                       | q :: _, _ -> disjoint p q
                        | _ -> assert false)
                      seen
               then
@@ -919,7 +935,7 @@ let insert_or_append p ps act ors no =
               else
                 (* fail to insert or append *)
                 (ors, (p :: ps, act) :: no)
-            else if condb act_q ps qs then
+            else if safe_below (qs, act_q) ps then
               (* check condition (b) for append *)
               attempt (cl :: seen) rem
             else
@@ -989,7 +1005,7 @@ let rec split_or argo cls args def =
             do_split before ors no rem
           else if up_ok cl ors then
             do_split (cl :: before) ors no rem
-          else if or_ok p ps ors then
+          else if safe_below_or_matrix ors (p, ps) then
             do_split before (cl :: ors) no rem
           else
             do_split before ors (cl :: no) rem

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -72,7 +72,7 @@ let all_record_args lbls =
       in
       List.iter (fun ((_, lbl, _) as x) -> t.(lbl.lbl_pos) <- x) lbls;
       Array.to_list t
-  | _ -> fatal_error "Parmatch.all_record_args"
+  | _ -> fatal_error "Matching.all_record_args"
 
 type matrix = pattern list list
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -525,7 +525,7 @@ let rec read_args xs r = match xs,r with
 | _,_ ->
     fatal_error "Parmatch.read_args"
 
-let do_set_args erase_mutable q r = match q with
+let do_set_args ~erase_mutable q r = match q with
 | {pat_desc = Tpat_tuple omegas} ->
     let args,rest = read_args omegas r in
     make_pat (Tpat_tuple args) q.pat_type q.pat_env::rest
@@ -576,8 +576,8 @@ let do_set_args erase_mutable q r = match q with
     q::r (* case any is used in matching.ml *)
 | _ -> fatal_error "Parmatch.set_args"
 
-let set_args q r = do_set_args false q r
-and set_args_erase_mutable q r = do_set_args true q r
+let set_args q r = do_set_args ~erase_mutable:false q r
+and set_args_erase_mutable q r = do_set_args ~erase_mutable:true q r
 
 (* Given a matrix of non-empty rows
    p1 :: r1...


### PR DESCRIPTION
First wave of changes, joint work with @gasche (with help from @maranget).
I could add a changelog entry in this PR already, but I have a slight preference for delaying this until all the changes (more PRs are in preparation) have been submitted.

The commits here are focused on documenting, renaming, and dusting off some old code. The code emitted by the compiler should be strictly the same before and after this PR (we have checked that this is true on the compiler codebase).