### PR TITLE
fix spurious 'unused open' warning with classes and polymorphic variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,13 +219,13 @@ OCaml 4.10 release branch
 - #8833: Hint for (type) redefinitions in toplevel session
   (Florian Angeletti, review by Gabriel Scherer)
 
-- #2127: Refactor lookup functions
+- #2127, #9185: Refactor lookup functions
   Included observable changes:
     - makes the location of usage warnings and alerts for constructors more
       precise
     - don't warn about a constructor never being used to build values when it
       has been defined as private
-  (Leo White, review by Thomas Refis)
+  (Leo White, Hugo Heuzard review by Thomas Refis, Florian Angeletti)
 
 - #8702, #8777: improved error messages for fixed row polymorphic variants
   (Florian Angeletti, report by Leo White, review by Thomas Refis)

--- a/testsuite/tests/messages/precise_locations.ml
+++ b/testsuite/tests/messages/precise_locations.ml
@@ -19,7 +19,7 @@ function (x :
 Line 2, characters 1-4:
 2 | #bar) -> ();;
      ^^^
-Error: Unbound class bar
+Error: Unbound class type bar
 |}];;
 
 function

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -195,14 +195,6 @@ Line 8, characters 11-13:
 8 |     val f: #t -> unit
                ^^
 Alert deprecated: old syntax for polymorphic variant type
-Line 4, characters 4-22:
-4 |     type t = [`A | `B]
-        ^^^^^^^^^^^^^^^^^^
-Warning 34: unused type t.
-Line 7, characters 4-10:
-7 |     open M
-        ^^^^^^
-Warning 33: unused open M.
 module T6 : sig end
 |}]
 

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -210,14 +210,6 @@ module T7 : sig end = struct
   let _ = fun ((module S : S)) -> S.f (object end)
 end;;
 [%%expect {|
-Line 4, characters 4-29:
-4 |     class type t = object end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 34: unused type t.
-Line 7, characters 4-10:
-7 |     open M
-        ^^^^^^
-Warning 33: unused open M.
 module T7 : sig end
 |}]
 
@@ -233,13 +225,5 @@ module T8 : sig end = struct
   let _ = fun ((module S : S)) -> S.f (object end)
 end;;
 [%%expect {|
-Line 4, characters 4-24:
-4 |     class t = object end
-        ^^^^^^^^^^^^^^^^^^^^
-Warning 34: unused type t.
-Line 7, characters 4-10:
-7 |     open M
-        ^^^^^^
-Warning 33: unused open M.
 module T8 : sig end
 |}]

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -177,3 +177,77 @@ Line 2, characters 12-13:
 Warning 37: unused constructor A.
 module T5_bis : sig end
 |}]
+
+
+module T6 : sig end = struct
+  (* GPR9170 *)
+  module M = struct
+    type t = [`A | `B]
+  end
+  module type S = sig
+    open M
+    val f: #t -> unit
+  end
+  let _ = fun ((module S : S)) -> S.f `A
+end;;
+[%%expect {|
+Line 8, characters 11-13:
+8 |     val f: #t -> unit
+               ^^
+Alert deprecated: old syntax for polymorphic variant type
+Line 4, characters 4-22:
+4 |     type t = [`A | `B]
+        ^^^^^^^^^^^^^^^^^^
+Warning 34: unused type t.
+Line 7, characters 4-10:
+7 |     open M
+        ^^^^^^
+Warning 33: unused open M.
+module T6 : sig end
+|}]
+
+module T7 : sig end = struct
+  (* GPR9170 *)
+  module M = struct
+    class type t = object end
+  end
+  module type S = sig
+    open M
+    val f: #t -> unit
+  end
+  let _ = fun ((module S : S)) -> S.f (object end)
+end;;
+[%%expect {|
+Line 4, characters 4-29:
+4 |     class type t = object end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34: unused type t.
+Line 7, characters 4-10:
+7 |     open M
+        ^^^^^^
+Warning 33: unused open M.
+module T7 : sig end
+|}]
+
+module T8 : sig end = struct
+  (* GPR9170 *)
+  module M = struct
+    class t = object end
+  end
+  module type S = sig
+    open M
+    val f: #t -> unit
+  end
+  let _ = fun ((module S : S)) -> S.f (object end)
+end;;
+[%%expect {|
+Line 4, characters 4-24:
+4 |     class t = object end
+        ^^^^^^^^^^^^^^^^^^^^
+Warning 34: unused type t.
+Line 7, characters 4-10:
+7 |     open M
+        ^^^^^^
+Warning 33: unused open M.
+module T8 : sig end
+|}]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -276,6 +276,7 @@ and transl_type_aux env policy styp =
             | Longident.Lapply(_, _) -> fatal_error "Typetexp.transl_type"
           in
           let path, decl = Env.find_type_by_name lid2 env in
+          ignore(Env.lookup_cltype ~loc:lid.loc lid.txt env);
           (path, decl, false)
         with Not_found ->
           ignore (Env.lookup_class ~loc:lid.loc lid.txt env); assert false

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -266,6 +266,7 @@ and transl_type_aux env policy styp =
           in check decl;
           Location.deprecated styp.ptyp_loc
             "old syntax for polymorphic variant type";
+          ignore(Env.lookup_type ~loc:lid.loc lid.txt env);
           (path, decl,true)
         with Not_found -> try
           let lid2 =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -279,7 +279,7 @@ and transl_type_aux env policy styp =
           ignore(Env.lookup_cltype ~loc:lid.loc lid.txt env);
           (path, decl, false)
         with Not_found ->
-          ignore (Env.lookup_class ~loc:lid.loc lid.txt env); assert false
+          ignore (Env.lookup_cltype ~loc:lid.loc lid.txt env); assert false
       in
       if List.length stl <> decl.type_arity then
         raise(Error(styp.ptyp_loc, env,


### PR DESCRIPTION
fix https://github.com/ocaml/ocaml/issues/9170