### PR TITLE
Deprecate -custom

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -89,7 +89,7 @@ else
 	                            $(WINTOPDIR)/flexdll/flexlink.exe" $(EMPTY)
   endif
 endif
-OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc $(CUSTOM) $(OCFLAGS) \
+OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc $(OCFLAGS) \
        $(RUNTIME_VARIANT)
 OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt $(OCFLAGS) \
          $(RUNTIME_VARIANT)

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -72,7 +72,7 @@ OCFLAGS=-nostdlib -I $(OTOPDIR)/stdlib $(COMPFLAGS)
 OCOPTFLAGS=
 
 ifeq ($(SUPPORTS_SHARED_LIBRARIES),false)
-  CUSTOM = -custom
+  CUSTOM = -output-complete-exe -ccopt -I$(OTOPDIR)/runtime
 else
   CUSTOM =
 endif

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -14,7 +14,7 @@ Here is a summary of the main differences between these ports:
 |                                        | Native Microsoft       | Native Mingw-w64 | Cygwin
 4+^| Third-party software required
 | for base bytecode system               | none                   | none             | none
-| for `ocamlc -custom`                     | Microsoft Visual C++   | Cygwin           | Cygwin
+| for `ocamlc -output-complete-exe`                     | Microsoft Visual C++   | Cygwin           | Cygwin
 | for native-code generation             | Microsoft Visual C++   | Cygwin           | Cygwin
 4+^| Features
 | Speed of bytecode interpreter          | 70%                    | 100%             | 100%
@@ -85,7 +85,7 @@ ports runs without any additional tools.
 === REQUIREMENTS
 
 The native-code compiler (`ocamlopt`) and static linking of OCaml bytecode with
-C code (`ocamlc -custom`) require a Microsoft Visual C/C++ Compiler and the
+C code (`ocamlc -output-complete-exe`) require a Microsoft Visual C/C++ Compiler and the
 `flexlink` tool (see <<bmflex,above>>).
 
 Any edition (including Express/Community editions) of Microsoft Visual Studio
@@ -211,7 +211,7 @@ Finally, use `make` to build the system, e.g.
 
 After installing, it is not necessary to keep the Cygwin installation (although
 you may require it to build additional third party libraries and tools).  You
-will need to use `ocamlopt` (or `ocamlc -custom`) from the same Visual Studio or
+will need to use `ocamlopt` (or `ocamlc -output-complete-exe`) from the same Visual Studio or
 Windows SDK Command Prompt as you compiled OCaml from, or `ocamlopt` will not
 be able to find `cl`.
 
@@ -240,7 +240,7 @@ changes to the OCaml project.
 === REQUIREMENTS
 
 The native-code compiler (`ocamlopt`) and static linking of OCaml bytecode with
-C code (`ocamlc -custom`) require the appropriate Mingw-w64 gcc and the
+C code (`ocamlc -output-complete-exe`) require the appropriate Mingw-w64 gcc and the
 `flexlink` tool (see <<bmflex,above>>). Mingw-w64 gcc is provided by the
 `mingw64-i686-gcc-core` package for 32-bit and the `mingw64-x86_64-gcc-core`
 package for 64-bit.
@@ -274,7 +274,7 @@ Finally, use `make` to build the system, e.g.
         make
         make install
 
-After installing, you will need to ensure that `ocamlopt` (or `ocamlc -custom`)
+After installing, you will need to ensure that `ocamlopt` (or `ocamlc -output-complete-exe`)
 can access the C compiler.  You can do this either by using OCaml from Cygwin's
 bash or by adding Cygwin's bin directory (e.g. `C:\cygwin\bin`) to your `PATH`.
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -82,7 +82,7 @@ let mk_config_var f =
 ;;
 
 let mk_custom f =
-  "-custom", Arg.Unit f, " Link in custom mode"
+  "-custom", Arg.Unit f, " Link in custom mode (deprecated)"
 ;;
 
 let mk_dllib f =

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -116,16 +116,16 @@ it is not linked in.
 
 Arguments ending in .c are passed to the C compiler, which generates
 a .o object file. This object file is linked with the program if the
