### PR TITLE
[matching.ml cleanup] merge split_constr and split_naive

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1229,21 +1229,13 @@ and split_no_or cls args def k =
     | [] -> (
         let yes = List.rev rev_yes and no = List.rev rev_no in
         match no with
-        | [] ->
-            ( { me = Pm { cases = yes; args; default = def };
-                matrix = as_matrix yes;
-                top_default = def
-              },
-              k )
+        | [] -> precompile_normal args yes def k
         | _ ->
             let { me = next; matrix; top_default = def }, nexts = split no in
             let idef = next_raise_count () in
-            let def = Default_environment.cons matrix idef def in
-            ( { me = Pm { cases = yes; args; default = def };
-                matrix = as_matrix yes;
-                top_default = def
-              },
-              (idef, next) :: nexts )
+            precompile_normal args yes
+              (Default_environment.cons matrix idef def)
+              ((idef, next) :: nexts)
       )
   and collect_vars rev_yes rev_no = function
     | ([], _) :: _ -> assert false
@@ -1269,6 +1261,13 @@ and split_no_or cls args def k =
       )
   in
   split cls
+
+and precompile_normal args cls default k =
+  ( { me = Pm { cases = cls; args; default };
+      matrix = as_matrix cls;
+      top_default = default
+    },
+    k )
 
 and precompile_var args cls def k =
   (* Strategy: pop the first column,

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1222,24 +1222,15 @@ and split_no_or cls args def k =
         (* This enables an extra division in some frequent cases:
                last row is made of variables only *)
         collect group_discr rev_yes (cl :: rev_no) []
-    | ((p :: _, _) as cl) :: rem -> (
+    | ((p :: _, _) as cl) :: rem ->
         if can_group group_discr p && safe_before cl rev_no then
           collect group_discr (cl :: rev_yes) rev_no rem
-        else
-          (* If we can't group the current clause, we have on more decision to
-             make: do we want to try raising lower clauses, or do we want to
-             split now?
-             The decision is made based on the following heuristic: if the group
-             consists of extension constructors, it is unlikely that we are
-             going to raise anything, so we split now.
-             Otherwise, we try to raise lower clauses. *)
-          match group_discr.pat_desc with
-          | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
-              assert (rev_no = []);
-              let yes = List.rev rev_yes in
-              insert_split group_discr yes (cl :: rem) def k
-          | _ -> collect group_discr rev_yes (cl :: rev_no) rem
-      )
+        else if should_split group_discr then (
+          assert (rev_no = []);
+          let yes = List.rev rev_yes in
+          insert_split group_discr yes (cl :: rem) def k
+        ) else
+          collect group_discr rev_yes (cl :: rev_no) rem
     | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
         insert_split group_discr yes no def k
@@ -1258,6 +1249,12 @@ and split_no_or cls args def k =
         precompile_group args yes
           (Default_environment.cons matrix idef def)
           ((idef, next) :: nexts)
+  and should_split group_discr =
+    match group_discr.pat_desc with
+    | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
+        (* it is unlikely that we will raise anything, so we split now *)
+        true
+    | _ -> false
   in
   split cls
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1248,7 +1248,7 @@ and split_no_or cls args def k =
       if group_var group_discr then
         precompile_var
       else
-        precompile_normal
+        do_not_precompile
     in
     match no with
     | [] -> precompile_group args yes def k
@@ -1261,18 +1261,11 @@ and split_no_or cls args def k =
   in
   split cls
 
-and precompile_normal args cls default k =
-  ( { me = Pm { cases = cls; args; default };
-      matrix = as_matrix cls;
-      top_default = default
-    },
-    k )
-
 and precompile_var args cls def k =
   (* Strategy: pop the first column,
      precompile the rest, add a PmVar to all precompiled submatrices.
 
-     If the rest doesn't generate any split, abort and dont_precompile_var. *)
+     If the rest doesn't generate any split, abort and do_not_precompile. *)
   match args with
   | [] -> assert false
   | _ :: ((Lvar v, _) as arg) :: rargs -> (
@@ -1281,7 +1274,7 @@ and precompile_var args cls def k =
       match cls with
       | [ _ ] ->
           (* as split as it can *)
-          dont_precompile_var args cls def k
+          do_not_precompile args cls def k
       | _ -> (
           (* Precompile *)
           let var_cls =
@@ -1301,7 +1294,7 @@ and precompile_var args cls def k =
           match nexts with
           | [] ->
               (* If you need *)
-              dont_precompile_var args cls def k
+              do_not_precompile args cls def k
           | _ ->
               let rec rebuild_matrix pmh =
                 match pmh with
@@ -1337,9 +1330,9 @@ and precompile_var args cls def k =
               (rfirst, rnexts)
         )
     )
-  | _ -> dont_precompile_var args cls def k
+  | _ -> do_not_precompile args cls def k
 
-and dont_precompile_var args cls def k =
+and do_not_precompile args cls def k =
   ( { me = Pm { cases = cls; args; default = def };
       matrix = as_matrix cls;
       top_default = def

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -998,7 +998,7 @@ and group_lazy = function
   | { pat_desc = Tpat_lazy _ } -> true
   | _ -> false
 
-let get_group p =
+let can_group p =
   match p.pat_desc with
   | Tpat_any -> group_var
   | Tpat_constant (Const_int _) -> group_const_int
@@ -1021,7 +1021,7 @@ let get_group p =
   | Tpat_array _ -> group_array
   | Tpat_variant (_, _, _) -> group_variant
   | Tpat_lazy _ -> group_lazy
-  | _ -> fatal_error "Matching.get_group"
+  | _ -> fatal_error "Matching.can_group"
 
 let is_or p =
   match p.pat_desc with
@@ -1218,14 +1218,14 @@ and split_no_or cls args def k =
     if group_var discr then
       collect_vars [] [] cls
     else
-      collect_group (get_group discr) [] [] cls
-  and collect_group can_group rev_yes rev_no = function
+      collect_group discr [] [] cls
+  and collect_group group_discr rev_yes rev_no = function
     | ([], _) :: _ -> assert false
     | ((p :: _, _) as cl) :: rem ->
-        if can_group p && safe_before cl rev_no then
-          collect_group can_group (cl :: rev_yes) rev_no rem
+        if can_group group_discr p && safe_before cl rev_no then
+          collect_group group_discr (cl :: rev_yes) rev_no rem
         else
-          collect_group can_group rev_yes (cl :: rev_no) rem
+          collect_group group_discr rev_yes (cl :: rev_no) rem
     | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
         insert_split precompile_normal yes no def k

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1220,7 +1220,8 @@ and split_no_or cls args def k =
     | ([], _) :: _ -> assert false
     | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
         (* This enables an extra division in some frequent cases:
-               last row is made of variables only *)
+               last row is made of variables only
+           Cf the first part of testsuite/tests/basic/patmatch_split_no_or.ml *)
         collect group_discr rev_yes (cl :: rev_no) []
     | ((p :: _, _) as cl) :: rem ->
         if can_group group_discr p && safe_before cl rev_no then

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1226,17 +1226,9 @@ and split_no_or cls args def k =
           collect_group can_group (cl :: rev_yes) rev_no rem
         else
           collect_group can_group rev_yes (cl :: rev_no) rem
-    | [] -> (
+    | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
-        match no with
-        | [] -> precompile_normal args yes def k
-        | _ ->
-            let { me = next; matrix; top_default = def }, nexts = split no in
-            let idef = next_raise_count () in
-            precompile_normal args yes
-              (Default_environment.cons matrix idef def)
-              ((idef, next) :: nexts)
-      )
+        insert_split precompile_normal yes no def k
   and collect_vars rev_yes rev_no = function
     | ([], _) :: _ -> assert false
     | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
@@ -1248,17 +1240,18 @@ and split_no_or cls args def k =
           collect_vars (cl :: rev_yes) rev_no rem
         else
           collect_vars rev_yes (cl :: rev_no) rem
-    | [] -> (
+    | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
-        match no with
-        | [] -> precompile_var args yes def k
-        | _ ->
-            let { me = next; matrix; top_default = def }, nexts = split no in
-            let idef = next_raise_count () in
-            precompile_var args yes
-              (Default_environment.cons matrix idef def)
-              ((idef, next) :: nexts)
-      )
+        insert_split precompile_var yes no def k
+  and insert_split precompile yes no def k =
+    match no with
+    | [] -> precompile args yes def k
+    | _ ->
+        let { me = next; matrix; top_default = def }, nexts = split no in
+        let idef = next_raise_count () in
+        precompile args yes
+          (Default_environment.cons matrix idef def)
+          ((idef, next) :: nexts)
   in
   split cls
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -32,9 +32,9 @@
    -- simplifying pattern heads in the process --, so that we obtain an ordered
    list of pms.
    For every pm in this list, and any two patterns in its first column, either
-   the patterns have the same head, or they match disjoint sets of values. (In
-   particular, two extension constructors that may or may not be equal due to
-   hidden rebinding cannot occur in the same simple pm.)
+   the patterns have the same head, or their heads match disjoint sets of
+   values. (In particular, two extension constructors that may or may not be
+   equal due to hidden rebinding cannot occur in the same simple pm.)
 
        2. Compilation
        --------------

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1200,6 +1200,19 @@ let rec split_or argo cls args def =
   do_split [] [] [] cls
 
 and split_no_or cls args def k =
+  (* We split the remaining clauses in as few pms as possible while maintaining
+     the property stated earlier (cf. {1. Precompilation}), i.e. for
+     any pm in the result, it is possible to decide for any two patterns
+     on the first column whether their heads are equal or not.
+
+     This generally means that we'll have two kinds of pms: ones where the first
+     column is made of variables only, and ones where the head is actually a
+     discriminating pattern.
+
+     There is some subtlety regarding the handling of extension constructors
+     (where it is not always possible to syntactically decide whether two
+     different heads match different values), but this is handled by the
+     [can_group] function. *)
   let rec split cls =
     let discr = what_is_first_case cls in
     if group_var discr then

--- a/testsuite/tests/basic/ocamltests
+++ b/testsuite/tests/basic/ocamltests
@@ -19,6 +19,7 @@ min_int.ml
 opt_variants.ml
 patmatch.ml
 patmatch_incoherence.ml
+patmatch_split_no_or.ml
 pr7253.ml
 pr7533.ml
 pr7657.ml

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -1,0 +1,89 @@
+(* TEST
+ flags = "-nostdlib -nopervasives -dlambda"
+ * expect
+ *)
+
+(******************************************************************************)
+
+(* Check that the extra split indeed happens when the last row is made of
+   "variables" only *)
+
+let last_is_anys = function
+  | true, false -> 1
+  | _, false -> 2
+  | _, _ -> 3
+;;
+[%%expect{|
+(let
+  (last_is_anys/10 =
+     (function param/11 : int
+       (catch
+         (if (field 0 param/11) (if (field 1 param/11) (exit 1) 1)
+           (if (field 1 param/11) (exit 1) 2))
+        with (1) 3)))
+  (apply (field 1 (global Toploop!)) "last_is_anys" last_is_anys/10))
+val last_is_anys : bool * bool -> int = <fun>
+|}]
+
+let last_is_vars = function
+  | true, false -> 1
+  | _, false -> 2
+  | _x, _y -> 3
+;;
+[%%expect{|
+(let
+  (last_is_vars/16 =
+     (function param/19 : int
+       (catch
+         (if (field 0 param/19) (if (field 1 param/19) (exit 3) 1) (exit 3))
+        with (3) (if (field 1 param/19) 3 2))))
+  (apply (field 1 (global Toploop!)) "last_is_vars" last_is_vars/16))
+val last_is_vars : bool * bool -> int = <fun>
+|}]
+
+(******************************************************************************)
+
+type t = ..
+type t += A | B of unit | C of bool * int;;
+[%%expect{|
+0a
+type t = ..
+(let
+  (A/22 = (makeblock 248 "A" (caml_fresh_oo_id 0))
+   B/23 = (makeblock 248 "B" (caml_fresh_oo_id 0))
+   C/24 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
+  (seq (apply (field 1 (global Toploop!)) "A/22" A/22)
+    (apply (field 1 (global Toploop!)) "B/23" B/23)
+    (apply (field 1 (global Toploop!)) "C/24" C/24)))
+type t += A | B of unit | C of bool * int
+|}]
+
+let f = function
+  | A, true, _ -> 1
+  | _, false, false -> 11
+  | B _, true, _ -> 2
+  | C _, true, _ -> 3
+  | _, false, true -> 12
+  | _ -> 4
+;;
+[%%expect{|
+(let
+  (C/24 = (apply (field 0 (global Toploop!)) "C/24")
+   B/23 = (apply (field 0 (global Toploop!)) "B/23")
+   A/22 = (apply (field 0 (global Toploop!)) "A/22")
+   f/25 =
+     (function param/26 : int
+       (let (*match*/27 =a (field 0 param/26))
+         (catch
+           (catch
+             (if (== *match*/27 A/22) (if (field 1 param/26) 1 (exit 8))
+               (exit 8))
+            with (8)
+             (if (field 1 param/26)
+               (if (== (field 0 *match*/27) B/23) 2
+                 (if (== (field 0 *match*/27) C/24) 3 (exit 5)))
+               (if (field 2 param/26) (exit 5) 11)))
+          with (5) (if (field 1 param/26) 4 12)))))
+  (apply (field 1 (global Toploop!)) "f" f/25))
+val f : t * bool * bool -> int = <fun>
+|}]

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -75,15 +75,13 @@ let f = function
      (function param/26 : int
        (let (*match*/27 =a (field 0 param/26))
          (catch
-           (catch
-             (if (== *match*/27 A/22) (if (field 1 param/26) 1 (exit 8))
-               (exit 8))
-            with (8)
-             (if (field 1 param/26)
-               (if (== (field 0 *match*/27) B/23) 2
-                 (if (== (field 0 *match*/27) C/24) 3 (exit 5)))
-               (if (field 2 param/26) (exit 5) 11)))
-          with (5) (if (field 1 param/26) 4 12)))))
+           (if (== *match*/27 A/22) (if (field 1 param/26) 1 (exit 8))
+             (exit 8))
+          with (8)
+           (if (field 1 param/26)
+             (if (== (field 0 *match*/27) B/23) 2
+               (if (== (field 0 *match*/27) C/24) 3 4))
+             (if (field 2 param/26) 12 11))))))
   (apply (field 1 (global Toploop!)) "f" f/25))
 val f : t * bool * bool -> int = <fun>
 |}]


