### PR TITLE
Fix some spelling typos

### DIFF
--- a/manual/manual/cmds/debugger.etex
+++ b/manual/manual/cmds/debugger.etex
@@ -315,7 +315,7 @@ Set a breakpoint at code address \var{frag}":"\var{pc}.  The integer
 \var{frag} is the identifier of a code fragment, a set of modules that
 have been loaded at once, either initially or with the "Dynlink"
 module. The integer \var{pc} is the instruction counter within this
-code fragment.  If \var{frag} is ommited, it defaults to 0, which is
+code fragment.  If \var{frag} is omitted, it defaults to 0, which is
 the code fragment of the program loaded initially.
 
 \item["delete "\optvar{breakpoint-numbers}]

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -235,7 +235,7 @@ val system : string -> process_status
    its termination status. The string is interpreted by the shell
    [/bin/sh] (or the command interpreter [cmd.exe] on Windows) and
    therefore can contain redirections, quotes, variables, etc.
-   To properly quote whitespace and shell special characters occuring
+   To properly quote whitespace and shell special characters occurring
    in file names or command arguments, the use of
    {!Filename.quote_command} is recommended.
    The result [WEXITED 127] indicates that the shell couldn't be

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -1083,7 +1083,7 @@ static large_free_block **bf_search (mlsize_t wosz)
   return p;
 }
 
-/* Search for the least node that is large enough to accomodate the given
+/* Search for the least node that is large enough to accommodate the given
    size. Return in [next_lower] an upper bound on either the size of the
    next-lower node in the tree, or BF_NUM_SMALL if there is no such node.
 */

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -77,7 +77,7 @@ external command : string -> int = "caml_sys_system_command"
   such as file redirections [>] and [<], which will be honored by the
   shell.
 
-  Conversely, whitespace or special shell characters occuring in
+  Conversely, whitespace or special shell characters occurring in
   command names or in their arguments must be quoted or escaped
   so that the shell does not interpret them.  The quoting rules vary
   between the POSIX shell and the Windows shell.


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.