### PR TITLE
Remove an unused variable

### DIFF
--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -924,7 +924,7 @@ static inline int ffs (int x)
 static inline int ffs (int x)
 {
   /* adapted from Hacker's Delight */
-  int result, bnz, b0, b1, b2, b3, b4;
+  int bnz, b0, b1, b2, b3, b4;
   CAMLassert ((x & 0xFFFFFFFF) == x);
   x = x & -x;
   bnz = x != 0;


### PR DESCRIPTION
This unused variable raises a warning turned into error when `HAS_FFS` and `HAS_BITSCANFORWARD` are not defined.
This case doesn't seem to be tested in the CI but this code is used by `ocaml-freestanding` and triggered the error.