### PR TITLE
Move contains_calls and num_stack_slots from Proc to Mach.fundecl

### DIFF
--- a/.depend
+++ b/.depend
@@ -2227,12 +2227,10 @@ asmcomp/cmmgen_state.cmi : \
     asmcomp/cmm.cmi \
     middle_end/clambda.cmi
 asmcomp/coloring.cmo : \
-    asmcomp/reloadgen.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     asmcomp/coloring.cmi
 asmcomp/coloring.cmx : \
-    asmcomp/reloadgen.cmx \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
     asmcomp/coloring.cmi
@@ -2403,13 +2401,11 @@ asmcomp/linearize.cmi : \
     asmcomp/mach.cmi \
     asmcomp/linear.cmi
 asmcomp/linscan.cmo : \
-    asmcomp/reloadgen.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     asmcomp/interval.cmi \
     asmcomp/linscan.cmi
 asmcomp/linscan.cmx : \
-    asmcomp/reloadgen.cmx \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
     asmcomp/interval.cmx \
@@ -2583,13 +2579,11 @@ asmcomp/reload.cmi : \
     asmcomp/mach.cmi
 asmcomp/reloadgen.cmo : \
     asmcomp/reg.cmi \
-    asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/reloadgen.cmi
 asmcomp/reloadgen.cmx : \
     asmcomp/reg.cmx \
-    asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/reloadgen.cmi

--- a/.depend
+++ b/.depend
@@ -2227,10 +2227,12 @@ asmcomp/cmmgen_state.cmi : \
     asmcomp/cmm.cmi \
     middle_end/clambda.cmi
 asmcomp/coloring.cmo : \
+    asmcomp/reloadgen.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     asmcomp/coloring.cmi
 asmcomp/coloring.cmx : \
+    asmcomp/reloadgen.cmx \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
     asmcomp/coloring.cmi
@@ -2401,11 +2403,13 @@ asmcomp/linearize.cmi : \
     asmcomp/mach.cmi \
     asmcomp/linear.cmi
 asmcomp/linscan.cmo : \
+    asmcomp/reloadgen.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     asmcomp/interval.cmi \
     asmcomp/linscan.cmi
 asmcomp/linscan.cmx : \
+    asmcomp/reloadgen.cmx \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
     asmcomp/interval.cmx \
@@ -2579,11 +2583,13 @@ asmcomp/reload.cmi : \
     asmcomp/mach.cmi
 asmcomp/reloadgen.cmo : \
     asmcomp/reg.cmi \
+    asmcomp/proc.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/reloadgen.cmi
 asmcomp/reloadgen.cmx : \
     asmcomp/reg.cmx \
+    asmcomp/proc.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/reloadgen.cmi

--- a/Changes
+++ b/Changes
@@ -59,6 +59,9 @@ Working version
   skipped lines/bytes into account
   (Gabriel Scherer, review by Sébastien Hinderer)
 
+- #8928: Move contains_calls and num_stack_slots from Proc to Mach.fundecl
+  (Greta Yorsh, review by Florian Angeletti and Vincent Laviron)
+
 ### Code generation and optimizations:
 
 - #8672: Optimise Switch code generation on booleans.

--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,9 @@ ASMCOMP=\
   asmcomp/CSEgen.cmo asmcomp/CSE.cmo \
   asmcomp/liveness.cmo \
   asmcomp/spill.cmo asmcomp/split.cmo \
-  asmcomp/reloadgen.cmo asmcomp/reload.cmo \
   asmcomp/interf.cmo asmcomp/coloring.cmo \
   asmcomp/linscan.cmo \
+  asmcomp/reloadgen.cmo asmcomp/reload.cmo \
   asmcomp/deadcode.cmo \
   asmcomp/linear.cmo asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \

--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,9 @@ ASMCOMP=\
   asmcomp/CSEgen.cmo asmcomp/CSE.cmo \
   asmcomp/liveness.cmo \
   asmcomp/spill.cmo asmcomp/split.cmo \
+  asmcomp/reloadgen.cmo asmcomp/reload.cmo \
   asmcomp/interf.cmo asmcomp/coloring.cmo \
   asmcomp/linscan.cmo \
-  asmcomp/reloadgen.cmo asmcomp/reload.cmo \
   asmcomp/deadcode.cmo \
   asmcomp/linear.cmo asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -70,12 +70,17 @@ let fp = Config.with_frame_pointers
 
 let fastcode_flag = ref true
 
+(* Layout of the stack frame *)
 let stack_offset = ref 0
 
-(* Layout of the stack frame *)
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
+let prologue_required = ref false
+
+let frame_required = ref false
 
 let frame_size () =                     (* includes return address *)
-  if frame_required() then begin
+  if !frame_required then begin
     let sz =
       (!stack_offset + 8 * (num_stack_slots.(0) + num_stack_slots.(1)) + 8
        + (if fp then 8 else 0))
@@ -442,7 +447,7 @@ let emit_float_test cmp i lbl =
 (* Deallocate the stack frame before a return or tail call *)
 
 let output_epilogue f =
-  if frame_required() then begin
+  if !frame_required then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
     if n <> 0
     then begin
@@ -514,13 +519,13 @@ let emit_instr fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
-    assert (Proc.prologue_required ());
+    assert (!prologue_required);
     if fp then begin
       I.push rbp;
       cfi_adjust_cfa_offset 8;
       I.mov rsp rbp;
     end;
-    if frame_required() then begin
+    if !frame_required then begin
       let n = frame_size() - 8 - (if fp then 8 else 0) in
       if n <> 0
       then begin
@@ -923,6 +928,11 @@ let fundecl fundecl =
   call_gc_sites := [];
   bound_error_sites := [];
   bound_error_call := 0;
+  for i = 0 to Proc.num_register_classes - 1 do
+    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
+  done;
+  prologue_required := fundecl.fun_prologue_required;
+  frame_required := fundecl.fun_frame_required;
   all_functions := fundecl :: !all_functions;
   emit_named_text_section !function_name;
   D.align 16;
@@ -940,7 +950,7 @@ let fundecl fundecl =
   emit_all true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   emit_call_bound_errors ();
-  if frame_required() then begin
+  if !frame_required then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
     if n <> 0
     then begin

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -375,14 +375,12 @@ let op_is_pure = function
 
 (* Layout of the stack frame *)
 
