### PR TITLE
Fix use of FILE_FLAG_BACKUP_SEMANTICS in win32unix

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,6 +75,10 @@ Working version
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.
   (Florent Monnier and Nicolás Ojeda Bär, review by David Allsopp)
 
+- #8796, #8797: Ensure Unix.utimes works on directories on Windows and correct
+  the use of FILE_FLAG_BACKUP_SEMANTICS in Unix.stat and Unix.readlink.
+  (David Allsopp, report by Daniil Baturin, review by ??)
+
 ### Build system:
 
 - #8650: ensure that "make" variables are defined before use;

--- a/otherlibs/win32unix/readlink.c
+++ b/otherlibs/win32unix/readlink.c
@@ -65,9 +65,9 @@ CAMLprim value unix_readlink(value opath)
                         OPEN_EXISTING,
                         flags,
                         NULL)) == INVALID_HANDLE_VALUE) {
+      win32_maperr(GetLastError());
       caml_leave_blocking_section();
       caml_stat_free(path);
-      errno = ENOENT;
       unix_restore_privilege(&restore, hToken);
       uerror("readlink", opath);
     } else {

--- a/otherlibs/win32unix/readlink.c
+++ b/otherlibs/win32unix/readlink.c
@@ -98,7 +98,7 @@ CAMLprim value unix_readlink(value opath)
           errno = EINVAL;
           CloseHandle(h);
           unix_restore_privilege(&restore, hToken);
-          uerror("readline", opath);
+          uerror("readlink", opath);
         }
       } else {
         caml_leave_blocking_section();

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -176,7 +176,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
    }
   }
   if (h == INVALID_HANDLE_VALUE) {
-    errno = ENOENT;
+    win32_maperr(GetLastError());
     unix_restore_privilege(&restore, hToken);
     return 0;
   }
