### PR TITLE
Fix tools/check-parser-uptodate-or-warn.sh

### DIFF
--- a/Changes
+++ b/Changes
@@ -257,6 +257,9 @@ Working version
   (Vincent Laviron, review by Pierre Chambart and Leo White,
    report by Aleksandr Kuzmenko)
 
+- #8965, #8979: Alpine build failure caused by check-parser-uptodate-or-warn.sh
+  (Gabriel Scherer and David Allsopp, report by Anton Kochkov)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -1094,9 +1094,9 @@ parsing/camlinternalMenhirLib.mli: boot/menhir/menhirLib.mli
 parsing/parser.ml: boot/menhir/parser.ml parsing/parser.mly \
   tools/check-parser-uptodate-or-warn.sh
 	@-tools/check-parser-uptodate-or-warn.sh
-	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@
+	sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 parsing/parser.mli: boot/menhir/parser.mli
-	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@
+	sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 
 beforedepend:: parsing/camlinternalMenhirLib.ml \
   parsing/camlinternalMenhirLib.mli \

--- a/Makefile
+++ b/Makefile
@@ -1093,7 +1093,7 @@ parsing/camlinternalMenhirLib.mli: boot/menhir/menhirLib.mli
 
 parsing/parser.ml: boot/menhir/parser.ml parsing/parser.mly \
   tools/check-parser-uptodate-or-warn.sh
-	@tools/check-parser-uptodate-or-warn.sh || true
+	@-tools/check-parser-uptodate-or-warn.sh
 	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@
 parsing/parser.mli: boot/menhir/parser.mli
 	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@

--- a/Makefile
+++ b/Makefile
@@ -1093,7 +1093,7 @@ parsing/camlinternalMenhirLib.mli: boot/menhir/menhirLib.mli
 
 parsing/parser.ml: boot/menhir/parser.ml parsing/parser.mly \
   tools/check-parser-uptodate-or-warn.sh
-	@tools/check-parser-uptodate-or-warn.sh
+	@tools/check-parser-uptodate-or-warn.sh || true
 	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@
 parsing/parser.mli: boot/menhir/parser.mli
 	cat $< | sed "s/MenhirLib/CamlinternalMenhirLib/g" > $@

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -15,6 +15,12 @@
 #*                                                                        *
 #**************************************************************************
 
+# stop early if we are not on a development version
+if test -z "$(cat VERSION | grep '+dev')"
+then
+    exit 0
+fi
+
 # We try to warn if the user edits parsing/parser.mly but forgets to
 # rebuild the generated parser. Our heuristic is to use the file
 # modification timestamp, but just testing

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -33,7 +33,7 @@ fi
 # using either
 #  GNU coreutils' stat --format, or
 #  busybox's stat -c, or
-#  BSD/macos stat -f.
+#  BSD/macOS stat -f.
 # Default to 0 if 'stat' is not available.
 
 stat . 2>/dev/null 1>/dev/null

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -53,7 +53,12 @@ mtime() {
 # The check itself
 SOURCE_MTIME=$(mtime parsing/parser.mly)
 GENERATED_MTIME=$(mtime boot/menhir/parser.ml)
-if test -n "$SOURCE_MTIME" -a -n "$GENERATED_MTIME" -a "$SOURCE_MTIME" -gt $(( GENERATED_MTIME + 10 ))
+if test -z "$SOURCE_MTIME" -o -z "$GENERATED_MTIME"
+then
+  echo
+  tput setaf 3; tput bold; printf "Warning: "; tput sgr0
+  echo "Failed to check if boot/menhir/parser.ml is up-to-date."
+elif test "$SOURCE_MTIME" -gt $(( GENERATED_MTIME + 10 ))
 then
   echo
   tput setaf 3; tput bold; printf "Warning: "; tput sgr0

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -16,10 +16,7 @@
 #**************************************************************************
 
 # stop early if we are not on a development version
-if test -z "$(cat VERSION | grep '+dev')"
-then
-    exit 0
-fi
+grep -Fq '+dev' VERSION || exit 0
 
 # We try to warn if the user edits parsing/parser.mly but forgets to
 # rebuild the generated parser. Our heuristic is to use the file
@@ -39,9 +36,9 @@ fi
 stat . 2>/dev/null 1>/dev/null
 if test $? != 0
 then MTIME=""
-elif test -n "$(stat --version 2>/dev/null | grep coreutils)"
+elif stat --version 2>/dev/null | grep -Fq 'coreutils'
 then MTIME="stat --format %Y"
-elif test -n "$(stat 2>&1 | grep busybox)"
+elif stat 2>&1 | grep -Fq 'busybox'
 then MTIME="stat -c %Y"
 else MTIME="stat -f %m" # BSD stat?
 fi

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -50,7 +50,7 @@ mtime() {
 # The check itself
 SOURCE_MTIME=$(mtime parsing/parser.mly)
 GENERATED_MTIME=$(mtime boot/menhir/parser.ml)
-if test "$SOURCE_MTIME" -gt $(( GENERATED_MTIME + 10 ))
+if test -n "$SOURCE_MTIME" -a -n "$GENERATED_MTIME" -a "$SOURCE_MTIME" -gt $(( GENERATED_MTIME + 10 ))
 then
   echo
   tput setaf 3; tput bold; printf "Warning: "; tput sgr0

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -24,7 +24,10 @@
 # seconds after boot/menhir/parser.ml.
 
 # mtime(): access a file's last modification time as a timestamp,
-# using either GNU coreutils' stat --format, or BSD/macos stat -f.
+# using either
+#  GNU coreutils' stat --format, or
+#  busybox's stat -c, or
+#  BSD/macos stat -f.
 # Default to 0 if 'stat' is not available.
 
 stat . 2>/dev/null 1>/dev/null
@@ -32,7 +35,9 @@ if test $? != 0
 then MTIME=""
 elif test -n "$(stat --version 2>/dev/null | grep coreutils)"
 then MTIME="stat --format %Y"
-else MTIME="stat -f %m"
+elif test -n "$(stat 2>&1 | grep busybox)"
+then MTIME="stat -c %Y"
+else MTIME="stat -f %m" # BSD stat?
 fi
 
 mtime() {


### PR DESCRIPTION
This PR fixes #8965 (a build failure caused by a warning script) by:
- adding support for Busybox' `stat` to the script
- making the script more robust to unexpected failures
- disabling the script on non-development versions (as suggested by @Octachron)