### PR TITLE
Fix bytecode backtrace generation when large integers are present (2).

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,7 +31,7 @@ Working version
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
 - #8920, #9238, #9239: New API for statistical memory profiling in
-  Memprof.Gc. The new version does no longer use ephemerons and allows
+  Gc.Memprof. The new version does no longer use ephemerons and allows
   registering callbacks for promotion and deallocation of memory
   blocks.
   The new API no longer gives the block tags to the allocation callback.
@@ -306,8 +306,10 @@ OCaml 4.10.0
   (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer
    and Damien Doligez)
 
-- #9268: Fix bytecode backtrace generation when large integers are present.
-  (Stephen Dolan and Mark Shinwell, review by Gabriel Scherer)
+- #9268, XXXXX: Fix bytecode backtrace generation when large integers are
+  present.
+  (Stephen Dolan, Jacques-Henri Jourdan and Mark Shinwell,
+   review by Gabriel Scherer)
 
 ### Standard library:
 

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -260,7 +260,9 @@ void caml_stash_backtrace(value exn, value * sp, int reraise)
 code_t caml_next_frame_pointer(value ** sp, value ** trsp)
 {
   while (*sp < Caml_state->stack_high) {
-    code_t *p = (code_t*) (*sp)++;
+    value *v = (*sp)++;
+    if (Is_long(*v)) continue;
+    code_t *p = (code_t*)v;
     if(&Trap_pc(*trsp) == p) {
       *trsp = Trap_link(*trsp);
       continue;


### PR DESCRIPTION
This PR fixes [caml_next_frame_pointer], while #9268 only fixed [caml_stash_backtrace].