### PR TITLE
Add `('a, 'b)  Either.t = Left of 'a | Right of 'b` and `List.partition_map`

### DIFF
--- a/Changes
+++ b/Changes
@@ -162,6 +162,10 @@ Working version
 - #9571: Make at_exit and Printexc.register_printer thread-safe.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)
 
+- #9066: a new Either module with
+  type 'a Either.t = Left of 'a | Right of 'b
+  (Gabriel Scherer, review by Daniel Bünzli, Thomas Refis, Jeremy Yallop)
+
 - #9587: Arg: new Rest_all spec to get all rest arguments in a list
   (this is similar to Rest, but makes it possible to detect when there
    are no arguments (an empty list) after the rest marker)

--- a/Changes
+++ b/Changes
@@ -166,6 +166,10 @@ Working version
   type 'a Either.t = Left of 'a | Right of 'b
   (Gabriel Scherer, review by Daniel Bünzli, Thomas Refis, Jeremy Yallop)
 
+- #9066: List.partition_map :
+    ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+  (Gabriel Scherer, review by Jeremy Yallop)
+
 - #9587: Arg: new Rest_all spec to get all rest arguments in a list
   (this is similar to Rest, but makes it possible to detect when there
    are no arguments (an empty list) after the rest marker)

--- a/manual/manual/library/stdlib-blurb.etex
+++ b/manual/manual/library/stdlib-blurb.etex
@@ -46,6 +46,7 @@ the above 4 modules \\
 "Int" & p.~\pageref{Int} & integer values \\
 "Option" & p.~\pageref{Option} & option values \\
 "Result" & p.~\pageref{Result} & result values \\
+"Either" & p.~\pageref{Either} & either values \\
 "Hashtbl" & p.~\pageref{Hashtbl} & hash tables and hash functions \\
 "Random" & p.~\pageref{Random} & pseudo-random number generator \\
 "Set" & p.~\pageref{Set} & sets over ordered types \\

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -409,7 +409,8 @@ stdlib__listLabels.cmx : \
     stdlib__list.cmx \
     stdlib__listLabels.cmi
 stdlib__listLabels.cmi : \
-    stdlib__seq.cmi
+    stdlib__seq.cmi \
+    stdlib__either.cmi
 stdlib__map.cmo : \
     stdlib__seq.cmi \
     stdlib__map.cmi

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -200,6 +200,11 @@ stdlib__digest.cmx : \
     stdlib__bytes.cmx \
     stdlib__digest.cmi
 stdlib__digest.cmi :
+stdlib__either.cmo : \
+    stdlib__either.cmi
+stdlib__either.cmx : \
+    stdlib__either.cmi
+stdlib__either.cmi :
 stdlib__ephemeron.cmo : \
     stdlib__sys.cmi \
     stdlib__seq.cmi \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -392,13 +392,16 @@ stdlib__lexing.cmi :
 stdlib__list.cmo : \
     stdlib__sys.cmi \
     stdlib__seq.cmi \
+    stdlib__either.cmi \
     stdlib__list.cmi
 stdlib__list.cmx : \
     stdlib__sys.cmx \
     stdlib__seq.cmx \
+    stdlib__either.cmx \
     stdlib__list.cmi
 stdlib__list.cmi : \
-    stdlib__seq.cmi
+    stdlib__seq.cmi \
+    stdlib__either.cmi
 stdlib__listLabels.cmo : \
     stdlib__list.cmi \
     stdlib__listLabels.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -31,7 +31,7 @@ endef
 # Modules should be listed in dependency order.
 STDLIB_MODS=\
   camlinternalFormatBasics camlinternalAtomic \
-  stdlib pervasives seq option result bool char uchar \
+  stdlib pervasives seq option either result bool char uchar \
   sys list bytes string unit marshal obj array float int int32 int64 nativeint \
   lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
   camlinternalFormat printf arg atomic \

