### PR TITLE
Fix different binaries produced by ocamlopt.byte and ocamlopt.opt with --enable-force-safe-string

### DIFF
--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -334,7 +334,7 @@ let need_send_fun n =
 let write_unit_info info filename =
   let oc = open_out_bin filename in
   output_string oc cmx_magic_number;
-  output_value oc info;
+  Marshal.to_channel oc info [Marshal.No_sharing_strings];
   flush oc;
   let crc = Digest.file filename in
   Digest.output oc crc;

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -42,8 +42,9 @@ static uintnat size_64;  /* Size in words of 64-bit block for struct. */
 enum {
   NO_SHARING = 1,               /* Flag to ignore sharing */
   CLOSURES = 2,                 /* Flag to allow marshaling code pointers */
-  COMPAT_32 = 4                 /* Flag to ensure that output can safely
+  COMPAT_32 = 4,                /* Flag to ensure that output can safely
                                    be read back on a 32-bit platform */
+  NO_SHARING_STRINGS = 8        /* Flag to ignore sharing string values */
 };
 
 static int extern_flags;        /* logical or of some of the flags above */
@@ -191,8 +192,10 @@ static void extern_record_location(value obj)
   extern_trail_cur->obj = obj | Colornum_hd(hdr);
   extern_trail_cur->field0 = Field(obj, 0);
   extern_trail_cur++;
-  Hd_val(obj) = Bluehd_hd(hdr);
-  Field(obj, 0) = (value) obj_counter;
+  if (!(extern_flags & NO_SHARING_STRINGS) || Tag_hd(hdr) != String_tag) {
+    Hd_val(obj) = Bluehd_hd(hdr);
+    Field(obj, 0) = (value) obj_counter;
+  }
   obj_counter++;
 }
 
@@ -635,7 +638,8 @@ static void extern_rec(value v)
   /* Never reached as function leaves with return */
 }
 
-static int extern_flag_values[] = { NO_SHARING, CLOSURES, COMPAT_32 };
+static int extern_flag_values[] =
+  { NO_SHARING, CLOSURES, COMPAT_32, NO_SHARING_STRINGS };
 
 static intnat extern_value(value v, value flags,
                            /*out*/ char header[32],

--- a/stdlib/marshal.ml
+++ b/stdlib/marshal.ml
@@ -17,6 +17,7 @@ type extern_flags =
     No_sharing
   | Closures
   | Compat_32
+  | No_sharing_strings
 (* note: this type definition is used in 'runtime/debugger.c' *)
 
 external to_channel: out_channel -> 'a -> extern_flags list -> unit

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -56,6 +56,7 @@ type extern_flags =
     No_sharing                          (** Don't preserve sharing *)
   | Closures                            (** Send function closures *)
   | Compat_32                           (** Ensure 32-bit compatibility *)
+  | No_sharing_strings                  (** Don't preserve sharing of strings *)
 (** The flags to the [Marshal.to_*] functions below. *)
 
 val to_channel : out_channel -> 'a -> extern_flags list -> unit


### PR DESCRIPTION
#1859 has revealed that three tests fail the "`ocamlopt.opt` and `ocamlopt.byte` should produce the same binary" test:

- `lib-bigarray/change_layout.ml`
- `lib-scanf/tscanf.ml`
- `lib-arg/testarg.ml`

The difference is caused by this part of closure (note that flambda is not affected - as witnessed in the Travis run for #1859):
https://github.com/ocaml/ocaml/blob/064ac56147d3bf8e7078ac2d4a96da2139be79d3/middle_end/closure/closure.ml#L872

Diffing the resulting binaries shows differences in `caml_globals_map`. A fix is simply to marshal the .cmx file without sharing, but this increases the .cmx files in the tree from 3.3M to 4.5M and a 36% increase a size for a better feature seems too harsh. Furthermore, for each of the tests the *implementation* digest of the .cmx is different.

In this PR, I've included a new flag to Marshal `No_sharing_strings` which works by not colouring string blocks blue (is that even sound?!). This at least seems to work, and reduces the .cmx files to 3.5M which is at least only a 6% increase in size.

The better solution would seem to be do the equivalent sharing in the bytecode compiler, but I'm not sure how to go about that, and the few bits of poking I tried didn't work.

Testing this out just requires configuring the tree with `--enable-force-safe-string` (and the implicit `--disable-flambda`)