### PR TITLE
Fix #8789

### DIFF
--- a/Changes
+++ b/Changes
@@ -85,6 +85,9 @@ Working version
 - #8992: share argument implementations between executables
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #9015: fix fatal error in pprint_ast (#8789)
+  (Damien Doligez, review by ...)
+
 ### Code generation and optimizations:
 
 - #8990: amd64: Emit 32bit registers for Iconst_int when we can

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1393,7 +1393,10 @@ and structure_item ctxt f x =
               (module_type ctxt) typ
               (module_expr ctxt) expr
               (item_attributes ctxt) pmb.pmb_attributes
-        | _ -> assert false
+        | pmb ->
+            pp f "@[<hov2>@ and@ %s@ =@ %a@]%a" pmb.pmb_name.txt
+              (module_expr ctxt) pmb.pmb_expr
+              (item_attributes ctxt) pmb.pmb_attributes
       in
       begin match decls with
       | ({pmb_expr={pmod_desc=Pmod_constraint (expr, typ)}} as pmb) :: l2 ->
@@ -1401,6 +1404,12 @@ and structure_item ctxt f x =
             pmb.pmb_name.txt
             (module_type ctxt) typ
             (module_expr ctxt) expr
+            (item_attributes ctxt) pmb.pmb_attributes
+            (fun f l2 -> List.iter (aux f) l2) l2
+      | pmb :: l2 ->
+          pp f "@[<hv>@[<hov2>module@ rec@ %s@ =@ %a@]%a@ %a@]"
+            pmb.pmb_name.txt
+            (module_expr ctxt) pmb.pmb_expr
             (item_attributes ctxt) pmb.pmb_attributes
             (fun f l2 -> List.iter (aux f) l2) l2
       | _ -> assert false


### PR DESCRIPTION
The parser accepts some invalid recursive module declarations, so we have to be able to print them.
