### PR TITLE
Add a type alias for location stack in the parsetree

### DIFF
--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -42,6 +42,8 @@ type constant =
      Suffixes are rejected by the typechecker.
   *)
 
+type location_stack = Location.t list
+
 (** {1 Extension points} *)
 
 type attribute = {
@@ -79,7 +81,7 @@ and core_type =
     {
      ptyp_desc: core_type_desc;
      ptyp_loc: Location.t;
-     ptyp_loc_stack: Location.t list;
+     ptyp_loc_stack: location_stack;
      ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
     }
 
@@ -188,7 +190,7 @@ and pattern =
     {
      ppat_desc: pattern_desc;
      ppat_loc: Location.t;
-     ppat_loc_stack: Location.t list;
+     ppat_loc_stack: location_stack;
      ppat_attributes: attributes; (* ... [@id1] [@id2] *)
     }
 
@@ -254,7 +256,7 @@ and expression =
     {
      pexp_desc: expression_desc;
      pexp_loc: Location.t;
-     pexp_loc_stack: Location.t list;
+     pexp_loc_stack: location_stack;
      pexp_attributes: attributes; (* ... [@id1] [@id2] *)
     }
 


### PR DESCRIPTION
Introduce a new type alias
`type location_stack = Location.t list`
and update type definitions of `core_type`, `pattern` and `expression` to use it.

This enforces that all `*_loc_stack` share the same type

The main motivation here is to make the life of the following packages easier when it comes to automatically derive code from the parsetree.
- ppxlib
- ppx_tools
- ppx_tools_versionned

In particular, it would be used when generating the metaquot lifters

Here are some connected issue/PR 
- https://github.com/ocaml-ppx/ppx_tools/issues/75
- https://github.com/ocaml-ppx/ppxlib/pull/81