### PR TITLE
Treat empty variants as GADTs for exhaustiveness check

### DIFF
--- a/Changes
+++ b/Changes
@@ -210,9 +210,10 @@ Working version
 
 ### Bug fixes:
 
-- #9309: Treat the empty variant as a GADT in or-patterns, so that the
-  exhaustiveness check will examine all cases in the or pattern.
-  (Stefan Muenzel, report by Robert Head, review by ????)
+- #9309: Treat the empty variant identical to a GADT in or-patterns, so that
+  the exhaustiveness check will not incorrectly terminate early.
+  (Stefan Muenzel, report by Robert Head, review by Thomas Refis
+  and Florian Angeletti)
 
 - #7683, #1499: Fixes one case where the evaluation order in native-code
   may not match the one in bytecode.

--- a/Changes
+++ b/Changes
@@ -210,6 +210,10 @@ Working version
 
 ### Bug fixes:
 
+- #9309: Treat the empty variant as a GADT in or-patterns, so that the
+  exhaustiveness check will examine all cases in the or pattern.
+  (Stefan Muenzel, report by Robert Head, review by ????)
+
 - #7683, #1499: Fixes one case where the evaluation order in native-code
   may not match the one in bytecode.
   (Nicolás Ojeda Bär, report by Pierre Chambart, review by Gabriel Scherer)

--- a/testsuite/tests/typing-misc/empty_variant.ml
+++ b/testsuite/tests/typing-misc/empty_variant.ml
@@ -55,5 +55,11 @@ let f () =
 type nothing = |
 type ('a, 'b, 'c) t = A of 'a | B of 'b | C of 'c
 module Runner : sig val ac : f:((unit, 'a, unit) t -> unit) -> unit end
+Lines 16-17, characters 8-18:
+16 | ........match abc with
+17 |         | A _ -> 1
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+C ()
 val f : unit -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/empty_variant.ml
+++ b/testsuite/tests/typing-misc/empty_variant.ml
@@ -30,7 +30,6 @@ let f : t option -> int = function None -> 3
 val f : t option -> int = <fun>
 |}]
 
-
 type nothing = |
 type ('a, 'b, 'c) t = | A of 'a | B of 'b | C of 'c
 module Runner : sig
@@ -62,4 +61,19 @@ Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C ()
 val f : unit -> unit = <fun>
+|}]
+
+type nothing = |
+type 'b t = A | B of 'b | C
+let g (x:nothing t) = match x with A -> ()
+[%%expect{|
+type nothing = |
+type 'b t = A | B of 'b | C
+Line 3, characters 22-42:
+3 | let g (x:nothing t) = match x with A -> ()
+                          ^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+C
+val g : nothing t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/empty_variant.ml
+++ b/testsuite/tests/typing-misc/empty_variant.ml
@@ -29,3 +29,31 @@ let f : t option -> int = function None -> 3
 [%%expect{|
 val f : t option -> int = <fun>
 |}]
+
+
+type nothing = |
+type ('a, 'b, 'c) t = | A of 'a | B of 'b | C of 'c
+module Runner : sig
+  val ac : f:((unit, _, unit) t -> unit) -> unit
+end = struct
+  let ac ~f =
+    f (A ());
+    f (C ());
+  ;;
+end
+
+let f () =
+  Runner.ac
+    ~f:(fun (abc : (_,nothing,_) t) ->
+      let value =
+        match abc with
+        | A _ -> 1
+      in
+      Printf.printf "%i\n" value
+    )
+[%%expect{|
+type nothing = |
+type ('a, 'b, 'c) t = A of 'a | B of 'b | C of 'c
+module Runner : sig val ac : f:((unit, 'a, unit) t -> unit) -> unit end
+val f : unit -> unit = <fun>
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1107,13 +1107,12 @@ and splitting_mode =
      find branches that do not introduce new constraints (because they
      do not contain GADT constructors), and are not matching on an empty
      type. Those branches are such that, if they fail, all other branches
-     will fail.
+     will fail. We call these branches "suitable branches".
 
-     If we find one such branch, we attempt to complete the subpattern
+     If we find a suitable branch, we attempt to complete the subpattern
      (checking what's outside the or-pattern), ignoring other
      branches -- we never consider another branch choice again. If no
-     branch match these criteria, it falls back to splitting the
-     or-pattern.
+     branch is suitable, it falls back to splitting the or-pattern.
 
      We use this mode when checking exhaustivity of pattern matching.
     *)
@@ -1262,7 +1261,7 @@ and type_pat_aux
   and rvp k x = k (rp (pure category x))
   and rcp k x = k (rp (only_impure category x)) in
   let construction_not_used_in_counterexamples = (mode = Normal) in
-  let must_backtrack_on_gadt_and_empty_type = match get_splitting_mode mode with
+  let must_backtrack_on_unsuitable_branches = match get_splitting_mode mode with
     | None -> false
     | Some Backtrack_or -> false
     | Some (Refine_or {inside_nonsplit_or}) -> inside_nonsplit_or
@@ -1284,7 +1283,7 @@ and type_pat_aux
          let open Parmatch in
          begin match ppat_of_type !env expected_ty with
          | PT_empty ->
-            if must_backtrack_on_gadt_and_empty_type then raise Need_backtrack;
+            if must_backtrack_on_unsuitable_branches then raise Need_backtrack;
             raise (Error (loc, !env, Empty_pattern))
          | PT_any -> k' Tpat_any
          | PT_pattern (explosion, sp, constrs, labels) ->
@@ -1292,7 +1291,7 @@ and type_pat_aux
               match explosion with
               | PE_single -> explosion_fuel - 1
               | PE_gadt_cases ->
-                  if must_backtrack_on_gadt_and_empty_type then
+                  if must_backtrack_on_unsuitable_branches then
                     raise Need_backtrack;
                   explosion_fuel - 5
             in
@@ -1441,7 +1440,7 @@ and type_pat_aux
           (mk_expected expected_ty)
           (Constructor.disambiguate Env.Pattern lid !env opath) candidates
       in
-      if constr.cstr_generalized && must_backtrack_on_gadt_and_empty_type then
+      if constr.cstr_generalized && must_backtrack_on_unsuitable_branches then
         raise Need_backtrack;
       begin match no_existentials, constr.cstr_existentials with
       | None, _ | _, [] -> ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1282,7 +1282,9 @@ and type_pat_aux
       | Counter_example ({explosion_fuel; _} as info) ->
          let open Parmatch in
          begin match ppat_of_type !env expected_ty with
-         | PT_empty -> raise (Error (loc, !env, Empty_pattern))
+         | PT_empty ->
+            if must_backtrack_on_gadt then raise Need_backtrack;
+            raise (Error (loc, !env, Empty_pattern))
          | PT_any -> k' Tpat_any
          | PT_pattern (explosion, sp, constrs, labels) ->
             let explosion_fuel =


### PR DESCRIPTION
Currently, the empty variant is not treated as a GADT when we're typing a pattern. This means that if we have an or pattern, and one case contains the empty variant, the other case may not be examined (example enclosed in the patch).
This patch attempts to treat the empty variant as a GADT, to fix this.

(Note: this is the first time I'm doing anything in /typing, so I expect that I may have gotten something wrong here).