### PR TITLE
Eliminate MKEXE_ANSI from build system

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -76,6 +76,28 @@ endif
 # By default, request ocamllex to be quiet
 OCAMLLEX_FLAGS ?= -q
 
+# Escape special characters in the argument string.
+# There are four characters that need escaping:
+# - backslash and ampersand, which are special in the replacement text
+#   of sed's "s" command
+# - exclamation mark, which is the delimiter we use for sed's "s" command
+# - single quote, which interferes with shell quoting.  We are inside
+#   single quotes already, so the proper escape is '\''
+#   (close single quotation, insert single quote character,
+#    reopen single quotation).
+SED_ESCAPE=$(subst ','\'',$(subst !,\!,$(subst &,\&,$(subst \,\\,$1))))
+
+# Escape special characters in an OCaml string literal "..."
+# There are two: backslash and double quote.
+OCAML_ESCAPE=$(subst ",\",$(subst \,\\,$1))
+
+# SUBST generates the sed substitution for the variable *named* in $1
+SUBST=-e 's!%%$1%%!$(call SED_ESCAPE,$($1))!'
+
+# SUBST_STRING does the same, for a variable that occurs between "..."
+# in config.mlp.  Thus, backslashes and double quotes must be escaped.
+SUBST_STRING=-e 's!%%$1%%!$(call SED_ESCAPE,$(call OCAML_ESCAPE,$($1)))!'
+
 # The rule to compile C files
 
 # This rule is similar to GNU make's implicit rule, except that it is more

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -276,7 +276,6 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
   SORT=/usr/bin/sort
   SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
   FLEXLINK_CMD=flexlink
-  MKEXE_ANSI=$(FLEXLINK) -exe
   FLEXDLL_CHAIN=@flexdll_chain@
   # FLEXLINK_FLAGS must be safe to insert in an OCaml string
   #   (see ocamlmklibconfig.ml in tools/Makefile)

--- a/configure
+++ b/configure
@@ -12794,13 +12794,13 @@ fi
 fi
     ostype="Win32"
     toolchain="mingw"
-    mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
     oc_ldflags='-municode'
     SO="dll" ;; #(
   *,*-pc-windows) :
     toolchain=msvc
     ostype="Win32"
-    mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
     oc_ldflags='/ENTRY:wmainCRTStartup'
     case $host in #(
   i686-pc-windows) :

--- a/configure.ac
+++ b/configure.ac
@@ -702,13 +702,13 @@ AS_CASE([$CC,$host],
       mkexedebugflag="-link -g"])
     ostype="Win32"
     toolchain="mingw"
-    mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
     oc_ldflags='-municode'
     SO="dll"],
   [*,*-pc-windows],
     [toolchain=msvc
     ostype="Win32"
-    mkexe='$(MKEXE_ANSI) $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
     oc_ldflags='/ENTRY:wmainCRTStartup'
     AS_CASE([$host],
       [i686-pc-windows], [flexdll_chain=msvc],

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -43,8 +43,7 @@ else
 endif
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
-  ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)"|cygpath -w -f - \
-    | sed 's/\\/\\\\\\\\/g')
+  ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)" | cygpath -w -f -)
   mkexe := $(MKEXE_ANSI) -link $(OC_LDFLAGS)
 else
   ocamlsrcdir := $(abspath $(shell pwd)/..)
@@ -237,43 +236,42 @@ ocamltest.opt$(EXE): $(compdeps_opt) $(native_modules)
 	$(ocamllex) $(OCAMLLEX_FLAGS) $<
 
 ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
