### PR TITLE
Stop before emit

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,9 @@ Working version
   (Florian Angeletti, review by Jacques Garrigue and Leo White,
    report by Chas Emerick)
 
+- #8938: Extend ocamlopt option "-stop-after" to handle "scheduling" argument.
+  (Greta Yorsh, review by Florian Angeletti and Sébastien Hinderer)
+
 ### Internal/compiler-libs changes:
 
 - #9078: make all compilerlibs/ available to ocamltest.

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -39,6 +39,17 @@ let pass_dump_linear_if ppf flag message phrase =
   if !flag then fprintf ppf "*** %s@.%a@." message Printlinear.fundecl phrase;
   phrase
 
+let should_emit () =
+  not (should_stop_after Compiler_pass.Scheduling)
+
+let if_emit_do f x = if should_emit () then f x else ()
+let emit_begin_assembly = if_emit_do Emit.begin_assembly
+let emit_end_assembly = if_emit_do Emit.end_assembly
+let emit_data = if_emit_do Emit.data
+let emit_fundecl =
+  if_emit_do
+    (Profile.record ~accumulate:true "emit" Emit.fundecl)
+
 let rec regalloc ~ppf_dump round fd =
   if round > 50 then
     fatal_error(fd.Mach.fun_name ^
@@ -92,13 +103,13 @@ let compile_fundecl ~ppf_dump fd_cmm =
   ++ pass_dump_linear_if ppf_dump dump_linear "Linearized code"
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
-  ++ Profile.record ~accumulate:true "emit" Emit.fundecl
+  ++ emit_fundecl
 
 let compile_phrase ~ppf_dump p =
   if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
   match p with
   | Cfunction fd -> compile_fundecl ~ppf_dump fd
-  | Cdata dl -> Emit.data dl
+  | Cdata dl -> emit_data dl
 
 
 (* For the native toplevel: generates generic functions unless
@@ -111,8 +122,10 @@ let compile_genfuns ~ppf_dump f =
        | _ -> ())
     (Cmm_helpers.generic_functions true [Compilenv.current_unit_infos ()])
 
-let compile_unit asm_filename keep_asm obj_filename gen =
-  let create_asm = keep_asm || not !Emitaux.binary_backend_available in
+let compile_unit asm_filename keep_asm
+      obj_filename gen =
+  let create_asm = should_emit () &&
+                   (keep_asm || not !Emitaux.binary_backend_available) in
   Emitaux.create_asm_file := create_asm;
   Misc.try_finally
     ~exceptionally:(fun () -> remove_file obj_filename)
@@ -123,18 +136,20 @@ let compile_unit asm_filename keep_asm obj_filename gen =
              if create_asm then close_out !Emitaux.output_channel)
          ~exceptionally:(fun () ->
              if create_asm && not keep_asm then remove_file asm_filename);
-       let assemble_result =
-         Profile.record "assemble"
-           (Proc.assemble_file asm_filename) obj_filename
-       in
-       if assemble_result <> 0
-       then raise(Error(Assembler_error asm_filename));
+       if should_emit () then begin
+         let assemble_result =
+           Profile.record "assemble"
+             (Proc.assemble_file asm_filename) obj_filename
+         in
+         if assemble_result <> 0
+         then raise(Error(Assembler_error asm_filename));
+       end;
        if create_asm && not keep_asm then remove_file asm_filename
     )
 
 let end_gen_implementation ?toplevel ~ppf_dump
     (clambda : Clambda.with_constants) =
-  Emit.begin_assembly ();
+  emit_begin_assembly ();
   clambda
   ++ Profile.record "cmm" Cmmgen.compunit
   ++ Profile.record "compile_phrases" (List.iter (compile_phrase ~ppf_dump))
@@ -151,7 +166,7 @@ let end_gen_implementation ?toplevel ~ppf_dump
            if not (Primitive.native_name_is_external prim) then None
            else Some (Primitive.native_name prim))
           !Translmod.primitive_declarations));
-  Emit.end_assembly ()
+  emit_end_assembly ()
 
 type middle_end =
      backend:(module Backend_intf.S)

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -56,6 +56,7 @@ let first_ppx = ref []
 let last_ppx = ref []
 let first_objfiles = ref []
 let last_objfiles = ref []
