### PR TITLE
Test make world on Inria CI

### DIFF
--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -114,6 +114,33 @@ export TSAN_SYMBOLIZER_PATH="$ASAN_SYMBOLIZER_PATH"
 
 #########################################################################
 
+# Ensure that the repo still passes the check-typo script
+if [ ! -x tools/check-typo ] ; then
+  error "tools/check-typo does not appear to be executable?"
+fi
+tools/check-typo
+
+#########################################################################
+
+echo "======== old school build =========="
+
+$make -s distclean || :
+
+instdir="$HOME/ocaml-tmp-install-$$"
+./configure --prefix "$instdir"
+
+# Build the system without using world.opt
+make $jobs world
+make $jobs opt
+make $jobs opt.opt
+make install
+
+rm -rf "$instdir"
+
+# It's a build system test only, so we don't bother testing the compiler
+
+#########################################################################
+
 echo "======== clang 6.0, address sanitizer, UB sanitizer =========="
 
 $make -s distclean || :
@@ -191,25 +218,6 @@ TSAN_OPTIONS="die_after_fork=0" $run_testsuite
 
 #########################################################################
 
-echo "======== old school build =========="
-
-$make -s distclean || :
-
-instdir="$HOME/ocaml-tmp-install-$$"
-./configure --prefix "$instdir"
-
-# Build the system without using world.opt
-make $jobs world
-make $jobs opt
-make $jobs opt.opt
-make install
-
-rm -rf "$instdir"
-
-# It's a build system test only, so we don't bother testing the compiler
-
-#########################################################################
-
 # This is a failed attempt at using the memory sanitizer
 # (to detect reads from uninitialized memory).
 # Some alarms are reported that look like false positive
@@ -241,11 +249,3 @@ rm -rf "$instdir"
 # # Build the system (bytecode only) and test
 # make $jobs world
 # $run_testsuite
-
-#########################################################################
-
-# Ensure that the repo still passes the check-typo script
-if [ ! -x tools/check-typo ] ; then
-  error "tools/check-typo does not appear to be executable?"
-fi
-tools/check-typo

--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -191,6 +191,25 @@ TSAN_OPTIONS="die_after_fork=0" $run_testsuite
 
 #########################################################################
 
+echo "======== old school build =========="
+
+$make -s distclean || :
+
+instdir="$HOME/ocaml-tmp-install-$$"
+./configure --prefix "$instdir"
+
+# Build the system without using world.opt
+make $jobs world
+make $jobs opt
+make $jobs opt.opt
+make install
+
+rm -rf "$instdir"
+
+# It's a build system test only, so we don't bother testing the compiler
+
+#########################################################################
+
 # This is a failed attempt at using the memory sanitizer
 # (to detect reads from uninitialized memory).
 # Some alarms are reported that look like false positive


### PR DESCRIPTION
Apropos a mix of @xavierleroy's https://github.com/ocaml/ocaml/pull/8837#issuecomment-516109972 and https://github.com/ocaml/ocaml/pull/8837#discussion_r307977269, this PR adds a check to Inria's `extra-checks` script to ensure that `make world` definitely works.

I don't think this is worth running on every PR, though.