### PR TITLE
manual: a cautionary internal runtime API section

### DIFF
--- a/Changes
+++ b/Changes
@@ -389,6 +389,11 @@ OCaml 4.10.0
   (Florian Angeletti, review by Daniel Bünzli, Sébastien Hinderer,
    and Gabriel Scherer)
 
+- #9257, cautionary guidelines for using the internal runtime API
+  without too much updating pain.
+  (Florian Angeletti, review by Daniel Bünzli, Guillaume Munch-Maccagnoni
+   and KC Sivaramakrishnan)
+
 
 - #8950: move local opens in pattern out of the extension chapter
   (Florian Angeletti, review and suggestion by Gabriel Scherer)

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -185,19 +185,25 @@ serialization and deserialization functions for custom blocks
 \entree{"caml/threads.h"}{operations for interfacing in the presence
   of multiple threads (see section~\ref{s:C-multithreading}).}
 \end{tableau}
+Before including any of these files, you should define the "OCAML_NAME_SPACE"
+macro. For instance,
+\begin{verbatim}
+#define CAML_NAME_SPACE
+#include "caml/mlvalues.h"
+#include "caml/fail.h"
+\end{verbatim}
 These files reside in the "caml/" subdirectory of the OCaml
 standard library directory, which is returned by the command
 "ocamlc -where" (usually "/usr/local/lib/ocaml" or "/usr/lib/ocaml").
 
-{\bf Note:} It is highly recommended to define the macro "CAML_NAME_SPACE"
-on the command line with "-DCAML_NAME_SPACE" when including any of these
-header files. Otherwise, it is your responsability to ensure that
-the macro "CAML_NAME_SPACE" is defined bedore any of these header files.
-If you do not define it, the header files will also define short names
-(without the "caml_" prefix) for most functions, which usually produce
-clashes with names defined by other C libraries that you might use.
-Including the header files without "CAML_NAME_SPACE" is only supported
-for backward compatibility and may be removed in the future.
+{\bf Note:}
+Including the header files without first defining "CAML_NAME_SPACE" is only
+supported for backward compatibility and may be removed in the future:
+without this definition, the header files will also define short names
+(without the "caml_" prefix) for most functions.
+Those short names usually produce clashes with names defined by other
+C libraries. Even defining "CAML_NAME_SPACE" after the inclusion of
+some "caml/" headers may produce clashes within OCaml header files.
 
 \subsection{ss:staticlink-c-code}{Statically linking C code with OCaml code}
 

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -189,19 +189,15 @@ These files reside in the "caml/" subdirectory of the OCaml
 standard library directory, which is returned by the command
 "ocamlc -where" (usually "/usr/local/lib/ocaml" or "/usr/lib/ocaml").
 
-By default, header files in the "caml/" subdirectory give only access
-to the public interface of the OCaml runtime. It is possible to define
-the macro "CAML_INTERNALS" to get access to a lower-level interface,
-but this lower-level interface is more likely to change and break
-programs that use it.
-
-{\bf Note:} It is recommended to define the macro "CAML_NAME_SPACE"
-before including these header files. If you do not define it, the
-header files will also define short names (without the "caml_" prefix)
-for most functions, which usually produce clashes with names defined
-by other C libraries that you might use. Including the header files
-without "CAML_NAME_SPACE" is only supported for backward
-compatibility.
+{\bf Note:} It is highly recommended to define the macro "CAML_NAME_SPACE"
+on the command line with "-DCAML_NAME_SPACE" when including any of these
+header files. Otherwise, it is your responsability to ensure that
+the macro "CAML_NAME_SPACE" is defined bedore any of these header files.
+If you do not define it, the header files will also define short names
+(without the "caml_" prefix) for most functions, which usually produce
+clashes with names defined by other C libraries that you might use.
+Including the header files without "CAML_NAME_SPACE" is only supported
+for backward compatibility and may be removed in the future.
 
 \subsection{ss:staticlink-c-code}{Statically linking C code with OCaml code}
 
@@ -2702,3 +2698,67 @@ support libraries ("-lz") and the corresponding options
 ("-L/usr/local/zlib") must be given on all three invocations of "ocamlmklib",
 because they are needed at different times depending on whether shared
 libraries are supported.
