### PR TITLE
Split Linearize into two modules

### DIFF
--- a/.depend
+++ b/.depend
@@ -2114,26 +2114,26 @@ asmcomp/asmpackager.cmi : \
 asmcomp/branch_relaxation.cmo : \
     utils/misc.cmi \
     asmcomp/mach.cmi \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     asmcomp/cmm.cmi \
     asmcomp/branch_relaxation_intf.cmo \
     asmcomp/branch_relaxation.cmi
 asmcomp/branch_relaxation.cmx : \
     utils/misc.cmx \
     asmcomp/mach.cmx \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     asmcomp/cmm.cmx \
     asmcomp/branch_relaxation_intf.cmx \
     asmcomp/branch_relaxation.cmi
 asmcomp/branch_relaxation.cmi : \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     asmcomp/branch_relaxation_intf.cmo
 asmcomp/branch_relaxation_intf.cmo : \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     asmcomp/cmm.cmi \
     asmcomp/arch.cmo
 asmcomp/branch_relaxation_intf.cmx : \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     asmcomp/cmm.cmx \
     asmcomp/arch.cmx
 asmcomp/cmm.cmo : \
@@ -2277,7 +2277,7 @@ asmcomp/emit.cmo : \
     asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     lambda/lambda.cmi \
     asmcomp/emitaux.cmi \
     utils/domainstate.cmi \
@@ -2299,7 +2299,7 @@ asmcomp/emit.cmx : \
     asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     lambda/lambda.cmx \
     asmcomp/emitaux.cmx \
     utils/domainstate.cmx \
@@ -2312,7 +2312,7 @@ asmcomp/emit.cmx : \
     asmcomp/arch.cmx \
     asmcomp/emit.cmi
 asmcomp/emit.cmi : \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
     lambda/debuginfo.cmi \
@@ -2357,12 +2357,32 @@ asmcomp/interval.cmx : \
 asmcomp/interval.cmi : \
     asmcomp/reg.cmi \
     asmcomp/mach.cmi
+asmcomp/linear.cmo : \
+    asmcomp/reg.cmi \
+    asmcomp/mach.cmi \
+    lambda/lambda.cmi \
+    lambda/debuginfo.cmi \
+    asmcomp/cmm.cmi \
+    asmcomp/linear.cmi
+asmcomp/linear.cmx : \
+    asmcomp/reg.cmx \
+    asmcomp/mach.cmx \
+    lambda/lambda.cmx \
+    lambda/debuginfo.cmx \
+    asmcomp/cmm.cmx \
+    asmcomp/linear.cmi
+asmcomp/linear.cmi : \
+    asmcomp/reg.cmi \
+    asmcomp/mach.cmi \
+    lambda/lambda.cmi \
+    lambda/debuginfo.cmi \
+    asmcomp/cmm.cmi
 asmcomp/linearize.cmo : \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
-    lambda/lambda.cmi \
+    asmcomp/linear.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
@@ -2372,17 +2392,14 @@ asmcomp/linearize.cmx : \
     asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
-    lambda/lambda.cmx \
+    asmcomp/linear.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
     asmcomp/linearize.cmi
 asmcomp/linearize.cmi : \
-    asmcomp/reg.cmi \
     asmcomp/mach.cmi \
-    lambda/lambda.cmi \
-    lambda/debuginfo.cmi \
-    asmcomp/cmm.cmi
+    asmcomp/linear.cmi
 asmcomp/linscan.cmo : \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
@@ -2464,19 +2481,19 @@ asmcomp/printcmm.cmi : \
 asmcomp/printlinear.cmo : \
     asmcomp/printmach.cmi \
     asmcomp/mach.cmi \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     asmcomp/printlinear.cmi
 asmcomp/printlinear.cmx : \
     asmcomp/printmach.cmx \
     asmcomp/mach.cmx \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     asmcomp/printlinear.cmi
 asmcomp/printlinear.cmi : \
-    asmcomp/linearize.cmi
+    asmcomp/linear.cmi
 asmcomp/printmach.cmo : \
     asmcomp/debug/reg_availability_set.cmi \
     asmcomp/reg.cmi \
@@ -2577,7 +2594,7 @@ asmcomp/schedgen.cmo : \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     asmcomp/mach.cmi \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
     asmcomp/arch.cmo \
