### PR TITLE
Improved error messages for exceptions in signature errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ Working version
   (Simon Parry, review by Gabriel Scherer, Jeremy Yallop,
   Alain Frisch, Florian Angeletti)
 
+- #9107: improved error message for exceptions in module signature errors
+  (Gabriel Scherer, review by Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #8970: separate value patterns (matching on values) from computation patterns

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -78,8 +78,7 @@ Error: Signature mismatch:
        At position module type x = <here>
        Illegal permutation of runtime components in a module type.
          For example,
-         the extension constructor "Three"
-         and the value "one" are not in the same order
+         the exception "Three" and the value "one" are not in the same order
          in the expected and actual module types.
 |}]
 
@@ -322,8 +321,7 @@ Error: Signature mismatch:
        At position module type x = <here>
        Illegal permutation of runtime components in a module type.
          For example,
-         the extension constructor "B"
-         and the extension constructor "A" are not in the same order
+         the exception "B" and the exception "A" are not in the same order
          in the expected and actual module types.
 |}]
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -155,6 +155,7 @@ let rec normalize_module_path env cxt path =
 type field_desc =
     Field_value of string
   | Field_type of string
+  | Field_exception of string
   | Field_typext of string
   | Field_module of string
   | Field_modtype of string
@@ -164,6 +165,7 @@ type field_desc =
 let kind_of_field_desc = function
   | Field_value _ -> "value"
   | Field_type _ -> "type"
+  | Field_exception _ -> "exception"
   | Field_typext _ -> "extension constructor"
   | Field_module _ -> "module"
   | Field_modtype _ -> "module type"
@@ -181,7 +183,13 @@ module FieldMap = Map.Make(struct
 let item_ident_name = function
     Sig_value(id, d, _) -> (id, d.val_loc, Field_value(Ident.name id))
   | Sig_type(id, d, _, _) -> (id, d.type_loc, Field_type(Ident.name id))
-  | Sig_typext(id, d, _, _) -> (id, d.ext_loc, Field_typext(Ident.name id))
+  | Sig_typext(id, d, _, _) ->
+     let kind =
+       if Path.same d.ext_type_path Predef.path_exn
+       then Field_exception(Ident.name id)
+       else Field_typext(Ident.name id)
+     in
+     (id, d.ext_loc, kind)
   | Sig_module(id, _, d, _, _) -> (id, d.md_loc, Field_module(Ident.name id))
   | Sig_modtype(id, d, _) -> (id, d.mtd_loc, Field_modtype(Ident.name id))
   | Sig_class(id, d, _, _) -> (id, d.cty_loc, Field_class(Ident.name id))


### PR DESCRIPTION
Example:

    module Test : sig
      exception Foo
    end = struct
    end

Before this PR:

    Modules do not match: sig end is not included in sig exception Foo end
    The extension constructor `Foo' is required but not provided

After this PR (second line changed):

    Modules do not match: sig end is not included in sig exception Foo end
    The exception `Foo' is required but not provided