### PR TITLE
opam: bump to 4.11.0

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-version: "4.10.0+trunk"
+version: "4.11.0+trunk"
 synopsis: "OCaml development version"
 depends: [
-  "ocaml" {= "4.10.0" & post}
+  "ocaml" {= "4.11.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}


### PR DESCRIPTION
without this, `opam switch create . --empty` (as documented in HACKING.adoc) fails with current master.