### PR TITLE
runtime/Makefile: Get rid of two useless calls to cat (cosmetic)

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -252,7 +252,7 @@ prims.c : primitives
 	 echo '	 0 };') > prims.c
 
 caml/opnames.h : caml/instruct.h
-	cat $^ | tr -d '\r' | \
+	tr -d '\r' < $< | \
 	sed -e '/\/\*/d' \
 	    -e '/^#/d' \
 	    -e 's/enum /static char * names_of_/' \
@@ -261,7 +261,7 @@ caml/opnames.h : caml/instruct.h
 
 # caml/jumptbl.h is required only if you have GCC 2.0 or later
 caml/jumptbl.h : caml/instruct.h
-	cat $^ | tr -d '\r' | \
+	tr -d '\r' < $< | \
 	sed -n -e '/^  /s/ \([A-Z]\)/ \&\&lbl_\1/gp' \
 	       -e '/^}/q' > $@
 


### PR DESCRIPTION
Their output was piped to the tr command, so it's better to redirect
tr's standard input directly. This PR also replaces $^ by $< which
seems more accurate here.