### PR TITLE
Avoid inclusion of caml/roots.h to fail when CAML_INTERNALS is defined but not CAML_NAME_SPACE

### DIFF
--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -32,9 +32,9 @@ extern uintnat caml_incremental_roots_count;
 CAMLextern void caml_do_local_roots (scanning_action, value *, value *,
                                      struct caml__roots_block *);
 #else
-CAMLextern void caml_do_local_roots(scanning_action, char *,
-                                    uintnat last_retaddr, value *,
-                                    struct caml__roots_block *);
+CAMLextern void caml_do_local_roots(scanning_action f, char * c_bottom_of_stack,
+                                    uintnat last_retaddr, value * v_gc_regs,
+                                    struct caml__roots_block * gc_local_roots);
 #endif
 
 CAMLextern void (*caml_scan_roots_hook) (scanning_action);

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -32,9 +32,9 @@ extern uintnat caml_incremental_roots_count;
 CAMLextern void caml_do_local_roots (scanning_action, value *, value *,
                                      struct caml__roots_block *);
 #else
-CAMLextern void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
-                                    uintnat last_retaddr, value * gc_regs,
-                                    struct caml__roots_block * local_roots);
+CAMLextern void caml_do_local_roots(scanning_action, char *,
+                                    uintnat last_retaddr, value *,
+                                    struct caml__roots_block *);
 #endif
 
 CAMLextern void (*caml_scan_roots_hook) (scanning_action);


### PR DESCRIPTION
cc @gadmm this would fix `delimcc` without including `caml/compatibility.h`. Instead the fix would be to just remove `-DCAML_NAME_SPACE` from the Makefile. With this fix, I've tested locally and it does compile with OCaml 4.04 to 4.10.

Apart from `delimcc` I think this PR should be correct in every case, the ifndef side of the conditional does not name the arguments of the function, and it feels like there is no reasons for the else side to name them.

Related to https://github.com/ocaml/ocaml/issues/9205