### PR TITLE
Resource-safe C interface, part 2

### DIFF
--- a/Changes
+++ b/Changes
@@ -88,6 +88,18 @@ Working version
   compaction algorithm and remove its dependence on the page table
   (Damien Doligez, review by Jacques-Henri Jourdan and Xavier Leroy)
 
+- #8997: Introduce new `_exn` variants of current functions in the public
+  API, to help clean-up after an asynchronous exception arises.
+
+   - `caml_{enter,leave}_blocking_section_exn` in caml/signals.h.
+
+   - Functions from caml/fail.h that raise exceptions, e.g.
+     `caml_failwith_exn` and many others.
+
+  Use them to fix various resource leaks in functions from `caml/io.h`,
+  dynlink, and marshalling.
+  (Guillaume Munch-Maccagnoni, review by)
+
 ### Code generation and optimizations:
 
 - #9620: Limit the number of parameters for an uncurried or untupled

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -21,7 +21,7 @@ include $(ROOTDIR)/Makefile.common
 
 BYTECODE_C_SOURCES := $(addsuffix .c, \
   interp misc stacks fix_code startup_aux startup_byt freelist major_gc \
-  minor_gc memory alloc roots_byt globroots fail_byt signals \
+  minor_gc memory alloc roots_byt globroots fail fail_byt signals \
   signals_byt printexc backtrace_byt backtrace compare ints eventlog \
   floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
   lexing callback debugger weak compact finalise custom dynlink \
@@ -29,7 +29,7 @@ BYTECODE_C_SOURCES := $(addsuffix .c, \
   skiplist codefrag)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
-  startup_aux startup_nat main fail_nat roots_nat signals \
+  startup_aux startup_nat main fail fail_nat roots_nat signals \
   signals_nat misc freelist major_gc minor_gc memory alloc compare ints \
   floats str array io extern intern hash sys parsing gc_ctrl eventlog md5 obj \
   lexing $(UNIX_OR_WIN32) printexc callback weak compact finalise custom \

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -36,6 +36,7 @@
 #include "caml/exec.h"
 #include "caml/fix_code.h"
 #include "caml/memory.h"
+#include "caml/signals.h"
 #include "caml/startup.h"
 #include "caml/stacks.h"
 #include "caml/sys.h"
@@ -412,7 +413,9 @@ static void read_main_debug_info(struct debug_info *di)
   CAMLreturn0;
 
  cleanup:
+  caml_enter_blocking_section_noexn();
   close(fd);
+  caml_leave_blocking_section_noexn();
   CAMLreturn0;
 }
 

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -354,6 +354,7 @@ static void read_main_debug_info(struct debug_info *di)
 {
   CAMLparam0();
   CAMLlocal3(events, evl, l);
+  value exn = Val_unit;
   char_os *exec_name;
   int fd, num_events, orig, i;
   struct channel *chan;
@@ -384,7 +385,8 @@ static void read_main_debug_info(struct debug_info *di)
 
   caml_read_section_descriptors(fd, &trail);
   if (caml_seek_optional_section(fd, &trail, "DBUG") != -1) {
-    chan = caml_open_descriptor_in(fd);
+    chan = caml_open_descriptor_in_exn(fd, &exn);
+    if (Is_exception_result(exn)) goto cleanup;
 
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
@@ -402,11 +404,15 @@ static void read_main_debug_info(struct debug_info *di)
       Store_field(events, i, evl);
     }
 
-    caml_close_channel(chan);
+    caml_close_channel(chan); // closes fd
 
     di->events = process_debug_events(caml_start_code, events, &di->num_events);
-  }
+  } else goto cleanup;
 
