### PR TITLE
Remove mentions of CAMLprim from the manual

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -86,7 +86,7 @@ functions and macros are described in detail below.  For instance,
 here is the declaration for the C function implementing the "input"
 primitive:
 \begin{verbatim}
-CAMLprim value input(value channel, value buffer, value offset, value length)
+value input(value channel, value buffer, value offset, value length)
 {
   ...
 }
@@ -106,13 +106,13 @@ to be used in conjunction with the native-code compiler "ocamlopt",
 takes its arguments directly. For instance, here are the two C
 functions for the 7-argument primitive "Nat.add_nat":
 \begin{verbatim}
-CAMLprim value add_nat_native(value nat1, value ofs1, value len1,
-                              value nat2, value ofs2, value len2,
-                              value carry_in)
+value add_nat_native(value nat1, value ofs1, value len1,
+                     value nat2, value ofs2, value len2,
+                     value carry_in)
 {
   ...
 }
-CAMLprim value add_nat_bytecode(value * argv, int argn)
+value add_nat_bytecode(value * argv, int argn)
 {
   return add_nat_native(argv[0], argv[1], argv[2], argv[3],
                         argv[4], argv[5], argv[6]);
@@ -144,7 +144,7 @@ call the first function, and convert the returned C value to OCaml
 value. For instance, here is the stub code for the "input"
 primitive:
 \begin{verbatim}
-CAMLprim value input(value channel, value buffer, value offset, value length)
+value input(value channel, value buffer, value offset, value length)
 {
   return Val_long(getblock((struct channel *) channel,
                            &Byte(buffer, Long_val(offset)),
@@ -152,9 +152,7 @@ CAMLprim value input(value channel, value buffer, value offset, value length)
 }
 \end{verbatim}
 (Here, "Val_long", "Long_val" and so on are conversion macros for the
-type "value", that will be described later.  The "CAMLprim" macro
-expands to the required compiler directives to ensure that the
-function is exported and accessible from OCaml.)
+type "value", that will be described later.)
 The hard work is performed by the function "getblock", which is
 declared as:
 \begin{verbatim}
@@ -1456,7 +1454,7 @@ example, if the OCaml code contains the declaration
 \end{verbatim}
 the corresponding C stub can be written as follows:
 \begin{verbatim}
-    CAMLprim value caml_apply(value vf, value vx)
+    value caml_apply(value vf, value vx)
     {
       CAMLparam2(vf, vx);
       CAMLlocal1(vy);
@@ -2236,12 +2234,12 @@ external foo
 In this case the C functions must look like:
 
 \begin{verbatim}
-CAMLprim double foo(double a, double b)
+double foo(double a, double b)
 {
   ...
 }
 
-CAMLprim value foo_byte(value a, value b)
+value foo_byte(value a, value b)
 {
   return caml_copy_double(foo(Double_val(a), Double_val(b)))
 }
@@ -2399,7 +2397,7 @@ IP address of a host name.  The "gethostbyname" function can block for
 a long time, so we choose to release the OCaml run-time system while it
 is running.
 \begin{verbatim}
-CAMLprim stub_gethostbyname(value vname)
+value stub_gethostbyname(value vname)
 {
   CAMLparam1 (vname);
   CAMLlocal1 (vres);
@@ -2576,7 +2574,7 @@ The rest of the binding is the same for both platforms:
 #include <caml/osdeps.h>
 #include <stdlib.h>
 
-CAMLprim value stub_getenv(value var_name)
+value stub_getenv(value var_name)
 {
   CAMLparam1(var_name);
   CAMLlocal1(var_value);


### PR DESCRIPTION
This macro is not necessary for user code anymore and it can be confusing to mention it in the manual.