### PR TITLE
Fix -i broken by PR #8938

### DIFF
--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -121,7 +121,8 @@ let implementation info ~backend =
     let parsed = parse_impl info in
     if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
       let typed = typecheck_impl info parsed in
-      if Clflags.(should_stop_after Compiler_pass.Typing) then () else begin
+      if Clflags.(should_stop_after Compiler_pass.Typing || !print_types)
+      then () else begin
         backend info typed
       end;
     end;

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -121,8 +121,7 @@ let implementation info ~backend =
     let parsed = parse_impl info in
     if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
       let typed = typecheck_impl info parsed in
-      if Clflags.(should_stop_after Compiler_pass.Typing || !print_types)
-      then () else begin
+      if Clflags.(should_stop_after Compiler_pass.Typing) then () else begin
         backend info typed
       end;
     end;

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -459,7 +459,7 @@ end
 let stop_after = ref None (* -stop-after *)
 
 let should_stop_after pass =
-  if pass = Compiler_pass.Typing && !print_types then true
+  if Compiler_pass.(rank Typing <= rank pass) && !print_types then true
   else
     match !stop_after with
     | None -> false

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -459,9 +459,11 @@ end
 let stop_after = ref None (* -stop-after *)
 
 let should_stop_after pass =
-  match !stop_after with
-  | None -> false
-  | Some stop -> Compiler_pass.rank stop <= Compiler_pass.rank pass
+  if pass = Compiler_pass.Typing && !print_types then true
+  else
+    match !stop_after with
+    | None -> false
+    | Some stop -> Compiler_pass.rank stop <= Compiler_pass.rank pass
 
 module String = Misc.Stdlib.String
 


### PR DESCRIPTION
With -i command line option, the compiler should stop after printing the interface, without generating any files. This behavior was broken by PR #8938, and this patch fixes it.
