### PR TITLE
Add Array.for_all2 and Array.exists2

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,7 +34,7 @@ Working version
 ### Standard library:
 
 - #9235: Add Array.exists2 and Array.for_all2  
-  (Bernhard Schommer)
+  (Bernhard Schommer, review by Armaël Guéneau)
 
 - #8771: Lexing: add set_position and set_filename to change (fake)
    the initial tracking position of the lexbuf.

--- a/Changes
+++ b/Changes
@@ -33,7 +33,7 @@ Working version
 
 ### Standard library:
 
-- #9235: Add Array.exists2 and Array.for_all2  
+- #9235: Add Array.exists2 and Array.for_all2
   (Bernhard Schommer, review by Armaël Guéneau)
 
 - #8771: Lexing: add set_position and set_filename to change (fake)

--- a/Changes
+++ b/Changes
@@ -33,6 +33,9 @@ Working version
 
 ### Standard library:
 
+- #9235: Add Array.exists2 and Array.for_all2  
+  (Bernhard Schommer)
+
 - #8771: Lexing: add set_position and set_filename to change (fake)
    the initial tracking position of the lexbuf.
    (Konstantin Romanov, Miguel Lumapat, review by Gabriel Scherer,

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -187,6 +187,32 @@ let for_all p a =
     else false in
   loop 0
 
+let for_all2 p l1 l2 =
+  let n1 = length l1
+  and n2 = length l2 in
+  let rec loop i =
+    if i = n1 || i = n2 then
+      if n1 <> n2 then
+        invalid_arg "Array.for_all2"
+      else
+        true
+    else if p (unsafe_get l1 i) (unsafe_get l2 i) then loop (succ i)
+    else false in
+  loop 0
+
+let exists2 p l1 l2 =
+  let n1 = length l1
+  and n2 = length l2 in
+  let rec loop i =
+    if i = n1 || i = n2 then
+      if n1 <> n2 then
+        invalid_arg "Array.exists2"
+      else
+        false
+    else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
+    else loop (succ i) in
+  loop 0
+
 let mem x a =
   let n = length a in
   let rec loop i =

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -190,12 +190,9 @@ let for_all p a =
 let for_all2 p l1 l2 =
   let n1 = length l1
   and n2 = length l2 in
-  let rec loop i =
-    if i = n1 || i = n2 then
-      if n1 <> n2 then
-        invalid_arg "Array.for_all2"
-      else
-        true
+  if n1 <> n2 then invalid_arg "Array.for_all2"
+  else let rec loop i =
+    if i = n1 then true
     else if p (unsafe_get l1 i) (unsafe_get l2 i) then loop (succ i)
     else false in
   loop 0
@@ -203,12 +200,9 @@ let for_all2 p l1 l2 =
 let exists2 p l1 l2 =
   let n1 = length l1
   and n2 = length l2 in
-  let rec loop i =
-    if i = n1 || i = n2 then
-      if n1 <> n2 then
-        invalid_arg "Array.exists2"
-      else
-        false
+  if n1 <> n2 then invalid_arg "Array.exists2"
+  else let rec loop i =
+    if i = n1 then false
     else if p (unsafe_get l1 i) (unsafe_get l2 i) then true
     else loop (succ i) in
   loop 0

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -211,13 +211,13 @@ val exists : ('a -> bool) -> 'a array -> bool
 
 val for_all2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!Array.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays are determined
-   to have different lengths. *)
+   Raise [Invalid_argument] if the two arrays have different lengths.
+   @since 4.11.0 *)
 
 val exists2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!Array.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays are determined
