### PR TITLE
formatter margins and color handling: revert #244

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,19 @@ Working version
   symbol in both the static and the dynamic symbol tables.
   (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)
 
+* #9197: remove compatibility logic from #244 that was designed to
+  synchronize toplevel printing margins with Format.std_formatter,
+  but also resulted in unpredictable/fragile changes to formatter
+  margins.
+  Setting the margins on the desired formatters should now work.
+  typically on `Format.std_formatter`.
+  Note that there currently is no robust way to do this from the
+  toplevel, as applications may redirect toplevel printing. In
+  a compiler/toplevel driver, one should instead access
+  `Location.formatter_for_warnings`; it is not currently exposed
+  to the toplevel.
+  (Gabriel Scherer, review by Armaël Guéneau)
+
 ### Manual and documentation:
 
 - #9141: beginning of the ocamltest reference manual

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -693,8 +693,6 @@ module Color = struct
     } in
     pp_set_mark_tags ppf true; (* enable tags *)
     pp_set_formatter_stag_functions ppf functions';
-    (* also setup margins *)
-    pp_set_margin ppf (pp_get_margin std_formatter());
     ()
 
   external isatty : out_channel -> bool = "caml_sys_isatty"


### PR DESCRIPTION
The logic in #244 is wrong:
- setting the margins is not the responsibility of the color-handling code
- because setup_colors is called at inpredictable times (on the first error/warning),
  the logic makes it very difficult to correctly set margins for `{str,err}_formatter`

The patch was originally proposed in the caml-list discussion
  https://sympa.inria.fr/sympa/arc/caml-list/2015-09/msg00164.html
but it does not convincingly solve the problem:
- there is no reason to use `std_formatter`
  rather than `err_formatter` as a reference, and
- the user can set the both margins themselves anyway.

We have an API in `Location` to access and configure error/warning
formatters, but it is not accessible from the toplevel. Changing the
margins without using this API is fragile, for example, utop or
expect-tests change the formatter from the defaut of `err_formatter`.