@@ -2586,14 +2603,14 @@ asmcomp/schedgen.cmx : \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
     asmcomp/mach.cmx \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
     asmcomp/arch.cmx \
     asmcomp/schedgen.cmi
 asmcomp/schedgen.cmi : \
     asmcomp/mach.cmi \
-    asmcomp/linearize.cmi
+    asmcomp/linear.cmi
 asmcomp/scheduling.cmo : \
     asmcomp/schedgen.cmi \
     asmcomp/scheduling.cmi
@@ -2601,7 +2618,7 @@ asmcomp/scheduling.cmx : \
     asmcomp/schedgen.cmx \
     asmcomp/scheduling.cmi
 asmcomp/scheduling.cmi : \
-    asmcomp/linearize.cmi
+    asmcomp/linear.cmi
 asmcomp/selectgen.cmo : \
     lambda/simplif.cmi \
     asmcomp/reg.cmi \
@@ -5460,7 +5477,7 @@ asmcomp/debug/compute_ranges.cmo : \
     asmcomp/printlinear.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     utils/int_replace_polymorphic_compare.cmi \
     asmcomp/debug/compute_ranges_intf.cmo \
     asmcomp/cmm.cmi \
@@ -5469,7 +5486,7 @@ asmcomp/debug/compute_ranges.cmx : \
     asmcomp/printlinear.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     utils/int_replace_polymorphic_compare.cmx \
     asmcomp/debug/compute_ranges_intf.cmx \
     asmcomp/cmm.cmx \
@@ -5478,11 +5495,11 @@ asmcomp/debug/compute_ranges.cmi : \
     asmcomp/debug/compute_ranges_intf.cmo
 asmcomp/debug/compute_ranges_intf.cmo : \
     utils/numbers.cmi \
-    asmcomp/linearize.cmi \
+    asmcomp/linear.cmi \
     utils/identifiable.cmi
 asmcomp/debug/compute_ranges_intf.cmx : \
     utils/numbers.cmx \
-    asmcomp/linearize.cmx \
+    asmcomp/linear.cmx \
     utils/identifiable.cmx
 asmcomp/debug/reg_availability_set.cmo : \
     asmcomp/debug/reg_with_debug_info.cmi \

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ ASMCOMP=\
   asmcomp/linscan.cmo \
   asmcomp/reloadgen.cmo asmcomp/reload.cmo \
   asmcomp/deadcode.cmo \
-  asmcomp/printlinear.cmo asmcomp/linearize.cmo \
+  asmcomp/linear.cmo asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \
   asmcomp/debug/compute_ranges_intf.cmo \
   asmcomp/debug/compute_ranges.cmo \

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -21,7 +21,7 @@ open Arch
 open Proc
 open Reg
 open Mach
-open Linearize
+open Linear
 open Emitaux
 
 open X86_ast
@@ -909,7 +909,7 @@ let rec emit_all fallthrough i =
   | Lend -> ()
   | _ ->
       emit_instr fallthrough i;
-      emit_all (Linearize.has_fallthrough i.desc) i.next
+      emit_all (Linear.has_fallthrough i.desc) i.next
 
 let all_functions = ref []
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -23,7 +23,7 @@ open Arch
 open Proc
 open Reg
 open Mach
-open Linearize
+open Linear
 open Emitaux
 
 (* Tradeoff between code size and code speed *)

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -24,7 +24,7 @@ open Arch
 open Proc
 open Reg
 open Mach
-open Linearize
+open Linear
 open Emitaux
 
 (* Tradeoff between code size and code speed *)

--- a/asmcomp/branch_relaxation.ml
+++ b/asmcomp/branch_relaxation.ml
@@ -15,7 +15,7 @@
 (**************************************************************************)
 
 open Mach
-open Linearize
+open Linear
 
 module Make (T : Branch_relaxation_intf.S) = struct
   let label_map code =
@@ -45,7 +45,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
     | Some branch ->
       let max_branch_offset =
         (* Remember to cut some slack for multi-word instructions (in the
-           [Linearize] sense of the word) where the branch can be anywhere in
+           [Linear] sense of the word) where the branch can be anywhere in
            the middle.  12 words of slack is plenty. *)
         T.Cond_branch.max_displacement branch - 12
       in

