### PR TITLE
Deprecate the addr typedef

### DIFF
--- a/Changes
+++ b/Changes
@@ -340,7 +340,10 @@ Working version
 
 - #8892, #8895: fix the definition of Is_young when CAML_INTERNALS is not
   defined.
-  (David Allsopp)
+  (David Allsopp, review by Xavier Leroy)
+
+- #8896: deprecate addr typedef in misc.h
+  (David Allsopp, suggestion by Xavier Leroy)
 
 OCaml 4.09 maintenance branch:
 ------------------------------

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -38,8 +38,20 @@ typedef size_t asize_t;
 #define NULL 0
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+  /* Supported since at least GCC 3.1 */
+  #define CAMLdeprecated_typedef(name, type) \
+    typedef type name __attribute ((deprecated))
+#elif _MSC_VER >= 1310
+  /* NB deprecated("message") only supported from _MSC_VER >= 1400 */
+  #define CAMLdeprecated_typedef(name, type) \
+    typedef __declspec(deprecated) type name
+#else
+  #define CAMLdeprecated_typedef(name, type) typedef type name
+#endif
+
 #ifdef CAML_INTERNALS
-typedef char * addr;
+CAMLdeprecated_typedef(addr, char *);
 #endif /* CAML_INTERNALS */
 
 /* Noreturn is preserved for compatibility reasons.

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -456,13 +456,13 @@ void caml_shrink_heap (char *chunk)
 
 color_t caml_allocation_color (void *hp)
 {
-  if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean
-      || (caml_gc_phase == Phase_sweep && (addr)hp >= (addr)caml_gc_sweep_hp)){
+  if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean ||
+      (caml_gc_phase == Phase_sweep && (char *)hp >= (char *)caml_gc_sweep_hp)){
     return Caml_black;
   }else{
     CAMLassert (caml_gc_phase == Phase_idle
             || (caml_gc_phase == Phase_sweep
-                && (addr)hp < (addr)caml_gc_sweep_hp));
+                && (char *)hp < (char *)caml_gc_sweep_hp));
     return Caml_white;
   }
 }
@@ -497,13 +497,13 @@ static inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
   CAMLassert (Is_in_heap (Val_hp (hp)));
 
   /* Inline expansion of caml_allocation_color. */
-  if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean
-      || (caml_gc_phase == Phase_sweep && (addr)hp >= (addr)caml_gc_sweep_hp)){
+  if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean ||
+      (caml_gc_phase == Phase_sweep && (char *)hp >= (char *)caml_gc_sweep_hp)){
     Hd_hp (hp) = Make_header_with_profinfo (wosize, tag, Caml_black, profinfo);
   }else{
     CAMLassert (caml_gc_phase == Phase_idle
             || (caml_gc_phase == Phase_sweep
-                && (addr)hp < (addr)caml_gc_sweep_hp));
+                && (char *)hp < (char *)caml_gc_sweep_hp));
     Hd_hp (hp) = Make_header_with_profinfo (wosize, tag, Caml_white, profinfo);
   }
   CAMLassert (Hd_hp (hp)


### PR DESCRIPTION
Implements @xavierleroy's suggestion in https://github.com/ocaml/ocaml/issues/8892#issuecomment-524566279

CI will fail as this depends on #8895