### PR TITLE
Fix a pointer comparison in an assertion in freelist.c

### DIFF
--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -1000,7 +1000,7 @@ static void bf_check (void)
     }else{
       CAMLassert (caml_gc_phase != Phase_sweep
                   || caml_fl_merge == Val_NULL
-                  || Val_bp (bf_small_fl[i].merge) < caml_fl_merge);
+                  || bf_small_fl[i].merge < &Next_small(caml_fl_merge));
     }
     CAMLassert (*bf_small_fl[i].merge == Val_NULL
                 || Color_val (*bf_small_fl[i].merge) == Caml_blue);


### PR DESCRIPTION
In the best-fit allocator, a debug assertion compares two pointers at type `value` rather than at pointer type. I suspect this will break on 32-bit Windows when a heap chunk crosses the 2GB boundary, in the same way that @dra27 describes in #1311.

This patch changes the comparison to be at pointer type, and thus unsigned. The only change in the generated assembly is the signedness of the comparison.

cc @damiendoligez 