### PR TITLE
Fix error submessages in the toplevel: do not display dummy locations

### DIFF
--- a/Changes
+++ b/Changes
@@ -228,6 +228,10 @@ Working version
 OCaml 4.09 maintenance branch:
 ------------------------------
 
+- #8953, #8954: Fix error submessages in the toplevel: do not display
+  dummy locations
+  (Armaël Guéneau, review by Gabriel Scherer)
+
 OCaml 4.09.0 (19 September 2019):
 ---------------------------------
 

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -778,7 +778,8 @@ let terminfo_toplevel_printer (lb: lexbuf): report_printer =
   in
   let pp_main_loc _ _ _ _ = () in
   let pp_submsg_loc _ _ ppf loc =
-    Format.fprintf ppf "%a:@ " print_loc loc in
+    if not loc.loc_ghost then
+      Format.fprintf ppf "%a:@ " print_loc loc in
   { batch_mode_printer with pp; pp_main_loc; pp_submsg_loc }
 
 let best_toplevel_printer () =


### PR DESCRIPTION
When an error sub-message is equipped with a ghost location, the error printing code should not print the location. This is done properly by the "batch mode" printer (used by `ocamlc` and the toplevel when `TERM=dumb`), but not by the printer used by the toplevel in presence of an ANSI-capable terminal.

This PR fixes the toplevel printer for ANSI terminals accordingly, and closes #8953.

I wanted to add a test, but it turns out that it is not possible using our current testing pipeline. Indeed, both inline tests and "toplevel" tests use the "batch mode" printer. To exercise the other printer, one would need to execute the tests while simulating an ANSI-capable terminal; this is not done currently anywhere as far as I'm aware.