### PR TITLE
Aliasing == and != with explicit names

### DIFF
--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -28,8 +28,12 @@ external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
 external compare : 'a -> 'a -> int = "%compare"
 let min = min
 let max = max
+external physical_equality : 'a -> 'a -> bool = "%eq"
+external physical_inequality : 'a -> 'a -> bool = "%noteq"
 external ( == ) : 'a -> 'a -> bool = "%eq"
+  [@@ocaml.deprecated "Use = or physical_equality instead."]
 external ( != ) : 'a -> 'a -> bool = "%noteq"
+  [@@ocaml.deprecated "Use <> or physical_inequality instead."]
 external not : bool -> bool = "%boolnot"
 external ( && ) : bool -> bool -> bool = "%sequand"
 external ( & ) : bool -> bool -> bool = "%sequand"

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -29,7 +29,6 @@ external compare : 'a -> 'a -> int = "%compare"
 let min = min
 let max = max
 external phys_equal : 'a -> 'a -> bool = "%eq"
-external phys_inequal : 'a -> 'a -> bool = "%noteq"
 external ( == ) : 'a -> 'a -> bool = "%eq"
 external ( != ) : 'a -> 'a -> bool = "%noteq"
 external not : bool -> bool = "%boolnot"

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -28,12 +28,10 @@ external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
 external compare : 'a -> 'a -> int = "%compare"
 let min = min
 let max = max
-external physical_equality : 'a -> 'a -> bool = "%eq"
-external physical_inequality : 'a -> 'a -> bool = "%noteq"
+external phys_equal : 'a -> 'a -> bool = "%eq"
+external phys_inequal : 'a -> 'a -> bool = "%noteq"
 external ( == ) : 'a -> 'a -> bool = "%eq"
-  [@@ocaml.deprecated "Use = or physical_equality instead."]
 external ( != ) : 'a -> 'a -> bool = "%noteq"
-  [@@ocaml.deprecated "Use <> or physical_inequality instead."]
 external not : bool -> bool = "%boolnot"
 external ( && ) : bool -> bool -> bool = "%sequand"
 external ( & ) : bool -> bool -> bool = "%sequand"

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -76,7 +76,6 @@ let max x y = if x >= y then x else y
 external ( == ) : 'a -> 'a -> bool = "%eq"
 external ( != ) : 'a -> 'a -> bool = "%noteq"
 external phys_equal : 'a -> 'a -> bool = "%eq"
