### PR TITLE
Dissecting let-recs

### DIFF
--- a/.depend
+++ b/.depend
@@ -3143,6 +3143,29 @@ lambda/debuginfo.cmx : \
     lambda/debuginfo.cmi
 lambda/debuginfo.cmi : \
     parsing/location.cmi
+lambda/dissect_letrec.cmo : \
+    typing/types.cmi \
+    lambda/printlambda.cmi \
+    typing/primitive.cmi \
+    utils/misc.cmi \
+    parsing/location.cmi \
+    lambda/lambda.cmi \
+    typing/ident.cmi \
+    parsing/asttypes.cmi \
+    lambda/dissect_letrec.cmi
+lambda/dissect_letrec.cmx : \
+    typing/types.cmx \
+    lambda/printlambda.cmx \
+    typing/primitive.cmx \
+    utils/misc.cmx \
+    parsing/location.cmx \
+    lambda/lambda.cmx \
+    typing/ident.cmx \
+    parsing/asttypes.cmi \
+    lambda/dissect_letrec.cmi
+lambda/dissect_letrec.cmi : \
+    lambda/lambda.cmi \
+    typing/ident.cmi
 lambda/lambda.cmo : \
     typing/types.cmi \
     typing/primitive.cmi \
@@ -3251,6 +3274,7 @@ lambda/simplif.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    lambda/dissect_letrec.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
     typing/annot.cmi \
@@ -3262,6 +3286,7 @@ lambda/simplif.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    lambda/dissect_letrec.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmi \
     typing/annot.cmi \
@@ -3418,6 +3443,7 @@ lambda/translmod.cmo : \
     lambda/lambda.cmi \
     typing/ident.cmi \
     typing/env.cmi \
+    lambda/dissect_letrec.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
@@ -3439,6 +3465,7 @@ lambda/translmod.cmx : \
     lambda/lambda.cmx \
     typing/ident.cmx \
     typing/env.cmx \
+    lambda/dissect_letrec.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmi \

--- a/Changes
+++ b/Changes
@@ -143,6 +143,10 @@ Working version
   untag_int (tag_int x) = x in Cmmgen.
   (Stephen Dolan, review by Vincent Laviron and Xavier Leroy)
 
+- #8956: Add a dissect_letrec pass in lambda that rewrites recursive value
+  definitions into initialisation and assignment.
+  (Pierre Chambart and Louis Gesbert)
+
 ### Runtime system:
 
 - #8809: Add a best-fit allocator, which should be much better for

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ LAMBDA=lambda/debuginfo.cmo \
   lambda/switch.cmo lambda/matching.cmo \
   lambda/translobj.cmo lambda/translattribute.cmo \
   lambda/translprim.cmo lambda/translcore.cmo \
+  lambda/dissect_letrec.cmo \
   lambda/translclass.cmo lambda/translmod.cmo \
   lambda/simplif.cmo lambda/runtimedef.cmo
 

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -505,6 +505,7 @@ let dissect_letrec ~bindings ~body =
         Printlambda.lambda (Lletrec (bindings, body))
 
 let preallocate_letrec ~bindings ~body =
