### PR TITLE
amd64: Emit 32bit registers for Iconst_int when we can

### DIFF
--- a/Changes
+++ b/Changes
@@ -79,6 +79,9 @@ Working version
 
 ### Code generation and optimizations:
 
+- #8990: amd64: Emit 32bit registers for Iconst_int when we can
+  (Xavier Clerc, Tom Kelly and Mark Shinwell, review by Xavier Leroy)
+
 - #8672: Optimise Switch code generation on booleans.
   (Stephen Dolan, review by Pierre Chambart)
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -544,10 +544,21 @@ let emit_instr fallthrough i =
   | Lop(Iconst_int n) ->
       if n = 0n then begin
         match i.res.(0).loc with
-        | Reg _ -> I.xor (res i 0) (res i 0)
-        | _     -> I.mov (int 0) (res i 0)
-      end
-      else
+        | Reg _ ->
+          (* Clearing the bottom half also clears the top half (except for
+             64-bit-only registers where the behaviour is as if the operands
+             were 64 bit). *)
+          I.xor (res32 i 0) (res32 i 0)
+        | _ ->
+          I.mov (int 0) (res i 0)
+      end else if n > 0n && n <= 0xFFFF_FFFFn then begin
+        match i.res.(0).loc with
+        | Reg _ ->
+          (* Similarly, setting only the bottom half clears the top half. *)
+          I.mov (nat n) (res32 i 0)
+        | _ ->
+          I.mov (nat n) (res i 0)
+      end else
         I.mov (nat n) (res i 0)
   | Lop(Iconst_float f) ->
       begin match f with


### PR DESCRIPTION
This PR alters how `Iconst_int` is emitted for x86_64 to use a more compact encoding.

Currently `Iconst_int` will emit:
```
48 31 c0                xor    %rax,%rax
48 c7 c0 01 00 00 00    mov    $0x1,%rax
```

The [Intel optimization reference manual](https://software.intel.com/sites/default/files/managed/9e/bc/64-ia-32-architectures-optimization-manual.pdf) recommends using 32bit registers (see section 12.2.1). This PR changes to emit:
```
31 c0                   xor    %eax,%eax
b8 01 00 00 00          mov    $0x1,%eax
```

Taking ocamlopt as the binary, this change reduces the text segment size by about 0.75%. I have also run sandmark benchmarks for the change, there was no significant evidence to suggest performance gains or losses. However as a comparison GCC, Clang and ICC are all emitting the 32bit variants.