### PR TITLE
Do not emit references to dead labels (spacetime)

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,9 @@ Working version
 - #9064: Relax the level handling when unifying row fields
   (Leo White, review by Jacques Garrigue)
 
+- #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
+  (Greta Yorsh, review by Mark Shinwell)
+
 OCaml 4.10.0
 ------------
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -171,7 +171,18 @@ let emit_label lbl =
 
 let label s = sym (emit_label s)
 
-let def_label s = D.label (emit_label s)
+module Int = Numbers.Int
+
+(* For Spacetime, keep track of code labels that have been emitted.  *)
+let used_labels = ref Int.Set.empty
+
+let mark_used lbl =
+  if Config.spacetime && not (Int.Set.mem lbl !used_labels) then
+    used_labels := Int.Set.add lbl !used_labels
+
+let def_label ?typ s =
+  mark_used s;
+  D.label ?typ (emit_label s)
 
 let emit_Llabel fallthrough lbl =
   if not fallthrough && !fastcode_flag then D.align 4;
@@ -1002,6 +1013,7 @@ let begin_assembly() =
   reset_imp_table();
   float_constants := [];
   all_functions := [];
+  used_labels := Int.Set.empty;
   if system = S_win64 then begin
     D.extrn "caml_call_gc" NEAR;
     D.extrn "caml_c_call" NEAR;
@@ -1049,10 +1061,14 @@ let emit_spacetime_shapes () =
       begin match fundecl.fun_spacetime_shape with
       | None -> ()
       | Some shape ->
-        let funsym = emit_symbol fundecl.fun_name in
-        D.comment ("Shape for " ^ funsym ^ ":");
-        D.qword (ConstLabel funsym);
-        List.iter (fun (part_of_shape, label) ->
+        (* Instrumentation that refers to dead code may have been eliminated. *)
+        match List.filter (fun (_, l) -> Int.Set.mem l !used_labels) shape with
+        | [] -> ()
+        | shape ->
+          let funsym = emit_symbol fundecl.fun_name in
+          D.comment ("Shape for " ^ funsym ^ ":");
+          D.qword (ConstLabel funsym);
+          List.iter (fun (part_of_shape, label) ->
             let tag =
               match part_of_shape with
               | Direct_call_point _ -> 1
@@ -1067,7 +1083,7 @@ let emit_spacetime_shapes () =
             | Indirect_call_point -> ()
             | Allocation_point -> ()
             end)
-          shape;
+            shape;
           D.qword (Const 0L)
       end)
     !all_functions;

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -28,6 +28,7 @@ open X86_ast
 open X86_proc
 open X86_dsl
 module String = Misc.Stdlib.String
+module Int = Numbers.Int
 
 (* [Branch_relaxation] is not used in this file, but is required by
    emit.mlp files for certain other targets; the reference here ensures
@@ -171,14 +172,13 @@ let emit_label lbl =
 
 let label s = sym (emit_label s)
 
-module Int = Numbers.Int
-
 (* For Spacetime, keep track of code labels that have been emitted.  *)
 let used_labels = ref Int.Set.empty
 
 let mark_used lbl =
-  if Config.spacetime && not (Int.Set.mem lbl !used_labels) then
+  if Config.spacetime && not (Int.Set.mem lbl !used_labels) then begin
     used_labels := Int.Set.add lbl !used_labels
+  end
 
 let def_label ?typ s =
   mark_used s;

--- a/utils/numbers.ml
+++ b/utils/numbers.ml
@@ -31,6 +31,8 @@ module Int = struct
 
   let rec zero_to_n n =
     if n < 0 then Set.empty else Set.add n (zero_to_n (n-1))
+
+  let to_string n = Int.to_string n
 end
 
 module Int8 = struct

--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -26,6 +26,7 @@ module Int : sig
 
   (** [zero_to_n n] is the set of numbers \{0, ..., n\} (inclusive). *)
   val zero_to_n : int -> Set.t
+  val to_string : int -> string
 end
 
 module Int8 : sig


### PR DESCRIPTION
Dead code elimination in the backend can remove spacetime instrumentation and labels that spacetime table refers to. The table emitted at the end of a compilation unit still contains references to these now-undefined labels, causing a linker error.  This PR fix it.

For example, the code
```
type op = Eq | Neq
let [@inline always] f a = print_endline (string_of_int a)
let foo op =
  let a = true in
  match op, a with
  | Eq, true -> f 1
  | Neq, true -> f 2
  | _, _ -> f 3
```
fails with a linker error:

``` 
$ ocamlopt test2.ml -o test 
test2.o: In function `camlTest2__spacetime_shapes':
:(.data+0x190): undefined reference to `.L112'
:(.data+0x1a8): undefined reference to `.L111'
collect2: error: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking
``` 
when compiled with spacetime and without flambda.

With flambda, the `match` is simplified before spacetime table is computed. Without flambda, the calls are instrumented with spacetime and `f` is inlined.  Then, dead code pass in the backend eliminates some of the inlined calls to f, including instrumentation, but spacetime table is not updated.

This is most likely caused by PR #2321 (in 4.10) that eliminates dead handlers, which may include inlined calls, and hence instrumentation and labels. It seems that prior to it, labels have never been eliminated in the backend.

The proposed fix is to keep track of local labels that are emitted for a compilation unit, and then use this information to clean spacetime table right before it is emitted.  The fix is in `amd64/emit.mlp` because spacetime is specific to amd64 and dead code elimination pass is generic. 

Keeping track of emitted labels has some overhead in terms of compilation time and memory, but it is only enabled when the compiler is configured with spacetime. Note that `used_labels` is a superset of labels that spacetime can refer to, but it simplifies the code that keeps track of them.

Testsuite: two tests are currently failing in my setup with spacetime enabled. The failures are unrelated to the PR: they fail without this patch.
- statmemprof/native does not terminate
- output-complete-obj/test fails to find libunwind. 

All other tests pass. The example above compiles and works under spacetime.
