### PR TITLE
Flambda: prevent recursive approximations in Build_export_info

### DIFF
--- a/Changes
+++ b/Changes
@@ -197,6 +197,10 @@ Working version
 - #8875: fix missing newlines in the output from MSVC invocation.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)
 
+- #8921, #8924: Fix stack overflow with Flambda
+  (Vincent Laviron, review by Pierre Chambart and Leo White,
+   report by Aleksandr Kuzmenko)
+
 OCaml 4.09.0
 ------------
 

--- a/middle_end/flambda/build_export_info.ml
+++ b/middle_end/flambda/build_export_info.ml
@@ -52,7 +52,6 @@ module Env : sig
 
     val symbol_to_export_id_map : t -> Export_id.t Symbol.Map.t
     val export_id_to_descr_map : t -> Export_info.descr Export_id.Map.t
-
   end
 
   (** Creates a new environment, sharing the mapping from export IDs to
@@ -440,9 +439,7 @@ let describe_constant_defining_value env export_id symbol
     Env.record_descr env export_id descr
   | Block (tag, fields) ->
     let approxs =
-      List.map
-        (approx_of_constant_defining_value_block_field env)
-        fields
+      List.map (approx_of_constant_defining_value_block_field env) fields
     in
     Env.record_descr env export_id (Value_block (tag, Array.of_list approxs))
   | Set_of_closures set_of_closures ->


### PR DESCRIPTION
This is a quick-and-dirty fix for the bug reported in #8921.
I think it's enough to cover all problematic cases (I don't think Let_rec in expressions is problematic).
I'll try to reuse the `env` parameter instead of introducing a new one, but functionally the current code is what I have in mind.