### PR TITLE
Implement `OCAMLPATH`

### DIFF
--- a/Changes
+++ b/Changes
@@ -118,6 +118,10 @@ Working version
 
 ### Tools:
 
+* #XXXX, `ocamldep` and `ocamlc -depend`: do not error if `-I dir` is
+  specified and `dir` does not exist; be silent and exit with `0`.
+  (Daniel Bünzli, review by XXXX)
+
 * #6792, #8654 ocamldebug now supports program using Dynlink. This
    breaks compatibility with emacs modes.
    (Whitequark and Jacques-Henri Jourdan, review by Gabriel Scherer

--- a/Changes
+++ b/Changes
@@ -122,6 +122,9 @@ Working version
   specified and `dir` does not exist; be silent and exit with `0`.
   (Daniel Bünzli, review by XXXX)
 
+* #XXXX: Only pass search directories that do exist to the C linker.
+  (Daniel Bünzli, review by XXXX)
+
 * #6792, #8654 ocamldebug now supports program using Dynlink. This
    breaks compatibility with emacs modes.
    (Whitequark and Jacques-Henri Jourdan, review by Gabriel Scherer

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -149,7 +149,7 @@ let anonymous s =
   program_name := Unix_tools.make_absolute s; raise Found_program_name
 let add_include d =
   default_load_path :=
-    Misc.expand_directory Config.standard_library d :: !default_load_path
+    Misc.expand_directory Config.ocamlpath d @ !default_load_path
 let set_socket s =
   socket_name := s
 let set_topdirs_path s =

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -23,9 +23,10 @@ open Compenv
 
 let init_path ?(dir="") () =
   let dirs =
-    if !Clflags.use_threads then "+threads" :: !Clflags.include_dirs
-    else
-      !Clflags.include_dirs
+    let dirs = !Clflags.include_dirs in
+    if !Clflags.use_threads
+    then Filename.concat Config.standard_library "threads" :: dirs
+    else dirs
   in
   let dirs =
     !last_include_dirs @ dirs @ Config.flexdll_dirs @ !first_include_dirs

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -31,7 +31,7 @@ let init_path ?(dir="") () =
     !last_include_dirs @ dirs @ Config.flexdll_dirs @ !first_include_dirs
   in
   let exp_dirs =
-    List.map (Misc.expand_directory Config.standard_library) dirs in
+    List.concat (List.map (Misc.expand_directory Config.ocamlpath) dirs) in
   Load_path.init (dir :: List.rev_append exp_dirs (Clflags.std_include_dir ()));
   Env.reset_cache ()
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -511,7 +511,7 @@ let mk_strict_sequence f =
 
 let mk_thread f =
   "-thread", Arg.Unit f,
-  " (deprecated) same as -I +threads"
+  " (deprecated) same as -I $(ocamlc -where)/threads"
 ;;
 
 let mk_dtimings f =

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -80,13 +80,9 @@ let add_to_list li s =
   li := s :: !li
 
 let add_to_load_path dir =
-  try
-    let dir = Misc.expand_directory Config.standard_library dir in
-    let contents = readdir dir in
-    add_to_list load_path (dir, contents)
-  with Sys_error msg ->
-    Format.fprintf Format.err_formatter "@[Bad -I option: %s@]@." msg;
-    Error_occurred.set ()
+  let dir = Misc.expand_directory Config.standard_library dir in
+  let contents = readdir dir in
+  add_to_list load_path (dir, contents)
 
 let add_to_synonym_list synonyms suffix =
   if (String.length suffix) > 1 && suffix.[0] = '.' then

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -79,9 +79,12 @@ let add_to_list li s =
   li := s :: !li
 
 let add_to_load_path dir =
-  let dir = Misc.expand_directory Config.standard_library dir in
-  let contents = readdir dir in
-  add_to_list load_path (dir, contents)
+  let dirs = Misc.expand_directory Config.ocamlpath dir in
+  let add dir =
+    let contents = readdir dir in
+    add_to_list load_path (dir, contents)
+  in
+  List.iter add dirs
 
 let add_to_synonym_list synonyms suffix =
   if (String.length suffix) > 1 && suffix.[0] = '.' then

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -279,8 +279,8 @@ let transl_path s =
 
 let flexdll_dirs =
   let dirs =
-    let expand = Misc.expand_directory Config.standard_library in
-    List.map expand Config.flexdll_dirs
+    let expand = Misc.expand_directory Config.ocamlpath in
+    List.concat (List.map expand Config.flexdll_dirs)
   in
   let f dir =
     let dir =

--- a/tools/ocamlmktop.ml
+++ b/tools/ocamlmktop.ml
@@ -24,8 +24,12 @@ let _ =
     if Sys.win32 then "ocamlc.exe","\"" else "ocamlc",""
   in
   let ocamlc = Filename.(quote (concat (dirname ocamlmktop) ocamlc)) in
+  let compiler_libs_inc =
+    " -I " ^
+    Filename.(quote (concat Config.standard_library "compiler-libs"))
+  in
   let cmdline =
-    extra_quote ^ ocamlc ^ " -I +compiler-libs -linkall ocamlcommon.cma " ^
+    extra_quote ^ ocamlc ^ compiler_libs_inc ^ " -linkall ocamlcommon.cma " ^
     "ocamlbytecomp.cma ocamltoplevel.cma " ^ args ^ " topstart.cmo" ^
     extra_quote
   in

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -561,15 +561,15 @@ let set_paths () =
   (* Add whatever -I options have been specified on the command line,
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
-  let expand = Misc.expand_directory Config.standard_library in
+  let expand = Misc.expand_directory Config.ocamlpath in
   let current_load_path = Load_path.get_paths () in
   let load_path = List.concat [
       [ "" ];
-      List.map expand (List.rev !Compenv.first_include_dirs);
-      List.map expand (List.rev !Clflags.include_dirs);
-      List.map expand (List.rev !Compenv.last_include_dirs);
+      List.concat (List.map expand (List.rev !Compenv.first_include_dirs));
+      List.concat (List.map expand (List.rev !Clflags.include_dirs));
+      List.concat (List.map expand (List.rev !Compenv.last_include_dirs));
       current_load_path;
-      [expand "+camlp4"];
+      expand "+camlp4";
     ]
   in
   Load_path.init load_path

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -515,15 +515,15 @@ let set_paths () =
   (* Add whatever -I options have been specified on the command line,
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
-  let expand = Misc.expand_directory Config.standard_library in
+  let expand = Misc.expand_directory Config.ocamlpath in
   let current_load_path = Load_path.get_paths () in
   let load_path = List.concat [
       [ "" ];
-      List.map expand (List.rev !Compenv.first_include_dirs);
-      List.map expand (List.rev !Clflags.include_dirs);
-      List.map expand (List.rev !Compenv.last_include_dirs);
+      List.concat (List.map expand (List.rev !Compenv.first_include_dirs));
+      List.concat (List.map expand (List.rev !Clflags.include_dirs));
+      List.concat (List.map expand (List.rev !Compenv.last_include_dirs));
       current_load_path;
-      [expand "+camlp4"];
+      expand "+camlp4";
     ]
   in
   Load_path.init load_path;

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -102,8 +102,9 @@ let compile_file ?output ?(opt="") ?stable_name name =
          (if !Clflags.debug && Config.ccomp_type <> "msvc" then "-g" else "")
          (String.concat " " (List.rev !Clflags.all_ccopts))
          (quote_prefixed "-I"
-            (List.map (Misc.expand_directory Config.standard_library)
-               (List.rev !Clflags.include_dirs)))
+            (List.concat
+               (List.map (Misc.expand_directory Config.ocamlpath)
+                  (List.rev !Clflags.include_dirs))))
          (Clflags.std_include_flag "-I")
          (Filename.quote name)
          (* cl tediously includes the name of the C file as the first thing it

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -192,7 +192,7 @@ let call_linker mode output_name files extra =
         Printf.sprintf "%s%s %s %s %s"
           Config.native_pack_linker
           (Filename.quote output_name)
-          (quote_prefixed l_prefix (Load_path.get_paths ()))
+          (quote_prefixed l_prefix (Load_path.get_existing_paths ()))
           (quote_files (remove_Wl files))
           extra
       else
@@ -206,7 +206,7 @@ let call_linker mode output_name files extra =
           )
           (Filename.quote output_name)
           ""  (*(Clflags.std_include_flag "-I")*)
-          (quote_prefixed "-L" (Load_path.get_paths ()))
+          (quote_prefixed "-L" (Load_path.get_existing_paths ()))
           (String.concat " " (List.rev !Clflags.all_ccopts))
           (quote_files files)
           extra

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -26,6 +26,10 @@ val version: string
 val standard_library: string
 (** The directory containing the standard libraries *)
 
+val ocamlpath: string list
+(** The compiler file search path as defined by the [OCAMLPATH] environment
+    variable. *)
+
 val ccomp_type: string
 (** The "kind" of the C compiler, assembler and linker used: one of
     "cc" (for Unix-style C compilers)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -28,6 +28,13 @@ let standard_library =
   with Not_found ->
     standard_library_default
 
+let ocamlpath = match Sys.getenv "OCAMLPATH" with
+  | exception Not_found -> [standard_library]
+  | p ->
+      let sep = if Sys.win32 then ';' else ':' in
+      let non_empty s = not (String.equal "" s) in
+      List.find_all non_empty (String.split_on_char sep p)
+
 let ccomp_type = "%%CCOMPTYPE%%"
 let c_compiler = "%%CC%%"
 let c_output_obj = "%%OUTPUTOBJ%%"
@@ -161,6 +168,7 @@ let configuration_variables =
   p "version" version;
   p "standard_library_default" standard_library_default;
   p "standard_library" standard_library;
+  p "ocamlpath" (String.concat (if Sys.win32 then ";" else ":") ocamlpath);
   p "ccomp_type" ccomp_type;
   p "c_compiler" c_compiler;
   p "ocamlc_cflags" ocamlc_cflags;

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -38,6 +38,10 @@ val get_paths : unit -> string list
 (** Return the list of directories passed to [add_dir] so far, in
     reverse order. *)
 
+val get_existing_paths : unit -> string list
+(** [get_existing_paths] is like {!get_paths} but returns only those
+    directories that do exist on the file system. *)
+
 val find : string -> string
 (** Locate a file in the load path. Raise [Not_found] if the file
     cannot be found. This function is optimized for the case where the
@@ -56,9 +60,13 @@ module Dir : sig
 
   val path : t -> string
 
+  val exists : t -> bool
+  (** [exists d] is [true] if directory [d] exists on the file system. *)
+
   val files : t -> string list
-  (** All the files in that directory. This doesn't include files in
-      sub-directories of this directory. *)
+  (** [files d] is the list of file and directory names (not paths)
+      found in directory [d]. This is the empty list if [exists d]
+      is [false]. *)
 end
 
 val add : Dir.t -> unit

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -286,14 +286,12 @@ let remove_file filename =
   with Sys_error _msg ->
     ()
 
-(* Expand a -I option: if it starts with +, make it relative to the standard
-   library directory *)
-
-let expand_directory alt s =
-  if String.length s > 0 && s.[0] = '+'
-  then Filename.concat alt
-                       (String.sub s 1 (String.length s - 1))
-  else s
+let expand_directory alts s =
+  match String.length s > 0 && s.[0] = '+' with
+  | false -> [s]
+  | true ->
+      let rel = String.sub s 1 (String.length s - 1) in
+      List.map (fun alt -> Filename.concat alt rel) alts
 
 let path_separator =
   match Sys.os_type with

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -187,9 +187,9 @@ val find_in_path_uncap: string list -> string -> string
            to match. *)
 val remove_file: string -> unit
         (* Delete the given file if it exists. Never raise an error. *)
-val expand_directory: string -> string -> string
-        (* [expand_directory alt file] eventually expands a [+] at the
-           beginning of file into [alt] (an alternate root directory) *)
+val expand_directory: string list -> string -> string list
+        (* [expand_directory alt file] expands a potential [+] at the
+           beginning of [file] into [alts] (alternate root directories) *)
 
 val split_path_contents: ?sep:char -> string -> string list
 (* [split_path_contents ?sep s] interprets [s] as the value of a "PATH"-like


### PR DESCRIPTION
This PR is a first shot at making the `OCAMLPATH` proposal concrete. The manuals are not updated yet since there are points that need to be discussed.

# What's the point ? 

The `OCAMLPATH` proposal allows to merge multiple OCaml compilation object install prefixes. It provides a way to identify directories therein and standard lookup procedures via short *relative* paths (aka as (sub)package names) independently from the concrete absolute install prefixes. These names can be used to gather, disambiguate and lookup compilation objects by simply looking up the state of the file system and without the need for third-party metadata or naming structures.

This allows the OCaml toolchain and infrastructure tool like `opam`, `odoc`, `odig`, `ocp-index`, `omod`, `ocamlmerlin`, `ocamlfind`, etc. to treat these short relative paths ("package names") in a uniform and standard manner, with precise lookup semantics.

# Why is that needed ?

The current status quo makes it difficult for the toolchain and third-party infrastructure tools to have a consistent view on installs that consists of multiple install prefixes without going through an
additional layer of indirection. For example in system installs augmented with an opam install prefix (so called `opam` "system" switches) or additional user install prefixes.

More specifically system distributions usually install an OCaml package `PKG` in `$(ocamlc -where)/PKG` and the `ocaml` package itself in `$(ocamlc -where)`. In that setting, system installed packages can be accessed from the toolchain via the `-I +PKG` notation but the `ocaml` package itself cannot be named, nor can any other package that may be installed at another install prefix (e.g. user or `opam` managed).

On the other hand install prefixes exclusively managed by `opam` install an OCaml package `PKG` in `$(opam var lib)/PKG`, including the `ocaml` package itself. In that setting all the package can be uniformly accessed by interpreting `PKG` relative to the `$(opam var lib)` absolute directory but the `-I +PKG` notation allows to name none of these packages.

`OCAMLPATH` provides the mecanism that allows to eventually reconcile and abstract these install structures so that all packages can be accessed uniformly from the toolchain via the `-I +PKG` notation without breaking backward compatibility. It also provides a simple convention for third party tools to lookup and associate files to `PKG` and `PKG/SUB` names by simply consulting the state of the file system.

# How does this interact with `ocamlfind` ? 

Short answer it doesn't. But `ocamlfind` already [supports](http://projects.camlcity.org/projects/dl/findlib-1.8.1/doc/ref-html/r865.html#AEN980) an `OCAMLPATH` variable with a similar library path semantics. However it uses it to define a search path for `META` files. `ocamlfind` itself attributes no semantics to the name of directories, the `ocamlfind` package names are defined in the `META` file themselves -- though in 99% of the cases the `ocamlfind` package named `PKG` is defined in the `$LIBDIR/PKG/META` file.

It is not expected that this proposal will pose interoperatibiliy problems with `ocamlfind`'s interpretation of `OCAMLPATH`.

# What does this PR change to the OCaml toolchain ? 

Not much. If `OCAMLPATH` is undefined this PR doesn't change anything. If `OCAMLPATH` is defined, the `-I +dir` flag looks up for `dir` in all the directories defined in `OCAMLPATH` rather than in `$(ocamlc -where)` – more on how exactly below.

# What does this PR change for `-I +DIR` end users ? 

This depends on how `OCAMLPATH` end up being used by installs. Mostly the effect should be that it allows more directories to be addressed via the `+DIR` notation while preserving the current usage.

With one exception. The `+DIR` notation was used to address both third-party packages installed in `ocamlc -where` and sub libraries provided by `ocaml` itself, namely `+threads`, `+vmthreads`, `+compiler-libs`.

In a scenario where distributions alter their install structure to `$LIBDIR/ocaml/PKG` with the `ocaml` package in `$LIBDIR/ocaml/ocaml` and an `OCAMLPATH=$LIBDIR/ocaml` the names of these libraries become `+ocaml/{threads,vmthreads,compiler-libs}`.

`vmthreads` seems to have been deleted from trunk so the problem remains only for `threads` and `compiler-libs` (thought the latter is not expected to be a stable interface).

Here are three things that can be done: 

1. Do nothing about it. Not very nice. But then you can expect most people use the `ocamlfind` indirection and not `-I +{threads,compiler-libs}`.
2. Ask prefix managers (`opam`, system package manager) to symlink `$LIBDIR/ocaml/ocaml/{threads,compiler-libs}` to `$LIBDIR/ocaml/{threads,compiler-libs}`.
3. Treat `+{threads,compiler-libs}` specially during `+` expansion in the compiler to replace them with `$OCAMLLIB/{threads,compiler-libs}` and warn that this identifier should not be used.

Option 1. is what allows to reach to a final nice state where people switch to `+ocaml/threads` or `$(ocamlc -where)/threads` the fastest. Option 2. likely enshrines the names for a very long time
since no warning can be provided. Option 3. would be the nicest but these kind of special treatement tend to make things worse in the long term as they force each other tool to implement the special cases aswell. An hybrid 2+3 (warn for a few versions about usages of `+threads` and `+compiler-libs` in the compiler) could be the best option.

# Implementation

Note that the implementation is made on top of the `-I` [uniformisation PR](https://github.com/ocaml/ocaml/pull/8942) but except for the agreed upon part (directory checks for C linker arguments) it's not tied to its outcome. The three last commits are the ones that implement `OCAMLPATH`.

## Adding `ocamlpath` to the OCaml configuration

[This commit](https://github.com/ocaml/ocaml/pull/8946/commits/b7008e9835e6ffb5a9ff71bccd3c7530794c54df) adds `Config.ocamlpath` whose value is either the list of paths found in `OCAMLPATH` if defined or the singleton list `[Config.standard_libary]` if `OCAMLPATH` is undefined. The latter is what provides backward compatibility for the `+` notation.

A few things to note and discuss about this commit:

1. If `OCAMLPATH` is defined but *empty* no fallback is provided which effectively disables the `+` notation. This was done so that reading `OCAMLPATH` fully tells you what is happening with `+DIR`, no additional  knowledge is needed in your head.
2. [`Misc.split_path_contents`](https://github.com/ocaml/ocaml/blob/5c7c619d4d335eddc58a0c5e889bb71174b0f829/utils/misc.ml#L298-L305) is not used to avoid a recursive dependency between `Misc` and `Config`. But a moral equivalent is used for parsing `OCAMLPATH`. This means `;` is used as path separator if `Sys.win32` is `true` which is consistent with how OCaml treats the `CAML_LD_LIBRARY_PATH` and `OCAMLTOP_INCLUDE_PATH` variables. It's not however with how `ocamlfind` [parses](https://gitlab.camlcity.org/gerd/lib-findlib/blob/9e406208dfe60160fbdc1ea135d1cc0e2ef8e216/src/findlib/fl_split.ml#L72-78) `OCAMLPATH` which also uses `';'` on Cygwin.

## Using `ocamlpath` to expand the `-I +DIR` notation

[This commit](https://github.com/ocaml/ocaml/pull/8946/commits/523d44ed3fa6a413aee08d3371a4646c4d2d257f) provides the multiple directory lookup semantics for `-I +DIR` via `Config.ocamlpath`. Effectively it changes `Misc.expand_directory` to expand `+DIR` with all directories of `Config.ocamlpath` instead of the single `Config.standard_library` directory. This means the function now returns a list of directories and the rest of the changes mostly deal with coping with that change (we want #8760 !).

One important thing to note and discuss about this commit is that two semantics can be had for `-I +DIR`: 

1. Directory shadowing. In that interpretation we lookup for the first root directory `R` in `Config.ocamlpath` such that `R/PKG` exists and only add this one. From a cli perspective this is equivalent to substitute `-I +DIR` by a single `-I R/DIR` flag.
2. Directory unioning. In that interpretation we have a left leaning union of all root directories `R` of `Config.ocamlpath` such that `R/DIR` exists. From a cli perspective this is equivalent to substitute `-I +DIR` by an ordered sequence of `-I R1/DIR`, `-I R2/DIR`, ... flags.

Both options are possible and both may introduce coherence problems if two directories of `R1` and `R2` of `Config.ocamlpath` are such that `R1/DIR` and `R2/DIR` exist with identical compilation unit names which digest differently. Note that these kind of coherence problems are not specific to this way of doing, e.g. `ocamlfind` also suffers from them.

Option 2. takes more of a "namespace" perspective by allowing further install prefixes to add new elements (e.g. subpackages) to the `DIR` root name of a previous install prefix. This is what this PR implements. I believe this was also the spirit of @lpw25's `OCAML_NAMESPACE` proposal.

Here are few comments about the effect of the expansion:

1. With the sanitization done in #8942 on the directories given to the C linker, the expansion of inexisting directories given to `Load_path` shouldn't pose a problem. Except in the following cases.
2. The expansion of `Config.flexdll_dir` flags in `ocamlmklib.ml` does not go through `Load_path` and are turned directly into `-L` arguments. Something should likely be done here (e.g. test for dir existence or move to use `Load_path`, if that makes sense).
3. The expansion might get wild in the `-I` flags passed for compiling C in `Ccomp.compile_file`. This code path does not use `Load_path` but sources directly from `!Cflags.include_dirs`. ~~It was not immediately clear to me whether this could be replaced by a call to `Load_path.existing_paths ()` like `Ccomp.call_linker` does.~~ Nothing harmful happens since `-I dir` in C compiler are silently allowed not to exist, ~~but then if we already checked if the dirs exist via `Load_path` there's no need to pollute these calls with nonsense~~. Just filtering by dir existence the list `!Cflags.include_dir` is also an option.
4. In the bytecode toplevel the expansion adds inexisting directories to `Dll.add_path` this is done just before use of `Load_path.Dir.create` which checks for existence so it could easily be prevented if needed. A cursory look at `Dll` seems to indicate that it should not be a problem though.
   
## Cleanup internal uses of `+DIR`

[This commit](https://github.com/ocaml/ocaml/pull/8946/commits/2c8ef58b768010dce3830d1e0e758e4c8a102f62) cleans up the compiler's internal uses of the `+DIR` notation.

There are three such occurences:

1. `+camlp4` in `{opt}toploop.ml`. These ones I didn't change. Basically they refer to an external package. Not doing anything allows `camlp4` to install in its own library prefix rather than in the `ocaml` prefix like it does now. I'm not even sure these `camlp4` remains should still be here in the first place -- formally they automatically add `Config.standard_library/camlp4` to includes in the toplevel, this can be done if perceived as useful.
2. `+threads` in `compmisc.ml`. This one deals with the deprecated `-threads` flags. I elected to simply replace the include by `Config.standard_library/threads`.
3. `+compiler-libs` in the `ocamlmktop.ml` shellout to `ocamlc`. I simply replaced the include by `Config.standard_library/compiler-libs`.