+  let bindings = List.rev bindings in
   let body_with_initialization =
   List.fold_left
     (fun body (id, def, _size) -> Lsequence (update_dummy id def, body))

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -1,0 +1,523 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Pierre Chambart and Vincent Laviron, OCamlPro                *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2018 OCamlPro SAS                                          *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Asttypes
+open Lambda
+
+(* Converts let-rec containing values into an initialization then
+   asignment sequence.
+
+   We assume that the typechecker correclty validated that the letrec
+   is compilable (See Typecore.check_recursive_expression).
+
+   That is, for every expression to which a variable is bound in
+   the let-rec verify:
+   * It does not inspect any variable bound by the let-rec.
+     This implies that the value of a variable bound by the let-rec
+     does not need to be valid during the computation of the other
+     bindings. Only the address is needed. This means that we can
+     preallocate values for which we know the size.
+   * If the value can't be preallocated (it can be because the
+     size can't be statically known, or because the value is not
+     allocated, like integers), then the value does not
+     depend on any other rec-bound variables.
+     This implies that any value that can't be preallocate can be
+     computed before any other binding. Note that this does not mean
+     that other variables can't be refered to by the expression,
+     but if it happens, then the value is useless.
+
+   We consider two cases for expressions that we consider of
+   known size: the makeblock primitive and function declarations.
+   Makeblocks will be preallocated, while all the functions will
+   be turned into a single letrec.
+
+   Note that this does not exactly match the definition of Static
+   and Dynamic size for check_recursive_expression. It considers
+   Static to be anything that can be preallocated or that can't
+   contain the value of its dependencies. Neitheir containing, nor
+   using (inspecting) a value means that its content is useless.
+   Hence it can be replaced by anything.
+
+   For instance
+
+   let rec a =
+     for i = 0 to 10 do let _ = () :: b in () done
+   and b = a :: []
+
+   The result of a 'for' expression cannot be preallocated, but also
+   cannot contain any value, hence, cannot contain b, even if it
+   depends on it. Since it also cannot inspect it, this means
+   that the value of b is completely useless in the definition
+   of a.
+
+   The structure of the generated code will be:
+
+   let p = expr in
+   (* Values that do not depend on any other from the let-rec *)
+   ...
+   let v = caml_alloc_dummy n in
+   (* With n the staticaly known size of blocks *)
+   ...
+   let n = dummy_value in
+   (* The values that can't be used *)
+   ...
+   let x = expr in
+   (* The values that can't be preallocated but can depend on
+      others. The expression might refer to dummy values, but
+      they will never be used. *)
+   ...
+   let rec f x = ...
+   and g x = ...
+   and ...
+   in
+   (* All the functions from the let-rec *)
+   let v_contents = expr in
+   (* The expressions with statically known size that have been
+      preallocated *)
+   ...
+   caml_update_dummy v v_contents;
+   ...
+
+
+   The recursive values of a letrec are not only the one bound
+   by the letrec expression itself. For instance
+
+   let rec f =
+     let rec g x = h (x+1)
+     and h x = i x
+     in
+     fun x -> g x
+   and i x =
+     if x > 33 then x
+     else f x
+
+   in this expression every function is recursively defined with
+   any other. Hence this is equivalent to
+
+   let rec f = fun x -> g x
+   and i x =
+     if x > 33 then x
+     else f x
+   and g x = h (x+1)
+   and h x = i x
+
+*)
+
+type block_type = Normal of int (* tag *) | Boxed_float
+
+type block = { block_type : block_type; size : int; }
+
+type letrec = {
+  blocks : (Ident.t * block) list;
+  (* Pre-allocated blocks.
+     Will result in [let id = caml_alloc_dummy size] or
+     [let id = caml_alloc_dummy_float size] *)
+  consts : (Ident.t * Lambda.structured_constant) list;
+  (* Statically known values *)
+  pre : tail:Lambda.lambda -> Lambda.lambda;
+  (* Prefix of the expression that does not depends on any recursive part.
+     This is presented as a function for easy 'concatenation':
+     to append 'expr': [fun ~tail -> Lsequence (expr, letrec.pre ~tail)] *)
+  effects : Lambda.lambda;
+  (* Effects that are applied afterward. *)
+  functions : (Ident.t * Lambda.lfunction) list;
+  substitution : Ident.t Ident.Map.t;
+  (* Alias to recursive variables should be forbidden, to prevent
+     non-productive definition like 'let rec a = a'. But some aliases
+     are allowed, for instance 'let rec a = let c = b in 1 :: b and b = 2 :: a'.
+     The simplest way to handle those aliases is simply
+     to apply a substitute of all these aliases afterward. *)
+  immutables : Ident.Set.t;
+  (* Set of known immutable variables. Mutable ones cannot define aliases *)
+}
+
+type let_def = {
+  let_kind : Lambda.let_kind;
+  value_kind : Lambda.value_kind;
+  ident : Ident.t;
+}
+
+exception Bug
+
+let lsequence (lam1, lam2) =
+  match lam1 with
+  | Lconst (Const_pointer 0) -> lam2
+  | _ -> Lsequence (lam1, lam2)
+
+let caml_update_dummy_prim =
+  Primitive.simple ~name:"caml_update_dummy" ~arity:2 ~alloc:true
+
+let update_dummy var expr =
+  Lprim (Pccall caml_update_dummy_prim, [Lvar var; expr], Location.none)
+
+let build_block let_def size block_type expr letrec =
+  { letrec with
+    blocks = (let_def.ident, { block_type; size }) :: letrec.blocks;
+    effects = Lsequence (update_dummy let_def.ident expr, letrec.effects);
+  }
+
+let is_simple (lam:Lambda.lambda) =
+  match lam with
+  | Lvar _
+  | Lconst _ -> true
+  | _ -> false
+
+(* We desconstruct the let-rec into a description *)
+
+let rec prepare_letrec
+    (recursive_set:Ident.Set.t)
+    (* Variables that depends on the let-rec bound variables *)
+    (current_let:let_def)
+    (* The variable to which the current expression is bound.
+       current_var is part of recursive_set *)
+    (lam:Lambda.lambda)
+    (letrec:letrec) =
+  match lam with
+  | Lfunction funct ->
+      if Ident.Set.mem current_let.ident recursive_set then
+        { letrec with functions = (current_let.ident, funct) :: letrec.functions }
+      else
+        (* If the currently bound function does not depend on any
+           recursive variable *)
+        let pre ~tail : Lambda.lambda =
+          Llet (current_let.let_kind, current_let.value_kind,
+                current_let.ident, lam, letrec.pre ~tail)
+        in
+        { letrec with pre }
+  | Lprim ((Pmakeblock _ | Pmakearray (_, _) | Pduprecord (_, _)) as prim, args, dbg)
+    when not (List.for_all is_simple args) ->
+      (* If there are some non-trivial expressions as arguments, we
+         first extract the arguments (to let-bound variables) before
+         deconstructing. Arguments could contain side effects and
+         other blocks declarations *)
+      let defs, args =
+        List.fold_right (fun (def:Lambda.lambda) (defs, args) ->
+            (* Fold-right to preserve the list order *)
+            if is_simple def then
+              (* This prevents looping on variables *)
+              defs, def :: args
+            else
+              let id = Ident.create_local "lift_in_letrec" in
+              (id, def) :: defs, (Lambda.Lvar id) :: args)
+          args ([], [])
+      in
+      (* Bytecode evaluates effects in blocks from right to left,
+         so reverse defs to preserve evaluation order.
+         Relevant test: letrec/evaluation_order_3 *)
+      let lam =
+        List.fold_left (fun body (id, def) : Lambda.lambda ->
+            Llet (Strict, Pgenval, id, def, body))
+          (Lambda.Lprim (prim, args, dbg)) defs
+      in
+      prepare_letrec recursive_set current_let lam letrec
+  | Lprim (Pmakeblock _, args, _)
+  | Lprim (Pmakearray ((Paddrarray|Pintarray), _), args, _) ->
+      build_block current_let (List.length args) (Normal 0) lam letrec
+  | Lprim (Pmakearray (Pfloatarray, _), args, _) ->
+      build_block current_let (List.length args) Boxed_float lam letrec
+  | Lprim (Pduprecord (kind, size), args, _) -> begin
+      let arg =
+        match args with
+        | [ arg ] -> arg
+        | _ -> Misc.fatal_error "Dissect_letrec.prepare_letrec duprecord"
+      in
+      match kind with
+      | Types.Record_regular ->
+          build_block current_let size (Normal 0) arg letrec
+      | Types.Record_inlined tag ->
+          build_block current_let size (Normal tag) arg letrec
+      | Types.Record_extension _ ->
+          build_block current_let (size + 1) (Normal 0) arg letrec
+      | Types.Record_unboxed _ ->
+          assert false
+      | Types.Record_float ->
+          build_block current_let size Boxed_float arg letrec
+    end
+  | Lconst const ->
+      { letrec with consts = (current_let.ident, const) :: letrec.consts }
+  | Llet (Variable, k, id, def, body) ->
+      let letrec = prepare_letrec recursive_set current_let body letrec in
+      (* Variable let comes from mutable values, and reading from it is
+         considered as inspections by Typecore.check_recursive_expression.
+         This means that either:
+         - the value does not depend on any recursive value,
+         - or it is not read in the let-rec
+      *)
+
+      (* TODO: binder dans une variable temporaire *)
+
+      let free_vars_def = Lambda.free_variables def in
+      if Ident.Set.is_empty (Ident.Set.inter free_vars_def recursive_set) then
+        let pre ~tail : Lambda.lambda =
+          Llet (Variable, k, id, def, letrec.pre ~tail)
+        in
+        { letrec with pre }
+      else begin
+        let free_vars_body = Lambda.free_variables body in
+        (* This is infrequent enought for not carring
+           about performances *)
+        assert(not (Ident.Set.mem id free_vars_body));
+        (* It is not used, we only keep the effect *)
+        { letrec with effects = Lsequence (def, letrec.effects) }
+      end
+  | Llet ((Strict | Alias | StrictOpt) as let_kind, value_kind, id, def, body) ->
+      let immutables = Ident.Set.add id letrec.immutables in
+      let letrec = { letrec with immutables } in
+      let free_vars = Lambda.free_variables def in
+      (* if Ident.Set.is_empty (Ident.Set.inter free_vars recursive_set) then
+       *   (\* Non recursive let *\)
+       *   let letrec = prepare_letrec recursive_set current_var body letrec in
+       *   let pre ~tail : Lambda.lambda =
+       *     Llet (let_kind, k, id, def, letrec.pre ~tail)
+       *   in
+       *   { letrec with pre }
+       * else *)
+      let recursive_set =
+        if Ident.Set.is_empty (Ident.Set.inter free_vars recursive_set) then
+          recursive_set
+        else
+          Ident.Set.add id recursive_set
+      in
+      let letrec = prepare_letrec recursive_set current_let body letrec in
+      let let_def = { let_kind; value_kind; ident = id } in
+      prepare_letrec recursive_set let_def def letrec
+  | Lsequence (lam1, lam2) ->
+      (* let () = Format.printf "seq %a@." Printlambda.lambda lam in
+       * let free_vars = Lambda.free_variables lam1 in *)
+      let letrec = prepare_letrec recursive_set current_let lam2 letrec in
+      let letrec = prepare_letrec recursive_set current_let lam1 letrec in
+      letrec
+      (* if Ident.Set.is_empty (Ident.Set.inter free_vars recursive_set) then
+       *   let () = Printf.printf "non req seq\n%!" in
+       *   (\* Non recursive lam1 *\)
+       *   let letrec = prepare_letrec recursive_set current_var lam2 letrec in
+       *   { letrec with pre = fun ~tail -> Lsequence (lam1, letrec.pre ~tail) }
+       * else
+       *   let () = Printf.printf "req seq\n%!" in
+       *   (\* Note that it is important not to handle this the same way as lets.
+       *      XXX: TODO think about an explanation *\)
+       *   let letrec = prepare_letrec recursive_set current_var lam2 letrec in
+       *   { letrec with effects = Lsequence (lam1, letrec.effects) } *)
+  | Levent (body, event) ->
+      let letrec = prepare_letrec recursive_set current_let body letrec in
+      { letrec with effects = Levent (letrec.effects, event) }
+  | Lletrec (bindings, body) ->
+      let immutables =
+        Ident.Set.union letrec.immutables
+          (Ident.Set.of_list (List.map fst bindings))
+      in
+      let letrec = { letrec with immutables } in
+      let free_vars =
+        List.fold_left (fun set (_, def) -> Ident.Set.union (Lambda.free_variables def) set)
+          Ident.Set.empty
+          bindings
+      in
+      if Ident.Set.is_empty (Ident.Set.inter free_vars recursive_set) then
+        (* Non recursive relative to top-level letrec, we can avoid dissecting it right now.
+           Its turn will come later. *)
+        let letrec = prepare_letrec recursive_set current_let body letrec in
+        let pre ~tail : Lambda.lambda =
+          Lletrec (bindings, letrec.pre ~tail)
+        in
+        { letrec with pre }
+      else
+        let recursive_set =
+          Ident.Set.union recursive_set
+            (Ident.Set.of_list (List.map fst bindings))
+        in
+        let letrec =
+          List.fold_right (fun (id, def) letrec ->
+              let let_def = {
+                let_kind = Strict;
+                value_kind = Pgenval;
+                ident = id;
+              } in
+              prepare_letrec recursive_set let_def def letrec)
+            bindings
+            letrec
+        in
+        prepare_letrec recursive_set current_let body letrec
+  | Lvar id when Ident.Set.mem id letrec.immutables ->
+      (* This cannot be a mutable variable: it is ok to copy it *)
+      { letrec with substitution = Ident.Map.add current_let.ident id letrec.substitution }
+
+  | Lifused (_v, lam) ->
+      prepare_letrec recursive_set current_let lam letrec
+
+  (* | Lwhile (_, _)
+   * | Lfor (_, _, _, _, _)
+   * | Lassign (_, _) ->
+   *     (\* Effect expressions returning unit. The result can be
+   *        pre-declared.  *\)
+   *     let const_unit = Const_pointer 0 in
+   *     { letrec with
+   *       effects = Lsequence (lam, letrec.effects);
+   *       consts = (current_let.ident, const_unit) :: letrec.consts } *)
+
+  | Lwhile (_, _)
+  | Lfor (_, _, _, _, _)
+  | Lassign (_, _)
+  | Lapply _
+  | Lswitch (_, _, _)
+  | Lstringswitch (_, _, _, _)
+  | Lstaticraise (_, _)
+  | Lstaticcatch (_, _, _)
+  | Ltrywith (_, _, _)
+  | Lifthenelse (_, _, _)
+  | Lsend (_, _, _, _, _)
+  | Lvar _
+  | Lprim (_, _, _) ->
+      (* This cannot be recursive, otherwise it should have been caught
+         by the well formedness check. Hence it is ok to evaluate it
+         before anything else. *)
+      (* CR vlaviron: This invariant is false when this expression is the result
+         of a previously dissected term, which can contain calls to
+         caml_update_dummy *)
+      let free_vars = Lambda.free_variables lam in
+      if not (Ident.Set.is_empty (Ident.Set.inter free_vars recursive_set)) then begin
+        Format.printf "case %a@.%a@."
+          Ident.Set.print
+          (Ident.Set.inter free_vars recursive_set)
+          Printlambda.lambda lam;
+        raise Bug;
+      end;
+      assert(Ident.Set.is_empty (Ident.Set.inter free_vars recursive_set));
+      let pre ~tail : Lambda.lambda =
+        Llet (current_let.let_kind, current_let.value_kind,
+              current_let.ident, lam, letrec.pre ~tail)
+      in
+      { letrec with pre }
+
+let dissect_letrec ~bindings ~body =
+(*
+  Format.printf "dissect@ %a@.@."
+    Printlambda.lambda (L.Lletrec (bindings, Lconst (Const_pointer 0)));
+*)
+  let recursive_set =
+    Ident.Set.of_list (List.map fst bindings)
+  in
+
+  let letrec =
+    List.fold_right (fun (id, def) letrec ->
+        let let_def = {
+          let_kind = Strict;
+          value_kind = Pgenval;
+          ident = id;
+        } in
+        prepare_letrec recursive_set let_def def letrec)
+      bindings
+      { blocks = [];
+        consts = [];
+        pre = (fun ~tail -> tail);
+        effects = Lconst (Const_pointer 0);
+        functions = [];
+        substitution = Ident.Map.empty;
+        immutables = Ident.Set.empty;
+      }
+  in
+
+  let preallocations =
+    let loc = Location.none in
+    List.map (fun (id, { block_type; size }) ->
+        let fn =
+          match block_type with
+          | Normal _tag -> "caml_alloc_dummy"
+          | Boxed_float -> "caml_alloc_dummy_float"
+        in
+        let desc = Primitive.simple ~name:fn ~arity:1 ~alloc:true in
+        let size : lambda = Lconst (Const_base (Const_int size)) in
+        id, Lprim (Pccall desc, [size], loc))
+      letrec.blocks
+  in
+
+  let effects_then_body = lsequence (letrec.effects, body) in
+  let functions =
+    match letrec.functions with
+    | [] -> effects_then_body
+    | _ :: _ ->
+        let functions =
+          List.map (fun (id, lfun) -> id, Lfunction lfun) letrec.functions
+        in
+        Lletrec (functions, effects_then_body)
+  in
+  let with_non_rec =
+    letrec.pre ~tail:functions
+  in
+  let with_preallocations =
+    List.fold_left
+      (fun body (id, binding) ->
+         Llet (Strict, Pgenval, id, binding, body))
+      with_non_rec
+      preallocations
+  in
+  let with_constants =
+    List.fold_left
+      (fun body (id, const) ->
+         Llet (Strict, Pgenval, id, Lconst const, body))
+      with_preallocations
+      letrec.consts
+  in
+  let substituted =
+    Lambda.rename
+      letrec.substitution
+      with_constants
+  in
+
+  (* let substituted =
+   *   List.fold_left (fun body (id, _) ->
+   *       Llet (Strict, Pgenval, id, Lconst (Const_pointer 99999), body))
+   *     substituted bindings
+   * in *)
+
+  Format.printf "dissected@ %a@.@."
+    Printlambda.lambda substituted;
+  substituted
+
+type dissected =
+  | Dissected of Lambda.lambda
+  | Unchanged
+
+let dissect_letrec ~bindings ~body =
+  let is_a_function = function
+    | _, Lfunction _ -> true
+    | _, _ -> false
+  in
+  if List.for_all is_a_function bindings then
+    Unchanged
+  else
+    try
+      Dissected (dissect_letrec ~bindings ~body)
+    with Bug ->
+      Misc.fatal_errorf "let-rec@.%a@."
+        Printlambda.lambda (Lletrec (bindings, body))
+
+let preallocate_letrec ~bindings ~body =
+  let body_with_initialization =
+  List.fold_left
+    (fun body (id, def, _size) -> Lsequence (update_dummy id def, body))
+    body bindings
+  in
+  List.fold_left
+    (fun body (id, _def, size) ->
+       let desc =
+         Primitive.simple ~name:"caml_alloc_dummy" ~arity:1 ~alloc:true
+       in
+       let size : lambda = Lconst (Const_base (Const_int size)) in
+       Llet (Strict, Pgenval, id,
+             Lprim (Pccall desc, [size], Location.none), body))
+    body_with_initialization bindings
+
+

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -18,10 +18,10 @@ open Asttypes
 open Lambda
 
 (* Converts let-rec containing values into an initialization then
-   asignment sequence.
+   assignment sequence.
 
    We assume that the typechecker correclty validated that the letrec
-   is compilable (See Typecore.check_recursive_expression).
+   is compilable (See typing/Rec_check.is_valid_recursive_expression).
 
    That is, for every expression to which a variable is bound in
    the let-rec verify:
@@ -34,7 +34,7 @@ open Lambda
      size can't be statically known, or because the value is not
      allocated, like integers), then the value does not
      depend on any other rec-bound variables.