+let stop_early = ref false
 
 (* Check validity of module name *)
 let is_unit_name name =
@@ -670,3 +671,9 @@ let process_deferred_actions env =
     fatal "Option -a cannot be used with .cmxa input files.";
   List.iter (process_action env) (List.rev !deferred_actions);
   output_name := final_output_name;
+  stop_early :=
+    !compile_only ||
+    !print_types ||
+    match !stop_after with
+    | None -> false
+    | Some p -> Clflags.Compiler_pass.is_compilation_pass p;

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -432,17 +432,16 @@ let read_one_param ppf position name v =
 
   | "stop-after" ->
     let module P = Clflags.Compiler_pass in
-    begin match P.of_string v with
+    let passes = P.stop_after_pass_names ~native:!native_code in
+    begin match List.find_opt (String.equal v) passes with
     | None ->
         Printf.ksprintf (print_error ppf)
           "bad value %s for option \"stop-after\" (expected one of: %s)"
-          v (String.concat ", " P.pass_names)
-    | Some pass ->
+          v (String.concat ", " passes)
+    | Some v ->
+        let pass = Option.get (P.of_string v)  in
         Clflags.stop_after := Some pass;
-        begin match pass with
-        | P.Parsing | P.Typing ->
-            compile_only := true
-        end;
+        compile_only := P.is_compilation_pass pass
     end
   | _ ->
     if not (List.mem name !can_discard) then begin

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -440,8 +440,7 @@ let read_one_param ppf position name v =
           v (String.concat ", " passes)
     | Some v ->
         let pass = Option.get (P.of_string v)  in
-        Clflags.stop_after := Some pass;
-        compile_only := P.is_compilation_pass pass
+        Clflags.stop_after := Some pass
     end
   | _ ->
     if not (List.mem name !can_discard) then begin

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -432,7 +432,7 @@ let read_one_param ppf position name v =
 
   | "stop-after" ->
     let module P = Clflags.Compiler_pass in
-    let passes = P.stop_after_pass_names ~native:!native_code in
+    let passes = P.available_pass_names ~native:!native_code in
     begin match List.find_opt (String.equal v) passes with
     | None ->
         Printf.ksprintf (print_error ppf)

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -34,6 +34,8 @@ val get_objfiles : with_ocamlparam:bool -> string list
 val last_objfiles : string list ref
 val first_objfiles : string list ref
 
+val stop_early : bool ref
+
 type filename = string
 
 type readenv_position =

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -49,21 +49,24 @@ let main () =
       end
     end;
     readenv ppf Before_link;
+    let module P = Clflags.Compiler_pass in
     if
       List.length
         (List.filter (fun x -> !x)
            [make_archive;make_package;compile_only;output_c_object])
         > 1
     then begin
-      let module P = Clflags.Compiler_pass in
       match !stop_after with
       | None ->
         fatal "Please specify at most one of -pack, -a, -c, -output-obj";
-      | Some (P.Parsing | P.Typing) ->
-          Printf.ksprintf fatal
-            "Options -i and -stop-after (%s)\
-             are  incompatible with -pack, -a, -output-obj"
-            (String.concat "|" P.pass_names)
+      | Some ((P.Parsing | P.Typing) as p) ->
+        assert (P.is_compilation_pass p);
+        Printf.ksprintf fatal
+          "Options -i and -stop-after (%s) \
+           are  incompatible with -pack, -a, -output-obj"
+          (String.concat "|"
+             (Clflags.Compiler_pass.stop_after_pass_names ~native:false))
+      | Some P.Scheduling -> assert false (* native only *)
     end;
     if !make_archive then begin
       Compmisc.init_path ();

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -70,7 +70,7 @@ let main () =
           "Options -i and -stop-after (%s) \
            are  incompatible with -pack, -a, -output-obj"
           (String.concat "|"
-             (Clflags.Compiler_pass.stop_after_pass_names ~native:false))
+             (Clflags.Compiler_pass.available_pass_names ~native:false))
       | Some P.Scheduling -> assert false (* native only *)
     end;
     if !make_archive then begin

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -49,18 +49,13 @@ let main () =
       end
     end;
     readenv ppf Before_link;
