### PR TITLE
Define to_rev_seq in Set and Map module

### DIFF
--- a/Changes
+++ b/Changes
@@ -674,7 +674,7 @@ OCaml 4.10.0 (21 February 2020)
    Jacques-Henri Jourdan)
 
 ### Standard library:
-- #9075: define rev_to_seq in Set and Map module
+- #9075: define to_rev_seq in Set and Map module
    (Sébastien Briais, review by Gabriel Scherer and Nicolas Ojeda Bär)
 
 - #8760: List.concat_map : ('a -> 'b list) -> 'a list -> 'b list

--- a/Changes
+++ b/Changes
@@ -680,7 +680,6 @@ OCaml 4.10.0 (21 February 2020)
 - #8760: List.concat_map : ('a -> 'b list) -> 'a list -> 'b list
   (Gabriel Scherer, review by Daniel Bünzli and Thomas Refis)
 
-
 - #8832: List.find_map : ('a -> 'b option) -> 'a list -> 'b option
   (Gabriel Scherer, review by Jeremy Yallop, Nicolás Ojeda Bär
    and Daniel Bünzli)

--- a/Changes
+++ b/Changes
@@ -30,6 +30,9 @@ Working version
   or function, including any enclosing module or class.
   (Nicolás Ojeda Bär, Stephen Dolan, review by Stephen Dolan)
 
+- #9075: define to_rev_seq in Set and Map modules.
+  (Sébastien Briais, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 * #9206, #9419: update documentation of the threads library;
@@ -674,8 +677,6 @@ OCaml 4.10.0 (21 February 2020)
    Jacques-Henri Jourdan)
 
 ### Standard library:
-- #9075: define to_rev_seq in Set and Map module
-   (Sébastien Briais, review by Gabriel Scherer and Nicolas Ojeda Bär)
 
 - #8760: List.concat_map : ('a -> 'b list) -> 'a list -> 'b list
   (Gabriel Scherer, review by Daniel Bünzli and Thomas Refis)

--- a/Changes
+++ b/Changes
@@ -674,9 +674,12 @@ OCaml 4.10.0 (21 February 2020)
    Jacques-Henri Jourdan)
 
 ### Standard library:
+- #9075: define rev_to_seq in Set and Map module
+   (Sébastien Briais, review by Gabriel Scherer and Nicolas Ojeda Bär)
 
 - #8760: List.concat_map : ('a -> 'b list) -> 'a list -> 'b list
   (Gabriel Scherer, review by Daniel Bünzli and Thomas Refis)
