### PR TITLE
Fix soundness bug in Rec_check with anonymous let module

### DIFF
--- a/Changes
+++ b/Changes
@@ -181,6 +181,9 @@ Working version
   even if they are at tail position.
   (Jacques-Henri Jourdan, review by Gabriel Scherer)
 
+- #XXXX: Fix a soundness bug in Rec_check
+  (Vincent Laviron, review by ...)
+
 OCaml 4.10.0
 ------------
 

--- a/Changes
+++ b/Changes
@@ -181,9 +181,6 @@ Working version
   even if they are at tail position.
   (Jacques-Henri Jourdan, review by Gabriel Scherer)
 
-- #9261: Fix a soundness bug in Rec_check
-  (Vincent Laviron, review by Jeremy Yallop and Gabriel Scherer)
-
 OCaml 4.10.0
 ------------
 
@@ -669,6 +666,9 @@ OCaml 4.10.0
 - #9209, #9212: fix a development-version regression caused by #2288
   (Kate Deplaix and David Allsopp, review by Sébastien Hinderer
    and Gabriel Scherer )
+
+- #9261: Fix a soundness bug in Rec_check introduced by #8908
+  (Vincent Laviron, review by Jeremy Yallop and Gabriel Scherer)
 
 OCaml 4.09 maintenance branch:
 ------------------------------

--- a/Changes
+++ b/Changes
@@ -667,7 +667,7 @@ OCaml 4.10.0
   (Kate Deplaix and David Allsopp, review by Sébastien Hinderer
    and Gabriel Scherer )
 
-- #9261: Fix a soundness bug in Rec_check introduced by #8908
+- #9261: Fix a soundness bug in Rec_check, new in 4.10 (from #8908)
   (Vincent Laviron, review by Jeremy Yallop and Gabriel Scherer)
 
 OCaml 4.09 maintenance branch:

--- a/Changes
+++ b/Changes
@@ -181,8 +181,8 @@ Working version
   even if they are at tail position.
   (Jacques-Henri Jourdan, review by Gabriel Scherer)
 
-- #XXXX: Fix a soundness bug in Rec_check
-  (Vincent Laviron, review by ...)
+- #9261: Fix a soundness bug in Rec_check
+  (Vincent Laviron, review by Jeremy Yallop and Gabriel Scherer)
 
 OCaml 4.10.0
 ------------

--- a/testsuite/tests/letrec-check/modules.ml
+++ b/testsuite/tests/letrec-check/modules.ml
@@ -15,6 +15,14 @@ Line 1, characters 12-76:
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
+let rec x = let module M = struct let _ = x () end in fun () -> ();;
+[%%expect{|
+Line 1, characters 12-66:
+1 | let rec x = let module M = struct let _ = x () end in fun () -> ();;
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}];;
+
 let rec x = let module M = struct let f = x () let g = x end in fun () -> ();;
 [%%expect{|
 Line 1, characters 12-76:

--- a/testsuite/tests/letrec-check/modules.ml
+++ b/testsuite/tests/letrec-check/modules.ml
@@ -15,10 +15,10 @@ Line 1, characters 12-76:
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
-let rec x = let module M = struct let _ = x () end in fun () -> ();;
+let rec x = let module _ = struct let _ = x () end in fun () -> ();;
 [%%expect{|
 Line 1, characters 12-66:
-1 | let rec x = let module M = struct let _ = x () end in fun () -> ();;
+1 | let rec x = let module _ = struct let _ = x () end in fun () -> ();;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -993,7 +993,7 @@ and module_binding : (Ident.t option * Typedtree.module_expr) -> bind_judg =
       *)
       let judg_E, env =
         match id with
-        | None -> modexp mexp << Ignore, env
+        | None -> modexp mexp << Guard, env
         | Some id ->
           let mM, env = Env.take id env in
           let judg_E = modexp mexp << (Mode.join mM Guard) in
@@ -1014,7 +1014,7 @@ and recursive_module_bindings
     let binding (mid, mexp) m =
       let judg_E =
         match mid with
-        | None -> modexp mexp << Ignore
+        | None -> modexp mexp << Guard
         | Some mid ->
           let mM = Env.find mid env in
           modexp mexp << (Mode.join mM Guard)


### PR DESCRIPTION
While working on the recursive check for #8956, I noticed that composing modes `Dereference` and `Ignore` would result in mode `Ignore`, which I found suspicious.

It turns out that composing by `Ignore` never occurs... except with anonymous `let module` bindings (of the form `let module _ = ...`).

My fix is to treat these cases as the regular `let` cases, composing by `Guard` instead of `Ignore`.
But I also think that `Ignore` should only be a left-annihilator, i.e. `compose Ignore m = Ignore`, but should preserve at least `Guard` and `Dereference` when composing on the right.
I can implement this too if needed, although this patch should ensure that it doesn't matter anymore in the rest of the code.

The following example, which I added to the testsuite, results in a segfault in the toplevel:
```ocaml
let rec x = let module _ = struct let _ = x () end in fun () -> ();;
```
