### PR TITLE
Fix definition of Is_young when CAML_INTERNALS isn't defined

### DIFF
--- a/Changes
+++ b/Changes
@@ -338,6 +338,10 @@ Working version
   (Vincent Laviron, review by Pierre Chambart and Leo White,
    report by Aleksandr Kuzmenko)
 
+- #8892, #8895: fix the definition of Is_young when CAML_INTERNALS is not
+  defined.
+  (David Allsopp)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -27,8 +27,8 @@
 
 #define Is_young(val) \
   (CAMLassert (Is_block (val)), \
-   (addr)(val) < (addr)Caml_state_field(young_end) && \
-   (addr)(val) > (addr)Caml_state_field(young_start))
+   (char *)(val) < (char *)Caml_state_field(young_end) && \
+   (char *)(val) > (char *)Caml_state_field(young_start))
 
 #define Is_in_heap(a) (Classify_addr(a) & In_heap)
 


### PR DESCRIPTION
Fixes #8892