-let num_stack_slots = [| 0; 0 |]
-let contains_calls = ref false
+let frame_required fd =
+  fp || fd.fun_contains_calls ||
+  fd.fun_num_stack_slots.(0) > 0 || fd.fun_num_stack_slots.(1) > 0
 
-let frame_required () =
-  fp || !contains_calls || num_stack_slots.(0) > 0 || num_stack_slots.(1) > 0
-
-let prologue_required () =
-  frame_required ()
+let prologue_required fd =
+  frame_required fd
 
 (* Calling the assembler *)
 

--- a/asmcomp/amd64/reload.ml
+++ b/asmcomp/amd64/reload.ml
@@ -124,5 +124,5 @@ method! reload_test tst arg =
 
 end
 
-let fundecl f =
-  (new reload)#fundecl f
+let fundecl f num_stack_slots =
+  (new reload)#fundecl f num_stack_slots

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -259,7 +259,7 @@ method select_floatarith commutative regular_op mem_op args =
       assert false
 
 method! mark_c_tailcall =
-  Proc.contains_calls := true
+  Selectgen.contains_calls := true
 
 (* Deal with register constraints *)
 

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -259,7 +259,7 @@ method select_floatarith commutative regular_op mem_op args =
       assert false
 
 method! mark_c_tailcall =
-  Selectgen.contains_calls := true
+  contains_calls := true
 
 (* Deal with register constraints *)
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -60,6 +60,12 @@ let emit_reg = function
 
 let stack_offset = ref 0
 
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
+let prologue_required = ref false
+
+let contains_calls = ref false
+
 let frame_size () =
   let sz =
     !stack_offset +
@@ -452,7 +458,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> 0
     | Lprologue ->
-      assert (Proc.prologue_required ());
+      assert (!prologue_required);
       let n = frame_size() in
       let num_instrs =
         if n > 0 then begin
@@ -968,6 +974,11 @@ let fundecl fundecl =
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];
+  for i = 0 to Proc.num_register_classes - 1 do
+    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
+  done;
+  contains_calls := fundecl.fun_contains_calls;
+  prologue_required := fundecl.fun_prologue_required;
   emit_named_text_section !function_name;
   `	.align	2\n`;
   `	.globl	{emit_symbol fundecl.fun_name}\n`;

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -342,17 +342,15 @@ let op_is_pure = function
 
 (* Layout of the stack *)
 
-let num_stack_slots = [| 0; 0; 0 |]
-let contains_calls = ref false
-
-let frame_required () =
-  !contains_calls
+let frame_required fd =
+  let num_stack_slots = fd.fun_num_stack_slots in
+  fd.fun_contains_calls
     || num_stack_slots.(0) > 0
     || num_stack_slots.(1) > 0
     || num_stack_slots.(2) > 0
 
-let prologue_required () =
-  frame_required ()
+let prologue_required fd =
+  frame_required fd
 
 (* Calling the assembler *)
 

--- a/asmcomp/arm/reload.ml
+++ b/asmcomp/arm/reload.ml
@@ -53,5 +53,5 @@ method! reload_operation op arg res =
       argres'
 end
 
-let fundecl f =
-  (new reload)#fundecl f
+let fundecl f num_stack_slots =
+  (new reload)#fundecl f num_stack_slots

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -72,6 +72,12 @@ let emit_wreg = function
 
 let stack_offset = ref 0
 
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
+let prologue_required = ref false
+
+let contains_calls = ref false
+
 let frame_size () =
   let sz =
     !stack_offset +
@@ -581,7 +587,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
-      assert (Proc.prologue_required ());
+      assert (!prologue_required);
       let n = frame_size() in
       if n > 0 then
         emit_stack_adjustment (-n);
@@ -926,6 +932,11 @@ let fundecl fundecl =
   stack_offset := 0;
   call_gc_sites := [];
   bound_error_sites := [];
+    for i = 0 to Proc.num_register_classes - 1 do
+    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
+  done;
+  prologue_required := fundecl.fun_prologue_required;
+  contains_calls := fundecl.fun_contains_calls;
   emit_named_text_section !function_name;
   `	.align	3\n`;
   `	.globl	{emit_symbol fundecl.fun_name}\n`;

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -251,17 +251,13 @@ let op_is_pure = function
   | _ -> true
 
 (* Layout of the stack *)
+let frame_required fd =
+  fd.fun_contains_calls
+    || fd.fun_num_stack_slots.(0) > 0
+    || fd.fun_num_stack_slots.(1) > 0
 
-let num_stack_slots = [| 0; 0 |]
-let contains_calls = ref false
-
-let frame_required () =
-  !contains_calls
-    || num_stack_slots.(0) > 0
-    || num_stack_slots.(1) > 0
-
-let prologue_required () =
-  frame_required ()
+let prologue_required fd =
+  frame_required fd
 
 (* Calling the assembler *)
 

--- a/asmcomp/arm64/reload.ml
+++ b/asmcomp/arm64/reload.ml
@@ -15,5 +15,5 @@
 
 (* Reloading for the ARM 64 bits *)
 
-let fundecl f =
-  (new Reloadgen.reload_generic)#fundecl f
+let fundecl f num_stack_slots =
+  (new Reloadgen.reload_generic)#fundecl f num_stack_slots

--- a/asmcomp/coloring.ml
+++ b/asmcomp/coloring.ml
@@ -43,13 +43,16 @@ let allocate_registers() =
   (* Unconstrained regs with degree < number of available registers *)
   let unconstrained = ref [] in
 
+  (* Reset the stack slot counts *)
+  let num_stack_slots = Array.make Proc.num_register_classes 0 in
+
   (* Preallocate the spilled registers in the stack.
      Split the remaining registers into constrained and unconstrained. *)
   let remove_reg reg =
     let cl = Proc.register_class reg in
     if reg.spill then begin
       (* Preallocate the registers in the stack *)
-      let nslots = Reloadgen.num_stack_slots.(cl) in
+      let nslots = num_stack_slots.(cl) in
       let conflict = Array.make nslots false in
       List.iter
         (fun r ->
@@ -61,7 +64,7 @@ let allocate_registers() =
       let slot = ref 0 in
       while !slot < nslots && conflict.(!slot) do incr slot done;
       reg.loc <- Stack(Local !slot);
-      if !slot >= nslots then Reloadgen.num_stack_slots.(cl) <- !slot + 1
+      if !slot >= nslots then num_stack_slots.(cl) <- !slot + 1
     end else if reg.degree < Proc.num_available_registers.(cl) then
       unconstrained := reg :: !unconstrained
     else begin
@@ -163,7 +166,7 @@ let allocate_registers() =
                                 if start >= num_regs then 0 else start)
     end else begin
       (* Sorry, we must put the pseudoreg in a stack location *)
