### PR TITLE
Keep information about allocation sizes, for statmemprof, and use during GC.

### DIFF
--- a/.depend
+++ b/.depend
@@ -2385,6 +2385,7 @@ asmcomp/emit.cmi : \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
+    asmcomp/mach.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
@@ -2392,6 +2393,7 @@ asmcomp/emitaux.cmo : \
     asmcomp/arch.cmo \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
+    asmcomp/mach.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
@@ -2399,6 +2401,7 @@ asmcomp/emitaux.cmx : \
     asmcomp/arch.cmx \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmi : \
+    asmcomp/mach.cmi \
     lambda/debuginfo.cmi
 asmcomp/interf.cmo : \
     asmcomp/reg.cmi \

--- a/.depend
+++ b/.depend
@@ -2152,10 +2152,12 @@ asmcomp/branch_relaxation.cmi : \
     asmcomp/linear.cmi \
     asmcomp/branch_relaxation_intf.cmo
 asmcomp/branch_relaxation_intf.cmo : \
+    asmcomp/mach.cmi \
     asmcomp/linear.cmi \
     asmcomp/cmm.cmi \
     asmcomp/arch.cmo
 asmcomp/branch_relaxation_intf.cmx : \
+    asmcomp/mach.cmx \
     asmcomp/linear.cmx \
     asmcomp/cmm.cmx \
     asmcomp/arch.cmx
@@ -2351,7 +2353,6 @@ asmcomp/emit.cmo : \
     lambda/lambda.cmi \
     asmcomp/emitaux.cmi \
     utils/domainstate.cmi \
-    lambda/debuginfo.cmi \
     utils/config.cmi \
     middle_end/compilenv.cmi \
     asmcomp/cmm.cmi \
@@ -2373,7 +2374,6 @@ asmcomp/emit.cmx : \
     lambda/lambda.cmx \
     asmcomp/emitaux.cmx \
     utils/domainstate.cmx \
-    lambda/debuginfo.cmx \
     utils/config.cmx \
     middle_end/compilenv.cmx \
     asmcomp/cmm.cmx \

--- a/Changes
+++ b/Changes
@@ -233,7 +233,8 @@ OCaml 4.10.0
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
 - #8637, #8805: Record debug info for each allocation
-  (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez)
+  (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez,
+   KC Sivaramakrishnan and Xavier Leroy)
 
 - #8713: Introduce a state table in the runtime to contain the global variables
    which must be duplicated for each domain in the multicore runtime.

--- a/Changes
+++ b/Changes
@@ -232,6 +232,9 @@ OCaml 4.10.0
   the new hook caml_fatal_error_hook.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
+- #8637, #8805: Record debug info for each allocation
+  (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez)
+
 - #8713: Introduce a state table in the runtime to contain the global variables
    which must be duplicated for each domain in the multicore runtime.
    (KC Sivaramakrishnan and Stephen Dolan, compatibility header hacking by
@@ -483,7 +486,6 @@ OCaml 4.09.0 (19 September 2019):
 
 - #8787, #8788: avoid integer overflow in caml_output_value_to_bytes
   (Jeremy Yallop, report by Marcello Seri)
-
 
 - #2075, #7729: rename _T macro used to support Unicode in the (Windows) runtime
   in order to avoid compiler warning

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1129,8 +1129,10 @@ let end_assembly() =
       efa_string = (fun s -> D.bytes (s ^ "\000"))
     };
 
-  let frametable = Compilenv.make_symbol (Some "frametable") in
-  D.size frametable (ConstSub (ConstThis, ConstLabel frametable));
+  if system = S_linux then begin
+    let frametable = Compilenv.make_symbol (Some "frametable") in
+    D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
+  end;
 
   if Config.spacetime then begin
     emit_spacetime_shapes ()

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -239,7 +239,7 @@ let addressing addr typ i n =
 
 (* Record live pointers at call points -- see Emitaux *)
 
-let record_frame_label ?label live raise_ dbg =
+let record_frame_label ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -258,11 +258,11 @@ let record_frame_label ?label live raise_ dbg =
     )
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   lbl
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
+let record_frame ?label live dbg =
+  let lbl = record_frame_label ?label live dbg in
   def_label lbl
 
 (* Spacetime instrumentation *)
@@ -327,7 +327,7 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg ~spacetime =
   if !Clflags.debug || Config.spacetime then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label Reg.Set.empty (Dbg_other dbg) in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error; bd_frame = lbl_frame;
         bd_spacetime = spacetime; } :: !bound_error_sites;
@@ -573,16 +573,16 @@ let emit_instr fallthrough i =
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind { label_after; }) ->
       I.call (arg i 0);
-      record_frame i.live false i.dbg ~label:label_after
+      record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
       add_used_symbol func;
       emit_call func;
-      record_frame i.live false i.dbg ~label:label_after
+      record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Itailcall_ind { label_after; }) ->
       output_epilogue begin fun () ->
         I.jmp (arg i 0);
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
+          record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
         end
       end
   | Lop(Itailcall_imm { func; label_after; }) ->
@@ -597,14 +597,14 @@ let emit_instr fallthrough i =
         end
       end;
       if Config.spacetime then begin
-        record_frame Reg.Set.empty false i.dbg ~label:label_after
+        record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
       end
   | Lop(Iextcall { func; alloc; label_after; }) ->
       add_used_symbol func;
       if alloc then begin
         load_symbol_addr func rax;
         emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:label_after;
+        record_frame i.live (Dbg_other i.dbg) ~label:label_after;
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
              This comes from:
@@ -618,7 +618,7 @@ let emit_instr fallthrough i =
       end else begin
         emit_call func;
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:label_after
+          record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
         end
       end
   | Lop(Istackoffset n) ->
@@ -668,7 +668,7 @@ let emit_instr fallthrough i =
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; }) ->
-      if !fastcode_flag then begin
+    if !fastcode_flag then begin
         let lbl_redo = new_label() in
         def_label lbl_redo;
         I.sub (int n) r15;
@@ -679,7 +679,7 @@ let emit_instr fallthrough i =
           else i.dbg
         in
         let lbl_frame =
-          record_frame_label ?label:label_after_call_gc i.live false dbg
+          record_frame_label ?label:label_after_call_gc i.live (Dbg_other dbg)
         in
         I.jb (label lbl_call_gc);
         I.lea (mem64 NONE 8 R15) (res i 0);
@@ -707,8 +707,8 @@ let emit_instr fallthrough i =
             emit_call "caml_allocN"
         end;
         let label =
-          record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+          record_frame_label ?label:label_after_call_gc i.live
+            (Dbg_other i.dbg)
         in
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)
@@ -914,10 +914,10 @@ let emit_instr fallthrough i =
       | Lambda.Raise_regular ->
           I.mov (int 0) (domain_field Domainstate.Domain_backtrace_pos);
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_reraise ->
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_notrace ->
           I.mov (domain_field Domainstate.Domain_exception_pointer) rsp;
           I.pop (domain_field Domainstate.Domain_exception_pointer);
@@ -1119,6 +1119,7 @@ let end_assembly() =
   emit_frames
     { efa_code_label = (fun l -> D.qword (ConstLabel (emit_label l)));
       efa_data_label = (fun l -> D.qword (ConstLabel (emit_label l)));
+      efa_8 = (fun n -> D.byte (const n));
       efa_16 = (fun n -> D.word (const n));
       efa_32 = (fun n -> D.long (const_32 n));
       efa_word = (fun n -> D.qword (const n));
@@ -1141,6 +1142,9 @@ let end_assembly() =
       efa_def_label = (fun l -> _label (emit_label l));
       efa_string = (fun s -> D.bytes (s ^ "\000"))
     };
+
+  let frametable = Compilenv.make_symbol (Some "frametable") in
+  D.size frametable (ConstSub (ConstThis, ConstLabel frametable));
 
   if Config.spacetime then begin
     emit_spacetime_shapes ()

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -281,8 +281,7 @@ let spacetime_before_uninstrumented_call ~node_ptr ~index =
 (* Record calls to the GC -- we've moved them out of the way *)
 
 type gc_call =
-  { gc_size: int;                       (* Allocation size, in bytes *)
-    gc_lbl: label;                      (* Entry label *)
+  { gc_lbl: label;                      (* Entry label *)
     gc_return_lbl: label;               (* Where to branch after GC *)
     gc_frame: label;                    (* Label of frame descriptor *)
     gc_spacetime : (X86_ast.arg * int) option;
@@ -663,10 +662,6 @@ let emit_instr fallthrough i =
       end
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; dbginfo }) ->
       assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
-      let dbginfo =
-        if not !Clflags.debug && not Config.spacetime then
-          List.map (fun d -> { d with alloc_dbg = Debuginfo.none }) dbginfo
-        else dbginfo in
       if !fastcode_flag then begin
         I.sub (int n) r15;
         I.cmp (domain_field Domainstate.Domain_young_limit) r15;
@@ -683,8 +678,7 @@ let emit_instr fallthrough i =
           else Some (arg i 0, spacetime_index)
         in
         call_gc_sites :=
-          { gc_size = n;
-            gc_lbl = lbl_call_gc;
+          { gc_lbl = lbl_call_gc;
             gc_return_lbl = lbl_after_alloc;
             gc_frame = lbl_frame;
             gc_spacetime; } :: !call_gc_sites
@@ -1010,9 +1004,6 @@ let begin_assembly() =
   all_functions := [];
   if system = S_win64 then begin
     D.extrn "caml_call_gc" NEAR;
-    D.extrn "caml_call_gc1" NEAR;
-    D.extrn "caml_call_gc2" NEAR;
-    D.extrn "caml_call_gc3" NEAR;
     D.extrn "caml_c_call" NEAR;
     D.extrn "caml_allocN" NEAR;
     D.extrn "caml_alloc1" NEAR;

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -299,13 +299,7 @@ let emit_call_gc gc =
     assert Config.spacetime;
     spacetime_before_uninstrumented_call ~node_ptr ~index
   end;
-  begin match gc.gc_size with
-  | 16 -> emit_call "caml_call_gc1"
-  | 24 -> emit_call "caml_call_gc2"
-  | 32 -> emit_call "caml_call_gc3"
-  | n ->  I.add (int n) r15;
-          emit_call "caml_call_gc"
-  end;
+  emit_call "caml_call_gc";
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
 
@@ -667,21 +661,21 @@ let emit_instr fallthrough i =
       | Double | Double_u ->
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
-  | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; }) ->
-    if !fastcode_flag then begin
-        let lbl_redo = new_label() in
-        def_label lbl_redo;
+  | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; dbginfo }) ->
+      let dbginfo =
+        if not !Clflags.debug && not Config.spacetime then
+          List.map (fun d -> { d with alloc_dbg = Debuginfo.none }) dbginfo
+        else dbginfo in
+      if !fastcode_flag then begin
         I.sub (int n) r15;
         I.cmp (domain_field Domainstate.Domain_young_limit) r15;
         let lbl_call_gc = new_label() in
-        let dbg =
-          if not Config.spacetime then Debuginfo.none
-          else i.dbg
-        in
         let lbl_frame =
-          record_frame_label ?label:label_after_call_gc i.live (Dbg_other dbg)
+          record_frame_label ?label:label_after_call_gc i.live (Dbg_alloc dbginfo)
         in
         I.jb (label lbl_call_gc);
+        let lbl_after_alloc = new_label() in
+        def_label lbl_after_alloc;
         I.lea (mem64 NONE 8 R15) (res i 0);
         let gc_spacetime =
           if not Config.spacetime then None
@@ -690,7 +684,7 @@ let emit_instr fallthrough i =
         call_gc_sites :=
           { gc_size = n;
             gc_lbl = lbl_call_gc;
-            gc_return_lbl = lbl_redo;
+            gc_return_lbl = lbl_after_alloc;
             gc_frame = lbl_frame;
             gc_spacetime; } :: !call_gc_sites
       end else begin
@@ -708,7 +702,7 @@ let emit_instr fallthrough i =
         end;
         let label =
           record_frame_label ?label:label_after_call_gc i.live
-            (Dbg_other i.dbg)
+            (Dbg_alloc dbginfo)
         in
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -662,6 +662,7 @@ let emit_instr fallthrough i =
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
   | Lop(Ialloc { bytes = n; label_after_call_gc; spacetime_index; dbginfo }) ->
+      assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
       let dbginfo =
         if not !Clflags.debug && not Config.spacetime then
           List.map (fun d -> { d with alloc_dbg = Debuginfo.none }) dbginfo

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -647,29 +647,23 @@ let emit_instr i =
           record_frame_label i.live (Dbg_alloc dbginfo) ?label:label_after_call_gc
         in
         if !fastcode_flag then begin
-          let lbl_redo = new_label() in
-          `{emit_label lbl_redo}:`;
-          let first = ref true in
-          let ninstr =
-            decompose_intconst (Int32.of_int (n - 4)) (fun a ->
-              if !first
-              then `	sub	{emit_reg i.res.(0)}, alloc_ptr, #{emit_int32 a}\n`
-              else `	sub	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, #{emit_int32 a}\n`;
-              first := false) in
+          let ninstr = decompose_intconst
+                         (Int32.of_int n)
+                         (fun i ->
+                           `   sub     alloc_ptr, alloc_ptr, #{emit_int32 i}\n`) in
           let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-          let tmp = if i.res.(0).loc = Reg 8 (* r12 *) then phys_reg 7 (* r7 *)
-                    else phys_reg 8 (* r12 *)
-          in
-          `	ldr	{emit_reg tmp}, [domain_state_ptr, {emit_int offset}]\n`;
-          `	cmp	{emit_reg i.res.(0)}, {emit_reg tmp}\n`;
+          `	ldr	{emit_reg i.res.(0)}, [domain_state_ptr, {emit_int offset}]\n`;
+          `     cmp     alloc_ptr, {emit_reg i.res.(0)}\n`;
           let lbl_call_gc = new_label() in
-          `	bls	{emit_label lbl_call_gc}\n`;
-          `	sub	alloc_ptr, {emit_reg i.res.(0)}, #4\n`;
+          `     bcc     {emit_label lbl_call_gc}\n`;
+          let lbl_after_alloc = new_label() in
+          `{emit_label lbl_after_alloc}:`;
+          `     add     {emit_reg i.res.(0)}, alloc_ptr, #4\n`;
           call_gc_sites :=
             { gc_lbl = lbl_call_gc;
-              gc_return_lbl = lbl_redo;
+              gc_return_lbl = lbl_after_alloc;
               gc_frame_lbl = lbl_frame } :: !call_gc_sites;
-          3 + ninstr
+          4 + ninstr
         end else begin
           let ninstr =
             begin match n with

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -105,7 +105,7 @@ let emit_addressing addr r n =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
+let record_frame_label ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -123,11 +123,11 @@ let record_frame_label ?label live raise_ dbg =
       | _ -> ())
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   lbl
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in `{emit_label lbl}:`
+let record_frame ?label live dbg =
+  let lbl = record_frame_label ?label live dbg in `{emit_label lbl}:`
 
 (* Record calls to the GC -- we've moved them out of the way *)
 
@@ -155,7 +155,7 @@ let bound_error_sites = ref ([] : bound_error_call list)
 let bound_error_label ?label dbg =
   if !Clflags.debug || !bound_error_sites = [] then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label Reg.Set.empty (Dbg_other dbg) in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error;
         bd_frame_lbl = lbl_frame } :: !bound_error_sites;
