### PR TITLE
Fix preprocessor error during make depend in runtime/

### DIFF
--- a/runtime/.depend
+++ b/runtime/.depend
@@ -1,157 +1,3 @@
-afl_b.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-alloc_b.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h caml/signals.h
-array_b.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_b.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_b.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
- caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
- caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_b.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_b.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_b.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
-clambda_checks_b.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_b.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_b.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h
-custom_b.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_b.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
-domain_b.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_b.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_b.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_b.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_b.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
-fail_nat_b.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_b.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_b.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_b.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_b.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_b.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
- caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
- caml/startup_aux.h
-globroots_b.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_b.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_b.$(O): instrtrace.c
-intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
 interp_b.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -160,150 +6,22 @@ interp_b.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
  caml/startup_aux.h caml/jumptbl.h
-ints_b.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_b.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_b.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_b.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_b.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_b.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_b.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_b.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_b.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_b.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_b.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
  caml/version.h
-obj_b.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_b.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_b.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_b.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_b.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
-roots_nat_b.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
-signals_b.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
- caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
- caml/roots.h caml/finalise.h
-signals_byt_b.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
-signals_nat_b.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
- caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_b.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
-spacetime_nat_b.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
- caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
- caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
-spacetime_snapshot_b.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
- caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
 stacks_b.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
+fix_code_b.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 startup_aux_b.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
@@ -321,62 +39,75 @@ startup_byt_b.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
  caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
-startup_nat_b.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
- caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_b.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+freelist_b.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_b.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_b.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_b.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_b.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_b.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_b.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_b.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_bd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-alloc_bd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_b.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/signals.h
-array_bd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+roots_byt_b.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
+ caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
+globroots_b.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_bd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+fail_byt_b.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_bd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+signals_b.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
+signals_byt_b.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
+ caml/signals.h caml/signals_machdep.h
+printexc_b.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+backtrace_byt_b.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
@@ -384,108 +115,79 @@ backtrace_byt_bd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
  caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
  caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_bd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_bd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+backtrace_b.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_bd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
-clambda_checks_bd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_bd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_bd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+compare_b.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h
-custom_bd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ints_b.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_bd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_b.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
-domain_bd.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_b.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_bd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_b.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_bd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_bd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_b.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_b.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
  caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_bd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
-fail_nat_bd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_bd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_bd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_b.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_b.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_bd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_bd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_bd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+meta_b.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+parsing_b.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_b.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
@@ -493,28 +195,104 @@ gc_ctrl_bd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
  caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
  caml/startup_aux.h
-globroots_bd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_bd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_bd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/instruct.h caml/misc.h caml/mlvalues.h \
- caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/startup_aux.h
-intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+md5_b.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_b.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_b.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+callback_b.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
+debugger_b.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
+weak_b.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_b.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_b.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_b.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+dynlink_b.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+spacetime_byt_b.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+ caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
+afl_b.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+unix_b.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+bigarray_b.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+main_b.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+memprof_b.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_b.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+win32_b.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+instrtrace_b.$(O): instrtrace.c
 interp_bd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -523,150 +301,22 @@ interp_bd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
  caml/startup_aux.h
-ints_bd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_bd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_bd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_bd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_bd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_bd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_bd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_bd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_bd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_bd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_bd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
  caml/version.h
-obj_bd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_bd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_bd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_bd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_bd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
-roots_nat_bd.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
-signals_bd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
- caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
- caml/roots.h caml/finalise.h
-signals_byt_bd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
-signals_nat_bd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
- caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_bd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
-spacetime_nat_bd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
- caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
- caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
-spacetime_snapshot_bd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
- caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
 stacks_bd.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
+fix_code_bd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 startup_aux_bd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
@@ -684,62 +334,75 @@ startup_byt_bd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h 
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
  caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
-startup_nat_bd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
- caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_bd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+freelist_bd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_bd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_bd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_bd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_bd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_bd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_bd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_bd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_bi.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-alloc_bi.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_bd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/signals.h
-array_bi.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+roots_byt_bd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
+ caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
+globroots_bd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_bi.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+fail_byt_bd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_bi.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+signals_bd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
+signals_byt_bd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
+ caml/signals.h caml/signals_machdep.h
+printexc_bd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+backtrace_byt_bd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
@@ -747,108 +410,79 @@ backtrace_byt_bi.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
  caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
  caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_bi.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_bi.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+backtrace_bd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_bi.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
