### PR TITLE
Ensure Makefile.config gets Windows-style prefix

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,6 +71,10 @@ Working version
 
 ### Build system:
 
+- #9136: Don't propagate Cygwin-style prefix from configure to Makefile.config
+  on Windows ports.
+  (David Allsopp, review by Sébastien Hinderer)
+
 ### Bug fixes:
 
 - #7683, #1499: Fixes one case where the evaluation order in native-code

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -202,9 +202,7 @@ for 32-bit, or:
 
         ./configure --build=x86_64-unknown-cygwin --host=x86_64-pc-windows
 
-for 64-bit. Then, edit `Makefile.config` as needed, following the comments in
-this file. Normally, the only variable that needs to be changed is `PREFIX`,
-which indicates where to install everything.
+for 64-bit.
 
 Finally, use `make` to build the system, e.g.
 
@@ -269,9 +267,7 @@ for 32-bit, or:
 
         ./configure --build=x86_64-unknown-cygwin --host=x86_64-w64-mingw32
 
-for 64-bit. Then, edit `Makefile.config` as needed, following the comments in
-this file. Normally, the only variable that needs to be changed is `PREFIX`,
-which indicates where to install everything.
+for 64-bit.
 
 Finally, use `make` to build the system, e.g.
 

--- a/configure
+++ b/configure
@@ -16832,6 +16832,16 @@ if test x"$prefix" = "xNONE"; then :
   *) :
      ;;
 esac
+else
+  if test x"$unix_or_win32" = "xwin32" \
+          && test "$host_vendor-$host_os" != "$build_vendor-$build_os" ; then :
+  case $build in #(
+  *-pc-cygwin) :
+    prefix=`cygpath -m "$prefix"` ;; #(
+  *) :
+     ;;
+esac
+fi
 fi
 
 # Define a few macros that were defined in config/m-nt.h

--- a/configure.ac
+++ b/configure.ac
@@ -1781,7 +1781,11 @@ AS_IF([test x"$prefix" = "xNONE"],
     [i686-w64-mingw32], [prefix='C:/ocamlmgw'],
     [x86_64-w64-mingw32], [prefix='C:/ocamlmgw64'],
     [i686-pc-windows], [prefix='C:/ocamlms'],
-    [x86_64-pc-windows], [prefix='C:/ocamlms64'])])
+    [x86_64-pc-windows], [prefix='C:/ocamlms64'])],
+  [AS_IF([test x"$unix_or_win32" = "xwin32" \
+          && test "$host_vendor-$host_os" != "$build_vendor-$build_os" ],
+    [AS_CASE([$build],
+      [*-pc-cygwin], [prefix=`cygpath -m "$prefix"`])])])
 
 # Define a few macros that were defined in config/m-nt.h
 # but whose value is not guessed properly by configure


### PR DESCRIPTION
It should be possible to configure the mingw and msvc ports using a Cygwin-style path (because it's configured in Cygwin) and get a working compiler. This patch ensures `prefix` is converted to a "mixed" PATH (`C:/...`) and allows incantations like `./configure --prefix ~/local --build=i686-pc-cygwin --host=x86_64-w64-mingw32`) to work as expected.

Hit "in the wild", where it was annoying to have to rebuild the entire compiler...