### PR TITLE
Add missing -function-sections in Makefile in otherlibs

### DIFF
--- a/Changes
+++ b/Changes
@@ -379,9 +379,6 @@ Working version
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
 
-- #9165: Add missing -function-sections and -O3 flags in Makefiles.
-  (Greta Yorsh, review by David Allsopp)
-
 OCaml 4.10 maintenance branch
 -----------------------------
 
@@ -392,6 +389,11 @@ OCaml 4.10 maintenance branch
   not embed debug information and exception backtraces where causing
   them to crash.
   (Jérémie Dimino, review by Nicolás Ojeda Bär)
+
+### Bug fixes:
+
+- #9165: Add missing -function-sections and -O3 flags in Makefiles.
+  (Greta Yorsh, review by David Allsopp)
 
 OCaml 4.10.0 (21 February 2020)
 -------------------------------

--- a/Changes
+++ b/Changes
@@ -379,6 +379,9 @@ Working version
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
 
+- #9165: Add missing -function-sections and -O3 flags in Makefiles.
+  (Greta Yorsh, review by David Allsopp)
+
 OCaml 4.10 maintenance branch
 -----------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,7 @@ INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
 	  -warn-error A \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
-ifeq "$(FUNCTION_SECTIONS)" "true"
-OPTCOMPFLAGS += -function-sections
-endif
+
 LINKFLAGS=
 
 ifeq "$(strip $(NATDYNLINKOPTS))" ""

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,7 @@ COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
 	  -warn-error A \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 ifeq "$(FUNCTION_SECTIONS)" "true"
-OPTCOMPFLAGS= -function-sections
-else
-OPTCOMPFLAGS=
+OPTCOMPFLAGS += -function-sections
 endif
 LINKFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
 	  -warn-error A \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
-
 LINKFLAGS=
 
 ifeq "$(strip $(NATDYNLINKOPTS))" ""

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -70,6 +70,9 @@ OPTCOMPFLAGS=
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif
+ifeq "$(FLAMBDA)" "true"
+OPTCOMPFLAGS += -O3
+endif
 
 # By default, request ocamllex to be quiet
 OCAMLLEX_FLAGS ?= -q

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -66,6 +66,8 @@ else
   ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
 endif
 
+OPTCOMPFLAGS=
+
 # By default, request ocamllex to be quiet
 OCAMLLEX_FLAGS ?= -q
 

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -67,6 +67,9 @@ else
 endif
 
 OPTCOMPFLAGS=
+ifeq "$(FUNCTION_SECTIONS)" "true"
+OPTCOMPFLAGS += -function-sections
+endif
 
 # By default, request ocamllex to be quiet
 OCAMLLEX_FLAGS ?= -q

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -73,7 +73,6 @@ endif
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-
 # By default, request ocamllex to be quiet
 OCAMLLEX_FLAGS ?= -q
 

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -31,9 +31,6 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 # Compilation options
 COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
           -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
-ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS += -O3
-endif
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 
 # Variables that must be defined by individual libraries:

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -34,9 +34,6 @@ COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-ifeq "$(FUNCTION_SECTIONS)" "true"
-OPTCOMPFLAGS += -function-sections
-endif
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 
 # Variables that must be defined by individual libraries:

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -32,9 +32,7 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
           -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
 ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS=-O3
-else
-OPTCOMPFLAGS=
+OPTCOMPFLAGS += -O3
 endif
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -39,6 +39,9 @@ OPTCOMPFLAGS=-O3
 else
 OPTCOMPFLAGS=
 endif
+ifeq "$(FUNCTION_SECTIONS)" "true"
+OPTCOMPFLAGS += -function-sections
+endif
 
 COMPFLAGS += -I byte
 OPTCOMPFLAGS += -I native

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -37,9 +37,6 @@ COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-ifeq "$(FUNCTION_SECTIONS)" "true"
-OPTCOMPFLAGS += -function-sections
-endif
 
 COMPFLAGS += -I byte
 OPTCOMPFLAGS += -I native

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -35,9 +35,7 @@ COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
 	  -warn-error A \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS=-O3
-else
-OPTCOMPFLAGS=
+OPTCOMPFLAGS += -O3
 endif
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -34,9 +34,6 @@ OCAMLOPT=$(BEST_OCAMLOPT) -g -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
 	  -warn-error A \
           -bin-annot -safe-string -strict-formats
-ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS += -O3
-endif
 
 COMPFLAGS += -I byte
 OPTCOMPFLAGS += -I native

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -40,6 +40,9 @@ OPTCOMPFLAGS=-O3
 else
 OPTCOMPFLAGS=
 endif
+ifeq "$(FUNCTION_SECTIONS)" "true"
+OPTCOMPFLAGS += -function-sections
+endif
 
 LIBNAME=threads
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -36,9 +36,7 @@ CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 COMPFLAGS=-w +33..39 -warn-error A -g -bin-annot -safe-string
 ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS=-O3
-else
-OPTCOMPFLAGS=
+OPTCOMPFLAGS += -O3
 endif
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -35,9 +35,6 @@ CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
 
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 COMPFLAGS=-w +33..39 -warn-error A -g -bin-annot -safe-string
-ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS += -O3
-endif
 
 LIBNAME=threads
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -38,9 +38,6 @@ COMPFLAGS=-w +33..39 -warn-error A -g -bin-annot -safe-string
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-ifeq "$(FUNCTION_SECTIONS)" "true"
-OPTCOMPFLAGS += -function-sections
-endif
 
 LIBNAME=threads
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -26,9 +26,7 @@ COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
           -g -warn-error A -bin-annot -nostdlib \
           -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS=-O3
-else
-OPTCOMPFLAGS=
+OPTCOMPFLAGS += -O3
 endif
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -25,7 +25,6 @@ CAMLC=$(CAMLRUN) $(COMPILER)
 COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
           -g -warn-error A -bin-annot -nostdlib \
           -safe-string -strict-formats
-
 OPTCOMPILER=$(ROOTDIR)/ocamlopt
 CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(BOOT_OCAMLC) -depend

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -25,9 +25,6 @@ CAMLC=$(CAMLRUN) $(COMPILER)
 COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
           -g -warn-error A -bin-annot -nostdlib \
           -safe-string -strict-formats
-ifeq "$(FLAMBDA)" "true"
-OPTCOMPFLAGS += -O3
-endif
 
 OPTCOMPILER=$(ROOTDIR)/ocamlopt
 CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -28,9 +28,7 @@ COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-ifeq "$(FUNCTION_SECTIONS)" "true"
-OPTCOMPFLAGS += -function-sections
-endif
+
 OPTCOMPILER=$(ROOTDIR)/ocamlopt
 CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(BOOT_OCAMLC) -depend


### PR DESCRIPTION
The flag -function-sections was not passed to ocamlopt as needed in two of the Makefiles under otherlibs. These two Makefiles don't include the common Makefile which takes care of adding this option.