### PR TITLE
fix Makefile dependencies of ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -125,7 +125,8 @@ Working version
 - #9178: start refactoring the label-disambiguation logic (Typecore.NameChoice)
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
-- #9211, #9215: fix Makefile dependencies of compilerlibs archives and dynlink
+- #9211, #9215, #9222: fix Makefile dependencies in
+  compilerlibs, dynlink, ocamltest.
   (Gabriel Scherer, review by Vincent Laviron and David Allsopp)
 
 ### Build system:

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -202,19 +202,24 @@ all: ocamltest$(EXE)
 allopt: ocamltest.opt$(EXE)
 opt.opt: allopt
 
-ocamltest$(EXE): $(bytecode_modules)
-	$(ocamlc_cmd) -custom ocamlcommon.cma ocamlbytecomp.cma -o $@ $^
+compdeps_names=ocamlcommon ocamlbytecomp
+compdeps_paths=$(addprefix $(ROOTDIR)/compilerlibs/,$(compdeps_names))
+compdeps_byte=$(addsuffix .cma,$(compdeps_paths))
+compdeps_opt=$(addsuffix .cmxa,$(compdeps_paths))
 
-%.cmo: %.ml
+ocamltest$(EXE): $(compdeps_byte) $(bytecode_modules)
+	$(ocamlc_cmd) -custom -o $@ $^
+
+%.cmo: %.ml $(compdeps_byte)
 	$(ocamlc) -c $<
 
-ocamltest.opt$(EXE): $(native_modules)
-	$(ocamlopt_cmd) ocamlcommon.cmxa ocamlbytecomp.cmxa -o $@ $^
+ocamltest.opt$(EXE): $(compdeps_opt) $(native_modules)
+	$(ocamlopt_cmd) -o $@ $^
 
-%.cmx: %.ml
+%.cmx: %.ml $(compdeps_opt)
 	$(ocamlopt) -c $<
 
-%.cmi: %.mli
+%.cmi: %.mli $(compdeps_byte)
 	$(ocamlc) -c $<
 
 %.ml %.mli: %.mly


### PR DESCRIPTION
The ocamltest modules depend on core-compiler modules and get linked
with compilerlibs archives, but those dependencies were not recorded
in the makefile, leading to incremental build errors.

(A particular error I encountered is that ocamltest/Ocaml_actions now
depends on Lambda through Cmo_format, but was not correctly rebuilt
after Lambda changes, leading to link-time failure when linking
ocaml_actions.cmo and ocamlcommon.cma together.)

This commit adds dependencies on the compilerlibs archives, as a proxy
for the corresponding compiler modules.