### PR TITLE
manual testsuite: case-insensitive name collisions

### DIFF
--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -1,9 +1,11 @@
 TOPDIR=$(abspath ../..)
+SRC=$(TOPDIR)
 include $(TOPDIR)/Makefile.tools
+include $(TOPDIR)/ocamldoc/Makefile.docfiles
 MANUAL=$(TOPDIR)/manual/manual
 
 .PHONY: all
-all: check-cross-references check-stdlib
+all: check-cross-references check-stdlib check-case-collision
 
 .PHONY: tools
 tools: cross-reference-checker
@@ -13,6 +15,7 @@ cross-reference-checker: cross_reference_checker.ml
 	  -I $(TOPDIR)/parsing -I $(TOPDIR)/driver \
 	  $< -o $@
 
+# check cross-references between the manual and error messages
 .PHONY: check-cross-references
 check-cross-references: cross-reference-checker
 	$(SET_LD_PATH) \
@@ -22,9 +25,30 @@ check-cross-references: cross-reference-checker
 	  $(TOPDIR)/driver/main_args.ml \
 	  $(TOPDIR)/lambda/translmod.ml
 
+# check that all standard library modules are referenced by the
+# standard library chapter of the manual
 .PHONY: check-stdlib
 check-stdlib:
 	./check-stdlib-modules $(TOPDIR)
+
+
+# check name collision between latex source file and module documentation
+# on case-insensitive file systems
+normalize = $(shell echo $(basename $(notdir $(1) )) | tr A-Z a-z)
+LOWER_MLIS= $(call normalize,$(DOC_ALL_MLIS))
+LOWER_ETEX= $(call normalize,$(wildcard $(MANUAL)/*/*.etex) $(wildcard *.etex))
+INTER = $(filter $(LOWER_ETEX), $(LOWER_MLIS))
+
+.PHONY: check-case-collision
+check-case-collision:
+ifeq ($(INTER),)
+else
+	@echo "The following names"
+	@echo "  $(INTER)"
+	@echo "are used by both an OCaml module and a latex source file."
+	@echo "This creates a conflict on case-insensitive file systems."
+	@false
+endif
 
 
 .PHONY: clean

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -164,13 +164,14 @@ CheckNoChangesMessage () {
 CheckManual () {
       cat<<EOF
 --------------------------------------------------------------------------
-This test checks that all standard library modules are referenced by the
-standard library chapter of the manual.
+This test checks the global structure of the reference manual
+(e.g. missing chapters).
 --------------------------------------------------------------------------
 EOF
   # we need some of the configuration data provided by configure
   ./configure
-  $MAKE check-stdlib -C manual/tests
+  $MAKE check-stdlib check-case-collision -C manual/tests
+
 }
 
 CheckTestsuiteModified () {


### PR DESCRIPTION
This companion PR to #8786 adds a test to the CI for name collisions on case-insensitive file systems in the manual. This test currently fails due to the issues reported in #8786.