### PR TITLE
An explicit representation for implicit unpacks

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -841,6 +841,12 @@ let half_simplify_cases args cls =
         | Tpat_var (id, s) ->
             let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
             simpl_clause (p :: patl, action)
+        | Tpat_unpack (None, _, _) ->
+            (omega :: patl, action)
+        | Tpat_unpack (Some id, s, _) ->
+            let s = { s with txt = Option.get s.txt } in
+            let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
+            simpl_clause (p :: patl, action)
         | Tpat_alias (p, id, _) ->
             let arg =
               match args with
@@ -3226,7 +3232,8 @@ let find_in_pat pred =
     | Tpat_constant _
     | Tpat_var _
     | Tpat_any
-    | Tpat_variant (_, None, _) ->
+    | Tpat_variant (_, None, _)
+    | Tpat_unpack _ ->
         false
     | Tpat_exception _ -> assert false
   in
@@ -3242,6 +3249,7 @@ let is_lazy_pat = function
   | Tpat_array _
   | Tpat_or _
   | Tpat_constant _
+  | Tpat_unpack _
   | Tpat_var _
   | Tpat_any ->
       false
@@ -3266,6 +3274,7 @@ let have_mutable_field p =
   | Tpat_array _
   | Tpat_or _
   | Tpat_constant _
+  | Tpat_unpack _
   | Tpat_var _
   | Tpat_any ->
       false

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -781,8 +781,8 @@ and transl_let rec_flag pat_expr_list =
       let idlist =
         List.map
           (fun {vb_pat=pat} -> match pat.pat_desc with
-              Tpat_var (id,_) -> id
-            | Tpat_alias ({pat_desc=Tpat_any}, id,_) -> id
+              Tpat_var (id,_)
+            | Tpat_unpack (Some id, _, _) -> id
             | _ -> assert false)
         pat_expr_list in
       let transl_case {vb_expr=expr; vb_attributes; vb_loc} id =

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -259,12 +259,10 @@ let init_shape id modl =
         raise (Initialization_failure (Unsafe {reason=Unsafe_typext;loc;subid}))
     | Sig_module(id, Mp_present, md, _, _) :: rem ->
         init_shape_mod id md.md_loc env md.md_type ::
-        init_shape_struct (Env.add_module_declaration ~check:false
-                             id Mp_present md env) rem
+        init_shape_struct (Env.add_module_declaration id Mp_present md env) rem
     | Sig_module(id, Mp_absent, md, _, _) :: rem ->
         init_shape_struct
-          (Env.add_module_declaration ~check:false
-                             id Mp_absent md env) rem
+          (Env.add_module_declaration id Mp_absent md env) rem
     | Sig_modtype(id, minfo, _) :: rem ->
         init_shape_struct (Env.add_modtype id minfo env) rem
     | Sig_class _ :: rem ->

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -137,7 +137,10 @@ f m 1 (module struct let x = 2 end);;
 
 let (module M) = m in M.x;;
 [%%expect{|
-- : int = 3
+Line 1, characters 4-14:
+1 | let (module M) = m in M.x;;
+        ^^^^^^^^^^
+Error: The signature for this packaged module couldn't be inferred.
 |}];;
 
 let (module M) = m;; (* Error: only allowed in [let .. in] *)

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -346,7 +346,7 @@ let not_ambiguous__module_variable x b =  match x with
 Line 2, characters 12-13:
 2 |   | (module M:S),_,(1,_)
                 ^
-Warning 60: unused module M.
+Warning 27: unused variable M.
 val not_ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 |}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2176,6 +2176,9 @@ let mark_cltype_used uid =
 let set_value_used_callback vd callback =
   Hashtbl.add value_declarations vd.val_uid callback
 
+let set_module_used_callback md callback =
+  Hashtbl.replace module_declarations md.md_uid callback
+
 let set_type_used_callback td callback =
   if Uid.for_actual_declaration td.type_uid then
     let old =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -404,6 +404,8 @@ val is_in_signature: t -> bool
 
 val set_value_used_callback:
     value_description -> (unit -> unit) -> unit
+val set_module_used_callback:
+    module_declaration -> (unit -> unit) -> unit
 val set_type_used_callback:
     type_declaration -> ((unit -> unit) -> unit) -> unit
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -266,8 +266,9 @@ val add_type: check:bool -> Ident.t -> type_declaration -> t -> t
 val add_extension: check:bool -> Ident.t -> extension_constructor -> t -> t
 val add_module:
   ?arg:bool -> Ident.t -> module_presence -> module_type -> t -> t
-val add_module_declaration: ?arg:bool -> check:bool -> Ident.t ->
-  module_presence -> module_declaration -> t -> t
+val add_module_declaration:
+  ?arg:bool -> ?check:(string -> Warnings.t) -> Ident.t -> module_presence ->
+    module_declaration -> t -> t
 val add_modtype: Ident.t -> modtype_declaration -> t -> t
 val add_class: Ident.t -> class_declaration -> t -> t
 val add_cltype: Ident.t -> class_type_declaration -> t -> t

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -48,7 +48,7 @@ let rec env_from_summary sum subst =
             (Subst.extension_constructor subst desc)
             (env_from_summary s subst)
       | Env_module(s, id, pres, desc) ->
