### PR TITLE
Fix 'extra-check' INRIA CI

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -503,12 +503,18 @@ extern void caml_instr_atexit (void);
 
 #endif /* CAML_INSTR */
 
-/* Macro used to deactivate thread sanitizer on some functions. */
+/* Macro used to deactivate thread and address sanitizers on some
+   functions. */
 #define CAMLno_tsan
+#define CAMLno_asan
 #if defined(__has_feature)
 #  if __has_feature(thread_sanitizer)
 #    undef CAMLno_tsan
 #    define CAMLno_tsan __attribute__((no_sanitize("thread")))
+#  endif
+#  if __has_feature(address_sanitizer)
+#    undef CAMLno_asan
+#    define CAMLno_asan __attribute__((no_sanitize("address")))
 #  endif
 #endif
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -56,6 +56,9 @@ CAMLnoreturn_start
   extern void caml_raise_exception (caml_domain_state* state, value bucket)
 CAMLnoreturn_end;
 
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan
 void caml_raise(value v)
 {
   Unlock_exn();
@@ -69,6 +72,9 @@ void caml_raise(value v)
   caml_raise_exception(Caml_state, v);
 }
 
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan
 void caml_raise_constant(value tag)
 {
   caml_raise(tag);
@@ -134,6 +140,9 @@ void caml_raise_out_of_memory(void)
   caml_raise_constant((value) caml_exn_Out_of_memory);
 }
 
+/* Used by the stack overflow handler -> deactivate ASAN (see
+   segv_handler in signals_nat.c). */
+CAMLno_asan
 void caml_raise_stack_overflow(void)
 {
   caml_raise_constant((value) caml_exn_Stack_overflow);

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -201,6 +201,10 @@ static char sig_alt_stack[SIGSTKSZ];
 extern void caml_stack_overflow(caml_domain_state*);
 #endif
 
+/* Address sanitizer is confused when running the stack overflow
+   handler in an alternate stack. We deactivate it for all the
+   functions used by the stack overflow handler. */
+CAMLno_asan
 DECLARE_SIGNAL_HANDLER(segv_handler)
 {
   struct sigaction act;

--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -183,11 +183,16 @@ LSAN_OPTIONS="suppressions=$(pwd)/tools/ci/inria/lsan-suppr.txt" \
 make $jobs world.opt
 
 # Run the testsuite.
-# The suppressed leak detections related to ocamlyacc mess up the output
-# of the tests and are reported as failures by ocamltest.
-# Hence, deactivate leak detection entirely.
+# We deactivate leak detection for two reasons:
+# - The suppressed leak detections related to ocamlyacc mess up the
+# output of the tests and are reported as failures by ocamltest.
+# - The Ocaml runtime does not free the memory when a fatal error
+# occurs.
 
-ASAN_OPTIONS="detect_leaks=0" $run_testsuite
+# We already use sigaltstack for stack overflow detection. Our use
+# interracts with ASAN's. Hence, we tell ASAN not to use it.
+
+ASAN_OPTIONS="detect_leaks=0,use_sigaltstack=0" $run_testsuite
 
 #########################################################################
 


### PR DESCRIPTION
Since the new stack overflow detection system (#8670), ASAN was confused.
We fix the issue by resetting the 'use_sigaltstack' flag and by disabling
ASAN on functions used by the stack overflow handler.