### PR TITLE
Added documentation for the no-float-const-prop option

### DIFF
--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -375,6 +375,14 @@ each functor application generates new types in its result and
 applying the same functor twice to the same argument yields two
 incompatible structures.
 
+\nat{%
+\item["-no-float-const-prop"]
+Deactivates the constant propagation for floating-point operations.
+With this option no propagation of floating-point constants is
+performed. This option should be given if the program changes the
+float rounding mode during its execution.
+}%nat
+
 \item["-noassert"]
 Do not compile assertion checks.  Note that the special form
 "assert false" is always compiled because it is typed specially.

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -378,9 +378,8 @@ incompatible structures.
 \nat{%
 \item["-no-float-const-prop"]
 Deactivates the constant propagation for floating-point operations.
-With this option no propagation of floating-point constants is
-performed. This option should be given if the program changes the
-float rounding mode during its execution.
+This option should be given if the program changes the float rounding
+mode during its execution.
 }%nat
 
 \item["-noassert"]


### PR DESCRIPTION
There was no documentation for that option, however the help option of `ocamlopt` printed a help message.