### PR TITLE
Add some tests for typechecking error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,10 @@ Working version
 - #8702, #8777: improved error messages for fixed row polymorphic variants
   (Florian Angeletti, report by Leo White, review by Thomas Refis)
 
+- #8874: add tests for typechecking error messages and pack them into
+  pretty-printing boxes.
+  (Oxana Kostikova, review by Gabriel Scherer)
+
 ### Bug fixes:
 
 - #8622: Don't generate #! headers over 127 characters.

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -1,0 +1,253 @@
+(* TEST
+   * expect
+*)
+
+class type foo_t =
+  object
+    method foo: string
+  end
+
+module M: sig
+  class type ct = object val m: string end
+end = struct
+  class type ct = object end
+end
+
+[%%expect{|
+class type foo_t = object method foo : string end
+Lines 8-10, characters 6-3:
+ 8 | ......struct
+ 9 |   class type ct = object end
+10 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class type ct = object  end end
+       is not included in
+         sig class type ct = object val m : string end end
+       Class type declarations do not match:
+         class type ct = object  end
+       does not match
+         class type ct = object val m : string end
+       The first class type has no instance variable m
+|}]
+
+module M: sig
+  class c : object
+    method a: string
+  end
+end = struct
+  class virtual c = object
+    method virtual a: string
+  end
+end
+;;
+[%%expect{|
+Lines 5-9, characters 6-3:
+5 | ......struct
+6 |   class virtual c = object
+7 |     method virtual a: string
+8 |   end
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class virtual c : object method virtual a : string end end
+       is not included in
+         sig class c : object method a : string end end
+       Class declarations do not match:
+         class virtual c : object method virtual a : string end
+       does not match
+         class c : object method a : string end
+       A class cannot be changed from virtual to concrete
+|}]
+
+class type ['a] ct = object val x: 'a end
+
+module M: sig
+  class type ['a] c = object end
+end = struct
+  class type c = object end
+end
+;;
+
+[%%expect{|
+class type ['a] ct = object val x : 'a end
+Lines 5-7, characters 6-3:
+5 | ......struct
+6 |   class type c = object end
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class type c = object  end end
+       is not included in
+         sig class type ['a] c = object  end end
+       Class type declarations do not match:
+         class type c = object  end
+       does not match
+         class type ['a] c = object  end
+       The classes do not have the same number of type parameters
+|}]
+
+module M: sig
+  class ['a] c: object constraint 'a = int end
+end = struct
+  class ['a] c = object end
+end
+;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   class ['a] c = object end
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class ['a] c : object  end end
+       is not included in
+         sig class ['a] c : object constraint 'a = int end end
+       Class declarations do not match:
+         class ['a] c : object  end
+       does not match
+         class ['a] c : object constraint 'a = int end
+       A type parameter has type 'a but is expected to have type int
+|}]
+
+module M: sig
+  class c : int -> object end
+end = struct
+  class c (x : float) = object end
+end
+;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   class c (x : float) = object end
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class c : float -> object  end end
+       is not included in
+         sig class c : int -> object  end end
+       Class declarations do not match:
+         class c : float -> object  end
+       does not match
+         class c : int -> object  end
+       A parameter has type float but is expected to have type int
+|}]
+
+class virtual foo: foo_t =
+    object
+        method foo = "foo"
+        method private virtual cast: int
+    end
+;;
+
+[%%expect{|
+Lines 2-5, characters 4-7:
+2 | ....object
+3 |         method foo = "foo"
+4 |         method private virtual cast: int
+5 |     end
+Error: The class type object method foo : string end
+       is not matched by the class type foo_t
+       The virtual method cast cannot be hidden
+|}]
+
+class type foo_t2 =
+    object
+        method private foo: string
+    end
+
+class foo: foo_t2 =
+    object
+        method foo = "foo"
+    end
+;;
+[%%expect{|
+class type foo_t2 = object method private foo : string end
+Lines 7-9, characters 4-7:
+7 | ....object
+8 |         method foo = "foo"
+9 |     end
+Error: The class type object method foo : string end
+       is not matched by the class type foo_t2
+       The public method foo cannot become private
+|}]
+
+class virtual foo: foo_t =
+    object
+        method virtual foo: string
+    end
+;;
+[%%expect{|
+Lines 2-4, characters 4-7:
+2 | ....object
+3 |         method virtual foo: string
+4 |     end
+Error: The class type object method virtual foo : string end
+       is not matched by the class type foo_t
+       The virtual method foo cannot become concrete
+|}]
+
+class type foo_t3 =
+    object
+        val mutable x : int
+    end
+
+class foo: foo_t3 =
+    object
+        val x = 1
+    end
+;;
+[%%expect{|
+class type foo_t3 = object val mutable x : int end
+Lines 7-9, characters 4-7:
+7 | ....object
+8 |         val x = 1
+9 |     end
+Error: The class type object val x : int end is not matched by the class type
+         foo_t3
+       The non-mutable instance variable x cannot become mutable
+|}]
+
+class type foo_t4 =
+    object
+        val x : int
+    end
+
+class virtual foo: foo_t4 =
+    object
+        val virtual x : int
+    end
+;;
+[%%expect{|
+class type foo_t4 = object val x : int end
+Lines 7-9, characters 4-7:
+7 | ....object
+8 |         val virtual x : int
+9 |     end
+Error: The class type object val virtual x : int end
+       is not matched by the class type foo_t4
+       The virtual instance variable x cannot become concrete
+|}]
+
+module M: sig
+  class type c = object method m: string end
+end = struct
+  class type c = object method private m: string end
+end
+;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   class type c = object method private m: string end
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig class type c = object method private m : string end end
+       is not included in
+         sig class type c = object method m : string end end
+       Class type declarations do not match:
+         class type c = object method private m : string end
+       does not match
+         class type c = object method m : string end
+       The private method m cannot become public
+|}]

--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -32,3 +32,4 @@ typecore_nolabel_errors.ml
 typecore_empty_polyvariant_error.ml
 typetexp_errors.ml
 external_arity.ml
+includeclass_errors.ml

--- a/testsuite/tests/typing-misc/typetexp_errors.ml
+++ b/testsuite/tests/typing-misc/typetexp_errors.ml
@@ -23,3 +23,11 @@ Error: The constructor C is missing from the upper bound (between '<'
        Hint: Either add `C in the upper bound, or remove it
        from the lower bound.
 |}]
+
+type ('_a) underscored = A of '_a
+[%%expect {|
+Line 1, characters 6-9:
+1 | type ('_a) underscored = A of '_a
+          ^^^
+Error: The type variable name '_a is not allowed in programs
+|}]

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -102,11 +102,11 @@ let include_err ppf =
   | CM_Hide_virtual (k, lab) ->
       fprintf ppf "@[The virtual %s %s cannot be hidden@]" k lab
   | CM_Public_method lab ->
-      fprintf ppf "The public method %s cannot become private" lab
+      fprintf ppf "@[The public method %s cannot become private@]" lab
   | CM_Virtual_method lab ->
-      fprintf ppf "The virtual method %s cannot become concrete" lab
+      fprintf ppf "@[The virtual method %s cannot become concrete@]" lab
   | CM_Private_method lab ->
-      fprintf ppf "The private method %s cannot become public" lab
+      fprintf ppf "@[The private method %s cannot become public@]" lab
 
 let report_error ppf = function
   |  [] -> ()

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -102,9 +102,9 @@ let include_err ppf =
   | CM_Hide_virtual (k, lab) ->
       fprintf ppf "@[The virtual %s %s cannot be hidden@]" k lab
   | CM_Public_method lab ->
-      fprintf ppf "@[The public method %s cannot become private" lab
+      fprintf ppf "The public method %s cannot become private" lab
   | CM_Virtual_method lab ->
-      fprintf ppf "@[The virtual method %s cannot become concrete" lab
+      fprintf ppf "The virtual method %s cannot become concrete" lab
   | CM_Private_method lab ->
       fprintf ppf "The private method %s cannot become public" lab
 


### PR DESCRIPTION
In the process of creating a tests coverage report for the compiler code using `bisect_ppx`, I generated a report specifically for the typechecking subsystem (you can see it [here](https://lereena.github.io/coverage/index.html)). Using this coverage report I found some gaps that could be easily fixed with few tests, so I added a small one for invalid type variable names and, more importantly, I added various tests covering all error messages related to inclusion checks for the class language.
Several unpaired opens of pretty-printing boxes in the error messages have also been removed to prevent printing errors.

I also used those tests to check that the coverage report works fine: after adding tests, the expected parts of the code were highlighted ([before](https://lereena.github.io/coverage/typing/includeclass.ml.html), [after](https://lereena.github.io/coverage_extended/typing/includeclass.ml.html)).

The bisect_ppx integration work is done under the guidance of @Octachron and @shindere.