### PR TITLE
Fix failure to install tools links

### DIFF
--- a/Changes
+++ b/Changes
@@ -260,6 +260,11 @@ Working version
   (Gabriel Scherer and Florian Angeletti,
    review by Florian Angeletti and Gabriel Radanne)
 
+- #8855, #8858: Links for tools not created when installing with
+  --disable-installing-byecode-programs (e.g. ocamldep.opt installed, but
+  ocamldep link not created)
+  (David Allsopp, report by Thomas Leonard)
+
 - #8875: fix missing newlines in the output from MSVC invocation.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -197,6 +197,7 @@ else
 	do \
 	  if test -f "$$i".opt; then \
 	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)"; \
+	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 endif


### PR DESCRIPTION
Fixes #8855 - error in #1776. If `configure`'d with `--disable-installing-bytecode-programs`, you'd get `ocamldep.opt`, `ocamlmklib.opt`, etc. but not the `ocamldep`, `ocamlmklib` symlinks.

I guess this went unnoticed because build systems usually look for the `.opt` first, but that doesn't make it any less a bug.