-external phys_inequal : 'a -> 'a -> bool = "%noteq"
 
 (* Boolean operations *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -75,8 +75,8 @@ let max x y = if x >= y then x else y
 
 external ( == ) : 'a -> 'a -> bool = "%eq"
 external ( != ) : 'a -> 'a -> bool = "%noteq"
-external physical_equality : 'a -> 'a -> bool = "%eq"
-external physical_inequality : 'a -> 'a -> bool = "%noteq"
+external phys_equal : 'a -> 'a -> bool = "%eq"
+external phys_inequal : 'a -> 'a -> bool = "%noteq"
 
 (* Boolean operations *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -75,6 +75,8 @@ let max x y = if x >= y then x else y
 
 external ( == ) : 'a -> 'a -> bool = "%eq"
 external ( != ) : 'a -> 'a -> bool = "%noteq"
+external physical_equality : 'a -> 'a -> bool = "%eq"
+external physical_inequality : 'a -> 'a -> bool = "%noteq"
 
 (* Boolean operations *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -185,23 +185,32 @@ val max : 'a -> 'a -> 'a
     The result is unspecified if one of the arguments contains
     the float value [nan]. *)
 
-external ( == ) : 'a -> 'a -> bool = "%eq"
-(** [e1 == e2] tests for physical equality of [e1] and [e2].
+external physical_equality : 'a -> 'a -> bool = "%eq"
+(** [physical_equality e1 e2] tests for physical equality of [e1] and [e2].
    On mutable types such as references, arrays, byte sequences, records with
    mutable fields and objects with mutable instance variables,
-   [e1 == e2] is true if and only if physical modification of [e1]
+   [physical_equality e1 e2] is true if and only if physical modification of [e1]
    also affects [e2].
-   On non-mutable types, the behavior of [( == )] is
+   On non-mutable types, the behavior of [physical_equality] is
    implementation-dependent; however, it is guaranteed that
-   [e1 == e2] implies [compare e1 e2 = 0].
+   [physical_equality e1 e2] implies [compare e1 e2 = 0].
+*)
+
+external physical_inequality : 'a -> 'a -> bool = "%noteq"
+(** Negation of {!Stdlib.physical_equality}.
+*)
+
+external ( == ) : 'a -> 'a -> bool = "%eq"
+  [@@ocaml.deprecated "Use = or physical_equality instead."]
+(** @deprecated {!Stdlib.physical_inequality} should be used instead.
    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
 external ( != ) : 'a -> 'a -> bool = "%noteq"
-(** Negation of {!Stdlib.( == )}.
+[@@ocaml.deprecated "Use <> or physical_inequality instead."]
+(** @deprecated {!Stdlib.physical_inequality} should be used instead.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
-
 
 (** {1 Boolean operations} *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -185,7 +185,7 @@ val max : 'a -> 'a -> 'a
     The result is unspecified if one of the arguments contains
     the float value [nan]. *)
 
-external physical_equality : 'a -> 'a -> bool = "%eq"
+external phys_equal : 'a -> 'a -> bool = "%eq"
 (** [physical_equality e1 e2] tests for physical equality of [e1] and [e2].
    On mutable types such as references, arrays, byte sequences, records with
    mutable fields and objects with mutable instance variables,
@@ -196,19 +196,17 @@ external physical_equality : 'a -> 'a -> bool = "%eq"
    [physical_equality e1 e2] implies [compare e1 e2 = 0].
 *)
 
-external physical_inequality : 'a -> 'a -> bool = "%noteq"
-(** Negation of {!Stdlib.physical_equality}.
+external phys_inequal : 'a -> 'a -> bool = "%noteq"
+(** Negation of {!Stdlib.phys_equal}.
 *)
 
 external ( == ) : 'a -> 'a -> bool = "%eq"
-  [@@ocaml.deprecated "Use = or physical_equality instead."]
-(** @deprecated {!Stdlib.physical_inequality} should be used instead.
+(** Operator alias to {!Stdlib.phys_equal}.
    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
 external ( != ) : 'a -> 'a -> bool = "%noteq"
-[@@ocaml.deprecated "Use <> or physical_inequality instead."]
-(** @deprecated {!Stdlib.physical_inequality} should be used instead.
+(** Operator alias to {!Stdlib.phys_inequal}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -196,17 +196,13 @@ external phys_equal : 'a -> 'a -> bool = "%eq"
    [phys_equal e1 e2] implies [compare e1 e2 = 0].
 *)
 
-external phys_inequal : 'a -> 'a -> bool = "%noteq"
-(** Negation of {!Stdlib.phys_equal}.
-*)
-
 external ( == ) : 'a -> 'a -> bool = "%eq"
 (** Operator alias to {!Stdlib.phys_equal}.
    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
 external ( != ) : 'a -> 'a -> bool = "%noteq"
-(** Operator alias to {!Stdlib.phys_inequal}.
+(** Negation of {!Stdlib.phys_equal}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -186,14 +186,14 @@ val max : 'a -> 'a -> 'a
     the float value [nan]. *)
 
 external phys_equal : 'a -> 'a -> bool = "%eq"
-(** [physical_equality e1 e2] tests for physical equality of [e1] and [e2].
+(** [phys_equal e1 e2] tests for physical equality of [e1] and [e2].
    On mutable types such as references, arrays, byte sequences, records with
    mutable fields and objects with mutable instance variables,
-   [physical_equality e1 e2] is true if and only if physical modification of [e1]
+   [phys_equal e1 e2] is true if and only if physical modification of [e1]
    also affects [e2].
-   On non-mutable types, the behavior of [physical_equality] is
+   On non-mutable types, the behavior of [phys_equal] is
    implementation-dependent; however, it is guaranteed that
-   [physical_equality e1 e2] implies [compare e1 e2 = 0].
+   [phys_equal e1 e2] implies [compare e1 e2 = 0].
 *)
 
 external phys_inequal : 'a -> 'a -> bool = "%noteq"


### PR DESCRIPTION
I like to spend time on [Stackoverflow's OCaml corner](https://stackoverflow.com/questions/tagged/ocaml). One mistake I repetitively see from beginners is them using the `==` operator instead of `=`. (see [[1]](https://stackoverflow.com/questions/58619586/expression-type-float-list-list-list-but-was-expected-of-type-float-list-list-b) [[2]](https://stackoverflow.com/questions/58141500/how-to-find-an-element-in-a-list-at-a-random-position) [[3]](https://stackoverflow.com/questions/57915875/ocaml-type-simple-recursive-function) [[4]](https://stackoverflow.com/questions/56318299/fizbuzz-in-ocaml-gets-gets-error-is-not-compatible-with-type-unit) [[5]](https://stackoverflow.com/questions/55773485/why-doesnt-this-code-work-recursive-function-gets-an-error) [[6]](https://stackoverflow.com/questions/55131535/printing-ocaml-function-after-compiling) and that's just the last few ones)

Of course, those newcomers usually only try to compare integers and therefore don't realize their mistake, and I pretty much always end up commenting something like "not the answer to your question but you shouldn't use `==`, or you will have a very bad surprise some day".

Unfortunately, the rise of Reason and the constant increase of newcomers only makes this problem more likely to cause serious bugs to happen in production OCaml code. That's why I'm proposing to deprecate the (much loved) `==` and `!=` operators.

Problems:
 * This PR adds a new name to `Stdlib`. I know this is bad. I don't think that the name I chose would collide with existing names, but that's possible. Of all the modules in the stdlib, perhaps only `Gc` could make sense hosting those new names, I don't think it is worth creating a new module though.
 * I count about 300 occurrences of `==` in trunk right now. I will change those if I get agreement in principle and a commonly accepted name.