### PR TITLE
Integer valued event major/mark/slice/remain should end with #

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -416,7 +416,7 @@ static void mark_slice (intnat work)
         CAMLassert (end >= start);
         INSTR (slice_fields += end - start;)
         INSTR (if (size > end)
-                 CAML_INSTR_INT ("major/mark/slice/remain", size - end);)
+                 CAML_INSTR_INT ("major/mark/slice/remain#", size - end);)
         for (i = start; i < end; i++){
           gray_vals_ptr = mark_slice_darken(gray_vals_ptr,v,i,
                                             /*in_ephemeron=*/ 0,


### PR DESCRIPTION
Otherwise, it gets mistaken for a timer event. 