-    let module P = Clflags.Compiler_pass in
-    let stop_early = !compile_only ||
-                     match !stop_after with
-                     | None -> false
-                     | Some p -> P.is_compilation_pass p
-    in
     if
       List.length
         (List.filter (fun x -> !x)
-           [make_archive;make_package;ref stop_early;output_c_object])
+           [make_archive;make_package;stop_early;output_c_object])
         > 1
     then begin
+      let module P = Clflags.Compiler_pass in
       match !stop_after with
       | None ->
         fatal "Please specify at most one of -pack, -a, -c, -output-obj";
@@ -90,7 +85,7 @@ let main () =
           revd (extracted_output));
       Warnings.check_fatal ();
     end
-    else if not stop_early && !objfiles <> [] then begin
+    else if not !stop_early && !objfiles <> [] then begin
       let target =
         if !output_c_object && not !output_complete_executable then
           let s = extract_output !output_name in

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -50,10 +50,15 @@ let main () =
     end;
     readenv ppf Before_link;
     let module P = Clflags.Compiler_pass in
+    let stop_early = !compile_only ||
+                     match !stop_after with
+                     | None -> false
+                     | Some p -> P.is_compilation_pass p
+    in
     if
       List.length
         (List.filter (fun x -> !x)
-           [make_archive;make_package;compile_only;output_c_object])
+           [make_archive;make_package;ref stop_early;output_c_object])
         > 1
     then begin
       match !stop_after with
@@ -85,7 +90,7 @@ let main () =
           revd (extracted_output));
       Warnings.check_fatal ();
     end
-    else if not !compile_only && !objfiles <> [] then begin
+    else if not stop_early && !objfiles <> [] then begin
       let target =
         if !output_c_object && not !output_complete_executable then
           let s = extract_output !output_name in

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -106,8 +106,9 @@ let mk_function_sections f =
     "-function-sections", Arg.Unit err, " (option not available)"
 ;;
 
-let mk_stop_after f =
-  "-stop-after", Arg.Symbol (Clflags.Compiler_pass.pass_names, f),
+let mk_stop_after ~native f =
+  "-stop-after",
+  Arg.Symbol (Clflags.Compiler_pass.stop_after_pass_names ~native, f),
   " Stop after the given compilation pass."
 ;;
 
@@ -1141,7 +1142,7 @@ struct
     mk_dtypes F._annot;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
-    mk_stop_after F._stop_after;
+    mk_stop_after ~native:false F._stop_after;
     mk_i F._i;
     mk_I F._I;
     mk_impl F._impl;
@@ -1316,7 +1317,7 @@ struct
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
     mk_function_sections F._function_sections;
-    mk_stop_after F._stop_after;
+    mk_stop_after ~native:true F._stop_after;
     mk_i F._i;
     mk_I F._I;
     mk_impl F._impl;
@@ -1840,8 +1841,7 @@ module Default = struct
         | None -> () (* this should not occur as we use Arg.Symbol *)
         | Some pass ->
             stop_after := (Some pass);
-            match pass with
-            | P.Parsing | P.Typing -> compile_only := true
+            compile_only := P.is_compilation_pass pass
     let _thread = set use_threads
     let _verbose = set verbose
     let _version () = print_version_string ()

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -108,7 +108,7 @@ let mk_function_sections f =
 
 let mk_stop_after ~native f =
   "-stop-after",
-  Arg.Symbol (Clflags.Compiler_pass.stop_after_pass_names ~native, f),
+  Arg.Symbol (Clflags.Compiler_pass.available_pass_names ~native, f),
   " Stop after the given compilation pass."
 ;;
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1814,10 +1814,7 @@ module Default = struct
     let _dump_into_file = set dump_into_file
     let _for_pack s = for_package := (Some s)
     let _g = set debug
-    let _i () =
-      print_types := true;
-      stop_after := (Some Compiler_pass.Typing);
-      ()
+    let _i = set print_types
     let _impl = impl
     let _intf = intf
     let _intf_suffix s = Config.interface_suffix := s
