### PR TITLE
Lexing: add set_position and set_filename (same as in Sedlexing)

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,11 @@ Working version
 
 ### Standard library:
 
+- #8771: Lexing: add set_position and set_filename to change (fake)
+   the initial tracking position of the lexbuf.
+   (Konstantin Romanov, Miguel Lumapat, review by Gabriel Scherer,
+    Sébastien Hinderer, and David Allsopp)
+
 - #9059: Added List.filteri function, same as List.filter but
   with the index of the element.
   (Léo Andrès, review by Alain Frisch)

--- a/stdlib/lexing.ml
+++ b/stdlib/lexing.ml
@@ -179,6 +179,13 @@ let from_string ?(with_positions = true) s =
     lex_curr_p = if with_positions then zero_pos else dummy_pos;
   }
 
+let set_position lexbuf position =
+  lexbuf.lex_curr_p  <- {position with pos_fname = lexbuf.lex_curr_p.pos_fname};
+  lexbuf.lex_abs_pos <- position.pos_cnum
+
+let set_filename lexbuf fname =
+  lexbuf.lex_curr_p <- {lexbuf.lex_curr_p with pos_fname = fname}
+
 let with_positions lexbuf = lexbuf.lex_curr_p != dummy_pos
 
 let lexeme lexbuf =

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -108,6 +108,16 @@ val from_function : ?with_positions:bool -> (bytes -> int -> int) -> lexbuf
    starting at index 0, and return the number of bytes
    provided. A return value of 0 means end of input. *)
 
+val set_position : lexbuf -> position -> unit
+(** Set the initial tracked input position for [lexbuf] to a custom value.
+   Ignores [pos_fname]. See {!set_file} for changing this field.
+   @since 4.11 *)
+
+val set_filename: lexbuf -> string -> unit
+(** Set filename in the initial tracked position to [file] in
+   [lexbuf].
+   @since 4.11 *)
+
 val with_positions : lexbuf -> bool
 (** Tell whether the lexer buffer keeps track of position fields
     [lex_curr_p] / [lex_start_p], as determined by the corresponding

--- a/testsuite/tests/parsing/change_start_loc.ml
+++ b/testsuite/tests/parsing/change_start_loc.ml
@@ -1,0 +1,32 @@
+(* TEST
+flags = "-I ${ocamlsrcdir}/parsing -I ${ocamlsrcdir}/toplevel"
+include ocamlcommon
+*)
+let position = Lexing.{ (* This corresponds to File "file.ml", line 100, character 10 *)
+    pos_fname = "------should not appear------";
+    pos_lnum = 100;
+    pos_bol = 1000;
+    pos_cnum = 1010;
+}
+
+(* We need to show, that just changing lex_curr_p is not enough.
+   See wrong columns in output for 'Incomplete version'. *)
+let set_position_incomplete lexbuf position =
+  let open Lexing in
+  lexbuf.lex_curr_p  <- {position with pos_fname = lexbuf.lex_curr_p.pos_fname}
+
+(* "Testing framework" *)
+let print_error_in_parse set_position_variant =
+    try
+        let _ =
+            let lexbuf = Lexing.from_string ")f x" in (* contains error in chars 0-1, line 0 *)
+            set_position_variant lexbuf position;
+            Lexing.set_filename lexbuf "file.ml"; (* also testing set_filename *)
+            Parse.expression lexbuf in ()
+    with e -> Location.report_exception Format.std_formatter e
+
+let _ =
+    print_string "Incomplete version:\n";
+    print_error_in_parse set_position_incomplete;
+    print_string "Good version:\n";
+    print_error_in_parse Lexing.set_position

--- a/testsuite/tests/parsing/change_start_loc.reference
+++ b/testsuite/tests/parsing/change_start_loc.reference
@@ -1,0 +1,6 @@
+Incomplete version:
+File "file.ml", line 100, characters 10--999:
+Error: Syntax error
+Good version:
+File "file.ml", line 100, characters 10-11:
+Error: Syntax error


### PR DESCRIPTION
When we use `Parse` module functions in PPXes, sometimes it is very convenient to shift the initial location from default "line 1; column 1". For instance, see https://github.com/janestreet/ppx_custom_printf/blob/master/src/ppx_custom_printf.ml#L163
Otherwise PPX author needs to traverse AST and manually shift location in every node - it is very risky from compatibility point of view and complicated.

In `Sedlex` authors added functions `set_position` and `set_filename`, which provide such an API - https://github.com/ocaml-community/sedlex/blob/master/src/lib/sedlexing.ml#L82. 

This PR adds similar API to Stdlib `Lexing` module. Of course, we can always alter internal fields of `lexbuf`, but it is better to have compatibility between two lexers and some API.

Also, I found by experiment and checked by reading the code, that to shift location we need not only change `lexbuf.lex_curr_p`, but also `lexbuf.lex_abs_pos`.