### PR TITLE
#9218: wrong file name error with -annot and inline records

### DIFF
--- a/Changes
+++ b/Changes
@@ -175,10 +175,6 @@ Working version
 - #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
   (Greta Yorsh, review by Mark Shinwell)
 
-- #9218, #9269: avoid a rare wrong module name error with "-annot" and
-  inline records.
-  (Florian Angeletti, review by Gabriel Scherer, report by Kate Deplaix)
-
 - #9225: Do not drop bytecode debug info after C calls.
   (Stephen Dolan, review by Gabriel Scherer and Jacques-Henri Jourdan)
 
@@ -673,6 +669,10 @@ OCaml 4.10.0
 - #9209, #9212: fix a development-version regression caused by #2288
   (Kate Deplaix and David Allsopp, review by Sébastien Hinderer
    and Gabriel Scherer )
+
+- #9218, #9269: avoid a rare wrong module name error with "-annot" and
+  inline records.
+  (Florian Angeletti, review by Gabriel Scherer, report by Kate Deplaix)
 
 - #9261: Fix a soundness bug in Rec_check, new in 4.10 (from #8908)
   (Vincent Laviron, review by Jeremy Yallop and Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -175,9 +175,9 @@ Working version
 - #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
   (Greta Yorsh, review by Mark Shinwell)
 
-- #9218, ???: avoid a rare wrong module name error with "-annot" and
+- #9218, #9269: avoid a rare wrong module name error with "-annot" and
   inline records.
-  (Florian Angeletti, review by ???, report by Kate Deplaix)
+  (Florian Angeletti, review by Gabriel Scherer, report by Kate Deplaix)
 
 - #9225: Do not drop bytecode debug info after C calls.
   (Stephen Dolan, review by Gabriel Scherer and Jacques-Henri Jourdan)

--- a/Changes
+++ b/Changes
@@ -175,6 +175,10 @@ Working version
 - #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
   (Greta Yorsh, review by Mark Shinwell)
 
+- #9218, ???: avoid a rare wrong module name error with "-annot" and
+  inline records.
+  (Florian Angeletti, review by ???, report by Kate Deplaix)
+
 - #9225: Do not drop bytecode debug info after C calls.
   (Stephen Dolan, review by Gabriel Scherer and Jacques-Henri Jourdan)
 

--- a/testsuite/tests/typing-multifile/pr9218.ml
+++ b/testsuite/tests/typing-multifile/pr9218.ml
@@ -1,0 +1,9 @@
+(* TEST
+   flags="-annot"
+   modules="a.ml"
+ *)
+
+(* Test interference between inline record path
+   [a.A] and the [a.ml] compilation unit *)
+type 'x a = A of { x: int }
+let v = A { x = 0 }

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1097,11 +1097,6 @@ let normalize_path_prefix oloc env path =
   | Papply _ ->
       assert false
 
-let is_uident s =
-  match s.[0] with
-  | 'A'..'Z' -> true
-  | _ -> false
-
 let normalize_type_path oloc env path =
   (* Inlined version of Path.is_constructor_typath:
      constructor type paths (i.e. path pointing to an inline
@@ -1112,7 +1107,7 @@ let normalize_type_path oloc env path =
       path
   | Pdot(p, s) ->
       let p2 =
-        if is_uident s && not (is_uident (Path.last p)) then
+        if Path.is_uident s && not (Path.is_uident (Path.last p)) then
           (* Cstr M.t.C *)
           normalize_path_prefix oloc env p
         else

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -37,6 +37,8 @@ val heads: t -> Ident.t list
 
 val last: t -> string
 
+val is_uident: string -> bool
+
 type typath =
   | Regular of t
   | Ext of t * string

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -389,15 +389,25 @@ let rewrite_double_underscore_paths env p =
   else
     rewrite_double_underscore_paths env p
 
-let rec tree_of_path namespace = function
+let rec regular_tree_of_path namespace = function
   | Pident id ->
       Oide_ident (ident_name namespace id)
   | Pdot(_, s) as path when non_shadowed_pervasive path ->
       Oide_ident (Naming_context.pervasives_name namespace s)
   | Pdot(p, s) ->
-      Oide_dot (tree_of_path Module p, s)
+      Oide_dot (regular_tree_of_path Module p, s)
   | Papply(p1, p2) ->
-      Oide_apply (tree_of_path Module p1, tree_of_path Module p2)
+      Oide_apply (regular_tree_of_path Module p1,
+                  regular_tree_of_path Module p2)
+
+let tree_of_path namespace p = match namespace with
+  | Module | Module_type | Class | Class_type | Other->
+      regular_tree_of_path namespace p
+  | Type ->
+      match Path.constructor_typath p with
+      | Regular _ | Ext _ | LocalExt _ -> regular_tree_of_path namespace p
+      | Cstr (p, s) -> (* t.A *)
+          Oide_dot (regular_tree_of_path Type p, s)
 
 let tree_of_path namespace p =
   tree_of_path namespace (rewrite_double_underscore_paths !printing_env p)


### PR DESCRIPTION
In presence of `-annot`, the type printer can be requested to print a inline record type constructor
(e.g "t.A").

Before this PR, the printing of these paths could trigger a lookup to a module with a invalid module name (e.g `t`). If this lookup failed this was fine.

However, if there was a cmi file in the environment sharing the name (e.g `t.cmi`), the lookup could partially succeed (since cmi are not required to start with a capital letter) until we compared the module name stored in the cmi with the requested module name.
Obviously, the valid module name (e.g. `T`) of the cmi could never match the invalid module name (e.g `t`) that was requested, and the cmi reader raised a wrong module file name error.

This commit avoids this whole process by detecting in the type printer when we are printing an inlined record type constructor and avoiding this wrong module name lookup.

Closes #9218