### PR TITLE
Fix bytecode backtrace generation when large integers are present

### DIFF
--- a/Changes
+++ b/Changes
@@ -296,6 +296,9 @@ OCaml 4.10.0
   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer
    and Damien Doligez)
 
+- #9268: Fix bytecode backtrace generation when large integers are present.
+  (Stephen Dolan and Mark Shinwell, review by Gabriel Scherer)
+
 ### Standard library:
 
 - #8760: List.concat_map : ('a -> 'b list) -> 'a list -> 'b list

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -244,7 +244,9 @@ void caml_stash_backtrace(value exn, value * sp, int reraise)
   /* Traverse the stack and put all values pointing into bytecode
      into the backtrace buffer. */
   for (/*nothing*/; sp < Caml_state->trapsp; sp++) {
-    code_t p = (code_t) *sp;
+    code_t p;
+    if (Is_long(*sp)) continue;
+    p = (code_t) *sp;
     if (Caml_state->backtrace_pos >= BACKTRACE_BUFFER_SIZE) break;
     if (find_debug_info(p) != NULL)
       Caml_state->backtrace_buffer[Caml_state->backtrace_pos++] = p;


### PR DESCRIPTION
This PR fixes a nasty bug in the generation of bytecode backtraces, which has caused nondeterministic CI failures (see #9230 and #8641)

The bug is that bytecode looks for return addresses on the stack by searching for words which are within the range of bytecode pointers, but does not check that these are actually pointers. Large integers with values in the range of pointers can be mistaken for return addresses. Since these do not actually have debug info attached, the result is an extra "Called from unknown location" line in the backtrace.

(props to @mshinwell for spotting this)

Since this bug depends on memory layouts, it's hard to reproduce reliably. This also explains why we only saw it on 32-bit platforms: on 64-bit platforms, memory space is big enough that collisions between bytecode pointers and integers are unlikely. Also, on 32-bit Linux the memory allocator seems to prefer to return high addresses, so it's difficult to trigger the bug there too with smallish integers.

Here's a manual reproduction of the bug on a 64-bit machine, using gdb to figure out the magic value that triggers it:

```
$ cat bt.ml
let () = Printexc.record_backtrace true
let f n =
  let _ = assert false in
  print_int n
let () = f (read_int ())
$ ./ocamlc -g bt.ml -o bt
$ ./bt
42
Fatal error: exception File "bt.ml", line 3, characters 10-16: Assertion failed
Raised at file "bt.ml", line 3, characters 10-22
Called from file "bt.ml", line 7, characters 2-17
$ gdb -q --args runtime/ocamlrun ./bt
Reading symbols from /usr/local/home/sdolan/ocaml-bugfix/runtime/ocamlrun...done.
(gdb) break caml_add_debug_info
Breakpoint 1 at 0x405570: file backtrace_byt.c, line 175.
(gdb) r
Starting program: /usr/local/home/sdolan/ocaml-bugfix/runtime/ocamlrun ./bt
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Breakpoint 1, caml_add_debug_info (code_start=0x66d580, code_size=252833, events_heap=events_heap@entry=1) at backtrace_byt.c:175
175	{
(gdb) p ((uintnat)code_start)>>1
$1 = 3369664
(gdb) c
Continuing.
3369664
Fatal error: exception File "bt.ml", line 3, characters 10-16: Assertion failed
Raised at file "bt.ml", line 3, characters 10-22
Called from unknown location
Called from file "bt.ml", line 7, characters 2-17
```

With this patch, the above sequence no longer prints a spurious "Called from unknown location" line.