-	sed \
-	  -e 's|@@AFL_INSTRUMENT@@|$(AFL_INSTRUMENT)|' \
-	  -e 's|@@RUNTIMEI@@|$(RUNTIMEI)|' \
-	  -e 's|@@ARCH@@|$(ARCH)|' \
-	  -e 's|@@SHARED_LIBRARIES@@|$(SUPPORTS_SHARED_LIBRARIES)|' \
-	  -e 's|@@UNIX@@|$(unix)|' \
-	  -e 's|@@SYSTHREADS@@|$(systhreads)|' \
-	  -e 's|@@STR@@|$(str)|' \
-	  -e 's|@@SYSTEM@@|$(SYSTEM)|' \
-	  -e 's|@@CPP@@|$(CPP)|' \
-	  -e 's|@@OCAMLCDEFAULTFLAGS@@|$(ocamlcdefaultflags)|' \
-	  -e 's|@@OCAMLOPTDEFAULTFLAGS@@|$(ocamloptdefaultflags)|' \
-	  -e 's|@@OCAMLSRCDIR@@|$(ocamlsrcdir)|' \
-	  -e 's|@@FLAMBDA@@|$(FLAMBDA)|' \
-	  -e 's|@@SPACETIME@@|$(WITH_SPACETIME)|' \
-	  -e 's|@@FORCE_SAFE_STRING@@|$(FORCE_SAFE_STRING)|' \
-	  -e 's|@@FLAT_FLOAT_ARRAY@@|$(FLAT_FLOAT_ARRAY)|' \
-	  -e 's|@@OCAMLDOC@@|$(WITH_OCAMLDOC)|' \
-	  -e 's|@@OCAMLDEBUG@@|$(WITH_OCAMLDEBUG)|' \
-	  -e 's|@@OBJEXT@@|$(O)|' \
-	  -e 's|@@ASMEXT@@|$(S)|' \
-	  -e 's|@@NATIVE_DYNLINK@@|$(NATDYNLINK)|' \
-	  -e 's|@@SHARED_LIBRARY_CFLAGS@@|$(SHAREDLIB_CFLAGS)|' \
-	  -e 's|@@SHAREDOBJEXT@@|$(SO)|' \
-	  -e 's|@@CSC@@|$(CSC)|' \
-	  -e 's|@@CSCFLAGS@@|$(CSCFLAGS)|' \
-	  -e 's|@@MKDLL@@|$(MKDLL)|' \
-	  -e 's|@@MKEXE@@|$(mkexe)|' \
-	  -e 's|@@BYTECCLIBS@@|$(BYTECCLIBS)|' \
-	  -e 's|@@NATIVECCLIBS@@|$(NATIVECCLIBS)|' \
-	  -e 's|@@ASM@@|$(ASM)|' \
-	  -e 's|@@CC@@|$(CC)|' \
-	  -e 's|@@CFLAGS@@|$(OC_CFLAGS)|' \
-	  -e 's|@@CCOMPTYPE@@|$(CCOMPTYPE)|' \
-	  -e 's|@@WINDOWS_UNICODE@@|$(WINDOWS_UNICODE)|' \
-	  -e 's|@@FUNCTION_SECTIONS@@|$(FUNCTION_SECTIONS)|' \
-	  $< > $@
+	sed $(call SUBST,AFL_INSTRUMENT) \
+	    $(call SUBST,RUNTIMEI) \
+	    $(call SUBST,ARCH) \
+	    $(call SUBST,SUPPORTS_SHARED_LIBRARIES) \
+	    $(call SUBST,unix) \
+	    $(call SUBST,systhreads) \
+	    $(call SUBST,str) \
+	    $(call SUBST,SYSTEM) \
+	    $(call SUBST_STRING,CPP) \
+	    $(call SUBST_STRING,ocamlcdefaultflags) \
+	    $(call SUBST_STRING,ocamloptdefaultflags) \
+	    $(call SUBST_STRING,ocamlsrcdir) \
+	    $(call SUBST,FLAMBDA) \
+	    $(call SUBST,WITH_SPACETIME) \
+	    $(call SUBST,FORCE_SAFE_STRING) \
+	    $(call SUBST,FLAT_FLOAT_ARRAY) \
+	    $(call SUBST,WITH_OCAMLDOC) \
+	    $(call SUBST,WITH_OCAMLDEBUG) \
+	    $(call SUBST,O) \
+	    $(call SUBST,S) \
+	    $(call SUBST,NATDYNLINK) \
+	    $(call SUBST_STRING,SHAREDLIB_CFLAGS) \
+	    $(call SUBST,SO) \
+	    $(call SUBST_STRING,CSC) \
+	    $(call SUBST_STRING,CSCFLAGS) \
+	    $(call SUBST_STRING,MKDLL) \
+	    $(call SUBST_STRING,mkexe) \
+	    $(call SUBST_STRING,BYTECCLIBS) \
+	    $(call SUBST_STRING,NATIVECCLIBS) \
+	    $(call SUBST_STRING,ASM) \
+	    $(call SUBST_STRING,CC) \
+	    $(call SUBST_STRING,OC_CFLAGS) \
+	    $(call SUBST,CCOMPTYPE) \
+	    $(call SUBST,WINDOWS_UNICODE) \
+	    $(call SUBST,FUNCTION_SECTIONS) \
+	    $< > $@
 
 # Manual
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -44,11 +44,10 @@ endif
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)" | cygpath -w -f -)
-  mkexe := $(MKEXE_ANSI) -link $(OC_LDFLAGS)
 else
   ocamlsrcdir := $(abspath $(shell pwd)/..)
