### PR TITLE
Add Seq.unfold.

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,6 +41,10 @@ Working version
 - #9235: Add Array.exists2 and Array.for_all2
   (Bernhard Schommer, review by Armaël Guéneau)
 
+- #9226: Add Seq.unfold.
+   (Jeremy Yallop, review by Hezekiah M. Carty, Gabriel Scherer and
+   Gabriel Radanne)
+
 - #8771: Lexing: add set_position and set_filename to change (fake)
    the initial tracking position of the lexbuf.
    (Konstantin Romanov, Miguel Lumapat, review by Gabriel Scherer,

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -71,3 +71,8 @@ let iter f seq =
         aux next
   in
   aux seq
+
+let rec unfold f u () =
+  match f u with
+  | None -> Nil
+  | Some (x, u') -> Cons (x, unfold f u')

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -80,3 +80,12 @@ val iter : ('a -> unit) -> 'a t -> unit
 (** Iterate on the sequence, calling the (imperative) function on every element.
     The traversal happens immediately and will not terminate on infinite
     sequences. *)
+
+val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
+(** Build a sequence from a step function and an initial value.
+    [unfold f u] returns [empty] if [f u] returns [None],
+    or [fun () -> Cons (x, unfold f y)] if [f u] returns [Some (x, y)].
+
+    For example, [unfold (function [] -> None | h::t -> Some (h,t)) l]
+    is equivalent to [List.to_seq l].
+    @since 4.11 *)

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -13,6 +13,19 @@ let () =
   ()
 ;;
 
+(* unfold *)
+let () =
+  let range first last =
+    let step i = if i > last then None
+                 else Some (i, succ i) in
+    Seq.unfold step first
+  in
+  begin
+    assert ([1;2;3] = List.of_seq (range 1 3));
+    assert ([] = List.of_seq (range 1 0));
+  end
+;;
+
 (* MPR 7820 *)
 let () =
   assert


### PR DESCRIPTION
The `Seq` module currently has several functions that take a sequence as input, but almost no functions for constructing sequences from scratch.

The `unfold` function proposed in this PR captures a common pattern, building a sequence from a "step" function and an initial seed:

```ocaml
val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
```

For example, the `range` function (such that `range x y` is the sequence `x … y`) can be written using `unfold` with a step function that increments a counter until it reaches the upper bound:

```ocaml
let range first last =
  let step i = if i > last then None
               else Some (i, succ i) in
  unfold step first
```

and conversions from other structures such as lists and arrays can be written similarly simply.  For arrays the step function increments an index, returning the array element at each step:

```ocaml
let array_to_seq arr =
  let step i = if i >= Array.length arr then None
               else Some (arr.(i), succ i) in
  unfold step 0
```

and for lists the step function simply returns the head and the tail, unless the list is empty:

```ocaml
let list_to_seq l =
  let step = function
    | [] -> None
    | x::xs -> Some (x, xs) in
  unfold step l
```

(One possible interface change: we could have a dedicated type for the step function in place of `('a * 'b) option`, to save the double indirection of an option-of-a-pair, at the cost of some interoperability.)