-     This implies that any value that can't be preallocate can be
+     This implies that any value that can't be preallocated can be
      computed before any other binding. Note that this does not mean
      that other variables can't be refered to by the expression,
      but if it happens, then the value is useless.
@@ -45,9 +45,9 @@ open Lambda
    be turned into a single letrec.
 
    Note that this does not exactly match the definition of Static
-   and Dynamic size for check_recursive_expression. It considers
+   and Dynamic size for is_valid_recursive_expression. It considers
    Static to be anything that can be preallocated or that can't
-   contain the value of its dependencies. Neitheir containing, nor
+   contain the value of its dependencies. Neither containing, nor
    using (inspecting) a value means that its content is useless.
    Hence it can be replaced by anything.
 
@@ -132,7 +132,7 @@ type letrec = {
      This is presented as a function for easy 'concatenation':
      to append 'expr': [fun ~tail -> Lsequence (expr, letrec.pre ~tail)] *)
   effects : Lambda.lambda;
-  (* Effects that are applied afterward. *)
+  (* Effects that are applied afterwards. *)
   functions : (Ident.t * Lambda.lfunction) list;
   substitution : Ident.t Ident.Map.t;
   (* Alias to recursive variables should be forbidden, to prevent

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*           Pierre Chambart and Vincent Laviron, OCamlPro                *)
+(*      Pierre Chambart, Vincent Laviron and Louis Gesbert, OCamlPro      *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2018 OCamlPro SAS                                          *)
@@ -203,7 +203,8 @@ let rec prepare_letrec
           { letrec with pre }
       | None -> dead_code lam letrec
     end
