### PR TITLE
Fix a typo in Stdlib.Lexing documentation

### DIFF
--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -110,7 +110,7 @@ val from_function : ?with_positions:bool -> (bytes -> int -> int) -> lexbuf
 
 val set_position : lexbuf -> position -> unit
 (** Set the initial tracked input position for [lexbuf] to a custom value.
-   Ignores [pos_fname]. See {!set_file} for changing this field.
+   Ignores [pos_fname]. See {!set_filename} for changing this field.
    @since 4.11 *)
 
 val set_filename: lexbuf -> string -> unit


### PR DESCRIPTION
This PR fixes a misreference in Stdlib.Lexing (as noted in [the original PR discussion](https://github.com/ocaml/ocaml/pull/8771#discussion_r298022705))