### PR TITLE
Yet another fix to BFD support

### DIFF
--- a/Changes
+++ b/Changes
@@ -561,7 +561,7 @@ OCaml 4.10.0
 - #8843, #8841: fix use of off_t on 32-bit systems.
   (Stephen Dolan, report by Richard Jones, review by Xavier Leroy)
 
-- #8947, #9134, #9302: fix/improve support for the BFD library
+- #8947, #9134, #9302, #9311: fix/improve support for the BFD library
   (Sébastien Hinderer, review by Damien Doligez and David Allsopp)
 
 - #8951: let make's default target build the compiler

--- a/configure
+++ b/configure
@@ -16135,7 +16135,7 @@ if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl $LIBS"
+LIBS="-lbfd $DLLIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16166,7 +16166,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl"
+  bfd_ldlibs="-lbfd $DLLIBS"
 fi
 
 fi
@@ -16178,7 +16178,7 @@ if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl -liberty $LIBS"
+LIBS="-lbfd $DLLIBS -liberty $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16209,7 +16209,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl -liberty"
+  bfd_ldlibs="-lbfd $DLLIBS -liberty"
 fi
 
 fi
@@ -16221,7 +16221,7 @@ if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl -liberty -lz $LIBS"
+LIBS="-lbfd $DLLIBS -liberty -lz $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16252,7 +16252,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl -liberty -lz"
+  bfd_ldlibs="-lbfd $DLLIBS -liberty -lz"
 fi
 
 fi
@@ -16264,7 +16264,7 @@ if ${ac_cv_lib_bfd_bfd_openr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lbfd -ldl -liberty -lz -lintl $LIBS"
+LIBS="-lbfd $DLLIBS -liberty -lz -lintl $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16295,7 +16295,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_bfd_bfd_openr" >&5
 $as_echo "$ac_cv_lib_bfd_bfd_openr" >&6; }
 if test "x$ac_cv_lib_bfd_bfd_openr" = xyes; then :
-  bfd_ldlibs="-lbfd -ldl -liberty -lz -lintl"
+  bfd_ldlibs="-lbfd $DLLIBS -liberty -lz -lintl"
 fi
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1526,20 +1526,20 @@ AS_IF([test x"$with_bfd" != "xno"],
     AS_IF([test -z "$bfd_ldlibs"],
       [unset ac_cv_lib_bfd_bfd_openr
       AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl"], [], [-ldl])])
+        [bfd_ldlibs="-lbfd $DLLIBS"], [], [$DLLIBS])])
     AS_IF([test -z "$bfd_ldlibs"],
       [unset ac_cv_lib_bfd_bfd_openr
       AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl -liberty"], [], [-ldl -liberty])])
+        [bfd_ldlibs="-lbfd $DLLIBS -liberty"], [], [$DLLIBS -liberty])])
     AS_IF([test -z "$bfd_ldlibs"],
       [unset ac_cv_lib_bfd_bfd_openr
       AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl -liberty -lz"], [], [-ldl -liberty -lz])])
+        [bfd_ldlibs="-lbfd $DLLIBS -liberty -lz"], [], [$DLLIBS -liberty -lz])])
     AS_IF([test -z "$bfd_ldlibs"],
       [unset ac_cv_lib_bfd_bfd_openr
       AC_CHECK_LIB([bfd], [bfd_openr],
-        [bfd_ldlibs="-lbfd -ldl -liberty -lz -lintl"], [],
-        [-ldl -liberty -lz -lintl])])
+        [bfd_ldlibs="-lbfd $DLLIBS -liberty -lz -lintl"], [],
+        [$DLLIBS -liberty -lz -lintl])])
     AS_IF([test -n "$bfd_ldlibs"],
       [bfd_available=true
       AC_DEFINE([HAS_LIBBFD])])])


### PR DESCRIPTION
This PR uses the previously computed set of options for linking
dynamic libraries (DLLIBS) in stead of hard-coding "-ldl" when trying
to find which libraries to link to get BFD support.

In particular, this fixes the build on OpenBSD64 where the use of
"-ldl" caused an error.