@@ -542,15 +542,15 @@ let emit_instr i =
     | Lop(Icall_ind { label_after; }) ->
         if !arch >= ARMv5 then begin
           `	blx	{emit_reg i.arg.(0)}\n`;
-          `{record_frame i.live false i.dbg ~label:label_after}\n`; 1
+          `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`; 1
         end else begin
           `	mov	lr, pc\n`;
           `	bx	{emit_reg i.arg.(0)}\n`;
-          `{record_frame i.live false i.dbg ~label:label_after}\n`; 2
+          `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`; 2
         end
     | Lop(Icall_imm { func; label_after; }) ->
         `	{emit_call func}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`; 1
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`; 1
     | Lop(Itailcall_ind { label_after = _; }) ->
         output_epilogue begin fun () ->
           if !contains_calls then
@@ -572,7 +572,7 @@ let emit_instr i =
     | Lop(Iextcall { func; alloc = true; label_after; }) ->
         let ninstr = emit_load_symbol_addr (phys_reg 7 (* r7 *)) func in
         `	{emit_call "caml_c_call"}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`;
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`;
         1 + ninstr
     | Lop(Istackoffset n) ->
         assert (n mod 8 = 0);
@@ -642,9 +642,9 @@ let emit_instr i =
           | Double_u -> "fstd"
           | _ (* 32-bit quantities *) -> "str" in
         `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 1}\n`; 1
-    | Lop(Ialloc { bytes = n; label_after_call_gc; }) ->
+    | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
         let lbl_frame =
-          record_frame_label i.live false i.dbg ?label:label_after_call_gc
+          record_frame_label i.live (Dbg_alloc dbginfo) ?label:label_after_call_gc
         in
         if !fastcode_flag then begin
           let lbl_redo = new_label() in
@@ -912,10 +912,10 @@ let emit_instr i =
           `	mov	r12, #0\n`;
           `	str	r12, [domain_state_ptr, {emit_int offset}]\n`;
           `	{emit_call "caml_raise_exn"}\n`;
-          `{record_frame Reg.Set.empty true i.dbg}\n`; 3
+          `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`; 3
         | Lambda.Raise_reraise ->
           `	{emit_call "caml_raise_exn"}\n`;
-          `{record_frame Reg.Set.empty true i.dbg}\n`; 1
+          `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`; 1
         | Lambda.Raise_notrace ->
           `	mov	sp, trap_ptr\n`;
           `	pop	\{trap_ptr, pc}\n`; 2
@@ -1072,6 +1072,7 @@ let end_assembly () =
       efa_data_label = (fun lbl ->
                        `	.type	{emit_label lbl}, %object\n`;
                        `	.word	{emit_label lbl}\n`);
+      efa_8 = (fun n -> `	.byte	{emit_int n}\n`);
       efa_16 = (fun n -> `	.short	{emit_int n}\n`);
       efa_32 = (fun n -> `	.long	{emit_int32 n}\n`);
       efa_word = (fun n -> `	.word	{emit_int n}\n`);

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -38,7 +38,8 @@ type cmm_label = int
   (* Do not introduce a dependency to Cmm *)
 
 type specific_operation =
-  | Ifar_alloc of { bytes : int; label_after_call_gc : cmm_label option; }
+  | Ifar_alloc of { bytes : int; label_after_call_gc : cmm_label option;
+                    dbginfo : Debuginfo.alloc_dbginfo }
   | Ifar_intop_checkbound of { label_after_error : cmm_label option; }
   | Ifar_intop_imm_checkbound of
       { bound : int; label_after_error : cmm_label option; }

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -126,7 +126,7 @@ let emit_addressing addr r =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
+let record_frame_label ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -144,11 +144,11 @@ let record_frame_label ?label live raise_ dbg =
       | _ -> ())
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   lbl
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in `{emit_label lbl}:`
+let record_frame ?label live dbg =
+  let lbl = record_frame_label ?label live dbg in `{emit_label lbl}:`
 
 (* Record calls to the GC -- we've moved them out of the way *)
 
@@ -176,7 +176,7 @@ let bound_error_sites = ref ([] : bound_error_call list)
 let bound_error_label ?label dbg =
   if !Clflags.debug || !bound_error_sites = [] then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label Reg.Set.empty (Dbg_other dbg) in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error;
         bd_frame_lbl = lbl_frame } :: !bound_error_sites;
@@ -512,8 +512,8 @@ module BR = Branch_relaxation.Make (struct
       | Lambda.Raise_notrace -> 4
       end
 
-  let relax_allocation ~num_bytes ~label_after_call_gc =
-    Lop (Ispecific (Ifar_alloc { bytes = num_bytes; label_after_call_gc; }))
+  let relax_allocation ~num_bytes ~label_after_call_gc ~dbginfo =
+    Lop (Ispecific (Ifar_alloc { bytes = num_bytes; label_after_call_gc; dbginfo }))
 
   let relax_intop_checkbound ~label_after_error =
     Lop (Ispecific (Ifar_intop_checkbound { label_after_error; }))
@@ -529,9 +529,9 @@ end)
 
 (* Output the assembly code for allocation. *)
 
-let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
+let assembly_code_for_allocation ~label_after_call_gc i ~n ~far ~dbginfo =
   let lbl_frame =
-    record_frame_label ?label:label_after_call_gc i.live false i.dbg
+    record_frame_label ?label:label_after_call_gc i.live (Dbg_alloc dbginfo)
   in
   if !fastcode_flag then begin
     let lbl_redo = new_label() in
