### PR TITLE
Add missing local root in win32 `Unix.select`

### DIFF
--- a/Changes
+++ b/Changes
@@ -427,6 +427,7 @@ OCaml 4.10.0
 
 - #9051: fix unregistered local root in win32unix/select.c (could result in
   `select` returning file_descr-like values which weren't in the original sets)
+  and correct initialisation of some blocks allocated with caml_alloc_small.
   (David Allsopp, review by Xavier Leroy)
 
 OCaml 4.09 maintenance branch:

--- a/Changes
+++ b/Changes
@@ -425,6 +425,10 @@ OCaml 4.10.0
 - #8981: Fix check for incompatible -c and -o options.
   (Greta Yorsh, review by Damien Doligez)
 
+- #9051: fix unregistered local root in win32unix/select.c (could result in
+  `select` returning file_descr-like values which weren't in the original sets)
+  (David Allsopp, review by Xavier Leroy)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/otherlibs/win32unix/select.c
+++ b/otherlibs/win32unix/select.c
@@ -1264,20 +1264,20 @@ CAMLprim value unix_select(value readfds, value writefds, value exceptfds,
                 {
                   iterResult = &(iterSelectData->aResults[i]);
                   l = caml_alloc_small(2, 0);
-                  Store_field(l, 0, find_handle(iterResult, readfds, writefds,
-                                                exceptfds));
+                  Field(l, 0) = find_handle(iterResult, readfds, writefds,
+                                            exceptfds);
                   switch (iterResult->EMode)
                     {
                     case SELECT_MODE_READ:
-                      Store_field(l, 1, read_list);
+                      Field(l, 1) =  read_list;
                       read_list = l;
                       break;
                     case SELECT_MODE_WRITE:
-                      Store_field(l, 1, write_list);
+                      Field(l, 1) = write_list;
                       write_list = l;
                       break;
                     case SELECT_MODE_EXCEPT:
-                      Store_field(l, 1, except_list);
+                      Field(l, 1) = except_list;
                       except_list = l;
                       break;
                     case SELECT_MODE_NONE:
@@ -1320,9 +1320,9 @@ CAMLprim value unix_select(value readfds, value writefds, value exceptfds,
 
   DEBUG_PRINT("Build final result");
   res = caml_alloc_small(3, 0);
-  Store_field(res, 0, read_list);
-  Store_field(res, 1, write_list);
-  Store_field(res, 2, except_list);
+  Field(res, 0) = read_list;
+  Field(res, 1) = write_list;
+  Field(res, 2) = except_list;
 
   DEBUG_PRINT("out select");
 

--- a/otherlibs/win32unix/select.c
+++ b/otherlibs/win32unix/select.c
@@ -960,20 +960,19 @@ static int fdlist_to_fdset(value fdlist, fd_set *fdset)
 
 static value fdset_to_fdlist(value fdlist, fd_set *fdset)
 {
-  value res = Val_int(0);
-  value s = Val_int(0);
-  Begin_roots3(fdlist, res, s)
-    for (/*nothing*/; fdlist != Val_int(0); fdlist = Field(fdlist, 1)) {
-      s = Field(fdlist, 0);
-      if (FD_ISSET(Socket_val(s), fdset)) {
-        value newres = caml_alloc_small(2, 0);
-        Field(newres, 0) = s;
-        Field(newres, 1) = res;
-        res = newres;
-      }
+  CAMLparam1(fdlist);
+  CAMLlocal2(res, s);
+  res = Val_int(0);
+  for (/*nothing*/; fdlist != Val_int(0); fdlist = Field(fdlist, 1)) {
+    s = Field(fdlist, 0);
+    if (FD_ISSET(Socket_val(s), fdset)) {
+      value newres = caml_alloc_small(2, 0);
+      Field(newres, 0) = s;
+      Field(newres, 1) = res;
+      res = newres;
     }
-  End_roots();
-  return res;
+  }
+  CAMLreturn(res);
 }
 
 CAMLprim value unix_select(value readfds, value writefds, value exceptfds,

--- a/otherlibs/win32unix/select.c
+++ b/otherlibs/win32unix/select.c
@@ -961,9 +961,10 @@ static int fdlist_to_fdset(value fdlist, fd_set *fdset)
 static value fdset_to_fdlist(value fdlist, fd_set *fdset)
 {
   value res = Val_int(0);
-  Begin_roots2(fdlist, res)
+  value s = Val_int(0);
+  Begin_roots3(fdlist, res, s)
     for (/*nothing*/; fdlist != Val_int(0); fdlist = Field(fdlist, 1)) {
-      value s = Field(fdlist, 0);
+      s = Field(fdlist, 0);
       if (FD_ISSET(Socket_val(s), fdset)) {
         value newres = caml_alloc_small(2, 0);
         Field(newres, 0) = s;


### PR DESCRIPTION
This fixes #9043.

The patch is organised in three commits. The first is the simplest fix:
```diff
-- a/otherlibs/win32unix/select.c
+++ b/otherlibs/win32unix/select.c
@@ -961,9 +961,10 @@ static int fdlist_to_fdset(value fdlist, fd_set *fdset)
 static value fdset_to_fdlist(value fdlist, fd_set *fdset)
 {
   value res = Val_int(0);
-  Begin_roots2(fdlist, res)
+  value s = Val_int(0);
+  Begin_roots3(fdlist, res, s)
     for (/*nothing*/; fdlist != Val_int(0); fdlist = Field(fdlist, 1)) {
-      value s = Field(fdlist, 0);
+      s = Field(fdlist, 0);
       if (FD_ISSET(Socket_val(s), fdset)) {
         value newres = caml_alloc_small(2, 0);
         Field(newres, 0) = s;
```
It appears that the planets aligned (consistently) in such a way that msvc64 AppVeyor was routinely triggering a GC at the `caml_alloc_small` and `fdlist` was moved. The planets had to be aligned to the point that the test was failing only as part of `make all` and not as `make one`.

I did a limited test to confirm the problem by manually inserting a call `caml_gc_full_major` immediately after the `value s = Field(…` line. This causes all the Windows ports to freeze at this stage, suggesting a problem. With the `Begin_roots3` version, they continue to work.

The second commit converts the entire function to use `CAMLparam` instead (I think it only used `Begin_roots2` because it was taken from an old function which predates those macros).

While going through `select.c`, I noticed uses of `Store_field` following `caml_alloc_small` which violates GC Rule 5 (although I'm not sure that it's a problematic violation of Rule 5, since the expressions in question don't allocate).