### PR TITLE
Restore Cygwin64 CI and test non-shared and minimal builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
         - libx11-dev:i386
         - libc6-dev:i386
   - env: CI_KIND=build XARCH=x64
+  - env: CI_KIND=build XARCH=x64 CONFIG_ARG=--disable-shared
+  - env: CI_KIND=build XARCH=x64 MIN_BUILD=1
   - env: CI_KIND=changes
   - env: CI_KIND=manual
   - env: CI_KIND=check-typo

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ git:
 script: tools/ci/travis/travis-ci.sh
 matrix:
   include:
+  - env: CI_KIND=build XARCH=x64 CONFIG_ARG=--enable-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=build XARCH=i386
     addons:
       apt:
@@ -32,7 +33,6 @@ matrix:
         - libx11-dev:i386
         - libc6-dev:i386
   - env: CI_KIND=build XARCH=x64
-  - env: CI_KIND=build XARCH=x64 CONFIG_ARG=--enable-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=changes
   - env: CI_KIND=manual
   - env: CI_KIND=check-typo

--- a/testsuite/tests/lib-systhreads/testyield.ml
+++ b/testsuite/tests/lib-systhreads/testyield.ml
@@ -1,10 +1,11 @@
 (* TEST
    (* Test that yielding between busy threads reliably triggers a thread
       switch. *)
+   * hassysthreads
    include systhreads
-   * not-windows
-   ** bytecode
-   ** native
+   ** not-windows
+   *** bytecode
+   *** native
 *)
 
 let threads = 4

--- a/testsuite/tests/lib-unix/common/truncate.ml
+++ b/testsuite/tests/lib-unix/common/truncate.ml
@@ -1,5 +1,8 @@
 (* TEST
 include unix
+* hasunix
+** bytecode
+** native
 *)
 
 let str = "Hello, OCaml!"

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom_unix.ml
@@ -1,9 +1,10 @@
 (* TEST
 include unix
 modules = "recvfrom.ml"
-* not-windows
-** bytecode
-** native
+* hasunix
+** not-windows
+*** bytecode
+*** native
 *)
 open Recvfrom
 

--- a/testsuite/tests/tool-debugger/dynlink/host.ml
+++ b/testsuite/tests/tool-debugger/dynlink/host.ml
@@ -9,25 +9,25 @@ ocamldebug_script = "${test_source_directory}/input_script"
 
 * debugger
 ** shared-libraries
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
-module = "host.ml"
+*** setup-ocamlc.byte-build-env
 **** ocamlc.byte
-module = "plugin.ml"
+module = "host.ml"
 ***** ocamlc.byte
+module = "plugin.ml"
+****** ocamlc.byte
 module = ""
 all_modules = "host.cmo"
 program = "${test_build_directory}/host.byte"
 libraries = "dynlink"
 
-****** run
+******* run
 output = "host.output"
-******* check-program-output
+******** check-program-output
 reference = "${test_source_directory}/host.reference"
 
-******* ocamldebug
+******** ocamldebug
 output = "host.debug.output"
-******** check-program-output
+********* check-program-output
 reference = "${test_source_directory}/host.debug.reference"
 
 *)

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -90,10 +90,25 @@ request can be merged.
 ------------------------------------------------------------------------
 EOF
 
-  configure_flags="\
-    --prefix=$PREFIX \
-    --enable-flambda-invariants \
-    $CONFIG_ARG"
+  if [ "$MIN_BUILD" = "1" ] ; then
+    configure_flags="\
+      --prefix=$PREFIX \
+      --disable-shared \
+      --disable-debug-runtime \
+      --disable-instrumented-runtime \
+      --disable-systhreads \
+      --disable-str-lib \
+      --disable-unix-lib \
+      --disable-bigarray-lib \
+      --disable-ocamldoc \
+      --disable-native-compiler \
+      $CONFIG_ARG"
+  else
+    configure_flags="\
+      --prefix=$PREFIX \
+      --enable-flambda-invariants \
+      $CONFIG_ARG"
+  fi
   case $XARCH in
   x64)
     ./configure $configure_flags
@@ -110,17 +125,30 @@ EOF
   esac
 
   export PATH=$PREFIX/bin:$PATH
-  $MAKE world.opt
-  $MAKE ocamlnat
+  if [ "$MIN_BUILD" = "1" ] ; then
+    if $MAKE world.opt ; then
+      echo "world.opt is not supposed to work!"
+      exit 1
+    else
+      $MAKE world
+    fi
+  else
+    $MAKE world.opt
+    $MAKE ocamlnat
+  fi
   cd testsuite
   echo Running the testsuite with the normal runtime
   $MAKE all
-  echo Running the testsuite with the debug runtime
-  $MAKE USE_RUNTIME='d' OCAMLTESTDIR="$(pwd)/_ocamltestd" TESTLOG=_logd all
+  if [ "$MIN_BUILD" != "1" ] ; then
+    echo Running the testsuite with the debug runtime
+    $MAKE USE_RUNTIME='d' OCAMLTESTDIR="$(pwd)/_ocamltestd" TESTLOG=_logd all
+  fi
   cd ..
   $MAKE install
-  echo Check the code examples in the manual
-  $MAKE manual-pregen
+  if fgrep 'SUPPORTS_SHARED_LIBRARIES=true' Makefile.config &>/dev/null ; then
+    echo Check the code examples in the manual
+    $MAKE manual-pregen
+  fi
   # check_all_arches checks tries to compile all backends in place,
   # we would need to redo (small parts of) world.opt afterwards to
   # use the compiler again


### PR DESCRIPTION
- #8654 introduced `tests/tool-debugger/dynlink` which has a typo in its ocamltest preamble
- #2248 introduced `tests/lib-unix/unix-socket/recvfrom_unix.ml` which missed the `hasunix` action
- #2023 introduced `tests/lib-unix/common/truncate.ml` which missed the `hasunix` action
- #2112 introduced `tests/lib-systhreads/testyield.ml` which missed the `hassysthreads` action

(NB No "blame" assigned to these errors, especially as I reviewed several of those PRs...! It's to demonstrate the need for the CI tests)

The typo in #8654 causes the Cygwin64 worker in Inria's CI to fail, since it builds with `--disable-shared`. Fixing this made me consider that the changes made in #2053 should be tested, so I have added two tests to the Travis matrix:
1. A `--disable-shared` test, so that Cygwin64 failing is not the first time we find the fault
2. A test which disables everything (including the native compiler) to ensure that the testsuite still runs correctly.