### PR TITLE
Fix missing Caml_state

### DIFF
--- a/Changes
+++ b/Changes
@@ -145,7 +145,7 @@ Working version
    which must be duplicated for each domain in the multicore runtime.
    (KC Sivaramakrishnan and Stephen Dolan, compatibility header hacking by
     David Allsopp, review by David Allsopp, Alain Frisch, Nicolas Ojeda Bar,
-    Gabriel Scherer and Damien Doligez)
+    Gabriel Scherer, Damien Doligez, and Guillaume Munch-Maccagnoni)
 
 ### Tools:
 

--- a/runtime/arm.S
+++ b/runtime/arm.S
@@ -153,7 +153,7 @@ FUNCTION(caml_call_gc)
 #else
         CFI_OFFSET(lr, -4)
 #endif
-    /* Store pointer to saved integer registers in caml_gc_regs */
+    /* Store pointer to saved integer registers in Caml_state->gc_regs */
         str     sp, Caml_state(gc_regs)
     /* Save current allocation pointer for debugging purposes */
         str     alloc_ptr, Caml_state(young_ptr)

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -142,7 +142,7 @@ FUNCTION(caml_call_gc)
         stp     d26, d27, [sp, 352]
         stp     d28, d29, [sp, 368]
         stp     d30, d31, [sp, 384]
-    /* Store pointer to saved integer registers in caml_gc_regs */
+    /* Store pointer to saved integer registers in Caml_state->gc_regs */
         add     TMP, sp, #16
         str     TMP, Caml_state(gc_regs)
     /* Save current allocation pointer for debugging purposes */
@@ -197,9 +197,9 @@ FUNCTION(caml_alloc1)
     /* Record the lowest address of the caller's stack frame.  This is the
        address immediately above the pair of words (x29 and x30) we just
        pushed.  Those must not be included since otherwise the distance from
-       [caml_bottom_of_stack] to the highest address in the caller's stack
-       frame won't match the frame size contained in the relevant frame
-       descriptor. */
+       [Caml_state->bottom_of_stack] to the highest address in the caller's
+       stack frame won't match the frame size contained in the relevant
+       frame descriptor. */
         add     x29, sp, #16
         str     x29, Caml_state(bottom_of_stack)
         add     x29, sp, #0

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -59,7 +59,7 @@
  *
  * They are part of the state specific to each thread, and threading libraries
  * are responsible for copying them on context switch.
- * See [otherlibs/systhreads/st_stubs.c] and [otherlibs/threads/scheduler.c].
+ * See [otherlibs/systhreads/st_stubs.c].
  *
  *
  * [Caml_state->backtrace_buffer] is filled by runtime when unwinding stack. It
@@ -79,7 +79,8 @@
  * raise and re-raise are distinguished by:
  * - passing reraise = 1 to [caml_stash_backtrace] (see below) in the bytecode
  *   interpreter;
- * - directly resetting [caml_backtrace_pos] to 0 in native runtimes for raise.
+ * - directly resetting [Caml_state->backtrace_pos] to 0 in native
+     runtimes for raise.
  */
 
 /* [caml_record_backtrace] toggle backtrace recording on and off.

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -71,7 +71,7 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li);
 #define Val_backtrace_slot(bslot) (Val_long(((uintnat)(bslot))>>1))
 #define Backtrace_slot_val(vslot) ((backtrace_slot)(Long_val(vslot) << 1))
 
-/* Allocate the caml_backtrace_buffer. Returns 0 on success, -1 otherwise */
+/* Allocate Caml_state->backtrace_buffer. Returns 0 on success, -1 otherwise */
 int caml_alloc_backtrace_buffer(void);
 
 #ifndef NATIVE_CODE

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -512,8 +512,8 @@ int caml_find_code_fragment(char *pc, int *index, struct code_fragment **cf);
 
 #endif /* CAML_INTERNALS */
 
-/* The [backtrace_slot] type represents values stored in the
- * [caml_backtrace_buffer].  In bytecode, it is the same as a
+/* The [backtrace_slot] type represents values stored in
+ * [Caml_state->backtrace_buffer].  In bytecode, it is the same as a
  * [code_t], in native code it as a [frame_descr *].  The difference
  * doesn't matter for code outside [backtrace_{byt,nat}.c],
  * so it is just exposed as a [void *].

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -129,7 +129,7 @@ LBL(105):
         movl    %eax, 0(%esp)
         addl    $(STACK_PROBE_SIZE), %esp; CFI_ADJUST(-STACK_PROBE_SIZE);
 #endif
-    /* Build array of registers, save it into caml_gc_regs */
+    /* Build array of registers, save it into Caml_state->gc_regs */
         pushl   %ebp; CFI_ADJUST(4)
         pushl   %edi; CFI_ADJUST(4)
         pushl   %esi; CFI_ADJUST(4)