-  | Lprim ((Pmakeblock _ | Pmakearray (_, _) | Pduprecord (_, _)) as prim, args, dbg)
+  | Lprim ((Pmakeblock _ | Pmakearray (_, _) | Pduprecord (_, _))
+           as prim, args, dbg)
     when not (List.for_all is_simple args) ->
       (* If there are some non-trivial expressions as arguments, we
          first extract the arguments (to let-bound variables) before
@@ -270,7 +271,8 @@ let rec prepare_letrec
   | Llet (Variable, _, _, _, _) ->
       (* This is not supposed to appear at this point *)
       assert false
-  | Llet ((Strict | Alias | StrictOpt) as let_kind, value_kind, id, def, body) ->
+  | Llet ((Strict | Alias | StrictOpt) as let_kind, value_kind, id, def, body)
+    ->
       let letbound = Ident.Set.add id letrec.letbound in
       let letrec = { letrec with letbound } in
       let free_vars = Lambda.free_variables def in
@@ -610,5 +612,3 @@ let preallocate_letrec ~bindings ~body =
        Llet (Strict, Pgenval, id,
              Lprim (Pccall desc, [size], Location.none), body))
     body_with_initialization bindings
-
-

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -140,6 +140,7 @@ let () = ignore Bug
 
 let lsequence (lam1, lam2) =
   match lam1 with
