### PR TITLE
type_pat: restrict the use of Need_backtrack

### DIFF
--- a/Changes
+++ b/Changes
@@ -70,12 +70,14 @@ Working version
 - #8928: Move contains_calls and num_stack_slots from Proc to Mach.fundecl
   (Greta Yorsh, review by Florian Angeletti and Vincent Laviron)
 
-- #8959, #8960, #8968: minor refactorings in the typing of patterns:
+- #8959, #8960, #8968, #9023: minor refactorings in the typing of patterns:
   + refactor the {let,pat}_bound_idents* functions
   + minor bugfix in type_pat
   + refactor the generic pattern-traversal functions
     in Typecore and Typedtree
-  (Gabriel Scherer, review by Thomas Refis)
+  + restrict the use of Need_backtrack
+  (Gabriel Scherer and Florian Angeletti,
+   review by Thomas Refis and Gabriel Scherer)
 
 - #8975: "ocamltests" files are no longer required or used by
   "ocamltest". Instead, any text file in the testsuite directory containing a


### PR DESCRIPTION
This small PR proposes to only raise `Need_backtrack` in the `Inside_mode` of `Typecore.type_pat` (in order to jump to the outermost or-pattern being checked for partiality).

Other uses of `Need_backtack` are replaced by a small `split_or_until` function that splits nested or-patterns (e.g `A|B|C`) until a counter-example is found.

This allow to remove one mode (`Splitting_or`) from the `type_pat` function going down to three modes (`Normal`, `Inside_or`, `Split_or`) in total.