### PR TITLE
Fix compatibility.h inclusion and add CAML_NAME_SPACE versioning

### DIFF
--- a/Changes
+++ b/Changes
@@ -208,13 +208,15 @@ OCaml 4.10.0
 * #8713: Introduce a state table in the runtime to contain the global variables.
   (The Multicore runtime will have one such state for each domain.)
 
-   This changes the name of some internal variables of the OCaml runtime;
-   in many cases <caml/compatibility.h> provides a compatibility macro with
-   the old name, but programs using runtime internals may need to be fixed.
+  This changes the name of some internal variables of the OCaml
+  runtime; in many cases <caml/compatibility.h>, automatically
+  included in all caml headers, provides a compatibility macro with
+  the old name, but programs using runtime internals may need to be
+  fixed.
 
-   (KC Sivaramakrishnan and Stephen Dolan, compatibility header hacking by
-    David Allsopp, review by David Allsopp, Alain Frisch, Nicolás Ojeda Bär,
-    Gabriel Scherer, Damien Doligez, and Guillaume Munch-Maccagnoni)
+  (KC Sivaramakrishnan and Stephen Dolan, compatibility header hacking by
+   David Allsopp, review by David Allsopp, Alain Frisch, Nicolás Ojeda Bär,
+   Gabriel Scherer, Damien Doligez, and Guillaume Munch-Maccagnoni)
 
 - #8993: New C functions caml_process_pending_actions{,_exn} in
   caml/signals.h, intended for executing all pending actions inside
@@ -242,7 +244,6 @@ OCaml 4.10.0
   with calls to caml_process_pending_actions at safe points.
   (Guillaume Munch-Maccagnoni, review by Jacques-Henri Jourdan and
    Stephen Dolan)
-
 
 - #8619: Ensure Gc.minor_words remains accurate after a GC.
   (Stephen Dolan, Xavier Leroy and David Allsopp,
@@ -273,6 +274,13 @@ OCaml 4.10.0
   Hence, there is not any public API for this feature yet.
   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer
    and Damien Doligez)
+
+- #9167: The macro CAML_NAME_SPACE now accepts a version number as
+  value. If the user defines CAML_NAME_SPACE=X, then only the
+  compatibility macros introduced for version X or later are defined by
+  <caml/compatibility.h>.
+  (Guillaume Munch-Maccagnoni, inspired by Stephen Dolan and James
+   Woodyatt, review by Stephen Dolan)
 
 ### Standard library:
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -206,6 +206,7 @@ CMXS=@cmxs@
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 
 MKEXE=@mkexe@
+MKEXE_ML=@mkexe_ml@
 MKDLL=@mksharedlib@
 MKMAINDLL=@mkmaindll@
 

--- a/configure
+++ b/configure
@@ -12536,7 +12536,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
 esac ;;
 esac
 
-internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
+internal_cppflags="-DCAML_NAME_SPACE=99999 $internal_cppflags"
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 case $host in #(

--- a/configure
+++ b/configure
@@ -815,6 +815,8 @@ oc_cflags
 toolchain
 ccomptype
 mkexedebugflag
+mkexe_extra
+mkexe_ml
 mkexe
 fpic
 libraries_man_section
@@ -2734,10 +2736,12 @@ programs_man_section=1
 # Library section of the Unix manual
 libraries_man_section=3
 
-# Command to build executalbes
+# Command to build executables
 mkexe="\$(CC) \$(OC_CFLAGS) \$(OC_CPPFLAGS) \$(OC_LDFLAGS)"
+mkexe_ml="\$(CC) \$(OC_CFLAGS) \$(ML_CPPFLAGS) \$(OC_LDFLAGS)"
 
 # Flags for building executable files with debugging symbols
+mkexe_extra=""
 mkexedebugflag="-g"
 common_cflags=""
 common_cppflags=""
@@ -2803,6 +2807,8 @@ VERSION=4.11.0+dev0-2019-10-18
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
+
 
 
 
