### PR TITLE
Improved error messages for type mismatches

### DIFF
--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -296,7 +296,11 @@ Error: Signature mismatch:
          type ('a, 'b) bar += A of float
        is not included in
          type ('a, 'b) bar += A of int
-       The types for field A are not equal.
+       Constructors do not match:
+         A of float
+       is not compatible with:
+         A of int
+       The types are not equal.
 |}]
 
 module M : sig
@@ -318,7 +322,11 @@ Error: Signature mismatch:
          type ('a, 'b) bar += A of 'b
        is not included in
          type ('a, 'b) bar += A of 'a
-       The types for field A are not equal.
+       Constructors do not match:
+         A of 'b
+       is not compatible with:
+         A of 'a0
+       The types are not equal.
 |}]
 
 module M : sig
@@ -340,7 +348,11 @@ Error: Signature mismatch:
          type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
        is not included in
          type ('a, 'b) bar += A : 'c -> ('c, 'd) bar
-       The types for field A are not equal.
+       Constructors do not match:
+         A : 'd -> ('c, 'd) bar
+       is not compatible with:
+         A : 'c -> ('c, 'd) bar
+       The types are not equal.
 |}]
 
 (* Extensions can be rebound *)

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -18,5 +18,9 @@ Lines 4-5, characters 0-77:
 4 | type 'a tt = 'a t =
 5 |   Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt..
 Error: This variant or record definition does not match that of type 'a t
-       The types for field Same are not equal.
+       Constructors do not match:
+         Same : 'l t -> 'l t
+       is not compatible with:
+         Same : 'l1 t -> 'l2 t
+       The types are not equal.
 |}];;

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -19,7 +19,11 @@ Lines 2-3, characters 2-37:
 2 | ..type t = X.t =
 3 |     | A : 'a * 'b * ('b -> unit) -> t
 Error: This variant or record definition does not match that of type X.t
-       The types for field A are not equal.
+       Constructors do not match:
+         A : 'a * 'b * ('a -> unit) -> X.t
+       is not compatible with:
+         A : 'a * 'b * ('b -> unit) -> X.t
+       The types are not equal.
 |}]
 
 (* would segfault

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -144,7 +144,7 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t [@@immediate]
-       the first is not an immediate type.
+       The first is not an immediate type.
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -160,7 +160,7 @@ Error: Signature mismatch:
          type t = string
        is not included in
          type t [@@immediate]
-       the first is not an immediate type.
+       The first is not an immediate type.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -50,7 +50,11 @@ Error: Signature mismatch:
          type u = A of t/1
        is not included in
          type u = A of t/2
-       The types for field A are not equal.
+       Constructors do not match:
+         A of t/1
+       is not compatible with:
+         A of t/2
+       The types are not equal.
        Line 4, characters 9-19:
          Definition of type t/1
        Line 2, characters 2-11:
@@ -113,7 +117,11 @@ Error: Signature mismatch:
          type t = A of T/1.t
        is not included in
          type t = A of T/2.t
-       The types for field A are not equal.
+       Constructors do not match:
+         A of T/1.t
+       is not compatible with:
+         A of T/2.t
+       The types are not equal.
        Line 5, characters 6-34:
          Definition of module T/1
        Line 2, characters 2-30:

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -208,7 +208,11 @@ Line 2, characters 0-37:
 2 | type mut = d = {x:int; mutable y:int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       The mutability of field y is different.
+       Fields do not match:
+         y : int;
+       is not compatible with:
+         mutable y : int;
+       This is mutable and the original is not.
 |}]
 
 type missing = d = { x:int }
@@ -226,7 +230,11 @@ Line 1, characters 0-31:
 1 | type wrong_type = d = {x:float}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       The types for field x are not equal.
+       Fields do not match:
+         x : int;
+       is not compatible with:
+         x : float;
+       The types are not equal.
 |}]
 
 type unboxed = d = {x:float} [@@unboxed]
@@ -245,5 +253,5 @@ Line 1, characters 0-30:
 1 | type perm = d = {y:int; x:int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       Fields number 1 have different names, x and y.
+       1st fields have different names, x and y.
 |}]

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -87,7 +87,7 @@ Line 3, characters 0-27:
 3 | type missing = d = X of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       The field Y is only present in the original definition.
+       The constructor Y is only present in the original definition.
 |}]
 
 type wrong_type = d = X of float
@@ -96,7 +96,11 @@ Line 1, characters 0-32:
 1 | type wrong_type = d = X of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       The types for field X are not equal.
+       Constructors do not match:
+         X of int
+       is not compatible with:
+         X of float
+       The types are not equal.
 |}]
 
 type unboxed = d = X of float [@@unboxed]
@@ -115,5 +119,5 @@ Line 1, characters 0-35:
 1 | type perm = d = Y of int | X of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       Fields number 1 have different names, X and Y.
+       1st constructors have different names, X and Y.
 |}]

