### PR TITLE
Fix bug in [caml_stat_resize_noexc] when the old block is NULL.

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Working version
 
 ### Runtime system:
 
+- #9119: Make [caml_stat_resize_noexc] compatible with the [realloc]
+  API when the old block is NULL.
+  (Jacques-Henri Jourdan, review by Xavier Leroy)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -883,6 +883,8 @@ CAMLexport void caml_stat_free(caml_stat_block b)
 /* [sz] is a number of bytes */
 CAMLexport caml_stat_block caml_stat_resize_noexc(caml_stat_block b, asize_t sz)
 {
+  if(b == NULL)
+    return caml_stat_alloc_noexc(sz);
   /* Backward compatibility mode */
   if (pool == NULL)
     return realloc(b, sz);


### PR DESCRIPTION
I uncovered this bug while working on #8920. It is not clear to me whether this bug can affect any code currently in the OCaml runtime, but this fix is cheap and improves the compatibility with libc's `realloc` function.