+
+
+\section{s:c-internal-guidelines}{Disavowed topic: the internal runtime API}
+
+Let's start with a warning, there is \emph{no} stability guarantee if you are
+using internals of the OCaml runtime. If you really need access
+to the runtime internal API, this section provides some guidelines
+that may help you to write code that might not break on every new version
+of OCaml.
+
+\subsection{ss:c-internals}{CAML_INTERNALS}
+First, by default header files in the "caml/" subdirectory give only access
+to the public interface of the OCaml runtime.
+It is necessary to define the macro "CAML_INTERNALS" to get access to
+the lower-level interface. Once again, this lower-level interface is likely to
+change and break programs that use it.
+Another caveat is that this lower-level interface is only publicly accessible
+since OCaml 4.04.
+
+\subsection{ss:c-internal-variables}{Internal variables}
+Second, if you are using internal C variables, do not redefine them
+by hand. You should import those variables by including the corresponding
+header files. The representation of those variables has already changed once in
+OCaml 4.10, and is still under evolution.
+If your code relies on such internal and brittle properties, it will be broken
+at some point in time.
+
+For instance, rather than redefining "caml_young_limit":
+\begin{verbatim}
+extern int caml_young_limit;
+\end{verbatim}
+which breaks in OCaml $\ge$ 4.10, you should include the "minor_gc" header:
+\begin{verbatim}
+#include <caml/minor_gc.h>
+\end{verbatim}
+
+\subsection{ss:c-internal-macros}{OCaml version macros}
+Finally, if including the right headers is not enough, or if you need to support
+version older than OCaml 4.04, the header file "caml/version.h" should help
+you to define your own compatibility layer.
+This file provides macros defining the current ocaml major
+version "OCAML_VERSION_MAJOR", the minor version "OCAML_VERSION_MINOR", the
+patch level "OCAML_VERSION_PATCHLEVEL" and the full version
+"OCAML_VERSION" (which is the concatenation of the three previous macros).
+
+For example, if you need some specific handling for versions more recent than 4.10.0,
+you could write
+\begin{verbatim}
+#include <caml/version.h>
+#if OCAML_VERSION > 41000
+...
+#else
+...
+#endif
+\end{verbatim}
+
+The "caml/version.h" header also defines a macro for the compiler variant
+"OCAML_VERSION_ADDITIONAL" which is used to distinguish alpha and beta releases
+or release candidates.
+Finally, the version string is available as "OCAML_VERSION_STRING".
+
+\subsection{ss:c-internal-no}{A final word of caution}
+Do not access the domain state directly. \\
+Always use the "Caml_state_field" macro.

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -197,13 +197,11 @@ standard library directory, which is returned by the command
 "ocamlc -where" (usually "/usr/local/lib/ocaml" or "/usr/lib/ocaml").
 
 {\bf Note:}
-Including the header files without first defining "CAML_NAME_SPACE" is only
-supported for backward compatibility and may be removed in the future:
-without this definition, the header files will also define short names
-(without the "caml_" prefix) for most functions.
-Those short names usually produce clashes with names defined by other
-C libraries. Even defining "CAML_NAME_SPACE" after the inclusion of
-some "caml/" headers may produce clashes within OCaml header files.
+Including the header files without first defining "CAML_NAME_SPACE"
+introduces in scope short names for most functions.
+Those short names are deprecated, and may be removed in the future
+because they usually produce clashes with names defined by other
+C libraries.
 
 \subsection{ss:staticlink-c-code}{Statically linking C code with OCaml code}
 

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2706,28 +2706,26 @@ because they are needed at different times depending on whether shared
 libraries are supported.
 
 
-\section{s:c-internal-guidelines}{Disavowed topic: the internal runtime API}
+\section{s:c-internal-guidelines}{Cautionary words: the internal runtime API}
 
-Let's start with a warning, there is \emph{no} stability guarantee if you are
-using internals of the OCaml runtime. If you really need access
-to the runtime internal API, this section provides some guidelines
+Not all header available in the "caml/" directory were described in previous
+sections. All those unmentioned headers are part of the internal runtime API,
+for which there is \emph{no} stability guarantee. If you really need access
+to this internal runtime API, this section provides some guidelines
 that may help you to write code that might not break on every new version
 of OCaml.
+\paragraph{Note} If you have a valid and non-experimental use case for a part
+of the internal runtime API, you are encouraged to report it.
 
-\subsection{ss:c-internals}{CAML_INTERNALS}
-First, by default header files in the "caml/" subdirectory give only access
-to the public interface of the OCaml runtime.
-It is necessary to define the macro "CAML_INTERNALS" to get access to
-the lower-level interface. Once again, this lower-level interface may change
-with every minor releases and break programs that use it.
-Another caveat is that this lower-level interface is only publicly accessible
-since OCaml 4.04.
+\subsection{ss:c-internals}{Internal variables and CAML_INTERNALS}
+Since OCaml 4.04, it is possible to get access to every part of the internal
+runtime API by defining the "CAML_INTERNALS" macro before loading caml header files.
+If this macro is not defined, parts of the internal runtime API are hidden.
 
-\subsection{ss:c-internal-variables}{Internal variables}
-Second, if you are using internal C variables, do not redefine them
-by hand. You should import those variables by including the corresponding
-header files. The representation of those variables has already changed once in
-OCaml 4.10, and is still under evolution.
+If you are using internal C variables, do not redefine them by hand. You should
+import those variables by including the corresponding header files. The
+representation of those variables has already changed once in OCaml 4.10, and is
+still under evolution.
 If your code relies on such internal and brittle properties, it will be broken
 at some point in time.
 
