### PR TITLE
Dynlink: preserve module initializers backtrace

### DIFF
--- a/Changes
+++ b/Changes
@@ -89,6 +89,10 @@ Working version
 - #9106: Register printer for Unix_error in win32unix, as in unix.
   (Christopher Zimmermann, review by David Allsopp)
 
+- #9183: Preserve exception backtrace of exceptions raised by top-level phrases
+  of dynlinked modules.
+  (Nicolás Ojeda Bär, review by Xavier Clerc and Gabriel Scherer)
+
 ### Tools:
 
 - #9276: objinfo: cm[x]a print extra C options, objects and dlls in

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -27,8 +27,8 @@ include $(ROOTDIR)/Makefile.best_binaries
 
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
-OCAMLC=$(BEST_OCAMLC) -nostdlib -I $(ROOTDIR)/stdlib
-OCAMLOPT=$(BEST_OCAMLOPT) -nostdlib -I $(ROOTDIR)/stdlib
+OCAMLC=$(BEST_OCAMLC) -g -nostdlib -I $(ROOTDIR)/stdlib
+OCAMLOPT=$(BEST_OCAMLOPT) -g -nostdlib -I $(ROOTDIR)/stdlib
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \

--- a/otherlibs/dynlink/byte/dynlink.ml
+++ b/otherlibs/dynlink/byte/dynlink.ml
@@ -134,7 +134,10 @@ module Bytecode = struct
     if priv then Symtable.hide_additions old_state;
     let _, clos = Meta.reify_bytecode code events (Some digest) in
     try ignore ((clos ()) : Obj.t)
