### PR TITLE
remove disambiguation for constructor map

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1165,14 +1165,13 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
             Some (p0, p, true)
         with Not_found -> None
       in
-      let candidates =
+      let constr =
         match lid.txt, constrs with
           Longident.Lident s, Some constrs when Hashtbl.mem constrs s ->
-            Ok [Hashtbl.find constrs s, (fun () -> ())]
+            Hashtbl.find constrs s
         | _ ->
-            Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env
-      in
-      let constr =
+        let candidates =
+          Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env in
         wrap_disambiguate "This variant pattern is expected to have"
           (mk_expected expected_ty)
           (Constructor.disambiguate Env.Pattern lid !env opath) candidates

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1167,8 +1167,8 @@ and type_pat_aux ~exception_allowed ~constrs ~labels ~no_existentials ~mode
       in
       let constr =
         match lid.txt, constrs with
-          Longident.Lident s, Some constrs when Hashtbl.mem constrs s ->
-            Hashtbl.find constrs s
+          Longident.Lident s, Some constrs ->
+            assert (Hashtbl.mem constrs s); Hashtbl.find constrs s
         | _ ->
         let candidates =
           Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env in


### PR DESCRIPTION
Simplify code as suggested by @trefis in #9012.
There is no need to disambiguate constructors obtained from the map generated by Parmatch for GADTs, and this is not done for records fields.