### PR TITLE
Fix check for incompatible -c and -o options

### DIFF
--- a/Changes
+++ b/Changes
@@ -372,6 +372,9 @@ Working version
 - #8896: deprecate addr typedef in misc.h
   (David Allsopp, suggestion by Xavier Leroy)
 
+- #8981: Fix check for incompatible -c and -o options.
+  (Greta Yorsh, review by Damien Doligez)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -661,7 +661,7 @@ let process_deferred_actions env =
 
           if List.length (List.filter (function
               | ProcessImplementation _
-              | ProcessInterface _
+              | ProcessInterface _ -> true
               | _ -> false) !deferred_actions) > 1 then
             fatal "Options -c -o are incompatible with compiling multiple files"
         end;


### PR DESCRIPTION
The check for incompatible -c and -o options always succeeds, even when it shouldn't. 

For example `ocamlopt test4.ml test3.ml -o test.exe -c`  attempts to compile the input files and generates incorrectly-named artifacts, and as a result might fail to find existing modules.

This PR adds the missing case.
