### PR TITLE
Fix missing newlines when buffering MSVC output

### DIFF
--- a/Changes
+++ b/Changes
@@ -161,6 +161,9 @@ Working version
 - #8862, #8871: subst: preserve scopes
   (Thomas Refis, report by Leo White)
 
+- #8875: fix missing newlines in the output from MSVC invocation.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 OCaml 4.09.0
 ------------
 

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -58,9 +58,9 @@ let display_msvc_output file name =
   try
     let first = input_line c in
     if first <> Filename.basename name then
-      print_string first;
+      print_endline first;
     while true do
-      print_string (input_line c)
+      print_endline (input_line c)
     done
   with _ ->
     close_in c;


### PR DESCRIPTION
Before:
```
$ ocamlc.opt.exe -o b.obj b.c
b.c(4): error C2086: 'int a': redefinitionb.c(3): note: see declaration of 'a'b.c(5): error C2086: 'int a': redefinitionb.c(3): note: see declaration of 'a'
```
After:
```
$ ~/ocaml/ocamlc.opt -o b.obj b.c
b.c(4): error C2086: 'int a': redefinition
b.c(3): note: see declaration of 'a'
b.c(5): error C2086: 'int a': redefinition
b.c(3): note: see declaration of 'a'
```