### PR TITLE
remove unused clos_vars from Uconst_closure and Const_closure

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -2665,7 +2665,7 @@ let fundecls_size fundecls =
 
 (* Emit constant closures *)
 
-let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
+let emit_constant_closure ((_, global_symb) as symb) fundecls cont =
   let closure_symbol (f : Clambda.ufunction) =
     if Config.flambda then
       cdefine_symbol (f.label ^ "_closure", global_symb)
@@ -2674,14 +2674,10 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
   in
   match (fundecls : Clambda.ufunction list) with
     [] ->
-      (* This should probably not happen: dead code has normally been
-         eliminated and a closure cannot be accessed without going through
-         a [Project_closure], which depends on the function. *)
-      assert (clos_vars = []);
-      cdefine_symbol symb @ clos_vars @ cont
+      cdefine_symbol symb @ cont
   | f1 :: remainder ->
       let rec emit_others pos = function
-          [] -> clos_vars @ cont
+          [] -> cont
       | (f2 : Clambda.ufunction) :: rem ->
           if f2.arity = 1 || f2.arity = 0 then
             Cint(infix_header pos) ::
@@ -2696,8 +2692,7 @@ let emit_constant_closure ((_, global_symb) as symb) fundecls clos_vars cont =
             cint_const f2.arity ::
             Csymbol_address f2.label ::
             emit_others (pos + 4) rem in
-      Cint(black_closure_header (fundecls_size fundecls
-                                 + List.length clos_vars)) ::
+      Cint(black_closure_header (fundecls_size fundecls)) ::
       cdefine_symbol symb @
       (closure_symbol f1) @
       if f1.arity = 1 || f1.arity = 0 then

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -642,7 +642,7 @@ val fundecls_size : Clambda.ufunction list -> int
 
 val emit_constant_closure :
   (string * Cmmgen_state.is_global) -> Clambda.ufunction list ->
-  data_item list -> data_item list -> data_item list
+  data_item list -> data_item list
 
 val emit_preallocated_blocks :
   Clambda.preallocated_block list -> phrase list -> phrase list

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -212,8 +212,8 @@ let emit_structured_constant ((_sym, is_global) as symb) cst cont =
       emit_block symb (block_header tag (List.length csts)) cont
   | Uconst_float_array fields ->
       emit_float_array_constant symb fields cont
-  | Uconst_closure(fundecls, lbl, fv) ->
-      Cmmgen_state.add_constant lbl (Const_closure (is_global, fundecls, fv));
+  | Uconst_closure(fundecls, lbl) ->
+      Cmmgen_state.add_constant lbl (Const_closure (is_global, fundecls));
       List.iter (fun f -> Cmmgen_state.add_function f) fundecls;
       cont
 
@@ -366,7 +366,7 @@ let rec transl env e =
       transl_constant Debuginfo.none sc
   | Uclosure(fundecls, []) ->
       let sym = Compilenv.new_const_symbol() in
-      Cmmgen_state.add_constant sym (Const_closure (Local, fundecls, []));
+      Cmmgen_state.add_constant sym (Const_closure (Local, fundecls));
       List.iter (fun f -> Cmmgen_state.add_function f) fundecls;
       let dbg =
         match fundecls with
@@ -1382,10 +1382,9 @@ let emit_cmm_data_items_for_constants cont =
   let c = ref cont in
   String.Map.iter (fun symbol (cst : Cmmgen_state.constant) ->
       match cst with
-      | Const_closure (global, fundecls, clos_vars) ->
+      | Const_closure (global, fundecls) ->
           let cmm =
-            emit_constant_closure (symbol, global) fundecls
-              (List.fold_right emit_constant clos_vars []) []
+            emit_constant_closure (symbol, global) fundecls []
           in
           c := (Cdata cmm) :: !c
       | Const_table (global, elems) ->

--- a/asmcomp/cmmgen_state.ml
+++ b/asmcomp/cmmgen_state.ml
@@ -22,7 +22,7 @@ module S = Misc.Stdlib.String
 type is_global = Global | Local
 
 type constant =
-  | Const_closure of is_global * Clambda.ufunction list * Clambda.uconstant list
+  | Const_closure of is_global * Clambda.ufunction list
   | Const_table of is_global * Cmm.data_item list
 
 type t = {

--- a/asmcomp/cmmgen_state.mli
+++ b/asmcomp/cmmgen_state.mli
@@ -22,7 +22,7 @@
 type is_global = Global | Local
 
 type constant =
-  | Const_closure of is_global * Clambda.ufunction list * Clambda.uconstant list
+  | Const_closure of is_global * Clambda.ufunction list
   | Const_table of is_global * Cmm.data_item list
 
 val add_constant : Misc.Stdlib.String.t -> constant -> unit

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -29,7 +29,7 @@ type ustructured_constant =
   | Uconst_block of int * uconstant list
   | Uconst_float_array of float list
   | Uconst_string of string
-  | Uconst_closure of ufunction list * string * uconstant list
+  | Uconst_closure of ufunction list * string
 
 and uconstant =
   | Uconst_ref of string * ustructured_constant option
@@ -199,7 +199,7 @@ let compare_structured_constants c1 c2 =
   | Uconst_float_array l1, Uconst_float_array l2 ->
       compare_float_lists l1 l2
   | Uconst_string s1, Uconst_string s2 -> String.compare s1 s2
-  | Uconst_closure (_,lbl1,_), Uconst_closure (_,lbl2,_) ->
+  | Uconst_closure (_,lbl1), Uconst_closure (_,lbl2) ->
       String.compare lbl1 lbl2
   | _, _ ->
     (* no overflow possible here *)

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -29,7 +29,7 @@ type ustructured_constant =
   | Uconst_block of int * uconstant list
   | Uconst_float_array of float list
   | Uconst_string of string
-  | Uconst_closure of ufunction list * string * uconstant list
+  | Uconst_closure of ufunction list * string
 
 and uconstant =
   | Uconst_ref of string * ustructured_constant option

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -598,7 +598,7 @@ and to_clambda_closed_set_of_closures t env symbol
   in
   let ufunct = List.map to_clambda_function functions in
   let closure_lbl = Linkage_name.to_string (Symbol.label symbol) in
-  Uconst_closure (ufunct, closure_lbl, [])
+  Uconst_closure (ufunct, closure_lbl)
 
 let to_clambda_initialize_symbol t env symbol fields : Clambda.ulambda =
   let fields =

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -51,12 +51,10 @@ let rec structured_constant ppf = function
       List.iter (fun f -> fprintf ppf ",%F" f) fl;
       fprintf ppf ")"
   | Uconst_string s -> fprintf ppf "%S" s
-  | Uconst_closure(clos, sym, fv) ->
+  | Uconst_closure(clos, sym) ->
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
-      let sconsts ppf scl =
-        List.iter (fun sc -> fprintf ppf "@ %a" uconstant sc) scl in
-      fprintf ppf "@[<2>(const_closure%a %s@ %a)@]" funs clos sym sconsts fv
+      fprintf ppf "@[<2>(const_closure%a %s @)@]" funs clos sym
 
 and one_fun ppf f =
   let idents ppf =


### PR DESCRIPTION
The clos_vars argument to Uconst_closure and Const_closure was added in #395, but was never used. This patch removes it.

I don't believe this needs a changes entry.