### PR TITLE
[RFC] Add a single file to load path

### DIFF
--- a/.depend
+++ b/.depend
@@ -32,6 +32,7 @@ utils/clflags.cmo : \
     utils/profile.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
+    utils/load_path.cmi \
     utils/config.cmi \
     utils/arg_helper.cmi \
     utils/clflags.cmi
@@ -39,12 +40,14 @@ utils/clflags.cmx : \
     utils/profile.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
+    utils/load_path.cmx \
     utils/config.cmx \
     utils/arg_helper.cmx \
     utils/clflags.cmi
 utils/clflags.cmi : \
     utils/profile.cmi \
-    utils/misc.cmi
+    utils/misc.cmi \
+    utils/load_path.cmi
 utils/config.cmo : \
     utils/config.cmi
 utils/config.cmx : \
@@ -3805,6 +3808,7 @@ file_formats/cmt_format.cmi : \
     typing/typedtree.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     typing/env.cmi \
     file_formats/cmi_format.cmi
 file_formats/cmx_format.cmi : \
@@ -5777,6 +5781,7 @@ driver/compenv.cmo : \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi \
@@ -5786,11 +5791,13 @@ driver/compenv.cmx : \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/load_path.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     utils/ccomp.cmx \
     driver/compenv.cmi
 driver/compenv.cmi : \
+    utils/load_path.cmi \
     utils/clflags.cmi
 driver/compile.cmo : \
     typing/typedtree.cmi \
@@ -5915,6 +5922,7 @@ driver/main_args.cmo : \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     utils/config.cmi \
     driver/compenv.cmi \
     utils/clflags.cmi \
@@ -5924,6 +5932,7 @@ driver/main_args.cmx : \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/load_path.cmx \
     utils/config.cmx \
     driver/compenv.cmx \
     utils/clflags.cmx \
@@ -5967,6 +5976,7 @@ driver/makedepend.cmo : \
     parsing/parse.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     parsing/lexer.cmi \
     parsing/depend.cmi \
     utils/config.cmi \
@@ -5980,6 +5990,7 @@ driver/makedepend.cmx : \
     parsing/parse.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    utils/load_path.cmx \
     parsing/lexer.cmx \
     parsing/depend.cmx \
     utils/config.cmx \

--- a/.depend
+++ b/.depend
@@ -6417,6 +6417,7 @@ toplevel/byte/topmain.cmo : \
     utils/misc.cmi \
     driver/main_args.cmi \
     parsing/location.cmi \
+    utils/load_path.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     driver/compmisc.cmi \
@@ -6434,6 +6435,7 @@ toplevel/byte/topmain.cmx : \
     utils/misc.cmx \
     driver/main_args.cmx \
     parsing/location.cmx \
+    utils/load_path.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     driver/compmisc.cmx \

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -34,7 +34,7 @@ let default_ui_export_info =
 let read_info name =
   let filename =
     try
-      Load_path.find name
+      Load_path.Cache.find name
     with Not_found ->
       raise(Error(File_not_found name)) in
   let (info, crc) = Compilenv.read_unit_info filename in

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -120,7 +120,7 @@ let runtime_lib () =
   let libname = "libasmrun" ^ !Clflags.runtime_variant ^ ext_lib in
   try
     if !Clflags.nopervasives || not !Clflags.with_runtime then []
-    else [ Load_path.find libname ]
+    else [ Load_path.Cache.find libname ]
   with Not_found ->
     raise(Error(File_not_found libname))
 
@@ -165,7 +165,7 @@ let object_file_name_of_file = function
 let read_file obj_name =
   let file_name =
     try
-      Load_path.find obj_name
+      Load_path.Cache.find obj_name
     with Not_found ->
       raise(Error(File_not_found obj_name)) in
   if Filename.check_suffix file_name ".cmx" then begin

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -254,7 +254,7 @@ let package_files ~ppf_dump initial_env files targetcmx ~backend =
   let files =
     List.map
       (fun f ->
-        try Load_path.find f
+        try Load_path.Cache.find f
         with Not_found -> raise(Error(File_not_found f)))
       files in
   let prefix = chop_extensions targetcmx in

--- a/bytecomp/bytelibrarian.ml
+++ b/bytecomp/bytelibrarian.ml
@@ -58,7 +58,7 @@ let add_ccobjs l =
 let copy_object_file oc name =
   let file_name =
     try
-      Load_path.find name
+      Load_path.Cache.find name
     with Not_found ->
       raise(Error(File_not_found name)) in
   let ic = open_in_bin file_name in

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -117,7 +117,7 @@ let remove_required (rel, _pos) =
 let scan_file obj_name tolink =
   let file_name =
     try
-      Load_path.find obj_name
+      Load_path.Cache.find obj_name
     with Not_found ->
       raise(Error(File_not_found obj_name)) in
   let ic = open_in_bin file_name in
@@ -330,7 +330,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
            then "camlheader_ur" else "camlheader" ^ !Clflags.runtime_variant
          in
          try
-           let inchan = open_in_bin (Load_path.find header) in
+           let inchan = open_in_bin (Load_path.Cache.find header) in
            copy_file inchan outchan;
            close_in inchan
          with
@@ -363,7 +363,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
        if check_dlls then begin
          (* Initialize the DLL machinery *)
          Dll.init_compile !Clflags.no_std_include;
-         Dll.add_path (Load_path.get_paths ());
+         Dll.add_path (Load_path.Cache.get_paths ());
          try Dll.open_dlls Dll.For_checking sharedobjs
          with Failure reason -> raise(Error(Cannot_open_dll reason))
        end;

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -363,7 +363,7 @@ let link_bytecode ?final_name tolink exec_name standalone =
        if check_dlls then begin
          (* Initialize the DLL machinery *)
          Dll.init_compile !Clflags.no_std_include;
-         Dll.add_path (Load_path.Cache.get_paths ());
+         Dll.add_path (Load_path.dirs (Load_path.Cache.get_paths ()));
          try Dll.open_dlls Dll.For_checking sharedobjs
          with Failure reason -> raise(Error(Cannot_open_dll reason))
        end;

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -282,7 +282,7 @@ let package_files ~ppf_dump initial_env files targetfile =
     let files =
     List.map
         (fun f ->
-        try Load_path.find f
+        try Load_path.Cache.find f
         with Not_found -> raise(Error(File_not_found f)))
         files in
     let prefix = chop_extensions targetfile in

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -31,10 +31,10 @@ UTILS = \
   utils/identifiable.cmo \
   utils/numbers.cmo \
   utils/arg_helper.cmo \
-  utils/clflags.cmo \
-  utils/profile.cmo \
   utils/local_store.cmo \
   utils/load_path.cmo \
+  utils/clflags.cmo \
+  utils/profile.cmo \
   utils/terminfo.cmo \
   utils/ccomp.cmo \
   utils/warnings.cmo \

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -551,13 +551,11 @@ show_source.cmi : \
     ../bytecomp/instruct.cmi
 source.cmo : \
     primitives.cmi \
-    ../utils/misc.cmi \
     ../utils/load_path.cmi \
     debugger_config.cmi \
     source.cmi
 source.cmx : \
     primitives.cmx \
-    ../utils/misc.cmx \
     ../utils/load_path.cmx \
     debugger_config.cmx \
     source.cmi

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -138,7 +138,8 @@ debugger_config.cmo : \
 debugger_config.cmx : \
     int64ops.cmx \
     debugger_config.cmi
-debugger_config.cmi :
+debugger_config.cmi : \
+    ../utils/load_path.cmi
 debugger_lexer.cmo : \
     debugger_parser.cmi \
     debugger_lexer.cmi
@@ -317,7 +318,6 @@ main.cmo : \
     primitives.cmi \
     ../typing/persistent_env.cmi \
     parameters.cmi \
-    ../utils/misc.cmi \
     loadprinter.cmi \
     ../utils/load_path.cmi \
     input_handling.cmi \
@@ -339,7 +339,6 @@ main.cmx : \
     primitives.cmx \
     ../typing/persistent_env.cmx \
     parameters.cmx \
-    ../utils/misc.cmx \
     loadprinter.cmx \
     ../utils/load_path.cmx \
     input_handling.cmx \
@@ -363,7 +362,8 @@ parameters.cmx : \
     debugger_config.cmx \
     ../utils/config.cmx \
     parameters.cmi
-parameters.cmi :
+parameters.cmi : \
+    ../utils/load_path.cmi
 parser_aux.cmi : \
     ../parsing/longident.cmi \
     debugcom.cmi

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -262,7 +262,7 @@ let instr_dir ppf lexbuf =
   let new_directory = argument_list_eol argument lexbuf in
     if new_directory = [] then begin
       if yes_or_no "Reinitialize directory list" then begin
-        Load_path.init !default_load_path;
+        Load_path.Cache.init !default_load_path;
         Envaux.reset_cache ();
         Hashtbl.clear Debugger_config.load_path_for;
         flush_buffer_list ()
@@ -278,7 +278,8 @@ let instr_dir ppf lexbuf =
           List.iter (function x -> add_path (expand_path x)) new_directory'
     end;
     let print_dirs ppf l = List.iter (function x -> fprintf ppf "@ %s" x) l in
