### PR TITLE
#9189: avoid one-letter make variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -437,6 +437,11 @@ OCaml 4.11
 - #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
   (Greta Yorsh, review by Mark Shinwell)
 
+- #9189, #9281: fix a conflict with Gentoo build system
+  by removing an one-letter Makefile variable.
+  (Florian Angeletti, report by Ralph Seichter, review by David Allsopp
+   and Damien Doligez)
+
 - #9225: Do not drop bytecode debug info after C calls.
   (Stephen Dolan, review by Gabriel Scherer and Jacques-Henri Jourdan)
 

--- a/ocamldoc/Makefile.docfiles
+++ b/ocamldoc/Makefile.docfiles
@@ -41,8 +41,6 @@ DOC_COMPILERLIBS_INCLUDES = $(addprefix -I $(SRC)/, $(DOC_COMPILERLIBS_DIRS))
 
 DOC_ALL_INCLUDES = $(DOC_STDLIB_INCLUDES) $(DOC_COMPILERLIBS_INCLUDES)
 
-STDLIB_MODS = $(STDLIB_MODULES:stdlib__%=%)
-
 STDLIB_MOD_WP = $(filter-out stdlib__pervasives, $(STDLIB_MODULES))
 STDLIB_MLI0 = $(SRC)/stdlib/pervasives.ml $(STDLIB_MOD_WP:%=$(SRC)/stdlib/%.mli)
 STDLIB_MLIS=\

--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -17,7 +17,7 @@ To add a new module, you must:
   the same style as the rest of the code, in particular the
   alphabetical ordering and whitespace alignment of module aliases.
 
-* Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
+* Add `module_name` to the definition of `STDLIB_MODS` in
   `stdlib/StdlibModules`. You must keep the list sorted in dependency order.
 
 * Run `make alldepend` to update all the `.depend` files. These files are not

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -32,7 +32,6 @@ DEPFLAGS=-slash
 
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 
-# Object file prefix
 include StdlibModules
 
 OBJS=$(addsuffix .cmo,$(STDLIB_MODULES))

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -33,8 +33,6 @@ DEPFLAGS=-slash
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 
 # Object file prefix
-P=stdlib__
-
 include StdlibModules
 
 OBJS=$(addsuffix .cmo,$(STDLIB_MODULES))

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -18,68 +18,68 @@
 # This file lists all standard library modules.
 # It is used in particular to know what to expunge in toplevels.
 
-P ?= stdlib__
+STDLIBPREFIX = stdlib__
 
 # Modules should be listed in dependency order.
 
 STDLIB_MODULES=\
   camlinternalFormatBasics \
   stdlib \
-  $(P)pervasives \
-  $(P)seq \
-  $(P)option \
-  $(P)result \
-  $(P)bool \
-  $(P)char \
-  $(P)uchar \
-  $(P)sys \
-  $(P)list \
-  $(P)bytes \
-  $(P)string \
-  $(P)unit \
-  $(P)marshal \
-  $(P)obj \
-  $(P)array \
-  $(P)float \
-  $(P)int \
-  $(P)int32 \
-  $(P)int64 \
-  $(P)nativeint \
-  $(P)lexing \
-  $(P)parsing \
-  $(P)set \
-  $(P)map \
-  $(P)stack \
-  $(P)queue \
+  $(STDLIBPREFIX)pervasives \
+  $(STDLIBPREFIX)seq \
+  $(STDLIBPREFIX)option \
+  $(STDLIBPREFIX)result \
+  $(STDLIBPREFIX)bool \
+  $(STDLIBPREFIX)char \
+  $(STDLIBPREFIX)uchar \
+  $(STDLIBPREFIX)sys \
+  $(STDLIBPREFIX)list \
+  $(STDLIBPREFIX)bytes \
+  $(STDLIBPREFIX)string \
+  $(STDLIBPREFIX)unit \
+  $(STDLIBPREFIX)marshal \
+  $(STDLIBPREFIX)obj \
+  $(STDLIBPREFIX)array \
+  $(STDLIBPREFIX)float \
+  $(STDLIBPREFIX)int \
+  $(STDLIBPREFIX)int32 \
+  $(STDLIBPREFIX)int64 \
+  $(STDLIBPREFIX)nativeint \
+  $(STDLIBPREFIX)lexing \
+  $(STDLIBPREFIX)parsing \
+  $(STDLIBPREFIX)set \
+  $(STDLIBPREFIX)map \
+  $(STDLIBPREFIX)stack \
+  $(STDLIBPREFIX)queue \
   camlinternalLazy \