-   to have different lengths. *)
+   Raise [Invalid_argument] if the two arrays have different lengths.
+   @since 4.11.0 *)
 
 val mem : 'a -> 'a array -> bool
 (** [mem a l] is true if and only if [a] is structurally equal

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -209,6 +209,16 @@ val exists : ('a -> bool) -> 'a array -> bool
     [(p a1) || (p a2) || ... || (p an)].
     @since 4.03.0 *)
 
+val for_all2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
+(** Same as {!Array.for_all}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two arrays are determined
+   to have different lengths. *)
+
+val exists2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
+(** Same as {!Array.exists}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two arrays are determined
+   to have different lengths. *)
+
 val mem : 'a -> 'a array -> bool
 (** [mem a l] is true if and only if [a] is structurally equal
     to an element of [l] (i.e. there is an [x] in [l] such that

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -202,6 +202,16 @@ val for_all : f:('a -> bool) -> 'a array -> bool
    [(f a1) && (f a2) && ... && (f an)].
    @since 4.03.0 *)
 
+val for_all2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
+(** Same as {!ArrayLabels.for_all}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two arrays are determined
+   to have different lengths. *)
+
+val exists2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
+(** Same as {!ArrayLabels.exists}, but for a two-argument predicate.
+   Raise [Invalid_argument] if the two arrays are determined
+   to have different lengths. *)
+
 val mem : 'a -> set:'a array -> bool
 (** [mem x ~set] is true if and only if [x] is equal
    to an element of [set].

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -204,13 +204,13 @@ val for_all : f:('a -> bool) -> 'a array -> bool
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!ArrayLabels.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays are determined
-   to have different lengths. *)
+   Raise [Invalid_argument] if the two arrays have different lengths.
+   @since 4.11.0 *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a array -> 'b array -> bool
 (** Same as {!ArrayLabels.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two arrays are determined
-   to have different lengths. *)
+   Raise [Invalid_argument] if the two arrays have different lengths.
+   @since 4.11.0 *)
 
 val mem : 'a -> set:'a array -> bool
 (** [mem x ~set] is true if and only if [x] is equal

--- a/testsuite/tests/array-functions/test.ml
+++ b/testsuite/tests/array-functions/test.ml
@@ -126,6 +126,97 @@ let () =
   assert (Array.for_all (fun _ -> true) a);
 ;;
 
+let does_raise3 f a b c =
+  try
+    ignore (f a b c);
+    false
+  with _ ->
+    true
+
+let () =
+  let a = [|1;2;3;4;5;6;7;8;9|]
+  and b = [|1;2;3;4;5;6;7;8;9|] in
+  assert (Array.exists2 (fun a b -> a = b) a b);
+  assert (Array.exists2 (fun a b -> a - b = 0) a b);
+  assert (Array.exists2 (fun a b -> a = 1 && b = 1) a b);
+  assert (Array.exists2 (fun a b -> a = 2 && b = 2) a b);
+  assert (Array.exists2 (fun a b -> a = 3 && b = 3) a b);
+  assert (Array.exists2 (fun a b -> a = 4 && b = 4) a b);
+  assert (Array.exists2 (fun a b -> a = 5 && b = 5) a b);
+  assert (Array.exists2 (fun a b -> a = 6 && b = 6) a b);
+  assert (Array.exists2 (fun a b -> a = 7 && b = 7) a b);
+  assert (Array.exists2 (fun a b -> a = 8 && b = 8) a b);
+  assert (Array.exists2 (fun a b -> a = 9 && b = 9) a b);
+  assert (not (Array.exists2 (fun a b -> a <> b) a b));
+;;
+
+let () =
+  let a = [|1|]
+  and b = [|1;2|] in
+  assert (does_raise3 Array.exists2 (fun a b -> a > 1 && a = b) a b);
+  assert (does_raise3 Array.exists2 (fun _ _ -> false) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 2 && b = 2) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 3 && b = 3) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 4 && b = 4) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 5 && b = 5) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 6 && b = 6) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 7 && b = 7) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 8 && b = 8) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 9 && b = 9) a b);
+;;
+
+let () =
+  assert (Array.exists2 (=) [|1;2;3|] [|3;2;1|]);
+  assert (not (Array.exists2 (<>) [|1;2;3|] [|1;2;3|]));
+  assert (does_raise3 Array.exists2 (=) [|1;2|] [|3|]);
+  let f = Array.create_float 10 in
+  let g = Array.create_float 10 in
+  Array.fill f 0 10 1.0;
+  Array.fill g 0 10 1.0;
+  assert (Array.exists2 (fun a b -> a = 1.0 && b = 1.0) f g);
+;;
+
+let () =
+  let a = [|1;2;3;4;5;6;7;8;9|]
+  and b = [|1;2;3;4;5;6;7;8;9|] in
+  assert (Array.for_all2 (fun a b -> a = b) a b);
+  assert (Array.for_all2 (fun a b -> a - b = 0) a b);
+  assert (Array.for_all2 (fun a b -> a > 0 && b > 0) a b);
+  assert (Array.for_all2 (fun a b -> a < 10 && b < 10) a b);
+  assert (Array.for_all2 (fun a b -> if a = 1 then b = 1 else b <> 1) a b);
+  assert (Array.for_all2 (fun a b -> if a = 2 then b = 2 else b <> 2) a b);
+  assert (Array.for_all2 (fun a b -> if a = 3 then b = 3 else b <> 3) a b);
+  assert (Array.for_all2 (fun a b -> if a = 4 then b = 4 else b <> 4) a b);
+  assert (Array.for_all2 (fun a b -> if a = 5 then b = 5 else b <> 5) a b);
+  assert (Array.for_all2 (fun a b -> if a = 6 then b = 6 else b <> 6) a b);
+  assert (Array.for_all2 (fun a b -> if a = 7 then b = 7 else b <> 7) a b);
+  assert (Array.for_all2 (fun a b -> if a = 8 then b = 8 else b <> 8) a b);
+  assert (Array.for_all2 (fun a b -> if a = 9 then b = 9 else b <> 9) a b);
+  assert (not (Array.for_all2 (fun a b -> a <> b) a b));
+;;
+
+let () =
+  let a = [|1|]
+  and b = [|1;2|] in
+  assert (does_raise3 Array.for_all2 (fun a b -> a = b) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 1 && b = 1) a b);
+  assert (not (Array.for_all2 (fun a b -> a = 2 && b = 2) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 3 && b = 3) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 4 && b = 4) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 5 && b = 5) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 6 && b = 6) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 7 && b = 7) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 8 && b = 8) a b));
+  assert (not (Array.for_all2 (fun a b -> a = 9 && b = 9) a b));
+;;
+
+let () =
+  assert (not (Array.for_all2 (=) [|1;2;3|] [|3;2;1|]));
+  assert (Array.for_all2 (=) [|1;2;3|] [|1;2;3|]);
+  assert (not (Array.for_all2 (<>) [|1;2;3|] [|3;2;1|]));
+  assert (does_raise3 Array.for_all2 (=) [|1;2;3|] [|1;2;3;4|]);
+  assert (does_raise3 Array.for_all2 (=) [|1;2|] [||]);
+;;
 
 let () =
   let a = [|1;2;3;4;5;6;7;8;9|] in

