### PR TITLE
Use ocaml{c,opt}.opt when available to build ocamldoc

### DIFF
--- a/Changes
+++ b/Changes
@@ -103,6 +103,9 @@ Working version
 
 ### Build system:
 
+- #8839: use ocaml{c,opt}.opt when available to build ocamldoc
+  (Gabriel Scherer, review by ??)
+
 - #8650: ensure that "make" variables are defined before use;
   revise generation of config/util.ml to better quote special characters
   (Xavier Leroy, review by David Allsopp)

--- a/Makefile
+++ b/Makefile
@@ -422,11 +422,11 @@ opt.opt: checknative
 	$(MAKE) ocaml
 	$(MAKE) opt-core
 	$(MAKE) ocamlc.opt
-	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) ocamltest
+	$(MAKE) otherlibraries $(WITH_DEBUGGER) ocamltest
 	$(MAKE) ocamlopt.opt
 	$(MAKE) otherlibrariesopt
-	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
-	  ocamltest.opt
+	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt \
+	        $(WITH_OCAMLDOC) $(OCAMLDOC_OPT) ocamltest.opt
 
 # Core bootstrapping cycle
 .PHONY: coreboot

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -22,11 +22,34 @@ OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
-OCAMLC    = $(OCAMLRUN) $(ROOTDIR)/ocamlc $(STDLIBFLAGS)
-OCAMLOPT  = $(OCAMLRUN) $(ROOTDIR)/ocamlopt $(STDLIBFLAGS)
-OCAMLDEP  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
+ifeq "$(wildcard $(ROOTDIR)/ocamlc.opt)" ""
+OCAMLC_CMD = $(OCAMLRUN) $(ROOTDIR)/ocamlc
+else
+OCAMLC_CMD = $(ROOTDIR)/ocamlc.opt
+endif
+
+ifeq "$(wildcard $(ROOTDIR)/ocamlopt.opt)" ""
+OCAMLOPT_CMD = $(OCAMLRUN) $(ROOTDIR)/ocamlopt
+else
+OCAMLOPT_CMD = $(ROOTDIR)/ocamlopt.opt
+endif
+
+ifeq "$(wildcard $(ROOTDIR)/lex/ocamllex.opt)" ""
+OCAMLLEX_CMD = $(ROOTDIR)/lex/ocamllex.opt
+else
+  ifeq "$(wildcard $(ROOTDIR)/lex/ocamllex)" ""
+  OCAMLLEX_CMD = $(OCAMLRUN) $(ROOTDIR)/lex/ocamllex
+  else
+  OCAMLLEX_CMD = $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
+  endif
+endif
+
+OCAMLC = $(OCAMLC_CMD) $(STDLIBFLAGS)
+OCAMLOPT = $(OCAMLOPT_CMD) $(STDLIBFLAGS)
+OCAMLDEP  = $(OCAMLC_CMD) -depend
 DEPFLAGS = -slash
-OCAMLLEX  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
+OCAMLLEX = $(OCAMLLEX_CMD)
+
 # TODO: figure out whether the DEBUG lines the following preprocessor removes
 # are actually useful.
 # If they are not, then the preprocessor logic (including the


### PR DESCRIPTION
This PR uses ocaml{c,opt}.opt (when available) instead of the bytecode versions to build ocamldoc -- as mentioned in #8835.

On my machine, a sequential build of ocamldoc goes from 31s to 11s, and a parallel build (-j5) goes from 16s to 6s.

It would of course be interesting to generalize this approach to other tools than ocamldoc (everything that can be delayed to after ocaml{c,opt}.opt in the opt.opt Makefile target; I'm not sure exactly what but at least the debugger could benefit), which would suggest factorizing the conditional logic in a root auxiliary Makefile file. I decided to start only with only ocamldoc (whose build is relatively separated from the others) in this first PR, and factorize later if the logic gets used in more than one place.
