### PR TITLE
Build system: use ocaml{c,opt}.opt instead of ocaml{c,opt} when available

### DIFF
--- a/Changes
+++ b/Changes
@@ -250,6 +250,10 @@ Working version
 
 ### Build system:
 
+- #8840: use ocaml{c,opt}.opt when available to build internal tools
+  On my machine this reduces parallel-build times from 3m30s to 2m50s.
+  (Gabriel Scherer, review by Xavier Leroy and Sébastien Hinderer)
+
 - #8650: ensure that "make" variables are defined before use;
   revise generation of config/util.ml to better quote special characters
   (Xavier Leroy, review by David Allsopp)

--- a/Makefile
+++ b/Makefile
@@ -1109,10 +1109,10 @@ ocamldoc.opt: ocamlc.opt ocamlyacc ocamllex
 
 # OCamltest
 ocamltest: ocamlc ocamlyacc ocamllex
-	$(MAKE) -C ocamltest
+	$(MAKE) -C ocamltest all
 
 ocamltest.opt: ocamlc.opt ocamlyacc ocamllex
-	$(MAKE) -C ocamltest ocamltest.opt$(EXE)
+	$(MAKE) -C ocamltest allopt
 
 partialclean::
 	$(MAKE) -C ocamltest clean

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -25,22 +25,29 @@
 # native binary, if available. Note that they never use the boot/
 # versions: we assume that ocamlc, ocamlopt, etc. have been run first.
 
-ifeq "$(wildcard $(ROOTDIR)/ocamlc.opt)" ""
-BEST_OCAMLC = $(CAMLRUN) $(ROOTDIR)/ocamlc
-else
-BEST_OCAMLC = $(ROOTDIR)/ocamlc.opt
-endif
+define define_best
+  ifeq "$(wildcard $(ROOTDIR)/$(3))" ""
+  $(1)=$(CAMLRUN) $(ROOTDIR)/$(2)
+  else
+    ifeq "$(shell \
+            if test $(ROOTDIR)/$(2) -nt $(ROOTDIR)/$(3); \
+	    then echo 'stale'; else echo 'good'; fi)" "stale"
+# the double-dollars ensure that the warning is displayed
+# only if the conditional fires (by the `eval` call below)
+# instead of always being shown as `define_best` is expanded.
+$$(info Warning: we are not using the native binary $(3) \
+because it is older than the bytecode binary $(2); \
+you should silence this warning by either removing $(3) \
+or rebuilding it (or `touch`-ing it) if you want it used.)
+      $(1)=$(CAMLRUN) $(ROOTDIR)/$(2)
+    else
+      $(1)=$(ROOTDIR)/$(3)
+    endif
+  endif
+endef
+
+$(eval $(call define_best,BEST_OCAMLC,ocamlc,ocamlc.opt))
+$(eval $(call define_best,BEST_OCAMLOPT,ocamlopt,ocamlopt.opt))
+$(eval $(call define_best,BEST_OCAMLLEX,lex/ocamllex,lex/ocamllex.opt))
 
 BEST_OCAMLDEP = $(BEST_OCAMLC) -depend
