### PR TITLE
Avoid scanning the stack twice when collecting callstacks in Memprof.

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,6 +44,9 @@ Working version
 - #9230: Memprof support for native allocations.
   (Jacques-Henri Jourdan and Stephen Dolan, review by Gabriel Scherer)
 
+- #??: Memprof optimisation.
+  (Stephen Dolan, review by ??)
+
 ### Code generation and optimizations:
 
 - #8637, #8805, #9247: Record debug info for each allocation.

--- a/Changes
+++ b/Changes
@@ -44,8 +44,8 @@ Working version
 - #9230: Memprof support for native allocations.
   (Jacques-Henri Jourdan and Stephen Dolan, review by Gabriel Scherer)
 
-- #??: Memprof optimisation.
-  (Stephen Dolan, review by ??)
+- #9279: Memprof optimisation.
+  (Stephen Dolan, review by Jacques-Henri Jourdan)
 
 ### Code generation and optimizations:
 

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -325,12 +325,17 @@ CAMLprim value caml_get_exception_backtrace(value unit)
   CAMLreturn(res);
 }
 
-CAMLprim value caml_get_current_callstack(value max_frames_value) {
+CAMLprim value caml_get_current_callstack(value max_frames_value)
+{
   CAMLparam1(max_frames_value);
   CAMLlocal1(res);
-
-  res = caml_alloc(caml_current_callstack_size(Long_val(max_frames_value)), 0);
-  caml_current_callstack_write(res, -1);
-
+  value* callstack = NULL;
+  intnat callstack_alloc_len = 0;
+  intnat callstack_len =
+    caml_collect_current_callstack(&callstack, &callstack_alloc_len,
+                                   Long_val(max_frames_value), -1);
+  res = caml_alloc(callstack_len, 0);
+  memcpy(Op_val(res), callstack, sizeof(value) * callstack_len);
+  caml_stat_free(callstack);
   CAMLreturn(res);
 }

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -90,33 +90,21 @@ value caml_remove_debug_info(code_t start);
  * It defines the [caml_stash_backtrace] function, which is called to quickly
  * fill the backtrace buffer by walking the stack when an exception is raised.
  *
- * It also defines the two following functions, which makes it possible
- * to store upto [max_frames_value] frames of the current call
- * stack. This is not used in an exception-raising context, but only
- * when the user requests to save the trace (hopefully less often), or
- * the context of profiling. Instead of using a bounded buffer as
- * [caml_stash_backtrace], we first traverse the stack to compute the
- * right size, then allocate space for the trace.
+ * It also defines [caml_collect_current_callstack], which stores up
+ * to [max_frames] frames of the current call stack into the
+ * statically allocated buffer [*pbuffer] of length [*plen]. If the
+ * buffer is not long enough, it will be reallocated. The number of
+ * frames collected is returned.
  *
- * The first function, [caml_current_callstack_size] computes the size
- * (in words) of the needed buffer, while the second actually writes
- * the call stack to the buffer as an object of type
- * [raw_backtrace]. It should always be called with a buffer of the
- * size predicted by [caml_current_callstack_size]. The reason we use
- * two separated functions is to allow using either [caml_alloc] (for
- * performance) or [caml_alloc_shr] (when we need to avoid a call to
- * the GC, in memprof.c).
- *
- * The alloc_idx parameter to [caml_current_callstack_write] is used
- * to select between the backtraces of different allocation sites which
- * were combined by Comballoc. Passing -1 here means the caller doesn't
- * care which is chosen.
+ * The alloc_idx parameter is used to select between the backtraces of
+ * different allocation sites which were combined by Comballoc.
+ * Passing -1 here means the caller doesn't care which is chosen.
  *
  * We use `intnat` for max_frames because, were it only `int`, passing
  * `max_int` from the OCaml side would overflow on 64bits machines. */
 
-intnat caml_current_callstack_size(intnat max_frames);
-void caml_current_callstack_write(value trace, int alloc_idx);
+intnat caml_collect_current_callstack(value** pbuffer, intnat* plen,
+                                      intnat max_frames, int alloc_idx);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -862,6 +862,9 @@ void caml_memprof_shutdown(void) {
   caml_stat_free(trackst.entries);
   trackst.entries = NULL;
   trackst.alloc_len = 0;
+  caml_stat_free(callstack_buffer);
+  callstack_buffer = NULL;
+  callstack_buffer_len = 0;
 }
 
 CAMLprim value caml_memprof_start(value lv, value szv,

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -63,6 +63,10 @@ static int init = 0;
 /* Whether memprof is started. */
 static int started = 0;
 
+/* Buffer used to compute backtraces */
+static value* callstack_buffer = NULL;
+static intnat callstack_buffer_len = 0;
+
 /**** Statistical sampling ****/
 
 static double mt_generate_uniform(void)
@@ -147,10 +151,20 @@ static uintnat mt_generate_binom(uintnat len)
 static value capture_callstack_postponed()
 {
   value res;
-  uintnat wosize = caml_current_callstack_size(callstack_size);
-  if (wosize == 0) return Atom(0);
-  res = caml_alloc_shr_no_track_noexc(wosize, 0);
-  if (res != 0) caml_current_callstack_write(res, -1);
+  intnat callstack_len =
+    caml_collect_current_callstack(&callstack_buffer, &callstack_buffer_len,
+                                   callstack_size, -1);
+  if (callstack_len == 0)
+    return Atom(0);
+  res = caml_alloc_shr_no_track_noexc(callstack_len, 0);
+  if (res == 0)
+    return Atom(0);
+  memcpy(Op_val(res), callstack_buffer, sizeof(value) * callstack_len);
+  if (callstack_buffer_len > 256 && callstack_buffer_len > callstack_len * 8) {
+    caml_stat_free(callstack_buffer);
+    callstack_buffer = NULL;
+    callstack_buffer_len = 0;
+  }
   return res;
 }
 
@@ -161,10 +175,17 @@ static value capture_callstack_postponed()
 static value capture_callstack(int alloc_idx)
 {
   value res;
-  uintnat wosize = caml_current_callstack_size(callstack_size);
+  intnat callstack_len =
+    caml_collect_current_callstack(&callstack_buffer, &callstack_buffer_len,
+                                   callstack_size, alloc_idx);
   CAMLassert(caml_memprof_suspended);
-  res = caml_alloc(wosize, 0);
-  caml_current_callstack_write(res, alloc_idx);
+  res = caml_alloc(callstack_len, 0);
+  memcpy(Op_val(res), callstack_buffer, sizeof(value) * callstack_len);
+  if (callstack_buffer_len > 256 && callstack_buffer_len > callstack_len * 8) {
+    caml_stat_free(callstack_buffer);
+    callstack_buffer = NULL;
+    callstack_buffer_len = 0;
+  }
   return res;
 }
 
@@ -925,6 +946,10 @@ CAMLprim value caml_memprof_stop(value unit)
   caml_remove_generational_global_root(&callback_promote);
   caml_remove_generational_global_root(&callback_dealloc_minor);
   caml_remove_generational_global_root(&callback_dealloc_major);
+
+  caml_stat_free(callstack_buffer);
+  callstack_buffer = NULL;
+  callstack_buffer_len = 0;
 
   return Val_unit;
 }


### PR DESCRIPTION
The logic for collecting callstacks for Memprof is split into two passes: first, the stack is scanned to work out its length, a buffer is allocated, and then the stack is scanned again to fill it.

This is a de-optimisation: scanning the stack is much more expensive than reallocating and copying a buffer that turned out to be too short.

This patch does only one stack scan, using an off-heap buffer that's resized if necessary, and copying the result to a correctly-sized buffer afterwards. It makes a simple benchmark that spends ~30% of its time in Memprof goes ~10% faster, so this cuts off close to a third of the Memprof overhead. (Numbers will vary wildly according to stack depth and sampling rate).

There's a further optimisation: memprof.c also caches the last used buffer to save a couple of allocations, as the stack size at the last sample is a good predictor of the stack size at the next.

@jhjourdan: Is the distinction between capture_callstack_postponed and capture_callstack still needed, now that caml_alloc doesn't invoke async callbacks?