### PR TITLE
Let make's default target build the compiler

### DIFF
--- a/Changes
+++ b/Changes
@@ -237,6 +237,9 @@ Working version
 - #8947: fix/improve support for the BFD library
   (Sébastien Hinderer, review by Damien Doligez)
 
+- #8951: let make's default target build the compiler
+  (Sébastien Hinderer, review by )
+
 - #8985, #8986: fix generation of the primitives when the locale collation is
   incompatible with C.
   (David Allsopp, review by Nicolás Ojeda Bär, report by Sebastian Rasmussen)

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -20,7 +20,7 @@ git checkout -b my-modification
 +
 ----
 ./configure
-make world.opt
+make
 ----
 
 3. Try the newly built compiler binaries `ocamlc`, `ocamlopt` or their

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -70,20 +70,13 @@ for guidance on how to edit the generated files by hand.
 
 From the top directory, do:
 
-        make world.opt
-+
-if your platform is supported by the native-code compiler (as reported during
-   the auto-configuration), or
+        make
 
-        make world
-+
-if not.
-
-This builds the OCaml bytecode compiler for the first time.  This phase is
+This builds the OCaml compiler for the first time.  This phase is
 fairly verbose; consider redirecting the output to a file:
 
-        make world > log.world 2>&1     # in sh
-        make world >& log.world         # in csh
+        make > make.log 2>&1     # in sh
+        make >& make.log         # in csh
 
 == (Optional) Running the testsuite
 

--- a/Makefile
+++ b/Makefile
@@ -20,18 +20,11 @@ ROOTDIR = .
 include Makefile.config
 include Makefile.common
 
-# For users who don't read the INSTALL file
 .PHONY: defaultentry
-defaultentry:
-ifeq "$(UNIX_OR_WIN32)" "unix"
-	@echo "Please refer to the installation instructions in file INSTALL."
-	@echo "If you've just unpacked the distribution, something like"
-	@echo "	./configure"
-	@echo "	make world.opt"
-	@echo "	make install"
-	@echo "should work.  But see the file INSTALL for more details."
+ifeq "$(NATIVE_COMPILER)" "true"
+defaultentry: world.opt
 else
-	@echo "Please refer to the instructions in file README.win32.adoc."
+defaultentry: world
 endif
 
 MKDIR=mkdir -p
@@ -1341,3 +1334,15 @@ distclean: clean
 	rm -f testsuite/_log*
 
 include .depend
+
+Makefile.config Makefile.common:
+	@echo "Please refer to the installation instructions:"
+	@echo "- In file INSTALL for Unix systems."
+	@echo "- In file README.win32.adoc for Windows systems."
+	@echo "On Unix systems, if you've just unpacked the distribution,"
+	@echo "something like"
+	@echo "	./configure"
+	@echo "	make"
+	@echo "	make install"
+	@echo "should work."
+	@false

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -113,6 +113,9 @@ RPATH=@rpath@
 
 ############# Configuration for the native-code compiler
 
+### Whether the native compiler has been enabled or not
+NATIVE_COMPILER=@native_compiler@
+
 ### Name of architecture for the native-code compiler
 ### Currently supported:
 ###

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -101,8 +101,6 @@ OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
 OCAMLYACC=$(TOPDIR)/yacc/ocamlyacc$(EXE)
 DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tools/dumpobj
 OBJINFO=$(OCAMLRUN) $(OTOPDIR)/tools/ocamlobjinfo
-BYTECODE_ONLY=[ "$(ARCH)" = "none" -o "$(ASM)" = "none" ]
-NATIVECODE_ONLY=false
 
 #FORTRAN_COMPILER=
 #FORTRAN_LIBRARY=

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -191,7 +191,7 @@ the top-level of the OCaml distribution by running:
 
   eval $(tools/msvs-promote-path)
 
-If you forget to do this, `make world.opt` will fail relatively
+If you forget to do this, `make` will fail relatively
 quickly as it will be unable to link `ocamlrun`.
 
 Now run:
@@ -208,7 +208,7 @@ which indicates where to install everything.
 
 Finally, use `make` to build the system, e.g.
 
