### PR TITLE
Prologue size should not depend on stack_offset (power, arm64)

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -78,7 +78,7 @@ let prologue_required = ref false
 
 let contains_calls = ref false
 
-let initial_frame_size () =
+let initial_stack_offset () =
     8 * num_stack_slots.(0) +
     8 * num_stack_slots.(1) +
     (if !contains_calls then 8 else 0)
@@ -86,7 +86,7 @@ let initial_frame_size () =
 let frame_size () =
   let sz =
     !stack_offset +
-    initial_frame_size ()
+    initial_stack_offset ()
   in Misc.align sz 16
 
 let slot_offset loc cl =
@@ -430,7 +430,7 @@ module BR = Branch_relaxation.Make (struct
   let offset_pc_at_branch = 0
 
   let prologue_size () =
-    (if initial_frame_size () > 0 then 2 else 0)
+    (if initial_stack_offset () > 0 then 2 else 0)
       + (if !contains_calls then 1 else 0)
 
   let epilogue_size () =

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -78,12 +78,15 @@ let prologue_required = ref false
 
 let contains_calls = ref false
 
-let frame_size () =
-  let sz =
-    !stack_offset +
+let initial_frame_size () =
     8 * num_stack_slots.(0) +
     8 * num_stack_slots.(1) +
     (if !contains_calls then 8 else 0)
+
+let frame_size () =
+  let sz =
+    !stack_offset +
+    initial_frame_size ()
   in Misc.align sz 16
 
 let slot_offset loc cl =
@@ -427,7 +430,7 @@ module BR = Branch_relaxation.Make (struct
   let offset_pc_at_branch = 0
 
   let prologue_size () =
-    (if frame_size () > 0 then 2 else 0)
+    (if initial_frame_size () > 0 then 2 else 0)
       + (if !contains_calls then 1 else 0)
 
   let epilogue_size () =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -42,14 +42,16 @@ let prologue_required = ref false
 
 let contains_calls = ref false
 
+let initial_frame_size () =
+  reserved_stack_space +
+  size_int * num_stack_slots.(0) +    (* Local int variables *)
+  size_float * num_stack_slots.(1) +  (* Local float variables *)
+  (if !contains_calls && abi = ELF32 then size_int else 0)
+                                        (* The return address *)
 let frame_size () =
   let size =
-    reserved_stack_space +
     !stack_offset +                     (* Trap frame, outgoing parameters *)
-    size_int * num_stack_slots.(0) +    (* Local int variables *)
-    size_float * num_stack_slots.(1) +  (* Local float variables *)
-    (if !contains_calls && abi = ELF32 then size_int else 0) in
-                                        (* The return address *)
+    initial_frame_size () in
   Misc.align size 16
 
 let slot_offset loc cls =
@@ -439,7 +441,7 @@ module BR = Branch_relaxation.Make (struct
 
   let prologue_size () =
     profiling_prologue_size ()
-      + (if frame_size () > 0 then 1 else 0)
+      + (if initial_frame_size () > 0 then 1 else 0)
       + (if !contains_calls then
            2 +
              match abi with

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -42,7 +42,7 @@ let prologue_required = ref false
 
 let contains_calls = ref false
 
-let initial_frame_size () =
+let initial_stack_offset () =
   reserved_stack_space +
   size_int * num_stack_slots.(0) +    (* Local int variables *)
   size_float * num_stack_slots.(1) +  (* Local float variables *)
@@ -51,7 +51,7 @@ let initial_frame_size () =
 let frame_size () =
   let size =
     !stack_offset +                     (* Trap frame, outgoing parameters *)
-    initial_frame_size () in
+    initial_stack_offset () in
   Misc.align size 16
 
 let slot_offset loc cls =
@@ -441,7 +441,7 @@ module BR = Branch_relaxation.Make (struct
 
   let prologue_size () =
     profiling_prologue_size ()
-      + (if initial_frame_size () > 0 then 1 else 0)
+      + (if initial_stack_offset () > 0 then 1 else 0)
       + (if !contains_calls then
            2 +
              match abi with


### PR DESCRIPTION
The calculation of `prologue_size` for branch relaxation on power and arm64 targets invokes frame_size function, which depends on stack_offset mutable variable.  The result is correct because the calculation is done at the beginning of the function, when stack_offset = 0.  This might lead to subtle bugs in the future if prologue_size is invoked in the middle of emit_all.

This PR defines `initial_frame_size` of a function, independently of stack_offset, and uses it to compute both `frame_size` and `prologue_size`.