@@ -12536,7 +12542,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
 esac ;;
 esac
 
-internal_cppflags="-DCAML_NAME_SPACE=99999 $internal_cppflags"
+compilation_cppflags="-DCAML_NAME_SPACE=99999"
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 case $host in #(
@@ -12570,7 +12576,7 @@ fi
 
 case $CC,$host in #(
   *,*-*-darwin*) :
-    mkexe="$mkexe -Wl,-no_compact_unwind";
+    mkexe_extra="$mkexe_extra -Wl,-no_compact_unwind";
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   *,*-*-haiku*) :
@@ -12597,13 +12603,14 @@ $as_echo "$as_me: WARNING: flexlink not found: native shared libraries won't be 
 else
   iflexdir="-I\"$flexdir\""
         mkexe="$flexlink -exe"
+        mkexe_ml=$mkexe
         mkexedebugflag="-link -g"
 
 fi
 
 fi
     if ! $with_sharedlibs; then :
-  mkexe="$mkexe -Wl,--stack,16777216"
+  mkexe_extra="$mkexe_extra -Wl,--stack,16777216"
       oc_ldflags="-Wl,--stack,16777216"
 
 fi
@@ -12629,12 +12636,14 @@ fi
     ostype="Win32"
     toolchain="mingw"
     mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_ml=$mkexe
     oc_ldflags='-municode'
     SO="dll" ;; #(
   *,*-pc-windows) :
     toolchain=msvc
     ostype="Win32"
     mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_ml=$mkexe
     oc_ldflags='/ENTRY:wmainCRTStartup'
     case $host in #(
   i686-pc-windows) :
@@ -16604,7 +16613,7 @@ fi
 
         if $libunwind_available && test x"$system" = "xmacosx"; then :
   extra_flags="-Wl,-keep_dwarf_unwind"
-          mkexe="$mkexe $extra_flags"
+          mkexe_extra="$mkexe_extra $extra_flags"
           mksharedlib="$mksharedlib $extra_flags"
 fi
 fi
@@ -16745,8 +16754,12 @@ else
   default_safe_string=true
 fi
 
+mkexe_ml="$mkexe_ml $mkexe_extra "
+mkexe="$mkexe $mkexe_extra "
+
 oc_cflags="$common_cflags $internal_cflags"
-oc_cppflags="$common_cppflags $internal_cppflags"
+ml_cppflags="$common_cppflags $internal_cppflags"
+oc_cppflags="$ml_cppflags $compilation_cppflags"
 ocamlc_cflags="$common_cflags $sharedlib_cflags"
 ocamlc_cppflags="$common_cppflags"
 ocamlopt_cflags="$common_cflags"

--- a/configure.ac
+++ b/configure.ac
@@ -36,10 +36,12 @@ programs_man_section=1
 # Library section of the Unix manual
 libraries_man_section=3
 
-# Command to build executalbes
+# Command to build executables
 mkexe="\$(CC) \$(OC_CFLAGS) \$(OC_CPPFLAGS) \$(OC_LDFLAGS)"
+mkexe_ml="\$(CC) \$(OC_CFLAGS) \$(ML_CPPFLAGS) \$(OC_LDFLAGS)"
 
 # Flags for building executable files with debugging symbols
+mkexe_extra=""
 mkexedebugflag="-g"
 common_cflags=""
 common_cppflags=""
@@ -98,6 +100,8 @@ AC_SUBST([programs_man_section])
 AC_SUBST([libraries_man_section])
 AC_SUBST([fpic])
 AC_SUBST([mkexe])
+AC_SUBST([mkexe_ml])
+AC_SUBST([mkexe_extra])
 AC_SUBST([mkexedebugflag])
 AC_SUBST([ccomptype])
 AC_SUBST([toolchain])
@@ -590,7 +594,7 @@ AS_CASE([$host],
       internal_cflags="$gcc_warnings"],
     [common_cflags="-O"])])
 