-  mkexe := $(MKEXE)
 endif
+mkexe := $(MKEXE)
 
 ifeq "$(TOOLCHAIN)" "msvc"
 CPP := $(CPP) 2> nul

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -15,70 +15,70 @@
 
 (* The configuration module for ocamltest *)
 
-let arch = "@@ARCH@@"
+let arch = "%%ARCH%%"
 
-let afl_instrument = @@AFL_INSTRUMENT@@
+let afl_instrument = %%AFL_INSTRUMENT%%
 
-let asm = "@@ASM@@"
+let asm = "%%ASM%%"
 
-let cc = "@@CC@@"
+let cc = "%%CC%%"
 
-let cflags = "@@CFLAGS@@"
+let cflags = "%%OC_CFLAGS%%"
 
-let ccomptype = "@@CCOMPTYPE@@"
+let ccomptype = "%%CCOMPTYPE%%"
 
-let shared_libraries = @@SHARED_LIBRARIES@@
+let shared_libraries = %%SUPPORTS_SHARED_LIBRARIES%%
 
-let libunix = @@UNIX@@
+let libunix = %%unix%%
 
-let systhreads = @@SYSTHREADS@@
+let systhreads = %%systhreads%%
 
-let str = @@STR@@
+let str = %%str%%
 
-let objext = "@@OBJEXT@@"
+let objext = "%%O%%"
 
-let asmext = "@@ASMEXT@@"
+let asmext = "%%S%%"
 
-let system = "@@SYSTEM@@"
+let system = "%%SYSTEM%%"
 
-let c_preprocessor = "@@CPP@@"
+let c_preprocessor = "%%CPP%%"
 
-let ocamlsrcdir = "@@OCAMLSRCDIR@@"
+let ocamlsrcdir = "%%ocamlsrcdir%%"
 
-let flambda = @@FLAMBDA@@
+let flambda = %%FLAMBDA%%
 
-let spacetime = @@SPACETIME@@
+let spacetime = %%WITH_SPACETIME%%
 
-let ocamlc_default_flags = "@@OCAMLCDEFAULTFLAGS@@"
-let ocamlopt_default_flags = "@@OCAMLOPTDEFAULTFLAGS@@"
+let ocamlc_default_flags = "%%ocamlcdefaultflags%%"
+let ocamlopt_default_flags = "%%ocamloptdefaultflags%%"
 
-let safe_string = @@FORCE_SAFE_STRING@@
+let safe_string = %%FORCE_SAFE_STRING%%
 
-let flat_float_array = @@FLAT_FLOAT_ARRAY@@
+let flat_float_array = %%FLAT_FLOAT_ARRAY%%
 
-let ocamldoc = @@OCAMLDOC@@
+let ocamldoc = %%WITH_OCAMLDOC%%
 