--- a/stdlib/either.ml
+++ b/stdlib/either.ml
@@ -1,0 +1,66 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*         Gabriel Scherer, projet Parsifal, INRIA Saclay                 *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ('a, 'b) t = Left of 'a | Right of 'b
+
+let left v = Left v
+let right v = Right v
+
+let is_left = function
+| Left _ -> true
+| Right _ -> false
+
+let is_right = function
+| Left _ -> false
+| Right _ -> true
+
+let find_left = function
+| Left v -> Some v
+| Right _ -> None
+
+let find_right = function
+| Left _ -> None
+| Right v -> Some v
+
+let map_left f = function
+| Left v -> Left (f v)
+| Right _ as e -> e
+
+let map_right f = function
+| Left _ as e -> e
+| Right v -> Right (f v)
+
+let map ~left ~right = function
+| Left v -> Left (left v)
+| Right v -> Right (right v)
+
+let fold ~left ~right = function
+| Left v -> left v
+| Right v -> right v
+
+let iter = fold
+
+let for_all = fold
+
+let equal ~left ~right e1 e2 = match e1, e2 with
+| Left v1, Left v2 -> left v1 v2
+| Right v1, Right v2 -> right v1 v2
+| Left _, Right _ | Right _, Left _ -> false
+
+let compare ~left ~right e1 e2 = match e1, e2 with
+| Left v1, Left v2 -> left v1 v2
+| Right v1, Right v2 -> right v1 v2
+| Left _, Right _ -> (-1)
+| Right _, Left _ -> 1