-      let nslots = Reloadgen.num_stack_slots.(cl) in
+      let nslots = num_stack_slots.(cl) in
       let score = Array.make nslots 0 in
       (* Compute the scores as for registers *)
       List.iter
@@ -206,21 +209,17 @@ let allocate_registers() =
       else begin
         (* Allocate a new stack slot *)
         reg.loc <- Stack(Local nslots);
-        Reloadgen.num_stack_slots.(cl) <- nslots + 1
+        num_stack_slots.(cl) <- nslots + 1
       end
     end;
     (* Cancel the preferences of this register so that they don't influence
        transitively the allocation of registers that prefer this reg. *)
     reg.prefer <- [] in
 
-  (* Reset the stack slot counts *)
-  for i = 0 to Proc.num_register_classes - 1 do
-    Reloadgen.num_stack_slots.(i) <- 0;
-  done;
-
   (* First pass: preallocate spill registers and split remaining regs
      Second pass: assign locations to constrained regs
      Third pass: assign locations to unconstrained regs *)
   List.iter remove_reg (Reg.all_registers());
   OrderedRegSet.iter assign_location !constrained;
-  List.iter assign_location !unconstrained
+  List.iter assign_location !unconstrained;
+  num_stack_slots

--- a/asmcomp/coloring.ml
+++ b/asmcomp/coloring.ml
@@ -49,7 +49,7 @@ let allocate_registers() =
     let cl = Proc.register_class reg in
     if reg.spill then begin
       (* Preallocate the registers in the stack *)
-      let nslots = Proc.num_stack_slots.(cl) in
+      let nslots = Reloadgen.num_stack_slots.(cl) in
       let conflict = Array.make nslots false in
       List.iter
         (fun r ->
@@ -61,7 +61,7 @@ let allocate_registers() =
       let slot = ref 0 in
       while !slot < nslots && conflict.(!slot) do incr slot done;
       reg.loc <- Stack(Local !slot);
-      if !slot >= nslots then Proc.num_stack_slots.(cl) <- !slot + 1
+      if !slot >= nslots then Reloadgen.num_stack_slots.(cl) <- !slot + 1
     end else if reg.degree < Proc.num_available_registers.(cl) then
       unconstrained := reg :: !unconstrained
     else begin
@@ -163,7 +163,7 @@ let allocate_registers() =
                                 if start >= num_regs then 0 else start)
     end else begin
       (* Sorry, we must put the pseudoreg in a stack location *)
-      let nslots = Proc.num_stack_slots.(cl) in
+      let nslots = Reloadgen.num_stack_slots.(cl) in
       let score = Array.make nslots 0 in
       (* Compute the scores as for registers *)
       List.iter
@@ -206,7 +206,7 @@ let allocate_registers() =
       else begin
         (* Allocate a new stack slot *)
         reg.loc <- Stack(Local nslots);
-        Proc.num_stack_slots.(cl) <- nslots + 1
+        Reloadgen.num_stack_slots.(cl) <- nslots + 1
       end
     end;
     (* Cancel the preferences of this register so that they don't influence
@@ -215,7 +215,7 @@ let allocate_registers() =
 
   (* Reset the stack slot counts *)
   for i = 0 to Proc.num_register_classes - 1 do
-    Proc.num_stack_slots.(i) <- 0;
+    Reloadgen.num_stack_slots.(i) <- 0;
   done;
 
   (* First pass: preallocate spill registers and split remaining regs

--- a/asmcomp/coloring.mli
+++ b/asmcomp/coloring.mli
@@ -15,4 +15,4 @@
 
 (* Register allocation by coloring of the interference graph *)
 
-val allocate_registers: unit -> unit
+val allocate_registers: unit -> int array

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -56,6 +56,9 @@ let fastcode_flag = ref true
 let stack_offset = ref 0
 
 (* Layout of the stack frame *)
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
+let prologue_required = ref false
 
 let frame_size () =                     (* includes return address *)
   let sz =
@@ -490,7 +493,7 @@ let emit_instr fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
-    assert (Proc.prologue_required ());
+    assert (!prologue_required);
     let n = frame_size() - 4 in
     if n > 0 then  begin
       I.sub (int n) esp;
@@ -925,6 +928,10 @@ let fundecl fundecl =
   call_gc_sites := [];
   bound_error_sites := [];
   bound_error_call := 0;
+  for i = 0 to Proc.num_register_classes - 1 do
+    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
+  done;
+  prologue_required := fundecl.fun_prologue_required;
   emit_named_text_section !function_name;
   add_def_symbol fundecl.fun_name;
   D.align (if system = S_win32 then 4 else 16);

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -241,19 +241,16 @@ let op_is_pure = function
 
 (* Layout of the stack frame *)
 
-let num_stack_slots = [| 0; 0 |]
-let contains_calls = ref false
-
-let frame_required () =
+let frame_required fd =
   let frame_size_at_top_of_function =
     (* cf. [frame_size] in emit.mlp. *)
-    Misc.align (4*num_stack_slots.(0) + 8*num_stack_slots.(1) + 4)
+    Misc.align (4*fd.fun_num_stack_slots.(0) + 8*fd.fun_num_stack_slots.(1) + 4)
       stack_alignment
   in
   frame_size_at_top_of_function > 4
 
-let prologue_required () =
-  frame_required ()
+let prologue_required fd =
+  frame_required fd
 
 (* Calling the assembler *)
 

--- a/asmcomp/i386/reload.ml
+++ b/asmcomp/i386/reload.ml
@@ -82,5 +82,5 @@ method! reload_test tst arg =
 
 end
 
-let fundecl f =
-  (new reload)#fundecl f
+let fundecl f num_stack_slots =
+  (new reload)#fundecl f num_stack_slots

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -302,7 +302,7 @@ method select_push exp =
   | _ -> (Ispecific(Ipush), exp)
 
 method! mark_c_tailcall =
-  Proc.contains_calls := true
+  Selectgen.contains_calls := true
 
 method! emit_extcall_args env args =
   let rec size_pushes = function

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -302,7 +302,7 @@ method select_push exp =
   | _ -> (Ispecific(Ipush), exp)
 
 method! mark_c_tailcall =
-  Selectgen.contains_calls := true
+  contains_calls := true
 
 method! emit_extcall_args env args =
   let rec size_pushes = function

--- a/asmcomp/linear.ml
+++ b/asmcomp/linear.ml
@@ -54,6 +54,10 @@ type fundecl =
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
     fun_tailrec_entry_point_label : label;
+    fun_contains_calls: bool;
+    fun_num_stack_slots: int array;
+    fun_frame_required: bool;
+    fun_prologue_required: bool;
   }
 
 (* Invert a test *)

--- a/asmcomp/linear.mli
+++ b/asmcomp/linear.mli
@@ -55,4 +55,8 @@ type fundecl =
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
     fun_tailrec_entry_point_label : label;
+    fun_contains_calls: bool;
+    fun_num_stack_slots: int array;
+    fun_frame_required: bool;
+    fun_prologue_required: bool;
   }

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -134,132 +134,132 @@ let local_exit k =
 
 (* Linearize an instruction [i]: add it in front of the continuation [n] *)
 let linear i n contains_calls =
