### PR TITLE
Add a toplevel directive to switch off debugging

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,6 +39,10 @@ Working version
 
 ### Tools:
 
+- #9290: Add a directive to switch off debugging in toplevel.
+  This allows to see optimized bytecode with -dlambda.
+  (Jacques Garrigue, review by Gabriel Scherer)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/manual/src/cmds/top.etex
+++ b/manual/src/cmds/top.etex
@@ -285,6 +285,9 @@ directories:
 
 \item[Compiler options]
   \begin{options}
+  \item["#debug "\var{bool}";;"]
+    Turn on/off the insertion of debugging events. Default is "true".
+
   \item["#labels "\var{bool}";;"]
     Ignore labels in function types if argument is "false", or switch back
     to default behaviour (commuting style) if argument is "true".

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -632,6 +632,13 @@ let _ = add_directive "print_length"
 
 (* Set various compiler flags *)
 
+let _ = add_directive "debug"
+    (Directive_bool(fun b -> Clflags.debug := b))
+    {
+      section = section_options;
+      doc = "Choose whether to generate debugging events.";
+    }
+
 let _ = add_directive "labels"
     (Directive_bool(fun b -> Clflags.classic := not b))
     {


### PR DESCRIPTION
At some time in the past, `Clflags.debug` has been set to true in the toplevel.
This makes very difficult to use `ocaml -dlambda` as debugging events get in the way.
This also disables some optimizations for code written in the toplevel.

This PR adds a direction `#debug` to change this flag.
Then one can disable debugging by writing
```ocaml
#debug false;;
```
and get some meaningful output for `-dlambda`