### PR TITLE
add List.filteri to the stdlib

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ Working version
 
 ### Standard library:
 
+- #9059: Added List.filteri function, same as List.filter but
+  with the index of the element.
+  (Léo Andrès, review by Alain Frisch)
+
 ### Other libraries:
 
 ### Tools:

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -244,6 +244,13 @@ let find_all p =
 
 let filter = find_all
 
+let filteri p l =
+  let rec aux i acc = function
+  | [] -> rev acc
+  | x::l -> aux (i + 1) (if p i x then x::acc else acc) l
+  in
+  aux 0 [] l
+
 let filter_map f =
   let rec aux accu = function
     | [] -> rev accu

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -252,6 +252,13 @@ val filter : ('a -> bool) -> 'a list -> 'a list
 val find_all : ('a -> bool) -> 'a list -> 'a list
 (** [find_all] is another name for {!List.filter}. *)
 
+val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
+(** Same as {!List.filter}, but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+   @since 4.11.0
+*)
+
 val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition p l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -266,6 +266,13 @@ val filter : f:('a -> bool) -> 'a list -> 'a list
 val find_all : f:('a -> bool) -> 'a list -> 'a list
 (** [find_all] is another name for {!List.filter}. *)
 
+val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
+(** Same as {!List.filter}, but the predicate is applied to the index of
+   the element as first argument (counting from 0), and the element
+   itself as second argument.
+   @since 4.11.0
+*)
+
 val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition p l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -33,6 +33,8 @@ let () =
     assert (List.find_map (f ~limit:30) l = None);
   end;
 
+  assert (List.filteri (fun i _ -> i < 2) (List.rev l) = [9; 8]);
+
   assert (List.compare_lengths [] [] = 0);
   assert (List.compare_lengths [1;2] ['a';'b'] = 0);
   assert (List.compare_lengths [] [1;2] < 0);


### PR DESCRIPTION
Hi,

I added a `List.filteri` function to the stdlib which does what you think:

```ocaml
# List.filteri (fun i el -> i > 1 && el <> 'd') ['a'; 'b'; 'c'; 'd'; 'e'] = ['c'; 'e'];;
- : bool = true
```

I found myself implementing this a few times, it's simple and useful thus I tought it would be a nice addition to the stdlib ; it's not particularly hard to implement in external code but I think it's in the spirit of all the recent additions.

This is my first PR against the stdlib, I think I did everything correctly. Sorry if I missed something !