### PR TITLE
Make ocamlobjinfo work on .cmxs files on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,10 @@ Working version
   from a different (older or newer), incompatible compiler version.
   (Gabriel Scherer, review by Gabriel Radanne and Damien Doligez)
 
+- #9181: make objinfo work on Cygwin and look for the caml_plugin_header
+  symbol in both the static and the dynamic symbol tables.
+  (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)
+
 ### Manual and documentation:
 
 - #9141: beginning of the ocamltest reference manual

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -264,10 +264,14 @@ beforedepend:: opnames.ml
 
 # Display info on compiled files
 
+DEF_SYMBOL_PREFIX = '-Dsymbol_prefix=""'
+
 ifeq "$(SYSTEM)" "macosx"
 DEF_SYMBOL_PREFIX = '-Dsymbol_prefix="_"'
-else
-DEF_SYMBOL_PREFIX = '-Dsymbol_prefix=""'
+endif
+
+ifeq "$(SYSTEM)" "cygwin"
+DEF_SYMBOL_PREFIX = '-Dsymbol_prefix="_"'
 endif
 
 objinfo_helper$(EXE): objinfo_helper.$(O)

--- a/tools/objinfo_helper.c
+++ b/tools/objinfo_helper.c
@@ -28,6 +28,45 @@
 
 #define plugin_header_sym (symbol_prefix "caml_plugin_header")
 
+/* We need to refer to a few functions of the BFD library that are */
+/* actually defined as macros. We thus define equivalent */
+/* functions below */
+
+long get_static_symtab_upper_bound(bfd *fd)
+{
+  return bfd_get_symtab_upper_bound(fd);
+}
+
+long get_dynamic_symtab_upper_bound(bfd *fd)
+{
+  return bfd_get_dynamic_symtab_upper_bound(fd);
+}
+
+long canonicalize_static_symtab(bfd * fd, asymbol **symbolTable)
+{
+  return bfd_canonicalize_symtab(fd, symbolTable);
+}
+
+long canonicalize_dynamic_symtab(bfd * fd, asymbol **symbolTable)
+{
+  return bfd_canonicalize_dynamic_symtab(fd, symbolTable);
+}
+
+typedef struct {
+  long (*get_upper_bound)(bfd *);
+  long (*canonicalize)(bfd *, asymbol **);
+} symTable_ops;
+
+symTable_ops staticSymTable_ops = {
+  &get_static_symtab_upper_bound,
+  &canonicalize_static_symtab
+};
+
+symTable_ops dynamicSymTable_ops = {
+  &get_dynamic_symtab_upper_bound,
+  &canonicalize_dynamic_symtab
+};
+
 /* Print an error message and exit */
 static void error(bfd *fd, char *msg, ...)
 {
@@ -40,14 +79,36 @@ static void error(bfd *fd, char *msg, ...)
   exit(2);
 }
 
+/* Look for plugin_header_sym in the specified symbol table */
+/* Return its address, -1 if not found */
+long lookup(bfd* fd, symTable_ops *ops)
+{
+  long st_size;
+  asymbol ** symbol_table;
+  long sym_count, i;
+
+  st_size = ops->get_upper_bound (fd);
+  if (st_size <= 0) return -1;
+
+  symbol_table = malloc(st_size);
+  if (! symbol_table)
+    error(fd, "Error: out of memory");
+
+  sym_count = ops->canonicalize (fd, symbol_table);
+
+  for (i = 0; i < sym_count; i++) {
+    if (strcmp(symbol_table[i]->name, plugin_header_sym) == 0)
+      return symbol_table[i]->value;
+  }
+  return -1;
+}
+
 int main(int argc, char ** argv)
 {
   bfd *fd;
   asection *sec;
   file_ptr offset;
-  long st_size;
-  asymbol ** symbol_table;
-  long sym_count, i;
+  long value;
 
   if (argc != 2)
     error(NULL, "Usage: objinfo_helper <dynamic library>");
@@ -63,25 +124,17 @@ int main(int argc, char ** argv)
     error(fd, "Error: section .data not found");
 
   offset = sec->filepos;
-  st_size = bfd_get_dynamic_symtab_upper_bound (fd);
-  if (st_size <= 0)
-    error(fd, "Error: size of section .data unknown");
 
-  symbol_table = malloc(st_size);
-  if (! symbol_table)
-    error(fd, "Error: out of memory");
+  value = lookup(fd, &dynamicSymTable_ops);
 
-  sym_count = bfd_canonicalize_dynamic_symtab (fd, symbol_table);
+  if (value == -1)
+    value = lookup(fd, &staticSymTable_ops);
+  bfd_close(fd);
 
-  for (i = 0; i < sym_count; i++) {
-    if (strcmp(symbol_table[i]->name, plugin_header_sym) == 0) {
-      printf("%ld\n", (long) (offset + symbol_table[i]->value));
-      bfd_close(fd);
-      return 0;
-    }
-  }
+  if (value == -1)
+    error(NULL, "Error: missing symbol %s", plugin_header_sym);
 
-  error(fd, "Error: missing symbol %s", plugin_header_sym);
+  printf("%ld\n", (long) offset + value);
 }
 
 #else


### PR DESCRIPTION
For a long time, the BFD support was not enabled on Windows.

Recently, commit 69316099b041089c096816da2685b99c59d10f2e changed this
and so objinfo_helper started to be compiled on Windows and the related
test to be run... and to fail.

There are two reasons why the test was failing:

- objinfo_helper was looking for the wrong symbol, caml_plugin_header
  in stead of _caml_plugin_header

- It was looking for in in the dynamic symbol table while on Windows
  it can be found in the static symbol table

The PR addresses all this. The modification in `tools/Makefile` is to
look for the right symblo.

`objinfo_helper` has been modified to look in both symbol tables.

It should now be possible to use `objinfo` on `.cmxs` files on Windows.