### PR TITLE
Fix exhaustivity of GADTs coming from incomplete unification

### DIFF
--- a/Changes
+++ b/Changes
@@ -534,7 +534,7 @@ OCaml 4.10.0
 - #8981: Fix check for incompatible -c and -o options.
   (Greta Yorsh, review by Damien Doligez)
 
-- #9019, #9153: Unsound exhaustivity of GADTs from incomplete unification
+- #9019, #9154: Unsound exhaustivity of GADTs from incomplete unification
   Also fixes bug found by Thomas Refis in #9012
   (Jacques Garrigue, report and review by Leo White, Thomas Refis)
 

--- a/Changes
+++ b/Changes
@@ -534,6 +534,10 @@ OCaml 4.10.0
 - #8981: Fix check for incompatible -c and -o options.
   (Greta Yorsh, review by Damien Doligez)
 
+- #9019, #9153: Unsound exhaustivity of GADTs from incomplete unification
+  Also fixes bug found by Thomas Refis in #9012
+  (Jacques Garrigue, report and review by Leo White, Thomas Refis)
+
 - #9031: Unregister Windows stack overflow handler while shutting
   the runtime down.
   (Dmitry Bely, review by David Allsopp)

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -7,6 +7,15 @@ File "robustmatch.ml", lines 33-37, characters 6-23:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (AB, MAB, A)
+File "robustmatch.ml", lines 43-47, characters 4-21:
+43 | ....match t1, t2, x with
+44 |     | AB,  AB, A -> ()
+45 |     | MAB, _, A -> ()
+46 |     | _,  AB, B -> ()
+47 |     | _, MAB, B -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(AB, MAB, A)
 File "robustmatch.ml", lines 54-56, characters 4-27:
 54 | ....match r1, r2, a with
 55 |     | R1, _, 0 -> ()

