### PR TITLE
manual: reference chapter, split the grammar of expressions

### DIFF
--- a/Changes
+++ b/Changes
@@ -129,6 +129,9 @@ Working version
 - #9141: beginning of the ocamltest reference manual
   (Sébastien Hinderer, review by Gabriel Scherer and Thomas Refis)
 
+- #9255, #9300: reference chapter, split the expression grammar
+  (Florian Angeletti, report by Harrison Ainsworth, review by Gabriel Scherer)
+
 ### Compiler user-interface and warnings:
 
 - #9074: reworded error message for non-regular structural types

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -63,24 +63,14 @@ expr:
   | 'try' expr 'with' pattern-matching
   | 'let' ['rec'] let-binding { 'and' let-binding } 'in' expr
   | "let" "exception" constr-decl "in" expr
-  | 'new' class-path
-  | 'object' class-body 'end'
-  | expr '#' method-name
-  | inst-var-name
-  | inst-var-name '<-' expr
-  | '(' expr ':>' typexpr ')'
-  | '(' expr ':' typexpr ':>' typexpr ')'
-  | '{<' [ inst-var-name ['=' expr] { ';' inst-var-name ['=' expr] } [';'] ] '>}'
-  | 'assert' expr
-  | 'lazy' expr
   | 'let' 'module' module-name { '(' module-name ':' module-type ')' }
     [ ':' module-type ] \\ '=' module-expr 'in' expr
-  | "let" "open" module-path "in" expr
-  | module-path '.(' expr ')'
-  | module-path '.[' expr ']'
-  | module-path '.[|' expr '|]'
-  | module-path '.{' expr '}'
-  | module-path '.{<' expr '>}'
+  | '(' expr ':>' typexpr ')'
+  | '(' expr ':' typexpr ':>' typexpr ')'
+  | 'assert' expr
+  | 'lazy' expr
+  | local-open
+  | object-expr
 ;
 %BEGIN LATEX
 \end{syntax} \begin{syntax}
@@ -111,6 +101,22 @@ parameter:
   | '?' '(' label-name [':' typexpr] ['=' expr] ')'
   | '?' label-name ':' pattern
   | '?' label-name ':' '(' pattern [':' typexpr] ['=' expr] ')'
+;
+local-open:
+  | "let" "open" module-path "in" expr
+  | module-path '.(' expr ')'
+  | module-path '.[' expr ']'
+  | module-path '.[|' expr '|]'
+  | module-path '.{' expr '}'
+  | module-path '.{<' expr '>}'
+;
+object-expr:
+  | 'new' class-path
+  | 'object' class-body 'end'
+  | expr '#' method-name
+  | inst-var-name
+  | inst-var-name '<-' expr
+  | '{<' [ inst-var-name ['=' expr] { ';' inst-var-name ['=' expr] } [';'] ] '>}'
 \end{syntax}
 See also the following language extensions:
 \hyperref[s:first-class-modules]{first-class modules},


### PR DESCRIPTION
As reported in #9255, the description of the expression grammar does not fit anymore on a single pdf page. This PR proposes to fix this issue by splitting the `local-open` and `object-expr` into two distincts thematic subgrammars.