### PR TITLE
Print parentheses in (A->B)->C

### DIFF
--- a/testsuite/tests/typing-modules/printing.ml
+++ b/testsuite/tests/typing-modules/printing.ml
@@ -28,3 +28,21 @@ module M = struct module N = struct let x = 1 end end;;
 module M : sig module N : sig val x : int end end
 module M : sig module N : sig ... end end
 |}];;
+
+(* Shortcut notation for functors *)
+module type A
+module type B
+module type C
+module type D
+module type E
+module type F
+module Test(X: ((A->(B->C)->D) -> (E -> F))) = struct end
+[%%expect {|
+module type A
+module type B
+module type C
+module type D
+module type E
+module type F
+module Test : functor (X : (A -> (B -> C) -> D) -> E -> F) -> sig  end
+|}]

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -468,10 +468,12 @@ let rec print_out_functor funct ppf =
       match name, funct with
       | "_", true ->
           fprintf ppf "->@ %a ->@ %a"
-            print_out_module_type mty_arg (print_out_functor false) mty_res
+            print_simple_out_module_type mty_arg
+            (print_out_functor false) mty_res
       | "_", false ->
           fprintf ppf "%a ->@ %a"
-            print_out_module_type mty_arg (print_out_functor false) mty_res
+            print_simple_out_module_type mty_arg
+            (print_out_functor false) mty_res
       | name, true ->
           fprintf ppf "(%s : %a) %a" name
             print_out_module_type mty_arg (print_out_functor true) mty_res
@@ -482,12 +484,13 @@ let rec print_out_functor funct ppf =
   | m ->
       if funct then fprintf ppf "->@ %a" print_out_module_type m
       else print_out_module_type ppf m
-
-and print_out_module_type ppf =
+and print_out_module_type ppf = function
+  | Omty_functor _ as t -> fprintf ppf "@[<2>%a@]" (print_out_functor false) t
+  | t -> print_simple_out_module_type ppf t
+and print_simple_out_module_type ppf =
   function
     Omty_abstract -> ()
-  | Omty_functor _ as t ->
-      fprintf ppf "@[<2>%a@]" (print_out_functor false) t
+  | Omty_functor _ as t -> fprintf ppf "(%a)" print_out_module_type t
   | Omty_ident id -> fprintf ppf "%a" print_ident id
   | Omty_signature sg ->
       fprintf ppf "@[<hv 2>sig@ %a@;<1 -2>end@]" !out_signature sg


### PR DESCRIPTION
Currently, the type of  the module `Test` in 

```OCaml
module type A
module type B
module type C
module Test( F: ( A -> B ) -> C ) = struct end
```
is printed as
```OCaml
module Test : functor (F : A -> B -> C) -> sig  end
```
This PR adds back the missing parentheses.