### PR TITLE
New configure option to disable building and installing library manpages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script: tools/ci/travis/travis-ci.sh
 matrix:
   include:
   - env: CI_KIND=build XARCH=x64 CONFIG_ARG=--enable-flambda OCAMLRUNPARAM=b,v=0
-  - env: CI_KIND=build XARCH=i386
+  - env: CI_KIND=build XARCH=i386 CONFIG_ARG=--disable-stdlib-manpages
     addons:
       apt:
         packages:

--- a/Changes
+++ b/Changes
@@ -221,6 +221,10 @@ Working version
   (Stephen Dolan, review by Gabriel Scherer, Sébastien Hinderer and
    Thomas Refis)
 
+- #8835: new configure option --disable-stdlib-manpages to disable building
+  and installation of the library manpages.
+  (David Allsopp, review by Florian Angeletti and Gabriel Scherer)
+
 - #8837: build manpages using ocamldoc.opt when available
   cuts the manpages build time from 14s to 4s
   (Gabriel Scherer, review by David Allsopp and Sébastien Hinderer,

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -234,6 +234,7 @@ MAX_TESTSUITE_DIR_RETRIES=@max_testsuite_dir_retries@
 FLAT_FLOAT_ARRAY=@flat_float_array@
 FUNCTION_SECTIONS=@function_sections@
 AWK=@AWK@
+STDLIB_MANPAGES=@stdlib_manpages@
 
 
 ### Native command to build ocamlrun.exe

--- a/configure
+++ b/configure
@@ -16778,9 +16778,9 @@ case $host in #(
 esac
 
 if test x"$enable_stdlib_manpages" != "xno"; then :
-  stdlib_manpages=manpages
+  stdlib_manpages=true
 else
-  stdlib_manpages=
+  stdlib_manpages=false
 fi
 
 cat >confcache <<\_ACEOF

--- a/configure
+++ b/configure
@@ -691,6 +691,7 @@ build_os
 build_vendor
 build_cpu
 build
+stdlib_manpages
 PACKLD
 flexlink_flags
 flexdll_chain
@@ -848,6 +849,7 @@ enable_flambda
 enable_flambda_invariants
 with_target_bindir
 enable_reserved_header_bits
+enable_stdlib_manpages
 enable_force_safe_string
 enable_flat_float_array
 enable_function_sections
@@ -1523,6 +1525,8 @@ Optional Features:
   --enable-reserved-header-bits=BITS
                           reserve BITS (between 0 and 31) bits in block
                           headers for profiling info
+  --disable-stdlib-manpages
+                          do not build or install the library man pages
   --disable-force-safe-string
                           do not force strings to be safe
   --disable-flat-float-array
@@ -2831,6 +2835,7 @@ VERSION=4.10.0+dev0-2019-04-23
 
 
 
+
 ## Generated files
 
 ac_config_files="$ac_config_files Makefile.common"
@@ -3152,6 +3157,12 @@ if test "${enable_reserved_header_bits+set}" = set; then :
   *) :
     as_fn_error $? "invalid argument to --enable-reserved-header-bits" "$LINENO" 5 ;;
 esac
+fi
+
+
+# Check whether --enable-stdlib-manpages was given.
+if test "${enable_stdlib_manpages+set}" = set; then :
+  enableval=$enable_stdlib_manpages;
 fi
 
 
@@ -16765,6 +16776,12 @@ case $host in #(
   *) :
      ;;
 esac
+
+if test x"$enable_stdlib_manpages" != "xno"; then :
+  stdlib_manpages=manpages
+else
+  stdlib_manpages=
+fi
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,7 @@ AC_SUBST([default_safe_string])
 AC_SUBST([flexdll_chain])
 AC_SUBST([flexlink_flags])
 AC_SUBST([PACKLD])
+AC_SUBST([stdlib_manpages])
 
 ## Generated files
 
@@ -328,6 +329,10 @@ AC_ARG_ENABLE([reserved-header-bits],
       [with_profinfo=true
       profinfo_width="$enable_reserved_header_bits"],
     [AC_MSG_ERROR([invalid argument to --enable-reserved-header-bits])])])
+
+AC_ARG_ENABLE([stdlib-manpages],
+  [AS_HELP_STRING([--disable-stdlib-manpages],
+    [do not build or install the library man pages])])
 
 AC_ARG_VAR([WINDOWS_UNICODE_MODE],
   [how to handle Unicode under Windows: ansi, compatible])
@@ -1781,5 +1786,8 @@ AS_CASE([$host],
     AC_DEFINE([HAS_STRERROR])
     AC_DEFINE([HAS_IPV6])
     AC_DEFINE([HAS_NICE])])
+
+AS_IF([test x"$enable_stdlib_manpages" != "xno"],
+  [stdlib_manpages=manpages],[stdlib_manpages=])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -1788,6 +1788,6 @@ AS_CASE([$host],
     AC_DEFINE([HAS_NICE])])
 
 AS_IF([test x"$enable_stdlib_manpages" != "xno"],
-  [stdlib_manpages=manpages],[stdlib_manpages=])
+  [stdlib_manpages=true],[stdlib_manpages=false])
 
 AC_OUTPUT

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -183,7 +183,7 @@ LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
 
 
 .PHONY: all
-all: lib exe generators
+all: lib exe generators $(STDLIB_MANPAGES)
 
 .PHONY: exe
 exe: $(OCAMLDOC)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -181,9 +181,14 @@ LIBCMOFILES = $(CMOFILES)
 LIBCMXFILES = $(LIBCMOFILES:.cmo=.cmx)
 LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
 
+ifeq "$(STDLIB_MANPAGES)" "true"
+DOCS_TARGET = manpages
+else
+DOCS_TARGET =
+endif
 
 .PHONY: all
-all: lib exe generators $(STDLIB_MANPAGES)
+all: lib exe generators $(DOCS_TARGET)
 
 .PHONY: exe
 exe: $(OCAMLDOC)


### PR DESCRIPTION
This PR adds -`--disable-stdlib-manpages` to `configure` to disable the compilation of the standard library and compilerlibs man-pages