### PR TITLE
Relicense the user's manual under CC BY-SA

### DIFF
--- a/manual/LICENSE-for-the-manual
+++ b/manual/LICENSE-for-the-manual
@@ -1,20 +1,36 @@
-The present documentation is copyright Institut National de Recherche
-en Informatique et en Automatique (INRIA).
+The OCaml documentation and user's manual is copyright
+Institut National de Recherche en Informatique et en Automatique (INRIA).
 
-The OCaml documentation and user's manual may be reproduced and
-distributed in whole or in part, subject to the following conditions:
+The OCaml documentation and user's manual is licensed under a Creative
+Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0)
+https://creativecommons.org/licenses/by-sa/4.0/
 
-- The copyright notice above and this permission notice must be
-  preserved complete on all complete or partial copies.
+This is a human-readable summary of (and not a substitute for) the
+license, which is available at
+https://creativecommons.org/licenses/by-sa/4.0/legalcode
 
-- Any translation or derivative work of the OCaml documentation and
-  user's manual must be approved by the authors in writing before
-  distribution.
+You are free to:
 
-- If you distribute the OCaml documentation and user's manual in part,
-  instructions for obtaining the complete version of this manual must
-  be included, and a means for obtaining a complete version provided.
+Share - copy and redistribute the material in any medium or format
 
-- Small portions may be reproduced as illustrations for reviews or
-  quotes in other works without this permission notice if proper
-  citation is given.
+Adapt - remix, transform, and build upon the material
+        for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the
+license terms.
+
+Under the following terms:
+
+Attribution - You must give appropriate credit, provide a link to
+    the license, and indicate if changes were made. You may do so in
+    any reasonable manner, but not in any way that suggests the
+    licensor endorses you or your use.
+
+ShareAlike - If you remix, transform, or build upon the material,
+    you must distribute your contributions under the same license as
+    the original.
+
+No additional restrictions - You may not apply legal terms or
+    technological measures that legally restrict others from doing
+    anything the license permits.
+

--- a/manual/manual/foreword.etex
+++ b/manual/manual/foreword.etex
@@ -58,7 +58,7 @@ Commons Attribution-ShareAlike 4.0 International License (CC BY-SA
 
 \begin{htmlonly}
 \begin{rawhtml}
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"></a>
+<a id="cc_license_logo" rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"></a>
 The OCaml documentation and user's manual is licensed under a
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
 \end{rawhtml}

--- a/manual/manual/foreword.etex
+++ b/manual/manual/foreword.etex
@@ -45,25 +45,24 @@ The OCaml system is open source and can be freely
 redistributed.  See the file "LICENSE" in the distribution for
 licensing information.
 
-The present documentation is copyright \copyright\ \number\year\
+The OCaml documentation and user's manual is
+copyright \copyright\ \number\year\
 Institut National de Recherche en Informatique et en
-Automatique (INRIA).  The OCaml documentation and user's
-manual may be reproduced and distributed in whole or
-in part, subject to the following conditions:
-\begin{itemize}
-\item The copyright notice above and this permission notice must be
-preserved complete on all complete or partial copies.
-\item Any translation or derivative work of the OCaml
-documentation and user's manual must be approved by the authors in
-writing before distribution.
-\item If you distribute the OCaml
-documentation and user's manual in part, instructions for obtaining
-the complete version of this manual must be included, and a
-means for obtaining a complete version provided.
-\item Small portions may be reproduced as illustrations for reviews or
-quotes in other works without this permission notice if proper
-citation is given.
-\end{itemize}
+Automatique (INRIA).
+
+\begin{latexonly}
+The OCaml documentation and user's manual is licensed under a Creative
+Commons Attribution-ShareAlike 4.0 International License (CC BY-SA
+4.0), \url{https://creativecommons.org/licenses/by-sa/4.0/}.
+\end{latexonly}
+
+\begin{htmlonly}
+\begin{rawhtml}
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"></a>
+The OCaml documentation and user's manual is licensed under a
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+\end{rawhtml}
+\end{htmlonly}
 
 \section*{Availability}
 

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -52,6 +52,12 @@
   white-space: pre-wrap;
 }
 
+% Creative commons license logo
+\newstyle{\#cc_license_logo}{
+  float:left;
+  margin-right: 1em;
+}
+
 % More spacing between lines and inside tables
 \newstyle{p,ul}{line-height:1.3em}
 \newstyle{.cellpadding1 tr td}{padding:1px 4px}

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -184,7 +184,7 @@
 
 \newcommand{\vfill}{}
 \def\number{}
-\def\year{2013}
+\def\year{\arabic{year}}
 
 % Pour alltt
 \def\rminalltt#1{{\rm #1}}


### PR DESCRIPTION
As discussed at the 2019-11-13 developers' meeting and agreed between the authors of the manual (@xavierleroy, @damiendoligez, @alainfrisch, @garrigue, @diremy, @vouillon), the first commit changes the license of the manual to be [CC BY-SA 4.0 ](https://creativecommons.org/licenses/by-sa/4.0/).

The second commit makes sure that the macro used to put the current year in copyright statements, namely `\number\year`, is correct and up to date in the HTML version of the manual.
