### PR TITLE
Warn about unused local modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -141,6 +141,9 @@ Working version
       has been defined as private
   (Leo White, review by Thomas Refis)
 
+- #8885: Warn about unused local modules
+  (Thomas Refis, review by Alain Frisch)
+
 ### Build system:
 
 - #8650: ensure that "make" variables are defined before use;

--- a/asmcomp/amd64/scheduling.ml
+++ b/asmcomp/amd64/scheduling.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let _ = let module M = Schedgen in () (* to create a dependency *)
+open! Schedgen (* to create a dependency *)
 
 (* Scheduling is turned off because the processor schedules dynamically
    much better than what we could do. *)

--- a/asmcomp/arm64/scheduling.ml
+++ b/asmcomp/arm64/scheduling.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let _ = let module M = Schedgen in () (* to create a dependency *)
+open! Schedgen (* to create a dependency *)
 
 (* Scheduling is turned off because the processor schedules dynamically
    much better than what we could do. *)

--- a/asmcomp/i386/scheduling.ml
+++ b/asmcomp/i386/scheduling.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let () = let module M = Schedgen in () (* to create a dependency *)
+open! Schedgen (* to create a dependency *)
 
 (* Scheduling is turned off because our model does not fit the 486
    nor the Pentium very well. In particular, it messes up with the

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -678,7 +678,6 @@ let subst update_env s lam =
     let remove_list l s =
       List.fold_left (fun s (id, _kind) -> Ident.Map.remove id s) s l
     in
-    let module M = Ident.Map in
     match lam with
     | Lvar id as l ->
         begin try Ident.Map.find id s with Not_found -> l end

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -1630,7 +1630,6 @@ let rec simplify_program_body env r (program : Flambda.program_body)
     let approx =
       A.augment_with_symbol (A.value_block tag (Array.of_list approxs)) symbol
     in
-    let module Backend = (val (E.backend env) : Backend_intf.S) in
     let env = E.add_symbol env symbol approx in
     let program, r = simplify_program_body env r program in
     Initialize_symbol (symbol, tag, fields, program), r

--- a/middle_end/flambda/lift_code.ml
+++ b/middle_end/flambda/lift_code.ml
@@ -87,7 +87,6 @@ and lift_lets_named_with_free_variables
     var, named
 
 and lift_lets_named _var (named:Flambda.named) ~toplevel : Flambda.named =
-  let module W = Flambda.With_free_variables in
   match named with
   | Expr e ->
     Expr (lift_lets_expr e ~toplevel)

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -343,6 +343,10 @@ let not_ambiguous__module_variable x b =  match x with
   | _ -> 2
 ;;
 [%%expect {|
+Line 2, characters 12-13:
+2 |   | (module M:S),_,(1,_)
+                ^
+Warning 60: unused module M.
 val not_ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 |}]

--- a/testsuite/tests/warnings/w60.compilers.reference
+++ b/testsuite/tests/warnings/w60.compilers.reference
@@ -1,0 +1,4 @@
+File "w60.ml", line 40, characters 13-14:
+40 |   let module M = struct end in
+                  ^
+Warning 60: unused module M.

--- a/testsuite/tests/warnings/w60.ml
+++ b/testsuite/tests/warnings/w60.ml
@@ -36,6 +36,6 @@ module O = M.N
 (***************)
 
 let () =
-  (* M is unused, but no warning is emitted. *)
+  (* M is unused, but no warning was emitted before 4.10. *)
   let module M = struct end in
   ()

--- a/testsuite/tests/warnings/w60.ml
+++ b/testsuite/tests/warnings/w60.ml
@@ -32,3 +32,10 @@ module M = struct
 end
 
 module O = M.N
+
+(***************)
+
+let () =
+  (* M is unused, but no warning is emitted. *)
+  let module M = struct end in
+  ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2000,7 +2000,7 @@ let create_package_type loc env (p, l) =
    let open Ast_helper in
    List.fold_left
      (fun sexp (name, loc) ->
-       Exp.letmodule ~loc:sexp.pexp_loc
+        Exp.letmodule ~loc:{ sexp.pexp_loc with loc_ghost = true }
          ~attrs:[Attr.mk (mknoloc "#modulepat") (PStr [])]
          name
          (Mod.unpack ~loc
@@ -2984,8 +2984,11 @@ and type_expect_
         | _ -> Mp_present
       in
       let scope = create_scope () in
+      let md =
+        { md_type = modl.mod_type; md_attributes = []; md_loc = name.loc }
+      in
       let (id, new_env) =
-        Env.enter_module ~scope name.txt pres modl.mod_type env
+        Env.enter_module_declaration ~scope name.txt pres md env
       in
       Typetexp.widen context;
       (* ideally, we should catch Expr_type_clash errors


### PR DESCRIPTION
The use of `Env.enter_module` in `Typecore` was incorrect: not only does it use `Location.none` as the location for the module declaration, it also turns off the usage checks (unused warning, and alerts on use) for that module.

This PR fixes that by replacing the call to `Env.enter_module` by `Env.enter_module_declaration`, and fixes the places in the codebase where warning 60 triggered for local modules.

Additionally, there is some fiddling with locations to get better error messages.