### PR TITLE
Move the Obj.id+serialization tests from expect tests to reference tests

### DIFF
--- a/testsuite/tests/runtime-objects/Tests.ml
+++ b/testsuite/tests/runtime-objects/Tests.ml
@@ -1,0 +1,37 @@
+(* TEST *)
+
+(* Marshaling (cf. PR#5436) *)
+
+(* Note: this test must *not* be made a toplevel or expect-style test,
+   because then the Obj.id counter of the compiler implementation
+   (called by the bytecode read-eval-print loop) would be the same as
+   the Obj.id counter of the test code below. In particular, any
+   change to the compiler implementation to use more objects or
+   exceptions would change the numbers below, making the test very
+   fragile. *)
+
+let r = ref 0;;
+let id o = Oo.id o - !r;;
+r := Oo.id (object end);;
+
+assert (id (object end) = 1);;
+assert (id (object end) = 2);;
+let o = object end in
+  let s = Marshal.to_string o [] in
+  let o' : < > = Marshal.from_string s 0 in
+  let o'' : < > = Marshal.from_string s 0 in
+  assert ((id o, id o', id o'') = (3, 4, 5));
+
+let o = object val x = 33 method m = x end in
+  let s = Marshal.to_string o [Marshal.Closures] in
+  let o' : <m:int> = Marshal.from_string s 0 in
+  let o'' : <m:int> = Marshal.from_string s 0 in
+  assert ((id o, id o', id o'', o#m, o'#m)
+          = (6, 7, 8, 33, 33));;
+
+let o = object val x = 33 val y = 44 method m = x end in
+  let s = Marshal.to_string (o,o) [Marshal.Closures] in
+  let (o1, o2) : (<m:int> * <m:int>) = Marshal.from_string s 0 in
+  let (o3, o4) : (<m:int> * <m:int>) = Marshal.from_string s 0 in
+  assert ((id o, id o1, id o2, id o3, id o4, o#m, o1#m)
+          = (9, 10, 10, 11, 11, 33, 33));;

--- a/testsuite/tests/runtime-objects/ocamltests
+++ b/testsuite/tests/runtime-objects/ocamltests
@@ -1,0 +1,1 @@
+Tests.ml

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -819,55 +819,6 @@ class c () = object method virtual m : int method private m = 1 end;;
 class c : unit -> object method m : int end
 |}];;
 
-(* Marshaling (cf. PR#5436) *)
-
-let r = ref 0;;
-[%%expect{|
-val r : int ref = {contents = 0}
-|}];;
-let id o = Oo.id o - !r;;
-[%%expect{|
-val id : < .. > -> int = <fun>
-|}];;
-r := Oo.id (object end);;
-[%%expect{|
-- : unit = ()
-|}];;
-id (object end);;
-[%%expect{|
-- : int = 1
-|}];;
-id (object end);;
-[%%expect{|
-- : int = 2
-|}];;
-let o = object end in
-  let s = Marshal.to_string o [] in
-  let o' : < > = Marshal.from_string s 0 in
-  let o'' : < > = Marshal.from_string s 0 in
-  (id o, id o', id o'');;
-[%%expect{|
-- : int * int * int = (3, 4, 5)
-|}];;
-
-let o = object val x = 33 method m = x end in
-  let s = Marshal.to_string o [Marshal.Closures] in
-  let o' : <m:int> = Marshal.from_string s 0 in
-  let o'' : <m:int> = Marshal.from_string s 0 in
-  (id o, id o', id o'', o#m, o'#m);;
-[%%expect{|
-- : int * int * int * int * int = (6, 7, 8, 33, 33)
-|}];;
-
-let o = object val x = 33 val y = 44 method m = x end in
-  let s = Marshal.to_string (o,o) [Marshal.Closures] in
-  let (o1, o2) : (<m:int> * <m:int>) = Marshal.from_string s 0 in
-  let (o3, o4) : (<m:int> * <m:int>) = Marshal.from_string s 0 in
-  (id o, id o1, id o2, id o3, id o4, o#m, o1#m);;
-[%%expect{|
-- : int * int * int * int * int * int * int = (9, 10, 10, 11, 11, 33, 33)
-|}];;
-
 (* Recursion (cf. PR#5291) *)
 
 class a = let _ = new b in object end


### PR DESCRIPTION
Those test should *not* be toplevel or expect-style tests, because
then the Obj.id counter of the compiler implementation (called by the
bytecode read-eval-print loop) is the same as the Obj.id counter of
the test code below. In particular, any change to the compiler
implementation to use more objects or exceptions will change the
reference numbers, making the test fragile in a very surprising way.

I found the issue while working on #8968, which hits the bug.

I tested this PR by adding a spurious

    let exception Unused in
    ignore Unused;

in typing/typecore.ml:unify_pat_types. Before this PR,

    make one DIR=tests/typing-objects

would be broken by the change. After this PR,

    make one DIR=tests/typing-objects
    make one DIR=tests/runtime-objects

works fine.

(no change entry needed)