### PR TITLE
Run whole of gen_primitives.sh with LC_ALL=C

### DIFF
--- a/Changes
+++ b/Changes
@@ -223,6 +223,10 @@ Working version
 - #8947: fix/improve support for the BFD library
   (Sébastien Hinderer, review by Damien Doligez)
 
+- #8985, #8986: fix generation of the primitives when the locale collation is
+  incompatible with C.
+  (David Allsopp, review by Nicolás Ojeda Bär, report by Sebastian Rasmussen)
+
 ### Compiler user-interface and warnings:
 
 - #8702, #8777: improved error messages for fixed row polymorphic variants

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -17,6 +17,9 @@
 
 # duplicated from $(ROOTDIR)/runtime/Makefile
 
+# #8985: the meaning of character range a-z depends on the locale, so force C
+#        locale throughout.
+export LC_ALL=C
 (
   for prim in \
       alloc array compare extern floats gc_ctrl hash intern interp ints io \
@@ -27,4 +30,4 @@
   done
   sed -n -e 's/^CAMLprim_int64_[0-9](\([a-z0-9_][a-z0-9_]*\)).*/caml_int64_\1\
 caml_int64_\1_native/p' ints.c
-) | LC_ALL=C sort | uniq
+) | sort | uniq


### PR DESCRIPTION
I reproduced #8985. The glibc bug report referenced there suggests that the collation rules are not correct for Swedish, but regardless that means we should switch to forcing C collation in the entire script, which this PR does.

CC @sebras