### PR TITLE
Add "since 4.08.0" for custom_fixed_length in the manual

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -1893,6 +1893,7 @@ do not register the "struct custom_operations" with the deserializer
 using "register_custom_operations" (see below).
 
 \item "const struct custom_fixed_length* fixed_length" \\
+(Since 4.08.0)
 Normally, space in the serialized output is reserved to write the
 "bsize_32" and "bsize_64" fields returned by "serialize". However, for
 very short custom blocks, this space can be larger than the data

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -861,9 +861,9 @@ module P = struct end
 module N = P
 \end{caml_example*}
 has type
-\caml
-\:module N = P
-\endcaml
+\begin{caml_example*}{signature}
+module N = P
+\end{caml_example*}
 
 Type-level module aliases are used when checking module path
 equalities. That is, in a context where module name @N@ is known to be


### PR DESCRIPTION
Closes #9142 

Also fixes a bug in #9089 (the `\\endcaml` macro was removed, but there was still one use)