### PR TITLE
dune: add an alias @libs that is buildable on 4.09

### DIFF
--- a/dune
+++ b/dune
@@ -112,7 +112,7 @@
    symbol variable
 
    ;; middle_end/closure/
-   closure
+   closure closure_middle_end
 
    ;; middle_end/flambda/base_types/
    closure_element closure_id closure_origin export_id id_types mutable_variable
@@ -148,10 +148,10 @@
    ;; asmcomp/
    afl_instrument arch asmgen asmlibrarian asmlink asmpackager branch_relaxation
    branch_relaxation_intf cmm cmmgen cmmgen_state coloring comballoc CSE CSEgen
-   deadcode emit emitaux interf interval linearize linscan liveness mach
-   printcmm printlinear printmach proc reg reload reloadgen schedgen scheduling
-   selectgen selection spacetime_profiling spill split strmatch x86_ast
-   x86_dsl x86_gas x86_masm x86_proc
+   deadcode domainstate emit emitaux interf interval linearize linscan liveness
+   mach printcmm printlinear printmach proc reg reload reloadgen schedgen
+   scheduling selectgen selection spacetime_profiling spill split strmatch
+   x86_ast x86_dsl x86_gas x86_masm x86_proc
 
    ;; asmcomp/debug/
    reg_availability_set compute_ranges_intf available_regs reg_with_debug_info
@@ -206,3 +206,16 @@
        toplevel/ocaml.byte
        toplevel/expunge.exe
        ))
+
+(alias
+  (name libs)
+  (deps
+    ocamloptcomp.cma
+    ocamlmiddleend.cma
+    ocamlcommon.cma
+    runtime/runtime.cma
+    stdlib/stdlib.cma
+    ocamlbytecomp.cma
+    ocamltest/ocamltest_core_and_plugin.cma
+    toplevel/ocamltoplevel.cma
+  ))

--- a/runtime/dune
+++ b/runtime/dune
@@ -33,7 +33,7 @@
           io.c extern.c intern.c hash.c sys.c meta.c parsing.c gc_ctrl.c md5.c
           obj.c lexing.c callback.c debugger.c weak.c compact.c finalise.c
           custom.c dynlink.c spacetime_byt.c afl.c unix.c win32.c bigarray.c
-          main.c)
+          main.c memprof.c domain.c)
  (action
    (progn
      (bash "touch .depend") ; hack.

--- a/utils/dune
+++ b/utils/dune
@@ -19,3 +19,25 @@
           ../Makefile.config
           config.mlp)
  (action  (system "make -f %{mk} %{targets}")))
+
+(rule
+ (targets domainstate.ml)
+ (mode    fallback)
+ (deps    (:conf ../Makefile.config)
+          (:c domainstate.ml.c)
+          (:tbl ../runtime/caml/domain_state.tbl))
+ (action
+   (with-stdout-to %{targets}
+     (bash
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c} %{tbl}"))))
+
+(rule
+ (targets domainstate.mli)
+ (mode    fallback)
+ (deps    (:conf ../Makefile.config)
+          (:c domainstate.mli.c)
+          (:tbl ../runtime/caml/domain_state.tbl))
+ (action
+   (with-stdout-to %{targets}
+     (bash
+       "`grep '^CPP=' %{conf} | cut -d'=' -f2` -I ../runtime/caml %{c} %{tbl}"))))


### PR DESCRIPTION
Also, fixes the build of `@world` when building with trunk.

I discovered the `@world` alias is not as complete as it once was, because @mshinwell has been secretly commenting out part of the dune files.
I find that somewhat frustrating, and impolite, but I don't have time to fix it right now.

---
This PR is "FYI", it only touches dune files, I'm going to merge it.