### PR TITLE
Fix bytecode backtrace generation when large integers are present.

### DIFF
--- a/Changes
+++ b/Changes
@@ -306,8 +306,9 @@ OCaml 4.10.0
   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer
    and Damien Doligez)
 
-- #9268: Fix bytecode backtrace generation when large integers are present.
-  (Stephen Dolan and Mark Shinwell, review by Gabriel Scherer)
+- #9268, #9271: Fix bytecode backtrace generation with large integers present.
+  (Stephen Dolan and Mark Shinwell, review by Gabriel Scherer and
+   Jacques-Henri Jourdan)
 
 ### Standard library:
 

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -260,7 +260,10 @@ void caml_stash_backtrace(value exn, value * sp, int reraise)
 code_t caml_next_frame_pointer(value ** sp, value ** trsp)
 {
   while (*sp < Caml_state->stack_high) {
-    code_t *p = (code_t*) (*sp)++;
+    value *spv = (*sp)++;
+    code_t *p;
+    if (Is_long(*spv)) continue;
+    p = (code_t*) spv;
     if(&Trap_pc(*trsp) == p) {
       *trsp = Trap_link(*trsp);
       continue;


### PR DESCRIPTION
#9268 again, since @jhjourdan noticed I only fixed half of the problem there.