### PR TITLE
typecore: fix a small bug in type_pat

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1464,7 +1464,7 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
       if not exception_allowed then
         raise (Error (loc, !env, Exception_pattern_disallowed))
       else begin
-        let p_exn = type_pat p Predef.type_exn k in
+        type_pat p Predef.type_exn (fun p_exn ->
         rp k {
           pat_desc = Tpat_exception p_exn;
           pat_loc = sp.ppat_loc;
@@ -1472,7 +1472,7 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
           pat_type = expected_ty;
           pat_env = !env;
           pat_attributes = sp.ppat_attributes;
-        }
+        })
       end
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))


### PR DESCRIPTION
The Tpat_exception case would make several calls to the continuation
'k', which must be used linearily -- exactly once.

This bug is harmless and hard to reach today because Tpat_exception is
mostly used at the toplevel or under an or-pattern, where the
continuation is the identity. But the type-checker still allows
Ppat_constraint and Ppat_open nodes above exception-patterns, allowing
to observe the duplication. And maybe more tomorrow?

    $ ocaml -dsource
    # fun f x -> match f x with _ -> () | (exception _ : exn) -> ();;
      [...]
        pattern
           Tpat_constraint
           core_type
             Ttyp_constr "exn/7!"
             []
           pattern
             Tpat_exception
             pattern
               Tpat_constraint
               core_type
                 Ttyp_constr "exn/7!"
                 []
               pattern
                 Tpat_any
      [...]
    # fun f x -> match f x with _ -> () | Stdlib.(exception _) -> ();;
      [...]
        pattern
          Tpat_open ""Stdlib!""
          pattern
            Tpat_exception
            pattern
              Tpat_open ""Stdlib!""
              pattern (//toplevel//[1,0+42]..//toplevel//[1,0+43])
                Tpat_any
      [...]