--- a/testsuite/tests/array-functions/test.ml
+++ b/testsuite/tests/array-functions/test.ml
@@ -153,8 +153,10 @@ let () =
 let () =
   let a = [|1|]
   and b = [|1;2|] in
-  assert (does_raise3 Array.exists2 (fun a b -> a > 1 && a = b) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = b) a b);
+  assert (does_raise3 Array.exists2 (fun _ _ -> true) a b);
   assert (does_raise3 Array.exists2 (fun _ _ -> false) a b);
+  assert (does_raise3 Array.exists2 (fun a b -> a = 1 && b = 1) a b);
   assert (does_raise3 Array.exists2 (fun a b -> a = 2 && b = 2) a b);
   assert (does_raise3 Array.exists2 (fun a b -> a = 3 && b = 3) a b);
   assert (does_raise3 Array.exists2 (fun a b -> a = 4 && b = 4) a b);
@@ -199,15 +201,17 @@ let () =
   let a = [|1|]
   and b = [|1;2|] in
   assert (does_raise3 Array.for_all2 (fun a b -> a = b) a b);
+  assert (does_raise3 Array.for_all2 (fun _ _ -> true) a b);
+  assert (does_raise3 Array.for_all2 (fun _ _ -> false) a b);
   assert (does_raise3 Array.for_all2 (fun a b -> a = 1 && b = 1) a b);
-  assert (not (Array.for_all2 (fun a b -> a = 2 && b = 2) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 3 && b = 3) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 4 && b = 4) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 5 && b = 5) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 6 && b = 6) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 7 && b = 7) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 8 && b = 8) a b));
-  assert (not (Array.for_all2 (fun a b -> a = 9 && b = 9) a b));
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 2 && b = 2) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 3 && b = 3) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 4 && b = 4) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 5 && b = 5) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 6 && b = 6) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 7 && b = 7) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 8 && b = 8) a b);
+  assert (does_raise3 Array.for_all2 (fun a b -> a = 9 && b = 9) a b);
 ;;
 
 let () =


### PR DESCRIPTION
This re-introduces the functions `Array.for_all2` and `Array.exists2`, restoring @bschommer's code from #329, where the two main objections were:

1. the difference in error handling between these new functions (which fail immediately on arrays of different lengths) and the list counterparts (which fail on lists of different lengths only if the end of one list is reached).  I think I was the main objector, and I'm no longer concerned about this.

2. the compatibility issues introduced by adding functions to the standard library.  We've had quite a few additions to the standard library since that discussion, so it's not such a strong objection as it once may have been.

(cc @gasche, @alainfrisch, @dbuenzli)