### PR TITLE
Fix GC ratio multiplier bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -509,6 +509,10 @@ OCaml 4.10.0
   and correct initialisation of some blocks allocated with caml_alloc_small.
   (David Allsopp, review by Xavier Leroy)
 
+- #9073, #9120: fix incorrect GC ratio multiplier when allocating custom blocks
+  with caml_alloc_custom_mem in runtime/custom.c
+  (Markus Mottl, review by Gabriel Scherer and Damien Doligez)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -90,6 +90,15 @@ CAMLexport value caml_alloc_custom_mem(struct custom_operations * ops,
   mlsize_t mem_minor =
     mem < caml_custom_minor_max_bsz ? mem : caml_custom_minor_max_bsz;
   mlsize_t max_major =
+    /* The major ratio is a percentage relative to the major heap size.
+       A complete GC cycle will be done every time 2/3 of that much memory
+       is allocated for blocks in the major heap.  Assuming constant
+       allocation and deallocation rates, this means there are at most
+       [M/100 * major-heap-size] bytes of floating garbage at any time.
+       The reason for a factor of 2/3 (or 1.5) is, roughly speaking, because
+       the major GC takes 1.5 cycles (previous cycle + marking phase) before
+       it starts to deallocate dead blocks allocated during the previous cycle.
+       [heap_size / 150] is really [heap_size * (2/3) / 100] (but faster). */
     Bsize_wsize (Caml_state->stat_heap_wsz) / 150 * caml_custom_major_ratio;
   mlsize_t max_minor =
     Bsize_wsize (Caml_state->minor_heap_wsz) / 100 * caml_custom_minor_ratio;

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -94,7 +94,7 @@ CAMLexport value caml_alloc_custom_mem(struct custom_operations * ops,
                            * caml_custom_major_ratio,
                            mem_minor,
                            Bsize_wsize (Caml_state->minor_heap_wsz) / 100
-                           * caml_custom_major_ratio);
+                           * caml_custom_minor_ratio);
 }
 
 struct custom_operations_list {

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -89,12 +89,11 @@ CAMLexport value caml_alloc_custom_mem(struct custom_operations * ops,
 {
   mlsize_t mem_minor =
     mem < caml_custom_minor_max_bsz ? mem : caml_custom_minor_max_bsz;
-  return alloc_custom_gen (ops, bsz, mem,
-                           Bsize_wsize (Caml_state->stat_heap_wsz) / 150
-                           * caml_custom_major_ratio,
-                           mem_minor,
-                           Bsize_wsize (Caml_state->minor_heap_wsz) / 100
-                           * caml_custom_minor_ratio);
+  mlsize_t max_major =
+    Bsize_wsize (Caml_state->stat_heap_wsz) / 150 * caml_custom_major_ratio;
+  mlsize_t max_minor =
+    Bsize_wsize (Caml_state->minor_heap_wsz) / 100 * caml_custom_minor_ratio;
+  return alloc_custom_gen (ops, bsz, mem, max_major, mem_minor, max_minor);
 }
 
 struct custom_operations_list {


### PR DESCRIPTION
This PR addresses the incorrect GC ratio multiplier as discussed in: https://github.com/ocaml/ocaml/issues/9073