### PR TITLE
Fix stack probe CFI information for amd64 and i386 

### DIFF
--- a/Changes
+++ b/Changes
@@ -131,6 +131,10 @@ Working version
   (Gabriel Scherer and Florian Angeletti,
    review by Florian Angeletti and Gabriel Radanne)
 
+- #8848: Fix x86 stack probe CFI information in caml_c_call and
+  caml_call_gc
+  (Tom Kelly, review by Xavier Leroy)
+
 OCaml 4.09.0
 ------------
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -277,11 +277,11 @@
 #  define PREPARE_FOR_C_CALL subq $32, %rsp; CFI_ADJUST(32)
 #  define CLEANUP_AFTER_C_CALL addq $32, %rsp; CFI_ADJUST(-32)
    /* Stack probing mustn't be larger than the page size */
-#  define STACK_PROBE_SIZE $4096
+#  define STACK_PROBE_SIZE 4096
 #else
 #  define PREPARE_FOR_C_CALL
 #  define CLEANUP_AFTER_C_CALL
-#  define STACK_PROBE_SIZE $32768
+#  define STACK_PROBE_SIZE 32768
 #endif
 
 /* Registers holding arguments of C functions. */
@@ -323,9 +323,9 @@ FUNCTION(G(caml_call_gc))
 LBL(caml_call_gc):
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
-        subq    STACK_PROBE_SIZE, %rsp
+        subq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(STACK_PROBE_SIZE);
         movq    %rax, 0(%rsp)
-        addq    STACK_PROBE_SIZE, %rsp
+        addq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(-STACK_PROBE_SIZE);
     /* Build array of registers, save it into caml_gc_regs */
 #ifdef WITH_FRAME_POINTERS
         ENTER_FUNCTION          ;
@@ -540,9 +540,9 @@ LBL(caml_c_call):
         subq    $8, %rsp; CFI_ADJUST(8) /* equivalent to pushq %r12 */
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
-        subq    STACK_PROBE_SIZE, %rsp
+        subq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(STACK_PROBE_SIZE);
         movq    %rax, 0(%rsp)
-        addq    STACK_PROBE_SIZE, %rsp
+        addq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(-STACK_PROBE_SIZE);
     /* Make the exception handler and alloc ptr available to the C code */
         STORE_VAR(%r15, caml_young_ptr)
         STORE_VAR(%r14, caml_exception_pointer)

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -78,6 +78,10 @@
 #define CFI_ADJUST(n)
 #endif
 
+#if !defined(SYS_mingw) && !defined(SYS_cygwin)
+#define STACK_PROBE_SIZE 16384
+#endif
+
 /* PR#6038: GCC and Clang seem to require 16-byte alignment nowadays,
    even if only MacOS X's ABI formally requires it. */
 #define ALIGN_STACK(amount) subl $ amount, %esp ; CFI_ADJUST(amount)
@@ -109,9 +113,9 @@ LBL(105):
 #if !defined(SYS_mingw) && !defined(SYS_cygwin)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
-        subl    $16384, %esp
+        subl    $(STACK_PROBE_SIZE), %esp; CFI_ADJUST(STACK_PROBE_SIZE);
         movl    %eax, 0(%esp)
-        addl    $16384, %esp
+        addl    $(STACK_PROBE_SIZE), %esp; CFI_ADJUST(-STACK_PROBE_SIZE);
 #endif
     /* Build array of registers, save it into caml_gc_regs */
         pushl   %ebp; CFI_ADJUST(4)
@@ -234,9 +238,9 @@ FUNCTION(caml_c_call)
 #if !defined(SYS_mingw) && !defined(SYS_cygwin)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
-        subl    $16384, %esp
+        subl    $(STACK_PROBE_SIZE), %esp; CFI_ADJUST(STACK_PROBE_SIZE);
         movl    %eax, 0(%esp)
-        addl    $16384, %esp
+        addl    $(STACK_PROBE_SIZE), %esp; CFI_ADJUST(-STACK_PROBE_SIZE);
 #endif
     /* Call the function (address in %eax) */
         jmp     *%eax


### PR DESCRIPTION
This PR fixes `caml_c_call` and `caml_call_gc` to have the right CFI information when the stack probe is being done on amd64 and i386.

This problem was discovered using perf on Linux to profile OCaml binaries and seeing bad call-stacks in some of the `caml_c_call` samples. 
