### PR TITLE
Tune testpreempt test to make it work on kfreebsd

### DIFF
--- a/testsuite/tests/lib-systhreads/testpreempt.ml
+++ b/testsuite/tests/lib-systhreads/testpreempt.ml
@@ -19,6 +19,7 @@ let rec generate_list n =
   aux [] n
 
 let rec long_computation time0 =
+  Thread.delay 0.1;
   let long_list = generate_list 100000 in
   let res = List.length (List.rev_map sin long_list) in
   if Sys.time () -. time0 > 2. then


### PR DESCRIPTION
Without this call to Thread.delay, the test is not deterministic on
kfreebsd: sometimes, the long computation finishes before Interaction
1; often, Interaction 2 does not even occur.

Note that, when calling Thread.yield instead of Thread.delay, the test
stays not deterministic.

Looking at history, @xavierleroy and @jhjourdan might be interested in this.