### PR TITLE
Keep track of unboxed constant values in Cmm's Const_symbol

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -20,8 +20,8 @@ open Cmm
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
-let afl_area_ptr dbg = Cconst_symbol ("caml_afl_area_ptr", dbg)
-let afl_prev_loc dbg = Cconst_symbol ("caml_afl_prev_loc", dbg)
+let afl_area_ptr dbg = Cconst_symbol ("caml_afl_area_ptr", None, dbg)
+let afl_prev_loc dbg = Cconst_symbol ("caml_afl_prev_loc", None, dbg)
 let afl_map_size = 1 lsl 16
 
 let rec with_afl_logging b dbg =

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -31,7 +31,7 @@ type addressing_expr =
 
 let rec select_addr exp =
   match exp with
-    Cconst_symbol (s, _) when not !Clflags.dlcode ->
+    Cconst_symbol (s, _, _) when not !Clflags.dlcode ->
       (Asymbol s, 0)
   | Cop((Caddi | Caddv | Cadda), [arg; Cconst_int (m, _)], _) ->
       let (a, n) = select_addr arg in (a, n + m)

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -109,7 +109,7 @@ method! effects_of e =
   | e -> super#effects_of e
 
 method select_addressing chunk = function
-  | Cop((Caddv | Cadda), [Cconst_symbol (s, _); Cconst_int (n, _)], _)
+  | Cop((Caddv | Cadda), [Cconst_symbol (s, _, _); Cconst_int (n, _)], _)
     when use_direct_addressing s ->
       (Ibased(s, n), Ctuple [])
   | Cop((Caddv | Cadda), [arg; Cconst_int (n, _)], _)
@@ -119,7 +119,7 @@ method select_addressing chunk = function
       [arg1; Cop(Caddi, [arg2; Cconst_int (n, _)], _)], dbg)
     when is_offset chunk n ->
       (Iindexed n, Cop(op, [arg1; arg2], dbg))
-  | Cconst_symbol (s, _)
+  | Cconst_symbol (s, _, _)
     when use_direct_addressing s ->
       (Ibased(s, 0), Ctuple [])
   | arg ->

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -142,11 +142,17 @@ and operation =
   | Craise of Lambda.raise_kind
   | Ccheckbound
 
+and cstructured_constant =
+  | Csc_float of float
+  | Csc_int32 of int32
+  | Csc_int64 of int64
+  | Csc_nativeint of nativeint
+
 type expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
-  | Cconst_symbol of string * Debuginfo.t
+  | Cconst_symbol of string * cstructured_constant option * Debuginfo.t
   | Cconst_pointer of int * Debuginfo.t
   | Cconst_natpointer of nativeint * Debuginfo.t
   | Cblockheader of nativeint * Debuginfo.t

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -147,13 +147,19 @@ and operation =
                    It results in a bounds error if the index is greater than
                    or equal to the bound. *)
 
+and cstructured_constant =
+  | Csc_float of float
+  | Csc_int32 of int32
+  | Csc_int64 of int64
+  | Csc_nativeint of nativeint
+
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
 and expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
-  | Cconst_symbol of string * Debuginfo.t
+  | Cconst_symbol of string * cstructured_constant option * Debuginfo.t
   | Cconst_pointer of int * Debuginfo.t
   | Cconst_natpointer of nativeint * Debuginfo.t
   | Cblockheader of nativeint * Debuginfo.t

--- a/asmcomp/cmmgen_state.ml
+++ b/asmcomp/cmmgen_state.ml
@@ -28,7 +28,6 @@ type constant =
 type t = {
   mutable constants : constant S.Map.t;
   mutable data_items : Cmm.data_item list list;
-  structured_constants : (string,  Clambda.ustructured_constant) Hashtbl.t;
   functions : Clambda.ufunction Queue.t;
 }
 
@@ -36,7 +35,6 @@ let empty = {
   constants = S.Map.empty;
   data_items = [];
   functions = Queue.create ();
-  structured_constants = Hashtbl.create 16;
 }
 
 let state = empty
@@ -67,19 +65,3 @@ let next_function () =
 
 let no_more_functions () =
   Queue.is_empty state.functions