-  $(P)lazy \
-  $(P)stream \
-  $(P)buffer \
+  $(STDLIBPREFIX)lazy \
+  $(STDLIBPREFIX)stream \
+  $(STDLIBPREFIX)buffer \
   camlinternalFormat \
-  $(P)printf \
-  $(P)arg \
-  $(P)printexc \
-  $(P)fun \
-  $(P)gc \
-  $(P)digest \
-  $(P)random \
-  $(P)hashtbl \
-  $(P)weak \
-  $(P)format \
-  $(P)scanf \
-  $(P)callback \
+  $(STDLIBPREFIX)printf \
+  $(STDLIBPREFIX)arg \
+  $(STDLIBPREFIX)printexc \
+  $(STDLIBPREFIX)fun \
+  $(STDLIBPREFIX)gc \
+  $(STDLIBPREFIX)digest \
+  $(STDLIBPREFIX)random \
+  $(STDLIBPREFIX)hashtbl \
+  $(STDLIBPREFIX)weak \
+  $(STDLIBPREFIX)format \
+  $(STDLIBPREFIX)scanf \
+  $(STDLIBPREFIX)callback \
   camlinternalOO \
-  $(P)oo \
+  $(STDLIBPREFIX)oo \
   camlinternalMod \
-  $(P)genlex \
-  $(P)ephemeron \
-  $(P)filename \
-  $(P)complex \
-  $(P)arrayLabels \
-  $(P)listLabels \
-  $(P)bytesLabels \
-  $(P)stringLabels \
-  $(P)moreLabels \
-  $(P)stdLabels \
-  $(P)spacetime \
-  $(P)bigarray
+  $(STDLIBPREFIX)genlex \
+  $(STDLIBPREFIX)ephemeron \
+  $(STDLIBPREFIX)filename \
+  $(STDLIBPREFIX)complex \
+  $(STDLIBPREFIX)arrayLabels \
+  $(STDLIBPREFIX)listLabels \
+  $(STDLIBPREFIX)bytesLabels \
+  $(STDLIBPREFIX)stringLabels \
+  $(STDLIBPREFIX)moreLabels \
+  $(STDLIBPREFIX)stdLabels \
+  $(STDLIBPREFIX)spacetime \
+  $(STDLIBPREFIX)bigarray

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -16,73 +16,27 @@
 #**************************************************************************
 
 # This file lists all standard library modules.
-# It is used in particular to know what to expunge in toplevels.
+# It is used by:
+# 1. stdlib/Makefile when building stdlib.cma
+# 2. Makefile to expunge the toplevels
+# 3. ocamldoc/Makefile.docfiles to compute all documentation files
+#    which need to be generated for the stdlib
 
+# add stdlib__ as prefix to a module except for internal modules
+# and the stdlib module itself
 define add_stdlib_prefix
- $(or $(filter stdlib, $1), $(filter camlinternal%, $1), stdlib__$1)
+  $(or $(filter stdlib camlinternal%,$1), stdlib__$1)
 endef
 
 # Modules should be listed in dependency order.
-STDLIB_MODULES=$(foreach module, \
-  camlinternalFormatBasics \
-  stdlib \
-  pervasives \
-  seq \
-  option \
-  result \
-  bool \
-  char \
-  uchar \
-  sys \
-  list \
-  bytes \
-  string \
-  unit \
-  marshal \
-  obj \
-  array \
-  float \
-  int \
-  int32 \
-  int64 \
-  nativeint \
-  lexing \
-  parsing \
-  set \
-  map \
-  stack \
-  queue \
-  camlinternalLazy \
-  lazy \
-  stream \
-  buffer \
-  camlinternalFormat \
-  printf \
-  arg \
-  printexc \
-  fun \
-  gc \
-  digest \
-  random \
-  hashtbl \
-  weak \
-  format \
-  scanf \
-  callback \
-  camlinternalOO \
-  oo \
-  camlinternalMod \
-  genlex \
-  ephemeron \
-  filename \
-  complex \
-  arrayLabels \
-  listLabels \
-  bytesLabels \
-  stringLabels \
-  moreLabels \
-  stdLabels \
-  spacetime \
-  bigarray ,\
-  $(call add_stdlib_prefix,$(module))\
-)
+STDLIB_MODS=\
+  camlinternalFormatBasics stdlib pervasives seq option result bool char uchar \
+  sys list bytes string unit marshal obj array float int int32 int64 nativeint \
+  lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
+  camlinternalFormat printf arg printexc fun gc digest random hashtbl weak \
+  format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \
+  filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
+  stdLabels spacetime bigarray
+
+STDLIB_MODULES=\
+  $(foreach module, $(STDLIB_MODS), $(call add_stdlib_prefix,$(module)))

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -18,68 +18,71 @@
 # This file lists all standard library modules.
 # It is used in particular to know what to expunge in toplevels.
 
