### PR TITLE
#9069: reworded error messages for non-regular structural types

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #9074: reworded error message for non-regular structural types
+  (Florian Angeletti, review by Jacques Garrigue and Leo White,
+   report by Chas Emerick)
+
 ### Internal/compiler-libs changes:
 
 ### Build system:

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -21,7 +21,12 @@ type 'a t = [`A of 'a t t];; (* fails *)
 Line 1, characters 0-26:
 1 | type 'a t = [`A of 'a t t];; (* fails *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of t, type 'a t t should be 'a t
+Error: This recursive type is not regular.
+       The type constructor t is defined as
+         type 'a t
+       but it is used as
+         'a t t.
+       All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
 [%%expect{|

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -176,3 +176,24 @@ Error: This expression has type t but an expression was expected of type
          [ `A ]
        The first variant type is private, it may not allow the tag(s) `A
 |}]
+
+
+(** Check that the non-regularity error message is robust to permutation *)
+
+type ('a,'b,'c,'d,'e) a = [ `A of ('d,'a,'e,'c,'b) b ]
+and  ('a,'b,'c,'d,'e) b = [ `B of ('c,'d,'e,'a,'b) c ]
+and  ('a,'b,'c,'d,'e) c = [ `C of ('a,'b,'c,'d,'e) a ]
+[%%expect {|
+Line 3, characters 0-54:
+3 | type ('a,'b,'c,'d,'e) a = [ `A of ('d,'a,'e,'c,'b) b ]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This recursive type is not regular.
+       The type constructor a is defined as
+         type ('a, 'b, 'c, 'd, 'e) a
+       but it is used as
+         ('e, 'c, 'b, 'd, 'a) a
+       after the following expansion(s):
+         ('d, 'a, 'e, 'c, 'b) b = [ `B of ('e, 'c, 'b, 'd, 'a) c ],
+         ('e, 'c, 'b, 'd, 'a) c = [ `C of ('e, 'c, 'b, 'd, 'a) a ]
+       All uses need to match the definition for the recursive type to be regular.
+|}]

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -179,7 +179,14 @@ and 'a d = <f : int c>;;
 Line 1, characters 0-32:
 1 | type 'a c = <f : 'a c; g : 'a d>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of d, type int c should be 'a c
+Error: This recursive type is not regular.
+       The type constructor c is defined as
+         type 'a c
+       but it is used as
+         int c
+       after the following expansion(s):
+         'a d = < f : int c >
+       All uses need to match the definition for the recursive type to be regular.
 |}];;
 type 'a c = <f : 'a c; g : 'a d>
 and 'a d = <f : 'a c>;;

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -972,7 +972,14 @@ type 'a u = < m : 'a v > and 'a v = 'a list u;;
 Line 1, characters 0-24:
 1 | type 'a u = < m : 'a v > and 'a v = 'a list u;;
     ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of v, type 'a list u should be 'a u
