### PR TITLE
Add Bool.{of,to}_option

### DIFF
--- a/Changes
+++ b/Changes
@@ -70,6 +70,9 @@ Working version
   commands for execution by Sys.command.
   (Xavier Leroy, review by David Allsopp and Damien Doligez)
 
+- #8782: Add Bool.{of,to}_option
+  (Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.

--- a/stdlib/bool.ml
+++ b/stdlib/bool.ml
@@ -31,3 +31,5 @@ let of_string = function
 *)
 
 let to_string = function false -> "false" | true -> "true"
+let of_option = function None -> false | Some () -> true
+let to_option = function false -> None | true -> Some ()

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -66,3 +66,9 @@ val of_string : string -> bool option
 val to_string : bool -> string
 (** [to_string b] is ["true"] if [b] is [true] and ["false"] if [b] is
     [false]. *)
+
+val of_option : unit option -> bool
+(** [of_option o] is [false] if [o] is [None] and [true] if [o] is [Some ()]. *)
+
+val to_option : bool -> unit option
+(** [to_option b] is [None] if [b] is [false] and [Some ()] if [b] is [true]. *)


### PR DESCRIPTION
As the title says. These functions are useful when dealing with optional arguments of `unit` type.