### PR TITLE
Fixes for refactoring to a structured representation of Typedecl_variance.Bad_variance exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ Working version
 - #8774: New implementation of Env.make_copy_of_types
   (Alain Frisch, review by Thomas Refis, Leo White and Jacques Garrigue)
 
+- #7924: Use a variant instead of an int in Bad_variance exception
+  (Rian Douglas, review by Gabriel Scherer)
+
 
 ### Code generation and optimizations:
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1754,27 +1754,29 @@ let report_error ppf = function
         | 3 when not teen -> "rd"
         | _ -> "th"
       in
-      (* FIXME: this test below is horrible, use a proper variant *)
-      if n = -1 then
+      (match n with
+      | Variance_not_reflected ->
         fprintf ppf "@[%s@ %s@ It"
           "In this definition, a type variable has a variance that"
           "is not reflected by its occurrence in type parameters."
-      else if n = -2 then
+      | No_variable ->
         fprintf ppf "@[%s@ %s@]"
           "In this definition, a type variable cannot be deduced"
           "from the type parameters."
-      else if n = -3 then
+      | Variance_not_deducible ->
         fprintf ppf "@[%s@ %s@ It"
           "In this definition, a type variable has a variance that"
           "cannot be deduced from the type parameters."
-      else
+      | Variance_not_satisfied n ->
         fprintf ppf "@[%s@ %s@ The %d%s type parameter"
           "In this definition, expected parameter"
           "variances are not satisfied."
-          n (suffix n);
-      if n <> -2 then
+          n (suffix n));
+      (match n with
+      | No_variable -> ()
+      | _ ->
         fprintf ppf " was expected to be %s,@ but it is %s.@]"
-          (variance v2) (variance v1)
+          (variance v2) (variance v1))
   | Unavailable_type_constructor p ->
       fprintf ppf "The definition of type %a@ is unavailable" Printtyp.path p
   | Bad_fixed_type r ->

--- a/typing/typedecl_variance.mli
+++ b/typing/typedecl_variance.mli
@@ -28,8 +28,14 @@ type prop = Variance.t list
 type req = surface_variance list
 val property : (Variance.t list, req) property
 
+type variance_error =
+| Variance_not_satisfied of int
+| No_variable
+| Variance_not_reflected
+| Variance_not_deducible
+
 type error =
-| Bad_variance of int * surface_variance * surface_variance
+| Bad_variance of variance_error * surface_variance * surface_variance
 | Varying_anonymous
 
 exception Error of Location.t * error


### PR DESCRIPTION
Some simple changes to address the issue #7924 

Added a structured representation of the first parameter as a variant, as suggested in the issue.