### PR TITLE
A beginner hint for type redefinitions in the toplevel

### DIFF
--- a/Changes
+++ b/Changes
@@ -109,6 +109,11 @@ Working version
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.
   (Florent Monnier and Nicolás Ojeda Bär, review by David Allsopp)
 
+### Compiler user-interface and warnings:
+
+    #8833: Hint for (type) redefinitions in toplevel session
+    (Florian Angeletti, review by Gabriel Scherer)
+
 ### Build system:
 
 - #8650: ensure that "make" variables are defined before use;

--- a/testsuite/tests/tool-toplevel/ocamltests
+++ b/testsuite/tests/tool-toplevel/ocamltests
@@ -2,6 +2,7 @@ exotic_lists.ml
 pr6468.ml
 pr7060.ml
 pr7751.ml
+redefinition_hints.ml
 strings.ml
 tracing.ml
 error_highlighting.ml

--- a/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
+++ b/testsuite/tests/tool-toplevel/redefinition_hints.compilers.reference
@@ -1,0 +1,40 @@
+module Empty : sig  end
+type u = A
+type v = B
+module type S = sig  end
+val m : (module S) = <module>
+module M : sig type 'a t = X of 'a end
+val x : (u * v * (module S)) M.t = M.X (A, B, <module>)
+module type S = sig  end
+val m : (module S) = <module>
+type u = A
+type v = B
+module M : sig type 'a t = X of 'a end
+val y : (u * v * (module S)) M.t = M.X (A, B, <module>)
+Line 2, characters 4-5:
+2 | x = y;;
+        ^
+Error: This expression has type (u/1 * v/1 * (module S/1)) M/1.t
+       but an expression was expected of type
+         (u/2 * v/2 * (module S/2)) M/2.t
+       Hint: The types v and u have been defined multiple times in this
+         toplevel session. Some toplevel values still refer to old versions
+         of those types. Did you try to redefine them?
+       Hint: The module M has been defined multiple times in this toplevel
+         session. Some toplevel values still refer to old versions of this
+         module. Did you try to redefine them?
+       Hint: The module type S has been defined multiple times in this
+         toplevel session. Some toplevel values still refer to old versions
+         of this module type. Did you try to redefine them?
+type a = A
+val a : a = A
+type a = A
+val b : a = A
+Line 2, characters 4-5:
+2 | a = b;;
+        ^
+Error: This expression has type a/1 but an expression was expected of type
+         a/2
+       Hint: The type a has been defined multiple times in this toplevel
+         session. Some toplevel values still refer to old versions of this
+         type. Did you try to redefine them?

--- a/testsuite/tests/tool-toplevel/redefinition_hints.ml
+++ b/testsuite/tests/tool-toplevel/redefinition_hints.ml
@@ -1,0 +1,40 @@
+(* TEST
+   * toplevel
+*)
+
+(* This is a toplevel test to trigger toplevel specific hints *)
+
+
+module Empty = struct end
+
+
+type u = A
+type v = B
+module type S = sig end
+let m = (module Empty:S)
+
+module M = struct
+  type 'a t = X of 'a
+end
+let x =M.X (A,B,m);;
+
+module type S = sig end
+let m = (module Empty:S)
+
+type u = A
+type v = B
+module M = struct
+  type 'a t = X of 'a
+end
+let y = M.X (A,B,m);;
+
+x = y;;
+
+type a = A
+let a = A;;
+
+type a = A
+let b = A;;
+
+a = b;;
+exit 0;;

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -839,7 +839,8 @@ let report_error ppf errs =
   let print_errs ppf = List.iter (include_err' ppf) in
   Printtyp.Conflicts.reset();
   fprintf ppf "@[<v>%a%a%t@]" print_errs errs include_err err
-    Printtyp.Conflicts.print
+    Printtyp.Conflicts.print_explanations
+
 (* We could do a better job to split the individual error items
    as sub-messages of the main interface mismatch on the whole unit. *)
 let () =

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -70,13 +70,21 @@ module Conflicts: sig
   type explanation =
     { kind: namespace;
       name:string;
-      common_name:string;
+      root_name:string;
       location:Location.t
     }
 
-  val take: unit -> explanation list
-  val pp: Format.formatter -> explanation list -> unit
-  val print: Format.formatter -> unit
+  val list_explanations: unit -> explanation list
+(** [list_explanations()] return the list of conflict explanations
+    collected up to this point, and reset the list of collected
+    explanations *)
+
+  val print_located_explanations:
+    Format.formatter -> explanation list -> unit
+
+  val print_explanations: Format.formatter -> unit
+  (** Print all conflict explanations collected up to this point *)
+
   val reset: unit -> unit
 end
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -69,7 +69,10 @@ module Conflicts: sig
 
   type explanation =
     { kind: namespace;
-      name:string; location:Location.t}
+      name:string;
+      common_name:string;
+      location:Location.t
+    }
 
   val take: unit -> explanation list
   val pp: Format.formatter -> explanation list -> unit

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -663,7 +663,8 @@ end) = struct
             use ();
             Printtyp.Conflicts.reset ();
             let paths = ambiguous_types env lbl rest in
-            let expansion = Format.asprintf "%t" Printtyp.Conflicts.print in
+            let expansion =
+              Format.asprintf "%t" Printtyp.Conflicts.print_explanations in
             if paths <> [] then
               warn lid.loc
                 (Warnings.Ambiguous_name ([Longident.last lid.txt],
@@ -691,7 +692,8 @@ end) = struct
                   Printtyp.Conflicts.reset ();
                   let paths = ambiguous_types env lbl rest in
                   let expansion =
-                    Format.asprintf "%t" Printtyp.Conflicts.print in
+                    Format.asprintf "%t"
+                      Printtyp.Conflicts.print_explanations in
                   if paths <> [] then
                     warn lid.loc
                       (Warnings.Ambiguous_name ([Longident.last lid.txt],


### PR DESCRIPTION
When using the toplevel, it can be quite easy for beginners to accumulate left-over values of which the type refer to old version of the types currently in the toplevel environment. For instance,

```OCaml
  type a = X
  let x = X;;
....
  type a = Y
  let y = Y;;
  x = y
```
In this case, the error message correctly mention that there is two type `a` at scope

> Error: This expression has type a/1 but an expression was expected of type
         a/2


But it may be hard for the uninitiated to understand what is going on the first time. At the same time, this error is very specific, thus this PR proposes to add a hint to explain the situation 

>```
>Hint: The type a has been defined multiple times in this toplevel
>  session. Some toplevel values still refer to old versions of this
>  type. Did you try to redefine them?
>```
 
This hint triggers only in the toplevel, when they are multiple definitions of types, modules or module types with the same root name, and when those definitions come from the toplevel. It is thus fairly unlikely to trigger outside of its narrow purpose.

cc @Drup 
