### PR TITLE
Caml_fatal_user_error

### DIFF
--- a/Changes
+++ b/Changes
@@ -124,8 +124,16 @@ Working version
    (Jacques-Henri Jourdan, review by Stephen Dolan and Gabriel Scherer)
 
 - #8630: Use abort() instead of exit(2) in caml_fatal_error, and add
-  the new hook caml_fatal_error_hook.
+  the new hook caml_fatal_error_hook. The function caml_fatal_error is now
+  more consistently used to denote internal errors in the runtime system.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
+
+- #8963: Introduce caml_fatal_user_error for runtime errors denoting
+  an error in the user's program. It defaults to printing an error
+  message on stderr and calling exit(2) and can be customised by the
+  hook caml_fatal_user_error_hook.
+  (Guillaume Munch-Maccagnoni, suggestion by Daniel Bünzli, review by
+   TODO)
 
 - #8713: Introduce a state table in the runtime to contain the global variables
    which must be duplicated for each domain in the multicore runtime.

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -166,17 +166,40 @@ CAMLnoreturn_end;
 #define CAMLassert(x) ((void) 0)
 #endif
 
-/* This hook is called when a fatal error occurs in the OCaml
-   runtime. It is given arguments to be passed to the [vprintf]-like
-   functions in order to synthetize the error message.
-   If it returns, the runtime calls [abort()].
+/* This hook is called when a fatal error occurs in the OCaml runtime.
+   It is given arguments to be passed to the [vprintf]-like functions
+   in order to synthetize the error message. It must not interact with
+   the OCaml runtime or heap, which should be assumed to be in
+   inconsistent states. If it returns, the runtime calls [abort()].
 
    If it is [NULL], the error message is printed on stderr and then
    [abort()] is called. */
 extern void (*caml_fatal_error_hook) (char *msg, va_list args);
 
+/* Denotes an internal error in the runtime system. Behaves as per
+   caml_fatal_error_hook. */
 CAMLnoreturn_start
 CAMLextern void caml_fatal_error (char *, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 1, 2)))
+#endif
+CAMLnoreturn_end;
+
+/* This hook is called when a fatal error occurs in the execution of
+   user's program. It is given arguments to be passed to the
+   [vprintf]-like functions in order to synthetize the error message.
+   It must not interact with the OCaml runtime or heap, which should
+   be assumed to be in inconsistent states. If it returns, the runtime
+   calls [exit(2)].
+
+   If it is [NULL], the error message is printed on stderr and then
+   [exit(2)] is called. */
+extern void (*caml_fatal_user_error_hook) (char *msg, va_list args);
+
+/* Denotes a fatal error during the execution of the user's program.
+   Behaves as per caml_fatal_user_error_hook. */
+CAMLnoreturn_start
+CAMLextern void caml_fatal_user_error (char *, ...)
 #ifdef __GNUC__
   __attribute__ ((format (printf, 1, 2)))
 #endif

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -137,7 +137,7 @@ static void open_shared_lib(char_os * name)
   handle = caml_dlopen(realname, 1, 1);
   caml_leave_blocking_section();
   if (handle == NULL)