-
-ifeq "$(wildcard $(ROOTDIR)/ocamlopt.opt)" ""
-BEST_OCAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt
-else
-BEST_OCAMLOPT = $(ROOTDIR)/ocamlopt.opt
-endif
-
-ifeq "$(wildcard $(ROOTDIR)/lex/ocamllex.opt)" ""
-BEST_OCAMLLEX = $(CAMLRUN) $(ROOTDIR)/lex/ocamllex
-else
-BEST_OCAMLLEX = $(ROOTDIR)/lex/ocamllex.opt
-endif

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -1,0 +1,46 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*            Gabriel Scherer, projet Parsifal, INRIA Saclay              *
+#*                                                                        *
+#*   Copyright 2019 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# This Makefile should be included.
+
+# It expects:
+# - Makefile.common to be included as well
+# - a ROOTDIR variable pointing to the repository root
+#   relative to the including Makefile
+
+# It exports definitions of BEST_OCAML{C,OPT,LEX,DEP} commands that
+# run to either the bytecode binary built in the repository or the
+# native binary, if available. Note that they never use the boot/
+# versions: we assume that ocamlc, ocamlopt, etc. have been run first.
+
+ifeq "$(wildcard $(ROOTDIR)/ocamlc.opt)" ""
+BEST_OCAMLC = $(CAMLRUN) $(ROOTDIR)/ocamlc
+else
+BEST_OCAMLC = $(ROOTDIR)/ocamlc.opt
+endif
+
+BEST_OCAMLDEP = $(BEST_OCAMLC) -depend
+
+ifeq "$(wildcard $(ROOTDIR)/ocamlopt.opt)" ""
+BEST_OCAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt
+else
+BEST_OCAMLOPT = $(ROOTDIR)/ocamlopt.opt
+endif
+
+ifeq "$(wildcard $(ROOTDIR)/lex/ocamllex.opt)" ""
+BEST_OCAMLLEX = $(CAMLRUN) $(ROOTDIR)/lex/ocamllex
+else
+BEST_OCAMLLEX = $(ROOTDIR)/lex/ocamllex.opt
+endif

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -25,29 +25,22 @@
 # native binary, if available. Note that they never use the boot/
 # versions: we assume that ocamlc, ocamlopt, etc. have been run first.
 
-define define_best
-  ifeq "$(wildcard $(ROOTDIR)/$(3))" ""
-  $(1)=$(CAMLRUN) $(ROOTDIR)/$(2)
-  else
-    ifeq "$(shell \
-            if test $(ROOTDIR)/$(2) -nt $(ROOTDIR)/$(3); \
-	    then echo 'stale'; else echo 'good'; fi)" "stale"
-# the double-dollars ensure that the warning is displayed
-# only if the conditional fires (by the `eval` call below)
-# instead of always being shown as `define_best` is expanded.
-$$(info Warning: we are not using the native binary $(3) \
-because it is older than the bytecode binary $(2); \
-you should silence this warning by either removing $(3) \
-or rebuilding it (or `touch`-ing it) if you want it used.)
-      $(1)=$(CAMLRUN) $(ROOTDIR)/$(2)
-    else
-      $(1)=$(ROOTDIR)/$(3)
-    endif
-  endif
-endef
+check_not_stale = \
+  $(if $(shell test $(ROOTDIR)/$1 -nt $(ROOTDIR)/$2 && echo stale), \
+    $(info Warning: we are not using the native binary $2 \
+because it is older than the bytecode binary $1; \
+you should silence this warning by either removing $2 \
+or rebuilding it (or `touch`-ing it) if you want it used.), \
+    ok)
 
-$(eval $(call define_best,BEST_OCAMLC,ocamlc,ocamlc.opt))
-$(eval $(call define_best,BEST_OCAMLOPT,ocamlopt,ocamlopt.opt))
-$(eval $(call define_best,BEST_OCAMLLEX,lex/ocamllex,lex/ocamllex.opt))
+choose_best = $(strip $(if \
+   $(and $(wildcard $(ROOTDIR)/$1.opt),$(strip \
+      $(call check_not_stale,$1,$1.opt))), \
+    $(ROOTDIR)/$1.opt, \
+    $(CAMLRUN) $(ROOTDIR)/$1))
 
-BEST_OCAMLDEP = $(BEST_OCAMLC) -depend
+BEST_OCAMLC := $(call choose_best,ocamlc)
+BEST_OCAMLOPT := $(call choose_best,ocamlopt)
+BEST_OCAMLLEX := $(call choose_best,lex/ocamllex)
+
+BEST_OCAMLDEP := $(BEST_OCAMLC) -depend

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -17,19 +17,20 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
+include $(ROOTDIR)/Makefile.best_binaries
 
 DYNLINKDIR=$(ROOTDIR)/otherlibs/dynlink
 UNIXDIR=$(ROOTDIR)/otherlibs/$(UNIXLIB)
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 
-CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc -g -nostdlib -I $(ROOTDIR)/stdlib
+CAMLC=$(BEST_OCAMLC) -g -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
           -safe-string -strict-sequence -strict-formats
 LINKFLAGS=-linkall -I $(UNIXDIR) -I $(DYNLINKDIR)
 YACCFLAGS=
