### PR TITLE
Call linker even when Clflags.objfiles is empty

### DIFF
--- a/Changes
+++ b/Changes
@@ -126,6 +126,9 @@ Working version
   (Gabriel Scherer, review by David Allsopp and Florian Angeletti
    and Daniel Bünzli, report by Robin Björklin)
 
+- #8877: Call the linker when ocamlopt is invoked with .o and .a files only.
+  (Greta Yorsh, review by Leo White)
+
 ### Internal/compiler-libs changes:
 
 - #9243, simplify parser rules for array indexing operations

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -600,6 +600,7 @@ let get_objfiles ~with_ocamlparam =
   else
     List.rev !objfiles
 
+let has_linker_inputs = ref false
 
 
 
@@ -653,8 +654,10 @@ let process_action
       else if Filename.check_suffix name ".cmi" && !make_package then
         objfiles := name :: !objfiles
       else if Filename.check_suffix name Config.ext_obj
-           || Filename.check_suffix name Config.ext_lib then
+           || Filename.check_suffix name Config.ext_lib then begin
+        has_linker_inputs := true;
         ccobjs := name :: !ccobjs
+      end
       else if not !native_code && Filename.check_suffix name Config.ext_dll then
         dllibs := name :: !dllibs
       else

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -37,6 +37,7 @@ val last_objfiles : string list ref
 val first_objfiles : string list ref
 
 val stop_early : bool ref
+val has_linker_inputs : bool ref
 
 type filename = string
 

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -106,7 +106,8 @@ let main argv ppf =
           (Compenv.get_objfiles ~with_ocamlparam:false) target);
       Warnings.check_fatal ();
     end
-    else if not !Compenv.stop_early && !objfiles <> [] then begin
+    else if not !Compenv.stop_early &&
+            (!objfiles <> [] || !Compenv.has_linker_inputs) then begin
       let target =
         if !output_c_object then
           let s = Compenv.extract_output !output_name in


### PR DESCRIPTION
I've encountered a surprising behavior of ocamlopt: it silently ignores some input .o and .a files, when compilation is done separately from linking. Here is how it happens:
```
$ ls
test.ml
$ ocamlopt test.ml -c
$ ocamlopt test.o -o test.exe
$ ls test.exe
<what do you expect? well, test.exe is not there!! >
```
It doesn't happen when at least one of the inputs is cmx or cmxa.

The linker is not called, because there are no input files to compile. That is, optmain discovers that Clflags.objfiles is empty and doesn't call link. The problem is that some link targets are in Clflags.ccobjs not in Clflags.objfiles.

This issue can cause missing files go unnoticed. For example, the following command returns successfully (i.e., with exit code 0), even when there is no `t.o` file:
```
ocamlopt t.o -o test.exe -verbose
```
It does not report an error, as would happen with other input file types, such as .ml and .cmx.  Of course, it does not generate test.exe either.

Normally, .o and .a files are passed to the linker directly, without checking if the files exist, because the linker would fail with an error if they don't.  However, in the above example, the linker was not called, because there were no input files to compile.

This one line PR removes the check that Clflags.objfiles is not empty before link.  I am not entirely sure that this won't have bad consequences, but it seems that asmlink works just fine with an empty Clflags.objfiles. Tests pass. 

