### PR TITLE
Fix soundness bug in extension constructor inclusion

### DIFF
--- a/Changes
+++ b/Changes
@@ -347,6 +347,9 @@ OCaml 4.09.0
 - #8769, #8770: Fix assertion failure with -pack
   (Leo White, review by Gabriel Scherer, report by Fabian @copy)
 
+- #8800: Fix soundness bug in extension constructor inclusion
+  (Leo White, review by Jacques Garrigue)
+
 OCaml 4.08.0
 ------------
 

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -327,7 +327,20 @@ end = struct
   type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
 end
 [%%expect {|
-module M : sig type ('a, 'b) bar += A : 'c -> ('c, 'd) bar end
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) bar += A : 'd -> ('c, 'd) bar end
+       is not included in
+         sig type ('a, 'b) bar += A : 'c -> ('c, 'd) bar end
+       Extension declarations do not match:
+         type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
+       is not included in
+         type ('a, 'b) bar += A : 'c -> ('c, 'd) bar
+       The types for field A are not equal.
 |}]
 
 (* Extensions can be rebound *)

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -270,6 +270,66 @@ Line 1, characters 9-17:
 Error: Cannot use private constructor A to create values of type foo
 |}]
 
+(* Signatures must respect the type of the constructor *)
+
+type ('a, 'b) bar = ..
+[%%expect {|
+type ('a, 'b) bar = ..
+|}]
+
+module M : sig
+  type ('a, 'b) bar += A of int
+end = struct
+  type ('a, 'b) bar += A of float
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) bar += A of float
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) bar += A of float end
+       is not included in
+         sig type ('a, 'b) bar += A of int end
+       Extension declarations do not match:
+         type ('a, 'b) bar += A of float
+       is not included in
+         type ('a, 'b) bar += A of int
+       The types for field A are not equal.
+|}]
+
+module M : sig
+  type ('a, 'b) bar += A of 'a
+end = struct
+  type ('a, 'b) bar += A of 'b
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) bar += A of 'b
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) bar += A of 'b end
+       is not included in
+         sig type ('a, 'b) bar += A of 'a end
+       Extension declarations do not match:
+         type ('a, 'b) bar += A of 'b
+       is not included in
+         type ('a, 'b) bar += A of 'a
+       The types for field A are not equal.
+|}]
+
+module M : sig
+  type ('a, 'b) bar += A : 'c -> ('c, 'd) bar
+end = struct
+  type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
+end
+[%%expect {|
+module M : sig type ('a, 'b) bar += A : 'c -> ('c, 'd) bar end
+|}]
+
 (* Extensions can be rebound *)
 
 type foo = ..

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -364,20 +364,22 @@ let extension_constructors ~loc env ~mark id ext1 ext2 =
   in
   if not (Ctype.equal env true (ty1 :: ext1.ext_type_params)
                                (ty2 :: ext2.ext_type_params))
-  then Some (Field_type id)
-  else
-    let r =
-      compare_constructor_arguments ~loc env id
-        ext1.ext_type_params ext2.ext_type_params
-        ext1.ext_args ext2.ext_args
-    in
-    if r <> None then r else
+  then Some (Field_type id) else
+  let r =
     match ext1.ext_ret_type, ext2.ext_ret_type with
-      Some r1, Some r2 when not (Ctype.equal env true [r1] [r2]) ->
-        Some (Field_type id)
+    | Some r1, Some r2 ->
+        if Ctype.equal env true [r1] [r2] then
+          compare_constructor_arguments ~loc env id [r1] [r2]
+            ext1.ext_args ext2.ext_args
+        else Some (Field_type id)
     | Some _, None | None, Some _ ->
         Some (Field_type id)
-    | _ ->
-        match ext1.ext_private, ext2.ext_private with
-          Private, Public -> Some Privacy
-        | _, _ -> None
+    | None, None ->
+        compare_constructor_arguments ~loc env id
+          ext1.ext_type_params ext2.ext_type_params
+          ext1.ext_args ext2.ext_args
+  in
+  if r <> None then r else
+  match ext1.ext_private, ext2.ext_private with
+  | Private, Public -> Some Privacy
+  | _, _ -> None


### PR DESCRIPTION
```
# type _ t = ..;;
type _ t = ..

# module M : sig
    type 'a t += Foo : 'b -> 'b t
    val x : string t
  end = struct
    type 'a t += Foo : 'b -> 'c t
    let x = Foo 0
  end;;
module M : sig type 'a t += Foo : 'b -> 'b t val x : string t end

# let M.Foo s = M.x;;
Characters 4-11:
  let M.Foo s = M.x;;
      ^^^^^^^
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
*extension*
Matching over values of extensible variant types (the *extension* above)
must include a wild card pattern in order to be exhaustive.

Process OCaml segmentation fault (core dumped)
```

The inclusion check for extension constructors with GADT syntax was comparing the types of the arguments in combination with the types of the type parameters rather than the return types. The fix is simple and follows how the same issue is handled in ordinary constructors.