-let rec linear i n =
-  match i.Mach.desc with
-    Iend -> n
-  | Iop(Itailcall_ind _ | Itailcall_imm _ as op) ->
-      if not Config.spacetime then
-        copy_instr (Lop op) i (discard_dead_code n)
-      else
+  let rec linear i n =
+    match i.Mach.desc with
+      Iend -> n
+    | Iop(Itailcall_ind _ | Itailcall_imm _ as op) ->
+        if not Config.spacetime then
+          copy_instr (Lop op) i (discard_dead_code n)
+        else
+          copy_instr (Lop op) i (linear i.Mach.next n)
+    | Iop(Imove | Ireload | Ispill)
+      when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
+        linear i.Mach.next n
+    | Iop op ->
         copy_instr (Lop op) i (linear i.Mach.next n)
-  | Iop(Imove | Ireload | Ispill)
-    when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
-      linear i.Mach.next n
-  | Iop op ->
-      copy_instr (Lop op) i (linear i.Mach.next n)
-  | Ireturn ->
-      let n1 = copy_instr Lreturn i (discard_dead_code n) in
-      if contains_calls
-      then cons_instr Lreloadretaddr n1
-      else n1
-  | Iifthenelse(test, ifso, ifnot) ->
-      let n1 = linear i.Mach.next n in
-      begin match (ifso.Mach.desc, ifnot.Mach.desc, n1.desc) with
-        Iend, _, Lbranch lbl ->
-          copy_instr (Lcondbranch(test, lbl)) i (linear ifnot n1)
-      | _, Iend, Lbranch lbl ->
-          copy_instr (Lcondbranch(invert_test test, lbl)) i (linear ifso n1)
-      | Iexit nfail1, Iexit nfail2, _
-            when is_next_catch nfail1 && local_exit nfail2 ->
-          let lbl2 = find_exit_label nfail2 in
-          copy_instr
-            (Lcondbranch (invert_test test, lbl2)) i (linear ifso n1)
-      | Iexit nfail, _, _ when local_exit nfail ->
-          let n2 = linear ifnot n1
-          and lbl = find_exit_label nfail in
-          copy_instr (Lcondbranch(test, lbl)) i n2
-      | _,  Iexit nfail, _ when local_exit nfail ->
-          let n2 = linear ifso n1 in
-          let lbl = find_exit_label nfail in
-          copy_instr (Lcondbranch(invert_test test, lbl)) i n2
-      | Iend, _, _ ->
-          let (lbl_end, n2) = get_label n1 in
-          copy_instr (Lcondbranch(test, lbl_end)) i (linear ifnot n2)
-      | _,  Iend, _ ->
-          let (lbl_end, n2) = get_label n1 in
-          copy_instr (Lcondbranch(invert_test test, lbl_end)) i
-                     (linear ifso n2)
-      | _, _, _ ->
-        (* Should attempt branch prediction here *)
-          let (lbl_end, n2) = get_label n1 in
-          let (lbl_else, nelse) = get_label (linear ifnot n2) in
-          copy_instr (Lcondbranch(invert_test test, lbl_else)) i
-            (linear ifso (add_branch lbl_end nelse))
-      end
-  | Iswitch(index, cases) ->
-      let lbl_cases = Array.make (Array.length cases) 0 in
-      let (lbl_end, n1) = get_label(linear i.Mach.next n) in
-      let n2 = ref (discard_dead_code n1) in
-      for i = Array.length cases - 1 downto 0 do
-        let (lbl_case, ncase) =
-                get_label(linear cases.(i) (add_branch lbl_end !n2)) in
-        lbl_cases.(i) <- lbl_case;
-        n2 := discard_dead_code ncase
-      done;
-      (* Switches with 1 and 2 branches have been eliminated earlier.
-         Here, we do something for switches with 3 branches. *)
-      if Array.length index = 3 then begin
-        let fallthrough_lbl = check_label !n2 in
-        let find_label n =
-          let lbl = lbl_cases.(index.(n)) in
-          if lbl = fallthrough_lbl then None else Some lbl in
-        copy_instr (Lcondbranch3(find_label 0, find_label 1, find_label 2))
-                   i !n2
-      end else
-        copy_instr (Lswitch(Array.map (fun n -> lbl_cases.(n)) index)) i !n2
-  | Icatch(_rec_flag, handlers, body) ->
-      let (lbl_end, n1) = get_label(linear i.Mach.next n) in
-      (* CR mshinwell for pchambart:
-         1. rename "io"
-         2. Make sure the test cases cover the "Iend" cases too *)
-      let labels_at_entry_to_handlers = List.map (fun (_nfail, handler) ->
-          match handler.Mach.desc with
-          | Iend -> lbl_end
-          | _ -> Cmm.new_label ())
-          handlers in
-      let exit_label_add = List.map2
-          (fun (nfail, _) lbl -> (nfail, (lbl, !try_depth)))
-          handlers labels_at_entry_to_handlers in
-      let previous_exit_label = !exit_label in
-      exit_label := exit_label_add @ !exit_label;
-      let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
-          match handler.Mach.desc with
-          | Iend -> n
-          | _ -> cons_instr (Llabel lbl_handler)
-                   (linear handler (add_branch lbl_end n)))
-          n1 handlers labels_at_entry_to_handlers
-      in
-      let n3 = linear body (add_branch lbl_end n2) in
-      exit_label := previous_exit_label;
-      n3
-  | Iexit nfail ->
-      let lbl, t = find_exit_label_try_depth nfail in
-      assert (i.Mach.next.desc = Mach.Iend);
-      let delta_traps = !try_depth - t in
-      let n1 = adjust_trap_depth delta_traps n in
-      let rec loop i tt =
-        if t = tt then i
-        else loop (cons_instr Lpoptrap i) (tt - 1)
-      in
-      loop (add_branch lbl n1) !try_depth
-  | Itrywith(body, handler) ->
-      let (lbl_join, n1) = get_label (linear i.Mach.next n) in
-      let (lbl_handler, n2) =
-        get_label (cons_instr Lentertrap (linear handler n1))
-      in
-      incr try_depth;
-      assert (i.Mach.arg = [| |] || Config.spacetime);
-      let n3 = cons_instr (Lpushtrap { lbl_handler; })
-                 (linear body
-                    (cons_instr
-                       Lpoptrap
-                       (add_branch lbl_join n2))) in
-      decr try_depth;
-      n3
+    | Ireturn ->
+        let n1 = copy_instr Lreturn i (discard_dead_code n) in
+        if contains_calls
+        then cons_instr Lreloadretaddr n1
+        else n1
+    | Iifthenelse(test, ifso, ifnot) ->
+        let n1 = linear i.Mach.next n in
+        begin match (ifso.Mach.desc, ifnot.Mach.desc, n1.desc) with
+          Iend, _, Lbranch lbl ->
+            copy_instr (Lcondbranch(test, lbl)) i (linear ifnot n1)
+        | _, Iend, Lbranch lbl ->
+            copy_instr (Lcondbranch(invert_test test, lbl)) i (linear ifso n1)
+        | Iexit nfail1, Iexit nfail2, _
+              when is_next_catch nfail1 && local_exit nfail2 ->
+            let lbl2 = find_exit_label nfail2 in
+            copy_instr
+              (Lcondbranch (invert_test test, lbl2)) i (linear ifso n1)
+        | Iexit nfail, _, _ when local_exit nfail ->
+            let n2 = linear ifnot n1
+            and lbl = find_exit_label nfail in
+            copy_instr (Lcondbranch(test, lbl)) i n2
+        | _,  Iexit nfail, _ when local_exit nfail ->
+            let n2 = linear ifso n1 in
+            let lbl = find_exit_label nfail in
+            copy_instr (Lcondbranch(invert_test test, lbl)) i n2
+        | Iend, _, _ ->
+            let (lbl_end, n2) = get_label n1 in
+            copy_instr (Lcondbranch(test, lbl_end)) i (linear ifnot n2)
+        | _,  Iend, _ ->
+            let (lbl_end, n2) = get_label n1 in
+            copy_instr (Lcondbranch(invert_test test, lbl_end)) i
+                       (linear ifso n2)
+        | _, _, _ ->
+          (* Should attempt branch prediction here *)
+            let (lbl_end, n2) = get_label n1 in
+            let (lbl_else, nelse) = get_label (linear ifnot n2) in
+            copy_instr (Lcondbranch(invert_test test, lbl_else)) i
+              (linear ifso (add_branch lbl_end nelse))
+        end
+    | Iswitch(index, cases) ->
+        let lbl_cases = Array.make (Array.length cases) 0 in
+        let (lbl_end, n1) = get_label(linear i.Mach.next n) in
+        let n2 = ref (discard_dead_code n1) in
+        for i = Array.length cases - 1 downto 0 do
+          let (lbl_case, ncase) =
+                  get_label(linear cases.(i) (add_branch lbl_end !n2)) in
+          lbl_cases.(i) <- lbl_case;
+          n2 := discard_dead_code ncase
+        done;
+        (* Switches with 1 and 2 branches have been eliminated earlier.
+           Here, we do something for switches with 3 branches. *)
+        if Array.length index = 3 then begin
+          let fallthrough_lbl = check_label !n2 in
+          let find_label n =
+            let lbl = lbl_cases.(index.(n)) in
+            if lbl = fallthrough_lbl then None else Some lbl in
+          copy_instr (Lcondbranch3(find_label 0, find_label 1, find_label 2))
+                     i !n2
+        end else
+          copy_instr (Lswitch(Array.map (fun n -> lbl_cases.(n)) index)) i !n2
+    | Icatch(_rec_flag, handlers, body) ->
+        let (lbl_end, n1) = get_label(linear i.Mach.next n) in
+        (* CR mshinwell for pchambart:
+           1. rename "io"
+           2. Make sure the test cases cover the "Iend" cases too *)
+        let labels_at_entry_to_handlers = List.map (fun (_nfail, handler) ->
+            match handler.Mach.desc with
+            | Iend -> lbl_end
+            | _ -> Cmm.new_label ())
+            handlers in
+        let exit_label_add = List.map2
+            (fun (nfail, _) lbl -> (nfail, (lbl, !try_depth)))
+            handlers labels_at_entry_to_handlers in
+        let previous_exit_label = !exit_label in
+        exit_label := exit_label_add @ !exit_label;
+        let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
+            match handler.Mach.desc with
+            | Iend -> n
+            | _ -> cons_instr (Llabel lbl_handler)
+                     (linear handler (add_branch lbl_end n)))
+            n1 handlers labels_at_entry_to_handlers
+        in
+        let n3 = linear body (add_branch lbl_end n2) in
+        exit_label := previous_exit_label;
+        n3
+    | Iexit nfail ->
+        let lbl, t = find_exit_label_try_depth nfail in
+        assert (i.Mach.next.desc = Mach.Iend);
+        let delta_traps = !try_depth - t in
+        let n1 = adjust_trap_depth delta_traps n in
+        let rec loop i tt =
+          if t = tt then i
+          else loop (cons_instr Lpoptrap i) (tt - 1)
+        in
+        loop (add_branch lbl n1) !try_depth
+    | Itrywith(body, handler) ->
+        let (lbl_join, n1) = get_label (linear i.Mach.next n) in
+        let (lbl_handler, n2) =
+          get_label (cons_instr Lentertrap (linear handler n1))
+        in
+        incr try_depth;
+        assert (i.Mach.arg = [| |] || Config.spacetime);
+        let n3 = cons_instr (Lpushtrap { lbl_handler; })
+                   (linear body
+                      (cons_instr
+                         Lpoptrap
+                         (add_branch lbl_join n2))) in
+        decr try_depth;
+        n3
 
