### PR TITLE
Compiler flag to disable the "implicit interface" feature

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -447,7 +447,8 @@ let read_one_param ppf position name v =
         let pass = Option.get (P.of_string v)  in
         Clflags.stop_after := Some pass
     end
-  | "no-implicit-interface" -> set "no-implicit-interface" [ no_implicit_interface ] v
+  | "no-implicit-interface" ->
+      set "no-implicit-interface" [ no_implicit_interface ] v
   | _ ->
     if not (List.mem name !can_discard) then begin
       can_discard := name :: !can_discard;

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -447,6 +447,7 @@ let read_one_param ppf position name v =
         let pass = Option.get (P.of_string v)  in
         Clflags.stop_after := Some pass
     end
+  | "no-implicit-interface" -> set "no-implicit-interface" [ no_implicit_interface ] v
   | _ ->
     if not (List.mem name !can_discard) then begin
       can_discard := name :: !can_discard;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -886,6 +886,11 @@ let mk__ f =
   "<file>  Treat <file> as a file name (even if it starts with `-')"
 ;;
 
+let mk_no_implicit_interface f =
+  "-no-implicit-interface", Arg.Unit f,
+  "Disallow implicit generation of interfaces for modules"
+;;
+
 module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
@@ -916,6 +921,7 @@ module type Common_options = sig
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
+  val _no_implicit_interface : unit -> unit
 
   val anonymous : string -> unit
 end
@@ -990,6 +996,8 @@ module type Compiler_options = sig
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
+
+  val _no_implicit_interface : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array
@@ -1238,6 +1246,8 @@ struct
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
 
+    mk_no_implicit_interface F._no_implicit_interface;
+
     mk_args F._args;
     mk_args0 F._args0;
   ]
@@ -1300,6 +1310,8 @@ struct
     mk_drawlambda F._drawlambda;
     mk_dlambda F._dlambda;
     mk_dinstr F._dinstr;
+
+    mk_no_implicit_interface F._no_implicit_interface;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1458,6 +1470,8 @@ struct
     mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
 
+    mk_no_implicit_interface F._no_implicit_interface;
+
     mk_args F._args;
     mk_args0 F._args0;
   ]
@@ -1560,6 +1574,8 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dump_pass F._dump_pass;
+
+    mk_no_implicit_interface F._no_implicit_interface;
   ]
 end;;
 
@@ -1607,6 +1623,7 @@ struct
     mk_vnum F._vnum;
     mk_w F._w;
     mk__ F.anonymous;
+    mk_no_implicit_interface F._no_implicit_interface;
   ]
 end;;
 
@@ -1687,6 +1704,7 @@ module Default = struct
     let _unboxed_types = set unboxed_types
     let _unsafe_string = set unsafe_string
     let _w s = Warnings.parse_options false s
+    let _no_implicit_interface = set no_implicit_interface
 
     let anonymous = anonymous
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -921,7 +921,6 @@ module type Common_options = sig
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
-  val _no_implicit_interface : unit -> unit
 
   val anonymous : string -> unit
 end
@@ -997,8 +996,6 @@ module type Compiler_options = sig
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
 
-  val _no_implicit_interface : unit -> unit
-
   val _args: string -> string array
   val _args0: string -> string array
 end
@@ -1025,6 +1022,7 @@ module type Bytecomp_options = sig
   val _compat_32 : unit -> unit
   val _custom : unit -> unit
   val _no_check_prims : unit -> unit
+  val _no_implicit_interface : unit -> unit
   val _dllib : string -> unit
   val _dllpath : string -> unit
   val _make_runtime : unit -> unit
@@ -1113,6 +1111,7 @@ module type Optcomp_options = sig
   val _afl_instrument : unit -> unit
   val _afl_inst_ratio : int -> unit
   val _function_sections : unit -> unit
+  val _no_implicit_interface : unit -> unit
 end;;
 
 module type Opttop_options = sig
@@ -1181,6 +1180,7 @@ struct
     mk_no_alias_deps F._no_alias_deps;
     mk_app_funct F._app_funct;
     mk_no_app_funct F._no_app_funct;
+    mk_no_implicit_interface F._no_implicit_interface;
     mk_no_check_prims F._no_check_prims;
     mk_noassert F._noassert;
     mk_noautolink_byt F._noautolink;
@@ -1246,8 +1246,6 @@ struct
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
 
-    mk_no_implicit_interface F._no_implicit_interface;
-
     mk_args F._args;
     mk_args0 F._args0;
   ]
@@ -1311,8 +1309,6 @@ struct
     mk_dlambda F._dlambda;
     mk_dinstr F._dinstr;
 
-    mk_no_implicit_interface F._no_implicit_interface;
-
     mk_args F._args;
     mk_args0 F._args0;
   ]
@@ -1373,6 +1369,7 @@ struct
     mk_app_funct F._app_funct;
     mk_no_app_funct F._no_app_funct;
     mk_no_float_const_prop F._no_float_const_prop;
+    mk_no_implicit_interface F._no_implicit_interface;
     mk_noassert F._noassert;
     mk_noautolink_opt F._noautolink;
     mk_nodynlink F._nodynlink;
@@ -1469,8 +1466,6 @@ struct
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
-
-    mk_no_implicit_interface F._no_implicit_interface;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1575,7 +1570,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dstartup F._dstartup;
     mk_dump_pass F._dump_pass;
 
-    mk_no_implicit_interface F._no_implicit_interface;
   ]
 end;;
 
@@ -1623,7 +1617,6 @@ struct
     mk_vnum F._vnum;
     mk_w F._w;
     mk__ F.anonymous;
-    mk_no_implicit_interface F._no_implicit_interface;
   ]
 end;;
 