-    fprintf ppf "@[<2>Directories: %a@]@." print_dirs (Load_path.get_paths ());
+    fprintf ppf "@[<2>Directories: %a@]@." print_dirs
+      (Load_path.Cache.get_paths ());
     Hashtbl.iter
       (fun mdl dirs ->
          fprintf ppf "@[<2>Source directories for %s: %a@]@." mdl print_dirs
@@ -561,7 +562,7 @@ let instr_source ppf lexbuf =
     let io_chan =
       try
         io_channel_of_descr
-          (openfile (Load_path.find (expand_path file))
+          (openfile (Load_path.Cache.find (expand_path file))
              [O_RDONLY] 0)
       with
       | Not_found -> error "Source file not found."

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -279,7 +279,7 @@ let instr_dir ppf lexbuf =
     end;
     let print_dirs ppf l =
       List.iter (function x -> fprintf ppf "@ %s" x)
-        (Load_path.paths l) in
+        (List.map Load_path.path_to_string (Load_path.paths l)) in
     fprintf ppf "@[<2>Directories: %a@]@." print_dirs
       (Load_path.Cache.get_paths ());
     Hashtbl.iter

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -277,7 +277,9 @@ let instr_dir ppf lexbuf =
       | _ ->
           List.iter (function x -> add_path (expand_path x)) new_directory'
     end;
-    let print_dirs ppf l = List.iter (function x -> fprintf ppf "@ %s" x) l in
+    let print_dirs ppf l =
+      List.iter (function x -> fprintf ppf "@ %s" x)
+        (Load_path.paths l) in
     fprintf ppf "@[<2>Directories: %a@]@." print_dirs
       (Load_path.Cache.get_paths ());
     Hashtbl.iter

--- a/debugger/debugger_config.mli
+++ b/debugger/debugger_config.mli
@@ -26,7 +26,7 @@ val event_mark_after : string
 val shell : string
 val runtime_program : string
 val history_size : int ref
-val load_path_for : (string, string list) Hashtbl.t
+val load_path_for : (string, Load_path.t) Hashtbl.t
 
 (*** Time travel parameters. ***)
 

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -36,13 +36,13 @@ open Format
 
 let rec loadfiles ppf name =
   try
-    let filename = Load_path.find name in
+    let filename = Load_path.Cache.find name in
     Dynlink.allow_unsafe_modules true;
     Dynlink.loadfile filename;
     let d = Filename.dirname name in
     if d <> Filename.current_dir_name then begin
-      if not (List.mem d (Load_path.get_paths ())) then
-        Load_path.add_dir d;
+      if not (List.mem d (Load_path.Cache.get_paths ())) then
+        Load_path.Cache.add_dir d;
     end;
     fprintf ppf "File %s loaded@."
       (if d <> Filename.current_dir_name then

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -41,7 +41,7 @@ let rec loadfiles ppf name =
     Dynlink.loadfile filename;
     let d = Filename.dirname name in
     if d <> Filename.current_dir_name then begin
-      if not (List.mem d (Load_path.Cache.get_paths ())) then
+      if not (Load_path.mem d (Load_path.Cache.get_paths ())) then
         Load_path.Cache.add_dir d;
     end;
     fprintf ppf "File %s loaded@."

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -41,7 +41,7 @@ let rec loadfiles ppf name =
     Dynlink.loadfile filename;
     let d = Filename.dirname name in
     if d <> Filename.current_dir_name then begin
-      if not (Load_path.mem d (Load_path.Cache.get_paths ())) then
+      if not Load_path.(mem (Dir d) (Cache.get_paths ())) then
         Load_path.Cache.add_dir d;
     end;
     fprintf ppf "File %s loaded@."

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -148,8 +148,7 @@ exception Found_program_name
 let anonymous s =
   program_name := Unix_tools.make_absolute s; raise Found_program_name
 let add_include d =
-  default_load_path :=
-    Misc.expand_directory Config.standard_library d :: !default_load_path
+  default_load_path := Load_path.add_dir !default_load_path d
 let set_socket s =
   socket_name := s
 let set_topdirs_path s =
@@ -230,7 +229,8 @@ let main () =
     if !Parameters.version
     then printf "\tOCaml Debugger version %s@.@." Config.version;
     Loadprinter.init();
-    Load_path.Cache.init !default_load_path;
+    Load_path.Cache.init
+      (Load_path.expand_directory Config.standard_library !default_load_path);
     Clflags.recursive_types := true;    (* Allow recursive types. *)
     toplevel_loop ();                   (* Toplevel. *)
     kill_program ();

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -230,7 +230,7 @@ let main () =
     if !Parameters.version
     then printf "\tOCaml Debugger version %s@.@." Config.version;
     Loadprinter.init();
-    Load_path.init !default_load_path;
+    Load_path.Cache.init !default_load_path;
     Clflags.recursive_types := true;    (* Allow recursive types. *)
     toplevel_loop ();                   (* Toplevel. *)
     kill_program ();

--- a/debugger/parameters.ml
+++ b/debugger/parameters.ml
@@ -33,7 +33,7 @@ let version = ref true
 let topdirs_path = ref (Filename.concat Config.standard_library "compiler-libs")
 
 let add_path dir =
-  Load_path.add_dir dir;
+  Load_path.Cache.add_dir dir;
   Envaux.reset_cache()
 
 let add_path_for mdl dir =

--- a/debugger/parameters.ml
+++ b/debugger/parameters.ml
@@ -23,7 +23,7 @@ let socket_name = ref ""
 let arguments = ref ""
 
 let default_load_path =
-  ref [ Filename.current_dir_name; Config.standard_library ]
+  ref (Load_path.of_dirs [ Filename.current_dir_name; Config.standard_library ])
 
 let breakpoint = ref true
 let prompt = ref true
@@ -37,8 +37,9 @@ let add_path dir =
   Envaux.reset_cache()
 
 let add_path_for mdl dir =
-  let old = try Hashtbl.find load_path_for mdl with Not_found -> [] in
-  Hashtbl.replace load_path_for mdl (dir :: old)
+  let old =
+    try Hashtbl.find load_path_for mdl with Not_found -> Load_path.empty in
+  Hashtbl.replace load_path_for mdl (Load_path.add_dir old dir)
 
 (* Used by emacs ? *)
 let emacs = ref false

--- a/debugger/parameters.mli
+++ b/debugger/parameters.mli
@@ -19,7 +19,7 @@
 val program_name : string ref
 val socket_name : string ref
 val arguments : string ref
-val default_load_path : string list ref
+val default_load_path : Load_path.t ref
 val breakpoint : bool ref
 val prompt : bool ref
 val time : bool ref

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -128,7 +128,8 @@ let initialize_loading () =
   end;
   Symbols.clear_symbols ();
   Symbols.read_symbols 0 !program_name;
-  Load_path.init (Load_path.get_paths () @ !Symbols.program_source_dirs);
+  Load_path.Cache.init
+    (Load_path.Cache.get_paths () @ !Symbols.program_source_dirs);
   Envaux.reset_cache ();
   if !debug_loading then
     prerr_endline "Opening a socket...";

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -129,7 +129,9 @@ let initialize_loading () =
   Symbols.clear_symbols ();
   Symbols.read_symbols 0 !program_name;
   Load_path.Cache.init
-    (Load_path.Cache.get_paths () @ !Symbols.program_source_dirs);
+    (Load_path.concat
+       [Load_path.Cache.get_paths ();
+        Load_path.of_dirs !Symbols.program_source_dirs]);
   Envaux.reset_cache ();
   if !debug_loading then
     prerr_endline "Opening a socket...";

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -41,6 +41,7 @@ let source_of_module pos mdle =
           acc)
       Debugger_config.load_path_for
       (Load_path.Cache.get_paths ()) in
+  let path = Load_path.paths path in
   let fname = pos.Lexing.pos_fname in
   if fname = "" then
     let innermost_module =

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -16,7 +16,6 @@
 
 (************************ Source management ****************************)
 
-open Misc
 open Primitives
 
 let source_extensions = [".ml"]
@@ -41,7 +40,6 @@ let source_of_module pos mdle =
           acc)
       Debugger_config.load_path_for
       (Load_path.Cache.get_paths ()) in
-  let path = Load_path.paths path in
   let fname = pos.Lexing.pos_fname in
   if fname = "" then
     let innermost_module =
@@ -53,11 +51,11 @@ let source_of_module pos mdle =
       function
         | [] -> raise Not_found
         | ext :: exts ->
-          try find_in_path_uncap path (innermost_module ^ ext)
+          try Load_path.find_uncap (innermost_module ^ ext) path
           with Not_found -> loop exts
     in loop source_extensions
   else if Filename.is_relative fname then
-    find_in_path_rel path fname
+    Load_path.find_rel fname path
   else if Sys.file_exists fname then fname
   else raise Not_found
 

--- a/debugger/source.ml
+++ b/debugger/source.ml
@@ -40,7 +40,7 @@ let source_of_module pos mdle =
         else
           acc)
       Debugger_config.load_path_for
-      (Load_path.get_paths ()) in
+      (Load_path.Cache.get_paths ()) in
   let fname = pos.Lexing.pos_fname in
   if fname = "" then
     let innermost_module =

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -52,8 +52,8 @@ let default_output = function
   | Some s -> s
   | None -> Config.default_executable_name
 
-let first_include_dirs = ref []
-let last_include_dirs = ref []
+let initial_load_path = ref Load_path.empty
+let final_load_path = ref Load_path.empty
 let first_ccopts = ref []
 let last_ccopts = ref []
 let first_ppx = ref []
@@ -399,9 +399,10 @@ let read_one_param ppf position name v =
 
   | "I" -> begin
       match position with
-      | Before_args -> first_include_dirs := v :: !first_include_dirs
+      | Before_args ->
+        initial_load_path := Load_path.add_dir !initial_load_path v
       | Before_link | Before_compile _ ->
-        last_include_dirs := v :: !last_include_dirs
+        final_load_path := Load_path.add_dir !final_load_path v
     end
 
   | "cclib" ->
@@ -590,7 +591,7 @@ let apply_config_file ppf position =
     config
 
 let readenv ppf position =
-  last_include_dirs := [];
+  final_load_path := Load_path.empty;
   last_ccopts := [];
   last_ppx := [];
   last_objfiles := [];

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -28,8 +28,8 @@ val fatal : string -> 'a
 
 val first_ccopts : string list ref
 val first_ppx : string list ref
-val first_include_dirs : string list ref
-val last_include_dirs : string list ref
+val initial_load_path : Load_path.t ref
+val final_load_path : Load_path.t ref
 
 (* return the list of objfiles, after OCAMLPARAM and List.rev *)
 val get_objfiles : with_ocamlparam:bool -> string list

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -21,18 +21,27 @@
 
 let init_path ?(dir="") () =
   let dirs =
-    if !Clflags.use_threads then "+threads" :: !Clflags.include_dirs
+    if !Clflags.use_threads then
+      Load_path.add_dir !Clflags.load_path "+threads"
     else
-      !Clflags.include_dirs
+      !Clflags.load_path
   in
   let dirs =
-    !Compenv.last_include_dirs @ dirs @ Config.flexdll_dirs @
-    !Compenv.first_include_dirs
+    Load_path.concat
+      [
+        !Compenv.initial_load_path;
+        Load_path.of_dirs Config.flexdll_dirs;
+        dirs;
+        !Compenv.final_load_path;
+      ]
   in
-  let exp_dirs =
-    List.map (Misc.expand_directory Config.standard_library) dirs in
   Load_path.Cache.init
-    (dir :: List.rev_append exp_dirs (Clflags.std_include_dir ()));
+    (Load_path.concat
+       [
+         Load_path.of_dirs [dir];
+         Load_path.expand_directory Config.standard_library dirs;
+         Load_path.of_dirs (Clflags.std_include_dir ());
+       ]);
   Env.reset_cache ()
 
 (* Return the initial environment in which compilation proceeds. *)

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -31,7 +31,8 @@ let init_path ?(dir="") () =
   in
   let exp_dirs =
     List.map (Misc.expand_directory Config.standard_library) dirs in
-  Load_path.init (dir :: List.rev_append exp_dirs (Clflags.std_include_dir ()));
+  Load_path.Cache.init
+    (dir :: List.rev_append exp_dirs (Clflags.std_include_dir ()));
   Env.reset_cache ()
 
 (* Return the initial environment in which compilation proceeds. *)

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1708,7 +1708,7 @@ module Default = struct
 
   module Core = struct
     include Common
-    let _I dir = include_dirs := (dir :: (!include_dirs))
+    let _I dir = load_path := Load_path.add_dir !load_path dir
     let _color = Misc.set_or_ignore color_reader.parse color
     let _dlambda = set dump_lambda
     let _dparsetree = set dump_parsetree

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -162,6 +162,10 @@ let mk_I f =
   "-I", Arg.String f, "<dir>  Add <dir> to the list of include directories"
 ;;
 
+let mk_inc f =
+  "-inc", Arg.String f, "<file>  Add <file> to the load path"
+;;
+
 let mk_impl f =
   "-impl", Arg.String f, "<file>  Compile <file> as a .ml file"
 ;;
@@ -902,6 +906,7 @@ module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
   val _I : string -> unit