+
 
 - #8832: List.find_map : ('a -> 'b option) -> 'a list -> 'b option
   (Gabriel Scherer, review by Jeremy Yallop, Nicolás Ojeda Bär

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -60,6 +60,7 @@ module type S =
     val map: ('a -> 'b) -> 'a t -> 'b t
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
+    val to_seq_rev : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t
@@ -507,6 +508,11 @@ module Make(Ord: OrderedType) = struct
 
     let to_seq m =
       seq_of_enum_ (cons_enum m End)
+
+    let rec to_seq_rev = function
+      | Empty -> Seq.empty
+      | Node {l; v; d; r; _} ->
+          Seq.append (to_seq_rev r) (Seq.cons (v, d) (to_seq_rev l))
 
     let to_seq_from low m =
       let rec aux low m c = match m with

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -516,7 +516,8 @@ module Make(Ord: OrderedType) = struct
 
     let rec rev_seq_of_enum_ c () = match c with
       | End -> Seq.Nil
-      | More (k,v,t,rest) -> Seq.Cons ((k,v), rev_seq_of_enum_ (snoc_enum t rest))
+      | More (k,v,t,rest) ->
+          Seq.Cons ((k,v), rev_seq_of_enum_ (snoc_enum t rest))
 
     let rev_to_seq c =
       rev_seq_of_enum_ (snoc_enum c End)

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -509,10 +509,17 @@ module Make(Ord: OrderedType) = struct
     let to_seq m =
       seq_of_enum_ (cons_enum m End)
 
-    let rec rev_to_seq = function
-      | Empty -> Seq.empty
-      | Node {l; v; d; r; _} ->
-          Seq.append (rev_to_seq r) (Seq.cons (v, d) (rev_to_seq l))
+    let rec snoc_enum s e =
+      match s with
+        Empty -> e
+      | Node{l; v; d; r} -> snoc_enum r (More(v, d, l, e))
+
+    let rec rev_seq_of_enum_ c () = match c with
+      | End -> Seq.Nil
+      | More (k,v,t,rest) -> Seq.Cons ((k,v), rev_seq_of_enum_ (snoc_enum t rest))
+
+    let rev_to_seq c =
+      rev_seq_of_enum_ (snoc_enum c End)
 
     let to_seq_from low m =
       let rec aux low m c = match m with

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -60,7 +60,7 @@ module type S =
     val map: ('a -> 'b) -> 'a t -> 'b t
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
-    val rev_to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t
@@ -519,7 +519,7 @@ module Make(Ord: OrderedType) = struct
       | More (k,v,t,rest) ->
           Seq.Cons ((k,v), rev_seq_of_enum_ (snoc_enum t rest))
 
-    let rev_to_seq c =
+    let to_rev_seq c =
       rev_seq_of_enum_ (snoc_enum c End)
 
     let to_seq_from low m =

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -60,7 +60,7 @@ module type S =
     val map: ('a -> 'b) -> 'a t -> 'b t
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
-    val to_seq_rev : 'a t -> (key * 'a) Seq.t
+    val rev_to_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t
@@ -509,10 +509,10 @@ module Make(Ord: OrderedType) = struct
     let to_seq m =
       seq_of_enum_ (cons_enum m End)
 
-    let rec to_seq_rev = function
+    let rec rev_to_seq = function
       | Empty -> Seq.empty
       | Node {l; v; d; r; _} ->
-          Seq.append (to_seq_rev r) (Seq.cons (v, d) (to_seq_rev l))
+          Seq.append (rev_to_seq r) (Seq.cons (v, d) (rev_to_seq l))
 
     let to_seq_from low m =
       let rec aux low m c = match m with

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -332,7 +332,7 @@ module type S =
     (** Iterate on the whole map, in ascending order of keys
         @since 4.07 *)
 
-    val to_seq_rev : 'a t -> (key * 'a) Seq.t
+    val rev_to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in descending order of keys
         @since 4.xx *)
 

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -334,7 +334,7 @@ module type S =
 
     val to_rev_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in descending order of keys
-        @since 4.11 *)
+        @since 4.12 *)
 
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     (** [to_seq_from k m] iterates on a subset of the bindings of [m],

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -334,7 +334,7 @@ module type S =
 
     val rev_to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in descending order of keys
-        @since 4.xx *)
+        @since 4.11 *)
 
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     (** [to_seq_from k m] iterates on a subset of the bindings of [m],

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -332,7 +332,7 @@ module type S =
     (** Iterate on the whole map, in ascending order of keys
         @since 4.07 *)
 
-    val rev_to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in descending order of keys
         @since 4.11 *)
 

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -332,6 +332,10 @@ module type S =
     (** Iterate on the whole map, in ascending order of keys
         @since 4.07 *)
 
+    val to_seq_rev : 'a t -> (key * 'a) Seq.t
+    (** Iterate on the whole map, in descending order of keys
+        @since 4.xx *)
+
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     (** [to_seq_from k m] iterates on a subset of the bindings of [m],
         in ascending order of keys, from key [k] or above.

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -226,6 +226,7 @@ module Set : sig
       val of_list: elt list -> t
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
+      val to_seq_rev : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
     end

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -172,7 +172,7 @@ module Map : sig
       val map : f:('a -> 'b) -> 'a t -> 'b t
       val mapi : f:(key -> 'a -> 'b) -> 'a t -> 'b t
       val to_seq : 'a t -> (key * 'a) Seq.t
