### PR TITLE
Reimplement Typecore.final_subexpression on Typedtree, not Parsetree

### DIFF
--- a/testsuite/tests/typing-warnings/never_returns.ml
+++ b/testsuite/tests/typing-warnings/never_returns.ml
@@ -5,17 +5,17 @@
 
 let () = (let module L = List in raise Exit); () ;;
 [%%expect {|
-Line 1, characters 9-44:
+Line 1, characters 33-43:
 1 | let () = (let module L = List in raise Exit); () ;;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                     ^^^^^^^^^^
 Warning 21: this statement never returns (or has an unsound type.)
 Exception: Stdlib.Exit.
 |}]
 let () = (let exception E in raise Exit); ();;
 [%%expect {|
-Line 1, characters 9-40:
+Line 1, characters 29-39:
 1 | let () = (let exception E in raise Exit); ();;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                 ^^^^^^^^^^
 Warning 21: this statement never returns (or has an unsound type.)
 Exception: Stdlib.Exit.
 |}]
@@ -29,9 +29,9 @@ Exception: Stdlib.Exit.
 |}]
 let () = (let open Stdlib in raise Exit); ();;
 [%%expect {|
-Line 1, characters 9-40:
+Line 1, characters 29-39:
 1 | let () = (let open Stdlib in raise Exit); ();;
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                 ^^^^^^^^^^
 Warning 21: this statement never returns (or has an unsound type.)
 Exception: Stdlib.Exit.
 |}]

--- a/testsuite/tests/typing-warnings/never_returns.ml
+++ b/testsuite/tests/typing-warnings/never_returns.ml
@@ -1,0 +1,37 @@
+(* TEST
+   flags = " -w -a+21 "
+   * expect
+*)
+
+let () = (let module L = List in raise Exit); () ;;
+[%%expect {|
+Line 1, characters 9-44:
+1 | let () = (let module L = List in raise Exit); () ;;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 21: this statement never returns (or has an unsound type.)
+Exception: Stdlib.Exit.
+|}]
+let () = (let exception E in raise Exit); ();;
+[%%expect {|
+Line 1, characters 9-40:
+1 | let () = (let exception E in raise Exit); ();;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 21: this statement never returns (or has an unsound type.)
+Exception: Stdlib.Exit.
+|}]
+let () = (raise Exit : _); ();;
+[%%expect {|
+Line 1, characters 10-20:
+1 | let () = (raise Exit : _); ();;
+              ^^^^^^^^^^
+Warning 21: this statement never returns (or has an unsound type.)
+Exception: Stdlib.Exit.
+|}]
+let () = (let open Stdlib in raise Exit); ();;
+[%%expect {|
+Line 1, characters 9-40:
+1 | let () = (let open Stdlib in raise Exit); ();;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 21: this statement never returns (or has an unsound type.)
+Exception: Stdlib.Exit.
+|}]

--- a/testsuite/tests/typing-warnings/ocamltests
+++ b/testsuite/tests/typing-warnings/ocamltests
@@ -14,3 +14,4 @@ records.ml
 unused_rec.ml
 unused_types.ml
 open_warnings.ml
+never_returns.ml

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1770,15 +1770,15 @@ let force_delayed_checks () =
   reset_delayed_checks ();
   Btype.backtrack snap
 
-let rec final_subexpression sexp =
-  match sexp.pexp_desc with
-    Pexp_let (_, _, e)
-  | Pexp_sequence (_, e)
-  | Pexp_try (e, _)
-  | Pexp_ifthenelse (_, e, _)
-  | Pexp_match (_, {pc_rhs=e} :: _)
+let rec final_subexpression exp =
+  match exp.exp_desc with
+    Texp_let (_, _, e)
+  | Texp_sequence (_, e)
+  | Texp_try (e, _)
+  | Texp_ifthenelse (_, e, _)
+  | Texp_match (_, {c_rhs=e} :: _, _)
     -> final_subexpression e
-  | _ -> sexp
+  | _ -> exp
 
 (* Generalization criterion for expressions *)
 
@@ -4243,13 +4243,14 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
 (* Typing of statements (expressions whose values are discarded) *)
 
 and type_statement ?explanation env sexp =
-  let loc = (final_subexpression sexp).pexp_loc in
   begin_def();
   let exp = type_exp env sexp in
   end_def();
   let ty = expand_head env exp.exp_type and tv = newvar() in
   if is_Tvar ty && ty.level > tv.level then
-    Location.prerr_warning loc Warnings.Nonreturning_statement;
+    Location.prerr_warning
+      (final_subexpression exp).exp_loc
+      Warnings.Nonreturning_statement;
   if !Clflags.strict_sequence then
     let expected_ty = instance Predef.type_unit in
     with_explanation explanation (fun () ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1777,6 +1777,9 @@ let rec final_subexpression exp =
   | Texp_try (e, _)
   | Texp_ifthenelse (_, e, _)
   | Texp_match (_, {c_rhs=e} :: _, _)
+  | Texp_letmodule (_, _, _, _, e)
+  | Texp_letexception (_, e)
+  | Texp_open (_, e)
     -> final_subexpression e
   | _ -> exp
 


### PR DESCRIPTION
This function is used to refine the location of warning 21 `"this statement never returns (or has an unsound type."`, e.g. to avoid pointing to an expression of the form `let ... = .... in e` (but point to `e` instead).  In this PR:

  - The traversal is done in the resulting Typedtree, not the original Parsetree.  This removes one ad hoc traversal of the Parsetree (see #8774 for some contexts of why this could be useful).
  - The traversal is done only when the warning needs to be raised.  This removes a quadratic behavior (ok, a cheap one) on long sequences.
  - Local opens/modules bindings/exception definitions are traversed as well.
