### PR TITLE
manual: move pattern open out of the extension chapter

### DIFF
--- a/Changes
+++ b/Changes
@@ -152,6 +152,12 @@ Working version
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.
   (Florent Monnier and Nicolás Ojeda Bär, review by David Allsopp)
 
+### Manual and documentation:
+
+- #8950: manual, move local opens in pattern out of the extension chapter
+  (Florian Angeletti, review and suggestion by Gabriel Scherer)
+
+
 ### Compiler user-interface and warnings:
 
 - #8833: Hint for (type) redefinitions in toplevel session

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -330,34 +330,6 @@ constructors of [t] could be present.
 Similarly to abstract types, the variance of type parameters
 is not inferred, and must be given explicitly.
 
-
-\section{Local opens for patterns}
-\ikwd{let\@\texttt{let}}
-\ikwd{open\@\texttt{open}} \label{s:local-opens}
-
-(Introduced in OCaml 4.04)
-
-\begin{syntax}
-pattern:
-       ...
-     | module-path '.(' pattern ')'
-     | module-path '.[' pattern ']'
-     | module-path '.[|' pattern '|]'
-     | module-path '.{' pattern '}'
-
-\end{syntax}
-
-For patterns, local opens are limited to the
-@module-path'.('pattern')'@ construction. This
-construction locally open the module referred to by the module path
-@module-path@ in the scope of the pattern @pattern@.
-
-When the body of a local open pattern is delimited by
-@'[' ']'@,  @'[|' '|]'@,  or @'{' '}'@, the parentheses can be omitted.
-For example, @module-path'.['pattern']'@ is equivalent to
-@module-path'.(['pattern'])'@, and @module-path'.[|' pattern '|]'@ is
-equivalent to @module-path'.([|' pattern '|])'@.
-
 \section{Locally abstract types}
 \ikwd{type\@\texttt{type}}
 \ikwd{fun\@\texttt{fun}} \label{s:locally-abstract}

--- a/manual/manual/refman/patterns.etex
+++ b/manual/manual/refman/patterns.etex
@@ -22,9 +22,12 @@ pattern:
   | char-literal '..' char-literal
   | 'lazy' pattern
   | 'exception' pattern
+  | module-path '.(' pattern ')'
+  | module-path '.[' pattern ']'
+  | module-path '.[|' pattern '|]'
+  | module-path '.{' pattern '}'
 \end{syntax}
 See also the following language extensions:
-\hyperref[s:local-opens]{local opens},
 \hyperref[s-first-class-modules]{first-class modules},
 \hyperref[s:attributes]{attributes} and
 \hyperref[s:extension-nodes]{extension nodes}.
@@ -225,3 +228,18 @@ call.
 A pattern match must contain at least one value case. It is an error if
 all cases are exceptions, because there would be no code to handle
 the return of a value.
+
+\subsubsection*{Local opens for patterns}
+\ikwd{open\@\texttt{open}} \label{s:local-opens-pattern}
+(Introduced in OCaml 4.04)
+
+For patterns, local opens are limited to the
+@module-path'.('pattern')'@ construction. This
+construction locally opens the module referred to by the module path
+@module-path@ in the scope of the pattern @pattern@.
+
+When the body of a local open pattern is delimited by
+@'[' ']'@,  @'[|' '|]'@,  or @'{' '}'@, the parentheses can be omitted.
+For example, @module-path'.['pattern']'@ is equivalent to
+@module-path'.(['pattern'])'@, and @module-path'.[|' pattern '|]'@ is
+equivalent to @module-path'.([|' pattern '|])'@.

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -99,7 +99,7 @@ becomes
 \begin{caml_example}{toplevel}
   PrioQueue.[insert empty 1 "hello"];;
 \end{caml_example}
-This second form also works inside pattern matching:
+This second form also works for patterns:
 \begin{caml_example}{toplevel}
   let at_most_one_element x = match x with
   | PrioQueue.( Empty| Node (_,_, Empty,Empty) ) -> true

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -85,8 +85,9 @@ Two constructions are available for this purpose:
 \end{caml_example}
 and
 \begin{caml_example}{toplevel}
-  PrioQueue.(insert empty 1 "hello");;
+  let PrioQueue.(Node _ | Empty) = PrioQueue.(insert empty 1 "hello");;
 \end{caml_example}
+Note that in patterns, only the second form is available.
 In the second form, when the body of a local open is itself delimited
 by parentheses, braces or bracket, the parentheses of the local open
 can be omitted. For instance,

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -85,9 +85,8 @@ Two constructions are available for this purpose:
 \end{caml_example}
 and
 \begin{caml_example}{toplevel}
-  let PrioQueue.(Node _ | Empty) = PrioQueue.(insert empty 1 "hello");;
+  PrioQueue.(insert empty 1 "hello");;
 \end{caml_example}
-Note that in patterns, only the second form is available.
 In the second form, when the body of a local open is itself delimited
 by parentheses, braces or bracket, the parentheses of the local open
 can be omitted. For instance,
@@ -99,6 +98,12 @@ can be omitted. For instance,
 becomes
 \begin{caml_example}{toplevel}
   PrioQueue.[insert empty 1 "hello"];;
+\end{caml_example}
+This second form also works inside pattern matching:
+\begin{caml_example}{toplevel}
+  let at_most_one_element x = match x with
+  | PrioQueue.( Empty| Node (_,_, Empty,Empty) ) -> true
+  | _ -> false ;;
 \end{caml_example}
 
 It is also possible to copy the components of a module inside


### PR DESCRIPTION
This is small manual PR proposes to move the manual section on local open in pattern, e.g.

```OCaml
let f = function Seq.( Nil | Cons _ ) -> ()
```
outside of the extension chapter.

Indeed, this extension seems reasonably small and discoverable starting from the syntax for local open in expressions, and has been part of the language since 4.04.
  