### PR TITLE
toplevel, show directive for constructors

### DIFF
--- a/Changes
+++ b/Changes
@@ -30,6 +30,10 @@ Working version
 - #8938: Extend ocamlopt option "-stop-after" to handle "scheduling" argument.
   (Greta Yorsh, review by Florian Angeletti and Sébastien Hinderer)
 
+- #8945: Fix toplevel show directive to work with constructors
+  (Simon Parry, review by Gabriel Scherer, Jeremy Yallop,
+  Alain Frisch, Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #8970: separate value patterns (matching on values) from computation patterns

--- a/testsuite/tests/tool-toplevel/show.ml
+++ b/testsuite/tests/tool-toplevel/show.ml
@@ -1,0 +1,106 @@
+(* TEST
+   * expect
+*)
+
+(* this is a set of tests to test the #show functionality
+ * of toplevel *)
+
+#show Foo;;
+[%%expect {|
+Unknown element.
+|}];;
+
+module type S = sig type t val x : t end;;
+module M : S = struct type t = int let x = 3 end;;
+
+[%%expect {|
+module type S = sig type t val x : t end
+module M : S
+|}];;
+
+#show M;;
+[%%expect {|
+module M : S
+|}];;
+
+#show S;;
+[%%expect {|
+module type S = sig type t val x : t end
+|}];;
+
+#show Invalid_argument;;
+[%%expect {|
+exception Invalid_argument of string
+|}];;
+
+#show Some;;
+[%%expect {|
+type 'a option = None | Some of 'a
+|}];;
+
+#show option;;
+[%%expect {|
+type 'a option = None | Some of 'a
+|}];;
+
+#show Open_binary;;
+[%%expect {|
+type Stdlib.open_flag =
+    Open_rdonly
+  | Open_wronly
+  | Open_append
+  | Open_creat
+  | Open_trunc
+  | Open_excl
+  | Open_binary
+  | Open_text
+  | Open_nonblock
+|}];;
+
+#show open_flag;;
+[%%expect {|
+type open_flag =
+    Open_rdonly
+  | Open_wronly
+  | Open_append
+  | Open_creat
+  | Open_trunc
+  | Open_excl
+  | Open_binary
+  | Open_text
+  | Open_nonblock
+|}];;
+
+type extensible = ..;;
+type extensible += A | B of int;;
+[%%expect {|
+type extensible = ..
+type extensible += A | B of int
+|}];;
+
+#show A;;
+[%%expect {|
+type extensible += A
+|}];;
+
+#show B;;
+[%%expect {|
+type extensible += B of int
+|}];;
+
+#show extensible;;
+[%%expect {|
+type extensible = ..
+|}];;
+
+type 'a t = ..;;
+type _ t += A : int t;;
+[%%expect{|
+type 'a t = ..
+type _ t += A : int t
+|}];;
+
+#show A;;
+[%%expect{|
+type 'a t += A : int t
+|}];;


### PR DESCRIPTION
toplevel: `#show Some;;` should show documentation on the option type #8945

I've got it to half work:
<pre>
# #show Some;;
type nonrec 'a <b>Some</b> = None | Some of 'a
</pre>

I think this is because I am passing the Ident of "Some" rather than the "option" into Sig_type - basically I'm not sure how to get from the ident of the value ctor to the ident of the type ctor?