-clambda_checks_bi.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_bi.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_bi.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+compare_bd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h
-custom_bi.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ints_bd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_bi.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_bd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
-domain_bi.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_bd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_bi.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_bd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_bi.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_bi.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_bd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_bd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
  caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_bi.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
-fail_nat_bi.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_bi.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_bi.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_bd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_bd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_bi.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_bi.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_bi.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+meta_bd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+parsing_bd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_bd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
@@ -856,23 +490,109 @@ gc_ctrl_bi.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
  caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
  caml/startup_aux.h
-globroots_bi.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_bi.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_bi.$(O): instrtrace.c
-intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+md5_bd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_bd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_bd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+callback_bd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
+debugger_bd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
+weak_bd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_bd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_bd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_bd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+dynlink_bd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+spacetime_byt_bd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+ caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
+afl_bd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+unix_bd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+bigarray_bd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+main_bd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+memprof_bd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_bd.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+win32_bd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+instrtrace_bd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/instruct.h caml/misc.h caml/mlvalues.h \
+ caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/startup_aux.h
 interp_bi.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -881,150 +601,22 @@ interp_bi.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
  caml/startup_aux.h caml/jumptbl.h
-ints_bi.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_bi.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_bi.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_bi.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_bi.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_bi.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_bi.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_bi.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_bi.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_bi.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_bi.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
  caml/version.h
-obj_bi.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_bi.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_bi.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_bi.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_bi.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
-roots_nat_bi.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
-signals_bi.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
- caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
- caml/roots.h caml/finalise.h
-signals_byt_bi.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
-signals_nat_bi.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
- caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_bi.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
-spacetime_nat_bi.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
- caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
- caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
-spacetime_snapshot_bi.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
- caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
 stacks_bi.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
+fix_code_bi.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 startup_aux_bi.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
@@ -1042,62 +634,75 @@ startup_byt_bi.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h 
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
  caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
-startup_nat_bi.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
- caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_bi.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+freelist_bi.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_bi.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_bi.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_bi.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_bi.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_bi.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_bi.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_bi.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_bpic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-alloc_bpic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_bi.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/signals.h
-array_bpic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+roots_byt_bi.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
+ caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
+globroots_bi.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_bpic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+fail_byt_bi.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_bpic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+signals_bi.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
+signals_byt_bi.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
+ caml/signals.h caml/signals_machdep.h
+printexc_bi.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+backtrace_byt_bi.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
@@ -1105,108 +710,79 @@ backtrace_byt_bpic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
  caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
  caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_bpic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_bpic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+backtrace_bi.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_bpic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
- caml/stacks.h caml/memory.h
-clambda_checks_bpic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_bpic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_bpic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+compare_bi.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h
-custom_bpic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ints_bi.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_bpic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_bi.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
- caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
- caml/stacks.h caml/sys.h
-domain_bpic.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_bi.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_bpic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_bi.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_bpic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_bpic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_bi.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_bi.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
  caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_bpic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
-fail_nat_bpic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_bpic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_bpic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_bi.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_bi.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_bpic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_bpic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_bpic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+meta_bi.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+parsing_bi.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_bi.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
@@ -1214,23 +790,104 @@ gc_ctrl_bpic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
  caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
  caml/startup_aux.h
-globroots_bpic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_bpic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_bpic.$(O): instrtrace.c
-intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+md5_bi.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_bi.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_bi.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+callback_bi.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
+debugger_bi.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
+weak_bi.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_bi.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_bi.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_bi.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+dynlink_bi.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+spacetime_byt_bi.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+ caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
+afl_bi.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+unix_bi.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+bigarray_bi.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+main_bi.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+memprof_bi.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_bi.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+win32_bi.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+instrtrace_bi.$(O): instrtrace.c
 interp_bpic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
@@ -1239,150 +896,22 @@ interp_bpic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
  caml/startup_aux.h caml/jumptbl.h
-ints_bpic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_bpic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_bpic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_bpic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_bpic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_bpic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_bpic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_bpic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_bpic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_bpic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
 misc_bpic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
  caml/version.h
