### PR TITLE
Allow recursive module cycles to go through functors

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,8 @@ Working version
   use String_val as a char* instead of const char*
   (Kate Deplaix)
 
+- #8948: Allow recursive module cycles to go through functors
+  (Mark Shinwell, Leo White, Stephen Dolan)
 
 ### Internal/compiler-libs changes:
 

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -28,7 +28,6 @@ open Translclass
 
 type unsafe_component =
   | Unsafe_module_binding
-  | Unsafe_functor
   | Unsafe_non_function
   | Unsafe_typext
 
@@ -222,8 +221,7 @@ let init_shape id modl =
     | Mty_signature sg ->
         Const_block(0, [Const_block(0, init_shape_struct env sg)])
     | Mty_functor _ ->
-        (* can we do better? *)
-        raise (Initialization_failure {reason=Unsafe_functor;loc;subid})
+        Const_pointer 0 (* camlinternalMod.Function *)
   and init_shape_struct env sg =
     match sg with
       [] -> []
@@ -1528,7 +1526,6 @@ let explanation_submsg (id, {reason;loc;subid}) =
     Location.mkloc printer loc in
   match reason with
   | Unsafe_module_binding -> print "Module %s defines an unsafe module, %s ."
-  | Unsafe_functor -> print "Module %s defines an unsafe functor, %s ."
   | Unsafe_typext ->
       print "Module %s defines an unsafe extension constructor, %s ."
   | Unsafe_non_function -> print "Module %s defines an unsafe value, %s ."

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -44,7 +44,6 @@ val primitive_declarations: Primitive.description list ref
 
 type unsafe_component =
   | Unsafe_module_binding
-  | Unsafe_functor
   | Unsafe_non_function
   | Unsafe_typext
 


### PR DESCRIPTION
Recursive modules, used carefully, form a powerful tool to allow abstraction in the face of recursive types.  Unfortunately at present they can be difficult to use when functors are involved, as any cycle that goes through a functor is prohibited.

Functors behave just like normal functions in terms of their dynamic semantics, so we can use the same patching mechanism as for functions, in order to remove this restriction.  This is believed not to cause any unsoundness.