### PR TITLE
[matching.ml cleanup] enable the extra division in more cases

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1028,6 +1028,15 @@ let is_or p =
   | Tpat_or _ -> true
   | _ -> false
 
+let rec omega_like p =
+  match p.pat_desc with
+  | Tpat_any
+  | Tpat_var _ ->
+      true
+  | Tpat_alias (p, _, _) -> omega_like p
+  | Tpat_or (p1, p2, _) -> omega_like p1 || omega_like p2
+  | _ -> false
+
 let equiv_pat p q = le_pat p q && le_pat q p
 
 let rec extract_equiv_head p l =
@@ -1218,7 +1227,7 @@ and split_no_or cls args def k =
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
     | ([], _) :: _ -> assert false
-    | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
+    | [ ((ps, _) as cl) ] when rev_yes <> [] && List.for_all omega_like ps ->
         (* This enables an extra division in some frequent cases:
                last row is made of variables only
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1221,7 +1221,14 @@ and split_no_or cls args def k =
     | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
         (* This enables an extra division in some frequent cases:
                last row is made of variables only
-           Cf the first part of testsuite/tests/basic/patmatch_split_no_or.ml *)
+
+           Splitting a matrix there creates two default environments (instead of
+           one for the non-split matrix), the first of which often gets
+           specialized away by further refinement, and the second one jumping
+           directly to the catch-all case -- this produces better code.
+
+           This optimisation is tested in the first part of
+           testsuite/tests/basic/patmatch_split_no_or.ml *)
         collect group_discr rev_yes (cl :: rev_no) []
     | ((p :: _, _) as cl) :: rem ->
         if can_group group_discr p && safe_before cl rev_no then

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -43,6 +43,8 @@ val last_is_vars : bool * bool -> int = <fun>
 
 (******************************************************************************)
 
+(* Check that the [| _, false, true -> 12] gets raised. *)
+
 type t = ..
 type t += A | B of unit | C of bool * int;;
 [%%expect{|

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -35,8 +35,9 @@ let last_is_vars = function
   (last_is_vars/16 =
      (function param/19 : int
        (catch
-         (if (field 0 param/19) (if (field 1 param/19) (exit 3) 1) (exit 3))
-        with (3) (if (field 1 param/19) 3 2))))
+         (if (field 0 param/19) (if (field 1 param/19) (exit 3) 1)
+           (if (field 1 param/19) (exit 3) 2))
+        with (3) 3)))
   (apply (field 1 (global Toploop!)) "last_is_vars" last_is_vars/16))
 val last_is_vars : bool * bool -> int = <fun>
 |}]
@@ -51,12 +52,12 @@ type t += A | B of unit | C of bool * int;;
 0a
 type t = ..
 (let
-  (A/22 = (makeblock 248 "A" (caml_fresh_oo_id 0))
-   B/23 = (makeblock 248 "B" (caml_fresh_oo_id 0))
-   C/24 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
-  (seq (apply (field 1 (global Toploop!)) "A/22" A/22)
-    (apply (field 1 (global Toploop!)) "B/23" B/23)
-    (apply (field 1 (global Toploop!)) "C/24" C/24)))
+  (A/23 = (makeblock 248 "A" (caml_fresh_oo_id 0))
+   B/24 = (makeblock 248 "B" (caml_fresh_oo_id 0))
+   C/25 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
+  (seq (apply (field 1 (global Toploop!)) "A/23" A/23)
+    (apply (field 1 (global Toploop!)) "B/24" B/24)
+    (apply (field 1 (global Toploop!)) "C/25" C/25)))
 type t += A | B of unit | C of bool * int
 |}]
 
@@ -70,20 +71,20 @@ let f = function
 ;;
 [%%expect{|
 (let
-  (C/24 = (apply (field 0 (global Toploop!)) "C/24")
-   B/23 = (apply (field 0 (global Toploop!)) "B/23")
-   A/22 = (apply (field 0 (global Toploop!)) "A/22")
-   f/25 =
-     (function param/26 : int
-       (let (*match*/27 =a (field 0 param/26))
+  (C/25 = (apply (field 0 (global Toploop!)) "C/25")
+   B/24 = (apply (field 0 (global Toploop!)) "B/24")
+   A/23 = (apply (field 0 (global Toploop!)) "A/23")
+   f/26 =
+     (function param/27 : int
+       (let (*match*/28 =a (field 0 param/27))
          (catch
-           (if (== *match*/27 A/22) (if (field 1 param/26) 1 (exit 8))
+           (if (== *match*/28 A/23) (if (field 1 param/27) 1 (exit 8))
              (exit 8))
           with (8)
-           (if (field 1 param/26)
-             (if (== (field 0 *match*/27) B/23) 2
-               (if (== (field 0 *match*/27) C/24) 3 4))
-             (if (field 2 param/26) 12 11))))))
-  (apply (field 1 (global Toploop!)) "f" f/25))
+           (if (field 1 param/27)
+             (if (== (field 0 *match*/28) B/24) 2
+               (if (== (field 0 *match*/28) C/25) 3 4))
+             (if (field 2 param/27) 12 11))))))
+  (apply (field 1 (global Toploop!)) "f" f/26))
 val f : t * bool * bool -> int = <fun>
 |}]


### PR DESCRIPTION
The commit message explains what's going on.

> One optimization in `split_no_or` is the insertion of a split before
a last matrix line that has only variables. Splitting a matrix there
creates two default environments (instead of one for the non-split
matrix), the first of which often gets specialized away by further
refinement, and the second one jumping directly to the catch-all
case -- this produces better code.
>
> The code would detect this case (all-variable last row) by calling
`group_var` on all the patterns of the row, but the `group_*`
functions assume that their input is already simplified, and only the
first column of the row is simplified.
>
> The present commit fixes it by defining a predicates that does not
assume the pattern is simple, and check that "all its heads" are
a variable. In the future we will refactor this code using
Parmatch.Simple_head.t, and the function invocation may change.
>
> Note: two testcases are changed in `tests/basic/patmatch_split_no_or`,
the first is the actual optimization and the second is just
stamp-related noise.

Apart from that, I also add the comments I told @Octachron I would add in #8861, but was prevented from doing because of @gasche's eagerness to click merge. :)