### PR TITLE
Add String.hash and String.seeded_hash

### DIFF
--- a/Changes
+++ b/Changes
@@ -125,6 +125,9 @@ Working version
   the same module.
   (Nicolás Ojeda Bär, review by Gabriel Scherer and Xavier Leroy)
 
+- #8878: Add String.hash and String.seeded_hash.
+  (Tom Kelly, review by Alain Frisch and Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 * #9071, #9100, #10935: Reimplement `Thread.exit()` as raising the

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -297,6 +297,15 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
   return Val_int(h & 0x3FFFFFFFU);
 }
 
+CAMLprim value caml_hash_string(value seed, value string)
+{
+  uint32_t h;
+  h = Int_val(seed);
+  h = caml_hash_mix_string (h, string);
+  FINAL_MIX(h);
+  return Val_int(h & 0x3FFFFFFFU);
+}
+
 /* Hashing variant tags */
 
 CAMLexport value caml_hash_variant(char const * tag)

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -297,7 +297,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
   return Val_int(h & 0x3FFFFFFFU);
 }
 
-CAMLprim value caml_hash_string(value seed, value string)
+CAMLprim value caml_string_hash(value seed, value string)
 {
   uint32_t h;
   h = Int_val(seed);

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -222,6 +222,10 @@ let ends_with ~suffix s =
     else aux (i + 1)
   in diff >= 0 && aux 0
 
+external seeded_hash_param : int -> 'a -> int = "caml_hash_string" [@@noalloc]
+let hash x = seeded_hash_param 0 x
+let seeded_hash seed x = seeded_hash_param seed x
+
 (* duplicated in bytes.ml *)
 let split_on_char sep s =
   let r = ref [] in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -222,7 +222,7 @@ let ends_with ~suffix s =
     else aux (i + 1)
   in diff >= 0 && aux 0
 
-external seeded_hash_param : int -> 'a -> int = "caml_hash_string" [@@noalloc]
+external seeded_hash_param : int -> 'a -> int = "caml_string_hash" [@@noalloc]
 let hash x = seeded_hash_param 0 x
 let seeded_hash seed x = seeded_hash_param seed x
 

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -222,9 +222,8 @@ let ends_with ~suffix s =
     else aux (i + 1)
   in diff >= 0 && aux 0
 
-external seeded_hash_param : int -> 'a -> int = "caml_string_hash" [@@noalloc]
-let hash x = seeded_hash_param 0 x
-let seeded_hash seed x = seeded_hash_param seed x
+external seeded_hash : int -> string -> int = "caml_string_hash" [@@noalloc]
+let hash x = seeded_hash 0 x
 
 (* duplicated in bytes.ml *)
 let split_on_char sep s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -494,16 +494,18 @@ val get_int32_ne : string -> int -> int32
 *)
 
 val hash : t -> int
-(** The hash function for strings, with the same specification as
-    {!Hashtbl.hash}. Along with the type [t], this function [hash]
-    allows the module [String] to be passed as argument to the functor
-    {!HashTbl.Make}.
+(** An unseeded hash function for strings, with the same output value as
+    {!Hashtbl.hash}. This function allows this module to be passed as argument
+    to the functor {!Hashtbl.Make}.
+
     @since 5.0.0 *)
 
 val seeded_hash : int -> t -> int
-(** A seeded hash function for strings, with the same specification as
-    {!Hashtbl.seeded_hash}.
-    @since 5.0.0. *)
+(** A seeded hash function for strings, with the same output value as
+    {!Hashtbl.seeded_hash}. This function allows this module to be passed as
+    argument to the functor {!Hashtbl.MakeSeeded}.
+
+    @since 5.0.0 *)
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -493,6 +493,18 @@ val get_int32_ne : string -> int -> int32
     @since 4.13.0
 *)
 