@@ -1838,7 +1835,12 @@ module Default = struct
       let module P = Compiler_pass in
         match P.of_string pass with
         | None -> () (* this should not occur as we use Arg.Symbol *)
-        | Some pass -> stop_after := (Some pass)
+        | Some pass ->
+          match !stop_after with
+          | None -> stop_after := (Some pass)
+          | Some p ->
+            if not (p = pass) then
+              fatal "Please specify at most one -stop-after <pass>."
     let _thread = set use_threads
     let _verbose = set verbose
     let _version () = print_version_string ()

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1816,7 +1816,6 @@ module Default = struct
     let _g = set debug
     let _i () =
       print_types := true;
-      compile_only := true;
       stop_after := (Some Compiler_pass.Typing);
       ()
     let _impl = impl
@@ -1839,9 +1838,7 @@ module Default = struct
       let module P = Compiler_pass in
         match P.of_string pass with
         | None -> () (* this should not occur as we use Arg.Symbol *)
-        | Some pass ->
-            stop_after := (Some pass);
-            compile_only := P.is_compilation_pass pass
+        | Some pass -> stop_after := (Some pass)
     let _thread = set use_threads
     let _verbose = set verbose
     let _version () = print_version_string ()

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -67,10 +67,15 @@ let main () =
     end;
     readenv ppf Before_link;
     let module P = Clflags.Compiler_pass in
+    let stop_early = !compile_only ||
+                     match !stop_after with
+                     | None -> false
+                     | Some p -> P.is_compilation_pass p
+    in
     if
       List.length (List.filter (fun x -> !x)
                      [make_package; make_archive; shared;
-                      compile_only; output_c_object]) > 1
+                      ref stop_early; output_c_object]) > 1
     then
     begin
       match !stop_after with
@@ -108,7 +113,7 @@ let main () =
           (get_objfiles ~with_ocamlparam:false) target);
       Warnings.check_fatal ();
     end
-    else if not !compile_only && !objfiles <> [] then begin
+    else if not stop_early && !objfiles <> [] then begin
       let target =
         if !output_c_object then
           let s = extract_output !output_name in

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -88,7 +88,7 @@ let main () =
           "Options -i and -stop-after (%s) \
            are  incompatible with -pack, -a, -shared, -output-obj"
           (String.concat "|"
-             (Clflags.Compiler_pass.stop_after_pass_names ~native:true))
+             (Clflags.Compiler_pass.available_pass_names ~native:true))
     end;
     if !make_archive then begin
       Compmisc.init_path ();

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -66,18 +66,13 @@ let main () =
       end
     end;
     readenv ppf Before_link;
-    let module P = Clflags.Compiler_pass in
-    let stop_early = !compile_only ||
-                     match !stop_after with
-                     | None -> false
-                     | Some p -> P.is_compilation_pass p
-    in
     if
       List.length (List.filter (fun x -> !x)
                      [make_package; make_archive; shared;
-                      ref stop_early; output_c_object]) > 1
+                      stop_early; output_c_object]) > 1
     then
     begin
+      let module P = Clflags.Compiler_pass in
       match !stop_after with
       | None ->
         fatal "Please specify at most one of -pack, -a, -shared, -c, \
@@ -113,7 +108,7 @@ let main () =
           (get_objfiles ~with_ocamlparam:false) target);
       Warnings.check_fatal ();
     end
-    else if not stop_early && !objfiles <> [] then begin
+    else if not !stop_early && !objfiles <> [] then begin
       let target =
         if !output_c_object then
           let s = extract_output !output_name in

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -243,6 +243,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	  -e 's|@@OCAMLDOC@@|$(WITH_OCAMLDOC)|' \
 	  -e 's|@@OCAMLDEBUG@@|$(WITH_OCAMLDEBUG)|' \
 	  -e 's|@@OBJEXT@@|$(O)|' \