-  | Iraise k ->
-      copy_instr (Lraise k) i (discard_dead_code n)
-in linear i n
+    | Iraise k ->
+        copy_instr (Lraise k) i (discard_dead_code n)
+  in linear i n
 
 let add_prologue first_insn prologue_required =
   (* The prologue needs to come after any [Iname_for_debugger] operations that

--- a/asmcomp/linscan.ml
+++ b/asmcomp/linscan.ml
@@ -73,8 +73,8 @@ let rec release_expired_inactive ci pos = function
 
 let allocate_stack_slot i =
   let cl = Proc.register_class i.reg in
-  let ss = Proc.num_stack_slots.(cl) in
-  Proc.num_stack_slots.(cl) <- succ ss;
+  let ss = Reloadgen.num_stack_slots.(cl) in
+  Reloadgen.num_stack_slots.(cl) <- succ ss;
   i.reg.loc <- Stack(Local ss);
   i.reg.spill <- true
 
@@ -187,7 +187,7 @@ let allocate_registers() =
       ci_active = [];
       ci_inactive = []
     };
-    Proc.num_stack_slots.(cl) <- 0
+    Reloadgen.num_stack_slots.(cl) <- 0
   done;
   (* Add all fixed intervals (sorted by end position) *)
   List.iter

--- a/asmcomp/linscan.ml
+++ b/asmcomp/linscan.ml
@@ -71,10 +71,10 @@ let rec release_expired_inactive ci pos = function
 
 (* Allocate a new stack slot to the interval. *)
 