-
-let set_structured_constants l =
-  Hashtbl.clear state.structured_constants;
-  List.iter
-    (fun (c : Clambda.preallocated_constant) ->
-       Hashtbl.add state.structured_constants c.symbol c.definition
-    )
-    l
-
-let get_structured_constant s =
-  Hashtbl.find_opt state.structured_constants s
-
-let structured_constant_of_sym s =
-  match Compilenv.structured_constant_of_symbol s with
-  | None -> get_structured_constant s
-  | Some _ as r -> r

--- a/asmcomp/cmmgen_state.mli
+++ b/asmcomp/cmmgen_state.mli
@@ -38,8 +38,3 @@ val get_and_clear_data_items : unit -> Cmm.data_item list
 val next_function : unit -> Clambda.ufunction option
 
 val no_more_functions : unit -> bool
-
-val set_structured_constants : Clambda.preallocated_constant list -> unit
-
-(* Also looks up using Compilenv.structured_constant_of_symbol *)
-val structured_constant_of_sym : string -> Clambda.ustructured_constant option

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -32,7 +32,7 @@ type addressing_expr =
 
 let rec select_addr exp =
   match exp with
-    Cconst_symbol (s, _) ->
+    Cconst_symbol (s, _, _) ->
       (Asymbol s, 0)
   | Cop((Caddi | Caddv | Cadda), [arg; Cconst_int (m, _)], _) ->
       let (a, n) = select_addr arg in (a, n + m)
@@ -200,7 +200,7 @@ method! select_store is_assign addr exp =
       (Ispecific(Istore_int(Nativeint.of_int n, addr, is_assign)), Ctuple [])
   | Cconst_natpointer (n, _) ->
       (Ispecific(Istore_int(n, addr, is_assign)), Ctuple [])
-  | Cconst_symbol (s, _) ->
+  | Cconst_symbol (s, _, _) ->
       (Ispecific(Istore_symbol(s, addr, is_assign)), Ctuple [])
   | _ ->
       super#select_store is_assign addr exp
@@ -292,7 +292,7 @@ method select_push exp =
   | Cconst_pointer (n, _) ->
       (Ispecific(Ipush_int(Nativeint.of_int n)), Ctuple [])
   | Cconst_natpointer (n, _) -> (Ispecific(Ipush_int n), Ctuple [])
-  | Cconst_symbol (s, _) -> (Ispecific(Ipush_symbol s), Ctuple [])
+  | Cconst_symbol (s, _, _) -> (Ispecific(Ipush_symbol s), Ctuple [])
   | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in
       (Ispecific(Ipush_load addr), arg)

--- a/asmcomp/power/selection.ml
+++ b/asmcomp/power/selection.ml
@@ -27,7 +27,7 @@ type addressing_expr =
   | Aadd of expression * expression
 
 let rec select_addr = function
-    Cconst_symbol (s, _) ->
+    Cconst_symbol (s, _, _) ->
       (Asymbol s, 0, Debuginfo.none)
   | Cop((Caddi | Caddv | Cadda), [arg; Cconst_int (m, _)], dbg) ->
       let (a, n, _) = select_addr arg in (a, n + m, dbg)

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -142,6 +142,12 @@ let operation d = function
   | Craise k -> Lambda.raise_kind k ^ location d
   | Ccheckbound -> "checkbound" ^ location d
 
+let cstructured_constant ppf = function
+  | Csc_float f -> fprintf ppf "%F" f
+  | Csc_int32 n -> fprintf ppf "%ldl" n
+  | Csc_int64 n -> fprintf ppf "%LdL" n
+  | Csc_nativeint n -> fprintf ppf "%ndn" n
+
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n
   | Cconst_natint (n, _dbg) ->
@@ -150,7 +156,10 @@ let rec expr ppf = function
     fprintf ppf "block-hdr(%s)%s"
       (Nativeint.to_string n) (location d)
   | Cconst_float (n, _dbg) -> fprintf ppf "%F" n
