### PR TITLE
Add -config option to ocamlrun

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,10 @@ Working version
 
 ### Runtime system:
 
+- #9284: Add -config option to display the configuration of ocamlrun on stdout,
+  including the search path for shared stub libraries.
+  (David Allsopp, review by Xavier Leroy)
+
 - #10025: Track custom blocks (e.g. Bigarray) with Statmemprof
   (Stephen Dolan, review by Leo White, Gabriel Scherer and Jacques-Henri
    Jourdan)

--- a/manual/manual/cmds/runtime.etex
+++ b/manual/manual/cmds/runtime.etex
@@ -57,6 +57,9 @@ back trace is printed only if the bytecode executable contains
 debugging information, i.e. was compiled and linked with the "-g"
 option to "ocamlc" set.  This is equivalent to setting the "b" flag
 in the "OCAMLRUNPARAM" environment variable (see below).
+\item["-config"]
+Print the version number of "ocamlrun" and a detailed summary of its
+configuration, then exit.
 \item["-I" \var{dir}]
 Search the directory \var{dir} for dynamically-loaded libraries,
 in addition to the standard search path (see

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -369,6 +369,8 @@ $(foreach object_type, $(object_types), \
 
 dynlink.%.$(O): OC_CPPFLAGS += $(STDLIB_CPP_FLAG)
 
+startup_byt.%.$(O): OC_CPPFLAGS += $(STDLIB_CPP_FLAG) -DHOST='"$(HOST)"'
+
 $(foreach object_type,$(subst %,,$(object_types)), \
   $(eval dynlink$(object_type).$(O): $(ROOTDIR)/Makefile.config))
 

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -44,6 +44,9 @@ extern void caml_free_shared_libs(void);
 /* Return the effective location of the standard library */
 extern char_os * caml_get_stdlib_location(void);
 
+/* Parse ld.conf and add the lines read to caml_shared_libs_path */
+extern char_os * caml_parse_ld_conf(void);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_DYNLINK_H */

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -41,6 +41,9 @@ extern void caml_build_primitive_table_builtin(void);
 /* Unload all the previously loaded shared libraries */
 extern void caml_free_shared_libs(void);
 
+/* Return the effective location of the standard library */
+extern char_os * caml_get_stdlib_location(void);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_DYNLINK_H */

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -75,6 +75,15 @@ static c_primitive lookup_primitive(char * name)
 
 #define LD_CONF_NAME T("ld.conf")
 
+CAMLexport char_os * caml_get_stdlib_location(void)
+{
+  char_os * stdlib;
+  stdlib = caml_secure_getenv(T("OCAMLLIB"));
+  if (stdlib == NULL) stdlib = caml_secure_getenv(T("CAMLLIB"));
+  if (stdlib == NULL) stdlib = OCAML_STDLIB_DIR;
+  return stdlib;
+}
+
 static char_os * parse_ld_conf(void)
 {
   char_os * stdlib, * ldconfname, * wconfig, * p, * q;
@@ -86,9 +95,7 @@ static char_os * parse_ld_conf(void)
 #endif
   int ldconf, nread;
 
-  stdlib = caml_secure_getenv(T("OCAMLLIB"));
-  if (stdlib == NULL) stdlib = caml_secure_getenv(T("CAMLLIB"));
-  if (stdlib == NULL) stdlib = OCAML_STDLIB_DIR;
+  stdlib = caml_get_stdlib_location();
   ldconfname = caml_stat_strconcat_os(3, stdlib, T("/"), LD_CONF_NAME);
   if (stat_os(ldconfname, &st) == -1) {
     caml_stat_free(ldconfname);

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -70,7 +70,7 @@ static c_primitive lookup_primitive(char * name)
   return NULL;
 }
 
-/* Parse the OCAML_STDLIB_DIR/ld.conf file and add the directories
+/* Parse the ld.conf file and add the directories
    listed there to the search path */
 
 #define LD_CONF_NAME T("ld.conf")
@@ -84,7 +84,7 @@ CAMLexport char_os * caml_get_stdlib_location(void)
   return stdlib;
 }
 
-static char_os * parse_ld_conf(void)
+CAMLexport char_os * caml_parse_ld_conf(void)
 {
   char_os * stdlib, * ldconfname, * wconfig, * p, * q;
   char * config;
@@ -176,7 +176,7 @@ void caml_build_primitive_table(char_os * lib_path,
   if (lib_path != NULL)
     for (p = lib_path; *p != 0; p += strlen_os(p) + 1)
       caml_ext_table_add(&caml_shared_libs_path, p);
-  tofree2 = parse_ld_conf();
+  tofree2 = caml_parse_ld_conf();
   /* Open the shared libraries */
   caml_ext_table_init(&shared_libs, 8);
   if (libs != NULL)

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -71,6 +71,7 @@
 
 static char magicstr[EXEC_MAGIC_LENGTH+1];
 static int print_magic = 0;
+static int print_config = 0;
 
 /* Print the specified error message followed by an end-of-line and exit */
 static void error(char *msg, ...)
@@ -279,6 +280,7 @@ static void do_print_help(void)
     "Usage: ocamlrun [<options>] [--] <executable> [<command-line>]\n"
     "Options are:\n"
     "  -b  Set runtime parameter b (detailed exception backtraces)\n"
+    "  -config  Print configuration values and exit\n"
     "  -I <dir>  Add <dir> to the list of DLL search directories\n"
     "  -m  Print the magic number of <executable> and exit\n"
     "  -M  Print the magic number expected by this runtime and exit\n"
@@ -351,6 +353,8 @@ static int parse_command_line(char_os **argv)
                  !strcmp_os(argv[i], T("--help"))) {
         do_print_help();
         exit(0);
+      } else if (!strcmp_os(argv[i], T("-config"))) {
+        print_config = 1;
       } else {
         parsed = 0;
       }
@@ -361,6 +365,65 @@ static int parse_command_line(char_os **argv)
   }
 
   return i;
+}
+
+/* Print the configuration of the runtime to stdout; memory allocated is not
+   freed, since the runtime will terminate after calling this. */
+static void do_print_config(void)
+{
+  int i;
+  char_os * dir;
+
+  /* Print the runtime configuration */
+  printf("version: %s\n", OCAML_VERSION_STRING);
+  printf("standard_library_default: %s\n",
+         caml_stat_strdup_of_os(OCAML_STDLIB_DIR));
+  printf("standard_library: %s\n",
+         caml_stat_strdup_of_os(caml_get_stdlib_location()));
+  printf("int_size: %d\n", 8 * (int)sizeof(value));
+  printf("word_size: %d\n", 8 * (int)sizeof(value) - 1);
+  printf("os_type: %s\n", OCAML_OS_TYPE);
+  printf("host: %s\n", HOST);
+  printf("flat_float_array: %s\n",
+#ifdef FLAT_FLOAT_ARRAY
+         "true");
+#else
+         "false");
+#endif
+  printf("supports_afl: %s\n",
+#ifdef HAS_SYS_SHM_H
+         "true");
+#else
+         "false");
+#endif
+  printf("windows_unicode: %s\n",
+#if WINDOWS_UNICODE
+         "true");
+#else
+         "false");
+#endif
+  printf("supports_shared_libraries: %s\n",
+#ifdef SUPPORT_DYNAMIC_LINKING
+         "true");
+#else
+         "false");
+#endif
+  printf("exec_magic_number: %s\n", EXEC_MAGIC);
+
+  /* Parse ld.conf and print the effective search path */
+  puts("shared_libs_path:");
+  caml_parse_ld_conf();
+  for (i = 0; i < caml_shared_libs_path.size; i++) {
+    dir = caml_shared_libs_path.contents[i];
+    if (dir[0] == 0)
+#ifdef _WIN32
+      /* See caml_search_in_path in win32.c */
+      continue;
+#else
+      dir = ".";
+#endif
+    printf("  %s\n", caml_stat_strdup_of_os(dir));
+  }
 }
 
 #ifdef _WIN32
