### PR TITLE
in ocamlopt, ensure the mapping from ocaml name to C symbol is injective

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,10 @@ Working version
 
 ### Code generation and optimizations:
 
+- #8998, #?: in ocamlopt, ensure the mapping from ocaml name to C
+  symbol is injective
+  (Valentin Gatien-Baron, ?)
+
 ### Standard library:
 
 - #9059: Added List.filteri function, same as List.filter but

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -104,8 +104,17 @@ let symbolname_for_pack pack name =
 
 let unit_id_from_name name = Ident.create_persistent name
 
+let no_leading_or_consecutive_underscores str =
+  String.mapi
+    (fun i c -> if c = '_' && (i = 0 || str.[i - 1] = '_') then '.' else c)
+    str
+
 let concat_symbol unitname id =
-  unitname ^ "__" ^ id
+  (* PR#8998: no_leading_or_consecutive_underscores prevents any
+     occurrence of "__" after the "__" we add, so concat_symbol is
+     injective. Since "." doesn't show up in value names, this doesn't
+     create more ambiguities. *)
+  unitname ^ "__" ^ no_leading_or_consecutive_underscores id
 
 let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
   let prefix = "caml" ^ unitname in


### PR DESCRIPTION
This fixes #8998, with a mix of the suggestions there. The scheme is to replace any annoying `_` by a `.`, and the `.` get escaped eventually when [emitting assembly](https://github.com/ocaml/ocaml/blob/a5e121621d58eab4d232d0788b13d2576fe53d18/asmcomp/amd64/emit.mlp#L104):

| ocaml identifier | C symbol before | C symbol after |
| ------- | -------- | ------ |
| `A__b.c` | `camlA__b__c_NUMBER` | same
| `A.b__c` | `camlA__b__c_NUMBER` | `A__b_$2ec_NUMBER`
| `A_.b` | `camlA___b_NUMBER` | same
| `A._b` | `camlA___b_NUMBER` | `camlA__$2eb_NUMBER`
