### PR TITLE
Uniform `-I` treatment

### DIFF
--- a/Changes
+++ b/Changes
@@ -118,6 +118,10 @@ Working version
 
 ### Tools:
 
+* #XXXX, `ocamldep` and `ocamlc -depend`: do not error if `-I dir` is
+  specified and `dir` does not exist; be silent and exit with `0`.
+  (Daniel Bünzli, review by XXXX)
+
 * #6792, #8654 ocamldebug now supports program using Dynlink. This
    breaks compatibility with emacs modes.
    (Whitequark and Jacques-Henri Jourdan, review by Gabriel Scherer

--- a/Changes
+++ b/Changes
@@ -122,6 +122,9 @@ Working version
   specified and `dir` does not exist; be silent and exit with `0`.
   (Daniel Bünzli, review by XXXX)
 
+* #XXXX: Only pass search directories that do exist to the C linker.
+  (Daniel Bünzli, review by XXXX)
+
 * #6792, #8654 ocamldebug now supports program using Dynlink. This
    breaks compatibility with emacs modes.
    (Whitequark and Jacques-Henri Jourdan, review by Gabriel Scherer

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -80,13 +80,9 @@ let add_to_list li s =
   li := s :: !li
 
 let add_to_load_path dir =
-  try
-    let dir = Misc.expand_directory Config.standard_library dir in
-    let contents = readdir dir in
-    add_to_list load_path (dir, contents)
-  with Sys_error msg ->
-    Format.fprintf Format.err_formatter "@[Bad -I option: %s@]@." msg;
-    Error_occurred.set ()
+  let dir = Misc.expand_directory Config.standard_library dir in
+  let contents = readdir dir in
+  add_to_list load_path (dir, contents)
 
 let add_to_synonym_list synonyms suffix =
   if (String.length suffix) > 1 && suffix.[0] = '.' then

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -192,7 +192,7 @@ let call_linker mode output_name files extra =
         Printf.sprintf "%s%s %s %s %s"
           Config.native_pack_linker
           (Filename.quote output_name)
-          (quote_prefixed l_prefix (Load_path.get_paths ()))
+          (quote_prefixed l_prefix (Load_path.get_existing_paths ()))
           (quote_files (remove_Wl files))
           extra
       else
@@ -206,7 +206,7 @@ let call_linker mode output_name files extra =
           )
           (Filename.quote output_name)
           ""  (*(Clflags.std_include_flag "-I")*)
-          (quote_prefixed "-L" (Load_path.get_paths ()))
+          (quote_prefixed "-L" (Load_path.get_existing_paths ()))
           (String.concat " " (List.rev !Clflags.all_ccopts))
           (quote_files files)
           extra

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -38,6 +38,10 @@ val get_paths : unit -> string list
 (** Return the list of directories passed to [add_dir] so far, in
     reverse order. *)
 
+val get_existing_paths : unit -> string list
+(** [get_existing_paths] is like {!get_paths} but returns only those
+    directories that do exist on the file system. *)
+
 val find : string -> string
 (** Locate a file in the load path. Raise [Not_found] if the file
     cannot be found. This function is optimized for the case where the
@@ -56,9 +60,13 @@ module Dir : sig
 
   val path : t -> string
 
+  val exists : t -> bool
+  (** [exists d] is [true] if directory [d] exists on the file system. *)
+
   val files : t -> string list
-  (** All the files in that directory. This doesn't include files in
-      sub-directories of this directory. *)
+  (** [files d] is the list of file and directory names (not paths)
+      found in directory [d]. This is the empty list if [exists d]
+      is [false]. *)
 end
 
 val add : Dir.t -> unit


### PR DESCRIPTION
While trying to implement the `OCAMLPATH` [proposal](https://github.com/ocaml/ocaml/issues/8898) I noticed the toolchain treats inexisting directories passed to `-I` in different ways:

```shell
> touch a.ml 
> ocaml -I +doesnotexist a.ml       # toplevel 
> ocamlc -c -I +doesnotexist a.ml    # byte compile 
> ocamlc -I +doesnotexist a.ml       # byte link 
> ocamlopt -c -I +doesnotexist a.ml  # native compile 
> ocamlopt -I +doesnotexist a.ml     # native link (c linker warning) 
ld: warning: directory not found for option '-L/Users/dbuenzli/.opam/4.08.0/lib/ocaml/doesnotexit' 
> ocamldep -I +doesnotexist a.ml 
Bad -I option: /Users/dbuenzli/.opam/4.08.0/lib/ocaml/doesnotexit: No such file or directory 
[...] 
> ocamlc -depend -I +doesnotexist a.ml
Bad -I option: /Users/dbuenzli/.opam/4.08.0/lib/ocaml/doesnotexist: No such file or directory
```

Note that the `+` is irrelevant here, the tools behave the same way if you pass an arbitrary inexisting path `/that/does/not/exist`. To sum up:

1. `ocamldep` and `ocamlc -depend` is the only tool that checks for include directory existence: if the include does not exist it exits with code 2.
2. Calls to the C linker pass unchecked `-I` arguments to the C linker as is which does (at least on macOS) check for directory existence and thus yields a warning from the linker.
   
Among sound harmonizing alternatives are the following:

1. The toolchain always check the existence of includes (for `OCAMLPATH` if the include is a `+` it must exist in one of the directories mentioned in `OCAMLPATH`). Inexistence may warn (zero exit code) or error (non zero exist code)
2. The toolchain never check for existence of includes.

It would likely better to do 1. but I suspect this may break certain build systems. So this PR implements 2 for the time being (1 with warning might be an option in the future) as follows:

1. `ocamldep` and `ocamlc -depend` no longer check the `-I` for existence.
   (I suspect the relevant code should in fact use `Load_path` but this can 
    be done in another PR).
2. Calls to the C linker only pass `-I` directories that do exist on the file system.

Thanks to @gasche for his private feedback on the issue.
