### PR TITLE
ocamltest: enable working with all compilerlibs

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #9078: make all compilerlibs/ available to ocamltest.
+  (Gabriel Scherer, review by Sébastien Hinderer)
+
 ### Build system:
 
 ### Bug fixes:

--- a/ocamltest/ocaml_modifiers.ml
+++ b/ocamltest/ocaml_modifiers.ml
@@ -97,15 +97,24 @@ let systhreads =
 
 let compilerlibs_subdirs =
 [
-  "utils"; "parsing"; "toplevel"; "typing"; "bytecomp"; "compilerlibs";
-  "file_formats"; "lambda";
+  "asmcomp";
+  "bytecomp";
+  "compilerlibs";
+  "driver";
+  "file_formats";
+  "lambda";
+  "middle_end";
+  "parsing";
+  "toplevel";
+  "typing";
+  "utils";
 ]
 
 let add_compiler_subdir subdir =
   Append (Ocaml_variables.directories, (wrap (compiler_subdir [subdir])))
 
-let ocamlcommon =
-  (Append (Ocaml_variables.libraries, wrap "ocamlcommon")) ::
+let compilerlibs_archive archive =
+  (Append (Ocaml_variables.libraries, wrap archive)) ::
   (List.map add_compiler_subdir compilerlibs_subdirs)
 
 let debugger = [add_compiler_subdir "debugger"]
@@ -117,7 +126,15 @@ let _ =
   register_modifiers "unix" unix;
   register_modifiers "dynlink" dynlink;
   register_modifiers "str" str;
-  register_modifiers "ocamlcommon" ocamlcommon;
+  List.iter
+    (fun archive -> register_modifiers archive (compilerlibs_archive archive))
+    [
+      "ocamlcommon";
+      "ocamlbytecomp";
+      "ocamlmiddleend";
+      "ocamloptcomp";
+      "ocamltoplevel";
+    ];
   register_modifiers "systhreads" systhreads;
   register_modifiers "latex" latex;
   register_modifiers "html" html;


### PR DESCRIPTION
ocamltest maintains a list of "subdirectories where .cmi files of
compilerlibs modules are", and uses "include ocamlcommon" to make the
content of ocamlcommon.cma available.

The present PR updates the list of subdirectories (driver/ was not
included, so Compmisc.initial_env() was unusable) and creates modifier
names (like "ocamlcommon") for all compilerlibs archives.