### PR TITLE
Add Lambda.shallow_fold_left and make use of it

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -516,86 +516,87 @@ let shallow_iter ~tail ~non_tail:f = function
   | Lifused (_v, e) ->
       tail e
 
-let iter_head_constructor f l =
-  shallow_iter ~tail:f ~non_tail:f l
+let fold_left_opt f init = function
+  | None -> init
+  | Some x -> f init x
 
-let rec free_variables = function
-  | Lvar id -> Ident.Set.singleton id
-  | Lconst _ -> Ident.Set.empty
-  | Lapply{ap_func = fn; ap_args = args} ->
-      free_variables_list (free_variables fn) args
-  | Lfunction{body; params} ->
-      Ident.Set.diff (free_variables body)
-        (Ident.Set.of_list (List.map fst params))
+let fold_left_assoc f init =
+  List.fold_left (fun init (_, x) -> f init x) init
+
+let fold_left_switch f init t =
+  let init = fold_left_assoc f init t.sw_consts in
+  let init = fold_left_assoc f init t.sw_blocks in
+  fold_left_opt f init t.sw_failaction
+
+let shallow_fold_left f init = function
+  | Lvar _
+  | Lconst _ ->
+      init
+  | Lfunction {body = t; _}
+  | Lassign (_, t)
+  | Lifused (_, t)
+  | Levent (t, _) ->
+      f init t
+  | Llet (_, _, _, t1, t2)
+  | Lstaticcatch (t1, _, t2)
+  | Lsequence (t1, t2)
+  | Lwhile (t1, t2)
+  | Ltrywith (t1, _, t2) ->
+      let init = f init t1 in
+      f init t2
+  | Lapply {ap_func = t; ap_args = ts; _} ->
+      let init = f init t in
+      List.fold_left f init ts
+  | Lletrec (decl, body) ->
+      let init = fold_left_assoc f init decl in
+      f init body
+  | Lprim (_, ts, _)
+  | Lstaticraise (_, ts) ->
+      List.fold_left f init ts
+  | Lswitch (t, switch, _) ->
+      let init = f init t in
+      fold_left_switch f init switch
+  | Lstringswitch (arg, cases, default, _) ->
+      let init = f init arg in
+      let init = fold_left_assoc f init cases in
+      fold_left_opt f init default
+  | Lifthenelse (t1, t2, t3)
+  | Lfor (_, t1, t2, _, t3) ->
+      let init = f init t1 in
+      let init = f init t2 in
+      f init t3
+  | Lsend (_, t1, t2, ts, _) ->
+      let init = f init t1 in
+      let init = f init t2 in
+      List.fold_left f init ts
+
+let free_variables_fixpoint recur =
+  let module Set = Ident.Set in
+  let folder env t = Set.union (recur t) env in
+  let set_of_keys assoc = Set.of_list (List.map fst assoc) in
+  function
+  | Lvar id ->
+      Set.singleton id
+  | Lfunction {body; params} ->
+      Set.diff (recur body) (set_of_keys params)
   | Llet(_str, _k, id, arg, body) ->
-      Ident.Set.union
-        (free_variables arg)
-        (Ident.Set.remove id (free_variables body))
+      Set.union (recur arg) (Set.remove id (recur body))
   | Lletrec(decl, body) ->
-      let set = free_variables_list (free_variables body) (List.map snd decl) in
-      Ident.Set.diff set (Ident.Set.of_list (List.map fst decl))
-  | Lprim(_p, args, _loc) ->
-      free_variables_list Ident.Set.empty args
-  | Lswitch(arg, sw,_) ->
-      let set =
-        free_variables_list
-          (free_variables_list (free_variables arg)
-             (List.map snd sw.sw_consts))
-          (List.map snd sw.sw_blocks)
-      in
-      begin match sw.sw_failaction with
-      | None -> set
-      | Some failaction -> Ident.Set.union set (free_variables failaction)
-      end
-  | Lstringswitch (arg,cases,default,_) ->
-      let set =
-        free_variables_list (free_variables arg)
-          (List.map snd cases)
-      in
-      begin match default with
-      | None -> set
-      | Some default -> Ident.Set.union set (free_variables default)
-      end
-  | Lstaticraise (_,args) ->
-      free_variables_list Ident.Set.empty args
+      Set.diff (fold_left_assoc folder (recur body) decl) (set_of_keys decl)
   | Lstaticcatch(body, (_, params), handler) ->