-internal_cppflags="-DCAML_NAME_SPACE=99999 $internal_cppflags"
+compilation_cppflags="-DCAML_NAME_SPACE=99999"
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 AS_CASE([$host],
@@ -616,7 +620,7 @@ AS_IF([test x"$enable_shared" = "xno"],[with_sharedlibs=false])
 
 AS_CASE([$CC,$host],
   [*,*-*-darwin*],
-    [mkexe="$mkexe -Wl,-no_compact_unwind";
+    [mkexe_extra="$mkexe_extra -Wl,-no_compact_unwind";
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [*,*-*-haiku*], [mathlib=""],
   [*,*-*-cygwin*],
@@ -635,11 +639,12 @@ AS_CASE([$CC,$host],
         with_sharedlibs=false],
         [iflexdir="-I\"$flexdir\""
         mkexe="$flexlink -exe"
+        mkexe_ml=$mkexe
         mkexedebugflag="-link -g"]
       )]
     )
     AS_IF([! $with_sharedlibs],
-      [mkexe="$mkexe -Wl,--stack,16777216"
+      [mkexe_extra="$mkexe_extra -Wl,--stack,16777216"
       oc_ldflags="-Wl,--stack,16777216"]
     )
     ostype="Cygwin"],
@@ -656,12 +661,14 @@ AS_CASE([$CC,$host],
     ostype="Win32"
     toolchain="mingw"
     mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_ml=$mkexe
     oc_ldflags='-municode'
     SO="dll"],
   [*,*-pc-windows],
     [toolchain=msvc
     ostype="Win32"
     mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_ml=$mkexe
     oc_ldflags='/ENTRY:wmainCRTStartup'
     AS_CASE([$host],
       [i686-pc-windows], [flexdll_chain=msvc],
@@ -1650,7 +1657,7 @@ AS_IF([test x"$enable_spacetime" != "xyes" ],
 
         AS_IF([$libunwind_available && test x"$system" = "xmacosx"],
           [extra_flags="-Wl,-keep_dwarf_unwind"
-          mkexe="$mkexe $extra_flags"
+          mkexe_extra="$mkexe_extra $extra_flags"
           mksharedlib="$mksharedlib $extra_flags"])])
     ],
     [AS_IF([test x"$enable_spacetime" = "xyes"],
@@ -1734,8 +1741,12 @@ AS_IF([test x"$DEFAULT_STRING" = "xunsafe"],
   [default_safe_string=false],
   [default_safe_string=true])
 
+mkexe_ml="$mkexe_ml $mkexe_extra "
+mkexe="$mkexe $mkexe_extra "
+
 oc_cflags="$common_cflags $internal_cflags"
-oc_cppflags="$common_cppflags $internal_cppflags"
+ml_cppflags="$common_cppflags $internal_cppflags"
+oc_cppflags="$ml_cppflags $compilation_cppflags"
 ocamlc_cflags="$common_cflags $sharedlib_cflags"
 ocamlc_cppflags="$common_cppflags"
 ocamlopt_cflags="$common_cflags"

--- a/configure.ac
+++ b/configure.ac
@@ -590,7 +590,7 @@ AS_CASE([$host],
       internal_cflags="$gcc_warnings"],
     [common_cflags="-O"])])
 
-internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
+internal_cppflags="-DCAML_NAME_SPACE=99999 $internal_cppflags"
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 AS_CASE([$host],

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -182,6 +182,9 @@ section~\ref{s:c-custom}).}
 \entree{"caml/intext.h"}{operations for writing user-defined
 serialization and deserialization functions for custom blocks
 (see section~\ref{s:c-custom}).}
+\entree{"caml/signals.h"}{runtime lock, signals, and other
+  asynchronous callbacks (see
+  section~\ref{ss:c-process-pending-actions}).}
 \entree{"caml/threads.h"}{operations for interfacing in the presence
   of multiple threads (see section~\ref{s:C-multithreading}).}
 \end{tableau}
