### PR TITLE
Remove Placeholder_value from Memprof

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,8 +16,8 @@ Working version
   API when the old block is NULL.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
-- #8920: New API for statistical memory profiling in Memprof.Gc. The
-  new version does no longer use ephemerons and allows registering
+- #8920, #9229: New API for statistical memory profiling in Memprof.Gc.
+  The new version does no longer use ephemerons and allows registering
   callbacks for promotion and deallocation of memory blocks.
   (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez
    and Gabriel Scherer)


### PR DESCRIPTION
Here's a slight simplification of #8920 that I missed at the time: we don't need to create a dummy tracked entry with block `Placeholder_value` for minor allocations, since minor allocations don't need to be tracked until they're actually allocated. This removes a few annoying special cases.