--- a/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr6293_bad.compilers.reference
@@ -7,6 +7,6 @@ Error: In this `with' constraint, the new definition of t
          type t
        is not included in
          type t = { a : int; b : int; }
+       Their kinds differ.
        File "pr6293_bad.ml", line 9, characters 20-50: Expected declaration
        File "pr6293_bad.ml", line 10, characters 18-37: Actual declaration
-       Their kinds differ.

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -95,7 +95,11 @@ Line 3, characters 23-33:
 3 | module type B = A with type t = u;; (* fail *)
                            ^^^^^^^^^^
 Error: This variant or record definition does not match that of type u
-       The types for field X are not equal.
+       Constructors do not match:
+         X of bool
+       is not compatible with:
+         X of int
+       The types are not equal.
 |}];;
 
 (* PR#5815 *)
@@ -141,7 +145,11 @@ Error: Signature mismatch:
          type t += E of int
        is not included in
          type t += E
-       The arities for field E differ.
+       Constructors do not match:
+         E of int
+       is not compatible with:
+         E
+       They have different arities.
 |}];;
 
 module M : sig type t += E of char end = struct type t += E of int end;;
@@ -158,7 +166,11 @@ Error: Signature mismatch:
          type t += E of int
        is not included in
          type t += E of char
-       The types for field E are not equal.
+       Constructors do not match:
+         E of int
+       is not compatible with:
+         E of char
+       The types are not equal.
 |}];;
 
 module M : sig type t += C of int end = struct type t += E of int end;;
@@ -193,5 +205,9 @@ Error: Signature mismatch:
          type t += E of int
        is not included in
          type t += E of { x : int; }
-       The types for field E are not equal.
+       Constructors do not match:
+         E of int
+       is not compatible with:
+         E of { x : int; }
+       The second uses inline records and the first doesn't.
 |}];;

--- a/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
+++ b/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
@@ -19,7 +19,11 @@ Error: Signature mismatch:
          type t += F of int
        is not included in
          type t += F
-       The arities for field F differ.
+       Constructors do not match:
+         F of int
+       is not compatible with:
+         F
+       They have different arities.
 |}];;
 
 module M1 : sig type t += A end = struct type t += private A end;;

--- a/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
+++ b/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
@@ -1,0 +1,40 @@
+(* TEST
+ * expect
+*)
+
+type t = ..;;
+
+module M : sig type t += E | F end = struct type t += E | F of int end;;
+[%%expect{|
+type t = ..
+Line 3, characters 37-70:
+3 | module M : sig type t += E | F end = struct type t += E | F of int end;;
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t += E | F of int  end
+       is not included in
+         sig type t += E | F  end
+       Extension declarations do not match:
+         type t += F of int
+       is not included in
+         type t += F
+       The arities for field F differ.
+|}];;
+
+module M1 : sig type t += A end = struct type t += private A end;;
+[%%expect{|
+Line 1, characters 34-64:
+1 | module M1 : sig type t += A end = struct type t += private A end;;
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t += private A end
+       is not included in
+         sig type t += A end
+       Extension declarations do not match:
+         type t += private A
+       is not included in
+         type t += A
+       A private type would be revealed.
+|}];;

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -18,3 +18,6 @@ printing.ml
 recursive.ml
 Test.ml
 unroll_private_abbrev.ml
+records_errors_test.ml
+variants_errors_test.ml
+extension_constructors_errors_test.ml

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -315,5 +315,9 @@ Line 15, characters 16-64:
 15 | module rec M1 : S' with module Term0 := Asc and module T := Desc = M1;;
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
-       The types for field E are not equal.
+       Constructors do not match:
+         E of (MkT(M.T).t, MkT(M.T).t) eq
+       is not compatible with:
+         E of (MkT(Desc).t, MkT(Desc).t) eq
+       The types are not equal.
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -27,7 +27,11 @@ Line 1, characters 16-53:
 1 | module rec M1 : S with type x = int and type y = bool = M1;;
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M1.t
-       The types for field E are not equal.
+       Constructors do not match:
+         E of M1.x
+       is not compatible with:
+         E of M1.y
+       The types are not equal.
 |}]
 
 let bool_of_int x =
@@ -75,5 +79,9 @@ Line 1, characters 16-53:
 1 | module rec M1 : S with type x = int and type y = bool = M1;;
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M1.t
-       The types for field E are not equal.
+       Constructors do not match:
+         E of (M1.x, M1.x) eq
+       is not compatible with:
+         E of (M1.x, M1.y) eq
+       The types are not equal.
 |}]

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -1,0 +1,130 @@
+(* TEST
+ * expect
+*)
+
+module M1 : sig
+  type t = {f0 : unit * unit * unit * int * unit * unit * unit;
+            f1 : unit * unit * unit * int * unit * unit * unit}
+end = struct
+  type t = {f0 : unit * unit * unit * float* unit * unit * unit;
+            f1 : unit * unit * unit * string * unit * unit * unit}
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
+6 |             f1 : unit * unit * unit * string * unit * unit * unit}
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = {
+             f0 : unit * unit * unit * float * unit * unit * unit;
+             f1 : unit * unit * unit * string * unit * unit * unit;
+           }
+         end
+       is not included in
+         sig
+           type t = {
+             f0 : unit * unit * unit * int * unit * unit * unit;
+             f1 : unit * unit * unit * int * unit * unit * unit;
+           }
+         end
+       Type declarations do not match:
+         type t = {
+           f0 : unit * unit * unit * float * unit * unit * unit;
+           f1 : unit * unit * unit * string * unit * unit * unit;
+         }
+       is not included in
+         type t = {
+           f0 : unit * unit * unit * int * unit * unit * unit;
+           f1 : unit * unit * unit * int * unit * unit * unit;
+         }
+       The types for field f0 are not equal.
+|}];;
+
+
+module M2 : sig
+  type t = {mutable f0 : unit * unit * unit * int * unit * unit * unit;
+            f1 : unit * unit * unit * int * unit * unit * unit}
+end = struct
+  type t = {f0 : unit * unit * unit * float* unit * unit * unit;
+            f1 : unit * unit * unit * string * unit * unit * unit}
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
+6 |             f1 : unit * unit * unit * string * unit * unit * unit}
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = {
+             f0 : unit * unit * unit * float * unit * unit * unit;
+             f1 : unit * unit * unit * string * unit * unit * unit;
+           }
+         end
+       is not included in
+         sig
+           type t = {
+             mutable f0 : unit * unit * unit * int * unit * unit * unit;
+             f1 : unit * unit * unit * int * unit * unit * unit;
+           }
+         end
+       Type declarations do not match:
+         type t = {
+           f0 : unit * unit * unit * float * unit * unit * unit;
+           f1 : unit * unit * unit * string * unit * unit * unit;
+         }
+       is not included in
+         type t = {
+           mutable f0 : unit * unit * unit * int * unit * unit * unit;
+           f1 : unit * unit * unit * int * unit * unit * unit;
+         }
+       The mutability of field f0 is different.
+|}];;
+
+module M3 : sig
+  type t = {f0 : unit}
+end = struct
+  type t = {f1 : unit}
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = {f1 : unit}
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { f1 : unit; } end
+       is not included in
+         sig type t = { f0 : unit; } end
+       Type declarations do not match:
+         type t = { f1 : unit; }
+       is not included in
+         type t = { f0 : unit; }
+       Fields number 1 have different names, f1 and f0.
+|}];;
+
+module M4 : sig
+  type t = {f0 : unit; f1 : unit}
+end = struct
+  type t = {f0 : unit}
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = {f0 : unit}
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { f0 : unit; } end
+       is not included in
+         sig type t = { f0 : unit; f1 : unit; } end
+       Type declarations do not match:
+         type t = { f0 : unit; }
+       is not included in
+         type t = { f0 : unit; f1 : unit; }
+       The field f1 is only present in the second declaration.
+|}];;

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -40,7 +40,11 @@ Error: Signature mismatch:
            f0 : unit * unit * unit * int * unit * unit * unit;
            f1 : unit * unit * unit * int * unit * unit * unit;
          }
-       The types for field f0 are not equal.
+       Fields do not match:
+         f0 : unit * unit * unit * float * unit * unit * unit;
+       is not compatible with:
+         f0 : unit * unit * unit * int * unit * unit * unit;
+       The types are not equal.
 |}];;
 
 
@@ -82,7 +86,11 @@ Error: Signature mismatch:
            mutable f0 : unit * unit * unit * int * unit * unit * unit;
            f1 : unit * unit * unit * int * unit * unit * unit;
          }
-       The mutability of field f0 is different.
+       Fields do not match:
+         f0 : unit * unit * unit * float * unit * unit * unit;
+       is not compatible with:
+         mutable f0 : unit * unit * unit * int * unit * unit * unit;
+       The second is mutable and the first is not.
 |}];;
 
 module M3 : sig
@@ -104,7 +112,7 @@ Error: Signature mismatch:
          type t = { f1 : unit; }
        is not included in
          type t = { f0 : unit; }
-       Fields number 1 have different names, f1 and f0.
+       1st fields have different names, f1 and f0.
 |}];;
 
 module M4 : sig

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -24,7 +24,11 @@ Error: Signature mismatch:
          type t = Foo of float * int
        is not included in
          type t = Foo of int * int
-       The types for field Foo are not equal.
+       Constructors do not match:
+         Foo of float * int
+       is not compatible with:
+         Foo of int * int
+       The types are not equal.
 |}];;
 
 module M2 : sig
@@ -49,7 +53,11 @@ Error: Signature mismatch:
          type t = Foo of float
        is not included in
          type t = Foo of int * int
-       The arities for field Foo differ.
+       Constructors do not match:
+         Foo of float
+       is not compatible with:
+         Foo of int * int
+       They have different arities.
 |}];;
 
 module M3 : sig
@@ -74,7 +82,15 @@ Error: Signature mismatch:
          type t = Foo of { x : float; y : int; }
        is not included in
          type t = Foo of { x : int; y : int; }
-       The types for field x are not equal.
+       Constructors do not match:
+         Foo of { x : float; y : int; }
+       is not compatible with:
+         Foo of { x : int; y : int; }
+       Fields do not match:
+         x : float;
+       is not compatible with:
+         x : int;
+       The types are not equal.
 |}];;
 
 module M4 : sig
@@ -99,7 +115,11 @@ Error: Signature mismatch:
          type t = Foo of float
        is not included in
          type t = Foo of { x : int; y : int; }
-       The types for field Foo are not equal.
+       Constructors do not match:
+         Foo of float
+       is not compatible with:
+         Foo of { x : int; y : int; }
+       The second uses inline records and the first doesn't.
 |}];;
 
 module M5 : sig
@@ -124,5 +144,9 @@ Error: Signature mismatch:
          type 'a t = Foo of 'a
        is not included in
          type 'a t = Foo : int -> int t
-       The types for field Foo are not equal.
+       Constructors do not match:
+         Foo of 'a
+       is not compatible with:
+         Foo : int -> int t
+       The second has explicit return type and the first doesn't.
 |}];;

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -1,0 +1,128 @@
+(* TEST
+  * expect
+ *)
+
+module M1 : sig
+  type t =
+    | Foo of int * int
+end = struct
+  type t =
+    | Foo of float * int
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t =
+6 |     | Foo of float * int
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Foo of float * int end
+       is not included in
+         sig type t = Foo of int * int end
+       Type declarations do not match:
+         type t = Foo of float * int
+       is not included in
+         type t = Foo of int * int
+       The types for field Foo are not equal.
+|}];;
+
+module M2 : sig
+  type t =
+    | Foo of int * int
+end = struct
+  type t =
+    | Foo of float
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t =
+6 |     | Foo of float
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Foo of float end
+       is not included in
+         sig type t = Foo of int * int end
+       Type declarations do not match:
+         type t = Foo of float
+       is not included in
+         type t = Foo of int * int
+       The arities for field Foo differ.
+|}];;
+
+module M3 : sig
+  type t =
+    | Foo of {x : int; y : int}
+end = struct
+  type t =
+    | Foo of {x : float; y : int}
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t =
+6 |     | Foo of {x : float; y : int}
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Foo of { x : float; y : int; } end
+       is not included in
+         sig type t = Foo of { x : int; y : int; } end
+       Type declarations do not match:
+         type t = Foo of { x : float; y : int; }
+       is not included in
+         type t = Foo of { x : int; y : int; }
+       The types for field x are not equal.
+|}];;
+
+module M4 : sig
+  type t =
+    | Foo of {x : int; y : int}
+end = struct
+  type t =
+    | Foo of float
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t =
+6 |     | Foo of float
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Foo of float end
+       is not included in
+         sig type t = Foo of { x : int; y : int; } end
+       Type declarations do not match:
+         type t = Foo of float
+       is not included in
+         type t = Foo of { x : int; y : int; }
+       The types for field Foo are not equal.
+|}];;
+
+module M5 : sig
+  type 'a t =
+    | Foo : int -> int t
+end = struct
+  type 'a t =
+    | Foo of 'a
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a t =
+6 |     | Foo of 'a
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Foo of 'a end
+       is not included in
+         sig type 'a t = Foo : int -> int t end
+       Type declarations do not match:
+         type 'a t = Foo of 'a
+       is not included in
+         type 'a t = Foo : int -> int t
+       The types for field Foo are not equal.
+|}];;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -35,7 +35,7 @@ let value_descriptions ~loc env name
     name;
   if Ctype.moregeneral env true vd1.val_type vd2.val_type then begin
     match (vd1.val_kind, vd2.val_kind) with
-        (Val_prim p1, Val_prim p2) ->
+      | (Val_prim p1, Val_prim p2) ->
           if p1 = p2 then Tcoerce_none else raise Dont_match
       | (Val_prim p, _) ->
           let pc = {pc_desc = p; pc_type = vd2.Types.val_type;
@@ -59,7 +59,7 @@ let private_flags decl1 decl2 =
 
 let is_absrow env ty =
   match ty.desc with
-    Tconstr(Pident _, _, _) ->
+  | Tconstr(Pident _, _, _) ->
       begin match Ctype.expand_head env ty with
         {desc=Tobject _|Tvariant _} -> true
       | _ -> false
@@ -69,7 +69,7 @@ let is_absrow env ty =
 let type_manifest env ty1 params1 ty2 params2 priv2 =
   let ty1' = Ctype.expand_head env ty1 and ty2' = Ctype.expand_head env ty2 in
   match ty1'.desc, ty2'.desc with
-    Tvariant row1, Tvariant row2 when is_absrow env (Btype.row_more row2) ->
+  | Tvariant row1, Tvariant row2 when is_absrow env (Btype.row_more row2) ->
       let row1 = Btype.row_repr row1 and row2 = Btype.row_repr row2 in
       Ctype.equal env true (ty1::params1) (row2.row_more::params2) &&
       begin match row1.row_more with
@@ -122,79 +122,185 @@ let type_manifest env ty1 params1 ty2 params2 priv2 =
 
 (* Inclusion between type declarations *)
 
+type label_mismatch =
+  | Type
+  | Mutable of bool
+
+type record_mismatch =
+  | Label_mismatch of Types.label_declaration
+                      * Types.label_declaration
+                      * label_mismatch
+  | Label_names of int * Ident.t * Ident.t
+  | Label_missing of bool * Ident.t
+  | Representation of bool   (* true means second one is unboxed float *)
+
+type constructor_mismatch =
+  | Type
+  | Arity
+  | Record of record_mismatch
+  | Kind of bool
+  | Explicit_return_type of bool
+
+type variant_mismatch =
+  | Constructor_mismatch of Types.constructor_declaration
+                            * Types.constructor_declaration
+                            * constructor_mismatch
+  | Constructor_names of int * Ident.t * Ident.t
+  | Constructor_missing of bool * Ident.t
+
+type extension_constructor_mismatch =
+  | Privacy
+  | Constructor_mismatch of Ident.t
+                            * Types.extension_constructor
+                            * Types.extension_constructor
+                            * constructor_mismatch
+
 type type_mismatch =
-    Arity
+  | Arity
   | Privacy
   | Kind
   | Constraint
   | Manifest
   | Variance
-  | Field_type of Ident.t
-  | Field_mutable of Ident.t
-  | Field_arity of Ident.t
-  | Field_names of int * Ident.t * Ident.t
-  | Field_missing of bool * Ident.t
-  | Record_representation of bool   (* true means second one is unboxed float *)
+  | Record_mismatch of record_mismatch
+  | Variant_mismatch of variant_mismatch
+  | Extension_constructor_mismatch of extension_constructor_mismatch
   | Unboxed_representation of bool  (* true means second one is unboxed *)
   | Immediate
+
+let report_label_mismatch first second ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  match (err : label_mismatch) with
+  | Type -> pr "The types are not equal."
+  | Mutable is_second ->
+      pr "%s is mutable and %s is not."
+        (String.capitalize_ascii (if is_second then second else first))
+        (if is_second then first else second)
+
+let report_record_mismatch first second decl ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  match err with
+  | Label_mismatch (l1, l2, err) ->
+      pr
+        "@[<hv>Fields do not match:@;<1 2>%a@ is not compatible with:\
+         @;<1 2>%a@ %a"
+        Printtyp.label l1
+        Printtyp.label l2
+        (report_label_mismatch first second) err
+  | Label_names (n, name1, name2) ->
+      pr "@[<hv>%i%s fields have different names, %s and %s.@]"
+        n (Misc.suffix n) (Ident.name name1) (Ident.name name2)
+  | Label_missing (b, s) ->
+      pr "@[<hv>The field %s is only present in %s %s.@]"
+        (Ident.name s) (if b then second else first) decl
+  | Representation b ->
+      pr "@[<hv>Their internal representations differ:@ %s %s %s.@]"
+        (if b then second else first) decl
+        "uses unboxed float representation"
+
+let report_constructor_mismatch first second decl ppf err =
+  let pr fmt  = Format.fprintf ppf fmt in
+  match (err : constructor_mismatch) with
+  | Type -> pr "The types are not equal."
+  | Arity -> pr "They have different arities."
+  | Record err -> report_record_mismatch first second decl ppf err
+  | Kind is_second ->
+      pr "%s uses inline records and %s doesn't."
+        (String.capitalize_ascii (if is_second then second else first))
+        (if is_second then first else second)
+  | Explicit_return_type is_second ->
+      pr "%s has explicit return type and %s doesn't."
+        (String.capitalize_ascii (if is_second then second else first))
+        (if is_second then first else second)
+
+let report_variant_mismatch first second decl ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  match (err : variant_mismatch) with
+  | Constructor_mismatch (c1, c2, err) ->
+      pr
+        "@[<hv>Constructors do not match:@;<1 2>%a@ is not compatible with:\
+         @;<1 2>%a@ %a"
+        Printtyp.constructor c1
+        Printtyp.constructor c2
+        (report_constructor_mismatch first second decl) err
+  | Constructor_names (n, name1, name2) ->
+      pr "%i%s constructors have different names, %s and %s."
+        n (Misc.suffix n) (Ident.name name1) (Ident.name name2)
+  | Constructor_missing (b, s) ->
+      pr "The constructor %s is only present in %s %s."
+        (Ident.name s) (if b then second else first) decl
+
+let report_extension_constructor_mismatch first second decl ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  match (err : extension_constructor_mismatch) with
+  | Privacy -> pr "A private type would be revealed."
+  | Constructor_mismatch (id, ext1, ext2, err) ->
+      pr "@[<hv>Constructors do not match:@;<1 2>%a@ is not compatible with:\
+          @;<1 2>%a@ %a@]"
+        (Printtyp.extension_only_constructor id) ext1
+        (Printtyp.extension_only_constructor id) ext2
+        (report_constructor_mismatch first second decl) err
 
 let report_type_mismatch0 first second decl ppf err =
   let pr fmt = Format.fprintf ppf fmt in
   match err with
-    Arity -> pr "They have different arities"
-  | Privacy -> pr "A private type would be revealed"
-  | Kind -> pr "Their kinds differ"
-  | Constraint -> pr "Their constraints differ"
+  | Arity -> pr "They have different arities."
+  | Privacy -> pr "A private type would be revealed."
+  | Kind -> pr "Their kinds differ."
+  | Constraint -> pr "Their constraints differ."
   | Manifest -> ()
-  | Variance -> pr "Their variances do not agree"
-  | Field_type s ->
-      pr "The types for field %s are not equal" (Ident.name s)
-  | Field_mutable s ->
-      pr "The mutability of field %s is different" (Ident.name s)
-  | Field_arity s ->
-      pr "The arities for field %s differ" (Ident.name s)
-  | Field_names (n, name1, name2) ->
-      pr "Fields number %i have different names, %s and %s"
-        n (Ident.name name1) (Ident.name name2)
-  | Field_missing (b, s) ->
-      pr "The field %s is only present in %s %s"
-        (Ident.name s) (if b then second else first) decl
-  | Record_representation b ->
-      pr "Their internal representations differ:@ %s %s %s"
-        (if b then second else first) decl
-        "uses unboxed float representation"
+  | Variance -> pr "Their variances do not agree."
+  | Record_mismatch err -> report_record_mismatch first second decl ppf err
+  | Variant_mismatch err -> report_variant_mismatch first second decl ppf err
+  | Extension_constructor_mismatch err -> report_extension_constructor_mismatch
+                                            first second decl ppf err
   | Unboxed_representation b ->
-      pr "Their internal representations differ:@ %s %s %s"
+      pr "Their internal representations differ:@ %s %s %s."
          (if b then second else first) decl
          "uses unboxed representation"
-  | Immediate -> pr "%s is not an immediate type" first
+  | Immediate -> pr "%s is not an immediate type." (StringLabels.capitalize_ascii first)
 
 let report_type_mismatch first second decl ppf err =
   if err = Manifest then () else
-  Format.fprintf ppf "@ %a." (report_type_mismatch0 first second decl) err
+  Format.fprintf ppf "@ %a" (report_type_mismatch0 first second decl) err
 
-let rec compare_constructor_arguments ~loc env cstr params1 params2 arg1 arg2 =
+let rec compare_constructor_arguments ~loc env params1 params2 arg1 arg2 =
   match arg1, arg2 with
   | Types.Cstr_tuple arg1, Types.Cstr_tuple arg2 ->
-      if List.length arg1 <> List.length arg2 then Some (Field_arity cstr)
+      if List.length arg1 <> List.length arg2 then
+        Some (Arity : constructor_mismatch)
       else if
         (* Ctype.equal must be called on all arguments at once, cf. PR#7378 *)
         Ctype.equal env true (params1 @ arg1) (params2 @ arg2)
-      then None else Some (Field_type cstr)
+      then None else Some (Type : constructor_mismatch)
   | Types.Cstr_record l1, Types.Cstr_record l2 ->
-      compare_records env ~loc params1 params2 0 l1 l2
-  | _ -> Some (Field_type cstr)
+      Option.map
+        (fun rec_err -> Record rec_err)
+        (compare_records env ~loc params1 params2 0 l1 l2)
+  | Types.Cstr_record _, _ -> Some (Kind false : constructor_mismatch)
+  | _, Types.Cstr_record _ -> Some (Kind true : constructor_mismatch)
+
+and compare_constructors ~loc env params1 params2 res1 res2 args1 args2 =
+  match res1, res2 with
+  | Some r1, Some r2 ->
+      if Ctype.equal env true [r1] [r2] then
+        compare_constructor_arguments ~loc env [r1] [r2] args1 args2
+      else Some (Type : constructor_mismatch)
+  | Some _, None -> Some (Explicit_return_type false : constructor_mismatch)
+  | None, Some _ -> Some (Explicit_return_type true : constructor_mismatch)
+  | None, None ->
+      compare_constructor_arguments ~loc env params1 params2 args1 args2
 
 and compare_variants ~loc env params1 params2 n
     (cstrs1 : Types.constructor_declaration list)
     (cstrs2 : Types.constructor_declaration list) =
   match cstrs1, cstrs2 with
-    [], []           -> None
-  | [], c::_ -> Some (Field_missing (true, c.Types.cd_id))
-  | c::_, [] -> Some (Field_missing (false, c.Types.cd_id))
+  | [], []   -> None
+  | [], c::_ -> Some (Constructor_missing (true, c.Types.cd_id))
+  | c::_, [] -> Some (Constructor_missing (false, c.Types.cd_id))
   | cd1::rem1, cd2::rem2 ->
       if Ident.name cd1.cd_id <> Ident.name cd2.cd_id then
-        Some (Field_names (n, cd1.cd_id, cd2.cd_id))
+        Some (Constructor_names (n, cd1.cd_id, cd2.cd_id))
       else begin
         Builtin_attributes.check_alerts_inclusion
           ~def:cd1.cd_loc
@@ -202,36 +308,33 @@ and compare_variants ~loc env params1 params2 n
           loc
           cd1.cd_attributes cd2.cd_attributes
           (Ident.name cd1.cd_id);
-        let r =
-          match cd1.cd_res, cd2.cd_res with
-          | Some r1, Some r2 ->
-              if Ctype.equal env true [r1] [r2] then
-                compare_constructor_arguments ~loc env cd1.cd_id [r1] [r2]
-                  cd1.cd_args cd2.cd_args
-              else Some (Field_type cd1.cd_id)
-          | Some _, None | None, Some _ ->
-              Some (Field_type cd1.cd_id)
-          | _ ->
-              compare_constructor_arguments ~loc env cd1.cd_id
-                params1 params2 cd1.cd_args cd2.cd_args
-        in
-        if r <> None then r
-        else compare_variants ~loc env params1 params2 (n+1) rem1 rem2
+        match compare_constructors ~loc env params1 params2
+                cd1.cd_res cd2.cd_res cd1.cd_args cd2.cd_args with
+        | Some r -> Some (
+            (Constructor_mismatch (cd1, cd2, r)) : variant_mismatch)
+        | None -> compare_variants ~loc env params1 params2 (n+1) rem1 rem2
       end
 
+and compare_labels env params1 params2
+      (ld1 : Types.label_declaration)
+      (ld2 : Types.label_declaration) =
+      if ld1.ld_mutable <> ld2.ld_mutable
+      then Some (Mutable (ld2.ld_mutable = Asttypes.Mutable))
+      else
+        if Ctype.equal env true (ld1.ld_type::params1) (ld2.ld_type::params2)
+        then None
+        else Some (Type : label_mismatch)
 
 and compare_records ~loc env params1 params2 n
     (labels1 : Types.label_declaration list)
     (labels2 : Types.label_declaration list) =
   match labels1, labels2 with
-    [], []           -> None
-  | [], l::_ -> Some (Field_missing (true, l.Types.ld_id))
-  | l::_, [] -> Some (Field_missing (false, l.Types.ld_id))
+  | [], []           -> None
+  | [], l::_ -> Some (Label_missing (true, l.Types.ld_id))
+  | l::_, [] -> Some (Label_missing (false, l.Types.ld_id))
   | ld1::rem1, ld2::rem2 ->
       if Ident.name ld1.ld_id <> Ident.name ld2.ld_id
-      then Some (Field_names (n, ld1.ld_id, ld2.ld_id))
-      else if ld1.ld_mutable <> ld2.ld_mutable then
-        Some (Field_mutable ld1.ld_id)
+      then Some (Label_names (n, ld1.ld_id, ld2.ld_id))
       else begin
         Builtin_attributes.check_deprecated_mutable_inclusion
           ~def:ld1.ld_loc
@@ -239,17 +342,24 @@ and compare_records ~loc env params1 params2 n
           loc
           ld1.ld_attributes ld2.ld_attributes
           (Ident.name ld1.ld_id);
-        if Ctype.equal env true (ld1.ld_type::params1)(ld2.ld_type::params2)
-        then (* add arguments to the parameters, cf. PR#7378 *)
-          compare_records ~loc env
-            (ld1.ld_type::params1) (ld2.ld_type::params2)
-            (n+1)
-            rem1 rem2
-        else
-          Some (Field_type ld1.ld_id)
+        match compare_labels env params1 params2 ld1 ld2 with
+        | Some r -> Some (Label_mismatch (ld1, ld2, r))
+        (* add arguments to the parameters, cf. PR#7378 *)
+        | None -> compare_records ~loc env
+                    (ld1.ld_type::params1) (ld2.ld_type::params2)
+                    (n+1)
+                    rem1 rem2
       end
 
-let type_declarations ?(equality = false) ~loc env ~mark name decl1 path decl2 =
+let compare_records_with_representation ~loc env params1 params2 n
+      labels1 labels2 rep1 rep2
+  =
+  match compare_records ~loc env params1 params2 n labels1 labels2 with
+  | None when rep1 <> rep2 -> Some (Representation (rep2 = Record_float))
+  | err -> err
+
+let type_declarations ?(equality = false) ~loc env ~mark name
+      decl1 path decl2 =
   Builtin_attributes.check_alerts_inclusion
     ~def:decl1.type_loc
     ~use:decl2.type_loc
@@ -303,15 +413,16 @@ let type_declarations ?(equality = false) ~loc env ~mark name decl1 path decl2 =
           mark cstrs1 usage name decl1;
           if equality then mark cstrs2 Env.Positive (Path.name path) decl2
         end;
-        compare_variants ~loc env decl1.type_params
-          decl2.type_params 1 cstrs1 cstrs2
+        Option.map
+          (fun var_err -> Variant_mismatch var_err)
+          (compare_variants ~loc env decl1.type_params decl2.type_params 1
+             cstrs1 cstrs2)
     | (Type_record(labels1,rep1), Type_record(labels2,rep2)) ->
-        let err =
-          compare_records ~loc env decl1.type_params
-            decl2.type_params 1 labels1 labels2
-        in
-        if err <> None || rep1 = rep2 then err else
-        Some (Record_representation (rep2 = Record_float))
+        Option.map (fun rec_err -> Record_mismatch rec_err)
+          (compare_records_with_representation ~loc env
+             decl1.type_params decl2.type_params 1
+             labels1 labels2
+             rep1 rep2)
     | (Type_open, Type_open) -> None
     | (_, _) -> Some Kind
   in
@@ -364,22 +475,24 @@ let extension_constructors ~loc env ~mark id ext1 ext2 =
   in
   if not (Ctype.equal env true (ty1 :: ext1.ext_type_params)
                                (ty2 :: ext2.ext_type_params))
-  then Some (Field_type id) else
-  let r =
-    match ext1.ext_ret_type, ext2.ext_ret_type with
-    | Some r1, Some r2 ->
-        if Ctype.equal env true [r1] [r2] then
-          compare_constructor_arguments ~loc env id [r1] [r2]
+  then Some (Constructor_mismatch (id, ext1, ext2, Type))
+  else
+    let r =
+      match ext1.ext_ret_type, ext2.ext_ret_type with
+      | Some r1, Some r2 ->
+          if Ctype.equal env true [r1] [r2] then
+            compare_constructor_arguments ~loc env [r1] [r2]
+              ext1.ext_args ext2.ext_args
+        else Some (Type : constructor_mismatch)
+      | Some _, None -> Some (Explicit_return_type false)
+      | None, Some _ -> Some (Explicit_return_type true)
+      | None, None ->
+          compare_constructor_arguments ~loc env
+            ext1.ext_type_params ext2.ext_type_params
             ext1.ext_args ext2.ext_args
-        else Some (Field_type id)
-    | Some _, None | None, Some _ ->
-        Some (Field_type id)
-    | None, None ->
-        compare_constructor_arguments ~loc env id
-          ext1.ext_type_params ext2.ext_type_params
-          ext1.ext_args ext2.ext_args
-  in
-  if r <> None then r else
-  match ext1.ext_private, ext2.ext_private with
-  | Private, Public -> Some Privacy
-  | _, _ -> None
+    in
+    match r with
+    | Some r -> Some (Constructor_mismatch (id, ext1, ext2, r))
+    | None -> match ext1.ext_private, ext2.ext_private with
+        Private, Public -> Some (Privacy:extension_constructor_mismatch)
+      | _, _ -> None

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -20,20 +20,48 @@ open Types
 
 exception Dont_match
 
+type label_mismatch =
+  | Type
+  | Mutable of bool
+
+type record_mismatch =
+  | Label_mismatch of label_declaration * label_declaration * label_mismatch
+  | Label_names of int * Ident.t * Ident.t
+  | Label_missing of bool * Ident.t
+  | Representation of bool   (* true means second one is unboxed float *)
+
+type constructor_mismatch =
+  | Type
+  | Arity
+  | Record of record_mismatch
+  | Kind of bool
+  | Explicit_return_type of bool
+
+type variant_mismatch =
+  | Constructor_mismatch of constructor_declaration
+                            * constructor_declaration
+                            * constructor_mismatch
+  | Constructor_names of int * Ident.t * Ident.t
+  | Constructor_missing of bool * Ident.t
+
+type extension_constructor_mismatch =
+  | Privacy
+  | Constructor_mismatch of Ident.t
+                            * extension_constructor
+                            * extension_constructor
+                            * constructor_mismatch
+
 type type_mismatch =
-    Arity
+  | Arity
   | Privacy
   | Kind
   | Constraint
   | Manifest
   | Variance
-  | Field_type of Ident.t
-  | Field_mutable of Ident.t
-  | Field_arity of Ident.t
-  | Field_names of int * Ident.t * Ident.t
-  | Field_missing of bool * Ident.t
-  | Record_representation of bool
-  | Unboxed_representation of bool
+  | Record_mismatch of record_mismatch
+  | Variant_mismatch of variant_mismatch
+  | Extension_constructor_mismatch of extension_constructor_mismatch
+  | Unboxed_representation of bool  (* true means second one is unboxed *)
   | Immediate
 
 val value_descriptions:
@@ -48,7 +76,8 @@ val type_declarations:
 
 val extension_constructors:
   loc:Location.t -> Env.t -> mark:bool -> Ident.t ->
-  extension_constructor -> extension_constructor -> type_mismatch option
+  extension_constructor -> extension_constructor ->
+  extension_constructor_mismatch option
 (*
 val class_types:
         Env.t -> class_type -> class_type -> bool
@@ -56,3 +85,5 @@ val class_types:
 
 val report_type_mismatch:
     string -> string -> string -> Format.formatter -> type_mismatch -> unit
+val report_extension_constructor_mismatch: string -> string -> string ->
+  Format.formatter -> extension_constructor_mismatch -> unit

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -25,7 +25,7 @@ type symptom =
   | Type_declarations of Ident.t * type_declaration
         * type_declaration * Includecore.type_mismatch
   | Extension_constructors of Ident.t * extension_constructor
-        * extension_constructor * Includecore.type_mismatch
+        * extension_constructor * Includecore.extension_constructor_mismatch
   | Module_types of module_type * module_type
   | Modtype_infos of Ident.t * modtype_declaration * modtype_declaration
   | Modtype_permutation of Types.module_type * Typedtree.module_coercion
@@ -760,20 +760,20 @@ let include_err env ppf = function
         "is not included in"
         !Oprint.out_sig_item
         (Printtyp.tree_of_type_declaration id d2 Trec_first)
-        show_locs (d1.type_loc, d2.type_loc)
         (Includecore.report_type_mismatch
            "the first" "the second" "declaration") err
+        show_locs (d1.type_loc, d2.type_loc)
   | Extension_constructors(id, x1, x2, err) ->
-      fprintf ppf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a@]"
+      fprintf ppf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]@ %a%a@]"
         "Extension declarations do not match"
         !Oprint.out_sig_item
         (Printtyp.tree_of_extension_constructor id x1 Text_first)
         "is not included in"
         !Oprint.out_sig_item
         (Printtyp.tree_of_extension_constructor id x2 Text_first)
-        show_locs (x1.ext_loc, x2.ext_loc)
-        (Includecore.report_type_mismatch
+        (Includecore.report_extension_constructor_mismatch
            "the first" "the second" "declaration") err
+        show_locs (x1.ext_loc, x2.ext_loc)
   | Module_types(mty1, mty2)->
       fprintf ppf
        "@[<hv 2>Modules do not match:@ \
@@ -840,7 +840,6 @@ let report_error ppf errs =
   Printtyp.Conflicts.reset();
   fprintf ppf "@[<v>%a%a%t@]" print_errs errs include_err err
     Printtyp.Conflicts.print
-
 (* We could do a better job to split the individual error items
    as sub-messages of the main interface mismatch on the whole unit. *)
 let () =

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -61,7 +61,7 @@ type symptom =
   | Type_declarations of Ident.t * type_declaration
         * type_declaration * Includecore.type_mismatch
   | Extension_constructors of Ident.t * extension_constructor
-        * extension_constructor * Includecore.type_mismatch
+        * extension_constructor * Includecore.extension_constructor_mismatch
   | Module_types of module_type * module_type
   | Modtype_infos of Ident.t * modtype_declaration * modtype_declaration
   | Modtype_permutation of Types.module_type * Typedtree.module_coercion

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -391,6 +391,8 @@ and print_out_label ppf (name, mut, arg) =
   fprintf ppf "@[<2>%s%s :@ %a@];" (if mut then "mutable " else "") name
     print_out_type arg
 
+let out_label = ref print_out_label
+
 let out_type = ref print_out_type
 
 (* Class types *)
@@ -704,6 +706,7 @@ and print_out_type_extension ppf te =
     (print_list print_out_constr (fun ppf -> fprintf ppf "@ | "))
     te.otyext_constructors
 
+let out_constr = ref print_out_constr
 let _ = out_module_type := print_out_module_type
 let _ = out_signature := print_out_signature
 let _ = out_sig_item := print_out_sig_item

--- a/typing/oprint.mli
+++ b/typing/oprint.mli
@@ -18,7 +18,10 @@ open Outcometree
 
 val out_ident : (formatter -> out_ident -> unit) ref
 val out_value : (formatter -> out_value -> unit) ref
+val out_label : (formatter -> string * bool * out_type -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
+val out_constr :
+  (formatter -> string * out_type list * out_type option -> unit) ref
 val out_class_type : (formatter -> out_class_type -> unit) ref
 val out_module_type : (formatter -> out_module_type -> unit) ref
 val out_sig_item : (formatter -> out_sig_item -> unit) ref

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1221,6 +1221,10 @@ and tree_of_constructor cd =
 and tree_of_label l =
   (Ident.name l.ld_id, l.ld_mutable = Mutable, tree_of_typexp false l.ld_type)
 
+let constructor ppf c = !Oprint.out_constr ppf (tree_of_constructor c)
+
+let label ppf l = !Oprint.out_label ppf (tree_of_label l)
+
 let tree_of_type_declaration id decl rs =
   Osig_type (tree_of_type_decl id decl, tree_of_rec rs)
 
@@ -1232,6 +1236,17 @@ let constructor_arguments ppf a =
   !Oprint.out_type ppf (Otyp_tuple tys)
 
 (* Print an extension declaration *)
+
+let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
+  match ext_ret_type with
+  | None -> (tree_of_constructor_arguments ext_args, None)
+  | Some res ->
+    let nm = !names in
+    names := [];
+    let ret = tree_of_typexp false res in
+    let args = tree_of_constructor_arguments ext_args in
+    names := nm;
+    (args, Some ret)
 
 let tree_of_extension_constructor id ext es =
   reset_except_context ();
@@ -1252,15 +1267,9 @@ let tree_of_extension_constructor id ext es =
   in
   let name = Ident.name id in
   let args, ret =
-    match ext.ext_ret_type with
-    | None -> (tree_of_constructor_arguments ext.ext_args, None)
-    | Some res ->
-        let nm = !names in
-        names := [];
-        let ret = tree_of_typexp false res in
-        let args = tree_of_constructor_arguments ext.ext_args in
-        names := nm;
-        (args, Some ret)
+    extension_constructor_args_and_ret_type_subtree
+      ext.ext_args
+      ext.ext_ret_type
   in
   let ext =
     { oext_name = name;
@@ -1280,6 +1289,16 @@ let tree_of_extension_constructor id ext es =
 
 let extension_constructor id ppf ext =
   !Oprint.out_sig_item ppf (tree_of_extension_constructor id ext Text_first)
+
+let extension_only_constructor id ppf ext =
+  let name = Ident.name id in
+  let args, ret =
+    extension_constructor_args_and_ret_type_subtree
+      ext.ext_args
+      ext.ext_ret_type
+  in
+  Format.fprintf ppf "@[<hv>%a@]"
+    !Oprint.out_constr (name, args, ret)
 
 (* Print a value declaration *)
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -94,12 +94,19 @@ val type_scheme_max: ?b_reset_names: bool ->
 (* End Maxence *)
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
 val value_description: Ident.t -> formatter -> value_description -> unit
+val tree_of_label : label_declaration -> string * bool * out_type
+val label : formatter -> label_declaration -> unit
+val tree_of_constructor :
+  constructor_declaration -> string * out_type list * out_type option
+val constructor : formatter -> constructor_declaration -> unit
 val tree_of_type_declaration:
     Ident.t -> type_declaration -> rec_status -> out_sig_item
 val type_declaration: Ident.t -> formatter -> type_declaration -> unit
 val tree_of_extension_constructor:
     Ident.t -> extension_constructor -> ext_status -> out_sig_item
 val extension_constructor:
+    Ident.t -> formatter -> extension_constructor -> unit
+val extension_only_constructor:
     Ident.t -> formatter -> extension_constructor -> unit
 val tree_of_module:
     Ident.t -> ?ellipsis:bool -> module_type -> rec_status -> out_sig_item

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1746,14 +1746,6 @@ let report_error ppf = function
         | false, true  -> inj ^ "contravariant"
         | false, false -> if inj = "" then "unrestricted" else inj
       in
-      let suffix n =
-        let teen = (n mod 100)/10 = 1 in
-        match n mod 10 with
-        | 1 when not teen -> "st"
-        | 2 when not teen -> "nd"
-        | 3 when not teen -> "rd"
-        | _ -> "th"
-      in
       (* FIXME: this test below is horrible, use a proper variant *)
       if n = -1 then
         fprintf ppf "@[%s@ %s@ It"

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -862,7 +862,6 @@ let print_if ppf flag printer arg =
   if !flag then Format.fprintf ppf "%a@." printer arg;
   arg
 
-
 type filepath = string
 type modname = string
 type crcs = (modname * Digest.t option) list
@@ -939,3 +938,11 @@ module EnvLazy = struct
     loop !log
 
 end
+
+let suffix n =
+  let teen = (n mod 100)/10 = 1 in
+  match n mod 10 with
+  | 1 when not teen -> "st"
+  | 2 when not teen -> "nd"
+  | 3 when not teen -> "rd"
+  | _ -> "th"

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -456,7 +456,6 @@ val print_if :
   Format.formatter -> bool ref -> (Format.formatter -> 'a -> unit) -> 'a -> 'a
 (** [print_if ppf flag fmt x] prints [x] with [fmt] on [ppf] if [b] is true. *)
 
-
 type filepath = string
 type modname = string
 type crcs = (modname * Digest.t option) list
@@ -483,3 +482,5 @@ module EnvLazy: sig
   val backtrack : log -> unit
 
 end
+
+val suffix : int -> string


### PR DESCRIPTION
This PR tries to improve error output for type mismatch during compilation.
Before: 
The types for field Foo are not equal. 

Now:
Constructors do not match: 
Foo of 'a 
is not compatible with: 
Foo : int -> int t 
The second has explicit return type and the first doesn't.

I've created abstractions for variants, records, constructors, fields and extension constructors types mismatch. During variant and record mismatch the type is zoomed and mistaken constructors' or fields' names and types are printed additionally. Also fixed some existing error output. 

New errors example are shown in tests.