-      val to_seq_rev : 'a t -> (key * 'a) Seq.t
+      val rev_to_seq : 'a t -> (key * 'a) Seq.t
       val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
       val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
       val of_seq : (key * 'a) Seq.t -> 'a t
@@ -227,7 +227,7 @@ module Set : sig
       val of_list: elt list -> t
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
-      val to_seq_rev : t -> elt Seq.t
+      val rev_to_seq : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
     end

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -172,6 +172,7 @@ module Map : sig
       val map : f:('a -> 'b) -> 'a t -> 'b t
       val mapi : f:(key -> 'a -> 'b) -> 'a t -> 'b t
       val to_seq : 'a t -> (key * 'a) Seq.t
+      val to_seq_rev : 'a t -> (key * 'a) Seq.t
       val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
       val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
       val of_seq : (key * 'a) Seq.t -> 'a t

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -172,7 +172,7 @@ module Map : sig
       val map : f:('a -> 'b) -> 'a t -> 'b t
       val mapi : f:(key -> 'a -> 'b) -> 'a t -> 'b t
       val to_seq : 'a t -> (key * 'a) Seq.t
-      val rev_to_seq : 'a t -> (key * 'a) Seq.t
+      val to_rev_seq : 'a t -> (key * 'a) Seq.t
       val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
       val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
       val of_seq : (key * 'a) Seq.t -> 'a t
@@ -227,7 +227,7 @@ module Set : sig
       val of_list: elt list -> t
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
-      val rev_to_seq : t -> elt Seq.t
+      val to_rev_seq : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
     end

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -64,7 +64,7 @@ module type S =
     val of_list: elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val to_seq_rev : t -> elt Seq.t
+    val rev_to_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -595,10 +595,10 @@ module Make(Ord: OrderedType) =
 
     let to_seq c = seq_of_enum_ (cons_enum c End)
 
-    let rec to_seq_rev = function
+    let rec rev_to_seq = function
       | Empty -> Seq.empty
       | Node {l; r; v; _} ->
-          Seq.append (to_seq_rev r) (Seq.cons v (to_seq_rev l))
+          Seq.append (rev_to_seq r) (Seq.cons v (rev_to_seq l))
 
     let to_seq_from low s =
       let rec aux low s c = match s with

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -64,6 +64,7 @@ module type S =
     val of_list: elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
+    val to_seq_rev : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -593,6 +594,11 @@ module Make(Ord: OrderedType) =
       | More (x, t, rest) -> Seq.Cons (x, seq_of_enum_ (cons_enum t rest))
 
     let to_seq c = seq_of_enum_ (cons_enum c End)
+
+    let rec to_seq_rev = function
+      | Empty -> Seq.empty
+      | Node {l; r; v; _} ->
+          Seq.append (to_seq_rev r) (Seq.cons v (to_seq_rev l))
 
     let to_seq_from low s =
       let rec aux low s c = match s with

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -64,7 +64,7 @@ module type S =
     val of_list: elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val rev_to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -604,7 +604,7 @@ module Make(Ord: OrderedType) =
       | End -> Seq.Nil
       | More (x, t, rest) -> Seq.Cons (x, rev_seq_of_enum_ (snoc_enum t rest))
 
-    let rev_to_seq c = rev_seq_of_enum_ (snoc_enum c End)
+    let to_rev_seq c = rev_seq_of_enum_ (snoc_enum c End)
 
     let to_seq_from low s =
       let rec aux low s c = match s with

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -595,10 +595,16 @@ module Make(Ord: OrderedType) =
 
     let to_seq c = seq_of_enum_ (cons_enum c End)
 
-    let rec rev_to_seq = function
-      | Empty -> Seq.empty
-      | Node {l; r; v; _} ->
-          Seq.append (rev_to_seq r) (Seq.cons v (rev_to_seq l))
+    let rec snoc_enum s e =
+      match s with
+        Empty -> e
+      | Node{l; v; r} -> snoc_enum r (More(v, l, e))
+
+    let rec rev_seq_of_enum_ c () = match c with
+      | End -> Seq.Nil
+      | More (x, t, rest) -> Seq.Cons (x, rev_seq_of_enum_ (snoc_enum t rest))
+
+    let rev_to_seq c = rev_seq_of_enum_ (snoc_enum c End)
 
     let to_seq_from low s =
       let rec aux low s c = match s with

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -293,7 +293,7 @@ module type S =
 
     val to_rev_seq : t -> elt Seq.t
     (** Iterate on the whole set, in descending order
-        @since 4.11 *)
+        @since 4.12 *)
 
     val add_seq : elt Seq.t -> t -> t
     (** Add the given elements to the set, in order.

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -291,7 +291,7 @@ module type S =
     (** Iterate on the whole set, in ascending order
         @since 4.07 *)
 
-    val to_seq_rev: t -> elt Seq.t
+    val rev_to_seq : t -> elt Seq.t
     (** Iterate on the whole set, in descending order
         @since 4.xx *)
 

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -291,7 +291,7 @@ module type S =
     (** Iterate on the whole set, in ascending order
         @since 4.07 *)
 
-    val rev_to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
     (** Iterate on the whole set, in descending order
         @since 4.11 *)
 

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -293,7 +293,7 @@ module type S =
 
     val rev_to_seq : t -> elt Seq.t
     (** Iterate on the whole set, in descending order
-        @since 4.xx *)
+        @since 4.11 *)
 
     val add_seq : elt Seq.t -> t -> t
     (** Add the given elements to the set, in order.

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -291,6 +291,10 @@ module type S =
     (** Iterate on the whole set, in ascending order
         @since 4.07 *)
 
+    val to_seq_rev: t -> elt Seq.t
+    (** Iterate on the whole set, in descending order
+        @since 4.10 *)
+
     val add_seq : elt Seq.t -> t -> t
     (** Add the given elements to the set, in order.
         @since 4.07 *)

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -293,7 +293,7 @@ module type S =
 
     val to_seq_rev: t -> elt Seq.t
     (** Iterate on the whole set, in descending order
-        @since 4.10 *)
+        @since 4.xx *)
 
     val add_seq : elt Seq.t -> t -> t
     (** Add the given elements to the set, in order.

--- a/testsuite/tests/generalized-open/accepted_expect.ml
+++ b/testsuite/tests/generalized-open/accepted_expect.ml
@@ -45,6 +45,7 @@ val find_last_opt : (elt -> bool) -> t -> elt option = <fun>
 val of_list : elt list -> t = <fun>
 val to_seq_from : elt -> t -> elt Seq.t = <fun>
 val to_seq : t -> elt Seq.t = <fun>
+val to_rev_seq : t -> elt Seq.t = <fun>
 val add_seq : elt Seq.t -> t -> t = <fun>
 val of_seq : elt Seq.t -> t = <fun>
 |}]

