### PR TITLE
Fixed #9207: ocamlyacc can now handle 255 entry points

### DIFF
--- a/Changes
+++ b/Changes
@@ -74,8 +74,8 @@ Working version
   (Gabriel Scherer, review by Armaël Guéneau)
 
 * #9207: fix ocamlyacc to work correctly with up to 255 entry points
-  to the grammar (previous limit was 127 due to a small bug).
-  (Andreas Abel)
+  to the grammar.
+  (Andreas Abel, review by Xavier Leroy)
 
 ### Manual and documentation:
 

--- a/Changes
+++ b/Changes
@@ -73,6 +73,10 @@ Working version
   to the toplevel.
   (Gabriel Scherer, review by Armaël Guéneau)
 
+* #9207: fix ocamlyacc to work correctly with up to 255 entry points
+  to the grammar (previous limit was 127 due to a small bug).
+  (Andreas Abel)
+
 ### Manual and documentation:
 
 - #9141: beginning of the ocamltest reference manual

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -150,8 +150,8 @@ struct bucket
 };
 
 /* MAX_ENTRY_POINT is the maximal number of entry points into the grammar. */
-/* At the time of writing (2019-12-25), there are assumptions              */
-/* that the octal value of entry fits into 3 digits (see reader.c).        */
+/* Entry points are identified by a non-zero byte in the input stream,     */
+/* so there are at most 255 entry points.                                  */
 
 #define MAX_ENTRY_POINT MAXCHAR
 

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -145,9 +145,15 @@ struct bucket
     short prec;
     char class;
     char assoc;
-    char entry;
+    unsigned char entry;  /* 1..MAX_ENTRY_POINT (0 for unassigned) */
     char true_token;
 };
+
+/* MAX_ENTRY_POINT is the maximal number of entry points into the grammar. */
+/* At the time of writing (2019-12-25), there are assumptions              */
+/* that the octal value of entry fits into 3 digits (see reader.c).        */
+
+#define MAX_ENTRY_POINT MAXCHAR
 
 /* TABLE_SIZE is the number of entries in the symbol table.      */
 /* TABLE_SIZE must be a power of two.                            */

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -177,8 +177,8 @@ token\n", virtual_input_file_name, lineno, s);
 
 void too_many_entries(void)
 {
-    fprintf(stderr, "File \"%s\", line %d: more than 256 entry points\n",
-            virtual_input_file_name, lineno);
+    fprintf(stderr, "File \"%s\", line %d: more than %u entry points\n",
+            virtual_input_file_name, lineno, MAX_ENTRY_POINT);
     done(1);
 }
 

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -978,9 +978,9 @@ void declare_start(void)
 
       if (bp->class == TERM)
         terminal_start(bp->name);
-      bp->entry = ++entry_counter;
-      if (entry_counter == 256)
+      if (entry_counter >= MAX_ENTRY_POINT)
         too_many_entries();
+      bp->entry = ++entry_counter;
     }
 }
 
@@ -1699,7 +1699,7 @@ void make_goal(void)
       if (is_polymorphic(bp->tag))
         polymorphic_entry_point(bp->name);
       fprintf(entry_file,
-              "let %s (lexfun : Lexing.lexbuf -> token) (lexbuf : Lexing.lexbuf) =\n   (Parsing.yyparse yytables %d lexfun lexbuf : %s)\n",
+              "let %s (lexfun : Lexing.lexbuf -> token) (lexbuf : Lexing.lexbuf) =\n   (Parsing.yyparse yytables %u lexfun lexbuf : %s)\n",
               bp->name, bp->entry, bp->tag);
       fprintf(interface_file,
               "val %s :\n  (Lexing.lexbuf  -> token) -> Lexing.lexbuf -> %s\n",


### PR DESCRIPTION
The previous promised limit of ocamlyacc was 256 entry points, the
actual limit was 127 due to representation of bucket->entry as char.
Switching to unsigned char extends the limit to 255.

I introduced a constant MAX_ENTRY_POINT as a synonym of MAXCHAR to
handle checks against the limit consistently over the different modules
of ocamlyacc.

Extensions beyond 255 entry points would require a bit more work (which
looks unrewarding) since there is an assumption in the implementation
that the octal representation of an entry point fits into 3 digits.

- [x] Documentation: the upper limit on entry points was not documented in the man page, so I did not edit the man pages.
- [x] Testing: I did not find a comprehensive testsuite in place for ocamlyacc, thus, I did not add any tests. The existing test (singular) runs fine.

Merry Christmas!