### PR TITLE
Memprof: wrap uncaught exceptions before re-raising them

### DIFF
--- a/Changes
+++ b/Changes
@@ -690,6 +690,11 @@ OCaml 4.11.0 (19 August 2020)
   (Guillaume Munch-Maccagnoni, review by Daniel Bünzli, Gabriel Radanne,
    and Gabriel Scherer)
 
+- #9267: Wrap uncaught exceptions in Memprof callbacks inside an
+  exception Memprof_raised.
+  (Guillaume Munch-Maccagnoni, review by Jacques-Henri Jourdan and
+   Stephen Dolan)
+
 ### Other libraries:
 
 - #9106: Register printer for Unix_error in win32unix, as in unix.

--- a/stdlib/callback.mli
+++ b/stdlib/callback.mli
@@ -31,4 +31,4 @@ val register_exception : string -> exn -> unit
    under the name [n]. C code can later retrieve a handle to
    the exception by calling [caml_named_value(n)]. The exception
    value thus obtained is suitable for passing as first argument
-   to [raise_constant] or [raise_with_arg]. *)
+   to [caml_raise_constant] or [caml_raise_with_arg]. *)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -520,6 +520,9 @@ module Memprof :
        The parameter [tracker] determines how to track sampled blocks
        over their lifetime in the minor and major heap.
 
+       If an exception [exn] is uncaught in a callback, then the
+       asynchronous exception [Memprof_raised exn] is raised.
+
        Sampling is temporarily disabled when calling a callback
        for the current thread. So they do not need to be reentrant if
        the program is single-threaded. However, if threads are used,
@@ -530,8 +533,8 @@ module Memprof :
        actual event. The callstack passed to the callback is always
        accurate, but the program state may have evolved.
 
-       Calling [Thread.exit] in a callback is currently unsafe and can
-       result in undefined behavior. *)
+       Calling {!Thread.exit} in a callback is currently unsafe and
+       can result in undefined behavior. *)
 
     val stop : unit -> unit
     (** Stop the sampling. Fails if sampling is not active.
@@ -544,4 +547,14 @@ module Memprof :
 
         Calling [stop] when a callback is running can lead to
         callbacks not being called even though some events happened. *)
+
+    exception Memprof_raised of exn
+    (** [Memprof_raised exn] is an asynchronous exception raised by
+       Memprof in case an exception [exn] is uncaught in a callback,
+       including other asynchronous exceptions such as {!Sys.Break}
+       and serious exceptions such as {!Stdlib.Out_of_memory} and
+       {!Stdlib.Stack_overflow}. As a general rule, this exception
+       should not be caught except as part of a catch-all handler
+       around isolated boundaries of your program. *)
+
 end

--- a/testsuite/tests/statmemprof/exception_callback.reference
+++ b/testsuite/tests/statmemprof/exception_callback.reference
@@ -1,1 +1,1 @@
-Fatal error: exception Failure("callback failed")
+Fatal error: exception Gc.Memprof.Memprof_raised: Failure("callback failed")

--- a/testsuite/tests/statmemprof/exception_callback2.ml
+++ b/testsuite/tests/statmemprof/exception_callback2.ml
@@ -1,0 +1,32 @@
+(* TEST
+*)
+
+(* Check that Memprof callbacks cannot raise exceptions like Failure
+   or Not_found out of thin air. *)
+
+open Gc.Memprof
+
+(* Makes sure that the Memprof queue is purged and does not cause
+   uncaught exceptions later on. *)
+let rec really_do_stop_memprof () =
+  try stop () with _ -> really_do_stop_memprof ()
+
+let pass () = really_do_stop_memprof () ; exit 0
+
+let fail () = really_do_stop_memprof () ; exit 1
+
+let _ =
+  try
+    let tracker = { null_tracker with
+                    alloc_minor = (fun _ -> failwith "");
+                    alloc_major = (fun _ -> failwith "");
+                  }
+    in
+    start ~callstack_size:10 ~sampling_rate:1. tracker ;
+    ignore (Sys.opaque_identity (Array.make 200 0)) ;
+    stop ()
+  with
+  | Failure _ -> fail ()
+  | _ -> pass ()
+
+let _ = fail () (* the test was not performed *)

--- a/testsuite/tests/statmemprof/exception_callback_minor.reference
+++ b/testsuite/tests/statmemprof/exception_callback_minor.reference
@@ -1,1 +1,1 @@
-Fatal error: exception File "exception_callback_minor.ml", line 16, characters 30-36: Assertion failed
+Fatal error: exception Gc.Memprof.Memprof_raised: File "exception_callback_minor.ml", line 16, characters 30-36: Assertion failed


### PR DESCRIPTION
Before this patch, a Memprof callback can potentially raise any exception, including for instance `Not_found` out of thin air. This means that when doing `try ... with Not_found ->...`, this might not
always mean what the programmer intends. This is a well-known theoretical bug already affecting the raising behaviour of finalisers (#8873).

In general, any exception raised by Memprof is an asynchronous exception subject to the discipline of ML interrupts: one must not discriminate interrupts, and an interrupt must always be re-raised promptly except at isolation boundaries (e.g. at toplevel for hardening purposes).

This patch avoids this sort of bugs, and it encourages and facilitates following the discipline of interrupts for catching exceptions arising from Memprof callbacks, by wrapping any uncaught exception inside a new exception `Memprof_raised`.

Note that some code in the wild exists of the form `try ... with Sys.Break -> ...`. Such code does not follow the interrupt discipline as it discriminates on interrupts. With this patch this practice becomes incompatible with Memprof (similarly to what it is already with `Fun.protect`). Users of such code who want to use Memprof must fix it to properly catch all exceptions, and can record the cancellation
state into a boolean flag inside the signal handler of SIGINT for the current thread.

Like for `Fun.Finally_raised`, choosing a particular form of enforcing a discipline for interrupts should be subject to careful discussion. In the case of this PR, the behaviour of Memprof callbacks and exceptions arising from them is documented as experimental still.

(cc @stedolan, @jhjourdan.)