--- a/stdlib/either.mli
+++ b/stdlib/either.mli
@@ -1,0 +1,114 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*         Gabriel Scherer, projet Parsifal, INRIA Saclay                 *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Either type.
+
+    @since 4.12
+
+    Either is the simplest and most generic sum/variant type:
+    a value of [('a, 'b) Either.t] is either a [Left (v : 'a)]
+    or a [Right (v : 'b)].
+
+    It is a natural choice in the API of generic functions where values
+    could fall in two different cases, possibly at different types,
+    without assigning a specific meaning to what each case should be.
+
+    For example:
+
+[List.partition_map: ('a -> ('b, 'c) either) -> 'a list -> 'b list * 'c list]
+
+    If you are looking for a parametrized type where
+    one alternative means success and the other means failure,
+    you should use the more specific type {!Result.t}.
+*)
+
+(* Unlike [result], no [either] type is made available in Stdlib,
+   one needs to access [Either.t] explicitly:
+
+   - This type is less common in typical OCaml codebases,
+     which prefer domain-specific variant types whose constructors
+     carry more meaning.
+   - Adding this to Stdlib would raise warnings in existing codebases
+     that already use a constructor named Left or Right:
+     + when opening a module that exports such a name,
+       warning 45 is raised
+     + adding a second constructor of the same name in scope kicks
+       in the disambiguation mechanisms, and warning 41 may now
+       be raised by existing code.
+
+   If the use becomes more common in the future we can always
+   revisit this choice.
+*)
+
+type ('a, 'b) t = Left of 'a | Right of 'b (**)
+(** A value of [('a, 'b) Either.t] contains
+    either a value of ['a]  or a value of ['b] *)
+
+val left : 'a -> ('a, 'b) t
+(** [left v] is [Left v]. *)
+
+val right : 'b -> ('a, 'b) t
+(** [right v] is [Right v]. *)
+
+val is_left : ('a, 'b) t -> bool
+(** [is_left (Left v)] is [true], [is_left (Right v)] is [false]. *)
+
+val is_right : ('a, 'b) t -> bool
+(** [is_right (Left v)] is [false], [is_right (Right v)] is [true]. *)
+
+val find_left : ('a, 'b) t -> 'a option
+(** [find_left (Left v)] is [Some v], [find_left (Right _)] is [None] *)
+
+val find_right : ('a, 'b) t -> 'b option
+(** [find_right (Right v)] is [Some v], [find_right (Left _)] is [None] *)
+
+val map_left : ('a1 -> 'a2) -> ('a1, 'b) t -> ('a2, 'b) t
+(** [map_left f e] is [Left (f v)] if [e] is [Left v]
+    and [e] if [e] is [Right _]. *)
+
+val map_right : ('b1 -> 'b2) -> ('a, 'b1) t -> ('a, 'b2) t
+(** [map_right f e] is [Right (f v)] if [e] is [Right v]
+    and [e] if [e] is [Left _]. *)
+
+val map :
+  left:('a1 -> 'a2) -> right:('b1 -> 'b2) -> ('a1, 'b1) t -> ('a2, 'b2) t
+(** [map ~left ~right (Left v)] is [Left (left v)],
+    [map ~left ~right (Right v)] is [Right (right v)]. *)
+
+val fold : left:('a -> 'c) -> right:('b -> 'c) -> ('a, 'b) t -> 'c
+(** [fold ~left ~right (Left v)] is [left v], and
+    [fold ~left ~right (Right v)] is [right v]. *)
+
+val iter : left:('a -> unit) -> right:('b -> unit) -> ('a, 'b) t -> unit
+(** [iter ~left ~right (Left v)] is [left v], and
+    [iter ~left ~right (Right v)] is [right v]. *)
+
+val for_all : left:('a -> bool) -> right:('b -> bool) -> ('a, 'b) t -> bool
+(** [for_all ~left ~right (Left v)] is [left v], and
+    [for_all ~left ~right (Right v)] is [right v]. *)
+
+val equal :
+  left:('a -> 'a -> bool) -> right:('b -> 'b -> bool) ->
+  ('a, 'b) t -> ('a, 'b) t -> bool
+(** [equal ~left ~right e0 e1] tests equality of [e0] and [e1] using [left]
+    and [right] to respectively compare values wrapped by [Left _] and
+    [Right _]. *)
+
+val compare :
+  left:('a -> 'a -> int) -> right:('b -> 'b -> int) ->
+  ('a, 'b) t -> ('a, 'b) t -> int
+(** [compare ~left ~right e0 e1] totally orders [e0] and [e1] using [left] and
+    [right] to respectively compare values wrapped by [Left _ ] and [Right _].
+    [Left _] values are smaller than [Right _] values. *)

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -283,6 +283,17 @@ let partition p l =
   | x :: l -> if p x then part (x :: yes) no l else part yes (x :: no) l in
   part [] [] l
 
+let partition_map p l =
+  let rec part left right = function
+  | [] -> (rev left, rev right)
+  | x :: l ->
+     begin match p x with
+       | Either.Left v -> part (v :: left) right l
+       | Either.Right v -> part left (v :: right) l
+     end
+  in
+  part [] [] l
+
 let rec split = function
     [] -> ([], [])
   | (x,y)::l ->

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -274,6 +274,21 @@ val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
    elements of [l] that do not satisfy [p].
    The order of the elements in the input list is preserved. *)
 
+val partition_map : ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+(** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
+    for each element [x] of the input list [l]:
+    - if [f x] is [Left y1], then [y1] is in [l1], and
+    - if [f x] is [Right y2], then [y2] is in [l2].
+
+    The output elements are included in [l1] and [l2] in the same
+    relative order as the corresponding input elements in [l].
+
+    In particular, [partition_map (fun x -> if p x then Left x else Right x) l]
+    is equivalent to [partition p l].
+
+    @since 4.12.0
+*)
+
 
 (** {1 Association lists} *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -318,6 +318,21 @@ val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
    The order of the elements in the input list is preserved.
  *)
 
+val partition_map : f:('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+(** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
+    for each element [x] of the input list [l]:
+    - if [f x] is [Left y1], then [y1] is in [l1], and
+    - if [f x] is [Right y2], then [y2] is in [l2].
+
+    The output elements are included in [l1] and [l2] in the same
+    relative order as the corresponding input elements in [l].
+
+    In particular, [partition_map (fun x -> if p x then Left x else Right x) l]
+    is equivalent to [partition p l].
+
+    @since 4.12.0
+*)
+
 
 (** {1 Association lists} *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -579,6 +579,7 @@ module Callback     = Callback
 module Char         = Char
 module Complex      = Complex
 module Digest       = Digest
+module Either       = Either
 module Ephemeron    = Ephemeron
 module Filename     = Filename
 module Float        = Float

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1347,6 +1347,7 @@ module Callback     = Callback
 module Char         = Char
 module Complex      = Complex
 module Digest       = Digest
+module Either       = Either
 module Ephemeron    = Ephemeron
 module Filename     = Filename
 module Float        = Float

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -12,16 +12,16 @@ match (3, 2, 1) with
 ;;
 [%%expect{|
 (let
-  (*match*/88 = 3
-   *match*/89 = 2
-   *match*/90 = 1
-   *match*/91 = *match*/88
+  (*match*/89 = 3
+   *match*/90 = 2
+   *match*/91 = 1
    *match*/92 = *match*/89
-   *match*/93 = *match*/90)
+   *match*/93 = *match*/90
+   *match*/94 = *match*/91)
   (catch
     (catch
-      (catch (if (!= *match*/92 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/91 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/93 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/92 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
 - : bool = false
@@ -36,24 +36,25 @@ match (3, 2, 1) with
 ;;
 [%%expect{|
 (let
-  (*match*/96 = 3
-   *match*/97 = 2
-   *match*/98 = 1
-   *match*/99 = (makeblock 0 *match*/96 *match*/97 *match*/98))
+  (*match*/97 = 3
+   *match*/98 = 2
+   *match*/99 = 1
+   *match*/100 = (makeblock 0 *match*/97 *match*/98 *match*/99))
   (catch
     (catch
-      (let (*match*/100 =a (field 0 *match*/99))
+      (let (*match*/101 =a (field 0 *match*/100))
         (catch
-          (let (*match*/101 =a (field 1 *match*/99))
-            (if (!= *match*/101 3) (exit 7)
-              (let (*match*/102 =a (field 2 *match*/99)) (exit 5 *match*/99))))
+          (let (*match*/102 =a (field 1 *match*/100))
+            (if (!= *match*/102 3) (exit 7)
+              (let (*match*/103 =a (field 2 *match*/100))
+                (exit 5 *match*/100))))
          with (7)
-          (if (!= *match*/100 1) (exit 6)
+          (if (!= *match*/101 1) (exit 6)
             (let
-              (*match*/104 =a (field 2 *match*/99)
-               *match*/103 =a (field 1 *match*/99))
-              (exit 5 *match*/99)))))
+              (*match*/105 =a (field 2 *match*/100)
+               *match*/104 =a (field 1 *match*/100))
+              (exit 5 *match*/100)))))
      with (6) 0)
-   with (5 x/94) (seq (ignore x/94) 1)))
+   with (5 x/95) (seq (ignore x/95) 1)))
 - : bool = false
 |}];;

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/150 introduced by this open appears in the signature
+Error: The type t/151 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/150 is hidden
+         The value x has no valid type if t/151 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/155 introduced by this open appears in the signature
+Error: The type t/156 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/155 is hidden
+         The value y has no valid type if t/156 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/160 introduced by this open appears in the signature
+Error: The type t/161 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/160 is hidden
+         The value y has no valid type if t/161 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/lib-either/test.ml
+++ b/testsuite/tests/lib-either/test.ml
@@ -1,0 +1,108 @@
+(* TEST
+   * expect
+*)
+
+open Either;;
+
+[left 1; right true];;
+[%%expect {|
+- : (int, bool) Either.t list = [Left 1; Right true]
+|}];;
+
+List.map is_left [left 1; right true];;
+[%%expect {|
+- : bool list = [true; false]
+|}];;
+
+List.map is_right [left 1; right true];;
+[%%expect {|
+- : bool list = [false; true]
+|}];;
+
+[find_left (Left 1); find_left (Right 1)];;
+[%%expect {|
+- : int option list = [Some 1; None]
+|}];;
+
+[find_right (Left 1); find_right (Right 1)];;
+[%%expect {|
+- : int option list = [None; Some 1]
+|}];;
+
+[map_left succ (Left 1); map_left succ (Right true)];;
+[%%expect {|
+- : (int, bool) Either.t list = [Left 2; Right true]
+|}];;
+
+[map_right succ (Left ()); map_right succ (Right 2)];;
+[%%expect {|
+- : (unit, int) Either.t list = [Left (); Right 3]
+|}];;
+
+[map succ not (Left 1); map succ not (Right true)];;
+[%%expect {|
+- : (int, bool) Either.t list = [Left 2; Right false]
+|}];;
+
+[fold ~left:succ ~right:int_of_string (Left 1);
+ fold ~left:succ ~right:int_of_string (Right "2")];;
+[%%expect {|
+- : int list = [2; 2]
+|}];;
+
+let li = ref [] in
+let add to_str x = li := to_str x :: !li in
+iter ~left:(add Fun.id) ~right:(add string_of_int) (Left "foo");
+iter ~left:(add Fun.id) ~right:(add string_of_int) (Right 2);
+List.rev !li;;
+[%%expect {|
+- : string list = ["foo"; "2"]
+|}];;
+
+(
+  for_all ~left:((=) 1) ~right:((=) "foo") (Left 1),
+  for_all ~left:((=) 1) ~right:((=) "foo") (Right "foo"),
+  for_all ~left:((=) 1) ~right:((=) "foo") (Left 2),
+  for_all ~left:((=) 1) ~right:((=) "foo") (Right "bar")
+);;
+[%%expect {|
+- : bool * bool * bool * bool = (true, true, false, false)
+|}];;
+
+equal ~left:(=) ~right:(=) (Left 1) (Left 1),
+equal ~left:(=) ~right:(=) (Right true) (Right true);;
+[%%expect {|
+- : bool * bool = (true, true)
+|}];;
+
+(equal ~left:(=) ~right:(=) (Left 1) (Left 2),
+ equal ~left:(=) ~right:(=) (Right true) (Right false),
+ equal ~left:(=) ~right:(=) (Left 1) (Right true),
+ equal ~left:(=) ~right:(=) (Right 1) (Left true));;
+[%%expect {|
+- : bool * bool * bool * bool = (false, false, false, false)
+|}];;
+
+equal ~left:(fun _ _ -> false) ~right:(=) (Left 1) (Left 1),
+equal ~left:(=) ~right:(fun _ _ -> false) (Right true) (Right true);;
+[%%expect {|
+- : bool * bool = (false, false)
+|}];;
+
+let cmp = Stdlib.compare in
+(
+ (compare ~left:cmp ~right:cmp (Left 0) (Left 1),
+  compare ~left:cmp ~right:cmp (Left 1) (Left 1),
+  compare ~left:cmp ~right:cmp (Left 1) (Left 0)),
+
+ (compare ~left:cmp ~right:cmp (Right 0) (Right 1),
+  compare ~left:cmp ~right:cmp (Right 1) (Right 1),
+  compare ~left:cmp ~right:cmp (Right 1) (Right 0)),
+
+ (compare ~left:cmp ~right:cmp (Left 1) (Right true),
+  compare ~left:cmp ~right:cmp (Right 1) (Left true))
+);;
+[%%expect {|
+- : (int * int * int) * (int * int * int) * (int * int) =
+((-1, 0, 1), (-1, 0, 1), (-1, 1))
+|}];;

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -1,11 +1,19 @@
 (* TEST
 *)
 
+let is_even x = (x mod 2 = 0)
+
 let string_of_even_opt x =
-  if x mod 2 = 0 then
+  if is_even x then
     Some (string_of_int x)
   else
     None
+
+let string_of_even_or_int x =
+  if is_even x then
+    Either.Left (string_of_int x)
+  else
+    Either.Right x
 
 (* Standard test case *)
 let () =
@@ -35,6 +43,11 @@ let () =
   end;
 
   assert (List.filteri (fun i _ -> i < 2) (List.rev l) = [9; 8]);
+
+  assert (List.partition is_even [1; 2; 3; 4; 5]
+          = ([2; 4], [1; 3; 5]));
+  assert (List.partition_map string_of_even_or_int [1; 2; 3; 4; 5]
+          = (["2"; "4"], [1; 3; 5]));
 
   assert (List.compare_lengths [] [] = 0);
   assert (List.compare_lengths [1;2] ['a';'b'] = 0);

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/98 by t/102
+Error: Illegal shadowing of included type t/99 by t/103
        Line 2, characters 2-19:
-         Type t/98 came from this include
+         Type t/99 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/98 is shadowed
+         The value print has no valid type if t/99 is shadowed
 |}]
 
 module type Sunderscore = sig

--- a/toplevel/dune
+++ b/toplevel/dune
@@ -54,6 +54,7 @@
                     stdlib__Char
                     stdlib__Complex
                     stdlib__Digest
+                    stdlib__Either
                     stdlib__Ephemeron
                     stdlib__Filename
                     stdlib__Float


### PR DESCRIPTION
This is a new attempt at #9047 (introducing `List.partition_map : ('a -> ('b, 'c) result) -> 'a list -> 'b list * 'c list`) with a brand new `Either.t` type.

(cc @yallop, @nojb)

```ocaml
val left : 'a -> ('a, 'b) t
val right : 'b -> ('a, 'b) t
val find_left : ('a, 'b) t -> 'a option
val find_right : ('a, 'b) t -> 'b option
val swap : ('a, 'b) t -> ('b, 'a) t
val map_left : ('a1 -> 'a2) -> ('a1, 'b) t -> ('a2, 'b) t
val map_right : ('b1 -> 'b2) -> ('a, 'b1) t -> ('a, 'b2) t
val map_both :
  left:('a1 -> 'a2) -> right:('b1 -> 'b2) -> ('a1, 'b1) t -> ('a2, 'b2) t
val fold : left:('a -> 'c) -> right:('b -> 'c) -> ('a, 'b) t -> 'c
val equal :
  left:('a -> 'a -> bool) -> right:('b -> 'b -> bool) ->
  ('a, 'b) t -> ('a, 'b) t -> bool
val compare :
  left:('a -> 'a -> int) -> right:('b -> 'b -> int) ->
  ('a, 'b) t -> ('a, 'b) t -> int
```

Unlike [result], no [either] type is made available in Stdlib,
one needs to access [Either.t] explicitly:

- This type is less common in typical OCaml codebases,
  which prefer domain-specific variant types whose constructors
  carry more meaning.
- Adding this to Stdlib would raise warnings in existing codebases
  that already use a constructor named Left or Right:
  + when opening a module that exports such a name,
    warning 45 is raised
  + adding a second constructor of the same name in scope kicks
    in the disambiguation mechanisms, and warning 41 may now
    be raised by existing code.

If the use becomes more common in the future we can always
revisit this choice.
