### PR TITLE
Save Linear IR before emit

### DIFF
--- a/.depend
+++ b/.depend
@@ -2061,6 +2061,7 @@ asmcomp/asmgen.cmo : \
     asmcomp/liveness.cmi \
     asmcomp/linscan.cmi \
     asmcomp/linearize.cmi \
+    file_formats/linear_format.cmi \
     lambda/lambda.cmi \
     asmcomp/interval.cmi \
     asmcomp/interf.cmi \
@@ -2101,6 +2102,7 @@ asmcomp/asmgen.cmx : \
     asmcomp/liveness.cmx \
     asmcomp/linscan.cmx \
     asmcomp/linearize.cmx \
+    file_formats/linear_format.cmx \
     lambda/lambda.cmx \
     asmcomp/interval.cmx \
     asmcomp/interf.cmx \
@@ -2272,6 +2274,7 @@ asmcomp/branch_relaxation_intf.cmx : \
     asmcomp/arch.cmx
 asmcomp/cmm.cmo : \
     utils/targetint.cmi \
+    utils/misc.cmi \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     middle_end/backend_var.cmi \
@@ -2280,6 +2283,7 @@ asmcomp/cmm.cmo : \
     asmcomp/cmm.cmi
 asmcomp/cmm.cmx : \
     utils/targetint.cmx \
+    utils/misc.cmx \
     lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     middle_end/backend_var.cmx \
@@ -3719,6 +3723,23 @@ file_formats/cmx_format.cmi : \
     middle_end/clambda.cmi
 file_formats/cmxs_format.cmi : \
     utils/misc.cmi
+file_formats/linear_format.cmo : \
+    utils/misc.cmi \
+    parsing/location.cmi \
+    asmcomp/linear.cmi \
+    utils/config.cmi \
+    asmcomp/cmm.cmi \
+    file_formats/linear_format.cmi
+file_formats/linear_format.cmx : \
+    utils/misc.cmx \
+    parsing/location.cmx \
+    asmcomp/linear.cmx \
+    utils/config.cmx \
+    asmcomp/cmm.cmx \
+    file_formats/linear_format.cmi
+file_formats/linear_format.cmi : \
+    asmcomp/linear.cmi \
+    asmcomp/cmm.cmi
 middle_end/closure/closure.cmo : \
     utils/warnings.cmi \
     lambda/switch.cmi \

--- a/Changes
+++ b/Changes
@@ -434,6 +434,9 @@ Working version
 -  #9590: fix pprint of extension constructors (and exceptions) that rebind
    (Chet Murthy, review by octachron@)
 
+- #8939: Command-line option to save Linear IR before emit.
+  (Greta Yorsh, review by Mark Shinwell, Sébastien Hinderer and Frédéric Bour)
+
 ### Build system:
 
 - #7121, #9558: Always the autoconf-discovered ld in PACKLD. For

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -42,10 +42,10 @@ let pass_dump_linear_if ppf flag message phrase =
 let should_save_before_emit () =
   should_save_ir_after Compiler_pass.Scheduling
 
-let linear_unit_info = { Linear_format.
-                         unit_name = "";
-                         items = [];
-                       }
+let linear_unit_info =
+  { Linear_format.unit_name = "";
+    items = [];
+  }
 
 let reset () =
   if should_save_before_emit () then begin
@@ -54,20 +54,23 @@ let reset () =
   end
 
 let save_data dl =
-  if should_save_before_emit () then
-    linear_unit_info.items <- Linear_format.(Data dl) :: linear_unit_info.items;
+  if should_save_before_emit () then begin
+    linear_unit_info.items <- Linear_format.(Data dl) :: linear_unit_info.items
+  end;
   dl
 
 let save_linear f =
-  if should_save_before_emit () then
-    linear_unit_info.items <- Linear_format.(Func f) :: linear_unit_info.items;
+  if should_save_before_emit () then begin
+    linear_unit_info.items <- Linear_format.(Func f) :: linear_unit_info.items
+  end;
   f
 
 let write_linear output_prefix =
-  if should_save_before_emit () then
+  if should_save_before_emit () then begin
     let filename = output_prefix ^ Clflags.Compiler_ir.(extension Linear) in
     linear_unit_info.items <- List.rev linear_unit_info.items;
     Linear_format.save filename linear_unit_info
