### PR TITLE
Fix BFD support on OpenBSD

### DIFF
--- a/Changes
+++ b/Changes
@@ -436,7 +436,7 @@ OCaml 4.10.0
 - #8843, #8841: fix use of off_t on 32-bit systems.
   (Stephen Dolan, report by Richard Jones, review by Xavier Leroy)
 
-- #8947: fix/improve support for the BFD library
+- #8947, #9134: fix/improve support for the BFD library
   (Sébastien Hinderer, review by Damien Doligez)
 
 - #8951: let make's default target build the compiler

--- a/configure
+++ b/configure
@@ -15990,6 +15990,13 @@ fi
       if test -z "$BFD_LIB_DIR"; then :
   BFD_LIB_DIR="/opt/local/lib"
 fi ;; #(
+  *-*openbsd*) :
+    if test -z "$BFD_INCLUDE_DIR"; then :
+  BFD_INCLUDE_DIR="/usr/local/include"
+fi
+      if test -z "$BFD_LIB_DIR"; then :
+  BFD_LIB_DIR="/usr/local/lib"
+fi ;; #(
   *) :
      ;;
 esac
@@ -16047,13 +16054,14 @@ if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
 fi
 
     if test -z "$bfd_ldlibs"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
+  unset ac_cv_lib_bfd_bfd_openr
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
 $as_echo_n "checking for bfd_openr in -lbfd... " >&6; }
 if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl $LIBS"
+LIBS="-lbfd -liberty $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16084,18 +16092,19 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl"
+  bfd_ldlibs="-lbfd -liberty"
 fi
 
 fi
     if test -z "$bfd_ldlibs"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
+  unset ac_cv_lib_bfd_bfd_openr
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
 $as_echo_n "checking for bfd_openr in -lbfd... " >&6; }
 if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl -liberty $LIBS"
+LIBS="-lbfd -liberty -lz $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16126,18 +16135,19 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl -liberty"
+  bfd_ldlibs="-lbfd -liberty -lz"
 fi
 
 fi
     if test -z "$bfd_ldlibs"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
+  unset ac_cv_lib_bfd_bfd_openr
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
 $as_echo_n "checking for bfd_openr in -lbfd... " >&6; }
 if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl -liberty -lz $LIBS"
+LIBS="-lbfd -liberty -lz -lintl $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16168,49 +16178,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl -liberty -lz"
-fi
-
-fi
-    if test -z "$bfd_ldlibs"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for bfd_openr in -lbfd" >&5
-$as_echo_n "checking for bfd_openr in -lbfd... " >&6; }
-if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl -liberty -lz -lintl $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char bfd_openr ();
-int
-main ()
-{
-return bfd_openr ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_bfd_bfd_openr=yes
-else
-  ac_cv_lib_bfd_bfd_openr=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
-$as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
-if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl -liberty -lz -lintl"
+  bfd_ldlibs="-lbfd -liberty -lz -lintl"
 fi
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1492,7 +1492,12 @@ AS_IF([test x"$with_bfd" != "xno"],
       [AS_IF([test -z "$BFD_INCLUDE_DIR"],
         [BFD_INCLUDE_DIR="/opt/local/include"])
       AS_IF([test -z "$BFD_LIB_DIR"],
-        [BFD_LIB_DIR="/opt/local/lib"])])
+        [BFD_LIB_DIR="/opt/local/lib"])],
+    [*-*openbsd*],
+      [AS_IF([test -z "$BFD_INCLUDE_DIR"],
+        [BFD_INCLUDE_DIR="/usr/local/include"])
+      AS_IF([test -z "$BFD_LIB_DIR"],
+        [BFD_LIB_DIR="/usr/local/lib"])])
   AS_IF([test -n "$BFD_INCLUDE_DIR"],
     [bfd_cppflags="-I$BFD_INCLUDE_DIR"])
   AS_IF([test -n "$BFD_LIB_DIR"],
@@ -1505,17 +1510,18 @@ AS_IF([test x"$with_bfd" != "xno"],
     [bfd_ldlibs=""
     AC_CHECK_LIB([bfd], [bfd_openr], [bfd_ldlibs="-lbfd"])
     AS_IF([test -z "$bfd_ldlibs"],
-      [AC_CHECK_LIB([bfd], [bfd_openr], [bfd_ldlibs="-lbfd -ldl"], [], [-ldl])])
+      [unset ac_cv_lib_bfd_bfd_openr
+      AC_CHECK_LIB([bfd], [bfd_openr],
+        [bfd_ldlibs="-lbfd -liberty"], [], [-liberty])])
     AS_IF([test -z "$bfd_ldlibs"],
-      [AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl -liberty"], [], [-ldl -liberty])])
+      [unset ac_cv_lib_bfd_bfd_openr
+      AC_CHECK_LIB([bfd], [bfd_openr],
+        [bfd_ldlibs="-lbfd -liberty -lz"], [], [-liberty -lz])])
     AS_IF([test -z "$bfd_ldlibs"],
-      [AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl -liberty -lz"], [], [-ldl -liberty -lz])])
-    AS_IF([test -z "$bfd_ldlibs"],
-      [AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl -liberty -lz -lintl"], [],
-        [-ldl -liberty -lz -lintl])])
+      [unset ac_cv_lib_bfd_bfd_openr
+      AC_CHECK_LIB([bfd], [bfd_openr],
+        [bfd_ldlibs="-lbfd -liberty -lz -lintl"], [],
+        [-liberty -lz -lintl])])
     AS_IF([test -n "$bfd_ldlibs"],
       [bfd_available=true
       AC_DEFINE([HAS_LIBBFD])])])

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -112,6 +112,8 @@ case $NODE_NAME in
   ocaml-ppc-64)
     CCOMP="CC='gcc -m64'"
     OCAML_CONFIGURE_OPTIONS=;;
+  ocaml-openbsd-64)
+    OCAML_CONFIGURE_OPTIONS='--with-bfd'
 esac
 
 #########################################################################


### PR DESCRIPTION
This is a follow-up to both #8947 and #8749.

The code proposed in #8749 does not work on the OpenBSD machine where I
tried it, because `bfd.h` is installed in `/usr/local/include` rather
than `/usr/include` and also because `-ldl` is in the way (the
library is not found, making all the tests fail, and it is anyway not
necessary).

So this PR fixes all this and makes sure the BFD support gets tested
on Inria's continuous integration infrastructure.

It would be nice to have this in 4.10, @Octachron