-obj_bpic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_bpic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_bpic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_bpic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_bpic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
-roots_nat_bpic.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/memory.h caml/major_gc.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/stack.h caml/roots.h caml/memprof.h
-signals_bpic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
- caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
- caml/roots.h caml/finalise.h
-signals_byt_bpic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
-signals_nat_bpic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
- signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
- caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_bpic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
-spacetime_nat_bpic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
- caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
- caml/backtrace.h caml/exec.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/roots.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
-spacetime_snapshot_bpic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/gc_ctrl.h \
- caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
- caml/stack.h
 stacks_bpic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
  caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
+fix_code_bpic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
+ caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 startup_aux_bpic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
@@ -1400,62 +929,75 @@ startup_byt_bpic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.
  caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
  caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
  caml/startup_aux.h caml/version.h
-startup_nat_bpic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
- caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_bpic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+freelist_bpic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_bpic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_bpic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_bpic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_bpic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_bpic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_bpic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_bpic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_n.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-alloc_n.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_bpic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
  caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
  caml/stacks.h caml/memory.h caml/signals.h
-array_n.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+roots_byt_bpic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
+ caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
+globroots_bpic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_n.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+fail_byt_bpic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_n.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+signals_bpic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
+ caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
+ caml/roots.h caml/finalise.h
+signals_byt_bpic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
+ caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
+ caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
+ caml/signals.h caml/signals_machdep.h
+printexc_bpic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+backtrace_byt_bpic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
  caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
  caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
@@ -1463,184 +1005,66 @@ backtrace_byt_n.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
  caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
  caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_n.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_n.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+backtrace_bpic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_n.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h
-clambda_checks_n.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_n.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_n.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+compare_bpic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
  caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
  caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
  caml/mlvalues.h
-custom_n.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ints_bpic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_n.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_bpic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-domain_n.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_bpic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_n.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_bpic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_n.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_n.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_bpic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_bpic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
  caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_n.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
-fail_nat_n.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_n.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_n.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_n.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_n.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_n.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
- caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
- caml/startup_aux.h
-globroots_n.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_n.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_n.$(O): instrtrace.c
-intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
  caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
  caml/misc.h caml/reverse.h caml/signals.h
-interp_n.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
- caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
- caml/startup_aux.h caml/jumptbl.h
-ints_n.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_n.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+hash_bpic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_bpic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_n.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_n.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_n.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_n.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_n.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_n.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_n.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+meta_bpic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
  caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
@@ -1648,44 +1072,142 @@ meta_n.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
  caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
  caml/stacks.h caml/memory.h
-minor_gc_n.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
-misc_n.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
- caml/version.h
-obj_n.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+parsing_bpic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_bpic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stacks.h \
+ caml/startup_aux.h
+md5_bpic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_bpic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
  caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
  caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_n.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_n.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_n.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+lexing_bpic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+callback_bpic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
  caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_n.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
+debugger_bpic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/fail.h caml/fix_code.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/io.h caml/mlvalues.h \
+ caml/stacks.h caml/sys.h
+weak_bpic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_bpic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_bpic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_bpic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+dynlink_bpic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+spacetime_byt_bpic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+ caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/mlvalues.h
+afl_bpic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+unix_bpic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+bigarray_bpic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+main_bpic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+memprof_bpic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_bpic.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+win32_bpic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+instrtrace_bpic.$(O): instrtrace.c
+startup_aux_n.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
+ caml/memory.h caml/startup_aux.h
+startup_nat_n.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
+ caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
+ caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
+main_n.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+fail_nat_n.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
+ caml/stack.h caml/roots.h caml/memory.h caml/callback.h
 roots_nat_n.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
@@ -1699,12 +1221,6 @@ signals_n.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
  caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
  caml/roots.h caml/finalise.h
-signals_byt_n.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
 signals_nat_n.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
@@ -1712,9 +1228,207 @@ signals_nat_n.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
  signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
  caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_n.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+misc_n.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
