### PR TITLE
Remove major/mark_weak1 and major/mark_weak2 from mark_slice_name

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -608,9 +608,7 @@ static char *mark_slice_name[] = {
   /* 9 */ NULL,
   /* 10 */  "major/mark_roots",
   /* 11 */  "major/mark_main",
-  /* 12 */  "major/mark_weak1",
-  /* 13 */  "major/mark_weak2",
-  /* 14 */  "major/mark_final",
+  /* 12 */  "major/mark_final",
 };
 #endif
 


### PR DESCRIPTION
The value `mark_slice_name` used by the instrumented runtime to name the various substeps reflected by the `caml_gc_subphase` variable seems to be off.

`mark_slice_name` is defined here and `major/mark_final` equals `14`
https://github.com/ocaml/ocaml/blob/trunk/runtime/major_gc.c#L609

This array is used by the instrumented runtime for logging purpose, accessing the array through the value of `caml_gc_subphase`:
https://github.com/ocaml/ocaml/blob/trunk/runtime/major_gc.c#L795

`caml_gc_subphase` however is only mutated to any of the following values:
https://github.com/ocaml/ocaml/blob/trunk/runtime/caml/major_gc.h#L49

So it seems that two names (`major/mark_weak2` and `major/mark_final`) are not being used. Also `major/mark_weak1` is logged when `major/mark_final` is expected.

It seems the defines were shuffled around when ephemerons were first introduced but this array was not kept up to date:

https://github.com/ocaml/ocaml/commit/d5fffddc638df21e24ecece1ff0883d327037991#diff-64b8b0eb170037392ede80351a5b5779

This PR removes `major/mark_weak1` and `major/mark_weak2` from `mark_slice_name`.