### PR TITLE
Removing infix tag, (Bytecode part)

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -129,7 +129,6 @@ let rec push_dummies n k = match n with
 
 type rhs_kind =
   | RHS_block of int
-  | RHS_infix of { blocksize : int; offset : int }
   | RHS_floatblock of int
   | RHS_nonrec
   | RHS_function of int * int
@@ -566,12 +565,6 @@ let rec comp_expr env exp sz cont =
             Kconst(Const_base(Const_int blocksize)) ::
             Kccall("caml_alloc_dummy", 1) :: Kpush ::
             comp_init (add_var id (sz+1) new_env) (sz+1) rem
-        | (id, _exp, RHS_infix { blocksize; offset }) :: rem ->
-            Kconst(Const_base(Const_int offset)) ::
-            Kpush ::
-            Kconst(Const_base(Const_int blocksize)) ::
-            Kccall("caml_alloc_dummy_infix", 2) :: Kpush ::
-            comp_init (add_var id (sz+1) new_env) (sz+1) rem
         | (id, _exp, RHS_function (blocksize,arity)) :: rem ->
             Kconst(Const_base(Const_int arity)) ::
             Kpush ::
@@ -583,8 +576,7 @@ let rec comp_expr env exp sz cont =
             comp_init (add_var id (sz+1) new_env) (sz+1) rem
       and comp_nonrec new_env sz i = function
         | [] -> comp_rec new_env sz ndecl decl_size
-        | (_id, _exp, (RHS_block _ | RHS_infix _ |
-                       RHS_floatblock _ | RHS_function _))
+        | (_id, _exp, (RHS_block _ | RHS_floatblock _ | RHS_function _))
           :: rem ->
             comp_nonrec new_env sz (i-1) rem
         | (_id, exp, RHS_nonrec) :: rem ->
@@ -592,8 +584,7 @@ let rec comp_expr env exp sz cont =
               (Kassign (i-1) :: comp_nonrec new_env sz (i-1) rem)
       and comp_rec new_env sz i = function
         | [] -> comp_expr new_env body sz (add_pop ndecl cont)
-        | (_id, exp, (RHS_block _ | RHS_infix _ |
-                      RHS_floatblock _ | RHS_function _))
+        | (_id, exp, (RHS_block _ | RHS_floatblock _ | RHS_function _))
           :: rem ->
             comp_expr new_env exp sz
               (Kpush :: Kacc i :: Kccall("caml_update_dummy", 2) ::


### PR DESCRIPTION
To continue the discussion on removing the dreaded infix tag. This is the bytecode part of https://github.com/ocaml/ocaml/pull/8984.

The runtime is unchanged yet. This is mainly meant to provide something for @ctk21 to benchmark to fuel the discussion.