### PR TITLE
Avoid rechecking functor applications

### DIFF
--- a/Changes
+++ b/Changes
@@ -339,6 +339,9 @@ OCaml 4.11
 - #2324: Replace caml_int_compare and caml_float_compare with primitives.
   (Greta Yorsh, review by Stephen Dolan and Vincent Laviron)
 
+- #9246: Avoid rechecking functor applications
+  (Leo White, review by Jacques Garrigue)
+
 * #9411: forbid optional arguments reordering with -nolabels
   (Thomas Refis, review by Frédéric Bour and Jacques Garrigue)
 


### PR DESCRIPTION
Take advantage of the existing functor application cache to avoid repeating checks that a functor application is valid.

Currently,
```ocaml
module F (X : sig type t end) = struct type t end
module M = struct type t = int end

type t = F(M).t * F(M).t
```
will check that `M` matches the signature `sig type t end` twice: once for each `F(M).t` in the source.

However, we already have a cache which keeps the type of `F(M)` -- and any entry in that cache must already have been checked. This PR skips checking the validity of the functor application if that application is already present in the cache.

This optimisation doesn't matter for small signatures like those in the example. However, for large signatures the effect can be quite large.