### PR TITLE
Remove leftover occurrences of "Pervasives" in the manual

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -23,11 +23,10 @@ User primitives are declared in an implementation file or
 \end{alltt}
 This defines the value name \var{name} as a function with type
 \var{type} that executes by calling the given C function.
-For instance, here is how the "input" primitive is declared in the
-standard library module "Pervasives":
+For instance, here is how the "input_char" primitive is declared in the
+standard library module "Stdlib":
 \begin{verbatim}
-        external input : in_channel -> bytes -> int -> int -> int
-                       = "input"
+        external input_char : in_channel -> char = "caml_ml_input_char"
 \end{verbatim}
 Primitives with several arguments are always curried. The C function
 does not necessarily have the same name as the ML function.
@@ -1624,10 +1623,10 @@ OCaml runtime explicitly, in order to avoid various system resource leaks.
 Since 4.05, "caml_shutdown" function can be used to shut the runtime down
 gracefully, which equals the following:
 \begin{itemize}
-\item Running the functions that were registered with "Pervasives.at_exit".
+\item Running the functions that were registered with "Stdlib.at_exit".
 \item Triggering finalization of allocated custom blocks (see
-section~\ref{s:custom}). For example, "Pervasives.in_channel" and
-"Pervasives.out_channel" are represented by custom blocks that enclose file
+section~\ref{s:custom}). For example, "Stdlib.in_channel" and
+"Stdlib.out_channel" are represented by custom blocks that enclose file
 descriptors, which are to be released.
 \item Unloading the dependent shared libraries that were loaded by the runtime,
 including "dynlink" plugins.

--- a/manual/manual/cmds/ocamldoc.etex
+++ b/manual/manual/cmds/ocamldoc.etex
@@ -98,7 +98,7 @@ read with the "-load" option in a subsequent invocation of "ocamldoc".
 \item["-hide" \var{modules}]
 Hide the given complete module names in the generated documentation.
 \var{modules} is a list of complete module names separated
- by '","', without blanks.  For instance: "Pervasives,M2.M3".
+ by '","', without blanks.  For instance: "Stdlib,M2.M3".
 
 \item["-inv-merge-ml-mli"]
 Reverse the precedence of implementations and interfaces when merging.

--- a/manual/manual/library/stdlib-blurb.etex
+++ b/manual/manual/library/stdlib-blurb.etex
@@ -8,7 +8,7 @@ having to add any ".cmo" file on the command line for the linking
 phase. Similarly, in interactive use, these globals can be used in
 toplevel phrases without having to load any ".cmo" file in memory.
 
-Unlike the "Pervasives" module from the core library, the modules from the
+Unlike the "Stdlib" module from the core library, the modules from the
 standard library are not automatically ``opened'' when a compilation
 starts, or when the toplevel system is launched. Hence it is necessary
 to use qualified identifiers to refer to the functions provided by these

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -703,7 +703,7 @@ interpreted as the application @'(' infix-symbol ')' expr_1 expr_2@.
 
 The table below lists the symbols defined in the initial environment
 and their initial meaning. (See the description of the core
-library module "Pervasives" in chapter~\ref{c:corelib} for more
+library module "Stdlib" in chapter~\ref{c:corelib} for more
 details). Their meaning may be changed at any time using
 @"let" "(" infix-op ")" name_1 name_2 "=" \ldots@
 

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -292,7 +292,7 @@ libraries.
 \entree{"src:"}{the source of an operation}
 \entree{"dst:"}{the destination of an operation}
 \entree{"init:"}{the initial value for an iterator}
-\entree{"cmp:"}{a comparison function, {\it e.g.} "Pervasives.compare"}
+\entree{"cmp:"}{a comparison function, {\it e.g.} "Stdlib.compare"}
 \entree{"mode:"}{an operation mode or a flag list}
 \end{tableau}
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -550,7 +550,7 @@ module Array : sig
       function.  The comparison function must return 0 if its arguments
       compare as equal, a positive integer if the first is greater,
       and a negative integer if the first is smaller (see below for a
-      complete specification).  For example, {!Pervasives.compare} is
+      complete specification).  For example, {!Stdlib.compare} is
       a suitable comparison function.  After calling [sort], the
       array is sorted in place in increasing order.
       [sort] is guaranteed to run in constant heap space


### PR DESCRIPTION
Following up to https://github.com/ocaml/ocaml/pull/1605#issuecomment-502899717 (@nobrowser).

One point that may need to be changed: there is no mention of `Pervasives` being a deprecated alias for `Stdlib` anywhere in the manual. Should we add something?
