### PR TITLE
Deanonymize functor arguments when printed

### DIFF
--- a/testsuite/tests/typing-modules/deanonymized_functor_args.ml
+++ b/testsuite/tests/typing-modules/deanonymized_functor_args.ml
@@ -1,0 +1,123 @@
+(* TEST
+  * expect
+*)
+
+(* Test that anonymous argument that appears in the resulting module type of a
+   functor (due to strengthening) are properly named by the typehecker
+   pretty-printer
+*)
+
+(* We use Arg_n as argument names, thus the following definition are here to
+   tests that the naming function avoid names pre-existing in the printing environment.
+*)
+module Arg_0 = struct end
+module Arg_2 = struct end
+
+
+module type Empty = sig end
+module type T = sig type t end;;
+[%%expect {|
+module Arg_0 : sig  end
+module Arg_2 : sig  end
+module type Empty = sig  end
+module type T = sig type t end
+|}]
+
+
+
+module Id(X: Empty -> T) = X;;
+[%%expect {|
+module Id :
+  functor (X : Empty -> T) (Arg_1 : Empty) -> sig type t = X(Arg_1).t end
+|}]
+
+
+module type Ty
+module type Endo = Ty -> Ty
+module Compose(F:Endo->Endo)(G:Endo->Endo)(X:Endo) = F(G(X))
+[%%expect {|
+module type Ty
+module type Endo = Ty -> Ty
+module Compose :
+  functor (F : Endo -> Endo) (G : Endo -> Endo) (X : Endo) -> Ty -> Ty
+|}]
+
+
+module type Mt = sig module type t end
+module Succ(A:Mt) = struct module type t = A.t -> A.t end
+module Zero = struct module type t = T end
+module Five = Succ(Succ(Succ(Succ(Succ(Zero)))));;
+[%%expect {|
+module type Mt = sig module type t end
+module Succ : functor (A : Mt) -> sig module type t = A.t -> A.t end
+module Zero : sig module type t = T end
+module Five :
+  sig
+    module type t =
+      Succ(Succ(Succ(Succ(Zero)))).t -> Succ(Succ(Succ(Succ(Zero)))).t
+  end
+|}]
+
+
+module Compose_5(Arg_4:Five.t->Five.t)(Arg_6:Five.t->Five.t)(Arg_8:Five.t) = Arg_4(Arg_6(Arg_8));;
+[%%expect {|
+module Compose_5 :
+  functor (Arg_4 : Five.t -> Five.t) (Arg_6 : Five.t -> Five.t)
+    (Arg_8 : Five.t) (Arg_9 : Succ(Succ(Succ(Succ(Zero)))).t)
+    (Arg_7 : Succ(Succ(Succ(Zero))).t) (Arg_5 : Succ(Succ(Zero)).t)
+    (Arg_3 : Succ(Zero).t) (Arg_1 : Zero.t) ->
+    sig type t = Arg_4(Arg_6(Arg_8))(Arg_9)(Arg_7)(Arg_5)(Arg_3)(Arg_1).t end
+|}]
+
+
+module type Ta = sig
+  module Arg_1: sig end
+  type u
+  module Arg_3: sig end
+  type t
+  module Arg_5: sig end
+end;;
+[%%expect {|
+module type Ta =
+  sig
+    module Arg_1 : sig  end
+    type u
+    module Arg_3 : sig  end
+    type t
+    module Arg_5 : sig  end
+  end
+|}]
+
+
+module F(Arg_4: Ta -> Ta) = Arg_4
+[%%expect {|
+module F :
+  functor (Arg_4 : Ta -> Ta) (Arg_5 : Ta) ->
+    sig
+      module Arg_1 : sig  end
+      type u = Arg_4(Arg_5).u
+      module Arg_3 : sig  end
+      type t = Arg_4(Arg_5).t
+      module Arg_5 : sig  end
+    end
+|}]
+
+module type With_subfunctor = sig
+  module F: functor(Arg_1:Empty) -> Empty ->  Mt
+end
+[%%expect {|
+module type With_subfunctor =
+  sig module F : functor (Arg_1 : Empty) -> Empty -> Mt end
+|}]
+
+
+module Id(X: Empty -> With_subfunctor) = X
+[%%expect {|
+module Id :
+  functor (X : Empty -> With_subfunctor) (Arg_4 : Empty) ->
+    sig
+      module F :
+        functor (Arg_1 : Empty) (Arg_3 : Empty) ->
+          sig module type t = X(Arg_4).F(Arg_1)(Arg_3).t end
+    end
+|}]

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -1,5 +1,6 @@
 aliases.ml
 applicative_functor_type.ml
+deanonymized_functor_args.ml
 firstclass.ml
 generative.ml
 illegal_permutation.ml

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -465,7 +465,7 @@ let rec print_out_functor funct ppf =
       if funct then fprintf ppf "() %a" (print_out_functor true) mty_res
       else fprintf ppf "functor@ () %a" (print_out_functor true) mty_res
   | Omty_functor (name, Some mty_arg, mty_res) -> begin
-      match name, funct with
+      match name.printed_name, funct with
       | "_", true ->
           fprintf ppf "->@ %a ->@ %a"
             print_out_module_type mty_arg (print_out_functor false) mty_res

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -91,7 +91,7 @@ and out_class_sig_item =
 
 type out_module_type =
   | Omty_abstract
-  | Omty_functor of string * out_module_type option * out_module_type
+  | Omty_functor of out_name * out_module_type option * out_module_type
   | Omty_ident of out_ident
   | Omty_signature of out_sig_item list
   | Omty_alias of out_ident


### PR DESCRIPTION
It may happen that the strengthening of a functor module type with anonymous
arguments creates explicit references to some of those anonymous arguments.

For instance, this is the case in

```OCaml
module type T = sig type t end
module Id(X: T -> T) = X
```
Currently, this results in a brutal display of the anonymous functor arguments:

```OCaml
module Id : functor (X : T -> T) -> T -> sig type t = X(_).t end
```
The resulting type, `X(_).t`, is not syntactically valid.
Moreover, more elaborate examples can even trigger name collisions, for instance

```OCaml
module Id2(X: (T -> T) -> T -> T) = X
```

is rendered as

```OCaml
module Id2 :
  functor (X : T -> T -> T -> T) -> T -> T -> T ->
    sig type t = X(_/2)(_/1).t end
```

This PR proposes to avoid this issue by renaming on the fly anonymous functor
arguments if they are ever printed using an extension of the mechanism already
in place for name collisions (to avoid collisions with other module names).

Currently, this PR proposes to use the first available module name in the sequence
`Arg_0`, `Arg_1`, `Arg_2`, …

Thus, this PR displays the two previous examples as

```OCaml
module Id : functor (X : T -> T) (Arg_0 : T) -> sig type t = X(Arg_0).t end
```

and

```OCaml
module Id2 :
  functor (X : T -> T -> T -> T) (Arg_1 : T -> T) (Arg_0 : T) ->
    sig type t = X(Arg_1)(Arg_0).t end
```