### PR TITLE
Suggest -rectypes in a relevant error message

### DIFF
--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -28,14 +28,14 @@ type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
 Line 1, characters 0-47:
 1 | type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation t is cyclic
+Error: The type abbreviation t is cyclic. Did you mean to use -rectypes?
 |}];;
 type 'a t = [`A of 'a t] constraint 'a = 'a t;; (* fails since 4.04 *)
 [%%expect{|
 Line 1, characters 0-45:
 1 | type 'a t = [`A of 'a t] constraint 'a = 'a t;; (* fails since 4.04 *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation t is cyclic
+Error: The type abbreviation t is cyclic. Did you mean to use -rectypes?
 |}];;
 type 'a t = [`A of 'a] as 'a;;
 [%%expect{|

--- a/testsuite/tests/typing-misc/wellfounded.ml
+++ b/testsuite/tests/typing-misc/wellfounded.ml
@@ -18,5 +18,5 @@ type _ prod = Prod : ('a * 'y) prod
 Line 6, characters 6-20:
 6 |       type d = d * d
           ^^^^^^^^^^^^^^
-Error: The type abbreviation d is cyclic
+Error: The type abbreviation d is cyclic. Did you mean to use -rectypes?
 |}];;

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -19,7 +19,8 @@ Line 1, characters 12-77:
 1 | module T1 = Fix(functor (X:sig type t end) -> struct type t = X.t option end);;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the signature of this functor application:
-       The type abbreviation Fixed.t is cyclic
+       The type abbreviation Fixed.t is cyclic.
+       Did you mean to use -rectypes?
 |}]
 module T2 = Fix(functor (X:sig type t end) -> struct type t = X.t end);;
 [%%expect{|

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -9,5 +9,5 @@ module rec T : sig type t = T.t end = T;;
 Line 1, characters 15-35:
 1 | module rec T : sig type t = T.t end = T;;
                    ^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation T.t is cyclic
+Error: The type abbreviation T.t is cyclic. Did you mean to use -rectypes?
 |}]

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -208,7 +208,7 @@ and 'a t = 'a t u;;
 Line 2, characters 0-17:
 2 | and 'a t = 'a t u;;
     ^^^^^^^^^^^^^^^^^
-Error: The type abbreviation t is cyclic
+Error: The type abbreviation t is cyclic. Did you mean to use -rectypes?
 |}];;
 type 'a u = 'a;;
 [%%expect{|
@@ -219,7 +219,7 @@ type t = t u * t u;;
 Line 1, characters 0-18:
 1 | type t = t u * t u;;
     ^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation t is cyclic
+Error: The type abbreviation t is cyclic. Did you mean to use -rectypes?
 |}];;
 
 type t = <x : 'a> as 'a;;

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -617,7 +617,7 @@ val app : int * bool = (1, true)
 Line 9, characters 0-25:
 9 | type 'a foo = 'a foo list
     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation foo is cyclic
+Error: The type abbreviation foo is cyclic. Did you mean to use -rectypes?
 |}];;
 
 class ['a] bar (x : 'a) = object end

--- a/testsuite/tests/typing-recmod/t01bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t01bad.compilers.reference
@@ -1,4 +1,4 @@
 File "t01bad.ml", line 10, characters 15-35:
 10 | module rec A : sig type t = A.t end = struct type t = A.t end;;
                     ^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation A.t is cyclic
+Error: The type abbreviation A.t is cyclic. Did you mean to use -rectypes?

--- a/testsuite/tests/typing-recmod/t15bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t15bad.compilers.reference
@@ -1,4 +1,4 @@
 File "t15bad.ml", line 11, characters 15-35:
 11 | module rec M : S' with type t = M.t = struct type t = M.t end;;
                     ^^^^^^^^^^^^^^^^^^^^
-Error: The type abbreviation M.t is cyclic
+Error: The type abbreviation M.t is cyclic. Did you mean to use -rectypes?

--- a/testsuite/tests/typing-rectypes-bugs/pr5343_bad.compilers.reference
+++ b/testsuite/tests/typing-rectypes-bugs/pr5343_bad.compilers.reference
@@ -1,4 +1,4 @@
 File "pr5343_bad.ml", line 11, characters 2-14:
 11 |   type u = u t and v = v t
        ^^^^^^^^^^^^
-Error: The type abbreviation u is cyclic
+Error: The type abbreviation u is cyclic. Did you mean to use -rectypes?

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1627,7 +1627,8 @@ let report_error ppf = function
   | Duplicate_label s ->
       fprintf ppf "Two labels are named %s" s
   | Recursive_abbrev s ->
-      fprintf ppf "The type abbreviation %s is cyclic" s
+      fprintf ppf "@[The type abbreviation %s is cyclic.@ \
+                     Did you mean to use -rectypes?@]" s
   | Cycle_in_def (s, ty) ->
       Printtyp.reset_and_mark_loops ty;
       fprintf ppf "@[<v>The definition of %s contains a cycle:@ %a@]"


### PR DESCRIPTION
What do you think about suggesting the user to use `-rectypes` in case of a type error that could be potentially resolved by the flag?

Right now if you find a snippet of code that might rely on `-rectypes` and try to use it, then you get an unhelpful error message. This PR tries to rectify this.

There is one drawback: this hint is shown also in some cases where `-rectypes` is not relevant:

```ocaml
type r = r * r  (* relevant to -rectypes *)
  
module rec T : sig type t = T.t end = T (* not relevant *)
```