-.B \-custom
+.B \-output-complete-exe
 flag is set (see the description of
-.B \-custom
+.B \-output-complete-exe
 below).
 
 Arguments ending in .o or .a are assumed to be C object files and
 libraries. They are passed to the C linker when linking in
-.B \-custom
+.B \-output-complete-exe
 mode (see the description of
-.B \-custom
+.B \-output-complete-exe
 below).
 
 Arguments ending in .so
@@ -232,14 +232,14 @@ compile modules separately.
 Use
 .I ccomp
 as the C linker when linking in "custom runtime" mode (see the
-.B \-custom
+.B \-output-complete-exe
 option) and as the C compiler for compiling .c source files.
 .TP
 .BI \-cclib\ -l libname
 Pass the
 .BI \-l libname
 option to the C linker when linking in "custom runtime" mode (see the
-.B \-custom
+.B \-output-complete-exe
 option). This causes the given C library to be linked with the program.
 .TP
 .BI \-ccopt \ option
@@ -247,7 +247,7 @@ Pass the given
 .I option
 to the C compiler and linker, when linking in
 "custom runtime" mode (see the
-.B \-custom
+.B \-output-complete-exe
 option). For instance,
 .BI \-ccopt\ \-L dir
 causes the C linker to search for C libraries in
@@ -683,7 +683,7 @@ standard library directory, then exit.
 .B \-verbose
 Print all external commands before they are executed, in particular
 invocations of the C compiler and linker in
-.B \-custom
+.B \-output-complete-exe
 mode.  Useful to debug C library problems.
 .TP
 .BR \-vnum \ or\  \-version

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -62,14 +62,14 @@ not referenced anywhere in the program, then it is not linked in.
 \item
 Arguments ending in ".c" are passed to the C compiler, which generates
 a ".o" object file (".obj" under Windows). This object file is linked
-with the program if the "-custom" flag is set (see the description of
-"-custom" below).
+with the program if the "-output-complete-exe" flag is set (see the description of
+"-output-complete-exe" below).
 
 \item
 Arguments ending in ".o" or ".a" (".obj" or ".lib" under Windows)
 are assumed to be C object files and libraries. They are passed to the
-C linker when linking in "-custom" mode (see the description of
-"-custom" below).
+C linker when linking in "-output-complete-exe" mode (see the description of
+"-output-complete-exe" below).
 
 \item
 Arguments ending in ".so" (".dll" under Windows)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -202,8 +202,15 @@ OCAMLDOC_LIBRARIES = ocamlcommon unix str dynlink
 OCAMLDOC_BCLIBRARIES = $(OCAMLDOC_LIBRARIES:%=%.cma)
 OCAMLDOC_NCLIBRARIES = $(OCAMLDOC_LIBRARIES:%=%.cmxa)
 
+ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
+CUSTOM=
+else
+CUSTOM=-ccopt -I$(ROOTDIR)/runtime -output-complete-exe
+endif
+
 $(OCAMLDOC): $(EXECMOFILES)
