### PR TITLE
Fix #9116: Error source highlighting in presence of tabs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -109,6 +109,7 @@ testsuite/tests/win-unicode/*.ml                        typo.utf8
 testsuite/tools/*.S                                     typo.missing-header
 testsuite/tools/*.asm                                   typo.missing-header
 testsuite/typing                                        typo.missing-header
+testsuite/tests/messages/highlight_tabs.ml              typo.tab
 
 # prune testsuite reference files
 testsuite/tests/**/*.reference               typo.prune

--- a/Changes
+++ b/Changes
@@ -45,6 +45,10 @@ Working version
 - #9107: improved error message for exceptions in module signature errors
   (Gabriel Scherer, review by Florian Angeletti)
 
+- #9116, #9118: fix error highlighting code in presence of tabulations
+  in the source code
+  (Armaël Guéneau, review by Gabriel Scherer, report by Ricardo M. Correia)
+
 ### Internal/compiler-libs changes:
 
 - #8970: separate value patterns (matching on values) from computation patterns

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -483,7 +483,10 @@ let highlight_quote ppf
         Misc.pp_two_columns ~sep:"|" ~max_lines ppf
         @@ List.map (fun (line, line_nb, line_start_cnum) ->
           let line = String.mapi (fun i c ->
-            if ISet.mem iset ~pos:(line_start_cnum + i) then c else '.'
+            if ISet.mem iset ~pos:(line_start_cnum + i)
+            || c = ' ' || c = '\t' (* display blank as itself *)
+            then c
+            else '.'
           ) line in
           (line_nb, line)
         ) lines

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -482,13 +482,42 @@ let highlight_quote ppf
         (* Multi-line error *)
         Misc.pp_two_columns ~sep:"|" ~max_lines ppf
         @@ List.map (fun (line, line_nb, line_start_cnum) ->
-          let line = String.mapi (fun i c ->
-            if ISet.mem iset ~pos:(line_start_cnum + i)
-            || c = ' ' || c = '\t' (* display blank as itself *)
-            then c
-            else '.'
-          ) line in
-          (line_nb, line)
+          (* whether a character should be displayed or discarded *)
+          let is_show i =
+            ISet.mem iset ~pos:(line_start_cnum + i)
+            (* for alignment purposes, display tabs as themselves
+               instead of replacing them by a space *)
+            || line.[i] = '\t'
+          in
+          let line = Bytes.of_string line in
+          (* Replace characters that do not satisfy [is_show] with spaces *)
+          for i = 0 to Bytes.length line - 1 do
+            if not (is_show i) then Bytes.set line i ' '
+          done;
+          (* Insert an ellipsis marker if possible *)
+          let (--^) i j = List.init (max 0 (j-i-1)) ((+) i) in
+          let insert_ellipsis b (side: [`Before | `After]) idx =
+            let ellipsis_before = "... " and ellipsis_after = " ..." in
+            let i, j, ellipsis = match side with
+              | `Before ->
+                  idx - String.length ellipsis_before, idx, ellipsis_before
+              | `After ->
+                  idx+1, idx+1 + String.length ellipsis_after, ellipsis_after in
+            let i = max 0 i in
+            let j = min (Bytes.length b) j in
+            if j - i = String.length ellipsis &&
+               List.for_all (Fun.negate is_show) (i --^ j) then
+              Bytes.blit_string ellipsis 0 line i (String.length ellipsis)
+          in
+          (* Insert ellipsis markers before and after locations when possible *)
+          for i = 0 to Bytes.length line - 1 do
+            let pos = line_start_cnum + i in
+            if ISet.is_start iset ~pos <> None then
+              insert_ellipsis line `Before i
+            else if ISet.is_end iset ~pos <> None then
+              insert_ellipsis line `After i
+          done;
+          (line_nb, Bytes.to_string line)
         ) lines
     end;
     Format.fprintf ppf "@]"

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -64,7 +64,7 @@ end
 and B: sig val value: unit end = struct let value = A.f () end
 [%%expect {|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   module F(X:sig end) = struct end
 6 |   let f () = B.value
 7 | end
@@ -94,7 +94,7 @@ module F(X: sig module type t module M: t end) = struct
 end
 [%%expect {|
 Lines 5-8, characters 8-5:
-5 | ........struct
+5 |   ... . struct
 6 |     module M = X.M
 7 |     let f () = B.value
 8 |   end

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -64,7 +64,7 @@ end
 and B: sig val value: unit end = struct let value = A.f () end
 [%%expect {|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   module F(X:sig end) = struct end
 6 |   let f () = B.value
 7 | end
@@ -94,7 +94,7 @@ module F(X: sig module type t module M: t end) = struct
 end
 [%%expect {|
 Lines 5-8, characters 8-5:
-5 |   ... . struct
+5 |     ... struct
 6 |     module M = X.M
 7 |     let f () = B.value
 8 |   end

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -43,7 +43,7 @@ File "morematch.ml", line 456, characters 2-7:
         ^^^^^
 Warning 11: this match case is unused.
 File "morematch.ml", lines 1050-1053, characters 8-10:
-1050 | ........function
+1050 | ... . . function
 1051 |   | A (`A|`C) -> 0
 1052 |   | B (`B,`D) -> 1
 1053 |   | C -> 2

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -43,7 +43,7 @@ File "morematch.ml", line 456, characters 2-7:
         ^^^^^
 Warning 11: this match case is unused.
 File "morematch.ml", lines 1050-1053, characters 8-10:
-1050 | ... . . function
+1050 |     ... function
 1051 |   | A (`A|`C) -> 0
 1052 |   | B (`B,`D) -> 1
 1053 |   | C -> 2

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -1,5 +1,5 @@
 File "robustmatch.ml", lines 33-37, characters 6-23:
-33 |       match t1, t2, x with
+33 |   ... match t1, t2, x with
 34 |       | AB, AB, A -> ()
 35 |       | MAB, _, A -> ()
 36 |       | _,  AB, B -> ()
@@ -8,42 +8,42 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
 File "robustmatch.ml", lines 54-56, characters 4-27:
-54 |     match r1, r2, a with
+54 | ... match r1, r2, a with
 55 |     | R1, _, 0 -> ()
 56 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 1)
 File "robustmatch.ml", lines 64-66, characters 4-27:
-64 |     match r1, r2, a with
+64 | ... match r1, r2, a with
 65 |     | R1, _, A -> ()
 66 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 69-71, characters 4-20:
-69 |     match r1, r2, a with
+69 | ... match r1, r2, a with
 70 |     | _, R2, "coucou" -> ()
 71 |     | R1, _, A -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 74-76, characters 4-20:
-74 |     match r1, r2, a with
+74 | ... match r1, r2, a with
 75 |     | _, R2, "coucou" -> ()
 76 |     | R1, _, _ -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, "")
 File "robustmatch.ml", lines 85-87, characters 4-20:
-85 |     match r1, r2, a with
+85 | ... match r1, r2, a with
 86 |     | R1, _, A -> ()
 87 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 90-93, characters 4-20:
-90 |     match r1, r2, a with
+90 | ... match r1, r2, a with
 91 |     | R1, _, A -> ()
 92 |     | _, R2, X -> ()
 93 |     | R1, _, _ -> ()
@@ -51,35 +51,35 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
 File "robustmatch.ml", lines 96-98, characters 4-20:
-96 |     match r1, r2, a with
+96 | ... match r1, r2, a with
 97 |     | R1, _, _ -> ()
 98 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
 File "robustmatch.ml", lines 107-109, characters 4-20:
-107 |     match r1, r2, a with
+107 | ... match r1, r2, a with
 108 |     | R1, _, A -> ()
 109 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 129-131, characters 4-20:
-129 |     match r1, r2, a with
+129 | ... match r1, r2, a with
 130 |     | R1, _, A -> ()
 131 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
 File "robustmatch.ml", lines 151-153, characters 4-20:
-151 |     match r1, r2, a with
+151 | ... match r1, r2, a with
 152 |     | R1, _, A -> ()
 153 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
 File "robustmatch.ml", lines 156-159, characters 4-20:
-156 |     match r1, r2, a with
+156 | ... match r1, r2, a with
 157 |     | R1, _, A -> ()
 158 |     | _, R2, X -> ()
 159 |     | R1, _, _ -> ()
@@ -87,21 +87,21 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
 File "robustmatch.ml", lines 162-164, characters 4-20:
-162 |     match r1, r2, a with
+162 | ... match r1, r2, a with
 163 |     | R1, _, _ -> ()
 164 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
 File "robustmatch.ml", lines 167-169, characters 4-20:
-167 |     match r1, r2, a with
+167 | ... match r1, r2, a with
 168 |     | R1, _, C -> ()
 169 |     | _, R2, Y -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, A)
 File "robustmatch.ml", lines 176-179, characters 4-20:
-176 |     match r1, r2, a with
+176 | ... match r1, r2, a with
 177 |     | _, R1, 0 -> ()
 178 |     | R2, _, [||] -> ()
 179 |     | _, R1, 1 -> ()
@@ -109,14 +109,14 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 File "robustmatch.ml", lines 182-184, characters 4-23:
-182 |     match r1, r2, a with
+182 | ... match r1, r2, a with
 183 |     | R1, _, _ -> ()
 184 |     | _, R2, [||] -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 File "robustmatch.ml", lines 187-190, characters 4-20:
-187 |     match r1, r2, a with
+187 | ... match r1, r2, a with
 188 |     | _, R2, [||] -> ()
 189 |     | R1, _, 0 -> ()
 190 |     | R1, _, _ -> ()
@@ -124,70 +124,70 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 File "robustmatch.ml", lines 200-203, characters 4-19:
-200 |     match r1, r2, a with
+200 | ... match r1, r2, a with
 201 |     | _, R2, [||] -> ()
 202 |     | R1, _, 0 -> ()
 203 |     | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
 File "robustmatch.ml", lines 210-212, characters 4-27:
-210 |     match r1, r2, a with
+210 | ... match r1, r2, a with
 211 |     | R1, _, 'c' -> ()
 212 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 'a')
 File "robustmatch.ml", lines 219-221, characters 4-27:
-219 |     match r1, r2, a with
+219 | ... match r1, r2, a with
 220 |     | R1, _, `A -> ()
 221 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, `B)
 File "robustmatch.ml", lines 228-230, characters 4-37:
-228 |     match r1, r2, a with
+228 | ... match r1, r2, a with
 229 |     | R1, _, (3, "") -> ()
 230 |     | _, R2, (1, "coucou", 'a') -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
 File "robustmatch.ml", lines 239-241, characters 4-51:
-239 |     match r1, r2, a with
+239 | ... match r1, r2, a with
 240 |     | R1, _, { x = 3; y = "" } -> ()
 241 |     | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
 File "robustmatch.ml", lines 244-246, characters 4-36:
-244 |     match r1, r2, a with
+244 | ... match r1, r2, a with
 245 |     | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
 246 |     | _, R1, { x = 3; y = "" } -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, {a=1; b="coucou"; c='b'})
 File "robustmatch.ml", lines 253-255, characters 4-20:
-253 |     match r1, r2, a with
+253 | ... match r1, r2, a with
 254 |     | R1, _, (3, "") -> ()
 255 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
 File "robustmatch.ml", lines 263-265, characters 4-20:
-263 |     match r1, r2, a with
+263 | ... match r1, r2, a with
 264 |     | R1, _, { x = 3; y = "" } -> ()
 265 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
 File "robustmatch.ml", lines 272-274, characters 4-20:
-272 |     match r1, r2, a with
+272 | ... match r1, r2, a with
 273 |     | R1, _, lazy 1 -> ()
 274 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, lazy 0)
 File "robustmatch.ml", lines 281-284, characters 4-24:
-281 |     match r1, r2, a with
+281 | ... match r1, r2, a with
 282 |     | R1, _, () -> ()
 283 |     | _, R2, "coucou" -> ()
 284 |     | _, R2, "foo" -> ()

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -1,5 +1,5 @@
 File "robustmatch.ml", lines 33-37, characters 6-23:
-33 | ......match t1, t2, x with
+33 |       match t1, t2, x with
 34 |       | AB, AB, A -> ()
 35 |       | MAB, _, A -> ()
 36 |       | _,  AB, B -> ()
@@ -8,42 +8,42 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
 File "robustmatch.ml", lines 54-56, characters 4-27:
-54 | ....match r1, r2, a with
+54 |     match r1, r2, a with
 55 |     | R1, _, 0 -> ()
 56 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 1)
 File "robustmatch.ml", lines 64-66, characters 4-27:
