### PR TITLE
Fix usage warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -618,6 +618,9 @@ OCaml 4.11
   even if they are at tail position.
   (Jacques-Henri Jourdan, review by Gabriel Scherer)
 
+- #9244: Fix some missing usage warnings
+  (Leo White, review by Florian Angeletti)
+
 - #9274, avoid reading cmi file while printing types
   (Florian Angeletti, review by Gabriel Scherer)
 

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -68,7 +68,7 @@ let typecheck_intf info ast =
         Format.(fprintf std_formatter) "%a@."
           (Printtyp.printed_signature info.source_file)
           sg);
-  ignore (Includemod.signatures info.env sg sg);
+  ignore (Includemod.signatures info.env ~mark:Mark_both sg sg);
   Typecore.force_delayed_checks ();
   Warnings.check_fatal ();
   tsg

--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -1,0 +1,47 @@
+(* TEST
+   flags = " -w A "
+   * expect
+*)
+
+module type U = sig end
+[%%expect {|
+module type U = sig end
+|}]
+
+module M : sig
+  module F2 (_ : U) : U
+end = struct
+  module X = struct
+    let x = 13
+  end
+
+  module F1 (_ : U) = X
+  module F2 (M : U) = F1 (M)
+end
+[%%expect {|
+Line 5, characters 8-9:
+5 |     let x = 13
+            ^
+Warning 32: unused value x.
+module M : sig module F2 : U -> U end
+|}]
+
+module N : sig
+  module F2 (_ : U) : U
+end = struct
+  module X = struct
+    let x = 13
+  end
+
+  module F1 (_ : U) = X
+  module F2 (_ : U) = F1 (struct end)
+end
+[%%expect {|
+module N : sig module F2 : U -> U end
+|}]
+
+
+module F (X : sig type t type s end) = struct type t = X.t end
+[%%expect {|
+module F : functor (X : sig type t type s end) -> sig type t = X.t end
+|}]

--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -37,6 +37,10 @@ end = struct
   module F2 (_ : U) = F1 (struct end)
 end
 [%%expect {|
+Line 5, characters 8-9:
+5 |     let x = 13
+            ^
+Warning 32: unused value x.
 module N : sig module F2 : U -> U end
 |}]
 

--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -47,5 +47,9 @@ module N : sig module F2 : U -> U end
 
 module F (X : sig type t type s end) = struct type t = X.t end
 [%%expect {|
+Line 1, characters 25-31:
+1 | module F (X : sig type t type s end) = struct type t = X.t end
+                             ^^^^^^
+Warning 34: unused type s.
 module F : functor (X : sig type t type s end) -> sig type t = X.t end
 |}]

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -335,8 +335,7 @@ let execute_phrase print_outcome ppf phr =
       let (str, sg, names, newenv) = Typemod.type_toplevel_phrase oldenv sstr in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv names sg in
-      (* Why is this done? *)
-      ignore (Includemod.signatures oldenv sg sg');
+      ignore (Includemod.signatures oldenv ~mark:Mark_positive sg sg');
       Typecore.force_delayed_checks ();
       let module_ident, res, required_globals, size =
         if Config.flambda then

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -275,7 +275,7 @@ let execute_phrase print_outcome ppf phr =
       let (str, sg, sn, newenv) = Typemod.type_toplevel_phrase oldenv sstr in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv sn sg in
-      ignore (Includemod.signatures oldenv sg sg');
+      ignore (Includemod.signatures ~mark:Mark_positive oldenv sg sg');
       Typecore.force_delayed_checks ();
       let lam = Translmod.transl_toplevel_definition str in
       Warnings.check_fatal ();

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -582,7 +582,7 @@ let () =
 (* Check that an implementation of a compilation unit meets its
    interface. *)
 
-let compunit env ?(mark=Mark_both) impl_name impl_sig intf_name intf_sig =
+let compunit env ~mark impl_name impl_sig intf_name intf_sig =
   try
     signatures ~loc:(Location.in_file impl_name) env ~mark []
       Subst.identity impl_sig intf_sig
@@ -592,13 +592,13 @@ let compunit env ?(mark=Mark_both) impl_name impl_sig intf_name intf_sig =
 
 (* Hide the context and substitution parameters to the outside world *)
 
-let modtypes ~loc env ?(mark=Mark_both) mty1 mty2 =
+let modtypes ~loc env ~mark mty1 mty2 =
   modtypes ~loc env ~mark [] Subst.identity mty1 mty2
-let signatures env ?(mark=Mark_both) sig1 sig2 =
+let signatures env ~mark sig1 sig2 =
   signatures ~loc:Location.none env ~mark [] Subst.identity sig1 sig2
-let type_declarations ~loc env ?(mark=Mark_both) id decl1 decl2 =
+let type_declarations ~loc env ~mark id decl1 decl2 =
   type_declarations ~loc env ~mark [] Subst.identity id decl1 decl2
-let strengthened_module_decl ~loc ~aliasable env ?(mark=Mark_both)
+let strengthened_module_decl ~loc ~aliasable env ~mark
       md1 path1 md2 =
   strengthened_module_decl ~loc ~aliasable env ~mark [] Subst.identity
     md1 path1 md2

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -32,11 +32,11 @@ type mark =
       (** Do not mark definitions used from either argument *)
 
 val modtypes:
-  loc:Location.t -> Env.t -> ?mark:mark ->
+  loc:Location.t -> Env.t -> mark:mark ->
   module_type -> module_type -> module_coercion
 
 val strengthened_module_decl:
-  loc:Location.t -> aliasable:bool -> Env.t -> ?mark:mark ->
+  loc:Location.t -> aliasable:bool -> Env.t -> mark:mark ->
   module_declaration -> Path.t -> module_declaration -> module_coercion
 
 val check_modtype_inclusion :
@@ -46,15 +46,15 @@ val check_modtype_inclusion :
     functor application F(M) is well typed, where mty2 is the type of
     the argument of F and path1/mty1 is the path/unstrenghened type of M. *)
 
-val signatures: Env.t -> ?mark:mark ->
+val signatures: Env.t -> mark:mark ->
   signature -> signature -> module_coercion
 
 val compunit:
-      Env.t -> ?mark:mark -> string -> signature ->
+      Env.t -> mark:mark -> string -> signature ->
       string -> signature -> module_coercion
 
 val type_declarations:
-  loc:Location.t -> Env.t -> ?mark:mark ->
+  loc:Location.t -> Env.t -> mark:mark ->
   Ident.t -> type_declaration -> type_declaration -> unit
 
 val print_coercion: formatter -> module_coercion -> unit

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1995,7 +1995,8 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
                                     Cannot_eliminate_dependency mty_functor))
                 in
                 begin match
-                  Includemod.modtypes ~loc:smod.pmod_loc env mty_res nondep_mty
+                  Includemod.modtypes ~mark:Mark_neither
+                    ~loc:smod.pmod_loc env mty_res nondep_mty
                 with
                 | Tcoerce_none -> ()
                 | _ ->


### PR DESCRIPTION
This fixes a couple of bugs with missing usage warnings. Both were caused by calls to functions from `Includemod` inappropriately using the default value for the `mark` parameter. This PR also makes this parameter non-optional to avoid similar problems in the future.