+  | Lsequence (lam, Lconst (Const_pointer 0)) -> Lsequence (lam, lam2)
   | Lconst (Const_pointer 0) -> lam2
   | _ -> Lsequence (lam1, lam2)
 
@@ -163,12 +164,9 @@ let is_simple (lam:Lambda.lambda) =
 
 let dead_code lam letrec =
   (* Some cases generate code without effects, and bound to nothing. We use this
-     function to insert it as [Lsequence] in [pre], for documentation.
+     function to insert it as [Lsequence] in [effects], for documentation.
      It would be correct to discard and just return [letrec] instead. *)
-  let pre ~tail : Lambda.lambda =
-    Lsequence (lam, letrec.pre ~tail)
-  in
-  { letrec with pre }
+  { letrec with effects = lsequence (lam, letrec.effects) }
 
 (* We desconstruct the let-rec into a description *)
 

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -17,13 +17,6 @@
 open Asttypes
 open Lambda
 
-let debug x =
-  match Sys.getenv "DISSECT_DEBUG" with
-  | "" | "0" | exception Not_found ->
-      Format.ifprintf Format.std_formatter x
-  | _ ->
-      Format.fprintf Format.std_formatter x
-
 (* Converts let-rec containing values into an initialization then
    assignment sequence.
 
@@ -424,8 +417,6 @@ let rec prepare_letrec
              Ident.Set.fold (fun from -> Ident.Map.add from id)
                substitute_from letrec.substitution
            in
-           debug "ADD SUBST: %a => %a@."
-             Ident.print cl.ident Ident.print id;
            let letbound = Ident.Set.add cl.ident letrec.letbound in
            { letrec with substitution; letbound }
        | None -> dead_code lam letrec)