+Error: This recursive type is not regular.
+       The type constructor u is defined as
+         type 'a u
+       but it is used as
+         'a list u
+       after the following expansion(s):
+         'a v = 'a list u
+       All uses need to match the definition for the recursive type to be regular.
 |}];;
 
 (* PR#8198: Ctype.matches *)
@@ -1449,7 +1456,12 @@ type 'x t = < f : 'y. 'y t >;;
 Line 1, characters 0-28:
 1 | type 'x t = < f : 'y. 'y t >;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of t, type 'y t should be 'x t
+Error: This recursive type is not regular.
+       The type constructor t is defined as
+         type 'x t
+       but it is used as
+         'y t.
+       All uses need to match the definition for the recursive type to be regular.
 |}];;
 
 (* PR#6056, PR#6057 *)

--- a/testsuite/tests/typing-recmod/t07bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t07bad.compilers.reference
@@ -1,4 +1,9 @@
 File "t07bad.ml", line 10, characters 15-51:
 10 | module rec A : sig type 'a t = <m: 'a list A.t> end
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of A.t, type 'a list A.t should be 'a A.t
+Error: This recursive type is not regular.
+       The type constructor A.t is defined as
+         type 'a A.t
+       but it is used as
+         'a list A.t.
+       All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t08bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t08bad.compilers.reference
@@ -1,4 +1,11 @@
 File "t08bad.ml", line 10, characters 15-68:
 10 | module rec A : sig type 'a t = <m: 'a list B.t; n: 'a array B.t> end
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of B.t, type 'a array A.t should be 'a A.t
+Error: This recursive type is not regular.
+       The type constructor A.t is defined as
+         type 'a A.t
+       but it is used as
+         'a array A.t
+       after the following expansion(s):
+         'a array B.t = 'a array A.t
+       All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t09bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t09bad.compilers.reference
@@ -1,4 +1,11 @@
 File "t09bad.ml", line 10, characters 15-41:
 10 | module rec A : sig type 'a t = 'a B.t end
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of B.t, type 'a array A.t should be 'a A.t
+Error: This recursive type is not regular.
+       The type constructor A.t is defined as
+         type 'a A.t
+       but it is used as
+         'a array A.t
+       after the following expansion(s):
+         'a B.t = < m : 'a list A.t; n : 'a array A.t >
+       All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t11bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t11bad.compilers.reference
@@ -1,4 +1,9 @@
 File "t11bad.ml", line 12, characters 15-52:
 12 |        and B : sig type 'a t = <m: 'a array B.t> end
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In the definition of B.t, type 'a array B.t should be 'a B.t
+Error: This recursive type is not regular.
+       The type constructor B.t is defined as
+         type 'a B.t
+       but it is used as
+         'a array B.t.
+       All uses need to match the definition for the recursive type to be regular.

--- a/testsuite/tests/typing-recmod/t12bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t12bad.compilers.reference
@@ -4,4 +4,9 @@ File "t12bad.ml", lines 11-15, characters 4-7:
 13 |         method map : ('a -> 'b) -> 'b M.c
 14 |       end
 15 |     end
-Error: In the definition of M.c, type 'b M.c should be 'a M.c
+Error: This recursive type is not regular.
+       The type constructor M.c is defined as
+         type 'a M.c
+       but it is used as
+         'b M.c.
+       All uses need to match the definition for the recursive type to be regular.

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -37,7 +37,12 @@ type error =
   | Constraint_failed of type_expr * type_expr
   | Inconsistent_constraint of Env.t * Ctype.Unification_trace.t
   | Type_clash of Env.t * Ctype.Unification_trace.t
-  | Parameters_differ of Path.t * type_expr * type_expr
+  | Non_regular of {
+      definition: Path.t;
+      used_as: type_expr;
+      defined_as: type_expr;
+      expansions: (type_expr * type_expr) list;
+    }
   | Null_arity_external
   | Missing_native_external
   | Unbound_type_var of type_expr * type_declaration
@@ -761,7 +766,7 @@ let check_recursion env loc path decl to_check =
 
   let visited = ref [] in
 
-  let rec check_regular cpath args prev_exp ty =
+  let rec check_regular cpath args prev_exp prev_expansions ty =
     let ty = Ctype.repr ty in
     if not (List.memq ty !visited) then begin
       visited := ty :: !visited;
@@ -770,7 +775,12 @@ let check_recursion env loc path decl to_check =
           if Path.same path path' then begin
             if not (Ctype.equal env false args args') then
               raise (Error(loc,
-                     Parameters_differ(cpath, ty, Ctype.newconstr path args)))
+                     Non_regular {
+                       definition=path;
+                       used_as=ty;
+                       defined_as=Ctype.newconstr path args;
+                       expansions=List.rev prev_expansions;
+                     }))
           end
           (* Attempt to expand a type abbreviation if:
               1- [to_check path'] holds
@@ -790,15 +800,18 @@ let check_recursion env loc path decl to_check =
                   raise (Error(loc, Constraint_failed
                                  (ty, Ctype.newconstr path' params0)));
               end;
-              check_regular path' args (path' :: prev_exp) body
+              check_regular path' args
+                (path' :: prev_exp) ((ty,body) :: prev_expansions)
+                body
             with Not_found -> ()
           end;
-          List.iter (check_regular cpath args prev_exp) args'
+          List.iter (check_regular cpath args prev_exp prev_expansions) args'
       | Tpoly (ty, tl) ->
           let (_, ty) = Ctype.instance_poly ~keep_names:true false tl ty in
-          check_regular cpath args prev_exp ty
+          check_regular cpath args prev_exp prev_expansions ty
       | _ ->
-          Btype.iter_type_expr (check_regular cpath args prev_exp) ty
+          Btype.iter_type_expr
+            (check_regular cpath args prev_exp prev_expansions) ty
     end in
 
   Option.iter
@@ -806,7 +819,7 @@ let check_recursion env loc path decl to_check =
       let (args, body) =
         Ctype.instance_parameterized_type
           ~keep_names:true decl.type_params body in
-      check_regular path args [] body)
+      check_regular path args [] [] body)
     decl.type_manifest
 
 let check_abbrev_recursion env id_loc_list to_check tdecl =
@@ -1656,15 +1669,41 @@ let report_error ppf = function
         "Constraints are not satisfied in this type."
         !Oprint.out_type (Printtyp.tree_of_typexp false ty)
         !Oprint.out_type (Printtyp.tree_of_typexp false ty')
-  | Parameters_differ (path, ty, ty') ->
-      Printtyp.reset_and_mark_loops ty;
-      Printtyp.mark_loops ty';
+  | Non_regular { definition; used_as; defined_as; expansions } ->
+      let pp_expansion ppf (ty,body) =
+        Format.fprintf ppf "%a = %a"
+          Printtyp.type_expr ty
+          Printtyp.type_expr body in
+      let comma ppf () = Format.fprintf ppf ",@;<1 2>" in
+      let pp_expansions ppf expansions =
+        Format.(pp_print_list ~pp_sep:comma pp_expansion) ppf expansions in
+      Printtyp.reset_and_mark_loops used_as;
+      Printtyp.mark_loops defined_as;
       Printtyp.Naming_context.reset ();
-      fprintf ppf
-        "@[<hv>In the definition of %s, type@ %a@ should be@ %a@]"
-        (Path.name path)
-        !Oprint.out_type (Printtyp.tree_of_typexp false ty)
-        !Oprint.out_type (Printtyp.tree_of_typexp false ty')
+      begin match expansions with
+      | [] ->
+          fprintf ppf
+            "@[<hv>This recursive type is not regular.@ \
+             The type constructor %s is defined as@;<1 2>type %a@ \
+             but it is used as@;<1 2>%a.@ \
+             All uses need to match the definition for the recursive type \
+             to be regular.@]"
+            (Path.name definition)
+            !Oprint.out_type (Printtyp.tree_of_typexp false defined_as)
+            !Oprint.out_type (Printtyp.tree_of_typexp false used_as)
+      | _ :: _ ->
+          fprintf ppf
+            "@[<hv>This recursive type is not regular.@ \
+             The type constructor %s is defined as@;<1 2>type %a@ \
+             but it is used as@;<1 2>%a@ \
+             after the following expansion(s):@;<1 2>%a@ \
+             All uses need to match the definition for the recursive type \
+             to be regular.@]"
+            (Path.name definition)
+            !Oprint.out_type (Printtyp.tree_of_typexp false defined_as)
+            !Oprint.out_type (Printtyp.tree_of_typexp false used_as)
+            pp_expansions expansions
+      end
   | Inconsistent_constraint (env, trace) ->
       fprintf ppf "The type constraints are not consistent.@.";
       Printtyp.report_unification_error ppf env trace

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -70,7 +70,12 @@ type error =
   | Constraint_failed of type_expr * type_expr
   | Inconsistent_constraint of Env.t * Ctype.Unification_trace.t
   | Type_clash of Env.t * Ctype.Unification_trace.t
-  | Parameters_differ of Path.t * type_expr * type_expr
+  | Non_regular of {
+      definition: Path.t;
+      used_as: type_expr;
+      defined_as: type_expr;
+      expansions: (type_expr * type_expr) list;
+    }
   | Null_arity_external
   | Missing_native_external
   | Unbound_type_var of type_expr * type_declaration


### PR DESCRIPTION
This PR proposes to reword the error message for non-regular structural types (see #9069). 
Compared to previous message, the new error message 
* mention explicitly the regularity issue
* avoid implicit substitution in type parameters
* do not propose a fix

For instance, the error message for:

```OCaml
type k = [ `A of int | `B of string | `Ks of (string fn * k) list ]
and 'a fn = 'a -> k -> bool
```
is expanded from
```OCaml
Error: In the definition of k, type string fn should be 'a fn
```
to
```
Error: This recursive type definition is not regular.
       The type constructor fn is defined as
         'a fn,
       but it is used as
        string fn
       after the following expansion(s):
         k = [ `A of int | `B of string | `Ks of (string fn * k) list ]
       All uses need to match the definition for the recursive type to be regular.
```

The structure of the new error message is quite different to avoid another issue with the current error message: it is possible to raise strange error messages where the printed types does not match the source code and the proposed fix matches perfectly the existing code source. Typically, the following erroneous definition

```OCaml
type ('a,'b,'c,'d,'e) a = [ `A of ('d,'a,'e,'c,'b) b ]
and  ('a,'b,'c,'d,'e) b = [ `B of ('c,'d,'e,'a,'b) c ]
and  ('a,'b,'c,'d,'e) c = [ `C of ('a,'b,'c,'d,'e) a ];;
```
ended up with this message:
```OCaml
Error: In the definition of c, type
       ('e, 'c, 'b, 'd, 'a) a
       should be
       ('a, 'b, 'c, 'd, 'e) a
```
The new error message is more explicit about the fact that we are checking the regularity of  `a`, and expanding the other abbreviations:
```
Error: This recursive type definition is not regular.
       The type constructor a is defined as
         ('a, 'b, 'c, 'd, 'e) a,
       but it is used as
         ('e, 'c, 'b, 'd, 'a) a
       after the following expansion(s):
         ('d, 'a, 'e, 'c, 'b) b = [ `B of ('e, 'c, 'b, 'd, 'a) c ],
         ('e, 'c, 'b, 'd, 'a) c = [ `C of ('e, 'c, 'b, 'd, 'a) a ]
       All uses need to match the definition for the recursive type to be regular.
```
