### PR TITLE
Fix lsl overflow detection

### DIFF
--- a/Changes
+++ b/Changes
@@ -146,6 +146,9 @@ Working version
   (Gabriel Scherer and Florian Angeletti,
    review by Florian Angeletti and Gabriel Radanne)
 
+- #8864, #8865: Fix native compilation of left shift by (word_size - 1)
+  (Vincent Laviron, report by Murilo Giacometti Rocha)
+
 OCaml 4.09.0
 ------------
 

--- a/Changes
+++ b/Changes
@@ -146,9 +146,6 @@ Working version
   (Gabriel Scherer and Florian Angeletti,
    review by Florian Angeletti and Gabriel Radanne)
 
-- #8864, #8865: Fix native compilation of left shift by (word_size - 1)
-  (Vincent Laviron, report by Murilo Giacometti Rocha)
-
 OCaml 4.09.0
 ------------
 
@@ -404,6 +401,9 @@ OCaml 4.09.0
 - #8848: Fix x86 stack probe CFI information in caml_c_call and
   caml_call_gc
   (Tom Kelly, review by Xavier Leroy)
+
+- #8864, #8865: Fix native compilation of left shift by (word_size - 1)
+  (Vincent Laviron, report by Murilo Giacometti Rocha, review by Xavier Leroy)
 
 OCaml 4.08 maintenance branch:
 ------------------------------

--- a/testsuite/tests/lib-int/test.ml
+++ b/testsuite/tests/lib-int/test.ml
@@ -25,6 +25,7 @@ let test_logops () =
   assert (Int.logxor 0xF0FF 0x0F0F = 0xFFF0);
   assert (Int.lognot Int.max_int = Int.min_int);
   assert (Int.shift_left 1 4 = 16);
+  assert (Int.shift_left (Int.compare 0 0) 63 = 0); (* Issue #8864 *)
   assert (Int.shift_right 16 4 = 1);
   assert (Int.shift_right (-16) 4 = (-1));
   assert (Int.shift_right (-16) 4 = (-1));

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -386,7 +386,7 @@ let no_overflow_mul a b =
   not ((a = min_int && b < 0) || (b <> 0 && (a * b) / b <> a))
 
 let no_overflow_lsl a k =
-  0 <= k && k < Sys.word_size && min_int asr k <= a && a <= max_int asr k
+  0 <= k && k < Sys.word_size - 1 && min_int asr k <= a && a <= max_int asr k
 
 module Int_literal_converter = struct
   (* To convert integer literals, allowing max_int + 1 (PR#4210) *)


### PR DESCRIPTION
A left shift by `Sys.word_size - 1` should be considered an overflow.

Fixes #8864 