@@ -232,9 +232,9 @@ FUNCTION(caml_allocN)
         pushl   %eax; CFI_ADJUST(4) /* saved desired size */
         pushl   %ebx; CFI_ADJUST(4)
         movl    G(Caml_state), %ebx
-        /* eax = size - caml_young_ptr */
+        /* eax = size - Caml_state->young_ptr */
         subl    CAML_STATE(young_ptr, %ebx), %eax
-        negl    %eax                    /* eax = caml_young_ptr - size */
+        negl    %eax              /* eax = Caml_state->young_ptr - size */
         cmpl    CAML_STATE(young_limit, %ebx), %eax
         jb      LBL(103)
         movl    %eax, CAML_STATE(young_ptr, %ebx)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -473,7 +473,8 @@ CAMLexport void caml_gc_dispatch (void)
 }
 
 /* Called by [Alloc_small] when [Caml_state->young_ptr] reaches
-   [caml_young_limit]. We may have to either call memprof or the gc. */
+   [Caml_state->young_limit]. We may have to either call memprof or
+   the gc. */
 void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags)
 {
   /* Async callbacks may fill the minor heap again, so we need a while

--- a/runtime/spacetime_nat.c
+++ b/runtime/spacetime_nat.c
@@ -789,7 +789,7 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
     while ((ret = unw_step(&cur)) > 0) {
       unw_word_t ip;
       unw_get_reg(&cur, UNW_REG_IP, &ip);
-      if (caml_last_return_address == (uintnat) ip) {
+      if (Caml_state->last_return_address == (uintnat) ip) {
         break;
       }
       else {
@@ -824,7 +824,7 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
   for (frame = frames->size - 1; frame >= innermost_frame; frame--) {
     c_node_type expected_type;
     void* pc = frames->contents[frame];
-    CAMLassert (pc != (void*) caml_last_return_address);
+    CAMLassert (pc != (void*) Caml_state->last_return_address);
 
     if (!for_allocation) {
       expected_type = CALL;

--- a/runtime/spacetime_nat.c
+++ b/runtime/spacetime_nat.c
@@ -686,8 +686,9 @@ CAMLprim value* caml_spacetime_indirect_node_hole_ptr
 
    caml_call_gc only invokes OCaml functions in the following circumstances:
    1. running an OCaml finaliser;
-   2. executing an OCaml signal handler.
-   Both of these are done on the finaliser trie.  Furthermore, both of
+   2. executing an OCaml signal handler;
+   3. executing memprof callbacks.
+   All of these are done on the finaliser trie.  Furthermore, all of
    these invocations start via caml_callback; the code in this file for
    handling that (caml_spacetime_c_to_ocaml) correctly copes with that by
    attaching a single "caml_start_program" node that can cope with any
@@ -708,10 +709,10 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
     uintnat wosize, struct ext_table** cached_frames)
 {
 #ifdef HAS_LIBUNWIND
-  /* Given that [caml_last_return_address] is the most recent call site in
-     OCaml code, and that we are now in C (or other) code called from that
+  /* Given that [Caml_state->last_return_address] is the most recent call site
+     in OCaml code, and that we are now in C (or other) code called from that
      site, obtain a backtrace using libunwind and graft the most recent
-     portion (everything back to but not including [caml_last_return_address])
+     portion (everything back to but not including [last_return_address])
      onto the trie.  See the important comment below regarding the fact that
      call site, and not callee, addresses are recorded during this process.
 
@@ -774,7 +775,7 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
   }
 
   if (!have_frames_already) {
-    /* Get the stack backtrace as far as [caml_last_return_address]. */
+    /* Get the stack backtrace as far as [Caml_state->last_return_address]. */
 
     ret = unw_getcontext(&ctx);
     if (ret != UNW_ESUCCESS) {
@@ -946,7 +947,7 @@ void caml_spacetime_c_to_ocaml(void* ocaml_entry_point,
   value node;
 
   /* Update the trie with the current backtrace, as far back as
-     [caml_last_return_address], and leave the node hole pointer at
+     [Caml_state->last_return_address], and leave the node hole pointer at
      the correct place for attachment of a [caml_start_program] node. */
 
 #ifdef HAS_LIBUNWIND

--- a/runtime/spacetime_snapshot.c
+++ b/runtime/spacetime_snapshot.c
@@ -108,17 +108,18 @@ static value take_gc_stats(void)
   v_stats = allocate_outside_heap(sizeof(gc_stats));
   stats = (gc_stats*) v_stats;
 
-  stats->minor_words = Val_long(caml_stat_minor_words);
-  stats->promoted_words = Val_long(caml_stat_promoted_words);
+  stats->minor_words = Val_long(Caml_state->stat_minor_words);
+  stats->promoted_words = Val_long(Caml_state->stat_promoted_words);
   stats->major_words =
-    Val_long(((uintnat) caml_stat_major_words)
+    Val_long(((uintnat) Caml_state->stat_major_words)
              + ((uintnat) caml_allocated_words));
-  stats->minor_collections = Val_long(caml_stat_minor_collections);
-  stats->major_collections = Val_long(caml_stat_major_collections);
-  stats->heap_words = Val_long(caml_stat_heap_wsz / sizeof(value));
-  stats->heap_chunks = Val_long(caml_stat_heap_chunks);
-  stats->compactions = Val_long(caml_stat_compactions);
-  stats->top_heap_words = Val_long(caml_stat_top_heap_wsz / sizeof(value));
+  stats->minor_collections = Val_long(Caml_state->stat_minor_collections);
+  stats->major_collections = Val_long(Caml_state->stat_major_collections);
+  stats->heap_words = Val_long(Caml_state->stat_heap_wsz / sizeof(value));
+  stats->heap_chunks = Val_long(Caml_state->stat_heap_chunks);
+  stats->compactions = Val_long(Caml_state->stat_compactions);
+  stats->top_heap_words =
+    Val_long(Caml_state->stat_top_heap_wsz / sizeof(value));
 
   return v_stats;
 }

--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -12,10 +12,10 @@ To add a new module, you must:
 
 * Create new `.mli` and `.ml` files for the modules, obviously.
 
-* Define the module in `stdlib/stdlib.mli`, `stdlib/stdlib.ml` in the section of
-  the code commented, "MODULE ALIASES". Please maintain the same style as the
-  rest of the code, in particular the alphabetical ordering and whitespace
-  alignment of module aliases.
+* Define the module in `stdlib/stdlib.mli` and `stdlib/stdlib.ml` in
+  the section of the code commented "MODULE ALIASES". Please maintain
+  the same style as the rest of the code, in particular the
+  alphabetical ordering and whitespace alignment of module aliases.
 
 * Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
   `stdlib/StdlibModules`. You must keep the list sorted in dependency order.

--- a/tools/gdb-macros
+++ b/tools/gdb-macros
@@ -124,11 +124,11 @@ define camlheader
 end
 
 define camlheap
-  if $arg0 >= caml_young_start && $arg0 < caml_young_end
+  if $arg0 >= Caml_state->young_start && $arg0 < Caml_state->young_end
     printf "YOUNG"
     set $camlheap_result = 1
   else
-    set $chunk = caml_heap_start
+    set $chunk = Caml_state->heap_start
     set $found = 0
     while $chunk != 0 && ! $found
       set $chunk_size = * (unsigned long *) ($chunk - 2 * $camlwordsize)
@@ -253,7 +253,7 @@ end
 
 # displays the list of heap chunks
 define camlchunks
-  set $chunk = * (unsigned long *) &caml_heap_start
+  set $chunk = * (unsigned long *) &Caml_state->heap_start
   while $chunk != 0
     set $chunk_size = * (unsigned long *) ($chunk - 2 * $camlwordsize)
     set $chunk_alloc = * (unsigned long *) ($chunk - 3 * $camlwordsize)
@@ -269,7 +269,7 @@ end
 # `camlvisitfun` can set `$camlvisitstop` to stop the iteration
 
 define camlvisit
-  set $cvchunk = * (unsigned long *) &caml_heap_start
+  set $cvchunk = * (unsigned long *) &Caml_state->heap_start
   set $camlvisitstop = 0
   while $cvchunk != 0 && ! $camlvisitstop
     set $cvchunk_size = * (unsigned long *) ($cvchunk - 2 * $camlwordsize)
@@ -290,7 +290,7 @@ define camlvisit
 end
 
 define caml_cv_check_fl0
-  if $hp == * (unsigned long *) &caml_heap_start
+  if $hp == * (unsigned long *) &Caml_state->heap_start
     set $flcheck_prev = ((unsigned long) &sentinels + 16)
   end
   if $color == 2 && $size > 5


### PR DESCRIPTION
Follow-up to #8713. Some substitutions `caml_` -> `Caml_state->` appear to have been forgotten on some untested paths. Not knowing these well, I was unable to test the patch properly, so some careful proofreading would be useful. I also included trivial similar updates to comments in a separate commit (read by commits to avoid the noise).

In addition, the following symbols are still mentioned in `caml/compatibility.h` but not defined anywhere: `caml_stack_low, caml_stack_high, caml_stack_threshold, caml_extern_sp, caml_trapsp, caml_trap_barrier, caml_external_raise, caml_backtrace_active, caml_backtrace_pos, caml_backtrace_buffer, caml_backtrace_last_exn, caml_stat_heap_wsz, caml_stat_top_heap_wsz`. I didn't know if I just had to change the definition of `x` or introduce a new definition of `caml_x`, or if there was some other trick or reason it was not done. (I am not sure I got the conclusion of the discussion about the idea of removing `compatibility.h` on the other thread, but such a file is going to be needed by people who want a program that compile with both OCaml 4.10 and OCaml ≤4.09.)