@@ -189,19 +192,30 @@ These files reside in the "caml/" subdirectory of the OCaml
 standard library directory, which is returned by the command
 "ocamlc -where" (usually "/usr/local/lib/ocaml" or "/usr/lib/ocaml").
 
-By default, header files in the "caml/" subdirectory give only access
-to the public interface of the OCaml runtime. It is possible to define
-the macro "CAML_INTERNALS" to get access to a lower-level interface,
-but this lower-level interface is more likely to change and break
-programs that use it.
+\paragraph{CAML_NAME_SPACE} OCaml C header files automatically
+include "caml/compatibility.h", which defines backwards compatibility
+helpers. It is possible and recommended to define the macro
+"CAML_NAME_SPACE" before including header files to control their
+presence. If you do not define "CAML_NAME_SPACE", the header files
+will define short names (without the "caml_" prefix) for most
+functions, which can produce clashes with names defined by other C
+libraries that you might use.
 
-{\bf Note:} It is recommended to define the macro "CAML_NAME_SPACE"
-before including these header files. If you do not define it, the
-header files will also define short names (without the "caml_" prefix)
-for most functions, which usually produce clashes with names defined
-by other C libraries that you might use. Including the header files
-without "CAML_NAME_SPACE" is only supported for backward
-compatibility.
+Starting from 4.10, "CAML_NAME_SPACE" accepts an integer value. If you
+define "CAML_NAME_SPACE=X" where "X" is an OCaml version number, then
+only the compatibility macros introduced for "X" or later versions will
+be defined. The format of the version number is the same as the macro
+"OCAML_VERSION" from "caml/version.h" (e.g. 41000). The recommended
+way of defining this macro is with a program-wide argument
+"-DCAML_NAME_SPACE=X" passed to the C preprocessor.
+
+\paragraph{CAML_INTERNALS} By default, header files mentioned in
+this documentation give only access to the public interface of the
+OCaml runtime. It is possible to define the macro "CAML_INTERNALS" to
+get access to a lower-level interface, but this lower-level interface
+is more likely to change and break programs that use it. Undocumented
+headers in the "caml/" subdirectory are considered internal as well,
+and can change in the same way.
 
 \subsection{ss:staticlink-c-code}{Statically linking C code with OCaml code}
 

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -17,9 +17,7 @@
 #define CAML_ALLOC_H
 
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -16,9 +16,6 @@
 #ifndef CAML_BIGARRAY_H
 #define CAML_BIGARRAY_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -18,9 +18,7 @@
 #ifndef CAML_CALLBACK_H
 #define CAML_CALLBACK_H
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 #include "mlvalues.h"
 
 #ifdef __cplusplus

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -18,9 +18,14 @@
 #ifndef CAML_COMPATIBILITY_H
 #define CAML_COMPATIBILITY_H
 
-/* internal global variables renamed between 4.02.1 and 4.03.0 */
-#define caml_stat_top_heap_size Bsize_wsize(caml_stat_top_heap_wsz)
-#define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
+#if defined(CAML_NAME_SPACE) && !(CAML_NAME_SPACE + 0)
+  // Ensure CAML_NAME_SPACE has an integer value
+  #undef CAML_NAME_SPACE
+  #define CAML_NAME_SPACE 1
+#endif
+
+
+#if !defined(CAML_NAME_SPACE) || CAML_NAME_SPACE < 41000
 
 /* global variables moved to Caml_state in 4.10.0 */
 #define caml_stat_top_heap_wsz (Caml_state_field(stat_top_heap_wsz))
@@ -64,6 +69,18 @@
 #define caml_stat_major_collections (Caml_state_field(stat_major_collections))
 #define caml_stat_compactions (Caml_state_field(stat_compactions))
 #define caml_stat_heap_chunks (Caml_state_field(stat_heap_chunks))
