### PR TITLE
Minor portability and standard-conformance issues in the runtime system

### DIFF
--- a/configure
+++ b/configure
@@ -14022,7 +14022,7 @@ fi
 fi
 
 
-CPP_FLAGS="$saved_CPPFLAGS"
+CPPFLAGS="$saved_CPPFLAGS"
 
 ## issetugid
 

--- a/configure.ac
+++ b/configure.ac
@@ -1074,7 +1074,7 @@ AC_CHECK_FUNC([secure_getenv],
   [AC_DEFINE([HAS_SECURE_GETENV])],
   [AC_CHECK_FUNC([__secure_getenv], [AC_DEFINE([HAS___SECURE_GETENV])])])
 
-CPP_FLAGS="$saved_CPPFLAGS"
+CPPFLAGS="$saved_CPPFLAGS"
 
 ## issetugid
 

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -69,14 +69,8 @@ static value alloc_host_entry(struct hostent *entry)
     else
       aliases = Atom(0);
     entry_h_length = entry->h_length;
-#ifdef h_addr
     addr_list =
       caml_alloc_array(alloc_one_addr, (const char**)entry->h_addr_list);
-#else
-    adr = alloc_one_addr(entry->h_addr);
-    addr_list = caml_alloc_small(1, 0);
-    Field(addr_list, 0) = adr;
-#endif
     res = caml_alloc_small(4, 0);
     Field(res, 0) = name;
     Field(res, 1) = aliases;

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -231,7 +231,8 @@ void caml_debugger_init(void)
       host = gethostbyname(address);
       if (host == NULL)
         caml_fatal_error("unknown debugging host %s", address);
-      memmove(&sock_addr.s_inet.sin_addr, host->h_addr, host->h_length);
+      memmove(&sock_addr.s_inet.sin_addr,
+              host->h_addr_list[0], host->h_length);
     }
     sock_addr.s_inet.sin_port = htons(atoi(port));
     sock_addr_len = sizeof(sock_addr.s_inet);

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -910,7 +910,7 @@ static struct large_free_block *bf_large_least;
 
 /* Find first (i.e. least significant) bit set in a word. */
 #ifdef HAS_FFS
-/* Nothing to do */
+#include <strings.h>
 #elif defined(HAS_BITSCANFORWARD)
 #include <intrin.h>
 static inline int ffs (int x)
@@ -924,7 +924,7 @@ static inline int ffs (int x)
 static inline int ffs (int x)
 {
   /* adapted from Hacker's Delight */
-  int result, bnz, b0, b1, b2, b3, b4;
+  int bnz, b0, b1, b2, b3, b4;
   CAMLassert ((x & 0xFFFFFFFF) == x);
   x = x & -x;
   bnz = x != 0;

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -244,7 +244,8 @@ void caml_instr_atexit (void)
     char *name = fname;
 
     if (name[0] == '@'){
-      snprintf (buf, sizeof(buf), "%s.%d", name + 1, getpid ());
+      snprintf (buf, sizeof(buf), "%s.%lld",
+                name + 1, (long long) (getpid ()));
       name = buf;
     }
     if (name[0] == '+'){


### PR DESCRIPTION
While playing with odd OS and C compilers recently, I found some anachronisms and minor mistakes that make the runtime system less portable and standard-conformant than it should be.   Each commit describes a different issue and its fix.

