### PR TITLE
type_package: packaged modules are not functor args

### DIFF
--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2356,7 +2356,7 @@ let type_package env m p nl =
         -> (mp, env)  (* PR#6982 *)
     | _ ->
       let (id, new_env) =
-        Env.enter_module ~scope ~arg:true "%M" Mp_present modl.mod_type env
+        Env.enter_module ~scope "%M" Mp_present modl.mod_type env
       in
       (Pident id, new_env)
   in


### PR DESCRIPTION
As far as I can tell, this was a typo in 9ddb346: not only is the module declaration we synthesize not for a functor argument, I also don't see how one could alias it.