### PR TITLE
Do not raise in Printexc.get_raw_backtrace

### DIFF
--- a/Changes
+++ b/Changes
@@ -178,6 +178,11 @@ Working version
   (Guillaume Munch-Maccagnoni, review by David Allsopp, Damien Doligez and
    Gabriel Scherer)
 
+- #8964: Printexc.get_raw_backtrace is now guaranteed not to raise any
+   exception.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, sliquister,
+   and Xavier Leroy)
+
 ### Other libraries:
 
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -38,8 +38,9 @@ let create fn arg =
       try
         fn arg; ()
       with exn ->
-             flush stdout; flush stderr;
-             thread_uncaught_exception exn)
+        (try flush stdout with _ -> ()) ;
+        (try flush stderr with _ -> ()) ;
+        thread_uncaught_exception exn )
 
 (* Thread.kill is currently not implemented due to problems with
    cleanup handlers on several platforms *)

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -181,6 +181,15 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
   CAMLreturn(res);
 }
 
+int caml_alloc_backtrace_buffer(void)
+{
+  CAMLassert(Caml_state->backtrace_pos == 0);
+  Caml_state->backtrace_buffer =
+    caml_stat_alloc_noexc(BACKTRACE_BUFFER_SIZE * sizeof(code_t));
+  if (Caml_state->backtrace_buffer == NULL) return -1;
+  return 0;
+}
+
 /* Copy back a backtrace and exception to the global state.
    This function should be used only with Printexc.raw_backtrace */
 /* noalloc (caml value): so no CAMLparam* CAMLreturn* */

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -222,14 +222,6 @@ CAMLprim value caml_remove_debug_info(code_t start)
   CAMLreturn(Val_unit);
 }
 
-int caml_alloc_backtrace_buffer(void){
-  CAMLassert(Caml_state->backtrace_pos == 0);
-  Caml_state->backtrace_buffer =
-    caml_stat_alloc_noexc(BACKTRACE_BUFFER_SIZE * sizeof(code_t));
-  if (Caml_state->backtrace_buffer == NULL) return -1;
-  return 0;
-}
-
 /* Store the return addresses contained in the given stack fragment
    into the backtrace array */
 

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -302,7 +302,7 @@ void caml_current_callstack_write(value trace) {
     code_t p = caml_next_frame_pointer(&sp, &trsp);
     CAMLassert(p != NULL);
     /* [Val_backtrace_slot(...)] is always a long, no need to call
-       [caml_modify]. */
+       [caml_modify] or [caml_initialize]. */
     Field(trace, trace_pos) = Val_backtrace_slot(p);
   }
 }

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -130,7 +130,7 @@ void caml_current_callstack_write(value trace) {
     frame_descr * descr = caml_next_frame_descriptor(&pc, &sp);
     CAMLassert(descr != NULL);
     /* [Val_backtrace_slot(...)] is always a long, no need to call
-       [caml_modify]. */
+       [caml_modify] or [caml_initialize]. */
     Field(trace, trace_pos) = Val_backtrace_slot((backtrace_slot) descr);
   }
 }

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -65,14 +65,6 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
   }
 }
 
-int caml_alloc_backtrace_buffer(void){
-  CAMLassert(Caml_state->backtrace_pos == 0);
-  Caml_state->backtrace_buffer =
-    caml_stat_alloc_noexc(BACKTRACE_BUFFER_SIZE * sizeof(backtrace_slot));
-  if (Caml_state->backtrace_buffer == NULL) return -1;
-  return 0;
-}
-
 /* Stores the return addresses contained in the given stack fragment
    into the backtrace array ; this version is performance-sensitive as
    it is called at each [raise] in a program compiled with [-g], so we

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -130,6 +130,9 @@ val get_raw_backtrace: unit -> raw_backtrace
     backtrace that [Printexc.print_backtrace] would print, but in
     a raw format. Same restriction usage than {!print_backtrace}.
 
+    Since 4.10, it is guaranteed not to raise any exception including
+    asynchronous ones.
+
     @since 4.01.0
 *)
 


### PR DESCRIPTION
This patch brings the guarantee that Printexc.get_raw_backtrace never raises anything. This function is raised at critical points during exception handlers, including resource clean-up, and it is better that it returns an empty value, rather than interfere with the control flow at that moment.

The second commit is minor, it is a similar concern but localised in the source code of systhreads (the implementation was not in line with the comment above it).