### PR TITLE
Improve errors for first-class modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -299,6 +299,9 @@ Working version
 - #8891: Warn about unused functor parameters
   (Thomas Refis, review by Gabriel Radanne)
 
+- #8903: Improve errors for first-class modules
+  (Leo White, review by Jacques Garrigue)
+
 - #9046: disable warning 30 by default
   This outdated warning complained on label/constructor name conflicts
   within a mutually-recursive type declarations; there is now no need

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -468,7 +468,7 @@ Line 4, characters 10-51:
 4 |   (module struct type elt = A type t = elt list end : S with type t = _ list)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type t in this module cannot be exported.
-       Its type contains local dependencies: %M.elt list
+       Its type contains local dependencies: elt list
 |}];;
 
 type 'a s = (module S with type t = 'a);;
@@ -487,7 +487,7 @@ Line 1, characters 23-44:
 1 | let x : 'a s = (module struct type t = A end);;
                            ^^^^^^^^^^^^^^^^^^^^^
 Error: The type t in this module cannot be exported.
-       Its type contains local dependencies: %M.t
+       Its type contains local dependencies: t
 |}];;
 
 let x : 'a s = (module struct end);;
@@ -495,6 +495,7 @@ let x : 'a s = (module struct end);;
 Line 1, characters 23-33:
 1 | let x : 'a s = (module struct end);;
                            ^^^^^^^^^^
-Error: The type t in this module cannot be exported.
-       Its type contains local dependencies: %M.t
+Error: Signature mismatch:
+       Modules do not match: sig end is not included in S
+       The type `t' is required but not provided
 |}];;

--- a/testsuite/tests/typing-short-paths/pr7543.compilers.reference
+++ b/testsuite/tests/typing-short-paths/pr7543.compilers.reference
@@ -5,13 +5,10 @@ Line 1, characters 19-20:
 1 | let () = f (module N);;
                        ^
 Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = 'a end
-       is not included in
-         sig type t = N.t end
+       Modules do not match: sig type 'a t = 'a end is not included in S
        Type declarations do not match:
          type 'a t = 'a
        is not included in
-         type t = N.t
+         type t
        They have different arities.
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2478,40 +2478,92 @@ let type_package env m p nl =
   let modl = type_module env m in
   let scope = Ctype.create_scope () in
   Typetexp.widen context;
-  let (mp, env) =
-    match modl.mod_desc with
-    | Tmod_ident (mp,_) -> (mp, env)
-    | Tmod_constraint ({mod_desc=Tmod_ident (mp,_)}, _, Tmodtype_implicit, _)
-        -> (mp, env)  (* PR#6982 *)
-    | _ ->
-      let (id, new_env) =
-        Env.enter_module ~scope "%M" Mp_present modl.mod_type env
+  let nl', tl', env =
+    match nl with
+    | [] -> [], [], env
+    | nl ->
+      let type_path, env =
+        match modl.mod_desc with
+        | Tmod_ident (mp,_)
+        | Tmod_constraint
+            ({mod_desc=Tmod_ident (mp,_)}, _, Tmodtype_implicit, _) ->
+          (* We special case these because interactions between
+             strengthening of module types and packages can cause
+             spurious escape errors. See examples from PR#6982 in the
+             testsuite. This can be removed when such issues are
+             fixed. *)
+          let rec path = function
+            | Lident name -> Pdot(mp, name)
+            | Ldot(m, name) -> Pdot(path m, name)
+            | Lapply _ -> assert false
+          in
+          path, env
+        | _ ->
+          let sg = extract_sig_open env modl.mod_loc modl.mod_type in
+          let sg, env = Env.enter_signature ~scope sg env in
+          let types, modules =
+            List.fold_left
+              (fun acc item ->
+                 match item with
+                 | Sig_type(id, _, _, _) ->
+                     let types, modules = acc in
+                     let types = String.Map.add (Ident.name id) id types in
+                     types, modules
+                 | Sig_module(id, _, _, _, _) ->
+                     let types, modules = acc in
+                     let modules = String.Map.add (Ident.name id) id modules in
+                     types, modules
+                 | _ -> acc)
+              (String.Map.empty, String.Map.empty) sg
+          in
+          let rec module_path = function
+            | Lident name -> Pident (String.Map.find name modules)
+            | Ldot(m, name) -> Pdot(module_path m, name)
+            | Lapply _ -> assert false
+          in
+          let type_path = function
+            | Lident name -> Pident (String.Map.find name types)
+            | Ldot(m, name) -> Pdot(module_path m, name)
+            | Lapply _ -> assert false
+          in
+          type_path, env
       in
-      (Pident id, new_env)
+      let nl', tl' =
+        List.fold_right
+          (fun lid (nl, tl) ->
+             match type_path lid with
+             | exception Not_found -> (nl, tl)
+             | path -> begin
+                 match Env.find_type path env with
+                 | exception Not_found -> (nl, tl)
+                 | decl ->
+                     if decl.type_arity > 0 then begin
+                       (nl, tl)
+                     end else begin
+                       let t = Btype.newgenty (Tconstr (path,[],ref Mnil)) in
+                       (lid :: nl, t :: tl)
+                     end
+               end)
+          nl ([], [])
+      in
+      nl', tl', env
   in
-  let rec mkpath mp = function
-    | Lident name -> Pdot(mp, name)
-    | Ldot (m, name) -> Pdot(mkpath mp m, name)
-    | _ -> assert false
-  in
-  let tl' =
-    List.map
-      (fun name -> Btype.newgenty (Tconstr (mkpath mp name,[],ref Mnil)))
-      (* beware of interactions with Printtyp and short-path:
-         mp.name may have an arity > 0, cf. PR#7534 *)
-      nl in
   (* go back to original level *)
   Ctype.end_def ();
-  if nl = [] then
-    (wrap_constraint env true modl (Mty_ident p) Tmodtype_implicit, [])
-  else let mty = modtype_of_package env modl.mod_loc p nl tl' in
+  let mty =
+    if nl = [] then (Mty_ident p)
+    else modtype_of_package env modl.mod_loc p nl' tl'
+  in
   List.iter2
     (fun n ty ->
       try Ctype.unify env ty (Ctype.newvar ())
       with Ctype.Unify _ ->
-        raise (Error(m.pmod_loc, env, Scoping_pack (n,ty))))
-    nl tl';
-  (wrap_constraint env true modl mty Tmodtype_implicit, tl')
+        raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
+    nl' tl';
+  let modl = wrap_constraint env true modl mty Tmodtype_implicit in
+  (* Dropped exports should have produced an error above *)
+  assert (List.length nl = List.length tl');
+  modl, tl'
 
 (* Fill in the forward declarations *)
 


### PR DESCRIPTION
This fixes some problems with errors for first-class modules, including those in #8899.
1. When given an expression like `(module struct ... end)` we no longer put a dummy `%M` module into the environment -- we use `Env.enter_siganture` instead. This removes all mention of `%M` from the errors.
2. In cases where we cannot add an exported type to the expected signature because either the type does not exist or it has the wrong arity then we drop the exported type and just run the inclusion check without it, which is guaranteed to fail but gives a better error message.