### PR TITLE
Use the autoconf- or system-provided off_t rather than redetecting.

### DIFF
--- a/Changes
+++ b/Changes
@@ -112,6 +112,9 @@ Working version
   (Stephen Dolan, review by Gabriel Scherer, Sébastien Hinderer and
    Thomas Refis)
 
+- #8843, #8841: fix use of off_t on 32-bit systems.
+  (Stephen Dolan, report by Richard Jones, review by Xavier Leroy)
+
 ### Compiler user-interface and warnings:
 
 - #8702, #8777: improved error messages for fixed row polymorphic variants

--- a/configure
+++ b/configure
@@ -12784,8 +12784,6 @@ _ACEOF
 
 fi
 
-$as_echo "#define HAS_OFF_T 1" >>confdefs.h
-
 
 # Checks for structures
 

--- a/configure.ac
+++ b/configure.ac
@@ -684,7 +684,6 @@ AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H])], [],
 
 ## off_t
 AC_TYPE_OFF_T
-AC_DEFINE([HAS_OFF_T])
 
 # Checks for structures
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -29,11 +29,9 @@
 
 #if defined(_WIN32)
 typedef __int64 file_offset;
-#elif defined(HAS_OFF_T)
+#else
 #include <sys/types.h>
 typedef off_t file_offset;
-#else
-typedef long file_offset;
 #endif
 
 struct channel {


### PR DESCRIPTION
Using a 64-bit file offset on a 32-bit system is broken in 4.08, because the use of `off_t` is guarded by `HAS_OFF_T`, which is not defined by the configure script. (It's mentioned in configure.ac, but there's no corresponding template line in `s.h.in`).

As suggested by @rwmjones in #8841, this just uses `off_t` unconditionally. (Except on Windows, where `off_t` is weird and broken).

