### PR TITLE
Fixes to ArrayLabels documentation

### DIFF
--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -22,21 +22,21 @@ external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)
 
 external get : 'a array -> int -> 'a = "%array_safe_get"
-(** [Array.get a n] returns the element number [n] of array [a].
+(** [ArrayLabels.get a n] returns the element number [n] of array [a].
    The first element has number 0.
-   The last element has number [Array.length a - 1].
-   You can also write [a.(n)] instead of [Array.get a n].
+   The last element has number [ArrayLabels.length a - 1].
+   You can also write [a.(n)] instead of [ArrayLabels.get a n].
 
-   Raise [Invalid_argument "index out of bounds"]
-   if [n] is outside the range 0 to [(Array.length a - 1)]. *)
+   Raise [Invalid_argument]
+   if [n] is outside the range 0 to [(ArrayLabels.length a - 1)]. *)
 
 external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
-(** [Array.set a n x] modifies array [a] in place, replacing
+(** [ArrayLabels.set a n x] modifies array [a] in place, replacing
    element number [n] with [x].
-   You can also write [a.(n) <- x] instead of [Array.set a n x].
+   You can also write [a.(n) <- x] instead of [ArrayLabels.set a n x].
 
-   Raise [Invalid_argument "index out of bounds"]
-   if [n] is outside the range 0 to [Array.length a - 1]. *)
+   Raise [Invalid_argument]
+   if [n] is outside the range 0 to [ArrayLabels.length a - 1]. *)
 
 external make : int -> 'a -> 'a array = "caml_make_vect"
 (** [Array.make n x] returns a fresh array of length [n],
@@ -56,9 +56,9 @@ external create : int -> 'a -> 'a array = "caml_make_vect"
 (** @deprecated [Array.create] is an alias for {!Array.make}. *)
 
 val init : int -> f:(int -> 'a) -> 'a array
-(** [Array.init n f] returns a fresh array of length [n],
+(** [ArrayLabels.init n ~f] returns a fresh array of length [n],
    with element number [i] initialized to the result of [f i].
-   In other terms, [Array.init n f] tabulates the results of [f]
+   In other terms, [ArrayLabels.init n ~f] tabulates the results of [f]
    applied to the integers [0] to [n-1].
 
    Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
@@ -66,7 +66,7 @@ val init : int -> f:(int -> 'a) -> 'a array
    size is only [Sys.max_array_length / 2].*)
 
 val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-(** [Array.make_matrix dimx dimy e] returns a two-dimensional array
+(** [ArrayLabels.make_matrix ~dimx ~dimy e] returns a two-dimensional array
    (an array of arrays) with first dimension [dimx] and
    second dimension [dimy]. All the elements of this new matrix
    are initially physically equal to [e].
@@ -79,9 +79,9 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
    size is only [Sys.max_array_length / 2]. *)
 
 val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-  [@@ocaml.deprecated "Use Array.make_matrix instead."]
-(** @deprecated [Array.create_matrix] is an alias for
-   {!Array.make_matrix}. *)
+  [@@ocaml.deprecated "Use ArrayLabels.make_matrix instead."]
+(** @deprecated [ArrayLabels.create_matrix] is an alias for
+   {!ArrayLabels.make_matrix}. *)
 
 val append : 'a array -> 'a array -> 'a array
 (** [Array.append v1 v2] returns a fresh array containing the
@@ -91,37 +91,37 @@ val concat : 'a array list -> 'a array
 (** Same as {!Array.append}, but concatenates a list of arrays. *)
 
 val sub : 'a array -> pos:int -> len:int -> 'a array
-(** [Array.sub a start len] returns a fresh array of length [len],
-   containing the elements number [start] to [start + len - 1]
+(** [ArrayLabels.sub a ~pos ~len] returns a fresh array of length [len],
+   containing the elements number [pos] to [pos + len - 1]
    of array [a].
 
-   Raise [Invalid_argument "Array.sub"] if [start] and [len] do not
+   Raise [Invalid_argument] if [pos] and [len] do not
    designate a valid subarray of [a]; that is, if
-   [start < 0], or [len < 0], or [start + len > Array.length a]. *)
+   [pos < 0], or [len < 0], or [pos + len > Array.length a]. *)
 
 val copy : 'a array -> 'a array
 (** [Array.copy a] returns a copy of [a], that is, a fresh array
    containing the same elements as [a]. *)
 
 val fill : 'a array -> pos:int -> len:int -> 'a -> unit
-(** [Array.fill a ofs len x] modifies the array [a] in place,
-   storing [x] in elements number [ofs] to [ofs + len - 1].
+(** [ArrayLabels.fill a ~pos ~len x] modifies the array [a] in place,
+   storing [x] in elements number [pos] to [pos + len - 1].
 
-   Raise [Invalid_argument "Array.fill"] if [ofs] and [len] do not
+   Raise [Invalid_argument] if [pos] and [len] do not
    designate a valid subarray of [a]. *)
 
 val blit :
   src:'a array -> src_pos:int -> dst:'a array -> dst_pos:int -> len:int ->
     unit
-(** [Array.blit v1 o1 v2 o2 len] copies [len] elements
-   from array [v1], starting at element number [o1], to array [v2],
-   starting at element number [o2]. It works correctly even if
-   [v1] and [v2] are the same array, and the source and
+(** [ArrayLabels.blit ~src ~src_pos ~dst ~dst_pos ~len] copies [len] elements
+   from array [src], starting at element number [src_pos], to array [dst],
+   starting at element number [dst_pos]. It works correctly even if
+   [src] and [dst] are the same array, and the source and
    destination chunks overlap.
 
-   Raise [Invalid_argument "Array.blit"] if [o1] and [len] do not
-   designate a valid subarray of [v1], or if [o2] and [len] do not
-   designate a valid subarray of [v2]. *)
+   Raise [Invalid_argument] if [src_pos] and [len] do not
+   designate a valid subarray of [src], or if [dst_pos] and [len] do not
+   designate a valid subarray of [dst]. *)
 
 val to_list : 'a array -> 'a list
 (** [Array.to_list a] returns the list of all the elements of [a]. *)
@@ -131,33 +131,33 @@ val of_list : 'a list -> 'a array
    of [l]. *)
 
 val iter : f:('a -> unit) -> 'a array -> unit
-(** [Array.iter f a] applies function [f] in turn to all
+(** [ArrayLabels.iter ~f a] applies function [f] in turn to all
    the elements of [a].  It is equivalent to
    [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
 
 val map : f:('a -> 'b) -> 'a array -> 'b array
-(** [Array.map f a] applies function [f] to all the elements of [a],
+(** [ArrayLabels.map ~f a] applies function [f] to all the elements of [a],
    and builds an array with the results returned by [f]:
    [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
 
 val iteri : f:(int -> 'a -> unit) -> 'a array -> unit
-(** Same as {!Array.iter}, but the
+(** Same as {!ArrayLabels.iter}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
 val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
-(** Same as {!Array.map}, but the
+(** Same as {!ArrayLabels.map}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
 val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b array -> 'a
-(** [Array.fold_left f x a] computes
-   [f (... (f (f x a.(0)) a.(1)) ...) a.(n-1)],
+(** [ArrayLabels.fold_left ~f ~init a] computes
+   [f (... (f (f init a.(0)) a.(1)) ...) a.(n-1)],
    where [n] is the length of the array [a]. *)
 
 val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
-(** [Array.fold_right f a x] computes
-   [f a.(0) (f a.(1) ( ... (f a.(n-1) x) ...))],
+(** [ArrayLabels.fold_right ~f a ~init] computes
+   [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
    where [n] is the length of the array [a]. *)
 
 
@@ -165,13 +165,13 @@ val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
 
 
 val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
-(** [Array.iter2 f a b] applies function [f] to all the elements of [a]
+(** [ArrayLabels.iter2 ~f a b] applies function [f] to all the elements of [a]
    and [b].
    Raise [Invalid_argument] if the arrays are not the same size.
    @since 4.05.0 *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
-(** [Array.map2 f a b] applies function [f] to all the elements of [a]
+(** [ArrayLabels.map2 ~f a b] applies function [f] to all the elements of [a]
    and [b], and builds an array with the results returned by [f]:
    [[| f a.(0) b.(0); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
    Raise [Invalid_argument] if the arrays are not the same size.
@@ -182,25 +182,25 @@ val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
 
 
 val exists : f:('a -> bool) -> 'a array -> bool
-(** [Array.exists p [|a1; ...; an|]] checks if at least one element of
-    the array satisfies the predicate [p]. That is, it returns
-    [(p a1) || (p a2) || ... || (p an)].
+(** [ArrayLabels.exists ~f [|a1; ...; an|]] checks if at least one element of
+    the array satisfies the predicate [f]. That is, it returns
+    [(f a1) || (f a2) || ... || (f an)].
     @since 4.03.0 *)
 
 val for_all : f:('a -> bool) -> 'a array -> bool
-(** [Array.for_all p [|a1; ...; an|]] checks if all elements of the array
-   satisfy the predicate [p]. That is, it returns
-   [(p a1) && (p a2) && ... && (p an)].
+(** [ArrayLabels.for_all ~f [|a1; ...; an|]] checks if all elements
+   of the array satisfy the predicate [f]. That is, it returns
+   [(f a1) && (f a2) && ... && (f an)].
    @since 4.03.0 *)
 
 val mem : 'a -> set:'a array -> bool
-(** [mem x a] is true if and only if [x] is equal
-   to an element of [a].
+(** [mem x ~set] is true if and only if [x] is equal
+   to an element of [set].
    @since 4.03.0 *)
 
 val memq : 'a -> set:'a array -> bool
-(** Same as {!Array.mem}, but uses physical equality instead of structural
-   equality to compare list elements.
+(** Same as {!ArrayLabels.mem}, but uses physical equality
+   instead of structural equality to compare list elements.
    @since 4.03.0 *)
 
 external create_float: int -> float array = "caml_make_float_vect"
@@ -224,9 +224,9 @@ val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
    and a negative integer if the first is smaller (see below for a
    complete specification).  For example, {!Stdlib.compare} is
    a suitable comparison function, provided there are no floating-point
-   NaN values in the data.  After calling [Array.sort], the
+   NaN values in the data.  After calling [ArrayLabels.sort], the
    array is sorted in place in increasing order.
-   [Array.sort] is guaranteed to run in constant heap space
+   [ArrayLabels.sort] is guaranteed to run in constant heap space
    and (at most) logarithmic stack space.
 
    The current implementation uses Heap Sort.  It runs in constant
@@ -238,23 +238,23 @@ val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 -   [cmp x y] > 0 if and only if [cmp y x] < 0
 -   if [cmp x y] >= 0 and [cmp y z] >= 0 then [cmp x z] >= 0
 
-   When [Array.sort] returns, [a] contains the same elements as before,
+   When [ArrayLabels.sort] returns, [a] contains the same elements as before,
    reordered in such a way that for all i and j valid indices of [a] :
 -   [cmp a.(i) a.(j)] >= 0 if and only if i >= j
 *)
 
 val stable_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
-(** Same as {!Array.sort}, but the sorting algorithm is stable (i.e.
+(** Same as {!ArrayLabels.sort}, but the sorting algorithm is stable (i.e.
    elements that compare equal are kept in their original order) and
    not guaranteed to run in constant heap space.
 
    The current implementation uses Merge Sort. It uses [n/2]
    words of heap space, where [n] is the length of the array.
-   It is usually faster than the current implementation of {!Array.sort}.
+   It is usually faster than the current implementation of {!ArrayLabels.sort}.
 *)
 
 val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
-(** Same as {!Array.sort} or {!Array.stable_sort}, whichever is
+(** Same as {!ArrayLabels.sort} or {!ArrayLabels.stable_sort}, whichever is
     faster on typical input.
 *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -27,7 +27,7 @@ external get : 'a array -> int -> 'a = "%array_safe_get"
    The last element has number [ArrayLabels.length a - 1].
    You can also write [a.(n)] instead of [ArrayLabels.get a n].
 
-   Raise [Invalid_argument]
+   @raise Invalid_argument
    if [n] is outside the range 0 to [(ArrayLabels.length a - 1)]. *)
 
 external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
@@ -35,7 +35,7 @@ external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
    element number [n] with [x].
    You can also write [a.(n) <- x] instead of [ArrayLabels.set a n x].
 
-   Raise [Invalid_argument]
+   @raise Invalid_argument
    if [n] is outside the range 0 to [ArrayLabels.length a - 1]. *)
 
 external make : int -> 'a -> 'a array = "caml_make_vect"
@@ -47,13 +47,13 @@ external make : int -> 'a -> 'a array = "caml_make_vect"
    of the array, and modifying [x] through one of the array entries
    will modify all other entries at the same time.
 
-   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
    If the value of [x] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2].*)
 
 external create : int -> 'a -> 'a array = "caml_make_vect"
   [@@ocaml.deprecated "Use Array.make instead."]
-(** @deprecated [Array.create] is an alias for {!Array.make}. *)
+(** @deprecated [Array.create] is an alias for {!make}. *)
 
 val init : int -> f:(int -> 'a) -> 'a array
 (** [ArrayLabels.init n ~f] returns a fresh array of length [n],
@@ -61,7 +61,7 @@ val init : int -> f:(int -> 'a) -> 'a array
    In other terms, [ArrayLabels.init n ~f] tabulates the results of [f]
    applied to the integers [0] to [n-1].
 
-   Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
+   @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
    If the return type of [f] is [float], then the maximum
    size is only [Sys.max_array_length / 2].*)
 
@@ -73,29 +73,29 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
    The element ([x,y]) of a matrix [m] is accessed
    with the notation [m.(x).(y)].
 
-   Raise [Invalid_argument] if [dimx] or [dimy] is negative or
+   @raise Invalid_argument if [dimx] or [dimy] is negative or
    greater than {!Sys.max_array_length}.
    If the value of [e] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
 val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-  [@@ocaml.deprecated "Use ArrayLabels.make_matrix instead."]
-(** @deprecated [ArrayLabels.create_matrix] is an alias for
-   {!ArrayLabels.make_matrix}. *)
+  [@@ocaml.deprecated "Use Array.make_matrix instead."]
+(** @deprecated [Array.create_matrix] is an alias for
+   {!make_matrix}. *)
 
 val append : 'a array -> 'a array -> 'a array
 (** [Array.append v1 v2] returns a fresh array containing the
    concatenation of the arrays [v1] and [v2]. *)
 
 val concat : 'a array list -> 'a array
-(** Same as {!Array.append}, but concatenates a list of arrays. *)
+(** Same as {!append}, but concatenates a list of arrays. *)
 
 val sub : 'a array -> pos:int -> len:int -> 'a array
 (** [ArrayLabels.sub a ~pos ~len] returns a fresh array of length [len],
    containing the elements number [pos] to [pos + len - 1]
    of array [a].
 
-   Raise [Invalid_argument] if [pos] and [len] do not
+   @raise Invalid_argument if [pos] and [len] do not
    designate a valid subarray of [a]; that is, if
    [pos < 0], or [len < 0], or [pos + len > Array.length a]. *)
 
@@ -107,7 +107,7 @@ val fill : 'a array -> pos:int -> len:int -> 'a -> unit
 (** [ArrayLabels.fill a ~pos ~len x] modifies the array [a] in place,
    storing [x] in elements number [pos] to [pos + len - 1].
 
-   Raise [Invalid_argument] if [pos] and [len] do not
+   @raise Invalid_argument if [pos] and [len] do not
    designate a valid subarray of [a]. *)
 
 val blit :
@@ -119,7 +119,7 @@ val blit :
    [src] and [dst] are the same array, and the source and
    destination chunks overlap.
 
-   Raise [Invalid_argument] if [src_pos] and [len] do not
+   @raise Invalid_argument if [src_pos] and [len] do not
    designate a valid subarray of [src], or if [dst_pos] and [len] do not
    designate a valid subarray of [dst]. *)
 
@@ -167,14 +167,14 @@ val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
 val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
 (** [ArrayLabels.iter2 ~f a b] applies function [f] to all the elements of [a]
    and [b].
-   Raise [Invalid_argument] if the arrays are not the same size.
+   @raise Invalid_argument if the arrays are not the same size.
    @since 4.05.0 *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
 (** [ArrayLabels.map2 ~f a b] applies function [f] to all the elements of [a]
    and [b], and builds an array with the results returned by [f]:
    [[| f a.(0) b.(0); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
-   Raise [Invalid_argument] if the arrays are not the same size.
+   @raise Invalid_argument if the arrays are not the same size.
    @since 4.05.0 *)
 
 
@@ -211,7 +211,7 @@ external create_float: int -> float array = "caml_make_float_vect"
 val make_float: int -> float array
   [@@ocaml.deprecated "Use Array.create_float instead."]
 (** @deprecated [Array.make_float] is an alias for
-    {!Array.create_float}. *)
+    {!create_float}. *)
 
 
 (** {1 Sorting} *)

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -13,10 +13,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Array operations
+
+   This module is intended to be used through {!StdLabels} which would replace
+   {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts
+
+   As an example usage:
+   {[
+      open StdLabels
+
+      let everything = Array.create_matrix ~dimx:42 ~dimy:42 42
+   ]} *)
+
 type 'a t = 'a array
 (** An alias for the type of arrays. *)
-
-(** Array operations. *)
 
 external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -22,24 +22,24 @@ external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)
 
 external get : 'a array -> int -> 'a = "%array_safe_get"
-(** [ArrayLabels.get a n] returns the element number [n] of array [a].
+(** [get a n] returns the element number [n] of array [a].
    The first element has number 0.
-   The last element has number [ArrayLabels.length a - 1].
-   You can also write [a.(n)] instead of [ArrayLabels.get a n].
+   The last element has number [length a - 1].
+   You can also write [a.(n)] instead of [get a n].
 
    @raise Invalid_argument
-   if [n] is outside the range 0 to [(ArrayLabels.length a - 1)]. *)
+   if [n] is outside the range 0 to [(length a - 1)]. *)
 
 external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
-(** [ArrayLabels.set a n x] modifies array [a] in place, replacing
+(** [set a n x] modifies array [a] in place, replacing
    element number [n] with [x].
-   You can also write [a.(n) <- x] instead of [ArrayLabels.set a n x].
+   You can also write [a.(n) <- x] instead of [set a n x].
 
    @raise Invalid_argument
-   if [n] is outside the range 0 to [ArrayLabels.length a - 1]. *)
+   if [n] is outside the range 0 to [length a - 1]. *)
 
 external make : int -> 'a -> 'a array = "caml_make_vect"
-(** [Array.make n x] returns a fresh array of length [n],
+(** [make n x] returns a fresh array of length [n],
    initialized with [x].
    All the elements of this new array are initially
    physically equal to [x] (in the sense of the [==] predicate).
@@ -53,12 +53,12 @@ external make : int -> 'a -> 'a array = "caml_make_vect"
 
 external create : int -> 'a -> 'a array = "caml_make_vect"
   [@@ocaml.deprecated "Use Array.make instead."]
-(** @deprecated [Array.create] is an alias for {!make}. *)
+(** @deprecated [create] is an alias for {!make}. *)
 
 val init : int -> f:(int -> 'a) -> 'a array
-(** [ArrayLabels.init n ~f] returns a fresh array of length [n],
+(** [init n ~f] returns a fresh array of length [n],
    with element number [i] initialized to the result of [f i].
-   In other terms, [ArrayLabels.init n ~f] tabulates the results of [f]
+   In other terms, [init n ~f] tabulates the results of [f]
    applied to the integers [0] to [n-1].
 
    @raise Invalid_argument if [n < 0] or [n > Sys.max_array_length].
@@ -66,7 +66,7 @@ val init : int -> f:(int -> 'a) -> 'a array
    size is only [Sys.max_array_length / 2].*)
 
 val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-(** [ArrayLabels.make_matrix ~dimx ~dimy e] returns a two-dimensional array
+(** [make_matrix ~dimx ~dimy e] returns a two-dimensional array
    (an array of arrays) with first dimension [dimx] and
    second dimension [dimy]. All the elements of this new matrix
    are initially physically equal to [e].
@@ -80,31 +80,30 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
 
 val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
   [@@ocaml.deprecated "Use Array.make_matrix instead."]
-(** @deprecated [Array.create_matrix] is an alias for
-   {!make_matrix}. *)
+(** @deprecated [create_matrix] is an alias for {!make_matrix}. *)
 
 val append : 'a array -> 'a array -> 'a array
-(** [Array.append v1 v2] returns a fresh array containing the
+(** [append v1 v2] returns a fresh array containing the
    concatenation of the arrays [v1] and [v2]. *)
 
 val concat : 'a array list -> 'a array
 (** Same as {!append}, but concatenates a list of arrays. *)
 
 val sub : 'a array -> pos:int -> len:int -> 'a array
-(** [ArrayLabels.sub a ~pos ~len] returns a fresh array of length [len],
+(** [sub a ~pos ~len] returns a fresh array of length [len],
    containing the elements number [pos] to [pos + len - 1]
    of array [a].
 
    @raise Invalid_argument if [pos] and [len] do not
    designate a valid subarray of [a]; that is, if
-   [pos < 0], or [len < 0], or [pos + len > Array.length a]. *)
+   [pos < 0], or [len < 0], or [pos + len > length a]. *)
 
 val copy : 'a array -> 'a array
-(** [Array.copy a] returns a copy of [a], that is, a fresh array
+(** [copy a] returns a copy of [a], that is, a fresh array
    containing the same elements as [a]. *)
 
 val fill : 'a array -> pos:int -> len:int -> 'a -> unit
-(** [ArrayLabels.fill a ~pos ~len x] modifies the array [a] in place,
+(** [fill a ~pos ~len x] modifies the array [a] in place,
    storing [x] in elements number [pos] to [pos + len - 1].
 
    @raise Invalid_argument if [pos] and [len] do not
@@ -113,7 +112,7 @@ val fill : 'a array -> pos:int -> len:int -> 'a -> unit
 val blit :
   src:'a array -> src_pos:int -> dst:'a array -> dst_pos:int -> len:int ->
     unit
-(** [ArrayLabels.blit ~src ~src_pos ~dst ~dst_pos ~len] copies [len] elements
+(** [blit ~src ~src_pos ~dst ~dst_pos ~len] copies [len] elements
    from array [src], starting at element number [src_pos], to array [dst],
    starting at element number [dst_pos]. It works correctly even if
    [src] and [dst] are the same array, and the source and
@@ -124,39 +123,39 @@ val blit :
    designate a valid subarray of [dst]. *)
 
 val to_list : 'a array -> 'a list
-(** [Array.to_list a] returns the list of all the elements of [a]. *)
+(** [to_list a] returns the list of all the elements of [a]. *)
 
 val of_list : 'a list -> 'a array
-(** [Array.of_list l] returns a fresh array containing the elements
+(** [of_list l] returns a fresh array containing the elements
    of [l]. *)
 
 val iter : f:('a -> unit) -> 'a array -> unit
-(** [ArrayLabels.iter ~f a] applies function [f] in turn to all
+(** [iter ~f a] applies function [f] in turn to all
    the elements of [a].  It is equivalent to
-   [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
+   [f a.(0); f a.(1); ...; f a.(length a - 1); ()]. *)
 
 val map : f:('a -> 'b) -> 'a array -> 'b array
-(** [ArrayLabels.map ~f a] applies function [f] to all the elements of [a],
+(** [map ~f a] applies function [f] to all the elements of [a],
    and builds an array with the results returned by [f]:
-   [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
+   [[| f a.(0); f a.(1); ...; f a.(length a - 1) |]]. *)
 
 val iteri : f:(int -> 'a -> unit) -> 'a array -> unit
-(** Same as {!ArrayLabels.iter}, but the
+(** Same as {!iter}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
 val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
-(** Same as {!ArrayLabels.map}, but the
+(** Same as {!map}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
 val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b array -> 'a
-(** [ArrayLabels.fold_left ~f ~init a] computes
+(** [fold_left ~f ~init a] computes
    [f (... (f (f init a.(0)) a.(1)) ...) a.(n-1)],
    where [n] is the length of the array [a]. *)
 
 val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
-(** [ArrayLabels.fold_right ~f a ~init] computes
+(** [fold_right ~f a ~init] computes
    [f a.(0) (f a.(1) ( ... (f a.(n-1) init) ...))],
    where [n] is the length of the array [a]. *)
 
@@ -165,15 +164,15 @@ val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
 
 
 val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
-(** [ArrayLabels.iter2 ~f a b] applies function [f] to all the elements of [a]
+(** [iter2 ~f a b] applies function [f] to all the elements of [a]
    and [b].
    @raise Invalid_argument if the arrays are not the same size.
    @since 4.05.0 *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
-(** [ArrayLabels.map2 ~f a b] applies function [f] to all the elements of [a]
+(** [map2 ~f a b] applies function [f] to all the elements of [a]
    and [b], and builds an array with the results returned by [f]:
-   [[| f a.(0) b.(0); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
+   [[| f a.(0) b.(0); ...; f a.(length a - 1) b.(length b - 1)|]].
    @raise Invalid_argument if the arrays are not the same size.
    @since 4.05.0 *)
 
@@ -182,13 +181,13 @@ val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
 
 
 val exists : f:('a -> bool) -> 'a array -> bool
-(** [ArrayLabels.exists ~f [|a1; ...; an|]] checks if at least one element of
+(** [exists ~f [|a1; ...; an|]] checks if at least one element of
     the array satisfies the predicate [f]. That is, it returns
     [(f a1) || (f a2) || ... || (f an)].
     @since 4.03.0 *)
 
 val for_all : f:('a -> bool) -> 'a array -> bool
-(** [ArrayLabels.for_all ~f [|a1; ...; an|]] checks if all elements
+(** [for_all ~f [|a1; ...; an|]] checks if all elements
    of the array satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)].
    @since 4.03.0 *)
@@ -199,18 +198,18 @@ val mem : 'a -> set:'a array -> bool
    @since 4.03.0 *)
 
 val memq : 'a -> set:'a array -> bool
-(** Same as {!ArrayLabels.mem}, but uses physical equality
+(** Same as {!mem}, but uses physical equality
    instead of structural equality to compare list elements.
    @since 4.03.0 *)
 
 external create_float: int -> float array = "caml_make_float_vect"
-(** [Array.create_float n] returns a fresh float array of length [n],
+(** [create_float n] returns a fresh float array of length [n],
     with uninitialized data.
     @since 4.03 *)
 
 val make_float: int -> float array
   [@@ocaml.deprecated "Use Array.create_float instead."]
-(** @deprecated [Array.make_float] is an alias for
+(** @deprecated {!make_float} is an alias for
     {!create_float}. *)
 
 
@@ -224,9 +223,9 @@ val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
    and a negative integer if the first is smaller (see below for a
    complete specification).  For example, {!Stdlib.compare} is
    a suitable comparison function, provided there are no floating-point
-   NaN values in the data.  After calling [ArrayLabels.sort], the
+   NaN values in the data.  After calling [sort], the
    array is sorted in place in increasing order.
-   [ArrayLabels.sort] is guaranteed to run in constant heap space
+   [sort] is guaranteed to run in constant heap space
    and (at most) logarithmic stack space.
 
    The current implementation uses Heap Sort.  It runs in constant
@@ -238,25 +237,23 @@ val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 -   [cmp x y] > 0 if and only if [cmp y x] < 0
 -   if [cmp x y] >= 0 and [cmp y z] >= 0 then [cmp x z] >= 0
 
-   When [ArrayLabels.sort] returns, [a] contains the same elements as before,
+   When [sort] returns, [a] contains the same elements as before,
    reordered in such a way that for all i and j valid indices of [a] :
 -   [cmp a.(i) a.(j)] >= 0 if and only if i >= j
 *)
 
 val stable_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
-(** Same as {!ArrayLabels.sort}, but the sorting algorithm is stable (i.e.
+(** Same as {!sort}, but the sorting algorithm is stable (i.e.
    elements that compare equal are kept in their original order) and
    not guaranteed to run in constant heap space.
 
    The current implementation uses Merge Sort. It uses [n/2]
    words of heap space, where [n] is the length of the array.
-   It is usually faster than the current implementation of {!ArrayLabels.sort}.
+   It is usually faster than the current implementation of {!sort}.
 *)
 
 val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
-(** Same as {!ArrayLabels.sort} or {!ArrayLabels.stable_sort}, whichever is
-    faster on typical input.
-*)
+(** Same as {!sort} or {!stable_sort}, whichever is faster on typical input. *)
 
 
 (** {1 Iterators} *)

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -15,10 +15,10 @@
 
 (** Array operations
 
-   This module is intended to be used through {!StdLabels} which would replace
+   This module is intended to be used via {!StdLabels} which replaces
    {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts
 
-   As an example usage:
+   For example:
    {[
       open StdLabels
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -16,10 +16,10 @@
 (** Byte sequence operations.
     @since 4.02.0
 
-    This module is intended to be used through {!StdLabels} which would replace
+    This module is intended to be used through {!StdLabels} which replaces
     {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts.
 
-    As an example usage:
+    For example:
     {[
        open StdLabels
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -15,7 +15,16 @@
 
 (** Byte sequence operations.
     @since 4.02.0
- *)
+
+    This module is intended to be used through {!StdLabels} which would replace
+    {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts.
+
+    As an example usage:
+    {[
+       open StdLabels
+
+       let first = Bytes.sub ~pos:0 ~len:1
+    ]} *)
 
 external length : bytes -> int = "%bytes_length"
 (** Return the length (number of bytes) of the argument. *)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -27,7 +27,16 @@ type 'a t = 'a list = [] | (::) of 'a * 'a list (**)
 
    The above considerations can usually be ignored if your lists are not
    longer than about 10000 elements.
-*)
+
+   This module is intended to be used through {!StdLabels} which would replace
+   {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts.
+
+   As an example usage:
+   {[
+      open StdLabels
+
+      let seq len = List.init ~f:(function i -> i) ~len
+   ]} *)
 
 val length : 'a list -> int
 (** Return the length (number of elements) of the given list. *)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -28,10 +28,10 @@ type 'a t = 'a list = [] | (::) of 'a * 'a list (**)
    The above considerations can usually be ignored if your lists are not
    longer than about 10000 elements.
 
-   This module is intended to be used through {!StdLabels} which would replace
+   This module is intended to be used through {!StdLabels} which replaces
    {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts.
 
-   As an example usage:
+   For example:
    {[
       open StdLabels
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -13,7 +13,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** String operations. *)
+(** String operations.
+   This module is intended to be used through {!StdLabels} which would replace
+   {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts
+
+   As an example usage:
+   {[
+      open StdLabels
+
+      let to_upper = String.map ~f:Char.uppercase_ascii
+   ]} *)
 
 external length : string -> int = "%string_length"
 (** Return the length (number of characters) of the given string. *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -14,10 +14,10 @@
 (**************************************************************************)
 
 (** String operations.
-   This module is intended to be used through {!StdLabels} which would replace
+   This module is intended to be used through {!StdLabels} which replaces
    {!Array}, {!Bytes}, {!List} and {!String} with their labeled counterparts
 
-   As an example usage:
+   For example:
    {[
       open StdLabels
 


### PR DESCRIPTION
- Removal of string arguments from exceptions in docs
- Changed references to `ArrayLabels` instead of `Array` whenever
  a labeled argument is present
- Fixes to code examples using the wrong argument(wrong name, or missing label)

There are many other references to `Array` in the documentation. Not sure if those should be changed as well.