+freelist_n.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_n.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_n.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_n.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_n.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h caml/signals.h
+compare_n.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
+ints_n.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_n.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_n.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_n.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_n.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_n.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
+ caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
+intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_n.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_n.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+parsing_n.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_n.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
+md5_n.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_n.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_n.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+unix_n.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+printexc_n.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+callback_n.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
+weak_n.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_n.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_n.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_n.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+globroots_n.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+backtrace_nat_n.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
+backtrace_n.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+dynlink_nat_n.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+debugger_n.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+meta_n.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+dynlink_n.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+clambda_checks_n.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl
 spacetime_nat_n.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
@@ -1733,29 +1447,41 @@ spacetime_snapshot_n.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
  caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
  caml/stack.h
-stacks_n.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
+afl_n.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+bigarray_n.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+memprof_n.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_n.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
-startup_aux_n.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
+win32_n.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+startup_aux_nd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
  caml/memory.h caml/startup_aux.h
-startup_byt_n.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
- caml/custom.h caml/debugger.h caml/domain.h caml/dynlink.h caml/exec.h \
- caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
- caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
- caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
- caml/startup_aux.h caml/version.h
-startup_nat_n.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
+startup_nat_nd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
@@ -1763,289 +1489,17 @@ startup_nat_n.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_n.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_n.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_n.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_n.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_n.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_nd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+main_nd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h
-alloc_nd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h caml/signals.h
-array_nd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_nd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_nd.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
- caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
- caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_nd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_nd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_nd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h
-clambda_checks_nd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_nd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_nd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h
-custom_nd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_nd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-domain_nd.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_nd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_nd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_nd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_nd.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
 fail_nat_nd.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
  caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_nd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_nd.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_nd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_nd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_nd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
- caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
- caml/startup_aux.h
-globroots_nd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_nd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_nd.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/instruct.h caml/misc.h caml/mlvalues.h \
- caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/startup_aux.h
-intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
-interp_nd.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
- caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
- caml/startup_aux.h
-ints_nd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_nd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_nd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_nd.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_nd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_nd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_nd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_nd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_nd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_nd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
-misc_nd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
- caml/version.h
-obj_nd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_nd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_nd.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_nd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_nd.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_nd.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
@@ -2059,12 +1513,6 @@ signals_nd.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
  caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
  caml/roots.h caml/finalise.h
-signals_byt_nd.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
 signals_nat_nd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
@@ -2072,9 +1520,207 @@ signals_nat_nd.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
  signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
  caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_nd.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+misc_nd.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
+freelist_nd.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_nd.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_nd.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_nd.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_nd.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h caml/signals.h
+compare_nd.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
+ints_nd.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_nd.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_nd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_nd.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_nd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_nd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
+ caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
+intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_nd.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_nd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+parsing_nd.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_nd.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
+md5_nd.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_nd.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_nd.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+unix_nd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+printexc_nd.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+callback_nd.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
+weak_nd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_nd.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_nd.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_nd.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+globroots_nd.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+backtrace_nat_nd.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
+backtrace_nd.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+dynlink_nat_nd.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+debugger_nd.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+meta_nd.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+dynlink_nd.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+clambda_checks_nd.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl
 spacetime_nat_nd.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
@@ -2093,29 +1739,41 @@ spacetime_snapshot_nd.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
  caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
  caml/stack.h
-stacks_nd.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
+afl_nd.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+bigarray_nd.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+memprof_nd.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_nd.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
-startup_aux_nd.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
+win32_nd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+startup_aux_ni.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
  caml/memory.h caml/startup_aux.h
-startup_byt_nd.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
- caml/custom.h caml/debugger.h caml/domain.h caml/dynlink.h caml/exec.h \
- caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
- caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
- caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
- caml/startup_aux.h caml/version.h
-startup_nat_nd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
+startup_nat_ni.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
@@ -2123,284 +1781,17 @@ startup_nat_nd.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_nd.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_nd.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_nd.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_nd.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_nd.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_ni.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+main_ni.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h
-alloc_ni.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h caml/signals.h
-array_ni.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_ni.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_ni.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
- caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
- caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_ni.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_ni.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_ni.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h
-clambda_checks_ni.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_ni.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_ni.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h
-custom_ni.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_ni.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-domain_ni.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_ni.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_ni.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_ni.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_ni.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
 fail_nat_ni.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
  caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_ni.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_ni.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_ni.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_ni.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_ni.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
- caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
- caml/startup_aux.h
-globroots_ni.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_ni.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_ni.$(O): instrtrace.c
-intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
-interp_ni.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
- caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
- caml/startup_aux.h caml/jumptbl.h
-ints_ni.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_ni.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_ni.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_ni.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_ni.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_ni.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_ni.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_ni.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_ni.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_ni.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
-misc_ni.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
- caml/version.h
-obj_ni.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_ni.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_ni.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_ni.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_ni.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_ni.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
@@ -2414,12 +1805,6 @@ signals_ni.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
  caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
  caml/roots.h caml/finalise.h
-signals_byt_ni.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
 signals_nat_ni.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
@@ -2427,9 +1812,207 @@ signals_nat_ni.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
  signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
  caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_ni.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+misc_ni.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
+freelist_ni.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_ni.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_ni.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_ni.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_ni.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h caml/signals.h
+compare_ni.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
+ints_ni.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_ni.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_ni.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_ni.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_ni.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_ni.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
+ caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
+intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_ni.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_ni.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+parsing_ni.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_ni.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
+md5_ni.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_ni.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_ni.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+unix_ni.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+printexc_ni.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+callback_ni.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
+weak_ni.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_ni.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_ni.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_ni.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+globroots_ni.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+backtrace_nat_ni.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
+backtrace_ni.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+dynlink_nat_ni.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+debugger_ni.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+meta_ni.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+dynlink_ni.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+clambda_checks_ni.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl
 spacetime_nat_ni.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
@@ -2448,29 +2031,41 @@ spacetime_snapshot_ni.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
  caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
  caml/stack.h
-stacks_ni.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
+afl_ni.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+bigarray_ni.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+memprof_ni.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_ni.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
-startup_aux_ni.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
+win32_ni.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
+ caml/sys.h caml/config.h
+startup_aux_npic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
  caml/memory.h caml/startup_aux.h
-startup_byt_ni.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
- caml/custom.h caml/debugger.h caml/domain.h caml/dynlink.h caml/exec.h \
- caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
- caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
- caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
- caml/startup_aux.h caml/version.h
-startup_nat_ni.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
+startup_nat_npic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
  caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
  caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
@@ -2478,284 +2073,17 @@ startup_nat_ni.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_ni.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_ni.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_ni.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_ni.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
-win32_ni.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/osdeps.h caml/memory.h caml/signals.h \
- caml/sys.h caml/config.h
-afl_npic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+main_npic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h
-alloc_npic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/stacks.h caml/memory.h caml/signals.h
-array_npic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-backtrace_npic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
- caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
-backtrace_byt_npic.$(O): backtrace_byt.c caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/mlvalues.h caml/domain_state.tbl caml/alloc.h caml/custom.h \
- caml/io.h caml/instruct.h caml/intext.h caml/io.h caml/exec.h \
- caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/startup.h \
- caml/exec.h caml/stacks.h caml/memory.h caml/sys.h caml/backtrace.h \
- caml/fail.h caml/backtrace_prim.h caml/backtrace.h caml/debugger.h
-backtrace_nat_npic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
- caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
- caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/stack.h
-bigarray_npic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
- caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/signals.h
-callback_npic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h
-clambda_checks_npic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl
-compact_npic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
- caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
-compare_npic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
- caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h
-custom_npic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/mlvalues.h caml/signals.h
-debugger_npic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-domain_npic.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h
-dynlink_npic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/prims.h caml/signals.h
-dynlink_nat_npic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
- caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
-extern_npic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
- caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-fail_byt_npic.$(O): fail_byt.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/fail.h caml/gc.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h \
- caml/stacks.h caml/memory.h
 fail_nat_npic.$(O): fail_nat.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/domain.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/mlvalues.h caml/printexc.h caml/signals.h \
  caml/stack.h caml/roots.h caml/memory.h caml/callback.h