-          Env.add_module_declaration ~check:false id pres
+          Env.add_module_declaration id pres
             (Subst.module_declaration Keep subst desc)
             (env_from_summary s subst)
       | Env_modtype(s, id, desc) ->
@@ -70,7 +70,7 @@ let rec env_from_summary sum subst =
           end
       | Env_functor_arg(Env_module(s, id, pres, desc), id')
             when Ident.same id id' ->
-          Env.add_module_declaration ~check:false
+          Env.add_module_declaration
             id pres (Subst.module_declaration Keep subst desc)
             ~arg:true (env_from_summary s subst)
       | Env_functor_arg _ -> assert false

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -81,7 +81,7 @@ and strengthen_sig ~aliasable env sg p =
       in
       Sig_module(id, pres, str, rs, vis)
       :: strengthen_sig ~aliasable
-        (Env.add_module_declaration ~check:false id pres md env) rem p
+        (Env.add_module_declaration id pres md env) rem p
       (* Need to add the module in case it defines manifest module types *)
   | Sig_modtype(id, decl, vis) :: rem ->
       let newdecl =
@@ -296,7 +296,7 @@ and type_paths_sig env p sg =
       Pdot(p, Ident.name id) :: type_paths_sig env p rem
   | Sig_module(id, pres, md, _, _) :: rem ->
       type_paths env (Pdot(p, Ident.name id)) md.md_type @
-      type_paths_sig (Env.add_module_declaration ~check:false id pres md env)
+      type_paths_sig (Env.add_module_declaration id pres md env)
         p rem
   | Sig_modtype(id, decl, _) :: rem ->
       type_paths_sig (Env.add_modtype id decl env) p rem
@@ -326,7 +326,7 @@ and no_code_needed_sig env sg =
   | Sig_module(id, pres, md, _, _) :: rem ->
       no_code_needed_mod env pres md.md_type &&
       no_code_needed_sig
-        (Env.add_module_declaration ~check:false id pres md env) rem
+        (Env.add_module_declaration id pres md env) rem
   | (Sig_type _ | Sig_modtype _ | Sig_class_type _) :: rem ->
       no_code_needed_sig env rem
   | (Sig_typext _ | Sig_class _) :: _ ->

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -37,8 +37,6 @@ let rec pretty_val ppf v =
   match v.pat_extra with
       (cstr, _loc, _attrs) :: rem ->
         begin match cstr with
-          | Tpat_unpack ->
-            fprintf ppf "@[(module %a)@]" pretty_val { v with pat_extra = rem }
           | Tpat_constraint _ ->
             fprintf ppf "@[(%a : _)@]" pretty_val { v with pat_extra = rem }
           | Tpat_type _ ->
@@ -95,6 +93,10 @@ let rec pretty_val ppf v =
       fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.print x
   | Tpat_or (v,w,_)    ->
       fprintf ppf "@[(%a|@,%a)@]" pretty_or v pretty_or w
+  | Tpat_unpack (None, _, _)->
+      fprintf ppf "@[(module _)@]"
+  | Tpat_unpack (Some x, _, _)->
+      fprintf ppf "@[(module %s)@]" (Ident.name x)
 
 and pretty_car ppf v = match v.pat_desc with
 | Tpat_construct (_,cstr, [_ ; _])

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -227,10 +227,6 @@ and pattern i ppf x =
   attributes i ppf x.pat_attributes;
   let i = i+1 in
   match x.pat_extra with
-    | (Tpat_unpack, _, attrs) :: rem ->
-        line i ppf "Tpat_unpack\n";
-        attributes i ppf attrs;
-        pattern i ppf { x with pat_extra = rem }
     | (Tpat_constraint cty, _, attrs) :: rem ->
         line i ppf "Tpat_constraint\n";
         attributes i ppf attrs;
@@ -248,6 +244,8 @@ and pattern i ppf x =
   match x.pat_desc with
   | Tpat_any -> line i ppf "Tpat_any\n";
   | Tpat_var (s,_) -> line i ppf "Tpat_var \"%a\"\n" fmt_ident s;
+  | Tpat_unpack (None,_,_) -> line i ppf "Tpat_unpack \"_\"\n";
+  | Tpat_unpack (Some s,_,_) -> line i ppf "Tpat_unpack \"%a\"\n" fmt_ident s;
   | Tpat_alias (p, s,_) ->
       line i ppf "Tpat_alias \"%a\"\n" fmt_ident s;
       pattern i ppf p;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -1188,6 +1188,7 @@ and is_destructuring_pattern : Typedtree.pattern -> bool =
   fun pat -> match pat.pat_desc with
     | Tpat_any -> false
     | Tpat_var (_, _) -> false
+    | Tpat_unpack (_, _, _) -> false
     | Tpat_alias (pat, _, _) -> is_destructuring_pattern pat
     | Tpat_constant _ -> true
     | Tpat_tuple _ -> true

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -152,7 +152,6 @@ let extension_constructor sub {ext_kind; _} =
 let pat sub {pat_extra; pat_desc; pat_env; _} =
   let extra = function
     | Tpat_type _ -> ()
-    | Tpat_unpack -> ()
     | Tpat_open (_, _, env) -> sub.env sub env
     | Tpat_constraint ct -> sub.typ sub ct
   in
@@ -161,6 +160,7 @@ let pat sub {pat_extra; pat_desc; pat_env; _} =
   match pat_desc with
   | Tpat_any  -> ()
   | Tpat_var _ -> ()
+  | Tpat_unpack _ -> ()
   | Tpat_constant _ -> ()
   | Tpat_tuple l -> List.iter (sub.pat sub) l
   | Tpat_construct (_, _, l) -> List.iter (sub.pat sub) l

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -197,8 +197,7 @@ let extension_constructor sub x =
 
 let pat sub x =
   let extra = function
-    | Tpat_type _
-    | Tpat_unpack as d -> d
+    | Tpat_type _ as d -> d
     | Tpat_open (path,loc,env) ->  Tpat_open (path, loc, sub.env sub env)
     | Tpat_constraint ct -> Tpat_constraint (sub.typ sub ct)
   in
@@ -208,6 +207,7 @@ let pat sub x =
     match x.pat_desc with
     | Tpat_any
     | Tpat_var _
+    | Tpat_unpack _
     | Tpat_constant _ as d -> d
     | Tpat_tuple l -> Tpat_tuple (List.map (sub.pat sub) l)
     | Tpat_construct (loc, cd, l) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -116,11 +116,14 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-(* Forward declaration, to be filled in by Typemod.type_module *)
+(* Forward declaration, to be filled in by Typemod *)
 
 let type_module =
   ref ((fun _env _md -> assert false) :
        Env.t -> Parsetree.module_expr -> Typedtree.module_expr)
+let type_unpack =
+  ref ((fun ~loc:_ _env _ty -> assert false) :
+         loc:Location.t -> Env.t -> Types.type_expr -> Types.module_type)
 
 (* Forward declaration, to be filled in by Typemod.type_open *)
 
@@ -356,53 +359,57 @@ type pattern_variable =
     pv_type: type_expr;
     pv_loc: Location.t;
     pv_as_var: bool;
+    pv_mty: Types.module_type option;
     pv_attributes: attributes;
   }