@@ -626,10 +626,10 @@ let emit_instr i =
         emit_load_symbol_addr i.res.(0) s
     | Lop(Icall_ind { label_after; }) ->
         `	blr	{emit_reg i.arg.(0)}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`
     | Lop(Icall_imm { func; label_after; }) ->
         `	bl	{emit_symbol func}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`
     | Lop(Itailcall_ind { label_after = _; }) ->
         output_epilogue (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
     | Lop(Itailcall_imm { func; label_after = _; }) ->
@@ -642,7 +642,7 @@ let emit_instr i =
     | Lop(Iextcall { func; alloc = true; label_after; }) ->
         emit_load_symbol_addr reg_x15 func;
         `	bl	{emit_symbol "caml_c_call"}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`
     | Lop(Istackoffset n) ->
         assert (n mod 16 = 0);
         emit_stack_adjustment (-n);
@@ -697,10 +697,10 @@ let emit_instr i =
         | Word_int | Word_val | Double | Double_u ->
             `	str	{emit_reg src}, {emit_addressing addr base}\n`
         end
-    | Lop(Ialloc { bytes = n; label_after_call_gc; }) ->
-        assembly_code_for_allocation i ~n ~far:false ?label_after_call_gc
-    | Lop(Ispecific (Ifar_alloc { bytes = n; label_after_call_gc; })) ->
-        assembly_code_for_allocation i ~n ~far:true ?label_after_call_gc
+    | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
+        assembly_code_for_allocation i ~n ~far:false ~label_after_call_gc ~dbginfo
+    | Lop(Ispecific (Ifar_alloc { bytes = n; label_after_call_gc; dbginfo })) ->
+        assembly_code_for_allocation i ~n ~far:true ~label_after_call_gc ~dbginfo
     | Lop(Iintop(Icomp cmp)) ->
         `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
         `	cset	{emit_reg i.res.(0)}, {emit_string (name_for_comparison cmp)}\n`
@@ -906,10 +906,10 @@ let emit_instr i =
           let offset = Domainstate.(idx_of_field Domain_backtrace_pos) * 8 in
           `	str	xzr, [{emit_reg reg_domain_state_ptr}, {emit_int offset}]\n`;
           `	bl	{emit_symbol "caml_raise_exn"}\n`;
-          `{record_frame Reg.Set.empty true i.dbg}\n`
+          `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_reraise ->
           `	bl	{emit_symbol "caml_raise_exn"}\n`;
-          `{record_frame Reg.Set.empty true i.dbg}\n`
+          `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_notrace ->
           `	mov	sp, {emit_reg reg_trap_ptr}\n`;
           `	ldr	{emit_reg reg_tmp1}, [sp, #8]\n`;
@@ -1027,6 +1027,7 @@ let end_assembly () =
       efa_data_label = (fun lbl ->
                        `	.type	{emit_label lbl}, %object\n`;
                        `	.quad	{emit_label lbl}\n`);
+      efa_8 = (fun n -> `	.byte	{emit_int n}\n`);
       efa_16 = (fun n -> `	.short	{emit_int n}\n`);
       efa_32 = (fun n -> `	.long	{emit_int32 n}\n`);
       efa_word = (fun n -> `	.quad	{emit_int n}\n`);

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -534,31 +534,27 @@ let assembly_code_for_allocation ~label_after_call_gc i ~n ~far ~dbginfo =
     record_frame_label ?label:label_after_call_gc i.live (Dbg_alloc dbginfo)
   in
   if !fastcode_flag then begin
-    let lbl_redo = new_label() in
+    let lbl_after_alloc = new_label() in
     let lbl_call_gc = new_label() in
     (* n is at most Max_young_whsize * 8, i.e. currently 0x808,
        so it is reasonable to assume n < 0x1_000.  This makes
        the generated code simpler. *)
     assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
-    (* Instead of checking whether young_ptr - n < young_limit, we check whether
-       young_ptr - (n - 8) <= young_limit. It's equivalent, but this way around
-       we can avoid mutating young_ptr on failed allocations, by doing the
-       calculations in i.res.(0) instead of young_ptr. *)
-    `{emit_label lbl_redo}:`;
-    `	sub	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #{emit_int (n - 8)}\n`;
-    `	cmp	{emit_reg i.res.(0)}, {emit_reg reg_alloc_limit}\n`;
+    `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
+    `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
     if not far then begin
-      `	b.ls	{emit_label lbl_call_gc}\n`
+      `	b.lo	{emit_label lbl_call_gc}\n`
     end else begin
       let lbl = new_label () in
-      `	b.hi	{emit_label lbl}\n`;
+      `	b.cs	{emit_label lbl}\n`;
       `	b	{emit_label lbl_call_gc}\n`;
       `{emit_label lbl}:\n`
     end;
-    `	sub	{emit_reg reg_alloc_ptr}, {emit_reg i.res.(0)}, #8\n`;
+    `{emit_label lbl_after_alloc}:`;
+    `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
     call_gc_sites :=
       { gc_lbl = lbl_call_gc;
-        gc_return_lbl = lbl_redo;
+        gc_return_lbl = lbl_after_alloc;
         gc_frame_lbl = lbl_frame } :: !call_gc_sites
   end else begin
     begin match n with

--- a/asmcomp/branch_relaxation.ml
+++ b/asmcomp/branch_relaxation.ml
@@ -86,8 +86,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
           fixup did_fix (pc + T.instr_size instr.desc) instr.next
         else
           match instr.desc with
-          | Lop (Ialloc { bytes = num_bytes; label_after_call_gc; }) ->
-            instr.desc <- T.relax_allocation ~num_bytes ~label_after_call_gc;
+          | Lop (Ialloc { bytes = num_bytes; label_after_call_gc; dbginfo }) ->
+            instr.desc <- T.relax_allocation ~num_bytes
+                            ~dbginfo ~label_after_call_gc;
             fixup true (pc + T.instr_size instr.desc) instr.next
           | Lop (Iintop (Icheckbound { label_after_error; })) ->
             instr.desc <- T.relax_intop_checkbound ~label_after_error;

--- a/asmcomp/branch_relaxation_intf.ml
+++ b/asmcomp/branch_relaxation_intf.ml
@@ -63,6 +63,7 @@ module type S = sig
   val relax_allocation
      : num_bytes:int
     -> label_after_call_gc:Cmm.label option
+    -> dbginfo:Debuginfo.alloc_dbginfo
     -> Linear.instruction_desc
   val relax_intop_checkbound
      : label_after_error:Cmm.label option

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -17,34 +17,41 @@
 
 open Mach
 
+type pending_alloc =
+  { reg: Reg.t;       (* register holding the result of the last allocation *)
+    dbginfos: alloc_dbginfo list; (* debug info for each pending allocation *)
+    totalsz: int }                  (* amount to be allocated in this block *)
+
 type allocation_state =
     No_alloc
-  | Pending_alloc of
-    { reg: Reg.t;    (* register holding the result of the last allocation *)
-      totalsz: int } (* amount to be allocated in this block *)
-
-let allocated_size = function
-    No_alloc -> 0
-  | Pending_alloc {totalsz; _} -> totalsz
+  | Pending_alloc of pending_alloc
 
 let rec combine i allocstate =
   match i.desc with
     Iend | Ireturn | Iexit _ | Iraise _ ->
-      (i, allocated_size allocstate)
-  | Iop(Ialloc { bytes = sz; _ }) ->
+      (i, allocstate)
+  | Iop(Ialloc { bytes = sz; dbginfo; _ }) ->
       begin match allocstate with
-      | Pending_alloc {reg; totalsz}
+      | Pending_alloc {reg; dbginfos; totalsz}
           when totalsz + sz < Config.max_young_wosize * Arch.size_addr ->
          let (next, totalsz) =
            combine i.next
-             (Pending_alloc { reg = i.res.(0); totalsz = totalsz + sz }) in
+             (Pending_alloc { reg = i.res.(0);
+                              dbginfos = dbginfo @ dbginfos;
+                              totalsz = totalsz + sz }) in
          (instr_cons_debug (Iop(Iintop_imm(Iadd, -sz)))
             [| reg |] i.res i.dbg next,
           totalsz)
       | No_alloc | Pending_alloc _ ->
-         let (next, totalsz) =
+         let (next, state) =
            combine i.next
-             (Pending_alloc { reg = i.res.(0); totalsz = sz }) in
+             (Pending_alloc { reg = i.res.(0);
+                              dbginfos = dbginfo;
+                              totalsz = sz }) in
+         let totalsz, dbginfo =
+           match state with
+           | No_alloc -> 0, dbginfo
+           | Pending_alloc { totalsz; dbginfos; _ } -> totalsz, dbginfos in
          let next =
            let offset = totalsz - sz in
            if offset = 0 then next
@@ -52,40 +59,40 @@ let rec combine i allocstate =
                 i.res i.dbg next
          in
          (instr_cons_debug (Iop(Ialloc {bytes = totalsz; spacetime_index = 0;
-                                        label_after_call_gc = None; }))
-          i.arg i.res i.dbg next, allocated_size allocstate)
+                                        dbginfo; label_after_call_gc = None; }))
+          i.arg i.res i.dbg next, allocstate)
       end
   | Iop(Icall_ind _ | Icall_imm _ | Iextcall _ |
         Itailcall_ind _ | Itailcall_imm _) ->
       let newnext = combine_restart i.next in
       (instr_cons_debug i.desc i.arg i.res i.dbg newnext,
-       allocated_size allocstate)
+       allocstate)
   | Iop _ ->
-      let (newnext, sz) = combine i.next allocstate in
-      (instr_cons_debug i.desc i.arg i.res i.dbg newnext, sz)
+      let (newnext, s') = combine i.next allocstate in
+      (instr_cons_debug i.desc i.arg i.res i.dbg newnext, s')
   | Iifthenelse(test, ifso, ifnot) ->
       let newifso = combine_restart ifso in
       let newifnot = combine_restart ifnot in
       let newnext = combine_restart i.next in
       (instr_cons (Iifthenelse(test, newifso, newifnot)) i.arg i.res newnext,
-       allocated_size allocstate)
+       allocstate)
   | Iswitch(table, cases) ->
       let newcases = Array.map combine_restart cases in
       let newnext = combine_restart i.next in
       (instr_cons (Iswitch(table, newcases)) i.arg i.res newnext,
-       allocated_size allocstate)
+       allocstate)
   | Icatch(rec_flag, handlers, body) ->
-      let (newbody, sz) = combine body allocstate in
+      let (newbody, s') = combine body allocstate in
       let newhandlers =
         List.map (fun (io, handler) -> io, combine_restart handler) handlers in
       let newnext = combine_restart i.next in
       (instr_cons (Icatch(rec_flag, newhandlers, newbody))
-         i.arg i.res newnext, sz)
+         i.arg i.res newnext, s')
   | Itrywith(body, handler) ->
-      let (newbody, sz) = combine body allocstate in
+      let (newbody, s') = combine body allocstate in
       let newhandler = combine_restart handler in
       let newnext = combine_restart i.next in
-      (instr_cons (Itrywith(newbody, newhandler)) i.arg i.res newnext, sz)
+      (instr_cons (Itrywith(newbody, newhandler)) i.arg i.res newnext, s')
 
 and combine_restart i =
   let (newi, _) = combine i No_alloc in newi

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -18,9 +18,9 @@
 open Mach
 
 type pending_alloc =
-  { reg: Reg.t;       (* register holding the result of the last allocation *)
-    dbginfos: alloc_dbginfo list; (* debug info for each pending allocation *)
-    totalsz: int }                  (* amount to be allocated in this block *)
+  { reg: Reg.t;         (* register holding the result of the last allocation *)
+    dbginfos: Debuginfo.alloc_dbginfo;   (* debug info for each pending alloc *)
+    totalsz: int }                    (* amount to be allocated in this block *)
 
 type allocation_state =
     No_alloc

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -106,6 +106,7 @@ let emit_float32_directive directive x =
 (* Record live pointers at call points *)
 
 type frame_debuginfo =
+  | Dbg_alloc of Mach.alloc_dbginfo list
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 
@@ -173,6 +174,10 @@ let emit_frames a =
       match fd.fd_debuginfo with
       | Dbg_other d | Dbg_raise d ->
         if Debuginfo.is_none d then 0 else 1
+      | Dbg_alloc dbgs ->
+        if List.for_all (fun d ->
+          Debuginfo.is_none d.Mach.alloc_dbg) dbgs
+        then 2 else 3
     in
     a.efa_code_label fd.fd_lbl;
     a.efa_16 (fd.fd_frame_size + flags);
@@ -187,6 +192,23 @@ let emit_frames a =
     | Dbg_raise dbg ->
       a.efa_align 4;
       a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    | Dbg_alloc dbg ->
+      assert (List.length dbg < 256);
+      a.efa_8 (List.length dbg);
+      List.iter (fun Mach.{alloc_words;_} ->
+        (* Possible allocations range between 2 and 257 *)
+        assert (2 <= alloc_words &&
+                alloc_words - 1 <= Config.max_young_wosize &&
+                Config.max_young_wosize <= 256);
+        a.efa_8 (alloc_words - 2)) dbg;
+      if flags = 3 then begin
+        a.efa_align 4;
+        List.iter (fun Mach.{alloc_dbg; _} ->
+          if Debuginfo.is_none alloc_dbg then
+            a.efa_32 Int32.zero
+          else
+            a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero) dbg
+      end
     end;
     a.efa_align Arch.size_addr
   in

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -105,26 +105,29 @@ let emit_float32_directive directive x =
 
 (* Record live pointers at call points *)
 
+type frame_debuginfo =
+  | Dbg_raise of Debuginfo.t
+  | Dbg_other of Debuginfo.t
+
 type frame_descr =
   { fd_lbl: int;                        (* Return address *)
     fd_frame_size: int;                 (* Size of stack frame *)
     fd_live_offset: int list;           (* Offsets/regs of live addresses *)
-    fd_raise: bool;                     (* Is frame for a raise? *)
-    fd_debuginfo: Debuginfo.t }         (* Location, if any *)
+    fd_debuginfo: frame_debuginfo }     (* Location, if any *)
 
 let frame_descriptors = ref([] : frame_descr list)
 
-let record_frame_descr ~label ~frame_size ~live_offset ~raise_frame debuginfo =
+let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
   frame_descriptors :=
     { fd_lbl = label;
       fd_frame_size = frame_size;
       fd_live_offset = List.sort_uniq (-) live_offset;
-      fd_raise = raise_frame;
       fd_debuginfo = debuginfo } :: !frame_descriptors
 
 type emit_frame_actions =
   { efa_code_label: int -> unit;
     efa_data_label: int -> unit;
+    efa_8: int -> unit;
     efa_16: int -> unit;
     efa_32: int32 -> unit;
     efa_word: int -> unit;
@@ -155,64 +158,73 @@ let emit_frames a =
     end)
   in
   let debuginfos = Label_table.create 7 in
-  let rec label_debuginfos rs rdbg =
+  let label_debuginfos rs dbg =
+    let rdbg = List.rev dbg in
     let key = (rs, rdbg) in
-    try fst (Label_table.find debuginfos key)
+    try Label_table.find debuginfos key
     with Not_found ->
       let lbl = Cmm.new_label () in
-      let next =
-        match rdbg with
-        | [] -> assert false
-        | _ :: [] -> None
-        | _ :: ((_ :: _) as rdbg') -> Some (label_debuginfos false rdbg')
-      in
-      Label_table.add debuginfos key (lbl, next);
+      Label_table.add debuginfos key lbl;
       lbl
   in
-  let emit_debuginfo_label rs rdbg =
-    a.efa_data_label (label_debuginfos rs rdbg)
-  in
   let emit_frame fd =
+    assert (fd.fd_frame_size land 3 = 0);
+    let flags =
+      match fd.fd_debuginfo with
+      | Dbg_other d | Dbg_raise d ->
+        if Debuginfo.is_none d then 0 else 1
+    in
     a.efa_code_label fd.fd_lbl;
-    a.efa_16 (if Debuginfo.is_none fd.fd_debuginfo
-              then fd.fd_frame_size
-              else fd.fd_frame_size + 1);
+    a.efa_16 (fd.fd_frame_size + flags);
     a.efa_16 (List.length fd.fd_live_offset);
     List.iter a.efa_16 fd.fd_live_offset;
-    a.efa_align Arch.size_addr;
-    match List.rev fd.fd_debuginfo with
-    | [] -> ()
-    | _ :: _ as rdbg -> emit_debuginfo_label fd.fd_raise rdbg
+    begin match fd.fd_debuginfo with
+    | _ when flags = 0 ->
+      ()
+    | Dbg_other dbg ->
+      a.efa_align 4;
+      a.efa_label_rel (label_debuginfos false dbg) Int32.zero
+    | Dbg_raise dbg ->
+      a.efa_align 4;
+      a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    end;
+    a.efa_align Arch.size_addr
   in
   let emit_filename name lbl =
     a.efa_def_label lbl;
     a.efa_string name;
     a.efa_align Arch.size_addr
   in
-  let pack_info fd_raise d =
+  let pack_info fd_raise d has_next =
     let line = min 0xFFFFF d.Debuginfo.dinfo_line
     and char_start = min 0xFF d.Debuginfo.dinfo_char_start
     and char_end = min 0x3FF d.Debuginfo.dinfo_char_end
-    and kind = if fd_raise then 1 else 0 in
+    and kind = if fd_raise then 1 else 0
+    and has_next = if has_next then 1 else 0 in
     Int64.(add (shift_left (of_int line) 44)
              (add (shift_left (of_int char_start) 36)
                 (add (shift_left (of_int char_end) 26)
-                   (of_int kind))))
+                   (add (shift_left (of_int kind) 1)
+                      (of_int has_next)))))
   in
-  let emit_debuginfo (rs, rdbg) (lbl,next) =
-    let d = List.hd rdbg in
+  let emit_debuginfo (rs, rdbg) lbl =
+    (* Due to inlined functions, a single debuginfo may have multiple locations.
+       These are represented sequentially in memory (innermost frame first),
+       with the low bit of the packed debuginfo being 0 on the last entry. *)
     a.efa_align Arch.size_addr;
     a.efa_def_label lbl;
-    let info = pack_info rs d in
-    a.efa_label_rel
-      (label_filename d.Debuginfo.dinfo_file)
-      (Int64.to_int32 info);
-    a.efa_32 (Int64.to_int32 (Int64.shift_right info 32));
-    begin match next with
-    | Some next -> a.efa_data_label next
-    | None -> a.efa_word 0
-    end
-  in
+    let rec emit rs d rest =
+      let info = pack_info rs d (rest <> []) in
+      a.efa_label_rel
+        (label_filename d.Debuginfo.dinfo_file)
+        (Int64.to_int32 info);
+      a.efa_32 (Int64.to_int32 (Int64.shift_right info 32));
+      match rest with
+      | [] -> ()
+      | d :: rest -> emit false d rest in
+    match rdbg with
+    | [] -> assert false
+    | d :: rest -> emit rs d rest in
   a.efa_word (List.length !frame_descriptors);
   List.iter emit_frame !frame_descriptors;
   Label_table.iter emit_debuginfo debuginfos;

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -38,17 +38,21 @@ val emit_debug_info_gen :
   (file_num:int -> file_name:string -> unit) ->
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
+type frame_debuginfo =
+  | Dbg_raise of Debuginfo.t
+  | Dbg_other of Debuginfo.t
+
 val record_frame_descr :
   label:int ->              (* Return address *)
   frame_size:int ->         (* Size of stack frame *)
   live_offset:int list ->   (* Offsets/regs of live addresses *)
-  raise_frame:bool ->       (* Is frame for a raise? *)
-  Debuginfo.t ->            (* Location, if any *)
+  frame_debuginfo ->        (* Location, if any *)
   unit
 
 type emit_frame_actions =
   { efa_code_label: int -> unit;
     efa_data_label: int -> unit;
+    efa_8: int -> unit;
     efa_16: int -> unit;
     efa_32: int32 -> unit;
     efa_word: int -> unit;

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -39,6 +39,7 @@ val emit_debug_info_gen :
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
 type frame_debuginfo =
+  | Dbg_alloc of Mach.alloc_dbginfo list
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -39,7 +39,7 @@ val emit_debug_info_gen :
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
 type frame_debuginfo =
-  | Dbg_alloc of Mach.alloc_dbginfo list
+  | Dbg_alloc of Debuginfo.alloc_dbginfo
   | Dbg_raise of Debuginfo.t
   | Dbg_other of Debuginfo.t
 

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -619,13 +619,13 @@ let emit_instr fallthrough i =
         load_domain_state ebx;
         I.mov (domain_field Domain_young_ptr RBX) eax;
         I.sub (int n) eax;
+        I.mov eax (domain_field Domain_young_ptr RBX);
         I.cmp (domain_field Domain_young_limit RBX) eax;
         let lbl_call_gc = new_label() in
         let lbl_frame =
           record_frame_label ?label:label_after_call_gc
             i.live (Dbg_alloc dbginfo) in
         I.jb (label lbl_call_gc);
-        I.mov eax (domain_field Domain_young_ptr RBX);
         let lbl_after_alloc = new_label() in
         def_label lbl_after_alloc;
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0));

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -200,7 +200,7 @@ let addressing addr typ i n =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
+let record_frame_label ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -218,11 +218,11 @@ let record_frame_label ?label live raise_ dbg =
       | _ -> ())
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   lbl
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
+let record_frame ?label live dbg =
+  let lbl = record_frame_label ?label live dbg in
   def_label lbl
 
 (* Record calls to the GC -- we've moved them out of the way *)
@@ -254,7 +254,7 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg =
   if !Clflags.debug then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label Reg.Set.empty (Dbg_other dbg) in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error; bd_frame = lbl_frame } :: !bound_error_sites;
     lbl_bound_error
@@ -540,11 +540,11 @@ let emit_instr fallthrough i =
       I.mov (immsym s) (reg i.res.(0))
   | Lop(Icall_ind { label_after; }) ->
       I.call (reg i.arg.(0));
-      record_frame i.live false i.dbg ~label:label_after
+      record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Icall_imm { func; label_after; }) ->
       add_used_symbol func;
       emit_call func;
-      record_frame i.live false i.dbg ~label:label_after
+      record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Itailcall_ind { label_after = _; }) ->
       output_epilogue begin fun () ->
         I.jmp (reg i.arg.(0))
@@ -563,7 +563,7 @@ let emit_instr fallthrough i =
       if alloc then begin
         I.mov (immsym func) eax;
         emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:label_after
+        record_frame i.live (Dbg_other i.dbg) ~label:label_after
       end else begin
         emit_call func
       end
@@ -614,22 +614,24 @@ let emit_instr fallthrough i =
             I.fstp (addressing addr REAL8 i 1)
           end
       end
-  | Lop(Ialloc { bytes = n; label_after_call_gc; }) ->
+  | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
       if !fastcode_flag then begin
-        let lbl_redo = new_label() in
-        def_label lbl_redo;
         load_domain_state ebx;
         I.mov (domain_field Domain_young_ptr RBX) eax;
         I.sub (int n) eax;
         I.cmp (domain_field Domain_young_limit RBX) eax;
         let lbl_call_gc = new_label() in
-        let lbl_frame = record_frame_label i.live false Debuginfo.none in
+        let lbl_frame =
+          record_frame_label ?label:label_after_call_gc
+            i.live (Dbg_alloc dbginfo) in
         I.jb (label lbl_call_gc);
         I.mov eax (domain_field Domain_young_ptr RBX);
+        let lbl_after_alloc = new_label() in
+        def_label lbl_after_alloc;
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0));
         call_gc_sites :=
           { gc_lbl = lbl_call_gc;
-            gc_return_lbl = lbl_redo;
+            gc_return_lbl = lbl_after_alloc;
             gc_frame = lbl_frame } :: !call_gc_sites
       end else begin
         begin match n with
@@ -641,8 +643,8 @@ let emit_instr fallthrough i =
             emit_call "caml_allocN"
         end;
         let label =
-          record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+          record_frame_label ?label:label_after_call_gc
+            i.live (Dbg_alloc dbginfo)
         in
         def_label label;
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0))
@@ -895,10 +897,10 @@ let emit_instr fallthrough i =
           load_domain_state ebx;
           I.mov (int 0) (domain_field Domain_backtrace_pos RBX);
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_reraise ->
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame Reg.Set.empty (Dbg_raise i.dbg)
       | Lambda.Raise_notrace ->
           load_domain_state ebx;
           I.mov (domain_field Domain_exception_pointer RBX) esp;
@@ -1019,6 +1021,7 @@ let end_assembly() =
   emit_frames
     { efa_code_label = (fun l -> D.long (ConstLabel (emit_label l)));
       efa_data_label = (fun l -> D.long (ConstLabel (emit_label l)));
+      efa_8 = (fun n -> D.byte (const n));
       efa_16 = (fun n -> D.word (const n));
       efa_32 = (fun n -> D.long (const_32 n));
       efa_word = (fun n -> D.long (const n));

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -39,6 +39,10 @@ type test =
   | Ioddtest
   | Ieventest
 
+type alloc_dbginfo =
+  { alloc_words : int;
+    alloc_dbg : Debuginfo.t }
+
 type operation =
     Imove
   | Ispill
@@ -55,7 +59,7 @@ type operation =
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Ialloc of { bytes : int; label_after_call_gc : label option;
-        spacetime_index : int; }
+      dbginfo : alloc_dbginfo list; spacetime_index : int; }
   | Iintop of integer_operation
   | Iintop_imm of integer_operation * int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -39,10 +39,6 @@ type test =
   | Ioddtest
   | Ieventest
 
-type alloc_dbginfo =
-  { alloc_words : int;
-    alloc_dbg : Debuginfo.t }
-
 type operation =
     Imove
   | Ispill
@@ -59,7 +55,7 @@ type operation =
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Ialloc of { bytes : int; label_after_call_gc : label option;
-      dbginfo : alloc_dbginfo list; spacetime_index : int; }
+      dbginfo : Debuginfo.alloc_dbginfo; spacetime_index : int; }
   | Iintop of integer_operation
   | Iintop_imm of integer_operation * int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -46,15 +46,6 @@ type test =
   | Ioddtest
   | Ieventest
 
-type alloc_dbginfo =
-  { alloc_words : int;
-    alloc_dbg : Debuginfo.t }
-(** Due to Comballoc, a single Ialloc instruction may combine several
-    unrelated allocations. Their Debuginfo.t (which may differ) are stored
-    as a list of alloc_dbginfo. This list is in order of increasing memory
-    address, which is the reverse of the original allocation order. Later
-    allocations are consed to the front of this list by Comballoc. *)
-
 type operation =
     Imove
   | Ispill
@@ -72,7 +63,7 @@ type operation =
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
   | Ialloc of { bytes : int; label_after_call_gc : label option;
-      dbginfo : alloc_dbginfo list; spacetime_index : int; }
+      dbginfo : Debuginfo.alloc_dbginfo; spacetime_index : int; }
     (** For Spacetime only, Ialloc instructions take one argument, being the
         pointer to the trie node for the current function. *)
   | Iintop of integer_operation

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -46,6 +46,15 @@ type test =
   | Ioddtest
   | Ieventest
 
+type alloc_dbginfo =
+  { alloc_words : int;
+    alloc_dbg : Debuginfo.t }
+(** Due to Comballoc, a single Ialloc instruction may combine several
+    unrelated allocations. Their Debuginfo.t (which may differ) are stored
+    as a list of alloc_dbginfo. This list is in order of increasing memory
+    address, which is the reverse of the original allocation order. Later
+    allocations are consed to the front of this list by Comballoc. *)
+
 type operation =
     Imove
   | Ispill
@@ -63,7 +72,7 @@ type operation =
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
   | Ialloc of { bytes : int; label_after_call_gc : label option;
-      spacetime_index : int; }
+      dbginfo : alloc_dbginfo list; spacetime_index : int; }
     (** For Spacetime only, Ialloc instructions take one argument, being the
         pointer to the trie node for the current function. *)
   | Iintop of integer_operation

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -47,7 +47,8 @@ type specific_operation =
     Imultaddf                           (* multiply and add *)
   | Imultsubf                           (* multiply and subtract *)
   | Ialloc_far of                       (* allocation in large functions *)
-      { bytes : int; label_after_call_gc : int (*Cmm.label*) option; }
+      { bytes : int; label_after_call_gc : int (*Cmm.label*) option;
+        dbginfo : Debuginfo.alloc_dbginfo }
 
 (* note: we avoid introducing a dependency to Cmm since this dep
    is not detected when "make depend" is run under amd64 *)

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -308,7 +308,7 @@ let adjust_stack_offset delta =
 
 (* Record live pointers at call points *)
 
-let record_frame ?label live raise_ dbg =
+let record_frame ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -326,7 +326,7 @@ let record_frame ?label live raise_ dbg =
       | _ -> ())
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   `{emit_label lbl}:\n`
 
 (* Record floating-point literals (for PPC32) *)
@@ -546,8 +546,8 @@ module BR = Branch_relaxation.Make (struct
     | Lpoptrap -> 2
     | Lraise _ -> 6
 
-  let relax_allocation ~num_bytes:bytes ~label_after_call_gc =
-    Lop (Ispecific (Ialloc_far { bytes; label_after_call_gc; }))
+  let relax_allocation ~num_bytes:bytes ~label_after_call_gc ~dbginfo =
+    Lop (Ispecific (Ialloc_far { bytes; label_after_call_gc; dbginfo }))
 
   (* [classify_addr], above, never identifies these instructions as needing
      relaxing.  As such, these functions should never be called. *)
@@ -652,26 +652,26 @@ let emit_instr i =
         | ELF32 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`;
           `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:label_after
+          record_frame i.live (Dbg_other i.dbg) ~label:label_after
         | ELF64v1 ->
           `	ld	0, 0({emit_reg i.arg.(0)})\n`;  (* code pointer *)
           `	mtctr	0\n`;
           `	ld	2, 8({emit_reg i.arg.(0)})\n`;  (* TOC for callee *)
           `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:label_after;
+          record_frame i.live (Dbg_other i.dbg) ~label:label_after;
           emit_reload_toc()
         | ELF64v2 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`;
           `	mr	12, {emit_reg i.arg.(0)}\n`;  (* addr of fn in r12 *)
           `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:label_after;
+          record_frame i.live (Dbg_other i.dbg) ~label:label_after;
           emit_reload_toc()
         end
     | Lop(Icall_imm { func; label_after; }) ->
         begin match abi with
         | ELF32 ->
             emit_call func;
-            record_frame i.live false i.dbg ~label:label_after
+            record_frame i.live (Dbg_other i.dbg) ~label:label_after
         | ELF64v1 | ELF64v2 ->
         (* For PPC64, we cannot just emit a "bl s; nop" sequence, because
            of the following scenario:
@@ -691,7 +691,7 @@ let emit_instr i =
                 Cost: 3 instructions if same TOC, 7 if different TOC.
            Let's try option 2. *)
             emit_call func;
-            record_frame i.live false i.dbg ~label:label_after;
+            record_frame i.live (Dbg_other i.dbg) ~label:label_after;
             `	nop\n`;
             emit_reload_toc()
         end
@@ -751,11 +751,11 @@ let emit_instr i =
             `	addis	25, 0, {emit_upper emit_symbol func}\n`;
             `	addi	25, 25, {emit_lower emit_symbol func}\n`;
             emit_call "caml_c_call";
-            record_frame i.live false i.dbg
+            record_frame i.live (Dbg_other i.dbg)
           | ELF64v1 | ELF64v2 ->
             emit_tocload emit_gpr 25 (TocSym func);
             emit_call "caml_c_call";
-            record_frame i.live false i.dbg;
+            record_frame i.live (Dbg_other i.dbg);
             `	nop\n`
         end
     | Lop(Istackoffset n) ->
@@ -786,15 +786,15 @@ let emit_instr i =
           | Single -> "stfs"
           | Double | Double_u -> "stfd" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
-    | Lop(Ialloc { bytes = n; label_after_call_gc; }) ->
+    | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
         let call_gc_lbl = label_for_call_gc ?label_after_call_gc n in
         `	addi    31, 31, {emit_int(-n)}\n`;
         `	{emit_string cmplg}	31, 30\n`;
         `	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`;
         `	bltl	{emit_label call_gc_lbl}\n`;
         (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live false Debuginfo.none
-    | Lop(Ispecific(Ialloc_far { bytes = n; label_after_call_gc; })) ->
+        record_frame i.live (Dbg_alloc dbginfo)
+    | Lop(Ispecific(Ialloc_far { bytes = n; label_after_call_gc; dbginfo })) ->
         let call_gc_lbl = label_for_call_gc ?label_after_call_gc n in
         let lbl = new_label() in
         `	addi    31, 31, {emit_int(-n)}\n`;
@@ -802,7 +802,7 @@ let emit_instr i =
         `	bge	{emit_label lbl}\n`;
         `	bl	{emit_label call_gc_lbl}\n`;
         (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live false Debuginfo.none;
+        record_frame i.live (Dbg_alloc dbginfo);
         `{emit_label lbl}:	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`
     | Lop(Iintop Isub) ->               (* subfc has swapped arguments *)
         `	subfc	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`
@@ -821,7 +821,7 @@ let emit_instr i =
         end
     | Lop(Iintop (Icheckbound { label_after_error; })) ->
         if !Clflags.debug then
-          record_frame Reg.Set.empty false i.dbg ?label:label_after_error;
+          record_frame Reg.Set.empty (Dbg_other i.dbg) ?label:label_after_error;
         `	{emit_string tglle}   {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Iintop op) ->
         let instr = name_for_intop op in
@@ -839,7 +839,7 @@ let emit_instr i =
         end
     | Lop(Iintop_imm(Icheckbound { label_after_error; }, n)) ->
         if !Clflags.debug then
-          record_frame Reg.Set.empty false i.dbg ?label:label_after_error;
+          record_frame Reg.Set.empty (Dbg_other i.dbg) ?label:label_after_error;
         `	{emit_string tglle}i   {emit_reg i.arg.(0)}, {emit_int n}\n`
     | Lop(Iintop_imm(op, n)) ->
         let instr = name_for_intop_imm op in
@@ -1023,11 +1023,11 @@ let emit_instr i =
             | _ -> `	std	0, {emit_int (backtrace_pos * 8)}(28)\n`
             end;
             emit_call "caml_raise_exn";
-            record_frame Reg.Set.empty true i.dbg;
+            record_frame Reg.Set.empty (Dbg_raise i.dbg);
             emit_call_nop()
         | Lambda.Raise_reraise ->
             emit_call "caml_raise_exn";
-            record_frame Reg.Set.empty true i.dbg;
+            record_frame Reg.Set.empty (Dbg_raise i.dbg);
             emit_call_nop()
         | Lambda.Raise_notrace ->
             `	{emit_string lg}	0, {emit_int trap_handler_offset}(29)\n`;
@@ -1249,6 +1249,7 @@ let end_assembly() =
          (fun l -> `	{emit_string datag}	{emit_label l}\n`);
       efa_data_label =
          (fun l -> `	{emit_string datag}	{emit_label l}\n`);
+      efa_8 = (fun n -> `	.byte	{emit_int n}\n`);
       efa_16 = (fun n -> `	.short	{emit_int n}\n`);
       efa_32 = (fun n -> `	.long	{emit_int32 n}\n`);
       efa_word = (fun n -> `	{emit_string datag}	{emit_int n}\n`);

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -398,38 +398,8 @@ let name_for_specific = function
 let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
-
-module IntSet = Stdlib.Set.Make(Stdlib.Int)
-module IntMap = Stdlib.Map.Make(Stdlib.Int)
-
-(* Labels of glue code for calling the GC.
-   There is one label per size allocated. *)
-let call_gc_labels : label IntMap.t ref = ref IntMap.empty
-                     (* size -> label *)
-
-(* Return the label of the call GC point for the given size *)
-
-let label_for_call_gc ?label_after_call_gc sz =
-  match IntMap.find_opt sz !call_gc_labels with
-  | Some lbl -> lbl
-  | None ->
-      let lbl =
-        match label_after_call_gc with Some l -> l | None -> new_label() in
-      call_gc_labels := IntMap.add sz lbl !call_gc_labels;
-      lbl
-
-(* Number of call GC points *)
-
-let num_call_gc instr =
-  let rec loop i cg =
-    match i.desc with
-    | Lend -> IntSet.cardinal cg
-    | Lop (Ialloc {bytes = sz}) -> loop i.next (IntSet.add sz cg)
-    (* The following should never be seen, since this function is run
-       before branch relaxation. *)
-    | Lop (Ispecific (Ialloc_far _)) -> assert false
-    | _ -> loop i.next cg
-  in loop instr IntSet.empty
+(* Label of glue code for calling the GC *)
+let call_gc_label = ref 0
 
 (* Relaxation of branches that exceed the span of a relative branch. *)
 
@@ -787,21 +757,27 @@ let emit_instr i =
           | Double | Double_u -> "stfd" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
-        let call_gc_lbl = label_for_call_gc ?label_after_call_gc n in
+        if !call_gc_label = 0 then begin
+          match label_after_call_gc with
+          | None -> call_gc_label := new_label ()
+          | Some label -> call_gc_label := label
+        end;
         `	addi    31, 31, {emit_int(-n)}\n`;
         `	{emit_string cmplg}	31, 30\n`;
+        `	bltl	{emit_label !call_gc_label}\n`;
+        record_frame i.live (Dbg_alloc dbginfo);
         `	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`;
-        `	bltl	{emit_label call_gc_lbl}\n`;
-        (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live (Dbg_alloc dbginfo)
     | Lop(Ispecific(Ialloc_far { bytes = n; label_after_call_gc; dbginfo })) ->
-        let call_gc_lbl = label_for_call_gc ?label_after_call_gc n in
+        if !call_gc_label = 0 then begin
+          match label_after_call_gc with
+          | None -> call_gc_label := new_label ()
+          | Some label -> call_gc_label := label
+        end;
         let lbl = new_label() in
         `	addi    31, 31, {emit_int(-n)}\n`;
         `	{emit_string cmplg}	31, 30\n`;
         `	bge	{emit_label lbl}\n`;
-        `	bl	{emit_label call_gc_lbl}\n`;
-        (* Exactly 4 instructions after the beginning of the alloc sequence *)
+        `	bl	{emit_label !call_gc_label}\n`;
         record_frame i.live (Dbg_alloc dbginfo);
         `{emit_label lbl}:	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`
     | Lop(Iintop Isub) ->               (* subfc has swapped arguments *)
@@ -1051,7 +1027,7 @@ let fundecl fundecl =
   function_name := fundecl.fun_name;
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
-  call_gc_labels := IntMap.empty;
+  call_gc_label := 0;
   float_literals := [];
   jumptables := []; jumptables_lbl := -1;
   for i = 0 to Proc.num_register_classes - 1 do
@@ -1088,30 +1064,14 @@ let fundecl fundecl =
   end;
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc();
-  let num_call_gc = num_call_gc fundecl.fun_body in
-  let max_out_of_line_code_offset = max (num_call_gc - 1) 0 in
-  BR.relax fundecl.fun_body ~max_out_of_line_code_offset;
+  (* On this target, there is at most one "out of line" code block per
+     function: a single "call GC" point.  It comes immediately after the
+     function's body. *)
+  BR.relax fundecl.fun_body ~max_out_of_line_code_offset:0;
   emit_all fundecl.fun_body;
   (* Emit the glue code to call the GC *)
-  assert (IntMap.cardinal !call_gc_labels = num_call_gc);
-  if num_call_gc > 0 then begin
-    (* Replace sizes by deltas with next size *)
-    let rec delta_encode = function
-      | (sz1, lbl1) :: ((sz2, _) :: _ as l) ->
-           (sz1 - sz2, lbl1) :: delta_encode l
-      | ([] | [(_,_)]) as l -> l in
-    (* Enumerate the GC call points by decreasing size.  This is not
-       necessary for correctness, but it is nice for two reasons:
-       1- all deltas are positive, making the generated code
-          easier to read, and
-       2- smaller allocation sizes, which are more frequent, execute
-          fewer instructions before calling the GC. *)
-    let delta_lbl_list =
-      delta_encode (List.rev (IntMap.bindings !call_gc_labels)) in
-    List.iter
-      (fun (delta, lbl) ->
-        `{emit_label lbl}:	addi	31, 31, {emit_int delta}\n`)
-      delta_lbl_list;
+  if !call_gc_label > 0 then begin
+    `{emit_label !call_gc_label}:\n`;
     match abi with
     | ELF32 ->
       `	b	{emit_symbol "caml_call_gc"}\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -168,7 +168,7 @@ let emit_set_comp cmp res =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
+let record_frame_label ?label live dbg =
   let lbl =
     match label with
     | None -> new_label()
@@ -186,11 +186,11 @@ let record_frame_label ?label live raise_ dbg =
       | _ -> ())
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
+    ~live_offset:!live_offset dbg;
   lbl
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
+let record_frame ?label live dbg =
+  let lbl = record_frame_label ?label live dbg in
   `{emit_label lbl}:`
 
 (* Record calls to caml_call_gc, emitted out of line. *)
@@ -218,7 +218,7 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg =
   if !Clflags.debug then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label Reg.Set.empty (Dbg_other dbg) in
     bound_error_sites :=
      { bd_lbl = lbl_bound_error; bd_frame = lbl_frame } :: !bound_error_sites;
    lbl_bound_error
@@ -357,11 +357,11 @@ let emit_instr i =
         emit_load_symbol_addr i.res.(0) s
     | Lop(Icall_ind { label_after; }) ->
         `	basr	%r14, {emit_reg i.arg.(0)}\n`;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`
 
     | Lop(Icall_imm { func; label_after; }) ->
         emit_call func;
-        `{record_frame i.live false i.dbg ~label:label_after}\n`
+        `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`
     | Lop(Itailcall_ind { label_after = _; }) ->
         let n = frame_size() in
         if !contains_calls then
@@ -387,7 +387,7 @@ let emit_instr i =
         else begin
           emit_load_symbol_addr reg_r7 func;
           emit_call "caml_c_call";
-          `{record_frame i.live false i.dbg ~label:label_after}\n`
+          `{record_frame i.live (Dbg_other i.dbg) ~label:label_after}\n`
         end
 
      | Lop(Istackoffset n) ->
@@ -424,11 +424,11 @@ let emit_instr i =
           | Double | Double_u -> "stdy" in
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
 
-    | Lop(Ialloc { bytes = n; label_after_call_gc; }) ->
+    | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
         let lbl_redo = new_label() in
         let lbl_call_gc = new_label() in
         let lbl_frame =
-          record_frame_label i.live false i.dbg ?label:label_after_call_gc
+          record_frame_label i.live (Dbg_alloc dbginfo) ?label:label_after_call_gc
         in
         call_gc_sites :=
           { gc_lbl = lbl_call_gc;
@@ -641,10 +641,10 @@ let emit_instr i =
           `	lghi	%r1, 0\n`;
           `	stg	%r1, {emit_int offset}(%r10)\n`;
           emit_call "caml_raise_exn";
-          `{record_frame Reg.Set.empty true i.dbg}\n`
+          `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_reraise ->
           emit_call "caml_raise_exn";
-          `{record_frame Reg.Set.empty true i.dbg}\n`
+          `{record_frame Reg.Set.empty (Dbg_raise i.dbg)}\n`
         | Lambda.Raise_notrace ->
           `	lg	%r1, 0(%r13)\n`;
           `	lgr	%r15, %r13\n`;
@@ -782,6 +782,7 @@ let end_assembly() =
   emit_frames
     { efa_code_label = (fun l -> `	.quad	{emit_label l}\n`);
       efa_data_label = (fun l -> `	.quad	{emit_label l}\n`);
+      efa_8 = (fun n -> `	.byte	{emit_int n}\n`);
       efa_16 = (fun n -> `	.short	{emit_int n}\n`);
       efa_32 = (fun n -> `	.long	{emit_int32 n}\n`);
       efa_word = (fun n -> `	.quad	{emit_int n}\n`);

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -425,22 +425,21 @@ let emit_instr i =
         emit_load_store storeinstr addr i.arg 1 i.arg.(0)
 
     | Lop(Ialloc { bytes = n; label_after_call_gc; dbginfo }) ->
-        let lbl_redo = new_label() in
+        let lbl_after_alloc = new_label() in
         let lbl_call_gc = new_label() in
         let lbl_frame =
           record_frame_label i.live (Dbg_alloc dbginfo) ?label:label_after_call_gc
         in
         call_gc_sites :=
           { gc_lbl = lbl_call_gc;
-            gc_return_lbl = lbl_redo;
+            gc_return_lbl = lbl_after_alloc;
             gc_frame_lbl = lbl_frame } :: !call_gc_sites;
-        `{emit_label lbl_redo}:`;
-        `	lay	{emit_reg i.res.(0)}, {emit_int(-n+8)}(%r11)\n`;
+        `	lay     %r11, {emit_int(-n)}(%r11)\n`;
         let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-        `	clg	{emit_reg i.res.(0)}, {emit_int offset}(%r10)\n`;
-        `	brcl	12, {emit_label lbl_call_gc}\n`;
-                                                 (* less than or equal *)
-        `	lay	%r11, -8({emit_reg i.res.(0)})\n`
+        `	clg	%r11, {emit_int offset}(%r10)\n`;
+        `	brcl    4, {emit_label lbl_call_gc}\n`;  (* less than *)
+        `{emit_label lbl_after_alloc}:`;
+        `	la      {emit_reg i.res.(0)}, 8(%r11)\n`
 
     | Lop(Iintop Imulh) ->
        (* Hacker's Delight section 8.3:

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -419,7 +419,8 @@ method mark_instr = function
 (* Default instruction selection for operators *)
 
 method select_allocation bytes =
-  Ialloc { bytes; spacetime_index = 0; label_after_call_gc = None; }
+  Ialloc { bytes; label_after_call_gc = None;
+           dbginfo = []; spacetime_index = 0; }
 method select_allocation_args _env = [| |]
 
 method select_checkbound () =
@@ -775,8 +776,11 @@ method emit_expr (env:environment) exp =
           | Ialloc { bytes = _; spacetime_index; label_after_call_gc; } ->
               let rd = self#regs_for typ_val in
               let bytes = size_expr env (Ctuple new_args) in
+              assert (bytes mod Arch.size_addr = 0);
+              let alloc_words = bytes / Arch.size_addr in
               let op =
-                Ialloc { bytes; spacetime_index; label_after_call_gc; }
+                Ialloc { bytes; spacetime_index; label_after_call_gc;
+                         dbginfo = [{alloc_words; alloc_dbg = dbg}] }
               in
               let args = self#select_allocation_args env in
               self#insert_debug env (Iop op) dbg args rd;

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -396,6 +396,7 @@ class virtual instruction_selection = object (self)
       in
       Mach.Ialloc {
         bytes;
+        dbginfo = [];
         label_after_call_gc = Some label;
         spacetime_index = index;
       }

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -29,6 +29,11 @@ type item = {
 
 type t = item list
 
+type alloc_dbginfo_item =
+  { alloc_words : int;
+    alloc_dbg : t }
+type alloc_dbginfo = alloc_dbginfo_item list
+
 let none = []
 
 let is_none = function

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -25,6 +25,17 @@ type item = private {
 
 type t = item list
 
+type alloc_dbginfo_item =
+  { alloc_words : int;
+    alloc_dbg : t }
+(** Due to Comballoc, a single Ialloc instruction may combine several
+    unrelated allocations. Their Debuginfo.t (which may differ) are stored
+    as a list of alloc_dbginfo. This list is in order of increasing memory
+    address, which is the reverse of the original allocation order. Later
+    allocations are consed to the front of this list by Comballoc. *)
+
+type alloc_dbginfo = alloc_dbginfo_item list
+
 val none : t
 
 val is_none : t -> bool

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -488,7 +488,7 @@ LBL(103):
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))
-        
+
 /* Call a C function from OCaml */
 
 FUNCTION(G(caml_c_call))

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -159,15 +159,6 @@
         movq    GREL(dstlabel)(%rip), %r11 ; \
         popq    (%r11);  CFI_ADJUST (-8)
 
-/* Record lowest stack address and return address.  Clobbers %rax. */
-#define RECORD_STACK_FRAME(OFFSET) \
-        pushq   %r11 ; CFI_ADJUST(8); \
-        movq    8+OFFSET(%rsp), %rax ; \
-        movq    %rax, Caml_state(last_return_address) ; \
-        leaq    16+OFFSET(%rsp), %rax ; \
-        movq    %rax, Caml_state(bottom_of_stack) ; \
-        popq    %r11; CFI_ADJUST(-8)
-
 /* Load address of global [label] in register [dst]. */
 #define LEA_VAR(label,dst) \
         movq    GREL(label)(%rip), dst
@@ -196,12 +187,6 @@
 
 #define POP_VAR(dstlabel) \
         popq    G(dstlabel)(%rip); CFI_ADJUST(-8)
-
-#define RECORD_STACK_FRAME(OFFSET) \
-        movq    OFFSET(%rsp), %rax ; \
-        movq    %rax, Caml_state(last_return_address) ; \
-        leaq    8+OFFSET(%rsp), %rax ; \
-        movq    %rax, Caml_state(bottom_of_stack)
 
 #define LEA_VAR(label,dst) \
         leaq    G(label)(%rip), dst
@@ -328,8 +313,12 @@ G(caml_system__code_begin):
 
 FUNCTION(G(caml_call_gc))
         CFI_STARTPROC
-        RECORD_STACK_FRAME(0)
 LBL(caml_call_gc):
+    /* Record lowest stack address and return address. */
+        movq    (%rsp), %rax
+        movq    %rax, Caml_state(last_return_address)
+        leaq    8(%rsp), %rax
+        movq    %rax, Caml_state(bottom_of_stack)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
         subq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(STACK_PROBE_SIZE);
@@ -427,15 +416,7 @@ FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
         subq    $16, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(100)
-        ret
-LBL(100):
-        RECORD_STACK_FRAME(0)
-        ENTER_FUNCTION
-/*        subq    $8, %rsp; CFI_ADJUST (8); */
-        call    LBL(caml_call_gc)
-/*        addq    $8, %rsp; CFI_ADJUST (-8); */
-        LEAVE_FUNCTION
+        jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc1))
@@ -444,15 +425,7 @@ FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
         subq    $24, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(101)
-        ret
-LBL(101):
-        RECORD_STACK_FRAME(0)
-        ENTER_FUNCTION
-/*        subq    $8, %rsp; CFI_ADJUST (8); */
-        call    LBL(caml_call_gc)
-/*        addq    $8, %rsp; CFI_ADJUST (-8); */
-        LEAVE_FUNCTION
+        jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc2))
@@ -461,15 +434,7 @@ FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
         subq    $32, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(102)
-        ret
-LBL(102):
-        RECORD_STACK_FRAME(0)
-        ENTER_FUNCTION
-/*        subq    $8, %rsp; CFI_ADJUST (8) */
-        call    LBL(caml_call_gc)
-/*        addq    $8, %rsp; CFI_ADJUST (-8) */
-        LEAVE_FUNCTION
+        jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc3))
@@ -478,13 +443,7 @@ FUNCTION(G(caml_allocN))
 CFI_STARTPROC
         subq    %rax, %r15
         cmpq    Caml_state(young_limit), %r15
