### PR TITLE
List.partition_map : (a -> (b, c) result) -> a list -> b list * c list

### DIFF
--- a/Changes
+++ b/Changes
@@ -235,6 +235,10 @@ Working version
 - #8971: Add `Filename.null`, the conventional name of the "null" device.
   (Nicolás Ojeda Bär, review by Xavier Leroy and Alain Frisch)
 
+- #NNN: List.partition_map :
+    ('a -> ('b, 'c) result) -> 'a list -> 'b list * 'c list
+  (Gabriel Scherer, review by ???)
+
 ### Other libraries:
 
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -268,6 +268,15 @@ let partition p l =
   | x :: l -> if p x then part (x :: yes) no l else part yes (x :: no) l in
   part [] [] l
 
+let partition_map p l =
+  let rec part yes no = function
+  | [] -> (rev yes, rev no)
+  | x :: l ->
+     begin match p x with
+       | Ok y -> part (y :: yes) no l
+       | Error n -> part yes (n :: no) l in
+  part [] [] l
+
 let rec split = function
     [] -> ([], [])
   | (x,y)::l ->

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -259,6 +259,21 @@ val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
    elements of [l] that do not satisfy [p].
    The order of the elements in the input list is preserved. *)
 
+val partition_map : ('a -> ('b, 'c) result) -> 'a list -> 'b list * 'c list
+(** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
+    for each element [x] of the input list [l]:
+    - if [f x] is [Ok y1], then [y1] is in [l1], and
+    - if [f x] is [Error y2], then [y2] is in [l2].
+
+    The output elements are included in [l1] and [l2] in the same
+    relative order as the corresponding input elements in [l].
+
+    In particular, [partition_map (fun x -> if p x then Ok x else Error x) l]
+    is equivalent to [partition p l].
+
+    @since NEXT_RELEASE
+*)
+
 
 (** {1 Association lists} *)
 

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -1,11 +1,19 @@
 (* TEST
 *)
 
+let is_even x = (x mod 2 = 0)
+
 let string_of_even_opt x =
-  if x mod 2 = 0 then
+  if is_even x then
     Some (string_of_int x)
   else
     None
+
+let string_of_even_or_int x =
+  if is_even x then
+    Ok (string_of_int x)
+  else
+    Error x
 
 (* Standard test case *)
 let () =
@@ -32,6 +40,11 @@ let () =
     assert (List.find_map (f ~limit:3) l = Some (3, 3));
     assert (List.find_map (f ~limit:30) l = None);
   end;
+
+  assert (List.partition is_even [1; 2; 3; 4; 5]
+          = ([2; 4], [1; 3; 5]));
+  assert (List.partition_map string_of_even_or_int [1; 2; 3; 4; 5]
+          = (["2"; "4"], [1; 3; 5]));
 
   assert (List.compare_lengths [] [] = 0);
   assert (List.compare_lengths [1;2] ['a';'b'] = 0);


### PR DESCRIPTION
Note: the docstring is copied from `partition`, then adapted. (In particular, it does not mention the fact that the function is tail-recursive, because `partition` also does not, because the module-level documentation states that all functions are tail-recursive unless stated otherwise.)