### PR TITLE
Misc.protect_refs: use Fun.protect to protect the backtrace

### DIFF
--- a/Changes
+++ b/Changes
@@ -43,6 +43,9 @@ Working version
   (matching on the effects of a copmutation) in the typedtree.
   (Gabriel Scherer, review by Jacques Garrigue and Alain Frisch)
 
+- #9060: ensure that Misc.protect_refs preserves backtraces
+  (Gabriel Scherer, review by Guillaume Munch-Maccagnoni and David Allsopp)
+
 - #9078: make all compilerlibs/ available to ocamltest.
   (Gabriel Scherer, review by Sébastien Hinderer)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -56,9 +56,7 @@ let protect_refs =
   fun refs f ->
     let backup = List.map (fun (R (r, _)) -> R (r, !r)) refs in
     set_refs refs;
-    match f () with
-    | x           -> set_refs backup; x
-    | exception e -> set_refs backup; raise e
+    Fun.protect ~finally:(fun () -> set_refs backup) f
 
 (* List functions *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -82,7 +82,8 @@ type ref_and_value = R : 'a ref * 'a -> ref_and_value
 val protect_refs : ref_and_value list -> (unit -> 'a) -> 'a
 (** [protect_refs l f] temporarily sets [r] to [v] for each [R (r, v)] in [l]
     while executing [f]. The previous contents of the references is restored
-    even if [f] raises an exception. *)
+    even if [f] raises an exception, without altering the exception backtrace.
+*)
 
 module Stdlib : sig
   module List : sig


### PR DESCRIPTION
Currently Fun.protect and Misc.try_finally can be used in code that
tries carefully to preserve the first-failure backtrace, but
Misc.protect_refs cannot. This PR fixes the discrepancy. See #9057 for
a use-case.