-        jb      LBL(103)
-        ret
-LBL(103):
-        RECORD_STACK_FRAME(0)
-        ENTER_FUNCTION
-        call    LBL(caml_call_gc)
-        LEAVE_FUNCTION
+        jb      LBL(caml_call_gc)
         ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -425,111 +425,70 @@ ENDFUNCTION(G(caml_call_gc))
 
 FUNCTION(G(caml_alloc1))
 CFI_STARTPROC
-LBL(caml_alloc1):
         subq    $16, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(100)
         ret
 LBL(100):
-        addq    $16, %r15
         RECORD_STACK_FRAME(0)
         ENTER_FUNCTION
 /*        subq    $8, %rsp; CFI_ADJUST (8); */
         call    LBL(caml_call_gc)
 /*        addq    $8, %rsp; CFI_ADJUST (-8); */
         LEAVE_FUNCTION
-        jmp     LBL(caml_alloc1)
+        ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc1))
 
 FUNCTION(G(caml_alloc2))
 CFI_STARTPROC
-LBL(caml_alloc2):
         subq    $24, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(101)
         ret
 LBL(101):
-        addq    $24, %r15
         RECORD_STACK_FRAME(0)
         ENTER_FUNCTION
 /*        subq    $8, %rsp; CFI_ADJUST (8); */
         call    LBL(caml_call_gc)
 /*        addq    $8, %rsp; CFI_ADJUST (-8); */
         LEAVE_FUNCTION
-        jmp     LBL(caml_alloc2)
+        ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc2))
 
 FUNCTION(G(caml_alloc3))
 CFI_STARTPROC
-LBL(caml_alloc3):
         subq    $32, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(102)
         ret
 LBL(102):
-        addq    $32, %r15
         RECORD_STACK_FRAME(0)
         ENTER_FUNCTION
 /*        subq    $8, %rsp; CFI_ADJUST (8) */
         call    LBL(caml_call_gc)
 /*        addq    $8, %rsp; CFI_ADJUST (-8) */
         LEAVE_FUNCTION
-        jmp     LBL(caml_alloc3)
+        ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
-LBL(caml_allocN):
-        pushq   %rax; CFI_ADJUST(8)        /* save desired size */
         subq    %rax, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(103)
-        addq    $8, %rsp; CFI_ADJUST (-8)  /* drop desired size */
         ret
 LBL(103):
-        addq    0(%rsp), %r15
-        CFI_ADJUST(8)
-        RECORD_STACK_FRAME(8)
-#ifdef WITH_FRAME_POINTERS
-        /* ensure 16 byte alignment by subq + enter using 16-bytes, PR#7417 */
-        subq    $8, %rsp; CFI_ADJUST (8)
+        RECORD_STACK_FRAME(0)
         ENTER_FUNCTION
-#endif
         call    LBL(caml_call_gc)
-#ifdef WITH_FRAME_POINTERS
-        /* ensure 16 byte alignment by leave + addq using 16-bytes PR#7417 */
         LEAVE_FUNCTION
