### PR TITLE
Drop support for tags in memprof.

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,9 +16,10 @@ Working version
   API when the old block is NULL.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
-- #8920: New API for statistical memory profiling in Memprof.Gc. The
+- #8920, #9238: New API for statistical memory profiling in Memprof.Gc. The
   new version does no longer use ephemerons and allows registering
   callbacks for promotion and deallocation of memory blocks.
+  The new API no longer gives the block tags to the allocation callback.
   (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez
    and Gabriel Scherer)
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -214,7 +214,7 @@ enum caml_alloc_small_flags {
   CAML_FROM_C = 0,     CAML_FROM_CAML = 2
 };
 
-extern void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags);
+extern void caml_alloc_small_dispatch (intnat wosize, int flags);
 // Do not call asynchronous callbacks from allocation functions
 #define Alloc_small_origin CAML_FROM_C
 #define Alloc_small_aux(result, wosize, tag, profinfo, track) do {     \
@@ -224,8 +224,7 @@ extern void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags);
   Caml_state_field(young_ptr) -= Whsize_wosize (wosize);               \
   if (Caml_state_field(young_ptr) < Caml_state_field(young_limit)) {   \
     Setup_for_gc;                                                      \
-    caml_alloc_small_dispatch((tag), (wosize),                         \
-                              (track) | Alloc_small_origin);           \
+    caml_alloc_small_dispatch((wosize), (track) | Alloc_small_origin); \
     Restore_after_gc;                                                  \
   }                                                                    \
   Hd_hp (Caml_state_field(young_ptr)) =                                \

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -28,7 +28,7 @@ extern value caml_memprof_handle_postponed_exn(void);
 extern void caml_memprof_check_action_pending(void);
 
 extern void caml_memprof_track_alloc_shr(value block);
