### PR TITLE
Add high-precision time primitives in Unix module

### DIFF
--- a/otherlibs/unix/gettimeofday.c
+++ b/otherlibs/unix/gettimeofday.c
@@ -30,9 +30,23 @@ CAMLprim value unix_gettimeofday(value unit)
   return caml_copy_double((double) tp.tv_sec + (double) tp.tv_usec / 1e6);
 }
 
+CAMLprim value unix_gettimeofday_int(value unit)
+{
+  value res;
+  struct timeval tp;
+  if (gettimeofday(&tp, NULL) == -1) uerror("gettimeofday_int", Nothing);
+  res = caml_alloc_small(2, 0);
+  Field(res, 0) = caml_copy_int64(tp.tv_sec);
+  Field(res, 1) = caml_copy_int32(tp.tv_usec);
+  return res;
+}
+
 #else
 
 CAMLprim value unix_gettimeofday(value unit)
 { caml_invalid_argument("gettimeofday not implemented"); }
+
+CAMLprim value unix_gettimeofday_int(value unit)
+{ caml_invalid_argument("gettimeofday_int not implemented"); }
 
 #endif

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -499,12 +499,14 @@ type tm =
 
 external time : unit -> float = "unix_time"
 external gettimeofday : unit -> float = "unix_gettimeofday"
+external gettimeofday_int : unit -> int64*int32 = "unix_gettimeofday_int"
 external gmtime : float -> tm = "unix_gmtime"
 external localtime : float -> tm = "unix_localtime"
 external mktime : tm -> float * tm = "unix_mktime"
 external alarm : int -> int = "unix_alarm"
 external sleepf : float -> unit = "unix_sleep"
 let sleep duration = sleepf (float duration)
+external sleep_int : int64 -> int32 -> unit = "unix_sleep_int"
 external times : unit -> process_times = "unix_times"
 external utimes : string -> float -> float -> unit = "unix_utimes"
 

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1092,6 +1092,12 @@ val time : unit -> float
 val gettimeofday : unit -> float
 (** Same as {!Unix.time}, but with resolution better than 1 second. *)
 
+val gettimeofday_int : unit -> int64*int32
+(** Same as {!Unix.gettimeofday}, but using high-precision integers.
+   Return the pair: [seconds, microseconds].
+
+    @since 4.11.0 *)
+
 val gmtime : float -> tm
 (** Convert a time in seconds, as returned by {!Unix.time}, into a date and
    a time. Assumes UTC (Coordinated Universal Time), also known as GMT.
@@ -1126,6 +1132,11 @@ val sleepf : float -> unit
     but fractions of seconds are supported.
 
     @since 4.03.0 *)
+
+val sleep_int : int64 -> int32 -> unit
+(** Like [sleepf] but takes a pair [seconds, microseconds].
+
+    @since 4.11.0 *)
 
 val times : unit -> process_times
 (** Return the execution times of the process.

--- a/otherlibs/win32unix/sleep.c
+++ b/otherlibs/win32unix/sleep.c
@@ -17,12 +17,18 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-CAMLprim value unix_sleep(t)
-     value t;
-{
+CAMLprim value unix_sleep(t) {
   double d = Double_val(t);
   caml_enter_blocking_section();
   Sleep(d * 1e3);
+  caml_leave_blocking_section();
+  return Val_unit;
+}
+
+CAMLprim value unix_sleep(value sec, value usec) {
+  DWORD time = Int64_val(sec) * 1e3 + Int64_val(usec) / 1e3; 
+  caml_enter_blocking_section();
+  Sleep(time);
   caml_leave_blocking_section();
   return Val_unit;
 }

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -549,12 +549,14 @@ type tm =
 
 external time : unit -> float = "unix_time"
 external gettimeofday : unit -> float = "unix_gettimeofday"
+external gettimeofday_int : unit -> int64*int32 = "unix_gettimeofday_int"
 external gmtime : float -> tm = "unix_gmtime"
 external localtime : float -> tm = "unix_localtime"
 external mktime : tm -> float * tm = "unix_mktime"
 let alarm _n = invalid_arg "Unix.alarm not implemented"
 external sleepf : float -> unit = "unix_sleep"
 let sleep n = sleepf (float n)
+external sleep_int : int64 -> int32 -> unit = "unix_sleep_int"
 external times: unit -> process_times = "unix_times"
 external utimes : string -> float -> float -> unit = "unix_utimes"
 


### PR DESCRIPTION
The `Unix` API currently lacks an option to get high-precision time measurements as `float` timestamps are imprecise by design in their lower-digits.

This is a problem for application relying on time-tracking for tasks such as latency control. Typically, we recently realized this in [liquidsoap](https://github.com/savonet/liquidsoap) and have a pending PR adding this functionality via a direct binding of `<sys/time.h>`: https://github.com/savonet/liquidsoap/pull/1050

This PR adds such API to the `Unix` module. The windows part hasn't been tested yet but the unix part seems to be working fine.

I figure I'd submit this early to get quick feedback on naming and implementation choices before finalizing the changes.