-        addq    $8, %rsp; CFI_ADJUST (-8)
-#endif
-        popq    %rax; CFI_ADJUST(-8)       /* recover desired size */
-        jmp     LBL(caml_allocN)
+        ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))
-
-/* Reset the allocation pointer and invoke the GC */
-
-FUNCTION(G(caml_call_gc1))
-CFI_STARTPROC
-        addq    $16, %r15
-        jmp     GCALL(caml_call_gc)
-CFI_ENDPROC
-
-FUNCTION(G(caml_call_gc2))
-CFI_STARTPROC
-        addq    $24, %r15
-        jmp     GCALL(caml_call_gc)
-CFI_ENDPROC
-
-FUNCTION(G(caml_call_gc3))
-CFI_STARTPROC
-        addq    $32, %r15
-        jmp     GCALL(caml_call_gc)
-CFI_ENDPROC
-
-
+        
 /* Call a C function from OCaml */
 
 FUNCTION(G(caml_c_call))

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -50,7 +50,6 @@ caml_call_gc:
         Store_last_return_address rax
         lea     rax, [rsp+8]
         Store_bottom_of_stack rax
-L105:
     ; Touch the stack to trigger a recoverable segfault
     ; if insufficient space remains
         sub     rsp, 01000h
@@ -139,92 +138,32 @@ ENDIF
 caml_alloc1:
         sub     r15, 16
         Cmp_young_limit r15
-        jb      L100
+        jb      caml_call_gc
         ret
-L100:
-        add     r15, 16
-        mov     rax, [rsp + 0]
-        Store_last_return_address rax
-        lea     rax, [rsp + 8]
-        Store_bottom_of_stack rax
-        sub     rsp, 8
-        call    L105
-        add     rsp, 8
-        jmp     caml_alloc1
 
         PUBLIC  caml_alloc2
         ALIGN   16
 caml_alloc2:
         sub     r15, 24
         Cmp_young_limit r15
-        jb      L101
+        jb      caml_call_gc
         ret
-L101:
-        add     r15, 24
-        mov     rax, [rsp + 0]
-        Store_last_return_address rax
-        lea     rax, [rsp + 8]
-        Store_bottom_of_stack rax
-        sub     rsp, 8
-        call    L105
-        add     rsp, 8
-        jmp     caml_alloc2
 
         PUBLIC  caml_alloc3
         ALIGN   16
 caml_alloc3:
         sub     r15, 32
         Cmp_young_limit r15
-        jb      L102
+        jb      caml_call_gc
         ret
-L102:
-        add     r15, 32
-        mov     rax, [rsp + 0]
-        Store_last_return_address rax
-        lea     rax, [rsp + 8]
-        Store_bottom_of_stack rax
-        sub     rsp, 8
-        call    L105
-        add     rsp, 8
-        jmp     caml_alloc3
 
         PUBLIC  caml_allocN
         ALIGN   16
 caml_allocN:
         sub     r15, rax
         Cmp_young_limit r15
-        jb      L103
+        jb      caml_call_gc
         ret
-L103:
-        add     r15, rax
-        push    rax                       ; save desired size
-        mov     rax, [rsp + 8]
-        Store_last_return_address rax
-        lea     rax, [rsp + 16]
-        Store_bottom_of_stack rax
-        call    L105
-        pop     rax                      ; recover desired size
-        jmp     caml_allocN
-
-; Reset the allocation pointer and invoke the GC
-
-        PUBLIC  caml_call_gc1
-        ALIGN   16
-caml_call_gc1:
-        add     r15, 16
-        jmp     caml_call_gc
-
-        PUBLIC  caml_call_gc2
-        ALIGN   16
-caml_call_gc2:
-        add     r15, 24
-        jmp     caml_call_gc
-
-        PUBLIC  caml_call_gc3
-        ALIGN 16
-caml_call_gc3:
-        add     r15, 32
-        jmp     caml_call_gc
 
 ; Call a C function from OCaml
 

--- a/runtime/arm.S
+++ b/runtime/arm.S
@@ -137,9 +137,9 @@ caml_system__code_begin:
 
 FUNCTION(caml_call_gc)
         CFI_STARTPROC
+.Lcaml_call_gc:
     /* Record return address */
         str     lr, Caml_state(last_return_address)
-.Lcaml_call_gc:
     /* Record lowest stack address */
         str     sp, Caml_state(bottom_of_stack)
 #if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
@@ -176,81 +176,41 @@ FUNCTION(caml_call_gc)
 
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
-.Lcaml_alloc1:
         sub     alloc_ptr, alloc_ptr, 8
         ldr     r7, Caml_state(young_limit)
         cmp     alloc_ptr, r7
-        bcc     1f
+        bcc     .Lcaml_call_gc
         bx      lr
-1:      add     alloc_ptr, alloc_ptr, 8
-    /* Record return address */
-        str     lr, Caml_state(last_return_address)
-    /* Call GC */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldr     lr, Caml_state(last_return_address)
-    /* Try again */
-        b       .Lcaml_alloc1
         CFI_ENDPROC
         .size   caml_alloc1, .-caml_alloc1
 
 FUNCTION(caml_alloc2)
         CFI_STARTPROC
-.Lcaml_alloc2:
         sub     alloc_ptr, alloc_ptr, 12
         ldr     r7, Caml_state(young_limit)
         cmp     alloc_ptr, r7
-        bcc     1f
+        bcc     .Lcaml_call_gc
         bx      lr
-1:      add     alloc_ptr, alloc_ptr, 12
-    /* Record return address */
-        str     lr, Caml_state(last_return_address)
-    /* Call GC */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldr     lr, Caml_state(last_return_address)
-    /* Try again */
-        b       .Lcaml_alloc2
         CFI_ENDPROC
         .size   caml_alloc2, .-caml_alloc2
 
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
-.Lcaml_alloc3:
         sub     alloc_ptr, alloc_ptr, 16
         ldr     r7, Caml_state(young_limit)
         cmp     alloc_ptr, r7
-        bcc     1f
+        bcc     .Lcaml_call_gc
         bx      lr
-1:      add     alloc_ptr, alloc_ptr, 16
-    /* Record return address */
-        str     lr, Caml_state(last_return_address)
-    /* Call GC */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldr     lr, Caml_state(last_return_address)
-    /* Try again */
-        b       .Lcaml_alloc3
         CFI_ENDPROC
         .size   caml_alloc3, .-caml_alloc3
 
 FUNCTION(caml_allocN)
         CFI_STARTPROC
-.Lcaml_allocN:
         sub     alloc_ptr, alloc_ptr, r7
-        ldr     r12, Caml_state(young_limit)
-        cmp     alloc_ptr, r12
-        bcc     1f
+        ldr     r7, Caml_state(young_limit)
+        cmp     alloc_ptr, r7
+        bcc     .Lcaml_call_gc
         bx      lr
-1:      add     alloc_ptr, alloc_ptr, r7
-    /* Record return address */
-        str     lr, Caml_state(last_return_address)
-    /* Call GC (preserves r7) */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldr     lr, Caml_state(last_return_address)
-    /* Try again */
-        b       .Lcaml_allocN
         CFI_ENDPROC
         .size   caml_allocN, .-caml_allocN
 

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -101,12 +101,12 @@ caml_system__code_begin:
 
 FUNCTION(caml_call_gc)
         CFI_STARTPROC
+.Lcaml_call_gc:
     /* Record return address */
         str     x30, Caml_state(last_return_address)
     /* Record lowest stack address */
         mov     TMP, sp
         str     TMP, Caml_state(bottom_of_stack)
-.Lcaml_call_gc:
     /* Set up stack space, saving return address and frame pointer */
     /* (2 regs RA/GP, 24 allocatable int regs, 24 caller-save float regs) * 8 */
         CFI_OFFSET(29, -400)
@@ -187,117 +187,37 @@ FUNCTION(caml_call_gc)
 
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
-1:      sub     ALLOC_PTR, ALLOC_PTR, #16
+        sub     ALLOC_PTR, ALLOC_PTR, #16
         cmp     ALLOC_PTR, ALLOC_LIMIT
-        b.lo    2f
+        b.lo    .Lcaml_call_gc
         ret
-2:      add     ALLOC_PTR, ALLOC_PTR, #16
-        stp     x29, x30, [sp, -16]!
-        CFI_ADJUST(16)
-    /* Record the lowest address of the caller's stack frame.  This is the
-       address immediately above the pair of words (x29 and x30) we just
-       pushed.  Those must not be included since otherwise the distance from
-       [Caml_state->bottom_of_stack] to the highest address in the caller's
-       stack frame won't match the frame size contained in the relevant
-       frame descriptor. */
-        add     x29, sp, #16
-        str     x29, Caml_state(bottom_of_stack)
-        add     x29, sp, #0
-    /* Record return address */
-        str     x30, Caml_state(last_return_address)
-    /* Call GC */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldp     x29, x30, [sp], 16
-        CFI_ADJUST(-16)
-    /* Try again */
-        b       1b
         CFI_ENDPROC
-        .type   caml_alloc1, %function
         .size   caml_alloc1, .-caml_alloc1
 
-        .align  2
-        .globl  caml_alloc2
-caml_alloc2:
+FUNCTION(caml_alloc2)
         CFI_STARTPROC
-1:      sub     ALLOC_PTR, ALLOC_PTR, #24
+        sub     ALLOC_PTR, ALLOC_PTR, #24
         cmp     ALLOC_PTR, ALLOC_LIMIT
-        b.lo    2f
+        b.lo    .Lcaml_call_gc
         ret
-2:      add     ALLOC_PTR, ALLOC_PTR, #24
-        stp     x29, x30, [sp, -16]!
-        CFI_ADJUST(16)
-    /* Record the lowest address of the caller's stack frame.
-       See comment above. */
-        add     x29, sp, #16
-        str     x29, Caml_state(bottom_of_stack)
-        add     x29, sp, #0
-    /* Record return address */
-        str     x30, Caml_state(last_return_address)
-    /* Call GC */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldp     x29, x30, [sp], 16
-        CFI_ADJUST(-16)
-    /* Try again */
-        b       1b
         CFI_ENDPROC
-        .type   caml_alloc2, %function
         .size   caml_alloc2, .-caml_alloc2
 
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
-1:      sub     ALLOC_PTR, ALLOC_PTR, #32
+        sub     ALLOC_PTR, ALLOC_PTR, #32
         cmp     ALLOC_PTR, ALLOC_LIMIT
-        b.lo    2f
+        b.lo    .Lcaml_call_gc
         ret
-2:      add     ALLOC_PTR, ALLOC_PTR, #32
-        stp     x29, x30, [sp, -16]!
-        CFI_ADJUST(16)
-    /* Record the lowest address of the caller's stack frame.
-       See comment above. */
-        add     x29, sp, #16
-        str     x29, Caml_state(bottom_of_stack)
-        add     x29, sp, #0
-    /* Record return address */
-        str     x30, Caml_state(last_return_address)
-    /* Call GC */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldp     x29, x30, [sp], 16
-        CFI_ADJUST(-16)
-    /* Try again */
-        b       1b
         CFI_ENDPROC
-        .type   caml_alloc3, %function
         .size   caml_alloc3, .-caml_alloc3
 
-        TEXT_SECTION(caml_allocN)
-        .align  2
-        .globl  caml_allocN
-caml_allocN:
+FUNCTION(caml_allocN)
         CFI_STARTPROC
-1:      sub     ALLOC_PTR, ALLOC_PTR, ARG
+        sub     ALLOC_PTR, ALLOC_PTR, ARG
         cmp     ALLOC_PTR, ALLOC_LIMIT
-        b.lo    2f
+        b.lo    .Lcaml_call_gc
         ret
-2:      add     ALLOC_PTR, ALLOC_PTR, ARG
-        stp     x29, x30, [sp, -16]!
-        CFI_ADJUST(16)
-    /* Record the lowest address of the caller's stack frame.
-       See comment above. */
-        add     x29, sp, #16
-        str     x29, Caml_state(bottom_of_stack)
-        add     x29, sp, #0
-    /* Record return address */
-        str     x30, Caml_state(last_return_address)
-    /* Call GC.  This preserves ARG */
-        bl      .Lcaml_call_gc
-    /* Restore return address */
-        ldp     x29, x30, [sp], 16
-        CFI_ADJUST(-16)
-    /* Try again */
-        b       1b
         CFI_ENDPROC
         .size   caml_allocN, .-caml_allocN
 

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -146,8 +146,20 @@ debuginfo caml_debuginfo_extract(backtrace_slot slot)
   }
   /* Recover debugging info */
   infoptr = (unsigned char*)&d->live_ofs[d->num_live];
-  /* align to 32 bits */
-  infoptr = Align_to(infoptr, uint32_t);
+  if (d->frame_size & 2) {
+    /* skip alloc_lengths */
+    infoptr += *infoptr + 1;
+    /* align to 32 bits */
+    infoptr = Align_to(infoptr, uint32_t);
+    /* we know there's at least one valid debuginfo,
+       but it may not be the one for the first alloc */
+    while (*(uint32_t*)infoptr == 0) {
+      infoptr += sizeof(uint32_t);
+    }
+  } else {
+    /* align to 32 bits */
+    infoptr = Align_to(infoptr, uint32_t);
+  }
   /* read offset to debuginfo */
   debuginfo_offset = *(uint32_t*)infoptr;
   return (debuginfo)(infoptr + debuginfo_offset);

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -200,7 +200,7 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   info2 = ((uint32_t *)dbg)[1];
   /* Format of the two info words:
        llllllllllllllllllll aaaaaaaa bbbbbbbbbb ffffffffffffffffffffffff k n
-                         44       36         26                       2  1 0
+                         44       36         26                        2 1 0
                        (32+12)    (32+4)
      n ( 1 bit ): 0 if this is the final debuginfo
                   1 if there's another following this one

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -137,18 +137,20 @@ void caml_current_callstack_write(value trace) {
 
 debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
-  uintnat infoptr;
+  unsigned char* infoptr;
+  uint32_t debuginfo_offset;
   frame_descr * d = (frame_descr *)slot;
 
   if ((d->frame_size & 1) == 0) {
     return NULL;
   }
   /* Recover debugging info */
-  infoptr = ((uintnat) d +
-             sizeof(char *) + sizeof(short) + sizeof(short) +
-             sizeof(short) * d->num_live + sizeof(frame_descr *) - 1)
-            & -sizeof(frame_descr *);
-  return *((debuginfo*)infoptr);
+  infoptr = (unsigned char*)&d->live_ofs[d->num_live];
+  /* align to 32 bits */
+  infoptr = Align_to(infoptr, uint32_t);
+  /* read offset to debuginfo */
+  debuginfo_offset = *(uint32_t*)infoptr;
+  return (debuginfo)(infoptr + debuginfo_offset);
 }
 
 debuginfo caml_debuginfo_next(debuginfo dbg)
@@ -159,8 +161,12 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
     return NULL;
 
   infoptr = dbg;
-  infoptr += 2; /* Two packed info fields */
-  return *((debuginfo*)infoptr);
+  if ((infoptr[0] & 1) == 0)
+    /* No next debuginfo */
+    return NULL;
+  else
+    /* Next debuginfo is after the two packed info fields */
+    return (debuginfo*)(infoptr + 2);
 }
 
 /* Extract location information for the given frame descriptor */