+
+#endif // 4.10
+
+
+#if !defined(CAML_NAME_SPACE) || CAML_NAME_SPACE < 40300
+
+/* internal global variables renamed between 4.02.1 and 4.03.0 */
+#define caml_stat_top_heap_size Bsize_wsize(caml_stat_top_heap_wsz)
+#define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
+
+#endif // 4.03
+
 
 #ifndef CAML_NAME_SPACE
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -43,9 +43,7 @@
 #undef SUPPORT_DYNAMIC_LINKING
 #endif
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 
 #ifndef CAML_CONFIG_H_NO_TYPEDEFS
 

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -17,9 +17,7 @@
 #define CAML_CUSTOM_H
 
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 #include "mlvalues.h"
 
 struct custom_fixed_length {

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -20,9 +20,7 @@
 #include <setjmp.h>
 #endif /* CAML_INTERNALS */
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -18,9 +18,7 @@
 #ifndef CAML_INTEXT_H
 #define CAML_INTEXT_H
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -18,9 +18,6 @@
 #ifndef CAML_MEMORY_H
 #define CAML_MEMORY_H
 
-#ifndef CAML_INTERNALS
-#include "compatibility.h"
-#endif
 #include "config.h"
 #ifdef CAML_INTERNALS
 #include "gc.h"

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -16,9 +16,6 @@
 #ifndef CAML_MINOR_GC_H
 #define CAML_MINOR_GC_H
 
-#ifndef CAML_INTERNALS
-#include "compatibility.h"
-#endif
 #include "address_class.h"
 #include "config.h"
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -18,9 +18,6 @@
 #ifndef CAML_MISC_H
 #define CAML_MISC_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 
 /* Standard definitions */

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -16,9 +16,6 @@
 #ifndef CAML_MLVALUES_H
 #define CAML_MLVALUES_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 #include "misc.h"
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -20,9 +20,7 @@
 #include<signal.h>
 #endif
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/testsuite/tests/compatibility/pr9167.ml
+++ b/testsuite/tests/compatibility/pr9167.ml
@@ -1,0 +1,7 @@
+(* TEST
+modules = "pr9167_stub.c"
+*)
+
+external retrieve_compare_unordered : unit -> bool = "retrieve_compare_unordered"
+
+let bar = retrieve_compare_unordered ()

--- a/testsuite/tests/compatibility/pr9167_stub.c
+++ b/testsuite/tests/compatibility/pr9167_stub.c
@@ -1,0 +1,10 @@
+#define CAML_NAME_SPACE
+#include <caml/custom.h>
+#include <caml/mlvalues.h>
+
+/* see PR#9167 */
+
+CAMLprim value retrieve_compare_unordered(value unit)
+{
+  return Bool_val(caml_compare_unordered);
+}

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -86,7 +86,7 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST,LIBUNWIND_AVAILABLE) \
 	    $(call SUBST,LIBUNWIND_LINK_FLAGS) \
 	    $(call SUBST_STRING,MKDLL) \
-	    $(call SUBST_STRING,MKEXE) \
+	    $(call SUBST_STRING,MKEXE_ML) \
 	    $(call SUBST_STRING,FLEXLINK_LDFLAGS) \
 	    $(call SUBST_STRING,MKMAINDLL) \
 	    $(call SUBST,MODEL) \

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -67,9 +67,9 @@ let mkdll, mkexe, mkmaindll =
       flexlink ^ " -exe%%FLEXLINK_LDFLAGS%%",
       flexlink ^ " -maindll"
     with Not_found ->
-      "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
+      "%%MKDLL%%", "%%MKEXE_ML%%", "%%MKMAINDLL%%"
   else
-    "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
+    "%%MKDLL%%", "%%MKEXE_ML%%", "%%MKMAINDLL%%"
 
 let flambda = %%FLAMBDA%%
 let with_flambda_invariants = %%WITH_FLAMBDA_INVARIANTS%%


