### PR TITLE
subst: preserve scopes (fixes #8862)

### DIFF
--- a/Changes
+++ b/Changes
@@ -149,6 +149,9 @@ Working version
   (Gabriel Scherer and Florian Angeletti,
    review by Florian Angeletti and Gabriel Radanne)
 
+- #8862, #8871: subst: preserve scopes
+  (Thomas Refis, report by Leo White)
+
 OCaml 4.09.0
 ------------
 

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -221,8 +221,18 @@ let foo p (e : (T.t, T.u) eq) (x : T.t) (y : T.u) =
 module type S = module type of M ;;
 [%%expect{|
 module M : sig val r : '_weak1 list ref end
-val foo : bool -> (T.t, T.u) eq -> T.t -> T.u -> unit = <fun>
-module type S = sig val r : T.u list ref end
+Line 12, characters 25-26:
+12 |     let module O : N.S = M in
+                              ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val r : '_weak1 list ref end
+       is not included in
+         N.S
+       Values do not match:
+         val r : '_weak1 list ref
+       is not included in
+         val r : T.u list ref
 |}]
 
 module M = struct
@@ -242,6 +252,16 @@ let foo p (e : (T.u, T.t) eq) (x : T.t) (y : T.u) =
 module type S = module type of M ;;
 [%%expect{|
 module M : sig val r : '_weak2 list ref end
-val foo : bool -> (T.u, T.t) eq -> T.t -> T.u -> unit = <fun>
-module type S = sig val r : T.t list ref end
+Line 12, characters 25-26:
+12 |     let module O : N.S = M in
+                              ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val r : '_weak2 list ref end
+       is not included in
+         N.S
+       Values do not match:
+         val r : '_weak2 list ref
+       is not included in
+         val r : T.t list ref
 |}]

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -173,6 +173,7 @@ let rec typexp copy_scope s ty =
       not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm in
     (* Make a stub *)
     let ty' = if s.for_saving then newpersty (Tvar None) else newgenvar () in
+    ty'.scope <- ty.scope;
     ty.desc <- Tsubst ty';
     ty'.desc <-
       begin if has_fixed_row then


### PR DESCRIPTION
When adding the explicit `scope` field to `type_expr` I remembered to update `Ctype.copy` but forgot about `Subst.typexp`, resulting in #8862 .
This PR fixes that