### PR TITLE
Fix the "Wrong file naming" error message

### DIFF
--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -343,7 +343,7 @@ let report_error ppf =
   let open Format in
   function
   | Illegal_renaming(modname, ps_name, filename) -> fprintf ppf
-      "Wrong file naming: %a@ contains the compiled interface for @ \
+      "Wrong file naming: %a@ contains the compiled interface for@ \
        %s when %s was expected"
       Location.print_filename filename ps_name modname
   | Inconsistent_import(name, source1, source2) -> fprintf ppf


### PR DESCRIPTION
In https://github.com/ocaml/ocaml/issues/9218, we can see that the error message has an extra space before `Result` that should not be here and might distract users getting the error:
```
File "core/irTransform.ml", line 1:
Error: Wrong file naming: /home/kit_ty_kate/.opam/4.10/lib/result/result.cmi
       contains the compiled interface for  Result when result was expected
```