### PR TITLE
Update depends

### DIFF
--- a/.depend
+++ b/.depend
@@ -1678,6 +1678,7 @@ bytecomp/bytepackager.cmo : \
     typing/typemod.cmi \
     lambda/translmod.cmi \
     typing/subst.cmi \
+    lambda/simplif.cmi \
     lambda/printlambda.cmi \
     typing/path.cmi \
     utils/misc.cmi \
@@ -1697,6 +1698,7 @@ bytecomp/bytepackager.cmx : \
     typing/typemod.cmx \
     lambda/translmod.cmx \
     typing/subst.cmx \
+    lambda/simplif.cmx \
     lambda/printlambda.cmx \
     typing/path.cmx \
     utils/misc.cmx \
@@ -2054,6 +2056,7 @@ asmcomp/asmlink.cmi : \
 asmcomp/asmpackager.cmo : \
     typing/typemod.cmi \
     lambda/translmod.cmi \
+    lambda/simplif.cmi \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -2077,6 +2080,7 @@ asmcomp/asmpackager.cmo : \
 asmcomp/asmpackager.cmx : \
     typing/typemod.cmx \
     lambda/translmod.cmx \
+    lambda/simplif.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -211,6 +211,7 @@ stdlib__filename.cmo : \
     stdlib__string.cmi \
     stdlib__random.cmi \
     stdlib__printf.cmi \
+    stdlib__list.cmi \
     stdlib__lazy.cmi \
     stdlib__buffer.cmi \
     stdlib__filename.cmi
@@ -219,6 +220,7 @@ stdlib__filename.cmx : \
     stdlib__string.cmx \
     stdlib__random.cmx \
     stdlib__printf.cmx \
+    stdlib__list.cmx \
     stdlib__lazy.cmx \
     stdlib__buffer.cmx \
     stdlib__filename.cmi


### PR DESCRIPTION
Some dependencies were out of date. Update them using `make depends` and `make alldepends`.