+val hash : t -> int
+(** The hash function for strings, with the same specification as
+    {!Hashtbl.hash}. Along with the type [t], this function [hash]
+    allows the module [String] to be passed as argument to the functor
+    {!HashTbl.Make}.
+    @since 5.0.0 *)
+
+val seeded_hash : int -> t -> int
+(** A seeded hash function for strings, with the same specification as
+    {!Hashtbl.seeded_hash}.
+    @since 5.0.0. *)
+
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer
     starting at character index [i].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -495,14 +495,17 @@ val get_int32_ne : string -> int -> int32
 
 val hash : t -> int
 (** An unseeded hash function for strings, with the same output value as
-    {!Hashtbl.hash}.
-    @since 4.10.0 *)
+    {!Hashtbl.hash}. This function allows this module to be passed as argument
+    to the functor {!Hashtbl.Make}.
+
+    @since 5.0.0 *)
 
 val seeded_hash : int -> t -> int
 (** A seeded hash function for strings, with the same output value as
-    {!Hashtbl.seeded_hash}. This function allows the module [StringLabels]
-    to be passed as argument to the functor {!Hashtbl.MakeSeeded}.
-    @since 4.10.0 *)
+    {!Hashtbl.seeded_hash}. This function allows this module to be passed as
+    argument to the functor {!Hashtbl.MakeSeeded}.
+
+    @since 5.0.0 *)
 
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -493,6 +493,17 @@ val get_int32_ne : string -> int -> int32
     @since 4.13.0
 *)
 
+val hash : t -> int
+(** An unseeded hash function for strings, with the same output value as
+    {!Hashtbl.hash}.
+    @since 4.10.0 *)
+
+val seeded_hash : int -> t -> int
+(** A seeded hash function for strings, with the same output value as
+    {!Hashtbl.seeded_hash}. This function allows the module [StringLabels]
+    to be passed as argument to the functor {!Hashtbl.MakeSeeded}.
+    @since 4.10.0 *)
+
 val get_int32_be : string -> int -> int32
 (** [get_int32_be b i] is [b]'s big-endian 32-bit integer
     starting at character index [i].

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -5,7 +5,7 @@
 
 open Printf
 
-module Test(H: Hashtbl.S) (M: Map.S with type key = H.key) = struct
+module Test(H: Hashtbl.SeededS) (M: Map.S with type key = H.key) = struct
 
   let incl_mh m h =
     try
@@ -85,31 +85,31 @@ module SS = struct
   type t = string
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.hash
+  let hash = Hashtbl.seeded_hash
 end
 module SI = struct
   type t = int
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.hash
+  let hash = Hashtbl.seeded_hash
 end
 module SSP = struct
   type t = string*string
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.hash
+  let hash = Hashtbl.seeded_hash
 end
 module SSL = struct
   type t = string list
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.hash
+  let hash = Hashtbl.seeded_hash
 end
 module SSA = struct
   type t = string array
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.hash
+  let hash = Hashtbl.seeded_hash
 end
 
 module MS = Map.Make(SS)
@@ -121,11 +121,11 @@ module MSA = Map.Make(SSA)
 
 (* Generic hash wrapped as a functorial hash *)
 
-module HofM (M: Map.S) : Hashtbl.S with type key = M.key =
+module HofM (M: Map.S) : Hashtbl.SeededS with type key = M.key =
   struct
     type key = M.key
     type 'a t = (key, 'a) Hashtbl.t
-    let create s = Hashtbl.create s
+    let create ?random:bool s = Hashtbl.create s
     let clear = Hashtbl.clear
     let reset = Hashtbl.reset
     let copy = Hashtbl.copy
@@ -156,16 +156,16 @@ module HSL = HofM(MSL)
 
 (* Specific functorial hashes *)
 
-module HS2 = Hashtbl.Make(SS)
-module HS3 = Hashtbl.Make(String)
-module HI2 = Hashtbl.Make(SI)
+module HS2 = Hashtbl.MakeSeeded(SS)
+module HS3 = Hashtbl.MakeSeeded(String)
+module HI2 = Hashtbl.MakeSeeded(SI)
 
 (* Specific weak functorial hashes *)
