### PR TITLE
Fix bug in best-fit on 32-bit

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,10 +25,10 @@ OCaml 4.10 release branch
 
 ### Runtime system:
 
-- #8809: Add a best-fit allocator for the major heap; still experimental,
-  it should be much better than current allocation policies (first-fit and
-  next-fit) for programs with large heaps, reducing both GC cost and
-  memory usage.
+- #8809, #9292: Add a best-fit allocator for the major heap; still
+  experimental, it should be much better than current allocation
+  policies (first-fit and next-fit) for programs with large heaps,
+  reducing both GC cost and memory usage.
   This new best-fit is not (yet) the default; set it explicitly with
   OCAMLRUNPARAM="a=2" (or Gc.set from the program). You may also want
   to increase the `space_overhead` parameter of the GC (a percentage,

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -1731,7 +1731,7 @@ static header_t *bf_merge_block (value bp, char *limit)
   while (wosz > Max_wosize){
     Hd_val (start) = Make_header (Max_wosize, 0, Caml_blue);
     bf_insert_sweep (start);
-    start = Next_small (start);
+    start = Next_in_mem (start);
     wosz -= Whsize_wosize (Max_wosize);
   }
   if (wosz > 0){

--- a/testsuite/tests/regression/pr9292/pr9292.ml
+++ b/testsuite/tests/regression/pr9292/pr9292.ml
@@ -1,0 +1,6 @@
+(* TEST *)
+
+let () =
+  Gc.set { (Gc.get ()) with allocation_policy = 2 };
+  ignore (Array.init 5_000 (fun _ -> Array.make 10_000 0));
+  Gc.full_major ()


### PR DESCRIPTION
The code in best-fit for merging blocks that are larger than `Max_wosize` is broken. Technically this affects both 64-bit and 32-bit but in practice this only really shows up on 32 bit.

Without this PR:
```
$ cat foo.ml
let () =
  ignore (Array.init 5_000 (fun _ -> Array.make 10_000 0));
  Gc.full_major ()

$ ocamlopt foo.ml -o foo

$ ./foo

$ OCAMLRUNPARAM=a=2 ./foo
Segmentation fault (core dumped)
```
