### PR TITLE
Treat loops properly in un_anf

### DIFF
--- a/Changes
+++ b/Changes
@@ -218,6 +218,9 @@ Working version
 
 ### Bug fixes:
 
+- #9163: Treat loops properly in un_anf
+  (Leo White, review by Mark Shinwell, Pierre Chambart and Vincent Laviron)
+
 - #9469: Better backtraces for lazy values
   (Leo White, review by Nicolás Ojeda Bär)
 

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -129,7 +129,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
          [const] cannot contain any variables that are bound in the current
          scope, so we do not need to count them here.  (The function bodies
          of the closures will be traversed when this function is called from
-         [Cmmgen.transl_function].) *)
+         [Flambda_to_clambda.to_clambda_closed_set_of_closures].) *)
       ignore_uconstant const
     | Udirect_apply (label, args, dbg) ->
       ignore_function_label label;


### PR DESCRIPTION
The un_anf pass in flambda detects linearity incorrectly -- it just counts uses ignoring whether or not those uses are inside loops. This leads to code like:

```ocaml
let foo foo bar =
  let scale = foo *. bar in
  for i = 0 to 100 do
    let v = scale +. float_of_int i in
    print_float v
  done
```
being compiled so that the `foo *. bar` is done on every loop iteration:
```
(for i/95 0 to 100
  (apply* camlStdlib__print_float_1169 
    (+. (*. foo/91 bar/90) (float_of_int i/95))))
```

This PR fixes the problem by tracking the loop depth at which a variable is defined and used -- treating uses within more loops than the definition as multiple uses.

I haven't included a test because this issue can only affect performance (and only by small constant factors) so it is a bit annoying to test.