--- a/testsuite/tests/typing-gadts/pr9019.ml
+++ b/testsuite/tests/typing-gadts/pr9019.ml
@@ -1,0 +1,236 @@
+(* TEST
+   * expect
+*)
+
+(* #9012 by Thomas Refix *)
+
+type ab = A | B
+
+module M : sig
+  type mab = A | B
+  type _ t = AB : ab t | MAB : mab t
+  val ab : mab t
+end = struct
+  type mab = ab = A | B
+  type _ t = AB : ab t | MAB : mab t
+  let ab = AB
+end
+[%%expect{|
+type ab = A | B
+module M :
+  sig type mab = A | B type _ t = AB : ab t | MAB : mab t val ab : mab t end
+|}]
+
+open M
+
+let f (type x) (t1 : x t) (t2 : x t) (x : x) =
+  match t1, t2, x with
+  | AB,  AB, A -> 1
+  | MAB, _, A -> 2
+  | _,  AB, B -> 3
+  | _, MAB, B -> 4
+[%%expect{|
+Lines 4-8, characters 2-18:
+4 | ..match t1, t2, x with
+5 |   | AB,  AB, A -> 1
+6 |   | MAB, _, A -> 2
+7 |   | _,  AB, B -> 3
+8 |   | _, MAB, B -> 4
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(AB, MAB, A)
+val f : 'x M.t -> 'x M.t -> 'x -> int = <fun>
+|}]
+
+let () = ignore (f M.ab MAB A)
+[%%expect{|
+Exception: Match_failure ("", 4, 2).
+|}]
+
+(* variant *)
+
+type _ ab = A | B
+
+module M : sig
+  type _ mab
+  type _ t = AB : unit ab t | MAB : unit mab t
+  val ab : unit mab t
+  val a : 'a mab
+  val b : 'a mab
+end = struct
+  type 'a mab = 'a ab = A | B
+  type _ t = AB : unit ab t | MAB : unit mab t
+  let ab = AB
+  let a = A
+  let b = B
+end;;
+[%%expect{|
+type _ ab = A | B
+module M :
+  sig
+    type _ mab
+    type _ t = AB : unit ab t | MAB : unit mab t
+    val ab : unit mab t
+    val a : 'a mab
+    val b : 'a mab
+  end
+|}]
+
+open M
+
+(* The second clause isn't redundant *)
+let f (type x) (t1 : x t) (t2 : x t) (x : x) =
+  match t1, t2, x with
+  | AB,  AB, A -> 1
+  | _, AB, A -> 2
+  | _, AB, B -> 3
+  | _, MAB, _ -> 4;;
+[%%expect{|
+val f : 'x M.t -> 'x M.t -> 'x -> int = <fun>
+|}]
+
+(* the answer shouldn't be 3 *)
+let x = f MAB M.ab M.a;;
+[%%expect{|
+val x : int = 2
+|}]
+
+(* using records *)
+
+type ab = { a : int }
+
+module M : sig
+  type mab = { a : int }
+
+  type _ t = AB : ab t | MAB : mab t
+
+  val a : mab
+  val ab : mab t
+end = struct
+  type mab = ab = { a : int }
+
+  type _ t = AB : ab t | MAB : mab t
+
+  let a = { a = 42 }
+  let ab = AB
+end;;
+[%%expect{|
+type ab = { a : int; }
+module M :
+  sig
+    type mab = { a : int; }
+    type _ t = AB : ab t | MAB : mab t
+    val a : mab
+    val ab : mab t
+  end
+|}]
+
+open M
+
+let f (type x) (t1 : x t) (t2 : x t) (x : x) =
+  match t1, t2, x with
+  | AB,  AB, { a = _ } -> 1
+  | MAB, _,  { a = _ } -> 2
+  | _,  AB,  { a = _ } -> 3
+  | _, MAB,  { a = _ } -> 4;;
+[%%expect{|
+Line 7, characters 4-22:
+7 |   | _,  AB,  { a = _ } -> 3
+        ^^^^^^^^^^^^^^^^^^
+Warning 11: this match case is unused.
+val f : 'x M.t -> 'x M.t -> 'x -> int = <fun>
+|}]
+
+let p = f M.ab MAB { a = 42 };;
+[%%expect{|
+val p : int = 4
+|}]
+
+
+(* #9019 by Leo White *)
+
+type _ a_or_b =
+  A_or_B : [< `A of string | `B of int] a_or_b
+
+type _ a =
+  | A : [> `A of string] a
+  | Not_A : _ a
+
+let f (type x) (a : x a) (a_or_b : x a_or_b) (x : x) =
+  match a, a_or_b, x with
+  | Not_A, A_or_B, `B i -> print_int i
+  | _, A_or_B, `A s -> print_string s
+[%%expect{|
+type _ a_or_b = A_or_B : [< `A of string | `B of int ] a_or_b
+type _ a = A : [> `A of string ] a | Not_A : 'a a
+Lines 9-11, characters 2-37:
+ 9 | ..match a, a_or_b, x with
+10 |   | Not_A, A_or_B, `B i -> print_int i
+11 |   | _, A_or_B, `A s -> print_string s
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(A, A_or_B, `B _)
+val f : 'x a -> 'x a_or_b -> 'x -> unit = <fun>
+|}]
+
+let segfault = f A A_or_B (`B 0)
+[%%expect{|
+Exception: Match_failure ("", 9, 2).
+|}]
+
+
+(* Another example *)
+type (_, _) b =
+  | A : ([< `A ], 'a) b
+  | B : ([< `B of 'a], 'a) b
+
+type _ ty =
+  | String_option : string option ty
+
+let f (type x) (type y) (b : (x, y ty) b) (x : x) (y : y) =
+  match b, x, y with
+  | B, `B String_option, Some s -> print_string s
+  | A, `A, _ -> ()
+[%%expect{|
+type (_, _) b = A : ([< `A ], 'a) b | B : ([< `B of 'a ], 'a) b
+type _ ty = String_option : string option ty
+Lines 9-11, characters 2-18:
+ 9 | ..match b, x, y with
+10 |   | B, `B String_option, Some s -> print_string s
+11 |   | A, `A, _ -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(B, `B String_option, None)
+val f : ('x, 'y ty) b -> 'x -> 'y -> unit = <fun>
+|}]
+
+let segfault = f B (`B String_option) None
+[%%expect{|
+Exception: Match_failure ("", 9, 2).
+|}]
+
+(* More polymorphic variants *)
+
+type 'a a = private [< `A of 'a];;
+let f (x : _ a) = match x with `A None -> ();;
+[%%expect{|
+type 'a a = private [< `A of 'a ]
+Line 2, characters 18-44:
+2 | let f (x : _ a) = match x with `A None -> ();;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+`A (Some _)
+val f : 'a option a -> unit = <fun>
+|}]
+
+let f (x : [> `A] a) = match x with `A `B -> ();;
+[%%expect{|
+Line 1, characters 23-47:
+1 | let f (x : [> `A] a) = match x with `A `B -> ();;
+                           ^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+`A `A
+val f : [< `A | `B > `A ] a -> unit = <fun>
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -269,16 +269,6 @@ let extract_label_names env ty =
 
 (* Typing of patterns *)
 
-(* unification inside type_pat*)
-let unify_pat_types loc env ty ty' =
-  try
-    unify env ty ty'
-  with
-    Unify trace ->
-      raise(Error(loc, env, Pattern_type_clash(trace, None)))
-  | Tags(l1,l2) ->
-      raise(Typetexp.Error(loc, env, Typetexp.Variant_tags (l1, l2)))
-
 (* unification inside type_exp and type_expect *)
 let unify_exp_types loc env ty expected_ty =
   (* Format.eprintf "@[%a@ %a@]@." Printtyp.raw_type_expr exp.exp_type
@@ -298,21 +288,25 @@ let get_gadt_equations_level () =
     Some y -> y
   | None -> assert false
 
-let unify_pat_types_gadt loc env ty ty' =
-  try unify_gadt ~equations_level:(get_gadt_equations_level ()) env ty ty'
+(* unification inside type_pat*)
+let unify_pat_types ?(gadt=false) loc env ty ty' =
+  try
+    if gadt then
+      unify_gadt ~equations_level:(get_gadt_equations_level ()) env ty ty'
+    else
+      unify !env ty ty'
   with
   | Unify trace ->
       raise(Error(loc, !env, Pattern_type_clash(trace, None)))
   | Tags(l1,l2) ->
       raise(Typetexp.Error(loc, !env, Typetexp.Variant_tags (l1, l2)))
 
-(* Creating new conjunctive types is not allowed when typing patterns *)
-
-let unify_pat env pat expected_ty =
-  try unify_pat_types pat.pat_loc env pat.pat_type expected_ty
+let unify_pat ?gadt env pat expected_ty =
+  try unify_pat_types ?gadt pat.pat_loc env pat.pat_type expected_ty
   with Error (loc, env, Pattern_type_clash(trace, None)) ->
     raise(Error(loc, env, Pattern_type_clash(trace, Some pat.pat_desc)))
 
+(* Creating new conjunctive types is not allowed when typing patterns *)
 (* make all Reither present in open variants *)
 let finalize_variant pat tag opat r =
   let row =
@@ -327,7 +321,8 @@ let finalize_variant pat tag opat r =
   | Reither (false, ty::tl, _, e) when not row.row_closed ->
       set_row_field e (Rpresent (Some ty));
       begin match opat with None -> assert false
-      | Some pat -> List.iter (unify_pat pat.pat_env pat) (ty::tl)
+      | Some pat ->
+          let env = ref pat.pat_env in List.iter (unify_pat env pat) (ty::tl)
       end
   | Reither (c, _l, true, e) when not (row_fixed row) ->
       set_row_field e (Reither (c, [], false, ref None))
@@ -488,7 +483,7 @@ let rec build_as_type env p =
           unify_pat env {arg with pat_type = build_as_type env arg} ty_arg
         end else begin
           let _, ty_arg', ty_res' = instance_label false lbl in
-          unify env ty_arg ty_arg';
+          unify !env ty_arg ty_arg';
           unify_pat env p ty_res'
         end in
       Array.iter do_label lbl.lbl_all;
@@ -927,13 +922,14 @@ end)
 
 (* unification of a type with a tconstr with
    freshly created arguments *)
-let unify_head_only loc env ty constr =
+let unify_head_only ~gadt loc env ty constr =
   let (_, ty_res) = instance_constructor constr in
-  match (repr ty_res).desc with
+  let ty_res = repr ty_res in
+  match ty_res.desc with
   | Tconstr(p,args,m) ->
       ty_res.desc <- Tconstr(p,List.map (fun _ -> newvar ()) args,m);
-      enforce_constraints env ty_res;
-      unify_pat_types loc env ty_res ty
+      enforce_constraints !env ty_res;
+      unify_pat_types ~gadt loc env ty_res ty
   | _ -> assert false
 
 (* Typing of patterns *)
@@ -1229,8 +1225,9 @@ and type_pat_aux
     type_pat category ~no_existentials ~mode ~env
   in
   let loc = sp.ppat_loc in
+  let gadt = (mode <> Normal) in
   let unif (x : pattern) : pattern =
-    unify_pat !env x (instance expected_ty);
+    unify_pat ~gadt env x (instance expected_ty);
     x
   in
   let rp x =
@@ -1324,7 +1321,7 @@ and type_pat_aux
       assert construction_not_used_in_counterexamples;
       let cty, force = Typetexp.transl_simple_type_delayed !env sty in
       let ty = cty.ctyp_type in
-      unify_pat_types lloc !env ty (instance expected_ty);
+      unify_pat_types ~gadt lloc env ty (instance expected_ty);
       pattern_force := force :: !pattern_force;
       begin match ty.desc with
       | Tpoly (body, tyl) ->
@@ -1347,7 +1344,7 @@ and type_pat_aux
       assert construction_not_used_in_counterexamples;
       type_pat Value sq expected_ty (fun q ->
         begin_def ();
-        let ty_var = build_as_type !env q in
+        let ty_var = build_as_type env q in
         end_def ();
         generalize ty_var;
         let id =
@@ -1391,7 +1388,7 @@ and type_pat_aux
       let expected_ty = instance expected_ty in
       end_def ();
       generalize_structure expected_ty;
-      unify_pat_types loc !env ty expected_ty;
+      unify_pat_types ~gadt loc env ty expected_ty;
       map_fold_cont (fun (p,t) -> type_pat Value p t) spl_ann (fun pl ->
         rvp k {
         pat_desc = Tpat_tuple pl;
@@ -1431,7 +1428,9 @@ and type_pat_aux
       (* if constructor is gadt, we must verify that the expected type has the
          correct head *)
       if constr.cstr_generalized then
-        unify_head_only loc !env (instance expected_ty) constr;
+        unify_head_only ~gadt loc env (instance expected_ty) constr;
+      (* unify_pat_types ~gadt loc env (instance expected_ty)
+                                      (snd (instance_constructor constr)); *)
       let sargs =
         match sarg with
           None -> []
@@ -1461,9 +1460,8 @@ and type_pat_aux
       in
       let expected_ty = instance expected_ty in
       (* PR#7214: do not use gadt unification for toplevel lets *)
-      if not constr.cstr_generalized || no_existentials <> None
-      then unify_pat_types loc !env ty_res expected_ty
-      else unify_pat_types_gadt loc env ty_res expected_ty;
+      (let gadt = gadt || (constr.cstr_generalized && no_existentials = None)
+       in unify_pat_types ~gadt loc env ty_res expected_ty);
       end_def ();
       generalize_structure expected_ty;
       generalize_structure ty_res;
@@ -1510,7 +1508,7 @@ and type_pat_aux
          the abstract row variable *)
       if l = Parmatch.some_private_tag
       then assert (match mode with Normal -> false | Counter_example _ -> true)
-      else unify_pat_types loc !env (newgenty (Tvariant row)) expected_ty;
+      else unify_pat_types ~gadt loc env (newgenty (Tvariant row)) expected_ty;
       let k arg =
         rvp k {
         pat_desc = Tpat_variant(l, arg, ref {row with row_more = newvar()});
@@ -1540,7 +1538,7 @@ and type_pat_aux
         begin_def ();
         let (_, ty_arg, ty_res) = instance_label false label in
         begin try
-          unify_pat_types loc !env ty_res (instance record_ty)
+          unify_pat_types ~gadt loc env ty_res (instance record_ty)
         with Error(_loc, _env, Pattern_type_clash(trace, _)) ->
           raise(Error(label_lid.loc, !env,
                       Label_mismatch(label_lid.txt, trace)))
@@ -1579,8 +1577,8 @@ and type_pat_aux
       let expected_ty = instance expected_ty in
       end_def ();
       generalize_structure expected_ty;
-      unify_pat_types
-        loc !env (Predef.type_array ty_elt) expected_ty;
+      unify_pat_types ~gadt
+        loc env (Predef.type_array ty_elt) expected_ty;
       map_fold_cont (fun p -> type_pat Value p ty_elt) spl (fun pl ->
         rvp k {
         pat_desc = Tpat_array pl;
@@ -1661,7 +1659,7 @@ and type_pat_aux
       end
   | Ppat_lazy sp1 ->
       let nv = newgenvar () in
-      unify_pat_types loc !env (Predef.type_lazy_t nv) expected_ty;
+      unify_pat_types ~gadt loc env (Predef.type_lazy_t nv) expected_ty;
       (* do not explode under lazy: PR#7421 *)
       type_pat Value ~mode:(no_explosion mode) sp1 nv (fun p1 ->
         rvp k {
@@ -1678,7 +1676,7 @@ and type_pat_aux
       end_def();
       generalize_structure ty;
       let ty, expected_ty' = instance ty, ty in
-      unify_pat_types loc !env ty (instance expected_ty);
+      unify_pat_types ~gadt loc env ty (instance expected_ty);
       type_pat category sp expected_ty' (fun p ->
         (*Format.printf "%a@.%a@."
           Printtyp.raw_type_expr ty
@@ -1700,7 +1698,7 @@ and type_pat_aux
         in k p)
   | Ppat_type lid ->
       let (path, p,ty) = build_or_pat !env loc lid in
-      unify_pat_types loc !env ty (instance expected_ty);
+      unify_pat_types ~gadt loc env ty (instance expected_ty);
       k @@ pure category @@ { p with pat_extra =
         (Tpat_type (path, lid), loc, sp.ppat_attributes)
         :: p.pat_extra }
@@ -1829,7 +1827,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
     finalize_variants pat;
   end;
   List.iter (fun f -> f()) (get_ref pattern_force);
-  if is_optional l then unify_pat val_env pat (type_option (newvar ()));
+  if is_optional l then unify_pat (ref val_env) pat (type_option (newvar ()));
   let (pv, met_env) =
     List.fold_right
       (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes} (pv, env) ->
@@ -2352,8 +2350,8 @@ let check_absent_variant env =
                   row_more = newvar (); row_bound = ();
                   row_closed = false; row_fixed = None; row_name = None} in
       (* Should fail *)
-      unify_pat env {pat with pat_type = newty (Tvariant row')}
-                    (correct_levels pat.pat_type)
+      unify_pat (ref env) {pat with pat_type = newty (Tvariant row')}
+                          (correct_levels pat.pat_type)
     | _ -> () }
 
 (* Getting proper location of already typed expressions.
@@ -4448,7 +4446,7 @@ and type_cases
   let ty_arg' = newvar () in
   let unify_pats ty =
     List.iter (fun { typed_pat = pat; pat_type_for_unif = pat_ty; _ } ->
-      unify_pat_types pat.pat_loc env pat_ty ty
+      unify_pat_types pat.pat_loc (ref env) pat_ty ty
     ) half_typed_cases
   in
   unify_pats ty_arg';
@@ -4621,7 +4619,7 @@ and type_let
               {pat with pat_type =
                snd (instance_poly ~keep_names:true false tl ty)}
           | _ -> pat
-        in unify_pat env pat (type_approx env binding.pvb_expr))
+        in unify_pat (ref env) pat (type_approx env binding.pvb_expr))
       pat_list spat_sexp_list;
   (* Polymorphic variant processing *)
   List.iter

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1429,8 +1429,6 @@ and type_pat_aux
          correct head *)
       if constr.cstr_generalized then
         unify_head_only ~gadt loc env (instance expected_ty) constr;
-      (* unify_pat_types ~gadt loc env (instance expected_ty)
-                                      (snd (instance_constructor constr)); *)
       let sargs =
         match sarg with
           None -> []


### PR DESCRIPTION
New fix for #9012 and #9019, replacing #9022 

In `Typecore`, have `unify_pat_types` use gadt unification when checking a pattern generated by `Parmatch`, fixing unsoundness due to incompatible environment.