### PR TITLE
Added in-code documentation for caml_stat_destroy_pool in memory.c

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -786,14 +786,26 @@ CAMLexport void caml_stat_create_pool(void)
 
 CAMLexport void caml_stat_destroy_pool(void)
 {
+  /** If the pool pointer is already NULL, don't do anything. The pool pointer
+   *  is explicitly set to NULL after its memory has been free'd as a simple
+   *  method of bookkeeping. This is crucial to prevent inadvertently
+   *  double-freeing heap-allocated memory, which can introduce security
+   *  vulnerabilities or crash the program.
+   * 
+   */
   if (pool != NULL) {
+    /** The previous pool block will have a pointer pointing to this memory
+     *  address that must be set to NULL to prevent a NULL pointer dereference
+     *  somewhere down the line.
+     * 
+     */
     pool->prev->next = NULL;
+
     while (pool != NULL) {
       struct pool_block *next = pool->next;
       free(pool);
       pool = next;
     }
-    pool = NULL;
   }
 }
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -806,6 +806,8 @@ CAMLexport void caml_stat_destroy_pool(void)
       free(pool);
       pool = next;
     }
+
+    pool = NULL;
   }
 }
 


### PR DESCRIPTION
I also removed the last assignment setting `pool` equal to `NULL` as it had no effect. The `while` loop will execute until `pool` is `NULL`, so if it isn't null the code will never reach the the assignment, and if it is null there's no point in re-assigning it.

There are no user-visible changes, so as per the contributing guidelines I did not feel a change to the Changes file was merited.

```
List of skipped tests:
    tests/unboxed-primitive-args/'test.ml' with 1.1.1 (ocaml) 
    tests/lib-unix/isatty/'isatty_tty.ml' with 1 (libwin32unix) 
    tests/asmcomp/'static_float_array_flambda.ml' with 1 (flambda) 
    tests/manual-intf-c
    tests/lib-unix/win-symlink
    tests/lib-unix/win-stat
    tests/unwind
    tests/runtime-errors/'syserror.ml' with 2.1.1.2 (libwin32unix) 
    tests/arch-power
    tests/lib-unix/unix-execvpe/'exec.ml' with 1.1 (script) 
    tests/lib-dynlink-csharp
    tests/translprim/'module_coercion.ml' with 1.1.2 (no-flat-float-array) 
    tests/runtime-errors/'syserror.ml' with 1.1.1.2 (libwin32unix) 
    tests/warnings/'w59.ml' with 3 (flambda) 
    tests/letrec-check/'no_flat_float_array.ml' with 1 (no-flat-float-array) 
    tests/asmcomp/'unrolling_flambda.ml' with 1 (flambda) 
    tests/flambda/'specialise.ml' with 1 (flambda) 
    tests/warnings/'w55.ml' with 3 (flambda) 
    tests/typing-unboxed-types/'test_no_flat.ml' with 1 (no-flat-float-array) 
    tests/translprim/'array_spec.ml' with 1.1.2 (no-flat-float-array) 
    tests/asmcomp/'is_static_flambda.ml' with 1 (flambda) 
    tests/lib-unix/win-env
    tests/flambda/'gpr2239.ml' with 1 (flambda) 
    tests/asmcomp/'static_float_array_flambda_opaque.ml' with 1 (flambda) 
    tests/runtime-errors/'stackoverflow.ml' with 2 (libwin32unix) 
    tests/tool-caml-tex/'redirections.ml' with 1.1.2 (no-shared-libraries) 
    tests/win-unicode
    tests/typing-misc/'pr6939-no-flat-float-array.ml' with 1 (no-flat-float-array) 
    tests/asmgen/'integr.cmm' with 1 (skip) 
    tests/asmcomp/'unrolling_flambda2.ml' with 1 (flambda) 
    tests/flambda/'approx_meet.ml' with 1 (flambda) 

Summary:
  2440 tests passed
   31 tests skipped
    0 tests failed
   79 tests not started (parent test skipped or failed)
    0 unexpected errors
  2550 tests considered
make[1]: Leaving directory '/home/jflopezfernandez/Build/ocaml/ocaml/testsuite'
```