@@ -2744,27 +2742,16 @@ which breaks in OCaml $\ge$ 4.10, you should include the "minor_gc" header:
 Finally, if including the right headers is not enough, or if you need to support
 version older than OCaml 4.04, the header file "caml/version.h" should help
 you to define your own compatibility layer.
-This file provides macros defining the current OCaml major
-version "OCAML_VERSION_MAJOR", the minor version "OCAML_VERSION_MINOR", the
-patch level "OCAML_VERSION_PATCHLEVEL" and the full version
-"OCAML_VERSION" (which is the concatenation of the three previous macros).
-
-For example, if you need some specific handling for versions more recent than 4.10.0,
+This file provides few macros defining the current OCaml version.
+In particular, the "OCAML_VERSION" macro describes the current version,
+its format is "MmmPP".
+For example, if you need some specific handling for versions older than 4.10.0,
 you could write
 \begin{verbatim}
 #include <caml/version.h>
-#if OCAML_VERSION > 41000
+#if OCAML_VERSION >= 41000
 ...
 #else
 ...
 #endif
 \end{verbatim}
-
-The "caml/version.h" header also defines a macro for the compiler variant
-"OCAML_VERSION_ADDITIONAL" which is used to distinguish alpha and beta releases
-or release candidates.
-Finally, the version string is available as "OCAML_VERSION_STRING".
-
-\subsection{ss:c-internal-no}{A final word of caution}
-Do not access the domain state directly. \\
-Always use the "Caml_state_field" macro.

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -1242,6 +1242,7 @@ The stub code file, "curses_stubs.c", looks like this:
 \begin{verbatim}
 /* File curses_stubs.c -- stub code for curses */
 #include <curses.h>
+#define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -1267,7 +1268,7 @@ static struct custom_operations curses_window_ops = {
 /* Allocating an OCaml custom block to hold the given WINDOW * */
 static value alloc_window(WINDOW * w)
 {
-  value v = alloc_custom(&curses_window_ops, sizeof(WINDOW *), 0, 1);
+  value v = caml_alloc_custom(&curses_window_ops, sizeof(WINDOW *), 0, 1);
   Window_val(v) = w;
   return v;
 }
@@ -2554,6 +2555,7 @@ The rest of the binding is the same for both platforms:
 
 \begin{verbatim}
 /* The following define is necessary because the API is experimental */
+#define CAML_NAME_SPACE
 #define CAML_INTERNALS
 
 #include <caml/mlvalues.h>

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2714,8 +2714,9 @@ for which there is \emph{no} stability guarantee. If you really need access
 to this internal runtime API, this section provides some guidelines
 that may help you to write code that might not break on every new version
 of OCaml.
-\paragraph{Note} If you have a valid and non-experimental use case for a part
-of the internal runtime API, you are encouraged to report it.
+\paragraph{Note} Programmers which come to rely on the internal API
+for a use-case which they find realistic and useful are encouraged to open
+a request for improvement on the bug tracker.
 
 \subsection{ss:c-internals}{Internal variables and CAML_INTERNALS}
 Since OCaml 4.04, it is possible to get access to every part of the internal

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2720,8 +2720,8 @@ of OCaml.
 First, by default header files in the "caml/" subdirectory give only access
 to the public interface of the OCaml runtime.
 It is necessary to define the macro "CAML_INTERNALS" to get access to
-the lower-level interface. Once again, this lower-level interface is likely to
-change and break programs that use it.
+the lower-level interface. Once again, this lower-level interface may change
+with every minor releases and break programs that use it.
 Another caveat is that this lower-level interface is only publicly accessible
 since OCaml 4.04.
 
@@ -2746,7 +2746,7 @@ which breaks in OCaml $\ge$ 4.10, you should include the "minor_gc" header:
 Finally, if including the right headers is not enough, or if you need to support
 version older than OCaml 4.04, the header file "caml/version.h" should help
 you to define your own compatibility layer.
-This file provides macros defining the current ocaml major
+This file provides macros defining the current OCaml major
 version "OCAML_VERSION_MAJOR", the minor version "OCAML_VERSION_MINOR", the
 patch level "OCAML_VERSION_PATCHLEVEL" and the full version
 "OCAML_VERSION" (which is the concatenation of the three previous macros).


### PR DESCRIPTION
This PR proposes to add a new "internal API" section to the manual. This section hopes to set some guidelines for people that, under duress or imperious necessity, stumble upon the internal runtime API. It is mostly a section of `don't but if you do` and of `really don't` that mostly documents the patch process established in #9205  . 