### PR TITLE
Unregister win32 stack overflow handler in caml_shutdown()

### DIFF
--- a/Changes
+++ b/Changes
@@ -356,6 +356,10 @@ Working version
   defined.
   (David Allsopp)
 
+- #9031: Unregister Windows stack overflow handler while shutting
+  the runtime down.
+  (Dmitry Bely, review by David Allsopp)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -30,6 +30,10 @@
 #include "caml/startup_aux.h"
 
 
+#ifdef _WIN32
+extern void caml_win32_unregister_overflow_detection (void);
+#endif
+
 /* Initialize the atom table */
 
 CAMLexport header_t caml_atom_table[256];
@@ -171,6 +175,9 @@ CAMLexport void caml_shutdown(void)
   caml_free_shared_libs();
 #endif
   caml_stat_destroy_pool();
+#if defined(_WIN32) && defined(NATIVE_CODE)
+  caml_win32_unregister_overflow_detection();
+#endif
 
   shutdown_happened = 1;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -602,9 +602,20 @@ static LONG CALLBACK
 }
 #endif /* _WIN64 */
 
+static PVOID caml_stack_overflow_handle;
+
 void caml_win32_overflow_detection(void)
 {
-  AddVectoredExceptionHandler(1, caml_stack_overflow_VEH);
+  caml_stack_overflow_handle =
+    AddVectoredExceptionHandler(1, caml_stack_overflow_VEH);
+  if (caml_stack_overflow_handle == NULL) {
+    caml_fatal_error("cannot install stack overflow detection");
+  }
+}
+
+void caml_win32_unregister_overflow_detection(void)
+{
+  RemoveVectoredExceptionHandler(caml_stack_overflow_handle);
 }
 
 #endif /* NATIVE_CODE */


### PR DESCRIPTION
Thanks to @murmour and his https://github.com/ocaml/ocaml/pull/71 it's now possible to run an OCaml app inside a DLL library with no resources leak on the DLL unload. But I discovered a very annoying bug on Windows: after `caml_shutdown()` and unloading an OCaml DLL any attempt to use Windows SEH-based code (including C++ exception handling) leads to Access Violation error. The problem is that `caml_startup()` installs SEH handler for stack overflow detection:
https://github.com/ocaml/ocaml/blob/8e928caea7c47e6ba8508cf2caaaa1ba9f8dca85/runtime/startup_nat.c#L146-L148 https://github.com/ocaml/ocaml/blob/8e928caea7c47e6ba8508cf2caaaa1ba9f8dca85/runtime/win32.c#L605-L608
But after `caml_shutdown()` and DLL unload the handler still remains active; OS calls it while searching 
for a proper handler for any SEH exception occurred.

The fix is quite trivial: we just have to unregister the handler in `caml_shutdown()`.

I did not rename `caml_win32_overflow_detection` into `caml_win32_register_overflow_detection` to minimize code changes.