-let allocate_stack_slot i =
+let allocate_stack_slot num_stack_slots i =
   let cl = Proc.register_class i.reg in
-  let ss = Reloadgen.num_stack_slots.(cl) in
-  Reloadgen.num_stack_slots.(cl) <- succ ss;
+  let ss = num_stack_slots.(cl) in
+  num_stack_slots.(cl) <- succ ss;
   i.reg.loc <- Stack(Local ss);
   i.reg.spill <- true
 
@@ -82,11 +82,11 @@ let allocate_stack_slot i =
    The interval is added to active. Raises Not_found if no free registers
    left. *)
 
-let allocate_free_register i =
+let allocate_free_register num_stack_slots i =
   begin match i.reg.loc, i.reg.spill with
     Unknown, true ->
       (* Allocate a stack slot for the already spilled interval *)
-      allocate_stack_slot i
+      allocate_stack_slot num_stack_slots i
   | Unknown, _ ->
       (* We need to allocate a register to this interval somehow *)
       let cl = Proc.register_class i.reg in
@@ -136,7 +136,7 @@ let allocate_free_register i =
   | _ -> ()
   end
 
-let allocate_blocked_register i =
+let allocate_blocked_register num_stack_slots i =
   let cl = Proc.register_class i.reg in
   let ci = active.(cl) in
   match ci.ci_active with
@@ -154,14 +154,14 @@ let allocate_blocked_register i =
       (* Remove the last interval from active and insert the current *)
       ci.ci_active <- insert_interval_sorted i il;
       (* Now get a new stack slot for the spilled register *)
-      allocate_stack_slot ilast
+      allocate_stack_slot num_stack_slots ilast
   | _ ->
       (* Either the current interval is last and we have to spill it,
          or there are no registers at all in the register class (i.e.
          floating point class on i386). *)
-      allocate_stack_slot i
+      allocate_stack_slot num_stack_slots i
 
-let walk_interval i =
+let walk_interval num_stack_slots i =
   let pos = i.ibegin land (lnot 0x01) in
   (* Release all intervals that have been expired at the current position *)
   Array.iter
@@ -172,11 +172,11 @@ let walk_interval i =
     active;
   try
     (* Allocate free register (if any) *)
-    allocate_free_register i
+    allocate_free_register num_stack_slots i
   with
     Not_found ->
       (* No free register, need to decide which interval to spill *)
-      allocate_blocked_register i
+      allocate_blocked_register num_stack_slots i
 
 let allocate_registers() =
   (* Initialize the stack slots and interval lists *)
@@ -187,8 +187,9 @@ let allocate_registers() =
       ci_active = [];
       ci_inactive = []
     };
-    Reloadgen.num_stack_slots.(cl) <- 0
   done;
+  (* Reset the stack slot counts *)
+  let num_stack_slots = Array.make Proc.num_register_classes 0 in
   (* Add all fixed intervals (sorted by end position) *)
   List.iter
     (fun i ->
@@ -196,4 +197,5 @@ let allocate_registers() =
       ci.ci_fixed <- insert_interval_sorted i ci.ci_fixed)
     (Interval.all_fixed_intervals());
   (* Walk all the intervals within the list *)
-  List.iter walk_interval (Interval.all_intervals())
+  List.iter (walk_interval num_stack_slots) (Interval.all_intervals());
+  num_stack_slots

--- a/asmcomp/linscan.mli
+++ b/asmcomp/linscan.mli
@@ -16,4 +16,4 @@
 
 (* Linear scan register allocation. *)
 
-val allocate_registers: unit -> unit
+val allocate_registers: unit -> int array

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -100,6 +100,8 @@ type fundecl =
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
+    fun_num_stack_slots: int array;
+    fun_contains_calls: bool;
   }
 
 let rec dummy_instr =

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -122,6 +122,8 @@ type fundecl =
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
+    fun_num_stack_slots: int array;
+    fun_contains_calls: bool;
   }
 
 val dummy_instr: instruction

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -36,6 +36,12 @@ let reserved_stack_space =
 
 let stack_offset = ref 0
 
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
+let prologue_required = ref false
+
+let contains_calls = ref false
+
 let frame_size () =
   let size =
     reserved_stack_space +
@@ -557,7 +563,7 @@ let emit_instr i =
     match i.desc with
     | Lend -> ()
     | Lprologue ->
-      assert (Proc.prologue_required ());
+      assert (!prologue_required);
       let n = frame_size() in
       if n > 0 then begin
         `	addi	1, 1, {emit_int(-n)}\n`;