-
-type module_variable =
-  string loc * Location.t
 
 let pattern_variables = ref ([] : pattern_variable list)
 let pattern_force = ref ([] : (unit -> unit) list)
 let pattern_scope = ref (None : Annot.ident option);;
 let allow_modules = ref false
-let module_variables = ref ([] : module_variable list)
 let reset_pattern scope allow =
   pattern_variables := [];
   pattern_force := [];
   pattern_scope := scope;
   allow_modules := allow;
-  module_variables := [];
 ;;
 
 let maybe_add_pattern_variables_ghost loc_let env pv =
-  List.fold_right
-    (fun {pv_id; _} env ->
-       let name = Ident.name pv_id in
-       if Env.bound_value name env then env
-       else begin
-         Env.enter_unbound_value name
-           (Val_unbound_ghost_recursive loc_let) env
-       end
-    ) pv env
+  List.fold_right (fun {pv_id; pv_mty; _} env ->
+    let name = Ident.name pv_id in
+    match pv_mty with
+    | None when not (Env.bound_value name env) ->
+        Env.enter_unbound_value name
+          (Val_unbound_ghost_recursive loc_let) env
+    | _ -> env
+  ) pv env
 
-let enter_variable ?(is_module=false) ?(is_as_variable=false) loc name ty
+let enter_variable ?module_type ?(is_as_variable=false) loc name ty
     attrs =
   if List.exists (fun {pv_id; _} -> Ident.name pv_id = name.txt)
       !pattern_variables
   then raise(Error(loc, Env.empty, Multiply_bound_variable name.txt));
-  let id = Ident.create_local name.txt in
+  let id =
+    match module_type with
+    | None ->
+        (* values are not scoped *)
+        Ident.create_local name.txt
+    | Some _ ->
+        (* modules are scoped to the match. *)
+        let scope = get_gadt_equations_level () in
+        Ident.create_scoped ~scope name.txt
+  in
   pattern_variables :=
     {pv_id = id;
      pv_type = ty;
      pv_loc = loc;
      pv_as_var = is_as_variable;
+     pv_mty = module_type;
      pv_attributes = attrs} :: !pattern_variables;
-  if is_module then begin
+  if Option.is_some module_type then begin
     (* Note: unpack patterns enter a variable of the same name *)
     if not !allow_modules then
-      raise (Error (loc, Env.empty, Modules_not_allowed));
-    module_variables := (name, loc) :: !module_variables
+      raise (Error (loc, Env.empty, Modules_not_allowed))
   end else begin
     (* moved to genannot *)
     Option.iter
@@ -501,7 +508,7 @@ let rec build_as_type env p =
           let row = row_repr row in
           newty (Tvariant{row with row_closed=false; row_more=newvar()})
       end
-  | Tpat_any | Tpat_var _ | Tpat_constant _
+  | Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_unpack _
   | Tpat_array _ | Tpat_lazy _ | Tpat_exception _ -> p.pat_type
 
 let build_or_pat env loc lid =
@@ -969,7 +976,6 @@ type half_typed_case =
     untyped_case: Parsetree.case;
     branch_env: Env.t;
     pat_vars: pattern_variable list;
-    unpacks: module_variable list;
     contains_gadt: bool; }
 
 let rec has_literal_pattern p = match p.ppat_desc with
@@ -1077,22 +1083,32 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
   | Ppat_unpack name ->
       assert (constrs = None);
       let t = instance expected_ty in
