### PR TITLE
better documentation for the best-fit allocation policy

### DIFF
--- a/Changes
+++ b/Changes
@@ -315,6 +315,10 @@ OCaml 4.10.0
   (Florian Angelettion, review by Gabriel Scherer,
    report by Clément Busschaert)
 
+- #9169: better documentation for the best-fit allocation policy
+  (Gabriel Scherer, review by Guillaume Munch-Maccagnoni
+   and Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #8833: Hint for (type) redefinitions in toplevel session

--- a/man/ocamlrun.m
+++ b/man/ocamlrun.m
@@ -153,6 +153,7 @@ The policy used for allocating in the OCaml heap.  Possible values
 are 0 for the next-fit policy, 1 for the first-fit
 policy, and 2 for the best-fit policy. Best-fit is still experimental,
 but probably the best of the three. The default is 0.
+See the Gc module documentation for details.
 .TP
 .BR s \ (minor_heap_size)
 The size of the minor heap (in words).

--- a/manual/manual/cmds/runtime.etex
+++ b/manual/manual/cmds/runtime.etex
@@ -125,15 +125,17 @@ The following environment variables are also consulted:
 \fi
         This option takes no argument.
   \item[h] The initial size of the major heap (in words).
-  \item[a] ("allocation_policy") The policy used for allocating in the
-  OCaml heap.  Possible values are 0 for the next-fit policy, and 1
-  for the first-fit policy.  Next-fit is usually faster, but first-fit
-  is better for avoiding fragmentation and the associated heap
-  compactions.
+  \item[a] ("allocation_policy")
+    The policy used for allocating in the OCaml heap. Possible values
+    are "0" for the next-fit policy, "1" for the first-fit
+    policy, and "2" for the best-fit policy. Best-fit is still experimental,
+    but probably the best of the three. The default is "0" (next-fit).
+    See the Gc module documentation for details.
   \item[s] ("minor_heap_size")  Size of the minor heap. (in words)
   \item[i] ("major_heap_increment")  Default size increment for the
   major heap. (in words)
   \item[o] ("space_overhead")  The major GC speed setting.
+    See the Gc module documentation for details.
   \item[O] ("max_overhead")  The heap compaction trigger setting.
   \item[l] ("stack_limit") The limit (in words) of the stack size.
   \item[v] ("verbose")  What GC messages to print to stderr.  This

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -145,17 +145,47 @@ type control =
     mutable allocation_policy : int;
     [@ocaml.deprecated_mutable
          "Use {(Gc.get()) with Gc.allocation_policy = ...}"]
-    (** The policy used for allocating in the heap.  Possible
-        values are 0 to 2.  0 is the original next-fit policy,
-        usually fast, but can result in fragmentation.  1 is the
-        first-fit policy, which can be slower in some cases but
-        can be better for programs with fragmentation problems.
-        2 is the best-fit allocation policy, the best for avoiding
-        fragmentation.
-        Note that changing the allocation policy at run-time forces
+    (** The policy used for allocating in the major heap.
+        Possible values are 0, 1 and 2.
+
+        - 0 is the next-fit policy, which is usually fast but can
+          result in fragmentation, increasing memory consumption.
+
+        - 1 is the first-fit policy, which avoids fragmentation but
+          has corner cases (in certain realistic workloads) where it
+          is sensibly slower.
+
+        - 2 is the best-fit policy, which is fast and avoids
+          fragmentation. In our experiments it is faster and uses less
+          memory than both next-fit and first-fit.
+          (since OCaml 4.10)
+
+        The current default is next-fit, as the best-fit policy is new
+        and not yet widely tested. We expect best-fit to become the
+        default in the future.
+
+        On one example that was known to be bad for next-fit and first-fit,
+        next-fit takes 28s using 855Mio of memory,
+        first-fit takes 47s using 566Mio of memory,
+        best-fit takes 27s using 545Mio of memory.
+
+        Note: When changing to a low-fragmentation policy, you may
+        need to augment the [space_overhead] setting, for example
+        using [100] instead of the default [80] which is tuned for
+        next-fit. Indeed, the difference in fragmentation behavior
+        means that different policies will have different proportion
+        of "wasted space" for a given program. Less fragmentation
+        means a smaller heap so, for the same amount of wasted space,
+        a higher proportion of wasted space. This makes the GC work
+        harder, unless you relax it by increasing [space_overhead].
+
+        Note: changing the allocation policy at run-time forces
         a heap compaction, which is a lengthy operation unless the
         heap is small (e.g. at the start of the program).
-        Default: 0. @since 3.11.0 *)
+
+        Default: 0.
+
+        @since 3.11.0 *)
 
     window_size : int;
     (** The size of the window used by the major GC for smoothing


### PR DESCRIPTION
Currently the manual for 4.10 contains a documentation of the major heap allocation policies that is out-of-date, as it does not mention the shiny new best-fit policy of #8809 (the gc.mli documentation does).  (See the identical [manual section for 4.09](http://caml.inria.fr/pub/docs/manual-ocaml-4.09/runtime.html#ocamlrun-options))

This PR fixes this error by removing the hard-coded list of allocation policies in the manual, and redirecting to the documentation of the Gc module instead (it is only mentioned in text form, but a link is present just above in the OCAMLRUNPARAM documentation header).

I also improved the `allocation_policy` in gc.mli, by adding a note on the impact of less-fragmentation policies on space_overhead tuning. I don't understand the details of this fully, and @lpw25 and @damiendoligez gave slightly different explanations for the difference in space_overhead behavior (Leo says: wasted-space calculation ignores fragmentation; Damien says: defragmentation results in a small heap), so a second read would be welcome.

This should go in 4.10 when it's ready.

(cc @lpw25 @damiendoligez @Octachron)