### PR TITLE
caml_output_value_to_bytes: avoid integer overflow

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,9 @@ Working version
 
 ### Runtime system:
 
+- #8787, #8788: avoid integer overflow in caml_output_value_to_bytes
+  (Jeremy Yallop, report by Marcello Seri)
+
 - #8619: Ensure Gc.minor_words remains accurate after a GC.
   (Stephen Dolan, Xavier Leroy and David Allsopp,
    review by Xavier Leroy and Gabriel Scherer)

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -800,7 +800,7 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
   memcpy(res, header, header_len);
   res += header_len;
   for (blk = extern_output_first; blk != NULL; blk = blk->next) {
-    int n = blk->end - blk->data;
+    intnat n = blk->end - blk->data;
     memcpy(res, blk->data, n);
     res += n;
   }

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -734,7 +734,7 @@ CAMLprim value caml_output_value_to_bytes(value v, value flags)
   memcpy(&Byte(res, ofs), header, header_len);
   ofs += header_len;
   while (blk != NULL) {
-    int n = blk->end - blk->data;
+    intnat n = blk->end - blk->data;
     memcpy(&Byte(res, ofs), blk->data, n);
     ofs += n;
     nextblk = blk->next;


### PR DESCRIPTION
Use `intnat`, not `int`, to represent pointer difference.

Fixes #8787