@@ -229,7 +229,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
                             OPEN_EXISTING,
                             flags,
                             NULL)) == INVALID_HANDLE_VALUE) {
-          errno = ENOENT;
+          win32_maperr(GetLastError());
           caml_leave_blocking_section();
           unix_restore_privilege(&restore, hToken);
           return 0;

--- a/otherlibs/win32unix/unixsupport.h
+++ b/otherlibs/win32unix/unixsupport.h
@@ -130,4 +130,11 @@ typedef struct _REPARSE_DATA_BUFFER
 
 #define EXECV_CAST (const char_os * const *)
 
+BOOL unix_drop_privilege(DWORD dwAttributes,
+                         LPCWSTR lpName,
+                         PHANDLE hToken_out,
+                         PTOKEN_PRIVILEGES restore,
+                         PDWORD dwFlags);
+void unix_restore_privilege(PTOKEN_PRIVILEGES restore, HANDLE hToken);
+
 #endif /* CAML_UNIXSUPPORT_H */

--- a/otherlibs/win32unix/utimes.c
+++ b/otherlibs/win32unix/utimes.c
@@ -24,6 +24,10 @@
 
 #include <windows.h>
 
+/* Used to prevent race conditions when disabling SeRestorePrivilege */
+static LONG processing = 0;
+static BOOL restore_privilege = FALSE;
+
 static void convert_time(double unixTime, FILETIME* ft)
 {
   ULARGE_INTEGER u;
@@ -40,46 +44,147 @@ CAMLprim value unix_utimes(value path, value atime, value mtime)
 {
   CAMLparam3(path, atime, mtime);
   WCHAR *wpath;
-  HANDLE hFile;
+  HANDLE hFile, hToken = INVALID_HANDLE_VALUE;
+  TOKEN_PRIVILEGES restore;
+  DWORD dwFlags = 0;
   FILETIME lastAccessTime, lastModificationTime;
   SYSTEMTIME systemTime;
+
   double at, mt;
-  BOOL res;
+  BOOL res = FALSE;
 
   caml_unix_check_path(path, "utimes");
   at = Double_val(atime);
   mt = Double_val(mtime);
   wpath = caml_stat_strdup_to_utf16(String_val(path));
-  caml_enter_blocking_section();
-  hFile = CreateFile(wpath,
-                     FILE_WRITE_ATTRIBUTES,
-                     FILE_SHARE_READ | FILE_SHARE_WRITE,
-                     NULL,
-                     OPEN_EXISTING,
-                     0,
-                     NULL);
-  caml_leave_blocking_section();
-  caml_stat_free(wpath);
-  if (hFile == INVALID_HANDLE_VALUE) {
-    win32_maperr(GetLastError());
-    uerror("utimes", path);
+
+  /* Directories require special handling for CreateFile */
+  if (((GetFileAttributes(wpath) & FILE_ATTRIBUTE_DIRECTORY) != 0)) {
+    LUID seRestorePrivilege;
+    DWORD dwReturnLength;
+
+    /* FILE_FLAG_BACKUP_SEMANTICS is required to get a handle to a directory */
+    dwFlags = FILE_FLAG_BACKUP_SEMANTICS;
+
+    /* However, we don't want to access a directory which we can only see
+       through SeRestorePrivilege, so check if it's enabled. There are two
+       possible race conditions:
+         - Another call may restore SeRestorePrivilege between
+           GetTokenInformation and CreateFile
+         - Another call may restore SeRestorePrivilege between
+           AdjustTokenPrivileges and CreateFile
+     */
+
+    LookupPrivilegeValue(NULL, SE_RESTORE_NAME, &seRestorePrivilege);
+    /* -4 is the pseudo-handle for GetCurrentProcessToken, which is not
+       present in the mingw-w64 headers */
+    if (!GetTokenInformation((HANDLE)(LONG_PTR)-4,
+                             TokenPrivileges,
+                             NULL, 0, &dwReturnLength)
+        && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+      TOKEN_PRIVILEGES* privs;
+
+      if (!(privs = (TOKEN_PRIVILEGES*)malloc(dwReturnLength)))
+        caml_raise_out_of_memory();
+
+      if (GetTokenInformation((HANDLE)(LONG_PTR)-4,
+                              TokenPrivileges, privs,
+                              dwReturnLength, &dwReturnLength)) {
+        int i = 0;
+        LUID_AND_ATTRIBUTES* privilege = privs->Privileges;
+
+        /* Search for SeRestorePrivilege */
+        while (i < privs->PrivilegeCount
+               && (privilege->Luid.HighPart != seRestorePrivilege.HighPart
+                   || privilege->Luid.LowPart != seRestorePrivilege.LowPart)) {
+          i++;
+          privilege++;
+        }
+
+        /* If SeRestorePrivilege is present, then open the process token */
+        if (i < privs->PrivilegeCount) {
+          if (OpenProcessToken(GetCurrentProcess(),
+                               TOKEN_ADJUST_PRIVILEGES,
+                               &hToken)) {
+            restore.PrivilegeCount = 1;
+            restore.Privileges->Luid = seRestorePrivilege;
+            restore.Privileges->Attributes = 0;
+            /* The first thread records whether ultimately the privilege must be
+               restored, but all threads will disable it (since we can't know
+               which will reach AdjustTokenPrivilege first) */
+            if (InterlockedIncrement(&processing) == 1)
+              restore_privilege =
+                (privilege->Attributes & SE_PRIVILEGE_ENABLED);
+          } else {
+            win32_maperr(GetLastError());
+            caml_stat_free(wpath);
+            uerror("utimes", path);
+          }
+        } else {
+          CloseHandle(hToken);
+          hToken = INVALID_HANDLE_VALUE;
+        }
+      } else {
+        win32_maperr(GetLastError());
+        caml_stat_free(wpath);
+        uerror("utimes", path);
+      }
+      free(privs);
+    } else {
+      win32_maperr(GetLastError());
+      caml_stat_free(wpath);
+      uerror("utimes", path);
+    }
   }
-  if (at == 0.0 && mt == 0.0) {
-    GetSystemTime(&systemTime);
-    SystemTimeToFileTime(&systemTime, &lastAccessTime);
-    memcpy(&lastModificationTime, &lastAccessTime, sizeof(FILETIME));
+
+  /* Disable SeRestorePrivilege, if necessary */
+  if (hToken != INVALID_HANDLE_VALUE
+      && !AdjustTokenPrivileges(hToken, FALSE,
+                                &restore, sizeof(TOKEN_PRIVILEGES),
+                                NULL, NULL)) {
+    win32_maperr(GetLastError());
   } else {
-    convert_time(at, &lastAccessTime);
-    convert_time(mt, &lastModificationTime);
+    caml_enter_blocking_section();
+    hFile = CreateFile(wpath,
+                       FILE_WRITE_ATTRIBUTES,
+                       FILE_SHARE_READ | FILE_SHARE_WRITE,
+                       NULL,
+                       OPEN_EXISTING,
+                       dwFlags,
+                       NULL);
+    caml_leave_blocking_section();
+    caml_stat_free(wpath);
+    if (hFile != INVALID_HANDLE_VALUE) {
+      if (at == 0.0 && mt == 0.0) {
+        GetSystemTime(&systemTime);
+        SystemTimeToFileTime(&systemTime, &lastAccessTime);
+        memcpy(&lastModificationTime, &lastAccessTime, sizeof(FILETIME));
+      } else {
+        convert_time(at, &lastAccessTime);
+        convert_time(mt, &lastModificationTime);
+      }
+      caml_enter_blocking_section();
+      res = SetFileTime(hFile, NULL, &lastAccessTime, &lastModificationTime);
+      caml_leave_blocking_section();
+      if (!res)
+        win32_maperr(GetLastError());
+      CloseHandle(hFile);
+    } else {
+      win32_maperr(GetLastError());
+    }
   }
-  caml_enter_blocking_section();
-  res = SetFileTime(hFile, NULL, &lastAccessTime, &lastModificationTime);
-  caml_leave_blocking_section();
-  if (res == 0) {
-    win32_maperr(GetLastError());
-    CloseHandle(hFile);
+  if (hToken != INVALID_HANDLE_VALUE) {
+    /* restore_privilege must be read before processing == 0 */
+    BOOL will_restore = restore_privilege;
+    if (InterlockedDecrement(&processing) == 0 && will_restore) {
+      /* Restore SeRestorePrivilege */
+      restore.Privileges->Attributes = SE_PRIVILEGE_ENABLED;
+      AdjustTokenPrivileges(hToken, FALSE,
+                            &restore, sizeof(TOKEN_PRIVILEGES), NULL, NULL);
+    }
+    CloseHandle(hToken);
+  }
+  if (!res)
     uerror("utimes", path);
-  }
-  CloseHandle(hFile);
   CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
This one needs some :popcorn:...

## Windows, ah, Windows

So, on Windows, directories and files are somewhat more distinct than they are on Unix. The Windows [`CreateFile`](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew) API (confusingly, this function is also responsible for opening existing files) will return handles to directories, but only if the strangely named `FILE_FLAG_BACKUP_SEMANTICS` is passed to it.

This is used in `Unix.stat` and `Unix.readlink` and #8796 noted that we should be doing it in `Unix.utimes` for directories. It all looks good, and it's at least what Python and Go do, if not other major cross-platform OS libraries.

But they are all wrong.

## It's all in the semantics

Everyone gets duped by the sentence "To open a directory using **CreateFile**, specify the **FILE_FLAG_BACKUP_SEMANTICS** flag as part of _dwFlagsAndAttributes_." but fail to spot the following sentence: "Appropriate security checks still apply when this flag is used without **SE_BACKUP_NAME** and **SE_RESTORE_NAME** privileges."

So far, so good - but what happens if we're running as a user who **has** `SE_BACKUP_NAME` or `SE_RESTORE_NAME`? Well, unfortunately that means that our standard library function merrily bypasses all security checks on the files it's reading. It's not a privilege escalation, because the user has the capability, but it's somewhat akin to having a call to `sudo` embedded in a function for seemingly no reason.

The cure? If we have `SeBackupPrivilege` (for `Unix.stat` and `Unix.readlink`) or `SeRestorePrivilege` (for `Unix.utimes`), then we need to drop that privilege when we open the directory, in order to ensure that we don't invoke those powers and access a directory **which you would not expect a general purpose function** to access.

Some background for why I think this subtlety matters: `SeBackupPrivilege` and `SeRestorePrivilege` are intended, as the name implies, for backup programs but the privilege is by default available for the Administrators group. However, there are intentionally various steps you have to go through in your program to invoke the privilege:
 - You have to have the right to use it in the first place
 - You have to call an API function ([AdjustTokenPrivileges](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges), since you asked) to *enable* the privilege
 - For every file you wish to access, you must add `FILE_FLAG_BACKUP_SEMANTICS` to the `CreateFile` call

Now, with a triple-lock like that in "the design", I don't think general purpose functions should be accidentally taking advantage of those privileges, however tricky it is to enable them.

## The implementation

First of all, the implementation only uses `FILE_FLAG_BACKUP_SEMANTICS` for directories. If a directory is encountered, then the three functions now analyse the privileges of the security token associated with the thread making the call.

The first commit in this chain attempted to solve this at the process level, but it requires some enormously subtle interlocking to avoid a race condition between multiple calls. I didn't like it.

The second solution, which I dislike less, is to ensure that the thread making the call to `CreateFile` drops the privilege if necessary. This is far more complicated than a Unix programmer might expect, but about par for the course for the Windows API. Essentially:
 - If the thread already has a specific security token, and the privilege is enabled, then it's disabled for the duration of the call. This scenario is very unlikely, because it requires the caller (i.e. the OCaml program running) to have done stuff to make this happen (there is also a highly obscure mode of failure which would cause the function to fail with an exception but, as Donald Knuth would say, "If you have been so devious as to get this message, you will understand it, and you deserve no sympathy.")
 - If the thread does not have a specific security token (the normal state of affairs), then the process's token is duplicated and the privilege dropped for the duration of the call. This is in fact impersonation, but the process would be impersonating itself - at the end of the call it simply reverts the impersonation (again, there is an obscure failure mode here, deserving no sympathy).

I have also, whilst here, changed the behaviour of `Unix.stat` and `Unix.readlink` to return `EACCES` instead of `ENOENT` in some cases (I think this is an error from my 2015 code - you don't expect `ENOENT` on a file to which you don't have access). That change possibly wants moving to a separate PR.