-let ocamldebug = @@OCAMLDEBUG@@
+let ocamldebug = %%WITH_OCAMLDEBUG%%
 
-let native_dynlink = @@NATIVE_DYNLINK@@
+let native_dynlink = %%NATDYNLINK%%
 
-let shared_library_cflags = "@@SHARED_LIBRARY_CFLAGS@@"
+let shared_library_cflags = "%%SHAREDLIB_CFLAGS%%"
 
-let sharedobjext = "@@SHAREDOBJEXT@@"
+let sharedobjext = "%%SO%%"
 
-let csc = "@@CSC@@"
+let csc = "%%CSC%%"
 
-let csc_flags = "@@CSCFLAGS@@"
+let csc_flags = "%%CSCFLAGS%%"
 
-let mkdll = "@@MKDLL@@"
-let mkexe = "@@MKEXE@@"
+let mkdll = "%%MKDLL%%"
+let mkexe = "%%mkexe%%"
 
-let bytecc_libs = "@@BYTECCLIBS@@"
+let bytecc_libs = "%%BYTECCLIBS%%"
 
-let nativecc_libs = "@@NATIVECCLIBS@@"
+let nativecc_libs = "%%NATIVECCLIBS%%"
 
-let windows_unicode = @@WINDOWS_UNICODE@@ != 0
+let windows_unicode = %%WINDOWS_UNICODE%% != 0
 
-let function_sections = @@FUNCTION_SECTIONS@@
+let function_sections = %%FUNCTION_SECTIONS%%
 
-let has_instrumented_runtime = @@RUNTIMEI@@
+let has_instrumented_runtime = %%RUNTIMEI%%

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -17,7 +17,7 @@
 
 ROOTDIR = ..
 
-include $(ROOTDIR)/Makefile.config
+include $(ROOTDIR)/Makefile.common
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
@@ -31,31 +31,9 @@ endif
 
 FLEXLINK_FLAGS ?=
 
-# Escape special characters in the argument string.
-# There are four characters that need escaping:
-# - backslash and ampersand, which are special in the replacement text
-#   of sed's "s" command
-# - exclamation mark, which is the delimiter we use for sed's "s" command
-# - single quote, which interferes with shell quoting.  We are inside
-#   single quotes already, so the proper escape is '\''
-#   (close single quotation, insert single quote character,
-#    reopen single quotation).
-SED_ESCAPE=$(subst ','\'',$(subst !,\!,$(subst &,\&,$(subst \,\\,$1))))
-
-# Escape special characters in an OCaml string literal "..."
-# There are two: backslash and double quote.
-OCAML_ESCAPE=$(subst ",\",$(subst \,\\,$1))
-
-# SUBST generates the sed substitution for the variable *named* in $1
-SUBST=-e 's!%%$1%%!$(call SED_ESCAPE,$($1))!'
-
-# SUBST_STRING does the same, for a variable that occurs between "..."
-# in config.mlp.  Thus, backslashes and double quotes must be escaped.
-SUBST_STRING=-e 's!%%$1%%!$(call SED_ESCAPE,$(call OCAML_ESCAPE,$($1)))!'
-
-# SUBST_QUOTE does the same, adding OCaml quotes around non-empty strings
-#   (see FLEXDLL_DIR which must empty if FLEXDLL_DIR is empty but an OCaml
-#    string otherwise)
+# SUBST_QUOTE does the same as SUBST_STRING, adding OCaml quotes around
+#   non-empty strings (see FLEXDLL_DIR which must empty if FLEXDLL_DIR is empty
+#   but an OCaml string otherwise)
 SUBST_QUOTE2=\
   -e 's!%%$1%%!$(if $2,$(call SED_ESCAPE,"$(call OCAML_ESCAPE,$2)"))!'
 SUBST_QUOTE=$(call SUBST_QUOTE2,$1,$($1))


### PR DESCRIPTION
Follow-up from #8621 - `MKEXE_ANSI` is no longer required.