@@ -1048,6 +1054,11 @@ let fundecl fundecl =
   call_gc_labels := IntMap.empty;
   float_literals := [];
   jumptables := []; jumptables_lbl := -1;
+  for i = 0 to Proc.num_register_classes - 1 do
+    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
+  done;
+  prologue_required := fundecl.fun_prologue_required;
+  contains_calls := fundecl.fun_contains_calls;
   begin match abi with
   | ELF32 ->
     emit_string code_space;

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -339,28 +339,25 @@ let op_is_pure = function
 
 (* Layout of the stack *)
 
-let num_stack_slots = [| 0; 0 |]
-let contains_calls = ref false
-
 (* See [reserved_stack_space] in emit.mlp. *)
 let reserved_stack_space_required () =
   match abi with
   | ELF32 -> false
   | ELF64v1 | ELF64v2 -> true
 
-let frame_required () =
+let frame_required fd =
   let is_elf32 =
     match abi with
     | ELF32 -> true
     | ELF64v1 | ELF64v2 -> false
   in
   reserved_stack_space_required ()
-    || num_stack_slots.(0) > 0
-    || num_stack_slots.(1) > 0
-    || (!contains_calls && is_elf32)
+    || fd.fun_num_stack_slots.(0) > 0
+    || fd.fun_num_stack_slots.(1) > 0
+    || (fd.fun_contains_calls && is_elf32)
 
-let prologue_required () =
-  frame_required ()
+let prologue_required fd =
+  frame_required fd
 
 (* Calling the assembler *)
 

--- a/asmcomp/power/reload.ml
+++ b/asmcomp/power/reload.ml
@@ -15,5 +15,5 @@
 
 (* Reloading for the PowerPC *)
 
-let fundecl f =
-  (new Reloadgen.reload_generic)#fundecl f
+let fundecl f num_stack_slots =
+  (new Reloadgen.reload_generic)#fundecl f num_stack_slots

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -65,12 +65,10 @@ val regs_are_volatile: Reg.t array -> bool
 val op_is_pure: Mach.operation -> bool
 
 (* Info for laying out the stack frame *)
-val num_stack_slots: int array
-val contains_calls: bool ref
-val frame_required : unit -> bool
+val frame_required : Mach.fundecl -> bool
 
 (* Function prologues *)
-val prologue_required : unit -> bool
+val prologue_required : Mach.fundecl -> bool
 
 (** For a given register class, the DWARF register numbering for that class.
     Given an allocated register with location [Reg n] and class [reg_class], the

--- a/asmcomp/reload.mli
+++ b/asmcomp/reload.mli
@@ -15,4 +15,4 @@
 
 (* Insert load/stores for pseudoregs that got assigned to stack locations. *)
 
-val fundecl: Mach.fundecl -> Mach.fundecl * bool
+val fundecl: Mach.fundecl -> int array -> Mach.fundecl * bool

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -19,8 +19,6 @@ open Misc
 open Reg
 open Mach
 
-let num_stack_slots = Array.make Proc.num_register_classes 0
-
 let insert_move src dst next =
   if src.loc = dst.loc
   then next
@@ -125,7 +123,7 @@ method private reload i =
       instr_cons (Itrywith(self#reload body, self#reload handler)) [||] [||]
         (self#reload i.next)
 
-method fundecl f =
+method fundecl f num_stack_slots =
   redo_regalloc <- false;
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -19,6 +19,8 @@ open Misc
 open Reg
 open Mach
 
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
 let insert_move src dst next =
   if src.loc = dst.loc
   then next
@@ -128,6 +130,9 @@ method fundecl f =
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
     fun_body = new_body; fun_codegen_options = f.fun_codegen_options;
-    fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape},
+    fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_contains_calls = f.fun_contains_calls;
+    fun_num_stack_slots = Array.copy num_stack_slots;
+   },
    redo_regalloc)
 end

--- a/asmcomp/reloadgen.mli
+++ b/asmcomp/reloadgen.mli
@@ -25,3 +25,5 @@ class reload_generic : object
   method fundecl : Mach.fundecl -> Mach.fundecl * bool
     (* The entry point *)
 end
+
+val num_stack_slots: int array

--- a/asmcomp/reloadgen.mli
+++ b/asmcomp/reloadgen.mli
@@ -22,8 +22,6 @@ class reload_generic : object
   method makereg : Reg.t -> Reg.t
     (* Can be overridden to avoid creating new registers of some class
        (i.e. if all "registers" of that class are actually on stack) *)
-  method fundecl : Mach.fundecl -> Mach.fundecl * bool
+  method fundecl : Mach.fundecl -> int array -> Mach.fundecl * bool
     (* The entry point *)
 end
-
-val num_stack_slots: int array

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -29,6 +29,12 @@ open Emitaux
 
 let stack_offset = ref 0
 
+let num_stack_slots = Array.make Proc.num_register_classes 0
+
+let prologue_required = ref false
+
+let contains_calls = ref false
+
 let frame_size () =
   let size =
     !stack_offset +                     (* Trap frame, outgoing parameters *)
@@ -308,7 +314,7 @@ let emit_instr i =
     match i.desc with
       Lend -> ()
     | Lprologue ->
-      assert (Proc.prologue_required ());
+      assert (!prologue_required);
       let n = frame_size() in
       emit_stack_adjust n;
       if !contains_calls then
@@ -668,6 +674,11 @@ let fundecl fundecl =
   bound_error_call := 0;
   float_literals := [];
   int_literals := [];
+  for i = 0 to Proc.num_register_classes - 1 do
+    num_stack_slots.(i) <- fundecl.fun_num_stack_slots.(i);
+  done;
+  prologue_required := fundecl.fun_prologue_required;
+  contains_calls := fundecl.fun_contains_calls;
   `	.globl	{emit_symbol fundecl.fun_name}\n`;
   emit_debug_info fundecl.fun_dbg;
   `	.type	{emit_symbol fundecl.fun_name}, @function\n`;

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -225,16 +225,13 @@ let op_is_pure = function
 
 (* Layout of the stack *)
 
-let num_stack_slots = [| 0; 0 |]
-let contains_calls = ref false
+let frame_required fd =
+  fd.fun_contains_calls
+    || fd.fun_num_stack_slots.(0) > 0
+    || fd.fun_num_stack_slots.(1) > 0
 
-let frame_required () =
-  !contains_calls
-    || num_stack_slots.(0) > 0
-    || num_stack_slots.(1) > 0
-
-let prologue_required () =
-  frame_required ()
+let prologue_required fd =
+  frame_required fd
 
 (* Calling the assembler *)
 

--- a/asmcomp/s390x/reload.ml
+++ b/asmcomp/s390x/reload.ml
@@ -46,5 +46,5 @@ method! reload_operation op arg res =
 
 end
 
-let fundecl f =
-  (new reload)#fundecl f
+let fundecl f num_stack_slots =
+  (new reload)#fundecl f num_stack_slots

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -393,6 +393,10 @@ method schedule_fundecl f =
       fun_dbg  = f.fun_dbg;
       fun_spacetime_shape = f.fun_spacetime_shape;
       fun_tailrec_entry_point_label = f.fun_tailrec_entry_point_label;
+      fun_contains_calls = f.fun_contains_calls;
+      fun_num_stack_slots = f.fun_num_stack_slots;
+      fun_frame_required = f.fun_frame_required;
+      fun_prologue_required = f.fun_prologue_required;
     }
   end else
     f

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -211,6 +211,8 @@ let join_array env rs =
       done;
       Some res
 