+  end
 
 let should_emit () =
   not (should_stop_after Compiler_pass.Scheduling)
@@ -158,8 +161,7 @@ let compile_genfuns ~ppf_dump f =
        | _ -> ())
     (Cmm_helpers.generic_functions true [Compilenv.current_unit_infos ()])
 
-let compile_unit output_prefix asm_filename keep_asm
-      obj_filename gen =
+let compile_unit ~output_prefix ~asm_filename ~keep_asm ~obj_filename gen =
   reset ();
   let create_asm = should_emit () &&
                    (keep_asm || not !Emitaux.binary_backend_available) in
@@ -218,12 +220,13 @@ type middle_end =
 
 let compile_implementation ?toplevel ~backend ~filename ~prefixname ~middle_end
       ~ppf_dump (program : Lambda.program) =
-  let asmfile =
+  let asm_filename =
     if !keep_asm_file || !Emitaux.binary_backend_available
     then prefixname ^ ext_asm
     else Filename.temp_file "camlasm" ext_asm
   in
-  compile_unit prefixname asmfile !keep_asm_file (prefixname ^ ext_obj)
+  compile_unit ~output_prefix:prefixname ~asm_filename ~keep_asm:!keep_asm_file
+    ~obj_filename:(prefixname ^ ext_obj)
     (fun () ->
       Ident.Set.iter Compilenv.require_global program.required_globals;
       let clambda_with_constants =

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -39,6 +39,36 @@ let pass_dump_linear_if ppf flag message phrase =
   if !flag then fprintf ppf "*** %s@.%a@." message Printlinear.fundecl phrase;
   phrase
 
+let should_save_before_emit () =
+  should_save_ir_after Compiler_pass.Scheduling
+
+let linear_unit_info = { Linear_format.
+                         unit_name = "";
+                         items = [];
+                       }
+
+let reset () =
+  if should_save_before_emit () then begin
+    linear_unit_info.unit_name <- Compilenv.current_unit_name ();
+    linear_unit_info.items <- [];
+  end
+
+let save_data dl =
+  if should_save_before_emit () then
+    linear_unit_info.items <- Linear_format.(Data dl) :: linear_unit_info.items;
+  dl
+
+let save_linear f =
+  if should_save_before_emit () then
+    linear_unit_info.items <- Linear_format.(Func f) :: linear_unit_info.items;
+  f
+
+let write_linear output_prefix =
+  if should_save_before_emit () then
+    let filename = output_prefix ^ Clflags.Compiler_ir.(extension Linear) in
+    linear_unit_info.items <- List.rev linear_unit_info.items;
+    Linear_format.save filename linear_unit_info
+
 let should_emit () =
   not (should_stop_after Compiler_pass.Scheduling)
 
@@ -103,13 +133,19 @@ let compile_fundecl ~ppf_dump fd_cmm =
   ++ pass_dump_linear_if ppf_dump dump_linear "Linearized code"
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
+  ++ save_linear
   ++ emit_fundecl
+
+let compile_data dl =
+  dl
+  ++ save_data
+  ++ emit_data
 
 let compile_phrase ~ppf_dump p =
   if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
   match p with
   | Cfunction fd -> compile_fundecl ~ppf_dump fd
-  | Cdata dl -> emit_data dl
+  | Cdata dl -> compile_data dl
 
 
 (* For the native toplevel: generates generic functions unless
@@ -122,8 +158,9 @@ let compile_genfuns ~ppf_dump f =
        | _ -> ())
     (Cmm_helpers.generic_functions true [Compilenv.current_unit_infos ()])
 
-let compile_unit asm_filename keep_asm
+let compile_unit output_prefix asm_filename keep_asm
       obj_filename gen =
+  reset ();
   let create_asm = should_emit () &&
                    (keep_asm || not !Emitaux.binary_backend_available) in
   Emitaux.create_asm_file := create_asm;
@@ -131,7 +168,10 @@ let compile_unit asm_filename keep_asm
     ~exceptionally:(fun () -> remove_file obj_filename)
     (fun () ->
        if create_asm then Emitaux.output_channel := open_out asm_filename;
-       Misc.try_finally gen
+       Misc.try_finally
+         (fun () ->
+            gen ();
+            write_linear output_prefix)
          ~always:(fun () ->
              if create_asm then close_out !Emitaux.output_channel)
          ~exceptionally:(fun () ->
@@ -183,7 +223,7 @@ let compile_implementation ?toplevel ~backend ~filename ~prefixname ~middle_end
     then prefixname ^ ext_asm
     else Filename.temp_file "camlasm" ext_asm
   in
-  compile_unit asmfile !keep_asm_file (prefixname ^ ext_obj)
+  compile_unit prefixname asmfile !keep_asm_file (prefixname ^ ext_obj)
     (fun () ->
       Ident.Set.iter Compilenv.require_global program.required_globals;
       let clambda_with_constants =

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -42,8 +42,10 @@ type error = Assembler_error of string
 exception Error of error
 val report_error: Format.formatter -> error -> unit
 
-
-val compile_unit:
-  string(*output prefix*) ->
-  string(*asm file*) -> bool(*keep asm*) ->
-  string(*obj file*) -> (unit -> unit) -> unit
+val compile_unit
+   : output_prefix:string
+   -> asm_filename:string
+   -> keep_asm:bool
+   -> obj_filename:string
+   -> (unit -> unit)
+   -> unit

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -314,8 +314,9 @@ let link_shared ~ppf_dump objfiles output_name =
       then output_name ^ ".startup" ^ ext_asm
       else Filename.temp_file "camlstartup" ext_asm in
     let startup_obj = output_name ^ ".startup" ^ ext_obj in
-    Asmgen.compile_unit
-      startup output_name !Clflags.keep_startup_file startup_obj
+    Asmgen.compile_unit ~output_prefix:output_name
+      ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
+      ~obj_filename:startup_obj
       (fun () ->
          make_shared_startup_file ~ppf_dump
            (List.map (fun (ui,_,crc) -> (ui,crc)) units_tolink)
@@ -382,8 +383,9 @@ let link ~ppf_dump objfiles output_name =
       then output_name ^ ".startup" ^ ext_asm
       else Filename.temp_file "camlstartup" ext_asm in
     let startup_obj = Filename.temp_file "camlstartup" ext_obj in
-    Asmgen.compile_unit output_name
-      startup !Clflags.keep_startup_file startup_obj
+    Asmgen.compile_unit ~output_prefix:output_name
+      ~asm_filename:startup ~keep_asm:!Clflags.keep_startup_file
+      ~obj_filename:startup_obj
       (fun () -> make_startup_file ~ppf_dump units_tolink ~crc_interfaces);
     Misc.try_finally
       (fun () ->

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -315,7 +315,7 @@ let link_shared ~ppf_dump objfiles output_name =
       else Filename.temp_file "camlstartup" ext_asm in
     let startup_obj = output_name ^ ".startup" ^ ext_obj in
     Asmgen.compile_unit
-      startup !Clflags.keep_startup_file startup_obj
+      startup output_name !Clflags.keep_startup_file startup_obj
       (fun () ->
          make_shared_startup_file ~ppf_dump
            (List.map (fun (ui,_,crc) -> (ui,crc)) units_tolink)
@@ -382,7 +382,7 @@ let link ~ppf_dump objfiles output_name =
       then output_name ^ ".startup" ^ ext_asm
       else Filename.temp_file "camlstartup" ext_asm in
     let startup_obj = Filename.temp_file "camlstartup" ext_obj in
-    Asmgen.compile_unit
+    Asmgen.compile_unit output_name
       startup !Clflags.keep_startup_file startup_obj
       (fun () -> make_startup_file ~ppf_dump units_tolink ~crc_interfaces);
     Misc.try_finally

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -109,7 +109,15 @@ let negate_float_comparison = Lambda.negate_float_comparison
 let swap_float_comparison = Lambda.swap_float_comparison
 type label = int
 
-let label_counter = ref 99
+let init_label = 99
+
+let label_counter = ref init_label
+
+let set_label l =
+  assert (l >= !label_counter);
+  label_counter := l
+
+let cur_label () = !label_counter
 
 let new_label() = incr label_counter; !label_counter
 
@@ -220,7 +228,7 @@ let ccatch (i, ids, e1, e2, dbg) =
   Ccatch(Nonrecursive, [i, ids, e2, dbg], e1)
 
 let reset () =
-  label_counter := 99
+  label_counter := init_label
 
 let iter_shallow_tail f = function
   | Clet(_, _, body) | Cphantom_let (_, _, body) | Clet_mut(_, _, _, body) ->

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -114,7 +114,10 @@ let init_label = 99
 let label_counter = ref init_label
 
 let set_label l =
-  assert (l >= !label_counter);
+  if (l < !label_counter) then begin
+    Misc.fatal_errorf "Cannot set label counter to %d, it must be >= %d"
+      l !label_counter ()
+  end;
   label_counter := l
 
 let cur_label () = !label_counter

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -93,6 +93,8 @@ val swap_float_comparison: float_comparison -> float_comparison
 
 type label = int
 val new_label: unit -> label
+val set_label: int -> unit
+val cur_label: unit -> label
 
 type rec_flag = Nonrecursive | Recursive
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -93,7 +93,7 @@ val swap_float_comparison: float_comparison -> float_comparison
 
 type label = int
 val new_label: unit -> label
-val set_label: int -> unit
+val set_label: label -> unit
 val cur_label: unit -> label
 
 type rec_flag = Nonrecursive | Recursive

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -145,6 +145,7 @@ ASMCOMP=\
   asmcomp/reloadgen.cmo asmcomp/reload.cmo \
   asmcomp/deadcode.cmo \
   asmcomp/linear.cmo asmcomp/printlinear.cmo asmcomp/linearize.cmo \
+  file_formats/linear_format.cmo \
   asmcomp/debug/available_regs.cmo \
   asmcomp/debug/compute_ranges_intf.cmo \
   asmcomp/debug/compute_ranges.cmo \

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -234,6 +234,7 @@ module type Optcomp_options = sig
   val _afl_instrument : unit -> unit
   val _afl_inst_ratio : int -> unit
   val _function_sections : unit -> unit
+  val _save_ir_after : string -> unit
 end;;
 
 module type Opttop_options = sig

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -62,7 +62,7 @@ let main argv ppf =
           "Options -i and -stop-after (%s) \
            are  incompatible with -pack, -a, -output-obj"
           (String.concat "|"
-             (Clflags.Compiler_pass.available_pass_names ~native:false))
+             (P.available_pass_names ~filter:(fun _ -> true) ~native:false))
       | Some P.Scheduling -> assert false (* native only *)
     end;
     if !make_archive then begin

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -81,7 +81,7 @@ let main argv ppf =
           "Options -i and -stop-after (%s) \
            are  incompatible with -pack, -a, -shared, -output-obj"
           (String.concat "|"
-             (Clflags.Compiler_pass.available_pass_names ~native:true))
+             (P.available_pass_names ~filter:(fun _ -> true) ~native:true))
     end;
     if !make_archive then begin
       Compmisc.init_path ();

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -1,0 +1,100 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                    Greta Yorsh, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* marshal and unmashal a compilation unit in linear format *)
+type linear_item_info =
+  | Func of Linear.fundecl
+  | Data of Cmm.data_item list
+
+type linear_unit_info =
+  {
+    mutable unit_name : string;
+    mutable items : linear_item_info list;
+  }
+
+type error =
+  | Wrong_format of string
+  | Wrong_version of string
+  | Corrupted of string
+  | Marshal_failed of string
+
+exception Error of error
+
+let save filename linear_unit_info =
+  let ch = open_out_bin filename in
+  Misc.try_finally (fun () ->
+    output_string ch Config.linear_magic_number;
+    output_value ch linear_unit_info;
+    (* Saved because linear and emit depend on cmm.label. *)
+    output_value ch (Cmm.cur_label ());
+    (* Compute digest of the contents and append it to the file. *)
+    flush ch;
+    let crc = Digest.file filename in
+    output_value ch crc
+  )
+    ~always:(fun () -> close_out ch)
+    ~exceptionally:(fun () -> raise(Error(Marshal_failed(filename))))
+
+let restore filename =
+  let ic = open_in_bin filename in
+  Misc.try_finally
+    (fun () ->
+       let magic = Config.linear_magic_number in
+       let buffer = really_input_string ic (String.length magic) in
+       if buffer = magic then begin
+         try
+           let linear_unit_info = (input_value ic : linear_unit_info) in
+           let last_label = (input_value ic : Cmm.label) in
+           Cmm.reset ();
+           Cmm.set_label last_label;
+           let crc = (input_value ic : Digest.t) in
+           (linear_unit_info, crc)
+         with End_of_file | Failure _ -> raise(Error(Corrupted(filename)))
+            | Error e -> raise (Error e)
+       end
+       else if String.sub buffer 0 9 = String.sub magic 0 9 then
+         raise(Error(Wrong_version(filename)))
+       else
+         raise(Error(Wrong_format(filename)))
+    )
+    ~always:(fun () -> close_in ic)
+
+(* Error report *)
+
+open Format
+
+let report_error ppf = function
+  | Wrong_format filename ->
+      fprintf ppf "Expected Linear format. Incompatible file %a"
+        Location.print_filename filename
+  | Wrong_version filename ->
+      fprintf ppf
+        "%a@ is not compatible with this version of OCaml"
+        Location.print_filename filename
+  | Corrupted filename ->
+      fprintf ppf "Corrupted format@ %a"
+        Location.print_filename filename
+  | Marshal_failed filename ->
+      fprintf ppf "Failed to marshal Linear to file@ %a"
+        Location.print_filename filename
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Error err -> Some (Location.error_of_printer_file report_error err)
+      | _ -> None
+    )

--- a/file_formats/linear_format.ml
+++ b/file_formats/linear_format.ml
@@ -15,7 +15,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* marshal and unmashal a compilation unit in linear format *)
+(* Marshal and unmarshal a compilation unit in linear format *)
 type linear_item_info =
   | Func of Linear.fundecl
   | Data of Cmm.data_item list
@@ -39,7 +39,7 @@ let save filename linear_unit_info =
   Misc.try_finally (fun () ->
     output_string ch Config.linear_magic_number;
     output_value ch linear_unit_info;
-    (* Saved because linear and emit depend on cmm.label. *)
+    (* Saved because Linearize and Emit depend on Cmm.label. *)
     output_value ch (Cmm.cur_label ());
     (* Compute digest of the contents and append it to the file. *)
     flush ch;
@@ -47,7 +47,7 @@ let save filename linear_unit_info =
     output_value ch crc
   )
     ~always:(fun () -> close_out ch)
-    ~exceptionally:(fun () -> raise(Error(Marshal_failed(filename))))
+    ~exceptionally:(fun () -> raise (Error (Marshal_failed filename)))
 
 let restore filename =
   let ic = open_in_bin filename in
@@ -55,21 +55,21 @@ let restore filename =
     (fun () ->
        let magic = Config.linear_magic_number in
        let buffer = really_input_string ic (String.length magic) in
-       if buffer = magic then begin
+       if String.equal buffer magic then begin
          try
            let linear_unit_info = (input_value ic : linear_unit_info) in
            let last_label = (input_value ic : Cmm.label) in
            Cmm.reset ();
            Cmm.set_label last_label;
            let crc = (input_value ic : Digest.t) in
-           (linear_unit_info, crc)
-         with End_of_file | Failure _ -> raise(Error(Corrupted(filename)))
+           linear_unit_info, crc
+         with End_of_file | Failure _ -> raise (Error (Corrupted filename))
             | Error e -> raise (Error e)
        end
        else if String.sub buffer 0 9 = String.sub magic 0 9 then
-         raise(Error(Wrong_version(filename)))
+         raise (Error (Wrong_version filename))
        else
-         raise(Error(Wrong_format(filename)))
+         raise (Error (Wrong_format filename))
     )
     ~always:(fun () -> close_in ic)
 

--- a/file_formats/linear_format.mli
+++ b/file_formats/linear_format.mli
@@ -29,7 +29,9 @@ type linear_unit_info =
     mutable items : linear_item_info list;
   }
 
-(* Marshal and unmashal a compilation unit in Linear format.
-   Save and restores global state required for Emit. *)
+(* Marshal and unmarshal a compilation unit in Linear format.
+   It includes saving and restoring global state required for Emit,
+   that currently consists of Cmm.label_counter.
+*)
 val save : string -> linear_unit_info -> unit
 val restore : string -> linear_unit_info * Digest.t

--- a/file_formats/linear_format.mli
+++ b/file_formats/linear_format.mli
@@ -3,9 +3,11 @@
 (*                                 OCaml                                  *)
 (*                                                                        *)
 (*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                    Greta Yorsh, Jane Street Europe                     *)
 (*                                                                        *)
 (*   Copyright 1996 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
+(*   Copyright 2019 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,37 +15,21 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** From Lambda to assembly code *)
+(* Format of .cmir-linear files *)
 
-(** The type of converters from Lambda to Clambda. *)
-type middle_end =
-     backend:(module Backend_intf.S)
-  -> filename:string
-  -> prefixname:string
-  -> ppf_dump:Format.formatter
-  -> Lambda.program
-  -> Clambda.with_constants
+(* Compiler can optionally save Linear representation of a compilation unit,
+   along with other information required to emit assembly. *)
+type linear_item_info =
+  | Func of Linear.fundecl
+  | Data of Cmm.data_item list
 
-(** Compile an implementation from Lambda using the given middle end. *)
-val compile_implementation
-   : ?toplevel:(string -> bool)
-  -> backend:(module Backend_intf.S)
-  -> filename:string
-  -> prefixname:string
-  -> middle_end:middle_end
-  -> ppf_dump:Format.formatter
-  -> Lambda.program
-  -> unit
+type linear_unit_info =
+  {
+    mutable unit_name : string;
+    mutable items : linear_item_info list;
+  }
 
-val compile_phrase :
-    ppf_dump:Format.formatter -> Cmm.phrase -> unit
-
-type error = Assembler_error of string
-exception Error of error
-val report_error: Format.formatter -> error -> unit
-
-
-val compile_unit:
-  string(*output prefix*) ->
-  string(*asm file*) -> bool(*keep asm*) ->
-  string(*obj file*) -> (unit -> unit) -> unit
+(* Marshal and unmashal a compilation unit in Linear format.
+   Save and restores global state required for Emit. *)
+val save : string -> linear_unit_info -> unit
+val restore : string -> linear_unit_info * Digest.t

--- a/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.ml
+++ b/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.ml
@@ -1,0 +1,15 @@
+(* TEST
+ * native-compiler
+ ** setup-ocamlopt.byte-build-env
+ *** ocamlopt.byte
+   flags = "-save-ir-after scheduling -S"
+   ocamlopt_byte_exit_status = "0"
+ **** check-ocamlopt.byte-output
+ ***** script
+   script = "sh ${test_source_directory}/save_ir_after_scheduling.sh"
+*)
+
+let foo f x =
+  if x > 0 then x * 7 else f x
+
+let bar x y = x + y

--- a/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.ml
+++ b/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.ml
@@ -3,7 +3,6 @@
  ** setup-ocamlopt.byte-build-env
  *** ocamlopt.byte
    flags = "-save-ir-after scheduling -S"
-   ocamlopt_byte_exit_status = "0"
  **** check-ocamlopt.byte-output
  ***** script
    script = "sh ${test_source_directory}/save_ir_after_scheduling.sh"

--- a/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.sh
+++ b/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_scheduling.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+cmir=save_ir_after_scheduling.cmir-linear
+
+# Check that cmir is generated
+if [ -e "$cmir" ] ; then
+    test_result=${TEST_PASS}
+else
+    echo "not found $cmir" > ${ocamltest_response}
+    test_result=${TEST_FAIL}
+fi
+exit ${test_result}

--- a/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
+++ b/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.compilers.reference
@@ -1,0 +1,1 @@
+wrong argument 'typing'; option '-save-ir-after' expects one of: scheduling.

--- a/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.ml
+++ b/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.ml
@@ -1,0 +1,15 @@
+(* TEST
+ * native-compiler
+ ** setup-ocamlopt.byte-build-env
+   compiler_output = "compiler-output.raw"
+ *** ocamlopt.byte
+   flags = "-save-ir-after typing"
+   ocamlopt_byte_exit_status = "2"
+ *** script
+   script = "sh ${test_source_directory}/save_ir_after_typing.sh"
+   output = "compiler-output"
+ **** check-ocamlopt.byte-output
+   compiler_output = "compiler-output"
+*)
+
+(* this file is just a test driver, the test does not contain real OCaml code *)

--- a/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.sh
+++ b/testsuite/tests/tool-ocamlopt-save-ir/save_ir_after_typing.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+grep "wrong argument 'typing'" compiler-output.raw | grep "save-ir-after" | sed 's/^.*: wrong argument/wrong argument/'

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -235,15 +235,25 @@ val unboxed_types : bool ref
 val insn_sched : bool ref
 val insn_sched_default : bool
 
+module Compiler_ir : sig
+  type t = Linear
+  val extension : t -> string
+  val magic : t -> string
+  val all : t list
+end
+
 module Compiler_pass : sig
   type t = Parsing | Typing | Scheduling
   val of_string : string -> t option
   val to_string : t -> string
   val is_compilation_pass : t -> bool
-  val available_pass_names : native:bool -> string list
+  val available_pass_names : filter:(t -> bool) -> native:bool -> string list
+  val can_save_ir_after : t -> bool
 end
 val stop_after : Compiler_pass.t option ref
 val should_stop_after : Compiler_pass.t -> bool
+val set_save_ir_after : Compiler_pass.t -> bool -> unit
+val should_save_ir_after : Compiler_pass.t -> bool
 
 val arg_spec : (string * Arg.spec * string) list ref
 

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -118,6 +118,9 @@ val cmxs_magic_number: string
 val cmt_magic_number: string
 (** Magic number for compiled interface files *)
 
+val linear_magic_number: string
+(** Magic number for Linear internal representation files *)
+
 val max_tag: int
 (** Biggest tag that can be stored in the header of a regular block. *)
 

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -104,6 +104,7 @@ and ast_impl_magic_number = "Caml1999M027"
 and ast_intf_magic_number = "Caml1999N027"
 and cmxs_magic_number = "Caml1999D027"
 and cmt_magic_number = "Caml1999T027"
+and linear_magic_number = "Caml1999L027"
 
 let interface_suffix = ref ".mli"
 
@@ -213,6 +214,7 @@ let configuration_variables =
   p "ast_intf_magic_number" ast_intf_magic_number;
   p "cmxs_magic_number" cmxs_magic_number;
   p "cmt_magic_number" cmt_magic_number;
+  p "linear_magic_number" linear_magic_number;
 ]
 
 let print_config_value oc = function


### PR DESCRIPTION
This PR adds command line option to marshal the compiler's intermediate representation of each compilation unit to a separate file. Currently, it is only implemented for saving the Linear IR.

This provides a convenient way for an external tool to get a hold of an intermediate representation and manipulate it using compiler-libs. It is analogous to the way ppx tools handle parse trees, but lets us access IRs down the compilation pipeline. There is no alternative way of doing it, as far as I can see, since the removal of compiler hooks in https://github.com/ocaml/ocaml/pull/2276

Adding this capability has previously been discussed, for example: https://github.com/ocaml/ocaml/pull/1945#issuecomment-410240495, https://github.com/ocaml/ocaml/pull/1945#issuecomment-410247545

Following the conventions established for other compilation articfacts, the IR will be saved to a file named <output_prefix>.cmir-linear. The format is defined in linear_format.ml.

The option is named "-save-ir-after <pass>" and supports only "scheduling" pass in this PR.

I have another patch that supports "-save-ir-after parsing" and "-save-ir-after typing" by invoking existing functionality in the compiler.  It seems redundant with other command line options and I don't have a way to test it, but happy to add it on for completeness if needed.  The passes "parsing" and "typing" were already defined in Clflags.Compiler_passes for use with command line option "-stop-after <pass>".

This PR is on top of PR #8938 in which I propose to add "scheduling" to the existing "-stop-after" option. The only new commit here to review is in https://github.com/ocaml/ocaml/commit/8ea2eb9a96ad06639586099bf814c25e8aa67954