-CAMLLEX=$(CAMLRUN) $(ROOTDIR)/boot/ocamllex
-CAMLDEP=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
+CAMLLEX=$(BEST_OCAMLLEX)
+CAMLDEP=$(BEST_OCAMLDEP)
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -17,16 +17,18 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
+include $(ROOTDIR)/Makefile.best_binaries
 
 OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
-OCAMLC    = $(OCAMLRUN) $(ROOTDIR)/ocamlc $(STDLIBFLAGS)
-OCAMLOPT  = $(OCAMLRUN) $(ROOTDIR)/ocamlopt $(STDLIBFLAGS)
-OCAMLDEP  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
+OCAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
+OCAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
+OCAMLDEP = $(BEST_OCAMLDEP)
 DEPFLAGS = -slash
-OCAMLLEX  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
+OCAMLLEX = $(BEST_OCAMLLEX)
+
 # TODO: figure out whether the DEBUG lines the following preprocessor removes
 # are actually useful.
 # If they are not, then the preprocessor logic (including the

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -19,6 +19,7 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
+include $(ROOTDIR)/Makefile.best_binaries
 
 ifeq "$(filter str,$(OTHERLIBRARIES))" ""
   str := false
@@ -178,15 +179,15 @@ flags := -g -nostdlib $(include_directories) \
   -strict-sequence -safe-string -strict-formats \
   -w +a-4-9-41-42-44-45-48 -warn-error A
 
-ocamlc := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlc $(flags)
+ocamlc := $(BEST_OCAMLC) $(flags)
 
-ocamlopt := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlopt $(flags)
+ocamlopt :=  $(BEST_OCAMLOPT) $(flags)
 
-ocamldep := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/boot/ocamlc -depend
+ocamldep := $(BEST_OCAMLDEP)
 depflags := -slash
 depincludes :=
 
-ocamllex := $(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/boot/ocamllex
+ocamllex := $(BEST_OCAMLLEX)
 
 ocamlyacc := $(ROOTDIR)/yacc/ocamlyacc
 

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -18,12 +18,13 @@
 ROOTDIR=../..
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
+include $(ROOTDIR)/Makefile.best_binaries
 
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
-CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -I $(ROOTDIR)/stdlib
-CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib \
-        -I $(ROOTDIR)/stdlib
+CAMLC := $(BEST_OCAMLC) -nostdlib -I $(ROOTDIR)/stdlib
+CAMLOPT := $(BEST_OCAMLOPT) -nostdlib -I $(ROOTDIR)/stdlib
+
 OC_CFLAGS += $(SHAREDLIB_CFLAGS) $(EXTRACFLAGS)
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -23,11 +23,12 @@ ROOTDIR = ../..
 
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
+include $(ROOTDIR)/Makefile.best_binaries
 
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
-OCAMLC    = $(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -I $(ROOTDIR)/stdlib
-OCAMLOPT  = $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
+OCAMLC=$(BEST_OCAMLC) -nostdlib -I $(ROOTDIR)/stdlib
+OCAMLOPT=$(BEST_OCAMLOPT) -nostdlib -I $(ROOTDIR)/stdlib
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -17,6 +17,7 @@ ROOTDIR=../..
 
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
+include $(ROOTDIR)/Makefile.best_binaries
 
 OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
@@ -29,8 +30,9 @@ CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
 LIBS = -nostdlib -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
 
-CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc $(LIBS)
-CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt $(LIBS)
+CAMLC=$(BEST_OCAMLC) $(LIBS)
+CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
+
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 COMPFLAGS=-w +33..39 -warn-error A -g -bin-annot -safe-string
 ifeq "$(FLAMBDA)" "true"


### PR DESCRIPTION
This PR supersedes #8839, it tweaks the build system to use native-compiled compilers (and lexer) in most of the tools that can be compiled after the .opt compilers are built in the opt.opt (world.opt) build scenarios: otherlibs, ocamltest, ocamldoc and the debugger.

On my machine the total `world.opt` build time with `-j5` decreases from 3m30s to 2m50s, and it seems to save around a minute of CPU time.

