### PR TITLE
Don't export ff_merge_block symbol in freelist.c

### DIFF
--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -702,7 +702,7 @@ static void ff_reset (void)
 }
 
 /* Note: the [limit] parameter is unused because we merge blocks one by one. */
-header_t *ff_merge_block (value bp, char *limit)
+static header_t *ff_merge_block (value bp, char *limit)
 {
   value prev, cur, adj;
   header_t hd = Hd_val (bp);


### PR DESCRIPTION
Some of the new symbols in the runtime are not prefixed by `caml_` . This PR is a naive fix for this issue. Note that the sceond commit adds `Caml_` to the list of allowed prefix.

cc @kayceesrk and @damiendoligez . 