### PR TITLE
Fix tests/backtrace/callstack.ml by changing the order of the content of that file.

### DIFF
--- a/testsuite/tests/backtrace/callstack.ml
+++ b/testsuite/tests/backtrace/callstack.ml
@@ -4,21 +4,29 @@
    include systhreads
    compare_programs = "false"
    ** no-flambda
-   reference = "${test_source_directory}/callstack.reference"
    *** native
    *** bytecode
 *)
+
 let[@inline never] f0 () =
   Printexc.print_raw_backtrace stdout (Printexc.get_callstack 100); ()
 let[@inline never] f1 () = f0 (); ()
 let[@inline never] f2 () = f1 (); ()
 let[@inline never] f3 () = f2 (); ()
+
 let () = Printf.printf "main thread:\n"
 let () = f3 ()
-let () = Printf.printf "new thread:\n"
-let () = Thread.join (Thread.create f3 ())
 
+let () = Printf.printf "from finalizer:\n"
 let () =
   Gc.finalise (fun _ -> f0 ()) [|1|];
   Gc.full_major ();
   ()
+
+(* We run this last, because the initialization of the thread library
+   starts the "tick thread", which periodically send a signal for
+   thread preemption. If the preempion occurs exactly when the
+   finalizer above runs, then a new row for [Thread.yield] appears in
+   the callstack, which breaks the test. *)
+let () = Printf.printf "new thread:\n"
+let () = Thread.join (Thread.create f3 ())

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -3,12 +3,13 @@ Raised by primitive operation at file "callstack.ml", line 12, characters 38-66
 Called from file "callstack.ml", line 13, characters 27-32
 Called from file "callstack.ml", line 14, characters 27-32
 Called from file "callstack.ml", line 15, characters 27-32
-Called from file "callstack.ml", line 17, characters 9-14
+Called from file "callstack.ml", line 18, characters 9-14
+from finalizer:
+Raised by primitive operation at file "callstack.ml", line 12, characters 38-66
+Called from file "callstack.ml", line 23, characters 2-18
 new thread:
 Raised by primitive operation at file "callstack.ml", line 12, characters 38-66
 Called from file "callstack.ml", line 13, characters 27-32
 Called from file "callstack.ml", line 14, characters 27-32
 Called from file "callstack.ml", line 15, characters 27-32
 Called from file "thread.ml", line 39, characters 8-14
-Raised by primitive operation at file "callstack.ml", line 12, characters 38-66
-Called from file "callstack.ml", line 23, characters 2-18


### PR DESCRIPTION
This is to fix the issue pointed out in https://github.com/ocaml/ocaml/pull/8641#issuecomment-544231899 by @xavierleroy.