@@ -181,17 +187,19 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   info1 = ((uint32_t *)dbg)[0];
   info2 = ((uint32_t *)dbg)[1];
   /* Format of the two info words:
-       llllllllllllllllllll aaaaaaaa bbbbbbbbbb nnnnnnnnnnnnnnnnnnnnnnnn kk
-                          44       36         26                       2  0
+       llllllllllllllllllll aaaaaaaa bbbbbbbbbb ffffffffffffffffffffffff k n
+                         44       36         26                       2  1 0
                        (32+12)    (32+4)
-     k ( 2 bits): 0 if it's a call
+     n ( 1 bit ): 0 if this is the final debuginfo
+                  1 if there's another following this one
+     k ( 1 bit ): 0 if it's a call
                   1 if it's a raise
-     n (24 bits): offset (in 4-byte words) of file name relative to dbg
+     f (24 bits): offset (in 4-byte words) of file name relative to dbg
      l (20 bits): line number
      a ( 8 bits): beginning of character range
      b (10 bits): end of character range */
   li->loc_valid = 1;
-  li->loc_is_raise = (info1 & 3) == 1;
+  li->loc_is_raise = (info1 & 2) == 2;
   li->loc_is_inlined = caml_debuginfo_next(dbg) != NULL;
   li->loc_filename = (char *) dbg + (info1 & 0x3FFFFFC);
   li->loc_lnum = info2 >> 12;

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -43,7 +43,7 @@ struct caml_loc_info {
 };
 
 /* When compiling with -g, backtrace slots have debug info associated.
- * When a call is inlined in native mode, debuginfos form a linked list.
+ * When a call is inlined in native mode, debuginfos form a sequence.
  */
 typedef void * debuginfo;
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -229,7 +229,7 @@ extern void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags);
     Restore_after_gc;                                                  \
   }                                                                    \
   Hd_hp (Caml_state_field(young_ptr)) =                                \
-    Make_header_with_profinfo ((wosize), (tag), Caml_black, profinfo); \
+    Make_header_with_profinfo ((wosize), (tag), 0, profinfo);          \
   (result) = Val_hp (Caml_state_field(young_ptr));                     \
   DEBUG_clear ((result), (wosize));                                    \
 }while(0)

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -89,9 +89,15 @@ typedef struct {
   unsigned short num_live;
   unsigned short live_ofs[1 /* num_live */];
   /*
+    If frame_size & 2, then allocation info follows:
+  unsigned char num_allocs;
+  unsigned char alloc_lengths[num_alloc];
+
     If frame_size & 1, then debug info follows:
-  uint32_t debug_info_offset;
-    Debug info is stored as a relative offset to a debuginfo structure. */
+  uint32_t debug_info_offset[num_debug];
+
+    Debug info is stored as relative offsets to debuginfo structures.
+    num_debug is num_alloc if frame_size & 2, otherwise 1. */
 } frame_descr;
 
 /* Used to compute offsets in frame tables.

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -87,8 +87,18 @@ typedef struct {
   uintnat retaddr;
   unsigned short frame_size;
   unsigned short num_live;
-  unsigned short live_ofs[1];
+  unsigned short live_ofs[1 /* num_live */];
+  /*
+    If frame_size & 1, then debug info follows:
+  uint32_t debug_info_offset;
+    Debug info is stored as a relative offset to a debuginfo structure. */
 } frame_descr;
+
+/* Used to compute offsets in frame tables.
+   ty must have power-of-2 size */
+#define Align_to(p, ty) \
+  (void*)(((uintnat)(p) + sizeof(ty) - 1) & -sizeof(ty))
+
 
 /* Hash table of frame descriptors */
 

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -148,8 +148,7 @@ LBL(caml_call_gc):
         popl    %edi; CFI_ADJUST(-4)
         popl    %ebp; CFI_ADJUST(-4)
     /* Return to caller. Returns young_ptr in %eax. */
-        movl    G(Caml_state), %eax
-        movl    CAML_STATE(young_ptr, %eax), %eax
+        movl    CAML_STATE(young_ptr, %ebx), %eax
         ret
         CFI_ENDPROC
         ENDFUNCTION(caml_call_gc)

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -113,15 +113,13 @@ G(caml_system__code_begin):
 
 FUNCTION(caml_call_gc)
         CFI_STARTPROC
+LBL(caml_call_gc):
     /* Record lowest stack address and return address */
-        pushl   %ebx; CFI_ADJUST(4)
         movl    G(Caml_state), %ebx
-        movl    4(%esp), %eax
+        movl    (%esp), %eax
         movl    %eax, CAML_STATE(last_return_address, %ebx)
