### PR TITLE
.gitattributes: do not show generated boot/menhir/parser.ml* in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,8 @@
 *.png binary
 *.tfm binary
 
+/boot/menhir/parser.ml* -diff
+
 # configure is declared as binary so that it doesn't get included in diffs.
 # This also means it will have the correct Unix line-endings, even on Windows.
 /configure binary


### PR DESCRIPTION
This PR makes it so that changes to the generated parser (which are huge and of no interest) do not appear in diffs.