### PR TITLE
Fix multiple definitions of a global variable when using the C interface with a C++ compiler

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -145,7 +145,7 @@ extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
 
 #define CAML_STATIC_ASSERT_3(b, l) \
   CAMLunused_start \
-    char static_assertion_failure_line_##l[(b) ? 1 : -1] \
+    CAMLextern char static_assertion_failure_line_##l[(b) ? 1 : -1] \
   CAMLunused_end
 
 #define CAML_STATIC_ASSERT_2(b, l) CAML_STATIC_ASSERT_3(b, l)


### PR DESCRIPTION
### The issue

I was looking into this error in `sfml.0.08.2` with OCaml 4.10:
```
#=== ERROR while compiling sfml.0.08.2 ========================================#
# context              2.0.5 | linux/x86_64 | ocaml-variants.4.10.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.10.0+trunk/.opam-switch/build/sfml.0.08.2
# command              /usr/bin/make -C src cxx_all
# exit-code            2
# env-file             ~/.opam/log/sfml-6-562576.env
# output-file          ~/.opam/log/sfml-6-562576.out
### output ###
# [...]
# g++ -g -Wall -Werror -Wno-deprecated-declarations -fPIC -c -I/home/opam/.opam/4.10.0+trunk/lib/ocaml -I/usr/include/ ./cxx_stubs/SFClock_stub.cpp
# ocamlmklib -oc sfml_system_stubs \
#    sf_caml_conv.o  sf_conv_vectors.o  SFConfig_stub.o  SFTime_stub.o  SFClock_stub.o \
#   -L/usr/lib/ \
#   -lsfml-system
# /usr/bin/ld: sf_conv_vectors.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: multiple definition of `static_assertion_failure_line_46'; sf_caml_conv.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: first defined here
# /usr/bin/ld: SFConfig_stub.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: multiple definition of `static_assertion_failure_line_46'; sf_caml_conv.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: first defined here
# /usr/bin/ld: SFTime_stub.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: multiple definition of `static_assertion_failure_line_46'; sf_caml_conv.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: first defined here
# /usr/bin/ld: SFClock_stub.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: multiple definition of `static_assertion_failure_line_46'; sf_caml_conv.o:/home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/domain_state.h:46: first defined here
# collect2: error: ld returned 1 exit status
# make: *** [Makefile:523: dllsfml_system_stubs.so] Error 2
# make: Leaving directory '/home/opam/.opam/4.10.0+trunk/.opam-switch/build/sfml.0.08.2/src'
```
The problem is that `CAML_STATIC_ASSERT` used in `caml/domain_state.h` produces a global variable that is included more than once all the way to the final library.
Here is a tiny reproduction case:
```
$ cat a.c
#include <caml/mlvalues.h>
$ cat b.c
#include <caml/mlvalues.h>
$ ocamlc -cc g++ a.c
$ ocamlc -cc g++ b.c
$ ocamlmklib -oc test a.o b.o
/usr/bin/ld: b.o:(.bss+0x0): multiple definition of `static_assertion_failure_line_46'; a.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
```
This error does not appear with a C compiler. Here is the output of `nm a.o` when using `-cc gcc`:
```
0000000000000001 C static_assertion_failure_line_46
```
and is the output of `nm a.o` when using `-cc g++`:
```
0000000000000000 B static_assertion_failure_line_46
```
### The fix

using `extern` allows the global (or local) variable created to be declared several times with C and C++. I don't think those variable are meant to be used anywhere so this should be safe to not define them.