### PR TITLE
Make Bool.to_int primitive.

### DIFF
--- a/stdlib/bool.ml
+++ b/stdlib/bool.ml
@@ -20,7 +20,7 @@ external ( && ) : bool -> bool -> bool = "%sequand"
 external ( || ) : bool -> bool -> bool = "%sequor"
 let equal : bool -> bool -> bool = ( = )
 let compare : bool -> bool -> int = Stdlib.compare
-let to_int = function false -> 0 | true -> 1
+external to_int : bool -> int = "%identity"
 let to_float = function false -> 0. | true -> 1.
 
 (*


### PR DESCRIPTION
It would be convenient to be able to use `Bool.to_int` without the worry of the overhead of an extra branch.