### PR TITLE
Test building ocamlnat on Inria's CI

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -230,6 +230,7 @@ eval ./configure "$CCOMP" $build $host --prefix='$instdir' $confoptions
 
 if $make_native; then
   $make $jobs --warn-undefined-variables world.opt
+  $make $jobs --warn-undefined-variables ocamlnat
   if $check_make_alldepend; then $make --warn-undefined-variables alldepend; fi
 else
   $make $jobs --warn-undefined-variables world


### PR DESCRIPTION
This pull request is a follow-up to an offline discussion with
@Armael and @Octachron, itself related to issue #8989.

All three of us agreed that if the native toplevel is distributed
with the compiler, it should at least compile.

I thus went ahead and added it to Inria's CI to see whether it
compiles everywhere, as @xavierleroy wondered.

As shown by precheck's build
#304(https://ci.inria.fr/ocaml/job/precheck/build/304) it turns out
that trunk's `ocmalnat` does compile on all architectures tested
by Inria's CI (there are a few failures but I made sure they are
unrelated).

This PR thus proposes to add this very minimal test to our CI
infrastructure. A later PR could then introduce a very simple
execution test to make sure problems like those fixed by @Octachron
in PR #8988 can be caught earlier.

Obviously, the goal of this PR is to agree on the principle, rather than
on the implementation. :)