### PR TITLE
Allow linking empty .cmxa files on MSVC

### DIFF
--- a/Changes
+++ b/Changes
@@ -648,8 +648,10 @@ OCaml 4.11
   avoiding a problem with x87 excess precision in Float.round.
   (Xavier Leroy, review by Sébastien Hinderer)
 
-- #9011: Allow linking .cmxa files with no units on MSVC by not requiring the
-  .lib file to be present.
+* #9011: Do not create .a/.lib files when creating a .cmxa with no modules.
+  macOS ar doesn't support creating empty .a files (#1094) and MSVC doesn't
+  permit .lib files to contain no objects. When linking with a .cmxa containing
+  no modules, it is now not an error for there to be no .a/.lib file.
   (David Allsopp, report by Dimitry Bely, review by Xavier Leroy)
 
 - #9064: Relax the level handling when unifying row fields

--- a/Changes
+++ b/Changes
@@ -648,6 +648,10 @@ OCaml 4.11
   avoiding a problem with x87 excess precision in Float.round.
   (Xavier Leroy, review by Sébastien Hinderer)
 
+- #9011: Allow linking .cmxa files with no units on MSVC by not requiring the
+  .lib file to be present.
+  (David Allsopp, report by Dimitry Bely, review by Xavier Leroy)
+
 - #9064: Relax the level handling when unifying row fields
   (Leo White, review by Jacques Garrigue)
 

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -212,13 +212,12 @@ let scan_file obj_name (tolink, objfiles) = match read_file obj_name with
                reqd)
           infos.lib_units tolink
       and objfiles =
-        if Config.ccomp_type = "msvc"
-        && infos.lib_units = []
+        if infos.lib_units = []
         && not (Sys.file_exists (object_file_name obj_name)) then
-          (* MSVC doesn't support empty .lib files, so there shouldn't be one
-             if the .cmxa contains no units. The file_exists check is added to
-             be ultra-defensive for the case where a user has manually added
-             things to the .lib file *)
+          (* MSVC doesn't support empty .lib files, and macOS struggles to make
+             them (#6550), so there shouldn't be one if the .cmxa contains no
+             units. The file_exists check is added to be ultra-defensive for the
+             case where a user has manually added things to the .a/.lib file *)
           objfiles
         else
           obj_name :: objfiles

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -186,30 +186,43 @@ let read_file obj_name =
   end
   else raise(Error(Not_an_object_file file_name))
 
-let scan_file obj_name tolink = match read_file obj_name with
+let scan_file obj_name (tolink, objfiles) = match read_file obj_name with
   | Unit (file_name,info,crc) ->
       (* This is a .cmx file. It must be linked in any case. *)
       remove_required info.ui_name;
       List.iter (add_required file_name) info.ui_imports_cmx;
-      (info, file_name, crc) :: tolink
+      ((info, file_name, crc) :: tolink, obj_name :: objfiles)
   | Library (file_name,infos) ->
       (* This is an archive file. Each unit contained in it will be linked
          in only if needed. *)
       add_ccobjs (Filename.dirname file_name) infos;
-      List.fold_right
-        (fun (info, crc) reqd ->
-           if info.ui_force_link
-             || !Clflags.link_everything
-             || is_required info.ui_name
-           then begin
-             remove_required info.ui_name;
-             List.iter (add_required (Printf.sprintf "%s(%s)"
-                                        file_name info.ui_name))
-               info.ui_imports_cmx;
-             (info, file_name, crc) :: reqd
-           end else
-             reqd)
-        infos.lib_units tolink
+      let tolink =
+        List.fold_right
+          (fun (info, crc) reqd ->
+             if info.ui_force_link
+               || !Clflags.link_everything
+               || is_required info.ui_name
+             then begin
+               remove_required info.ui_name;
+               List.iter (add_required (Printf.sprintf "%s(%s)"
+                                          file_name info.ui_name))
+                 info.ui_imports_cmx;
+               (info, file_name, crc) :: reqd
+             end else
+               reqd)
+          infos.lib_units tolink
+      and objfiles =
+        if Config.ccomp_type = "msvc"
+        && infos.lib_units = []
+        && not (Sys.file_exists (object_file_name obj_name)) then
+          (* MSVC doesn't support empty .lib files, so there shouldn't be one
+             if the .cmxa contains no units. The file_exists check is added to
+             be ultra-defensive for the case where a user has manually added
+             things to the .lib file *)
+          objfiles
+        else
+          obj_name :: objfiles
+      in (tolink, objfiles)
 
 (* Second pass: generate the startup file and link it with everything else *)
 
@@ -286,13 +299,15 @@ let call_linker_shared file_list output_name =
 
 let link_shared ~ppf_dump objfiles output_name =
   Profile.record_call output_name (fun () ->
-    let units_tolink = List.fold_right scan_file objfiles [] in
+    let units_tolink, objfiles =
+      List.fold_right scan_file objfiles ([], [])
+    in
     List.iter
       (fun (info, file_name, crc) -> check_consistency file_name info crc)
       units_tolink;
     Clflags.ccobjs := !Clflags.ccobjs @ !lib_ccobjs;
     Clflags.all_ccopts := !lib_ccopts @ !Clflags.all_ccopts;
-    let objfiles = List.rev (List.map object_file_name objfiles) @
+    let objfiles = List.rev_map object_file_name objfiles @
       (List.rev !Clflags.ccobjs) in
 
     let startup =
@@ -348,7 +363,9 @@ let link ~ppf_dump objfiles output_name =
       if !Clflags.nopervasives then objfiles
       else if !Clflags.output_c_object then stdlib :: objfiles
       else stdlib :: (objfiles @ [stdexit]) in
-    let units_tolink = List.fold_right scan_file objfiles [] in
+    let units_tolink, objfiles =
+      List.fold_right scan_file objfiles ([], [])
+    in
     Array.iter remove_required Runtimedef.builtin_exceptions;
     begin match extract_missing_globals() with
       [] -> ()

--- a/testsuite/tests/link-test/empty.ml
+++ b/testsuite/tests/link-test/empty.ml
@@ -1,0 +1,29 @@
+(* TEST
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+module = "empty.ml"
+*** ocamlc.byte
+module = ""
+flags = "-a"
+all_modules = ""
+program = "empty.cma"
+**** ocamlc.byte
+flags = ""
+program = "${test_build_directory}/empty.byte"
+all_modules = "empty.cma empty.cmo"
+***** check-ocamlc.byte-output
+* setup-ocamlopt.byte-build-env
+** ocamlopt.byte
+module = "empty.ml"
+*** ocamlopt.byte
+module = ""
+flags = "-a"
+all_modules = ""
+program = "empty.cmxa"
+**** ocamlopt.byte
+flags = ""
+program = "${test_build_directory}/empty.native"
+all_modules = "empty.cmxa empty.cmx"
+***** check-ocamlopt.byte-output
+*)


### PR DESCRIPTION
MSVC .lib format doesn't support having no `.obj` files in the library, so `ocamlopt -o foo.cmxa -a` generates `foo.cmxa` but not `foo.lib` (there's no error from the Microsoft Linker). The resulting `foo.cmxa` is un-linkable, since OCaml passes `foo.lib` on to the linker. This doesn't affect cc-based toolchains since `ar` rather more logically allows empty files!

This patch relaxes the requirement for `foo.lib` if `foo.cmxa` contains no units.

This is part of a fix for https://github.com/ocaml/stdlib-shims/issues/11

cc @db4