### PR TITLE
Use a machtype on Cconst_symbol to fix a bug in no-naked-pointers mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -60,6 +60,9 @@ Working version
 - #9316: Use typing information from Clambda for mutable Cmm variables.
   (Stephen Dolan, review by Vincent Laviron, Guillaume Bury and Xavier Leroy)
 
+- #9282: Make Cconst_symbol have typ_int to fix no-naked-pointers mode.
+  (Stephen Dolan, review by Mark Shinwell, Xavier Leroy and Vincent Laviron)
+
 ### Code generation and optimizations:
 
 - #8637, #8805, #9247, #9296: Record debug info for each allocation.

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -663,7 +663,14 @@ method emit_expr (env:environment) exp =
       let r = self#regs_for typ_float in
       Some(self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
   | Cconst_symbol (n, _dbg) ->
-      let r = self#regs_for typ_val in
+      (* Cconst_symbol _ evaluates to a statically-allocated address, so its
+         value fits in a typ_int register and is never changed by the GC.
+
+         Some Cconst_symbols point to statically-allocated blocks, some of
+         which may point to heap values. However, any such blocks will be
+         registered in the compilation unit's global roots structure, so
+         adding this register to the frame table would be redundant *)
+      let r = self#regs_for typ_int in
       Some(self#insert_op env (Iconst_symbol n) [||] r)
   | Cconst_pointer (n, _dbg) ->
       let r = self#regs_for typ_int in


### PR DESCRIPTION
There's a bug in no-naked-pointers mode currently, which leads to various segfaults. (I'm afraid I don't have a compact reproduction case).

The issue is that `Cconst_symbol`, used to represent addresses of constant values in Cmm, is assumed always to be of type `typ_val`, and registers containing such values are therefore always added to the frame table.

Many `Cconst_symbol`s are not in fact values. Instead, many are raw code pointers (used in constructing closures), pointers to `caml_apply2` and friends, addresses of global variables used by the runtime (e.g. `caml_globals_inited`) and so on.

If registers containing the addresses of these non-value symbols are added to the frametable, then the GC sees pointers that do not point to valid OCaml values. The default GC, with the page table, silently ignores these, but the no-naked-pointers GC explodes.

The fix is to put a type parameter in `Cconst_symbol`, and specify `typ_int` for the ones that do not look like valid values. So, this patch changes all instances of `Cconst_symbol(s,dbg)` to either `Cconst_symbol(s,typ_val,dbg)` or `Cconst_symbol(s,typ_int,dbg)`. Only the latter is a change from the current behaviour.

cc @mshinwell 