### PR TITLE
Micro-optimise allocations on amd64 to save a register.

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,6 +57,9 @@ Working version
 - #9279: Memprof optimisation.
   (Stephen Dolan, review by Jacques-Henri Jourdan)
 
+- #9280: Micro-optimise allocations on amd64 to save a register.
+  (Stephen Dolan, review by Xavier Leroy)
+
 - #9316: Use typing information from Clambda for mutable Cmm variables.
   (Stephen Dolan, review by Vincent Laviron, Guillaume Bury and Xavier Leroy)
 

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -703,7 +703,7 @@ let emit_instr fallthrough i =
         | 24 -> emit_call "caml_alloc2"
         | 32 -> emit_call "caml_alloc3"
         | _  ->
-            I.mov (int n) rax;
+            I.sub (int n) r15;
             emit_call "caml_allocN"
         end;
         let label =

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -301,14 +301,20 @@ let destroyed_at_c_call =
        100;101;102;103;104;105;106;107;
        108;109;110;111;112;113;114;115])
 
+let destroyed_by_spacetime_at_alloc =
+  if Config.spacetime then
+    [| loc_spacetime_node_hole |]
+  else
+    [| |]
+
 let destroyed_at_alloc =
   let regs =
-    if Config.spacetime then
-      [| rax; loc_spacetime_node_hole |]
+    if X86_proc.use_plt then
+      destroyed_by_plt_stub
     else
-      [| rax |]
+      [| r11 |]
   in
-  Array.concat [regs; destroyed_by_plt_stub]
+  Array.concat [regs; destroyed_by_spacetime_at_alloc]
 
 let destroyed_at_oper = function
     Iop(Icall_ind _ | Icall_imm _ | Iextcall { alloc = true; }) ->

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -315,14 +315,14 @@ FUNCTION(G(caml_call_gc))
         CFI_STARTPROC
 LBL(caml_call_gc):
     /* Record lowest stack address and return address. */
-        movq    (%rsp), %rax
-        movq    %rax, Caml_state(last_return_address)
-        leaq    8(%rsp), %rax
-        movq    %rax, Caml_state(bottom_of_stack)
+        movq    (%rsp), %r11
+        movq    %r11, Caml_state(last_return_address)
+        leaq    8(%rsp), %r11
+        movq    %r11, Caml_state(bottom_of_stack)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
         subq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(STACK_PROBE_SIZE);
-        movq    %rax, 0(%rsp)
+        movq    %r11, 0(%rsp)
         addq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(-STACK_PROBE_SIZE);
     /* Build array of registers, save it into Caml_state->gc_regs */
 #ifdef WITH_FRAME_POINTERS
@@ -441,7 +441,6 @@ ENDFUNCTION(G(caml_alloc3))
 
 FUNCTION(G(caml_allocN))
 CFI_STARTPROC
-        subq    %rax, %r15
         cmpq    Caml_state(young_limit), %r15
         jb      LBL(caml_call_gc)
         ret


### PR DESCRIPTION
Since #8805, there's no need for allocation on amd64 to clobber the %rax register. It's only used in one case (`-compact` out-of-line allocation of >3 words), and only used there to do a single subtraction. That subtraction can be done by the caller at no code size penalty, freeing up %rax.

This is a mild code size improvement: perhaps we avoid some spilling, but more importantly we don't clobber %rax, the register used for return values. Code like `Some (f x)` no longer needs to shuffle the return value of `f` into and out of another register across the allocation. (It might also be a mild perf improvement, but I don't imagine it would be noticeable).