### PR TITLE
Disallow function sections for arm32

### DIFF
--- a/configure
+++ b/configure
@@ -16685,8 +16685,9 @@ if test x"$enable_function_sections" = "xno"; then :
   function_sections=false
 else
   case $arch in #(
-  amd64|i386|arm|arm64) :
-    case $target in #(
+  amd64|i386|arm64) :
+    # not supported on arm32, see issue #9124.
+     case $target in #(
   *-cygwin*|*-mingw*|*-windows|*-apple-darwin*) :
     function_sections=false;
            { $as_echo "$as_me:${as_lineno-$LINENO}: No support for function sections on $target." >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1681,7 +1681,7 @@ AS_IF([test x"$enable_flat_float_array" = "xno"],
 AS_IF([test x"$enable_function_sections" = "xno"],
   [function_sections=false],
   [AS_CASE([$arch],
-    [amd64|i386|arm|arm64],
+    [amd64|i386|arm64], # not supported on arm32, see issue #9124.
      [AS_CASE([$target],
         [*-cygwin*|*-mingw*|*-windows|*-apple-darwin*],
           [function_sections=false;


### PR DESCRIPTION
Disallow function sections on arm32, as the simplest way to address issue #9124 and get the CI working on the newer versions of GNU binutils for Raspbian. After this change, `configure --enable-function-sections` is an error on arm32.  

When the issue with GNU ld is resolved, this can be added back with appropriate checks on version of binutils. In the meantime, I'll try to figure out what causes this.