### PR TITLE
4.09.0: backport the error message fix in #8777

### DIFF
--- a/Changes
+++ b/Changes
@@ -239,6 +239,10 @@ OCaml 4.09.0
 - #8701, #8725: Variance of constrained parameters causes principality issues
   (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
 
+- #8777(partial): fix position information in some polymorphic variant
+  error messages about missing tags
+  (Florian Angeletti, review by Thomas Refis)
+
 - #8779, more cautious variance computation to avoid missing cmis
   (Florian Angeletti, report by Antonio Nuno Monteiro, review by Leo White)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -124,6 +124,7 @@ module Unification_trace = struct
         Incompatible_fields { name; diff = swap_diff diff}
     | Obj (Missing_field(pos,s)) -> Obj(Missing_field(swap_position pos,s))
     | Obj (Abstract_row pos) -> Obj(Abstract_row (swap_position pos))
+    | Variant (No_tags(pos,f)) -> Variant (No_tags(swap_position pos,f))
     | x -> x
   let swap x = List.map swap_elt x
 


### PR DESCRIPTION
This PR backports the vanilla error message fix in #8777 in 4.09.0 .

I will merge it once CI passes.