### PR TITLE
stdlib/Makefile: use list of modules from StdlibModules

### DIFF
--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -12,20 +12,13 @@ To add a new module, you must:
 
 * Create new `.mli` and `.ml` files for the modules, obviously.
 
-* Define the module in `stdlib/stdlib.mli`, `stdlib/stdlib.ml`, and
-  `otherlibs/threads/stdlib.ml` in the section of the code commented,
-  "MODULE ALIASES". Please maintain the same style as the rest of the code, in
-  particular the alphabetical ordering and whitespace alignment of module
-  aliases. Note that `otherlibs/threads/stdlib.mli` is a symbolic link to
-  `stdlib/stdlib.mli`.
-
-* Add `$(P)module_name.cmo` to the definition of `OTHERS` in `stdlib/Makefile`.
-
-* Add `$(LIB)/$(P)module_name.cmo` to the definition of `LIB_OBJS` in
-  `otherlibs/threads/Makefile`.
+* Define the module in `stdlib/stdlib.mli`, `stdlib/stdlib.ml` in the section of
+  the code commented, "MODULE ALIASES". Please maintain the same style as the
+  rest of the code, in particular the alphabetical ordering and whitespace
+  alignment of module aliases.
 
 * Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
-  `stdlib/StdlibModules`. Please maintain the alphabetical order.
+  `stdlib/StdlibModules`. You must keep the list sorted in dependency order.
 
 * Run `make alldepend` to update all the `.depend` files. These files are not
   edited by hand.

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -43,25 +43,10 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 # Object file prefix
 P=stdlib__
 
-OBJS=camlinternalFormatBasics.cmo stdlib.cmo $(OTHERS)
-OTHERS= $(P)pervasives.cmo $(P)seq.cmo $(P)option.cmo $(P)result.cmo \
-  $(P)bool.cmo $(P)char.cmo $(P)uchar.cmo $(P)sys.cmo $(P)list.cmo \
-  $(P)bytes.cmo $(P)string.cmo $(P)unit.cmo \
-  $(P)marshal.cmo $(P)obj.cmo $(P)array.cmo $(P)float.cmo \
-  $(P)int.cmo $(P)int32.cmo $(P)int64.cmo $(P)nativeint.cmo \
-  $(P)lexing.cmo $(P)parsing.cmo \
-  $(P)set.cmo $(P)map.cmo $(P)stack.cmo $(P)queue.cmo \
-  camlinternalLazy.cmo $(P)lazy.cmo $(P)stream.cmo \
-  $(P)buffer.cmo camlinternalFormat.cmo $(P)printf.cmo \
-  $(P)arg.cmo $(P)printexc.cmo $(P)fun.cmo $(P)gc.cmo \
-  $(P)digest.cmo $(P)random.cmo $(P)hashtbl.cmo $(P)weak.cmo \
-  $(P)format.cmo $(P)scanf.cmo $(P)callback.cmo \
-  camlinternalOO.cmo $(P)oo.cmo camlinternalMod.cmo \
-  $(P)genlex.cmo $(P)ephemeron.cmo \
-  $(P)filename.cmo $(P)complex.cmo \
-  $(P)arrayLabels.cmo $(P)listLabels.cmo $(P)bytesLabels.cmo \
-  $(P)stringLabels.cmo $(P)moreLabels.cmo $(P)stdLabels.cmo \
-  $(P)spacetime.cmo $(P)bigarray.cmo
+include StdlibModules
+
+OBJS=$(addsuffix .cmo,$(STDLIB_MODULES))
+OTHERS=$(filter-out camlinternalFormatBasics.cmo stdlib.cmo,$(OBJS))
 
 PREFIXED_OBJS=$(filter stdlib__%.cmo,$(OBJS))
 UNPREFIXED_OBJS=$(PREFIXED_OBJS:stdlib__%.cmo=%)

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -20,64 +20,66 @@
 
 P ?= stdlib__
 
+# Modules should be listed in dependency order.
+
 STDLIB_MODULES=\
-  $(P)spacetime \
-  $(P)arg \
-  $(P)array \
-  $(P)arrayLabels \
-  $(P)bigarray \
-  $(P)bool \
-  $(P)buffer \
-  $(P)bytes \
-  $(P)bytesLabels \
-  $(P)callback \
-  camlinternalFormat \
   camlinternalFormatBasics \
-  camlinternalLazy \
-  camlinternalMod \
-  camlinternalOO \
+  stdlib \
+  $(P)pervasives \
+  $(P)seq \
+  $(P)option \
+  $(P)result \
+  $(P)bool \
   $(P)char \
-  $(P)complex \
-  $(P)digest \
-  $(P)ephemeron \
-  $(P)filename \
+  $(P)uchar \
+  $(P)sys \
+  $(P)list \
+  $(P)bytes \
+  $(P)string \
+  $(P)unit \
+  $(P)marshal \
+  $(P)obj \
+  $(P)array \
   $(P)float \
-  $(P)format \
-  $(P)fun \
-  $(P)gc \
-  $(P)genlex \
-  $(P)hashtbl \
   $(P)int \
   $(P)int32 \
   $(P)int64 \
-  $(P)lazy \
-  $(P)lexing \
-  $(P)list \
-  $(P)listLabels \
-  $(P)map \
-  $(P)marshal \
-  $(P)moreLabels \
   $(P)nativeint \
-  $(P)obj \
-  $(P)oo \
-  $(P)option \
+  $(P)lexing \
   $(P)parsing \
-  $(P)pervasives \
-  $(P)printexc \
-  $(P)printf \
-  $(P)queue \
-  $(P)random \
-  $(P)result \
-  $(P)scanf \
-  $(P)seq \
   $(P)set \
+  $(P)map \
   $(P)stack \
-  $(P)stdLabels \
-  stdlib \
+  $(P)queue \
+  camlinternalLazy \
+  $(P)lazy \
   $(P)stream \
-  $(P)string \
+  $(P)buffer \
+  camlinternalFormat \
+  $(P)printf \
+  $(P)arg \
+  $(P)printexc \
+  $(P)fun \
+  $(P)gc \
+  $(P)digest \
+  $(P)random \
+  $(P)hashtbl \
+  $(P)weak \
+  $(P)format \
+  $(P)scanf \
+  $(P)callback \
+  camlinternalOO \
+  $(P)oo \
+  camlinternalMod \
+  $(P)genlex \
+  $(P)ephemeron \
+  $(P)filename \
+  $(P)complex \
+  $(P)arrayLabels \
+  $(P)listLabels \
+  $(P)bytesLabels \
   $(P)stringLabels \
-  $(P)sys \
-  $(P)uchar \
-  $(P)unit \
-  $(P)weak
+  $(P)moreLabels \
+  $(P)stdLabels \
+  $(P)spacetime \
+  $(P)bigarray


### PR DESCRIPTION
This is a tweak in `stdlib/Makefile` to re-use the list of modules from `stdlib/StdlibModules`, so that there is one less spot that needs to be updated when adding a new stdlib module.

On the other hand, this means that the modules in `stdlib/StdlibModules` need to be listed in dependency order.