### PR TITLE
Get rid of /bytecomp/runtimedef.ml in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,6 @@ _build
 /boot/camlheader
 /boot/ocamlc.opt
 
-/bytecomp/runtimedef.ml
 /bytecomp/opcodes.ml
 /bytecomp/opcodes.mli
 


### PR DESCRIPTION
This file is no longer generated since #2281, and keeping an old one
makes `make depend` produce an invalid file.

No change entry needed