-finalise_npic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
- caml/roots.h caml/signals.h
-fix_code_npic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/fix_code.h caml/instruct.h caml/intext.h \
- caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
-floats_npic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
-freelist_npic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
- caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
- caml/mlvalues.h
-gc_ctrl_npic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
- caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
- caml/startup_aux.h
-globroots_npic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
- caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
- caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
-hash_npic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
-instrtrace_npic.$(O): instrtrace.c
-intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
- caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
- caml/misc.h caml/reverse.h caml/signals.h
-interp_npic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace.h caml/exec.h caml/callback.h caml/debugger.h caml/fail.h \
- caml/fix_code.h caml/instrtrace.h caml/instruct.h caml/interp.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
- caml/mlvalues.h caml/prims.h caml/signals.h caml/stacks.h caml/memory.h \
- caml/startup_aux.h caml/jumptbl.h
-ints_npic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
- caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h
-io_npic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/signals.h caml/sys.h
-lexing_npic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
- caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
-main_npic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/sys.h caml/osdeps.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h
-major_gc_npic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
- caml/signals.h caml/weak.h
-md5_npic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/mlvalues.h caml/io.h caml/reverse.h
-memory_npic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
- caml/memory.h
-memprof_npic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
- caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
- caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
- caml/weak.h caml/stack.h caml/misc.h
-meta_npic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
- caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
- caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
- caml/stacks.h caml/memory.h
-minor_gc_npic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
- caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
-misc_npic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
- caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
- caml/version.h
-obj_npic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
- caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
- caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
-parsing_npic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
- caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
- caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/alloc.h
-prims_npic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
- caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
- caml/prims.h
-printexc_npic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
- caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
- caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
- caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/memprof.h caml/roots.h caml/memory.h
-roots_byt_npic.$(O): roots_byt.c caml/finalise.h caml/roots.h caml/misc.h \
- caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
- caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h caml/memprof.h
 roots_nat_npic.$(O): roots_nat.c caml/finalise.h caml/roots.h caml/misc.h \
  caml/config.h caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
@@ -2769,12 +2097,6 @@ signals_npic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/roots.h caml/memory.h \
  caml/signals.h caml/signals_machdep.h caml/sys.h caml/memprof.h \
  caml/roots.h caml/finalise.h
-signals_byt_npic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
- caml/memory.h caml/config.h caml/gc.h caml/mlvalues.h caml/misc.h \
- caml/domain_state.h caml/domain_state.tbl caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/osdeps.h \
- caml/signals.h caml/signals_machdep.h
 signals_nat_npic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
  caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
@@ -2782,9 +2104,207 @@ signals_nat_npic.$(O): signals_nat.c caml/fail.h caml/misc.h caml/config.h \
  caml/osdeps.h caml/memory.h caml/signals.h caml/signals_machdep.h \
  signals_osdep.h caml/stack.h caml/spacetime.h caml/io.h caml/stack.h \
  caml/memprof.h caml/roots.h caml/finalise.h
-spacetime_byt_npic.$(O): spacetime_byt.c caml/fail.h caml/misc.h caml/config.h \
+misc_npic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/osdeps.h caml/memory.h \
+ caml/version.h
+freelist_npic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/major_gc.h caml/misc.h \
+ caml/mlvalues.h
+major_gc_npic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/freelist.h caml/gc.h \
+ caml/gc_ctrl.h caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
+minor_gc_npic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/roots.h caml/signals.h caml/weak.h caml/memprof.h
+memory_npic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/fail.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/signals.h caml/memprof.h caml/roots.h \
+ caml/memory.h
+alloc_npic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/stacks.h caml/memory.h caml/signals.h
+compare_npic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h
+ints_npic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/custom.h \
+ caml/fail.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h
+floats_npic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
+str_npic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
+array_npic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+io_npic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
+ caml/signals.h caml/sys.h
+extern_npic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
+ caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
+intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/memprof.h caml/roots.h caml/memory.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/signals.h
+hash_npic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/domain_state.h caml/mlvalues.h caml/domain_state.tbl \
+ caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/hash.h
+sys_npic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
+ caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
+ caml/startup_aux.h
+parsing_npic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
+ caml/config.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/alloc.h
+gc_ctrl_npic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace.h caml/exec.h caml/compact.h caml/custom.h caml/fail.h \
+ caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/memory.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h caml/stack.h \
+ caml/startup_aux.h
+md5_npic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h caml/io.h caml/reverse.h
+obj_npic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/spacetime.h caml/io.h caml/stack.h
+lexing_npic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h
+unix_npic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
+printexc_npic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/exec.h caml/callback.h caml/debugger.h caml/fail.h caml/misc.h \
+ caml/mlvalues.h caml/printexc.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/memprof.h caml/roots.h caml/memory.h
+callback_npic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/domain.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/mlvalues.h
+weak_npic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
+ caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
+compact_npic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
+ caml/misc.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/freelist.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h caml/compact.h
+finalise_npic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
+ caml/m.h caml/s.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/compact.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/minor_gc.h caml/mlvalues.h \
+ caml/roots.h caml/signals.h
+custom_npic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/custom.h caml/fail.h caml/gc_ctrl.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h caml/mlvalues.h caml/signals.h
+globroots_npic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/domain_state.h \
+ caml/domain_state.tbl caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/globroots.h caml/roots.h
+backtrace_nat_npic.$(O): backtrace_nat.c caml/alloc.h caml/misc.h caml/config.h \
  caml/m.h caml/s.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/mlvalues.h
+ caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/backtrace_prim.h \
+ caml/backtrace.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/misc.h \
+ caml/mlvalues.h caml/stack.h
+backtrace_npic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h caml/debugger.h
+dynlink_nat_npic.$(O): dynlink_nat.c caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/stack.h caml/callback.h caml/alloc.h caml/intext.h caml/io.h \
+ caml/osdeps.h caml/memory.h caml/fail.h caml/signals.h caml/hooks.h
+debugger_npic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/config.h caml/debugger.h caml/misc.h caml/osdeps.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h
+meta_npic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/backtrace_prim.h caml/backtrace.h caml/exec.h caml/config.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/interp.h caml/intext.h \
+ caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/domain.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/signals.h \
+ caml/stacks.h caml/memory.h
+dynlink_npic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
+ caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
+ caml/domain_state.tbl caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
+ caml/memory.h caml/prims.h caml/signals.h
+clambda_checks_npic.$(O): clambda_checks.c caml/mlvalues.h caml/config.h caml/m.h \
+ caml/s.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl
 spacetime_nat_npic.$(O): spacetime_nat.c caml/config.h caml/m.h caml/s.h \
  caml/alloc.h caml/misc.h caml/config.h caml/mlvalues.h \
  caml/domain_state.h caml/domain_state.tbl caml/backtrace_prim.h \
@@ -2803,57 +2323,28 @@ spacetime_snapshot_npic.$(O): spacetime_snapshot.c caml/alloc.h caml/misc.h \
  caml/domain.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
  caml/memory.h caml/signals.h caml/stack.h caml/sys.h caml/spacetime.h \
  caml/stack.h
-stacks_npic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/misc.h caml/mlvalues.h caml/stacks.h \
+afl_npic.$(O): afl.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/mlvalues.h \
+ caml/domain_state.tbl caml/osdeps.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/domain.h
+bigarray_npic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
+ caml/bigarray.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/hash.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
+ caml/signals.h
+memprof_npic.$(O): memprof.c caml/memprof.h caml/config.h caml/m.h caml/s.h \
+ caml/mlvalues.h caml/misc.h caml/domain_state.h caml/domain_state.tbl \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/domain.h caml/fail.h \
+ caml/alloc.h caml/callback.h caml/signals.h caml/memory.h \
+ caml/minor_gc.h caml/backtrace_prim.h caml/backtrace.h caml/exec.h \
+ caml/weak.h caml/stack.h caml/misc.h
+domain_npic.$(O): domain.c caml/domain_state.h caml/misc.h caml/config.h caml/m.h \
+ caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
  caml/address_class.h caml/domain.h
