### PR TITLE
printing: add a break hint after functor arguments

### DIFF
--- a/testsuite/tests/typing-misc/pr8548.ml
+++ b/testsuite/tests/typing-misc/pr8548.ml
@@ -112,7 +112,8 @@ module Assume :
                            range -> 'a
                        end
                    end
-             end) ->
+             end)
+    ->
     sig
       module Point : sig type t end
       module Test_range :

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -503,29 +503,23 @@ Error: Signature mismatch:
                    module B :
                      sig
                        module C :
-                         functor
-                           (X : sig  end) (Y : sig  end) (Z : sig
-                                                                module D :
-                                                                  sig
-                                                                    module E :
-                                                                    sig
-                                                                    module F :
-                                                                    functor
-                                                                    (X :
-                                                                    sig
-
-                                                                    end) (Arg :
-                                                                    sig
-                                                                    val two :
-                                                                    int
-                                                                    val one :
-                                                                    int
-                                                                    end) ->
-                                                                    sig  end
-                                                                    end
-                                                                  end
-                                                              end) ->
-                           sig  end
+                         functor (X : sig  end) (Y : sig  end)
+                           (Z : sig
+                                  module D :
+                                    sig
+                                      module E :
+                                        sig
+                                          module F :
+                                            functor (X : sig  end)
+                                              (Arg : sig
+                                                       val two : int
+                                                       val one : int
+                                                     end)
+                                              -> sig  end
+                                        end
+                                    end
+                                end)
+                           -> sig  end
                      end
                  end
              end
@@ -539,29 +533,23 @@ Error: Signature mismatch:
                    module B :
                      sig
                        module C :
-                         functor
-                           (X : sig  end) (Y : sig  end) (Z : sig
-                                                                module D :
-                                                                  sig
-                                                                    module E :
-                                                                    sig
-                                                                    module F :
-                                                                    functor
-                                                                    (X :
-                                                                    sig
-
-                                                                    end) (Arg :
-                                                                    sig
-                                                                    val one :
-                                                                    int
-                                                                    val two :
-                                                                    int
-                                                                    end) ->
-                                                                    sig  end
-                                                                    end
-                                                                  end
-                                                              end) ->
-                           sig  end
+                         functor (X : sig  end) (Y : sig  end)
+                           (Z : sig
+                                  module D :
+                                    sig
+                                      module E :
+                                        sig
+                                          module F :
+                                            functor (X : sig  end)
+                                              (Arg : sig
+                                                       val one : int
+                                                       val two : int
+                                                     end)
+                                              -> sig  end
+                                        end
+                                    end
+                                end)
+                           -> sig  end
                      end
                  end
              end
@@ -574,29 +562,23 @@ Error: Signature mismatch:
                  module B :
                    sig
                      module C :
-                       functor
-                         (X : sig  end) (Y : sig  end) (Z : sig
-                                                              module D :
-                                                                sig
-                                                                  module E :
-                                                                    sig
-                                                                    module F :
-                                                                    functor
-                                                                    (X :
-                                                                    sig
-
-                                                                    end) (Arg :
-                                                                    sig
-                                                                    val two :
-                                                                    int
-                                                                    val one :
-                                                                    int
-                                                                    end) ->
-                                                                    sig  end
-                                                                    end
-                                                                end
-                                                            end) ->
-                         sig  end
+                       functor (X : sig  end) (Y : sig  end)
+                         (Z : sig
+                                module D :
+                                  sig
+                                    module E :
+                                      sig
+                                        module F :
+                                          functor (X : sig  end)
+                                            (Arg : sig
+                                                     val two : int
+                                                     val one : int
+                                                   end)
+                                            -> sig  end
+                                      end
+                                  end
+                              end)
+                         -> sig  end
                    end
                end
            end
@@ -608,29 +590,23 @@ Error: Signature mismatch:
                  module B :
                    sig
                      module C :
-                       functor
-                         (X : sig  end) (Y : sig  end) (Z : sig
-                                                              module D :
-                                                                sig
-                                                                  module E :
-                                                                    sig
-                                                                    module F :
-                                                                    functor
-                                                                    (X :
-                                                                    sig
-
-                                                                    end) (Arg :
-                                                                    sig
-                                                                    val one :
-                                                                    int
-                                                                    val two :
-                                                                    int
-                                                                    end) ->
-                                                                    sig  end
-                                                                    end
-                                                                end
-                                                            end) ->
-                         sig  end
+                       functor (X : sig  end) (Y : sig  end)
+                         (Z : sig
+                                module D :
+                                  sig
+                                    module E :
+                                      sig
+                                        module F :
+                                          functor (X : sig  end)
+                                            (Arg : sig
+                                                     val one : int
+                                                     val two : int
+                                                   end)
+                                            -> sig  end
+                                      end
+                                  end
+                              end)
+                         -> sig  end
                    end
                end
            end

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -37,8 +37,8 @@ module Make1 :
     (T' : sig
             module Term0 : Termsig.Term0.S
             module T : sig module Id : sig  end end
-          end) ->
-    sig module T : sig module Id : sig  end val u : int end end
+          end)
+    -> sig module T : sig module Id : sig  end val u : int end end
 |}]
 
 module Make2 (T' : Termsig.Term.S) = struct
@@ -54,7 +54,8 @@ module Make2 :
     (T' : sig
             module Term0 : Termsig.Term0.S
             module T : sig module Id : sig  end end
-          end) ->
+          end)
+    ->
     sig
       module T : sig module Id : sig  end module Id2 = Id val u : int end
     end
