### PR TITLE
Fix caml_young_* macros in compatibility.h

### DIFF
--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -23,11 +23,11 @@
 #define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
 
 /* global variables moved to Caml_state in 4.10.0 */
-#define caml_young_start (Caml_state->young_start)
-#define caml_young_end (Caml_state->young_end)
-#define caml_young_ptr (Caml_state->young_ptr)
-#define caml_young_limit (Caml_state->young_limit)
-#define caml_local_roots (Caml_state->local_roots)
+#define caml_young_start (Caml_state->_young_start)
+#define caml_young_end (Caml_state->_young_end)
+#define caml_young_ptr (Caml_state->_young_ptr)
+#define caml_young_limit (Caml_state->_young_limit)
+#define caml_local_roots (Caml_state->_local_roots)
 
 #ifndef CAML_NAME_SPACE
 

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -23,11 +23,11 @@
 #define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
 
 /* global variables moved to Caml_state in 4.10.0 */
-#define caml_young_start (Caml_state->_young_start)
-#define caml_young_end (Caml_state->_young_end)
-#define caml_young_ptr (Caml_state->_young_ptr)
-#define caml_young_limit (Caml_state->_young_limit)
-#define caml_local_roots (Caml_state->_local_roots)
+#define caml_young_start (Caml_state_field(young_start))
+#define caml_young_end (Caml_state_field(young_end))
+#define caml_young_ptr (Caml_state_field(young_ptr))
+#define caml_young_limit (Caml_state_field(young_limit))
+#define caml_local_roots (Caml_state_field(local_roots))
 
 #ifndef CAML_NAME_SPACE
 

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -242,10 +242,10 @@
 /* **** meta.c */
 
 /* **** minor_gc.c */
-#define young_start (Caml_state->_young_start)
-#define young_end (Caml_state->_young_end)
-#define young_ptr (Caml_state->_young_ptr)
-#define young_limit (Caml_state->_young_limit)
+#define young_start caml_young_start
+#define young_end caml_young_end
+#define young_ptr caml_young_ptr
+#define young_limit caml_young_limit
 #define ref_table caml_ref_table
 #define minor_collection caml_minor_collection
 #define check_urgent_gc caml_check_urgent_gc
@@ -262,7 +262,7 @@
 #define format_caml_exception caml_format_exception /*SP*/
 
 /* **** roots.c */
-#define local_roots (Caml_state->_local_roots)
+#define local_roots caml_local_roots
 #define scan_roots_hook caml_scan_roots_hook
 #define do_local_roots caml_do_local_roots
 


### PR DESCRIPTION
The `caml_young_*` macros at the beginning of compatibility.h access `Caml_state` using internal field names, which are then redefined to mean the above macros, resulting in [errors](https://github.com/garrigue/lablgtk/issues/92) in lablgtk.

This is fixed by accessing it using external field names.