@@ -494,9 +485,6 @@ let rec prepare_letrec
       { letrec with pre }
 
 let dissect_letrec ~bindings ~body =
-
-  debug "dissect@ %a@.@."
-    Printlambda.lambda (Lletrec (bindings, Lconst (Const_pointer 0)));
 
   let letbound =
     Ident.Set.of_list (List.map fst bindings)
@@ -568,14 +556,6 @@ let dissect_letrec ~bindings ~body =
       with_constants
   in
 
-  (* let substituted =
-   *   List.fold_left (fun body (id, _) ->
-   *       Llet (Strict, Pgenval, id, Lconst (Const_pointer 99999), body))
-   *     substituted bindings
-   * in *)
-
-  debug "dissected@ %a@.@."
-    Printlambda.lambda substituted;
   substituted
 
 type dissected =

--- a/lambda/dissect_letrec.mli
+++ b/lambda/dissect_letrec.mli
@@ -1,0 +1,32 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Pierre Chambart and Vincent Laviron, OCamlPro                *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2018 OCamlPro SAS                                          *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Compile let-rec defining non-function values into separate allocation
+    and assignments. *)
+
+type dissected =
+  | Dissected of Lambda.lambda
+  | Unchanged
+
+val dissect_letrec :
+  bindings:(Ident.t * Lambda.lambda) list -> body:Lambda.lambda ->
+  dissected
+(** [dissect_letrec] assumes that bindings have not been dissected yet.
+    In particular, that no arguments of function call are recursive. *)
+
+val preallocate_letrec :
+  bindings:(Ident.t * Lambda.lambda * int) list -> body:Lambda.lambda ->
+  Lambda.lambda

--- a/lambda/dissect_letrec.mli
+++ b/lambda/dissect_letrec.mli
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*           Pierre Chambart and Vincent Laviron, OCamlPro                *)
+(*      Pierre Chambart, Vincent Laviron and Louis Gesbert, OCamlPro      *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2018 OCamlPro SAS                                          *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -235,7 +235,7 @@ type let_kind = Strict | Alias | StrictOpt | Variable
       in e'
     StrictOpt: e does not have side-effects, but depend on the store;
       we can discard e if x does not appear in e'
-    Variable: the variable x is assigned later in e'
+    Variable: the variable x is assigned to later in e'
  *)
 
 type meth_kind = Self | Public | Cached

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -554,8 +554,14 @@ let simplify_lets lam =
       | _ -> mklet StrictOpt kind v (simplif l1) (simplif l2)
       end
   | Llet(str, kind, v, l1, l2) -> mklet str kind v (simplif l1) (simplif l2)
