### PR TITLE
manual: operator char classes description

### DIFF
--- a/Changes
+++ b/Changes
@@ -340,6 +340,9 @@ OCaml 4.10.0
 - #8950: manual, move local opens in pattern out of the extension chapter
   (Florian Angeletti, review and suggestion by Gabriel Scherer)
 
+- #9088, #9097: manual, fix operator character classes
+  (Florian Angelettion, review by Gabriel Scherer,
+   report by Clément Busschaert)
 
 ### Compiler user-interface and warnings:
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -2280,7 +2280,10 @@ type t =  T of string
 \begin{syntax}
 
 dot-ext:
-   | ('!'||'$'||'%'||'&'||'*'||'+'||'-'||'/'||':'||'='||'>'||'?'||'@'||'^'||'|'||'~') { operator-char }
+   | dot-operator-char { operator-char }
+;
+dot-operator-char:
+  '!' ||  '?' || core-operator-char || '%' || ':'
 ;
 expr:
           ...
@@ -2600,10 +2603,10 @@ class c =
 
 \begin{syntax}
 let-operator:
- | 'let' ('$'||'&'||'*'||'+'||'-'||'/'||'<'||'='||'>'||'@'||'^'||'|') { operator-char }
+ | 'let' (core-operator-char || '<') { dot-operator-char }
 ;
 and-operator:
- | 'and' ('$'||'&'||'*'||'+'||'-'||'/'||'<'||'='||'>'||'@'||'^'||'|') { operator-char }
+ | 'and' (core-operator-char || '<') { dot-operator-char }
 ;
 operator-name :
           ...

--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -230,8 +230,7 @@ there are really 3 tokens, with optional blanks between them.
 
 \begin{syntax}
 infix-symbol:
-        ('=' || '<' || '>' || '@' || '^' || '|' || '&' ||
-         '+' || '-' || '*' || '/' || '$' || '%') { operator-char }
+        ( core-operator-char || '%' || '<' ) { operator-char }
       | "#" {{ operator-char }}
 ;
 prefix-symbol:
@@ -239,13 +238,15 @@ prefix-symbol:
       | ('?' || '~') {{ operator-char }}
 ;
 operator-char:
-        '!' || '$' || '%' || '&' || '*' || '+' || '-' || '.' ||
-        '/' || ':' || '<' || '=' || '>' || '?' || '@' ||
-        '^' || '|' || '~'
+        '~' || '!' || '?' || core-operator-char || '%' || '<' || ':' || '.'
+;
+core-operator-char:
+        '$' || '&' || '*' || '+' || '-' || '/' || '=' || '>' || '@' || '^' || '|'
 \end{syntax}
 See also the following language extensions:
-\hyperref[s:ext-ops]{extension operators} and
-\hyperref[s:index-operators]{extended indexing operators}.
+\hyperref[s:ext-ops]{extension operators},
+\hyperref[s:index-operators]{extended indexing operators},
+and \hyperref[s:binding-operators]{binding operators}.
 
 Sequences of ``operator characters'', such as "<=>" or "!!",
 are read as a single token from the @infix-symbol@ or @prefix-symbol@


### PR DESCRIPTION
This PR updates the language reference in the manual to synchronize it with the various actual operator lexemes defined in the lexer.

A small peculiarity of this PR is that it defines a fictional `core-operator-class` that is never used by the lexer itself, but is useful to factorize the common core amongst the various operator character classes in the lexer. 

Closes #9088 