### PR TITLE
parmatch: don't rename idents when typing witnesses

### DIFF
--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -7,6 +7,15 @@ File "robustmatch.ml", lines 33-37, characters 6-23:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
+File "robustmatch.ml", lines 43-47, characters 4-21:
+43 | ....match t1, t2, x with
+44 |     | AB,  AB, A -> ()
+45 |     | MAB, _, A -> ()
+46 |     | _,  AB, B -> ()
+47 |     | _, MAB, B -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(AB, MAB, A)
 File "robustmatch.ml", lines 54-56, characters 4-27:
 54 | ....match r1, r2, a with
 55 |     | R1, _, 0 -> ()

--- a/testsuite/tests/typing-misc/pattern_open.ml
+++ b/testsuite/tests/typing-misc/pattern_open.ml
@@ -153,8 +153,10 @@ let () =
 ;;
 [%%expect {|
 val eval : 't Exterior.Gadt.t -> 't = <fun>
-Right function print
-Right function print
+Line 11, characters 18-44:
+11 |       | Exterior.(Gadt.Bool Gadt.Boolean.{b}), _ , true -> print(); true
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Unbound module Gadt
 |}
 ]
 (* existential type *)

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -84,24 +84,13 @@ val complete_constrs :
 
 (** [ppat_of_type] builds an untyped or-pattern from its expected type.
      May raise [Empty] when [type_expr] is an empty variant *)
-val ppat_of_type :
-    Env.t -> type_expr ->
-    Parsetree.pattern *
-    (string, constructor_description) Hashtbl.t *
-    (string, label_description) Hashtbl.t
+val ppat_of_type : Env.t -> type_expr -> Parsetree.pattern
 
 val pressure_variants: Env.t -> pattern list -> unit
 val check_partial:
-    ((string, constructor_description) Hashtbl.t ->
-     (string, label_description) Hashtbl.t ->
-     Parsetree.pattern -> pattern option) ->
-    Location.t -> case list -> partial
+    (Parsetree.pattern -> pattern option) -> Location.t -> case list -> partial
 val check_unused:
-    (bool ->
-     (string, constructor_description) Hashtbl.t ->
-     (string, label_description) Hashtbl.t ->
-     Parsetree.pattern -> pattern option) ->
-    case list -> unit
+    (bool -> Parsetree.pattern -> pattern option) -> case list -> unit
 
 (* Irrefutability tests *)
 val irrefutable : pattern -> bool


### PR DESCRIPTION
I guess this is my alternative #9009 .

Context:
When type_pat is called from `Parmatch` (eg. to type check a pattern which is supposed to cover values not handled by the pattern matching) it is given: an `explode` parameter, a `constrs` parameter and a `labels` parameter (#9009 proposes to regroup these last two.. but not the first one).

These last two parameters are used in various ways:
- to detect whether we're being called from parmatch (in which case, we, for instance, don't want to record annots) ; that is: their value is not useful
- to do the lookup of the constructors and label names present in the part, instead of going through the environment as one usually would.

That last step is a bit surprising: why wouldn't we want to go through the normal lookup process? My initial guess was: so we avoid marking as used candidates that are rejected, and to avoid getting any warnings (type disambiguation might be happening!).
But the code looks like this:
```ocaml
match lid.txt, constrs with
  Longident.Lident s, Some constrs when Hashtbl.mem constrs s ->
    Ok [Hashtbl.find constrs s, (fun () -> ())]
| _ ->
    Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env
```
Which is definitely weird: if the ident is not a simple Lident (e.g. if it contains a dot), or if it's not in the table then we revert back to normal resolving?
Well, turns out that `Parmatch` is "freshening" all the lids (to look `#$ID42`), so the lookup never actually fails. And if it did, then so would the call to `Env.lookup_all_constructors`.

So how about we remove all that extra complexity, and just go through the normal lookup process (taking care to silence warnings beforehand)?

Well, then we get two test failures:
1. some lookups now fail if the source contained some pattern-local open. I believe we can get around that by making the lids absolute when creating the candidate in `Parmatch`. Which should be doable given that we have the type path at that point. (There will be some subtlety regarding inline record fields, and extensible types, but I don't expect any major problem)
2. some match which was marked as exhaustive, is now deemed non exhaustive, namely that one:
```ocaml
  type ab = A | B

  module M : sig
    type mab = A | B

    type _ t = AB : ab t | MAB : mab t

    val ab : mab t
  end = struct
    type mab = ab = A | B

    type _ t = AB : ab t | MAB : mab t

    let ab = AB
  end

  open M

  let f (type x) (t1 : x t) (t2 : x t) (x : x) =
    match t1, t2, x with
    | AB,  AB, A -> 1
    | MAB, _, A -> 2
    | _,  AB, B -> 3
    | _, MAB, B -> 4
```
But as it turns out, the match is indeed non exhaustive!
```
# f M.ab MAB A;;
4
```
Woops.

So what was happening there?
- On this branch, the candidate that is generated is `AB, MAB, A`, which typechecks fine (because `ab` and `M.mab` might be equal).
- On trunk (and older versions) the candidate is `#$AB0, #$MAB1, #$A2`, and we have a `constr` table which contains which associates each of these to the right constructor description.
We then go into type pat, type the first element of the tuple, then the second, then we arrive on the third: so we're in typecore on line 1162 (as of today):
  1. we get the type path through the expected type (it's `x`, also known as `ab`, because the first constructor pattern we saw was `AB`)
  2. we get the constructor description from our table (which in particular has the field `cstr_res = mab`)
  3. we go on to call `Constructor.disambiguate` on that single candidate list. Which tries to do type disambiguation, and that fails (because `ab` is not `mab` from the point of view of disambiguation), so it then tries to lookup the constructor using the type, but that fails (because `#$A2` is not a real constructor), so it... fails.
That is: our candidate as produced by `Parmatch` doesn't typecheck. So it must mean that the matching is exhaustive.  ¯\\_(ツ)_/¯

So the current PR as it stands is unfinished, and here is a summary of the situation:
- it cleans up some weird logic from typecore and parmatch
- it fixes a typechecker big (which currently leads to a miscompilation)
- it introduces a regression in the handling of pattern-local module opens

I have other things on my plate right now, and @gasche seems to be having a lot of fun in that area f the typechecker. So: @gasche why don't you pick things up from here and give a go at fixing the regression (possibly along the lines suggested above, possibly some other way)?