-  | Lletrec(bindings, body) ->
-      Lletrec(List.map (fun (v, l) -> (v, simplif l)) bindings, simplif body)
+  | Lletrec(bindings, body) -> begin
+      match Dissect_letrec.dissect_letrec ~bindings ~body with
+      | Dissect_letrec.Unchanged ->
+          Lletrec(List.map (fun (v, l) -> (v, simplif l)) bindings,
+                  simplif body)
+      | Dissect_letrec.Dissected expr ->
+          simplif expr
+    end
   | Lprim(p, ll, loc) -> Lprim(p, List.map simplif ll, loc)
   | Lswitch(l, sw, loc) ->
       let new_l = simplif l

--- a/testsuite/tests/asmcomp/is_static_flambda.ml
+++ b/testsuite/tests/asmcomp/is_static_flambda.ml
@@ -62,12 +62,12 @@ let () =
  *   and g1 a = E (f1 a, l2)
  *   and l1 = E (f1, l2)
  *   and l2 = E (g1, l1) in
- * 
+ *
  *   assert(is_in_static_data f1);
  *   assert(is_in_static_data g1);
  *   assert(is_in_static_data l1);
  *   assert(is_in_static_data l2)
- * 
+ *
  * let () = (i [@inlined never]) () *)
 
 module type P = module type of Stdlib

--- a/testsuite/tests/asmcomp/is_static_flambda.ml
+++ b/testsuite/tests/asmcomp/is_static_flambda.ml
@@ -33,11 +33,12 @@ let () = (h [@inlined always]) (Sys.opaque_identity 2)
 *)
 
 (* Recursive constant values should be static *)
-let rec a = 1 :: b
-and b = 2 :: a
-let () =
-  assert(is_in_static_data a);
-  assert(is_in_static_data b)
+(* Disabled since adding the dissect_letrec pass *)
+(* let rec a = 1 :: b
+ * and b = 2 :: a
+ * let () =
+ *   assert(is_in_static_data a);
+ *   assert(is_in_static_data b) *)
 
 (* And a mix *)
 type e = E : 'a -> e
@@ -49,23 +50,25 @@ and l2 = E (g1, l1)
 
 let () =
   assert(is_in_static_data f1);
-  assert(is_in_static_data g1);
-  assert(is_in_static_data l1);
-  assert(is_in_static_data l2)
+  assert(is_in_static_data g1)
+  (* disabled since adding the dissect_letrec pass *)
+  (* assert(is_in_static_data l1); *)
+  (* assert(is_in_static_data l2) *)
 
 (* Also in functions *)
-let i () =
-  let rec f1 a = E (g1 a, l1)
-  and g1 a = E (f1 a, l2)
-  and l1 = E (f1, l2)
-  and l2 = E (g1, l1) in
-
-  assert(is_in_static_data f1);
-  assert(is_in_static_data g1);
-  assert(is_in_static_data l1);
-  assert(is_in_static_data l2)
-
-let () = (i [@inlined never]) ()
+(* Disabled since adding the dissect_letrec pass *)
+(* let i () =
+ *   let rec f1 a = E (g1 a, l1)
+ *   and g1 a = E (f1 a, l2)
+ *   and l1 = E (f1, l2)
+ *   and l2 = E (g1, l1) in
+ * 
+ *   assert(is_in_static_data f1);
+ *   assert(is_in_static_data g1);
+ *   assert(is_in_static_data l1);
+ *   assert(is_in_static_data l2)
+ * 
+ * let () = (i [@inlined never]) () *)
 
 module type P = module type of Stdlib
 (* Top-level modules should be static *)

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -398,3 +398,15 @@ val a : int list = [0; 1; <cycle>]
 val b : int list = [1; 0; <cycle>]
 val f : int -> int = <fun>
 |}]
+
+let rec okay =
+  let rec x = let r = "bar" in ref r
+  and y = fun s -> ignore xx; ref s
+  and _z = fun s -> y s
+  and xx = let k = 0 in k::yy
+  and yy = 1::xx
+  in
+  ref ("foo" ^ ! (y !x));;
+[%%expect{|
+val okay : string ref = {contents = "foobar"}
+|}]

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -361,3 +361,40 @@ let rec okay =
 [%%expect{|
 val okay : string ref = {contents = "foobar"}
 |}]
