### PR TITLE
Add padding before and after the atom table

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,13 @@ Working version
   (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez
    and Gabriel Scherer)
 
+- #9128: Fix a bug in bytecode mode which could lead to a segmentation
+  fault. The bug was caused by the fact that the atom table shared a
+  page with some bytecode. The fix makes sure both the atom table and
+  the minor heap have their own pages.
+  (Jacques-Henri Jourdan, review by Stephen Dolan, Xavier Leroy and
+   Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #8637, #8805: Record debug info for each allocation

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -20,8 +20,6 @@
 
 #include "misc.h"
 
-uintnat caml_normalize_heap_increment (uintnat);
-
 /*
   minor_size: cf. minor_heap_size in gc.mli
   major_size: Size in words of the initial major heap

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -354,7 +354,7 @@ CAMLextern int64_t caml_Int64_val(value v);
 
 /* 3- Atoms are 0-tuples.  They are statically allocated once and for all. */
 
-CAMLextern header_t caml_atom_table[];
+CAMLextern header_t *caml_atom_table;
 #define Atom(tag) (Val_hp (&(caml_atom_table [(tag)])))
 
 /* Booleans are integers 0 or 1 */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -388,8 +388,13 @@ static uintnat norm_pmax (uintnat p)
 
 static intnat norm_minsize (intnat s)
 {
+  intnat page_wsize = Wsize_bsize(Page_size);
   if (s < Minor_heap_min) s = Minor_heap_min;
   if (s > Minor_heap_max) s = Minor_heap_max;
+  /* PR#9128 : Make sure the minor heap occupies an integral number of
+     pages, so that no page contains both bytecode and OCaml
+     values. This would confuse, e.g., caml_hash. */
+  s = (s + page_wsize - 1) / page_wsize * page_wsize;
   return s;
 }
 
@@ -636,7 +641,7 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
                    uintnat custom_bsz)
 {
   uintnat major_bsize;
-  if(major_size < Heap_chunk_min) major_size = Heap_chunk_min;
+  if (major_size < Heap_chunk_min) major_size = Heap_chunk_min;
   major_bsize = Bsize_wsize(major_size);
   major_bsize = ((major_bsize + Page_size - 1) >> Page_log) << Page_log;
 

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -533,6 +533,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         Alloc_small(accu, num_args + 2, Closure_tag);
         Field(accu, 1) = env;
         for (i = 0; i < num_args; i++) Field(accu, i + 2) = sp[i];
+        CAMLassert(!Is_in_value_area(pc-3));
         Code_val(accu) = pc - 3; /* Point to the preceding RESTART instr. */
         sp += num_args;
         pc = (code_t)(sp[0]);
@@ -560,6 +561,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       }
       /* The code pointer is not in the heap, so no need to go through
          caml_initialize. */
+      CAMLassert(!Is_in_value_area(pc + *pc));
       Code_val(accu) = pc + *pc;
       pc++;
       sp += nvars;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -148,6 +148,7 @@ void caml_set_minor_heap_size (asize_t bsz)
 
   CAMLassert (bsz >= Bsize_wsize(Minor_heap_min));
   CAMLassert (bsz <= Bsize_wsize(Minor_heap_max));
+  CAMLassert (bsz % Page_size == 0);
   CAMLassert (bsz % sizeof (value) == 0);
   if (Caml_state->young_ptr != Caml_state->young_alloc_end){
     CAML_INSTR_INT ("force_minor/set_minor_heap_size@", 1);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -35,12 +35,30 @@
 extern void caml_win32_unregister_overflow_detection (void);
 #endif
 
-/* Initialize the atom table */
+CAMLexport header_t *caml_atom_table = NULL;
 
-CAMLexport header_t caml_atom_table[256];
+/* Initialize the atom table */
 void caml_init_atom_table(void)
 {
+  caml_stat_block b;
   int i;
+
+  /* PR#9128: We need to give the atom table its own page to make sure
+     it does not share a page with a non-value, which would break code
+     which depend on the correctness of the page table. For example,
+     if the atom table shares a page with bytecode, then functions in
+     the runtime may decide to follow a code pointer in a closure, as
+     if it were a pointer to a value.
+
+     We add 1 padding at the end of the atom table because the atom
+     pointer actually points to the word *following* the corresponding
+     entry in the table (the entry is an empty block *header*).
+  */
+  asize_t request = (256 + 1) * sizeof(header_t);
+  request = (request + Page_size - 1) / Page_size * Page_size;
+  caml_atom_table =
+    caml_stat_alloc_aligned_noexc(request, 0, &b);
+
   for(i = 0; i < 256; i++) {
 #ifdef NATIVE_CODE
     caml_atom_table[i] = Make_header_allocated_here(0, i, Caml_white);
@@ -49,7 +67,7 @@ void caml_init_atom_table(void)
 #endif
   }
   if (caml_page_table_add(In_static_data,
-                          caml_atom_table, caml_atom_table + 256) != 0) {
+                          caml_atom_table, caml_atom_table + 256 + 1) != 0) {
     caml_fatal_error("not enough memory for initial page table");
   }
 }

--- a/testsuite/tests/c-api/alloc_async_stubs.c
+++ b/testsuite/tests/c-api/alloc_async_stubs.c
@@ -12,9 +12,9 @@ value stub(value ref)
 
   printf("C, before: %d\n", Int_val(Field(ref, 0)));
 
-  /* First, do enough major allocation to trigger a major collection */
+  /* First, do enough major allocations to do a full major collection cycle */
   coll_before = Caml_state_field(stat_major_collections);
-  while (Caml_state_field(stat_major_collections) == coll_before) {
+  while (Caml_state_field(stat_major_collections) <= coll_before+1) {
     caml_alloc(10000, 0);
   }
 


### PR DESCRIPTION
We need to make sure it does not share a page with code, otherwise the GC and the polymorphic hash and comparison functions will follow code pointers and potentially trigger a segfault.

This seems to be the cause of the segfaults that we observed recently on Alpine Linux. It seems like the linker and musl conspired by putting some bytecode next to the atom table. Then, the polymorphic hash function decided to follow the code pointer of a closure, which did not point to any valid block, finally triggering the segfault.

Even though this PR fixes the issue of Alpine, I am still slightly concerned by a similar issue : in native mode, static data is not surrounded by similar padding, so that, in theory, the OS could decide to map the static data in the same page as some code. I know most OSes would typically use different pages for code and data in order to give the different permissions, but there is no guarantee here. Also, when not in the no-naked-pointers mode, it is possible that the heap contains a pointer to some non-heap data in a page registered as a value page.

So, there is a possible extension to this fix: add padding before and after any static data segment in native mode. Of course, this means we increase by 8kB the size of the binary generated for any OCaml compilation unit...