### PR DESCRIPTION
## A bit of history

Remember the invariant on the output of `split_and_precompile`:
> For every pm in this list, and any two patterns in its first column, either the patterns have the same head, or their heads match disjoint sets of values.

Given that the first column is always well typed, one can assume that the list contains only two kinds of pms:
- the ones where the first column is made of variables only
- the ones where the first column is made of discriminating patterns (eg. constants, constructors, whatever)

Initially, it was thought that splitting rows between these two kinds would be enough to enforce the invariant.
So `split_constr` was implemented to do just that, it consists of two mutually recursive functions: `split_ex`, which produces "discriminating" pms, and `split_noex`, which produces "variable" pms.
To produce as few pms as possible, both these functions try to raise rows as much as possible (to regroup rows of the same kind).

Then, in #5788, it was noticed that due to rebinding, this wasn't actually enforcing the invariant. So `split_naive` was introduced to be used in situations where rebinding can happen. It still uses the same `split_exc` / `split_noexc` recursion scheme, but these never try to raise any row, instead the pm is splitted whenever we go from one to the other. Additionally, `split_exc` will also split the pm whenever encountering a different constructor.

This of course generates less efficient code, so `split_constr` was also kept and the decision to use one or the other is made on each pm depending on what's in its first column.

## This PR ...

... replaces these two functions by a new `split_no_or`, which enforces the invariant in a more direct way: it folds over the rows of the pm, producing pms respecting the invariant as it goes. For each row, it first checks whether it can add it to the current pm it's producing. If doing so respects the invariant, then it does and moves on the next row.
If it doesn't, then it must chose whether to split here, or to try to raise later rows to add them to the current pm. This decision is made by looking at the first column of the current pm: if it's extension constructors we split, otherwise we try to raise later rows (this is slightly different from before: in `split_naive`, we did not attempt to raise rows for variable pms).

... adds a couple of tests: to illustrate the change mentioned above, and also to ensure that some specific optimizations (not discussed here) still work as intended.

### Reviewing

It might be easier to just read the old implementation and the new one, and check that they match what is described here.
But, I've also left quite a bit of history in the commit list that might also be useful?

Potentially interested reviewers: @Octachron, @Armael .