+	  -e 's|@@ASMEXT@@|$(S)|' \
 	  -e 's|@@NATIVE_DYNLINK@@|$(NATDYNLINK)|' \
 	  -e 's|@@SHARED_LIBRARY_CFLAGS@@|$(SHAREDLIB_CFLAGS)|' \
 	  -e 's|@@SHAREDOBJEXT@@|$(SO)|' \

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1124,6 +1124,7 @@ let config_variables _log env =
     Ocaml_variables.shared_library_cflags,
       Ocamltest_config.shared_library_cflags;
     Ocaml_variables.objext, Ocamltest_config.objext;
+    Ocaml_variables.asmext, Ocamltest_config.asmext;
     Ocaml_variables.sharedobjext, Ocamltest_config.sharedobjext;
     Ocaml_variables.ocamlc_default_flags,
       Ocamltest_config.ocamlc_default_flags;

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -120,6 +120,9 @@ let nativecc_libs = make ("nativecc_libs",
 let objext = make ("objext",
   "Extension of object files")
 
+let asmext = make ("asmext",
+  "Extension of assembly files")
+
 let ocamlc_byte = make ("ocamlc_byte",
   "Path of the ocamlc.byte executable")
 
@@ -254,6 +257,7 @@ let _ = List.iter register_variable
     modules;
     nativecc_libs;
     objext;
+    asmext;
     ocamlc_byte;
     ocamlopt_byte;
     ocamlrun;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -74,6 +74,7 @@ val nativecc_libs : Variables.t
 (** Libraries to link with for native code *)
 
 val objext : Variables.t
+val asmext : Variables.t
 
 val ocamlc_byte : Variables.t
 val ocamlopt_byte : Variables.t

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -37,6 +37,8 @@ let str = @@STR@@
 
 let objext = "@@OBJEXT@@"
 
+let asmext = "@@ASMEXT@@"
+
 let system = "@@SYSTEM@@"
 
 let c_preprocessor = "@@CPP@@"

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -49,6 +49,9 @@ val str : bool
 val objext : string
 (** Extension of object files *)
 
+val asmext : string
+(** Extension of assembly files *)
+
 val system : string
 (** The content of the SYSTEM Make variable *)
 

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_scheduling.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_scheduling.compilers.reference
@@ -1,0 +1,1 @@
+wrong argument 'scheduling'; option '-stop-after' expects one of: parsing typing.

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_scheduling.ml
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_scheduling.ml
@@ -1,0 +1,14 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+compiler_output = "compiler-output.raw"
+** ocamlc.byte
+   flags = "-stop-after scheduling"
+   ocamlc_byte_exit_status = "2"
+*** script
+   script = "sh ${test_source_directory}/stop_after_scheduling.sh"
+   output = "compiler-output"
+**** check-ocamlc.byte-output
+compiler_output = "compiler-output"
+*)
+
+(* this file is just a test driver, the test does not contain real OCaml code *)

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_scheduling.sh
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_scheduling.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+grep "wrong argument 'scheduling'" compiler-output.raw | grep "stop-after" | sed 's/^.*: wrong argument/wrong argument/'

--- a/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.ml
+++ b/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.ml
@@ -1,0 +1,12 @@
+(* TEST
+ * native-compiler
+ ** setup-ocamlopt.byte-build-env
+ *** ocamlopt.byte
+   flags = "-stop-after scheduling -S"
+   ocamlopt_byte_exit_status = "0"
+ **** check-ocamlopt.byte-output
+ ***** script
+   script = "sh ${test_source_directory}/stop_after_scheduling.sh"
+*)
+
+(* this file is just a test driver, the test does not contain real OCaml code *)

--- a/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.sh
+++ b/testsuite/tests/tool-ocamlopt-stop-after/stop_after_scheduling.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+asm=stop_after_scheduling.${asmext}
+obj=stop_after_scheduling.${objext}
+cmx=stop_after_scheduling.cmx
+
+# Check that cmx is generated but asm and obj are not
+if [ -e "$asm" ] ; then
+    echo "unexpected $asm found" > ${ocamltest_response}
+    test_result=${TEST_FAIL}
+else if [ -e "$obj" ] ; then
+         echo "unexpected $obj found" > ${ocamltest_response}
+         test_result=${TEST_FAIL}
+     else if [ -e "$cmx" ] ; then
+              test_result=${TEST_PASS}
+          else
+              echo "not found expected $cmx" > ${ocamltest_response}
+              test_result=${TEST_FAIL}
+          fi
+     fi
+fi
+exit ${test_result}

