### PR TITLE
disable warning 30 (same constructor/label used in two mutually-recursive declarations)

### DIFF
--- a/Changes
+++ b/Changes
@@ -270,6 +270,12 @@ Working version
 - #8891: Warn about unused functor parameters
   (Thomas Refis, review by Gabriel Radanne)
 
+- #9046: disable warning 30 by default
+  This outdated warning complained on label/constructor name conflicts
+  within a mutually-recursive type declarations; there is now no need
+  to complain thanks to type-based disambiguation.
+  (Gabriel Scherer)
+
 ### Build system:
 
 - #8840: use ocaml{c,opt}.opt when available to build internal tools

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -1018,7 +1018,7 @@ mentioned here corresponds to the empty set.
 
 .IP
 The default setting is
-.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..42\-44\-45\-48\-50\-60\-66 .
+.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-30\-32..42\-44\-45\-48\-50\-60\-66 .
 Note that warnings
 .BR 5 \ and \ 10
 are not always triggered, depending on the internals of the type checker.

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -393,7 +393,7 @@ let parse_options errflag s =
   current := {(!current) with error; active}
 
 (* If you change these, don't forget to change them in man/ocamlc.m *)
-let defaults_w = "+a-4-6-7-9-27-29-32..42-44-45-48-50-60-66-67";;
+let defaults_w = "+a-4-6-7-9-27-29-30-32..42-44-45-48-50-60-66-67";;
 let defaults_warn_error = "-a+31";;
 
 let () = parse_options false defaults_w;;


### PR DESCRIPTION
Warning 30 warns when the same constructor/label is used in two
mutually-recursive type declarations. This warning (added in OCaml
3.12, 2010) was meaningful at the time where constructor/label
conflicts had a shadowing semantics: the "last" definition would mean,
while ideally mutually-recursive definitions should not be strictly
ordered but defined "all at once".

Since OCaml 4.01 (2013) we support type-based disambiguation of
constructor/label names and it is now common to write code such as,
say

    type pattern = Var of var | ...
    type expr = Var of var | ...

(no warning, of course). But warning 30 fires if you instead write

    type pattern = Var of var | ...
    and expr = Var of var | ...

This doesn't make much sense, and in particular it certainly makes no
sense to enable this warning by default. The present PR disables it by
default.