### PR TITLE
Fixing typos

### DIFF
--- a/Changes
+++ b/Changes
@@ -292,7 +292,7 @@ OCaml 4.10.0
   functions, this can be replaced with calls to
   caml_process_pending_actions at safe points.
   Side effect of this change: in bytecode mode, polling for
-  asynchronous callbacks is perfomed at every minor heap allocation,
+  asynchronous callbacks is performed at every minor heap allocation,
   in addition to function calls and loops as in previous OCaml
   releases.
   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer and

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1153,7 +1153,7 @@ let as_matrix cases = get_mins le_pats (List.map (fun (ps, _) -> ps) cases)
 
   Note: we assume that the first column of each pattern is coherent -- all
   patterns match values of the same type. This comes from the fact that
-  we make agressive splitting decisions, splitting pattern heads that
+  we make aggressive splitting decisions, splitting pattern heads that
   may be different into different submatrices; in particular, in a given
   submatrix the first column is formed of first arguments to the same
   constructor.
@@ -1168,7 +1168,7 @@ let as_matrix cases = get_mins le_pats (List.map (fun (ps, _) -> ps) cases)
   in a leftmost column.
 
   Parmatch has to be more conservative because it splits less
-  agressively: submatrices will contain not just the arguments of
+  aggressively: submatrices will contain not just the arguments of
   a given pattern head, but also other lines that may be compatible with
   it, in particular those with a leftmost omega and those starting with
   an extension constructor that may be equal to it.
@@ -1323,7 +1323,7 @@ and precompile_var args cls def k =
                        (fun (mat, e) -> add_omega_column mat, e)
                        top_default (* assuming it'd been bound. *)
                    ]}
-                   As we would be loosing information: [def] is more precise
+                   As we would be losing information: [def] is more precise
                    than [add_omega_column (pop_column def)]. *)
                 List.fold_right
                   (fun (e, pmh) ->

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -87,7 +87,7 @@ int caml_gc_subphase;     /* Subphase_{mark_roots,mark_main,mark_final} */
       - the ephemerons in (3) are in an unknown state and must be checked
 
     At the end of mark phase, (3) is empty and ephe_list_pure is true.
-    The ephemeron in (1) and (2) will be cleaned (white keys and datas
+    The ephemeron in (1) and (2) will be cleaned (white keys and data
     replaced by none or the ephemeron is removed from the list if it is white)
     in clean phase.
 

--- a/testsuite/tests/regression/pr3612/pr3612.ml
+++ b/testsuite/tests/regression/pr3612/pr3612.ml
@@ -6,7 +6,7 @@ type t
 
 external test_alloc : unit -> t = "caml_test_pr3612_alloc"
 external get_counter : unit -> int = "caml_test_pr3612_counter"
-(* The number of deserialized blocs minus the number of freed blocs *)
+(* The number of deserialized blocks minus the number of freed blocks *)
 
 external init : unit -> unit = "caml_test_pr3612_init"
 

--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -190,7 +190,7 @@ make $jobs world.opt
 # occurs.
 
 # We already use sigaltstack for stack overflow detection. Our use
-# interracts with ASAN's. Hence, we tell ASAN not to use it.
+# interacts with ASAN's. Hence, we tell ASAN not to use it.
 
 ASAN_OPTIONS="detect_leaks=0,use_sigaltstack=0" $run_testsuite
 

--- a/tools/release-checklist
+++ b/tools/release-checklist
@@ -134,7 +134,7 @@ git push --tags
 
 ## 5-bis: Alternative for branching
 
-This needs to be more tested, tread with care.
+This needs to be more tested, treat with care.
 ```
 # at this point, the VERSION file contains N+devD
 # increment it into N+dev(D+1); for example,

--- a/tools/release-checklist
+++ b/tools/release-checklist
@@ -134,7 +134,7 @@ git push --tags
 
 ## 5-bis: Alternative for branching
 
-This needs to be more tested, treat with care.
+This needs to be more tested, tread with care.
 ```
 # at this point, the VERSION file contains N+devD
 # increment it into N+dev(D+1); for example,

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -761,7 +761,7 @@ let rec expression : Typedtree.expression -> term_judg =
       ]
     | Texp_override (pth, fields) ->
       (*
-         G |- pth : m   (Gi |- ei : m[Derefence])^i
+         G |- pth : m   (Gi |- ei : m[Dereference])^i
          ----------------------------------------------------
          G + sum(Gi)^i |- {< (xi = ei)^i >} (at path pth) : m
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -490,7 +490,7 @@ end
 
 module Magic_number : sig
   (** a typical magic number is "Caml1999I011"; it is formed of an
-      alpha-numeric prefix, here Caml1990I, followed by a version,
+      alphanumeric prefix, here Caml1990I, followed by a version,
       here 011. The prefix identifies the kind of the versioned data:
       here the I indicates that it is the magic number for .cmi files.
 


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell