### PR TITLE
Env.lookup_module: don't allow creating loops

### DIFF
--- a/Changes
+++ b/Changes
@@ -123,9 +123,6 @@ Working version
   native-code on amd64.  (observed with the mingw64 compiler)
   (Nicolás Ojeda Bär, review by David Allsopp)
 
-- #8810: Env.lookup_module: don't allow creating loops
-  (Thomas Refis, report by Leo White, review by Jacques Garrigue)
-
 OCaml 4.09.0
 ------------
 
@@ -378,6 +375,9 @@ OCaml 4.09.0
 
 - #8800: Fix soundness bug in extension constructor inclusion
   (Leo White, review by Jacques Garrigue)
+
+- #8810: Env.lookup_module: don't allow creating loops
+  (Thomas Refis, report by Leo White, review by Jacques Garrigue)
 
 OCaml 4.08.0
 ------------

--- a/Changes
+++ b/Changes
@@ -123,6 +123,9 @@ Working version
   native-code on amd64.  (observed with the mingw64 compiler)
   (Nicolás Ojeda Bär, review by David Allsopp)
 
+- #8810: Env.lookup_module: don't allow creating loops
+  (Thomas Refis, report by Leo White, review by Jacques Garrigue)
+
 OCaml 4.09.0
 ------------
 

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -14,6 +14,7 @@ pr7726.ml
 pr7787.ml
 pr7818.ml
 pr7851.ml
+pr8810.ml
 printing.ml
 recursive.ml
 Test.ml

--- a/testsuite/tests/typing-modules/pr8810.ml
+++ b/testsuite/tests/typing-modules/pr8810.ml
@@ -1,0 +1,7 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+flags = "-no-alias-deps -w -49 -c"
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*)
+module Loop = Pr8810

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1083,7 +1083,10 @@ and lookup_module ~load ?loc ~mark lid env : Path.t =
   match lid with
     Lident s ->
       begin match IdTbl.find_name ~mark s env.modules with
-      | exception Not_found when !Clflags.transparent_modules && not load ->
+      | exception Not_found
+        when not (Current_unit_name.is s)
+          && !Clflags.transparent_modules
+          && not load ->
           check_pers_mod s
             ~loc:(Option.value loc ~default:Location.none);
           Path.Pident (Ident.create_persistent s)


### PR DESCRIPTION
```
$ cat bar.ml
module Foo = Bar

$ ~/.opam/4.07.1/bin/ocamlc -c -no-alias-deps -w -49 ./bar.ml
File "./bar.ml", line 1, characters 13-16:
Error: Unbound module Bar

$ ~/.opam/4.08.0/bin/ocamlc -c -no-alias-deps -w -49 ./bar.ml

$ cat baz.ml
module type X = module type of Bar [@remove_aliases]

$ ~/.opam/4.08.0/bin/ocamlc -c -no-alias-deps -w -49 ./baz.ml
Fatal error: exception Stack overflow
Raised by primitive operation at file "typing/ident.ml" (inlined), line 102, characters 20-40
Called from file "typing/ident.ml", line 200, characters 14-46
Called from file "typing/env.ml" (inlined), line 328, characters 26-52
Called from file "typing/env.ml", line 2146, characters 6-208
Called from file "typing/env.ml", line 2221, characters 12-76
Called from file "typing/mtype.ml", line 79, characters 8-64
Called from file "typing/mtype.ml", line 39, characters 19-55
Called from file "typing/env.ml", line 1753, characters 8-65
Called from file "typing/env.ml" (inlined), line 2169, characters 27-52
Called from file "typing/mtype.ml", line 444, characters 19-43
Called from file "typing/mtype.ml", line 470, characters 12-48
Called from file "typing/mtype.ml", line 442, characters 34-67
Called from file "typing/mtype.ml", line 449, characters 10-54
Called from file "typing/mtype.ml", line 470, characters 12-48
Called from file "typing/mtype.ml", line 442, characters 34-67
Called from file "typing/mtype.ml", line 449, characters 10-54
Called from file "typing/mtype.ml", line 470, characters 12-48
...
```

After this PR, `bar.ml` is rejected.