### PR TITLE
Make tuple matching optimisation apply to Lswitch and Lstringswitch

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,9 @@ Working version
   (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez,
    KC Sivaramakrishnan and Xavier Leroy)
 
+- #9193: Make tuple matching optimisation apply to Lswitch and Lstringswitch.
+  (Stephen Dolan, review by Thomas Refis and Gabriel Scherer)
+
 ### Standard library:
 
 - #8771: Lexing: add set_position and set_filename to change (fake)

--- a/testsuite/tests/basic/tuple_match.ml
+++ b/testsuite/tests/basic/tuple_match.ml
@@ -1,0 +1,56 @@
+(* TEST *)
+
+let[@inline never] small_match n x =
+  let (left, right) = match x with
+    | 0 -> n, 42
+    | 1 -> 42, n
+    | _ -> assert false in
+  left - right
+
+let[@inline never] big_match n x =
+  let (left, right) = match x with
+    | 0 -> n, 42
+    | 1 -> 42, n
+    | 2 -> 42-n, 0
+    | 3 -> 0, 42-n
+    | 4 -> n/2, n/2
+    | 5 -> n, n
+    | _ -> assert false in
+  left - right
+
+let[@inline never] string_match n x =
+  let (left, right) = match x with
+    | "0" -> n, 42
+    | "1" -> 42, n
+    | "2" -> 42-n, 0
+    | "3" -> 0, 42-n
+    | "4" -> n/2, n/2
+    | "5" -> n, n
+    | _ -> assert false in
+  left - right
+
+
+
+
+let printf = Printf.printf
+
+let test f n i =
+  let mw_overhead =
+    let a = Gc.minor_words () in
+    let b = Gc.minor_words () in
+    b -. a in
+  let mw = Gc.minor_words () in
+  let k = f n i in
+  assert (k = 0);
+  let mw' = Gc.minor_words () in
+  let delta = int_of_float (mw' -. mw -. mw_overhead) in
+  printf "allocated %d words\n" delta
+
+let () =
+  let n = 42 in
+  printf "small_match:\n";
+  for i = 0 to 1 do test small_match n i done;
+  printf "big_match:\n";
+  for i = 0 to 5 do test big_match n i done;
+  printf "string_match:\n";
+  for i = 0 to 5 do test string_match n (string_of_int i) done

--- a/testsuite/tests/basic/tuple_match.reference
+++ b/testsuite/tests/basic/tuple_match.reference
@@ -1,0 +1,17 @@
+small_match:
+allocated 0 words
+allocated 0 words
+big_match:
+allocated 0 words
+allocated 0 words
+allocated 0 words
+allocated 0 words
+allocated 0 words
+allocated 0 words
+string_match:
+allocated 0 words
+allocated 0 words
+allocated 0 words
+allocated 0 words
+allocated 0 words
+allocated 0 words


### PR DESCRIPTION
There's an optimisation to avoid allocations when multiple values are bound by a single `let`:
```
let (a, b) =
  match foo with Some x -> (p, q) | None -> (r, s)
```
Here, no allocation is incurred for `(p, q)` or `(r, s)`.

However, because of a couple of missing cases in `map_return`, the optimisation stops working if the match above has more than three cases. This patch adds the missing cases and a test. (Trunk passes the `small_match` part of the test, but neither the `big_match` nor the `string_match` parts)