-      Ident.Set.union
-        (Ident.Set.diff
-           (free_variables handler)
-           (Ident.Set.of_list (List.map fst params)))
-        (free_variables body)
+      Set.union (Set.diff (recur handler) (set_of_keys params)) (recur body)
   | Ltrywith(body, param, handler) ->
-      Ident.Set.union
-        (Ident.Set.remove
-           param
-           (free_variables handler))
-        (free_variables body)
-  | Lifthenelse(e1, e2, e3) ->
-      Ident.Set.union
-        (Ident.Set.union (free_variables e1) (free_variables e2))
-        (free_variables e3)
-  | Lsequence(e1, e2) ->
-      Ident.Set.union (free_variables e1) (free_variables e2)
-  | Lwhile(e1, e2) ->
-      Ident.Set.union (free_variables e1) (free_variables e2)
+      Set.union (Set.remove param (recur handler)) (recur body)
   | Lfor(v, lo, hi, _dir, body) ->
-      let set = Ident.Set.union (free_variables lo) (free_variables hi) in
-      Ident.Set.union set (Ident.Set.remove v (free_variables body))
+      Set.union (Set.union (recur lo) (recur hi)) (Set.remove v (recur body))
   | Lassign(id, e) ->
-      Ident.Set.add id (free_variables e)
-  | Lsend (_k, met, obj, args, _) ->
-      free_variables_list
-        (Ident.Set.union (free_variables met) (free_variables obj))
-        args
-  | Levent (lam, _evt) ->
-      free_variables lam
-  | Lifused (_v, e) ->
-      (* Shouldn't v be considered a free variable ? *)
-      free_variables e
+      Set.add id (recur e)
+  | Lconst _ | Lapply _ | Lprim _ | Lswitch _ | Lstringswitch _
+  | Lstaticraise _ | Lifthenelse _ | Lsequence _ | Lwhile _ | Lsend _
+  | Levent _ | Lifused _ as other ->
+      shallow_fold_left folder Set.empty other
 
-and free_variables_list set exprs =
-  List.fold_left (fun set expr -> Ident.Set.union (free_variables expr) set)
-    set exprs
+let rec free_variables lam = free_variables_fixpoint free_variables lam
 
 (* Check if an action has a "when" guard *)
 let raise_count = ref 0

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -340,18 +340,14 @@ val lambda_unit: lambda
 val name_lambda: let_kind -> lambda -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda
 
-val iter_head_constructor: (lambda -> unit) -> lambda -> unit
-(** [iter_head_constructor f lam] apply [f] to only the first level of
-    sub expressions of [lam]. It does not recursively traverse the
-    expression.
-*)
+val shallow_fold_left: ('a -> lambda -> 'a) -> 'a -> lambda -> 'a
 
 val shallow_iter:
   tail:(lambda -> unit) ->
   non_tail:(lambda -> unit) ->
   lambda -> unit
-(** Same as [iter_head_constructor], but use a different callback for
-    sub-terms which are in tail position or not. *)
+(** Iterate over the first level of sub-terms and use a different callback
+    depending on whether the term is in a tail position or not. *)
 
 val transl_prim: string -> string -> lambda
 (** Translate a value from a persistent module. For instance:
@@ -362,6 +358,7 @@ val transl_prim: string -> string -> lambda
 *)
 
 val free_variables: lambda -> Ident.Set.t
+val free_variables_fixpoint: (lambda -> Ident.Set.t) -> lambda -> Ident.Set.t
 
 val transl_module_path: Location.t -> Env.t -> Path.t -> lambda
 val transl_value_path: Location.t -> Env.t -> Path.t -> lambda


### PR DESCRIPTION
I added `Lambda.fold_left` and used it to rewrite `Transmod.scan_used_globals`, `Translclass.free_methods`, and `Lambda.free_variables`. The later two turned out to be very similar, so I made an extensible version of `Lambda.free_variables` called `Lambda.free_variables_open` and made `Translate.free_methods` rely on it.

If you think this general direction makes sense I will move on to the next steps: 
* Testing and benchmarking. My idea was to make a version of this branch that keeps the old functions, and then add a wrapper that runs both old and new functions on the each input, asserts that the results are the same, and saves some timing information to a file.
* Use `Lambda.fold_left` to try to rewrite `Lambda.make_key` and maybe replace the uses of `Lambda.shallow_iter`.