### PR TITLE
Accept ocamltests files not terminated by a newline

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -205,7 +205,7 @@ exec-ocamltest:
 	@if [ -z "$(DIR)" ]; then exit 1; fi
 	@if [ ! -d "$(DIR)" ]; then exit 1; fi
 	@file=$(DIR)/ocamltests; \
-	(IFS=$$(printf "\r\n"); while read testfile; do \
+	(IFS=$$(printf "\r\n"); while read testfile || [ -n "$$testfile" ]; do \
 	   TERM=dumb $(OCAMLTESTENV) \
 	     $(ocamltest) $(OCAMLTESTFLAGS) $(DIR)/$$testfile || \
 	   echo " ... testing '$$testfile' => unexpected error"; \


### PR DESCRIPTION
This is a follow-up to issue #8957

Cc @nojb @garrigue @mshinwell

Closes #8957