### PR TITLE
In Typecore.type_pat, coalesce `constrs` and `labels` into map

### DIFF
--- a/Changes
+++ b/Changes
@@ -70,12 +70,12 @@ Working version
 - #8928: Move contains_calls and num_stack_slots from Proc to Mach.fundecl
   (Greta Yorsh, review by Florian Angeletti and Vincent Laviron)
 
-- #8959, #8960, #8968: minor refactorings in the typing of patterns:
+- #8959, #8960, #8968, #9008: minor refactorings in the typing of patterns:
   + refactor the {let,pat}_bound_idents* functions
-  + minor bugfix in type_pat
+  + minor bugfixes and simplifications in type_pat
   + refactor the generic pattern-traversal functions
     in Typecore and Typedtree
-  (Gabriel Scherer, review by Thomas Refis)
+  (Gabriel Scherer, review by Thomas Refis, Jacques Garrigue and Florian Angeletti)
 
 - #8975: "ocamltests" files are no longer required or used by
   "ocamltest". Instead, any text file in the testsuite directory containing a

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -998,15 +998,16 @@ let check_scope_escape loc env level ty =
   with Unify trace ->
     raise(Error(loc, env, Pattern_type_clash(trace, None)))
 
+type pattern_names_map =
+    { constrs: (string, Types.constructor_description) Hashtbl.t;
+      labels: (string, Types.label_description) Hashtbl.t }
+
 (* type_pat propagates the expected type as well as maps for
    constructors and labels.
    Unification may update the typing environment. *)
 (* map <> None => called from parmatch: backtrack on or-patterns
    explode > 0 => explode Ppat_any for gadts *)
-type map =
-    { constrs: (string, Types.constructor_description) Hashtbl.t;
-      labels: (string, Types.label_description) Hashtbl.t }
-let rec type_pat : ?exception_allowed:bool -> map:map option ->
+let rec type_pat : ?exception_allowed:bool -> map:pattern_names_map option ->
   no_existentials:existential_restriction option -> mode:type_pat_mode ->
   explode:int -> env:Env.t ref ->
   Parsetree.pattern -> type_expr -> (pattern -> 'a) -> 'a =


### PR DESCRIPTION
This PR is a commit from @garrigue that supersedes and reduces #8969 -- it is less invasive and more consensual.