--- a/testsuite/tests/unwind/check-linker-version.sh
+++ b/testsuite/tests/unwind/check-linker-version.sh
@@ -10,7 +10,7 @@ elif [[ $LDVER -lt 224 ]]; then
   echo "ld version is $LDVER, only 224 or above are supported";
   test_result=${TEST_SKIP};
 else
-  test_reslut=${TEST_PASS};
+  test_result=${TEST_PASS};
 fi
 
 exit ${TEST_RESULT}

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -420,26 +420,43 @@ module Compiler_pass = struct
      - the manpages in man/ocaml{c,opt}.m
      - the manual manual/manual/cmds/unified-options.etex
   *)
-  type t = Parsing | Typing
+  type t = Parsing | Typing | Scheduling
 
   let to_string = function
     | Parsing -> "parsing"
     | Typing -> "typing"
+    | Scheduling -> "scheduling"
 
   let of_string = function
     | "parsing" -> Some Parsing
     | "typing" -> Some Typing
+    | "scheduling" -> Some Scheduling
     | _ -> None
 
   let rank = function
     | Parsing -> 0
     | Typing -> 1
+    | Scheduling -> 50
 
   let passes = [
     Parsing;
     Typing;
+    Scheduling;
   ]
-  let pass_names = List.map to_string passes
+  let is_compilation_pass _ = true
+  let is_native_only = function
+    | Scheduling -> true
+    | _ -> false
+
+  let enabled is_native t = not (is_native_only t) || is_native
+
+  let pass_names is_native =
+    passes
+    |> List.filter (enabled is_native)
+    |> List.map to_string
+
+  let stop_after_pass_names ~native =
+    pass_names native
 end
 
 let stop_after = ref None (* -stop-after *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -450,13 +450,10 @@ module Compiler_pass = struct
 
   let enabled is_native t = not (is_native_only t) || is_native
 
-  let pass_names is_native =
+  let available_pass_names ~native =
     passes
-    |> List.filter (enabled is_native)
+    |> List.filter (enabled native)
     |> List.map to_string
-
-  let stop_after_pass_names ~native =
-    pass_names native
 end
 
 let stop_after = ref None (* -stop-after *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -235,11 +235,11 @@ val insn_sched : bool ref
 val insn_sched_default : bool
 
 module Compiler_pass : sig
-  type t = Parsing | Typing
+  type t = Parsing | Typing | Scheduling
   val of_string : string -> t option
   val to_string : t -> string
-  val passes : t list
-  val pass_names : string list
+  val is_compilation_pass : t -> bool
+  val stop_after_pass_names : native:bool -> string list
 end
 val stop_after : Compiler_pass.t option ref
 val should_stop_after : Compiler_pass.t -> bool

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -239,7 +239,7 @@ module Compiler_pass : sig
   val of_string : string -> t option
   val to_string : t -> string
   val is_compilation_pass : t -> bool
-  val stop_after_pass_names : native:bool -> string list
+  val available_pass_names : native:bool -> string list
 end
 val stop_after : Compiler_pass.t option ref
 val should_stop_after : Compiler_pass.t -> bool


### PR DESCRIPTION
This PR extends the existing command-line option "-stop-after <pass>" to accept the argument "scheduling" in addition to the existing "parsing" and "typing" which were added in https://github.com/ocaml/ocaml/pull/1945.

With "-stop-after scheduling", the native compiler will stop compilation after scheduling pass. It will produce .cmi and .cmx files as usual, and perform the optimizations in the backend, but won't emit
assembly or object files, and won't perform linking, packing, etc. The bytecode compiler will not accept "-stop-after scheduling".

It may be more accurate to call the option "-stop-before emit" rather than "-stop-after scheduling", but it doesn't fit with the existing option's naming convention.

Clflags.Compiler_pass.pass_names is extended to take a filter function as an argument, in preparation for another command-line option I'd like to propose shortly, in a separate PR.