+let contains_calls = ref false
+
 (* Name of function being compiled *)
 let current_function_name = ref ""
 
@@ -386,7 +388,7 @@ method select_store is_assign addr arg =
 (* call marking methods, documented in selectgen.mli *)
 
 method mark_call =
-  Proc.contains_calls := true
+  contains_calls := true
 
 method mark_tailcall = ()
 
@@ -1216,7 +1218,7 @@ method insert_prologue _f ~loc_arg ~rarg ~spacetime_node_hole:_ ~env =
 method initial_env () = env_empty
 
 method emit_fundecl f =
-  Proc.contains_calls := false;
+  contains_calls := false;
   current_function_name := f.Cmm.fun_name;
   let rargs =
     List.map
@@ -1255,6 +1257,8 @@ method emit_fundecl f =
     fun_codegen_options = f.Cmm.fun_codegen_options;
     fun_dbg  = f.Cmm.fun_dbg;
     fun_spacetime_shape;
+    fun_num_stack_slots = Array.make Proc.num_register_classes 0;
+    fun_contains_calls = !contains_calls;
   }
 
 end

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -211,8 +211,6 @@ let join_array env rs =
       done;
       Some res
 
-let contains_calls = ref false
-
 (* Name of function being compiled *)
 let current_function_name = ref ""
 
@@ -386,6 +384,7 @@ method select_store is_assign addr arg =
   (Istore(Word_val, addr, is_assign), arg)
 
 (* call marking methods, documented in selectgen.mli *)
+val contains_calls = ref false
 
 method mark_call =
   contains_calls := true
@@ -1218,7 +1217,6 @@ method insert_prologue _f ~loc_arg ~rarg ~spacetime_node_hole:_ ~env =
 method initial_env () = env_empty
 
 method emit_fundecl f =
-  contains_calls := false;
   current_function_name := f.Cmm.fun_name;
   let rargs =
     List.map

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -181,8 +181,10 @@ class virtual selector_generic : object
 
   val mutable instr_seq : Mach.instruction
 
+  (* [contains_calls] is declared as a reference instance variable,
+     instead of a mutable boolean instance variable,
+     because the traversal uses functional object copies. *)
+  val contains_calls : bool ref
 end
 
 val reset : unit -> unit
-
-val contains_calls : bool ref

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -107,7 +107,7 @@ class virtual selector_generic : object
   method mark_call : unit
   (* informs the code emitter that the current function is non-leaf:
      it may perform a (non-tail) call; by default, sets
-     [Proc.contains_calls := true] *)
+     [contains_calls := true] *)
 
   method mark_tailcall : unit
   (* informs the code emitter that the current function may end with
@@ -121,7 +121,7 @@ class virtual selector_generic : object
      (which is the main purpose of tracking leaf functions) but some
      architectures still need to ensure that the stack is properly
      aligned when the C function is called. This is achieved by
-     overloading this method to set [Proc.contains_calls := true] *)
+     overloading this method to set [contains_calls := true] *)
 
   method mark_instr : Mach.instruction_desc -> unit
   (* dispatches on instructions to call one of the marking function
@@ -184,3 +184,5 @@ class virtual selector_generic : object
 end
 
 val reset : unit -> unit
+
+val contains_calls : bool ref

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -432,4 +432,6 @@ let fundecl f =
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_num_stack_slots = f.fun_num_stack_slots;
+    fun_contains_calls = f.fun_contains_calls;
   }

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -220,4 +220,6 @@ let fundecl f =
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_num_stack_slots = f.fun_num_stack_slots;
+    fun_contains_calls = f.fun_contains_calls;
   }


### PR DESCRIPTION
I am working on a tool [1] that manipulates, via compiler-libs, the intermediate representation created by Linearize pass.  The design of ocamlopt backend makes it possible, thanks to the separation of code of passes into modules. However, I found it tricky to use the intermediate representation independently, because different passes communicate by storing some function-specific information in the global state. This PR makes small changes to store this information in the record that describes the individual functions.

Global variables Proc.contains_calls and Proc.num_stack_slots hold per-function information, used by Linearize and Emit. These variables are updated every time Asmgen.compile_fundecl is invoked to compile another function.  This PR moves the variables contains_calls and num_stack_slots from Proc to the passes that produce these values: Selectgen and Reloadgen, respectively. The values are then stored per-function in Mach.fundecl, and propagated to Linearize and Emit as needed.

This approach is not ideal, because the individual passes still use global variables, but there are other such variables there already and the intention is that the uses should be limited to a particular pass (rather than communication between passes). Information produced in each pass that need to be propagated further is then recorded in Mach.fundecl.  This design makes it easier to understand the code in the backend, and save and restore IR after each pass.

To make the intermediate representation stand-alone, the remaining global state is Cmm.label_counter, which is per compilation unit and not per function. It is being addressed separately.

This PR is on top of (PR #8870) to split Linearize into two modules.

Passes on precheck:
https://ci.inria.fr/ocaml/job/precheck/292/

[1] Feedback-directed optimizations for Ocaml, mentioned in the context of PR #8526 on function sections (see https://github.com/ocaml/ocaml/pull/8526#issuecomment-511786569)