### PR TITLE
NameChoice (disambiguation): minor refactoring

### DIFF
--- a/Changes
+++ b/Changes
@@ -92,6 +92,9 @@ Working version
 - #9081: typedtree, make the pat_env field of pattern data immutable
   (Gabriel Scherer, review by Jacques Garrigue, report by Alain Frisch)
 
+- #9178: start refactoring the label-disambiguation logic (Typecore.NameChoice)
+  (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
+
 ### Build system:
 
 ### Bug fixes:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -40,21 +40,21 @@ type type_expected = {
   explanation: type_forcing_context option;
 }
 
-module Name_kind = struct
-  type t = Field | Constructor
+module Datatype_kind = struct
+  type t = Record | Variant
 
   let type_name = function
-    | Field -> "record"
-    | Constructor -> "variant"
+    | Record -> "record"
+    | Variant -> "variant"
 
-  let name = function
-    | Field -> "field"
-    | Constructor -> "constructor"
+  let label_name = function
+    | Record -> "field"
+    | Variant -> "constructor"
 end
 
 type wrong_name = {
   type_path: Path.t;
-  kind: Name_kind.t;
+  kind: Datatype_kind.t;
   name: string loc;
   valid_names: string list;
 }
@@ -86,7 +86,7 @@ type error =
   | Label_not_mutable of Longident.t
   | Wrong_name of string * type_expected * wrong_name
   | Name_type_mismatch of
-      Name_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
+      Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
   | Undefined_method of type_expr * string * string list option
   | Undefined_inherited_method of string * string list
@@ -608,7 +608,7 @@ exception Wrong_name_disambiguation of Env.t * wrong_name
 module NameChoice(Name : sig
   type t
   type usage
-  val kind: Name_kind.t
+  val kind: Datatype_kind.t
   val get_name: t -> string
   val get_type: t -> type_expr
   val lookup_all_from_type:
@@ -693,7 +693,7 @@ end) = struct
         end
     | Some(tpath0, tpath, pr) ->
         let warn_pr () =
-          let name = Name_kind.name kind in
+          let name = Datatype_kind.label_name kind in
           warn lid.loc
             (Warnings.Not_principal
                ("this type-based " ^ name ^ " disambiguation"))
@@ -767,7 +767,7 @@ let wrap_disambiguate msg ty f x =
 module Label = NameChoice (struct
   type t = label_description
   type usage = unit
-  let kind = Name_kind.Field
+  let kind = Datatype_kind.Record
   let get_name lbl = lbl.lbl_name
   let get_type lbl = lbl.lbl_res
   let lookup_all_from_type loc () path env =
@@ -933,7 +933,7 @@ let check_recordpat_labels loc lbl_pat_list closed =
 module Constructor = NameChoice (struct
   type t = constructor_description
   type usage = Env.constructor_usage
-  let kind = Name_kind.Constructor
+  let kind = Datatype_kind.Variant
   let get_name cstr = cstr.cstr_name
   let get_type cstr = cstr.cstr_res
   let lookup_all_from_type loc usage path env =
@@ -5118,14 +5118,14 @@ let report_error ~loc env = function
              The %s %s does not belong to type %a@]"
             eorp type_expr ty
             (report_type_expected_explanation_opt explanation)
-            (Name_kind.name kind)
+            (Datatype_kind.label_name kind)
             name.txt (*kind*) path type_path;
         end;
         spellcheck ppf name.txt valid_names
       ) ()
   | Name_type_mismatch (kind, lid, tp, tpl) ->
-      let type_name = Name_kind.type_name kind in
-      let name = Name_kind.name kind in
+      let type_name = Datatype_kind.type_name kind in
+      let name = Datatype_kind.label_name kind in
       Location.error_of_printer ~loc (fun ppf () ->
         report_ambiguous_type_error ppf env tp tpl
           (function ppf ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -55,15 +55,15 @@ val mk_expected:
 
 val is_nonexpansive: Typedtree.expression -> bool
 
-module Name_kind : sig
-  type t = Field | Constructor
+module Datatype_kind : sig
+  type t = Record | Variant
   val type_name : t -> string
-  val name : t -> string
+  val label_name : t -> string
 end
 
 type wrong_name = {
   type_path: Path.t;
-  kind: Name_kind.t;
+  kind: Datatype_kind.t;
   name: string loc;
   valid_names: string list;
 }
@@ -145,7 +145,7 @@ type error =
   | Label_not_mutable of Longident.t
   | Wrong_name of string * type_expected * wrong_name
   | Name_type_mismatch of
-      Name_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
+      Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
   | Undefined_method of type_expr * string * string list option
   | Undefined_inherited_method of string * string list

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -114,6 +114,12 @@ val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t
 
 val self_coercion : (Path.t * Location.t list ref) list ref
 
+module Label_kind : sig
+  type t = Field | Constructor
+  val type_name : t -> string
+  val label_name : t -> string
+end
+
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Ctype.Unification_trace.t
@@ -131,9 +137,9 @@ type error =
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t
   | Wrong_name of
-      string * type_expected * string * Path.t * string * string list
+      string * type_expected * Label_kind.t * Path.t * string * string list
   | Name_type_mismatch of
-      string * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
+      Label_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
   | Undefined_method of type_expr * string * string list option
   | Undefined_inherited_method of string * string list

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -55,6 +55,19 @@ val mk_expected:
 
 val is_nonexpansive: Typedtree.expression -> bool
 
+module Label_kind : sig
+  type t = Field | Constructor
+  val type_name : t -> string
+  val label_name : t -> string
+end
+
+type wrong_name = {
+  type_path: Path.t;
+  kind: Label_kind.t;
+  name: string loc;
+  valid_names: string list;
+}
+
 type existential_restriction =
   | At_toplevel (** no existential types at the toplevel *)
   | In_group (** nor with [let ... and ...] *)
@@ -114,12 +127,6 @@ val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t
 
 val self_coercion : (Path.t * Location.t list ref) list ref
 
-module Label_kind : sig
-  type t = Field | Constructor
-  val type_name : t -> string
-  val label_name : t -> string
-end
-
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Ctype.Unification_trace.t
@@ -136,8 +143,7 @@ type error =
   | Label_multiply_defined of string
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t
-  | Wrong_name of
-      string * type_expected * Label_kind.t * Path.t * string * string list
+  | Wrong_name of string * type_expected * wrong_name
   | Name_type_mismatch of
       Label_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -55,15 +55,15 @@ val mk_expected:
 
 val is_nonexpansive: Typedtree.expression -> bool
 
-module Label_kind : sig
+module Name_kind : sig
   type t = Field | Constructor
   val type_name : t -> string
-  val label_name : t -> string
+  val name : t -> string
 end
 
 type wrong_name = {
   type_path: Path.t;
-  kind: Label_kind.t;
+  kind: Name_kind.t;
   name: string loc;
   valid_names: string list;
 }
@@ -145,7 +145,7 @@ type error =
   | Label_not_mutable of Longident.t
   | Wrong_name of string * type_expected * wrong_name
   | Name_type_mismatch of
-      Label_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
+      Name_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
   | Undefined_method of type_expr * string * string list option
   | Undefined_inherited_method of string * string list


### PR DESCRIPTION
@trefis and myself tried to start cleaning up the fairly horrible code of NameChoice.

This PR has two independent commits (better reviewed separately) that simplify one tiny part of the error logic.