### PR TITLE
Relax the level handling when unifying row fields

### DIFF
--- a/Changes
+++ b/Changes
@@ -56,6 +56,9 @@ Working version
   may not match the one in bytecode.
   (Nicolás Ojeda Bär, report by Pierre Chambart, review by Gabriel Scherer)
 
+- #9064: Relax the level handling when unifying row fields
+  (Leo White, review by Jacques Garrigue)
+
 OCaml 4.10.0
 ------------
 

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -281,13 +281,7 @@ let simple_merged_annotated_under_poly_variant (type a) (pair : a t * a) =
 ;;
 
 [%%expect{|
-Line 3, characters 19-20:
-3 |   | `Foo ( IntLit, 3
-                       ^
-Error: This pattern matches values of type int
-       but a pattern was expected which matches values of type a = int
-       This instance of int is ambiguous:
-       it would escape the scope of its equation
+val simple_merged_annotated_under_poly_variant : 'a t * 'a -> unit = <fun>
 |}]
 
 let simple_merged_annotated_under_poly_variant_annotated (type a) pair =


### PR DESCRIPTION
Currently when unifying types like: ``[< `A of 'a | `B of 'b > `B ]`` and ``[> `A of 'c | `B of 'd ]`` the type-checker will lower the levels of `'a` and `'c` to the minimum of the levels of the row variables of both types. This is a sufficient condition but it is stronger than necessary -- the row variable of the right-hand type is not related to the `` `A`` part of the type and so does not need to be considered.

This PR changes `unify_row_field` to use the level of the `Reither` side in such cases and to ignore the row variable on the `Rpresent` side. Now it lowers things to the level of the row variable of the `Reither` side. The result of this change is to fix an existing test involving polymorphic variants, GADTs and or-patterns.

The PR also changes the `Reither/Reither` case to only lower types levels to that of the row variable from the other side. This seems more sensible -- why would we need to use the level from another part of the type on the same side -- but I'm not sure it makes any actual difference.