-    caml_fatal_error
+    caml_fatal_user_error
     (
       "cannot load shared library %s\n"
       "Reason: %s",
@@ -183,7 +183,7 @@ void caml_build_primitive_table(char_os * lib_path,
   for (q = req_prims; *q != 0; q += strlen(q) + 1) {
     c_primitive prim = lookup_primitive(q);
     if (prim == NULL)
-          caml_fatal_error("unknown C primitive `%s'", q);
+          caml_fatal_user_error("unknown C primitive `%s'", q);
     caml_ext_table_add(&caml_prim_table, (void *) prim);
 #ifdef DEBUG
     caml_ext_table_add(&caml_prim_name_table, caml_stat_strdup(q));

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -90,18 +90,14 @@ CAMLexport void caml_raise_with_string(value tag, char const *msg)
 */
 static void check_global_data(char const *exception_name)
 {
-  if (caml_global_data == 0) {
-    fprintf(stderr, "Fatal error: exception %s\n", exception_name);
-    exit(2);
-  }
+  if (caml_global_data == 0)
+    caml_fatal_user_error("exception %s", exception_name);
 }
 
 static void check_global_data_param(char const *exception_name, char const *msg)
 {
-  if (caml_global_data == 0) {
-    fprintf(stderr, "Fatal error: exception %s(\"%s\")\n", exception_name, msg);
-    exit(2);
-  }
+  if (caml_global_data == 0)
+    caml_fatal_user_error("exception %s(\"%s\")", exception_name, msg);
 }
 
 static inline value caml_get_failwith_tag (char const *msg)

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -175,11 +175,9 @@ void caml_array_bound_error(void)
   if (caml_array_bound_error_exn == NULL) {
     caml_array_bound_error_exn =
       caml_named_value("Pervasives.array_bound_error");
-    if (caml_array_bound_error_exn == NULL) {
-      fprintf(stderr, "Fatal error: exception "
-                      "Invalid_argument(\"index out of bounds\")\n");
-      exit(2);
-    }
+    if (caml_array_bound_error_exn == NULL)
+      caml_fatal_user_error
+        ("exception Invalid_argument(\"index out of bounds\")");
   }
   caml_raise(*caml_array_bound_error_exn);
 }

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -76,7 +76,7 @@ static void alloc_to_do (int size)
 {
   struct to_do *result = caml_stat_alloc_noexc (sizeof (struct to_do) +
                                                 size * sizeof (struct final));
-  if (result == NULL) caml_fatal_error ("out of memory");
+  if (result == NULL) caml_fatal_user_error ("out of memory");
   result->next = NULL;
   result->size = size;
   if (to_do_tl == NULL){

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -24,7 +24,8 @@ export LC_ALL=C
   for prim in \
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
       lexing md5 meta memprof obj parsing signals str sys callback weak \
-      finalise stacks dynlink backtrace_byt backtrace spacetime_byt afl bigarray
+      finalise stacks dynlink backtrace_byt backtrace spacetime_byt afl \
+      bigarray misc
   do
       sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -486,7 +486,7 @@ static inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
       if (!raise_oom)
         return 0;
       else if (Caml_state->in_minor_collection)
-        caml_fatal_error ("out of memory");
+        caml_fatal_user_error ("out of memory");
       else
         caml_raise_out_of_memory ();
     }
@@ -769,7 +769,7 @@ CAMLexport void caml_stat_create_pool(void)
   if (pool == NULL) {
     pool = malloc(SIZEOF_POOL_BLOCK);
     if (pool == NULL)
-      caml_fatal_error("out of memory");
+      caml_fatal_user_error("out of memory");
 #ifdef DEBUG
     pool->magic = Debug_pool_magic;
 #endif

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -93,6 +93,28 @@ CAMLexport void caml_fatal_error (char *msg, ...)
   abort();
 }
 
+void (*caml_fatal_user_error_hook) (char *msg, va_list args) = NULL;
+
+CAMLexport void caml_fatal_user_error (char *msg, ...)
+{
+  va_list ap;
+  va_start(ap, msg);
+  if(caml_fatal_user_error_hook != NULL) {
+    caml_fatal_user_error_hook(msg, ap);
+  } else {
+    fprintf (stderr, "Fatal error: ");
+    vfprintf (stderr, msg, ap);
+    fprintf (stderr, "\n");
+  }
+  va_end(ap);
+  exit(2);
+}
+
+CAMLprim value caml_fatal_user_error_caml (value msg)
+{
+  caml_fatal_user_error("%s", String_val(msg));
+}
+
 /* If you change the caml_ext_table* functions, also update
    runtime/spacetime_nat.c:find_trie_node_from_libunwind. */
 

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -136,8 +136,6 @@ static void default_fatal_uncaught_exception(value exn, int output_stderr)
   caml_stat_free(msg);
 }
 
-int caml_abort_on_uncaught_exn = 0; /* see afl.c */
-
 void caml_fatal_uncaught_exception(value exn)
 {
   const value *handle_uncaught_exception;
@@ -161,9 +159,5 @@ void caml_fatal_uncaught_exception(value exn)
   else
     default_fatal_uncaught_exception(exn, output_stderr);
   /* Terminate the process */
-  if (caml_abort_on_uncaught_exn) {
-    abort();
-  } else {
-    exit(2);
-  }
+  exit(2);
 }

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -108,7 +108,7 @@ CAMLexport char * caml_format_exception(value exn)
 #endif
 
 /* Default C implementation in case the OCaml one is not registered. */
-static void default_fatal_uncaught_exception(value exn)
+static void default_fatal_uncaught_exception(value exn, int output_stderr)
 {
   char * msg;
   const value * at_exit;
@@ -125,12 +125,15 @@ static void default_fatal_uncaught_exception(value exn)
   if (at_exit != NULL) caml_callback_exn(*at_exit, Val_unit);
   Caml_state->backtrace_active = saved_backtrace_active;
   Caml_state->backtrace_pos = saved_backtrace_pos;
-  /* Display the uncaught exception */
-  fprintf(stderr, "Fatal error: exception %s\n", msg);
+  if (output_stderr) {
+    /* Display the uncaught exception */
+    fprintf(stderr, "Fatal error: exception %s\n", msg);
+    /* Display the backtrace if available */
+    if (Caml_state->backtrace_active && !DEBUGGER_IN_USE)
+      caml_print_exception_backtrace();
+  } else
+    caml_fatal_user_error("exception %s", msg);
   caml_stat_free(msg);
-  /* Display the backtrace if available */
-  if (Caml_state->backtrace_active && !DEBUGGER_IN_USE)
-    caml_print_exception_backtrace();
 }
 
 int caml_abort_on_uncaught_exn = 0; /* see afl.c */
@@ -138,6 +141,7 @@ int caml_abort_on_uncaught_exn = 0; /* see afl.c */
 void caml_fatal_uncaught_exception(value exn)
 {
   const value *handle_uncaught_exception;
+  int output_stderr;
 
   handle_uncaught_exception =
     caml_named_value("Printexc.handle_uncaught_exception");
@@ -148,11 +152,14 @@ void caml_fatal_uncaught_exception(value exn)
      the exception fails. */
   caml_memprof_suspended = 1;
 
+  output_stderr = !DEBUGGER_IN_USE || caml_fatal_user_error_hook == NULL;
+  if (DEBUGGER_IN_USE) Caml_state->backtrace_pos = 0;
+
   if (handle_uncaught_exception != NULL)
     /* [Printexc.handle_uncaught_exception] does not raise exception. */
-    caml_callback2(*handle_uncaught_exception, exn, Val_bool(DEBUGGER_IN_USE));
+    caml_callback2(*handle_uncaught_exception, exn, Val_bool(output_stderr));
   else
-    default_fatal_uncaught_exception(exn);
+    default_fatal_uncaught_exception(exn, output_stderr);
   /* Terminate the process */
   if (caml_abort_on_uncaught_exn) {
     abort();

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -155,8 +155,8 @@ static void call_registered_value(char* name)
 CAMLexport void caml_shutdown(void)
 {
   if (startup_count <= 0)
-    caml_fatal_error("a call to caml_shutdown has no "
-                     "corresponding call to caml_startup");
+    caml_fatal_user_error("a call to caml_shutdown has no "
+                          "corresponding call to caml_startup");
 
   /* Do nothing unless it's the last call remaining */
   startup_count--;


### PR DESCRIPTION
This introduces a new kind of fatal error, `caml_fatal_user_error`, denoting unrecoverable error in user code, which by default calls exit(2) and is customisable with a dbünzli-hook. This is inspired by the guideline from https://github.com/ocaml/ocaml/pull/8630#pullrequestreview-230487319. According to it, `caml_fatal_error`, which now calls `abort`, should only be used for internal runtime failures. I needed a fatal error which denotes an error in user code at https://github.com/ocaml/ocaml/pull/8962. Then I noticed that some actual uses of caml_fatal_error would be better as caml_fatal_user_error (mainly related to out of memory conditions). Overall, I do not have strong opinions on this patch. On the principle of a new function for error in user code, I think it corresponds to current usage in the compiler codebase (some calls to exit(2) are factored and now customisable), and to what people want according to what I read on this github. On the changing of some fatal_error into fatal_user_error, this is subjective, and I don't care that much. It is open to unlimited bikeshedding.

If the principle of the patch is accepted, then it is good to have it in 4.10 to avoid changing between abort/exit semantics back and forth.