### PR TITLE
ocamldoc: use ocamldoc.opt when available to build documentation and manpages

### DIFF
--- a/Changes
+++ b/Changes
@@ -154,6 +154,11 @@ Working version
   (Stephen Dolan, review by Gabriel Scherer, Sébastien Hinderer and
    Thomas Refis)
 
+- #8837: build manpages using ocamldoc.opt when available
+  cuts the manpages build time from 14s to 4s
+  (Gabriel Scherer, review by David Allsopp and Sébastien Hinderer,
+   report by David Allsopp)
+
 - #8843, #8841: fix use of off_t on 32-bit systems.
   (Stephen Dolan, report by Richard Jones, review by Xavier Leroy)
 

--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,9 @@ opt.opt: checknative
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
 	  ocamltest.opt
+ifneq "$(WITH_OCAMLDOC)" ""
+	$(MAKE) manpages
+endif
 
 # Core bootstrapping cycle
 .PHONY: coreboot
@@ -458,6 +461,9 @@ coreboot:
 all: coreall
 	$(MAKE) ocaml
 	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) ocamltest
+ifneq "$(WITH_OCAMLDOC)" ""
+	$(MAKE) manpages
+endif
 
 # Bootstrap and rebuild the whole system.
 # The compilation of ocaml will fail if the runtime has changed.
@@ -612,9 +618,9 @@ endif
 # from an previous installation of OCaml before otherlibs/num was removed.
 	rm -f "$(INSTALL_LIBDIR)"/num.cm?
 # End transitional
-	if test -n "$(WITH_OCAMLDOC)"; then \
-	  $(MAKE) -C ocamldoc install; \
-	fi
+ifneq "$(WITH_OCAMLDOC)" ""
+	$(MAKE) -C ocamldoc install
+endif
 	if test -n "$(WITH_DEBUGGER)"; then \
 	  $(MAKE) -C debugger install; \
 	fi
@@ -683,9 +689,9 @@ endif
 	$(INSTALL_DATA) \
 	    compilerlibs/ocamloptcomp.cma $(OPTSTART) \
 	    "$(INSTALL_COMPLIBDIR)"
-	if test -n "$(WITH_OCAMLDOC)"; then \
-	  $(MAKE) -C ocamldoc installopt; \
-	fi
+ifneq "$(WITH_OCAMLDOC)" ""
+	$(MAKE) -C ocamldoc installopt
+endif
 	for i in $(OTHERLIBRARIES); do \
 	  $(MAKE) -C otherlibs/$$i installopt || exit $$?; \
 	done
@@ -1116,6 +1122,10 @@ partialclean::
 html_doc: ocamldoc
 	$(MAKE) -C ocamldoc $@
 	@echo "documentation is in ./ocamldoc/stdlib_html/"
+
+.PHONY: manpages
+manpages:
+	$(MAKE) -C ocamldoc $@
 
 partialclean::
 	$(MAKE) -C ocamldoc clean

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -44,24 +44,34 @@ OCAMLPP=-pp 'sh ./remove_DEBUG'
 MKDIR=mkdir -p
 CP=cp
 OCAMLDOC=ocamldoc
+OCAMLDOC_OPT=$(OCAMLDOC).opt
 
 # TODO: clarify whether the following really needs to be that complicated
 ifeq "$(UNIX_OR_WIN32)" "unix"
   ifeq "$(TARGET)" "$(HOST)"
     ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-      OCAMLDOC_RUN=$(OCAMLRUN) -I $(ROOTDIR)/otherlibs/$(UNIXLIB) -I $(ROOTDIR)/otherlibs/str ./$(OCAMLDOC)
+      OCAMLDOC_RUN_BYTE=$(OCAMLRUN) -I $(ROOTDIR)/otherlibs/$(UNIXLIB) -I $(ROOTDIR)/otherlibs/str ./$(OCAMLDOC)
     else
-      OCAMLDOC_RUN=./$(OCAMLDOC)
+      OCAMLDOC_RUN_BYTE=./$(OCAMLDOC)
     endif
   else
-    OCAMLDOC_RUN=$(OCAMLRUN) ./$(OCAMLDOC)
+    OCAMLDOC_RUN_BYTE=$(OCAMLRUN) ./$(OCAMLDOC)
   endif
 else # Windows
-  OCAMLDOC_RUN = \
+  OCAMLDOC_RUN_BYTE = \
     CAML_LD_LIBRARY_PATH="$(ROOTDIR)/otherlibs/win32unix;$(ROOTDIR)/otherlibs/str" $(OCAMLRUN) ./$(OCAMLDOC)
 endif
 