@@ -1704,7 +1697,6 @@ module Default = struct
     let _unboxed_types = set unboxed_types
     let _unsafe_string = set unsafe_string
     let _w s = Warnings.parse_options false s
-    let _no_implicit_interface = set no_implicit_interface
 
     let anonymous = anonymous
 
@@ -1935,6 +1927,7 @@ module Default = struct
       assert Config.function_sections;
       first_ccopts := ("-ffunction-sections" :: (!first_ccopts));
       function_sections := true
+    let _no_implicit_interface = set no_implicit_interface
     let _nodynlink = clear dlcode
     let _output_complete_obj () =
       set output_c_object (); set output_complete_object ()
@@ -1990,6 +1983,7 @@ third-party libraries such as Lwt, but with a different API."
     let _make_runtime () =
       custom_runtime := true; make_runtime := true; link_everything := true
     let _no_check_prims = set no_check_prims
+    let _no_implicit_interface = set no_implicit_interface
     let _output_complete_obj () =
       output_c_object := true;
       output_complete_object := true;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -46,7 +46,6 @@ module type Common_options = sig
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
-  val _no_implicit_interface : unit -> unit
 
   val anonymous : string -> unit
 end
@@ -121,8 +120,6 @@ module type Compiler_options = sig
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
 
-  val _no_implicit_interface : unit -> unit
-
   val _args: string -> string array
   val _args0: string -> string array
 end
@@ -149,6 +146,7 @@ module type Bytecomp_options = sig
   val _compat_32 : unit -> unit
   val _custom : unit -> unit
   val _no_check_prims : unit -> unit
+  val _no_implicit_interface : unit -> unit
   val _dllib : string -> unit
   val _dllpath : string -> unit
   val _make_runtime : unit -> unit
@@ -237,6 +235,7 @@ module type Optcomp_options = sig
   val _afl_instrument : unit -> unit
   val _afl_inst_ratio : int -> unit
   val _function_sections : unit -> unit
+  val _no_implicit_interface : unit -> unit
 end;;
 
 module type Opttop_options = sig

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -46,6 +46,7 @@ module type Common_options = sig
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
+  val _no_implicit_interface : unit -> unit
 
   val anonymous : string -> unit
 end
@@ -119,6 +120,8 @@ module type Compiler_options = sig
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
   val _dump_into_file : unit -> unit
+
+  val _no_implicit_interface : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -484,6 +484,10 @@ each functor application generates new types in its result and
 applying the same functor twice to the same argument yields two
 incompatible structures.
 .TP
+.B \-no\-implicit\-interface
+Raises an error when compiling an implementation file that has no
+corresponding interface file.
+.TP
 .B \-noassert
 Do not compile assertion checks.  Note that the special form
 .B assert\ false

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -401,6 +401,10 @@ each functor application generates new types in its result and
 applying the same functor twice to the same argument yields two
 incompatible structures.
 .TP
+.B \-no\-implicit\-interface
+Raises an error when compiling an implementation file that has no
+corresponding interface file.
+.TP
 .B \-noassert
 Do not compile assertion checks.  Note that the special form
 .B assert\ false

--- a/testsuite/tests/tool-ocaml-no-implicit-interface/failure.compilers.reference
+++ b/testsuite/tests/tool-ocaml-no-implicit-interface/failure.compilers.reference
@@ -1,0 +1,2 @@
+File "failure.ml", line 1:
+Error: Cannot find interface file and implicit interface generation has been turned off (-no-implicit-interface)

--- a/testsuite/tests/tool-ocaml-no-implicit-interface/failure.ml
+++ b/testsuite/tests/tool-ocaml-no-implicit-interface/failure.ml
@@ -1,0 +1,21 @@
+(* TEST
+
+all_modules = "failure.ml"
+flags = "-no-implicit-interface"
+compiler_output = "compiler-output.raw"
+
+ocamlc_byte_exit_status = "2"
+ocamlopt_byte_exit_status = "2"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** check-ocamlc.byte-output
+
+* setup-ocamlopt.byte-build-env
+** ocamlopt.byte
+*** check-ocamlopt.byte-output
+*)
+
+(* Check that error is raised when compiling ml file with no mli file. *)
+type t = int
+let x = 3

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -130,6 +130,7 @@ type error =
   | Badly_formed_signature of string * Typedecl.error
   | Cannot_hide_id of hiding_error
   | Invalid_type_subst_rhs
+  | Implicit_interfaces_not_allowed
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -466,6 +466,8 @@ let should_stop_after pass =
     | None -> false
     | Some stop -> Compiler_pass.rank stop <= Compiler_pass.rank pass
 
+let no_implicit_interface = ref false (* -no-implicit-interface *)
+
 module String = Misc.Stdlib.String
 
 let arg_spec = ref []

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -245,6 +245,8 @@ end
 val stop_after : Compiler_pass.t option ref
 val should_stop_after : Compiler_pass.t -> bool
 
+val no_implicit_interface : bool ref
+
 val arg_spec : (string * Arg.spec * string) list ref
 
 (* [add_arguments __LOC__ args] will add the arguments from [args] at


### PR DESCRIPTION
re: #7493

added a command line flag "-no-implicit-interface" to the compiler that will cause compilation to error when processing an ml file that has no corresponding mli file, e.g.

file ../scratch/test.ml
```
type t = int

let add x y = x + y
```

with 
```
./runtime/ocamlrun ./ocamlc -nostdlib -I stdlib  -I ../scratch/ -verbose -no-implicit-interface -c ../scratch/test.ml
```

gives 
```
File "../scratch/test.ml", line 1:
Error: Cannot find interface file and implicit interface generation has been turned off (-no-implicit-interface)
```