+
+let rec okay =
+  let ok = okay in
+  let rec x = ref "bar"
+  and _y = ref ok
+  and _z = ref x, ok
+  in
+  ref ("foo" ^ ! x);;
+[%%expect{|
+val okay : string ref = {contents = "foobar"}
+|}]
+
+let rec a = 0 :: b
+and b = 1 :: a
+and f =
+  let x = a in
+  let y = x in
+  let z = y in
+  fun i -> List.hd z + i
+[%%expect{|
+val a : int list = [0; 1; <cycle>]
+val b : int list = [1; 0; <cycle>]
+val f : int -> int = <fun>
+|}]
+
+let rec a = 0 :: b
+and b = 1 :: a
+and f =
+  let rec x = a in
+  let y = x in
+  let z = y in
+  fun i -> List.hd z + i
+[%%expect{|
+val a : int list = [0; 1; <cycle>]
+val b : int list = [1; 0; <cycle>]
+val f : int -> int = <fun>
+|}]

--- a/testsuite/tests/letrec-compilation/modules.ml
+++ b/testsuite/tests/letrec-compilation/modules.ml
@@ -1,0 +1,27 @@
+(* TEST *)
+
+module type A = sig
+  val a : int
+  val b : int
+end
+
+module type B = sig
+  val b : int
+end
+
+module F(A:A) = struct
+  let a = 1
+  let b = A.a + A.b
+end
+
+module Ax = struct let a = 33 let b = 44 end
+let rec a =
+  let _ = (a,a) in
+  (module F (Ax) : A)
+
+let rec a =
+  let _ = (a,a) in
+  (module (F (struct let a = 33 let b = 44 end)) : A)
+and b =
+  let exception E : 'a -> exn in
+  E b

--- a/testsuite/tests/letrec-compilation/spaghetti.ml
+++ b/testsuite/tests/letrec-compilation/spaghetti.ml
@@ -1,0 +1,32 @@
+(* TEST
+   * expect
+*)
+
+type t = T0 | T1 of t | Tf of (unit -> t)
+[%%expect{|
+type t = T0 | T1 of t | Tf of (unit -> t)
+|}]
+;;
+
+let rec a = T0
+and b =
+  let rec f () = T1 a
+  and x = Tf f
+  in x
+[%%expect{|
+val a : t = T0
+val b : t = Tf <fun>
+|}]
+;;
+
+let rec a = T0
+and b =
+  let rec f () = T1 a
+  and x = Tf f
+  and y = ref "foo"
+  in !y, x
+[%%expect{|
+val a : t = T0
+val b : string * t = ("foo", Tf <fun>)
+|}]
+;;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -1074,7 +1074,7 @@ and value_bindings : rec_flag -> Typedtree.value_binding list -> bind_judg =
            (Gi, (xj : mdef_ij)^j |- ei : m[mbody_i])^i   (xi : mbody_i -| D)^i
            G'i = Gi + mdef_ij[G'j]
            -------------------------------------------------------------------
-           Sum(G'i) + (D - (pi)^i) |- let rec (xi=ei)^i : m -| D
+           Sum(G'i) + (D - (xi)^i) |- let rec (xi=ei)^i : m -| D
 
            The (mdef_ij)^i,j are a family of modes over two indices:
            mdef_ij represents the mode of use, within e_i the definition of x_i,

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -35,6 +35,7 @@ module type Set = sig
   val to_string : t -> string
   val of_list : elt list -> t
   val map : (elt -> elt) -> t -> t
+  val fixpoint : (elt -> t) -> t -> t
 end
 
 module type Map = sig
@@ -202,6 +203,16 @@ module Make_set (T : Thing) = struct
     | t :: q -> List.fold_left (fun acc e -> add e acc) (singleton t) q
 
   let map f s = of_list (List.map f (elements s))
+
+  let fixpoint f set =
+    let rec aux acc set =
+      if is_empty set then acc else
+        let set' = fold (fun x -> union (f x)) set empty in
+        let acc = union acc set in
+        aux acc (diff set' acc)
+    in
+    aux empty set
+
 end
 
 module Make_tbl (T : Thing) = struct

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -44,6 +44,10 @@ module type Set = sig
   val to_string : t -> string
   val of_list : elt list -> t
   val map : (elt -> elt) -> t -> t
+
+  (** [fixpoint f t] repeatedly applies [f] to every element of the set and adds
+      the results to [t], until no new elements are found *)
+  val fixpoint : (elt -> t) -> t -> t
 end
 
 module type Map = sig


### PR DESCRIPTION
This pull-request (started by Pierre Chambart) adds a pass in Lambda
that reorganises let-recs to lift all recursive value definitions. The
resulting lambda contains `Lletrec` only for recursive function
definitions, and initialisation + assignment sequences for recursive
values. The rewrite is made so that it preserves evaluation order for
side-effects (including for depdendent nested let-recs).

This is expected to be cleaner than the previous handling, and to make
the resulting lambda easier to work with. It's also our hope that it
will more easily be tied with the checks in `Rec_check`.

The PR contains:
- a new module `lambda/dissect_letrec.ml` that does the translation
- a tiny change to `simplif.ml` to trigger the rewrite
- a tiny change in `translmod.ml` for the class handling case


I am now reasonably convinced that it complies with what `Rec_check`
considers valid or not, but we probably should go further in
justifying that part; I would very grateful if @gasche could have an
eye at it, which is the main reason for submitting already.