-64 | ....match r1, r2, a with
+64 |     match r1, r2, a with
 65 |     | R1, _, A -> ()
 66 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 69-71, characters 4-20:
-69 | ....match r1, r2, a with
+69 |     match r1, r2, a with
 70 |     | _, R2, "coucou" -> ()
 71 |     | R1, _, A -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 74-76, characters 4-20:
-74 | ....match r1, r2, a with
+74 |     match r1, r2, a with
 75 |     | _, R2, "coucou" -> ()
 76 |     | R1, _, _ -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, "")
 File "robustmatch.ml", lines 85-87, characters 4-20:
-85 | ....match r1, r2, a with
+85 |     match r1, r2, a with
 86 |     | R1, _, A -> ()
 87 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 90-93, characters 4-20:
-90 | ....match r1, r2, a with
+90 |     match r1, r2, a with
 91 |     | R1, _, A -> ()
 92 |     | _, R2, X -> ()
 93 |     | R1, _, _ -> ()
@@ -51,35 +51,35 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
 File "robustmatch.ml", lines 96-98, characters 4-20:
-96 | ....match r1, r2, a with
+96 |     match r1, r2, a with
 97 |     | R1, _, _ -> ()
 98 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, (Y|Z))
 File "robustmatch.ml", lines 107-109, characters 4-20:
-107 | ....match r1, r2, a with
+107 |     match r1, r2, a with
 108 |     | R1, _, A -> ()
 109 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (B|C))
 File "robustmatch.ml", lines 129-131, characters 4-20:
-129 | ....match r1, r2, a with
+129 |     match r1, r2, a with
 130 |     | R1, _, A -> ()
 131 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
 File "robustmatch.ml", lines 151-153, characters 4-20:
-151 | ....match r1, r2, a with
+151 |     match r1, r2, a with
 152 |     | R1, _, A -> ()
 153 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, B)
 File "robustmatch.ml", lines 156-159, characters 4-20:
-156 | ....match r1, r2, a with
+156 |     match r1, r2, a with
 157 |     | R1, _, A -> ()
 158 |     | _, R2, X -> ()
 159 |     | R1, _, _ -> ()
@@ -87,21 +87,21 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
 File "robustmatch.ml", lines 162-164, characters 4-20:
-162 | ....match r1, r2, a with
+162 |     match r1, r2, a with
 163 |     | R1, _, _ -> ()
 164 |     | _, R2, X -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, Y)
 File "robustmatch.ml", lines 167-169, characters 4-20:
-167 | ....match r1, r2, a with
+167 |     match r1, r2, a with
 168 |     | R1, _, C -> ()
 169 |     | _, R2, Y -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, A)
 File "robustmatch.ml", lines 176-179, characters 4-20:
-176 | ....match r1, r2, a with
+176 |     match r1, r2, a with
 177 |     | _, R1, 0 -> ()
 178 |     | R2, _, [||] -> ()
 179 |     | _, R1, 1 -> ()
@@ -109,14 +109,14 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 File "robustmatch.ml", lines 182-184, characters 4-23:
-182 | ....match r1, r2, a with
+182 |     match r1, r2, a with
 183 |     | R1, _, _ -> ()
 184 |     | _, R2, [||] -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 File "robustmatch.ml", lines 187-190, characters 4-20:
-187 | ....match r1, r2, a with
+187 |     match r1, r2, a with
 188 |     | _, R2, [||] -> ()
 189 |     | R1, _, 0 -> ()
 190 |     | R1, _, _ -> ()
@@ -124,70 +124,70 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, [| _ |])
 File "robustmatch.ml", lines 200-203, characters 4-19:
-200 | ....match r1, r2, a with
+200 |     match r1, r2, a with
 201 |     | _, R2, [||] -> ()
 202 |     | R1, _, 0 -> ()
 203 |     | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
 File "robustmatch.ml", lines 210-212, characters 4-27:
-210 | ....match r1, r2, a with
+210 |     match r1, r2, a with
 211 |     | R1, _, 'c' -> ()
 212 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, 'a')
 File "robustmatch.ml", lines 219-221, characters 4-27:
-219 | ....match r1, r2, a with
+219 |     match r1, r2, a with
 220 |     | R1, _, `A -> ()
 221 |     | _, R2, "coucou" -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, `B)
 File "robustmatch.ml", lines 228-230, characters 4-37:
-228 | ....match r1, r2, a with
+228 |     match r1, r2, a with
 229 |     | R1, _, (3, "") -> ()
 230 |     | _, R2, (1, "coucou", 'a') -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
 File "robustmatch.ml", lines 239-241, characters 4-51:
-239 | ....match r1, r2, a with
+239 |     match r1, r2, a with
 240 |     | R1, _, { x = 3; y = "" } -> ()
 241 |     | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
 File "robustmatch.ml", lines 244-246, characters 4-36:
-244 | ....match r1, r2, a with
+244 |     match r1, r2, a with
 245 |     | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
 246 |     | _, R1, { x = 3; y = "" } -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R2, R2, {a=1; b="coucou"; c='b'})
 File "robustmatch.ml", lines 253-255, characters 4-20:
-253 | ....match r1, r2, a with
+253 |     match r1, r2, a with
 254 |     | R1, _, (3, "") -> ()
 255 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, (3, "*"))
 File "robustmatch.ml", lines 263-265, characters 4-20:
-263 | ....match r1, r2, a with
+263 |     match r1, r2, a with
 264 |     | R1, _, { x = 3; y = "" } -> ()
 265 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, {x=3; y="*"})
 File "robustmatch.ml", lines 272-274, characters 4-20:
-272 | ....match r1, r2, a with
+272 |     match r1, r2, a with
 273 |     | R1, _, lazy 1 -> ()
 274 |     | _, R2, 1 -> ()
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (R1, R1, lazy 0)
 File "robustmatch.ml", lines 281-284, characters 4-24:
