### PR TITLE
ocamldoc: better support of multiline code blocks in the manpage backend

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,10 @@ Working version
 
 ### Tools:
 
+- #9113: fix the rendering of ocamldoc multi-line code blocks
+  in the 'man' backend.
+  (Gabriel Scherer, review by Florian Angeletti)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -288,7 +288,10 @@ class man =
       match txt with
       | Odoc_info.Raw s -> bs b (self#escape s)
       | Odoc_info.Code s -> self#man_of_code b s
-      | Odoc_info.CodePre s -> self#man_of_code b s
+      | Odoc_info.CodePre s ->
+         bs b "\n.EX";
+         self#man_of_code b s;
+         bs b "\n.EE";
       | Odoc_info.Verbatim s ->
           bs b (self#escape s)
       | Odoc_info.Bold t

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -287,12 +287,8 @@ class man =
     method man_of_text_element b txt =
       match txt with
       | Odoc_info.Raw s -> bs b (self#escape s)
-      | Odoc_info.Code s ->
-          bs b "\n.B ";
-          bs b ((Str.global_replace (Str.regexp "\n") "\n.B " (self#escape s))^"\n")
-      | Odoc_info.CodePre s ->
-          bs b "\n.B ";
-          bs b ((Str.global_replace (Str.regexp "\n") "\n.B " (self#escape s))^"\n")
+      | Odoc_info.Code s -> self#man_of_code b s
+      | Odoc_info.CodePre s -> self#man_of_code b s
       | Odoc_info.Verbatim s ->
           bs b (self#escape s)
       | Odoc_info.Bold t
@@ -346,7 +342,11 @@ class man =
       if String.lowercase_ascii target = "man" then bs b code else ()
 
     (** Print groff string to display code. *)
-    method man_of_code b s = self#man_of_text b [ Code s ]
+    method man_of_code b code =
+      let code = self#escape code in
+      bs b "\n.ft B\n";
+      bs b (Str.global_replace (Str.regexp "\n") "\n.br\n\\&" code);
+      bs b "\n.ft R\n";
 
     (** Take a string and return the string where fully qualified idents
        have been replaced by idents relative to the given module name.*)

--- a/testsuite/tests/tool-ocamldoc/Inline_records.man.reference
+++ b/testsuite/tests/tool-ocamldoc/Inline_records.man.reference
@@ -45,13 +45,17 @@ An open sum type
  lbl : 
 .B int
 ;  (* Field documentation for non\-inline, 
-.B lbl : int
+.ft B
+lbl : int
+.ft R
 
  *) 
  more : 
 .B int list
 ;  (* More documentation for r, 
-.B more : int list
+.ft B
+more : int list
+.ft R
 
  *) 
  }
@@ -67,13 +71,17 @@ A simple record type for reference
  lbl : 
 .B int
 ;  (* 
-.B A
+.ft B
+A
+.ft R
 field documentation
  *) 
  more : 
 .B int list
 ;  (* More 
-.B A
+.ft B
+A
+.ft R
 field documentation
  *) 
  }
@@ -92,13 +100,17 @@ A sum type with one inline record
  a_label_for_B : 
 .B int
 ;  (* 
-.B B
+.ft B
+B
+.ft R
 field documentation
  *) 
  more_label_for_B : 
 .B int list
 ;  (* More 
-.B B
+.ft B
+B
+.ft R
 field documentation
  *) 
  }
@@ -110,7 +122,9 @@ field documentation
  c_has_label_too : 
 .B float
 ;  (* 
-.B C
+.ft B
+C
+.ft R
 field documentation
  *) 
  more_than_one : 
@@ -133,13 +147,21 @@ A sum type with two inline records
  any : 
 .B 'a
 ;  (* 
-.B A
+.ft B
+A
+.ft R
 field 
-.B any:\&'a
+.ft B
+any:\&'a
+.ft R
 for 
-.B D
+.ft B
+D
+.ft R
 in 
-.B any
+.ft B
+any
+.ft R
 \&.
  *) 
  }
@@ -159,7 +181,9 @@ A gadt constructor
  name : 
 .B string
 ;  (* Error field documentation 
-.B name:string
+.ft B
+name:string
+.ft R
 
  *) 
  }
@@ -174,7 +198,9 @@ A gadt constructor
  yet_another_field : 
 .B unit
 ;  (* Field documentation for 
-.B E
+.ft B
+E
+.ft R
 in ext
  *) 
  }
@@ -186,7 +212,9 @@ in ext
  even_more : 
 .B int -> int
 ;  (* Some field documentations for 
-.B F
+.ft B
+F
+.ft R
 
  *) 
  }


### PR DESCRIPTION
Before, `man Map` would show:

```
For instance: module IntPairs = struct type t = int * int let compare (x0,y0) (x1,y1) = match Stdlib.compare x0 x1 with 0 -> Stdlib.compare y0 y1 |
c -> c end module PairsMap = Map.Make(IntPairs) let m = PairsMap.(empty |> add (0,1) hello |> add (1,0) world )
```

Now it shows:

```
For instance:
     module IntPairs =
       struct
         type t = int * int
         let compare (x0,y0) (x1,y1) =
           match Stdlib.compare x0 x1 with
               0 -> Stdlib.compare y0 y1
             | c -> c
       end

     module PairsMap = Map.Make(IntPairs)

     let m = PairsMap.(empty |> add (0,1) "hello" |> add (1,0) "world")
```

(in both cases the code is in bold)