-        leal    8(%esp), %eax
+        leal    4(%esp), %eax
         movl    %eax, CAML_STATE(bottom_of_stack, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
-LBL(105):
 #if !defined(SYS_mingw) && !defined(SYS_cygwin)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
@@ -137,7 +135,6 @@ LBL(105):
         pushl   %ecx; CFI_ADJUST(4)
         pushl   %ebx; CFI_ADJUST(4)
         pushl   %eax; CFI_ADJUST(4)
-        movl    G(Caml_state), %ebx
         movl    %esp, CAML_STATE(gc_regs, %ebx)
         /* MacOSX note: 16-alignment of stack preserved at this point */
     /* Call the garbage collector */
@@ -150,108 +147,59 @@ LBL(105):
         popl    %esi; CFI_ADJUST(-4)
         popl    %edi; CFI_ADJUST(-4)
         popl    %ebp; CFI_ADJUST(-4)
-    /* Return to caller */
+    /* Return to caller. Returns young_ptr in %eax. */
+        movl    G(Caml_state), %eax
+        movl    CAML_STATE(young_ptr, %eax), %eax
         ret
         CFI_ENDPROC
         ENDFUNCTION(caml_call_gc)
 
 FUNCTION(caml_alloc1)
         CFI_STARTPROC
-        pushl   %ebx; CFI_ADJUST(4)
         movl    G(Caml_state), %ebx
         movl    CAML_STATE(young_ptr, %ebx), %eax
         subl    $8, %eax
-        cmpl    CAML_STATE(young_limit, %ebx), %eax
-        jb      LBL(100)
         movl    %eax, CAML_STATE(young_ptr, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
+        cmpl    CAML_STATE(young_limit, %ebx), %eax
+        jb      LBL(caml_call_gc)
         ret
-LBL(100):
-        movl    4(%esp), %eax
-        movl    %eax, CAML_STATE(last_return_address, %ebx)
-        leal    8(%esp), %eax
-        movl    %eax, CAML_STATE(bottom_of_stack, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
-        ALIGN_STACK(12)
-        call    LBL(105)
-        UNDO_ALIGN_STACK(12)
-        jmp     G(caml_alloc1)
         CFI_ENDPROC
         ENDFUNCTION(caml_alloc1)
 
 FUNCTION(caml_alloc2)
         CFI_STARTPROC
-        pushl   %ebx; CFI_ADJUST(4)
         movl    G(Caml_state), %ebx
         movl    CAML_STATE(young_ptr, %ebx), %eax
         subl    $12, %eax
-        cmpl    CAML_STATE(young_limit, %ebx), %eax
-        jb      LBL(101)
         movl    %eax, CAML_STATE(young_ptr, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
+        cmpl    CAML_STATE(young_limit, %ebx), %eax
+        jb      LBL(caml_call_gc)
         ret
-LBL(101):
-        movl    4(%esp), %eax
-        movl    %eax, CAML_STATE(last_return_address, %ebx)
-        leal    8(%esp), %eax
-        movl    %eax, CAML_STATE(bottom_of_stack, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
-        ALIGN_STACK(12)
-        call    LBL(105)
-        UNDO_ALIGN_STACK(12)
-        jmp     G(caml_alloc2)
         CFI_ENDPROC
         ENDFUNCTION(caml_alloc2)
 
 FUNCTION(caml_alloc3)
         CFI_STARTPROC
-        pushl   %ebx; CFI_ADJUST(4)
         movl    G(Caml_state), %ebx
         movl    CAML_STATE(young_ptr, %ebx), %eax
         subl    $16, %eax
-        cmpl    CAML_STATE(young_limit, %ebx), %eax
-        jb      LBL(102)
         movl    %eax, CAML_STATE(young_ptr, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
+        cmpl    CAML_STATE(young_limit, %ebx), %eax
+        jb      LBL(caml_call_gc)
         ret
-LBL(102):
-        movl    4(%esp), %eax
-        movl    %eax, CAML_STATE(last_return_address, %ebx)
-        leal    8(%esp), %eax
-        movl    %eax, CAML_STATE(bottom_of_stack, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
-        ALIGN_STACK(12)
-        call    LBL(105)
-        UNDO_ALIGN_STACK(12)
-        jmp     G(caml_alloc3)
         CFI_ENDPROC
         ENDFUNCTION(caml_alloc3)
 
 FUNCTION(caml_allocN)
         CFI_STARTPROC
-        pushl   %eax; CFI_ADJUST(4) /* saved desired size */
-        pushl   %ebx; CFI_ADJUST(4)
         movl    G(Caml_state), %ebx
         /* eax = size - Caml_state->young_ptr */
         subl    CAML_STATE(young_ptr, %ebx), %eax
         negl    %eax              /* eax = Caml_state->young_ptr - size */
-        cmpl    CAML_STATE(young_limit, %ebx), %eax
-        jb      LBL(103)
         movl    %eax, CAML_STATE(young_ptr, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
-        addl    $4, %esp; CFI_ADJUST(-4) /* drop desired size */
+        cmpl    CAML_STATE(young_limit, %ebx), %eax
+        jb      LBL(caml_call_gc)
         ret
-LBL(103):
-        movl    8(%esp), %eax
-        movl    %eax, CAML_STATE(last_return_address, %ebx)
-        leal    12(%esp), %eax
-        movl    %eax, CAML_STATE(bottom_of_stack, %ebx)
-        popl    %ebx; CFI_ADJUST(-4)
-        ALIGN_STACK(8)
-        call    LBL(105)
-        UNDO_ALIGN_STACK(8)
-        popl    %eax; CFI_ADJUST(-4)    /* recover desired size */
-        jmp     G(caml_allocN)
         CFI_ENDPROC
         ENDFUNCTION(caml_allocN)
 

--- a/runtime/i386nt.asm
+++ b/runtime/i386nt.asm
@@ -39,22 +39,19 @@ INCLUDE domain_state32.inc
 
 _caml_call_gc:
     ; Record lowest stack address and return address
-        push    ebx ; make a tmp reg
         mov     ebx, _Caml_state
-        mov     eax, [esp+4]
+        mov     eax, [esp]
         Store_last_return_address ebx, eax
-        lea     eax, [esp+8]
+        lea     eax, [esp+4]
         Store_bottom_of_stack ebx, eax
-        pop     ebx
     ; Save all regs used by the code generator
-L105:   push    ebp
+        push    ebp
         push    edi
         push    esi
         push    edx
         push    ecx
         push    ebx
         push    eax
-        mov     ebx, _Caml_state
         Store_gc_regs ebx, esp
     ; Call the garbage collector
         call    _caml_garbage_collection
@@ -66,88 +63,50 @@ L105:   push    ebp
         pop     esi
         pop     edi
         pop     ebp
-    ; Return to caller
+    ; Return to caller. Returns young_ptr in eax
+        mov     eax, _Caml_state
+        Load_young_ptr eax, eax
         ret
 
         ALIGN  4
 _caml_alloc1:
-        push    ebx ; make a tmp reg
         mov     ebx, _Caml_state
         Load_young_ptr ebx, eax
         sub     eax, 8
-        Cmp_young_limit ebx, eax
-        jb      L100
         Store_young_ptr ebx, eax
-        pop     ebx
+        Cmp_young_limit ebx, eax
+        jb      _caml_call_gc
         ret
-L100:   mov     eax, [esp + 4]
-        Store_last_return_address ebx, eax
-        lea     eax, [esp+8]
-        Store_bottom_of_stack ebx, eax
-        pop     ebx
-        call    L105
-        jmp     _caml_alloc1
 
         ALIGN  4
 _caml_alloc2:
-        push    ebx ; make a tmp reg
         mov     ebx, _Caml_state
         Load_young_ptr ebx, eax
         sub     eax, 12
-        Cmp_young_limit ebx, eax
-        jb      L101
         Store_young_ptr ebx, eax
-        pop     ebx
+        Cmp_young_limit ebx, eax
+        jb      _caml_call_gc
         ret
-L101:   mov     eax, [esp+4]
-        Store_last_return_address ebx, eax
-        lea     eax, [esp+8]
-        Store_bottom_of_stack ebx, eax
-        pop     ebx
-        call    L105
-        jmp     _caml_alloc2
 
         ALIGN  4
 _caml_alloc3:
-        push    ebx ; make a tmp reg
         mov     ebx, _Caml_state
         Load_young_ptr ebx, eax
         sub     eax, 16
-        Cmp_young_limit ebx, eax
-        jb      L102
         Store_young_ptr ebx, eax
-        pop     ebx
+        Cmp_young_limit ebx, eax
+        jb      _caml_call_gc
         ret
-L102:   mov     eax, [esp+4]
-        Store_last_return_address ebx, eax
-        lea     eax, [esp+8]
-        Store_bottom_of_stack ebx, eax
-        pop     ebx
-        call    L105
-        jmp     _caml_alloc3
-
 
         ALIGN  4
 _caml_allocN:
-        push    eax ; Save desired size
-        push    ebx ; Make a tmp reg
         mov     ebx, _Caml_state
         Sub_young_ptr ebx, eax ; eax = size - young_ptr
         neg     eax            ; eax = young_ptr - size
-        Cmp_young_limit ebx, eax
-        jb      L103
         Store_young_ptr ebx, eax
-        pop     ebx
-        add     esp, 4 ; drop desired size
+        Cmp_young_limit ebx, eax
+        jb      _caml_call_gc
         ret
-L103:   mov     eax, [esp+8]
-        Store_last_return_address ebx, eax
-        lea     eax, [esp+12]
-        Store_bottom_of_stack ebx, eax
-        pop     ebx
-        call    L105
-        pop     eax                     ; recover desired size
-        jmp     _caml_allocN
 
 ; Call a C function from OCaml
 

--- a/runtime/i386nt.asm
+++ b/runtime/i386nt.asm
@@ -64,8 +64,7 @@ _caml_call_gc:
         pop     edi
         pop     ebp
     ; Return to caller. Returns young_ptr in eax
-        mov     eax, _Caml_state
-        Load_young_ptr eax, eax
+        Load_young_ptr ebx, eax
         ret
 
         ALIGN  4

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -508,6 +508,11 @@ void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags)
        callbacks. */
     CAML_INSTR_INT ("force_minor/alloc_small@", 1);
     caml_gc_dispatch ();
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+    if (caml_young_ptr == caml_young_alloc_end) {
+      caml_spacetime_automatic_snapshot();
+    }
+#endif
   }
 
   /* Re-do the allocation: we now have enough space in the minor heap. */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -60,6 +60,12 @@
             + or [Caml_state->young_trigger].
 */
 
+/* Asserts that a word is a valid header for a young object */
+#define CAMLassert_young_header(hd)                \
+  CAMLassert(Wosize_hd(hd) > 0 &&                  \
+             Wosize_hd(hd) <= Max_young_wosize &&  \
+             Color_hd(hd) == 0)
+
 struct generic_table CAML_TABLE_STRUCT(char);
 
 void caml_alloc_minor_tables ()
@@ -198,6 +204,7 @@ void caml_oldify_one (value v, value *p)
     if (hd == 0){         /* If already forwarded */
       *p = Field (v, 0);  /*  then forward pointer is first field. */
     }else{
+      CAMLassert_young_header(hd);
       tag = Tag_hd (hd);
       if (tag < Infix_tag){
         value field0;
@@ -351,6 +358,7 @@ void caml_empty_minor_heap (void)
   struct caml_ephe_ref_elt *re;
 
   if (Caml_state->young_ptr != Caml_state->young_alloc_end){
+    CAMLassert_young_header(*(header_t*)Caml_state->young_ptr);
     if (caml_minor_gc_begin_hook != NULL) (*caml_minor_gc_begin_hook) ();
     CAML_INSTR_SETUP (tmr, "minor");
     prev_alloc_words = caml_allocated_words;

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -153,6 +153,7 @@ CAMLprim value caml_obj_truncate (value v, value newsize)
   header_t hd = Hd_val (v);
   tag_t tag = Tag_hd (hd);
   color_t color = Color_hd (hd);
+  color_t frag_color = Is_young(v) ? 0 : Caml_black;
   mlsize_t wosize = Wosize_hd (hd);
   mlsize_t i;
 
@@ -177,7 +178,7 @@ CAMLprim value caml_obj_truncate (value v, value newsize)
      look like a pointer because there may be some references to it in
      ref_table. */
   Field (v, new_wosize) =
-    Make_header (Wosize_whsize (wosize-new_wosize), Abstract_tag, Caml_black);
+    Make_header (Wosize_whsize (wosize-new_wosize), Abstract_tag, frag_color);
   Hd_val (v) =
     Make_header_with_profinfo (new_wosize, tag, color, Profinfo_val(v));
   return Val_unit;

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -301,9 +301,8 @@ FUNCTION(caml_call_gc)
         lfdu    29, 8(11)
         lfdu    30, 8(11)
         lfdu    31, 8(11)
-    /* Return to caller, restarting the allocation */
+    /* Return to caller, resuming the allocation */
         lg      11, Caml_state(last_return_address)
-        addi    11, 11, -16     /* Restart the allocation (4 instructions) */
         mtlr    11
     /* For PPC64: restore the TOC that the caller saved at the usual place */
 #ifdef TOC_SAVE

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -83,6 +83,11 @@ static frame_descr * next_frame_descr(frame_descr * d) {
   CAMLassert(d->retaddr >= 4096);
   /* Skip to end of live_ofs */
   p = (unsigned char*)&d->live_ofs[d->num_live];
+  /* Skip alloc_lengths if present */
+  if (d->frame_size & 2) {
+    num_allocs = *p;
+    p += num_allocs + 1;
+  }
   /* Skip debug info if present */
   if (d->frame_size & 1) {
     /* Align to 32 bits */

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -29,7 +29,6 @@
 #include "caml/memprof.h"
 #include <string.h>
 #include <stdio.h>
-#include <stddef.h>
 
 /* Roots registered from C functions */
 

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -29,6 +29,7 @@
 #include "caml/memprof.h"
 #include <string.h>
 #include <stdio.h>
+#include <stddef.h>
 
 /* Roots registered from C functions */
 
@@ -78,14 +79,19 @@ static link* frametables_list_tail(link *list) {
 }
 
 static frame_descr * next_frame_descr(frame_descr * d) {
-  uintnat nextd;
-  nextd =
-    ((uintnat)d +
-     sizeof(char *) + sizeof(short) + sizeof(short) +
-     sizeof(short) * d->num_live + sizeof(frame_descr *) - 1)
-    & -sizeof(frame_descr *);
-  if (d->frame_size & 1) nextd += sizeof(void *); /* pointer to debuginfo */
-  return((frame_descr *) nextd);
+  unsigned char num_allocs = 0, *p;
+  CAMLassert(d->retaddr >= 4096);
+  /* Skip to end of live_ofs */
+  p = (unsigned char*)&d->live_ofs[d->num_live];
+  /* Skip debug info if present */
+  if (d->frame_size & 1) {
+    /* Align to 32 bits */
+    p = Align_to(p, uint32_t);
+    p += sizeof(uint32_t) * (d->frame_size & 2 ? num_allocs : 1);
+  }
+  /* Align to word size */
+  p = Align_to(p, void*);
+  return ((frame_descr*) p);
 }
 
 static void fill_hashtable(link *frametables) {

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -86,8 +86,8 @@ void caml_garbage_collection(void)
   { /* Compute the total allocation size at this point,
        including allocations combined by Comballoc */
     unsigned char* alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
-    int nallocs = *alloc_len++;
-    for (int i = 0; i < nallocs; i++) {
+    int i, nallocs = *alloc_len++;
+    for (i = 0; i < nallocs; i++) {
       /* Since 2 words is the smallest allocation, sizes are
          encoded as (wosize - 2).
          See Emitaux.emit_frames and caml/stack.h */

--- a/testsuite/tests/statmemprof/arrays_in_major.ml
+++ b/testsuite/tests/statmemprof/arrays_in_major.ml
@@ -54,11 +54,7 @@ let check_no_nested () =
   Printf.printf "check_no_nested\n%!";
   let in_callback = ref false in
   start {
-      (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-      sampling_rate = 0.5;
+      sampling_rate = 1.;
       callstack_size = 10;
       callback = fun _ ->
         assert (not !in_callback);
@@ -118,11 +114,7 @@ let[@inline never] check_callstack () =
   Printf.printf "check_callstack\n%!";
   let callstack = ref None in
   start {
-      (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-      sampling_rate = 0.5;
+      sampling_rate = 1.;
       callstack_size = 10;
       callback = fun info ->
         if info.kind = Major then callstack := Some info.callstack;

--- a/testsuite/tests/statmemprof/arrays_in_major.reference
+++ b/testsuite/tests/statmemprof/arrays_in_major.reference
@@ -9,6 +9,6 @@ check_distrib 300 300 100000 0.100000
 check_distrib 300000 300000 30 0.100000
 check_callstack
 Raised by primitive operation at file "arrays_in_major.ml", line 13, characters 14-28
-Called from file "arrays_in_major.ml", line 131, characters 2-35
-Called from file "arrays_in_major.ml", line 137, characters 9-27
+Called from file "arrays_in_major.ml", line 123, characters 2-35
+Called from file "arrays_in_major.ml", line 129, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/arrays_in_minor.ml
+++ b/testsuite/tests/statmemprof/arrays_in_minor.ml
@@ -60,11 +60,7 @@ let check_no_nested () =
   Printf.printf "check_no_nested\n%!";
   let in_callback = ref false in
   start {
-      (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-      sampling_rate = 0.5;
+      sampling_rate = 1.;
       callstack_size = 10;
       callback = fun _ ->
         assert (not !in_callback);
@@ -137,11 +133,7 @@ let[@inline never] check_callstack () =
   Printf.printf "check_callstack\n%!";
   let callstack = ref None in
   start {
-      (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-      sampling_rate = 0.5;
+      sampling_rate = 1.;
       callstack_size = 10;
       callback = fun info ->
         if info.tag = 0 then callstack := Some info.callstack;

--- a/testsuite/tests/statmemprof/arrays_in_minor.reference
+++ b/testsuite/tests/statmemprof/arrays_in_minor.reference
@@ -9,6 +9,6 @@ check_distrib 1 1 10000000 0.010000
 check_distrib 250 250 100000 0.100000
 check_callstack
 Raised by primitive operation at file "arrays_in_minor.ml", line 18, characters 20-34
-Called from file "arrays_in_minor.ml", line 150, characters 2-35
-Called from file "arrays_in_minor.ml", line 156, characters 9-27
+Called from file "arrays_in_minor.ml", line 142, characters 2-35
+Called from file "arrays_in_minor.ml", line 148, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/exception_callback.ml
+++ b/testsuite/tests/statmemprof/exception_callback.ml
@@ -12,11 +12,7 @@ let _ = Printexc.record_backtrace false
 
 let _ =
   start {
-    (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-    sampling_rate = 0.5;
+    sampling_rate = 1.;
     callstack_size = 10;
     callback = fun _ -> assert false
   };

--- a/testsuite/tests/statmemprof/exception_callback.reference
+++ b/testsuite/tests/statmemprof/exception_callback.reference
@@ -1,1 +1,1 @@
-Fatal error: exception File "exception_callback.ml", line 21, characters 24-30: Assertion failed
+Fatal error: exception File "exception_callback.ml", line 17, characters 24-30: Assertion failed

--- a/testsuite/tests/statmemprof/intern.byte.reference
+++ b/testsuite/tests/statmemprof/intern.byte.reference
@@ -9,6 +9,6 @@ check_distrib 300000 300000 20 0.100000
 check_callstack
 Raised by primitive operation at unknown location
 Called from file "intern.ml", line 32, characters 14-35
-Called from file "intern.ml", line 168, characters 2-25
-Called from file "intern.ml", line 174, characters 9-27
+Called from file "intern.ml", line 160, characters 2-25
+Called from file "intern.ml", line 166, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/intern.ml
+++ b/testsuite/tests/statmemprof/intern.ml
@@ -76,11 +76,7 @@ let check_no_nested () =
   precompute_marshalled_data 2 300;
   let in_callback = ref false in
   start {
-      (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-      sampling_rate = 0.5;
+      sampling_rate = 1.;
       callstack_size = 10;
       callback = fun _ ->
         assert (not !in_callback);
@@ -155,11 +151,7 @@ let[@inline never] check_callstack () =
   precompute_marshalled_data 2 300;
   let callstack = ref None in
   start {
-      (* FIXME: we should use 1. to make sure the block is sampled,
-       but the runtime does an infinite loop in native mode in this
-       case. This bug will go away when the sampling of natively
-       allocated will be correctly implemented. *)
-      sampling_rate = 0.5;
+      sampling_rate = 1.;
       callstack_size = 10;
       callback = fun info ->
         if info.kind = Unmarshalled then callstack := Some info.callstack;

--- a/testsuite/tests/statmemprof/intern.opt.reference
+++ b/testsuite/tests/statmemprof/intern.opt.reference
@@ -9,6 +9,6 @@ check_distrib 300000 300000 20 0.100000
 check_callstack
 Raised by primitive operation at file "marshal.ml", line 61, characters 9-35
 Called from file "intern.ml", line 32, characters 14-35
-Called from file "intern.ml", line 168, characters 2-25
-Called from file "intern.ml", line 174, characters 9-27
+Called from file "intern.ml", line 160, characters 2-25
+Called from file "intern.ml", line 166, characters 9-27
 OK !


### PR DESCRIPTION
This patch makes some subtle changes to how allocations work that are needed for statmemprof, as recently discussed with @damiendoligez and @jhjourdan. The main change is to make information about allocation sizes available to the GC, and to make native-code allocations work like bytecode allocations. (Bytecode allocations are simpler, but require size information that was not previously available).

---

In bytecode mode, small allocations on the minor heap are straightforward, following roughly this pattern:

```c
caml_young_ptr -= Whsize_wosize(wosize);
if (caml_young_ptr < caml_young_limit) {
  caml_alloc_small_dispatch(tag, wosize, CAML_DO_TRACK | CAML_FROM_CAML);
}
Hd_hp(caml_young_ptr) = header;
```

The function `caml_alloc_small_dispatch` undoes the failed allocation, then does a minor GC and runs any pending signal handlers / finalisers, and retries the allocation. (It may have to do this several times, as it's possible for a signal handler / finaliser to re-fill the minor heap). Finally, it logs the now-successful allocation with statmemprof, if needed.

Note that this logic requires knowing how big the allocation is.

In native code, allocations are more complicated. They look like this:

```c
redo:
caml_young_ptr -= Whsize_wosize(wosize);
if (caml_young_ptr < caml_young_limit) goto gc;
Hd_hp(caml_young_ptr) = header;
...

gc:
caml_young_ptr += Whsize_wosize(wosize); // [*]
caml_garbage_collection();
goto redo
```

The function `caml_garbage_collection` does *not* know how big the allocation is. Instead, it ensures that there is enough space on the minor heap for the largest possible allocation (256 words). Not passing the allocation size translates to a small saving in code size. (The line `[*]` was added by #8619: without it, failed allocations take twice the space they should, throwing off GC stats.)

For statmemprof to work, it needs to know how big the allocations are. To avoid affecting code size, this patch extends the frame table with a compact representation of allocation size, so that `caml_garbage_collection` can determine the allocation size without needing to be passed it explicitly.

However, simply encoding the allocation size information is not quite enough. The problem is a subtle one: the allocation that we sample during `caml_garbage_collection` may not be the next one to be allocated. The issue is the `redo` label: it comes before the young_limit check, so after caml_garbage_collection returns there's a new opportunity to run signal handlers and finalisers. This means that the following sequence of events is possible:

```
caml_young_ptr -= 3; // try to allocate a 2-word block, e.g. cons cell
if (caml_young_ptr < caml_young_limit) goto gc; // allocation fails
gc:
caml_young_ptr += 3; // undo failed allocation
caml_garbage_collection(); // statmemprof samples about-to-be-allocated cell
goto redo;
*** SIGINT received, caml_young_limit updated ***
caml_young_ptr -= 3; // retry allocation of cons cell
if (caml_young_ptr < caml_young_limit) goto gc; // allocation fails due to signal
gc:
caml_young_ptr += 3; // undo failed allocation
caml_garbage_collection(); // runs signal handler
// signal handler allocates, say, a 1-word ref.
```
The data maintained by statmemprof becomes corrupted, because the next allocation is not the one that statmemprof was expecting to happen. The problem is due to the extra polling of signals that happens between `caml_garbage_collection` and the actual allocation, and the fix is to make allocations work the same way they do on bytecode:

```c
caml_young_ptr -= Whsize_wosize(wosize);
if (caml_young_ptr < caml_young_limit) goto gc;
gc_done:
Hd_hp(caml_young_ptr) = header;

gc:
caml_garbage_collection();
goto gc_done
```

This way, once caml_garbage_collection returns the space has definitely been allocated, and natively-compiled code need not redo the check. Internally, this calls the same `caml_alloc_small_dispatch` function used for bytecode allocations.

---

The code used to record allocation information is lifted from 2c93ca1e711. (@jhjourdan: since I pretty much copy-pasted your approach, I've added you as an author to the Changes file of this PR). The tricky bit here is keeping track of allocation sizes through `Comballoc`, which may combine several allocations into one.

This requires storing a lot more information in the frame tables, and generating more debug info. To keep this small, I've adapted the compact debuginfo format from #8637, which this PR supersedes.

---

There are a few bits left to do here:

  - [x] numbers for frame table overhead (see https://github.com/ocaml/ocaml/pull/8805#issuecomment-545457567)
  - [x] clean up / refactor / move frametable parsing code in signals.c
  - [x] architectures other than amd64

Left for a later PR:
  - update the statmemprof tests to be aware of native-code allocations
  - use the new debug info in statmemprof to track inside comballoc'd blocks
  - either remove tags from the statmemprof API, or pass them from native blocks

