### PR TITLE
Trivial: remove NONSTANDARD_DIV_MOD from m.h

### DIFF
--- a/runtime/caml/m.h.in
+++ b/runtime/caml/m.h.in
@@ -81,14 +81,6 @@
 #undef WITH_SPACETIME
 #undef ENABLE_CALL_COUNTS
 
-#undef NONSTANDARD_DIV_MOD
-
-/* Leave NONSTANDARD_DIV_MOD undefined if the C operators / and % implement
-   round-towards-zero semantics, as specified by ISO C 9x and implemented
-   by most contemporary processors.  Otherwise, or if you don't know,
-   define NONSTANDARD_DIV_MOD: this will select a slower but correct
-   software emulation of division and modulus. */
-
 #undef ASM_CFI_SUPPORTED
 
 #undef WITH_FRAME_POINTERS


### PR DESCRIPTION
@xavierleroy's patch for #6075 introduced the requirement for C99 support, which removed all
code which depended on this setting.

The variable hasn't been set by `configure` since 4.02, so it has no purpose in `m.h.in`