-    with exn -> raise (DT.Error (Library's_module_initializers_failed exn))
+    with exn ->
+      Printexc.raise_with_backtrace
+        (DT.Error (Library's_module_initializers_failed exn))
+        (Printexc.get_raw_backtrace ())
 
   let load ~filename:file_name ~priv:_ =
     let ic = open_in_bin file_name in

--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -82,7 +82,10 @@ module Native = struct
   let run handle ~unit_header ~priv:_ =
     List.iter (fun cu ->
         try ndl_run handle cu
-        with exn -> raise (DT.Error (Library's_module_initializers_failed exn)))
+        with exn ->
+          Printexc.raise_with_backtrace
+            (DT.Error (Library's_module_initializers_failed exn))
+            (Printexc.get_raw_backtrace ()))
       (Unit_header.defined_symbols unit_header)
 
   let load ~filename ~priv =

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -103,10 +103,37 @@ static struct debug_info *find_debug_info(code_t pc)
 
 static int cmp_ev_info(const void *a, const void *b)
 {
-  code_t pc_a = ((const struct ev_info*)a)->ev_pc;
-  code_t pc_b = ((const struct ev_info*)b)->ev_pc;
+  const struct ev_info* ev_a = a;
+  const struct ev_info* ev_b = b;
+  code_t pc_a = ev_a->ev_pc;
+  code_t pc_b = ev_b->ev_pc;
+  int num_a;
+  int num_b;
+
+  /* Perform a full lexicographic comparison to make sure the resulting order is
+     the same under all implementations of qsort (which is not stable). */
+
   if (pc_a > pc_b) return 1;
   if (pc_a < pc_b) return -1;
+
+  num_a = ev_a->ev_lnum;
+  num_b = ev_b->ev_lnum;
+
+  if (num_a > num_b) return 1;
+  if (num_a < num_b) return -1;
+
+  num_a = ev_a->ev_startchr;
+  num_b = ev_b->ev_startchr;
+
+  if (num_a > num_b) return 1;
+  if (num_a < num_b) return -1;
+
+  num_a = ev_a->ev_endchr;
+  num_b = ev_b->ev_endchr;
+
+  if (num_a > num_b) return 1;
+  if (num_a < num_b) return -1;
+
   return 0;
 }
 

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -1,6 +1,6 @@
 Error: Failure("Plugin error")
 Raised at file "stdlib.ml", line 29, characters 22-33
-Called from file "test10_plugin.ml", line 2, characters 15-38
+Called from file "test10_plugin.ml", line 3, characters 2-21
 Called from file "test10_plugin.ml", line 6, characters 2-6
 Called from file "test10_plugin.ml", line 10, characters 2-6
 Called from file "otherlibs/dynlink/dynlink.ml", line 137, characters 16-25

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -1,0 +1,12 @@
+Error: Failure("Plugin error")
+Raised at file "stdlib.ml", line 29, characters 22-33
+Called from file "test10_plugin.ml", line 2, characters 15-38
+Called from file "test10_plugin.ml", line 6, characters 2-6
+Called from file "test10_plugin.ml", line 10, characters 2-6
+Called from file "otherlibs/dynlink/dynlink.ml", line 137, characters 16-25
+Re-raised at file "otherlibs/dynlink/dynlink.ml", line 140, characters 8-61
+Called from file "otherlibs/dynlink/dynlink_common.ml", line 344, characters 13-44
+Called from file "list.ml", line 110, characters 12-15
+Called from file "otherlibs/dynlink/dynlink_common.ml", line 342, characters 8-240
+Re-raised at file "otherlibs/dynlink/dynlink_common.ml", line 352, characters 14-17
+Called from file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.ml
@@ -1,0 +1,57 @@
+(* TEST
+
+include dynlink
+
+files = "test10_plugin.ml"
+flags += "-g"
+
+libraries = ""
+
+* no-flambda
+** shared-libraries
+*** setup-ocamlc.byte-build-env
+**** ocamlc.byte
+module = "test10_main.ml"
+**** ocamlc.byte
+module = "test10_plugin.ml"
+**** ocamlc.byte
+program = "${test_build_directory}/test10.byte"
+libraries = "dynlink"
+all_modules = "test10_main.cmo"
+***** run
+****** check-program-output
+reference = "${test_source_directory}/test10_main.byte.reference"
+
+*** native-dynlink
+**** setup-ocamlopt.byte-build-env
+***** ocamlopt.byte
+module = "test10_main.ml"
+***** ocamlopt.byte
+program = "test10_plugin.cmxs"
+flags = "-shared"
+all_modules = "test10_plugin.ml"
+***** ocamlopt.byte
+program = "${test_build_directory}/test10.exe"
+libraries = "dynlink"
+all_modules = "test10_main.cmx"
+****** run
+******* check-program-output
+reference = "${test_source_directory}/test10_main.native.reference"
+*)
+
+(* Check that a module in the main program whose initializer has not
+   executed completely cannot be depended upon by a shared library being
+   loaded. *)
+
+let () =
+  Printexc.record_backtrace true;
+  try
+    if Dynlink.is_native then begin
+      Dynlink.loadfile "test10_plugin.cmxs"
+    end else begin
+      Dynlink.loadfile "test10_plugin.cmo"
+    end
+  with
+  | Dynlink.Error (Dynlink.Library's_module_initializers_failed exn) ->
+      Printf.eprintf "Error: %s\n%!" (Printexc.to_string exn);
+      Printexc.print_backtrace stderr

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -1,0 +1,14 @@
+Error: Failure("Plugin error")
+Raised at file "stdlib.ml", line 29, characters 17-33
+Called from file "test10_plugin.ml", line 2, characters 15-38
+Called from file "test10_plugin.ml", line 10, characters 2-6
+Called from file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Called from file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
+Re-raised at file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
+Called from file "list.ml", line 110, characters 12-15
+Called from file "otherlibs/dynlink/dynlink_common.ml", line 344, characters 13-44
+Called from file "list.ml", line 110, characters 12-15
+Called from file "otherlibs/dynlink/dynlink_common.ml", line 342, characters 8-240
+Re-raised at file "otherlibs/dynlink/dynlink_common.ml", line 352, characters 8-17
+Called from file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 354, characters 26-45
+Called from file "test10_main.ml", line 49, characters 30-87

--- a/testsuite/tests/lib-dynlink-initializers/test10_plugin.ml
+++ b/testsuite/tests/lib-dynlink-initializers/test10_plugin.ml
@@ -1,0 +1,11 @@
+let g () =
+  if true then failwith "Plugin error";
+  print_endline "xxx"
+
+let f () =
+  g ();
+  print_endline "xxx"
+
+let () =
+  f ();
+  print_endline "xxx"


### PR DESCRIPTION
When dynlinking a module, if a top-level phrase raises, then we currently discard the backtrace of the exception, which makes it hard to locate the error. This PR tries to improve on this by using `Printexc.raise_with_backtrace`.

Currently only the native version seems to work correctly (see the `.reference` files). Not sure why the bytecode version does not work. Suggestions welcome!