### PR TITLE
Windows supports make reconfigure now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,11 +330,9 @@ endif
 utils/config.ml: utils/config.mlp Makefile.config utils/Makefile
 	$(MAKE) -C utils config.ml
 
-ifeq "$(UNIX_OR_WIN32)" "unix"
 .PHONY: reconfigure
 reconfigure:
 	./configure $(CONFIGURE_ARGS)
-endif
 
 utils/domainstate.ml: utils/domainstate.ml.c runtime/caml/domain_state.tbl
 	$(CPP) -I runtime/caml $< > $@


### PR DESCRIPTION
Since 4.08.0, it's possible to use the `reconfigure` target on Windows.