### PR DESCRIPTION
This was originally meant as a comment to https://github.com/ocaml/ocaml/pull/1798, but in the course of writing it I realised that this fixes an issue with `compatibility.h` for 4.10, so I decided to upgrade it to a pull request. (In case my approach is not found to be consensual, then I intend that it still serves as bug report.)

### Issue

To begin with, the issue I noticed in 4.10: a lot of macros are now included for backwards-compatibility in the file `compatibility.h`. However, the way users automatically get the benefits of `compatibility.h` is quite irregular. Indeed, it is included automatically in most caml headers _when `CAML_NAME_SPACE` is unset_; it is also included automatically in `caml/memory.h` and  `caml/minor_gc.h` _when either `CAML_NAME_SPACE` or `CAML_INTERNALS` is unset_. Thus, users do not automatically get the benefits of `compatibility.h`, unless they forget to define `CAML_NAME_SPACE` (which docs says they should), or if they happen to include `caml/memory.h`. I want to fix this irregularity by letting them automatically benefit from `compatibility.h` on a similar principle as before 4.10. To do so I repurpose the user-defined `CAML_NAME_SPACE` macro, whose initial purpose is to control exactly that. Only, now it gets a version number.

(What about the practice of including `compatibility.h` by hand? Opam audit suggests that it is marginal before 4.10, as the only true positives I have found are `bap` and `imagemagick`.)

### Version macros

For context, see #1798 and the discussion about macros `CAML_API_VERSION` and `CAML_API_COMPATIBILITY`. There is much in common with the patch at #1798. But there seemed to be doubts about the semantics and purpose of the latter. My macro `CAML_NAME_SPACE` is meant to replace it, I will explain the semantics and purpose below, and I think we need this in 4.10.

First, it is not about permitting weaker backwards compatibility requirements (to quote the title of #1798). As a backwards compatibility helper, we have `OCAML_VERSION` (playing the role of `CAML_API_VERSION` in the sense of the latests comments there, i.e. "the actual version number defined by the runtime's headers"). I leave this one aside as we already have it.

Second, about reusing the macro name `CAML_NAME_SPACE`: no strong opinion here, but the following rationale:

1. Not introducing yet another versioning macro;
2. I like it more than the `CAML_API_*` names because it emphasizes that _it is about syntax and not semantics_.

### Meaning of `CAML_NAME_SPACE=X`

Defined by the user, means _“please rid me of these troublesome identifiers that are obsolete in version X”_. It is the user asserting that the program is written for OCaml ≥ X. By default (undefined) it is the lowest possible, i.e. all compatibility helpers defined. It does _not_ mean "please try to respect the API of version X".

(Terminology: obsolete does not mean deprecated. But it can also help with deprecation since it gives a mean to the user to prepare to removal ahead of time.)

### Purpose

It is meant to solve the following problem: imagine you want to track down obsolete identifiers to modernize your code. Before 4.10 you would just compile with "-DCAML_NAME_SPACE", which rids you of `compatibility.h`. Now with the new compatibility helpers, we want to still include this header for people who already define `CAML_NAME_SPACE`, so that the helpers continue to be defined automatically and we can hope that the user has nothing to change to their code. However, as of now there is no mechanism to let the user turn off the new compatibility helpers. The new mechanism lets the user do that by increasing `CAML_NAME_SPACE` to the version of their choice.

Like it was intended with #1798, it can be re-used to fit the purpose of the versioning macro introduced in #1003.

### Notes

* The value `CAML_NAME_SPACE=1`, i.e. with `-DCAML_NAME_SPACE`, of course keeps its current meaning.
* Clean-up redundant inclusions. `compatibility.h` remains included everywhere (via `config.h`).
* The OCaml compiler always enforces the latest name space for itself, via the definition `CAML_NAME_SPACE=99999`.
* Automatically-generated changes to `configure`: I do not know what to do of them.
* Optionally, we can add other conditional definitions, e.g. `Begin/end_roots`, like #1798.

(cc @stedolan for the multicore api version business, pinging also @gasche since you told me you are interested in `compatiblity.h` issues.)