--- a/asmcomp/branch_relaxation.mli
+++ b/asmcomp/branch_relaxation.mli
@@ -18,7 +18,7 @@
 
 module Make (T : Branch_relaxation_intf.S) : sig
   val relax
-     : Linearize.instruction
+     : Linear.instruction
     (* [max_offset_of_out_of_line_code] specifies the furthest distance,
        measured from the first address immediately after the last instruction
        of the function, that may be branched to from within the function in

--- a/asmcomp/branch_relaxation_intf.ml
+++ b/asmcomp/branch_relaxation_intf.ml
@@ -46,7 +46,7 @@ module type S = sig
                 - Lcondbranch3 (_, _, _)
        [classify_instr] is expected to return [None] when called on any
        instruction not in this list. *)
-    val classify_instr : Linearize.instruction_desc -> t option
+    val classify_instr : Linear.instruction_desc -> t option
   end
 
   (* The value to be added to the program counter (in [distance] units)
@@ -55,7 +55,7 @@ module type S = sig
   val offset_pc_at_branch : distance
 
   (* The maximum size of a given instruction. *)
-  val instr_size : Linearize.instruction_desc -> distance
+  val instr_size : Linear.instruction_desc -> distance
 
   (* Insertion of target-specific code to relax operations that cannot be
      relaxed generically.  It is assumed that these rewrites do not change
@@ -63,13 +63,13 @@ module type S = sig
   val relax_allocation
      : num_bytes:int
     -> label_after_call_gc:Cmm.label option
-    -> Linearize.instruction_desc
+    -> Linear.instruction_desc
   val relax_intop_checkbound
      : label_after_error:Cmm.label option
-    -> Linearize.instruction_desc
+    -> Linear.instruction_desc
   val relax_intop_imm_checkbound
      : bound:int
     -> label_after_error:Cmm.label option
-    -> Linearize.instruction_desc
-  val relax_specific_op : Arch.specific_operation -> Linearize.instruction_desc
+    -> Linear.instruction_desc
+  val relax_specific_op : Arch.specific_operation -> Linear.instruction_desc
 end

--- a/asmcomp/debug/compute_ranges.ml
+++ b/asmcomp/debug/compute_ranges.ml
@@ -16,7 +16,7 @@
 
 open! Int_replace_polymorphic_compare
 
-module L = Linearize
+module L = Linear
 
 module Make (S : Compute_ranges_intf.S_functor) = struct
   module Subrange_state = S.Subrange_state
@@ -39,7 +39,7 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
       subrange_info : Subrange_info.t;
     }
 
-    let create ~(start_insn : Linearize.instruction)
+    let create ~(start_insn : L.instruction)
           ~start_pos ~start_pos_offset
           ~end_pos ~end_pos_offset
           ~subrange_info =

--- a/asmcomp/debug/compute_ranges_intf.ml
+++ b/asmcomp/debug/compute_ranges_intf.ml
@@ -28,7 +28,7 @@
     the documentation on module type [S], below.
 *)
 
