### PR TITLE
#8917, printtyp: fix printing of nested recursive definitions

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,6 +339,10 @@ Working version
   constructor disambiguation.
   (Jacques Garrigue, report and review by Thomas Refis)
 
+- #8917, #8929, #9889, #10219: fix printing of nested recursive definitions
+  in presence of a name collision.
+  (Florian Angeletti, report by Thomas Refis, review by Gabriel Scherer)
+
 - #9936: Make sure that `List.([1;2;3])` is printed `[1;2;3]` in the toplevel
   by identifying lists by their types.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
+++ b/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
@@ -36,9 +36,9 @@ module M : sig type t val x : t end
 |}];;
 
 module rec M : sig type t val x : M.t end = struct type t = int let x = 0 end;;
-(* this output is strange, it is surprising to use M/2 here. *)
+(* this output is CORRECT . *)
 [%%expect{|
-module rec M : sig type t val x : M/2.t end
+module rec M : sig type t val x : M.t end
 |}];;
 #show_module M;;
 (* this output is INCORRECT, it should use 'rec' *)

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -116,3 +116,25 @@ Line 4, characters 7-29:
 Error: This expression has type int
        This is not a function; it cannot be applied.
 |}]
+
+
+(* PR#8917
+   In nested recursive definitions, we have to remember all recursive items
+   under definitions, not just the last one
+ *)
+
+module RecMod = struct
+  module A= struct end
+  module type s = sig
+    module rec A: sig type t end
+    and B: sig type t = A.t end
+  end
+end
+[%%expect {|
+module RecMod :
+  sig
+    module A : sig end
+    module type s =
+      sig module rec A : sig type t end and B : sig type t = A.t end end
+  end
+|}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -146,8 +146,8 @@ module CorrectEnvConstructionTest :
         and +'a abstract
         module M :
           sig
-            type 'a user = 'a user = Foo of 'a abstract
-            and 'a abstract = 'a abstract
+            type 'a user = 'a user = Foo of 'a abstract/1
+            and 'a abstract = 'a abstract/2
           end
         type 'a foo = 'a M.user
       end


### PR DESCRIPTION
This PR fixes disambiguation issue when printing nested recursive definitions. For instance,
```OCaml
module A= struct end
module type s = sig
  module rec A: sig type t end
  and B: sig type t = A.t end
end
```
is currently printed as

> module A : sig  end
module type s =
  sig module rec A : sig type t end and B : sig type t = A/2.t end end

because the printing code forgets about `A` when it enters the recursive definition of `t`.

This PR solves this issue by making the management of state in `Printtyp` more cautious (and maybe more straightforward).

The first commit is mostly preparatory: it reorganizes the printing code for signature by splitting it in three phases:

* identification of syntactic signature items (class (and private variant) definitions generate ghost signature items)
* identification of recursive groups (to hide some types inside of their recursive definitions)
* printing.

The second commit is the fix itself which backtracks some of the printer state after the printing of signature items rather than erasing them.

The fourth commit simplifies the printer code by using the notion of syntactic item for private variant definitions. 

The last two commits are refactoring commits that align the management of the naming context state with the rest of the printer state inside signature.

Closes #8917 