-OCAMLDOC_OPT=$(OCAMLDOC).opt
+OCAMLDOC_RUN_OPT=./$(OCAMLDOC_OPT)
+
+OCAMLDOC_RUN_PLUGINS=$(OCAMLDOC_RUN_BYTE)
+
+ifeq "$(wildcard $(OCAMLDOC_OPT))" ""
+  OCAMLDOC_RUN=$(OCAMLDOC_RUN_BYTE)
+else
+  OCAMLDOC_RUN=$(OCAMLDOC_RUN_OPT)
+endif
+
 OCAMLDOC_LIBCMA=odoc_info.cma
 OCAMLDOC_LIBCMI=odoc_info.cmi
 OCAMLDOC_LIBCMXA=odoc_info.cmxa
@@ -341,7 +351,7 @@ test:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -html -colorize-code -sort -d $@ $(INCLUDES) -dump $@/ocamldoc.odoc odoc*.ml odoc*.mli -v
 	$(MKDIR) $@-custom
-	$(OCAMLDOC_RUN) -colorize-code -sort -d $@-custom $(INCLUDES) \
+	$(OCAMLDOC_RUN_PLUGINS) -colorize-code -sort -d $@-custom $(INCLUDES) \
 	-g generators/odoc_literate.cmo -g generators/odoc_todo.cmo \
 	-load $@/ocamldoc.odoc -v
 
@@ -364,7 +374,7 @@ test_stdlib_code:
 .PHONY: test_framed
 test_framed:
 	$(MKDIR) $@
-	$(OCAMLDOC_RUN) -g odoc_fhtml.cmo -sort -colorize-code -d $@ $(INCLUDES) odoc*.ml odoc*.mli
+	$(OCAMLDOC_RUN_PLUGINS) -g odoc_fhtml.cmo -sort -colorize-code -d $@ $(INCLUDES) odoc*.ml odoc*.mli
 
 .PHONY: test_latex
 test_latex:
@@ -444,7 +454,7 @@ stdlib_latex/stdlib.pdf: stdlib_latex/stdlib.tex
 .PHONY: autotest_stdlib
 autotest_stdlib:
 	$(MKDIR) $@
-	$(OCAMLDOC_RUN) -g autotest/odoc_test.cmo\
+	$(OCAMLDOC_RUN_PLUGINS) -g autotest/odoc_test.cmo\
 	$(INCLUDES) -keep-code \
 	$(ROOTDIR)/stdlib/*.mli \
 	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.mli \

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -371,11 +371,6 @@ test_stdlib_code:
 	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.ml \
 	$(ROOTDIR)/otherlibs/str/str.ml
 
-.PHONY: test_framed
-test_framed:
-	$(MKDIR) $@
-	$(OCAMLDOC_RUN_PLUGINS) -g odoc_fhtml.cmo -sort -colorize-code -d $@ $(INCLUDES) odoc*.ml odoc*.mli
-
 .PHONY: test_latex
 test_latex:
 	$(MKDIR) $@

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -170,7 +170,7 @@ LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
 
 
 .PHONY: all
-all: lib exe generators manpages
+all: lib exe generators
 
 .PHONY: exe
 exe: $(OCAMLDOC)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -52,6 +52,9 @@ ifeq "$(UNIX_OR_WIN32)" "unix"
     ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
       OCAMLDOC_RUN_BYTE=$(OCAMLRUN) -I $(ROOTDIR)/otherlibs/$(UNIXLIB) -I $(ROOTDIR)/otherlibs/str ./$(OCAMLDOC)
     else
+# if shared-libraries are not supported, unix.cma and str.cma
+# are compiled with -custom, so ocamldoc also uses -custom,
+# and (ocamlrun ocamldoc) does not work.
       OCAMLDOC_RUN_BYTE=./$(OCAMLDOC)
     endif
   else

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -172,8 +172,6 @@ LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
 .PHONY: all
 all: lib exe generators manpages
 
-manpages: generators
-
 .PHONY: exe
 exe: $(OCAMLDOC)
 


### PR DESCRIPTION
This PR tweaks the build system of ocamldoc to use ocamldoc.opt to build documentation when available, and it also tweaks the root Makefile to build manpages (whose compilation time has been a hot topic of discussion in #8835) later in the build, when ocamldoc.opt may be available.

Before that PR, building the manpages takes 14s on my machine (it was 16s before #8836). After that PR, it takes 4s (5s before #8836). All other document targets benefit (`html_doc`, introduced to test HTML rendering of documentation comments, goes from 36s to 8.5s) but they are not part of the default build.

To check this PR I tried to run all the tests from ocamldoc's Makefile; it looks like some of them have bitrotten away, and I removed one that could not be run at all.