### PR TITLE
ci: check the prefixing policy for runtime symbols

### DIFF
--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -20,9 +20,9 @@ set -o pipefail
 
 nm -A -P "$@" | awk '
 # ignore caml_foo, camlFoo_bar, _caml_foo, _camlFoo_bar
-$2 ~ /^(_?caml[_A-Z])/ { next }
+$2 ~ /^(_?[c|C]aml[_A-Z])/ { next }
 # ignore local and undefined symbols
-$3 ~ /^[rbdtsU]$/ { next }
+$3 ~ /^[a-zU]$/ { next }
 # ignore "main", which should be externally linked
 $2 ~ /^_?main$/ { next }
 # print the rest

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -25,6 +25,14 @@ $2 ~ /^(_?[c|C]aml[_A-Z])/ { next }
 $3 ~ /^[a-zU]$/ { next }
 # ignore "main", which should be externally linked
 $2 ~ /^_?main$/ { next }
+$2 ~ /^_?wmain$/ { next }
+# for x86 PIC mode
+$2 ~ /^__x86.get_pc_thunk./ { next }
+# for mingw32
+$2 ~ /^.debug_/ { next }
+#window unicode support
+$2 ~ /^_win_multi_byte_to_wide_char$/ { next }
+$2 ~ /^_win_wide_char_to_multi_byte$/ { next }
 # print the rest
 { found=1; print $1 " " $2 " " $3 }
 # fail if there were any results

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -18,19 +18,21 @@ set -o pipefail
 
 [ -z "$*" ] && { echo "Usage: $0 libfoo.a" 1>&2; exit 2; }
 
-nm -A -P "$@" | awk '
+nm -A -P "$@" | LC_ALL=C awk '
 # ignore caml_foo, camlFoo_bar, _caml_foo, _camlFoo_bar
-$2 ~ /^(_?[c|C]aml[_A-Z])/ { next }
+$2 ~ /^(_?caml[_A-Z])/ { next }
 # ignore local and undefined symbols
 $3 ~ /^[a-zU]$/ { next }
 # ignore "main", which should be externally linked
 $2 ~ /^_?main$/ { next }
 $2 ~ /^_?wmain$/ { next }
+# Caml_state escapes the prefixing rule for now
+$2 ~ /^_?Caml_state$/ { next }
 # for x86 PIC mode
 $2 ~ /^__x86.get_pc_thunk./ { next }
 # for mingw32
 $2 ~ /^.debug_/ { next }
-#window unicode support
+# windows unicode support
 $2 ~ /^_win_multi_byte_to_wide_char$/ { next }
 $2 ~ /^_win_wide_char_to_multi_byte$/ { next }
 # print the rest

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -103,6 +103,11 @@ case "$1" in
   test)
     FULL_BUILD_PREFIX="$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX"
     run 'ocamlc.opt -version' "$FULL_BUILD_PREFIX-$PORT/ocamlc.opt" -version
+    if [[ $PORT = 'mingw32' ]] ; then
+      run "Check runtime symbols" \
+          "$FULL_BUILD_PREFIX-$PORT/tools/check-symbol-names" \
+          $FULL_BUILD_PREFIX-$PORT/runtime/*.a
+    fi
     run "test $PORT" make -C "$FULL_BUILD_PREFIX-$PORT" tests
     run "install $PORT" make -C "$FULL_BUILD_PREFIX-$PORT" install
     if [[ $PORT = 'msvc64' ]] ; then

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -136,6 +136,8 @@ EOF
     $MAKE world.opt
     $MAKE ocamlnat
   fi
+  echo Ensuring that all names are prefixed in the runtime
+  ./tools/check-symbol-names runtime/*.a
   cd testsuite
   echo Running the testsuite with the normal runtime
   $MAKE all


### PR DESCRIPTION
This PR proposes to always run the release test for exported runtime symbols, which checks that all those symbols are prefixed by `caml_`. The test is quick to run and is currently broken. 