### PR TITLE
[WIP] Better stripping of environments in .cmt files

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -69,7 +69,7 @@ open Tast_iterator
 
 let cenv =
   {Tast_iterator.default_iterator with
-   env = fun _sub env -> Env.keep_only_summary env}
+   env = fun _sub env -> Env.keep_only_summary ~initial:false env}
 
 let clear_part = function
   | Partial_structure s -> cenv.structure cenv s
@@ -164,7 +164,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi =
          Fun.protect
            ~finally:Env.restore_full_env
            (fun () ->
-              Env.keep_only_summary initial_env;
+              Env.keep_only_summary ~initial:true initial_env;
               clear_env binary_annots;
               let cmt = {
                 cmt_modname = modname;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -90,6 +90,7 @@ type summary =
   | Env_persistent of summary * Ident.t
   | Env_value_unbound of summary * string * value_unbound_reason
   | Env_module_unbound of summary * string * module_unbound_reason
+  | Env_initial of {mutable initial: summary}
 
 type address =
   | Aident of Ident.t
@@ -589,6 +590,9 @@ let empty = {
   flags = 0;
   functor_args = Ident.empty;
  }
+
+let mark_initial initial =
+  {initial with summary = Env_initial {initial = initial.summary}}
 
 let in_signature b env =
   let flags =
@@ -2953,6 +2957,8 @@ let filter_non_loaded_persistent f env =
           Env_value_unbound (filter_summary s ids, n, r)
       | Env_module_unbound (s, n, r) ->
           Env_module_unbound (filter_summary s ids, n, r)
+      | Env_initial {initial} ->
+          Env_initial {initial = filter_summary initial ids}
   in
   { env with
     modules = remove_ids env.modules to_remove;
@@ -2965,7 +2971,7 @@ let summary env =
   if Path.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let restore_summary_list = ref []
+let restore_summary = ref []
 
 let copy_env
     ~src:{values; constrs; labels; types; modules; modtypes; classes; cltypes; summary;
@@ -2984,19 +2990,51 @@ let copy_env
     dst.local_constraints <- local_constraints;
     dst.summary <- summary
 
-let keep_only_summary env =
+
+let rec filter_summary = function
+  | Env_empty -> Env_empty
+  | Env_value (s, id, vd) -> Env_value (filter_summary s, id, vd)
+  | Env_type (s, id, td) ->  Env_type (filter_summary s, id, td)
+  | Env_extension (s, id, ec) -> Env_extension (filter_summary s, id, ec)
+  | Env_module (s, id, mp, md) -> Env_module (filter_summary s, id, mp, md)
+  | Env_modtype (s, id, md) -> Env_modtype (filter_summary s, id, md)
+  | Env_class (s, id, cd) -> Env_class (filter_summary s, id, cd)
+  | Env_cltype (s, id, ctd) -> Env_cltype (filter_summary s, id, ctd)
+  | Env_open (s, p) -> Env_open (filter_summary s, p)
+  | Env_functor_arg (s, id) -> Env_functor_arg (filter_summary s, id)
+  | Env_constraints (s, cstrs) -> Env_constraints (filter_summary s, cstrs)
+  | Env_copy_types s -> Env_copy_types (filter_summary s)
+  | Env_persistent (s, id) ->
+      let s = filter_summary s in
+      begin match Persistent_env.find_in_cache persistent_env (Ident.name id) with
+      | Some _ -> Env_persistent (s, id)
+      | None -> s
+      end
+  | Env_value_unbound (s, n, r) -> Env_value_unbound (filter_summary s, n, r)
+  | Env_module_unbound (s, n, r) -> Env_module_unbound (filter_summary s, n, r)
+  | Env_initial _ -> assert false
+
+let keep_only_summary ~initial env =
   if env.flags land only_summary_flag = 0 then begin
     let backup = {env with flags = env.flags} in
     copy_env ~src:empty ~dst:env;
     env.flags <- backup.flags lor only_summary_flag;
+    if initial then begin
+      match backup.summary with
+      | Env_initial r ->
+          let old = r.initial in
+          restore_summary := (fun () -> r.initial <- old) :: !restore_summary;
+          r.initial <- filter_summary old
+      | _ -> assert false
+    end;
     env.summary <- backup.summary;
     env.local_constraints <- backup.local_constraints;
-    restore_summary_list := (backup, env) :: !restore_summary_list;
+    restore_summary := (fun () -> copy_env ~src:backup ~dst:env) :: !restore_summary;
   end
 
 let restore_full_env () =
-  List.iter (fun (backup, env) -> copy_env ~src:backup ~dst:env) !restore_summary_list;
-  restore_summary_list := []
+  List.iter (fun f -> f ()) !restore_summary;
+  restore_summary := []
 
 
 let env_of_only_summary env_from_summary env =

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -385,20 +385,21 @@ type type_descriptions =
     constructor_description list * label_description list
 
 let in_signature_flag = 0x01
+let only_summary_flag = 0x02
 
 type t = {
-  values: (value_entry, value_data) IdTbl.t;
-  constrs: constructor_data TycompTbl.t;
-  labels: label_data TycompTbl.t;
-  types: (type_data, type_data) IdTbl.t;
-  modules: (module_entry, module_data) IdTbl.t;
-  modtypes: (modtype_data, modtype_data) IdTbl.t;
-  classes: (class_data, class_data) IdTbl.t;
-  cltypes: (cltype_data, cltype_data) IdTbl.t;
-  functor_args: unit Ident.tbl;
-  summary: summary;
-  local_constraints: type_declaration Path.Map.t;
-  flags: int;
+  mutable values: (value_entry, value_data) IdTbl.t;
+  mutable constrs: constructor_data TycompTbl.t;
+  mutable labels: label_data TycompTbl.t;
+  mutable types: (type_data, type_data) IdTbl.t;
+  mutable modules: (module_entry, module_data) IdTbl.t;
+  mutable modtypes: (modtype_data, modtype_data) IdTbl.t;
+  mutable classes: (class_data, class_data) IdTbl.t;
+  mutable cltypes: (cltype_data, cltype_data) IdTbl.t;
+  mutable functor_args: unit Ident.tbl;
+  mutable summary: summary;
+  mutable local_constraints: type_declaration Path.Map.t;
+  mutable flags: int;
 }
 
 and module_declaration_lazy =
@@ -2964,24 +2965,38 @@ let summary env =
   if Path.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = ref empty
-let last_reduced_env = ref empty
+let restore_summary_list = ref []
+
+let copy_env
+    ~src:{values; constrs; labels; types; modules; modtypes; classes; cltypes; summary;
+          local_constraints; flags; functor_args}
+    ~dst =
+    dst.flags <- flags;
+    dst.values <- values;
+    dst.constrs <- constrs;
+    dst.labels <- labels;
+    dst.types <- types;
+    dst.modules <- modules;
+    dst.modtypes <- modtypes;
+    dst.classes <- classes;
+    dst.cltypes <- cltypes;
+    dst.functor_args <- functor_args;
+    dst.local_constraints <- local_constraints;
+    dst.summary <- summary
 
 let keep_only_summary env =
-  if !last_env == env then !last_reduced_env
-  else begin
-    let new_env =
-      {
-       empty with
-       summary = env.summary;
-       local_constraints = env.local_constraints;
-       flags = env.flags;
-      }
-    in
-    last_env := env;
-    last_reduced_env := new_env;
-    new_env
+  if env.flags land only_summary_flag = 0 then begin
+    let backup = {env with flags = env.flags} in
+    copy_env ~src:empty ~dst:env;
+    env.flags <- backup.flags lor only_summary_flag;
+    env.summary <- backup.summary;
+    env.local_constraints <- backup.local_constraints;
+    restore_summary_list := (backup, env) :: !restore_summary_list;
   end
+
+let restore_full_env () =
+  List.iter (fun (backup, env) -> copy_env ~src:backup ~dst:env) !restore_summary_list;
+  restore_summary_list := []
 
 
 let env_of_only_summary env_from_summary env =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -45,6 +45,7 @@ type summary =
   | Env_persistent of summary * Ident.t
   | Env_value_unbound of summary * string * value_unbound_reason
   | Env_module_unbound of summary * string * module_unbound_reason
+  | Env_initial of {mutable initial: summary}
 
 type address =
   | Aident of Ident.t
@@ -55,6 +56,7 @@ type t
 val empty: t
 val initial_safe_string: t
 val initial_unsafe_string: t
+val mark_initial: t -> t
 val diff: t -> t -> Ident.t list
 val copy_local: from:t -> t -> t
 
@@ -380,7 +382,7 @@ val summary: t -> summary
    except the summary. The initial environment can be rebuilt from the
    summary, using Envaux.env_of_only_summary. *)
 
-val keep_only_summary : t -> unit
+val keep_only_summary : initial:bool -> t -> unit
 val restore_full_env : unit -> unit
 
 val env_of_only_summary : (summary -> Subst.t -> t) -> t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -380,7 +380,9 @@ val summary: t -> summary
    except the summary. The initial environment can be rebuilt from the
    summary, using Envaux.env_of_only_summary. *)
 
-val keep_only_summary : t -> t
+val keep_only_summary : t -> unit
+val restore_full_env : unit -> unit
+
 val env_of_only_summary : (summary -> Subst.t -> t) -> t -> t
 
 (* Error report *)

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -92,6 +92,8 @@ let rec env_from_summary sum subst =
       | Env_module_unbound (s, str, reason) ->
           let env = env_from_summary s subst in
           Env.enter_unbound_module str reason env
+      | Env_initial {initial} ->
+          Env.mark_initial (env_from_summary initial subst)
     in
       Hashtbl.add env_cache (sum, subst) env;
       env

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -189,7 +189,8 @@ let initial_env ~loc ~safe_string ~initially_opened_module
         (open_module env m, units)
   in
   let env = List.fold_left add_units env units in
-  List.fold_left open_module env open_implicit_modules
+  let env = List.fold_left open_module env open_implicit_modules in
+  Env.mark_initial env
 
 let type_open_descr ?used_slot ?toplevel env sod =
   let (path, newenv) =


### PR DESCRIPTION
Each Typedtree node marshaled in .cmt file contains an `Env.t` value, where only the "summary" field is kept (it can be used to rebuild the full `Env.t` when needed).  This PR changes this "reduction" process as follows:

  - Instead of mapping over the Typedtree and rewriting Env.t values, the Env.t values are modified in place to keep only the summary field, and then restored to their initial content after the .cmt file has been written.  In particular, this preserves (physical) sharing between different environments in the Typedtree.  Previously, only "adjacent" equal environments were kept identifical (adjacent considering the depth-first traversal of the Typedtree).

  - Since #2041, the summary also contains an entry for each available "persistent module" found in the load path.  This means that .cmt file will depend on .cmi files available at the time the module was compiled, which makes the build less deterministic.  In this PR, the summary for the initial environment (which is a "tail" shared by all other environments in the same typedtree) is trimmed of entries corresponding to .cmi files which haven't been loaded, thus restoring a more deterministic behavior.

With these two changes, the size of .cmt files is reduced, and any tool that need to unmarshal many .cmt file (e.g. global refactoring tools) will use less RAM (and RAM can be a bottleneck for such project-wide tools).  For instance, typecore.cmt produced by `ocamlc -annot` goes from 2296736 bytes on trunk to 2230616 bytes with this PR (a 2.9% gain).

Note: the .cmt are slightly different when produced with ocamlc, ocamlc.opt and ocamlopt; I suspect the difference is due the difference in sharing only.

In addition, this PR also removes support for OCAML_BINANNOT_WITHENV (an env variable used to keep the "full environment" in .cmt files), which I suspect has never been used.