### PR TITLE
Caml_alloc: Document new behaviour and upgrade path (check_urgent_gc)

### DIFF
--- a/Changes
+++ b/Changes
@@ -119,9 +119,11 @@ Working version
    OCaml heap.
    (Jacques-Henri Jourdan, review by Damien Doligez)
 
-- #8691, #8897: Allocation functions are now guaranteed not to trigger any
-   OCaml callback when called from C.
-   (Jacques-Henri Jourdan, review by Stephen Dolan and Gabriel Scherer)
+* #8691, #8897: Allocation functions are now guaranteed not to trigger any
+   OCaml callback when called from C. In long-running C functions,
+   this can be replaced with calls to caml_check_urgent_gc.
+   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer and
+    Guillaume Munch-Maccagnoni)
 
 - #8630: Use abort() instead of exit(2) in caml_fatal_error, and add
   the new hook caml_fatal_error_hook.

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -1166,6 +1166,19 @@ It would be incorrect to perform
 has taken place since "r" was allocated.
 
 
+\subsection{Asynchronous callbacks}
+\label{caml-check-urgent-gc}
+
+Since 4.10, allocation functions called from C do not call finalisers,
+signal handlers, and memory profiler callbacks, but delays their
+execution. These asychronous callbacks can execute arbitrary OCaml
+code, including raising asynchronous exceptions.
+
+The function \verb"caml_check_urgent_gc" from "memory.h" checks for
+pending signals and executes delayed callbacks. In long-running C
+code, it can be called at safe points with
+\verb"caml_check_urgent_gc(Val_unit)".
+
 \section{A complete example}
 
 This section outlines how the functions from the Unix "curses" library
@@ -2325,6 +2338,11 @@ The calling thread re-acquires the master lock and other OCaml
 resources.  It may block until no other thread uses the OCaml run-time
 system.
 \end{itemize}
+
+These functions check for pending signals by calling asynchronous
+callbacks (section~\ref{caml-check-urgent-gc}) before releasing and
+after acquiring the lock. They can therefore execute arbitrary OCaml
+code including raising an asynchronous exception.
 
 After "caml_release_runtime_system()" was called and until
 "caml_acquire_runtime_system()" is called, the C code must not access

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -215,6 +215,7 @@ enum caml_alloc_small_flags {
 };
 
 extern void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags);
+// Do not call asynchronous callbacks from allocation functions
 #define Alloc_small_origin CAML_FROM_C
 #define Alloc_small_aux(result, wosize, tag, profinfo, track) do {     \
   CAMLassert ((wosize) >= 1);                                          \

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -68,6 +68,7 @@ sp is a local copy of the global variable Caml_state->extern_sp. */
 /* GC interface */
 
 #undef Alloc_small_origin
+// Do call asynchronous callbacks from allocation functions
 #define Alloc_small_origin CAML_FROM_CAML
 #define Setup_for_gc \
   { sp -= 2; sp[0] = accu; sp[1] = env; Caml_state->extern_sp = sp; }


### PR DESCRIPTION
This is a follow-up to https://github.com/ocaml/ocaml/pull/8691#issuecomment-521181762. I find it a good idea to document the new behaviour of allocation functions and give an upgrade path for users of the C FFI in case they could be affected, e.g. if they have long-running C code. Currently this does not change any code.

However, I find three issues with the current interface and I may improve it according to feedback.
- I find it better to give the FFI user a function that does not take an extra root as argument. What would be the name?
- The advice to call `check_urgent_gc` is currently hard to follow in resource-conscious C code, because when an asynchronous exception must be raised, it automatically jumps back to the OCaml caller and prevents cleanup. (This is an issue the Coq VM is facing for instance.) A solution would be to have a variant of `check_urgent_gc_exn` that returns the exception, and document that it has to be reraised with `raise_in_async_callback`. (It looks like some amount of work, but I see how it could help in situations like the Coq VM.). The same should be done for `{enter,leave}_blocking_section`.
- `check_urgent_gc` is not called when an allocating C function returns to OCaml, unlike I had documented at first. This can have unexpected consequences given that OCaml is currently poor in emitted safe points (cf. the problem of uninterruptible loops). There are possibilities that this causes bugs in current programs. I read that a solution is to change `caml_c_call`, but this could also have a much simpler fix after the better safe points patch.

Note: it's good to consider this for 4.10

- [ ] Update after #8993 