-  | Cconst_symbol (s, _dbg) -> fprintf ppf "\"%s\"" s
+  | Cconst_symbol (s, None, _dbg) -> fprintf ppf "\"%s\"" s
+  | Cconst_symbol (s, Some apx, _dbg) ->
+    fprintf ppf "\"%s\"=%a" s
+      cstructured_constant apx
   | Cconst_pointer (n, _dbg) -> fprintf ppf "%ia" n
   | Cconst_natpointer (n, _dbg) -> fprintf ppf "%sa" (Nativeint.to_string n)
   | Cvar id -> V.print ppf id

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -429,7 +429,7 @@ method select_checkbound_extra_args () = []
 
 method select_operation op args _dbg =
   match (op, args) with
-  | (Capply _, Cconst_symbol (func, _dbg) :: rem) ->
+  | (Capply _, Cconst_symbol (func, _, _dbg) :: rem) ->
     let label_after = Cmm.new_label () in
     (Icall_imm { func; label_after; }, rem)
   | (Capply _, _) ->
@@ -668,7 +668,7 @@ method emit_expr (env:environment) exp =
   | Cconst_float (n, _dbg) ->
       let r = self#regs_for typ_float in
       Some(self#insert_op env (Iconst_float (Int64.bits_of_float n)) [||] r)
-  | Cconst_symbol (n, _dbg) ->
+  | Cconst_symbol (n, _, _dbg) ->
       let r = self#regs_for typ_val in
       Some(self#insert_op env (Iconst_symbol n) [||] r)
   | Cconst_pointer (n, _dbg) ->

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -34,7 +34,7 @@ let reverse_shape = ref ([] : Mach.spacetime_shape)
    in [Cmmgen]. *)
 let cconst_int i = Cmm.Cconst_int (i, Debuginfo.none)
 let cconst_natint i = Cmm.Cconst_natint (i, Debuginfo.none)
-let cconst_symbol s = Cmm.Cconst_symbol (s, Debuginfo.none)
+let cconst_symbol s = Cmm.Cconst_symbol (s, None, Debuginfo.none)
 
 let something_was_instrumented () =
   !index_within_node > node_num_header_words

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -118,9 +118,6 @@ val structured_constants:
   unit -> Clambda.preallocated_constant list
 val clear_structured_constants: unit -> unit
 
-val structured_constant_of_symbol:
-  string -> Clambda.ustructured_constant option
-
 val add_exported_constant: string -> unit
         (* clambda-only *)
 type structured_constants

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -202,7 +202,7 @@ componentlist:
 expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
   | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
-  | STRING      { Cconst_symbol ($1, debuginfo ()) }
+  | STRING      { Cconst_symbol ($1, None, debuginfo ()) }
   | POINTER     { Cconst_pointer ($1, debuginfo ()) }
   | IDENT       { Cvar(find_ident $1) }
   | LBRACKET RBRACKET { Ctuple [] }


### PR DESCRIPTION
#2165 optimised unboxing at Cmm level, but also introduced a regression in unboxing across module boundaries. 4.09 compiled `let f x = x *. Float.pi` to this cmm:

    (function{timespi.ml:1,6-23} camlTimespi__f_80 (x/81: val)
     (alloc{timespi.ml:1,10-23} block-hdr(1277){timespi.ml:1,10-23}
       (*f (load float64u x/81) 3.14159265359)))

while trunk does the following:

    (function{timespi.ml:1,6-23} camlTimespi__f_80 (x/82: val)
     (alloc{timespi.ml:1,10-23} block-hdr(1277){timespi.ml:1,10-23}
       (*f (load float64u x/82) (load float64u "camlStdlib__float__4"))))

The Clambda representation attaches an optional constant value to each symbol, so the unboxed value of a statically-allocated constant is available if required. Instead of passing the optional constant value around, the patch in #2165 introduces a global hashtable into which the constant value is inserted. However, this global hashtable was not populated in all cases: it missed constants important from another module, only being populated with constants defined in the current compilation unit.

This patch removes the global hashtable, and instead extends the Cmm `Const_symbol` constructor to take an optional constant definition, mirroring Clambda's `Uconst_ref`, and always populates it with the constant information from Clambda.

cc @alainfrisch 