### PR TITLE
Clear destination registers before sqrt instruction on amd64

### DIFF
--- a/Changes
+++ b/Changes
@@ -145,7 +145,7 @@ Working version
 
 - #9041: amd64: Avoid stall in sqrtsd by clearing destination.
   (Stephen Dolan, with thanks to Andrew Hunter, Will Hasenplaugh,
-   Spiros Eliopoulos and Brian Nigito. Review by ??)
+   Spiros Eliopoulos and Brian Nigito. Review by Xavier Leroy)
 
 ### Runtime system:
 

--- a/Changes
+++ b/Changes
@@ -143,6 +143,10 @@ Working version
   untag_int (tag_int x) = x in Cmmgen.
   (Stephen Dolan, review by Vincent Laviron and Xavier Leroy)
 
+- #9041: amd64: Avoid stall in sqrtsd by clearing destination.
+  (Stephen Dolan, with thanks to Andrew Hunter, Will Hasenplaugh,
+   Spiros Eliopoulos and Brian Nigito. Review by ??)
+
 ### Runtime system:
 
 - #8809: Add a best-fit allocator, which should be much better for

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -786,8 +786,11 @@ let emit_instr fallthrough i =
   | Lop(Ispecific(Ibswap _)) ->
       assert false
   | Lop(Ispecific Isqrtf) ->
+      if arg i 0 <> res i 0 then
+        I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
       I.sqrtsd (arg i 0) (res i 0)
   | Lop(Ispecific(Ifloatsqrtf addr)) ->
+      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
       I.sqrtsd (addressing addr REAL8 i 0) (res i 0)
   | Lop(Ispecific(Isextend32)) ->
       I.movsxd (arg32 i 0) (res i 0)


### PR DESCRIPTION
This is a tiny patch to `amd64.S` which adds a seemingly-useless instruction before `sqrtsd`, and makes this microbenchmark ~3x faster (compiled with `ocamlopt -unsafe`):
```ocaml
let xs = [| 42.; 42.; 42.; 42.; 42.; 42.; 42.; 42.; 42.; 42. |]
let go () = for i = 0 to 9 do xs.(i) <- sqrt xs.(i) done
let () = for i = 0 to 10_000_000 do go () done
```
This result is for an Intel Skylake, but I've seen a similar difference on several other Intel processors.

---

The `sqrtsd` instruction operates on the SSE vector registers, which are 128 bits wide and can store two 64-bit doubles. OCaml uses the SSE vector registers to implement `float` arithmetic, using the scalar instructions (`addsd`, `mulsd`, `sqrtsd`, etc.) to operate only on the lower half of the register.

Most of the scalar operations leave the upper half of the register unchanged. This causes a dependency-tracking issue for unary operations: the operand that OCaml thinks is purely a destination register is also a source register (for a part of the register that OCaml doesn't use).

This means that the processor's dependency-tracking and out-of-order execution gets confused: when it sees `sqrtsd %xmm0, %xmm1` it will stall the instruction until the previous value of `%xmm1` as been computed, even though this should be an independent operation.

This is known as a *partial register stall* and has a standard fix: zero the entire destination register before the offending instruction, so that the processor does not see a dependency to some previous instruction (or in the benchmark above, to the same instruction on a previous iteration of the loop).

The register-zeroing is done by a *dependency-breaking idiom* (in this case, `xorpd`), which are special sequences recognised by the processor as not depending on the previous value.

As far as I can tell, this only affects `sqrt`. It doesn't matter for binary operations, as both of their operands are genuinely sources, and `sqrtsd` is currently the only unary SSE operation that OCaml generates.

For more on partial register stalls and dependency-breaking idioms, read sections 3.5.1.8 and 3.5.2.4 of the [Intel optimisation manual](https://www.intel.co.uk/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-optimization-manual.pdf).

*(Thanks to Andrew Hunter, Will Hasenplaugh, Spiros Eliopoulos and Brian Nigito for help figuring out what was going on here)*
