### PR TITLE
Install pretty printer for the Fun.Finally_raised exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -115,6 +115,10 @@ Working version
 - #9365: Set.filter_map and Map.filter_map
   (Gabriel Scherer, review by Stephen Dolan and Nicolás Ojeda Bär)
 
+- #9266: Install pretty-printer for the exception Fun.Finally_raised.
+  (Guillaume Munch-Maccagnoni, review by Daniel Bünzli, Gabriel Radanne,
+   and Gabriel Scherer)
+
 ### Other libraries:
 
 - #9106: Register printer for Unix_error in win32unix, as in unix.

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -20,6 +20,10 @@ let negate p v = not (p v)
 
 exception Finally_raised of exn
 
+let () = Printexc.register_printer @@ function
+| Finally_raised exn -> Some ("Fun.Finally_raised: " ^ Printexc.to_string exn)
+| _ -> None
+
 let protect ~(finally : unit -> unit) work =
   let finally_no_exn () =
     try finally () with e ->


### PR DESCRIPTION
This patch improves the display of exceptions arising from the `finally` branch of `Fun.protect`, say a failed assertion, from:
```
fatal error: exception Fun.Finally_raised(_)
```
to
```
fatal error: exception re-raised from Fun.protect: File … Line …: Assertion failed
```