-module WS = Ephemeron.K1.Make(SS)
-module WSP1 = Ephemeron.K1.Make(SSP)
-module WSP2 = Ephemeron.K2.Make(SS)(SS)
-module WSL = Ephemeron.K1.Make(SSL)
-module WSA = Ephemeron.Kn.Make(SS)
+module WS = Ephemeron.K1.MakeSeeded(SS)
+module WSP1 = Ephemeron.K1.MakeSeeded(SSP)
+module WSP2 = Ephemeron.K2.MakeSeeded(SS)(SS)
+module WSL = Ephemeron.K1.MakeSeeded(SSL)
+module WSA = Ephemeron.Kn.MakeSeeded(SS)
 
 (* Instantiating the test *)
 

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -85,31 +85,31 @@ module SS = struct
   type t = string
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.seeded_hash
+  let seeded_hash = Hashtbl.seeded_hash
 end
 module SI = struct
   type t = int
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.seeded_hash
+  let seeded_hash = Hashtbl.seeded_hash
 end
 module SSP = struct
   type t = string*string
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.seeded_hash
+  let seeded_hash = Hashtbl.seeded_hash
 end
 module SSL = struct
   type t = string list
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.seeded_hash
+  let seeded_hash = Hashtbl.seeded_hash
 end
 module SSA = struct
   type t = string array
   let compare (x:t) (y:t) = Stdlib.compare x y
   let equal (x:t) (y:t) = x=y
-  let hash = Hashtbl.seeded_hash
+  let seeded_hash = Hashtbl.seeded_hash
 end
 
 module MS = Map.Make(SS)

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -157,6 +157,7 @@ module HSL = HofM(MSL)
 (* Specific functorial hashes *)
 
 module HS2 = Hashtbl.Make(SS)
+module HS3 = Hashtbl.Make(String)
 module HI2 = Hashtbl.Make(SI)
 
 (* Specific weak functorial hashes *)
@@ -170,6 +171,7 @@ module WSA = Ephemeron.Kn.Make(SS)
 
 module TS1 = Test(HS1)(MS)
 module TS2 = Test(HS2)(MS)
+module TS3 = Test(HS3)(MS)
 module TI1 = Test(HI1)(MI)
 module TI2 = Test(HI2)(MI)
 module TSP = Test(HSP)(MSP)
@@ -246,6 +248,8 @@ let _ =
   TS1.test d;
   printf "-- Strings, functorial interface\n%!";
   TS2.test d;
+  printf "-- Strings, functorial(String) interface\n%!";
+  TS3.test d;
   printf "-- Pairs of strings\n%!";
   TSP.test (pair_data d);
   printf "-- Lists of strings\n%!";

--- a/testsuite/tests/lib-hashtbl/htbl.reference
+++ b/testsuite/tests/lib-hashtbl/htbl.reference
@@ -14,6 +14,10 @@ Removal: passed
 Insertion: passed
 Insertion: passed
 Removal: passed
+-- Strings, functorial(String) interface
+Insertion: passed
+Insertion: passed
+Removal: passed
 -- Pairs of strings
 Insertion: passed
 Insertion: passed

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -40,6 +40,11 @@ let () =
   done
 ;;
 
