### PR TITLE
Revert an include of compatibility.h

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -18,7 +18,7 @@
 #ifndef CAML_MEMORY_H
 #define CAML_MEMORY_H
 
-#ifndef CAML_INTERNALS
+#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
 #endif
 #include "config.h"


### PR DESCRIPTION
Before a7b5bb6f06 from #8713, includes of compatibility.h used to be
all guarded by `#ifndef CAML_NAME_SPACE`. The solution at a7b5bb6f06
required to change two of those guard into `#ifndef CAML_INTERNALS`.
The solution finally retained for 4.10 at #9253 (646d30404e6b in
trunk) does not depend on this change anymore, and one of the two
guards was changed back into `#ifndef CAML_NAME_SPACE`. This patch
changes the second one back as before.

Since a second CAML_NAME_SPACE guard is contained in compatibility.h,
the potential impact is limited to two of the macros that are not
guarded in this way: caml_stat_top_heap_size and caml_stat_heap_size,
and limited to programs that somehow came to rely on this in 4.10.

Since this patch reverts the situation as in 4.09, the current patch
is preferable to be included in 4.10, and it is very low risk.

No Changes needed.

(cc @Octachron)