### PR TITLE
typedtree: make the pat_env field of patterns immutable

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,9 @@ Working version
   (Florian Angeletti, Jacques Garrigue, Gabriel Scherer,
    review by Thomas Refis)
 
+- #9081: typedtree, make the pat_env field of pattern data immutable
+  (Gabriel Scherer, review by Jacques Garrigue, report by Alain Frisch)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1733,9 +1733,7 @@ let type_pat category ?no_existentials ?(mode=Normal)
         type_pat category ~no_existentials ~mode
           ~env sp expected_ty (fun x -> x)
       in
-      iter_general_pattern
-        { f = fun p -> p.pat_env <- !env } r;
-      r
+      map_general_pattern { f = fun p -> { p with pat_env = !env } } r
     )
 
 (* this function is passed to Partial.parmatch

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -40,7 +40,7 @@ and 'a pattern_data =
     pat_loc: Location.t;
     pat_extra : (pat_extra * Location.t * attribute list) list;
     pat_type: type_expr;
-    mutable pat_env: Env.t;
+    pat_env: Env.t;
     pat_attributes: attribute list;
    }
 
@@ -713,6 +713,15 @@ let iter_pattern (f : pattern -> unit) =
           match classify_pattern p with
           | Value -> f p
           | Computation -> () }
+
+let rec map_general_pattern
+  : type k . pattern_transformation -> k general_pattern -> k general_pattern
+  = fun f p ->
+  let pat_desc =
+    shallow_map_pattern_desc
+      { f = fun p -> map_general_pattern f p }
+      p.pat_desc in
+  f.f { p with pat_desc }
 
 type pattern_predicate = { f : 'k . 'k general_pattern -> bool }
 let exists_general_pattern (f : pattern_predicate) p =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -50,7 +50,7 @@ and 'a pattern_data =
     pat_loc: Location.t;
     pat_extra : (pat_extra * Location.t * attributes) list;
     pat_type: type_expr;
-    mutable pat_env: Env.t;
+    pat_env: Env.t;
     pat_attributes: attributes;
    }
 
@@ -779,6 +779,11 @@ val iter_pattern: (pattern -> unit) -> pattern -> unit
 type pattern_predicate = { f : 'k . 'k general_pattern -> bool }
 val exists_general_pattern: pattern_predicate -> 'k general_pattern -> bool
 val exists_pattern: (pattern -> bool) -> pattern -> bool
+
+(** bottom-up mapping of patterns: the transformation function is
+    called on the children before being called on the parent *)
+val map_general_pattern:
+  pattern_transformation -> 'k general_pattern -> 'k general_pattern
 
 val let_bound_idents: value_binding list -> Ident.t list
 val let_bound_idents_full:


### PR DESCRIPTION
Alain wondered about the mutations of the `pat_env` field of patterns in [this thread](https://github.com/ocaml/ocaml/pull/8970#issuecomment-547947491), and we realized that they don't actually need to be mutable.

A further change that was proposed in this PR is to remove the `pat_env` field completely, and store it at the toplevel of pattern clauses (in the expression containing the toplevel pattern). This is a more invasive change (it affects many pattern-traversing functions that use the type environment, which would now need to be threaded through), out of the scope of the current PR.

One embarrassing thing: I checked that *not* changing `pat_env` at all (in the place that used to mutate) would result in a test failure, but in fact it doesn't: all typing tests pass, and the modified compiler bootstraps. Could someone propose a test for the testsuite that would fail if the pattern environment were not updated after type-checking?