@@ -74,7 +75,8 @@ module Make3 :
     (T' : sig
             module Term0 : Termsig.Term0.S
             module T : sig module Id : sig  end end
-          end) ->
+          end)
+    ->
     sig
       module T : sig module Id : sig  end module Id2 = Id val u : int end
     end
@@ -98,8 +100,8 @@ module Make1 :
     (T' : sig
             module Term0 : sig module Id : sig  end end
             module T : sig module Id : sig  end end
-          end) ->
-    sig module Id : sig  end module Id2 = Id end
+          end)
+    -> sig module Id : sig  end module Id2 = Id end
 |}]
 
 module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
@@ -136,7 +138,8 @@ module Make3 :
     (T' : sig
             module Term0 : sig module Id : sig  end end
             module T : sig module Id : sig  end end
-          end) ->
+          end)
+    ->
     sig
       module T : sig module Id : sig  end module Id2 = Id val u : int end
     end
@@ -190,8 +193,8 @@ module Make1 :
             module Term0 : sig module Id : sig  end end
             module T : sig module Id : sig  end end
             type t = MkT(T).t
-          end) ->
-    sig module Id : sig  end module Id2 = Id type t = T'.t end
+          end)
+    -> sig module Id : sig  end module Id2 = Id type t = T'.t end
 module IS :
   sig
     module Term0 : sig module Id : sig val x : string end end
@@ -287,7 +290,8 @@ module F :
            module T : sig type t = int val compare : t -> t -> int end
            type t = E of (MkT(T).t, MkT(T).t) eq
            type u = t = E of (MkT(Term0).t, MkT(T).t) eq
-         end) ->
+         end)
+    ->
     sig
       module Term0 : sig type t = int val compare : t -> t -> int end
       module T : sig type t = int val compare : t -> t -> int end

--- a/testsuite/tests/typing-signatures/els.ocaml.reference
+++ b/testsuite/tests/typing-signatures/els.ocaml.reference
@@ -71,8 +71,8 @@ module USERCODE :
                    sig type value type state type usert = X.combined end
                  val setglobal : V.state -> string -> V.value -> unit
                  val apply : V.value -> V.state -> V.value list -> V.value
-               end) ->
-          sig val init : C.V.state -> unit end
+               end)
+          -> sig val init : C.V.state -> unit end
     end
 module Weapon : sig type t end
 module type WEAPON_LIB =
@@ -86,8 +86,8 @@ module type WEAPON_LIB =
                 type combined
                 type t = t
                 val map : (combined -> t) * (t -> combined)
-              end) ->
-        USERCODE(TV).F
+              end)
+        -> USERCODE(TV).F
   end
 module type X = functor (X : CORE) -> BARECODE
 module type X = CORE -> BARECODE

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -473,10 +473,10 @@ let rec print_out_functor funct ppf =
           fprintf ppf "%a ->@ %a"
             print_out_module_type mty_arg (print_out_functor false) mty_res
       | name, true ->
-          fprintf ppf "(%s : %a) %a" name
+          fprintf ppf "(%s : %a)@ %a" name
             print_out_module_type mty_arg (print_out_functor true) mty_res
       | name, false ->
-            fprintf ppf "functor@ (%s : %a) %a" name
+            fprintf ppf "functor@ (%s : %a)@ %a" name
               print_out_module_type mty_arg (print_out_functor true) mty_res
     end
   | m ->


### PR DESCRIPTION
This PR proposes to add a break hints after a functor argument. Without this change, long lists of arguments can overflow the formatting margin. For instance,

```OCaml
module F
  (X: AVeryLongNameUsedToTestFormatting)
  (Y: AVeryLongNameUsedToTestFormatting)
  (Z: AVeryLongNameUsedToTestFormatting)
  (W: AVeryLongNameUsedToTestFormatting)
= struct end;;
```

is currently printed as 

```OCaml
module F :
  functor
    (X : AVeryLongNameUsedToTestFormatting) (Y : AVeryLongNameUsedToTestFormatting) (Z : AVeryLongNameUsedToTestFormatting) (W : AVeryLongNameUsedToTestFormatting) ->
    sig  end

```

With this PR, the above example becomes

```OCaml
module F :
  functor
    (X : AVeryLongNameUsedToTestFormatting)
    (Y : AVeryLongNameUsedToTestFormatting)
    (Z : AVeryLongNameUsedToTestFormatting)
    (W : AVeryLongNameUsedToTestFormatting) -> sig  end
```
(This changes make it also possible to satisfy check-typo for some pathologic tests I am working on)