+
+let () =
+  assert((Hashtbl.hash raw_string) = (String.hash raw_string))
+;;
+
 (* GPR#805/815/833 *)
 
 let ()  =

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -1,5 +1,6 @@
 (* TEST
 *)
+open Printf
 
 let rec build_string f n accu =
   if n <= 0
@@ -42,7 +43,10 @@ let () =
 
 
 let () =
-  assert((Hashtbl.hash raw_string) = (String.hash raw_string))
+  printf "-- Hashtbl.hash raw_string: %x \n%!" (Hashtbl.hash raw_string);
+  printf "-- String.unseeded_hash raw_string: %x \n%!" (String.unseeded_hash raw_string);
+  printf "-- Hashtbl.seeded_hash 16 raw_string: %x \n%!" (Hashtbl.seeded_hash 16 raw_string);
+  printf "-- String.hash 16 raw_string: %x \n%!" (String.hash 16 raw_string);
 ;;
 
 (* GPR#805/815/833 *)

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -43,10 +43,10 @@ let () =
 
 
 let () =
-  printf "-- Hashtbl.hash raw_string: %x \n%!" (Hashtbl.hash raw_string);
-  printf "-- String.unseeded_hash raw_string: %x \n%!" (String.unseeded_hash raw_string);
-  printf "-- Hashtbl.seeded_hash 16 raw_string: %x \n%!" (Hashtbl.seeded_hash 16 raw_string);
-  printf "-- String.hash 16 raw_string: %x \n%!" (String.hash 16 raw_string);
+  printf "-- Hashtbl.hash raw_string: %x\n%!" (Hashtbl.hash raw_string);
+  printf "-- String.unseeded_hash raw_string: %x\n%!" (String.hash raw_string);
+  printf "-- Hashtbl.seeded_hash 16 raw_string: %x\n%!" (Hashtbl.seeded_hash 16 raw_string);
+  printf "-- String.hash 16 raw_string: %x\n%!" (String.seeded_hash 16 raw_string);
 ;;
 
 (* GPR#805/815/833 *)

--- a/testsuite/tests/lib-string/test_string.reference
+++ b/testsuite/tests/lib-string/test_string.reference
@@ -1,0 +1,4 @@
+-- Hashtbl.hash raw_string: 240a0e56 
+-- String.unseeded_hash raw_string: 240a0e56 
+-- Hashtbl.seeded_hash 16 raw_string: 3210af30 
+-- String.hash 16 raw_string: 3210af30 

--- a/testsuite/tests/lib-string/test_string.reference
+++ b/testsuite/tests/lib-string/test_string.reference
@@ -1,4 +1,4 @@
--- Hashtbl.hash raw_string: 240a0e56 
--- String.unseeded_hash raw_string: 240a0e56 
--- Hashtbl.seeded_hash 16 raw_string: 3210af30 
--- String.hash 16 raw_string: 3210af30 
+-- Hashtbl.hash raw_string: 240a0e56
+-- String.unseeded_hash raw_string: 240a0e56
+-- Hashtbl.seeded_hash 16 raw_string: 3210af30
+-- String.hash 16 raw_string: 3210af30


### PR DESCRIPTION
This PR adds a specialization of `caml_hash` for type `string` and adds it to the stdlib `String` module. 

There are two motivations for this change:
 (i) It allows the user to easily improve the performance of their string hash tables by using the new string hash function.
 (ii) It allows the user to easily create a string based hash table with less boiler plate `Hashtbl.Make(String)`. Within stdlib you can already do `Map.Make(String)` and when using zarith `Hashtbl.Make(Z)` works.

We can add further definitions of `hash` across stdlib to get (ii) for more types, which could be desirable.

The performance impact of the change will vary depending on the length of the string being hashed. Micro-benchmarking the change, I see the following results:
```
string length    old (s)  new (s)  improvement (%)
            8      0.225    0.156             30.6
           16      0.252    0.194             22.9
           32      0.322    0.253             21.3
           64      0.461    0.393             14.8
          128      0.775     0.74             4.52
          256       1.45     1.36             6.02
          512        2.8     2.73             2.55
```
with this code:
```ocaml
let rec test fn test_str n_iter acc =
  match n_iter with
    | 0 -> acc
    | n ->
      let h = fn test_str in
      test fn test_str (n_iter-1) (acc+h)
```
and 10,000,000 iterations on a x86 E5-2430L v2.

These results suggest a reasonable performance improvement for strings up to 128 characters in length. These results are consistent with (the identical) specialization used in the Base library:
https://github.com/janestreet/base/blob/master/src/string.ml#L839

I also tried the change (from `Hashtbl.hash` to `String.hash`) in the F* compiler and it showed a 4-5% improvement in the F* user library benchmark (in aggregate across the whole suite).