+      let original_level = get_gadt_equations_level () in
+      begin_def ();
+      let context = Typetexp.narrow () in
+      let mty = !type_unpack ~loc !env expected_ty in
+      Mtype.lower_nongen original_level mty;
+      Typetexp.widen context;
+      end_def ();
+      (* go back to original level *)
       begin match name.txt with
       | None ->
           rp k {
-            pat_desc = Tpat_any;
+            pat_desc = Tpat_unpack (None, name, mty);
             pat_loc = sp.ppat_loc;
-            pat_extra=[Tpat_unpack, name.loc, sp.ppat_attributes];
+            pat_extra=[];
             pat_type = t;
             pat_attributes = [];
             pat_env = !env }
       | Some s ->
           let v = { name with txt = s } in
-          let id = enter_variable loc v t ~is_module:true sp.ppat_attributes in
+          let id =
+            enter_variable name.loc v t ~module_type:mty sp.ppat_attributes
+          in
           rp k {
-            pat_desc = Tpat_var (id, v);
+            pat_desc = Tpat_unpack (Some id, name, mty);
             pat_loc = sp.ppat_loc;
-            pat_extra=[Tpat_unpack, loc, sp.ppat_attributes];
+            pat_extra=[];
             pat_type = t;
             pat_attributes = [];
             pat_env = !env }
@@ -1365,7 +1381,6 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
       begin match
         if mode = Split_or || mode = Splitting_or then raise Need_backtrack;
         let initial_pattern_variables = !pattern_variables in
-        let initial_module_variables = !module_variables in
         let equation_level = !gadt_equations_level in
         let outter_lev = get_current_level () in
         (* introduce a new scope *)
@@ -1378,9 +1393,7 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
                       ~env:env1 (fun x -> x))
           with Need_backtrack -> None in
         let p1_variables = !pattern_variables in
-        let p1_module_variables = !module_variables in
         pattern_variables := initial_pattern_variables;