+  val _inc : string -> unit
   val _labels : unit -> unit
   val _alias_deps : unit -> unit
   val _no_alias_deps : unit -> unit
@@ -1169,6 +1174,7 @@ struct
     mk_stop_after ~native:false F._stop_after;
     mk_i F._i;
     mk_I F._I;
+    mk_inc F._inc;
     mk_impl F._impl;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1262,6 +1268,7 @@ struct
     mk_absname F._absname;
     mk_alert F._alert;
     mk_I F._I;
+    mk_inc F._inc;
     mk_init F._init;
     mk_labels F._labels;
     mk_alias_deps F._alias_deps;
@@ -1350,6 +1357,7 @@ struct
     mk_save_ir_after ~native:true F._save_ir_after;
     mk_i F._i;
     mk_I F._I;
+    mk_inc F._inc;
     mk_impl F._impl;
     mk_inline F._inline;
     mk_inline_toplevel F._inline_toplevel;
@@ -1483,6 +1491,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_alert F._alert;
     mk_compact F._compact;
     mk_I F._I;
+    mk_inc F._inc;
     mk_init F._init;
     mk_inline F._inline;
     mk_inline_toplevel F._inline_toplevel;
@@ -1583,6 +1592,7 @@ struct
     mk_absname F._absname;
     mk_alert F._alert;
     mk_I F._I;
+    mk_inc F._inc;
     mk_impl F._impl;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1709,6 +1719,7 @@ module Default = struct
   module Core = struct
     include Common
     let _I dir = load_path := Load_path.add_dir !load_path dir
+    let _inc file = load_path := Load_path.add_file !load_path file
     let _color = Misc.set_or_ignore color_reader.parse color
     let _dlambda = set dump_lambda
     let _dparsetree = set dump_parsetree
@@ -1956,6 +1967,7 @@ module Default = struct
       (* placeholder:
          Odoc_global.include_dirs := (s :: (!Odoc_global.include_dirs))
       *) ()
+    let _inc(_:string) = ()
     let _impl (_:string) =
       (* placeholder:
          Odoc_global.files := ((!Odoc_global.files) @ [Odoc_global.Impl_file s])

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -20,6 +20,7 @@ module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
   val _I : string -> unit
+  val _inc : string -> unit
   val _labels : unit -> unit
   val _alias_deps : unit -> unit
   val _no_alias_deps : unit -> unit

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -416,7 +416,7 @@ let process_file_as process_fun def source_file =
         !Compenv.final_load_path;
       ]
   in
-  List.iter add_to_load_path (Load_path.paths load_path);
+  List.iter add_to_load_path (Load_path.dirs load_path); (* FIXME *)
   Location.input_name := source_file;
   try
     if Sys.file_exists source_file then process_fun source_file else def

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -181,7 +181,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env cmi =
            cmt_args = Sys.argv;
            cmt_sourcefile = sourcefile;
            cmt_builddir = Location.rewrite_absolute_path (Sys.getcwd ());
