### PR TITLE
Fix ocamlnat

### DIFF
--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -262,7 +262,7 @@ let load_lambda ppf ~module_ident ~required_globals lam size =
     else Closure_middle_end.lambda_to_clambda
   in
   Asmgen.compile_implementation ~toplevel:need_symbol
-    ~backend ~filename ~prefixname:""
+    ~backend ~filename ~prefixname:filename
     ~middle_end ~ppf_dump:ppf program;
   Asmlink.call_linker_shared [filename ^ ext_obj] dll;
   Sys.remove (filename ^ ext_obj);


### PR DESCRIPTION
Currently, ocamlnat fails to execute any phrase because it tries to link an object file named ".o" (and just ".o").

This PR fixes  this issue by using the right name.

I am proposing to backport this fix on 4.09, to have at least a working version of ocamlnat on the dev version of the branch.