### PR TITLE
Ensure that C allocation functions do not trigger callbacks

### DIFF
--- a/Changes
+++ b/Changes
@@ -77,7 +77,7 @@ Working version
    OCaml heap.
    (Jacques-Henri Jourdan, review by Damien Doligez)
 
-- #8691: Allocation functions are now guaranteed not to trigger any
+- #8691, #8897: Allocation functions are now guaranteed not to trigger any
    OCaml callback when called from C.
    (Jacques-Henri Jourdan, review by Stephen Dolan and Gabriel Scherer)
 

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -27,6 +27,7 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/stacks.h"
+#include "caml/signals.h"
 
 #define Setup_for_gc
 #define Restore_after_gc
@@ -52,7 +53,7 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
     if (tag < No_scan_tag){
       for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
     }
-    result = caml_check_urgent_gc (result);
+    result = caml_check_gc_without_async_callbacks (result);
   }
   return result;
 }
@@ -102,7 +103,7 @@ CAMLexport value caml_alloc_string (mlsize_t len)
     Alloc_small (result, wosize, String_tag);
   }else{
     result = caml_alloc_shr (wosize, String_tag);
-    result = caml_check_urgent_gc (result);
+    result = caml_check_gc_without_async_callbacks (result);
   }
   Field (result, wosize - 1) = 0;
   offset_index = Bsize_wsize (wosize) - 1;
@@ -174,7 +175,7 @@ value caml_alloc_float_array(mlsize_t len)
       Alloc_small (result, wosize, Double_array_tag);
   }else {
     result = caml_alloc_shr (wosize, Double_array_tag);
-    result = caml_check_urgent_gc (result);
+    result = caml_check_gc_without_async_callbacks (result);
   }
   return result;
 #else

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -42,6 +42,7 @@ CAMLextern int caml_rev_convert_signal_number (int);
 void caml_execute_signal(int signal_number, int in_signal_handler);
 void caml_record_signal(int signal_number);
 void caml_set_something_to_do (void);
+value caml_check_gc_without_async_callbacks(value root);
 void caml_raise_in_async_callback (value exc);
 void caml_process_event(void);
 int caml_set_signal_action(int signo, int action);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -472,7 +472,7 @@ CAMLexport void caml_gc_dispatch (void)
 }
 
 /* Called by [Alloc_small] when [Caml_state->young_ptr] reaches
-   [caml_young_limit]. We have to either call memprof or the gc. */
+   [caml_young_limit]. We may have to either call memprof or the gc. */
 void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags)
 {
   /* Async callbacks may fill the minor heap again, so we need a while

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -289,6 +289,15 @@ void caml_request_minor_gc (void)
   caml_set_something_to_do();
 }
 
+value caml_check_gc_without_async_callbacks(value extra_root)
+{
+  CAMLparam1 (extra_root);
+  if (Caml_state->requested_major_slice || Caml_state->requested_minor_gc){
+    CAML_INSTR_INT ("force_minor/check_gc_without_async_callbacks@", 1);
+    caml_gc_dispatch();
+  }
+  CAMLreturn (extra_root);
+}
 
 CAMLexport value caml_check_urgent_gc (value extra_root)
 {

--- a/testsuite/tests/c-api/alloc_async.ml
+++ b/testsuite/tests/c-api/alloc_async.ml
@@ -2,7 +2,7 @@
    modules = "alloc_async_stubs.c"
 *)
 
-external test : int ref -> unit = "test"
+external test : int ref -> unit = "stub"
 
 let f () =
   let r = ref 42 in

--- a/testsuite/tests/c-api/alloc_async.ml
+++ b/testsuite/tests/c-api/alloc_async.ml
@@ -1,0 +1,17 @@
+(* TEST
+   modules = "alloc_async_stubs.c"
+*)
+
+external test : int ref -> unit = "test"
+
+let f () =
+  let r = ref 42 in
+  Gc.finalise (fun s -> r := !s) (ref 17);
+  Printf.printf "OCaml, before: %d\n%!" !r;
+  test r;
+  Printf.printf "OCaml, after: %d\n%!" !r;
+  ignore (Sys.opaque_identity (ref 100));
+  Printf.printf "OCaml, after alloc: %d\n%!" !r;
+  ()
+
+let () = (f [@inlined never]) ()

--- a/testsuite/tests/c-api/alloc_async.reference
+++ b/testsuite/tests/c-api/alloc_async.reference
@@ -1,0 +1,5 @@
+OCaml, before: 42
+C, before: 42
+C, after: 42
+OCaml, after: 42
+OCaml, after alloc: 17

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "caml/alloc.h"
+#include "caml/memory.h"
+
+const char* strs[] = { "foo", "bar", 0 };
+value test(value ref)
+{
+  CAMLparam1(ref);
+  CAMLlocal2(x, y);
+  int i; char* s; intnat coll_before;
+
+  printf("C, before: %d\n", Int_val(Field(ref, 0)));
+
+  /* First, do enough major allocation to trigger a major collection */
+  coll_before = Caml_state_field(stat_major_collections);
+  while (Caml_state_field(stat_major_collections) == coll_before) {
+    caml_alloc(10000, 0);
+  }
+
+  /* Now, call lots of allocation functions */
+
+  /* Small allocations */
+  caml_alloc(10, 0);
+  x = caml_alloc_small(2, 0);
+  Field(x, 0) = Val_unit;
+  Field(x, 1) = Val_unit;
+  caml_alloc_tuple(3);
+  caml_alloc_float_array(10);
+  caml_alloc_string(42);
+  caml_alloc_initialized_string(10, "abcdeabcde");
+  caml_copy_string("asoidjfa");
+  caml_copy_string_array(strs);
+  caml_copy_double(42.0);
+  caml_copy_int32(100);
+  caml_copy_int64(100);
+  caml_alloc_array(caml_copy_string, strs);
+  caml_alloc_sprintf("[%d]", 42);
+
+  /* Large allocations */
+  caml_alloc(1000, 0);
+  caml_alloc_shr(1000, 0);
+  caml_alloc_tuple(1000);
+  caml_alloc_float_array(1000);
+  caml_alloc_string(10000);
+  s = calloc(10000, 1);
+  caml_alloc_initialized_string(10000, s);
+  free(s);
+
+
+  printf("C, after: %d\n", Int_val(Field(ref, 0)));
+  fflush(stdout);
+  CAMLreturn (Val_unit);
+}

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -4,7 +4,7 @@
 #include "caml/memory.h"
 
 const char* strs[] = { "foo", "bar", 0 };
-value test(value ref)
+value stub(value ref)
 {
   CAMLparam1(ref);
   CAMLlocal2(x, y);

--- a/testsuite/tests/c-api/ocamltests
+++ b/testsuite/tests/c-api/ocamltests
@@ -1,0 +1,1 @@
+alloc_async.ml


### PR DESCRIPTION
Despite reviewing and merging #8691, I didn't notice a serious bug in that patch: it fails to prevent callbacks during allocation functions in the codepaths that allocate directly to the major heap (for large allocations).

The fix is trivial. Most of the code in this PR is to add some testing for this invariant. The test works by setting up a finaliser, then doing lots of allocation from C and verifying that the finaliser doesn't actually run until control returns to OCaml.
