### PR TITLE
ocamltest: fix "promote" actions on reference files with skipped lines/bytes

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,6 +48,10 @@ Working version
 - #8890: in -dtimings output, show time spent in C linker clearly
   (Valentin Gatien-Baron)
 
+- #8913: ocamltest: improve 'promote' implementation to take
+  skipped lines/bytes into account
+  (Gabriel Scherer, review by Sébastien Hinderer)
+
 ### Code generation and optimizations:
 
 - #8672: Optimise Switch code generation on booleans.

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -287,8 +287,12 @@ let check_output kind_of_output output_variable reference_variable log
     Filecompare.reference_filename = reference_filename;
     Filecompare.output_filename = output_filename
   } in
+  let ignore_header_conf = {
+      Filecompare.lines = skip_lines;
+      Filecompare.bytes = skip_bytes;
+    } in
   let tool =
-    Filecompare.(make_cmp_tool ~ignore:{lines=skip_lines;bytes=skip_bytes}) in
+    Filecompare.make_cmp_tool ~ignore:ignore_header_conf in
   match Filecompare.check_file ~tool files with
     | Filecompare.Same -> (Result.pass, env)
     | Filecompare.Different ->
@@ -303,7 +307,7 @@ let check_output kind_of_output output_variable reference_variable log
       then begin
         Printf.fprintf log "Promoting %s output %s to reference %s\n%!"
           kind_of_output output_filename reference_filename;
-        Sys.copy_file output_filename reference_filename;
+        Filecompare.promote files ignore_header_conf;
       end;
       (Result.fail_with_reason reason, env)
     | Filecompare.Unexpected_output ->

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -179,3 +179,22 @@ let diff files =
   in
   Sys.force_remove temporary_file;
   result
+
+let promote files ignore_conf =
+  match files.filetype, ignore_conf with
+    | Text, {lines = skip_lines; _} ->
+       let reference = open_out files.reference_filename in
+       let output = open_in files.output_filename in
+       for _ = 1 to skip_lines do
+         try ignore (input_line output) with End_of_file -> ()
+       done;
+       Sys.copy_chan output reference;
+       close_out reference;
+       close_in output
+    | Binary, {bytes = skip_bytes; _} ->
+       let reference = open_out_bin files.reference_filename in
+       let output = open_in_bin files.output_filename in
+       seek_in output skip_bytes;
+       Sys.copy_chan output reference;
+       close_out reference;
+       close_in output

--- a/ocamltest/filecompare.mli
+++ b/ocamltest/filecompare.mli
@@ -46,3 +46,5 @@ val check_file : ?tool:tool -> files -> result
 val cmp_result_of_exitcode : string -> int -> result
 
 val diff : files -> (string, string) Stdlib.result
+
+val promote : files -> ignore -> unit

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -49,6 +49,7 @@ module Sys : sig
   val run_system_command : string -> unit
   val make_directory : string -> unit
   val string_of_file : string -> string
+  val copy_chan : in_channel -> out_channel -> unit
   val copy_file : string -> string -> unit
   val force_remove : string -> unit
   val has_symlink : unit -> bool


### PR DESCRIPTION
This PR fixes a deficiency in ocamltest's "promote" implementation: it currently just copies the result file into the reference file, which is incorrect if the test is configured to skip lines or bytes of the output (the skipped lines/bytes are currently *not* part of the versioned reference files).

The new implementation is careful to skip the lines/bytes of the output file, and only copy the rest into the reference file.

This fixes a real problem that made me lose time on #8910 -- which touches an ocamldoc test which does use skip lines. I checked on #8910 that the new implementation behaves as it should.