### PR TITLE
Better printing of functor types

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,6 +48,9 @@ Working version
 - #8890: in -dtimings output, show time spent in C linker clearly
   (Valentin Gatien-Baron)
 
+- #8910, #8911: minor improvements to the printing of module types
+  (Gabriel Scherer, review by Florian Angeletti)
+
 - #8913: ocamltest: improve 'promote' implementation to take
   skipped lines/bytes into account
   (Gabriel Scherer, review by Sébastien Hinderer)

--- a/testsuite/tests/typing-modules/printing.ml
+++ b/testsuite/tests/typing-modules/printing.ml
@@ -50,11 +50,9 @@ module Test : functor (X : (A -> (B -> C) -> D) -> E -> F) -> sig end
 (* test reprinting of functors *)
 module type LongFunctor1 = functor (X : A) () (_ : B) () -> C -> D -> sig end
 [%%expect {|
-module type LongFunctor1 =
-  functor (X : A) () -> B -> functor () -> C -> D -> sig end
+module type LongFunctor1 = functor (X : A) () (_ : B) () -> C -> D -> sig end
 |}]
 module type LongFunctor2 = functor (_ : A) () (_ : B) () -> C -> D -> sig end
 [%%expect {|
-module type LongFunctor2 =
-  A -> functor () -> B -> functor () -> C -> D -> sig end
+module type LongFunctor2 = A -> functor () (_ : B) () -> C -> D -> sig end
 |}]

--- a/testsuite/tests/typing-modules/printing.ml
+++ b/testsuite/tests/typing-modules/printing.ml
@@ -46,3 +46,15 @@ module type E
 module type F
 module Test : functor (X : (A -> (B -> C) -> D) -> E -> F) -> sig end
 |}]
+
+(* test reprinting of functors *)
+module type LongFunctor1 = functor (X : A) () (_ : B) () -> C -> D -> sig end
+[%%expect {|
+module type LongFunctor1 =
+  functor (X : A) () -> B -> functor () -> C -> D -> sig end
+|}]
+module type LongFunctor2 = functor (_ : A) () (_ : B) () -> C -> D -> sig end
+[%%expect {|
+module type LongFunctor2 =
+  A -> functor () -> B -> functor () -> C -> D -> sig end
+|}]


### PR DESCRIPTION
This PR sits on top of #8910.

The [new implementation](https://github.com/gasche/ocaml/blob/better-printing-of-functor-types/typing/oprint.ml#L462-L517) is closer to the grammar rules, and I find it
easier about.

For example, I was able to implement the long-form-or-short-form
heuristic easily, improving the printing from (before)

    module type LongFunctor =
      functor (X : A) -> B -> functor (Z : C) -> D -> E -> sig end

to (with this commit)

    module type LongFunctor =
      functor (X : A) (_ : B) (Z : C) -> D -> E -> sig end