### PR TITLE
Fix addition kind in cache_public_method

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1721,7 +1721,7 @@ let cache_public_method meths tag cache dbg =
      dbg),
   Clet (
     VP.create tagged,
-      Cop(Cadda, [lsl_const (Cvar li) log2_size_addr dbg;
+      Cop(Caddi, [lsl_const (Cvar li) log2_size_addr dbg;
         cconst_int(1 - 3 * size_addr)], dbg),
     Csequence(Cop (Cstore (Word_int, Assignment), [cache; Cvar tagged], dbg),
               Cvar tagged)))))


### PR DESCRIPTION
The addition produces an odd number, which is always safe for the GC to see.
Furthermore, storing values of type `Addr` into a memory location of type `Word_int` breaks some invariants that we'd like to enforce, which is why we propose the fix.

Cc @Gbury who noticed the problem.
