### PR TITLE
Do not drop bytecode debug info after C calls

### DIFF
--- a/Changes
+++ b/Changes
@@ -142,6 +142,9 @@ Working version
 - #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
   (Greta Yorsh, review by Mark Shinwell)
 
+- #9225: Do not drop bytecode debug info after C calls.
+  (Stephen Dolan, review by Gabriel Scherer and Jacques-Henri Jourdan)
+
 OCaml 4.10.0
 ------------
 

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -904,6 +904,7 @@ let rec comp_expr env exp sz cont =
             match lam with
               Lapply{ap_args = args}  -> Event_return (List.length args)
             | Lsend(_, _, _, args, _) -> Event_return (List.length args + 1)
+            | Lprim(_,args,_)         -> Event_return (List.length args)
             | _                       -> Event_other
           in
           let ev = event (Event_after ty) info in

--- a/testsuite/tests/backtrace/event_after_prim.ml
+++ b/testsuite/tests/backtrace/event_after_prim.ml
@@ -1,0 +1,14 @@
+(* TEST
+   flags = "-g"
+   compare_programs = "false" *)
+
+let f n b =
+  let arr = Array.make n 42 in
+  if b then (arr, [| |]) else ([| |], arr)
+
+let () =
+  Printexc.record_backtrace true;
+  match Sys.opaque_identity f (-1) true with
+  | _ -> assert false
+  | exception _ ->
+    Printexc.print_backtrace stdout

--- a/testsuite/tests/backtrace/event_after_prim.reference
+++ b/testsuite/tests/backtrace/event_after_prim.reference
@@ -1,0 +1,2 @@
+Raised by primitive operation at file "event_after_prim.ml", line 6, characters 12-27
+Called from file "event_after_prim.ml", line 11, characters 8-39


### PR DESCRIPTION
Because of a missing case in Bytegen.comp_expr, debug events appearing after external (C) calls were not correctly recorded, which meant that their lines in bytecode backtraces could be wrong or missing.

(I ran into this doing some memprof hacking, but the bug does not seem to be memprof-related)