### PR TITLE
Use addrmap hash table for marshaling

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
 
 ### Runtime system:
 
+- #9293: Use addrmap hash table for marshaling
+  (Stephen Dolan and KC Sivaramakrishnan)
+
 - #9119: Make [caml_stat_resize_noexc] compatible with the [realloc]
   API when the old block is NULL.
   (Jacques-Henri Jourdan, review by Xavier Leroy)

--- a/runtime/.depend
+++ b/runtime/.depend
@@ -151,12 +151,15 @@ io_b.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_b.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_b.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_b.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -448,12 +451,15 @@ io_bd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_bd.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_bd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_bd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -750,12 +756,15 @@ io_bi.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_bi.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_bi.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_bi.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -1047,12 +1056,15 @@ io_bpic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_bpic.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_bpic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_bpic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -1303,12 +1315,15 @@ io_n.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_n.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_n.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_n.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -1596,12 +1611,15 @@ io_nd.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_nd.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_nd.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_nd.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -1889,12 +1907,15 @@ io_ni.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_ni.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_ni.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_ni.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
@@ -2182,12 +2203,15 @@ io_npic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
  caml/domain.h caml/misc.h caml/mlvalues.h caml/osdeps.h caml/memory.h \
  caml/signals.h caml/sys.h
+addrmap_npic.$(O): addrmap.c caml/config.h caml/m.h caml/s.h caml/memory.h \
+ caml/compatibility.h caml/config.h caml/misc.h caml/mlvalues.h \
+ caml/domain_state.h caml/domain_state.tbl caml/domain.h caml/addrmap.h
 extern_npic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/config.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
  caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/domain.h \
- caml/misc.h caml/mlvalues.h caml/reverse.h
+ caml/misc.h caml/mlvalues.h caml/reverse.h caml/addrmap.h
 intern_npic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
  caml/s.h caml/mlvalues.h caml/domain_state.h caml/domain_state.tbl \
  caml/callback.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -24,14 +24,14 @@ BYTECODE_C_SOURCES := $(addsuffix .c, \
   interp misc stacks fix_code startup_aux startup_byt freelist major_gc \
   minor_gc memory alloc roots_byt globroots fail_byt signals \
   signals_byt printexc backtrace_byt backtrace compare ints \
-  floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
-  lexing callback debugger weak compact finalise custom dynlink \
+  floats str array io addrmap extern intern hash sys meta parsing gc_ctrl \
+  md5 obj lexing callback debugger weak compact finalise custom dynlink \
   spacetime_byt afl $(UNIX_OR_WIN32) bigarray main memprof domain)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
   startup_aux startup_nat main fail_nat roots_nat signals \
   signals_nat misc freelist major_gc minor_gc memory alloc compare ints \
-  floats str array io extern intern hash sys parsing gc_ctrl md5 obj \
+  floats str array io addrmap extern intern hash sys parsing gc_ctrl md5 obj \
   lexing $(UNIX_OR_WIN32) printexc callback weak compact finalise custom \
   globroots backtrace_nat backtrace dynlink_nat debugger meta \
   dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray \

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -54,7 +54,7 @@ void caml_addrmap_clear(struct addrmap* t) {
 void caml_addrmap_initialize(struct addrmap *t) {
   if (!t->entries) {
     /* first call, initialise table with a small initial size */
-    addrmap_alloc(t, caml_init_alloc_size);
+    addrmap_alloc(t, caml_init_intern_addrmap_size);
   }
 }
 

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*      KC Sivaramakrishnan, Indian Institute of Technology, Madras       */
+/*                Stephen Dolan, University of Cambridge                  */
+/*                                                                        */
+/*   Copyright 2020 Indian Institute of Technology, Madras                */
+/*   Copyright 2020 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include "caml/config.h"
+#include "caml/memory.h"
+#include "caml/addrmap.h"
+
+#define MAX_CHAIN 100
+
+static uintnat pos_initial(struct addrmap* t, value key)
+{
+  uintnat pos = (uintnat)key;
+  pos *= 0xcc9e2d51;
+  pos ^= (pos >> 17);
+
+  CAMLassert(Is_power_of_2(t->size));
+  return pos & (t->size - 1);
+}
+
+static uintnat pos_next(struct addrmap* t, uintnat pos)
+{
+  return (pos + 1) & (t->size - 1);
+}
+
+int caml_addrmap_contains(struct addrmap* t, value key)
+{
+  CAMLassert(Is_block(key));
+  if (!t->entries) return 0;
+
+  uintnat pos, i;
+  for (i = 0, pos = pos_initial(t, key);
+       i < MAX_CHAIN;
+       i++, pos = pos_next(t, pos)) {
+    if (t->entries[pos].key == ADDRMAP_INVALID_KEY) break;
+    if (t->entries[pos].key == key) return 1;
+  }
+  return 0;
+}
+
+value caml_addrmap_lookup(struct addrmap* t, value key)
+{
+  CAMLassert(Is_block(key));
+  CAMLassert(t->entries);
+
+  uintnat pos;
+  for (pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
+    CAMLassert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
+    if (t->entries[pos].key == key)
+      return t->entries[pos].value;
+  }
+}
+
+static void addrmap_alloc(struct addrmap* t, uintnat sz)
+{
+  uintnat i;
+  CAMLassert(sz > 0 && (sz & (sz - 1)) == 0); /* sz must be a power of 2 */
+  t->entries = caml_stat_alloc(sizeof(struct addrmap_entry) * sz);
+  t->size = sz;
+  for (i = 0; i < sz; i++) {
+    t->entries[i].key = ADDRMAP_INVALID_KEY;
+    t->entries[i].value = ADDRMAP_NOT_PRESENT;
+  }
+}
+
+void caml_addrmap_clear(struct addrmap* t) {
+  caml_stat_free(t->entries);
+  t->entries = 0;
+  t->size = 0;
+}
+
+
+
+value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
+  uintnat i, pos;
+  CAMLassert(Is_block(key));
+  if (!t->entries) {
+    /* first call, initialise table with a small initial size */
+    addrmap_alloc(t, 256);
+  }
+  for (i = 0, pos = pos_initial(t, key);
+       i < MAX_CHAIN;
+       i++,   pos = pos_next(t, pos)) {
+    if (t->entries[pos].key == ADDRMAP_INVALID_KEY) {
+      t->entries[pos].key = key;
+    }
+    if (t->entries[pos].key == key) {
+      return &t->entries[pos].value;
+    }
+  }
+  /* failed to insert, rehash and try again */
+  struct addrmap_entry* old_table = t->entries;
+  uintnat old_size = t->size;
+  addrmap_alloc(t, old_size * 2);
+  for (i = 0; i < old_size; i++) {
+    if (old_table[i].key != ADDRMAP_INVALID_KEY) {
+      value* p = caml_addrmap_insert_pos(t, old_table[i].key);
+      CAMLassert(*p == ADDRMAP_NOT_PRESENT);
+      *p = old_table[i].value;
+    }
+  }
+  caml_stat_free(old_table);
+  return caml_addrmap_insert_pos(t, key);
+}
+
+void caml_addrmap_insert(struct addrmap* t, value k, value v) {
+  value* p = caml_addrmap_insert_pos(t, k);
+  CAMLassert(*p == ADDRMAP_NOT_PRESENT);
+  *p = v;
+}
+
+void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value)) {
+  addrmap_iterator i;
+  for (i = caml_addrmap_iterator(t);
+       caml_addrmap_iter_ok(t, i);
+       i = caml_addrmap_next(t, i)) {
+    f(caml_addrmap_iter_key(t, i),
+      caml_addrmap_iter_value(t, i));
+  }
+}

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -33,36 +33,6 @@ static uintnat pos_next(struct addrmap* t, uintnat pos)
   return (pos + 1) % (t->size);
 }
 