-startup_aux_npic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/exec.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/callback.h caml/major_gc.h caml/osdeps.h \
- caml/memory.h caml/startup_aux.h
-startup_byt_npic.$(O): startup_byt.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
- caml/misc.h caml/config.h caml/mlvalues.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/callback.h \
- caml/custom.h caml/debugger.h caml/domain.h caml/dynlink.h caml/exec.h \
- caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
- caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/minor_gc.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/prims.h caml/printexc.h \
- caml/reverse.h caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
- caml/startup_aux.h caml/version.h
-startup_nat_npic.$(O): startup_nat.c caml/callback.h caml/mlvalues.h \
- caml/config.h caml/m.h caml/s.h caml/misc.h caml/domain_state.h \
- caml/domain_state.tbl caml/backtrace.h caml/exec.h caml/custom.h \
- caml/debugger.h caml/domain.h caml/fail.h caml/freelist.h caml/gc.h \
- caml/gc_ctrl.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
- caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
- caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
- caml/printexc.h caml/stack.h caml/startup_aux.h caml/sys.h
-str_npic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/mlvalues.h caml/misc.h
-sys_npic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/io.h caml/misc.h \
- caml/mlvalues.h caml/osdeps.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
- caml/startup_aux.h
-unix_npic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
- caml/config.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
- caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
- caml/address_class.h caml/domain.h caml/misc.h caml/osdeps.h \
- caml/memory.h caml/signals.h caml/sys.h caml/io.h caml/alloc.h
-weak_npic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
- caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl caml/fail.h \
- caml/major_gc.h caml/freelist.h caml/memory.h caml/gc.h caml/major_gc.h \
- caml/minor_gc.h caml/address_class.h caml/domain.h caml/mlvalues.h \
- caml/weak.h caml/memory.h caml/minor_gc.h caml/signals.h
 win32_npic.$(O): win32.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
  caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/address_class.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -382,24 +382,29 @@ depend:
 else
 
 NATIVE_DEP_CPPFLAGS := $(OC_CPPFLAGS) $(OC_NATIVE_CPPFLAGS)
+BYTECODE_DEP_FILES := $(BYTECODE_C_SOURCES) $(other_files) instrtrace.c
 NATIVE_DEP_FILES := $(NATIVE_C_SOURCES) $(other_files)
 
 depend: *.c caml/opnames.h caml/jumptbl.h caml/version.h
-	$(CC) -MM $(OC_CPPFLAGS) *.c | \
+	$(CC) -MM $(OC_CPPFLAGS) $(BYTECODE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_b.$$(O)/' > .depend
-	$(CC) -MM $(OC_CPPFLAGS) $(OC_DEBUG_CPPFLAGS) *.c | \
+	$(CC) -MM $(OC_CPPFLAGS) $(OC_DEBUG_CPPFLAGS) \
+                  $(BYTECODE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_bd.$$(O)/' >> .depend
-	$(CC) -MM $(OC_CPPFLAGS) $(OC_INSTR_CPPFLAGS) *.c | \
+	$(CC) -MM $(OC_CPPFLAGS) $(OC_INSTR_CPPFLAGS) \
+               $(BYTECODE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_bi.$$(O)/' >> .depend
-	$(CC) -MM $(OC_CPPFLAGS) *.c | \
+	$(CC) -MM $(OC_CPPFLAGS) $(BYTECODE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_bpic.$$(O)/' >> .depend
-	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) *.c | \
+	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) $(NATIVE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_n.$$(O)/' >> .depend
-	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) $(OC_DEBUG_CPPFLAGS) *.c | \
+	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) $(OC_DEBUG_CPPFLAGS) \
+                  $(NATIVE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_nd.$$(O)/' >> .depend
-	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) $(OC_INSTR_CPPFLAGS) *.c | \
+	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) $(OC_INSTR_CPPFLAGS) \
+                  $(NATIVE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_ni.$$(O)/' >> .depend
-	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) *.c | \
+	$(CC) -MM $(NATIVE_DEP_CPPFLAGS) $(NATIVE_DEP_FILES) | \
 	  sed -e 's/\([^.]*\)\.o/\1_npic.$$(O)/' >> .depend
 endif
 


### PR DESCRIPTION
Currently, `make depend` in `runtime/` computes dependencies in bytecode mode and in native-code mode for all .c files.  For signals_nat.c, this causes an error in bytecode mode:
```
signals_nat.c:191:2: error: #error "CONTEXT_SP is required if HAS_STACK_OVERFLOW_DETECTION is defined"
```
That's because no `-DTARGET_$(ARCH)` option is given on the command line for `gcc -MM`.

This commit separates bytecode-relevant source files and native-code-relevant source files when computing dependencies.  The error goes away; the `.depend` file is smaller; and it feels in the spirit of @shindere 's recent refactoring of `bytecode/Makefile`.