-281 | ....match r1, r2, a with
+281 |     match r1, r2, a with
 282 |     | R1, _, () -> ()
 283 |     | _, R2, "coucou" -> ()
 284 |     | _, R2, "foo" -> ()

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -116,7 +116,7 @@ module A = struct
 end
 [%%expect{|
 Lines 3-6, characters 4-7:
-3 | ....open struct
+3 |     open struct
 4 |       type t = T
 5 |       let x = T
 6 |     end
@@ -136,7 +136,7 @@ module A = struct
 end
 [%%expect{|
 Lines 3-5, characters 4-7:
-3 | ....open struct
+3 |     open struct
 4 |       type t = T
 5 |     end
 Error: The type t/159 introduced by this open appears in the signature

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -116,7 +116,7 @@ module A = struct
 end
 [%%expect{|
 Lines 3-6, characters 4-7:
-3 |     open struct
+3 | ... open struct
 4 |       type t = T
 5 |       let x = T
 6 |     end
@@ -136,7 +136,7 @@ module A = struct
 end
 [%%expect{|
 Lines 3-5, characters 4-7:
-3 |     open struct
+3 | ... open struct
 4 |       type t = T
 5 |     end
 Error: The type t/159 introduced by this open appears in the signature

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -291,9 +291,9 @@ let ill_typed_5 =
   );;
 [%%expect{|
 Lines 3-5, characters 9-14:
-3 | .........x = 1
+3 |     .... x = 1
 4 |     and+ y = 2
-5 |     and+ z = 3...
+5 |     and+ z = 3 ..
 Error: These bindings have type (int * int) * int
        but bindings were expected of type bool
 |}];;
@@ -321,7 +321,7 @@ let ill_typed_6 =
   );;
 [%%expect{|
 Lines 3-4, characters 9-14:
-3 | .........x = 1
+3 |     .... x = 1
 4 |     and+ y = 2
 Error: These bindings have type int * int but bindings were expected of type
          int
@@ -513,7 +513,7 @@ let indexed_monad4 =
   );;
 [%%expect{|
 Lines 6-7, characters 4-29:
-6 | ....let* second = read in
+6 |     let* second = read in
 7 |       return (first ^ second)
 Error: This expression has type
          (Indexed_monad.opened, Indexed_monad.opened, string) Indexed_monad.t

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -291,9 +291,9 @@ let ill_typed_5 =
   );;
 [%%expect{|
 Lines 3-5, characters 9-14:
-3 |     .... x = 1
+3 |      ... x = 1
 4 |     and+ y = 2
-5 |     and+ z = 3 ..
+5 |     and+ z = 3
 Error: These bindings have type (int * int) * int
        but bindings were expected of type bool
 |}];;
@@ -321,7 +321,7 @@ let ill_typed_6 =
   );;
 [%%expect{|
 Lines 3-4, characters 9-14:
-3 |     .... x = 1
+3 |      ... x = 1
 4 |     and+ y = 2
 Error: These bindings have type int * int but bindings were expected of type
          int
@@ -513,7 +513,7 @@ let indexed_monad4 =
   );;
 [%%expect{|
 Lines 6-7, characters 4-29:
-6 |     let* second = read in
+6 | ... let* second = read in
 7 |       return (first ^ second)
 Error: This expression has type
          (Indexed_monad.opened, Indexed_monad.opened, string) Indexed_monad.t

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -349,7 +349,7 @@ let rec wrong =
 Lines 10-12, characters 2-25:
 10 |   let rec x = ref y
 11 |   and y = ref wrong
-12 |   in ref ("foo" ^ ! ! !x)..
+12 |   in ref ("foo" ^ ! ! !x)
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}]
 

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -173,7 +173,7 @@ let rec x =
 and y = x; ();;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..for i = 0 to 1 do
+2 |   for i = 0 to 1 do
 3 |     let z = y in ignore z
 4 |   done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -186,7 +186,7 @@ let rec x =
 and y = 10;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..for i = 0 to y do
+2 |   for i = 0 to y do
 3 |     ()
 4 |   done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -199,7 +199,7 @@ let rec x =
 and y = 0;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..for i = y to 10 do
+2 |   for i = y to 10 do
 3 |     ()
 4 |   done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -212,7 +212,7 @@ let rec x =
 and y = x; ();;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..while false do
+2 |   while false do
 3 |     let y = x in ignore y
 4 |   done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -225,7 +225,7 @@ let rec x =
 and y = false;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..while y do
+2 |   while y do
 3 |     ()
 4 |   done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -238,7 +238,7 @@ let rec x =
 and y = false;;
 [%%expect{|
 Lines 2-4, characters 2-6:
-2 | ..while y do
+2 |   while y do
 3 |     let y = x in ignore y
 4 |   done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -321,7 +321,7 @@ and y = match x with
   z -> ("y", z);;
 [%%expect{|
 Lines 2-4, characters 2-30:
-2 | ..match let _ = y in raise Not_found with
+2 |   match let _ = y in raise Not_found with
 3 |     _ -> "x"
 4 |   | exception Not_found -> "z"
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -347,7 +347,7 @@ let rec wrong =
   in ref ("foo" ^ ! ! !x);;
 [%%expect{|
 Lines 10-12, characters 2-25:
-10 | ..let rec x = ref y
+10 |   let rec x = ref y
 11 |   and y = ref wrong
 12 |   in ref ("foo" ^ ! ! !x)..
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-check/extension_constructor.ml
+++ b/testsuite/tests/letrec-check/extension_constructor.ml
@@ -19,7 +19,7 @@ and (m : (module T)) =
   (module (struct exception A of int end) : T);;
 [%%expect{|
 Lines 2-3, characters 2-8:
-2 | ..let module M = (val m) in
+2 |   let module M = (val m) in
 3 |   M.A 42
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;

--- a/testsuite/tests/letrec-check/modules.ml
+++ b/testsuite/tests/letrec-check/modules.ml
@@ -40,7 +40,7 @@ let rec x =
 Lines 2-4, characters 2-14:
 2 |   let module M = struct
 3 |     module N = struct let y = x end
-4 |   end in M.N.y..
+4 |   end in M.N.y
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 

--- a/testsuite/tests/letrec-check/modules.ml
+++ b/testsuite/tests/letrec-check/modules.ml
@@ -38,7 +38,7 @@ let rec x =
   end in M.N.y;;
 [%%expect{|
 Lines 2-4, characters 2-14:
-2 | ..let module M = struct
+2 |   let module M = struct
 3 |     module N = struct let y = x end
 4 |   end in M.N.y..
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-check/pr7706.ocaml.reference
+++ b/testsuite/tests/letrec-check/pr7706.ocaml.reference
@@ -1,6 +1,6 @@
 Lines 5-6, characters 2-3:
 5 |   let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
-6 |   y..
+6 |   y  
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 Line 2, characters 17-18:
 2 | let () = ignore (x 42);;

--- a/testsuite/tests/letrec-check/pr7706.ocaml.reference
+++ b/testsuite/tests/letrec-check/pr7706.ocaml.reference
@@ -1,5 +1,5 @@
 Lines 5-6, characters 2-3:
-5 | ..let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
+5 |   let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
 6 |   y..
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 Line 2, characters 17-18:

--- a/testsuite/tests/letrec-check/unboxed.ml
+++ b/testsuite/tests/letrec-check/unboxed.ml
@@ -64,7 +64,7 @@ Lines 5-9, characters 2-10:
 6 |     (if Sys.opaque_identity true then
 7 |        X a
 8 |      else
-9 |        Y)}..
+9 |        Y)}
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
@@ -104,6 +104,6 @@ Lines 5-9, characters 2-9:
 6 |     (if Sys.opaque_identity true then
 7 |        V d
 8 |      else
-9 |        W)..
+9 |        W)
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;

--- a/testsuite/tests/letrec-check/unboxed.ml
+++ b/testsuite/tests/letrec-check/unboxed.ml
@@ -60,7 +60,7 @@ let rec a =
 type a = { a : b; } [@@unboxed]
 and b = X of a | Y
 Lines 5-9, characters 2-10:
-5 | ..{a=
+5 |   {a=
 6 |     (if Sys.opaque_identity true then
 7 |        X a
 8 |      else
@@ -100,7 +100,7 @@ let rec d =
 type d = D of e [@@unboxed]
 and e = V of d | W
 Lines 5-9, characters 2-9:
-5 | ..D
+5 |   D
 6 |     (if Sys.opaque_identity true then
 7 |        V d
 8 |      else

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -17,7 +17,7 @@ let test_match_exhaustiveness () =
 
 [%%expect{|
 Lines 8-11, characters 4-16:
- 8 |     match None with
+ 8 | ... match None with
  9 |     | exception e -> ()
 10 |     | Some false -> ()
 11 |     | None -> ()
@@ -36,7 +36,7 @@ let test_match_exhaustiveness_nest1 () =
 
 [%%expect{|
 Lines 2-4, characters 4-30:
-2 |     match None with
+2 | ... match None with
 3 |     | Some false -> ()
 4 |     | None | exception _ -> ()
 Warning 8: this pattern-matching is not exhaustive.
@@ -54,7 +54,7 @@ let test_match_exhaustiveness_nest2 () =
 
 [%%expect{|
 Lines 2-4, characters 4-16:
-2 |     match None with
+2 | ... match None with
 3 |     | Some false | exception _ -> ()
 4 |     | None -> ()
 Warning 8: this pattern-matching is not exhaustive.
@@ -73,7 +73,7 @@ let test_match_exhaustiveness_full () =
 
 [%%expect{|
 Lines 2-5, characters 4-30:
-2 |     match None with
+2 | ... match None with
 3 |     | exception e -> ()
 4 |     | Some false | exception _ -> ()
 5 |     | None | exception _ -> ()

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -17,7 +17,7 @@ let test_match_exhaustiveness () =
 
 [%%expect{|
 Lines 8-11, characters 4-16:
- 8 | ....match None with
+ 8 |     match None with
  9 |     | exception e -> ()
 10 |     | Some false -> ()
 11 |     | None -> ()
@@ -36,7 +36,7 @@ let test_match_exhaustiveness_nest1 () =
 
 [%%expect{|
 Lines 2-4, characters 4-30:
-2 | ....match None with
+2 |     match None with
 3 |     | Some false -> ()
 4 |     | None | exception _ -> ()
 Warning 8: this pattern-matching is not exhaustive.
@@ -54,7 +54,7 @@ let test_match_exhaustiveness_nest2 () =
 
 [%%expect{|
 Lines 2-4, characters 4-16:
-2 | ....match None with
+2 |     match None with
 3 |     | Some false | exception _ -> ()
 4 |     | None -> ()
 Warning 8: this pattern-matching is not exhaustive.
@@ -73,7 +73,7 @@ let test_match_exhaustiveness_full () =
 
 [%%expect{|
 Lines 2-5, characters 4-30:
-2 | ....match None with
+2 |     match None with
 3 |     | exception e -> ()
 4 |     | Some false | exception _ -> ()
 5 |     | None | exception _ -> ()

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -1,0 +1,13 @@
+(* TEST
+  * expect
+*)
+
+		let x = abc
+;;
+[%%expect{|
+Line 1, characters 10-13:
+1 | 		let x = abc
+              ^^^
+Error: Unbound value abc
+Hint: Did you mean abs?
+|}];;

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -7,7 +7,7 @@
 [%%expect{|
 Line 1, characters 10-13:
 1 | 		let x = abc
-              ^^^
+    		        ^^^
 Error: Unbound value abc
 Hint: Did you mean abs?
 |}];;

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -20,7 +20,7 @@ module M : sig type t end =
 ;;
 [%%expect{|
 Lines 2-4, characters 2-5:
-2 | ..struct
+2 | 		struct
 3 | 		  type u
 4 | 		end
 Error: Signature mismatch:

--- a/testsuite/tests/messages/highlight_tabs.ml
+++ b/testsuite/tests/messages/highlight_tabs.ml
@@ -11,3 +11,19 @@ Line 1, characters 10-13:
 Error: Unbound value abc
 Hint: Did you mean abs?
 |}];;
+
+
+module M : sig type t end =
+		struct
+		  type u
+		end
+;;
+[%%expect{|
+Lines 2-4, characters 2-5:
+2 | ..struct
+3 | 		  type u
+4 | 		end
+Error: Signature mismatch:
+       Modules do not match: sig type u end is not included in sig type t end
+       The type `t' is required but not provided
+|}];;

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -34,9 +34,9 @@ Line 2, characters 8-9:
             ^
   This '(' might be unmatched
 Lines 2-4, characters 8-2:
-2 | ........(1
+2 | ... . . (1
 3 |   +
-4 | 2)...
+4 | 2) ..
 Error: This expression has type int but an expression was expected of type
          float
 Line 2, characters 12-17:
@@ -66,9 +66,9 @@ File "error_highlighting_use3.ml", line 1, characters 8-9:
             ^
   This '(' might be unmatched
 File "error_highlighting_use4.ml", lines 1-3, characters 8-2:
-1 | ........(1
+1 | ... . . (1
 2 |   +
-3 | 2)...
+3 | 2) ..
 Error: This expression has type int but an expression was expected of type
          float
 

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -34,9 +34,9 @@ Line 2, characters 8-9:
             ^
   This '(' might be unmatched
 Lines 2-4, characters 8-2:
-2 | ... . . (1
+2 |     ... (1
 3 |   +
-4 | 2) ..
+4 | 2)   
 Error: This expression has type int but an expression was expected of type
          float
 Line 2, characters 12-17:
@@ -66,9 +66,9 @@ File "error_highlighting_use3.ml", line 1, characters 8-9:
             ^
   This '(' might be unmatched
 File "error_highlighting_use4.ml", lines 1-3, characters 8-2:
-1 | ... . . (1
+1 |     ... (1
 2 |   +
-3 | 2) ..
+3 | 2)   
 Error: This expression has type int but an expression was expected of type
          float
 

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -284,7 +284,7 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('a, 'b) bar += A of float
 5 | end
 Error: Signature mismatch:
@@ -310,7 +310,7 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('a, 'b) bar += A of 'b
 5 | end
 Error: Signature mismatch:
@@ -336,7 +336,7 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('b, 'a) bar = A of 'a
 5 | end..
 Error: Signature mismatch:
@@ -363,7 +363,7 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
 5 | end
 Error: Signature mismatch:

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -284,7 +284,7 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('a, 'b) bar += A of float
 5 | end
 Error: Signature mismatch:
@@ -310,7 +310,7 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('a, 'b) bar += A of 'b
 5 | end
 Error: Signature mismatch:
@@ -336,9 +336,9 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('b, 'a) bar = A of 'a
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type ('b, 'a) bar = A of 'a end
@@ -363,7 +363,7 @@ end = struct
 end
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('a, 'b) bar += A : 'd -> ('c, 'd) bar
 5 | end
 Error: Signature mismatch:

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -323,7 +323,7 @@ let f = function
 ;;
 [%%expect {|
 Lines 1-4, characters 8-11:
-1 | ........function
+1 | ... . . function
 2 |   | [Foo] -> 1
 3 |   | _::_::_ -> 3
 4 |   | [] -> 2

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -323,7 +323,7 @@ let f = function
 ;;
 [%%expect {|
 Lines 1-4, characters 8-11:
-1 | ... . . function
+1 |     ... function
 2 |   | [Foo] -> 1
 3 |   | _::_::_ -> 3
 4 |   | [] -> 2

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -13,7 +13,7 @@ let fbool (type t) (x : t) (tag : t ty) =
 [%%expect{|
 type 'a ty = Int : int ty | Bool : bool ty
 Lines 6-7, characters 2-13:
-6 | ..match tag with
+6 |   match tag with
 7 |   | Bool -> x
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
@@ -29,7 +29,7 @@ let fint (type t) (x : t) (tag : t ty) =
 ;;
 [%%expect{|
 Lines 2-3, characters 2-16:
-2 | ..match tag with
+2 |   match tag with
 3 |   | Int -> x > 0
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -241,8 +241,8 @@ let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
 
 [%%expect{|
 Lines 3-4, characters 4-30:
-3 | ....IntLit, ((3 : a) as x)
-4 |   | BoolLit, ((true : a) as x)............
+3 |   . IntLit, ((3 : a) as x)
+4 |   | BoolLit, ((true : a) as x) .. ...... .
 Error: The variable x on the left-hand side of this or-pattern has type
        a but on the right-hand side it has type bool
 |}]
@@ -546,8 +546,8 @@ let extract_merged_annotated (type a) (t2 : a t2) : a =
 
 [%%expect{|
 Lines 3-4, characters 4-10:
-3 | ....Int x
-4 |   | Bool x.....
+3 |   . Int x
+4 |   | Bool x .. .
 Error: The variable x on the left-hand side of this or-pattern has type
        int but on the right-hand side it has type bool
 |}]
@@ -570,8 +570,8 @@ let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
 
 [%%expect{|
 Lines 3-4, characters 4-10:
-3 | ....Int (x : a)
-4 |   | Bool x.....
+3 |   . Int (x : a)
+4 |   | Bool x .. .
 Error: The variable x on the left-hand side of this or-pattern has type
        a but on the right-hand side it has type bool
 |}]
@@ -726,8 +726,8 @@ let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
 ;;
 [%%expect{|
 Lines 3-4, characters 4-65:
-3 | ....IntLit,  ({ contents = true } as x), _
-4 |   | BoolLit,  _,                        ({ contents = true} as x)............
+3 |   . IntLit,  ({ contents = true } as x), _
+4 |   | BoolLit,  _,                        ({ contents = true} as x) .. ...... .
 Error: The variable x on the left-hand side of this or-pattern has type
          bool ref
        but on the right-hand side it has type a ref

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -241,8 +241,8 @@ let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
 
 [%%expect{|
 Lines 3-4, characters 4-30:
-3 |   . IntLit, ((3 : a) as x)
-4 |   | BoolLit, ((true : a) as x) .. ...... .
+3 | ... IntLit, ((3 : a) as x)
+4 |   | BoolLit, ((true : a) as x) ...
 Error: The variable x on the left-hand side of this or-pattern has type
        a but on the right-hand side it has type bool
 |}]
@@ -546,8 +546,8 @@ let extract_merged_annotated (type a) (t2 : a t2) : a =
 
 [%%expect{|
 Lines 3-4, characters 4-10:
-3 |   . Int x
-4 |   | Bool x .. .
+3 | ... Int x
+4 |   | Bool x ...
 Error: The variable x on the left-hand side of this or-pattern has type
        int but on the right-hand side it has type bool
 |}]
@@ -570,8 +570,8 @@ let extract_merged_too_lightly_annotated (type a) (t2 : a t2) : a =
 
 [%%expect{|
 Lines 3-4, characters 4-10:
-3 |   . Int (x : a)
-4 |   | Bool x .. .
+3 | ... Int (x : a)
+4 |   | Bool x ...
 Error: The variable x on the left-hand side of this or-pattern has type
        a but on the right-hand side it has type bool
 |}]
@@ -726,8 +726,8 @@ let f_amb (type a) (t : a t) (a : bool ref) (b : a ref) =
 ;;
 [%%expect{|
 Lines 3-4, characters 4-65:
-3 |   . IntLit,  ({ contents = true } as x), _
-4 |   | BoolLit,  _,                        ({ contents = true} as x) .. ...... .
+3 | ... IntLit,  ({ contents = true } as x), _
+4 |   | BoolLit,  _,                        ({ contents = true} as x) ...
 Error: The variable x on the left-hand side of this or-pattern has type
          bool ref
        but on the right-hand side it has type a ref

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -14,7 +14,7 @@ struct
 end;;
 [%%expect{|
 Lines 7-9, characters 43-24:
-7 | ...........................................function
+7 |   ... ... ..... .. . . . . . . .. ...... . function
 8 |     | One, One -> "two"
 9 |     | Two, Two -> "four"
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -14,7 +14,7 @@ struct
 end;;
 [%%expect{|
 Lines 7-9, characters 43-24:
-7 |   ... ... ..... .. . . . . . . .. ...... . function
+7 |                                        ... function
 8 |     | One, One -> "two"
 9 |     | Two, Two -> "four"
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -28,7 +28,7 @@ type (_, _, _) binop =
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
 Lines 12-16, characters 2-36:
-12 | ..match bop, x, y with
+12 |   match bop, x, y with
 13 |   | Eq, Bool x, Bool y -> Bool (if x then y else not y)
 14 |   | Leq, Int x, Int y -> Bool (x <= y)
 15 |   | Leq, Bool x, Bool y -> Bool (x <= y)

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -13,7 +13,7 @@ module F(S : sig type 'a t end) = struct
 end;;
 [%%expect{|
 Lines 7-8, characters 47-21:
-7 | ...............................................match l, r with
+7 |     ... .. . ... ... ... .. . ..... ... ... .. match l, r with
 8 |     | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
@@ -40,7 +40,7 @@ module F(S : sig type 'a t end) = struct
 end;;
 [%%expect{|
 Lines 10-11, characters 15-21:
-10 | ...............match l, r with
+10 |     ... . . .. match l, r with
 11 |     | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -13,7 +13,7 @@ module F(S : sig type 'a t end) = struct
 end;;
 [%%expect{|
 Lines 7-8, characters 47-21:
-7 |     ... .. . ... ... ... .. . ..... ... ... .. match l, r with
+7 |                                            ... match l, r with
 8 |     | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
@@ -40,7 +40,7 @@ module F(S : sig type 'a t end) = struct
 end;;
 [%%expect{|
 Lines 10-11, characters 15-21:
-10 |     ... . . .. match l, r with
+10 |            ... match l, r with
 11 |     | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -38,7 +38,7 @@ module F(T:sig type 'a t end) = struct
 end;; (* fail *)
 [%%expect{|
 Lines 2-3, characters 2-67:
-2 | ..class ['a] c x =
+2 |   class ['a] c x =
 3 |     object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
 Error: In this definition, a type variable cannot be deduced
        from the type parameters.

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -26,7 +26,7 @@ let () = print_endline (f M.eq) ;;
 type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig type s = private [> `A ] val eq : (s, [ `A | `B ]) t end
 Lines 16-17, characters 39-16:
-16 | ... . . ..... ... . .... . .. ...... . function
+16 |                                    ... function
 17 |   | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
@@ -56,7 +56,7 @@ module N :
     val eq : (s, < a : int; b : bool >) t
   end
 Lines 12-13, characters 49-16:
-12 | ... . . ..... .. . .... . . ...... . .. ...... . function
+12 |                                              ... function
 13 |   | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -26,7 +26,7 @@ let () = print_endline (f M.eq) ;;
 type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig type s = private [> `A ] val eq : (s, [ `A | `B ]) t end
 Lines 16-17, characters 39-16:
-16 | .......................................function
+16 | ... . . ..... ... . .... . .. ...... . function
 17 |   | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
@@ -56,7 +56,7 @@ module N :
     val eq : (s, < a : int; b : bool >) t
   end
 Lines 12-13, characters 49-16:
-12 | .................................................function
+12 | ... . . ..... .. . .... . . ...... . .. ...... . function
 13 |   | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -22,7 +22,7 @@ let x = N.f A;;
 [%%expect{|
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
 Lines 8-9, characters 52-13:
-8 |  ... . . ........ ..... ....... ..... . .. ...... . function
+8 |                                                 ... function
 9 |    | B s -> s
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -22,7 +22,7 @@ let x = N.f A;;
 [%%expect{|
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
 Lines 8-9, characters 52-13:
-8 | ....................................................function
+8 |  ... . . ........ ..... ....... ..... . .. ...... . function
 9 |    | B s -> s
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -16,7 +16,7 @@ type _ t =
 val f : int t -> int = <fun>
 Lines 4-5, characters 0-77:
 4 | type 'a tt = 'a t =
-5 |   Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt..
+5 |   Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt
 Error: This variant or record definition does not match that of type 'a t
        Constructors do not match:
          Same : 'l t -> 'l t

--- a/testsuite/tests/typing-gadts/pr7260.ml
+++ b/testsuite/tests/typing-gadts/pr7260.ml
@@ -25,7 +25,7 @@ Lines 7-12, characters 0-5:
  9 |     method foo (Dyn ty) =
 10 |       match ty with
 11 |       | Int -> (this :> bar)
-12 |   end..  .. ..... ... ... ... ..... ..
+12 |   end ...
 Error: This class should be virtual.
        The following methods are undefined : bar
 |}];;

--- a/testsuite/tests/typing-gadts/pr7260.ml
+++ b/testsuite/tests/typing-gadts/pr7260.ml
@@ -25,7 +25,7 @@ Lines 7-12, characters 0-5:
  9 |     method foo (Dyn ty) =
 10 |       match ty with
 11 |       | Int -> (this :> bar)
-12 |   end.................................
+12 |   end..  .. ..... ... ... ... ..... ..
 Error: This class should be virtual.
        The following methods are undefined : bar
 |}];;

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -16,7 +16,7 @@ module Y = struct
 end;; (* should fail *)
 [%%expect{|
 Lines 2-3, characters 2-37:
-2 | ..type t = X.t =
+2 |   type t = X.t =
 3 |     | A : 'a * 'b * ('b -> unit) -> t
 Error: This variant or record definition does not match that of type X.t
        Constructors do not match:

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -104,13 +104,13 @@ module Nonexhaustive =
 ;;
 [%%expect{|
 Lines 11-12, characters 6-19:
-11 |       function
+11 |   ... function
 12 |         | C2 x -> x
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C1 _
 Lines 24-26, characters 6-30:
-24 |       function
+24 |   ... function
 25 |         | Foo _ , Foo _ -> true
 26 |         | Bar _, Bar _ -> true
 Warning 8: this pattern-matching is not exhaustive.
@@ -261,8 +261,8 @@ module PR6801 = struct
 end;;
 [%%expect{|
 Lines 8-9, characters 4-33:
-8 |     match x with
-9 |     | String s -> print_endline s .. .... . ... ..
+8 | ... match x with
+9 |     | String s -> print_endline s ...
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Any
@@ -815,7 +815,7 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 [%%expect{|
 Lines 1-2, characters 4-15:
 1 | ... f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
-2 |   fun Eq o -> o .. .. .... ..
+2 |   fun Eq o -> o ...
 Error: This definition has type
          ('a, 'b) eq -> ([< `A of 'b & 'a | `B ] as 'c) -> 'c
        which is less general than 'a0 'b0. ('a0, 'b0) eq -> 'c -> 'c

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -104,13 +104,13 @@ module Nonexhaustive =
 ;;
 [%%expect{|
 Lines 11-12, characters 6-19:
-11 | ......function
+11 |       function
 12 |         | C2 x -> x
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C1 _
 Lines 24-26, characters 6-30:
-24 | ......function
+24 |       function
 25 |         | Foo _ , Foo _ -> true
 26 |         | Bar _, Bar _ -> true
 Warning 8: this pattern-matching is not exhaustive.
@@ -261,8 +261,8 @@ module PR6801 = struct
 end;;
 [%%expect{|
 Lines 8-9, characters 4-33:
-8 | ....match x with
-9 |     | String s -> print_endline s.................
+8 |     match x with
+9 |     | String s -> print_endline s .. .... . ... ..
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Any
@@ -688,7 +688,7 @@ let f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
 [%%expect{|
 type (_, _) eq = Eq : ('a, 'a) eq
 Lines 3-4, characters 4-15:
-3 | ....f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
+3 | ... f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
 4 |   fun Eq o -> o
 Error: The universal type variable 'b cannot be generalized:
        it is already bound to another variable.
@@ -814,8 +814,8 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
   fun Eq o -> o ;; (* fail *)
 [%%expect{|
 Lines 1-2, characters 4-15:
-1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
-2 |   fun Eq o -> o..............
+1 | ... f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
+2 |   fun Eq o -> o .. .. .... ..
 Error: This definition has type
          ('a, 'b) eq -> ([< `A of 'b & 'a | `B ] as 'c) -> 'c
        which is less general than 'a0 'b0. ('a0, 'b0) eq -> 'c -> 'c
@@ -916,7 +916,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 ;; (* warn *)
 [%%expect{|
 Lines 2-8, characters 2-16:
-2 | ..match x, y with
+2 |   match x, y with
 3 |   | _, A z -> z
 4 |   | _, B z -> if z then 1 else 2
 5 |   | _, C z -> truncate z
@@ -980,7 +980,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 [%%expect{|
 type ('a, 'b) pair = { left : 'a; right : 'b; }
 Lines 4-10, characters 2-29:
- 4 | ..match {left=x; right=y} with
+ 4 |   match {left=x; right=y} with
  5 |   | {left=_; right=A z} -> z
  6 |   | {left=_; right=B z} -> if z then 1 else 2
  7 |   | {left=_; right=C z} -> truncate z

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -57,7 +57,7 @@ let check : type s . s t * s -> bool = function
 [%%expect{|
 type _ t = IntLit : int t | BoolLit : bool t
 Lines 5-7, characters 39-23:
-5 | .......................................function
+5 | ... ..... . .... . . . . . . .. .... . function
 6 |   | BoolLit, false -> false
 7 |   | IntLit , 6 -> false
 Warning 8: this pattern-matching is not exhaustive.
@@ -75,7 +75,7 @@ let check : type s . (s t, s) pair -> bool = function
 [%%expect{|
 type ('a, 'b) pair = { fst : 'a; snd : 'b; }
 Lines 3-5, characters 45-38:
-3 | .............................................function
+3 | ... ..... . .... . . .. .. .. .... .. .... . function
 4 |   | {fst = BoolLit; snd = false} -> false
 5 |   | {fst = IntLit ; snd =  6} -> false
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -57,7 +57,7 @@ let check : type s . s t * s -> bool = function
 [%%expect{|
 type _ t = IntLit : int t | BoolLit : bool t
 Lines 5-7, characters 39-23:
-5 | ... ..... . .... . . . . . . .. .... . function
+5 |                                    ... function
 6 |   | BoolLit, false -> false
 7 |   | IntLit , 6 -> false
 Warning 8: this pattern-matching is not exhaustive.
@@ -75,7 +75,7 @@ let check : type s . (s t, s) pair -> bool = function
 [%%expect{|
 type ('a, 'b) pair = { fst : 'a; snd : 'b; }
 Lines 3-5, characters 45-38:
-3 | ... ..... . .... . . .. .. .. .... .. .... . function
+3 |                                          ... function
 4 |   | {fst = BoolLit; snd = false} -> false
 5 |   | {fst = IntLit ; snd =  6} -> false
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -132,9 +132,9 @@ module D : sig type t [@@immediate] end = struct
 end;;
 [%%expect{|
 Lines 1-3, characters 42-3:
-1 | ...... . . ... .... . ............. ... . struct
+1 |                                       ... struct
 2 |   type t = string
-3 | end..
+3 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = string end

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -132,7 +132,7 @@ module D : sig type t [@@immediate] end = struct
 end;;
 [%%expect{|
 Lines 1-3, characters 42-3:
-1 | ..........................................struct
+1 | ...... . . ... .... . ............. ... . struct
 2 |   type t = string
 3 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -495,7 +495,7 @@ let t = function
 ;;
 [%%expect{|
 Lines 1-3, characters 8-10:
-1 | ........function
+1 | ... . . function
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
 Warning 8: this pattern-matching is not exhaustive.
@@ -508,7 +508,7 @@ Line 3, characters 9-10:
              ^
 Warning 18: this type-based constructor disambiguation is not principal.
 Lines 1-3, characters 8-10:
-1 | ........function
+1 | ... . . function
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -495,7 +495,7 @@ let t = function
 ;;
 [%%expect{|
 Lines 1-3, characters 8-10:
-1 | ... . . function
+1 |     ... function
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
 Warning 8: this pattern-matching is not exhaustive.
@@ -508,7 +508,7 @@ Line 3, characters 9-10:
              ^
 Warning 18: this type-based constructor disambiguation is not principal.
 Lines 1-3, characters 8-10:
-1 | ... . . function
+1 |     ... function
 2 |   | ({ contents = M.A } : M.t ref) as x ->
 3 |     x := B
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -14,7 +14,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type t = A | B
  5 |
  6 |   let f (x : t) =
@@ -45,7 +45,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
@@ -76,7 +76,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
@@ -109,7 +109,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
@@ -140,7 +140,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
@@ -171,7 +171,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
@@ -202,7 +202,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ......struct
+ 3 | ... . struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
@@ -233,7 +233,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-9, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('a, 'b) t = Foo of 'b
 5 |
 6 |   (* this function typechecks properly, which means that we've added the

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -14,14 +14,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type t = A | B
  5 |
  6 |   let f (x : t) =
  7 |     match x with
  8 |     | A -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A.t = A | B val f : t -> unit end
@@ -45,14 +45,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
  7 |     match x with
  8 |     | A _ -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a B.t = A of 'a | B val f : 'a t -> unit end
@@ -76,14 +76,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
  7 |     match x with
  8 |     | A _ -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a C.t = A of 'a | B val f : 'a t -> unit end
@@ -109,14 +109,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
  7 |     match x with
  8 |     | A _ -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a D.t = A of 'a | B val f : 'a t -> unit end
@@ -140,14 +140,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
  7 |     match x with
  8 |     | A _ -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a E.t = A of 'a | B val f : 'a t -> unit end
@@ -171,14 +171,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
  7 |     match x with
  8 |     | A _ -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a E2.t = A of 'a | B val f : 'a t -> unit end
@@ -202,14 +202,14 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-10, characters 6-3:
- 3 | ... . struct
+ 3 |   ... struct
  4 |   type 'a t = A of 'a | B
  5 |
  6 |   let f (x : _ t) =
  7 |     match x with
  8 |     | A _ -> ()
  9 |     | B -> ()
-10 | end..
+10 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a E3.t = A of 'a | B val f : 'a t -> unit end
@@ -233,13 +233,13 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-9, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('a, 'b) t = Foo of 'b
 5 |
 6 |   (* this function typechecks properly, which means that we've added the
 7 |      manisfest. *)
 8 |   let coerce : 'a 'b. ('a, 'b) t -> ('a, 'b) F.t = fun x -> x
-9 | end..
+9 | end
 Error: Signature mismatch:
        Modules do not match:
          sig

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -16,7 +16,7 @@ end
 [%%expect{|
 class type foo_t = object method foo : string end
 Lines 8-10, characters 6-3:
- 8 | ... . struct
+ 8 |   ... struct
  9 |   class type ct = object end
 10 | end
 Error: Signature mismatch:
@@ -43,7 +43,7 @@ end
 ;;
 [%%expect{|
 Lines 5-9, characters 6-3:
-5 | ... . struct
+5 |   ... struct
 6 |   class virtual c = object
 7 |     method virtual a: string
 8 |   end
@@ -72,7 +72,7 @@ end
 [%%expect{|
 class type ['a] ct = object val x : 'a end
 Lines 5-7, characters 6-3:
-5 | ... . struct
+5 |   ... struct
 6 |   class type c = object end
 7 | end
 Error: Signature mismatch:
@@ -95,7 +95,7 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   class ['a] c = object end
 5 | end
 Error: Signature mismatch:
@@ -118,7 +118,7 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   class c (x : float) = object end
 5 | end
 Error: Signature mismatch:
@@ -142,7 +142,7 @@ class virtual foo: foo_t =
 
 [%%expect{|
 Lines 2-5, characters 4-7:
-2 |     object
+2 | ... object
 3 |         method foo = "foo"
 4 |         method private virtual cast: int
 5 |     end
@@ -164,7 +164,7 @@ class foo: foo_t2 =
 [%%expect{|
 class type foo_t2 = object method private foo : string end
 Lines 7-9, characters 4-7:
-7 |     object
+7 | ... object
 8 |         method foo = "foo"
 9 |     end
 Error: The class type object method foo : string end
@@ -179,7 +179,7 @@ class virtual foo: foo_t =
 ;;
 [%%expect{|
 Lines 2-4, characters 4-7:
-2 |     object
+2 | ... object
 3 |         method virtual foo: string
 4 |     end
 Error: The class type object method virtual foo : string end
@@ -200,7 +200,7 @@ class foo: foo_t3 =
 [%%expect{|
 class type foo_t3 = object val mutable x : int end
 Lines 7-9, characters 4-7:
-7 |     object
+7 | ... object
 8 |         val x = 1
 9 |     end
 Error: The class type object val x : int end is not matched by the class type
@@ -221,7 +221,7 @@ class virtual foo: foo_t4 =
 [%%expect{|
 class type foo_t4 = object val x : int end
 Lines 7-9, characters 4-7:
-7 |     object
+7 | ... object
 8 |         val virtual x : int
 9 |     end
 Error: The class type object val virtual x : int end
@@ -237,7 +237,7 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   class type c = object method private m: string end
 5 | end
 Error: Signature mismatch:

--- a/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -16,7 +16,7 @@ end
 [%%expect{|
 class type foo_t = object method foo : string end
 Lines 8-10, characters 6-3:
- 8 | ......struct
+ 8 | ... . struct
  9 |   class type ct = object end
 10 | end
 Error: Signature mismatch:
@@ -43,7 +43,7 @@ end
 ;;
 [%%expect{|
 Lines 5-9, characters 6-3:
-5 | ......struct
+5 | ... . struct
 6 |   class virtual c = object
 7 |     method virtual a: string
 8 |   end
@@ -72,7 +72,7 @@ end
 [%%expect{|
 class type ['a] ct = object val x : 'a end
 Lines 5-7, characters 6-3:
-5 | ......struct
+5 | ... . struct
 6 |   class type c = object end
 7 | end
 Error: Signature mismatch:
@@ -95,7 +95,7 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   class ['a] c = object end
 5 | end
 Error: Signature mismatch:
@@ -118,7 +118,7 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   class c (x : float) = object end
 5 | end
 Error: Signature mismatch:
@@ -142,7 +142,7 @@ class virtual foo: foo_t =
 
 [%%expect{|
 Lines 2-5, characters 4-7:
-2 | ....object
+2 |     object
 3 |         method foo = "foo"
 4 |         method private virtual cast: int
 5 |     end
@@ -164,7 +164,7 @@ class foo: foo_t2 =
 [%%expect{|
 class type foo_t2 = object method private foo : string end
 Lines 7-9, characters 4-7:
-7 | ....object
+7 |     object
 8 |         method foo = "foo"
 9 |     end
 Error: The class type object method foo : string end
@@ -179,7 +179,7 @@ class virtual foo: foo_t =
 ;;
 [%%expect{|
 Lines 2-4, characters 4-7:
-2 | ....object
+2 |     object
 3 |         method virtual foo: string
 4 |     end
 Error: The class type object method virtual foo : string end
@@ -200,7 +200,7 @@ class foo: foo_t3 =
 [%%expect{|
 class type foo_t3 = object val mutable x : int end
 Lines 7-9, characters 4-7:
-7 | ....object
+7 |     object
 8 |         val x = 1
 9 |     end
 Error: The class type object val x : int end is not matched by the class type
@@ -221,7 +221,7 @@ class virtual foo: foo_t4 =
 [%%expect{|
 class type foo_t4 = object val x : int end
 Lines 7-9, characters 4-7:
-7 | ....object
+7 |     object
 8 |         val virtual x : int
 9 |     end
 Error: The class type object val virtual x : int end
@@ -237,7 +237,7 @@ end
 ;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   class type c = object method private m: string end
 5 | end
 Error: Signature mismatch:

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -13,7 +13,7 @@ module M = struct
 end;;
 [%%expect{|
 Lines 5-8, characters 8-5:
-5 |   ... . struct
+5 |     ... struct
 6 |     type t = B
 7 |     let f B = ()
 8 |   end
@@ -72,7 +72,7 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 4-7:
-4 |     struct
+4 | ... struct
 5 |       module type s
 6 |       module A(X:s) =struct end
 7 |     end
@@ -104,7 +104,7 @@ module L = struct
 end;;
       [%%expect {|
 Lines 4-7, characters 4-7:
-4 |     struct
+4 | ... struct
 5 |       module T = struct type t end
 6 |       type t = A of T.t
 7 |     end
@@ -275,14 +275,14 @@ end;;
 
 [%%expect{|
 Lines 8-15, characters 6-3:
- 8 | ... . struct
+ 8 |   ... struct
  9 |   type t
 10 |   class type a = object method m:t end
 11 |   module K = struct
 12 |     type t
 13 |     class type c = object inherit a end
 14 |   end
-15 | end..
+15 | end
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -352,9 +352,9 @@ type t = B
 type t = C
 type t = D
 Lines 5-7, characters 44-3:
-5 | ...... .. ... ... .. . .. . .. . .. . ... . struct
+5 |                                         ... struct
 6 |   let f A B C = D
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig val f : t/2 -> t/3 -> t/4 -> t/1 end

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -13,7 +13,7 @@ module M = struct
 end;;
 [%%expect{|
 Lines 5-8, characters 8-5:
-5 | ........struct
+5 |   ... . struct
 6 |     type t = B
 7 |     let f B = ()
 8 |   end
@@ -72,7 +72,7 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 4-7:
-4 | ....struct
+4 |     struct
 5 |       module type s
 6 |       module A(X:s) =struct end
 7 |     end
@@ -104,7 +104,7 @@ module L = struct
 end;;
       [%%expect {|
 Lines 4-7, characters 4-7:
-4 | ....struct
+4 |     struct
 5 |       module T = struct type t end
 6 |       type t = A of T.t
 7 |     end
@@ -196,7 +196,7 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 2-5:
-4 | ..struct
+4 |   struct
 5 |     class a = object method c = let module X = struct type t end in () end
 6 |     class b = a
 7 |   end
@@ -228,7 +228,7 @@ end;;
 
 [%%expect{|
 Lines 4-7, characters 2-5:
-4 | ..struct
+4 |   struct
 5 |     class type a = object end
 6 |     class type b = a
 7 |   end
@@ -275,7 +275,7 @@ end;;
 
 [%%expect{|
 Lines 8-15, characters 6-3:
- 8 | ......struct
+ 8 | ... . struct
  9 |   type t
 10 |   class type a = object method m:t end
 11 |   module K = struct
@@ -352,7 +352,7 @@ type t = B
 type t = C
 type t = D
 Lines 5-7, characters 44-3:
-5 | ............................................struct
+5 | ...... .. ... ... .. . .. . .. . .. . ... . struct
 6 |   let f A B C = D
 7 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -13,7 +13,7 @@ type t = int
 Lines 3-5, characters 0-3:
 3 | struct
 4 |   type t = [`T of t]
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = [ `T of t ] end

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -21,7 +21,7 @@ val partition_map :
   ('a -> [< `Left of 'b | `Right of 'c ]) -> 'a list -> 'b list * 'c list =
   <fun>
 Lines 12-13, characters 35-18:
-12 | ...................................partition_map (fun x -> if x then `Left ()
+12 | ... . .. . .... .... . ... ..... . partition_map (fun x -> if x then `Left ()
 13 | else `Right ()) xs
 Error: This expression has type unit list * unit list
        but an expression was expected of type int list * int list
@@ -58,7 +58,7 @@ end
 ;;
 [%%expect{|
 Lines 8-27, characters 6-3:
- 8 | ......struct
+ 8 | ... . struct
  9 |   type t = [
 10 |     | `A of int
 11 |     | `B of [ `BA | `BB of unit list ]

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -21,7 +21,7 @@ val partition_map :
   ('a -> [< `Left of 'b | `Right of 'c ]) -> 'a list -> 'b list * 'c list =
   <fun>
 Lines 12-13, characters 35-18:
-12 | ... . .. . .... .... . ... ..... . partition_map (fun x -> if x then `Left ()
+12 |                                ... partition_map (fun x -> if x then `Left ()
 13 | else `Right ()) xs
 Error: This expression has type unit list * unit list
        but an expression was expected of type int list * int list
@@ -58,7 +58,7 @@ end
 ;;
 [%%expect{|
 Lines 8-27, characters 6-3:
- 8 | ... . struct
+ 8 |   ... struct
  9 |   type t = [
 10 |     | `A of int
 11 |     | `B of [ `BA | `BB of unit list ]

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -12,7 +12,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-6, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |  type t = A | B
 5 |  let f = function A | B -> 0
 6 | end..
@@ -129,7 +129,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = Foo : int -> t
 5 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -12,10 +12,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-6, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |  type t = A | B
 5 |  let f = function A | B -> 0
-6 | end..
+6 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = X.t = A | B val f : t -> int end
@@ -129,9 +129,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = Foo : int -> t
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo : int -> t end

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -193,7 +193,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t += E of int
 5 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -193,9 +193,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t += E of int
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t += E of int end

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -102,7 +102,7 @@ end = struct
 end
 [%%expect {|
 Lines 9-17, characters 6-3:
- 9 | ......struct
+ 9 | ... . struct
 10 |   module type x = sig
 11 |     val a:int
 12 |     val b:int
@@ -172,7 +172,7 @@ end = struct
 end
 [%%expect {|
 Lines 6-11, characters 6-3:
- 6 | ......struct
+ 6 | ... . struct
  7 |   module type x= sig
  8 |     val x:int
  9 |     class x:ct
@@ -211,7 +211,7 @@ end = struct
 end
 [%%expect {|
 Lines 8-15, characters 6-3:
- 8 | ......struct
+ 8 | ... . struct
  9 |   module type a = sig
 10 |     module type b = sig
 11 |       val y:int
@@ -268,7 +268,7 @@ end
 [%%expect{|
 class type ct = object  end
 Lines 7-12, characters 6-3:
- 7 | ......struct
+ 7 | ... . struct
  8 |   module type x = sig
  9 |     class b: ct
 10 |     class a: ct
@@ -303,7 +303,7 @@ end = struct
 end
 [%%expect{|
 Lines 6-11, characters 6-3:
- 6 | ......struct
+ 6 | ... . struct
  7 |   module type x = sig
  8 |     type exn+=B
  9 |     type exn+=A

--- a/testsuite/tests/typing-modules/illegal_permutation.ml
+++ b/testsuite/tests/typing-modules/illegal_permutation.ml
@@ -102,7 +102,7 @@ end = struct
 end
 [%%expect {|
 Lines 9-17, characters 6-3:
- 9 | ... . struct
+ 9 |   ... struct
 10 |   module type x = sig
 11 |     val a:int
 12 |     val b:int
@@ -172,7 +172,7 @@ end = struct
 end
 [%%expect {|
 Lines 6-11, characters 6-3:
- 6 | ... . struct
+ 6 |   ... struct
  7 |   module type x= sig
  8 |     val x:int
  9 |     class x:ct
@@ -211,7 +211,7 @@ end = struct
 end
 [%%expect {|
 Lines 8-15, characters 6-3:
- 8 | ... . struct
+ 8 |   ... struct
  9 |   module type a = sig
 10 |     module type b = sig
 11 |       val y:int
@@ -268,7 +268,7 @@ end
 [%%expect{|
 class type ct = object  end
 Lines 7-12, characters 6-3:
- 7 | ... . struct
+ 7 |   ... struct
  8 |   module type x = sig
  9 |     class b: ct
 10 |     class a: ct
@@ -303,7 +303,7 @@ end = struct
 end
 [%%expect{|
 Lines 6-11, characters 6-3:
- 6 | ... . struct
+ 6 |   ... struct
  7 |   module type x = sig
  8 |     type exn+=B
  9 |     type exn+=A
@@ -481,7 +481,7 @@ end=struct
 end
 [%%expect {|
 Lines 22-43, characters 4-3:
-22 | ....struct
+22 | ... struct
 23 |   module type x = sig
 24 |     module A: sig
 25 |       module B: sig

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -100,7 +100,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type s = t
 5 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -100,9 +100,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type s = t
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type s = t end

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -11,10 +11,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t = A | B
 6 |   let f = function A | B -> 0
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = X.t = A | B val f : t -> int end

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -11,7 +11,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t = A | B
 6 |   let f = function A | B -> 0
 7 | end..

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -111,10 +111,10 @@ module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
 end;;
 [%%expect{|
 Lines 2-5, characters 57-3:
-2 |                         .... ...... .. .. ...........  . struct
+2 |                                                      ... struct
 3 |   module Id = T'.T.Id
 4 |   module Id2 = Id
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig module Id : sig end module Id2 = Id end

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -111,7 +111,7 @@ module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
 end;;
 [%%expect{|
 Lines 2-5, characters 57-3:
-2 | .........................................................struct
+2 |                         .... ...... .. .. ...........  . struct
 3 |   module Id = T'.T.Id
 4 |   module Id2 = Id
 5 | end..

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -11,10 +11,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
 6 |             f1 : unit * unit * unit * string * unit * unit * unit}
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -57,10 +57,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
 6 |             f1 : unit * unit * unit * string * unit * unit * unit}
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig
@@ -100,9 +100,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = {f1 : unit}
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f1 : unit; } end
@@ -122,9 +122,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = {f0 : unit}
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f0 : unit; } end

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -11,7 +11,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
 6 |             f1 : unit * unit * unit * string * unit * unit * unit}
 7 | end..
@@ -57,7 +57,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t = {f0 : unit * unit * unit * float* unit * unit * unit;
 6 |             f1 : unit * unit * unit * string * unit * unit * unit}
 7 | end..
@@ -100,7 +100,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = {f1 : unit}
 5 | end..
 Error: Signature mismatch:
@@ -122,7 +122,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = {f0 : unit}
 5 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -11,10 +11,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t =
 6 |     | Foo of float * int
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of float * int end
@@ -40,10 +40,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t =
 6 |     | Foo of float
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of float end
@@ -69,10 +69,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t =
 6 |     | Foo of {x : float; y : int}
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of { x : float; y : int; } end
@@ -102,10 +102,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t =
 6 |     | Foo of float
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = Foo of float end
@@ -131,10 +131,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type 'a t =
 6 |     | Foo of 'a
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = Foo of 'a end
@@ -158,9 +158,9 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('a, 'b) t = A of 'b
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type ('a, 'b) t = A of 'b end
@@ -184,9 +184,9 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type ('b, 'a) t = A of 'a
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type ('b, 'a) t = A of 'a end

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -11,7 +11,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t =
 6 |     | Foo of float * int
 7 | end..
@@ -40,7 +40,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t =
 6 |     | Foo of float
 7 | end..
@@ -69,7 +69,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t =
 6 |     | Foo of {x : float; y : int}
 7 | end..
@@ -102,7 +102,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t =
 6 |     | Foo of float
 7 | end..
@@ -131,7 +131,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type 'a t =
 6 |     | Foo of 'a
 7 | end..
@@ -158,7 +158,7 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('a, 'b) t = A of 'b
 5 | end..
 Error: Signature mismatch:
@@ -184,7 +184,7 @@ end = struct
 end;;
 [%%expect {|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type ('b, 'a) t = A of 'a
 5 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -100,7 +100,7 @@ Lines 1-5, characters 0-3:
 2 |   val mutable x = x_init
 3 |   method get = x
 4 |   method set y = x <- y
-5 | end..
+5 | end
 Error: Some type variables are unbound in this type:
          class ref :
            'a ->

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -32,7 +32,7 @@ end and d () = object
 end;;
 [%%expect{|
 Lines 3-5, characters 4-3:
-3 | ....and d () = object
+3 | ... and d () = object
 4 |   inherit ['a] c ()
 5 | end..
 Error: Some type variables are unbound in this type:
@@ -675,9 +675,9 @@ end : sig
 end);;
 [%%expect{|
 Lines 1-3, characters 12-3:
-1 | ............struct
+1 | ...... . . .struct
 2 |   let f (x : #c) = x
-3 | end......
+3 | end . ...
 Error: Signature mismatch:
        Modules do not match:
          sig val f : (#c as 'a) -> 'a end

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -34,7 +34,7 @@ end;;
 Lines 3-5, characters 4-3:
 3 | ... and d () = object
 4 |   inherit ['a] c ()
-5 | end..
+5 | end
 Error: Some type variables are unbound in this type:
          class d : unit -> object method f : 'a -> unit end
        The method f has type 'a -> unit where 'a is unbound
@@ -91,7 +91,7 @@ end;;
 Lines 1-3, characters 0-3:
 1 | class x () = object
 2 |   method virtual f : int
-3 | end..
+3 | end
 Error: This class should be virtual. The following methods are undefined : f
 |}];;
 (* The class x should be virtual:  its methods f is undefined *)
@@ -120,7 +120,7 @@ Lines 1-4, characters 0-3:
 1 | class ['a] c () = object
 2 |   constraint 'a = int
 3 |   method f x = (x : bool c)
-4 | end..
+4 | end
 Error: The abbreviation c is used with parameters bool c
        which are incompatible with constraints int c
 |}];;
@@ -165,7 +165,7 @@ end;;
 Lines 1-3, characters 0-3:
 1 | class ['a] c () = object
 2 |   method f = (x : 'a)
-3 | end..
+3 | end
 Error: The type of this class,
        class ['a] c :
          unit -> object constraint 'a = '_weak1 list ref method f : 'a end,
@@ -629,7 +629,7 @@ Lines 1-4, characters 0-3:
 1 | class virtual ['a] matrix (sz, init : int * 'a) = object
 2 |   val m = Array.make_matrix sz sz init
 3 |   method add (mtx : 'a matrix) = (mtx#m.(0).(0) : 'a)
-4 | end..
+4 | end
 Error: The abbreviation 'a matrix expands to type < add : 'a matrix -> 'a >
        but is used with type < m : 'a array array; .. >
 |}];;
@@ -675,9 +675,9 @@ end : sig
 end);;
 [%%expect{|
 Lines 1-3, characters 12-3:
-1 | ...... . . .struct
+1 |         ... struct
 2 |   let f (x : #c) = x
-3 | end . ...
+3 | end ...
 Error: Signature mismatch:
        Modules do not match:
          sig val f : (#c as 'a) -> 'a end

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -140,7 +140,7 @@ class leading_up_to = object(self : 'a)
 end;;
 [%%expect{|
 Lines 4-7, characters 4-7:
-4 | ....object
+4 |     object
 5 |       inherit child1 self
 6 |       inherit child2
 7 |     end
@@ -163,7 +163,7 @@ class assertion_failure = object(self : 'a)
 end;;
 [%%expect{|
 Lines 4-10, characters 4-7:
- 4 | ....object
+ 4 |     object
  5 |       inherit child1 self
  6 |       inherit child2
  7 |

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -140,7 +140,7 @@ class leading_up_to = object(self : 'a)
 end;;
 [%%expect{|
 Lines 4-7, characters 4-7:
-4 |     object
+4 | ... object
 5 |       inherit child1 self
 6 |       inherit child2
 7 |     end
@@ -163,7 +163,7 @@ class assertion_failure = object(self : 'a)
 end;;
 [%%expect{|
 Lines 4-10, characters 4-7:
- 4 |     object
+ 4 | ... object
  5 |       inherit child1 self
  6 |       inherit child2
  7 |

--- a/testsuite/tests/typing-objects/pr5619_bad.ml
+++ b/testsuite/tests/typing-objects/pr5619_bad.ml
@@ -41,7 +41,7 @@ class foo: foo_t =
 ;;
 [%%expect{|
 Lines 2-8, characters 2-5:
-2 | ..object(self)
+2 |   object(self)
 3 |     method foo = "foo"
 4 |     method cast: type a. a name -> a =
 5 |       function

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -55,7 +55,7 @@ let _ = f (object
 class type t_a = object method f : 'a -> int end
 val f : t_a -> int = <fun>
 Lines 5-7, characters 10-5:
-5 | ..........(object
+5 | ... . . . (object
 6 |     method f _ = 0
 7 |  end)..
 Error: This expression has type < f : 'a -> int >

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -55,9 +55,9 @@ let _ = f (object
 class type t_a = object method f : 'a -> int end
 val f : t_a -> int = <fun>
 Lines 5-7, characters 10-5:
-5 | ... . . . (object
+5 |       ... (object
 6 |     method f _ = 0
-7 |  end)..
+7 |  end)
 Error: This expression has type < f : 'a -> int >
        but an expression was expected of type t_a
        The method f has type 'a -> int, but the expected method type was

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -556,7 +556,7 @@ end
 ;;
 [%%expect {|
 Lines 4-7, characters 12-17:
-4 | ............x =
+4 |   ...... .. x =
 5 |     match r with
 6 |       None -> r <- Some x; x
 7 |     | Some y -> y
@@ -1232,7 +1232,7 @@ let f6 x =
   (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
 [%%expect {|
 Lines 2-3, characters 2-47:
-2 | ..(x : <m:'a. (<p:int;..> as 'a) -> int>
+2 |   (x : <m:'a. (<p:int;..> as 'a) -> int>
 3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)..
 Error: Type < m : 'a. (< p : int; .. > as 'a) -> int > is not a subtype of
          < m : 'b. (< p : int; q : int; .. > as 'b) -> int >

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -556,7 +556,7 @@ end
 ;;
 [%%expect {|
 Lines 4-7, characters 12-17:
-4 |   ...... .. x =
+4 |         ... x =
 5 |     match r with
 6 |       None -> r <- Some x; x
 7 |     | Some y -> y
@@ -1233,7 +1233,7 @@ let f6 x =
 [%%expect {|
 Lines 2-3, characters 2-47:
 2 |   (x : <m:'a. (<p:int;..> as 'a) -> int>
-3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)..
+3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)
 Error: Type < m : 'a. (< p : int; .. > as 'a) -> int > is not a subtype of
          < m : 'b. (< p : int; q : int; .. > as 'b) -> int >
        Type < p : int; q : int; .. > as 'c is not a subtype of

--- a/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
@@ -38,7 +38,7 @@ let f x =
 ;;
 [%%expect{|
 Lines 4-5, characters 2-38:
-4 | ..match [] with
+4 |   match [] with
 5 |   | _::_ -> (x :> [`A | `C] Element.t)
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-recmod/t12bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t12bad.compilers.reference
@@ -1,5 +1,5 @@
 File "t12bad.ml", lines 11-15, characters 4-7:
-11 | ....sig
+11 |     sig
 12 |       class ['a] c : 'a -> object
 13 |         method map : ('a -> 'b) -> 'b M.c
 14 |       end

--- a/testsuite/tests/typing-recmod/t12bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t12bad.compilers.reference
@@ -1,5 +1,5 @@
 File "t12bad.ml", lines 11-15, characters 4-7:
-11 |     sig
+11 | ... sig
 12 |       class ['a] c : 'a -> object
 13 |         method map : ('a -> 'b) -> 'b M.c
 14 |       end

--- a/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
+++ b/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
@@ -1,5 +1,5 @@
 File "b_bad.ml", lines 13-14, characters 29-28:
-13 | ... . . ...... ... .. .... . function
+13 |                          ... function
 14 |     A.X s -> print_endline s
 Error (warning 8): this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
+++ b/testsuite/tests/typing-safe-linking/b_bad.compilers.reference
@@ -1,5 +1,5 @@
 File "b_bad.ml", lines 13-14, characters 29-28:
-13 | .............................function
+13 | ... . . ...... ... .. .... . function
 14 |     A.X s -> print_endline s
 Error (warning 8): this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -48,7 +48,7 @@ module type S0 = sig
 end with type M.t = int
 [%%expect {|
 Lines 1-4, characters 17-23:
-1 | ...... .... .. . sig
+1 |              ... sig
 2 |   module rec M : sig type t = M2.t end
 3 |   and M2 : sig type t = int end
 4 | end with type M.t = int
@@ -163,7 +163,7 @@ end with type 'a t2 := 'a t * bool
 [%%expect {|
 type 'a t constraint 'a = 'b list
 Lines 2-6, characters 16-34:
-2 | ...... .... . . sig
+2 |             ... sig
 3 |   type 'a t2 constraint 'a = 'b list
 4 |   type 'a mylist = 'a list
 5 |   val x : int mylist t2
@@ -268,7 +268,7 @@ module type S = sig
 end with type M.t := float
 [%%expect {|
 Lines 1-4, characters 16-26:
-1 | ...... .... . . sig
+1 |             ... sig
 2 |   module M : sig type t end
 3 |   module A = M
 4 | end with type M.t := float
@@ -330,7 +330,7 @@ end with type M2.t := int
 [%%expect {|
 module Id : functor (X : sig type t end) -> sig type t = X.t end
 Lines 2-5, characters 17-25:
-2 | ...... .... .. . sig
+2 |              ... sig
 3 |   module rec M : sig type t = A of Id(M2).t end
 4 |   and M2 : sig type t end
 5 | end with type M2.t := int
@@ -373,7 +373,7 @@ module type S = sig
 end with module M.N := A
 [%%expect {|
 Lines 1-10, characters 16-24:
- 1 | ...... .... . . sig
+ 1 |             ... sig
  2 |   module M : sig
  3 |     module N : sig
  4 |       module P : sig

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -48,7 +48,7 @@ module type S0 = sig
 end with type M.t = int
 [%%expect {|
 Lines 1-4, characters 17-23:
-1 | .................sig
+1 | ...... .... .. . sig
 2 |   module rec M : sig type t = M2.t end
 3 |   and M2 : sig type t = int end
 4 | end with type M.t = int
@@ -163,7 +163,7 @@ end with type 'a t2 := 'a t * bool
 [%%expect {|
 type 'a t constraint 'a = 'b list
 Lines 2-6, characters 16-34:
-2 | ................sig
+2 | ...... .... . . sig
 3 |   type 'a t2 constraint 'a = 'b list
 4 |   type 'a mylist = 'a list
 5 |   val x : int mylist t2
@@ -268,7 +268,7 @@ module type S = sig
 end with type M.t := float
 [%%expect {|
 Lines 1-4, characters 16-26:
-1 | ................sig
+1 | ...... .... . . sig
 2 |   module M : sig type t end
 3 |   module A = M
 4 | end with type M.t := float
@@ -330,7 +330,7 @@ end with type M2.t := int
 [%%expect {|
 module Id : functor (X : sig type t end) -> sig type t = X.t end
 Lines 2-5, characters 17-25:
-2 | .................sig
+2 | ...... .... .. . sig
 3 |   module rec M : sig type t = A of Id(M2).t end
 4 |   and M2 : sig type t end
 5 | end with type M2.t := int
@@ -373,7 +373,7 @@ module type S = sig
 end with module M.N := A
 [%%expect {|
 Lines 1-10, characters 16-24:
- 1 | ................sig
+ 1 | ...... .... . . sig
  2 |   module M : sig
  3 |     module N : sig
  4 |       module P : sig

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -112,9 +112,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = A of string [@@ocaml.unboxed]
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of string [@@unboxed] end
@@ -135,9 +135,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = A of string
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of string end
@@ -158,9 +158,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = { f : string } [@@ocaml.unboxed]
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f : string; } [@@unboxed] end
@@ -181,9 +181,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = { f : string }
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = { f : string; } end
@@ -204,9 +204,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = A of { f : string } [@@ocaml.unboxed]
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of { f : string; } [@@unboxed] end
@@ -227,9 +227,9 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   type t = A of { f : string }
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of { f : string; } end
@@ -293,10 +293,10 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ... . struct
+4 |   ... struct
 5 |   type t = A of float [@@ocaml.unboxed]
 6 |   type u = { f1 : t; f2 : t }
-7 | end..
+7 | end
 Error: Signature mismatch:
        Modules do not match:
          sig type t = A of float [@@unboxed] type u = { f1 : t; f2 : t; } end

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -112,7 +112,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = A of string [@@ocaml.unboxed]
 5 | end..
 Error: Signature mismatch:
@@ -135,7 +135,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = A of string
 5 | end..
 Error: Signature mismatch:
@@ -158,7 +158,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = { f : string } [@@ocaml.unboxed]
 5 | end..
 Error: Signature mismatch:
@@ -181,7 +181,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = { f : string }
 5 | end..
 Error: Signature mismatch:
@@ -204,7 +204,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = A of { f : string } [@@ocaml.unboxed]
 5 | end..
 Error: Signature mismatch:
@@ -227,7 +227,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   type t = A of { f : string }
 5 | end..
 Error: Signature mismatch:
@@ -293,7 +293,7 @@ end = struct
 end;;
 [%%expect{|
 Lines 4-7, characters 6-3:
-4 | ......struct
+4 | ... . struct
 5 |   type t = A of float [@@ocaml.unboxed]
 6 |   type u = { f1 : t; f2 : t }
 7 | end..

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -107,7 +107,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : int -> (int [@untagged]) = "f" "f_nat"
 5 | end..
 Error: Signature mismatch:
@@ -129,7 +129,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : (int [@untagged]) -> int = "f" "f_nat"
 5 | end..
 Error: Signature mismatch:
@@ -151,7 +151,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : float -> (float [@unboxed]) = "f" "f_nat"
 5 | end..
 Error: Signature mismatch:
@@ -173,7 +173,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : (float [@unboxed]) -> float = "f" "f_nat"
 5 | end..
 Error: Signature mismatch:
@@ -197,7 +197,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : int -> int = "f" "f_nat"
 5 | end..
 Error: Signature mismatch:
@@ -219,7 +219,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : int -> int = "a" "a_nat"
 5 | end..
 Error: Signature mismatch:
@@ -241,7 +241,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : float -> float = "f" "f_nat"
 5 | end..
 Error: Signature mismatch:
@@ -263,7 +263,7 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ......struct
+3 | ... . struct
 4 |   external f : float -> float = "a" "a_nat"
 5 | end..
 Error: Signature mismatch:

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -107,9 +107,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : int -> (int [@untagged]) = "f" "f_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> (int [@untagged]) = "f" "f_nat" end
@@ -129,9 +129,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : (int [@untagged]) -> int = "f" "f_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : (int [@untagged]) -> int = "f" "f_nat" end
@@ -151,9 +151,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : float -> (float [@unboxed]) = "f" "f_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> (float [@unboxed]) = "f" "f_nat" end
@@ -173,9 +173,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : (float [@unboxed]) -> float = "f" "f_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
@@ -197,9 +197,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : int -> int = "f" "f_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "f" "f_nat" end
@@ -219,9 +219,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : int -> int = "a" "a_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : int -> int = "a" "a_nat" end
@@ -241,9 +241,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : float -> float = "f" "f_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> float = "f" "f_nat" end
@@ -263,9 +263,9 @@ end;;
 
 [%%expect{|
 Lines 3-5, characters 6-3:
-3 | ... . struct
+3 |   ... struct
 4 |   external f : float -> float = "a" "a_nat"
-5 | end..
+5 | end
 Error: Signature mismatch:
        Modules do not match:
          sig external f : float -> float = "a" "a_nat" end

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -198,8 +198,8 @@ let ambiguous__first_orpat = function
 ;;
 [%%expect {|
 Lines 2-3, characters 4-58:
-2 |   . `A ((`B (Some x, _) | `B (_, Some x)),
-3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))) .... . . . .. ..
+2 | ... `A ((`B (Some x, _) | `B (_, Some x)),
+3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))) ...
 Warning 57: Ambiguous or-pattern variables under guard;
 variable x may match different arguments. (See manual section 9.5)
 val ambiguous__first_orpat :
@@ -216,8 +216,8 @@ let ambiguous__second_orpat = function
 ;;
 [%%expect {|
 Lines 2-3, characters 4-42:
-2 |   . `A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
-3 |         (`C (Some y, _) | `C (_, Some y))) .... . . . .. ..
+2 | ... `A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
+3 |         (`C (Some y, _) | `C (_, Some y))) ...
 Warning 57: Ambiguous or-pattern variables under guard;
 variable y may match different arguments. (See manual section 9.5)
 val ambiguous__second_orpat :
@@ -309,7 +309,7 @@ let ambiguous__amoi a = match a with
 ;;
 [%%expect {|
 Lines 2-3, characters 2-17:
-2 | . X (Z x,Y (y,0))
+2 |   X (Z x,Y (y,0))
 3 | | X (Z y,Y (x,_))
 Warning 57: Ambiguous or-pattern variables under guard;
 variables x,y may match different arguments. (See manual section 9.5)
@@ -329,8 +329,8 @@ let ambiguous__module_variable x b =  match x with
 ;;
 [%%expect {|
 Lines 2-3, characters 4-24:
-2 |   . (module M:S),_,(1,_)
-3 |   | _,(module M:S),(_,1) .... ... .. . .. .
+2 | ... (module M:S),_,(1,_)
+3 |   | _,(module M:S),(_,1) ...
 Warning 57: Ambiguous or-pattern variables under guard;
 variable M may match different arguments. (See manual section 9.5)
 val ambiguous__module_variable :
@@ -370,7 +370,7 @@ Line 2, characters 4-5:
 Warning 41: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
 Lines 1-3, characters 41-10:
-1 | ... ................................ . . function
+1 |                                      ... function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2
 Warning 4: this pattern-matching is fragile.

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -198,8 +198,8 @@ let ambiguous__first_orpat = function
 ;;
 [%%expect {|
 Lines 2-3, characters 4-58:
-2 | ....`A ((`B (Some x, _) | `B (_, Some x)),
-3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
+2 |   . `A ((`B (Some x, _) | `B (_, Some x)),
+3 |         (`C (Some y, Some _, _) | `C (Some y, _, Some _))) .... . . . .. ..
 Warning 57: Ambiguous or-pattern variables under guard;
 variable x may match different arguments. (See manual section 9.5)
 val ambiguous__first_orpat :
@@ -216,8 +216,8 @@ let ambiguous__second_orpat = function
 ;;
 [%%expect {|
 Lines 2-3, characters 4-42:
-2 | ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
-3 |         (`C (Some y, _) | `C (_, Some y))).................
+2 |   . `A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
+3 |         (`C (Some y, _) | `C (_, Some y))) .... . . . .. ..
 Warning 57: Ambiguous or-pattern variables under guard;
 variable y may match different arguments. (See manual section 9.5)
 val ambiguous__second_orpat :
@@ -309,7 +309,7 @@ let ambiguous__amoi a = match a with
 ;;
 [%%expect {|
 Lines 2-3, characters 2-17:
-2 | ..X (Z x,Y (y,0))
+2 | . X (Z x,Y (y,0))
 3 | | X (Z y,Y (x,_))
 Warning 57: Ambiguous or-pattern variables under guard;
 variables x,y may match different arguments. (See manual section 9.5)
@@ -329,8 +329,8 @@ let ambiguous__module_variable x b =  match x with
 ;;
 [%%expect {|
 Lines 2-3, characters 4-24:
-2 | ....(module M:S),_,(1,_)
-3 |   | _,(module M:S),(_,1)...................
+2 |   . (module M:S),_,(1,_)
+3 |   | _,(module M:S),(_,1) .... ... .. . .. .
 Warning 57: Ambiguous or-pattern variables under guard;
 variable M may match different arguments. (See manual section 9.5)
 val ambiguous__module_variable :
@@ -370,7 +370,7 @@ Line 2, characters 4-5:
 Warning 41: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
 Lines 1-3, characters 41-10:
-1 | .........................................function
+1 | ... ................................ . . function
 2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
 3 |   | _ -> 2
 Warning 4: this pattern-matching is fragile.

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -9,9 +9,9 @@ let f = function
   | Some _, Some _ -> 2;;
 [%%expect {|
 Lines 1-3, characters 8-23:
-1 | ... . . function
+1 |     ... function
 2 |     None, None -> 1
-3 |   | Some _, Some _ -> 2..
+3 |   | Some _, Some _ -> 2
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 ((Some _, None)|(None, Some _))
@@ -359,7 +359,7 @@ let f = function
 ;;
 [%%expect {|
 Lines 1-4, characters 8-28:
-1 | ... . . function
+1 |     ... function
 2 |   | None -> ()
 3 |   | Some x when x > 0 -> ()
 4 |   | Some x when x <= 0 -> ()

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -9,7 +9,7 @@ let f = function
   | Some _, Some _ -> 2;;
 [%%expect {|
 Lines 1-3, characters 8-23:
-1 | ........function
+1 | ... . . function
 2 |     None, None -> 1
 3 |   | Some _, Some _ -> 2..
 Warning 8: this pattern-matching is not exhaustive.
@@ -39,7 +39,7 @@ let f : type a b c d e f g.
 ;;
 [%%expect {|
 Lines 4-5, characters 1-38:
-4 | .function A, A, A, A, A, A, A, _, U, U -> 1
+4 |  function A, A, A, A, A, A, A, _, U, U -> 1
 5 |    | _, _, _, _, _, _, _, G, _, _ -> 1
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
@@ -359,7 +359,7 @@ let f = function
 ;;
 [%%expect {|
 Lines 1-4, characters 8-28:
-1 | ........function
+1 | ... . . function
 2 |   | None -> ()
 3 |   | Some x when x > 0 -> ()
 4 |   | Some x when x <= 0 -> ()

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -24,7 +24,7 @@ module B: sig val f: fpclass -> fpclass end =
     ;;
 [%%expect {|
 Lines 2-4, characters 2-5:
-2 | ..struct
+2 |   struct
 3 |     let f A = FP_normal
 4 |   end
 Error: Signature mismatch:

--- a/testsuite/tests/warnings/w04.compilers.reference
+++ b/testsuite/tests/warnings/w04.compilers.reference
@@ -1,5 +1,5 @@
 File "w04.ml", lines 21-23, characters 10-8:
-21 | ..........match x with
+21 | ... . . . match x with
 22 | | A -> 0
 23 | | _ -> 1
 Warning 4: this pattern-matching is fragile.

--- a/testsuite/tests/warnings/w04.compilers.reference
+++ b/testsuite/tests/warnings/w04.compilers.reference
@@ -1,5 +1,5 @@
 File "w04.ml", lines 21-23, characters 10-8:
-21 | ... . . . match x with
+21 |       ... match x with
 22 | | A -> 0
 23 | | _ -> 1
 Warning 4: this pattern-matching is fragile.

--- a/testsuite/tests/warnings/w04_failure.compilers.reference
+++ b/testsuite/tests/warnings/w04_failure.compilers.reference
@@ -1,19 +1,19 @@
 File "w04_failure.ml", lines 20-23, characters 2-17:
-20 | ..match r1, r2, t with
+20 |   match r1, r2, t with
 21 |   | AB, _, A -> ()
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type repr.
 File "w04_failure.ml", lines 20-23, characters 2-17:
-20 | ..match r1, r2, t with
+20 |   match r1, r2, t with
 21 |   | AB, _, A -> ()
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type ab.
 File "w04_failure.ml", lines 20-23, characters 2-17:
-20 | ..match r1, r2, t with
+20 |   match r1, r2, t with
 21 |   | AB, _, A -> ()
 22 |   | _, XY, X -> ()
 23 |   | _, _, _ -> ()


### PR DESCRIPTION
This PR fixes error messages with source highlight in batch mode in presence of tabulations, that is, messages of the form:

```
File ..., line ..., characters ...:
23 | <TAB><TAB>...error...
                  ^^^^^
```

Before the PR, the `^` characters are aligned using spaces. After the PR, the spikes (`^`) are aligned using tabs whenever a tab is used in the source code (and spaces otherwise). (I added a test in a first commit, then fixed the test in the next commit)

Note that this PR does not addresses situations where tabs are used in the middle of the error (how many spikes for each tab?) ~~or multi-line errors.~~ It's not so clear what to do in those cases, but fortunately I don't think they would come up too much in practice.

Fixes #9116 .