@@ -428,6 +491,10 @@ CAMLexport void caml_main(char_os **argv)
 
   if (fd < 0) {
     pos = parse_command_line(argv);
+    if (print_config) {
+      do_print_config();
+      exit(0);
+    }
     if (argv[pos] == 0) {
       error("no bytecode file specified");
     }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -408,6 +408,12 @@ static void do_print_config(void)
 #else
          "false");
 #endif
+  printf("no_naked_pointers: %s\n",
+#ifdef NO_NAKED_POINTERS
+         "true");
+#else
+         "false");
+#endif
   printf("exec_magic_number: %s\n", EXEC_MAGIC);
 
   /* Parse ld.conf and print the effective search path */

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -414,6 +414,13 @@ static void do_print_config(void)
 #else
          "false");
 #endif
+  printf("profinfo: %s\n"
+         "profinfo_width: %d\n",
+#ifdef WITH_PROFINFO
+         "true", PROFINFO_WIDTH);
+#else
+         "false", 0);
+#endif
   printf("exec_magic_number: %s\n", EXEC_MAGIC);
 
   /* Parse ld.conf and print the effective search path */


### PR DESCRIPTION
The main purpose of this PR is to add a `-config` option to `ocamlrun` similar to the one already in `ocamlc`/`ocamlopt`. This is loosely related to the work I'm doing with relocating the compiler, but independent enough to push it now - it's obviously non-urgent. `ocamlrun -config` gives output like:

```
version: 4.11.0+dev0-2019-10-18
standard_library_default: /usr/local/lib/ocaml
standard_library: runtime
int_size: 64
word_size: 63
os_type: Unix
host: x86_64-pc-linux-gnu
flat_float_array: true
supports_afl: true
windows_unicode: false
supports_shared_libraries: true
no_naked_pointers: false
profinfo: false
profinfo_width: 0
exec_magic_number: Caml1999X027
shared_libs_path:
  /usr/local/lib/ocaml/stublibs
  /usr/local/lib/ocaml
```

Options are exactly the same as `ocamlc -config`, with four exceptions:
- `supports_afl` indicates that the runtime has the shared memory support for execution with AFL, which is independent of using a compiler which had AFL instrumentation turned on for a particular build. cc @stedolan to ensure I got the detail of that correct
- `shared_libs_path` which contains the contents of `caml_shared_libs_path` after parsing `ld.conf` and any `-I` parameters on the command line (this is the feature I particularly wanted).
- `no_naked_pointers` and `profinfo`/`profinfo_width`

There's also a little shopping list of other things related to `ocamlrun`'s argument parsing:
- Support `--` so you can now have bytecode programs which begin with `-` if you, um, want
- Support `-Ifoo` as `-I foo` (previously, this was interpreted as `-I`
- Update some missing things in the manual
- Use `puts` instead of `printf("%s\n", …)` in a few places in `startup_byt.c`
- Strictly recognise command line parameters (previously, the first letter was checked only, so `-backtrace` was equivalent to `-b` - `-backtrace` is now an error).
- Display a slightly improved message for `ocamlrun -I` (indicate that `-I` expects a `<dir>` rather than that no bytecode file was specified).
- Add `-help`/`--help`