-module L = Linearize
+module L = Linear
 
 (** The type of caller-defined contextual state associated with subranges.
     This may be used to track information throughout the range-computing
@@ -81,7 +81,7 @@ module type S_functor = sig
   module Index : Identifiable.S
 
   (** The module [Key] corresponds to the identifiers that define the ranges in
-      [Linearize] instructions. Each instruction should have two sets of keys,
+      [Linear] instructions. Each instruction should have two sets of keys,
       [available_before] and [available_across], with accessor functions of
       these names being provided to retrieve them. The notion of "availability"
       is not prescribed. The availability sets are used to compute subranges
@@ -158,7 +158,7 @@ end
 (** This module type is the result type of the [Compute_ranges.Make] functor.
 
     The _ranges_ being computed are composed of contiguous _subranges_ delimited
-    by two labels (of type [Linearize.label]). These labels will be added by
+    by two labels (of type [Linear.label]). These labels will be added by
     this pass to the code being inspected, which is why the [create] function in
     the result of the functor returns not only the ranges but also the updated
     function with the labels added. The [start_pos_offset] and [end_pos_offset]
@@ -199,7 +199,7 @@ module type S = sig
     val info : t -> Subrange_info.t
 
     (** The label at the start of the range. *)
-    val start_pos : t -> Linearize.label
+    val start_pos : t -> Linear.label
 
     (** How many bytes from the label at [start_pos] the range actually
         commences.  If this value is zero, then the first byte of the range
@@ -207,7 +207,7 @@ module type S = sig
     val start_pos_offset : t -> int
 
     (** The label at the end of the range. *)
-    val end_pos : t -> Linearize.label
+    val end_pos : t -> Linear.label
 
     (** Like [start_pos_offset], but analogously for the end of the range. (The
         sense is not inverted; a positive [end_pos_offset] means the range ends
@@ -232,7 +232,7 @@ module type S = sig
         cross an extremity of any other range. (This should be satisfied in
         typical uses because the offsets are typically zero or one.) If there
         are no ranges supplied then [None] is returned. *)
-    val estimate_lowest_address : t -> (Linearize.label * int) option
+    val estimate_lowest_address : t -> (Linear.label * int) option
 
     (** Fold over all subranges within the given range. *)
     val fold
@@ -251,7 +251,7 @@ module type S = sig
   (** Compute ranges for the code in the given linearized function
       declaration, returning the ranges as a value of type [t] and the
       rewritten code that must go forward for emission. *)
-  val create : Linearize.fundecl -> t * Linearize.fundecl
+  val create : Linear.fundecl -> t * Linear.fundecl
 
   (** Iterate through ranges.  Each range is associated with an index. *)
   val iter : t -> f:(Index.t -> Range.t -> unit) -> unit

--- a/asmcomp/emit.mli
+++ b/asmcomp/emit.mli
@@ -15,7 +15,7 @@
 
 (* Generation of assembly code *)
 
-val fundecl: Linearize.fundecl -> unit
+val fundecl: Linear.fundecl -> unit
 val data: Cmm.data_item list -> unit
 val begin_assembly: unit -> unit
 val end_assembly: unit -> unit

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -22,7 +22,7 @@ open Arch
 open Proc
 open Reg
 open Mach
-open Linearize
+open Linear
 open Emitaux
 module String = Misc.Stdlib.String
 
@@ -912,7 +912,7 @@ let rec emit_all fallthrough i =
   | _ ->
       emit_instr fallthrough i;
       emit_all
-        (system = S_win32 || Linearize.has_fallthrough i.desc)
+        (system = S_win32 || Linear.has_fallthrough i.desc)
         i.next
 
 (* Emission of a function declaration *)

--- a/asmcomp/linear.ml
+++ b/asmcomp/linear.ml
@@ -1,0 +1,88 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+open Mach
+
+(* Transformation of Mach code into a list of pseudo-instructions. *)
+type label = Cmm.label
+
+type instruction =
+  { mutable desc: instruction_desc;
+    mutable next: instruction;
+    arg: Reg.t array;
+    res: Reg.t array;
+    dbg: Debuginfo.t;
+    live: Reg.Set.t }
+
+and instruction_desc =
+  | Lprologue
+  | Lend
+  | Lop of Mach.operation
+  | Lreloadretaddr
+  | Lreturn
+  | Llabel of label
+  | Lbranch of label
+  | Lcondbranch of Mach.test * label
+  | Lcondbranch3 of label option * label option * label option
+  | Lswitch of label array
+  | Lentertrap
+  | Ladjust_trap_depth of { delta_traps : int; }
+  | Lpushtrap of { lbl_handler : label; }
+  | Lpoptrap
+  | Lraise of Lambda.raise_kind
+
+let has_fallthrough = function
+  | Lreturn | Lbranch _ | Lswitch _ | Lraise _
+  | Lop Itailcall_ind _ | Lop (Itailcall_imm _) -> false
+  | _ -> true
+
+type fundecl =
+  { fun_name: string;
+    fun_body: instruction;
+    fun_fast: bool;
+    fun_dbg : Debuginfo.t;
+    fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_tailrec_entry_point_label : label;
+  }
+
+(* Invert a test *)
+
+let invert_integer_test = function
+    Isigned cmp -> Isigned(Cmm.negate_integer_comparison cmp)
+  | Iunsigned cmp -> Iunsigned(Cmm.negate_integer_comparison cmp)
+
+let invert_test = function
+    Itruetest -> Ifalsetest
+  | Ifalsetest -> Itruetest
+  | Iinttest(cmp) -> Iinttest(invert_integer_test cmp)
+  | Iinttest_imm(cmp, n) -> Iinttest_imm(invert_integer_test cmp, n)
+  | Ifloattest(cmp) -> Ifloattest(Cmm.negate_float_comparison cmp)
+  | Ieventest -> Ioddtest
+  | Ioddtest -> Ieventest
+
+(* The "end" instruction *)
+
+let rec end_instr =
+  { desc = Lend;
+    next = end_instr;
+    arg = [||];
+    res = [||];
+    dbg = Debuginfo.none;
+    live = Reg.Set.empty }
+
+(* Cons an instruction (live, debug empty) *)
+
+let instr_cons d a r n =
+  { desc = d; next = n; arg = a; res = r;
+    dbg = Debuginfo.none; live = Reg.Set.empty }

--- a/asmcomp/linear.mli
+++ b/asmcomp/linear.mli
@@ -14,4 +14,45 @@
 (**************************************************************************)
 
 (* Transformation of Mach code into a list of pseudo-instructions. *)
-val fundecl: Mach.fundecl -> Linear.fundecl
+
+type label = Cmm.label
+
+type instruction =
+  { mutable desc: instruction_desc;
+    mutable next: instruction;
+    arg: Reg.t array;
+    res: Reg.t array;
+    dbg: Debuginfo.t;
+    live: Reg.Set.t }
+
+and instruction_desc =
+  | Lprologue
+  | Lend
+  | Lop of Mach.operation
+  | Lreloadretaddr
+  | Lreturn
+  | Llabel of label
+  | Lbranch of label
+  | Lcondbranch of Mach.test * label
+  | Lcondbranch3 of label option * label option * label option
+  | Lswitch of label array
+  | Lentertrap
+  | Ladjust_trap_depth of { delta_traps : int; }
+  | Lpushtrap of { lbl_handler : label; }
+  | Lpoptrap
+  | Lraise of Lambda.raise_kind
+
+val has_fallthrough :  instruction_desc -> bool
+val end_instr: instruction
+val instr_cons:
+  instruction_desc -> Reg.t array -> Reg.t array -> instruction -> instruction
+val invert_test: Mach.test -> Mach.test
+
+type fundecl =
+  { fun_name: string;
+    fun_body: instruction;
+    fun_fast: bool;
+    fun_dbg : Debuginfo.t;
+    fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_tailrec_entry_point_label : label;
+  }

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -14,81 +14,7 @@
 (**************************************************************************)
 
 (* Transformation of Mach code into a list of pseudo-instructions. *)
-
-open Reg
-open Mach
-
-type label = Cmm.label
-
-type instruction =
-  { mutable desc: instruction_desc;
-    mutable next: instruction;
-    arg: Reg.t array;
-    res: Reg.t array;
-    dbg: Debuginfo.t;
-    live: Reg.Set.t }
-
-and instruction_desc =
-  | Lprologue
-  | Lend
-  | Lop of operation
-  | Lreloadretaddr
-  | Lreturn
-  | Llabel of label
-  | Lbranch of label
-  | Lcondbranch of test * label
-  | Lcondbranch3 of label option * label option * label option
-  | Lswitch of label array
-  | Lentertrap
-  | Ladjust_trap_depth of { delta_traps : int; }
-  | Lpushtrap of { lbl_handler : label; }
-  | Lpoptrap
-  | Lraise of Lambda.raise_kind
-
-let has_fallthrough = function
-  | Lreturn | Lbranch _ | Lswitch _ | Lraise _
-  | Lop Itailcall_ind _ | Lop (Itailcall_imm _) -> false
-  | _ -> true
-
-type fundecl =
-  { fun_name: string;
-    fun_body: instruction;
-    fun_fast: bool;
-    fun_dbg : Debuginfo.t;
-    fun_spacetime_shape : Mach.spacetime_shape option;
-    fun_tailrec_entry_point_label : label;
-  }
-
-(* Invert a test *)
-
-let invert_integer_test = function
-    Isigned cmp -> Isigned(Cmm.negate_integer_comparison cmp)
-  | Iunsigned cmp -> Iunsigned(Cmm.negate_integer_comparison cmp)
-
-let invert_test = function
-    Itruetest -> Ifalsetest
-  | Ifalsetest -> Itruetest
-  | Iinttest(cmp) -> Iinttest(invert_integer_test cmp)
-  | Iinttest_imm(cmp, n) -> Iinttest_imm(invert_integer_test cmp, n)
-  | Ifloattest(cmp) -> Ifloattest(Cmm.negate_float_comparison cmp)
-  | Ieventest -> Ioddtest
-  | Ioddtest -> Ieventest
-
-(* The "end" instruction *)
-
-let rec end_instr =
-  { desc = Lend;
-    next = end_instr;
-    arg = [||];
-    res = [||];
-    dbg = Debuginfo.none;
-    live = Reg.Set.empty }
-
-(* Cons an instruction (live, debug empty) *)
-
-let instr_cons d a r n =
-  { desc = d; next = n; arg = a; res = r;
-    dbg = Debuginfo.none; live = Reg.Set.empty }
+open Linear
 
 (* Cons a simple instruction (arg, res, live empty) *)
 
@@ -308,7 +234,7 @@ let rec linear i n =
       n3
   | Iexit nfail ->
       let lbl, t = find_exit_label_try_depth nfail in
-      assert (i.Mach.next.desc = Iend);
+      assert (i.Mach.next.desc = Mach.Iend);
       let delta_traps = !try_depth - t in
       let n1 = adjust_trap_depth delta_traps n in
       let rec loop i tt =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -21,7 +21,7 @@ open Arch
 open Proc
 open Reg
 open Mach
-open Linearize
+open Linear
 open Emitaux
 
 (* Reserved space at bottom of stack *)

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -18,7 +18,7 @@
 open Format
 open Mach
 open Printmach
-open Linearize
+open Linear
 
 let label ppf l =
   Format.fprintf ppf "L%i" l

--- a/asmcomp/printlinear.mli
+++ b/asmcomp/printlinear.mli
@@ -16,7 +16,7 @@
 (* Pretty-printing of linearized machine code *)
 
 open Format
-open Linearize
+open Linear
 
 val instr: formatter -> instruction -> unit
 val fundecl: formatter -> fundecl -> unit

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -22,7 +22,7 @@ open Arch
 open Proc
 open Reg
 open Mach
-open Linearize
+open Linear
 open Emitaux
 
 (* Layout of the stack.  The stack is kept 8-aligned. *)

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -17,7 +17,7 @@
 
 open Reg
 open Mach
-open Linearize
+open Linear
 
 (* Representation of the code DAG. *)
 

--- a/asmcomp/schedgen.mli
+++ b/asmcomp/schedgen.mli
@@ -16,7 +16,7 @@
 (* Instruction scheduling *)
 
 type code_dag_node =
-  { instr: Linearize.instruction;
+  { instr: Linear.instruction;
     delay: int;
     mutable sons: (code_dag_node * int) list;
     mutable date: int;
@@ -43,7 +43,7 @@ class virtual scheduler_generic : object
   method is_checkbound : Mach.operation -> bool
       (* Says whether the given operation is a checkbound *)
   (* Entry point *)
-  method schedule_fundecl : Linearize.fundecl -> Linearize.fundecl
+  method schedule_fundecl : Linear.fundecl -> Linear.fundecl
 end
 
 val reset : unit -> unit

--- a/asmcomp/scheduling.mli
+++ b/asmcomp/scheduling.mli
@@ -15,4 +15,4 @@
 
 (* Instruction scheduling *)
 
-val fundecl: Linearize.fundecl -> Linearize.fundecl
+val fundecl: Linear.fundecl -> Linear.fundecl

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -7,7 +7,7 @@ alloc_b.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_b.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -363,7 +363,7 @@ alloc_bd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h 
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_bd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -724,7 +724,7 @@ alloc_bi.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h 
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_bi.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -1080,7 +1080,7 @@ alloc_bpic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_bpic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -1436,7 +1436,7 @@ alloc_n.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_n.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -1789,7 +1789,7 @@ alloc_nd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h 
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_nd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -2147,7 +2147,7 @@ alloc_ni.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h 
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_ni.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
@@ -2500,7 +2500,7 @@ alloc_npic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h
+ caml/stacks.h caml/memory.h caml/signals.h
 array_npic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \


### PR DESCRIPTION
This PR moves type declarations from Linearize into their own module, called Linear. It separates the description of the IR from transformations performed on it, similarly to the way Cmm and Mach are already arranged. There is no change in functionality.
