### PR TITLE
Rebuild dynlink_*.o when tree re-configured

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -124,10 +124,10 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 # than \UXXXXXXXX). The \u is then translated to \x in order to accommodate
 # pre-Visual Studio 2013 compilers where \x is a non-standard alias for \u.
 OCAML_STDLIB_DIR = $(shell echo $(LIBDIR)| iconv -t JAVA | sed -e 's/\\u/\\x/g')
-OC_CPPFLAGS += -DOCAML_STDLIB_DIR='L"$(OCAML_STDLIB_DIR)"'
+STDLIB_CPP_FLAG = -DOCAML_STDLIB_DIR='L"$(OCAML_STDLIB_DIR)"'
 else # Unix
 OCAML_STDLIB_DIR = $(LIBDIR)
-OC_CPPFLAGS += -DOCAML_STDLIB_DIR='"$(OCAML_STDLIB_DIR)"'
+STDLIB_CPP_FLAG = -DOCAML_STDLIB_DIR='"$(OCAML_STDLIB_DIR)"'
 endif
 
 OC_CPPFLAGS += $(IFLEXDIR)
@@ -340,6 +340,8 @@ object_types := % %_b %_bd %_bi %_bpic %_n %_nd %_ni %_np %_npic
 
 $(foreach object_type, $(object_types), \
   $(eval $(call COMPILE_C_FILE,$(object_type))))
+
+dynlink_%.$(O): OC_CPPFLAGS += $(STDLIB_CPP_FLAG)
 
 $(foreach object_type,$(subst %,,$(object_types)), \
   $(eval dynlink$(object_type).$(O): $(ROOTDIR)/Makefile.config))

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -341,6 +341,9 @@ object_types := % %_b %_bd %_bi %_bpic %_n %_nd %_ni %_np %_npic
 $(foreach object_type, $(object_types), \
   $(eval $(call COMPILE_C_FILE,$(object_type))))
 
+$(foreach object_type,$(subst %,,$(object_types)), \
+  $(eval dynlink$(object_type).$(O): $(ROOTDIR)/Makefile.config))
+
 # Compilation of assembly files
 
 %.o: %.S


### PR DESCRIPTION
I got stung doing a rebuild after re-running `configure` in order to change `--prefix`. This change updates `Makefile.config` which you'd expect to propagate through the compiler. `runtime/dynlink.c` picks up this change via the `-DOCAML_STDLIB_DIR` flag, which is derived using `Makefile.config` but does not depend on it.

This PR makes two changes:
- It adds a dependency on `Makefile.config` to all the `dynlink_*.o` files (this is done using a mechanism already there, as you can't use pattern rules directly for this).
- `-DOCAML_STDLIB_DIR` is applied to `dynlink_*.o` in the same way as the other flags - in other words, the flag is now available for the explicit files which use it (and which should also therefore have the dependency manually added).

If any future file were to end up depending on `OCAML_STDLIB_DIR`, it would be better to apply the define once in a generated header file and then `#include` that, but that seems overkill at the moment where it's definitely only the one place where the value is ever used.