-STDLIBPREFIX = stdlib__
+define add_stdlib_prefix
+ $(or $(filter stdlib, $1), $(filter camlinternal%, $1), stdlib__$1)
+endef
 
 # Modules should be listed in dependency order.
-
-STDLIB_MODULES=\
+STDLIB_MODULES=$(foreach module, \
   camlinternalFormatBasics \
   stdlib \
-  $(STDLIBPREFIX)pervasives \
-  $(STDLIBPREFIX)seq \
-  $(STDLIBPREFIX)option \
-  $(STDLIBPREFIX)result \
-  $(STDLIBPREFIX)bool \
-  $(STDLIBPREFIX)char \
-  $(STDLIBPREFIX)uchar \
-  $(STDLIBPREFIX)sys \
-  $(STDLIBPREFIX)list \
-  $(STDLIBPREFIX)bytes \
-  $(STDLIBPREFIX)string \
-  $(STDLIBPREFIX)unit \
-  $(STDLIBPREFIX)marshal \
-  $(STDLIBPREFIX)obj \
-  $(STDLIBPREFIX)array \
-  $(STDLIBPREFIX)float \
-  $(STDLIBPREFIX)int \
-  $(STDLIBPREFIX)int32 \
-  $(STDLIBPREFIX)int64 \
-  $(STDLIBPREFIX)nativeint \
-  $(STDLIBPREFIX)lexing \
-  $(STDLIBPREFIX)parsing \
-  $(STDLIBPREFIX)set \
-  $(STDLIBPREFIX)map \
-  $(STDLIBPREFIX)stack \
-  $(STDLIBPREFIX)queue \
+  pervasives \
+  seq \
+  option \
+  result \
+  bool \
+  char \
+  uchar \
+  sys \
+  list \
+  bytes \
+  string \
+  unit \
+  marshal \
+  obj \
+  array \
+  float \
+  int \
+  int32 \
+  int64 \
+  nativeint \
+  lexing \
+  parsing \
+  set \
+  map \
+  stack \
+  queue \
   camlinternalLazy \
-  $(STDLIBPREFIX)lazy \
-  $(STDLIBPREFIX)stream \
-  $(STDLIBPREFIX)buffer \
+  lazy \
+  stream \
+  buffer \
   camlinternalFormat \
-  $(STDLIBPREFIX)printf \
-  $(STDLIBPREFIX)arg \
-  $(STDLIBPREFIX)printexc \
-  $(STDLIBPREFIX)fun \
-  $(STDLIBPREFIX)gc \
-  $(STDLIBPREFIX)digest \
-  $(STDLIBPREFIX)random \
-  $(STDLIBPREFIX)hashtbl \
-  $(STDLIBPREFIX)weak \
-  $(STDLIBPREFIX)format \
-  $(STDLIBPREFIX)scanf \
-  $(STDLIBPREFIX)callback \
+  printf \
+  arg \
+  printexc \
+  fun \
+  gc \
+  digest \
+  random \
+  hashtbl \
+  weak \
+  format \
+  scanf \
+  callback \
   camlinternalOO \
-  $(STDLIBPREFIX)oo \
+  oo \
   camlinternalMod \
-  $(STDLIBPREFIX)genlex \
-  $(STDLIBPREFIX)ephemeron \
-  $(STDLIBPREFIX)filename \
-  $(STDLIBPREFIX)complex \
-  $(STDLIBPREFIX)arrayLabels \
-  $(STDLIBPREFIX)listLabels \
-  $(STDLIBPREFIX)bytesLabels \
-  $(STDLIBPREFIX)stringLabels \
-  $(STDLIBPREFIX)moreLabels \
-  $(STDLIBPREFIX)stdLabels \
-  $(STDLIBPREFIX)spacetime \
-  $(STDLIBPREFIX)bigarray
+  genlex \
+  ephemeron \
+  filename \
+  complex \
+  arrayLabels \
+  listLabels \
+  bytesLabels \
+  stringLabels \
+  moreLabels \
+  stdLabels \
+  spacetime \
+  bigarray ,\
+  $(call add_stdlib_prefix,$(module))\
+)


### PR DESCRIPTION
This micro PR proposes to rename the one letter make variable `P` that was used in `stdlib/StdlibModules` and created a conflict with gentoo's portage to `STDLIBPREFIX` .

Closes #9189 