-           cmt_loadpath = Load_path.get_paths ();
+           cmt_loadpath = Load_path.Cache.get_paths ();
            cmt_source_digest = source_digest;
            cmt_initial_env = if need_to_clear_env then
                keep_only_summary initial_env else initial_env;

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -54,7 +54,7 @@ type cmt_infos = {
   cmt_args : string array;
   cmt_sourcefile : string option;
   cmt_builddir : string;
-  cmt_loadpath : string list;
+  cmt_loadpath : Load_path.t;
   cmt_source_digest : Digest.t option;
   cmt_initial_env : Env.t;
   cmt_imports : (string * Digest.t option) list;

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -59,7 +59,7 @@ type cmt_infos = {
   cmt_args : string array;
   cmt_sourcefile : string option;
   cmt_builddir : string;
-  cmt_loadpath : string list;
+  cmt_loadpath : Load_path.t;
   cmt_source_digest : string option;
   cmt_initial_env : Env.t;
   cmt_imports : crcs;

--- a/manual/src/cmds/comp.etex
+++ b/manual/src/cmds/comp.etex
@@ -173,13 +173,13 @@ the name of the module they describe (for ".cmi" files) or implement
 (for ".cmo" files).
 
 When the compiler encounters a reference to a free module identifier
-"Mod", it looks in the search path for a file named "Mod.cmi" or "mod.cmi"
-and loads the compiled interface
+"Mod", it looks in the load path (see below) for a file named "Mod.cmi"
+or "mod.cmi" and loads the compiled interface
 contained in that file. As a consequence, renaming ".cmi" files is not
 advised: the name of a ".cmi" file must always correspond to the name
 of the compilation unit it implements. It is admissible to move them
-to another directory, if their base name is preserved, and the correct
-"-I" options are given to the compiler. The compiler will flag an
+to another directory, if their base name is preserved, and the file
+can still be found in the load path. The compiler will flag an
 error if it loads a ".cmi" file that has been renamed.
 
 Compiled bytecode files (".cmo" files), on the other hand, can be
@@ -187,6 +187,13 @@ freely renamed once created. That's because the linker never attempts
 to find by itself the ".cmo" file that implements a module with a
 given name: it relies instead on the user providing the list of ".cmo"
 files by hand.
+
+The {\em load path} is a list of directories and single files maintained by the
+compiler to look up, in order, for files needed to compile and/or link programs.
+
+By default the load path consists of the current directory and the standard
+library directory, but new entries can be added by using the "-I" and "-inc"
+flags.
 
 \section{s:comp-errors}{Common errors}
 
@@ -197,7 +204,7 @@ error messages.
 
 \item[Cannot find file \var{filename}]
 The named file could not be found in the current directory, nor in the
-directories of the search path. The \var{filename} is either a
+directories of the load path. The \var{filename} is either a
 compiled interface file (".cmi" file), or a compiled bytecode file
 (".cmo" file). If \var{filename} has the format \var{mod}".cmi", this
 means you are trying to compile a file that references identifiers

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -256,9 +256,9 @@ and edit that file to remove all declarations of unexported names.
 }%notop
 
 \item["-I" \var{directory}]
-Add the given directory to the list of directories searched for
-\nat{compiled interface files (".cmi"), compiled object code files (".cmx"),
-and libraries (".cmxa").}
+Add the given directory to the {em load path}, the list of directories and
+files searched for \nat{compiled interface files (".cmi"), compiled object
+code files (".cmx"), and libraries (".cmxa").}
 \comp{compiled interface files (".cmi"), compiled object code files ".cmo",
 libraries (".cma") and C libraries specified with "-cclib -lxxx".}
 \top{source and compiled files.}
@@ -269,13 +269,38 @@ but before the standard library directory. See also option "-nostdlib".
 
 If the given directory starts with "+", it is taken relative to the
 standard library directory.  For instance, "-I +unix" adds the
-subdirectory "unix" of the standard library to the search path.
+subdirectory "unix" of the standard library to the load path.
+
+Note that "<dir>" will be searched whenever the compiler needs to look up a file
+given by a relative path. This includes the case of compilation objects of
+top-level modules mentioned in the program text, but also relative paths passed
+on the command-line.
 
 \top{%
 Directories can also be added to the list once
 the toplevel is running with the "#directory" directive
 (section~\ref{s:toplevel-directives}).
 }%top
+
+\item["-inc" \var{file}]
+
+Add the given file to the {em load path} (see also option "-I"). In contrast to
+"-I", this flag only adds the given file to the load path, the rest of the files
+in the parent directory of "file" remain hidden from the compiler unless they
+are added to the load path in some other way.
+
+As for "-I", files added to the load path using this flag are inserted in order
+after the current directory but before the standard library directory, and
+precedence is left-to-right.
+
+Similarly, if the given file starts with "+", it is taken relative to the
+standard library directory.  For instance, "-inc +list.cmi" adds the file
+"list.cmi" of the standard library to the load path.
+
+Note that in contrast to "-I", arguments to "-inc" will only be used when
+looking up paths consisting of a single basename. This includes the case of
+compilation objects of top-level modules mentioned in the program text, but also
+basenames passed on the command line.
 
 \top{%
 \item["-init" \var{file}]

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -197,7 +197,7 @@ let get_global_info global_ident = (
         else begin
           try
             let filename =
-              Load_path.find_uncap (modname ^ ".cmx") in
+              Load_path.Cache.find_uncap (modname ^ ".cmx") in
             let (ui, crc) = read_unit_info filename in
             if ui.ui_name <> modname then
               raise(Error(Illegal_renaming(modname, ui.ui_name, filename)));

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -85,6 +85,7 @@ odoc_args.cmo : \
     odoc_dot.cmo \
     odoc_config.cmi \
     ../driver/main_args.cmi \
+    ../utils/load_path.cmi \
     ../utils/config.cmi \
     ../driver/compenv.cmi \
     odoc_args.cmi
@@ -100,6 +101,7 @@ odoc_args.cmx : \
     odoc_dot.cmx \
     odoc_config.cmx \
     ../driver/main_args.cmx \
+    ../utils/load_path.cmx \
     ../utils/config.cmx \
     ../driver/compenv.cmx \
     odoc_args.cmi
@@ -353,7 +355,8 @@ odoc_global.cmx : \
     ../utils/clflags.cmx \
     odoc_global.cmi
 odoc_global.cmi : \
-    odoc_types.cmi
+    odoc_types.cmi \
+    ../utils/load_path.cmi
 odoc_html.cmo : \
     odoc_text.cmi \
     odoc_ocamlhtml.cmo \
@@ -395,6 +398,7 @@ odoc_info.cmo : \
     odoc_class.cmo \
     odoc_analyse.cmi \
     ../parsing/location.cmi \
+    ../utils/load_path.cmi \
     odoc_info.cmi
 odoc_info.cmx : \
     ../typing/printtyp.cmx \
@@ -419,6 +423,7 @@ odoc_info.cmx : \
     odoc_class.cmx \
     odoc_analyse.cmx \
     ../parsing/location.cmx \
+    ../utils/load_path.cmx \
     odoc_info.cmi
 odoc_info.cmi : \
     ../typing/types.cmi \
@@ -433,6 +438,7 @@ odoc_info.cmi : \
     odoc_exception.cmo \
     odoc_class.cmo \
     ../parsing/location.cmi \
+    ../utils/load_path.cmi \
     ../parsing/asttypes.cmi
 odoc_inherit.cmo :
 odoc_inherit.cmx :

--- a/ocamldoc/odoc_args.ml
+++ b/ocamldoc/odoc_args.ml
@@ -198,7 +198,7 @@ let anonymous f =
 
 module Options = Main_args.Make_ocamldoc_options(struct
     include Main_args.Default.Odoc_args
-    let _I s = Odoc_global.include_dirs := s :: !Odoc_global.include_dirs
+    let _I s = Odoc_global.load_path := Load_path.add_dir !Odoc_global.load_path s
     let _impl s = Odoc_global.files := !Odoc_global.files @ [Odoc_global.Impl_file s]
     let _intf s = Odoc_global.files := !Odoc_global.files @ [Odoc_global.Intf_file s]
 end)

--- a/ocamldoc/odoc_global.ml
+++ b/ocamldoc/odoc_global.ml
@@ -23,7 +23,7 @@ type source_file =
   | Intf_file of string
   | Text_file of string
 
-let include_dirs = Clflags.include_dirs
+let load_path = Clflags.load_path
 
 let errors = ref 0
 

--- a/ocamldoc/odoc_global.mli
+++ b/ocamldoc/odoc_global.mli
@@ -21,8 +21,8 @@ type source_file =
   | Intf_file of string
   | Text_file of string
 
-(** The include_dirs in the OCaml compiler. *)
-val include_dirs : string list ref
+(** The load path in the OCaml compiler. *)
+val load_path : Load_path.t ref
 
 (** The merge options to be used. *)
 val merge_options : Odoc_types.merge_option list ref

--- a/ocamldoc/odoc_info.ml
+++ b/ocamldoc/odoc_info.ml
@@ -104,14 +104,14 @@ module Module = Odoc_module
 
 let analyse_files
     ?(merge_options=([] : Odoc_types.merge_option list))
-    ?(include_dirs=([] : string list))
+    ?(load_path=(Load_path.empty : Load_path.t))
     ?(labels=false)
     ?(sort_modules=false)
     ?(no_stop=false)
     ?(init=[])
     files =
   Odoc_global.merge_options := merge_options;
-  Odoc_global.include_dirs := include_dirs;
+  Odoc_global.load_path := load_path;
   Odoc_global.classic := not labels;
   Odoc_global.sort_modules := sort_modules;
   Odoc_global.no_stop := no_stop;

--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -1080,7 +1080,7 @@ end
    @return the list of analysed top modules. *)
 val analyse_files :
     ?merge_options:Odoc_types.merge_option list ->
-      ?include_dirs:string list ->
+      ?load_path:Load_path.t ->
         ?labels:bool ->
           ?sort_modules:bool ->
             ?no_stop:bool ->

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -79,13 +79,13 @@ COMPILERLIBS_SOURCES=\
   utils/identifiable.ml \
   utils/numbers.ml \
   utils/arg_helper.ml \
+  utils/local_store.ml \
+  utils/load_path.ml \
   utils/clflags.ml \
   utils/profile.ml \
   utils/consistbl.ml \
   utils/terminfo.ml \
   utils/warnings.ml \
-  utils/local_store.ml \
-  utils/load_path.ml \
   utils/int_replace_polymorphic_compare.ml \
   utils/lazy_backtrack.ml \
   parsing/location.ml \

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -827,9 +827,10 @@ module PpxContext = struct
     let fields =
       [
         lid "tool_name",    make_string tool_name;
-        lid "include_dirs", make_list make_string !Clflags.include_dirs;
+        lid "include_dirs", make_list make_string
+          (Load_path.paths !Clflags.load_path);
         lid "load_path",    make_list make_string
-          (Load_path.Cache.get_paths ());
+          (Load_path.paths (Load_path.Cache.get_paths ()));
         lid "open_modules", make_list make_string !Clflags.open_modules;
         lid "for_package",  make_option make_string !Clflags.for_package;
         lid "debug",        make_bool !Clflags.debug;
@@ -897,9 +898,11 @@ module PpxContext = struct
       | "tool_name" ->
           tool_name_ref := get_string payload
       | "include_dirs" ->
-          Clflags.include_dirs := get_list get_string payload
+          Clflags.load_path :=
+            Load_path.of_paths (get_list get_string payload)
       | "load_path" ->
-          Load_path.Cache.init (get_list get_string payload)
+          Load_path.Cache.init
+            (Load_path.of_paths (get_list get_string payload))
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -796,6 +796,14 @@ module PpxContext = struct
     then Exp.construct (lid "true") None
     else Exp.construct (lid "false") None
 
+  let make_path = function
+    | Load_path.Dir s ->
+        Exp.construct (lid "Dir")
+          (Some (Exp.constant (Const.string s)))
+    | Load_path.File s ->
+        Exp.construct (lid "File")
+          (Some (Exp.constant (Const.string s)))
+
   let rec make_list f lst =
     match lst with
     | x :: rest ->
@@ -827,9 +835,9 @@ module PpxContext = struct
     let fields =
       [
         lid "tool_name",    make_string tool_name;
-        lid "include_dirs", make_list make_string
+        lid "load_path", make_list make_path
           (Load_path.paths !Clflags.load_path);
-        lid "load_path",    make_list make_string
+        lid "cached_load_path", make_list make_path
           (Load_path.paths (Load_path.Cache.get_paths ()));
         lid "open_modules", make_list make_string !Clflags.open_modules;
         lid "for_package",  make_option make_string !Clflags.for_package;
@@ -869,6 +877,20 @@ module PpxContext = struct
             false
         | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
                              { %s }] bool syntax" name
+      and get_path = function
+        | {pexp_desc =
+             Pexp_construct
+               ({txt = Longident.Lident "Dir"},
+                Some {pexp_desc = Pexp_constant (Pconst_string (s, _, None)); _}); _} ->
+            Load_path.Dir s
+        | {pexp_desc =
+             Pexp_construct
+               ({txt = Longident.Lident "File"},
+                Some {pexp_desc = Pexp_constant (Pconst_string (s, _, None)); _}); _} ->
+            Load_path.File s
+        | _ ->
+            raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
+                          { %s }] path syntax" name
       and get_list elem = function
         | {pexp_desc =
              Pexp_construct ({txt = Longident.Lident "::"},
@@ -897,12 +919,12 @@ module PpxContext = struct
       match name with
       | "tool_name" ->
           tool_name_ref := get_string payload
-      | "include_dirs" ->
-          Clflags.load_path :=
-            Load_path.of_paths (get_list get_string payload)
       | "load_path" ->
+          Clflags.load_path :=
+            Load_path.of_paths (get_list get_path payload)
+      | "cached_load_path" ->
           Load_path.Cache.init
-            (Load_path.of_paths (get_list get_string payload))
+            (Load_path.of_paths (get_list get_path payload))
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -828,7 +828,8 @@ module PpxContext = struct
       [
         lid "tool_name",    make_string tool_name;
         lid "include_dirs", make_list make_string !Clflags.include_dirs;
-        lid "load_path",    make_list make_string (Load_path.get_paths ());
+        lid "load_path",    make_list make_string
+          (Load_path.Cache.get_paths ());
         lid "open_modules", make_list make_string !Clflags.open_modules;
         lid "for_package",  make_option make_string !Clflags.for_package;
         lid "debug",        make_bool !Clflags.debug;
@@ -898,7 +899,7 @@ module PpxContext = struct
       | "include_dirs" ->
           Clflags.include_dirs := get_list get_string payload
       | "load_path" ->
-          Load_path.init (get_list get_string payload)
+          Load_path.Cache.init (get_list get_string payload)
       | "open_modules" ->
           Clflags.open_modules := get_list get_string payload
       | "for_package" ->

--- a/testsuite/tests/tool-ocamlc-open/inc.ml
+++ b/testsuite/tests/tool-ocamlc-open/inc.ml
@@ -1,0 +1,10 @@
+(* TEST
+
+script = "sh ${test_source_directory}/inc.sh"
+output = "inc.output"
+reference = "${test_source_directory}/inc.reference"
+
+* script
+** check-program-output
+
+*)

--- a/testsuite/tests/tool-ocamlc-open/inc.reference
+++ b/testsuite/tests/tool-ocamlc-open/inc.reference
@@ -1,0 +1,44 @@
+
+# ${OCAMLC} -c d/a.ml
+
+# ${OCAMLC} -c main.ml
+File "main.ml", line 1, characters 9-12:
+1 | let () = A.f ()
+             ^^^
+Error: Unbound module A
+
+# ${OCAMLC} -inc d/a.cmi -c main.ml
+
+# ${OCAMLC} -c d2/a.ml
+
+# ${OCAMLC} -inc d/a.cmi -I d2 -c main.ml
+
+# ${OCAMLC} -I d2 -inc d/a.cmi -c main.ml
+File "main.ml", line 1, characters 9-15:
+1 | let () = A.f ()
+             ^^^^^^
+Error: This expression has type int but an expression was expected of type
+         unit
+
+# ${OCAMLC} -inc d/a.cmi -inc d2/a.cmi -c main.ml
+
+# ${OCAMLC} -inc d2/a.cmi -inc d/a.cmi -c main.ml
+File "main.ml", line 1, characters 9-15:
+1 | let () = A.f ()
+             ^^^^^^
+Error: This expression has type int but an expression was expected of type
+         unit
+
+# ${OCAMLC} -inc foo/a.cmi -c main.ml
+File "main.ml", line 1:
+Error: I/O error: foo/a.cmi: No such file or directory
+
+# ${OCAMLC} -inc foo/foo.cmi -inc d/a.cmi -c main.ml
+
+# ${OCAMLC} -inc $(pwd)/d/a.cmi -c main.ml
+
+# ${OCAMLC} -inc ${ocamlsrcdir}/parsing/longident.cmi main.ml
+File "main.ml", line 1:
+Error: Module `Longident' is unavailable (required by `Main')
+
+# ${OCAMLC} -inc ${ocamlsrcdir}/parsing/longident.cmi -inc ${ocamlsrcdir}/compilerlibs/ocamlcommon.cma ocamlcommon.cma main.ml

--- a/testsuite/tests/tool-ocamlc-open/inc.sh
+++ b/testsuite/tests/tool-ocamlc-open/inc.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+exe() {
+    echo
+    echo "# $@"
+    eval $@
+}
+
+OCAMLC="${ocamlrun} ${ocamlc_byte} -nostdlib -I ${ocamlsrcdir}/stdlib"
+
+mkdir -p d
+
+cat > d/a.ml <<EOF
+let f () = print_endline "A"
+EOF
+
+cat > main.ml <<EOF
+let () = A.f ()
+EOF
+
+# Check basic use
+
+exe \${OCAMLC} -c d/a.ml
+
+exe \${OCAMLC} -c main.ml
+
+exe \${OCAMLC} -inc d/a.cmi -c main.ml
+
+# Check precedence between -I and -inc
+
+mkdir -p d2
+
+cat > d2/a.ml <<EOF
+let f () = 12
+EOF
+
+exe \${OCAMLC} -c d2/a.ml
+
+exe \${OCAMLC} -inc d/a.cmi -I d2 -c main.ml
+
+exe \${OCAMLC} -I d2 -inc d/a.cmi -c main.ml
+
+# Check precedence between -inc
+
+exe \${OCAMLC} -inc d/a.cmi -inc d2/a.cmi -c main.ml
+
+exe \${OCAMLC} -inc d2/a.cmi -inc d/a.cmi -c main.ml
+
+# Check handling of non-existent files
+
+exe \${OCAMLC} -inc foo/a.cmi -c main.ml
+
+exe \${OCAMLC} -inc foo/foo.cmi -inc d/a.cmi -c main.ml
+
+# Check non-relative paths
+
+exe \${OCAMLC} -inc "\$(pwd)/d/a.cmi" -c main.ml
+
+# Check non-cmi case
+
+cat > main.ml <<EOF
+let _ = Longident.last (Longident.Lident "hola")
+EOF
+
+exe \${OCAMLC} -inc \${ocamlsrcdir}/parsing/longident.cmi main.ml
+
+exe \${OCAMLC} \
+    -inc \${ocamlsrcdir}/parsing/longident.cmi \
+    -inc \${ocamlsrcdir}/compilerlibs/ocamlcommon.cma ocamlcommon.cma main.ml
+
+exit 0

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -332,7 +332,7 @@ let main fname =
            [Compenv.last_include_dirs] to make sure that the stdlib
            directory is the last one. *)
         Clflags.no_std_include := true;
-        Compenv.last_include_dirs := [Filename.concat dir "stdlib"]
+        Compenv.final_load_path := Load_path.of_dirs [Filename.concat dir "stdlib"]
   end;
   Compmisc.init_path ();
   Toploop.initialize_toplevel_env ();

--- a/tools/.depend
+++ b/tools/.depend
@@ -5,6 +5,7 @@ caml_tex.cmo : \
     ../parsing/parse.cmi \
     ../utils/misc.cmi \
     ../parsing/location.cmi \
+    ../utils/load_path.cmi \
     ../parsing/lexer.cmi \
     ../driver/compmisc.cmi \
     ../driver/compenv.cmi \
@@ -18,6 +19,7 @@ caml_tex.cmx : \
     ../parsing/parse.cmx \
     ../utils/misc.cmx \
     ../parsing/location.cmx \
+    ../utils/load_path.cmx \
     ../parsing/lexer.cmx \
     ../driver/compmisc.cmx \
     ../driver/compenv.cmx \
@@ -89,6 +91,7 @@ objinfo.cmo : \
     ../middle_end/symbol.cmi \
     ../middle_end/printclambda.cmi \
     ../utils/misc.cmi \
+    ../utils/load_path.cmi \
     ../middle_end/linkage_name.cmi \
     ../typing/ident.cmi \
     ../middle_end/flambda/export_info.cmi \
@@ -105,6 +108,7 @@ objinfo.cmx : \
     ../middle_end/symbol.cmx \
     ../middle_end/printclambda.cmx \
     ../utils/misc.cmx \
+    ../utils/load_path.cmx \
     ../middle_end/linkage_name.cmx \
     ../typing/ident.cmx \
     ../middle_end/flambda/export_info.cmx \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -83,7 +83,7 @@ ocamldep.opt$(EXE): $(call byte2native, $(OCAMLDEP))
 # The profiler
 
 OCAMLPROF=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
-  numbers.cmo arg_helper.cmo clflags.cmo terminfo.cmo \
+  numbers.cmo arg_helper.cmo local_store.cmo load_path.cmo clflags.cmo terminfo.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo \
   camlinternalMenhirLib.cmo parser.cmo \
@@ -97,8 +97,8 @@ opt.opt: profiling.cmx
 
 OCAMLCP = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
           warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
-          clflags.cmo local_store.cmo \
-          terminfo.cmo location.cmo load_path.cmo ccomp.cmo compenv.cmo \
+          local_store.cmo load_path.cmo clflags.cmo \
+          terminfo.cmo location.cmo ccomp.cmo compenv.cmo \
           main_args.cmo
 
 ocamlcp$(EXE): $(OCAMLCP) ocamlcp.cmo
@@ -132,8 +132,8 @@ ocamlmklib.opt$(EXE): $(call byte2native, $(OCAMLMKLIB))
 # To make custom toplevels
 
 OCAMLMKTOP=config.cmo build_path_prefix_map.cmo misc.cmo \
-       identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo \
-       local_store.cmo load_path.cmo profile.cmo ccomp.cmo ocamlmktop.cmo
+       identifiable.cmo numbers.cmo arg_helper.cmo local_store.cmo load_path.cmo clflags.cmo \
+       profile.cmo ccomp.cmo ocamlmktop.cmo
 
 ocamlmktop$(EXE): $(OCAMLMKTOP)
 ocamlmktop.opt$(EXE): $(call byte2native, $(OCAMLMKTOP))

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -181,7 +181,8 @@ module Toplevel = struct
     Location.report_printer := (fun () -> report_printer);
     Clflags.color := Some Misc.Color.Never;
     Clflags.no_std_include := true;
-    Compenv.last_include_dirs := [Filename.concat !repo_root "stdlib"];
+    Compenv.final_load_path :=
+      Load_path.of_dirs [Filename.concat !repo_root "stdlib"];
     Compmisc.init_path ();
     try
       Toploop.initialize_toplevel_env ();

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -99,6 +99,9 @@ let print_cmi_infos name crcs =
   printf "Interfaces imported:\n";
   List.iter print_name_crc crcs
 
+let print_spaced_path path =
+  print_spaced_string (Load_path.path_to_string path)
+
 let print_cmt_infos cmt =
   let open Cmt_format in
   printf "Cmt unit name: %s\n" cmt.cmt_modname;
@@ -109,7 +112,7 @@ let print_cmt_infos cmt =
   printf "Compilation flags:";
   Array.iter print_spaced_string cmt.cmt_args;
   printf "\nLoad path:";
-  List.iter print_spaced_string (Load_path.paths cmt.cmt_loadpath);
+  List.iter print_spaced_path (Load_path.paths cmt.cmt_loadpath);
   printf "\n";
   printf "cmt interface digest: %s\n"
     (match cmt.cmt_interface_digest with

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -109,7 +109,7 @@ let print_cmt_infos cmt =
   printf "Compilation flags:";
   Array.iter print_spaced_string cmt.cmt_args;
   printf "\nLoad path:";
-  List.iter print_spaced_string cmt.cmt_loadpath;
+  List.iter print_spaced_string (Load_path.paths cmt.cmt_loadpath);
   printf "\n";
   printf "cmt interface digest: %s\n"
     (match cmt.cmt_interface_digest with

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -70,7 +70,8 @@ let print_info cmt =
   end;
   Printf.fprintf oc "build directory: %s\n" cmt.cmt_builddir;
   List.iter (Printf.fprintf oc "load path: %s\n%!")
-    (Load_path.paths cmt.cmt_loadpath);
+    (List.map Load_path.path_to_string
+       (Load_path.paths cmt.cmt_loadpath));
   begin
     match cmt.cmt_source_digest with
       None -> ()
@@ -150,8 +151,9 @@ let record_cmt_info cmt =
                                     Annot.Idef (location_file value)))
   in
   let open Cmt_format in
-  List.iter (fun dir -> record_info "include" dir)
-    (Load_path.paths cmt.cmt_loadpath);
+  List.iter (record_info "include")
+    (List.map Load_path.path_to_string
+       (Load_path.paths cmt.cmt_loadpath));
   record_info "chdir" cmt.cmt_builddir;
   (match cmt.cmt_sourcefile with
     None -> () | Some file -> record_info "source" file)
@@ -176,7 +178,7 @@ let main () =
           | Some _ as x -> x
         in
         Envaux.reset_cache ();
-        List.iter Load_path.Cache.add_dir
+        List.iter Load_path.Cache.add_path
           (Load_path.paths cmt.cmt_loadpath);
         Cmt2annot.gen_annot target_filename
           ~sourcefile:cmt.cmt_sourcefile

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -174,7 +174,7 @@ let main () =
           | Some _ as x -> x
         in
         Envaux.reset_cache ();
-        List.iter Load_path.add_dir cmt.cmt_loadpath;
+        List.iter Load_path.Cache.add_dir cmt.cmt_loadpath;
         Cmt2annot.gen_annot target_filename
           ~sourcefile:cmt.cmt_sourcefile
           ~use_summaries:cmt.cmt_use_summaries

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -36,7 +36,7 @@ let arg_list = Arg.align [
     "<file> Read additional NUL separated command line arguments from \n\
     \      <file>";
   "-I", Arg.String (fun s ->
-    Clflags.include_dirs := s :: !Clflags.include_dirs),
+    Clflags.load_path := Load_path.add_dir !Clflags.load_path s),
     "<dir> Add <dir> to the list of include directories";
   ]
 
@@ -69,7 +69,8 @@ let print_info cmt =
     Printf.fprintf oc "sourcefile: %s\n" name;
   end;
   Printf.fprintf oc "build directory: %s\n" cmt.cmt_builddir;
-  List.iter (Printf.fprintf oc "load path: %s\n%!") cmt.cmt_loadpath;
+  List.iter (Printf.fprintf oc "load path: %s\n%!")
+    (Load_path.paths cmt.cmt_loadpath);
   begin
     match cmt.cmt_source_digest with
       None -> ()
@@ -149,7 +150,8 @@ let record_cmt_info cmt =
                                     Annot.Idef (location_file value)))
   in
   let open Cmt_format in
-  List.iter (fun dir -> record_info "include" dir) cmt.cmt_loadpath;
+  List.iter (fun dir -> record_info "include" dir)
+    (Load_path.paths cmt.cmt_loadpath);
   record_info "chdir" cmt.cmt_builddir;
   (match cmt.cmt_sourcefile with
     None -> () | Some file -> record_info "source" file)
@@ -174,7 +176,8 @@ let main () =
           | Some _ as x -> x
         in
         Envaux.reset_cache ();
-        List.iter Load_path.Cache.add_dir cmt.cmt_loadpath;
+        List.iter Load_path.Cache.add_dir
+          (Load_path.paths cmt.cmt_loadpath);
         Cmt2annot.gen_annot target_filename
           ~sourcefile:cmt.cmt_sourcefile
           ~use_summaries:cmt.cmt_use_summaries

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -270,7 +270,7 @@ let load_compunit ic filename ppf compunit =
 
 let rec load_file recursive ppf name =
   let filename =
-    try Some (Load_path.find name) with Not_found -> None
+    try Some (Load_path.Cache.find name) with Not_found -> None
   in
   match filename with
   | None -> fprintf ppf "Cannot find file %s.@." name; false
@@ -293,7 +293,7 @@ and really_load_file recursive ppf name filename ic =
             | (Reloc_getglobal id, _)
               when not (Symtable.is_global_defined id) ->
                 let file = Ident.name id ^ ".cmo" in
-                begin match Load_path.find_uncap file with
+                begin match Load_path.Cache.find_uncap file with
                 | exception Not_found -> ()
                 | file ->
                     if not (load_file recursive ppf file) then raise Load_failed

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -205,7 +205,7 @@ let () =
     | exception Not_found -> []
     | s -> Misc.split_path_contents s
   in
-  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
+  Clflags.load_path := Load_path.concat [ !Clflags.load_path; Load_path.of_dirs extra_paths ]
 
 let main () =
   let ppf = Format.err_formatter in

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -98,7 +98,8 @@ let () =
     | exception Not_found -> []
     | s -> Misc.split_path_contents s
   in
-  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
+  Clflags.load_path :=
+    Load_path.concat [!Clflags.load_path; Load_path.of_dirs extra_paths]
 
 let main () =
   let ppf = Format.err_formatter in

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -251,19 +251,19 @@ let set_paths () =
   (* Add whatever -I options have been specified on the command line,
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
-  let expand = Misc.expand_directory Config.standard_library in
+  let expand = Load_path.expand_directory Config.standard_library in
   let current_load_path = Load_path.Cache.get_paths () in
-  let load_path = List.concat [
-      [ "" ];
-      List.map expand (List.rev !Compenv.first_include_dirs);
-      List.map expand (List.rev !Clflags.include_dirs);
-      List.map expand (List.rev !Compenv.last_include_dirs);
+  let load_path = Load_path.concat [
+      Load_path.of_dirs [ "" ];
+      expand !Compenv.initial_load_path;
+      expand !Clflags.load_path;
+      expand !Compenv.final_load_path;
       current_load_path;
-      [expand "+camlp4"];
+      expand (Load_path.of_dirs [ "+camlp4" ]);
     ]
   in
   Load_path.Cache.init load_path;
-  Dll.add_path load_path
+  Dll.add_path (Load_path.dirs load_path)
 
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()

--- a/toplevel/topcommon.ml
+++ b/toplevel/topcommon.ml
@@ -252,7 +252,7 @@ let set_paths () =
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
   let expand = Misc.expand_directory Config.standard_library in
-  let current_load_path = Load_path.get_paths () in
+  let current_load_path = Load_path.Cache.get_paths () in
   let load_path = List.concat [
       [ "" ];
       List.map expand (List.rev !Compenv.first_include_dirs);
@@ -262,7 +262,7 @@ let set_paths () =
       [expand "+camlp4"];
     ]
   in
-  Load_path.init load_path;
+  Load_path.Cache.init load_path;
   Dll.add_path load_path
 
 let initialize_toplevel_env () =

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -69,8 +69,8 @@ let _ = add_directive "quit" (Directive_none dir_quit)
 let dir_directory s =
   let d = expand_directory Config.standard_library s in
   Dll.add_path [d];
-  let dir = Load_path.Dir.create d in
-  Load_path.add dir;
+  let dir = Load_path.Cache.Dir.create d in
+  Load_path.Cache.add dir;
   toplevel_env :=
     Stdlib.String.Set.fold
       (fun name env ->
@@ -89,12 +89,12 @@ let _ = add_directive "directory" (Directive_string dir_directory)
 let dir_remove_directory s =
   let d = expand_directory Config.standard_library s in
   let keep id =
-    match Load_path.find_uncap (Ident.name id ^ ".cmi") with
+    match Load_path.Cache.find_uncap (Ident.name id ^ ".cmi") with
     | exception Not_found -> true
     | fn -> Filename.dirname fn <> d
   in
   toplevel_env := Env.filter_non_loaded_persistent keep !toplevel_env;
-  Load_path.remove_dir s;
+  Load_path.Cache.remove_dir s;
   Dll.remove_path [d]
 
 let _ = add_directive "remove_directory" (Directive_string dir_remove_directory)
@@ -104,7 +104,7 @@ let _ = add_directive "remove_directory" (Directive_string dir_remove_directory)
     }
 
 let dir_show_dirs () =
-  List.iter print_endline (Load_path.get_paths ())
+  List.iter print_endline (Load_path.Cache.get_paths ())
 
 let _ = add_directive "show_dirs" (Directive_none dir_show_dirs)
     {

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -104,7 +104,7 @@ let _ = add_directive "remove_directory" (Directive_string dir_remove_directory)
     }
 
 let dir_show_dirs () =
-  List.iter print_endline (Load_path.Cache.get_paths ())
+  List.iter print_endline (Load_path.paths (Load_path.Cache.get_paths ()))
 
 let _ = add_directive "show_dirs" (Directive_none dir_show_dirs)
     {

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -69,13 +69,13 @@ let _ = add_directive "quit" (Directive_none dir_quit)
 let dir_directory s =
   let d = expand_directory Config.standard_library s in
   Dll.add_path [d];
-  let dir = Load_path.Cache.Dir.create d in
+  let dir = Load_path.Cache.Path.dir d in
   Load_path.Cache.add dir;
   toplevel_env :=
     Stdlib.String.Set.fold
       (fun name env ->
          Env.add_persistent_structure (Ident.create_persistent name) env)
-      (Env.persistent_structures_of_dir dir)
+      (Env.persistent_structures_of_path dir)
       !toplevel_env
 
 let _ = add_directive "directory" (Directive_string dir_directory)
@@ -104,7 +104,8 @@ let _ = add_directive "remove_directory" (Directive_string dir_remove_directory)
     }
 
 let dir_show_dirs () =
-  List.iter print_endline (Load_path.paths (Load_path.Cache.get_paths ()))
+  List.iter (fun path -> print_endline (Load_path.path_to_string path))
+    (Load_path.paths (Load_path.Cache.get_paths ()))
 
 let _ = add_directive "show_dirs" (Directive_none dir_show_dirs)
     {

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -81,7 +81,7 @@ let use_input ppf ~wrap_in_module input =
     let lexbuf = Lexing.from_string value in
     use_lexbuf ppf ~wrap_in_module lexbuf "" "(command-line input)"
   | File name ->
-    match Load_path.find name with
+    match Load_path.Cache.find name with
     | filename ->
       let ic = open_in_bin filename in
       Misc.try_finally ~always:(fun () -> close_in ic)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2342,8 +2342,8 @@ let unit_name_of_filename fn =
     end
   | _ -> None
 
-let persistent_structures_of_dir dir =
-  Load_path.Cache.Dir.files dir
+let persistent_structures_of_path path =
+  Load_path.Cache.Path.files path
   |> List.to_seq
   |> Seq.filter_map unit_name_of_filename
   |> String.Set.of_seq

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2343,7 +2343,7 @@ let unit_name_of_filename fn =
   | _ -> None
 
 let persistent_structures_of_dir dir =
-  Load_path.Dir.files dir
+  Load_path.Cache.Dir.files dir
   |> List.to_seq
   |> Seq.filter_map unit_name_of_filename
   |> String.Set.of_seq

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -295,7 +295,8 @@ val add_persistent_structure : Ident.t -> t -> t
 
 (* Returns the set of persistent structures found in the given
    directory. *)
-val persistent_structures_of_dir : Load_path.Dir.t -> Misc.Stdlib.String.Set.t
+val persistent_structures_of_dir :
+  Load_path.Cache.Dir.t -> Misc.Stdlib.String.Set.t
 
 (* [filter_non_loaded_persistent f env] removes all the persistent
    structures that are not yet loaded and for which [f] returns

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -293,10 +293,10 @@ val add_local_type: Path.t -> type_declaration -> t -> t
    contents of the module is accessed. *)
 val add_persistent_structure : Ident.t -> t -> t
 
-(* Returns the set of persistent structures found in the given
-   directory. *)
-val persistent_structures_of_dir :
-  Load_path.Cache.Dir.t -> Misc.Stdlib.String.Set.t
+(* Returns the set of persistent structures found in the
+   current load path. *)
+val persistent_structures_of_path :
+  Load_path.Cache.Path.t -> Misc.Stdlib.String.Set.t
 
 (* [filter_non_loaded_persistent f env] removes all the persistent
    structures that are not yet loaded and for which [f] returns

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -38,7 +38,7 @@ module Persistent_signature = struct
       cmi : Cmi_format.cmi_infos }
 
   let load = ref (fun ~unit_name ->
-      match Load_path.find_uncap (unit_name ^ ".cmi") with
+      match Load_path.Cache.find_uncap (unit_name ^ ".cmi") with
       | filename -> Some { filename; cmi = read_cmi filename }
       | exception Not_found -> None)
 end

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -169,7 +169,7 @@ let initial_env ~loc ~safe_string ~initially_opened_module
       env
   in
   let units =
-    List.map Env.persistent_structures_of_dir (Load_path.get ())
+    List.map Env.persistent_structures_of_dir (Load_path.Cache.get ())
   in
   let env, units =
     match initially_opened_module with
@@ -2885,7 +2885,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
         if Sys.file_exists sourceintf then begin
           let intf_file =
             try
-              Load_path.find_uncap (modulename ^ ".cmi")
+              Load_path.Cache.find_uncap (modulename ^ ".cmi")
             with Not_found ->
               raise(Error(Location.in_file sourcefile, Env.empty,
                           Interface_not_compiled sourceintf)) in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -169,7 +169,7 @@ let initial_env ~loc ~safe_string ~initially_opened_module
       env
   in
   let units =
-    List.map Env.persistent_structures_of_dir (Load_path.Cache.get ())
+    List.map Env.persistent_structures_of_path (Load_path.Cache.get ())
   in
   let env, units =
     match initially_opened_module with

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -113,8 +113,9 @@ let compile_file ?output ?(opt="") ?stable_name name =
          (if !Clflags.debug && Config.ccomp_type <> "msvc" then "-g" else "")
          (String.concat " " (List.rev !Clflags.all_ccopts))
          (quote_prefixed "-I"
-            (List.map (Misc.expand_directory Config.standard_library)
-               (List.rev !Clflags.include_dirs)))
+            (Load_path.dirs
+               (Load_path.expand_directory Config.standard_library
+                  !Clflags.load_path)))
          (Clflags.std_include_flag "-I")
          (Filename.quote name)
          (* cl tediously includes the name of the C file as the first thing it
@@ -184,7 +185,8 @@ let call_linker mode output_name files extra =
         Printf.sprintf "%s%s %s %s %s"
           Config.native_pack_linker
           (Filename.quote output_name)
-          (quote_prefixed l_prefix (Load_path.Cache.get_paths ()))
+          (quote_prefixed l_prefix
+             (Load_path.dirs (Load_path.Cache.get_paths ())))
           (quote_files (remove_Wl files))
           extra
       else
@@ -198,7 +200,8 @@ let call_linker mode output_name files extra =
           )
           (Filename.quote output_name)
           ""  (*(Clflags.std_include_flag "-I")*)
-          (quote_prefixed "-L" (Load_path.Cache.get_paths ()))
+          (quote_prefixed "-L"
+             (Load_path.dirs (Load_path.Cache.get_paths ())))
           (String.concat " " (List.rev !Clflags.all_ccopts))
           (quote_files files)
           extra

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -153,7 +153,7 @@ let expand_libname cclibs =
       let libname =
         "lib" ^ String.sub cclib 2 (String.length cclib - 2) ^ Config.ext_lib in
       try
-        Load_path.find libname
+        Load_path.Cache.find libname
       with Not_found ->
         libname
     else cclib)
@@ -184,7 +184,7 @@ let call_linker mode output_name files extra =
         Printf.sprintf "%s%s %s %s %s"
           Config.native_pack_linker
           (Filename.quote output_name)
-          (quote_prefixed l_prefix (Load_path.get_paths ()))
+          (quote_prefixed l_prefix (Load_path.Cache.get_paths ()))
           (quote_files (remove_Wl files))
           extra
       else
@@ -198,7 +198,7 @@ let call_linker mode output_name files extra =
           )
           (Filename.quote output_name)
           ""  (*(Clflags.std_include_flag "-I")*)
-          (quote_prefixed "-L" (Load_path.get_paths ()))
+          (quote_prefixed "-L" (Load_path.Cache.get_paths ()))
           (String.concat " " (List.rev !Clflags.all_ccopts))
           (quote_files files)
           extra

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -44,7 +44,7 @@ and dllibs = ref ([] : string list)     (* .so and -dllib -lxxx *)
 
 let compile_only = ref false            (* -c *)
 and output_name = ref (None : string option) (* -o *)
-and include_dirs = ref ([] : string list)(* -I *)
+and load_path = ref Load_path.empty     (* -I or -inc *)
 and no_std_include = ref false          (* -nostdlib *)
 and print_types = ref false             (* -i *)
 and make_archive = ref false            (* -a *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -73,7 +73,7 @@ val ccobjs : string list ref
 val dllibs : string list ref
 val compile_only : bool ref
 val output_name : string option ref
-val include_dirs : string list ref
+val load_path : Load_path.t ref
 val no_std_include : bool ref
 val print_types : bool ref
 val make_archive : bool ref

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -12,104 +12,106 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Local_store
+module Cache = struct
+  open Local_store
 
-module STbl = Misc.Stdlib.String.Tbl
+  module STbl = Misc.Stdlib.String.Tbl
 
-(* Mapping from basenames to full filenames *)
-type registry = string STbl.t
+  (* Mapping from basenames to full filenames *)
+  type registry = string STbl.t
 
-let files : registry ref = s_table STbl.create 42
-let files_uncap : registry ref = s_table STbl.create 42
+  let files : registry ref = s_table STbl.create 42
+  let files_uncap : registry ref = s_table STbl.create 42
 
-module Dir = struct
-  type t = {
-    path : string;
-    files : string list;
-  }
+  module Dir = struct
+    type t = {
+      path : string;
+      files : string list;
+    }
 
-  let path t = t.path
-  let files t = t.files
+    let path t = t.path
+    let files t = t.files
 
-  (* For backward compatibility reason, simulate the behavior of
-     [Misc.find_in_path]: silently ignore directories that don't exist
-     + treat [""] as the current directory. *)
-  let readdir_compat dir =
-    try
-      Sys.readdir (if dir = "" then Filename.current_dir_name else dir)
-    with Sys_error _ ->
-      [||]
+    (* For backward compatibility reason, simulate the behavior of
+       [Misc.find_in_path]: silently ignore directories that don't exist
+       + treat [""] as the current directory. *)
+    let readdir_compat dir =
+      try
+        Sys.readdir (if dir = "" then Filename.current_dir_name else dir)
+      with Sys_error _ ->
+        [||]
 
-  let create path =
-    { path; files = Array.to_list (readdir_compat path) }
-end
-
-let dirs = s_ref []
-
-let reset () =
-  assert (not Config.merlin || Local_store.is_bound ());
-  STbl.clear !files;
-  STbl.clear !files_uncap;
-  dirs := []
-
-let get () = List.rev !dirs
-let get_paths () = List.rev_map Dir.path !dirs
-
-(* Optimized version of [add] below, for use in [init] and [remove_dir]: since
-   we are starting from an empty cache, we can avoid checking whether a unit
-   name already exists in the cache simply by adding entries in reverse
-   order. *)
-let add dir =
-  List.iter (fun base ->
-      let fn = Filename.concat dir.Dir.path base in
-      STbl.replace !files base fn;
-      STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
-    ) dir.Dir.files
-
-let init l =
-  reset ();
-  dirs := List.rev_map Dir.create l;
-  List.iter add !dirs
-
-let remove_dir dir =
-  assert (not Config.merlin || Local_store.is_bound ());
-  let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
-  if List.compare_lengths new_dirs !dirs <> 0 then begin
-    reset ();
-    List.iter add new_dirs;
-    dirs := new_dirs
+    let create path =
+      { path; files = Array.to_list (readdir_compat path) }
   end
 
-(* General purpose version of function to add a new entry to load path: We only
-   add a basename to the cache if it is not already present in the cache, in
-   order to enforce left-to-right precedence. *)
-let add dir =
-  assert (not Config.merlin || Local_store.is_bound ());
-  List.iter
-    (fun base ->
-       let fn = Filename.concat dir.Dir.path base in
-       if not (STbl.mem !files base) then
-         STbl.replace !files base fn;
-       let ubase = String.uncapitalize_ascii base in
-       if not (STbl.mem !files_uncap ubase) then
-         STbl.replace !files_uncap ubase fn)
-    dir.Dir.files;
-  dirs := dir :: !dirs
+  let dirs = s_ref []
 
-let add_dir dir = add (Dir.create dir)
+  let reset () =
+    assert (not Config.merlin || Local_store.is_bound ());
+    STbl.clear !files;
+    STbl.clear !files_uncap;
+    dirs := []
 
-let is_basename fn = Filename.basename fn = fn
+  let get () = List.rev !dirs
+  let get_paths () = List.rev_map Dir.path !dirs
 
-let find fn =
-  assert (not Config.merlin || Local_store.is_bound ());
-  if is_basename fn && not !Sys.interactive then
-    STbl.find !files fn
-  else
-    Misc.find_in_path (get_paths ()) fn
+  (* Optimized version of [add] below, for use in [init] and [remove_dir]: since
+     we are starting from an empty cache, we can avoid checking whether a unit
+     name already exists in the cache simply by adding entries in reverse
+     order. *)
+  let add dir =
+    List.iter (fun base ->
+        let fn = Filename.concat dir.Dir.path base in
+        STbl.replace !files base fn;
+        STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
+      ) dir.Dir.files
 
-let find_uncap fn =
-  assert (not Config.merlin || Local_store.is_bound ());
-  if is_basename fn && not !Sys.interactive then
-    STbl.find !files_uncap (String.uncapitalize_ascii fn)
-  else
-    Misc.find_in_path_uncap (get_paths ()) fn
+  let init l =
+    reset ();
+    dirs := List.rev_map Dir.create l;
+    List.iter add !dirs
+
+  let remove_dir dir =
+    assert (not Config.merlin || Local_store.is_bound ());
+    let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
+    if List.compare_lengths new_dirs !dirs <> 0 then begin
+      reset ();
+      List.iter add new_dirs;
+      dirs := new_dirs
+    end
+
+  (* General purpose version of function to add a new entry to load path: We only
+     add a basename to the cache if it is not already present in the cache, in
+     order to enforce left-to-right precedence. *)
+  let add dir =
+    assert (not Config.merlin || Local_store.is_bound ());
+    List.iter
+      (fun base ->
+         let fn = Filename.concat dir.Dir.path base in
+         if not (STbl.mem !files base) then
+           STbl.replace !files base fn;
+         let ubase = String.uncapitalize_ascii base in
+         if not (STbl.mem !files_uncap ubase) then
+           STbl.replace !files_uncap ubase fn)
+      dir.Dir.files;
+    dirs := dir :: !dirs
+
+  let add_dir dir = add (Dir.create dir)
+
+  let is_basename fn = Filename.basename fn = fn
+
+  let find fn =
+    assert (not Config.merlin || Local_store.is_bound ());
+    if is_basename fn && not !Sys.interactive then
+      STbl.find !files fn
+    else
+      Misc.find_in_path (get_paths ()) fn
+
+  let find_uncap fn =
+    assert (not Config.merlin || Local_store.is_bound ());
+    if is_basename fn && not !Sys.interactive then
+      STbl.find !files_uncap (String.uncapitalize_ascii fn)
+    else
+      Misc.find_in_path_uncap (get_paths ()) fn
+end

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -12,30 +12,44 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = string list
+
+type path = Dir of string | File of string
+
+let path_to_string (Dir s | File s) = s
+
+type t = path list
 (* Kept in reverse order *)
 
 let empty = []
 
-let of_dirs l = List.rev l
+let of_dirs l = List.rev_map (fun dir -> Dir dir) l
 
 let of_paths l = List.rev l
 
-let add_dir t dir = dir :: t
+let add_dir t dir = Dir dir :: t
 
-let dirs t = List.rev t
+let add_file t file = File file :: t
+
+let dirs t =
+  List.rev (List.filter_map (function Dir dir -> Some dir | File _ -> None) t)
 
 let paths t = List.rev t
 
-let mem s t = List.mem s t
+let mem = List.mem
 
 let concat ts = List.concat (List.rev ts)
 
-let expand_directory dir t = List.map (Misc.expand_directory dir) t
+let expand_directory s t =
+  List.map (function
+      | Dir dir -> Dir (Misc.expand_directory s dir)
+      | File file -> File (Misc.expand_directory s file)
+    ) t
 
-let find fn t = Misc.find_in_path (List.rev t) fn
+let find fn t = Misc.find_in_path (dirs t) fn
 
-let find_uncap fn t = Misc.find_in_path_uncap (List.rev t) fn
+let find_uncap fn t = Misc.find_in_path_uncap (dirs t) fn
+
+let find_rel fn t = Misc.find_in_path_rel (dirs t) fn
 
 module Cache = struct
   open Local_store
@@ -70,59 +84,102 @@ module Cache = struct
       { path; files = Array.to_list (readdir_compat path) }
   end
 
-  let dirs = s_ref []
+  module Path = struct
+    type t =
+      | Dir of Dir.t
+      | File of string
+
+    let create : path -> t = function
+      | Dir dir -> Dir (Dir.create dir)
+      | File file -> File file
+
+    let dir dir = Dir (Dir.create dir)
+
+    let file file = File file
+
+    let path : t -> path = function
+      | Dir dir -> Dir (Dir.path dir)
+      | File file -> File file
+
+    let files : t -> string list = function
+      | Dir dir -> Dir.files dir
+      | File file -> [Filename.basename file]
+  end
+
+  let paths : Path.t list ref = ref []
 
   let reset () =
     assert (not Config.merlin || Local_store.is_bound ());
     STbl.clear !files;
     STbl.clear !files_uncap;
-    dirs := []
+    paths := []
 
-  let get () = List.rev !dirs
-  let get_paths () = List.map Dir.path !dirs
+  let get () = List.rev !paths
+  let get_paths () = List.map Path.path !paths
 
   (* Optimized version of [add] below, for use in [init] and [remove_dir]: since
      we are starting from an empty cache, we can avoid checking whether a unit
      name already exists in the cache simply by adding entries in reverse
      order. *)
-  let add dir =
-    List.iter (fun base ->
-        let fn = Filename.concat dir.Dir.path base in
+  let add = function
+    | Path.Dir dir ->
+        List.iter (fun base ->
+            let fn = Filename.concat dir.Dir.path base in
+            STbl.replace !files base fn;
+            STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
+          ) dir.Dir.files
+    | Path.File fn ->
+        let base = Filename.basename fn in
         STbl.replace !files base fn;
         STbl.replace !files_uncap (String.uncapitalize_ascii base) fn
-      ) dir.Dir.files
 
   let init l =
     reset ();
-    dirs := List.map Dir.create l;
-    List.iter add !dirs
+    paths := List.rev_map Path.create l;
+    List.iter add !paths
 
   let remove_dir dir =
     assert (not Config.merlin || Local_store.is_bound ());
-    let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
-    if List.compare_lengths new_dirs !dirs <> 0 then begin
+    let new_paths = List.filter (function Path.Dir d -> Dir.path d <> dir | Path.File _ -> true) !paths in
+    if List.compare_lengths new_paths !paths <> 0 then begin
       reset ();
-      List.iter add new_dirs;
-      dirs := new_dirs
+      List.iter add new_paths;
+      paths := new_paths
     end
 
   (* General purpose version of function to add a new entry to load path: We only
      add a basename to the cache if it is not already present in the cache, in
      order to enforce left-to-right precedence. *)
-  let add dir =
+  let add path =
     assert (not Config.merlin || Local_store.is_bound ());
-    List.iter
-      (fun base ->
-         let fn = Filename.concat dir.Dir.path base in
-         if not (STbl.mem !files base) then
-           STbl.replace !files base fn;
-         let ubase = String.uncapitalize_ascii base in
-         if not (STbl.mem !files_uncap ubase) then
-           STbl.replace !files_uncap ubase fn)
-      dir.Dir.files;
-    dirs := dir :: !dirs
+    begin match path with
+    | Path.Dir dir ->
+        List.iter
+          (fun base ->
+             let fn = Filename.concat dir.Dir.path base in
+             if not (STbl.mem !files base) then
+               STbl.replace !files base fn;
+             let ubase = String.uncapitalize_ascii base in
+             if not (STbl.mem !files_uncap ubase) then
+               STbl.replace !files_uncap ubase fn)
+          dir.Dir.files
+    | Path.File fn ->
+        let base = Filename.basename fn in
+        if not (STbl.mem !files base) then
+          STbl.replace !files base fn;
+        let ubase = String.uncapitalize_ascii base in
+        if not (STbl.mem !files_uncap ubase) then
+          STbl.replace !files_uncap ubase fn
+    end;
+    paths := path :: !paths
 
-  let add_dir dir = add (Dir.create dir)
+  let add_dir dir = add (Path.dir dir)
+
+  let add_file file = add (Path.file file)
+
+  let add_path = function
+    | Dir dir -> add_dir dir
+    | File file -> add_file file
 
   let is_basename fn = Filename.basename fn = fn
 

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -12,6 +12,31 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type t = string list
+(* Kept in reverse order *)
+
+let empty = []
+
+let of_dirs l = List.rev l
+
+let of_paths l = List.rev l
+
+let add_dir t dir = dir :: t
+
+let dirs t = List.rev t
+
+let paths t = List.rev t
+
+let mem s t = List.mem s t
+
+let concat ts = List.concat (List.rev ts)
+
+let expand_directory dir t = List.map (Misc.expand_directory dir) t
+
+let find fn t = Misc.find_in_path (List.rev t) fn
+
+let find_uncap fn t = Misc.find_in_path_uncap (List.rev t) fn
+
 module Cache = struct
   open Local_store
 
@@ -54,7 +79,7 @@ module Cache = struct
     dirs := []
 
   let get () = List.rev !dirs
-  let get_paths () = List.rev_map Dir.path !dirs
+  let get_paths () = List.map Dir.path !dirs
 
   (* Optimized version of [add] below, for use in [init] and [remove_dir]: since
      we are starting from an empty cache, we can avoid checking whether a unit
@@ -69,7 +94,7 @@ module Cache = struct
 
   let init l =
     reset ();
-    dirs := List.rev_map Dir.create l;
+    dirs := List.map Dir.create l;
     List.iter add !dirs
 
   let remove_dir dir =
@@ -106,12 +131,12 @@ module Cache = struct
     if is_basename fn && not !Sys.interactive then
       STbl.find !files fn
     else
-      Misc.find_in_path (get_paths ()) fn
+      find fn (get_paths ())
 
   let find_uncap fn =
     assert (not Config.merlin || Local_store.is_bound ());
     if is_basename fn && not !Sys.interactive then
       STbl.find !files_uncap (String.uncapitalize_ascii fn)
     else
-      Misc.find_in_path_uncap (get_paths ()) fn
+      find_uncap fn (get_paths ())
 end

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -17,50 +17,55 @@
     This module offers a high level interface to locating files in the
     load path, which is constructed from [-I] command line flags and a few
     other parameters.
-
-    It makes the assumption that the contents of include directories
-    doesn't change during the execution of the compiler.
 *)
 
-val add_dir : string -> unit
-(** Add a directory to the load path *)
+module Cache : sig
+  (** This module takes care of caching the contents of the load path, to avoid
+      costly directory traversals each time a file needs to be looked up.
 
-val remove_dir : string -> unit
-(** Remove a directory from the load path *)
+      It makes the assumption that the contents of include directories
+      doesn't change during the execution of the compiler. *)
 
-val reset : unit -> unit
-(** Remove all directories *)
+  val add_dir : string -> unit
+  (** Add a directory to the load path *)
 
-val init : string list -> unit
-(** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
+  val remove_dir : string -> unit
+  (** Remove a directory from the load path *)
 
-val get_paths : unit -> string list
-(** Return the list of directories passed to [add_dir] so far. *)
+  val reset : unit -> unit
+  (** Remove all directories *)
 
-val find : string -> string
-(** Locate a file in the load path. Raise [Not_found] if the file
-    cannot be found. This function is optimized for the case where the
-    filename is a basename, i.e. doesn't contain a directory
-    separator. *)
+  val init : string list -> unit
+  (** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
 
-val find_uncap : string -> string
-(** Same as [find], but search also for uncapitalized name, i.e.  if
-    name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
+  val get_paths : unit -> string list
+  (** Return the list of directories passed to [add_dir] so far. *)
 
-module Dir : sig
-  type t
-  (** Represent one directory in the load path. *)
+  val find : string -> string
+  (** Locate a file in the load path. Raise [Not_found] if the file
+      cannot be found. This function is optimized for the case where the
+      filename is a basename, i.e. doesn't contain a directory
+      separator. *)
 
-  val create : string -> t
+  val find_uncap : string -> string
+  (** Same as [find], but search also for uncapitalized name, i.e.  if
+      name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
 
-  val path : t -> string
+  module Dir : sig
+    type t
+    (** Represent one directory in the load path. *)
 
-  val files : t -> string list
-  (** All the files in that directory. This doesn't include files in
-      sub-directories of this directory. *)
+    val create : string -> t
+
+    val path : t -> string
+
+    val files : t -> string list
+    (** All the files in that directory. This doesn't include files in
+        sub-directories of this directory. *)
+  end
+
+  val add : Dir.t -> unit
+
+  val get : unit -> Dir.t list
+  (** Same as [get_paths ()], except that it returns a [Dir.t list]. *)
 end
-
-val add : Dir.t -> unit
-
-val get : unit -> Dir.t list
-(** Same as [get_paths ()], except that it returns a [Dir.t list]. *)

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -19,6 +19,30 @@
     other parameters.
 *)
 
+type t
+(** The type of load paths, mostly specified by sequences of [-I] flags. *)
+
+val empty : t
+
+val of_dirs : string list -> t
+
+val of_paths : string list -> t
+
+val add_dir : t -> string -> t
+(** Add a directory to the load path. *)
+
+val dirs : t -> string list
+(** Return the sequence of directories in the load path. *)
+
+val paths : t -> string list
+(** Return the full sequence of entries in the load path. *)
+
+val mem : string -> t -> bool
+
+val concat : t list -> t
+
+val expand_directory : string -> t -> t
+
 module Cache : sig
   (** This module takes care of caching the contents of the load path, to avoid
       costly directory traversals each time a file needs to be looked up.
@@ -27,19 +51,22 @@ module Cache : sig
       doesn't change during the execution of the compiler. *)
 
   val add_dir : string -> unit
-  (** Add a directory to the load path *)
+  (** Add a directory to the cache *)
 
   val remove_dir : string -> unit
-  (** Remove a directory from the load path *)
+  (** Remove a directory from the cache *)
 
   val reset : unit -> unit
   (** Remove all directories *)
 
-  val init : string list -> unit
-  (** [init l] is the same as [reset (); List.iter add_dir (List.rev l)] *)
+  val init : t -> unit
+  (** Initialize the cache with the given load path.  Earlier entries in the
+      load path take precedence over later entries (ie left-to-right precedence
+      for command-line flags). *)
 
-  val get_paths : unit -> string list
-  (** Return the list of directories passed to [add_dir] so far. *)
+  val get_paths : unit -> t
+  (** Return a load path such that [init (get_paths ())] is equivalent to the
+      current cache. *)
 
   val find : string -> string
   (** Locate a file in the load path. Raise [Not_found] if the file

--- a/utils/load_path.mli
+++ b/utils/load_path.mli
@@ -22,26 +22,38 @@
 type t
 (** The type of load paths, mostly specified by sequences of [-I] flags. *)
 
+type path = Dir of string | File of string
+(** The type of load path entries *)
+
+val path_to_string : path -> string
+
 val empty : t
 
 val of_dirs : string list -> t
 
-val of_paths : string list -> t
+val of_paths : path list -> t
 
 val add_dir : t -> string -> t
 (** Add a directory to the load path. *)
 
+val add_file : t -> string -> t
+(** Add a file to the load path. *)
+
 val dirs : t -> string list
 (** Return the sequence of directories in the load path. *)
 
-val paths : t -> string list
+val paths : t -> path list
 (** Return the full sequence of entries in the load path. *)
 
-val mem : string -> t -> bool
+val mem : path -> t -> bool
 
 val concat : t list -> t
 
 val expand_directory : string -> t -> t
+
+val find_uncap : string -> t -> string
+
+val find_rel : string -> t -> string
 
 module Cache : sig
   (** This module takes care of caching the contents of the load path, to avoid
@@ -52,6 +64,11 @@ module Cache : sig
 
   val add_dir : string -> unit
   (** Add a directory to the cache *)
+
+  val add_file : string -> unit
+  (** Add a file to the cache *)
+
+  val add_path : path -> unit
 
   val remove_dir : string -> unit
   (** Remove a directory from the cache *)
@@ -78,21 +95,21 @@ module Cache : sig
   (** Same as [find], but search also for uncapitalized name, i.e.  if
       name is Foo.ml, allow /path/Foo.ml and /path/foo.ml to match. *)
 
-  module Dir : sig
+  module Path : sig
     type t
-    (** Represent one directory in the load path. *)
+    (** Represent a cached version of an entry in the load path. *)
 
-    val create : string -> t
+    val dir : string -> t
 
-    val path : t -> string
+    val path : t -> path
 
     val files : t -> string list
     (** All the files in that directory. This doesn't include files in
         sub-directories of this directory. *)
   end
 
-  val add : Dir.t -> unit
+  val add : Path.t -> unit
 
-  val get : unit -> Dir.t list
+  val get : unit -> Path.t list
   (** Same as [get_paths ()], except that it returns a [Dir.t list]. *)
 end


### PR DESCRIPTION
This PR proposes a way to add a **single file** to the load path (which up to now consisted of a list of directories). The reasons for doing so are multiple but they revolve around the need for greater control over dependencies.

For the user interface, I reuse the `-I` flag, but for files: `-I foo`, where `foo` is a filename. Here, `foo` can be any file, but the situation to keep in mind is when `foo` is a `.cmi` and/or `.cmx` file.

The following interaction gives a sense of what this patch does:
```
$ cat > foo.ml <<EOF
> let _ = Unix.system
> EOF
$ ocamlopt -nostdlib -nopervasives -I +unix.cmi -c foo.ml
File "_none_", line 1:
Warning 58: no cmx file was found in path for module Unix, and its interface was not compiled with -opaque
$ ocamlopt -nostdlib -nopervasives -I +unix.cmi -I +unix.cmx -c foo.ml
$
```

In order not to pollute the patch, I left for later renaming `dir` for something more appropriate reflecting that now both files and directories can be used in the load path.

Opinions welcome!

@trefis @alainfrisch @diml 