-extern void caml_memprof_track_young(tag_t tag, uintnat wosize, int from_caml);
+extern void caml_memprof_track_young(uintnat wosize, int from_caml);
 extern void caml_memprof_track_interned(header_t* block, header_t* blockend);
 
 extern void caml_memprof_renew_minor_sample(void);

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -181,8 +181,8 @@ struct tracked {
   /* Number of samples in this block. */
   uintnat n_samples;
 
-  /* The header of this block (useful for tag and size) */
-  header_t header;
+  /* The size of this block. */
+  uintnat wosize;
 
   /* The value returned by the previous callback for this block, or
      the callstack if the alloc callback has not been called yet.
@@ -263,7 +263,7 @@ static int realloc_trackst(void) {
   return 1;
 }
 
-static inline uintnat new_tracked(uintnat n_samples, header_t header,
+static inline uintnat new_tracked(uintnat n_samples, uintnat wosize,
                                   int is_unmarshalled, int is_young,
                                   value block, value user_data)
 {
@@ -276,7 +276,7 @@ static inline uintnat new_tracked(uintnat n_samples, header_t header,
   t = &trackst.entries[trackst.len - 1];
   t->block = block;
   t->n_samples = n_samples;
-  t->header = header;
+  t->wosize = wosize;
   t->user_data = user_data;
   t->idx_ptr = NULL;
   t->alloc_young = is_young;
@@ -351,12 +351,11 @@ static value handle_entry_callbacks_exn(uintnat* t_idx)
     CAMLassert(Is_block(t->block)
                || t->block == Placeholder_value
                || t->deallocated);
-    sample_info = caml_alloc_small(5, 0);
+    sample_info = caml_alloc_small(4, 0);
     Field(sample_info, 0) = Val_long(t->n_samples);
-    Field(sample_info, 1) = Val_long(Wosize_hd(t->header));
-    Field(sample_info, 2) = Val_long(Tag_hd(t->header));
-    Field(sample_info, 3) = Val_long(t->unmarshalled);
-    Field(sample_info, 4) = t->user_data;
+    Field(sample_info, 1) = Val_long(t->wosize);
+    Field(sample_info, 2) = Val_long(t->unmarshalled);
+    Field(sample_info, 3) = t->user_data;
     t->user_data = Val_unit;
     res = run_callback_exn(t_idx,
         t->alloc_young ? callback_alloc_minor : callback_alloc_major,
@@ -540,7 +539,7 @@ void caml_memprof_track_alloc_shr(value block)
   callstack = capture_callstack_postponed();
   if (callstack == 0) return;
 
-  new_tracked(n_samples, Hd_val(block), 0, 0, block, callstack);
+  new_tracked(n_samples, Wosize_val(block), 0, 0, block, callstack);
   caml_memprof_check_action_pending();
 }
 
@@ -581,7 +580,7 @@ void caml_memprof_renew_minor_sample(void)
 /* Called when exceeding the threshold for the next sample in the
    minor heap, from the C code (the handling is different when called
    from natively compiled OCaml code). */
-void caml_memprof_track_young(tag_t tag, uintnat wosize, int from_caml)
+void caml_memprof_track_young(uintnat wosize, int from_caml)
 {
   uintnat whsize = Whsize_wosize(wosize), n_samples;
   uintnat t_idx;
@@ -607,7 +606,7 @@ void caml_memprof_track_young(tag_t tag, uintnat wosize, int from_caml)
     callstack = capture_callstack_postponed();
     if (callstack == 0) return;
 
-    new_tracked(n_samples, Make_header(wosize, tag, Caml_white),
+    new_tracked(n_samples, wosize,
                 0, 1, Val_hp(Caml_state->young_ptr), callstack);
     caml_memprof_check_action_pending();
     return;
@@ -627,8 +626,7 @@ void caml_memprof_track_young(tag_t tag, uintnat wosize, int from_caml)
 
   caml_memprof_suspended = 1;
   callstack = capture_callstack();
-  t_idx = new_tracked(n_samples, Make_header(wosize, tag, Caml_white),
-                      0, 1, Placeholder_value, callstack);
+  t_idx = new_tracked(n_samples, wosize, 0, 1, Placeholder_value, callstack);
   if (t_idx == Invalid_index)
     res = Val_unit;
   else
@@ -714,7 +712,7 @@ void caml_memprof_track_interned(header_t* block, header_t* blockend) {
     if (callstack == 0) callstack = capture_callstack_postponed();
     if (callstack == 0) break;  /* OOM */
     new_tracked(mt_generate_binom(next_p - next_sample_p) + 1,
-                Hd_hp(p), 1, is_young, Val_hp(p), callstack);
+                Wosize_hp(p), 1, is_young, Val_hp(p), callstack);
     p = next_p;
   }
   caml_memprof_check_action_pending();

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -488,7 +488,7 @@ CAMLexport void caml_gc_dispatch (void)
 /* Called by [Alloc_small] when [Caml_state->young_ptr] reaches
    [Caml_state->young_limit]. We may have to either call memprof or
    the gc. */
-void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags)
+void caml_alloc_small_dispatch (intnat wosize, int flags)
 {
   intnat whsize = Whsize_wosize (wosize);
 
@@ -532,7 +532,7 @@ void caml_alloc_small_dispatch (tag_t tag, intnat wosize, int flags)
   /* Check if the allocated block has been sampled by memprof. */
   if(Caml_state->young_ptr < caml_memprof_young_trigger){
     if(flags & CAML_DO_TRACK) {
-      caml_memprof_track_young(tag, wosize, flags & CAML_FROM_CAML);
+      caml_memprof_track_young(wosize, flags & CAML_FROM_CAML);
       /* Until the allocation actually takes place, the heap is in an invalid
          state (see comments in [caml_memprof_track_young]). Hence, very little
          heap operations are allowed before the actual allocation.

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -97,8 +97,7 @@ void caml_garbage_collection(void)
     allocsz -= 1;
   }
 
-  caml_alloc_small_dispatch(0 /* FIXME */, allocsz,
-                            /* CAML_DO_TRACK | */ CAML_FROM_CAML);
+  caml_alloc_small_dispatch(allocsz, /* CAML_DO_TRACK | */ CAML_FROM_CAML);
 }
 
 DECLARE_SIGNAL_HANDLER(handle_signal)

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -124,7 +124,6 @@ module Memprof =
     type allocation =
       { n_samples : int;
         size : int;
-        tag : int;
         unmarshalled : bool;
         callstack : Printexc.raw_backtrace }
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -448,9 +448,6 @@ module Memprof :
         size : int;
         (** The size of the block, in words, excluding the header. *)
 
-        tag : int;
-        (** The tag of the block. *)
-
         unmarshalled : bool;
         (** Whether the block comes from unmarshalling. *)
 

--- a/testsuite/tests/statmemprof/arrays_in_major.ml
+++ b/testsuite/tests/statmemprof/arrays_in_major.ml
@@ -105,7 +105,6 @@ let check_distrib lo hi cnt rate =
   let smp = ref 0 in
   start ~callstack_size:10
         ~major_alloc_callback:(fun info ->
-           assert (info.tag = 0);
            assert (info.size >= lo && info.size <= hi);
            assert (info.n_samples > 0);
            assert (not info.unmarshalled);

--- a/testsuite/tests/statmemprof/arrays_in_major.reference
+++ b/testsuite/tests/statmemprof/arrays_in_major.reference
@@ -10,6 +10,6 @@ check_distrib 300 300 100000 0.100000
 check_distrib 300000 300000 30 0.100000
 check_callstack
 Raised by primitive operation at file "arrays_in_major.ml", line 13, characters 14-28
-Called from file "arrays_in_major.ml", line 151, characters 2-35
-Called from file "arrays_in_major.ml", line 157, characters 9-27
+Called from file "arrays_in_major.ml", line 150, characters 2-35
+Called from file "arrays_in_major.ml", line 156, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/arrays_in_minor.ml
+++ b/testsuite/tests/statmemprof/arrays_in_minor.ml
@@ -5,19 +5,22 @@
 
 open Gc.Memprof
 
-type 'a list2 =  (* A list type where [Cons] has tag 1 *)
-  | Nil
-  | Dummy of int
-  | Cons of 'a * 'a list2
+let roots = Array.make 1000000 [||]
+let roots_pos = ref 0
+let add_root r =
+  roots.(!roots_pos) <- r;
+  incr roots_pos
+let clear_roots () =
+  Array.fill roots 0 !roots_pos [||];
+  roots_pos := 0
 
-let root = ref Nil
 let[@inline never] allocate_arrays lo hi cnt keep =
   assert (0 < lo && hi <= 250);  (* Fits in minor heap. *)
   for j = 0 to cnt-1 do
     for i = lo to hi do
-      root := Cons (Array.make i 0, !root)
+      add_root (Array.make i 0)
     done;
-    if not keep then root := Nil
+    if not keep then clear_roots ()
   done
 
 let check_nosample () =
@@ -43,7 +46,6 @@ let check_counts_full_major force_promote =
   start ~callstack_size:10
         ~minor_alloc_callback:(fun info ->
           if !enable then begin
-            assert (info.tag = 0 || info.tag = 1);
             incr nalloc_minor; if !nalloc_minor mod 100 = 0 then Gc.minor ();
             Some (ref 42)
           end else begin
@@ -68,11 +70,11 @@ let check_counts_full_major force_promote =
     Gc.full_major ();
     assert (!ndealloc_minor = 0 && !ndealloc_major = 0 &&
             !npromote = !nalloc_minor);
-    root := Nil;
+    clear_roots ();
     Gc.full_major ();
     assert (!ndealloc_minor = 0 && !ndealloc_major = !nalloc_minor);
   end else begin
-    root := Nil;
+    clear_roots ();
     Gc.minor ();
     Gc.full_major ();
     Gc.full_major ();
@@ -113,14 +115,11 @@ let check_distrib lo hi cnt rate =
   start ~callstack_size:10
         ~major_alloc_callback:(fun _ -> assert false)
         ~minor_alloc_callback:(fun info ->
-          (* Exclude noise such as spurious closures and the root list. *)
-           if info.tag = 0 then begin
-             assert (info.size >= lo && info.size <= hi);
-             assert (info.n_samples > 0);
-             assert (not info.unmarshalled);
-             smp := !smp + info.n_samples
-           end;
-           None
+          assert (info.size >= lo && info.size <= hi);
+          assert (info.n_samples > 0);
+          assert (not info.unmarshalled);
+          smp := !smp + info.n_samples;
+          None
         )
         ~sampling_rate:rate ();
   allocate_arrays lo hi cnt false;
@@ -154,7 +153,7 @@ let[@inline never] check_callstack () =
   let callstack = ref None in
   start ~callstack_size:10
         ~minor_alloc_callback:(fun info ->
-          if info.tag = 0 then callstack := Some info.callstack;
+          if info.size > 100 then callstack := Some info.callstack;
           None
         )
         ~sampling_rate:1. ();

--- a/testsuite/tests/statmemprof/arrays_in_minor.reference
+++ b/testsuite/tests/statmemprof/arrays_in_minor.reference
@@ -9,7 +9,7 @@ check_distrib 1 250 1000 0.900000
 check_distrib 1 1 10000000 0.010000
 check_distrib 250 250 100000 0.100000
 check_callstack
-Raised by primitive operation at file "arrays_in_minor.ml", line 18, characters 20-34
-Called from file "arrays_in_minor.ml", line 161, characters 2-35
-Called from file "arrays_in_minor.ml", line 167, characters 9-27
+Raised by primitive operation at file "arrays_in_minor.ml", line 21, characters 15-31
+Called from file "arrays_in_minor.ml", line 160, characters 2-35
+Called from file "arrays_in_minor.ml", line 166, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/intern.ml
+++ b/testsuite/tests/statmemprof/intern.ml
@@ -7,7 +7,7 @@
 
 open Gc.Memprof
 
-type t = Dummy of int (* Skip tag 0. *) | I of int | II of int * int | Cons of t
+type t = I of int | II of int * int | Cons of t
 let rec t_of_len = function
   | len when len <= 1 -> assert false
   | 2 -> I 1
@@ -128,10 +128,7 @@ let check_distrib lo hi cnt rate =
     (* We also allocate the list constructor in the minor heap,
        so we filter that out. *)
     if info.unmarshalled then begin
-      begin match info.tag, info.size with
-      | 1, 1 | 2, 2 | 3, 1 -> ()
-      | _ -> assert false
-      end;
+      assert (info.size = 1 || info.size = 2);
       assert (info.n_samples > 0);
       smp := !smp + info.n_samples
     end;

--- a/testsuite/tests/statmemprof/intern.reference
+++ b/testsuite/tests/statmemprof/intern.reference
@@ -10,6 +10,6 @@ check_distrib 300000 300000 20 0.100000
 check_callstack
 Raised by primitive operation at file "marshal.ml", line 61, characters 9-35
 Called from file "intern.ml", line 30, characters 14-35
-Called from file "intern.ml", line 183, characters 2-25
-Called from file "intern.ml", line 189, characters 9-27
+Called from file "intern.ml", line 180, characters 2-25
+Called from file "intern.ml", line 186, characters 9-27
 OK !

--- a/testsuite/tests/statmemprof/lists_in_minor.reference
+++ b/testsuite/tests/statmemprof/lists_in_minor.reference
@@ -7,6 +7,6 @@ check_distrib 100000 10 0.100000
 check_distrib 100000 10 0.900000
 check_callstack
 Raised by primitive operation at file "lists_in_minor.ml", line 14, characters 11-33
-Called from file "lists_in_minor.ml", line 67, characters 2-26
-Called from file "lists_in_minor.ml", line 74, characters 2-20
+Called from file "lists_in_minor.ml", line 66, characters 2-26
+Called from file "lists_in_minor.ml", line 73, characters 2-20
 OK !


### PR DESCRIPTION
They are somewhat difficult to handle for native allocations, and it is not clear how useful they are. Moreover, they are easy to add back since [Gc.Memprof.allocation] is a private record.

This has been discussed in #9025 

CC @stedolan.