### PR TITLE
Fix tool check-parser-uptodate-or-warn.sh

### DIFF
--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -24,14 +24,14 @@
 # seconds after boot/menhir/parser.ml.
 
 # mtime(): access a file's last modification time as a timestamp,
-# using either GNU coreutils' stat --format, or BSD/macos stat -f.
+# using either GNU coreutils' stat -c, or BSD/macos stat -f.
 # Default to 0 if 'stat' is not available.
 
 stat . 2>/dev/null 1>/dev/null
 if test $? != 0
 then MTIME=""
-elif test -n "$(stat --version 2>/dev/null | grep coreutils)"
-then MTIME="stat --format %Y"
+elif stat -c %Y . 2>/dev/null 1>/dev/null
+then MTIME="stat -c %Y"
 else MTIME="stat -f %m"
 fi
 


### PR DESCRIPTION
OCaml 4.08 does not compile in Alpine Linux. Indeed, this Linux distribution uses BusyBox which supports neither `stat --format %Y` nor `stat -f %m`. Thus, instead of checking the version of stat, we test whether `stat -c %Y` (supported by both GNU coreutils and BusyBox) works.