-	$(OCAMLC) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_BCLIBRARIES) $^
+	$(OCAMLC) -o $@ -linkall $(CUSTOM) $(LINKFLAGS) \
+	  $(OCAMLDOC_BCLIBRARIES) $^
 
 $(OCAMLDOC_OPT): $(EXECMXFILES)
 	$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -182,6 +182,7 @@ directories := $(addprefix $(ROOTDIR)/,utils bytecomp parsing stdlib \
 include_directories := $(addprefix -I , $(directories))
 
 flags := -g -nostdlib $(include_directories) \
+  -ccopt -I$(ROOTDIR)/runtime \
   -strict-sequence -safe-string -strict-formats \
   -w +a-4-9-41-42-44-45-48 -warn-error A
 
@@ -214,7 +215,7 @@ compdeps_byte=$(addsuffix .cma,$(compdeps_paths))
 compdeps_opt=$(addsuffix .cmxa,$(compdeps_paths))
 
 ocamltest$(EXE): $(compdeps_byte) $(bytecode_modules)
-	$(ocamlc_cmd) -custom -o $@ $^
+	$(ocamlc_cmd) -output-complete-exe -o $@ $^
 
 %.cmo: %.ml $(compdeps_byte)
 	$(ocamlc) -c $<

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -276,7 +276,8 @@ let compile_program (compiler : Ocaml_compilers.compiler) log env =
           log env commandline in
       let env =
         if has_c_file || bytecode_links_c_code then
-          Environments.add_if_undefined Ocaml_variables.compare_byte_programs "false" env
+          Environments.add_if_undefined
+            Ocaml_variables.compare_byte_programs "false" env
         else
           env
       in
@@ -901,7 +902,9 @@ let native_programs_comparison_tool = Filecompare.default_comparison_tool
 let compare_bytecode_programs_code log env =
   let bytecode_programs_comparison_tool =
     make_bytecode_programs_comparison_tool in
-  match Environments.lookup_as_bool Ocaml_variables.compare_byte_programs env with
+  match
+    Environments.lookup_as_bool Ocaml_variables.compare_byte_programs env
+  with
   | Some false ->
       let reason = "program comparison disabled" in
       (Result.pass_with_reason reason, env)

--- a/ocamltest/ocaml_commands.ml
+++ b/ocamltest/ocaml_commands.ml
@@ -16,7 +16,10 @@
 (* Helper functions to build OCaml-related commands *)
 
 let ocamlrun program =
-  Ocaml_files.ocamlrun ^ " " ^ program
+  if Ocamltest_config.shared_libraries then
+    Ocaml_files.ocamlrun ^ " " ^ program
+  else
+    program
 
 let ocamlrun_ocamlc = ocamlrun Ocaml_files.ocamlc
 

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -38,8 +38,11 @@ let runtime_flags env backend c_files =
     | Ocaml_backends.Native -> runtime_variant_flags ()
     | Ocaml_backends.Bytecode ->
       begin
-        if c_files then begin (* custom mode *)
-          "-custom " ^ (runtime_variant_flags ())
+        if c_files &&
+           Environments.lookup_as_bool Ocaml_variables.compile_only env <> Some true then
+          begin (* custom mode *)
+          "-output-complete-exe " ^
+          (runtime_variant_flags ())
         end else begin (* non-custom mode *)
           let use_runtime =
             Environments.lookup_as_bool Ocaml_variables.use_runtime env

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -32,8 +32,9 @@ let runtime_variant_flags () = match Ocaml_files.runtime_variant() with
   | Ocaml_files.Instrumented -> " -runtime-variant i"
 
 let runtime_flags env backend c_files =
-  let runtime_library_flags = "-I " ^
-    Ocaml_directories.runtime in
+  let runtimedir = Ocaml_directories.runtime in
+  let runtime_library_flags =
+    "-I " ^ runtimedir ^ " -ccopt -I" ^ runtimedir ^ " " in
   let rt_flags = match backend with
     | Ocaml_backends.Native -> runtime_variant_flags ()
     | Ocaml_backends.Bytecode ->

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -40,7 +40,9 @@ let runtime_flags env backend c_files =
     | Ocaml_backends.Bytecode ->
       begin
         if c_files &&
-           Environments.lookup_as_bool Ocaml_variables.compile_only env <> Some true then
+           Environments.lookup_as_bool
+             Ocaml_variables.compile_only env <> Some true
+        then
           begin (* custom mode *)
           "-output-complete-exe " ^
           (runtime_variant_flags ())

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -62,6 +62,9 @@ let caml_ld_library_path =
 let compare_programs = make ("compare_programs",
   "Set to \"false\" to disable program comparison")
 
+let compare_byte_programs = make ("compare_byte_programs",
+  "Set to \"false\" to disable bytecode program comparison")
+
 let compiler_directory_suffix = make ("compiler_directory_suffix",
   "Suffix to add to the directory where the test will be compiled")
 
@@ -238,6 +241,7 @@ let _ = List.iter register_variable
     c_preprocessor;
     caml_ld_library_path;
     compare_programs;
+    compare_byte_programs;
     compiler_directory_suffix;
     compiler_reference;
     compiler_reference2;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -32,6 +32,8 @@ val caml_ld_library_path : Variables.t
 
 val compare_programs : Variables.t
 
+val compare_byte_programs : Variables.t
+
 val compiler_directory_suffix : Variables.t
 
 val compiler_reference : Variables.t

--- a/testsuite/tests/embedded/cmcaml.ml
+++ b/testsuite/tests/embedded/cmcaml.ml
@@ -1,5 +1,6 @@
 (* TEST
    modules = "cmstub.c cmmain.c"
+   * native
 *)
 
 (* OCaml part of the code *)

--- a/testsuite/tests/lib-dynlink-bytecode/main.ml
+++ b/testsuite/tests/lib-dynlink-bytecode/main.ml
@@ -45,7 +45,7 @@ reference = "${test_source_directory}/static.reference"
 
 ******** ocamlc.byte
 program = "${test_build_directory}/custom.exe"
-flags = "-custom -linkall -I ."
+flags = "-output-complete-exe -linkall -I ."
 all_modules = "registry.cmo plug2.cma plug1.cma"
 use_runtime = "false"
 ********* run

--- a/testsuite/tests/lib-threads/delayintr.ml
+++ b/testsuite/tests/lib-threads/delayintr.ml
@@ -11,10 +11,10 @@ files = "sigint.c"
 
 program = "${test_build_directory}/delayintr.byte"
 
-**** ocamlc.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlc.byte
 
@@ -29,10 +29,10 @@ all_modules = "delayintr.ml"
 
 program = "${test_build_directory}/delayintr.opt"
 
-**** ocamlopt.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlopt.byte
 

--- a/testsuite/tests/lib-threads/signal.ml
+++ b/testsuite/tests/lib-threads/signal.ml
@@ -11,10 +11,10 @@ files = "sigint.c"
 
 program = "${test_build_directory}/signal.byte"
 
-**** ocamlc.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlc.byte
 
@@ -29,10 +29,10 @@ all_modules = "signal.ml"
 
 program = "${test_build_directory}/signal.opt"
 
-**** ocamlopt.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlopt.byte
 

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -54,7 +54,7 @@ endif
 all: $(tools)
 
 $(expect_PROG): $(expect_LIBS:=.cma) $(expect_MAIN).cmo
-	$(OCAMLC) -linkall -o $@ $^
+	$(OCAMLC) $(CUSTOM) -linkall -o $@ $^
 
 $(expect_PROG): COMPFLAGS = $(expect_OCAMLFLAGS)
 
@@ -63,7 +63,7 @@ $(codegen_PROG): COMPFLAGS = $(codegen_OCAMLFLAGS)
 codegen_main.cmo: parsecmm.cmo
 
 $(codegen_PROG): $(codegen_OBJECTS)
-	$(OCAMLC) -o $@ $(codegen_LIBS:=.cma) $^
+	$(OCAMLC) $(CUSTOM) -o $@ $(codegen_LIBS:=.cma) $^
 
 parsecmm.mli parsecmm.ml: parsecmm.mly
 	$(OCAMLYACC) -q parsecmm.mly

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -47,7 +47,7 @@ define byte_and_opt_
 $(and $(filter-out 1,$(words $1)),$(error \
    cannot build file with whitespace in name))
 $1: $3 $2
-	$$(CAMLC) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ $2
+	$$(CAMLC) $$(CUSTOM) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ $2
 
 $1.opt: $3 $$(call byte2native,$2)
 	$$(CAMLOPT_CMD) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ \


### PR DESCRIPTION
Fixes #9234

We build `ocamltest` with `-output-complete-exe`. In my machine, trying to use `ocamlrun` with it results in the error:
```
Fatal error: the file 'ocamltest' has not the right magic number: expected Caml1999X025, got _Caml_state
```
A follow-up PR will deal with the deprecation of `-custom`, which was a left-over from #8872.