### PR TITLE
Shifts can ignore high order bits when untagging

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -2201,16 +2201,16 @@ let xor_int_caml arg1 arg2 dbg =
             Cconst_int (1, dbg)], dbg)
 
 let lsl_int_caml arg1 arg2 dbg =
-  incr_int(lsl_int (decr_int arg1 dbg)
-             (untag_int arg2 dbg) dbg) dbg
+  let k = ignore_high_bit_int (untag_int arg2 dbg) in
+  incr_int(lsl_int (decr_int arg1 dbg) k dbg) dbg
 
 let lsr_int_caml arg1 arg2 dbg =
-  Cop(Cor, [lsr_int arg1 (untag_int arg2 dbg) dbg;
-            Cconst_int (1, dbg)], dbg)
+  let k = ignore_high_bit_int (untag_int arg2 dbg) in
+  Cop(Cor, [lsr_int arg1 k dbg; Cconst_int (1, dbg)], dbg)
 
 let asr_int_caml arg1 arg2 dbg =
-  Cop(Cor, [asr_int arg1 (untag_int arg2 dbg) dbg;
-            Cconst_int (1, dbg)], dbg)
+  let k = ignore_high_bit_int (untag_int arg2 dbg) in
+  Cop(Cor, [asr_int arg1 k dbg; Cconst_int (1, dbg)], dbg)
 
 let int_comp_caml cmp arg1 arg2 dbg =
   tag_int(Cop(Ccmpi cmp,

--- a/testsuite/tests/basic/ignore_high_bit_int.ml
+++ b/testsuite/tests/basic/ignore_high_bit_int.ml
@@ -1,0 +1,15 @@
+(* TEST *)
+
+(* Test the semantics of untagging and particularly what happens to
+   the high bit during tagging/untagging. *)
+
+let opaque_shift_by_int64 x n =
+  x lsl Int64.(to_int (Sys.opaque_identity n))
+
+let test_shift () =
+  assert (42 = opaque_shift_by_int64 42 Int64.min_int);
+  ()
+
+let _ =
+  test_shift ()
+


### PR DESCRIPTION
Since the behaviour of shifts is undefined when the second argument is negative or `> Sys.int_size`, it should be safe to ignore the high bit of that second argument when untagging it before using if for a shift.
cc @stedolan 

Does this change deserve a line in the changelog ?