-        module_variables := initial_module_variables;
         let env2 = ref !env in
         let p2 =
           try Some (type_pat ~exception_allowed ~mode:Inside_or sp2 expected_ty
@@ -1404,7 +1417,6 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
         let alpha_env =
           enter_orpat_variables loc !env p1_variables p2_variables in
         pattern_variables := p1_variables;
-        module_variables := p1_module_variables;
         { pat_desc = Tpat_or(p1, alpha_pat alpha_env p2, None);
           pat_loc = loc; pat_extra=[];
           pat_type = instance expected_ty;
@@ -1542,13 +1554,22 @@ let iter_pattern_variables_type f : pattern_variable list -> unit =
 
 let add_pattern_variables ?check ?check_as env pv =
   List.fold_right
-    (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes} env ->
+    (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes; pv_mty} env ->
        let check = if pv_as_var then check_as else check in
-       Env.add_value ?check pv_id
-         {val_type = pv_type; val_kind = Val_reg; Types.val_loc = pv_loc;
-          val_attributes = pv_attributes;
-          val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
-         } env
+       match pv_mty with
+       | None ->
+           Env.add_value ?check pv_id
+             {val_type = pv_type; val_kind = Val_reg; Types.val_loc = pv_loc;
+              val_attributes = pv_attributes;
+              val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
+             } env
+       | Some mty ->
+           let md =
+             { md_type = mty; md_attributes=[]; md_loc = pv_loc
+             ; md_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
+           in
+           Env.add_module_declaration ~check:true (* FIXME *) pv_id
+             Mp_present md env
     )
     pv env
 
@@ -1557,8 +1578,7 @@ let type_pattern ?exception_allowed ~lev env spat scope expected_ty =
   let new_env = ref env in
   let pat = type_pat ?exception_allowed ~lev new_env spat expected_ty in
   let pvs = get_ref pattern_variables in
-  let unpacks = get_ref module_variables in
-  (pat, !new_env, get_ref pattern_force, pvs, unpacks)
+  (pat, !new_env, get_ref pattern_force, pvs)
 
 let type_pattern_list no_existentials env spatl scope expected_tys allow =
   reset_pattern scope allow;
@@ -1571,13 +1591,8 @@ let type_pattern_list no_existentials env spatl scope expected_tys allow =
   in
   let patl = List.map2 type_pat spatl expected_tys in
   let pvs = get_ref pattern_variables in
-  let unpacks =
-    List.map (fun (name, loc) ->
-      name, loc, Uid.mk ~current_unit:(Env.get_unit_name ())
-    ) (get_ref module_variables)
-  in
   let new_env = add_pattern_variables !new_env pvs in
-  (patl, new_env, get_ref pattern_force, pvs, unpacks)
+  (patl, new_env, get_ref pattern_force, pvs)
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   reset_pattern None false;
@@ -1591,32 +1606,50 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
   if is_optional l then unify_pat val_env pat (type_option (newvar ()));
   let (pv, val_env, met_env) =
     List.fold_right
-      (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes}
+      (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes; pv_mty}
         (pv, val_env, met_env) ->
          let check s =
            if pv_as_var then Warnings.Unused_var s
            else Warnings.Unused_var_strict s in
          let id' = Ident.rename pv_id in
-         let val_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
+         let uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
          let val_env =
-          Env.add_value pv_id
-            { val_type = pv_type
-            ; val_kind = Val_reg
-            ; val_attributes = pv_attributes
-            ; val_loc = pv_loc
-            ; val_uid
-            }
-            val_env
+           match pv_mty with
+           | None ->
+              Env.add_value pv_id
+                { val_type = pv_type
+                ; val_kind = Val_reg
+                ; val_attributes = pv_attributes
+                ; val_loc = pv_loc
+                ; val_uid = uid
+                }
+                val_env
+           | Some mty ->
+               let md =
+                 { md_type = mty; md_attributes=[]; md_loc = pv_loc
+                 ; md_uid = uid }
+               in
+               Env.add_module_declaration ~check:false (* FIXME *) pv_id
+                 Mp_present md val_env
          in
          let met_env =
-          Env.add_value id' ~check
-            { val_type = pv_type
-            ; val_kind = Val_ivar (Immutable, cl_num)
-            ; val_attributes = pv_attributes
-            ; val_loc = pv_loc
-            ; val_uid
-            }
-            met_env
+           match pv_mty with
+           | None ->
+               Env.add_value id' ~check
+                 { val_type = pv_type
+                 ; val_kind = Val_ivar (Immutable, cl_num)
+                 ; val_attributes = pv_attributes
+                 ; val_loc = pv_loc
+                 ; val_uid = uid
+                 }
+                 met_env
+           | Some mty ->
+               let md =
+                 { md_type = mty; md_attributes=[]; md_loc = pv_loc
+                 ; md_uid = uid }
+               in
+               Env.add_module_declaration ~check:true (* FIXME *) pv_id
+                 Mp_present md met_env
          in
          ((id', pv_id, pv_type)::pv, val_env, met_env))
       !pattern_variables ([], val_env, met_env)
@@ -2283,9 +2316,9 @@ and type_expect_
         | _, Recursive -> Some (Annot.Idef loc)
         | _, Nonrecursive -> Some (Annot.Idef sbody.pexp_loc)
       in
-      let (pat_exp_list, new_env, unpacks) =
+      let (pat_exp_list, new_env) =
         type_let existential_context env rec_flag spat_sexp_list scp true in
-      let body = type_unpacks new_env unpacks sbody ty_expected_explained in
+      let body = type_expect new_env sbody ty_expected_explained in
       let () =
         if rec_flag = Recursive then
           check_recursive_bindings env pat_exp_list
@@ -4128,59 +4161,6 @@ and type_statement ?explanation env sexp =
     exp
   end
 
-and type_unpacks ?in_function env unpacks sbody expected_ty =
-  let ty = newvar() in
-  (* remember original level *)
-  let extended_env, tunpacks =
-    List.fold_left (fun (env, unpacks) (name, loc, uid) ->
-      begin_def ();
-      let context = Typetexp.narrow () in
-      let modl =
-        !type_module env
-          Ast_helper.(
-            Mod.unpack ~loc
-              (Exp.ident ~loc:name.loc (mkloc (Longident.Lident name.txt)
-                                          name.loc)))
-      in
-      Mtype.lower_nongen ty.level modl.mod_type;
-      let pres =
-        match modl.mod_type with
-        | Mty_alias _ -> Mp_absent
-        | _ -> Mp_present
-      in
-      let scope = create_scope () in
-      let md =
-        { md_type = modl.mod_type; md_attributes = []; md_loc = name.loc;
-          md_uid = uid; }
-      in
-      let (id, env) =
-        Env.enter_module_declaration ~scope name.txt pres md env
-      in
-      Typetexp.widen context;
-      env, (id, name, pres, modl) :: unpacks
-    ) (env, []) unpacks
-  in
-  (* ideally, we should catch Expr_type_clash errors
-     in type_expect triggered by escaping identifiers from the local module
-     and refine them into Scoping_let_module errors
-  *)
-  let body = type_expect ?in_function extended_env sbody expected_ty in
-  let exp_loc = { body.exp_loc with loc_ghost = true } in
-  let exp_attributes = [Ast_helper.Attr.mk (mknoloc "#modulepat") (PStr [])] in
-  List.fold_left (fun body (id, name, pres, modl) ->
-    (* go back to parent level *)
-    end_def ();
-    Ctype.unify_var extended_env ty body.exp_type;
-    re {
-      exp_desc = Texp_letmodule(Some id, { name with txt = Some name.txt },
-                                pres, modl, body);
-      exp_loc;
-      exp_attributes;
-      exp_extra = [];
-      exp_type = ty;
-      exp_env = env }
-  ) body tunpacks
-
 (* Typing of match cases *)
 and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
       loc caselist =
@@ -4206,7 +4186,7 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
   in
   let outer_level = get_current_level () in
   let lev =
-    if may_contain_gadts then begin_def ();
+    begin_def ();
     get_current_level ()
   in
   let take_partial_instance =
@@ -4232,7 +4212,7 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
         let ty_arg = instance ?partial:take_partial_instance ty_arg in
         end_def ();
         generalize_structure ty_arg;
-        let (pat, ext_env, force, pvs, unpacks) =
+        let (pat, ext_env, force, pvs) =
           type_pattern ?exception_allowed ~lev env pc_lhs scope ty_arg
         in
         pattern_force := force @ !pattern_force;
@@ -4250,7 +4230,6 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
           untyped_case = case;
           branch_env = ext_env;
           pat_vars = pvs;
-          unpacks;
           contains_gadt = contains_gadt pat; }
         )
       caselist in
@@ -4292,7 +4271,7 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
   let in_function = if List.length caselist = 1 then in_function else None in
   let cases =
     List.map
-      (fun { typed_pat = pat; branch_env = ext_env; pat_vars = pvs; unpacks;
+      (fun { typed_pat = pat; branch_env = ext_env; pat_vars = pvs;
              untyped_case = {pc_lhs = _; pc_guard; pc_rhs};
              contains_gadt; _ }  ->
         let ext_env =
@@ -4305,11 +4284,6 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
           add_pattern_variables ext_env pvs
             ~check:(fun s -> Warnings.Unused_var_strict s)
             ~check_as:(fun s -> Warnings.Unused_var s)
-        in
-        let unpacks =
-          List.map (fun (name, loc) ->
-            name, loc, Uid.mk ~current_unit:(Env.get_unit_name ())
-          ) unpacks
         in
         let ty_res' =
           if !Clflags.principal then begin
@@ -4332,11 +4306,11 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
           | None -> None
           | Some scond ->
               Some
-                (type_unpacks ext_env unpacks scond
+                (type_expect ext_env scond
                    (mk_expected ~explanation:When_guard Predef.type_bool))
         in
         let exp =
-          type_unpacks ?in_function ext_env unpacks pc_rhs (mk_expected ty_res')
+          type_expect ?in_function ext_env pc_rhs (mk_expected ty_res')
         in
         {
          c_lhs = pat;
@@ -4382,11 +4356,9 @@ and type_cases ?exception_allowed ?in_function env ty_arg ty_res partial_flag
   else
     (* Check for unused cases, do not delay because of gadts *)
     unused_check false;
-  if may_contain_gadts then begin
-    end_def ();
-    (* Ensure that existential types do not escape *)
-    unify_exp_types loc env (instance ty_res) (newvar ()) ;
-  end;
+  end_def ();
+  (* Ensure that existential types do not escape *)
+  unify_exp_types loc env (instance ty_res) (newvar ()) ;
   cases, partial
 
 (* Typing of let bindings *)
@@ -4427,7 +4399,7 @@ and type_let
         | _ -> spat)
       spat_sexp_list in
   let nvs = List.map (fun _ -> newvar ()) spatl in
-  let (pat_list, new_env, force, pvs, unpacks) =
+  let (pat_list, new_env, force, pvs) =
     type_pattern_list existential_context env spatl scope nvs allow in
   let attrs_list = List.map fst spatl in
   let is_recursive = (rec_flag = Recursive) in
@@ -4527,29 +4499,57 @@ and type_let
              let slot = ref [] in
              List.iter
                (fun id ->
-                  let vd = Env.find_value (Path.Pident id) new_env in
-                  (* note: Env.find_value does not trigger the value_used
-                           event *)
                   let name = Ident.name id in
+                  let path = Path.Pident id in
                   let used = ref false in
-                  if not (name = "" || name.[0] = '_' || name.[0] = '#') then
+                  (* FIXME *)
+                  if (name <> "" && match name.[0] with 'A' .. 'Z' -> true | _ ->
+                    false)  then
+                    let md =
+                      try Env.find_module path new_env
+                      with _ -> fatal_error name
+                    in
+                    (* note: Env.find_module does not trigger the module_used
+                             event *)
                     add_delayed_check
                       (fun () ->
                          if not !used then
-                           Location.prerr_warning vd.Types.val_loc
+                           Location.prerr_warning md.Types.md_loc
                              ((if !some_used then check_strict else check) name)
                       );
-                  Env.set_value_used_callback
-                    vd
-                    (fun () ->
-                       match !current_slot with
-                       | Some slot ->
-                         slot := vd.val_uid :: !slot; rec_needed := true
-                       | None ->
-                         List.iter Env.mark_value_used (get_ref slot);
-                         used := true;
-                         some_used := true
-                    )
+                    Env.set_module_used_callback
+                      md
+                      (fun () ->
+                         match !current_slot with
+                         | Some slot ->
+                           slot := md.md_uid :: !slot; rec_needed := true
+                         | None ->
+                           List.iter Env.mark_module_used (get_ref slot);
+                           used := true;
+                           some_used := true
+                      )
+                  else
+                    let vd = Env.find_value path new_env in
+                    (* note: Env.find_value does not trigger the value_used
+                             event *)
+                    if not (name = "" || name.[0] = '_' || name.[0] = '#') then
+                      add_delayed_check
+                        (fun () ->
+                           if not !used then
+                             Location.prerr_warning vd.Types.val_loc
+                               ((if !some_used then check_strict else check) name)
+                        );
+                    Env.set_value_used_callback
+                      vd
+                      (fun () ->
+                         match !current_slot with
+                         | Some slot ->
+                           slot := vd.val_uid :: !slot; rec_needed := true
+                         | None ->
+                           List.iter Env.mark_value_used (get_ref slot);
+                           used := true;
+                           some_used := true
+                      )
                )
                (Typedtree.pat_bound_idents pat);
              pat, Some slot
@@ -4572,10 +4572,7 @@ and type_let
             end;
             let exp =
               Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                if rec_flag = Recursive then
-                  type_unpacks exp_env unpacks sexp (mk_expected ty')
-                else
-                  type_expect exp_env sexp (mk_expected ty')
+                type_expect exp_env sexp (mk_expected ty')
               )
             in
             end_def ();
@@ -4583,10 +4580,7 @@ and type_let
             {exp with exp_type = instance exp.exp_type}
         | _ ->
             Builtin_attributes.warning_scope pvb_attributes (fun () ->
-                if rec_flag = Recursive then
-                  type_unpacks exp_env unpacks sexp (mk_expected pat.pat_type)
-                else
-                  type_expect exp_env sexp (mk_expected pat.pat_type)))
+              type_expect exp_env sexp (mk_expected pat.pat_type)))
       spat_sexp_list pat_slot_list in
   current_slot := None;
   if is_recursive && not !rec_needed then begin
@@ -4634,8 +4628,10 @@ and type_let
   if is_recursive then
     List.iter
       (fun {vb_pat=pat} -> match pat.pat_desc with
-           Tpat_var _ -> ()
-         | Tpat_alias ({pat_desc=Tpat_any}, _, _) -> ()
+           Tpat_var _
+         | Tpat_alias ({pat_desc=Tpat_any}, _, _) (* pretty sure that's the old
+                                                     Tpat_unpack. *)
+         | Tpat_unpack _ -> ()
          | _ -> raise(Error(pat.pat_loc, env, Illegal_letrec_pat)))
       l;
   List.iter (function
@@ -4644,7 +4640,7 @@ and type_let
                                       | _ -> false) pat_extra) then
             check_partial_application false vb_expr
       | _ -> ()) l;
-  (l, new_env, unpacks)
+  (l, new_env)
 
 and type_andops env sarg sands expected_ty =
   let rec loop env let_sarg rev_sands expected_ty =
@@ -4694,7 +4690,7 @@ and type_andops env sarg sands expected_ty =
 
 let type_binding env rec_flag spat_sexp_list scope =
   Typetexp.reset_type_variables();
-  let (pat_exp_list, new_env, _unpacks) =
+  let (pat_exp_list, new_env) =
     type_let
       ~check:(fun s -> Warnings.Unused_value_declaration s)
       ~check_strict:(fun s -> Warnings.Unused_value_declaration s)
@@ -4704,7 +4700,7 @@ let type_binding env rec_flag spat_sexp_list scope =
   (pat_exp_list, new_env)
 
 let type_let existential_ctx env rec_flag spat_sexp_list scope =
-  let (pat_exp_list, new_env, _unpacks) =
+  let (pat_exp_list, new_env) =
     type_let existential_ctx env rec_flag spat_sexp_list scope false in
   (pat_exp_list, new_env)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -406,11 +406,7 @@ let enter_variable ?module_type ?(is_as_variable=false) loc name ty
      pv_as_var = is_as_variable;
      pv_mty = module_type;
      pv_attributes = attrs} :: !pattern_variables;
-  if Option.is_some module_type then begin
-    (* Note: unpack patterns enter a variable of the same name *)
-    if not !allow_modules then
-      raise (Error (loc, Env.empty, Modules_not_allowed))
-  end else begin
+  if Option.is_none module_type then begin
     (* moved to genannot *)
     Option.iter
       (fun s -> Stypes.record (Stypes.An_ident (name.loc, name.txt, s)))
@@ -1082,6 +1078,8 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
         pat_env = !env }
   | Ppat_unpack name ->
       assert (constrs = None);
+      if not !allow_modules then
+        raise (Error (loc, Env.empty, Modules_not_allowed));
       let t = instance expected_ty in
       let original_level = get_gadt_equations_level () in
       begin_def ();

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1566,8 +1566,7 @@ let add_pattern_variables ?check ?check_as env pv =
              { md_type = mty; md_attributes=[]; md_loc = pv_loc
              ; md_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
            in
-           Env.add_module_declaration ~check:true (* FIXME *) pv_id
-             Mp_present md env
+           Env.add_module_declaration ?check pv_id Mp_present md env
     )
     pv env
 
@@ -1627,8 +1626,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
                  { md_type = mty; md_attributes=[]; md_loc = pv_loc
                  ; md_uid = uid }
                in
-               Env.add_module_declaration ~check:false (* FIXME *) pv_id
-                 Mp_present md val_env
+               Env.add_module_declaration pv_id Mp_present md val_env
          in
          let met_env =
            match pv_mty with
@@ -1646,8 +1644,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
                  { md_type = mty; md_attributes=[]; md_loc = pv_loc
                  ; md_uid = uid }
                in
-               Env.add_module_declaration ~check:true (* FIXME *) pv_id
-                 Mp_present md met_env
+               Env.add_module_declaration ~check pv_id Mp_present md met_env
          in
          ((id', pv_id, pv_type)::pv, val_env, met_env))
       !pattern_variables ([], val_env, met_env)

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -186,8 +186,10 @@ exception Error_forward of Location.error
 val report_error: loc:Location.t -> Env.t -> error -> Location.error
  (** @deprecated.  Use {!Location.error_of_exn}, {!Location.print_report}. *)
 
-(* Forward declaration, to be filled in by Typemod.type_module *)
+(* Forward declaration, to be filled in by Typemod *)
 val type_module: (Env.t -> Parsetree.module_expr -> Typedtree.module_expr) ref
+val type_unpack:
+  (loc:Location.t -> Env.t -> Types.type_expr -> Types.module_type) ref
 (* Forward declaration, to be filled in by Typemod.type_open *)
 val type_open:
   (?used_slot:bool ref -> override_flag -> Env.t -> Location.t ->

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -56,10 +56,6 @@ and pat_extra =
                            branches of [tconst].
          *)
   | Tpat_open of Path.t * Longident.t loc * Env.t
-  | Tpat_unpack
-        (** (module P)     { pat_desc  = Tpat_var "P"
-                           ; pat_extra = (Tpat_unpack, _, _) :: ... }
-         *)
 
 and pattern_desc =
     Tpat_any
@@ -107,6 +103,9 @@ and pattern_desc =
         (** lazy P *)
   | Tpat_exception of pattern
         (** exception P *)
+  | Tpat_unpack of Ident.t option * string option loc * Types.module_type
+        (** (module _)     (None)
+            (module M)     (Some "M") *)
 
 and expression =
   { exp_desc: expression_desc;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -795,8 +795,8 @@ and approx_sig env ssg =
           in
           let newenv =
             List.fold_left
-              (fun env (id, md) -> Env.add_module_declaration ~check:false
-                  id Mp_present md env)
+              (fun env (id, md) ->
+                 Env.add_module_declaration id Mp_present md env)
               env decls
           in
           map_rec
@@ -2313,7 +2313,8 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr scope =
                        md_uid = uid;
                      }
                    in
-                   Env.add_module_declaration ~check:true
+                   Env.add_module_declaration
+                     ~check:(fun s -> Warnings.Unused_module s)
                      id Mp_present mdecl env
             )
             env decls

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -30,7 +30,9 @@ module Signature_names : sig
 end
 
 val type_module:
-        Env.t -> Parsetree.module_expr -> Typedtree.module_expr
+  Env.t -> Parsetree.module_expr -> Typedtree.module_expr
+val type_unpack :
+  loc:Warnings.loc -> Env.t -> Typedtree.expression -> Types.module_type
 val type_structure:
   Env.t -> Parsetree.structure -> Location.t ->
   Typedtree.structure * Types.signature * Signature_names.t * Env.t

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -31,8 +31,7 @@ end
 
 val type_module:
   Env.t -> Parsetree.module_expr -> Typedtree.module_expr
-val type_unpack :
-  loc:Warnings.loc -> Env.t -> Typedtree.expression -> Types.module_type
+val type_unpack : loc:Warnings.loc -> Env.t -> type_expr -> module_type
 val type_structure:
   Env.t -> Parsetree.structure -> Location.t ->
   Typedtree.structure * Types.signature * Signature_names.t * Env.t

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -296,10 +296,6 @@ let pattern sub pat =
   let attrs = sub.attributes sub pat.pat_attributes in
   let desc =
   match pat with
-      { pat_extra=[Tpat_unpack, loc, _attrs]; pat_desc = Tpat_any; _ } ->
-        Ppat_unpack { txt = None; loc  }
-    | { pat_extra=[Tpat_unpack, _, _attrs]; pat_desc = Tpat_var (_,name); _ } ->
-        Ppat_unpack { name with txt = Some name.txt }
     | { pat_extra=[Tpat_type (_path, lid), _, _attrs]; _ } ->
         Ppat_type (map_loc sub lid)
     | { pat_extra= (Tpat_constraint ct, _, _attrs) :: rem; _ } ->
@@ -325,6 +321,8 @@ let pattern sub pat =
          when pat_loc = pat.pat_loc ->
        Ppat_var name
 
+    | Tpat_unpack (_, strloc, _) ->
+        Ppat_unpack strloc
     | Tpat_alias (pat, _id, name) ->
         Ppat_alias (sub.pat sub pat, name)
     | Tpat_constant cst -> Ppat_constant (constant cst)


### PR DESCRIPTION
On trunk the following:
```ocaml
module type S = sig val b : bool end
let f = function (module M : S) when M.b -> ()
```
gets desugared to:
```ocaml
module type S = sig val b : bool end
let f = function
  | x when let module M = ((val x) : S) in M.b ->
    let module M = ((val x) : S) in
    ()
```
before/during typechecking.

This caused some issues for #8934: if you only look at the AST, the second "M" is clearly unused.
However, this doesn't trigger any warning currently, because they both share the same location (i.e. "they are the same").
To keep that behavior, #8934 assigns them the same id. Which is a bit tricky to do: we can't just rewrite the AST and call the typechecker again (which is what is currently done).

Instead of doing that (i.e. generating parsetree fragments during typechecking), you could also imagine giving a proper representation (in the typedtree) to that construct. Which is what this PR does.

Unfortunately, if you do that then you run into a familiar problem, the following code won't typecheck anymore:
```ocaml
let f (m : (module S)) =
  let (module M) = m in M.b
```
The reason being that the typechecker first looks at the pattern `(module M)` and goes "I can't magically infer the signature of that module!". Whereas previously, this was translated to:
```ocaml
let f (m : (module S)) =
  let x = m in let module M = (val x) in M.b
```
where type information flows the right way around.

This PR doesn't propose a fix for that, the problem will disappear if/when [this suggestion](https://blog.janestreet.com/plans-for-ocaml-408/#improve-type-propagation-in-lets) is implemented.

I understand that it is unlikely for this PR to be accepted with this regression, so feel free to regard this PR as "look at the nice things we could have if ..." (nice things = simpler codebase, more consistent warnings, ...).