-int caml_addrmap_contains(struct addrmap* t, value key)
-{
-  uintnat pos, i;
-
-  CAMLassert(Is_block(key));
-  if (!t->entries) return 0;
-
-  for (i = 0, pos = pos_initial(t, key);
-       i < MAX_CHAIN;
-       i++, pos = pos_next(t, pos)) {
-    if (t->entries[pos].key == ADDRMAP_INVALID_KEY) break;
-    if (t->entries[pos].key == key) return 1;
-  }
-  return 0;
-}
-
-value caml_addrmap_lookup(struct addrmap* t, value key)
-{
-  uintnat pos;
-
-  CAMLassert(Is_block(key));
-  CAMLassert(t->entries);
-
-  for (pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
-    CAMLassert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
-    if (t->entries[pos].key == key)
-      return t->entries[pos].value;
-  }
-}
-
 static void addrmap_alloc(struct addrmap* t, uintnat sz)
 {
   uintnat i;
@@ -118,20 +88,4 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
   }
   caml_stat_free(old_table);
   return caml_addrmap_insert_pos(t, key);
-}
-
-void caml_addrmap_insert(struct addrmap* t, value k, value v) {
-  value* p = caml_addrmap_insert_pos(t, k);
-  CAMLassert(*p == ADDRMAP_NOT_PRESENT);
-  *p = v;
-}
-
-void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value)) {
-  addrmap_iterator i;
-  for (i = caml_addrmap_iterator(t);
-       caml_addrmap_iter_ok(t, i);
-       i = caml_addrmap_next(t, i)) {
-    f(caml_addrmap_iter_key(t, i),
-      caml_addrmap_iter_value(t, i));
-  }
 }

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -25,6 +25,7 @@ int caml_addrmap_initialize(struct addrmap_page_table *t)
 {
   mlsize_t sz = 0;
   uintnat pagesize = Page(caml_init_intern_addrmap_size * 4);
+  uintnat i;
 
   t->size  = 1;
   t->shift = 8 * sizeof(uintnat);
@@ -41,7 +42,7 @@ int caml_addrmap_initialize(struct addrmap_page_table *t)
   sz = t->size;
   CAMLassert(sz > 0 && (sz & (sz - 1)) == 0); /* sz must be a power of 2 */
   t->entries = caml_stat_alloc(sizeof(struct addrmap_entry) * sz);
-  for (int i = 0; i < sz; i++) {
+  for (i = 0; i < sz; i++) {
     t->entries[i].key   = ADDRMAP_INVALID_KEY;
     t->entries[i].value = ADDRMAP_NOT_PRESENT;
   }
@@ -66,7 +67,7 @@ int caml_addrmap_resize(struct addrmap_page_table* t)
   new_mask    = new_size - 1;
   new_entries = caml_stat_alloc(sizeof(struct addrmap_entry) * new_size);
 
-  for (int i = 0; i < new_size; i++) {
+  for (i = 0; i < new_size; i++) {
     new_entries[i].key   = ADDRMAP_INVALID_KEY;
     new_entries[i].value = ADDRMAP_NOT_PRESENT;
   }
@@ -104,7 +105,7 @@ int caml_addrmap_resize(struct addrmap_page_table* t)
 
 value* caml_addrmap_lookup(struct addrmap_page_table* t, value key)
 {
-  uintnat h; /* e, i; */
+  uintnat h;
 
   h = Hash(Page(key), t->shift);
   /* The first hit is almost always successful, so optimize for this case */

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -21,71 +21,148 @@
 #include "caml/addrmap.h"
 #include "caml/startup_aux.h"
 
-#define MAX_CHAIN 10
-
-static uintnat pos_initial(struct addrmap* t, value key)
+int addrmap_page_table_initialize(struct addrmap_page_table *t, mlsize_t count)
 {
-  return key % (t->size);
-}
+  uintnat pagesize = Page(count * 4);
 
-static uintnat pos_next(struct addrmap* t, uintnat pos)
-{
-  return (pos + 1) % (t->size);
-}
+  t->size  = 1;
+  t->shift = 8 * sizeof(uintnat);
 
-static void addrmap_alloc(struct addrmap* t, uintnat sz)
-{
-  uintnat i;
+  /* Aim for initial load factor between 1/4 and 1/2 */
+  while (t->size < 2 * pagesize) {
+    t->size <<= 1;
+    t->shift -= 1;
+  }
+  t->mask      = t->size - 1;
+  t->occupancy = 0;
+
+  /* Allocate for entries */
+  mlsize_t sz = t->size;
   CAMLassert(sz > 0 && (sz & (sz - 1)) == 0); /* sz must be a power of 2 */
   t->entries = caml_stat_alloc(sizeof(struct addrmap_entry) * sz);
-  t->size = sz;
-  for (i = 0; i < sz; i++) {
-    t->entries[i].key = ADDRMAP_INVALID_KEY;
+  for (int i = 0; i < sz; i++) {
+    t->entries[i].key   = ADDRMAP_INVALID_KEY;
     t->entries[i].value = ADDRMAP_NOT_PRESENT;
   }
+
+  if (t->entries == NULL)
+    return -1;
+  else
+    return 0;
 }
 
-void caml_addrmap_clear(struct addrmap* t) {
-  caml_stat_free(t->entries);
-  t->entries = 0;
-  t->size = 0;
+void display_addrmap(struct addrmap_page_table* t)
+{
+  mlsize_t i;
+
+  printf("Display addrmap page table entries\n");
+  printf("size       = %ld\n", t->size);
+  printf("occupancy  = %ld\n", t->occupancy);
+  for (i = 0; i < t->size; i++)
+    printf("addrmap_page_table.entries[%ld] = %ld:%ld\n", i, t->entries[i].key, t->entries[i].value);
+  printf("\n\n");
 }
 
-void caml_addrmap_initialize(struct addrmap *t) {
-  if (!t->entries) {
-    /* first call, initialise table with a small initial size */
-    addrmap_alloc(t, caml_init_intern_addrmap_size);
+int addrmap_page_table_resize(struct addrmap_page_table* t)
+{
+  struct addrmap_entry* new_entries;
+  uintnat i, h, new_size, new_shift, new_mask;
+
+  caml_gc_message (0x08, "Growing page table to %"
+                   ARCH_INTNAT_PRINTF_FORMAT "u entries\n",
+                   t->size);
+
+  new_size    = t->size * 2;
+  new_shift   = t->shift - 1;
+  new_mask    = new_size - 1;
+  new_entries = caml_stat_alloc(sizeof(struct addrmap_entry) * new_size);
+
+  for (int i = 0; i < new_size; i++) {
+    new_entries[i].key   = ADDRMAP_INVALID_KEY;
+    new_entries[i].value = ADDRMAP_NOT_PRESENT;
   }
+
+  for (i = 0; i < t->size; i++) {
+    struct addrmap_entry e = t->entries[i];
+    if (e.key != ADDRMAP_INVALID_KEY) {
+      h = Hash(Page(e.key), new_shift);
+
+      if (new_entries[h].key == ADDRMAP_INVALID_KEY) {
+        new_entries[h].key   = t->entries[i].key;
+        new_entries[h].value = t->entries[i].value;
+      }
+      else {
+        while (1) {
+          h = (h + 1) & new_mask;
+          if (new_entries[h].key == ADDRMAP_INVALID_KEY) {
+            new_entries[h].key   = t->entries[i].key;
+            new_entries[h].value = t->entries[i].value;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  t->size  = new_size;
+  t->shift = new_shift;
+  t->mask  = new_mask;
+
+  caml_stat_free(t->entries);
+  t->entries = new_entries;
+  return 0;
 }
 
-value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
-  uintnat i, pos , old_size;
-  struct addrmap_entry* old_table;
+value* addrmap_page_table_lookup(struct addrmap_page_table* t, value key)
+{
+  uintnat h; /* e, i; */
 
+  h = Hash(Page(key), t->shift);
+  /* The first hit is almost always successful, so optimize for this case */
+  if (t->entries[h].key == ADDRMAP_INVALID_KEY) {
+      t->entries[h].key = key;
+      t->occupancy++;
+    }
+  if (t->entries[h].key == key) {
+    return &t->entries[h].value;
+  }
+
+  while (1) {
+    h = (h + 1) & t->mask;
+    if (t->entries[h].key == ADDRMAP_INVALID_KEY) {
+      t->entries[h].key = key;
+      t->occupancy++;
+    }
+    if (t->entries[h].key == key) {
+      return &t->entries[h].value;
+    }
+  }
+
+  return NULL;
+}
+
+void caml_addrmap_clear(struct addrmap_page_table* t) {
+  caml_stat_free(t->entries);
+  t->entries   = NULL;
+  t->occupancy = 0;
+  t->mask      = 0;
+  t->shift     = 0;
+  t->size      = 0;
+}
+
+void caml_addrmap_initialize(struct addrmap_page_table* t) {
+  addrmap_page_table_initialize(t, caml_init_intern_addrmap_size);
+}
+
+value* caml_addrmap_insert_pos(struct addrmap_page_table* t, value key) {
   CAMLassert(Is_block(key));
 
-  for (i = 0, pos = pos_initial(t, key);
-       i < MAX_CHAIN;
-       i++,   pos = pos_next(t, pos)) {
-    if (t->entries[pos].key == ADDRMAP_INVALID_KEY) {
-      t->entries[pos].key = key;
-    }
-    if (t->entries[pos].key == key) {
-      return &t->entries[pos].value;
-    }
-  }
+  /* Resize to keep load factor around 0.9 */
+  if (t->occupancy > 0.9 * t->size) {
 
-  /* failed to insert, rehash and try again */
-  old_table = t->entries;
-  old_size = t->size;
-  addrmap_alloc(t, old_size * 2);
-  for (i = 0; i < old_size; i++) {
-    if (old_table[i].key != ADDRMAP_INVALID_KEY) {
-      value* p = caml_addrmap_insert_pos(t, old_table[i].key);
-      CAMLassert(*p == ADDRMAP_NOT_PRESENT);
-      *p = old_table[i].value;
+    if (addrmap_page_table_resize(t) != 0) {
+      return NULL;
     }
   }
-  caml_stat_free(old_table);
-  return caml_addrmap_insert_pos(t, key);
+  return addrmap_page_table_lookup(t, key);
 }

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -21,10 +21,10 @@
 #include "caml/addrmap.h"
 #include "caml/startup_aux.h"
 
-int addrmap_page_table_initialize(struct addrmap_page_table *t, mlsize_t count)
+int caml_addrmap_initialize(struct addrmap_page_table *t)
 {
   mlsize_t sz = 0;
-  uintnat pagesize = Page(count * 4);
+  uintnat pagesize = Page(caml_init_intern_addrmap_size * 4);
 
   t->size  = 1;
   t->shift = 8 * sizeof(uintnat);
@@ -52,7 +52,7 @@ int addrmap_page_table_initialize(struct addrmap_page_table *t, mlsize_t count)
     return 0;
 }
 
-int addrmap_page_table_resize(struct addrmap_page_table* t)
+int caml_addrmap_resize(struct addrmap_page_table* t)
 {
   struct addrmap_entry* new_entries;
   uintnat i, h, new_size, new_shift, new_mask;
@@ -102,7 +102,7 @@ int addrmap_page_table_resize(struct addrmap_page_table* t)
   return 0;
 }
 
-value* addrmap_page_table_lookup(struct addrmap_page_table* t, value key)
+value* caml_addrmap_lookup(struct addrmap_page_table* t, value key)
 {
   uintnat h; /* e, i; */
 
@@ -139,19 +139,15 @@ void caml_addrmap_clear(struct addrmap_page_table* t) {
   t->size      = 0;
 }
 
-void caml_addrmap_initialize(struct addrmap_page_table* t) {
-  addrmap_page_table_initialize(t, caml_init_intern_addrmap_size);
-}
-
 value* caml_addrmap_insert_pos(struct addrmap_page_table* t, value key) {
   CAMLassert(Is_block(key));
 
   /* Resize to keep load factor around 0.9 */
   if (t->occupancy > 0.9 * t->size) {
 
-    if (addrmap_page_table_resize(t) != 0) {
+    if (caml_addrmap_resize(t) != 0) {
       return NULL;
     }
   }
-  return addrmap_page_table_lookup(t, key);
+  return caml_addrmap_lookup(t, key);
 }

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -77,20 +77,14 @@ int caml_addrmap_resize(struct addrmap_page_table* t)
     if (e.key != ADDRMAP_INVALID_KEY) {
       h = Hash(Page(e.key), new_shift);
 
-      if (new_entries[h].key == ADDRMAP_INVALID_KEY) {
-        new_entries[h].key   = t->entries[i].key;
-        new_entries[h].value = t->entries[i].value;
-      }
-      else {
-        while (1) {
-          h = (h + 1) & new_mask;
-          if (new_entries[h].key == ADDRMAP_INVALID_KEY) {
-            new_entries[h].key   = t->entries[i].key;
-            new_entries[h].value = t->entries[i].value;
-            break;
-          }
+      do {
+        if (new_entries[h].key == ADDRMAP_INVALID_KEY) {
+          new_entries[h].key   = t->entries[i].key;
+          new_entries[h].value = t->entries[i].value;
+          break;
         }
-      }
+        h = (h + 1) & new_mask;
+      } while (1);
     }
   }
 

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -23,6 +23,7 @@
 
 int addrmap_page_table_initialize(struct addrmap_page_table *t, mlsize_t count)
 {
+  mlsize_t sz = 0;
   uintnat pagesize = Page(count * 4);
 
   t->size  = 1;
@@ -37,7 +38,7 @@ int addrmap_page_table_initialize(struct addrmap_page_table *t, mlsize_t count)
   t->occupancy = 0;
 
   /* Allocate for entries */
-  mlsize_t sz = t->size;
+  sz = t->size;
   CAMLassert(sz > 0 && (sz & (sz - 1)) == 0); /* sz must be a power of 2 */
   t->entries = caml_stat_alloc(sizeof(struct addrmap_entry) * sz);
   for (int i = 0; i < sz; i++) {

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -52,18 +52,6 @@ int addrmap_page_table_initialize(struct addrmap_page_table *t, mlsize_t count)
     return 0;
 }
 
-void display_addrmap(struct addrmap_page_table* t)
-{
-  mlsize_t i;
-
-  printf("Display addrmap page table entries\n");
-  printf("size       = %ld\n", t->size);
-  printf("occupancy  = %ld\n", t->occupancy);
-  for (i = 0; i < t->size; i++)
-    printf("addrmap_page_table.entries[%ld] = %ld:%ld\n", i, t->entries[i].key, t->entries[i].value);
-  printf("\n\n");
-}
-
 int addrmap_page_table_resize(struct addrmap_page_table* t)
 {
   struct addrmap_entry* new_entries;

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -14,6 +14,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include "caml/config.h"
 #include "caml/memory.h"
 #include "caml/addrmap.h"
@@ -82,8 +84,6 @@ void caml_addrmap_clear(struct addrmap* t) {
   t->entries = 0;
   t->size = 0;
 }
-
-
 
 value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
   uintnat i, pos, old_size;

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -1,0 +1,99 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                Stephen Dolan, University of Cambridge                  */
+/*                                                                        */
+/*   Copyright 2020 Indian Institute of Technology, Madras                */
+/*   Copyright 2020 University of Cambridge                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include "mlvalues.h"
+
+#ifndef CAML_ADDRMAP_H
+#define CAML_ADDRMAP_H
+
+/* An addrmap is a value -> value hashmap, where
+   the values are blocks */
+
+struct addrmap_entry { value key, value; };
+struct addrmap {
+  struct addrmap_entry* entries;
+  uintnat size;
+};
+
+#define ADDRMAP_INIT {0,0}
+
+int caml_addrmap_contains(struct addrmap* t, value v);
+value caml_addrmap_lookup(struct addrmap* t, value v);
+
+#define ADDRMAP_NOT_PRESENT ((value)(0))
+#define ADDRMAP_INVALID_KEY ((value)(0))
+
+value* caml_addrmap_insert_pos(struct addrmap* t, value v);
+
+/* must not already be present */
+void caml_addrmap_insert(struct addrmap* t, value k, value v);
+
+void caml_addrmap_clear(struct addrmap* t);
+
+void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value));
+
+/* iteration */
+typedef uintnat addrmap_iterator;
+static inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t,
+                                                    addrmap_iterator i)
+{
+  if (i < t->size) {
+    CAMLassert(t->entries[i].key != ADDRMAP_INVALID_KEY);
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+static inline addrmap_iterator caml_addrmap_next(struct addrmap* t,
+                                                 addrmap_iterator i)
+{
+  if (!t->entries) return (uintnat)(-1);
+  i++;
+  while (i < t->size && t->entries[i].key == ADDRMAP_INVALID_KEY) {
+    i++;
+  }
+  caml_addrmap_iter_ok(t, i); /* just for assert-checks */
+  return i;
+}
+
+static inline value caml_addrmap_iter_key(struct addrmap* t,
+                                          addrmap_iterator i)
+{
+  CAMLassert(caml_addrmap_iter_ok(t, i));
+  return t->entries[i].key;
+}
+
+static inline value caml_addrmap_iter_value(struct addrmap* t,
+                                            addrmap_iterator i)
+{
+  CAMLassert(caml_addrmap_iter_ok(t, i));
+  return t->entries[i].value;
+}
+
+static inline value* caml_addrmap_iter_val_pos(struct addrmap* t,
+                                               addrmap_iterator i)
+{
+  CAMLassert(caml_addrmap_iter_ok(t, i));
+  return &t->entries[i].value;
+}
+
+static inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
+{
+  return caml_addrmap_next(t, (uintnat)(-1));
+}
+
+
+#endif

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -13,10 +13,12 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "mlvalues.h"
-
 #ifndef CAML_ADDRMAP_H
 #define CAML_ADDRMAP_H
+
+#ifdef CAML_INTERNALS
+
+#include "mlvalues.h"
 
 /* An addrmap is a value -> value hashmap, where
    the values are blocks */
@@ -95,5 +97,6 @@ static inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
   return caml_addrmap_next(t, (uintnat)(-1));
 }
 
+#endif /* CAML_INTERNALS */
 
-#endif
+#endif /* CAML_ADDRMAP_H */

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -44,60 +44,7 @@ void caml_addrmap_insert(struct addrmap* t, value k, value v);
 
 void caml_addrmap_clear(struct addrmap* t);
 
-void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value));
-
 void caml_addrmap_initialize(struct addrmap* t);
-
-/* iteration */
-typedef uintnat addrmap_iterator;
-static inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t,
-                                                    addrmap_iterator i)
-{
-  if (i < t->size) {
-    CAMLassert(t->entries[i].key != ADDRMAP_INVALID_KEY);
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
-static inline addrmap_iterator caml_addrmap_next(struct addrmap* t,
-                                                 addrmap_iterator i)
-{
-  if (!t->entries) return (uintnat)(-1);
-  i++;
-  while (i < t->size && t->entries[i].key == ADDRMAP_INVALID_KEY) {
-    i++;
-  }
-  caml_addrmap_iter_ok(t, i); /* just for assert-checks */
-  return i;
-}
-
-static inline value caml_addrmap_iter_key(struct addrmap* t,
-                                          addrmap_iterator i)
-{
-  CAMLassert(caml_addrmap_iter_ok(t, i));
-  return t->entries[i].key;
-}
-
-static inline value caml_addrmap_iter_value(struct addrmap* t,
-                                            addrmap_iterator i)
-{
-  CAMLassert(caml_addrmap_iter_ok(t, i));
-  return t->entries[i].value;
-}
-
-static inline value* caml_addrmap_iter_val_pos(struct addrmap* t,
-                                               addrmap_iterator i)
-{
-  CAMLassert(caml_addrmap_iter_ok(t, i));
-  return &t->entries[i].value;
-}
-
-static inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)
-{
-  return caml_addrmap_next(t, (uintnat)(-1));
-}
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -46,6 +46,8 @@ void caml_addrmap_clear(struct addrmap* t);
 
 void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value));
 
+void caml_addrmap_initialize(struct addrmap* t);
+
 /* iteration */
 typedef uintnat addrmap_iterator;
 static inline addrmap_iterator caml_addrmap_iter_ok(struct addrmap* t,

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -42,19 +42,18 @@ struct addrmap_page_table {
   struct addrmap_entry* entries;   /* [size]  */
 };
 
-value* caml_addrmap_lookup(struct addrmap_page_table* t, value key);
-
 #define ADDRMAP_NOT_PRESENT ((value)(0))
 #define ADDRMAP_INVALID_KEY ((value)(0))
 
+int caml_addrmap_initialize(struct addrmap_page_table* t);
+
 value* caml_addrmap_insert_pos(struct addrmap_page_table* t, value v);
 
+value* caml_addrmap_lookup(struct addrmap_page_table* t, value key);
+
+int caml_addrmap_resize(struct addrmap_page_table* t);
+
 void caml_addrmap_clear(struct addrmap_page_table* t);
-
-void caml_addrmap_initialize(struct addrmap_page_table* t);
-
-value* addrmap_page_table_lookup(struct addrmap_page_table* t, value key);
-int addrmap_page_table_resize(struct addrmap_page_table* t);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -53,7 +53,6 @@ void caml_addrmap_clear(struct addrmap_page_table* t);
 
 void caml_addrmap_initialize(struct addrmap_page_table* t);
 
-void display_addrmap(struct addrmap_page_table* t);
 value* addrmap_page_table_lookup(struct addrmap_page_table* t, value key);
 int addrmap_page_table_resize(struct addrmap_page_table* t);
 

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -39,7 +39,7 @@ struct addrmap_page_table {
   int shift;
   mlsize_t mask;                   /* mask == size - 1 */
   mlsize_t occupancy;
-  struct addrmap_entry* entries;   /* [size]  */
+  struct addrmap_entry* entries;   /* [count]  */
 };
 
 #define ADDRMAP_NOT_PRESENT ((value)(0))

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -20,31 +20,42 @@
 
 #include "mlvalues.h"
 
-/* An addrmap is a value -> value hashmap, where
-   the values are blocks */
+#define Page(p) ((uintnat) (p) >> 2)
+
+/* Multiplicative Fibonacci hashing
+   (Knuth, TAOCP vol 3, section 6.4, page 518).
+   HASH_FACTOR is (sqrt(5) - 1) / 2 * 2^wordsize. */
+#ifdef ARCH_SIXTYFOUR
+#define HASH_FACTOR 11400714819323198486UL
+#else
+#define HASH_FACTOR 2654435769UL
+#endif
+#define Hash(key,shift) (((key) * HASH_FACTOR) >> shift)
 
 struct addrmap_entry { value key, value; };
-struct addrmap {
-  struct addrmap_entry* entries;
-  uintnat size;
+
+struct addrmap_page_table {
+  mlsize_t size;                   /* size == 1 << (wordsize - shift) */
+  int shift;
+  mlsize_t mask;                   /* mask == size - 1 */
+  mlsize_t occupancy;
+  struct addrmap_entry* entries;   /* [size]  */
 };
 
-#define ADDRMAP_INIT {0,0}
-
-int caml_addrmap_contains(struct addrmap* t, value v);
-value caml_addrmap_lookup(struct addrmap* t, value v);
+value* caml_addrmap_lookup(struct addrmap_page_table* t, value key);
 
 #define ADDRMAP_NOT_PRESENT ((value)(0))
 #define ADDRMAP_INVALID_KEY ((value)(0))
 
-value* caml_addrmap_insert_pos(struct addrmap* t, value v);
+value* caml_addrmap_insert_pos(struct addrmap_page_table* t, value v);
 
-/* must not already be present */
-void caml_addrmap_insert(struct addrmap* t, value k, value v);
+void caml_addrmap_clear(struct addrmap_page_table* t);
 
-void caml_addrmap_clear(struct addrmap* t);
+void caml_addrmap_initialize(struct addrmap_page_table* t);
 
-void caml_addrmap_initialize(struct addrmap* t);
+void display_addrmap(struct addrmap_page_table* t);
+value* addrmap_page_table_lookup(struct addrmap_page_table* t, value key);
+int addrmap_page_table_resize(struct addrmap_page_table* t);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -254,4 +254,7 @@ typedef uint64_t uintnat;
    Documented in gc.mli */
 #define Custom_minor_max_bsz_def 8192
 
+/* Default initial size for addrmap hash table: 256 bytes */
+#define Init_addrmap_def 256
+
 #endif /* CAML_CONFIG_H */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -254,7 +254,7 @@ typedef uint64_t uintnat;
    Documented in gc.mli */
 #define Custom_minor_max_bsz_def 8192
 
-/* Default initial size for addrmap hash table: 256 bytes */
-#define Init_addrmap_def 256
+/* Default initial number of entries in the addrmap hash table */
+#define Init_intern_addrmap_def 256
 
 #endif /* CAML_CONFIG_H */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -199,6 +199,8 @@ CAMLextern void caml_fatal_error (char *, ...)
 #endif
 CAMLnoreturn_end;
 
+#define Is_power_of_2(x) (((x) & ((x) - 1)) == 0)
+
 /* Detection of available C built-in functions, the Clang way. */
 
 #ifdef __has_builtin

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -199,7 +199,9 @@ CAMLextern void caml_fatal_error (char *, ...)
 #endif
 CAMLnoreturn_end;
 
+#ifdef CAML_INTERNALS
 #define Is_power_of_2(x) (((x) & ((x) - 1)) == 0)
+#endif /* CAML_INTERNALS */
 
 /* Detection of available C built-in functions, the Clang way. */
 

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -36,6 +36,7 @@ extern uintnat caml_init_custom_major_ratio;
 extern uintnat caml_init_custom_minor_ratio;
 extern uintnat caml_init_custom_minor_max_bsz;
 extern uintnat caml_trace_level;
+extern uintnat caml_init_alloc_size;
 extern int caml_cleanup_on_exit;
 
 extern void caml_parse_ocamlrunparam (void);

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -36,7 +36,7 @@ extern uintnat caml_init_custom_major_ratio;
 extern uintnat caml_init_custom_minor_ratio;
 extern uintnat caml_init_custom_minor_max_bsz;
 extern uintnat caml_trace_level;
-extern uintnat caml_init_alloc_size;
+extern uintnat caml_init_intern_addrmap_size;
 extern int caml_cleanup_on_exit;
 
 extern void caml_parse_ocamlrunparam (void);

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -49,7 +49,7 @@ enum {
 
 static int extern_flags;        /* logical or of some of the flags above */
 
-static struct addrmap recorded_objs = ADDRMAP_INIT;
+static struct addrmap_page_table recorded_objs;
 
 /* Stack for pending values to marshal */
 

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -32,6 +32,7 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/reverse.h"
+#include "caml/addrmap.h"
 
 static uintnat obj_counter;  /* Number of objects emitted so far */
 static uintnat size_32;  /* Size in words of 32-bit block for struct. */
@@ -48,22 +49,7 @@ enum {
 
 static int extern_flags;        /* logical or of some of the flags above */
 
-/* Trail mechanism to undo forwarding pointers put inside objects */
-
-struct trail_entry {
-  value obj;    /* address of object + initial color in low 2 bits */
-  value field0; /* initial contents of field 0 */
-};
-
-struct trail_block {
-  struct trail_block * previous;
-  struct trail_entry entries[ENTRIES_PER_TRAIL_BLOCK];
-};
-
-static struct trail_block extern_trail_first;
-static struct trail_block * extern_trail_block;
-static struct trail_entry * extern_trail_cur, * extern_trail_limit;
-
+static struct addrmap recorded_objs = ADDRMAP_INIT;
 
 /* Stack for pending values to marshal */
 
@@ -96,7 +82,6 @@ CAMLnoreturn_start
 static void extern_stack_overflow(void)
 CAMLnoreturn_end;
 
-static void extern_replay_trail(void);
 static void free_extern_output(void);
 
 /* Free the extern stack if needed */
@@ -132,68 +117,10 @@ static struct extern_item * extern_resize_stack(struct extern_item * sp)
   return newstack + sp_offset;
 }
 
-/* Initialize the trail */
-
-static void init_extern_trail(void)
-{
-  extern_trail_block = &extern_trail_first;
-  extern_trail_cur = extern_trail_block->entries;
-  extern_trail_limit = extern_trail_block->entries + ENTRIES_PER_TRAIL_BLOCK;
-}
-
-/* Replay the trail, undoing the in-place modifications
-   performed on objects */
-
-static void extern_replay_trail(void)
-{
-  struct trail_block * blk, * prevblk;
-  struct trail_entry * ent, * lim;
-
-  blk = extern_trail_block;
-  lim = extern_trail_cur;
-  while (1) {
-    for (ent = &(blk->entries[0]); ent < lim; ent++) {
-      value obj = ent->obj;
-      color_t colornum = obj & 3;
-      obj = obj & ~3;
-      Hd_val(obj) = Coloredhd_hd(Hd_val(obj), colornum);
-      Field(obj, 0) = ent->field0;
-    }
-    if (blk == &extern_trail_first) break;
-    prevblk = blk->previous;
-    caml_stat_free(blk);
-    blk = prevblk;
-    lim = &(blk->entries[ENTRIES_PER_TRAIL_BLOCK]);
-  }
-  /* Protect against a second call to extern_replay_trail */
-  extern_trail_block = &extern_trail_first;
-  extern_trail_cur = extern_trail_block->entries;
-}
-
-/* Set forwarding pointer on an object and add corresponding entry
-   to the trail. */
-
-static void extern_record_location(value obj)
-{
-  header_t hdr;
-
+static void extern_record_location(value* loc) {
   if (extern_flags & NO_SHARING) return;
-  if (extern_trail_cur == extern_trail_limit) {
-    struct trail_block * new_block =
-      caml_stat_alloc_noexc(sizeof(struct trail_block));
-    if (new_block == NULL) extern_out_of_memory();
-    new_block->previous = extern_trail_block;
-    extern_trail_block = new_block;
-    extern_trail_cur = extern_trail_block->entries;
-    extern_trail_limit = extern_trail_block->entries + ENTRIES_PER_TRAIL_BLOCK;
-  }
-  hdr = Hd_val(obj);
-  extern_trail_cur->obj = obj | Colornum_hd(hdr);
-  extern_trail_cur->field0 = Field(obj, 0);
-  extern_trail_cur++;
-  Hd_val(obj) = Bluehd_hd(hdr);
-  Field(obj, 0) = (value) obj_counter;
-  obj_counter++;
+  CAMLassert(loc);
+  *loc = Val_long(obj_counter++);
 }
 
 /* To buffer the output */
@@ -280,21 +207,21 @@ static intnat extern_output_length(void)
 
 static void extern_out_of_memory(void)
 {
-  extern_replay_trail();
+  caml_addrmap_clear(&recorded_objs);
   free_extern_output();
   caml_raise_out_of_memory();
 }
 
 static void extern_invalid_argument(char *msg)
 {
-  extern_replay_trail();
+  caml_addrmap_clear(&recorded_objs);
   free_extern_output();
   caml_invalid_argument(msg);
 }
 
 static void extern_failwith(char *msg)
 {
-  extern_replay_trail();
+  caml_addrmap_clear(&recorded_objs);
   free_extern_output();
   caml_failwith(msg);
 }
@@ -302,7 +229,7 @@ static void extern_failwith(char *msg)
 static void extern_stack_overflow(void)
 {
   caml_gc_message (0x04, "Stack overflow in marshaling value\n");
-  extern_replay_trail();
+  caml_addrmap_clear(&recorded_objs);
   free_extern_output();
   caml_raise_out_of_memory();
 }
@@ -417,6 +344,7 @@ static void extern_rec(value v)
     header_t hd = Hd_val(v);
     tag_t tag = Tag_hd(hd);
     mlsize_t sz = Wosize_hd(hd);
+    value* output_location;
 
     if (tag == Forward_tag) {
       value f = Forward_val (v);
@@ -447,9 +375,9 @@ static void extern_rec(value v)
       }
       goto next_item;
     }
-    /* Check if already seen */
-    if (Color_hd(hd) == Caml_blue) {
-      uintnat d = obj_counter - (uintnat) Field(v, 0);
+    output_location = caml_addrmap_insert_pos(&recorded_objs, v);
+    if (output_location && *output_location != ADDRMAP_NOT_PRESENT) {
+      uintnat d = obj_counter - (uintnat)Long_val(*output_location);
       if (d < 0x100) {
         writecode8(CODE_SHARED8, d);
       } else if (d < 0x10000) {
@@ -488,7 +416,7 @@ static void extern_rec(value v)
       writeblock(String_val(v), len);
       size_32 += 1 + (len + 4) / 4;
       size_64 += 1 + (len + 8) / 8;
-      extern_record_location(v);
+      extern_record_location(output_location);
       break;
     }
     case Double_tag: {
@@ -498,7 +426,7 @@ static void extern_rec(value v)
       writeblock_float8((double *) v, 1);
       size_32 += 1 + 2;
       size_64 += 1 + 1;
-      extern_record_location(v);
+      extern_record_location(output_location);
       break;
     }
     case Double_array_tag: {
@@ -524,7 +452,7 @@ static void extern_rec(value v)
       writeblock_float8((double *) v, nfloats);
       size_32 += 1 + nfloats * 2;
       size_64 += 1 + nfloats;
-      extern_record_location(v);
+      extern_record_location(output_location);
       break;
     }
     case Abstract_tag:
@@ -568,7 +496,7 @@ static void extern_rec(value v)
       }
       size_32 += 2 + ((sz_32 + 3) >> 2);  /* header + ops + data */
       size_64 += 2 + ((sz_64 + 7) >> 3);
-      extern_record_location(v);
+      extern_record_location(output_location);
       break;
     }
     default: {
@@ -596,12 +524,12 @@ static void extern_rec(value v)
       size_32 += 1 + sz;
       size_64 += 1 + sz;
       field0 = Field(v, 0);
-      extern_record_location(v);
+      extern_record_location(output_location);
       /* Remember that we still have to serialize fields 1 ... sz - 1 */
       if (sz > 1) {
         sp++;
         if (sp >= extern_stack_limit) sp = extern_resize_stack(sp);
-        sp->v = &Field(v,1);
+        sp->v = &Field(v, 0) + 1;
         sp->count = sz-1;
       }
       /* Continue serialization with the first field */
@@ -645,7 +573,7 @@ static intnat extern_value(value v, value flags,
   /* Parse flag list */
   extern_flags = caml_convert_flag_list(flags, extern_flag_values);
   /* Initializations */
-  init_extern_trail();
+  caml_addrmap_clear(&recorded_objs);
   obj_counter = 0;
   size_32 = 0;
   size_64 = 0;
@@ -653,9 +581,9 @@ static intnat extern_value(value v, value flags,
   extern_rec(v);
   /* Record end of output */
   close_extern_output();
-  /* Undo the modifications done on externed blocks */
-  extern_replay_trail();
-  /* Write the header */
+  /* Delete the hashtable of recorded objects */
+  caml_addrmap_clear(&recorded_objs);
+  /* Write the sizes */
   res_len = extern_output_length();
 #ifdef ARCH_SIXTYFOUR
   if (res_len >= ((intnat)1 << 32) ||

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -577,6 +577,7 @@ static intnat extern_value(value v, value flags,
   obj_counter = 0;
   size_32 = 0;
   size_64 = 0;
+  caml_addrmap_initialize(&recorded_objs);
   /* Marshal the object */
   extern_rec(v);
   /* Record end of output */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -85,6 +85,7 @@ uintnat caml_init_major_window = Major_window_def;
 uintnat caml_init_custom_major_ratio = Custom_major_ratio_def;
 uintnat caml_init_custom_minor_ratio = Custom_minor_ratio_def;
 uintnat caml_init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
+uintnat caml_init_alloc_size = Init_addrmap_def;
 extern int caml_parser_trace;
 uintnat caml_trace_level = 0;
 int caml_cleanup_on_exit = 0;
@@ -116,6 +117,7 @@ void caml_parse_ocamlrunparam(void)
       switch (*opt++){
       case 'a': scanmult (opt, &p); caml_set_allocation_policy ((intnat) p);
         break;
+      case 'A': scanmult (opt, &caml_init_alloc_size); break;
       case 'b': scanmult (opt, &p); caml_record_backtrace(Val_bool (p));
         break;
       case 'c': scanmult (opt, &p); caml_cleanup_on_exit = (p != 0); break;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -85,7 +85,7 @@ uintnat caml_init_major_window = Major_window_def;
 uintnat caml_init_custom_major_ratio = Custom_major_ratio_def;
 uintnat caml_init_custom_minor_ratio = Custom_minor_ratio_def;
 uintnat caml_init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
-uintnat caml_init_alloc_size = Init_addrmap_def;
+uintnat caml_init_intern_addrmap_size = Init_addrmap_def;
 extern int caml_parser_trace;
 uintnat caml_trace_level = 0;
 int caml_cleanup_on_exit = 0;
@@ -117,7 +117,7 @@ void caml_parse_ocamlrunparam(void)
       switch (*opt++){
       case 'a': scanmult (opt, &p); caml_set_allocation_policy ((intnat) p);
         break;
-      case 'A': scanmult (opt, &caml_init_alloc_size); break;
+      case 'A': scanmult (opt, &caml_init_intern_addrmap_size); break;
       case 'b': scanmult (opt, &p); caml_record_backtrace(Val_bool (p));
         break;
       case 'c': scanmult (opt, &p); caml_cleanup_on_exit = (p != 0); break;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -85,7 +85,7 @@ uintnat caml_init_major_window = Major_window_def;
 uintnat caml_init_custom_major_ratio = Custom_major_ratio_def;
 uintnat caml_init_custom_minor_ratio = Custom_minor_ratio_def;
 uintnat caml_init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
-uintnat caml_init_intern_addrmap_size = Init_addrmap_def;
+uintnat caml_init_intern_addrmap_size = Init_intern_addrmap_def;
 extern int caml_parser_trace;
 uintnat caml_trace_level = 0;
 int caml_cleanup_on_exit = 0;


### PR DESCRIPTION
Abstract
=======

The OCaml runtime uses a linked data structure implementation (trail_block in trunk/runtime/extern.c) for marshaling.

```
/* Trail mechanism to undo forwarding pointers put inside objects */

struct trail_entry {
  value obj;    /* address of object + initial color in low 2 bits */
  value field0; /* initial contents of field 0 */
};

struct trail_block {
  struct trail_block * previous;
  struct trail_entry entries[ENTRIES_PER_TRAIL_BLOCK];
};
```

Source: https://github.com/ocaml/ocaml/blob/trunk/runtime/extern.c

In OCaml, the visited set is maintained by mutating the header and the first fields of the objects being marshaled in place and then rolling back the changes after marshaling. This is incompatible with concurrent mutators and GC threads. Hence, Multicore ocaml uses an external data structure i.e, the hashmap (addrmap in byterun/caml/addrmap.h), and does not modify the objects which are being marshaled.

```
struct addrmap_entry { value key, value; };

struct addrmap {
  struct addrmap_entry* entries;
  uintnat size;
};
```
Source: https://github.com/ocaml-multicore/ocaml-multicore/blob/master/byterun/caml/addrmap.h

The goal is to port the use of the hashmap from Multicore OCaml to OCaml runtime. The marshalling tests for both OCaml and Multicore OCaml are present in testsuite/tests/lib-marshal directory.

Changes
=======

- PR: Use hashmap for marshaling
  (Stephen Dolan, KC Sivaramakrishnan)

  Copied runtime/addrmap.c and runtime/caml/addrmap.h.

  Add addrmap.h and addrmap.c to runtime/.depend by including them in
  runtime/Makefile.

  Defined Is_power_of_2() function in runtime/caml/misc.h.

  Updated runtime/extern.c to include addrmap.h and to use addrmap.c
  functions.

Tests
=====

After porting the changes from Multicore OCaml to Ocaml trunk, there
are no errors or failing tests:

~~~~{.sh}
Summary:
  2642 tests passed
  40 tests skipped
   0 tests failed
  100 tests not started (parent test skipped or failed)
   0 unexpected errors
2782 tests considered
~~~~

The compilation time for `make world` and `make world.opt` for both
trunk and multicore/use-addrmap-hash-table-for-marshaling branches are
provided below for reference:

| Branch         | trunk             | hash-table-for-marshaling |
|----------------|-------------------|---------------------------|
| make world     | real    2m54.526s | real    2m57.806s         |
|                | user    2m41.816s | user    2m45.053s         |
|                | sys     0m11.904s | sys     0m12.345s         |
| make world.opt | real    5m26.222s | real    5m31.342s         |
|                | user     5m0.913s | user     5m5.496s         |
|                | sys     0m24.386s | sys      0m24.972s        |

Test system: Parabola GNU/Linux-libre on Intel(R) Core(TM) i5-6200 CPU @ 2.30GHz

The [http://bench2.ocamllabs.io:8083](http://bench2.ocamllabs.io:8083) tests do not use a lot of marshaling, but, here is the value of `maxrss_kB` from the test suite run for both trunk and multicore/use-addrmap-hash-table-for-marshaling branch:

| Metric | trunk     | hash-table-for-marshaling |
|--------|-----------|---------------------------|
| count  | 192       | 192                       |
| mean   | 24702.625 | 24701.5                   |
| std    | 72617.01  | 72612.89                  |
| min    | 2476      | 2476                      |
| 25%    | 4524      | 4524                      |
| 50%    | 5212      | 5212                      |
| 75%    | 9531      | 9531                      |
| max    | 730868    | 730868                    |

Source: [Comparison of multicore/use-addrmap-hash-table-for-marshaling with vanilla OCaml trunk](http://bench2.ocamllabs.io:8083/comparison/?exe=6%2BL%2Btrunk%2C26%2BL%2Bmulticore%2Fuse-addrmap-hash-table-for-marshaling&ben=1%2C2%2C161%2C162%2C3%2C4%2C5%2C6%2C188%2C189%2C163%2C7%2C8%2C9%2C10%2C11%2C12%2C13%2C14%2C15%2C16%2C17%2C18%2C164%2C165%2C166%2C167%2C168%2C169%2C170%2C171%2C172%2C19%2C20%2C21%2C22%2C23%2C24%2C25%2C26%2C27%2C28%2C173%2C29%2C190%2C191%2C30%2C192%2C31%2C193%2C32%2C194%2C33%2C195%2C34%2C196%2C35%2C197%2C36%2C198%2C37%2C199%2C38%2C200%2C39%2C201%2C40%2C202%2C41%2C203%2C174%2C42%2C43%2C175%2C44%2C45%2C46%2C47%2C48%2C49%2C50%2C51%2C52%2C53%2C54%2C55%2C56%2C57%2C58%2C59%2C60%2C61%2C62%2C63%2C64%2C65%2C66%2C67%2C68%2C69%2C70%2C71%2C72%2C73%2C74%2C176%2C75%2C76%2C77%2C78%2C79%2C80%2C81%2C82%2C83%2C84%2C85%2C86%2C177%2C178%2C87%2C88%2C89%2C90%2C91%2C92%2C93%2C94%2C95%2C96%2C97%2C98%2C99%2C100%2C179%2C180%2C181%2C182%2C101%2C102%2C103%2C104%2C183%2C105%2C106%2C107%2C108%2C109%2C110%2C111%2C112%2C113%2C114%2C115%2C116%2C117%2C118%2C119%2C120%2C121%2C122%2C123%2C124%2C125%2C126%2C127%2C128%2C129%2C130%2C131%2C132%2C204%2C133%2C134%2C205%2C135%2C136%2C137%2C138%2C206%2C139%2C140%2C141%2C184%2C142%2C143%2C144%2C145%2C146%2C147%2C185%2C186%2C187%2C148%2C149%2C150%2C151%2C152%2C153%2C154%2C155%2C156%2C157%2C158%2C159%2C160%2C207%2C208%2C209%2C210&env=3&hor=true&bas=none&chart=normal+bars)