--- a/testsuite/tests/lib-set/testmap.ml
+++ b/testsuite/tests/lib-set/testmap.ml
@@ -177,8 +177,8 @@ let test x v s1 s2 =
   checkbool "to_seq_of_seq"
     (M.equal (=) s1 (M.of_seq @@ M.to_seq s1));
 
-  checkbool "rev_to_seq_of_seq"
-    (M.equal (=) s1 (M.of_seq @@ M.rev_to_seq s1));
+  checkbool "to_rev_seq_of_seq"
+    (M.equal (=) s1 (M.of_seq @@ M.to_rev_seq s1));
 
   checkbool "to_seq_from"
     (let seq = M.to_seq_from x s1 in
@@ -196,8 +196,8 @@ let test x v s1 s2 =
      Seq.iter (fun (x, _) -> assert (!last <= x); last := x) seq;
      true);
 
-  checkbool "rev_to_seq_decreasing"
-    (let seq = M.rev_to_seq s1 in
+  checkbool "to_rev_seq_decreasing"
+    (let seq = M.to_rev_seq s1 in
      let last = ref max_int in
      Seq.iter (fun (x, _) -> assert (x <= !last); last := x) seq;
      true);

--- a/testsuite/tests/lib-set/testmap.ml
+++ b/testsuite/tests/lib-set/testmap.ml
@@ -177,6 +177,9 @@ let test x v s1 s2 =
   checkbool "to_seq_of_seq"
     (M.equal (=) s1 (M.of_seq @@ M.to_seq s1));
 
+  checkbool "rev_to_seq_of_seq"
+    (M.equal (=) s1 (M.of_seq @@ M.rev_to_seq s1));
+
   checkbool "to_seq_from"
     (let seq = M.to_seq_from x s1 in
      let ok1 = List.of_seq seq |> List.for_all (fun (y,_) -> y >= x) in
@@ -186,6 +189,18 @@ let test x v s1 s2 =
        (List.of_seq seq)
      in
      ok1 && ok2);
+
+  checkbool "to_seq_increasing"
+    (let seq = M.to_seq s1 in
+     let last = ref min_int in
+     Seq.iter (fun (x, _) -> assert (!last <= x); last := x) seq;
+     true);
+
+  checkbool "rev_to_seq_decreasing"
+    (let seq = M.rev_to_seq s1 in
+     let last = ref max_int in
+     Seq.iter (fun (x, _) -> assert (x <= !last); last := x) seq;
+     true);
 
   ()
 

--- a/testsuite/tests/lib-set/testset.ml
+++ b/testsuite/tests/lib-set/testset.ml
@@ -190,6 +190,9 @@ let test x s1 s2 =
   checkbool "to_seq_of_seq"
     (S.equal s1 (S.of_seq @@ S.to_seq s1));
 
+  checkbool "to_seq_of_seq"
+    (S.equal s1 (S.of_seq @@ S.rev_to_seq s1));
+
   checkbool "to_seq_from"
     (let seq = S.to_seq_from x s1 in
      let ok1 = List.of_seq seq |> List.for_all (fun y -> y >= x) in
@@ -199,6 +202,18 @@ let test x s1 s2 =
        (List.of_seq seq)
      in
      ok1 && ok2);
+
+  checkbool "to_seq_increasing"
+    (let seq = S.to_seq s1 in
+     let last = ref min_int in
+     Seq.iter (fun x -> assert (!last <= x); last := x) seq;
+     true);
+
+  checkbool "rev_to_seq_decreasing"
+    (let seq = S.rev_to_seq s1 in
+     let last = ref max_int in
+     Seq.iter (fun x -> assert (x <= !last); last := x) seq;
+     true);
 
   ()
 

--- a/testsuite/tests/lib-set/testset.ml
+++ b/testsuite/tests/lib-set/testset.ml
@@ -191,7 +191,7 @@ let test x s1 s2 =
     (S.equal s1 (S.of_seq @@ S.to_seq s1));
 
   checkbool "to_seq_of_seq"
-    (S.equal s1 (S.of_seq @@ S.rev_to_seq s1));
+    (S.equal s1 (S.of_seq @@ S.to_rev_seq s1));
 
   checkbool "to_seq_from"
     (let seq = S.to_seq_from x s1 in
@@ -209,8 +209,8 @@ let test x s1 s2 =
      Seq.iter (fun x -> assert (!last <= x); last := x) seq;
      true);
 
-  checkbool "rev_to_seq_decreasing"
-    (let seq = S.rev_to_seq s1 in
+  checkbool "to_rev_seq_decreasing"
+    (let seq = S.to_rev_seq s1 in
      let last = ref max_int in
      Seq.iter (fun x -> assert (x <= !last); last := x) seq;
      true);

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -341,7 +341,7 @@ module type MapT =
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
-    val rev_to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t
@@ -394,7 +394,7 @@ module SSMap :
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
-    val rev_to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -341,6 +341,7 @@ module type MapT =
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
+    val to_seq_rev : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t
@@ -393,6 +394,7 @@ module SSMap :
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
+    val to_seq_rev : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -341,7 +341,7 @@ module type MapT =
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
-    val to_seq_rev : 'a t -> (key * 'a) Seq.t
+    val rev_to_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t
@@ -394,7 +394,7 @@ module SSMap :
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
-    val to_seq_rev : 'a t -> (key * 'a) Seq.t
+    val rev_to_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
     val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
     val of_seq : (key * 'a) Seq.t -> 'a t

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -318,6 +318,7 @@ module StringSet :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
+    val to_seq_rev : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -364,6 +365,7 @@ module SSet :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
+    val to_seq_rev : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -442,6 +444,7 @@ module A :
         val of_list : elt list -> t
         val to_seq_from : elt -> t -> elt Seq.t
         val to_seq : t -> elt Seq.t
+        val to_seq_rev : t -> elt Seq.t
         val add_seq : elt Seq.t -> t -> t
         val of_seq : elt Seq.t -> t
       end
@@ -555,6 +558,7 @@ module SInt :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
+    val to_seq_rev : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -318,7 +318,7 @@ module StringSet :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val to_seq_rev : t -> elt Seq.t
+    val rev_to_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -365,7 +365,7 @@ module SSet :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val to_seq_rev : t -> elt Seq.t
+    val rev_to_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -444,7 +444,7 @@ module A :
         val of_list : elt list -> t
         val to_seq_from : elt -> t -> elt Seq.t
         val to_seq : t -> elt Seq.t
-        val to_seq_rev : t -> elt Seq.t
+        val rev_to_seq : t -> elt Seq.t
         val add_seq : elt Seq.t -> t -> t
         val of_seq : elt Seq.t -> t
       end
@@ -558,7 +558,7 @@ module SInt :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val to_seq_rev : t -> elt Seq.t
+    val rev_to_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -318,7 +318,7 @@ module StringSet :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val rev_to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -365,7 +365,7 @@ module SSet :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val rev_to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end
@@ -444,7 +444,7 @@ module A :
         val of_list : elt list -> t
         val to_seq_from : elt -> t -> elt Seq.t
         val to_seq : t -> elt Seq.t
-        val rev_to_seq : t -> elt Seq.t
+        val to_rev_seq : t -> elt Seq.t
         val add_seq : elt Seq.t -> t -> t
         val of_seq : elt Seq.t -> t
       end
@@ -558,7 +558,7 @@ module SInt :
     val of_list : elt list -> t
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
-    val rev_to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
     val add_seq : elt Seq.t -> t -> t
     val of_seq : elt Seq.t -> t
   end

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -274,7 +274,7 @@ module MkT :
       val of_list : elt list -> t
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
-      val rev_to_seq : t -> elt Seq.t
+      val to_rev_seq : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
     end

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -274,7 +274,7 @@ module MkT :
       val of_list : elt list -> t
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
-      val to_seq_rev : t -> elt Seq.t
+      val rev_to_seq : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
     end

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -274,6 +274,7 @@ module MkT :
       val of_list : elt list -> t
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
+      val to_seq_rev : t -> elt Seq.t
       val add_seq : elt Seq.t -> t -> t
       val of_seq : elt Seq.t -> t
     end

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -54,6 +54,7 @@ module Core :
             val map : ('a -> 'b) -> 'a t -> 'b t
             val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
             val to_seq : 'a t -> (key * 'a) Seq.t
+            val to_seq_rev : 'a t -> (key * 'a) Seq.t
             val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
             val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
             val of_seq : (key * 'a) Seq.t -> 'a t

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -54,7 +54,7 @@ module Core :
             val map : ('a -> 'b) -> 'a t -> 'b t
             val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
             val to_seq : 'a t -> (key * 'a) Seq.t
-            val to_seq_rev : 'a t -> (key * 'a) Seq.t
+            val rev_to_seq : 'a t -> (key * 'a) Seq.t
             val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
             val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
             val of_seq : (key * 'a) Seq.t -> 'a t

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -54,7 +54,7 @@ module Core :
             val map : ('a -> 'b) -> 'a t -> 'b t
             val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
             val to_seq : 'a t -> (key * 'a) Seq.t
-            val rev_to_seq : 'a t -> (key * 'a) Seq.t
+            val to_rev_seq : 'a t -> (key * 'a) Seq.t
             val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
             val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
             val of_seq : (key * 'a) Seq.t -> 'a t


### PR DESCRIPTION
Following discussion of #9054 I switched to the Seq approach and define functions ~~`to_seq_rev`~~ `rev_to_seq` in  Set and Map modules.
