### PR TITLE
testsuite: add more examples of the Scoping_pack error

### DIFF
--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -470,3 +470,31 @@ Line 4, characters 10-51:
 Error: The type t in this module cannot be exported.
        Its type contains local dependencies: %M.elt list
 |}];;
+
+type 'a s = (module S with type t = 'a);;
+[%%expect{|
+type 'a s = (module S with type t = 'a)
+|}];;
+
+let x : 'a s = (module struct type t = int end);;
+[%%expect{|
+val x : int s = <module>
+|}];;
+
+let x : 'a s = (module struct type t = A end);;
+[%%expect{|
+Line 1, characters 23-44:
+1 | let x : 'a s = (module struct type t = A end);;
+                           ^^^^^^^^^^^^^^^^^^^^^
+Error: The type t in this module cannot be exported.
+       Its type contains local dependencies: %M.t
+|}];;
+
+let x : 'a s = (module struct end);;
+[%%expect{|
+Line 1, characters 23-33:
+1 | let x : 'a s = (module struct end);;
+                           ^^^^^^^^^^
+Error: The type t in this module cannot be exported.
+       Its type contains local dependencies: %M.t
+|}];;


### PR DESCRIPTION
I believe the last of these to is fairly confusing (the error message basically makes no sense?) and could be improved fairly easily.
Ideally the error message you'd get, would be the same as in this situation:
```
# let x = (module struct end : S);;                                                                                                     
Line 1, characters 16-26:
1 | let x = (module struct end : S);;
                    ^^^^^^^^^^
Error: Signature mismatch:
       Modules do not match: sig  end is not included in S
       The type `t' is required but not provided
```

Ping @Armael, @Octachron :see_no_evil: 