### PR TITLE
Don't treat definitions from the current module specially

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,14 @@ Working version
   would previous behave incorrectly, and now results in a clean error.
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
+- #8900: Don't treat definitions from the current module
+  specially. Abstract types defined in the current module were
+  previously treated as incompatible to all other types. That meant that
+  two such types could be used as distinct GADT indices. That will no
+  longer work and distinct GADT indices should now be made incompatible
+  by giving them incompatible definitions.
+  (Leo White, review by Jacques Garrigue and Jeremy Yallop)
+
 - #11879: Bugfix for Ctype.nondep_type
   (Stephen Dolan, review by Gabriel Scherer)
 

--- a/testsuite/tests/typing-gadts/packed-module-recasting.ml
+++ b/testsuite/tests/typing-gadts/packed-module-recasting.ml
@@ -357,7 +357,7 @@ val cast_via_module_type_under_equality2 :
 |}]
 
 (* Test from issue #10768 *)
-type _ t
+type _ t = private T
 
 module type S = sig type t end
 
@@ -389,7 +389,7 @@ let get (type a) : a t -> (module S with type t = a)  = fun index ->
   in
   unpack dispatch
 [%%expect {|
-type _ t
+type _ t = private T
 module type S = sig type t end
 type pack = Pack : 'a t * (module S with type t = 'a) -> pack
 val dispatch : pack list ref = {contents = []}

--- a/testsuite/tests/typing-gadts/pr11492.ml
+++ b/testsuite/tests/typing-gadts/pr11492.ml
@@ -26,6 +26,12 @@ end
 [%%expect {|
 type _ is_int = Int : int is_int
 module F : functor (X : sig end) -> sig type t val int : t is_int end
+Line 16, characters 4-22:
+16 |     fun (Error s) -> s
+         ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Ok Int
 module Foo :
   sig
     type t
@@ -49,6 +55,12 @@ module Bar = struct
 
 end
 [%%expect {|
+Line 8, characters 4-22:
+8 |     fun (Error s) -> s
+        ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Ok Int
 module Bar :
   sig
     module M : sig type t = int val int : int is_int end

--- a/testsuite/tests/typing-gadts/pr11492.ml
+++ b/testsuite/tests/typing-gadts/pr11492.ml
@@ -1,0 +1,60 @@
+(* TEST
+   * expect
+*)
+
+type _ is_int = Int : int is_int
+
+module F (X : sig end) : sig
+  type t
+  val int : t is_int
+end = struct
+  type t = int
+  let int = Int
+end
+
+module Foo = struct
+
+  include F (struct end)
+
+  let f : (t is_int, string) result -> string =
+    fun (Error s) -> s
+
+  let segfault () =
+    print_endline (f (Ok int))
+
+end
+[%%expect {|
+type _ is_int = Int : int is_int
+module F : functor (X : sig end) -> sig type t val int : t is_int end
+module Foo :
+  sig
+    type t
+    val int : t is_int
+    val f : (t is_int, string) result -> string
+    val segfault : unit -> unit
+  end
+|}]
+
+module Bar = struct
+
+  module M = struct type t = int let int = Int end
+
+  include (M : sig type t val int : t is_int end)
+
+  let f : (t is_int, string) result -> string =
+    fun (Error s) -> s
+
+  let segfault () =
+    print_endline (f (Ok int))
+
+end
+[%%expect {|
+module Bar :
+  sig
+    module M : sig type t = int val int : int is_int end
+    type t
+    val int : t is_int
+    val f : (t is_int, string) result -> string
+    val segfault : unit -> unit
+  end
+|}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -47,7 +47,7 @@ module Exp :
 
 module List =
   struct
-    type zero
+    type zero = private Zero
     type _ t =
       | Nil : zero t
       | Cons : 'a * 'b t -> ('a * 'b) t
@@ -66,7 +66,7 @@ module List =
 [%%expect{|
 module List :
   sig
-    type zero
+    type zero = private Zero
     type _ t = Nil : zero t | Cons : 'a * 'b t -> ('a * 'b) t
     val head : ('a * 'b) t -> 'a
     val tail : ('a * 'b) t -> 'b t


### PR DESCRIPTION
The type-checker treats abstract type definitions in the current specially:

```ocaml
# type (_, _) eq = Refl : ('a, 'a) eq;;
    
# module M = struct
      type a
      type b
      let absurd : 'a. (a, b) eq -> 'a = function _ -> .
    end;;
module M : sig type a type b val absurd : (a, b) eq -> 'a end

# module M = struct
      module N = struct
        type a
        type b
      end
      let absurd : 'a. (N.a, N.b) eq -> 'a = function _ -> .
    end;;
Line 6, characters 54-55:
6 |       let absurd : 'a. (N.a, N.b) eq -> 'a = function _ -> .
                                                          ^
Error: This match case could not be refuted.
       Here is an example of a value that would reach it: Refl
```
In my experience this special treatment confuses people a lot and is not really useful for anything.

This PR removes the special treatment. This is not a backwards compatible change so it could probably use some testing on opam.