+  CAMLreturn0;
+
+ cleanup:
+  close(fd);
   CAMLreturn0;
 }
 

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -65,8 +65,6 @@ struct longjmp_buffer {
 
 int caml_is_special_exception(value exn);
 
-value caml_raise_if_exception(value res);
-
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus
@@ -75,71 +73,96 @@ extern "C" {
 
 CAMLnoreturn_start
 CAMLextern void caml_raise (value bucket)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_constant (value tag)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_with_arg (value tag, value arg)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[])
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_with_string (value tag, char const * msg)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_failwith (char const *msg)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_failwith_value (value msg)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_invalid_argument (char const *msg)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_invalid_argument_value (value msg)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_out_of_memory (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_stack_overflow (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_sys_error (value)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_end_of_file (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_zero_divide (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_not_found (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_array_bound_error (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
 
 CAMLnoreturn_start
 CAMLextern void caml_raise_sys_blocked_io (void)
-CAMLnoreturn_end;
+CAMLnoreturn_end; // raises
+
+/* Non-raising variants of the above functions. The result is an
+   encoded exception to use with Is_exception_result and
+   Extract_exception. */
+
+CAMLextern value caml_raise_with_arg_exn (value tag, value arg);
+CAMLextern value caml_raise_with_args_exn (value tag, int nargs, value arg[]);
+CAMLextern value caml_raise_with_string_exn (value tag, char const * msg);
+CAMLextern value caml_failwith_exn (char const *msg);
+CAMLextern value caml_failwith_value_exn (value msg);
+CAMLextern value caml_invalid_argument_exn (char const *msg);
+CAMLextern value caml_invalid_argument_value_exn (value msg);
+CAMLextern value caml_raise_out_of_memory_exn (void);
+CAMLextern value caml_raise_stack_overflow_exn (void);
+CAMLextern value caml_raise_sys_error_exn (value msg);
+CAMLextern value caml_raise_end_of_file_exn (void);
+CAMLextern value caml_raise_zero_divide_exn (void);
+CAMLextern value caml_raise_not_found_exn (void);
+CAMLextern value caml_array_bound_error_exn (void);
+CAMLextern value caml_raise_sys_blocked_io_exn (void);
+
+CAMLextern value caml_raise_if_exception (value val);
+/* If [val] is an encoded exception as returned by _exn functions,
+   raise the exception it encodes. Otherwise, [val] is returned
+   unchanged with the guarantee that it is a regular value. Raises. */
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -126,12 +126,12 @@ CAMLextern intnat caml_output_value_to_block(value v, value flags,
 
 #ifdef CAML_INTERNALS
 value caml_input_val (struct channel * chan);
-  /* Read a structured value from the channel [chan]. */
+  /* Read a structured value from the channel [chan]. Raises. */
 
 extern value caml_input_value_to_outside_heap (value channel);
   /* As for [caml_input_value], but the value is unmarshalled into
      malloc blocks that are not added to the heap.  Not for the
-     casual user. */
+     casual user. Raises */
 
 extern int caml_extern_allow_out_of_heap;
   /* Permit the marshaller to traverse structures that look like OCaml

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -103,7 +103,7 @@
 /* The entry points */
 
 void caml_output_val (struct channel * chan, value v, value flags);
-  /* Output [v] with flags [flags] on the channel [chan]. */
+  /* Output [v] with flags [flags] on the channel [chan]. Raises. */
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -77,8 +77,14 @@ enum {
    ? caml_refill(channel)                                                   \
    : (unsigned char) *((channel)->curr)++)
 
-CAMLextern struct channel * caml_open_descriptor_in (int);
-CAMLextern struct channel * caml_open_descriptor_out (int);
+CAMLextern struct channel * caml_open_descriptor_in (int); //raises
+CAMLextern struct channel * caml_open_descriptor_out (int); //raises
+CAMLextern struct channel * caml_open_descriptor_in_exn (int, value * exn);
+CAMLextern struct channel * caml_open_descriptor_out_exn (int, value * exn);
+/* These functions take ownership of the file descriptor. The [*_exn]
+   variants return NULL and set [exn] to an exception value if an
+   exception arises. */
+
 CAMLextern void caml_close_channel (struct channel *);
 CAMLextern int caml_channel_binary_mode (struct channel *);
 CAMLextern value caml_alloc_channel(struct channel *chan);

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -72,6 +72,7 @@ enum {
   *((channel)->curr)++ = (ch);                                            \
 }while(0)
 
+// raises
 #define caml_getch(channel)                                                 \
   ((channel)->curr >= (channel)->max                                        \
    ? caml_refill(channel)                                                   \
@@ -95,10 +96,15 @@ CAMLextern void caml_putword (struct channel *, uint32_t);
 CAMLextern int caml_putblock (struct channel *, char *, intnat);
 CAMLextern void caml_really_putblock (struct channel *, char *, intnat);
 
-CAMLextern unsigned char caml_refill (struct channel *);
-CAMLextern uint32_t caml_getword (struct channel *);
-CAMLextern int caml_getblock (struct channel *, char *, intnat);
-CAMLextern intnat caml_really_getblock (struct channel *, char *, intnat);
+CAMLextern unsigned char caml_refill (struct channel *); // raises
+CAMLextern uint32_t caml_getword (struct channel *); //raises
+CAMLextern int caml_getblock (struct channel *, char *, intnat); // raises
+CAMLextern int caml_getblock_exn (struct channel *, char *, intnat,
+                                  value * exn);
+CAMLextern intnat caml_really_getblock (struct channel *, char *,
+                                        intnat); // raises
+CAMLextern intnat caml_really_getblock_exn (struct channel *, char *,
+                                            intnat, value * exn);
 
 /* Extract a struct channel * from the heap object representing it */
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -67,6 +67,7 @@ enum {
 /* Functions and macros that can be called from C.  Take arguments of
    type struct channel *.  No locking is performed. */
 
+// raises
 #define caml_putch(channel, ch) do{                                       \
   if ((channel)->curr >= (channel)->end) caml_flush_partial(channel);     \
   *((channel)->curr)++ = (ch);                                            \
@@ -90,11 +91,13 @@ CAMLextern void caml_close_channel (struct channel *);
 CAMLextern int caml_channel_binary_mode (struct channel *);
 CAMLextern value caml_alloc_channel(struct channel *chan);
 
-CAMLextern int caml_flush_partial (struct channel *);
-CAMLextern void caml_flush (struct channel *);
-CAMLextern void caml_putword (struct channel *, uint32_t);
-CAMLextern int caml_putblock (struct channel *, char *, intnat);
-CAMLextern void caml_really_putblock (struct channel *, char *, intnat);
+CAMLextern int caml_flush_partial (struct channel *); // raises
+CAMLextern void caml_flush (struct channel *); // raises
+CAMLextern void caml_putword (struct channel *, uint32_t); // raises
+CAMLextern int caml_putblock (struct channel *, char *, intnat); // raises
+CAMLextern int caml_putblock_exn(struct channel *, char *, intnat, value * exn);
+CAMLextern void caml_really_putblock(struct channel *, char *, intnat);// raises
+CAMLextern value caml_really_putblock_exn(struct channel *, char *, intnat);
 
 CAMLextern unsigned char caml_refill (struct channel *); // raises
 CAMLextern uint32_t caml_getword (struct channel *); //raises

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -87,7 +87,7 @@ CAMLextern struct channel * caml_open_descriptor_out_exn (int, value * exn);
    variants return NULL and set [exn] to an exception value if an
    exception arises. */
 
-CAMLextern void caml_close_channel (struct channel *);
+CAMLextern void caml_close_channel (struct channel *); // raises
 CAMLextern int caml_channel_binary_mode (struct channel *);
 CAMLextern value caml_alloc_channel(struct channel *chan);
 
@@ -115,15 +115,17 @@ CAMLextern intnat caml_really_getblock_exn (struct channel *, char *,
 
 /* The locking machinery */
 
-CAMLextern void (*caml_channel_mutex_free) (struct channel *);
-CAMLextern void (*caml_channel_mutex_lock) (struct channel *);
-CAMLextern void (*caml_channel_mutex_unlock) (struct channel *);
-CAMLextern void (*caml_channel_mutex_unlock_exn) (void);
+CAMLextern void (*caml_channel_mutex_lock) (struct channel *); // may raise
+CAMLextern void (*caml_channel_mutex_free) (struct channel *); // non-raising
+CAMLextern void (*caml_channel_mutex_unlock) (struct channel *); // non-raising
+CAMLextern void (*caml_channel_mutex_unlock_exn) (void); // non-raising
 
 CAMLextern struct channel * caml_all_opened_channels;
 
+// raises
 #define Lock(channel) \
   if (caml_channel_mutex_lock != NULL) (*caml_channel_mutex_lock)(channel)
+
 #define Unlock(channel) \
   if (caml_channel_mutex_unlock != NULL) (*caml_channel_mutex_unlock)(channel)
 #define Unlock_exn() \

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -34,16 +34,30 @@ extern unsigned short caml_win32_revision;
    [flags] indicates whether [fd] is a socket
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
-   Return number of bytes read.
-   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
+   Return number of bytes read or -1.
+   In case of error, sets [exn] to an encoded exception value
+   [Sys_error], [Sys_blocked_io] or an exception raised from a signal
+   handler, if any. If the return value is -1 then [exn] contains an
+   encoded exception.  */
+extern int caml_read_fd_exn(int fd, int flags, void * buf, int n, value * exn);
+
+/* Same as [caml_read_fd_exn], but immediately raises the exception
+   if any, and never returns -1. */
 extern int caml_read_fd(int fd, int flags, void * buf, int n);
 
 /* Write at most [n] bytes from buffer [buf] onto file descriptor [fd].
    [flags] indicates whether [fd] is a socket
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
-   Return number of bytes written.
-   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
+   Return number of bytes written or -1.
+   In case of error, sets [exn] to an encoded exception value
+   [Sys_error], [Sys_blocked_io] or an exception raised from a signal
+   handler, if any. If the return value is -1 then [exn] contains an
+   encoded exception. */
+extern int caml_write_fd_exn(int fd, int flags, void * buf, int n, value * exn);
+
+/* Same as [caml_write_fd_exn], but immediately raises the exception
+   if any, and never returns -1. */
 extern int caml_write_fd(int fd, int flags, void * buf, int n);
 
 /* Decompose the given path into a list of directories, and add them

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -30,8 +30,17 @@
 extern "C" {
 #endif
 
-CAMLextern void caml_enter_blocking_section (void);
-CAMLextern void caml_leave_blocking_section (void);
+CAMLextern void caml_enter_blocking_section (void); // raises
+CAMLextern void caml_leave_blocking_section (void); // raises
+
+CAMLextern value caml_enter_blocking_section_exn (void);
+/* Same as [caml_enter_blocking_section], but return the exception if
+   any. The runtime lock is held upon return if and only if the result
+   satisfies Is_exception_result. */
+
+CAMLextern value caml_leave_blocking_section_exn (void);
+/* Same as [caml_leave_blocking_section], but return the exception if
+   any. The runtime lock is held upon return in all cases. */
 
 CAMLextern void caml_process_pending_actions (void);
 /* Checks for pending actions and executes them. This includes pending

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -93,6 +93,9 @@ value caml_process_pending_actions_with_root (value extra_root); // raises
 int caml_set_signal_action(int signo, int action);
 void caml_setup_stack_overflow_detection(void);
 
+void caml_enter_blocking_section_noexn (void);
+void caml_leave_blocking_section_noexn (void);
+
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);
 CAMLextern int (*caml_try_leave_blocking_section_hook)(void);

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -30,9 +30,9 @@ CAMLnoreturn_start
 CAMLextern void caml_sys_error (value)
 CAMLnoreturn_end;
 
-CAMLnoreturn_start
-CAMLextern void caml_sys_io_error (value)
-CAMLnoreturn_end;
+CAMLextern value caml_sys_error_exn (value);
+
+CAMLextern value caml_sys_io_error_exn (value);
 
 CAMLextern double caml_sys_time_unboxed(value);
 CAMLextern void caml_sys_init (char_os * exe_name, char_os ** argv);

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -156,6 +156,7 @@ static void open_connection(void)
 
 static void close_connection(void)
 {
+  // FIXME prevent leak with masking
   caml_close_channel(dbg_in);
   caml_close_channel(dbg_out);
   dbg_socket = -1;              /* was closed by caml_close_channel */

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -102,6 +102,7 @@ static struct skiplist event_points_table = SKIPLIST_STATIC_INITIALIZER;
 
 static void open_connection(void)
 {
+  int dbg_socket_in;
 #ifdef _WIN32
   /* Set socket to synchronous mode so that file descriptor-oriented
      functions (read()/write() etc.) can be used */
@@ -139,7 +140,10 @@ static void open_connection(void)
   if (dbg_socket == -1)
     caml_fatal_error("_open_osfhandle failed");
 #endif
-  dbg_in = caml_open_descriptor_in(dbg_socket);
+  dbg_socket_in = dup(dbg_socket);
+  if (dbg_socket_in == -1)
+    caml_fatal_error("dup failed");
+  dbg_in = caml_open_descriptor_in(dbg_socket_in);
   dbg_out = caml_open_descriptor_out(dbg_socket);
   if (!caml_debugger_in_use) caml_putword(dbg_out, -1); /* first connection */
 #ifdef _WIN32

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -101,9 +101,11 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
   CAMLreturn(res);
 
  cleanup2:
-  // TODO: blocking section with masking
-  if (dlhandle)
+  if (dlhandle) {
+    caml_enter_blocking_section_noexn();
     caml_dlclose(dlhandle);
+    caml_leave_blocking_section_noexn();
+  }
  cleanup1:
   caml_stat_free(p);
   caml_raise(Extract_exception(exn));
@@ -183,9 +185,11 @@ CAMLprim value caml_natdynlink_run_toplevel(value filename, value symbol)
   CAMLreturn(res);
 
  cleanup2:
-  // TODO: blocking section with masking
-  if (handle)
+  if (handle) {
+    caml_enter_blocking_section_noexn();
     caml_dlclose(handle);
+    caml_leave_blocking_section_noexn();
+  }
  cleanup1:
   caml_stat_free(p);
   caml_raise(Extract_exception(exn));

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -71,21 +71,25 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
   void *sym;
   void *dlhandle;
   char_os *p;
-
-  /* TODO: dlclose in case of error... */
+  value exn;
 
   p = caml_stat_strdup_to_os(String_val(filename));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup1;
   dlhandle = caml_dlopen(p, 1, Int_val(global));
-  caml_leave_blocking_section();
-  caml_stat_free(p);
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup2;
 
-  if (NULL == dlhandle)
-    caml_failwith(caml_dlerror());
+  if (NULL == dlhandle) {
+    exn = caml_failwith_exn(caml_dlerror());
+    goto cleanup2;
+  }
 
   sym = caml_dlsym(dlhandle, "caml_plugin_header");
-  if (NULL == sym)
-    caml_failwith("not an OCaml plugin");
+  if (NULL == sym) {
+    exn = caml_failwith_exn("not an OCaml plugin");
+    goto cleanup2;
+  }
 
   handle = Val_handle(dlhandle);
   header = caml_input_value_from_block(sym, INT_MAX);
@@ -93,7 +97,16 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
   res = caml_alloc_tuple(2);
   Field(res, 0) = handle;
   Field(res, 1) = header;
+  caml_stat_free(p);
   CAMLreturn(res);
+
+ cleanup2:
+  // TODO: blocking section with masking
+  if (dlhandle)
+    caml_dlclose(dlhandle);
+ cleanup1:
+  caml_stat_free(p);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
@@ -147,13 +160,14 @@ CAMLprim value caml_natdynlink_run_toplevel(value filename, value symbol)
   CAMLlocal3 (res, v, handle_v);
   void *handle;
   char_os *p;
-
-  /* TODO: dlclose in case of error... */
+  value exn;
 
   p = caml_stat_strdup_to_os(String_val(filename));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup1;
   handle = caml_dlopen(p, 1, 1);
-  caml_leave_blocking_section();
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup2;
   caml_stat_free(p);
 
   if (NULL == handle) {
@@ -167,6 +181,14 @@ CAMLprim value caml_natdynlink_run_toplevel(value filename, value symbol)
     Store_field(res, 0, v);
   }
   CAMLreturn(res);
+
+ cleanup2:
+  // TODO: blocking section with masking
+  if (handle)
+    caml_dlclose(handle);
+ cleanup1:
+  caml_stat_free(p);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_natdynlink_loadsym(value symbol)

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+/* Raising exceptions from C. */
+
+#include "caml/alloc.h"
+#include "caml/fail.h"
+#include "caml/memory.h"
+#include "caml/mlvalues.h"
+
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan
+CAMLexport void caml_raise_constant(value tag)
+{
+  caml_raise(tag);
+}
+
+CAMLexport void caml_raise_with_arg(value tag, value arg)
+{
+  CAMLparam2 (tag, arg);
+  CAMLlocal1 (bucket);
+
+  bucket = caml_alloc_small (2, 0);
+  Field(bucket, 0) = tag;
+  Field(bucket, 1) = arg;
+  caml_raise(bucket);
+  CAMLnoreturn;
+}
+
+CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
+{
+  CAMLparam1 (tag);
+  CAMLxparamN (args, nargs);
+  value bucket;
+  int i;
+
+  CAMLassert(1 + nargs <= Max_young_wosize);
+  bucket = caml_alloc_small (1 + nargs, 0);
+  Field(bucket, 0) = tag;
+  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
+  caml_raise(bucket);
+  CAMLnoreturn;
+}
+
+CAMLexport void caml_raise_with_string(value tag, char const *msg)
+{
+  CAMLparam1(tag);
+  value v_msg = caml_copy_string(msg);
+  caml_raise_with_arg(tag, v_msg);
+  CAMLnoreturn;
+}
+
+CAMLexport value caml_raise_if_exception(value val)
+{
+  if (Is_exception_result(val)) caml_raise(Extract_exception(val));
+  return val;
+}

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -68,12 +68,11 @@ CAMLexport value caml_raise_if_exception(value val)
   return val;
 }
 
-
 CAMLnoreturn_start
-static inline void raise_encoded(value)
+Caml_inline void raise_encoded(value)
 CAMLnoreturn_end;
 
-static inline void raise_encoded(value exn)
+Caml_inline void raise_encoded(value exn)
 {
   CAMLassert(Is_exception_result(exn));
   caml_raise(Extract_exception(exn));

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -30,7 +30,7 @@ CAMLexport void caml_raise_constant(value tag)
   caml_raise(tag);
 }
 
-CAMLexport void caml_raise_with_arg(value tag, value arg)
+CAMLexport value caml_raise_with_arg_exn(value tag, value arg)
 {
   CAMLparam2 (tag, arg);
   CAMLlocal1 (bucket);
@@ -38,11 +38,10 @@ CAMLexport void caml_raise_with_arg(value tag, value arg)
   bucket = caml_alloc_small (2, 0);
   Field(bucket, 0) = tag;
   Field(bucket, 1) = arg;
-  caml_raise(bucket);
-  CAMLnoreturn;
+  CAMLreturn(Make_exception_result(bucket));
 }
 
-CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
+CAMLexport value caml_raise_with_args_exn(value tag, int nargs, value args[])
 {
   CAMLparam1 (tag);
   CAMLxparamN (args, nargs);
@@ -53,20 +52,104 @@ CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
   bucket = caml_alloc_small (1 + nargs, 0);
   Field(bucket, 0) = tag;
   for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
-  caml_raise(bucket);
-  CAMLnoreturn;
+  CAMLreturn(Make_exception_result(bucket));
 }
 
-CAMLexport void caml_raise_with_string(value tag, char const *msg)
+CAMLexport value caml_raise_with_string_exn(value tag, char const *msg)
 {
   CAMLparam1(tag);
   value v_msg = caml_copy_string(msg);
-  caml_raise_with_arg(tag, v_msg);
-  CAMLnoreturn;
+  CAMLreturn(caml_raise_with_arg_exn(tag, v_msg));
 }
 
 CAMLexport value caml_raise_if_exception(value val)
 {
   if (Is_exception_result(val)) caml_raise(Extract_exception(val));
   return val;
+}
+
+
+CAMLnoreturn_start
+static inline void raise_encoded(value)
+CAMLnoreturn_end;
+
+static inline void raise_encoded(value exn)
+{
+  CAMLassert(Is_exception_result(exn));
+  caml_raise(Extract_exception(exn));
+}
+
+CAMLexport void caml_raise_with_arg(value tag, value arg)
+{
+  raise_encoded(caml_raise_with_arg_exn(tag, arg));
+}
+
+CAMLexport void caml_raise_with_args(value tag, int nargs, value arg[])
+{
+  raise_encoded(caml_raise_with_args_exn(tag, nargs, arg));
+}
+
+CAMLexport void caml_raise_with_string(value tag, char const * msg)
+{
+  raise_encoded(caml_raise_with_string_exn(tag, msg));
+}
+
+CAMLexport void caml_failwith(char const *msg)
+{
+  raise_encoded(caml_failwith_exn(msg));
+}
+
+CAMLexport void caml_failwith_value(value msg)
+{
+  raise_encoded(caml_failwith_value_exn(msg));
+}
+
+CAMLexport void caml_invalid_argument(char const *msg)
+{
+  raise_encoded(caml_invalid_argument_exn(msg));
+}
+
+CAMLexport void caml_invalid_argument_value(value msg)
+{
+  raise_encoded(caml_invalid_argument_value_exn(msg));
+}
+
+CAMLexport void caml_raise_out_of_memory(void)
+{
+  raise_encoded(caml_raise_out_of_memory_exn());
+}
+
+CAMLexport void caml_raise_stack_overflow(void)
+{
+  raise_encoded(caml_raise_stack_overflow_exn());
+}
+
+CAMLexport void caml_raise_sys_error(value msg)
+{
+  raise_encoded(caml_raise_sys_error_exn(msg));
+}
+
+CAMLexport void caml_raise_end_of_file(void)
+{
+  raise_encoded(caml_raise_end_of_file_exn());
+}
+
+CAMLexport void caml_raise_zero_divide(void)
+{
+  raise_encoded(caml_raise_zero_divide_exn());
+}
+
+CAMLexport void caml_raise_not_found(void)
+{
+  raise_encoded(caml_raise_not_found_exn());
+}
+
+CAMLexport void caml_array_bound_error(void)
+{
+  raise_encoded(caml_array_bound_error_exn());
+}
+
+CAMLexport void caml_raise_sys_blocked_io(void)
+{
+  raise_encoded(caml_raise_sys_blocked_io_exn());
 }

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -39,46 +39,6 @@ CAMLexport void caml_raise(value v)
   siglongjmp(Caml_state->external_raise->buf, 1);
 }
 
-CAMLexport void caml_raise_constant(value tag)
-{
-  caml_raise(tag);
-}
-
-CAMLexport void caml_raise_with_arg(value tag, value arg)
-{
-  CAMLparam2 (tag, arg);
-  CAMLlocal1 (bucket);
-
-  bucket = caml_alloc_small (2, 0);
-  Field(bucket, 0) = tag;
-  Field(bucket, 1) = arg;
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
-{
-  CAMLparam1 (tag);
-  CAMLxparamN (args, nargs);
-  value bucket;
-  int i;
-
-  CAMLassert(1 + nargs <= Max_young_wosize);
-  bucket = caml_alloc_small (1 + nargs, 0);
-  Field(bucket, 0) = tag;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-CAMLexport void caml_raise_with_string(value tag, char const *msg)
-{
-  CAMLparam1(tag);
-  value v_msg = caml_copy_string(msg);
-  caml_raise_with_arg(tag, v_msg);
-  CAMLnoreturn;
-}
-
 /* PR#5115: Built-in exceptions can be triggered by input_value
    while reading the initial value of [caml_global_data].
 
@@ -188,12 +148,6 @@ CAMLexport void caml_raise_sys_blocked_io(void)
 {
   check_global_data("Sys_blocked_io");
   caml_raise_constant(Field(caml_global_data, SYS_BLOCKED_IO));
-}
-
-value caml_raise_if_exception(value res)
-{
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
-  return res;
 }
 
 int caml_is_special_exception(value exn) {

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -71,17 +71,16 @@ Caml_inline value caml_get_failwith_tag (char const *msg)
   return Field(caml_global_data, FAILURE_EXN);
 }
 
-CAMLexport void caml_failwith (char const *msg)
+CAMLexport value caml_failwith_exn (char const *msg)
 {
-  caml_raise_with_string(caml_get_failwith_tag(msg), msg);
+  return caml_raise_with_string_exn(caml_get_failwith_tag(msg), msg);
 }
 
-CAMLexport void caml_failwith_value (value msg)
+CAMLexport value caml_failwith_value_exn (value msg)
 {
   CAMLparam1(msg);
   value tag = caml_get_failwith_tag(String_val(msg));
-  caml_raise_with_arg(tag, msg);
-  CAMLnoreturn;
+  CAMLreturn(caml_raise_with_arg_exn(tag, msg));
 }
 
 Caml_inline value caml_get_invalid_argument_tag (char const *msg)
@@ -90,64 +89,63 @@ Caml_inline value caml_get_invalid_argument_tag (char const *msg)
   return Field(caml_global_data, INVALID_EXN);
 }
 
-CAMLexport void caml_invalid_argument (char const *msg)
+CAMLexport value caml_invalid_argument_exn (char const *msg)
 {
-  caml_raise_with_string(caml_get_invalid_argument_tag(msg), msg);
+  return caml_raise_with_string_exn(caml_get_invalid_argument_tag(msg), msg);
 }
 
-CAMLexport void caml_invalid_argument_value (value msg)
+CAMLexport value caml_invalid_argument_value_exn (value msg)
 {
   CAMLparam1(msg);
   value tag = caml_get_invalid_argument_tag(String_val(msg));
-  caml_raise_with_arg(tag, msg);
-  CAMLnoreturn;
+  CAMLreturn(caml_raise_with_arg_exn(tag, msg));
 }
 
-CAMLexport void caml_array_bound_error(void)
+CAMLexport value caml_array_bound_error_exn(void)
 {
-  caml_invalid_argument("index out of bounds");
+  return caml_invalid_argument_exn("index out of bounds");
 }
 
-CAMLexport void caml_raise_out_of_memory(void)
+CAMLexport value caml_raise_out_of_memory_exn(void)
 {
   check_global_data("Out_of_memory");
-  caml_raise_constant(Field(caml_global_data, OUT_OF_MEMORY_EXN));
+  return Make_exception_result(Field(caml_global_data, OUT_OF_MEMORY_EXN));
 }
 
-CAMLexport void caml_raise_stack_overflow(void)
+CAMLexport value caml_raise_stack_overflow_exn(void)
 {
   check_global_data("Stack_overflow");
-  caml_raise_constant(Field(caml_global_data, STACK_OVERFLOW_EXN));
+  return Make_exception_result(Field(caml_global_data, STACK_OVERFLOW_EXN));
 }
 
-CAMLexport void caml_raise_sys_error(value msg)
+CAMLexport value caml_raise_sys_error_exn(value msg)
 {
   check_global_data_param("Sys_error", String_val(msg));
-  caml_raise_with_arg(Field(caml_global_data, SYS_ERROR_EXN), msg);
+  return caml_raise_with_arg_exn(Field(caml_global_data, SYS_ERROR_EXN), msg);
 }
 
-CAMLexport void caml_raise_end_of_file(void)
+CAMLexport value caml_raise_end_of_file_exn(void)
 {
   check_global_data("End_of_file");
-  caml_raise_constant(Field(caml_global_data, END_OF_FILE_EXN));
+  return Make_exception_result(Field(caml_global_data, END_OF_FILE_EXN));
 }
 
-CAMLexport void caml_raise_zero_divide(void)
+CAMLexport value caml_raise_zero_divide_exn(void)
 {
   check_global_data("Division_by_zero");
-  caml_raise_constant(Field(caml_global_data, ZERO_DIVIDE_EXN));
+  return Make_exception_result(Field(caml_global_data, ZERO_DIVIDE_EXN));
 }
 
-CAMLexport void caml_raise_not_found(void)
+CAMLexport value caml_raise_not_found_exn(void)
 {
   check_global_data("Not_found");
-  caml_raise_constant(Field(caml_global_data, NOT_FOUND_EXN));
+  return Make_exception_result(Field(caml_global_data, NOT_FOUND_EXN));
 }
 
-CAMLexport void caml_raise_sys_blocked_io(void)
+CAMLexport value caml_raise_sys_blocked_io_exn(void)
 {
   check_global_data("Sys_blocked_io");
-  caml_raise_constant(Field(caml_global_data, SYS_BLOCKED_IO));
+  return Make_exception_result(Field(caml_global_data, SYS_BLOCKED_IO));
 }
 
 int caml_is_special_exception(value exn) {

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -72,82 +72,82 @@ void caml_raise(value v)
   caml_raise_exception(Caml_state, v);
 }
 
-void caml_failwith (char const *msg)
+value caml_failwith_exn(char const *msg)
 {
-  caml_raise_with_string((value) caml_exn_Failure, msg);
+  return caml_raise_with_string_exn((value) caml_exn_Failure, msg);
 }
 
-void caml_failwith_value (value msg)
+value caml_failwith_value_exn(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Failure, msg);
+  return caml_raise_with_arg_exn((value) caml_exn_Failure, msg);
 }
 
-void caml_invalid_argument (char const *msg)
+value caml_invalid_argument_exn(char const *msg)
 {
-  caml_raise_with_string((value) caml_exn_Invalid_argument, msg);
+  return caml_raise_with_string_exn((value) caml_exn_Invalid_argument, msg);
 }
 
-void caml_invalid_argument_value (value msg)
+value caml_invalid_argument_value_exn(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Invalid_argument, msg);
+  return caml_raise_with_arg_exn((value) caml_exn_Invalid_argument, msg);
 }
 
-void caml_raise_out_of_memory(void)
+value caml_raise_out_of_memory_exn(void)
 {
-  caml_raise_constant((value) caml_exn_Out_of_memory);
+  return Make_exception_result((value) caml_exn_Out_of_memory);
 }
 
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
 CAMLno_asan
-void caml_raise_stack_overflow(void)
+value caml_raise_stack_overflow_exn(void)
 {
-  caml_raise_constant((value) caml_exn_Stack_overflow);
+  return Make_exception_result((value) caml_exn_Stack_overflow);
 }
 
-void caml_raise_sys_error(value msg)
+value caml_raise_sys_error_exn(value msg)
 {
-  caml_raise_with_arg((value) caml_exn_Sys_error, msg);
+  return caml_raise_with_arg_exn((value) caml_exn_Sys_error, msg);
 }
 
-void caml_raise_end_of_file(void)
+value caml_raise_end_of_file_exn(void)
 {
-  caml_raise_constant((value) caml_exn_End_of_file);
+  return Make_exception_result((value) caml_exn_End_of_file);
 }
 
-void caml_raise_zero_divide(void)
+value caml_raise_zero_divide_exn(void)
 {
-  caml_raise_constant((value) caml_exn_Division_by_zero);
+  return Make_exception_result((value) caml_exn_Division_by_zero);
 }
 
-void caml_raise_not_found(void)
+value caml_raise_not_found_exn(void)
 {
-  caml_raise_constant((value) caml_exn_Not_found);
+  return Make_exception_result((value) caml_exn_Not_found);
 }
 
-void caml_raise_sys_blocked_io(void)
+value caml_raise_sys_blocked_io_exn(void)
 {
-  caml_raise_constant((value) caml_exn_Sys_blocked_io);
+  return Make_exception_result((value) caml_exn_Sys_blocked_io);
 }
 
 /* We use a pre-allocated exception because we can't
    do a GC before the exception is raised (lack of stack descriptors
    for the ccall to [caml_array_bound_error]).  */
 
-static const value * caml_array_bound_error_exn = NULL;
+static const value * caml_array_bound_error_exception = NULL;
 
-void caml_array_bound_error(void)
+value caml_array_bound_error_exn(void)
 {
-  if (caml_array_bound_error_exn == NULL) {
-    caml_array_bound_error_exn =
+  if (caml_array_bound_error_exception == NULL) {
+    caml_array_bound_error_exception =
       caml_named_value("Pervasives.array_bound_error");
-    if (caml_array_bound_error_exn == NULL) {
+    if (caml_array_bound_error_exception == NULL) {
       fprintf(stderr, "Fatal error: exception "
                       "Invalid_argument(\"index out of bounds\")\n");
       exit(2);
     }
   }
-  caml_raise(*caml_array_bound_error_exn);
+  return Make_exception_result(*caml_array_bound_error_exception);
 }
 
 int caml_is_special_exception(value exn) {

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -72,49 +72,6 @@ void caml_raise(value v)
   caml_raise_exception(Caml_state, v);
 }
 
-/* Used by the stack overflow handler -> deactivate ASAN (see
-   segv_handler in signals_nat.c). */
-CAMLno_asan
-void caml_raise_constant(value tag)
-{
-  caml_raise(tag);
-}
-
-void caml_raise_with_arg(value tag, value arg)
-{
-  CAMLparam2 (tag, arg);
-  CAMLlocal1 (bucket);
-
-  bucket = caml_alloc_small (2, 0);
-  Field(bucket, 0) = tag;
-  Field(bucket, 1) = arg;
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-void caml_raise_with_args(value tag, int nargs, value args[])
-{
-  CAMLparam1 (tag);
-  CAMLxparamN (args, nargs);
-  value bucket;
-  int i;
-
-  CAMLassert(1 + nargs <= Max_young_wosize);
-  bucket = caml_alloc_small (1 + nargs, 0);
-  Field(bucket, 0) = tag;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
-  caml_raise(bucket);
-  CAMLnoreturn;
-}
-
-void caml_raise_with_string(value tag, char const *msg)
-{
-  CAMLparam1(tag);
-  value v_msg = caml_copy_string(msg);
-  caml_raise_with_arg(tag, v_msg);
-  CAMLnoreturn;
-}
-
 void caml_failwith (char const *msg)
 {
   caml_raise_with_string((value) caml_exn_Failure, msg);
@@ -171,12 +128,6 @@ void caml_raise_not_found(void)
 void caml_raise_sys_blocked_io(void)
 {
   caml_raise_constant((value) caml_exn_Sys_blocked_io);
-}
-
-value caml_raise_if_exception(value res)
-{
-  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
-  return res;
 }
 
 /* We use a pre-allocated exception because we can't

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -186,6 +186,15 @@ CAMLexport int caml_channel_binary_mode(struct channel *channel)
 
 /* Output */
 
+CAMLexport int caml_write_fd(int fd, int flags, void * buf, int n)
+{
+  value exn = Val_unit;
+  int retcode = caml_write_fd_exn(fd, flags, buf, n, &exn);
+  caml_raise_if_exception(exn);
+  CAMLassert(retcode > 0);
+  return retcode;
+}
+
 /* Attempt to flush the buffer. This will make room in the buffer for
    at least one character. Returns true if the buffer is empty at the
    end of the flush, or false if some data remains in the buffer.
@@ -282,6 +291,15 @@ CAMLexport file_offset caml_pos_out(struct channel *channel)
 }
 
 /* Input */
+
+CAMLexport int caml_read_fd(int fd, int flags, void * buf, int n)
+{
+  value exn = Val_unit;
+  int retcode = caml_read_fd_exn(fd, flags, buf, n, &exn);
+  caml_raise_if_exception(exn);
+  CAMLassert(retcode >= 0);
+  return retcode;
+}
 
 /* caml_do_read is exported for Cash */
 CAMLexport int caml_do_read(int fd, char *p, unsigned int n)

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -97,7 +97,9 @@ CAMLexport struct channel * caml_open_descriptor_in_exn(int fd, value * exn)
 
  cleanup:
   caml_stat_free(channel);
+  caml_enter_blocking_section_noexn();
   close(fd);
+  caml_leave_blocking_section_noexn();
   return NULL;
 }
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -180,6 +180,11 @@ CAMLexport value caml_enter_blocking_section_exn(void)
   return Val_unit;
 }
 
+void caml_enter_blocking_section_noexn(void)
+{
+  caml_enter_blocking_section_hook ();
+}
+
 CAMLexport void caml_enter_blocking_section(void)
 {
   caml_raise_if_exception(caml_enter_blocking_section_exn());
@@ -210,6 +215,15 @@ CAMLexport value caml_leave_blocking_section_exn(void)
 
   errno = saved_errno;
   return exn;
+}
+
+void caml_leave_blocking_section_noexn(void)
+{
+  int saved_errno;
+  saved_errno = errno;
+  caml_leave_blocking_section_hook ();
+  signals_are_pending = 1;
+  errno = saved_errno;
 }
 
 CAMLexport void caml_leave_blocking_section(void)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -165,21 +165,29 @@ CAMLexport int (*caml_try_leave_blocking_section_hook)(void) =
    caml_try_leave_blocking_section_default;
 
 CAMLno_tsan /* The read of [caml_something_to_do] is not synchronized. */
-CAMLexport void caml_enter_blocking_section(void)
+CAMLexport value caml_enter_blocking_section_exn(void)
 {
   while (1){
     /* Process all pending signals now */
-    caml_raise_if_exception(caml_process_pending_signals_exn());
+    value exn = caml_process_pending_signals_exn();
+    if (Is_exception_result(exn)) return exn;
     caml_enter_blocking_section_hook ();
     /* Check again for pending signals.
        If none, done; otherwise, try again */
     if (! signals_are_pending) break;
     caml_leave_blocking_section_hook ();
   }
+  return Val_unit;
 }
 
-CAMLexport void caml_leave_blocking_section(void)
+CAMLexport void caml_enter_blocking_section(void)
 {
+  caml_raise_if_exception(caml_enter_blocking_section_exn());
+}
+
+CAMLexport value caml_leave_blocking_section_exn(void)
+{
+  value exn;
   int saved_errno;
   /* Save the value of errno (PR#5982). */
   saved_errno = errno;
@@ -198,9 +206,15 @@ CAMLexport void caml_leave_blocking_section(void)
      [signals_are_pending] is 0 but the signal needs to be
      handled at this point. */
   signals_are_pending = 1;
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  exn = caml_process_pending_signals_exn();
 
   errno = saved_errno;
+  return exn;
+}
+
+CAMLexport void caml_leave_blocking_section(void)
+{
+  caml_raise_if_exception(caml_leave_blocking_section_exn());
 }
 
 /* Execute a signal handler immediately */

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -72,7 +72,7 @@ static char * error_message(void)
 #define EWOULDBLOCK (-1)
 #endif
 
-CAMLexport void caml_sys_error(value arg)
+CAMLexport value caml_sys_error_exn(value arg)
 {
   CAMLparam1 (arg);
   char * err;
@@ -89,16 +89,20 @@ CAMLexport void caml_sys_error(value arg)
     memmove(&Byte(str, arg_len), ": ", 2);
     memmove(&Byte(str, arg_len + 2), err, err_len);
   }
-  caml_raise_sys_error(str);
-  CAMLnoreturn;
+  CAMLreturn (caml_raise_sys_error_exn(str));
 }
 
-CAMLexport void caml_sys_io_error(value arg)
+CAMLexport void caml_sys_error(value arg)
+{
+  caml_raise(Extract_exception(caml_sys_error_exn(arg)));
+}
+
+CAMLexport value caml_sys_io_error_exn(value arg)
 {
   if (errno == EAGAIN || errno == EWOULDBLOCK) {
-    caml_raise_sys_blocked_io();
+    return caml_raise_sys_blocked_io_exn();
   } else {
-    caml_sys_error(arg);
+    return caml_sys_error_exn(arg);
   }
 }
 

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -229,10 +229,17 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
 CAMLprim value caml_sys_close(value fd_v)
 {
   int fd = Int_val(fd_v);
-  caml_enter_blocking_section();
+  value exn;
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   close(fd);
   caml_leave_blocking_section();
   return Val_unit;
+
+ cleanup:
+  // TODO: blocking & masked
+  close(fd);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_sys_file_exists(value name)
@@ -244,15 +251,22 @@ CAMLprim value caml_sys_file_exists(value name)
 #endif
   char_os * p;
   int ret;
+  value exn;
 
   if (! caml_string_is_c_safe(name)) return Val_false;
   p = caml_stat_strdup_to_os(String_val(name));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   ret = stat_os(p, &st);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
 
+  caml_stat_free(p);
   return Val_bool(ret == 0);
+
+ cleanup:
+  caml_stat_free(p);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_sys_is_directory(value name)
@@ -265,12 +279,16 @@ CAMLprim value caml_sys_is_directory(value name)
 #endif
   char_os * p;
   int ret;
+  value exn;
 
   caml_sys_check_path(name);
   p = caml_stat_strdup_to_os(String_val(name));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   ret = stat_os(p, &st);
-  caml_leave_blocking_section();
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
+
   caml_stat_free(p);
 
   if (ret == -1) caml_sys_error(name);
@@ -279,6 +297,10 @@ CAMLprim value caml_sys_is_directory(value name)
 #else
   CAMLreturn(Val_bool(st.st_mode & S_IFDIR));
 #endif
+
+ cleanup:
+  caml_stat_free(p);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_sys_remove(value name)
@@ -286,14 +308,22 @@ CAMLprim value caml_sys_remove(value name)
   CAMLparam1(name);
   char_os * p;
   int ret;
+  value exn;
+
   caml_sys_check_path(name);
   p = caml_stat_strdup_to_os(String_val(name));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   ret = unlink_os(p);
-  caml_leave_blocking_section();
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   caml_stat_free(p);
   if (ret != 0) caml_sys_error(name);
   CAMLreturn(Val_unit);
+
+ cleanup:
+  caml_stat_free(p);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_sys_rename(value oldname, value newname)
@@ -301,18 +331,26 @@ CAMLprim value caml_sys_rename(value oldname, value newname)
   char_os * p_old;
   char_os * p_new;
   int ret;
+  value exn;
   caml_sys_check_path(oldname);
   caml_sys_check_path(newname);
   p_old = caml_stat_strdup_to_os(String_val(oldname));
   p_new = caml_stat_strdup_to_os(String_val(newname));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   ret = rename_os(p_old, p_new);
-  caml_leave_blocking_section();
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   caml_stat_free(p_new);
   caml_stat_free(p_old);
   if (ret != 0)
     caml_sys_error(NO_ARG);
   return Val_unit;
+
+ cleanup:
+  caml_stat_free(p_new);
+  caml_stat_free(p_old);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_sys_chdir(value dirname)
@@ -320,14 +358,21 @@ CAMLprim value caml_sys_chdir(value dirname)
   CAMLparam1(dirname);
   char_os * p;
   int ret;
+  value exn;
   caml_sys_check_path(dirname);
   p = caml_stat_strdup_to_os(String_val(dirname));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   ret = chdir_os(p);
-  caml_leave_blocking_section();
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   caml_stat_free(p);
   if (ret != 0) caml_sys_error(dirname);
   CAMLreturn(Val_unit);
+
+ cleanup:
+  caml_stat_free(p);
+  caml_raise(Extract_exception(exn));
 }
 
 CAMLprim value caml_sys_getcwd(value unit)
@@ -638,13 +683,16 @@ CAMLprim value caml_sys_read_directory(value path)
   struct ext_table tbl;
   char_os * p;
   int ret;
+  value exn;
 
   caml_sys_check_path(path);
   caml_ext_table_init(&tbl, 50);
   p = caml_stat_strdup_to_os(String_val(path));
-  caml_enter_blocking_section();
+  exn = caml_enter_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   ret = caml_read_directory(p, &tbl);
-  caml_leave_blocking_section();
+  exn = caml_leave_blocking_section_exn();
+  if (Is_exception_result(exn)) goto cleanup;
   caml_stat_free(p);
   if (ret == -1){
     caml_ext_table_free(&tbl, 1);
@@ -654,6 +702,11 @@ CAMLprim value caml_sys_read_directory(value path)
   result = caml_copy_string_array((char const **) tbl.contents);
   caml_ext_table_free(&tbl, 1);
   CAMLreturn(result);
+
+ cleanup:
+  caml_stat_free(p);
+  caml_ext_table_free(&tbl, 1);
+  caml_raise(Extract_exception(exn));
 }
 
 /* Return true if the value is a filedescriptor (int) that is

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -218,9 +218,9 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
   CAMLreturn(Val_long(fd));
 
  cleanup2:
-  // FIXME: inside blocking section with masking
+  caml_enter_blocking_section_noexn();
   close(fd);
-  // fall through
+  caml_leave_blocking_section_noexn();
  cleanup1:
   caml_stat_free(p);
   caml_raise(Extract_exception(exn));
@@ -237,8 +237,9 @@ CAMLprim value caml_sys_close(value fd_v)
   return Val_unit;
 
  cleanup:
-  // TODO: blocking & masked
+  caml_enter_blocking_section_noexn();
   close(fd);
+  caml_leave_blocking_section_noexn();
   caml_raise(Extract_exception(exn));
 }
 


### PR DESCRIPTION
This PR continues with the resource-safe C interface to allow writing resource-safe C functions in the presence of asynchronous exceptions. The ultimately goal is to make runtime correct in the face of asynchronous exceptions. It introduces new `_exn` variants of current functions to allow cleaning-up after asynchronous exceptions, in the public interface:

- `caml_{enter,leave}_blocking_section_exn`.
- Functions from `caml/fail.h` that raise exceptions, e.g. `caml_failwith_exn` and many others.

In the second part, these are used to fix leaks in several places of the runtime. The general strategy is to make the exception raising explicit through error codes / exception monad by replacing raising functions by functions that return encoded exceptions. This has been made possible by the work on making polling predictable in the C API.

This contains a proposal for a public-facing interface. This is best read commit-per-commit, with further details in the commit logs.

Left for future work:
- Audit the runtime for further leaks by documenting all raising C functions with `// raises`. This PR fixes quite a few leaks but those only were obvious ones.
- Do the same for the Out_of_memory exception raised by some allocation functions, and find a general strategy to deal with it.