-        make world.opt
+        make
         make install
 
 After installing, it is not necessary to keep the Cygwin installation (although
@@ -275,7 +275,7 @@ which indicates where to install everything.
 
 Finally, use `make` to build the system, e.g.
 
-        make world.opt
+        make
         make install
 
 After installing, you will need to ensure that `ocamlopt` (or `ocamlc -custom`)
@@ -314,10 +314,10 @@ done in one of three ways:
   git submodule update --init
 
 OCaml is then compiled as normal for the port you require, except that before
-compiling `world`, you must compile `flexdll`, i.e.:
+building the compiler itself, you must compile `flexdll`, i.e.:
 
   make flexdll
-  make world.opt
+  make
   make flexlink.opt
   make install
 

--- a/configure
+++ b/configure
@@ -782,6 +782,7 @@ ac_tool_prefix
 DIRECT_CPP
 CC
 VERSION
+native_compiler
 CONFIGURE_ARGS
 target_alias
 host_alias
@@ -2733,6 +2734,7 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 ## Output variables
+
 
 
 VERSION=4.10.0+dev0-2019-04-23

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 ## Output variables
 
 AC_SUBST([CONFIGURE_ARGS])
+AC_SUBST([native_compiler])
 AC_SUBST([VERSION], [AC_PACKAGE_VERSION])
 AC_SUBST([CC])
 # Note: This is present for the flexdll bootstrap where it exposed as the old

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -12,8 +12,7 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix=%{prefix}%"]
-  [make "-j%{jobs}%" "world"]
-  [make "-j%{jobs}%" "world.opt"]
+  [make "-j%{jobs}%"]
 ]
 install: [make "install"]
 maintainer: "caml-list@inria.fr"

--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -5,7 +5,7 @@ link:../CONTRIBUTING.md#contributing-to-the-standard-library[].
 
 Note: All paths are given relative to the root of the repository.
 
-First, build the compiler. Run `./configure`, then `make world.opt`. See
+First, build the compiler. Run `./configure`, then `make`. See
 link:../HACKING.adoc[].
 
 To add a new module, you must:
@@ -30,7 +30,7 @@ To add a new module, you must:
 * Run `make alldepend` to update all the `.depend` files. These files are not
   edited by hand.
 
-* Run `make clean` or `make partialclean`, then `make world.opt`.
+* Run `make clean` or `make partialclean`, then `make`.
 
 If you are adding multiple modules, follow the steps above and rebuild the
 compiler after adding each module. If you add multiple modules before

--- a/testsuite/lib/Makefile
+++ b/testsuite/lib/Makefile
@@ -22,7 +22,7 @@ include $(TOPDIR)/Makefile.tools
 libraries := testing.cmi testing.cma lib.cmo
 
 # If the native compiler is enabled, then also compile testing.cmxa
-ifneq "$(ARCH)" "none"
+ifeq "$(NATIVE_COMPILER)" "true"
 libraries += testing.cmxa
 endif
 

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -40,7 +40,7 @@ codegen_OBJECTS = $(addsuffix .cmo,\
 
 tools := $(expect_PROG)
 
-ifneq "$(ARCH)" "none"
+ifeq "$(NATIVE_COMPILER)" "true"
 tools += $(codegen_PROG)
 ifneq "$(CCOMPTYPE)-$(ARCH)" "msvc-amd64"
 # The asmgen tests are not ported to MSVC64 yet

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -229,10 +229,10 @@ fi
 eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
 
 if $make_native; then
-  $make $jobs --warn-undefined-variables world.opt
+  $make $jobs --warn-undefined-variables
   if $check_make_alldepend; then $make --warn-undefined-variables alldepend; fi
 else
-  $make $jobs --warn-undefined-variables world
+  $make $jobs --warn-undefined-variables
 fi
 if $dorebase; then
     # temporary solution to the cygwin fork problem

--- a/tools/release-checklist
+++ b/tools/release-checklist
@@ -78,7 +78,7 @@ INSTDIR=/tmp/ocaml-${VERSION}
 rm -rf ${INSTDIR}
 ./configure -prefix ${INSTDIR}
 
-make world.opt -j5
+make -j5
 make alldepend
 
 # check that .depend files have no absolute path in them
@@ -228,7 +228,7 @@ it was a release candidate.
 
 ```
 cd $WORKTREE
-make world.opt
+make
 make install
 export PATH="$INSTDIR/bin:$PATH"
 cd manual


### PR DESCRIPTION
This PR makes it possible to build the OCaml compiler according to
its configuration by simply runnning `make`. There is no need to specify
neither world nor world.opt explicitly, although the two targets
remain available.

This PR also introduces (and starts making use of) the
NATIVE_COMPILER build variable whosse value is true when the native
compiler is enabled and false otherwise.