### PR TITLE
Stdlib: Add curry/uncurry functions to Fun

### DIFF
--- a/Changes
+++ b/Changes
@@ -33,6 +33,8 @@ Working version
 
 ### Standard library:
 
+- #9220: Add `curry` and `uncurry` functions to `Fun` module.
+
 - #8771: Lexing: add set_position and set_filename to change (fake)
    the initial tracking position of the lexbuf.
    (Konstantin Romanov, Miguel Lumapat, review by Gabriel Scherer,

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -16,6 +16,8 @@
 external id : 'a -> 'a = "%identity"
 let const c _ = c
 let flip f x y = f y x
+let curry f x y = f (x, y)
+let uncurry f (x, y) = f x y
 let negate p v = not (p v)
 
 exception Finally_raised of exn

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -30,6 +30,16 @@ val flip : ('a -> 'b -> 'c) -> ('b -> 'a -> 'c)
 (** [flip f] reverses the argument order of the binary function
     [f]. For any arguments [x] and [y], [(flip f) x y] is [f y x]. *)
 
+val curry : (('a * 'b) -> 'c) -> 'a -> 'b -> 'c
+(** [curry f] converts an uncurried function to a curried function.
+    @since 4.11
+*)
+
+val uncurry : ('a -> 'b -> 'c) -> ('a * 'b) -> 'c
+(** [uncurry f] converts a curried function to a function of pairs.
+    @since 4.11
+*)
+
 val negate : ('a -> bool) -> ('a -> bool)
 (** [negate p] is the negation of the predicate function [p]. For any
     argument [x], [(negate p) x] is [not (p x)]. *)

--- a/testsuite/tests/lib-fun/test.ml
+++ b/testsuite/tests/lib-fun/test.ml
@@ -19,6 +19,16 @@ let test_flip () =
   assert (Fun.flip List.cons [2] 1 = [1;2]);
   ()
 
+let test_curry () =
+  let f (a,b) = a + b in
+  assert (Fun.curry f 1 2 = 3);
+  ()
+
+let test_uncurry () =
+  let f a b = a + b in
+  assert (Fun.uncurry f (1,2) = 3);
+  ()
+
 let test_negate () =
   assert (Fun.negate (Bool.equal true) true = false);
   assert (Fun.negate (Bool.equal true) false = true);
@@ -42,6 +52,8 @@ let tests () =
   test_id ();
   test_const ();
   test_flip ();
+  test_curry ();
+  test_uncurry ();
   test_negate ();
   test_protect ();
   ()


### PR DESCRIPTION
Add two functions to the `Fun` module that I think can be pretty
useful.

The use of `uncurry` in some tests entails changing a reference file
so it refers to `Stdlib__fun!`.
