### PR TITLE
in -dtimings output, show time spent in C linker clearly

### DIFF
--- a/.depend
+++ b/.depend
@@ -1515,7 +1515,6 @@ typing/typetexp.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    typing/includemod.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -1536,7 +1535,6 @@ typing/typetexp.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-    typing/includemod.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
@@ -1552,7 +1550,6 @@ typing/typetexp.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    typing/includemod.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -6022,7 +6019,6 @@ toplevel/opttopstart.cmx : \
     toplevel/opttopmain.cmx
 toplevel/topdirs.cmo : \
     utils/warnings.cmi \
-    typing/typetexp.cmi \
     typing/types.cmi \
     toplevel/trace.cmi \
     toplevel/toploop.cmi \
@@ -6051,7 +6047,6 @@ toplevel/topdirs.cmo : \
     toplevel/topdirs.cmi
 toplevel/topdirs.cmx : \
     utils/warnings.cmx \
-    typing/typetexp.cmx \
     typing/types.cmx \
     toplevel/trace.cmx \
     toplevel/toploop.cmx \

--- a/.depend
+++ b/.depend
@@ -9,12 +9,14 @@ utils/build_path_prefix_map.cmx : \
     utils/build_path_prefix_map.cmi
 utils/build_path_prefix_map.cmi :
 utils/ccomp.cmo : \
+    utils/profile.cmi \
     utils/misc.cmi \
     utils/load_path.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi
 utils/ccomp.cmx : \
+    utils/profile.cmx \
     utils/misc.cmx \
     utils/load_path.cmx \
     utils/config.cmx \

--- a/Changes
+++ b/Changes
@@ -45,6 +45,8 @@ Working version
 - #7924: Use a variant instead of an int in Bad_variance exception
   (Rian Douglas, review by Gabriel Scherer)
 
+- #8890: in -dtimings output, show time spent in C linker clearly
+  (Valentin Gatien-Baron)
 
 ### Code generation and optimizations:
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -166,7 +166,7 @@ clean::
 OCAMLMKTOP=ocamlmktop.cmo
 OCAMLMKTOP_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo \
        identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo \
-       load_path.cmo ccomp.cmo
+       load_path.cmo profile.cmo ccomp.cmo
 
 $(call byte_and_opt,ocamlmktop,$(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP),)
 

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -181,33 +181,35 @@ let remove_Wl cclibs =
     else cclib)
 
 let call_linker mode output_name files extra =
-  let cmd =
-    if mode = Partial then
-      let l_prefix =
-        match Config.ccomp_type with
-        | "msvc" -> "/libpath:"
-        | _ -> "-L"
-      in
-      Printf.sprintf "%s%s %s %s %s"
-        Config.native_pack_linker
-        (Filename.quote output_name)
-        (quote_prefixed l_prefix (Load_path.get_paths ()))
-        (quote_files (remove_Wl files))
-        extra
-    else
-      Printf.sprintf "%s -o %s %s %s %s %s %s"
-        (match !Clflags.c_compiler, mode with
-        | Some cc, _ -> cc
-        | None, Exe -> Config.mkexe
-        | None, Dll -> Config.mkdll
-        | None, MainDll -> Config.mkmaindll
-        | None, Partial -> assert false
-        )
-        (Filename.quote output_name)
-        ""  (*(Clflags.std_include_flag "-I")*)
-        (quote_prefixed "-L" (Load_path.get_paths ()))
-        (String.concat " " (List.rev !Clflags.all_ccopts))
-        (quote_files files)
-        extra
-  in
-  command cmd = 0
+  Profile.record_call "c-linker" (fun () ->
+    let cmd =
+      if mode = Partial then
+        let l_prefix =
+          match Config.ccomp_type with
+          | "msvc" -> "/libpath:"
+          | _ -> "-L"
+        in
+        Printf.sprintf "%s%s %s %s %s"
+          Config.native_pack_linker
+          (Filename.quote output_name)
+          (quote_prefixed l_prefix (Load_path.get_paths ()))
+          (quote_files (remove_Wl files))
+          extra
+      else
+        Printf.sprintf "%s -o %s %s %s %s %s %s"
+          (match !Clflags.c_compiler, mode with
+          | Some cc, _ -> cc
+          | None, Exe -> Config.mkexe
+          | None, Dll -> Config.mkdll
+          | None, MainDll -> Config.mkmaindll
+          | None, Partial -> assert false
+          )
+          (Filename.quote output_name)
+          ""  (*(Clflags.std_include_flag "-I")*)
+          (quote_prefixed "-L" (Load_path.get_paths ()))
+          (String.concat " " (List.rev !Clflags.all_ccopts))
+          (quote_files files)
+          extra
+    in
+    command cmd = 0
+  )


### PR DESCRIPTION
Before:

```
$ ./ocamlopt.opt -I otherlibs/unix -I stdlib -dtimings unix.cmxa -o foo
0.134s foo
  0.001s selection
  0.001s cse
  0.002s liveness
  0.001s spill
  0.001s split
  0.007s regalloc
  0.001s emit
  0.011s assemble
  0.109s other
0.008s other
```

After:
```
$ ./ocamlopt.opt -I otherlibs/unix -I stdlib -dtimings unix.cmxa -o foo
0.130s foo
  0.001s selection
  0.001s cse
  0.002s liveness
  0.001s spill
  0.001s split
  0.007s regalloc
  0.001s emit
  0.011s assemble
  0.100s c-linker
  0.004s other
0.006s other
```
