### PR TITLE
[matching.ml cleanup] overview PR

### DIFF
--- a/.depend
+++ b/.depend
@@ -741,6 +741,7 @@ typing/parmatch.cmo : \
     typing/subst.cmi \
     typing/printpat.cmi \
     typing/predef.cmi \
+    typing/patterns.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     utils/misc.cmi \
@@ -763,6 +764,7 @@ typing/parmatch.cmx : \
     typing/subst.cmx \
     typing/printpat.cmx \
     typing/predef.cmx \
+    typing/patterns.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     utils/misc.cmx \
@@ -791,6 +793,32 @@ typing/path.cmx : \
     typing/path.cmi
 typing/path.cmi : \
     typing/ident.cmi
+typing/patterns.cmo : \
+    typing/types.cmi \
+    typing/typedtree.cmi \
+    parsing/longident.cmi \
+    parsing/location.cmi \
+    typing/env.cmi \
+    typing/ctype.cmi \
+    typing/btype.cmi \
+    parsing/asttypes.cmi \
+    typing/patterns.cmi
+typing/patterns.cmx : \
+    typing/types.cmx \
+    typing/typedtree.cmx \
+    parsing/longident.cmx \
+    parsing/location.cmx \
+    typing/env.cmx \
+    typing/ctype.cmx \
+    typing/btype.cmx \
+    parsing/asttypes.cmi \
+    typing/patterns.cmi
+typing/patterns.cmi : \
+    typing/types.cmi \
+    typing/typedtree.cmi \
+    parsing/location.cmi \
+    typing/env.cmi \
+    parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \
     utils/misc.cmi \
@@ -3235,6 +3263,7 @@ lambda/matching.cmo : \
     lambda/printlambda.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
+    typing/patterns.cmi \
     typing/parmatch.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
@@ -3255,6 +3284,7 @@ lambda/matching.cmx : \
     lambda/printlambda.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
+    typing/patterns.cmx \
     typing/parmatch.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \

--- a/.depend
+++ b/.depend
@@ -781,6 +781,7 @@ typing/parmatch.cmx : \
 typing/parmatch.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/patterns.cmi \
     parsing/parsetree.cmi \
     parsing/location.cmi \
     typing/env.cmi \
@@ -798,6 +799,7 @@ typing/patterns.cmo : \
     typing/typedtree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    typing/ident.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
@@ -808,6 +810,7 @@ typing/patterns.cmx : \
     typing/typedtree.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    typing/ident.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
@@ -816,8 +819,8 @@ typing/patterns.cmx : \
 typing/patterns.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
-    parsing/location.cmi \
-    typing/env.cmi \
+    parsing/longident.cmi \
+    typing/ident.cmi \
     parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -57,7 +57,7 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/tast_iterator.cmo typing/tast_mapper.cmo \
   file_formats/cmt_format.cmo typing/untypeast.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/printpat.cmo \
-  typing/parmatch.cmo typing/stypes.cmo \
+  typing/patterns.cmo typing/parmatch.cmo typing/stypes.cmo \
   typing/typedecl_properties.cmo typing/typedecl_variance.cmo \
   typing/typedecl_unboxed.cmo typing/typedecl_immediacy.cmo \
   typing/typedecl_separability.cmo \

--- a/dune
+++ b/dune
@@ -59,7 +59,8 @@
    cmi_format persistent_env env type_immediacy
    typedtree printtyped ctype printtyp includeclass mtype envaux includecore
    tast_iterator tast_mapper cmt_format untypeast includemod
-   typetexp printpat parmatch stypes typedecl typeopt rec_check typecore
+   typetexp patterns printpat parmatch stypes typedecl typeopt rec_check
+   typecore
    typeclass typemod typedecl_variance typedecl_properties typedecl_immediacy
    typedecl_unboxed typedecl_separability
    ; manual update: mli only files

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3144,7 +3144,7 @@ let rec comp_match_handlers comp_fun partial ctx first_match next_matchs =
 (* To find reasonable names for variables *)
 
 let rec name_pattern default = function
-  | (pat :: _, _) :: rem -> (
+  | ((pat, _), _) :: rem -> (
       match pat.pat_desc with
       | Tpat_var (id, _) -> id
       | Tpat_alias (_, id, _) -> id
@@ -3171,9 +3171,8 @@ let arg_to_var arg cls =
 *)
 
 let rec compile_match repr partial ctx (m : initial_clause pattern_matching) =
-  match m with
-  | { cases = []; args = [] } -> comp_exit ctx m
-  | { cases = ([], action) :: rem } ->
+  match m.cases with
+  | ([], action) :: rem ->
       if is_guarded action then
         let lambda, total =
           compile_match None partial ctx { m with cases = rem }
@@ -3181,11 +3180,18 @@ let rec compile_match repr partial ctx (m : initial_clause pattern_matching) =
         (event_branch repr (patch_guarded lambda action), total)
       else
         (event_branch repr action, Jumps.empty)
+  | nonempty_cases ->
+      compile_match_nonempty repr partial ctx
+        { m with cases = List.map Non_empty_clause.of_initial nonempty_cases }
+
+and compile_match_nonempty repr partial ctx
+    (m : Typedtree.pattern Non_empty_clause.t pattern_matching) =
+  match m with
+  | { cases = []; args = [] } -> comp_exit ctx m
   | { args = (arg, str) :: argl } ->
       let v, newarg = arg_to_var arg m.cases in
       let args = (newarg, Alias) :: argl in
-      let cases = List.map Non_empty_clause.of_initial m.cases in
-      let cases = List.map (half_simplify_nonempty args) cases in
+      let cases = List.map (half_simplify_nonempty args) m.cases in
       let m = { m with args; cases } in
       let first_match, rem = split_and_precompile_half_simplified (Some v) m in
       let lam, total =
@@ -3209,29 +3215,6 @@ and compile_match_simplified repr partial ctx
       let args = (arg, Alias) :: argl in
       let m = { m with args } in
       let first_match, rem = split_and_precompile_simplified m in
-      let lam, total =
-        comp_match_handlers
-          (( if dbg then
-             do_compile_matching_pr
-           else
-             do_compile_matching
-           )
-             repr)
-          partial ctx first_match rem
-      in
-      (bind_check str v arg lam, total)
-  | _ -> assert false
-
-and compile_match_nonempty repr partial ctx
-    (m : Typedtree.pattern Non_empty_clause.t pattern_matching) =
-  match m with
-  | { cases = []; args = [] } -> comp_exit ctx m
-  | { args = ((Lvar v as arg), str) :: argl } ->
-      (* Not sure we need to do anything with arg/v *)
-      let args = (arg, Alias) :: argl in
-      let cases = List.map (half_simplify_nonempty args) m.cases in
-      let m = { m with args; cases } in
-      let first_match, rem = split_and_precompile_half_simplified (Some v) m in
       let lam, total =
         comp_match_handlers
           (( if dbg then

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -160,79 +160,18 @@ let map_on_row f (row, action) = (f row, action)
 
 let map_on_rows f = List.map (map_on_row f)
 
-module Non_empty_row = struct
-  type 'a t = 'a * Typedtree.pattern list
+module Non_empty_row = Patterns.Non_empty_row
 
-  let of_initial = function
-    | [] -> assert false
-    | pat :: patl -> (pat, patl)
+type simple_view = Patterns.simple_view
 
-  let map_first f (p, patl) = (f p, patl)
-end
+type half_simple_view = Patterns.half_simple_view
 
-type simple_view =
-  [ `Any
-  | `Constant of constant
-  | `Tuple of pattern list
-  | `Construct of Longident.t loc * constructor_description * pattern list
-  | `Variant of label * pattern option * row_desc ref
-  | `Record of
-    (Longident.t loc * label_description * pattern) list * closed_flag
-  | `Array of pattern list
-  | `Lazy of pattern ]
+type general_view = Patterns.general_view
 
-type half_simple_view =
-  [ simple_view | `Or of pattern * pattern * row_desc option ]
-
-type general_view =
-  [ half_simple_view
-  | `Var of Ident.t * string loc
-  | `Alias of pattern * Ident.t * string loc ]
-
-module General : sig
-  type pattern = general_view pattern_data
+module General = struct
+  include Patterns.General
 
   type nonrec clause = pattern Non_empty_row.t clause
-
-  val view : Typedtree.pattern -> pattern
-
-  val erase : [< general_view ] pattern_data -> Typedtree.pattern
-end = struct
-  type pattern = general_view pattern_data
-
-  type nonrec clause = pattern Non_empty_row.t clause
-
-  let view_desc = function
-    | Tpat_any -> `Any
-    | Tpat_var (id, str) -> `Var (id, str)
-    | Tpat_alias (p, id, str) -> `Alias (p, id, str)
-    | Tpat_constant cst -> `Constant cst
-    | Tpat_tuple ps -> `Tuple ps
-    | Tpat_construct (cstr, cstr_descr, args) ->
-        `Construct (cstr, cstr_descr, args)
-    | Tpat_variant (cstr, arg, row_desc) -> `Variant (cstr, arg, row_desc)
-    | Tpat_record (fields, closed) -> `Record (fields, closed)
-    | Tpat_array ps -> `Array ps
-    | Tpat_or (p, q, row_desc) -> `Or (p, q, row_desc)
-    | Tpat_lazy p -> `Lazy p
-
-  let view p : pattern = { p with pat_desc = view_desc p.pat_desc }
-
-  let erase_desc = function
-    | `Any -> Tpat_any
-    | `Var (id, str) -> Tpat_var (id, str)
-    | `Alias (p, id, str) -> Tpat_alias (p, id, str)
-    | `Constant cst -> Tpat_constant cst
-    | `Tuple ps -> Tpat_tuple ps
-    | `Construct (cstr, cst_descr, args) ->
-        Tpat_construct (cstr, cst_descr, args)
-    | `Variant (cstr, arg, row_desc) -> Tpat_variant (cstr, arg, row_desc)
-    | `Record (fields, closed) -> Tpat_record (fields, closed)
-    | `Array ps -> Tpat_array ps
-    | `Or (p, q, row_desc) -> Tpat_or (p, q, row_desc)
-    | `Lazy p -> Tpat_lazy p
-
-  let erase p = { p with pat_desc = erase_desc p.pat_desc }
 end
 
 module Half_simple : sig

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3609,6 +3609,17 @@ let do_for_multiple_match loc paraml pat_act_list partial =
       } )
   in
   try
+    (* TODO: this split_and_precompile call is the only use remaining
+       of [split_and_precompile], which first half-simplifies the
+       matrix then call the more common
+       [split_and_precompile_half_compiled]. By inlining it here, we
+       should be able to share the half-simplification part with what
+       the half-simplification step that also happens in the
+       Cannot_flatten case.
+
+       This comes from a suggestion by Florian Angeletti in
+         https://github.com/ocaml/ocaml/pull/9447#discussion_r408910756
+    *)
     match split_and_precompile ~arg_id:None pm1 with
     | exception Cannot_flatten -> (
         (* One pattern binds the whole tuple, flattening is not possible.

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -127,8 +127,13 @@ let string_of_lam lam =
   Printlambda.lambda Format.str_formatter lam;
   Format.flush_str_formatter ()
 
+let all_record_labels = function
+  | [] -> fatal_error "Matching.all_record_labels"
+  | { lbl_all } :: _ -> Array.to_list lbl_all
+
 let all_record_args lbls =
   match lbls with
+  | [] -> fatal_error "Matching.all_record_args"
   | (_, { lbl_all }, _) :: _ ->
       let t =
         Array.map
@@ -137,7 +142,13 @@ let all_record_args lbls =
       in
       List.iter (fun ((_, lbl, _) as x) -> t.(lbl.lbl_pos) <- x) lbls;
       Array.to_list t
-  | _ -> fatal_error "Matching.all_record_args"
+
+let rec expand_record p =
+  match p.pat_desc with
+  | Tpat_record (l, _) ->
+      { p with pat_desc = Tpat_record (all_record_args l, Closed) }
+  | Tpat_alias (p, _, _) -> expand_record p
+  | _ -> p
 
 type 'a clause = 'a * lambda
 
@@ -493,13 +504,6 @@ end = struct
   let combine ctx = List.map Row.combine ctx
 
   let ctx_matcher p q rem =
-    let rec expand_record p =
-      match p.pat_desc with
-      | Tpat_record (l, _) ->
-          { p with pat_desc = Tpat_record (all_record_args l, Closed) }
-      | Tpat_alias (p, _, _) -> expand_record p
-      | _ -> p
-    in
     let ph, omegas =
       let ph, p_args = Pattern_head.deconstruct (expand_record p) in
       (ph, List.map (fun _ -> omega) p_args)
@@ -594,6 +598,62 @@ end = struct
   let union pss qss = get_mins Row.le (pss @ qss)
 end
 
+let matcher discr p rem =
+  let ph, args =
+    General.erase p |> expand_record |> Pattern_head.deconstruct
+  in
+  let omegas = omegas (Pattern_head.arity discr) in
+  let yes () = args @ rem in
+  let no () = raise NoMatch in
+  let yesif b =
+    if b then
+      yes ()
+    else
+      no ()
+  in
+  match (Pattern_head.desc discr, Pattern_head.desc ph) with
+  | Any, _ -> rem
+  | ( ( Constant _ | Construct _ | Variant _ | Lazy | Array _ | Record _
+      | Tuple _ ),
+      Any ) ->
+      omegas @ rem
+  | Constant cst, Constant cst' -> yesif (const_compare cst cst' = 0)
+  | Constant _, (Construct _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+  | Construct cstr, Construct cstr' ->
+      (* NB: may_equal_constr considers (potential) constructor rebinding;
+          Types.may_equal_constr does check that the arities are the same,
+          preserving row-size coherence. *)
+      yesif (Types.may_equal_constr cstr cstr')
+  | Construct _, (Constant _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+  | Variant { tag; has_arg }, Variant { tag = tag'; has_arg = has_arg' } ->
+      yesif (tag = tag' && has_arg = has_arg')
+  | Variant _, (Constant _ | Construct _ | Lazy | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+  | Array n1, Array n2 -> yesif (n1 = n2)
+  | Array _, (Constant _ | Construct _ | Variant _ | Lazy | Record _ | Tuple _)
+    ->
+      no ()
+  | Tuple n1, Tuple n2 -> yesif (n1 = n2)
+  | Tuple _, (Constant _ | Construct _ | Variant _ | Lazy | Array _ | Record _)
+    ->
+      no ()
+  | Record l, Record l' ->
+      let l = all_record_labels l in
+      let l' = all_record_labels l' in
+      yesif (List.length l = List.length l')
+  | Record _, (Constant _ | Construct _ | Variant _ | Lazy | Array _ | Tuple _)
+    ->
+      no ()
+  | Lazy, Lazy -> yes ()
+  | Lazy, (Constant _ | Construct _ | Variant _ | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+
 let rec flatten_pat_line size p k =
   match p.pat_desc with
   | Tpat_any -> omegas size :: k
@@ -643,8 +703,7 @@ module Default_environment : sig
 
   val cons : matrix -> int -> t -> t
 
-  val specialize :
-    int -> (Simple.pattern -> pattern list -> pattern list) -> t -> t
+  val specialize : Pattern_head.t -> t -> t
 
   val pop_column : t -> t
 
@@ -742,7 +801,7 @@ end = struct
     in
     filter_rec pss
 
-  let specialize arity matcher env =
+  let specialize_ arity matcher env =
     let rec make_rec = function
       | [] -> []
       | ([ [] ], i) :: _ -> [ ([ [] ], i) ]
@@ -763,7 +822,10 @@ end = struct
     in
     make_rec env
 
-  let pop_column def = specialize 0 (fun _p rem -> rem) def
+  let specialize head def =
+    specialize_ (Pattern_head.arity head) (matcher head) def
+
+  let pop_column def = specialize_ 0 (fun _p rem -> rem) def
 
   let pop_compat p def =
     let compat_matcher q rem =
@@ -772,7 +834,7 @@ end = struct
       else
         raise NoMatch
     in
-    specialize 0 compat_matcher def
+    specialize_ 0 compat_matcher def
 
   let pop = function
     | [] -> None
@@ -1629,22 +1691,12 @@ let divide_line make_ctx make get_args discr ctx
    There is one set of functions per matching style
    (constants, constructors etc.)
 
-   - matcher functions are arguments to Default_environment.specialize (for
-   default handlers)
-   They may raise NoMatch and perform the full matching (selection + arguments).
-
    - get_args and get_key are for the compiled matrices, note that
    selection and getting arguments are separated.
 
    - make_*_matching combines the previous functions for producing
    new  ``pattern_matching'' records.
 *)
-
-let matcher_const cst p rem =
-  match p.pat_desc with
-  | `Constant c1 when const_compare c1 cst = 0 -> rem
-  | `Any -> rem
-  | _ -> raise NoMatch
 
 let get_key_constant caller = function
   | { pat_desc = Tpat_constant cst } -> cst
@@ -1655,13 +1707,12 @@ let get_key_constant caller = function
 
 let get_args_constant _ rem = rem
 
+let matcher_of_pattern p = fst (Pattern_head.deconstruct p)
+
 let make_constant_matching p def ctx = function
   | [] -> fatal_error "Matching.make_constant_matching"
   | _ :: argl ->
-      let def =
-        Default_environment.specialize 0
-          (matcher_const (get_key_constant "make" p))
-          def
+      let def = Default_environment.specialize (matcher_of_pattern p) def
       and ctx = Context.specialize p ctx in
       { pm = { cases = []; args = argl; default = def };
         ctx;
@@ -1694,20 +1745,6 @@ let get_args_constr p rem =
   | { pat_desc = Tpat_construct (_, _, args) } -> args @ rem
   | _ -> assert false
 
-(* NB: matcher_constr applies to default matrices.
-
-       In that context, matching by constructors of extensible
-       types degrades to arity checking, due to potential rebinding.
-       This comparison is performed by Types.may_equal_constr.
-*)
-
-let matcher_constr cstr q rem =
-  match q.pat_desc with
-  | `Construct (_, cstr', args) when Types.may_equal_constr cstr cstr' ->
-      args @ rem
-  | `Any -> Parmatch.omegas cstr.cstr_arity @ rem
-  | _ -> raise NoMatch
-
 let make_constr_matching p def ctx = function
   | [] -> fatal_error "Matching.make_constr_matching"
   | (arg, _mut) :: argl ->
@@ -1727,9 +1764,7 @@ let make_constr_matching p def ctx = function
       { pm =
           { cases = [];
             args = newargs;
-            default =
-              Default_environment.specialize cstr.cstr_arity
-                (matcher_constr cstr) def
+            default = Default_environment.specialize (matcher_of_pattern p) def
           };
         ctx = Context.specialize p ctx;
         discr = normalize_pat p
@@ -1740,34 +1775,20 @@ let divide_constructor ctx pm =
 
 (* Matching against a variant *)
 
-let matcher_variant_const lab p rem =
-  match p.pat_desc with
-  | `Variant (lab1, _, _) when lab1 = lab -> rem
-  | `Any -> rem
-  | _ -> raise NoMatch
-
-let make_variant_matching_constant p lab def ctx = function
+let make_variant_matching_constant p def ctx = function
   | [] -> fatal_error "Matching.make_variant_matching_constant"
   | _ :: argl ->
-      let def =
-        Default_environment.specialize 0 (matcher_variant_const lab) def
+      let def = Default_environment.specialize (matcher_of_pattern p) def
       and ctx = Context.specialize p ctx in
       { pm = { cases = []; args = argl; default = def };
         ctx;
         discr = normalize_pat p
       }
 
-let matcher_variant_nonconst lab p rem =
-  match p.pat_desc with
-  | `Variant (lab1, Some arg, _) when lab1 = lab -> arg :: rem
-  | `Any -> omega :: rem
-  | _ -> raise NoMatch
-
-let make_variant_matching_nonconst p lab def ctx = function
+let make_variant_matching_nonconst p def ctx = function
   | [] -> fatal_error "Matching.make_variant_matching_nonconst"
   | (arg, _mut) :: argl ->
-      let def =
-        Default_environment.specialize 1 (matcher_variant_nonconst lab) def
+      let def = Default_environment.specialize (matcher_of_pattern p) def
       and ctx = Context.specialize p ctx in
       { pm =
           { cases = [];
@@ -1795,11 +1816,11 @@ let divide_variant row ctx { cases = cl; args; default = def } =
           match pato with
           | None ->
               add_in_div
-                (make_variant_matching_constant p lab def ctx)
+                (make_variant_matching_constant p def ctx)
                 ( = ) (Cstr_constant tag) (patl, action) variants
           | Some pat ->
               add_in_div
-                (make_variant_matching_nonconst p lab def ctx)
+                (make_variant_matching_nonconst p def ctx)
                 ( = ) (Cstr_block tag)
                 (pat :: patl, action)
                 variants
@@ -1820,7 +1841,7 @@ let make_var_matching def = function
   | _ :: argl ->
       { cases = [];
         args = argl;
-        default = Default_environment.specialize 0 get_args_var def
+        default = Default_environment.specialize Pattern_head.omega def
       }
 
 let divide_var ctx pm =
@@ -1833,12 +1854,6 @@ let get_arg_lazy p rem =
   | { pat_desc = Tpat_any } -> omega :: rem
   | { pat_desc = Tpat_lazy arg } -> arg :: rem
   | _ -> assert false
-
-let matcher_lazy p rem =
-  match p.pat_desc with
-  | `Any -> omega :: rem
-  | `Lazy arg -> arg :: rem
-  | _ -> raise NoMatch
 
 (* Inlining the tag tests before calling the primitive that works on
    lazy blocks. This is also used in translcore.ml.
@@ -1973,16 +1988,17 @@ let inline_lazy_force arg loc =
          tables (~ 250 elts); conditionals are better *)
     inline_lazy_force_cond arg loc
 
-let make_lazy_matching def = function
+let make_lazy_matching p def = function
   | [] -> fatal_error "Matching.make_lazy_matching"
   | (arg, _mut) :: argl ->
       { cases = [];
         args = (inline_lazy_force arg Location.none, Strict) :: argl;
-        default = Default_environment.specialize 1 matcher_lazy def
+        default = Default_environment.specialize (matcher_of_pattern p) def
       }
 
 let divide_lazy p ctx pm =
-  divide_line (Context.specialize p) make_lazy_matching get_arg_lazy p ctx pm
+  divide_line (Context.specialize p) (make_lazy_matching p) get_arg_lazy p ctx
+    pm
 
 (* Matching against a tuple pattern *)
 
@@ -1992,13 +2008,7 @@ let get_args_tuple arity p rem =
   | { pat_desc = Tpat_tuple args } -> args @ rem
   | _ -> assert false
 
-let matcher_tuple arity p rem =
-  match p.pat_desc with
-  | `Any -> omegas arity @ rem
-  | `Tuple args when List.length args = arity -> args @ rem
-  | _ -> raise NoMatch
-
-let make_tuple_matching loc arity def = function
+let make_tuple_matching p loc arity def = function
   | [] -> fatal_error "Matching.make_tuple_matching"
   | (arg, _mut) :: argl ->
       let rec make_args pos =
@@ -2009,13 +2019,12 @@ let make_tuple_matching loc arity def = function
       in
       { cases = [];
         args = make_args 0;
-        default =
-          Default_environment.specialize arity (matcher_tuple arity) def
+        default = Default_environment.specialize (matcher_of_pattern p) def
       }
 
 let divide_tuple arity p ctx pm =
   divide_line (Context.specialize p)
-    (make_tuple_matching p.pat_loc arity)
+    (make_tuple_matching p p.pat_loc arity)
     (get_args_tuple arity) p ctx pm
 
 (* Matching against a record pattern *)
@@ -2032,16 +2041,7 @@ let get_args_record num_fields p rem =
       record_matching_line num_fields lbl_pat_list @ rem
   | _ -> assert false
 
-let matcher_record num_fields p rem =
-  match p.pat_desc with
-  | `Any -> record_matching_line num_fields [] @ rem
-  | `Record ([], _) when num_fields = 0 -> rem
-  | `Record (((_, lbl, _) :: _ as lbl_pat_list), _)
-    when Array.length lbl.lbl_all = num_fields ->
-      record_matching_line num_fields lbl_pat_list @ rem
-  | _ -> raise NoMatch
-
-let make_record_matching loc all_labels def = function
+let make_record_matching p loc all_labels def = function
   | [] -> fatal_error "Matching.make_record_matching"
   | (arg, _mut) :: argl ->
       let rec make_args pos =
@@ -2066,16 +2066,14 @@ let make_record_matching loc all_labels def = function
           in
           (access, str) :: make_args (pos + 1)
       in
-      let nfields = Array.length all_labels in
-      let def =
-        Default_environment.specialize nfields (matcher_record nfields) def
-      in
+      let p = expand_record p in
+      let def = Default_environment.specialize (matcher_of_pattern p) def in
       { cases = []; args = make_args 0; default = def }
 
 let divide_record all_labels p ctx pm =
   let get_args = get_args_record (Array.length all_labels) in
   divide_line (Context.specialize p)
-    (make_record_matching p.pat_loc all_labels)
+    (make_record_matching p p.pat_loc all_labels)
     get_args p ctx pm
 
 (* Matching against an array pattern *)
@@ -2088,12 +2086,6 @@ let get_args_array p rem =
   match p with
   | { pat_desc = Tpat_array patl } -> patl @ rem
   | _ -> assert false
-
-let matcher_array len p rem =
-  match p.pat_desc with
-  | `Array args when List.length args = len -> args @ rem
-  | `Any -> Parmatch.omegas len @ rem
-  | _ -> raise NoMatch
 
 let make_array_matching kind p def ctx = function
   | [] -> fatal_error "Matching.make_array_matching"
@@ -2110,7 +2102,7 @@ let make_array_matching kind p def ctx = function
             StrictOpt )
           :: make_args (pos + 1)
       in
-      let def = Default_environment.specialize len (matcher_array len) def
+      let def = Default_environment.specialize (matcher_of_pattern p) def
       and ctx = Context.specialize p ctx in
       { pm = { cases = []; args = make_args 0; default = def };
         ctx;

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -645,7 +645,7 @@ module Default_environment : sig
 
   val cons : matrix -> int -> t -> t
 
-  val specialize : (pattern -> pattern list -> pattern list) -> t -> t
+  val specialize : int -> (pattern -> pattern list -> pattern list) -> t -> t
 
   val pop_column : t -> t
 
@@ -671,7 +671,7 @@ end = struct
     | [] -> default
     | _ -> (matrix, raise_num) :: default
 
-  let specialize_matrix matcher pss =
+  let specialize_matrix arity matcher pss =
     let rec filter_rec = function
       | (p :: ps) :: rem -> (
           match p.pat_desc with
@@ -679,14 +679,17 @@ end = struct
           | Tpat_var _ -> filter_rec ((omega :: ps) :: rem)
           | _ -> (
               let rem = filter_rec rem in
-              try matcher p ps :: rem with
-              | NoMatch -> rem
-              | OrPat -> (
+              match matcher p ps with
+              | exception NoMatch -> rem
+              | exception OrPat -> (
                   match p.pat_desc with
                   | Tpat_or (p1, p2, _) ->
                       filter_rec [ p1 :: ps; p2 :: ps ] @ rem
                   | _ -> assert false
                 )
+              | specialized ->
+                  assert (List.length specialized = List.length ps + arity);
+                  specialized :: rem
             )
         )
       | [] -> []
@@ -696,13 +699,13 @@ end = struct
     in
     filter_rec pss
 
-  let specialize matcher env =
+  let specialize arity matcher env =
     let rec make_rec = function
       | [] -> []
       | ([ [] ], i) :: _ -> [ ([ [] ], i) ]
       | (pss, i) :: rem -> (
           let rem = make_rec rem in
-          match specialize_matrix matcher pss with
+          match specialize_matrix arity matcher pss with
           | [] -> rem
           | [] :: _ -> [ ([ [] ], i) ]
           | pss -> (pss, i) :: rem
@@ -710,7 +713,7 @@ end = struct
     in
     make_rec env
 
-  let pop_column def = specialize (fun _p rem -> rem) def
+  let pop_column def = specialize 0 (fun _p rem -> rem) def
 
   let pop_compat p def =
     let compat_matcher q rem =
@@ -719,7 +722,7 @@ end = struct
       else
         raise NoMatch
     in
-    specialize compat_matcher def
+    specialize 0 compat_matcher def
 
   let pop = function
     | [] -> None
@@ -1610,7 +1613,7 @@ let make_constant_matching p def ctx = function
   | [] -> fatal_error "Matching.make_constant_matching"
   | _ :: argl ->
       let def =
-        Default_environment.specialize
+        Default_environment.specialize 0
           (matcher_const (get_key_constant "make" p))
           def
       and ctx = Context.specialize p ctx in
@@ -1730,7 +1733,9 @@ let make_constr_matching p def ctx = function
       { pm =
           { cases = [];
             args = newargs;
-            default = Default_environment.specialize (matcher_constr cstr) def
+            default =
+              Default_environment.specialize cstr.cstr_arity
+                (matcher_constr cstr) def
           };
         ctx = Context.specialize p ctx;
         discr = normalize_pat p
@@ -1754,7 +1759,8 @@ let rec matcher_variant_const lab p rem =
 let make_variant_matching_constant p lab def ctx = function
   | [] -> fatal_error "Matching.make_variant_matching_constant"
   | _ :: argl ->
-      let def = Default_environment.specialize (matcher_variant_const lab) def
+      let def =
+        Default_environment.specialize 0 (matcher_variant_const lab) def
       and ctx = Context.specialize p ctx in
       { pm = { cases = []; args = argl; default = def };
         ctx;
@@ -1772,7 +1778,7 @@ let make_variant_matching_nonconst p lab def ctx = function
   | [] -> fatal_error "Matching.make_variant_matching_nonconst"
   | (arg, _mut) :: argl ->
       let def =
-        Default_environment.specialize (matcher_variant_nonconst lab) def
+        Default_environment.specialize 1 (matcher_variant_nonconst lab) def
       and ctx = Context.specialize p ctx in
       { pm =
           { cases = [];
@@ -1825,7 +1831,7 @@ let make_var_matching def = function
   | _ :: argl ->
       { cases = [];
         args = argl;
-        default = Default_environment.specialize get_args_var def
+        default = Default_environment.specialize 0 get_args_var def
       }
 
 let divide_var ctx pm =
@@ -1986,7 +1992,7 @@ let make_lazy_matching def = function
   | (arg, _mut) :: argl ->
       { cases = [];
         args = (inline_lazy_force arg Location.none, Strict) :: argl;
-        default = Default_environment.specialize matcher_lazy def
+        default = Default_environment.specialize 1 matcher_lazy def
       }
 
 let divide_lazy p ctx pm =
@@ -2020,7 +2026,8 @@ let make_tuple_matching loc arity def = function
       in
       { cases = [];
         args = make_args 0;
-        default = Default_environment.specialize (matcher_tuple arity) def
+        default =
+          Default_environment.specialize arity (matcher_tuple arity) def
       }
 
 let divide_tuple arity p ctx pm =
@@ -2080,7 +2087,9 @@ let make_record_matching loc all_labels def = function
           (access, str) :: make_args (pos + 1)
       in
       let nfields = Array.length all_labels in
-      let def = Default_environment.specialize (matcher_record nfields) def in
+      let def =
+        Default_environment.specialize nfields (matcher_record nfields) def
+      in
       { cases = []; args = make_args 0; default = def }
 
 let divide_record all_labels p ctx pm =
@@ -2122,7 +2131,7 @@ let make_array_matching kind p def ctx = function
             StrictOpt )
           :: make_args (pos + 1)
       in
-      let def = Default_environment.specialize (matcher_array len) def
+      let def = Default_environment.specialize len (matcher_array len) def
       and ctx = Context.specialize p ctx in
       { pm = { cases = []; args = make_args 0; default = def };
         ctx;

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -162,12 +162,6 @@ let map_on_rows f = List.map (map_on_row f)
 
 module Non_empty_row = Patterns.Non_empty_row
 
-type simple_view = Patterns.simple_view
-
-type half_simple_view = Patterns.half_simple_view
-
-type general_view = Patterns.general_view
-
 module General = struct
   include Patterns.General
 
@@ -175,6 +169,7 @@ module General = struct
 end
 
 module Half_simple : sig
+  include module type of Patterns.Half_simple
   (** Half-simplified patterns are patterns where:
         - records are expanded so that they possess all fields
         - aliases are removed and replaced by bindings in actions.
@@ -196,13 +191,11 @@ module Half_simple : sig
       In particular, or-patterns may still occur in the leading column,
       so this is only a "half-simplification". *)
 
-  type pattern = half_simple_view pattern_data
-
   type nonrec clause = pattern Non_empty_row.t clause
 
   val of_clause : args:(lambda * 'a) list -> General.clause -> clause
 end = struct
-  type pattern = half_simple_view pattern_data
+  include Patterns.Half_simple
 
   type nonrec clause = pattern Non_empty_row.t clause
 
@@ -226,10 +219,10 @@ end = struct
 
   let of_clause ~args cl =
     let rec aux (((p, patl), action) : General.clause) : clause =
-      let continue p (view : general_view) : clause =
+      let continue p (view : General.view) : clause =
         aux (({ p with pat_desc = view }, patl), action)
       in
-      let stop p (view : half_simple_view) : clause =
+      let stop p (view : view) : clause =
         (({ p with pat_desc = view }, patl), action)
       in
       match p.pat_desc with
@@ -265,7 +258,7 @@ end
 exception Cannot_flatten
 
 module Simple : sig
-  type pattern = simple_view pattern_data
+  include module type of Patterns.Simple
 
   type nonrec clause = pattern Non_empty_row.t clause
 
@@ -279,12 +272,11 @@ module Simple : sig
     clause list ->
     clause list
 end = struct
-  type pattern = simple_view pattern_data
+  include Patterns.Simple
 
   type nonrec clause = pattern Non_empty_row.t clause
 
-  let head p =
-    fst (Patterns.Head.deconstruct (General.erase (p :> General.pattern)))
+  let head p = fst (Patterns.Head.deconstruct (Patterns.General.erase p))
 
   let alpha env (p : pattern) : pattern =
     let alpha_pat env p = Typedtree.alpha_pat env p in
@@ -329,7 +321,7 @@ end = struct
           explode
             { p with pat_desc = `Alias (Patterns.omega, id, str) }
             aliases rem
-      | #simple_view as view ->
+      | #view as view ->
           let env = mk_alpha_env arg aliases vars in
           ( (alpha env { p with pat_desc = view }, patl),
             mk_action ~vars:(List.map snd env) )
@@ -528,7 +520,7 @@ end = struct
               filter_rec ((left, p1, right) :: (left, p2, right) :: rem)
           | `Alias (p, _, _) -> filter_rec ((left, p, right) :: rem)
           | `Var _ -> filter_rec ((left, Patterns.omega, right) :: rem)
-          | #simple_view as view -> (
+          | #Simple.view as view -> (
               let p = { p with pat_desc = view } in
               let rem = filter_rec rem in
               match matcher head p right with
@@ -706,7 +698,7 @@ end = struct
                      as (p1 .. pn | q1 .. qn) *)
                   filter_rec ((p1, ps) :: (p2, ps) :: rem)
             )
-          | #simple_view as view -> (
+          | #Simple.view as view -> (
               let p = { p with pat_desc = view } in
               let rem = filter_rec rem in
               match matcher p ps with
@@ -1284,7 +1276,7 @@ let rec split_or argo (cls : Half_simple.clause list) args def =
         do_split rev_before rev_ors (cl :: rev_no) rem
     | (((p, ps), act) as cl) :: rem -> (
         match p.pat_desc with
-        | #simple_view as view when safe_before cl rev_ors ->
+        | #Simple.view as view when safe_before cl rev_ors ->
             do_split
               ((({ p with pat_desc = view }, ps), act) :: rev_before)
               rev_ors rev_no rem
@@ -1462,7 +1454,7 @@ and precompile_or argo (cls : Simple.clause list) ors args def k =
     | [] -> ([], [])
     | ((p, patl), action) :: rem -> (
         match p.pat_desc with
-        | #simple_view as view ->
+        | #Simple.view as view ->
             let new_ord, new_to_catch = do_cases rem in
             ( (({ p with pat_desc = view }, patl), action) :: new_ord,
               new_to_catch )

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -142,18 +142,81 @@ let all_record_args lbls =
 type 'a clause = 'a * lambda
 
 module Non_empty_clause = struct
-  type 'a t = ('a * pattern list) clause
+  type 'a t = ('a * Typedtree.pattern list) clause
 
   let of_initial = function
     | [], _ -> assert false
     | pat :: patl, act -> ((pat, patl), act)
+
+  let map_head f ((p, patl), act) = ((f p, patl), act)
 end
 
-module General = struct
-  type nonrec pattern = pattern
+type simple_view =
+  [ `Any
+  | `Constant of constant
+  | `Tuple of pattern list
+  | `Construct of Longident.t loc * constructor_description * pattern list
+  | `Variant of label * pattern option * row_desc ref
+  | `Record of
+    (Longident.t loc * label_description * pattern) list * closed_flag
+  | `Array of pattern list
+  | `Lazy of pattern ]
+
+type half_simple_view =
+  [ simple_view | `Or of pattern * pattern * row_desc option ]
+
+type general_view =
+  [ half_simple_view
+  | `Var of Ident.t * string loc
+  | `Alias of pattern * Ident.t * string loc ]
+
+module General : sig
+  type pattern = general_view pattern_data
 
   type clause = pattern Non_empty_clause.t
+
+  val view : Typedtree.pattern -> pattern
+
+  val erase : [< general_view ] pattern_data -> Typedtree.pattern
+end = struct
+  type pattern = general_view pattern_data
+
+  type clause = pattern Non_empty_clause.t
+
+  let view_desc = function
+    | Tpat_any -> `Any
+    | Tpat_var (id, str) -> `Var (id, str)
+    | Tpat_alias (p, id, str) -> `Alias (p, id, str)
+    | Tpat_constant cst -> `Constant cst
+    | Tpat_tuple ps -> `Tuple ps
+    | Tpat_construct (cstr, cstr_descr, args) ->
+        `Construct (cstr, cstr_descr, args)
+    | Tpat_variant (cstr, arg, row_desc) -> `Variant (cstr, arg, row_desc)
+    | Tpat_record (fields, closed) -> `Record (fields, closed)
+    | Tpat_array ps -> `Array ps
+    | Tpat_or (p, q, row_desc) -> `Or (p, q, row_desc)
+    | Tpat_lazy p -> `Lazy p
+
+  let view p : pattern = { p with pat_desc = view_desc p.pat_desc }
+
+  let erase_desc = function
+    | `Any -> Tpat_any
+    | `Var (id, str) -> Tpat_var (id, str)
+    | `Alias (p, id, str) -> Tpat_alias (p, id, str)
+    | `Constant cst -> Tpat_constant cst
+    | `Tuple ps -> Tpat_tuple ps
+    | `Construct (cstr, cst_descr, args) ->
+        Tpat_construct (cstr, cst_descr, args)
+    | `Variant (cstr, arg, row_desc) -> Tpat_variant (cstr, arg, row_desc)
+    | `Record (fields, closed) -> Tpat_record (fields, closed)
+    | `Array ps -> Tpat_array ps
+    | `Or (p, q, row_desc) -> Tpat_or (p, q, row_desc)
+    | `Lazy p -> Tpat_lazy p
+
+  let erase p = { p with pat_desc = erase_desc p.pat_desc }
 end
+
+let omega_ : [> `Any ] pattern_data = { Parmatch.omega with pat_desc = `Any }
 
 module Half_simple : sig
   (** Half-simplified patterns are patterns where:
@@ -177,29 +240,25 @@ module Half_simple : sig
       In particular, or-patterns may still occur in the leading column,
       so this is only a "half-simplification". *)
 
-  type pattern
-
-  val to_pattern : pattern -> General.pattern
+  type pattern = half_simple_view pattern_data
 
   type clause = pattern Non_empty_clause.t
 
   val of_clause : args:(lambda * 'a) list -> General.clause -> clause
 end = struct
-  type nonrec pattern = pattern
+  type pattern = half_simple_view pattern_data
 
   type clause = pattern Non_empty_clause.t
 
-  let to_pattern p = p
-
-  let rec simpl_orpat p =
+  let rec simpl_under_orpat p =
     match p.pat_desc with
     | Tpat_any
     | Tpat_var _ ->
         p
     | Tpat_alias (q, id, s) ->
-        { p with pat_desc = Tpat_alias (simpl_orpat q, id, s) }
+        { p with pat_desc = Tpat_alias (simpl_under_orpat q, id, s) }
     | Tpat_or (p1, p2, o) ->
-        let p1, p2 = (simpl_orpat p1, simpl_orpat p2) in
+        let p1, p2 = (simpl_under_orpat p1, simpl_under_orpat p2) in
         if le_pat p1 p2 then
           p1
         else
@@ -210,40 +269,39 @@ end = struct
     | _ -> p
 
   let of_clause ~args cl =
-    let rec aux ((pat, patl), action) =
-      match pat.pat_desc with
-      | Tpat_any -> ((pat, patl), action)
-      | Tpat_var (id, s) ->
-          let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
-          aux ((p, patl), action)
-      | Tpat_alias (p, id, _) ->
+    let rec aux (((p, patl), action) : General.clause) : clause =
+      let continue p (view : general_view) : clause =
+        aux (({ p with pat_desc = view }, patl), action)
+      in
+      let stop p (view : half_simple_view) : clause =
+        (({ p with pat_desc = view }, patl), action)
+      in
+      match p.pat_desc with
+      | `Any -> stop p `Any
+      | `Var (id, s) -> continue p (`Alias (omega, id, s))
+      | `Alias (p, id, _) ->
           let arg =
             match args with
             | [] -> assert false
             | (arg, _) :: _ -> arg
           in
-          let k = Typeopt.value_kind pat.pat_env pat.pat_type in
-          aux ((p, patl), bind_with_value_kind Alias (id, k) arg action)
-      | Tpat_record ([], _) -> ((omega, patl), action)
-      | Tpat_record (lbls, closed) ->
-          let all_lbls = all_record_args lbls in
-          let full_pat =
-            { pat with pat_desc = Tpat_record (all_lbls, closed) }
-          in
-          ((full_pat, patl), action)
-      | Tpat_or _ -> (
-          let pat_simple = simpl_orpat pat in
-          match pat_simple.pat_desc with
-          | Tpat_or _ -> ((pat_simple, patl), action)
-          | _ -> aux ((pat_simple, patl), action)
+          let k = Typeopt.value_kind p.pat_env p.pat_type in
+          aux
+            ( (General.view p, patl),
+              bind_with_value_kind Alias (id, k) arg action )
+      | `Record ([], _) as view -> stop p view
+      | `Record (lbls, closed) ->
+          let full_view = `Record (all_record_args lbls, closed) in
+          stop p full_view
+      | `Or _ -> (
+          let orpat = General.view (simpl_under_orpat (General.erase p)) in
+          match orpat.pat_desc with
+          | `Or _ as or_view -> stop orpat or_view
+          | other_view -> continue orpat other_view
         )
-      | Tpat_constant _
-      | Tpat_tuple _
-      | Tpat_construct _
-      | Tpat_variant _
-      | Tpat_array _
-      | Tpat_lazy _ ->
-          ((pat, patl), action)
+      | ( `Constant _ | `Tuple _ | `Construct _ | `Variant _ | `Array _
+        | `Lazy _ ) as view ->
+          stop p view
     in
     aux cl
 end
@@ -251,37 +309,45 @@ end
 exception Cannot_flatten
 
 module Simple : sig
-  type pattern
-  (** A fully simplified pattern: or-patterns have been exploded, and the
-      remaining aliases have been removed and replaced by bindings in actions *)
+  type pattern = simple_view pattern_data
 
   type clause = pattern Non_empty_clause.t
-
-  val try_no_or : Half_simple.pattern -> pattern option
-
-  val to_pattern : pattern -> General.pattern
 
   val head : pattern -> Pattern_head.t
 
   val explode_or_pat :
-    Half_simple.pattern * General.pattern list ->
+    Half_simple.pattern * Typedtree.pattern list ->
     arg:Ident.t option ->
     mk_action:(vars:Ident.t list -> lambda) ->
     vars:Ident.t list ->
     clause list ->
     clause list
-
-  val omega : pattern
 end = struct
-  type nonrec pattern = pattern
-
-  let omega = omega
+  type pattern = simple_view pattern_data
 
   type clause = pattern Non_empty_clause.t
 
-  let to_pattern p = p
+  let head p =
+    fst (Pattern_head.deconstruct (General.erase (p :> General.pattern)))
 
-  let head p = fst (Pattern_head.deconstruct p)
+  let alpha env (p : pattern) : pattern =
+    let alpha_pat env p = Typedtree.alpha_pat env p in
+    let pat_desc =
+      match p.pat_desc with
+      | `Any -> `Any
+      | `Constant cst -> `Constant cst
+      | `Tuple ps -> `Tuple (List.map (alpha_pat env) ps)
+      | `Construct (cstr, cst_descr, args) ->
+          `Construct (cstr, cst_descr, List.map (alpha_pat env) args)
+      | `Variant (cstr, argo, row_desc) ->
+          `Variant (cstr, Option.map (alpha_pat env) argo, row_desc)
+      | `Record (fields, closed) ->
+          let alpha_field env (lid, l, p) = (lid, l, alpha_pat env p) in
+          `Record (List.map (alpha_field env) fields, closed)
+      | `Array ps -> `Array (List.map (alpha_pat env) ps)
+      | `Lazy p -> `Lazy (alpha_pat env p)
+    in
+    { p with pat_desc }
 
   let mk_alpha_env arg aliases ids =
     List.map
@@ -295,25 +361,25 @@ end = struct
             Ident.create_local (Ident.name id) ))
       ids
 
-  let explode_or_pat (p, patl) ~arg ~mk_action ~vars rem =
+  let explode_or_pat ((p : Half_simple.pattern), patl) ~arg ~mk_action ~vars
+      (rem : clause list) : clause list =
     let rec explode p aliases rem =
+      let split_explode p aliases rem = explode (General.view p) aliases rem in
       match p.pat_desc with
-      | Tpat_or (p1, p2, _) -> explode p1 aliases (explode p2 aliases rem)
-      | Tpat_alias (p, id, _) -> explode p (id :: aliases) rem
-      | Tpat_var (x, _) ->
-          let env = mk_alpha_env arg (x :: aliases) vars in
-          ((omega, patl), mk_action ~vars:(List.map snd env)) :: rem
-      | _ ->
+      | `Or (p1, p2, _) ->
+          split_explode p1 aliases (split_explode p2 aliases rem)
+      | `Alias (p, id, _) -> split_explode p (id :: aliases) rem
+      | `Var (id, str) ->
+          explode
+            { p with pat_desc = `Alias (Parmatch.omega, id, str) }
+            aliases rem
+      | #simple_view as view ->
           let env = mk_alpha_env arg aliases vars in
-          ((alpha_pat env p, patl), mk_action ~vars:(List.map snd env)) :: rem
+          ( (alpha env { p with pat_desc = view }, patl),
+            mk_action ~vars:(List.map snd env) )
+          :: rem
     in
-    explode (Half_simple.to_pattern p) [] rem
-
-  let try_no_or hsp =
-    let p = Half_simple.to_pattern hsp in
-    match p.pat_desc with
-    | Tpat_or _ -> None
-    | _ -> Some p
+    explode (p : Half_simple.pattern :> General.pattern) [] rem
 end
 
 type initial_clause = pattern list clause
@@ -832,15 +898,13 @@ let pretty_pm pm =
 
 let pretty_hc_pm pm =
   pretty_cases
-    (List.map
-       (fun ((p, ps), act) -> (Half_simple.to_pattern p :: ps, act))
-       pm.cases);
+    (List.map (fun ((p, ps), act) -> (General.erase p :: ps, act)) pm.cases);
   if not (Default_environment.is_empty pm.default) then
     Default_environment.pp pm.default
 
 let pretty_sc_pm pm =
   pretty_cases
-    (List.map (fun ((p, ps), act) -> (Simple.to_pattern p :: ps, act)) pm.cases);
+    (List.map (fun ((p, ps), act) -> (General.erase p :: ps, act)) pm.cases);
   if not (Default_environment.is_empty pm.default) then
     Default_environment.pp pm.default
 
@@ -944,7 +1008,7 @@ let same_actions = function
             None
     )
 
-let safe_before to_pattern ((p, ps), act_p) l =
+let safe_before ((p, ps), act_p) l =
   (* Test for swapping two clauses *)
   let same_actions act1 act2 =
     match (make_key act1, make_key act2) with
@@ -956,11 +1020,15 @@ let safe_before to_pattern ((p, ps), act_p) l =
   List.for_all
     (fun ((q, qs), act_q) ->
       same_actions act_p act_q
-      || not (may_compats (to_pattern p :: ps) (to_pattern q :: qs)))
+      || not (may_compats (General.erase p :: ps) (General.erase q :: qs)))
     l
 
-let half_simplify_clause args cls =
-  cls |> Non_empty_clause.of_initial |> Half_simple.of_clause ~args
+let half_simplify_nonempty args (cls : Typedtree.pattern Non_empty_clause.t) :
+    Half_simple.clause =
+  cls |> Non_empty_clause.map_head General.view |> Half_simple.of_clause ~args
+
+let half_simplify_clause args (cls : Typedtree.pattern list clause) =
+  cls |> Non_empty_clause.of_initial |> half_simplify_nonempty args
 
 let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
@@ -969,7 +1037,7 @@ let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
 let rec what_is_cases ~skip_any cases =
   match cases with
-  | [] -> Simple.omega
+  | [] -> omega_
   | ((p, _), _) :: rem -> (
       match Pattern_head.desc (Simple.head p) with
       | Any when skip_any -> what_is_cases ~skip_any rem
@@ -1109,11 +1177,11 @@ let rec omega_like p =
 
 let equiv_pat p q = le_pat p q && le_pat q p
 
-let rec extract_equiv_head to_pattern p l =
+let rec extract_equiv_head p l =
   match l with
   | (((q, _), _) as cl) :: rem ->
-      if equiv_pat p (to_pattern q) then
-        let others, rem = extract_equiv_head to_pattern p rem in
+      if equiv_pat p (General.erase q) then
+        let others, rem = extract_equiv_head p rem in
         (cl :: others, rem)
       else
         ([], l)
@@ -1142,10 +1210,10 @@ module Or_matrix = struct
   let safe_below (ps, act) qs =
     (not (is_guarded act)) && Parmatch.le_pats ps qs
 
-  let safe_below_or_matrix to_pattern l (q, qs) =
+  let safe_below_or_matrix l (q, qs) =
     List.for_all
       (fun ((p, ps), act_p) ->
-        let p = to_pattern p in
+        let p = General.erase p in
         match p.pat_desc with
         | Tpat_or _ -> disjoint p q || safe_below (ps, act_p) qs
         | _ -> true)
@@ -1159,21 +1227,19 @@ module Or_matrix = struct
    *)
   let insert_or_append (head, ps, act) rev_ors rev_no =
     let safe_to_insert rem (p, ps) seen =
-      let _, not_e = extract_equiv_head Half_simple.to_pattern p rem in
+      let _, not_e = extract_equiv_head p rem in
       (* check append condition for head of O *)
-      safe_below_or_matrix Half_simple.to_pattern not_e (p, ps)
+      safe_below_or_matrix not_e (p, ps)
       && (* check insert condition for tail of O *)
-         List.for_all
-           (fun ((q, _), _) -> disjoint p (Half_simple.to_pattern q))
-           seen
+         List.for_all (fun ((q, _), _) -> disjoint p (General.erase q)) seen
     in
     let rec attempt seen = function
       (* invariant: the new clause is safe to append at the end of
          [seen] (but maybe not [rem] yet) *)
       | [] -> (((head, ps), act) :: rev_ors, rev_no)
       | (((q, qs), act_q) as cl) :: rem ->
-          let p = Half_simple.to_pattern head in
-          let q = Half_simple.to_pattern q in
+          let p = General.erase head in
+          let q = General.erase q in
           if (not (is_or q)) || disjoint p q then
             attempt (cl :: seen) rem
           else if
@@ -1197,8 +1263,8 @@ end
 
 (* Reconstruct default information from half_compiled  pm list *)
 
-let as_matrix pat_of_head cases =
-  get_mins le_pats (List.map (fun ((p, ps), _) -> pat_of_head p :: ps) cases)
+let as_matrix cases =
+  get_mins le_pats (List.map (fun ((p, ps), _) -> General.erase p :: ps) cases)
 
 (*
   Split a matching along the first column.
@@ -1249,12 +1315,14 @@ let rec split_or argo (cls : Half_simple.clause list) args def =
   let rec do_split (rev_before : Simple.clause list) rev_ors rev_no = function
     | [] ->
         cons_next (List.rev rev_before) (List.rev rev_ors) (List.rev rev_no)
-    | cl :: rem when not (safe_before Half_simple.to_pattern cl rev_no) ->
+    | cl :: rem when not (safe_before cl rev_no) ->
         do_split rev_before rev_ors (cl :: rev_no) rem
     | (((p, ps), act) as cl) :: rem -> (
-        match Simple.try_no_or p with
-        | Some sp when safe_before Half_simple.to_pattern cl rev_ors ->
-            do_split (((sp, ps), act) :: rev_before) rev_ors rev_no rem
+        match p.pat_desc with
+        | #simple_view as view when safe_before cl rev_ors ->
+            do_split
+              ((({ p with pat_desc = view }, ps), act) :: rev_before)
+              rev_ors rev_no rem
         | _ ->
             let rev_ors, rev_no =
               Or_matrix.insert_or_append (p, ps, act) rev_ors rev_no
@@ -1310,8 +1378,7 @@ and split_no_or cls args def k =
            testsuite/tests/basic/patmatch_split_no_or.ml *)
         collect group_discr rev_yes (cl :: rev_no) []
     | (((p, _), _) as cl) :: rem ->
-        if can_group group_discr p && safe_before Simple.to_pattern cl rev_no
-        then
+        if can_group group_discr p && safe_before cl rev_no then
           collect group_discr (cl :: rev_yes) rev_no rem
         else if should_split group_discr then (
           assert (rev_no = []);
@@ -1338,8 +1405,8 @@ and split_no_or cls args def k =
           (Default_environment.cons matrix idef def)
           ((idef, next) :: nexts)
   and should_split group_discr =
-    match (Simple.to_pattern group_discr).pat_desc with
-    | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
+    match Pattern_head.desc (Simple.head group_discr) with
+    | Construct { cstr_tag = Cstr_extension _ } ->
         (* it is unlikely that we will raise anything, so we split now *)
         true
     | _ -> false
@@ -1381,7 +1448,7 @@ and precompile_var args cls def k =
           | _ ->
               let rec rebuild_matrix pmh =
                 match pmh with
-                | Pm pm -> as_matrix Simple.to_pattern pm.cases
+                | Pm pm -> as_matrix pm.cases
                 | PmOr { or_matrix = m } -> m
                 | PmVar x -> add_omega_column (rebuild_matrix x.inside)
               in
@@ -1417,24 +1484,23 @@ and precompile_var args cls def k =
 
 and do_not_precompile args cls def k =
   ( { me = Pm { cases = cls; args; default = def };
-      matrix = as_matrix Simple.to_pattern cls;
+      matrix = as_matrix cls;
       top_default = def
     },
     k )
 
-and precompile_or argo cls ors args def k =
+and precompile_or argo (cls : Simple.clause list) ors args def k =
   let rec do_cases = function
     | [] -> ([], [])
     | ((p, patl), action) :: rem -> (
-        match Simple.try_no_or p with
-        | Some sp ->
+        match p.pat_desc with
+        | #simple_view as view ->
             let new_ord, new_to_catch = do_cases rem in
-            (((sp, patl), action) :: new_ord, new_to_catch)
-        | None ->
-            let orp = Half_simple.to_pattern p in
-            let others, rem =
-              extract_equiv_head Half_simple.to_pattern orp rem
-            in
+            ( (({ p with pat_desc = view }, patl), action) :: new_ord,
+              new_to_catch )
+        | `Or _ ->
+            let orp = General.erase p in
+            let others, rem = extract_equiv_head orp rem in
             let orpm =
               { cases =
                   (patl, action)
@@ -1478,11 +1544,8 @@ and precompile_or argo cls ors args def k =
   let cases, handlers = do_cases ors in
   let matrix =
     as_matrix
-      (fun x -> x)
-      (List.map (fun ((p, ps), act) -> ((Simple.to_pattern p, ps), act)) cls
-      @ List.map
-          (fun ((p, ps), act) -> ((Half_simple.to_pattern p, ps), act))
-          ors
+      ((cls : Simple.clause list :> General.clause list)
+      @ (ors : Half_simple.clause list :> General.clause list)
       )
   and body = { cases = cls @ cases; args; default = def } in
   ( { me = PmOr { body; handlers; or_matrix = matrix };
@@ -1493,7 +1556,7 @@ and precompile_or argo cls ors args def k =
 
 let split_and_precompile_nonempty argo pm =
   let pm =
-    { pm with cases = List.map (Half_simple.of_clause ~args:pm.args) pm.cases }
+    { pm with cases = List.map (half_simplify_nonempty pm.args) pm.cases }
   in
   let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
   if
@@ -1577,7 +1640,7 @@ let add_in_div make_matching_fun eq_key key patl_action division =
 let divide make eq_key get_key get_args ctx
     (pm : Simple.clause pattern_matching) =
   let add ((p, patl), action) division =
-    let p = Simple.to_pattern p in
+    let p = General.erase p in
     add_in_div (make p pm.default ctx) eq_key (get_key p)
       (get_args p patl, action)
       division
@@ -1591,7 +1654,7 @@ let add_line patl_action pm =
 let divide_line make_ctx make get_args discr ctx
     (pm : Simple.clause pattern_matching) =
   let add ((p, patl), action) submatrix =
-    let p = Simple.to_pattern p in
+    let p = General.erase p in
     add_line (get_args p patl, action) submatrix
   in
   let pm = List.fold_right add pm.cases (make pm.default pm.args) in
@@ -1811,36 +1874,30 @@ let make_variant_matching_nonconst p lab def ctx = function
 let divide_variant row ctx { cases = cl; args; default = def } =
   let row = Btype.row_repr row in
   let rec divide = function
-    | [] -> { args; cells = [] }
-    | ((p, patl), action) :: rem -> (
-        let p = Simple.to_pattern p in
-        match p.pat_desc with
-        | Tpat_variant (lab, pato, _) -> (
-            let variants = divide rem in
-            if
-              try
-                Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
-              with Not_found -> true
-            then
-              variants
-            else
-              let tag = Btype.hash_variant lab in
-              match pato with
-              | None ->
-                  add_in_div
-                    (make_variant_matching_constant p lab def ctx)
-                    ( = ) (Cstr_constant tag) (patl, action) variants
-              | Some pat ->
-                  add_in_div
-                    (make_variant_matching_nonconst p lab def ctx)
-                    ( = ) (Cstr_block tag)
-                    (pat :: patl, action)
-                    variants
-          )
-        | _ ->
-            (* I really want to assert false here. *)
-            { args; cells = [] }
+    | ((({ pat_desc = `Variant (lab, pato, _) } as p), patl), action) :: rem
+      -> (
+        let p = General.erase p in
+        let variants = divide rem in
+        if
+          try Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
+          with Not_found -> true
+        then
+          variants
+        else
+          let tag = Btype.hash_variant lab in
+          match pato with
+          | None ->
+              add_in_div
+                (make_variant_matching_constant p lab def ctx)
+                ( = ) (Cstr_constant tag) (patl, action) variants
+          | Some pat ->
+              add_in_div
+                (make_variant_matching_nonconst p lab def ctx)
+                ( = ) (Cstr_block tag)
+                (pat :: patl, action)
+                variants
       )
+    | _ -> { args; cells = [] }
   in
   divide cl
 
@@ -3252,7 +3309,7 @@ and compile_simplified repr partial ctx (m : Simple.clause pattern_matching) =
   | _ -> assert false
 
 and compile_half_compiled repr partial ctx
-    (m : pattern Non_empty_clause.t pattern_matching) =
+    (m : Typedtree.pattern Non_empty_clause.t pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
   | { args = ((Lvar v as arg), str) :: argl } ->
@@ -3307,7 +3364,7 @@ and do_compile_matching repr partial ctx pmh =
       in
       let pat = what_is_cases pm.cases in
       let ph = Simple.head pat in
-      let pat = Simple.to_pattern pat in
+      let pat = General.erase pat in
       match Pattern_head.desc ph with
       | Any -> compile_no_test divide_var Context.rshift repr partial ctx pm
       | Tuple l ->
@@ -3705,7 +3762,7 @@ let flatten_cases size cases =
   List.map
     (function
       | (p, []), action -> (
-          match flatten_pattern size (Simple.to_pattern p) with
+          match flatten_pattern size (General.erase p) with
           | p :: ps -> ((p, ps), action)
           | [] -> assert false
         )

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -623,8 +623,12 @@ end
 
 (* Pattern matching before any compilation *)
 
-type pattern_matching = {
-  mutable cases : (pattern list * lambda) list;
+type initial_row = pattern list * lambda
+
+type half_compiled_row = pattern * pattern list * lambda
+
+type 'row pattern_matching = {
+  mutable cases : 'row list;
   args : (lambda * let_kind) list;
       (** args are not just Ident.t in at least the following cases:
         - when matching the arguments of a constructor,
@@ -638,11 +642,11 @@ type handler = {
   provenance : matrix;
   exit : int;
   vars : (Ident.t * Lambda.value_kind) list;
-  pm : pattern_matching
+  pm : initial_row pattern_matching
 }
 
 type pm_or_compiled = {
-  body : pattern_matching;
+  body : initial_row pattern_matching;
   handlers : handler list;
   or_matrix : matrix
 }
@@ -653,7 +657,7 @@ type pm_or_compiled = {
 type pm_half_compiled =
   | PmOr of pm_or_compiled
   | PmVar of { inside : pm_half_compiled }
-  | Pm of pattern_matching
+  | Pm of half_compiled_row pattern_matching
 
 (* Only used inside the various split functions, we only keep [me] when we're
    done splitting / precompiling. *)
@@ -678,10 +682,14 @@ let pretty_pm pm =
   if not (Default_environment.is_empty pm.default) then
     Default_environment.pp pm.default
 
+let pretty_hc_pm pm =
+  pretty_cases (List.map (fun (p, ps, act) -> (p :: ps, act)) pm.cases);
+  if pm.default <> [] then pretty_def pm.default
+
 let rec pretty_precompiled = function
   | Pm pm ->
       Format.eprintf "++++ PM ++++\n";
-      pretty_pm pm
+      pretty_hc_pm pm
   | PmVar x ->
       Format.eprintf "++++ VAR ++++\n";
       pretty_precompiled x.inside
@@ -778,7 +786,7 @@ let same_actions = function
             None
     )
 
-let safe_before (ps, act_p) l =
+let safe_before (p, ps, act_p) l =
   (* Test for swapping two clauses *)
   let same_actions act1 act2 =
     match (make_key act1, make_key act2) with
@@ -788,7 +796,8 @@ let safe_before (ps, act_p) l =
         false
   in
   List.for_all
-    (fun (qs, act_q) -> same_actions act_p act_q || not (may_compats ps qs))
+    (fun (q, qs, act_q) ->
+      same_actions act_p act_q || not (may_compats (p :: ps) (q :: qs)))
     l
 
 (*
@@ -832,12 +841,11 @@ let half_simplify_cases args cls =
         { p with pat_desc = Tpat_record (all_lbls, closed) }
     | _ -> p
   in
-  let rec simpl_clause cl =
-    match cl with
+  let rec simpl_clause = function
     | [], _ -> assert false
     | pat :: patl, action -> (
         match pat.pat_desc with
-        | Tpat_any -> cl
+        | Tpat_any -> (pat, patl, action)
         | Tpat_var (id, s) ->
             let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
             simpl_clause (p :: patl, action)
@@ -850,17 +858,17 @@ let half_simplify_cases args cls =
             let k = Typeopt.value_kind pat.pat_env pat.pat_type in
             simpl_clause
               (p :: patl, bind_with_value_kind Alias (id, k) arg action)
-        | Tpat_record ([], _) -> (omega :: patl, action)
+        | Tpat_record ([], _) -> (omega, patl, action)
         | Tpat_record (lbls, closed) ->
             let all_lbls = all_record_args lbls in
             let full_pat =
               { pat with pat_desc = Tpat_record (all_lbls, closed) }
             in
-            (full_pat :: patl, action)
+            (full_pat, patl, action)
         | Tpat_or _ -> (
             let pat_simple = simpl_pat pat in
             match pat_simple.pat_desc with
-            | Tpat_or _ -> (pat_simple :: patl, action)
+            | Tpat_or _ -> (pat_simple, patl, action)
             | _ -> simpl_clause (pat_simple :: patl, action)
           )
         | Tpat_constant _
@@ -869,7 +877,7 @@ let half_simplify_cases args cls =
         | Tpat_variant _
         | Tpat_array _
         | Tpat_lazy _ ->
-            cl
+            (pat, patl, action)
       )
   in
   List.map simpl_clause cls
@@ -880,8 +888,7 @@ let half_simplify_cases args cls =
 let rec what_is_cases ~skip_any cases =
   match cases with
   | [] -> omega
-  | ([], _) :: _ -> assert false
-  | (p :: _, _) :: rem -> (
+  | (p, _, _) :: rem -> (
       match p.pat_desc with
       | Tpat_any when skip_any -> what_is_cases ~skip_any rem
       | Tpat_var _
@@ -1040,7 +1047,7 @@ let equiv_pat p q = le_pat p q && le_pat q p
 
 let rec extract_equiv_head p l =
   match l with
-  | ((q :: _, _) as cl) :: rem ->
+  | ((q, _, _) as cl) :: rem ->
       if equiv_pat p q then
         let others, rem = extract_equiv_head p rem in
         (cl :: others, rem)
@@ -1074,7 +1081,7 @@ module Or_matrix = struct
   let safe_below_or_matrix l (q, qs) =
     List.for_all
       (function
-        | ({ pat_desc = Tpat_or _ } as p) :: ps, act_p ->
+        | ({ pat_desc = Tpat_or _ } as p), ps, act_p ->
             disjoint p q || safe_below (ps, act_p) qs
         | _ -> true)
       l
@@ -1091,19 +1098,13 @@ module Or_matrix = struct
       (* check append condition for head of O *)
       safe_below_or_matrix not_e (p, ps)
       && (* check insert condition for tail of O *)
-         List.for_all
-           (fun cl ->
-             match cl with
-             | q :: _, _ -> disjoint p q
-             | _ -> assert false)
-           seen
+         List.for_all (fun (q, _, _) -> disjoint p q) seen
     in
     let rec attempt seen = function
       (* invariant: the new clause is safe to append at the end of
          [seen] (but maybe not [rem] yet) *)
-      | [] -> ((p :: ps, act) :: rev_ors, rev_no)
-      | ([], _act) :: _ -> assert false
-      | ((q :: qs, act_q) as cl) :: rem ->
+      | [] -> ((p, ps, act) :: rev_ors, rev_no)
+      | ((q, qs, act_q) as cl) :: rem ->
           if (not (is_or q)) || disjoint p q then
             attempt (cl :: seen) rem
           else if
@@ -1113,21 +1114,22 @@ module Or_matrix = struct
           then
             (* attempt insertion, for equivalent orpats with no variables *)
             if safe_to_insert rem (p, ps) seen then
-              (List.rev_append seen ((p :: ps, act) :: cl :: rem), rev_no)
+              (List.rev_append seen ((p, ps, act) :: cl :: rem), rev_no)
             else
               (* fail to insert or append *)
-              (rev_ors, (p :: ps, act) :: rev_no)
+              (rev_ors, (p, ps, act) :: rev_no)
           else if safe_below (qs, act_q) ps then
             attempt (cl :: seen) rem
           else
-            (rev_ors, (p :: ps, act) :: rev_no)
+            (rev_ors, (p, ps, act) :: rev_no)
     in
     attempt [] rev_ors
 end
 
 (* Reconstruct default information from half_compiled  pm list *)
 
-let as_matrix cases = get_mins le_pats (List.map (fun (ps, _) -> ps) cases)
+let as_matrix cases =
+  get_mins le_pats (List.map (fun (p, ps, _) -> p :: ps) cases)
 
 (*
   Split a matching along the first column.
@@ -1179,7 +1181,7 @@ let rec split_or argo cls args def =
   let rec do_split rev_before rev_ors rev_no = function
     | [] ->
         cons_next (List.rev rev_before) (List.rev rev_ors) (List.rev rev_no)
-    | ((p :: ps, act) as cl) :: rem ->
+    | ((p, ps, act) as cl) :: rem ->
         if not (safe_before cl rev_no) then
           do_split rev_before rev_ors (cl :: rev_no) rem
         else if (not (is_or p)) && safe_before cl rev_ors then
@@ -1189,7 +1191,6 @@ let rec split_or argo cls args def =
             Or_matrix.insert_or_append (p, ps, act) rev_ors rev_no
           in
           do_split rev_before rev_ors rev_no rem
-    | _ -> assert false
   and cons_next yes yesor no =
     let def, nexts =
       match no with
@@ -1226,7 +1227,8 @@ and split_no_or cls args def k =
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
     | ([], _) :: _ -> assert false
-    | [ ((ps, _) as cl) ] when rev_yes <> [] && List.for_all omega_like ps ->
+    | [ ((p, ps, _) as cl) ]
+      when rev_yes <> [] && List.for_all omega_like (p :: ps) ->
         (* This enables an extra division in some frequent cases:
                last row is made of variables only
 
@@ -1238,7 +1240,7 @@ and split_no_or cls args def k =
            This optimisation is tested in the first part of
            testsuite/tests/basic/patmatch_split_no_or.ml *)
         collect group_discr rev_yes (cl :: rev_no) []
-    | ((p :: _, _) as cl) :: rem ->
+    | ((p, _, _) as cl) :: rem ->
         if can_group group_discr p && safe_before cl rev_no then
           collect group_discr (cl :: rev_yes) rev_no rem
         else if should_split group_discr then (
@@ -1292,12 +1294,9 @@ and precompile_var args cls def k =
           (* Precompile *)
           let var_cls =
             List.map
-              (fun (ps, act) ->
-                match ps with
-                | p :: ps ->
-                    assert (group_var p);
-                    (ps, act)
-                | _ -> assert false)
+              (fun (p, ps, act) ->
+                assert (group_var p);
+                (ps, act))
               cls
           and var_def = Default_environment.pop_column def in
           let { me = first; matrix }, nexts =
@@ -1354,16 +1353,12 @@ and do_not_precompile args cls def k =
 
 and precompile_or argo cls ors args def k =
   let rec do_cases = function
-    | (({ pat_desc = Tpat_or _ } as orp) :: patl, action) :: rem ->
+    | (({ pat_desc = Tpat_or _ } as orp), patl, action) :: rem ->
         let others, rem = extract_equiv_head orp rem in
         let orpm =
           { cases =
               (patl, action)
-              :: List.map
-                   (function
-                     | _ :: ps, action -> (ps, action)
-                     | _ -> assert false)
-                   others;
+              :: List.map (fun (_, ps, action) -> (ps, action)) others;
             args =
               ( match args with
               | _ :: r -> r
@@ -1394,14 +1389,19 @@ and precompile_or argo cls ors args def k =
           { provenance = [ [ orp ] ]; exit = or_num; vars; pm = orpm }
         in
         (cases, handler :: rem_handlers)
-    | cl :: rem ->
+    | (p, ps, act) :: rem ->
         let new_ord, new_to_catch = do_cases rem in
-        (cl :: new_ord, new_to_catch)
+        ((p :: ps, act) :: new_ord, new_to_catch)
     | [] -> ([], [])
   in
   let cases, handlers = do_cases ors in
   let matrix = as_matrix (cls @ ors)
-  and body = { cases = cls @ cases; args; default = def } in
+  and body =
+    { cases = List.map (fun (p, ps, act) -> (p :: ps, act)) cls @ cases;
+      args;
+      default = def
+    }
+  in
   ( { me = PmOr { body; handlers; or_matrix = matrix };
       matrix;
       top_default = def
@@ -1427,7 +1427,11 @@ let split_and_precompile argo pm =
 
 (* General divide functions *)
 
-type cell = { pm : pattern_matching; ctx : Context.t; discr : pattern }
+type cell = {
+  pm : initial_row pattern_matching;
+  ctx : Context.t;
+  discr : pattern
+}
 (** a submatrix after specializing by discriminant pattern;
     [ctx] is the context shared by all rows. *)
 
@@ -1449,14 +1453,12 @@ let add_in_div make_matching_fun eq_key key patl_action division =
   in
   { division with cells }
 
-let divide make eq_key get_key get_args ctx (pm : pattern_matching) =
-  let add clause division =
-    match clause with
-    | [], _ -> assert false
-    | p :: patl, action ->
-        add_in_div (make p pm.default ctx) eq_key (get_key p)
-          (get_args p patl, action)
-          division
+let divide make eq_key get_key get_args ctx
+    (pm : half_compiled_row pattern_matching) =
+  let add (p, patl, action) division =
+    add_in_div (make p pm.default ctx) eq_key (get_key p)
+      (get_args p patl, action)
+      division
   in
   List.fold_right add pm.cases { args = pm.args; cells = [] }
 
@@ -1464,11 +1466,10 @@ let add_line patl_action pm =
   pm.cases <- patl_action :: pm.cases;
   pm
 
-let divide_line make_ctx make get_args discr ctx (pm : pattern_matching) =
-  let add clause submatrix =
-    match clause with
-    | [], _ -> assert false
-    | p :: patl, action -> add_line (get_args p patl, action) submatrix
+let divide_line make_ctx make get_args discr ctx
+    (pm : half_compiled_row pattern_matching) =
+  let add (p, patl, action) submatrix =
+    add_line (get_args p patl, action) submatrix
   in
   let pm = List.fold_right add pm.cases (make pm.default pm.args) in
   { pm; ctx = make_ctx ctx; discr }
@@ -1687,8 +1688,8 @@ let make_variant_matching_nonconst p lab def ctx = function
 let divide_variant row ctx { cases = cl; args; default = def } =
   let row = Btype.row_repr row in
   let rec divide = function
-    | (({ pat_desc = Tpat_variant (lab, pato, _) } as p) :: patl, action)
-      :: rem -> (
+    | (({ pat_desc = Tpat_variant (lab, pato, _) } as p), patl, action) :: rem
+      -> (
         let variants = divide rem in
         if
           try Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
@@ -3070,7 +3071,7 @@ let arg_to_var arg cls =
    Output: a lambda term, a jump summary {..., exit number -> context, .. }
 *)
 
-let rec compile_match repr partial ctx (m : pattern_matching) =
+let rec compile_match repr partial ctx (m : initial_row pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
   | { cases = ([], action) :: rem } ->
@@ -3533,7 +3534,18 @@ let flatten_cases size cases =
       | _ -> fatal_error "Matching.flatten_case")
     cases
 
-let flatten_pm size args pm =
+let flatten_hc_cases size cases =
+  List.map
+    (function
+      | p, [], action -> (
+          match flatten_pattern size p with
+          | p :: ps -> (p, ps, action)
+          | [] -> assert false
+        )
+      | _ -> fatal_error "Matching.flatten_hc_cases")
+    cases
+
+let flatten_pm flatten_cases size args pm =
   { args;
     cases = flatten_cases size pm.cases;
     default = Default_environment.flatten size pm.default
@@ -3544,10 +3556,10 @@ let flatten_handler size handler =
 
 let flatten_precompiled size args pmh =
   match pmh with
-  | Pm pm -> Pm (flatten_pm size args pm)
+  | Pm pm -> Pm (flatten_pm flatten_hc_cases size args pm)
   | PmOr { body = b; handlers = hs; or_matrix = m } ->
       PmOr
-        { body = flatten_pm size args b;
+        { body = flatten_pm flatten_cases size args b;
           handlers = List.map (flatten_handler size) hs;
           or_matrix = flatten_matrix size m
         }
@@ -3560,7 +3572,11 @@ let flatten_precompiled size args pmh =
 
 let compile_flattened repr partial ctx pmh =
   match pmh with
-  | Pm pm -> compile_match repr partial ctx pm
+  | Pm pm ->
+      compile_match repr partial ctx
+        { pm with
+          cases = List.map (fun (p, ps, act) -> (p :: ps, act)) pm.cases
+        }
   | PmOr { body = b; handlers = hs } ->
       let lam, total = compile_match repr partial ctx b in
       compile_orhandlers (compile_match repr partial) lam total ctx hs

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -260,11 +260,14 @@ module Simple : sig
 
   val explode_or_pat :
     Half_simple.pattern * Typedtree.pattern list ->
-    arg:Ident.t option ->
+    arg_id:Ident.t option ->
     mk_action:(vars:Ident.t list -> lambda) ->
     vars:Ident.t list ->
     clause list ->
     clause list
+  (** If the toplevel pattern is given a name, but the scrutinee is not named
+        (i.e. [arg_id = None]), which happens (only) when we're matching a literal
+        tuple, then [Cannot_flatten] is raised. *)
 end = struct
   include Patterns.Simple
 
@@ -291,19 +294,19 @@ end = struct
     in
     { p with pat_desc }
 
-  let mk_alpha_env arg aliases ids =
+  let mk_alpha_env arg_id aliases ids =
     List.map
       (fun id ->
         ( id,
           if List.mem id aliases then
-            match arg with
+            match arg_id with
             | Some v -> v
             | _ -> raise Cannot_flatten
           else
             Ident.create_local (Ident.name id) ))
       ids
 
-  let explode_or_pat ((p : Half_simple.pattern), patl) ~arg ~mk_action ~vars
+  let explode_or_pat ((p : Half_simple.pattern), patl) ~arg_id ~mk_action ~vars
       (rem : clause list) : clause list =
     let rec explode p aliases rem =
       let split_explode p aliases rem = explode (General.view p) aliases rem in
@@ -316,7 +319,7 @@ end = struct
             { p with pat_desc = `Alias (Patterns.omega, id, str) }
             aliases rem
       | #view as view ->
-          let env = mk_alpha_env arg aliases vars in
+          let env = mk_alpha_env arg_id aliases vars in
           ( (alpha env { p with pat_desc = view }, patl),
             mk_action ~vars:(List.map snd env) )
           :: rem
@@ -1262,7 +1265,7 @@ let as_matrix cases =
 
 *)
 
-let rec split_or argo (cls : Half_simple.clause list) args def =
+let rec split_or ~arg_id (cls : Half_simple.clause list) args def =
   let rec do_split (rev_before : Simple.clause list) rev_ors rev_no = function
     | [] ->
         cons_next (List.rev rev_before) (List.rev rev_ors) (List.rev rev_no)
@@ -1293,7 +1296,7 @@ let rec split_or argo (cls : Half_simple.clause list) args def =
     in
     match yesor with
     | [] -> split_no_or yes args def nexts
-    | _ -> precompile_or argo yes yesor args def nexts
+    | _ -> precompile_or ~arg_id yes yesor args def nexts
   in
   do_split [] [] [] cls
 
@@ -1392,7 +1395,7 @@ and precompile_var args cls def k =
               cls
           and var_def = Default_environment.pop_column def in
           let { me = first; matrix }, nexts =
-            split_or (Some v) var_cls var_args var_def
+            split_or ~arg_id:(Some v) var_cls var_args var_def
           in
           (* Compute top information *)
           match nexts with
@@ -1443,7 +1446,7 @@ and do_not_precompile args cls def k =
     },
     k )
 
-and precompile_or argo (cls : Simple.clause list) ors args def k =
+and precompile_or ~arg_id (cls : Simple.clause list) ors args def k =
   let rec do_cases = function
     | [] -> ([], [])
     | ((p, patl), action) :: rem -> (
@@ -1482,7 +1485,7 @@ and precompile_or argo (cls : Simple.clause list) ors args def k =
             in
             let rem_cases, rem_handlers = do_cases rem in
             let cases =
-              Simple.explode_or_pat (p, new_patl) ~arg:argo
+              Simple.explode_or_pat (p, new_patl) ~arg_id
                 ~mk_action:mk_new_action ~vars:(List.map fst vars) rem_cases
             in
             let handler =
@@ -1528,16 +1531,16 @@ let split_and_precompile_simplified pm =
   dbg_split_and_precompile pm next nexts;
   (next, nexts)
 
-let split_and_precompile_half_simplified argo pm =
-  let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
+let split_and_precompile_half_simplified ~arg_id pm =
+  let { me = next }, nexts = split_or ~arg_id pm.cases pm.args pm.default in
   dbg_split_and_precompile pm next nexts;
   (next, nexts)
 
-let split_and_precompile argo pm =
+let split_and_precompile ~arg_id pm =
   let pm =
     { pm with cases = List.map (half_simplify_clause pm.args) pm.cases }
   in
-  split_and_precompile_half_simplified argo pm
+  split_and_precompile_half_simplified ~arg_id pm
 
 (* General divide functions *)
 
@@ -3055,7 +3058,9 @@ and compile_match_nonempty repr partial ctx
       let args = (newarg, Alias) :: argl in
       let cases = List.map (half_simplify_nonempty args) m.cases in
       let m = { m with args; cases } in
-      let first_match, rem = split_and_precompile_half_simplified (Some v) m in
+      let first_match, rem =
+        split_and_precompile_half_simplified ~arg_id:(Some v) m
+      in
       let lam, total =
         comp_match_handlers
           (( if dbg then
@@ -3584,7 +3589,7 @@ let do_for_multiple_match loc paraml pat_act_list partial =
   try
     try
       (* Once for checking that compilation is possible *)
-      let next, nexts = split_and_precompile None pm1 in
+      let next, nexts = split_and_precompile ~arg_id:None pm1 in
       let size = List.length paraml
       and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
       let args = List.map (fun id -> (Lvar id, Alias)) idl in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -684,7 +684,7 @@ end = struct
               | exception OrPat -> (
                   match p.pat_desc with
                   | Tpat_or (p1, p2, _) ->
-                      filter_rec [ p1 :: ps; p2 :: ps ] @ rem
+                      filter_rec ((p1 :: ps) :: (p2 :: ps) :: rem)
                   | _ -> assert false
                 )
               | specialized ->

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3523,7 +3523,23 @@ let flatten_simple_pattern size (p : Simple.pattern) =
   match p.pat_desc with
   | `Tuple args -> args
   | `Any -> Patterns.omegas size
-  | _ -> raise Cannot_flatten
+  | `Array _
+  | `Variant _
+  | `Record _
+  | `Lazy _
+  | `Construct _
+  | `Constant _ ->
+      (* If you trace where this function is called from, you'll notice all
+         the calls originate from [do_for_multiple_match], where we know we're
+         the scrutinee is a tuple literal.
+
+         Since the PM is well typed, none of this cases is possible. *)
+      let msg =
+        Format.fprintf Format.str_formatter
+          "Matching.flatten_pattern: got '%a'" top_pretty (General.erase p);
+        Format.flush_str_formatter ()
+      in
+      fatal_error msg
 
 let flatten_cases size cases =
   List.map

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3519,11 +3519,17 @@ let flatten_pattern size p =
   | Tpat_any -> Patterns.omegas size
   | _ -> raise Cannot_flatten
 
+let flatten_simple_pattern size (p : Simple.pattern) =
+  match p.pat_desc with
+  | `Tuple args -> args
+  | `Any -> Patterns.omegas size
+  | _ -> raise Cannot_flatten
+
 let flatten_cases size cases =
   List.map
     (function
       | (p, []), action -> (
-          match flatten_pattern size (General.erase p) with
+          match flatten_simple_pattern size p with
           | p :: ps -> ((p, ps), action)
           | [] -> assert false
         )

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -216,8 +216,6 @@ end = struct
   let erase p = { p with pat_desc = erase_desc p.pat_desc }
 end
 
-let omega_ : [> `Any ] pattern_data = { Parmatch.omega with pat_desc = `Any }
-
 module Half_simple : sig
   (** Half-simplified patterns are patterns where:
         - records are expanded so that they possess all fields
@@ -1037,11 +1035,12 @@ let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
 let rec what_is_cases ~skip_any cases =
   match cases with
-  | [] -> omega_
+  | [] -> Pattern_head.omega
   | ((p, _), _) :: rem -> (
-      match Pattern_head.desc (Simple.head p) with
+      let head = Simple.head p in
+      match Pattern_head.desc head with
       | Any when skip_any -> what_is_cases ~skip_any rem
-      | _ -> p
+      | _ -> head
     )
 
 let what_is_first_case = what_is_cases ~skip_any:false
@@ -1297,7 +1296,7 @@ and split_no_or cls args def k =
      different heads match different values), but this is handled by the
      [can_group] function. *)
   let rec split (cls : Simple.clause list) =
-    let discr = Simple.head (what_is_first_case cls) in
+    let discr = what_is_first_case cls in
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
     | [ (((p, ps), _) as cl) ]
@@ -2769,7 +2768,7 @@ let split_extension_cases tag_lambda_list =
   in
   split_rec tag_lambda_list
 
-let combine_constructor loc arg ex_pat cstr partial ctx def
+let combine_constructor loc arg pat_env cstr partial ctx def
     (tag_lambda_list, total1, pats) =
   match cstr.cstr_tag with
   | Cstr_extension _ ->
@@ -2795,7 +2794,7 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
               let tests =
                 List.fold_right
                   (fun (path, act) rem ->
-                    let ext = transl_extension_path loc ex_pat.pat_env path in
+                    let ext = transl_extension_path loc pat_env path in
                     Lifthenelse
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
                   nonconsts default
@@ -2804,7 +2803,7 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
         in
         List.fold_right
           (fun (path, act) rem ->
-            let ext = transl_extension_path loc ex_pat.pat_env path in
+            let ext = transl_extension_path loc pat_env path in
             Lifthenelse (Lprim (Pintcomp Ceq, [ arg; ext ], loc), act, rem))
           consts nonconst_lambda
       in
@@ -3276,48 +3275,46 @@ and do_compile_matching repr partial ctx pmh =
             *)
             assert false
       in
-      let pat = what_is_cases pm.cases in
-      let ph = Simple.head pat in
-      let pat = General.erase pat in
+      let ph = what_is_cases pm.cases in
+      let pomega = Pattern_head.to_omega_pattern ph in
+      let ploc = Pattern_head.loc ph in
       match Pattern_head.desc ph with
       | Any -> compile_no_test divide_var Context.rshift repr partial ctx pm
       | Tuple l ->
-          compile_no_test
-            (divide_tuple l (normalize_pat pat))
-            Context.combine repr partial ctx pm
+          compile_no_test (divide_tuple l pomega) Context.combine repr partial
+            ctx pm
       | Record [] -> assert false
       | Record (lbl :: _) ->
           compile_no_test
-            (divide_record lbl.lbl_all (normalize_pat pat))
+            (divide_record lbl.lbl_all pomega)
             Context.combine repr partial ctx pm
       | Constant cst ->
           compile_test
             (compile_match repr partial)
             partial divide_constant
-            (combine_constant pat.pat_loc arg cst partial)
+            (combine_constant ploc arg cst partial)
             ctx pm
       | Construct cstr ->
           compile_test
             (compile_match repr partial)
             partial divide_constructor
-            (combine_constructor pat.pat_loc arg pat cstr partial)
+            (combine_constructor ploc arg (Pattern_head.env ph) cstr partial)
             ctx pm
       | Array _ ->
-          let kind = Typeopt.array_pattern_kind pat in
+          let kind = Typeopt.array_pattern_kind pomega in
           compile_test
             (compile_match repr partial)
             partial (divide_array kind)
-            (combine_array pat.pat_loc arg kind partial)
+            (combine_array ploc arg kind partial)
             ctx pm
       | Lazy ->
-          compile_no_test
-            (divide_lazy (normalize_pat pat))
-            Context.combine repr partial ctx pm
+          compile_no_test (divide_lazy pomega) Context.combine repr partial ctx
+            pm
       | Variant { cstr_row = row } ->
           compile_test
             (compile_match repr partial)
             partial (divide_variant !row)
-            (combine_variant pat.pat_loc !row arg partial)
+            (combine_variant ploc !row arg partial)
             ctx pm
     )
   | PmVar { inside = pmh } ->

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -428,76 +428,49 @@ end = struct
 
   let combine ctx = List.map Row.combine ctx
 
-  let ctx_matcher p =
-    let p = normalize_pat p in
-    match p.pat_desc with
-    | Tpat_construct (_, cstr, omegas) -> (
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_construct (_, cstr', args)
-          (* NB: may_constr_equal considers (potential) constructor rebinding *)
-            when Types.may_equal_constr cstr cstr' ->
-              (p, args @ rem)
-          | Tpat_any -> (p, omegas @ rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_constant cst -> (
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_constant cst' when const_compare cst cst' = 0 -> (p, rem)
-          | Tpat_any -> (p, rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_variant (lab, Some omega, _) -> (
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_variant (lab', Some arg, _) when lab = lab' -> (p, arg :: rem)
-          | Tpat_any -> (p, omega :: rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_variant (lab, None, _) -> (
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_variant (lab', None, _) when lab = lab' -> (p, rem)
-          | Tpat_any -> (p, rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_array omegas -> (
-        let len = List.length omegas in
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_array args when List.length args = len -> (p, args @ rem)
-          | Tpat_any -> (p, omegas @ rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_tuple omegas -> (
-        let len = List.length omegas in
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_tuple args when List.length args = len -> (p, args @ rem)
-          | Tpat_any -> (p, omegas @ rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_record (((_, lbl, _) :: _ as l), _) -> (
-        (* Records are normalized *)
-        let len = Array.length lbl.lbl_all in
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_record (((_, lbl', _) :: _ as l'), _)
-            when Array.length lbl'.lbl_all = len ->
-              let l' = all_record_args l' in
-              (p, List.fold_right (fun (_, _, p) r -> p :: r) l' rem)
-          | Tpat_any -> (p, List.fold_right (fun (_, _, p) r -> p :: r) l rem)
-          | _ -> raise NoMatch
-      )
-    | Tpat_lazy omega -> (
-        fun q rem ->
-          match q.pat_desc with
-          | Tpat_lazy arg -> (p, arg :: rem)
-          | Tpat_any -> (p, omega :: rem)
-          | _ -> raise NoMatch
-      )
-    | _ -> fatal_error "Matching.Context.matcher"
+  let ctx_matcher p q rem =
+    let rec expand_record p =
+      match p.pat_desc with
+      | Tpat_record (l, _) ->
+          { p with pat_desc = Tpat_record (all_record_args l, Closed) }
+      | Tpat_alias (p, _, _) -> expand_record p
+      | _ -> p
+    in
+    let ph, omegas =
+      let ph, p_args = Pattern_head.deconstruct (expand_record p) in
+      (ph, List.map (fun _ -> omega) p_args)
+    in
+    let qh, args = Pattern_head.deconstruct (expand_record q) in
+    let yes () = (p, args @ rem) in
+    let no () = raise NoMatch in
+    let yesif b =
+      if b then
+        yes ()
+      else
+        no ()
+    in
+    match (Pattern_head.desc ph, Pattern_head.desc qh) with
+    | Any, _ -> fatal_error "Matching.Context.matcher"
+    | _, Any -> (p, omegas @ rem)
+    | Construct cstr, Construct cstr' ->
+        (* NB: may_equal_constr considers (potential) constructor rebinding *)
+        yesif (Types.may_equal_constr cstr cstr')
+    | Construct _, _ -> no ()
+    | Constant cst, Constant cst' -> yesif (const_compare cst cst' = 0)
+    | Constant _, _ -> no ()
+    | Variant { tag; has_arg }, Variant { tag = tag'; has_arg = has_arg' } ->
+        yesif (tag = tag' && has_arg = has_arg')
+    | Variant _, _ -> no ()
+    | Array n1, Array n2 -> yesif (n1 = n2)
+    | Array _, _ -> no ()
+    | Tuple n1, Tuple n2 -> yesif (n1 = n2)
+    | Tuple _, _ -> no ()
+    | Record l, Record l' ->
+        (* we called extend_records on both arguments so l, l' are full *)
+        yesif (List.length l = List.length l')
+    | Record _, _ -> no ()
+    | Lazy, Lazy -> yes ()
+    | Lazy, _ -> no ()
 
   let specialize q ctx =
     let matcher = ctx_matcher q in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -140,19 +140,13 @@ let all_record_args lbls =
       List.iter (fun ((_, lbl, _) as x) -> t.(lbl.lbl_pos) <- x) lbls;
       Array.to_list t
 
-let rec expand_record p =
-  match p.pat_desc with
-  | Tpat_record (l, _) ->
-      { p with pat_desc = Tpat_record (all_record_args l, Closed) }
-  | Tpat_alias (p, _, _) -> expand_record p
-  | _ -> p
-
-let expand_record_head head =
-  match head.pat_desc with
-  | Patterns.Head.Record _ ->
-      head |> Patterns.Head.to_omega_pattern |> expand_record
-      |> Patterns.Head.deconstruct |> fst
-  | _ -> head
+let expand_record_head h =
+  let open Patterns.Head in
+  match h.pat_desc with
+  | Record [] -> fatal_error "Matching.expand_record_head"
+  | Record ({ lbl_all } :: _) ->
+      { h with pat_desc = Record (Array.to_list lbl_all) }
+  | _ -> h
 
 type 'a clause = 'a * lambda
 
@@ -276,7 +270,7 @@ end = struct
 
   type nonrec clause = pattern Non_empty_row.t clause
 
-  let head p = fst (Patterns.Head.deconstruct (Patterns.General.erase p))
+  let head p = fst (Patterns.Head.deconstruct p)
 
   let alpha env (p : pattern) : pattern =
     let alpha_pat env p = Typedtree.alpha_pat env p in
@@ -358,7 +352,7 @@ let matcher discr (p : Simple.pattern) rem =
   let discr = expand_record_head discr in
   let p = expand_record_simple p in
   let omegas = Patterns.(omegas (Head.arity discr)) in
-  let ph, args = Patterns.Head.deconstruct (General.erase p) in
+  let ph, args = Patterns.Head.deconstruct p in
   let yes () = args @ rem in
   let no () = raise NoMatch in
   let yesif b =
@@ -2464,8 +2458,9 @@ let rec list_as_pat = function
 
 let complete_pats_constrs = function
   | p :: _ as pats ->
+      let p_simple = General.(view p |> assert_simple) in
       List.map (pat_of_constr p)
-        (complete_constrs p (List.map get_key_constr pats))
+        (complete_constrs p_simple (List.map get_key_constr pats))
   | _ -> assert false
 
 (*

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -150,6 +150,13 @@ let rec expand_record p =
   | Tpat_alias (p, _, _) -> expand_record p
   | _ -> p
 
+let expand_record_head head =
+  match Pattern_head.desc head with
+  | Record _ ->
+      head |> Pattern_head.to_omega_pattern |> expand_record
+      |> Pattern_head.deconstruct |> fst
+  | _ -> head
+
 type 'a clause = 'a * lambda
 
 module Non_empty_clause = struct
@@ -391,6 +398,12 @@ end = struct
     explode (p : Half_simple.pattern :> General.pattern) [] rem
 end
 
+let expand_record_simple : Simple.pattern -> Simple.pattern =
+ fun p ->
+  match p.pat_desc with
+  | `Record (l, _) -> { p with pat_desc = `Record (all_record_args l, Closed) }
+  | _ -> p
+
 type initial_clause = pattern list clause
 
 type matrix = pattern list list
@@ -503,13 +516,13 @@ end = struct
 
   let combine ctx = List.map Row.combine ctx
 
-  let ctx_matcher p q rem =
-    let ph, omegas =
-      let ph, p_args = Pattern_head.deconstruct (expand_record p) in
-      (ph, List.map (fun _ -> omega) p_args)
+  let ctx_matcher ph (q : Simple.pattern) rem =
+    let ph = expand_record_head ph in
+    let omegas = omegas (Pattern_head.arity ph) in
+    let qh, args =
+      Pattern_head.deconstruct (General.erase (expand_record_simple q))
     in
-    let qh, args = Pattern_head.deconstruct (expand_record q) in
-    let yes () = (p, args @ rem) in
+    let yes () = args @ rem in
     let no () = raise NoMatch in
     let yesif b =
       if b then
@@ -518,8 +531,8 @@ end = struct
         no ()
     in
     match (Pattern_head.desc ph, Pattern_head.desc qh) with
-    | Any, _ -> fatal_error "Matching.Context.matcher"
-    | _, Any -> (p, omegas @ rem)
+    | Any, _ -> rem
+    | _, Any -> omegas @ rem
     | Construct cstr, Construct cstr' ->
         (* NB: may_equal_constr considers (potential) constructor rebinding *)
         yesif (Types.may_equal_constr cstr cstr')
@@ -541,31 +554,30 @@ end = struct
     | Lazy, _ -> no ()
 
   let specialize q ctx =
-    let matcher = ctx_matcher q in
-    let rec filter_rec : t -> t = function
-      | ({ right = p :: ps } as l) :: rem -> (
+    let qh = fst (Pattern_head.deconstruct q) in
+    let nonempty = function
+      | { Row.left = _; right = [] } ->
+          fatal_error "Matching.Context.specialize"
+      | { Row.left; right = p :: ps } -> (left, p, ps)
+    in
+    let ctx = List.map nonempty ctx in
+    let rec filter_rec = function
+      | [] -> []
+      | (left, p, right) :: rem -> (
+          let p = General.view p in
           match p.pat_desc with
-          | Tpat_or (p1, p2, _) ->
-              filter_rec
-                ({ l with right = p1 :: ps }
-                :: { l with
-                     Row.right (* disam not principal, OK *) = p2 :: ps
-                   }
-                :: rem
-                )
-          | Tpat_alias (p, _, _) ->
-              filter_rec ({ l with right = p :: ps } :: rem)
-          | Tpat_var _ -> filter_rec ({ l with right = omega :: ps } :: rem)
-          | _ -> (
+          | `Or (p1, p2, _) ->
+              filter_rec ((left, p1, right) :: (left, p2, right) :: rem)
+          | `Alias (p, _, _) -> filter_rec ((left, p, right) :: rem)
+          | `Var _ -> filter_rec ((left, omega, right) :: rem)
+          | #simple_view as view -> (
+              let p = { p with pat_desc = view } in
               let rem = filter_rec rem in
-              try
-                let to_left, right = matcher p ps in
-                { left = to_left :: l.left; right } :: rem
-              with NoMatch -> rem
+              match ctx_matcher qh p right with
+              | exception NoMatch -> rem
+              | right -> { Row.left = q :: left; right } :: rem
             )
         )
-      | [] -> []
-      | _ -> fatal_error "Matching.Context.specialize"
     in
     filter_rec ctx
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -163,7 +163,7 @@ module Non_empty_clause = struct
     | [], _ -> assert false
     | pat :: patl, act -> ((pat, patl), act)
 
-  let map_head f ((p, patl), act) = ((f p, patl), act)
+  let map_first f ((p, patl), act) = ((f p, patl), act)
 end
 
 type simple_view =
@@ -1112,7 +1112,7 @@ let safe_before ((p, ps), act_p) l =
 
 let half_simplify_nonempty args (cls : Typedtree.pattern Non_empty_clause.t) :
     Half_simple.clause =
-  cls |> Non_empty_clause.map_head General.view |> Half_simple.of_clause ~args
+  cls |> Non_empty_clause.map_first General.view |> Half_simple.of_clause ~args
 
 let half_simplify_clause args (cls : Typedtree.pattern list clause) =
   cls |> Non_empty_clause.of_initial |> half_simplify_nonempty args

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1955,6 +1955,14 @@ let get_expr_args_record head (arg, _mut) rem =
   make_args 0
 
 let divide_record all_labels head ctx pm =
+  (* TODO: there is redundant record expansion going on, with an expansion here
+     (necessary to get the right arity) but also an expansion in the 'matcher'
+     call within Context.specialize. We should use a separate type representation
+     for "expanded heads" to be able to reason statically on when expansion
+     happens, and avoid the redundancy.
+  
+     This is a suggestion by Florian Angeletti in #9493.
+  *)
   let head = expand_record_head head in
   divide_line (Context.specialize head) get_expr_args_record
     (get_pat_args_record (Array.length all_labels))

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -127,10 +127,6 @@ let string_of_lam lam =
   Printlambda.lambda Format.str_formatter lam;
   Format.flush_str_formatter ()
 
-let all_record_labels = function
-  | [] -> fatal_error "Matching.all_record_labels"
-  | { lbl_all } :: _ -> Array.to_list lbl_all
-
 let all_record_args lbls =
   match lbls with
   | [] -> fatal_error "Matching.all_record_args"
@@ -422,6 +418,61 @@ let rec rev_split_at n ps =
 
 exception NoMatch
 
+let matcher discr (p : Simple.pattern) rem =
+  let discr = expand_record_head discr in
+  let p = expand_record_simple p in
+  let omegas = omegas (Pattern_head.arity discr) in
+  let ph, args = Pattern_head.deconstruct (General.erase p) in
+  let yes () = args @ rem in
+  let no () = raise NoMatch in
+  let yesif b =
+    if b then
+      yes ()
+    else
+      no ()
+  in
+  match (Pattern_head.desc discr, Pattern_head.desc ph) with
+  | Any, _ -> rem
+  | ( ( Constant _ | Construct _ | Variant _ | Lazy | Array _ | Record _
+      | Tuple _ ),
+      Any ) ->
+      omegas @ rem
+  | Constant cst, Constant cst' -> yesif (const_compare cst cst' = 0)
+  | Constant _, (Construct _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+  | Construct cstr, Construct cstr' ->
+      (* NB: may_equal_constr considers (potential) constructor rebinding;
+          Types.may_equal_constr does check that the arities are the same,
+          preserving row-size coherence. *)
+      yesif (Types.may_equal_constr cstr cstr')
+  | Construct _, (Constant _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+  | Variant { tag; has_arg }, Variant { tag = tag'; has_arg = has_arg' } ->
+      yesif (tag = tag' && has_arg = has_arg')
+  | Variant _, (Constant _ | Construct _ | Lazy | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+  | Array n1, Array n2 -> yesif (n1 = n2)
+  | Array _, (Constant _ | Construct _ | Variant _ | Lazy | Record _ | Tuple _)
+    ->
+      no ()
+  | Tuple n1, Tuple n2 -> yesif (n1 = n2)
+  | Tuple _, (Constant _ | Construct _ | Variant _ | Lazy | Array _ | Record _)
+    ->
+      no ()
+  | Record l, Record l' ->
+      (* we already expanded the record fully *)
+      yesif (List.length l = List.length l')
+  | Record _, (Constant _ | Construct _ | Variant _ | Lazy | Array _ | Tuple _)
+    ->
+      no ()
+  | Lazy, Lazy -> yes ()
+  | Lazy, (Constant _ | Construct _ | Variant _ | Array _ | Record _ | Tuple _)
+    ->
+      no ()
+
 let ncols = function
   | [] -> 0
   | ps :: _ -> List.length ps
@@ -516,43 +567,6 @@ end = struct
 
   let combine ctx = List.map Row.combine ctx
 
-  let ctx_matcher ph (q : Simple.pattern) rem =
-    let ph = expand_record_head ph in
-    let omegas = omegas (Pattern_head.arity ph) in
-    let qh, args =
-      Pattern_head.deconstruct (General.erase (expand_record_simple q))
-    in
-    let yes () = args @ rem in
-    let no () = raise NoMatch in
-    let yesif b =
-      if b then
-        yes ()
-      else
-        no ()
-    in
-    match (Pattern_head.desc ph, Pattern_head.desc qh) with
-    | Any, _ -> rem
-    | _, Any -> omegas @ rem
-    | Construct cstr, Construct cstr' ->
-        (* NB: may_equal_constr considers (potential) constructor rebinding *)
-        yesif (Types.may_equal_constr cstr cstr')
-    | Construct _, _ -> no ()
-    | Constant cst, Constant cst' -> yesif (const_compare cst cst' = 0)
-    | Constant _, _ -> no ()
-    | Variant { tag; has_arg }, Variant { tag = tag'; has_arg = has_arg' } ->
-        yesif (tag = tag' && has_arg = has_arg')
-    | Variant _, _ -> no ()
-    | Array n1, Array n2 -> yesif (n1 = n2)
-    | Array _, _ -> no ()
-    | Tuple n1, Tuple n2 -> yesif (n1 = n2)
-    | Tuple _, _ -> no ()
-    | Record l, Record l' ->
-        (* we called extend_records on both arguments so l, l' are full *)
-        yesif (List.length l = List.length l')
-    | Record _, _ -> no ()
-    | Lazy, Lazy -> yes ()
-    | Lazy, _ -> no ()
-
   let specialize q ctx =
     let qh = fst (Pattern_head.deconstruct q) in
     let nonempty = function
@@ -573,7 +587,7 @@ end = struct
           | #simple_view as view -> (
               let p = { p with pat_desc = view } in
               let rem = filter_rec rem in
-              match ctx_matcher qh p right with
+              match matcher qh p right with
               | exception NoMatch -> rem
               | right -> { Row.left = q :: left; right } :: rem
             )
@@ -609,62 +623,6 @@ end = struct
 
   let union pss qss = get_mins Row.le (pss @ qss)
 end
-
-let matcher discr p rem =
-  let ph, args =
-    General.erase p |> expand_record |> Pattern_head.deconstruct
-  in
-  let omegas = omegas (Pattern_head.arity discr) in
-  let yes () = args @ rem in
-  let no () = raise NoMatch in
-  let yesif b =
-    if b then
-      yes ()
-    else
-      no ()
-  in
-  match (Pattern_head.desc discr, Pattern_head.desc ph) with
-  | Any, _ -> rem
-  | ( ( Constant _ | Construct _ | Variant _ | Lazy | Array _ | Record _
-      | Tuple _ ),
-      Any ) ->
-      omegas @ rem
-  | Constant cst, Constant cst' -> yesif (const_compare cst cst' = 0)
-  | Constant _, (Construct _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
-    ->
-      no ()
-  | Construct cstr, Construct cstr' ->
-      (* NB: may_equal_constr considers (potential) constructor rebinding;
-          Types.may_equal_constr does check that the arities are the same,
-          preserving row-size coherence. *)
-      yesif (Types.may_equal_constr cstr cstr')
-  | Construct _, (Constant _ | Variant _ | Lazy | Array _ | Record _ | Tuple _)
-    ->
-      no ()
-  | Variant { tag; has_arg }, Variant { tag = tag'; has_arg = has_arg' } ->
-      yesif (tag = tag' && has_arg = has_arg')
-  | Variant _, (Constant _ | Construct _ | Lazy | Array _ | Record _ | Tuple _)
-    ->
-      no ()
-  | Array n1, Array n2 -> yesif (n1 = n2)
-  | Array _, (Constant _ | Construct _ | Variant _ | Lazy | Record _ | Tuple _)
-    ->
-      no ()
-  | Tuple n1, Tuple n2 -> yesif (n1 = n2)
-  | Tuple _, (Constant _ | Construct _ | Variant _ | Lazy | Array _ | Record _)
-    ->
-      no ()
-  | Record l, Record l' ->
-      let l = all_record_labels l in
-      let l' = all_record_labels l' in
-      yesif (List.length l = List.length l')
-  | Record _, (Constant _ | Construct _ | Variant _ | Lazy | Array _ | Tuple _)
-    ->
-      no ()
-  | Lazy, Lazy -> yes ()
-  | Lazy, (Constant _ | Construct _ | Variant _ | Array _ | Record _ | Tuple _)
-    ->
-      no ()
 
 let rec flatten_pat_line size p k =
   match p.pat_desc with

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -822,7 +822,7 @@ let safe_before (p, ps, act_p) l =
    In particular, or-patterns may still occur in the head of the output row,
    so this is only a "half-simplification".
 *)
-let half_simplify_cases args cls =
+let half_simplify_clause args cls =
   let rec simpl_pat p =
     match p.pat_desc with
     | Tpat_any
@@ -880,7 +880,9 @@ let half_simplify_cases args cls =
             (pat, patl, action)
       )
   in
-  List.map simpl_clause cls
+  simpl_clause cls
+
+let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
 (* Once matchings are *fully* simplified, one can easily find
    their nature. *)
@@ -1177,7 +1179,6 @@ let as_matrix cases =
 *)
 
 let rec split_or argo cls args def =
-  let cls = half_simplify_cases args cls in
   let rec do_split rev_before rev_ors rev_no = function
     | [] ->
         cons_next (List.rev rev_before) (List.rev rev_ors) (List.rev rev_no)
@@ -1292,15 +1293,16 @@ and precompile_var args cls def k =
           do_not_precompile args cls def k
       | _ -> (
           (* Precompile *)
+          let var_args = arg :: rargs in
           let var_cls =
             List.map
               (fun (p, ps, act) ->
                 assert (group_var p);
-                (ps, act))
+                half_simplify_clause var_args (ps, act))
               cls
           and var_def = Default_environment.pop_column def in
           let { me = first; matrix }, nexts =
-            split_or (Some v) var_cls (arg :: rargs) var_def
+            split_or (Some v) var_cls var_args var_def
           in
           (* Compute top information *)
           match nexts with
@@ -1409,7 +1411,8 @@ and precompile_or argo cls ors args def k =
     k )
 
 let split_and_precompile argo pm =
-  let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
+  let cases = half_simplify_cases pm.args pm.cases in
+  let { me = next }, nexts = split_or argo cases pm.args pm.default in
   if
     dbg
     && (nexts <> []

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1058,108 +1058,44 @@ let pat_as_constr = function
   | { pat_desc = Tpat_construct (_, cstr, _) } -> cstr
   | _ -> fatal_error "Matching.pat_as_constr"
 
-let group_const_int p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_int _) -> true
-  | _ -> false
-
-let group_const_char p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_char _) -> true
-  | _ -> false
-
-let group_const_string p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_string _) -> true
-  | _ -> false
-
-let group_const_float p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_float _) -> true
-  | _ -> false
-
-let group_const_int32 p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_int32 _) -> true
-  | _ -> false
-
-let group_const_int64 p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_int64 _) -> true
-  | _ -> false
-
-let group_const_nativeint p =
-  match Pattern_head.desc (Simple.head p) with
-  | Constant (Const_nativeint _) -> true
-  | _ -> false
-
-and group_constructor p =
-  match Pattern_head.desc (Simple.head p) with
-  | Construct _ -> true
-  | _ -> false
-
-and group_same_constructor tag p =
-  match Pattern_head.desc (Simple.head p) with
-  | Construct cstr -> Types.equal_tag tag cstr.cstr_tag
-  | _ -> false
-
-and group_variant p =
-  match Pattern_head.desc (Simple.head p) with
-  | Variant _ -> true
-  | _ -> false
-
 and group_var p =
   match Pattern_head.desc (Simple.head p) with
   | Any -> true
   | _ -> false
 
-and group_tuple p =
-  match Pattern_head.desc (Simple.head p) with
-  | Tuple _
-  | Any ->
+let can_group discr pat =
+  match (Pattern_head.desc discr, Pattern_head.desc (Simple.head pat)) with
+  | Any, Any
+  | Constant (Const_int _), Constant (Const_int _)
+  | Constant (Const_char _), Constant (Const_char _)
+  | Constant (Const_string _), Constant (Const_string _)
+  | Constant (Const_float _), Constant (Const_float _)
+  | Constant (Const_int32 _), Constant (Const_int32 _)
+  | Constant (Const_int64 _), Constant (Const_int64 _)
+  | Constant (Const_nativeint _), Constant (Const_nativeint _) ->
       true
-  | _ -> false
-
-and group_record p =
-  match Pattern_head.desc (Simple.head p) with
-  | Record _
-  | Any ->
-      true
-  | _ -> false
-
-and group_array p =
-  match Pattern_head.desc (Simple.head p) with
-  | Array _ -> true
-  | _ -> false
-
-and group_lazy p =
-  match Pattern_head.desc (Simple.head p) with
-  | Lazy -> true
-  | _ -> false
-
-let can_group p =
-  match Pattern_head.desc (Simple.head p) with
-  | Any -> group_var
-  | Constant (Const_int _) -> group_const_int
-  | Constant (Const_char _) -> group_const_char
-  | Constant (Const_string _) -> group_const_string
-  | Constant (Const_float _) -> group_const_float
-  | Constant (Const_int32 _) -> group_const_int32
-  | Constant (Const_int64 _) -> group_const_int64
-  | Constant (Const_nativeint _) -> group_const_nativeint
-  | Construct { cstr_tag = Cstr_extension _ as t } ->
+  | Construct { cstr_tag = Cstr_extension _ as discr_tag }, Construct pat_cstr
+    ->
       (* Extension constructors with distinct names may be equal thanks to
          constructor rebinding. So we need to produce a specialized
          submatrix for each syntactically-distinct constructor (with a threading
          of exits such that each submatrix falls back to the
          potentially-compatible submatrices below it).  *)
-      group_same_constructor t
-  | Construct _ -> group_constructor
-  | Tuple _ -> group_tuple
-  | Record _ -> group_record
-  | Array _ -> group_array
-  | Variant _ -> group_variant
-  | Lazy -> group_lazy
+      Types.equal_tag discr_tag pat_cstr.cstr_tag
+  | Construct _, Construct _
+  | Tuple _, (Tuple _ | Any)
+  | Record _, (Record _ | Any)
+  | Array _, Array _
+  | Variant _, Variant _
+  | Lazy, Lazy ->
+      true
+  | ( _,
+      ( Any
+      | Constant
+          ( Const_int _ | Const_char _ | Const_string _ | Const_float _
+          | Const_int32 _ | Const_int64 _ | Const_nativeint _ )
+      | Construct _ | Tuple _ | Record _ | Array _ | Variant _ | Lazy ) ) ->
+      false
 
 let is_or p =
   match p.pat_desc with
@@ -1361,7 +1297,7 @@ and split_no_or cls args def k =
      different heads match different values), but this is handled by the
      [can_group] function. *)
   let rec split (cls : Simple.clause list) =
-    let discr = what_is_first_case cls in
+    let discr = Simple.head (what_is_first_case cls) in
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
     | [ (((p, ps), _) as cl) ]
@@ -1391,10 +1327,9 @@ and split_no_or cls args def k =
         insert_split group_discr yes no def k
   and insert_split group_discr yes no def k =
     let precompile_group =
-      if group_var group_discr then
-        precompile_var
-      else
-        do_not_precompile
+      match Pattern_head.desc group_discr with
+      | Any -> precompile_var
+      | _ -> do_not_precompile
     in
     match no with
     | [] -> precompile_group args yes def k
@@ -1405,7 +1340,7 @@ and split_no_or cls args def k =
           (Default_environment.cons matrix idef def)
           ((idef, next) :: nexts)
   and should_split group_discr =
-    match Pattern_head.desc (Simple.head group_discr) with
+    match Pattern_head.desc group_discr with
     | Construct { cstr_tag = Cstr_extension _ } ->
         (* it is unlikely that we will raise anything, so we split now *)
         true

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -139,6 +139,181 @@ let all_record_args lbls =
       Array.to_list t
   | _ -> fatal_error "Matching.all_record_args"
 
+type 'a clause = 'a * lambda
+
+module Non_empty_clause = struct
+  type 'a t = ('a * pattern list) clause
+
+  let of_initial = function
+    | [], _ -> assert false
+    | pat :: patl, act -> ((pat, patl), act)
+end
+
+module General = struct
+  type nonrec pattern = pattern
+
+  type clause = pattern Non_empty_clause.t
+end
+
+module Half_simple : sig
+  (** Half-simplified patterns are patterns where:
+        - records are expanded so that they possess all fields
+        - aliases are removed and replaced by bindings in actions.
+
+      Or-patterns are not removed, they are only "half-simplified":
+        - aliases under or-patterns are kept
+        - or-patterns whose right-hand-side is subsumed by their lhs
+          are simplified to their lhs.
+          For instance: [(_ :: _ | 1 :: _)] is changed into [_ :: _]
+        - or-patterns whose left-hand-side is not simplified
+          are preserved: (p|q) is changed into (simpl(p)|simpl(q))
+            {v
+                # match lazy (print_int 3; 3) with _ | lazy 2 -> ();;
+                - : unit = ()
+                # match lazy (print_int 3; 3) with lazy 2 | _ -> ();;
+                3- : unit = ()
+            v}
+
+      In particular, or-patterns may still occur in the leading column,
+      so this is only a "half-simplification". *)
+
+  type pattern
+
+  val to_pattern : pattern -> General.pattern
+
+  type clause = pattern Non_empty_clause.t
+
+  val of_clause : args:(lambda * 'a) list -> General.clause -> clause
+end = struct
+  type nonrec pattern = pattern
+
+  type clause = pattern Non_empty_clause.t
+
+  let to_pattern p = p
+
+  let rec simpl_orpat p =
+    match p.pat_desc with
+    | Tpat_any
+    | Tpat_var _ ->
+        p
+    | Tpat_alias (q, id, s) ->
+        { p with pat_desc = Tpat_alias (simpl_orpat q, id, s) }
+    | Tpat_or (p1, p2, o) ->
+        let p1, p2 = (simpl_orpat p1, simpl_orpat p2) in
+        if le_pat p1 p2 then
+          p1
+        else
+          { p with pat_desc = Tpat_or (p1, p2, o) }
+    | Tpat_record (lbls, closed) ->
+        let all_lbls = all_record_args lbls in
+        { p with pat_desc = Tpat_record (all_lbls, closed) }
+    | _ -> p
+
+  let of_clause ~args cl =
+    let rec aux ((pat, patl), action) =
+      match pat.pat_desc with
+      | Tpat_any -> ((pat, patl), action)
+      | Tpat_var (id, s) ->
+          let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
+          aux ((p, patl), action)
+      | Tpat_alias (p, id, _) ->
+          let arg =
+            match args with
+            | [] -> assert false
+            | (arg, _) :: _ -> arg
+          in
+          let k = Typeopt.value_kind pat.pat_env pat.pat_type in
+          aux ((p, patl), bind_with_value_kind Alias (id, k) arg action)
+      | Tpat_record ([], _) -> ((omega, patl), action)
+      | Tpat_record (lbls, closed) ->
+          let all_lbls = all_record_args lbls in
+          let full_pat =
+            { pat with pat_desc = Tpat_record (all_lbls, closed) }
+          in
+          ((full_pat, patl), action)
+      | Tpat_or _ -> (
+          let pat_simple = simpl_orpat pat in
+          match pat_simple.pat_desc with
+          | Tpat_or _ -> ((pat_simple, patl), action)
+          | _ -> aux ((pat_simple, patl), action)
+        )
+      | Tpat_constant _
+      | Tpat_tuple _
+      | Tpat_construct _
+      | Tpat_variant _
+      | Tpat_array _
+      | Tpat_lazy _ ->
+          ((pat, patl), action)
+    in
+    aux cl
+end
+
+exception Cannot_flatten
+
+module Simple : sig
+  type pattern
+  (** A fully simplified pattern: or-patterns have been exploded, and the
+      remaining aliases have been removed and replaced by bindings in actions *)
+
+  type clause = pattern Non_empty_clause.t
+
+  val try_no_or : Half_simple.pattern -> pattern option
+
+  val to_pattern : pattern -> General.pattern
+
+  val explode_or_pat :
+    Half_simple.pattern * General.pattern list ->
+    arg:Ident.t option ->
+    mk_action:(vars:Ident.t list -> lambda) ->
+    vars:Ident.t list ->
+    clause list ->
+    clause list
+
+  val omega : pattern
+end = struct
+  type nonrec pattern = pattern
+
+  let omega = omega
+
+  type clause = pattern Non_empty_clause.t
+
+  let to_pattern p = p
+
+  let mk_alpha_env arg aliases ids =
+    List.map
+      (fun id ->
+        ( id,
+          if List.mem id aliases then
+            match arg with
+            | Some v -> v
+            | _ -> raise Cannot_flatten
+          else
+            Ident.create_local (Ident.name id) ))
+      ids
+
+  let explode_or_pat (p, patl) ~arg ~mk_action ~vars rem =
+    let rec explode p aliases rem =
+      match p.pat_desc with
+      | Tpat_or (p1, p2, _) -> explode p1 aliases (explode p2 aliases rem)
+      | Tpat_alias (p, id, _) -> explode p (id :: aliases) rem
+      | Tpat_var (x, _) ->
+          let env = mk_alpha_env arg (x :: aliases) vars in
+          ((omega, patl), mk_action ~vars:(List.map snd env)) :: rem
+      | _ ->
+          let env = mk_alpha_env arg aliases vars in
+          ((alpha_pat env p, patl), mk_action ~vars:(List.map snd env)) :: rem
+    in
+    explode (Half_simple.to_pattern p) [] rem
+
+  let try_no_or hsp =
+    let p = Half_simple.to_pattern hsp in
+    match p.pat_desc with
+    | Tpat_or _ -> None
+    | _ -> Some p
+end
+
+type initial_clause = pattern list clause
+
 type matrix = pattern list list
 
 let add_omega_column pss = List.map (fun ps -> omega :: ps) pss
@@ -623,10 +798,6 @@ end
 
 (* Pattern matching before any compilation *)
 
-type initial_row = pattern list * lambda
-
-type half_compiled_row = pattern * pattern list * lambda
-
 type 'row pattern_matching = {
   mutable cases : 'row list;
   args : (lambda * let_kind) list;
@@ -642,11 +813,11 @@ type handler = {
   provenance : matrix;
   exit : int;
   vars : (Ident.t * Lambda.value_kind) list;
-  pm : initial_row pattern_matching
+  pm : initial_clause pattern_matching
 }
 
-type pm_or_compiled = {
-  body : initial_row pattern_matching;
+type 'head_pat pm_or_compiled = {
+  body : 'head_pat Non_empty_clause.t pattern_matching;
   handlers : handler list;
   or_matrix : matrix
 }
@@ -655,9 +826,9 @@ type pm_or_compiled = {
    mixture rule *)
 
 type pm_half_compiled =
-  | PmOr of pm_or_compiled
+  | PmOr of Simple.pattern pm_or_compiled
   | PmVar of { inside : pm_half_compiled }
-  | Pm of half_compiled_row pattern_matching
+  | Pm of Simple.clause pattern_matching
 
 (* Only used inside the various split functions, we only keep [me] when we're
    done splitting / precompiling. *)
@@ -683,19 +854,29 @@ let pretty_pm pm =
     Default_environment.pp pm.default
 
 let pretty_hc_pm pm =
-  pretty_cases (List.map (fun (p, ps, act) -> (p :: ps, act)) pm.cases);
-  if pm.default <> [] then pretty_def pm.default
+  pretty_cases
+    (List.map
+       (fun ((p, ps), act) -> (Half_simple.to_pattern p :: ps, act))
+       pm.cases);
+  if not (Default_environment.is_empty pm.default) then
+    Default_environment.pp pm.default
+
+let pretty_sc_pm pm =
+  pretty_cases
+    (List.map (fun ((p, ps), act) -> (Simple.to_pattern p :: ps, act)) pm.cases);
+  if not (Default_environment.is_empty pm.default) then
+    Default_environment.pp pm.default
 
 let rec pretty_precompiled = function
   | Pm pm ->
       Format.eprintf "++++ PM ++++\n";
-      pretty_hc_pm pm
+      pretty_sc_pm pm
   | PmVar x ->
       Format.eprintf "++++ VAR ++++\n";
       pretty_precompiled x.inside
   | PmOr x ->
       Format.eprintf "++++ OR ++++\n";
-      pretty_pm x.body;
+      pretty_sc_pm x.body;
       pretty_matrix Format.err_formatter x.or_matrix;
       List.iter
         (fun { exit = i; pm; _ } ->
@@ -786,7 +967,7 @@ let same_actions = function
             None
     )
 
-let safe_before (p, ps, act_p) l =
+let safe_before to_pattern ((p, ps), act_p) l =
   (* Test for swapping two clauses *)
   let same_actions act1 act2 =
     match (make_key act1, make_key act2) with
@@ -796,91 +977,13 @@ let safe_before (p, ps, act_p) l =
         false
   in
   List.for_all
-    (fun (q, qs, act_q) ->
-      same_actions act_p act_q || not (may_compats (p :: ps) (q :: qs)))
+    (fun ((q, qs), act_q) ->
+      same_actions act_p act_q
+      || not (may_compats (to_pattern p :: ps) (to_pattern q :: qs)))
     l
 
-(*
-   The half-simplify functions transforms the first column of the match
-     - records are expanded so that they possess all fields
-     - aliases are removed and replaced by bindings in actions.
-
-   However or-patterns are only half-simplified,
-     - aliases under or-patterns are kept
-     - or-patterns whose right-hand-side is subsumed by their lhs
-       are simplified to their lhs.
-       For instance: [(_ :: _ | 1 :: _)] is changed into [_ :: _]
-     - or-patterns whose left-hand-side is not simplified
-       are preserved: (p|q) is changed into (simpl(p)|simpl(q))
-         {v
-             # match lazy (print_int 3; 3) with _ | lazy 2 -> ();;
-             - : unit = ()
-             # match lazy (print_int 3; 3) with lazy 2 | _ -> ();;
-             3- : unit = ()
-         v}
-
-   In particular, or-patterns may still occur in the head of the output row,
-   so this is only a "half-simplification".
-*)
 let half_simplify_clause args cls =
-  let rec simpl_pat p =
-    match p.pat_desc with
-    | Tpat_any
-    | Tpat_var _ ->
-        p
-    | Tpat_alias (q, id, s) ->
-        { p with pat_desc = Tpat_alias (simpl_pat q, id, s) }
-    | Tpat_or (p1, p2, o) ->
-        let p1, p2 = (simpl_pat p1, simpl_pat p2) in
-        if le_pat p1 p2 then
-          p1
-        else
-          { p with pat_desc = Tpat_or (p1, p2, o) }
-    | Tpat_record (lbls, closed) ->
-        let all_lbls = all_record_args lbls in
-        { p with pat_desc = Tpat_record (all_lbls, closed) }
-    | _ -> p
-  in
-  let rec simpl_clause = function
-    | [], _ -> assert false
-    | pat :: patl, action -> (
-        match pat.pat_desc with
-        | Tpat_any -> (pat, patl, action)
-        | Tpat_var (id, s) ->
-            let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
-            simpl_clause (p :: patl, action)
-        | Tpat_alias (p, id, _) ->
-            let arg =
-              match args with
-              | [] -> assert false
-              | (arg, _) :: _ -> arg
-            in
-            let k = Typeopt.value_kind pat.pat_env pat.pat_type in
-            simpl_clause
-              (p :: patl, bind_with_value_kind Alias (id, k) arg action)
-        | Tpat_record ([], _) -> (omega, patl, action)
-        | Tpat_record (lbls, closed) ->
-            let all_lbls = all_record_args lbls in
-            let full_pat =
-              { pat with pat_desc = Tpat_record (all_lbls, closed) }
-            in
-            (full_pat, patl, action)
-        | Tpat_or _ -> (
-            let pat_simple = simpl_pat pat in
-            match pat_simple.pat_desc with
-            | Tpat_or _ -> (pat_simple, patl, action)
-            | _ -> simpl_clause (pat_simple :: patl, action)
-          )
-        | Tpat_constant _
-        | Tpat_tuple _
-        | Tpat_construct _
-        | Tpat_variant _
-        | Tpat_array _
-        | Tpat_lazy _ ->
-            (pat, patl, action)
-      )
-  in
-  simpl_clause cls
+  cls |> Non_empty_clause.of_initial |> Half_simple.of_clause ~args
 
 let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
@@ -889,9 +992,9 @@ let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
 let rec what_is_cases ~skip_any cases =
   match cases with
-  | [] -> omega
-  | (p, _, _) :: rem -> (
-      match p.pat_desc with
+  | [] -> Simple.omega
+  | ((p, _), _) :: rem -> (
+      match (Simple.to_pattern p).pat_desc with
       | Tpat_any when skip_any -> what_is_cases ~skip_any rem
       | Tpat_var _
       | Tpat_or (_, _, _)
@@ -905,36 +1008,6 @@ let what_is_first_case = what_is_cases ~skip_any:false
 
 let what_is_cases = what_is_cases ~skip_any:true
 
-(* Or-pattern expansion, variables are a complication w.r.t. the article *)
-
-exception Cannot_flatten
-
-let mk_alpha_env arg aliases ids =
-  List.map
-    (fun id ->
-      ( id,
-        if List.mem id aliases then
-          match arg with
-          | Some v -> v
-          | _ -> raise Cannot_flatten
-        else
-          Ident.create_local (Ident.name id) ))
-    ids
-
-let rec explode_or_pat p arg patl mk_action vars aliases rem =
-  match p.pat_desc with
-  | Tpat_or (p1, p2, _) ->
-      explode_or_pat p1 arg patl mk_action vars aliases
-        (explode_or_pat p2 arg patl mk_action vars aliases rem)
-  | Tpat_alias (p, id, _) ->
-      explode_or_pat p arg patl mk_action vars (id :: aliases) rem
-  | Tpat_var (x, _) ->
-      let env = mk_alpha_env arg (x :: aliases) vars in
-      (omega :: patl, mk_action (List.map snd env)) :: rem
-  | _ ->
-      let env = mk_alpha_env arg aliases vars in
-      (alpha_pat env p :: patl, mk_action (List.map snd env)) :: rem
-
 let pm_free_variables { cases } =
   List.fold_right
     (fun (_, act) r -> Ident.Set.union (free_variables act) r)
@@ -945,69 +1018,89 @@ let pat_as_constr = function
   | { pat_desc = Tpat_construct (_, cstr, _) } -> cstr
   | _ -> fatal_error "Matching.pat_as_constr"
 
-let group_const_int = function
-  | { pat_desc = Tpat_constant (Const_int _) } -> true
+let group_const_int p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_int _) -> true
   | _ -> false
 
-let group_const_char = function
-  | { pat_desc = Tpat_constant (Const_char _) } -> true
+let group_const_char p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_char _) -> true
   | _ -> false
 
-let group_const_string = function
-  | { pat_desc = Tpat_constant (Const_string _) } -> true
+let group_const_string p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_string _) -> true
   | _ -> false
 
-let group_const_float = function
-  | { pat_desc = Tpat_constant (Const_float _) } -> true
+let group_const_float p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_float _) -> true
   | _ -> false
 
-let group_const_int32 = function
-  | { pat_desc = Tpat_constant (Const_int32 _) } -> true
+let group_const_int32 p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_int32 _) -> true
   | _ -> false
 
-let group_const_int64 = function
-  | { pat_desc = Tpat_constant (Const_int64 _) } -> true
+let group_const_int64 p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_int64 _) -> true
   | _ -> false
 
-let group_const_nativeint = function
-  | { pat_desc = Tpat_constant (Const_nativeint _) } -> true
+let group_var_p p =
+  match p.pat_desc with
+  | Tpat_any -> true
   | _ -> false
 
-and group_constructor = function
-  | { pat_desc = Tpat_construct (_, _, _) } -> true
+let group_const_nativeint p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_constant (Const_nativeint _) -> true
   | _ -> false
 
-and group_same_constructor tag = function
-  | { pat_desc = Tpat_construct (_, cstr, _) } ->
-      Types.equal_tag tag cstr.cstr_tag
+and group_constructor p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_construct (_, _, _) -> true
   | _ -> false
 
-and group_variant = function
-  | { pat_desc = Tpat_variant (_, _, _) } -> true
+and group_same_constructor tag p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_construct (_, cstr, _) -> Types.equal_tag tag cstr.cstr_tag
   | _ -> false
 
-and group_var = function
-  | { pat_desc = Tpat_any } -> true
+and group_variant p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_variant (_, _, _) -> true
   | _ -> false
 
-and group_tuple = function
-  | { pat_desc = Tpat_tuple _ | Tpat_any } -> true
+and group_var p = group_var_p (Simple.to_pattern p)
+
+and group_tuple p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_tuple _
+  | Tpat_any ->
+      true
   | _ -> false
 
-and group_record = function
-  | { pat_desc = Tpat_record _ | Tpat_any } -> true
+and group_record p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_record _
+  | Tpat_any ->
+      true
   | _ -> false
 
-and group_array = function
-  | { pat_desc = Tpat_array _ } -> true
+and group_array p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_array _ -> true
   | _ -> false
 
-and group_lazy = function
-  | { pat_desc = Tpat_lazy _ } -> true
+and group_lazy p =
+  match (Simple.to_pattern p).pat_desc with
+  | Tpat_lazy _ -> true
   | _ -> false
 
 let can_group p =
-  match p.pat_desc with
+  match (Simple.to_pattern p).pat_desc with
   | Tpat_any -> group_var
   | Tpat_constant (Const_int _) -> group_const_int
   | Tpat_constant (Const_char _) -> group_const_char
@@ -1047,11 +1140,11 @@ let rec omega_like p =
 
 let equiv_pat p q = le_pat p q && le_pat q p
 
-let rec extract_equiv_head p l =
+let rec extract_equiv_head to_pattern p l =
   match l with
-  | ((q, _, _) as cl) :: rem ->
-      if equiv_pat p q then
-        let others, rem = extract_equiv_head p rem in
+  | (((q, _), _) as cl) :: rem ->
+      if equiv_pat p (to_pattern q) then
+        let others, rem = extract_equiv_head to_pattern p rem in
         (cl :: others, rem)
       else
         ([], l)
@@ -1080,11 +1173,12 @@ module Or_matrix = struct
   let safe_below (ps, act) qs =
     (not (is_guarded act)) && Parmatch.le_pats ps qs
 
-  let safe_below_or_matrix l (q, qs) =
+  let safe_below_or_matrix to_pattern l (q, qs) =
     List.for_all
-      (function
-        | ({ pat_desc = Tpat_or _ } as p), ps, act_p ->
-            disjoint p q || safe_below (ps, act_p) qs
+      (fun ((p, ps), act_p) ->
+        let p = to_pattern p in
+        match p.pat_desc with
+        | Tpat_or _ -> disjoint p q || safe_below (ps, act_p) qs
         | _ -> true)
       l
 
@@ -1094,19 +1188,23 @@ module Or_matrix = struct
 
      If neither are possible we add to the bottom of the No matrix.
    *)
-  let insert_or_append (p, ps, act) rev_ors rev_no =
+  let insert_or_append (head, ps, act) rev_ors rev_no =
     let safe_to_insert rem (p, ps) seen =
-      let _, not_e = extract_equiv_head p rem in
+      let _, not_e = extract_equiv_head Half_simple.to_pattern p rem in
       (* check append condition for head of O *)
-      safe_below_or_matrix not_e (p, ps)
+      safe_below_or_matrix Half_simple.to_pattern not_e (p, ps)
       && (* check insert condition for tail of O *)
-         List.for_all (fun (q, _, _) -> disjoint p q) seen
+         List.for_all
+           (fun ((q, _), _) -> disjoint p (Half_simple.to_pattern q))
+           seen
     in
     let rec attempt seen = function
       (* invariant: the new clause is safe to append at the end of
          [seen] (but maybe not [rem] yet) *)
-      | [] -> ((p, ps, act) :: rev_ors, rev_no)
-      | ((q, qs, act_q) as cl) :: rem ->
+      | [] -> (((head, ps), act) :: rev_ors, rev_no)
+      | (((q, qs), act_q) as cl) :: rem ->
+          let p = Half_simple.to_pattern head in
+          let q = Half_simple.to_pattern q in
           if (not (is_or q)) || disjoint p q then
             attempt (cl :: seen) rem
           else if
@@ -1116,22 +1214,22 @@ module Or_matrix = struct
           then
             (* attempt insertion, for equivalent orpats with no variables *)
             if safe_to_insert rem (p, ps) seen then
-              (List.rev_append seen ((p, ps, act) :: cl :: rem), rev_no)
+              (List.rev_append seen (((head, ps), act) :: cl :: rem), rev_no)
             else
               (* fail to insert or append *)
-              (rev_ors, (p, ps, act) :: rev_no)
+              (rev_ors, ((head, ps), act) :: rev_no)
           else if safe_below (qs, act_q) ps then
             attempt (cl :: seen) rem
           else
-            (rev_ors, (p, ps, act) :: rev_no)
+            (rev_ors, ((head, ps), act) :: rev_no)
     in
     attempt [] rev_ors
 end
 
 (* Reconstruct default information from half_compiled  pm list *)
 
-let as_matrix cases =
-  get_mins le_pats (List.map (fun (p, ps, _) -> p :: ps) cases)
+let as_matrix pat_of_head cases =
+  get_mins le_pats (List.map (fun ((p, ps), _) -> pat_of_head p :: ps) cases)
 
 (*
   Split a matching along the first column.
@@ -1178,20 +1276,22 @@ let as_matrix cases =
 
 *)
 
-let rec split_or argo cls args def =
-  let rec do_split rev_before rev_ors rev_no = function
+let rec split_or argo (cls : Half_simple.clause list) args def =
+  let rec do_split (rev_before : Simple.clause list) rev_ors rev_no = function
     | [] ->
         cons_next (List.rev rev_before) (List.rev rev_ors) (List.rev rev_no)
-    | ((p, ps, act) as cl) :: rem ->
-        if not (safe_before cl rev_no) then
-          do_split rev_before rev_ors (cl :: rev_no) rem
-        else if (not (is_or p)) && safe_before cl rev_ors then
-          do_split (cl :: rev_before) rev_ors rev_no rem
-        else
-          let rev_ors, rev_no =
-            Or_matrix.insert_or_append (p, ps, act) rev_ors rev_no
-          in
-          do_split rev_before rev_ors rev_no rem
+    | cl :: rem when not (safe_before Half_simple.to_pattern cl rev_no) ->
+        do_split rev_before rev_ors (cl :: rev_no) rem
+    | (((p, ps), act) as cl) :: rem -> (
+        match Simple.try_no_or p with
+        | Some sp when safe_before Half_simple.to_pattern cl rev_ors ->
+            do_split (((sp, ps), act) :: rev_before) rev_ors rev_no rem
+        | _ ->
+            let rev_ors, rev_no =
+              Or_matrix.insert_or_append (p, ps, act) rev_ors rev_no
+            in
+            do_split rev_before rev_ors rev_no rem
+      )
   and cons_next yes yesor no =
     let def, nexts =
       match no with
@@ -1223,13 +1323,12 @@ and split_no_or cls args def k =
      (where it is not always possible to syntactically decide whether two
      different heads match different values), but this is handled by the
      [can_group] function. *)
-  let rec split cls =
+  let rec split (cls : Simple.clause list) =
     let discr = what_is_first_case cls in
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
-    | ([], _) :: _ -> assert false
-    | [ ((p, ps, _) as cl) ]
-      when rev_yes <> [] && List.for_all omega_like (p :: ps) ->
+    | [ (((p, ps), _) as cl) ]
+      when rev_yes <> [] && group_var p && List.for_all omega_like ps ->
         (* This enables an extra division in some frequent cases:
                last row is made of variables only
 
@@ -1241,8 +1340,9 @@ and split_no_or cls args def k =
            This optimisation is tested in the first part of
            testsuite/tests/basic/patmatch_split_no_or.ml *)
         collect group_discr rev_yes (cl :: rev_no) []
-    | ((p, _, _) as cl) :: rem ->
-        if can_group group_discr p && safe_before cl rev_no then
+    | (((p, _), _) as cl) :: rem ->
+        if can_group group_discr p && safe_before Simple.to_pattern cl rev_no
+        then
           collect group_discr (cl :: rev_yes) rev_no rem
         else if should_split group_discr then (
           assert (rev_no = []);
@@ -1269,7 +1369,7 @@ and split_no_or cls args def k =
           (Default_environment.cons matrix idef def)
           ((idef, next) :: nexts)
   and should_split group_discr =
-    match group_discr.pat_desc with
+    match (Simple.to_pattern group_discr).pat_desc with
     | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
         (* it is unlikely that we will raise anything, so we split now *)
         true
@@ -1296,7 +1396,7 @@ and precompile_var args cls def k =
           let var_args = arg :: rargs in
           let var_cls =
             List.map
-              (fun (p, ps, act) ->
+              (fun ((p, ps), act) ->
                 assert (group_var p);
                 half_simplify_clause var_args (ps, act))
               cls
@@ -1312,7 +1412,7 @@ and precompile_var args cls def k =
           | _ ->
               let rec rebuild_matrix pmh =
                 match pmh with
-                | Pm pm -> as_matrix pm.cases
+                | Pm pm -> as_matrix Simple.to_pattern pm.cases
                 | PmOr { or_matrix = m } -> m
                 | PmVar x -> add_omega_column (rebuild_matrix x.inside)
               in
@@ -1348,71 +1448,85 @@ and precompile_var args cls def k =
 
 and do_not_precompile args cls def k =
   ( { me = Pm { cases = cls; args; default = def };
-      matrix = as_matrix cls;
+      matrix = as_matrix Simple.to_pattern cls;
       top_default = def
     },
     k )
 
 and precompile_or argo cls ors args def k =
   let rec do_cases = function
-    | (({ pat_desc = Tpat_or _ } as orp), patl, action) :: rem ->
-        let others, rem = extract_equiv_head orp rem in
-        let orpm =
-          { cases =
-              (patl, action)
-              :: List.map (fun (_, ps, action) -> (ps, action)) others;
-            args =
-              ( match args with
-              | _ :: r -> r
-              | _ -> assert false
-              );
-            default = Default_environment.pop_compat orp def
-          }
-        in
-        let pm_fv = pm_free_variables orpm in
-        let vars =
-          (* bound variables of the or-pattern and used in the orpm actions *)
-          Typedtree.pat_bound_idents_full orp
-          |> List.filter (fun (id, _, _) -> Ident.Set.mem id pm_fv)
-          |> List.map (fun (id, _, ty) ->
-                 (id, Typeopt.value_kind orp.pat_env ty))
-        in
-        let or_num = next_raise_count () in
-        let new_patl = Parmatch.omega_list patl in
-        let mk_new_action vs =
-          Lstaticraise (or_num, List.map (fun v -> Lvar v) vs)
-        in
-        let rem_cases, rem_handlers = do_cases rem in
-        let cases =
-          explode_or_pat orp argo new_patl mk_new_action (List.map fst vars) []
-            rem_cases
-        in
-        let handler =
-          { provenance = [ [ orp ] ]; exit = or_num; vars; pm = orpm }
-        in
-        (cases, handler :: rem_handlers)
-    | (p, ps, act) :: rem ->
-        let new_ord, new_to_catch = do_cases rem in
-        ((p :: ps, act) :: new_ord, new_to_catch)
     | [] -> ([], [])
+    | ((p, patl), action) :: rem -> (
+        match Simple.try_no_or p with
+        | Some sp ->
+            let new_ord, new_to_catch = do_cases rem in
+            (((sp, patl), action) :: new_ord, new_to_catch)
+        | None ->
+            let orp = Half_simple.to_pattern p in
+            let others, rem =
+              extract_equiv_head Half_simple.to_pattern orp rem
+            in
+            let orpm =
+              { cases =
+                  (patl, action)
+                  :: List.map (fun ((_, ps), action) -> (ps, action)) others;
+                args =
+                  ( match args with
+                  | _ :: r -> r
+                  | _ -> assert false
+                  );
+                default = Default_environment.pop_compat orp def
+              }
+            in
+            let pm_fv = pm_free_variables orpm in
+            let vars =
+              (* bound variables of the or-pattern and used in the orpm actions *)
+              Typedtree.pat_bound_idents_full orp
+              |> List.filter (fun (id, _, _) -> Ident.Set.mem id pm_fv)
+              |> List.map (fun (id, _, ty) ->
+                     (id, Typeopt.value_kind orp.pat_env ty))
+            in
+            let or_num = next_raise_count () in
+            let new_patl = Parmatch.omega_list patl in
+            let mk_new_action ~vars =
+              Lstaticraise (or_num, List.map (fun v -> Lvar v) vars)
+            in
+            let rem_cases, rem_handlers = do_cases rem in
+            let cases =
+              Simple.explode_or_pat (p, new_patl) ~arg:argo
+                ~mk_action:mk_new_action ~vars:(List.map fst vars) rem_cases
+            in
+            let handler =
+              { provenance = [ [ orp (* FIXME? *) ] ];
+                exit = or_num;
+                vars;
+                pm = orpm
+              }
+            in
+            (cases, handler :: rem_handlers)
+      )
   in
   let cases, handlers = do_cases ors in
-  let matrix = as_matrix (cls @ ors)
-  and body =
-    { cases = List.map (fun (p, ps, act) -> (p :: ps, act)) cls @ cases;
-      args;
-      default = def
-    }
-  in
+  let matrix =
+    as_matrix
+      (fun x -> x)
+      (List.map (fun ((p, ps), act) -> ((Simple.to_pattern p, ps), act)) cls
+      @ List.map
+          (fun ((p, ps), act) -> ((Half_simple.to_pattern p, ps), act))
+          ors
+      )
+  and body = { cases = cls @ cases; args; default = def } in
   ( { me = PmOr { body; handlers; or_matrix = matrix };
       matrix;
       top_default = def
     },
     k )
 
-let split_and_precompile argo pm =
-  let cases = half_simplify_cases pm.args pm.cases in
-  let { me = next }, nexts = split_or argo cases pm.args pm.default in
+let split_and_precompile_nonempty argo pm =
+  let pm =
+    { pm with cases = List.map (Half_simple.of_clause ~args:pm.args) pm.cases }
+  in
+  let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
   if
     dbg
     && (nexts <> []
@@ -1423,7 +1537,42 @@ let split_and_precompile argo pm =
        )
   then (
     Format.eprintf "** SPLIT **\n";
-    pretty_pm pm;
+    pretty_hc_pm pm;
+    pretty_precompiled_res next nexts
+  );
+  (next, nexts)
+
+let split_and_precompile_simplified pm =
+  let { me = next }, nexts = split_no_or pm.cases pm.args pm.default [] in
+  if
+    dbg
+    && (nexts <> []
+       ||
+       match next with
+       | PmOr _ -> true
+       | _ -> false
+       )
+  then (
+    Format.eprintf "** SPLIT **\n";
+    pretty_sc_pm pm;
+    pretty_precompiled_res next nexts
+  );
+  (next, nexts)
+
+let split_and_precompile argo pm =
+  let pm = { pm with cases = half_simplify_cases pm.args pm.cases } in
+  let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
+  if
+    dbg
+    && (nexts <> []
+       ||
+       match next with
+       | PmOr _ -> true
+       | _ -> false
+       )
+  then (
+    Format.eprintf "** SPLIT **\n";
+    pretty_hc_pm pm;
     pretty_precompiled_res next nexts
   );
   (next, nexts)
@@ -1431,7 +1580,7 @@ let split_and_precompile argo pm =
 (* General divide functions *)
 
 type cell = {
-  pm : initial_row pattern_matching;
+  pm : initial_clause pattern_matching;
   ctx : Context.t;
   discr : pattern
 }
@@ -1457,8 +1606,9 @@ let add_in_div make_matching_fun eq_key key patl_action division =
   { division with cells }
 
 let divide make eq_key get_key get_args ctx
-    (pm : half_compiled_row pattern_matching) =
-  let add (p, patl, action) division =
+    (pm : Simple.clause pattern_matching) =
+  let add ((p, patl), action) division =
+    let p = Simple.to_pattern p in
     add_in_div (make p pm.default ctx) eq_key (get_key p)
       (get_args p patl, action)
       division
@@ -1470,8 +1620,9 @@ let add_line patl_action pm =
   pm
 
 let divide_line make_ctx make get_args discr ctx
-    (pm : half_compiled_row pattern_matching) =
-  let add (p, patl, action) submatrix =
+    (pm : Simple.clause pattern_matching) =
+  let add ((p, patl), action) submatrix =
+    let p = Simple.to_pattern p in
     add_line (get_args p patl, action) submatrix
   in
   let pm = List.fold_right add pm.cases (make pm.default pm.args) in
@@ -1691,29 +1842,36 @@ let make_variant_matching_nonconst p lab def ctx = function
 let divide_variant row ctx { cases = cl; args; default = def } =
   let row = Btype.row_repr row in
   let rec divide = function
-    | (({ pat_desc = Tpat_variant (lab, pato, _) } as p), patl, action) :: rem
-      -> (
-        let variants = divide rem in
-        if
-          try Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
-          with Not_found -> true
-        then
-          variants
-        else
-          let tag = Btype.hash_variant lab in
-          match pato with
-          | None ->
-              add_in_div
-                (make_variant_matching_constant p lab def ctx)
-                ( = ) (Cstr_constant tag) (patl, action) variants
-          | Some pat ->
-              add_in_div
-                (make_variant_matching_nonconst p lab def ctx)
-                ( = ) (Cstr_block tag)
-                (pat :: patl, action)
-                variants
+    | [] -> { args; cells = [] }
+    | ((p, patl), action) :: rem -> (
+        let p = Simple.to_pattern p in
+        match p.pat_desc with
+        | Tpat_variant (lab, pato, _) -> (
+            let variants = divide rem in
+            if
+              try
+                Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
+              with Not_found -> true
+            then
+              variants
+            else
+              let tag = Btype.hash_variant lab in
+              match pato with
+              | None ->
+                  add_in_div
+                    (make_variant_matching_constant p lab def ctx)
+                    ( = ) (Cstr_constant tag) (patl, action) variants
+              | Some pat ->
+                  add_in_div
+                    (make_variant_matching_nonconst p lab def ctx)
+                    ( = ) (Cstr_block tag)
+                    (pat :: patl, action)
+                    variants
+          )
+        | _ ->
+            (* I really want to assert false here. *)
+            { args; cells = [] }
       )
-    | _ -> { args; cells = [] }
   in
   divide cl
 
@@ -3074,7 +3232,7 @@ let arg_to_var arg cls =
    Output: a lambda term, a jump summary {..., exit number -> context, .. }
 *)
 
-let rec compile_match repr partial ctx (m : initial_row pattern_matching) =
+let rec compile_match repr partial ctx (m : initial_clause pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
   | { cases = ([], action) :: rem } ->
@@ -3089,6 +3247,50 @@ let rec compile_match repr partial ctx (m : initial_row pattern_matching) =
       let v, newarg = arg_to_var arg m.cases in
       let first_match, rem =
         split_and_precompile (Some v) { m with args = (newarg, Alias) :: argl }
+      in
+      let lam, total =
+        comp_match_handlers
+          (( if dbg then
+             do_compile_matching_pr
+           else
+             do_compile_matching
+           )
+             repr)
+          partial ctx first_match rem
+      in
+      (bind_check str v arg lam, total)
+  | _ -> assert false
+
+and compile_simplified repr partial ctx (m : Simple.clause pattern_matching) =
+  match m with
+  | { cases = []; args = [] } -> comp_exit ctx m
+  | { args = ((Lvar v as arg), str) :: argl } ->
+      (* Not sure we need to do anything with arg/v *)
+      let first_match, rem =
+        split_and_precompile_simplified { m with args = (arg, Alias) :: argl }
+      in
+      let lam, total =
+        comp_match_handlers
+          (( if dbg then
+             do_compile_matching_pr
+           else
+             do_compile_matching
+           )
+             repr)
+          partial ctx first_match rem
+      in
+      (bind_check str v arg lam, total)
+  | _ -> assert false
+
+and compile_half_compiled repr partial ctx
+    (m : pattern Non_empty_clause.t pattern_matching) =
+  match m with
+  | { cases = []; args = [] } -> comp_exit ctx m
+  | { args = ((Lvar v as arg), str) :: argl } ->
+      (* Not sure we need to do anything with arg/v *)
+      let first_match, rem =
+        split_and_precompile_nonempty (Some v)
+          { m with args = (arg, Alias) :: argl }
       in
       let lam, total =
         comp_match_handlers
@@ -3135,6 +3337,7 @@ and do_compile_matching repr partial ctx pmh =
             assert false
       in
       let pat = what_is_cases pm.cases in
+      let pat = Simple.to_pattern pat in
       match pat.pat_desc with
       | Tpat_any ->
           compile_no_test divide_var Context.rshift repr partial ctx pm
@@ -3183,7 +3386,7 @@ and do_compile_matching repr partial ctx pmh =
       in
       (lam, Jumps.map Context.rshift total)
   | PmOr { body; handlers } ->
-      let lam, total = compile_match repr partial ctx body in
+      let lam, total = compile_simplified repr partial ctx body in
       compile_orhandlers (compile_match repr partial) lam total ctx handlers
 
 and compile_no_test divide up_ctx repr partial ctx to_match =
@@ -3531,24 +3734,16 @@ let flatten_pattern size p =
 
 let flatten_cases size cases =
   List.map
-    (fun (ps, action) ->
-      match ps with
-      | [ p ] -> (flatten_pattern size p, action)
-      | _ -> fatal_error "Matching.flatten_case")
-    cases
-
-let flatten_hc_cases size cases =
-  List.map
     (function
-      | p, [], action -> (
-          match flatten_pattern size p with
-          | p :: ps -> (p, ps, action)
+      | (p, []), action -> (
+          match flatten_pattern size (Simple.to_pattern p) with
+          | p :: ps -> ((p, ps), action)
           | [] -> assert false
         )
       | _ -> fatal_error "Matching.flatten_hc_cases")
     cases
 
-let flatten_pm flatten_cases size args pm =
+let flatten_pm size args pm =
   { args;
     cases = flatten_cases size pm.cases;
     default = Default_environment.flatten size pm.default
@@ -3557,12 +3752,16 @@ let flatten_pm flatten_cases size args pm =
 let flatten_handler size handler =
   { handler with provenance = flatten_matrix size handler.provenance }
 
+type pm_flattened =
+  | FPmOr of pattern pm_or_compiled
+  | FPm of pattern Non_empty_clause.t pattern_matching
+
 let flatten_precompiled size args pmh =
   match pmh with
-  | Pm pm -> Pm (flatten_pm flatten_hc_cases size args pm)
+  | Pm pm -> FPm (flatten_pm size args pm)
   | PmOr { body = b; handlers = hs; or_matrix = m } ->
-      PmOr
-        { body = flatten_pm flatten_cases size args b;
+      FPmOr
+        { body = flatten_pm size args b;
           handlers = List.map (flatten_handler size) hs;
           or_matrix = flatten_matrix size m
         }
@@ -3575,15 +3774,10 @@ let flatten_precompiled size args pmh =
 
 let compile_flattened repr partial ctx pmh =
   match pmh with
-  | Pm pm ->
-      compile_match repr partial ctx
-        { pm with
-          cases = List.map (fun (p, ps, act) -> (p :: ps, act)) pm.cases
-        }
-  | PmOr { body = b; handlers = hs } ->
-      let lam, total = compile_match repr partial ctx b in
+  | FPm pm -> compile_half_compiled repr partial ctx pm
+  | FPmOr { body = b; handlers = hs } ->
+      let lam, total = compile_half_compiled repr partial ctx b in
       compile_orhandlers (compile_match repr partial) lam total ctx hs
-  | PmVar _ -> assert false
 
 let do_for_multiple_match loc paraml pat_act_list partial =
   let repr = None in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1489,59 +1489,38 @@ and precompile_or argo (cls : Simple.clause list) ors args def k =
     },
     k )
 
+let dbg_split_and_precompile pm next nexts =
+  if
+    dbg
+    && (nexts <> []
+       ||
+       match next with
+       | PmOr _ -> true
+       | _ -> false
+       )
+  then (
+    Format.eprintf "** SPLIT **\n";
+    pretty_hc_pm pm;
+    pretty_precompiled_res next nexts
+  )
+
 let split_and_precompile_nonempty argo pm =
   let pm =
     { pm with cases = List.map (half_simplify_nonempty pm.args) pm.cases }
   in
   let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
-  if
-    dbg
-    && (nexts <> []
-       ||
-       match next with
-       | PmOr _ -> true
-       | _ -> false
-       )
-  then (
-    Format.eprintf "** SPLIT **\n";
-    pretty_hc_pm pm;
-    pretty_precompiled_res next nexts
-  );
+  dbg_split_and_precompile pm next nexts;
   (next, nexts)
 
 let split_and_precompile_simplified pm =
   let { me = next }, nexts = split_no_or pm.cases pm.args pm.default [] in
-  if
-    dbg
-    && (nexts <> []
-       ||
-       match next with
-       | PmOr _ -> true
-       | _ -> false
-       )
-  then (
-    Format.eprintf "** SPLIT **\n";
-    pretty_sc_pm pm;
-    pretty_precompiled_res next nexts
-  );
+  dbg_split_and_precompile pm next nexts;
   (next, nexts)
 
 let split_and_precompile argo pm =
   let pm = { pm with cases = half_simplify_cases pm.args pm.cases } in
   let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
-  if
-    dbg
-    && (nexts <> []
-       ||
-       match next with
-       | PmOr _ -> true
-       | _ -> false
-       )
-  then (
-    Format.eprintf "** SPLIT **\n";
-    pretty_hc_pm pm;
-    pretty_precompiled_res next nexts
-  );
+  dbg_split_and_precompile pm next nexts;
   (next, nexts)
 
 (* General divide functions *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3194,17 +3194,7 @@ and compile_match_nonempty repr partial ctx
       let cases = List.map (half_simplify_nonempty args) m.cases in
       let m = { m with args; cases } in
       let first_match, rem = split_and_precompile_half_simplified (Some v) m in
-      let lam, total =
-        comp_match_handlers
-          (( if dbg then
-             do_compile_matching_pr
-           else
-             do_compile_matching
-           )
-             repr)
-          partial ctx first_match rem
-      in
-      (bind_check str v arg lam, total)
+      combine_handlers repr partial ctx (v, str, arg) first_match rem
   | _ -> assert false
 
 and compile_match_simplified repr partial ctx
@@ -3215,18 +3205,21 @@ and compile_match_simplified repr partial ctx
       let args = (arg, Alias) :: argl in
       let m = { m with args } in
       let first_match, rem = split_and_precompile_simplified m in
-      let lam, total =
-        comp_match_handlers
-          (( if dbg then
-             do_compile_matching_pr
-           else
-             do_compile_matching
-           )
-             repr)
-          partial ctx first_match rem
-      in
-      (bind_check str v arg lam, total)
+      combine_handlers repr partial ctx (v, str, arg) first_match rem
   | _ -> assert false
+
+and combine_handlers repr partial ctx (v, str, arg) first_match rem =
+  let lam, total =
+    comp_match_handlers
+      (( if dbg then
+         do_compile_matching_pr
+       else
+         do_compile_matching
+       )
+         repr)
+      partial ctx first_match rem
+  in
+  (bind_check str v arg lam, total)
 
 (* verbose version of do_compile_matching, for debug *)
 and do_compile_matching_pr repr partial ctx x =

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3609,35 +3609,37 @@ let do_for_multiple_match loc paraml pat_act_list partial =
       } )
   in
   try
-    try
-      (* Once for checking that compilation is possible *)
-      let next, nexts = split_and_precompile ~arg_id:None pm1 in
-      let size = List.length paraml
-      and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
-      let args = List.map (fun id -> (Lvar id, Alias)) idl in
-      let flat_next = flatten_precompiled size args next
-      and flat_nexts =
-        List.map (fun (e, pm) -> (e, flatten_precompiled size args pm)) nexts
-      in
-      let lam, total =
-        comp_match_handlers (compile_flattened repr) partial
-          (Context.start size) flat_next flat_nexts
-      in
-      List.fold_right2 (bind Strict) idl paraml
-        ( match partial with
-        | Partial -> check_total total lam raise_num (partial_function loc)
+    match split_and_precompile ~arg_id:None pm1 with
+    | exception Cannot_flatten -> (
+        (* One pattern binds the whole tuple, flattening is not possible.
+           We need to allocate the scrutinee. *)
+        let lambda, total = compile_match None partial (Context.start 1) pm1 in
+        match partial with
+        | Partial -> check_total total lambda raise_num (partial_function loc)
         | Total ->
             assert (Jumps.is_empty total);
-            lam
-        )
-    with Cannot_flatten -> (
-      let lambda, total = compile_match None partial (Context.start 1) pm1 in
-      match partial with
-      | Partial -> check_total total lambda raise_num (partial_function loc)
-      | Total ->
-          assert (Jumps.is_empty total);
-          lambda
-    )
+            lambda
+      )
+    | next, nexts ->
+        let size = List.length paraml
+        and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
+        let args = List.map (fun id -> (Lvar id, Alias)) idl in
+        (* This will not raise, since the PM is well typed. *)
+        let flat_next = flatten_precompiled size args next
+        and flat_nexts =
+          List.map (fun (e, pm) -> (e, flatten_precompiled size args pm)) nexts
+        in
+        let lam, total =
+          comp_match_handlers (compile_flattened repr) partial
+            (Context.start size) flat_next flat_nexts
+        in
+        List.fold_right2 (bind Strict) idl paraml
+          ( match partial with
+          | Partial -> check_total total lam raise_num (partial_function loc)
+          | Total ->
+              assert (Jumps.is_empty total);
+              lam
+          )
   with Unused -> assert false
 
 (* ; partial_function loc () *)

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -1,0 +1,60 @@
+(* TEST
+   flags = "-drawlambda"
+   * expect
+*)
+
+(* Successful flattening *)
+
+match (3, 2, 1) with
+| (_, 3, _)
+| (1, _, _) -> true
+| _ -> false
+;;
+[%%expect{|
+(let
+  (*match*/87 = 3
+   *match*/88 = 2
+   *match*/89 = 1
+   *match*/90 = *match*/87
+   *match*/91 = *match*/88
+   *match*/92 = *match*/89)
+  (catch
+    (catch
+      (catch (if (!= *match*/91 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/90 1) (exit 2) (exit 1)))
+     with (2) 0a)
+   with (1) 1a))
+- : bool = false
+|}];;
+
+(* Failed flattening: we need to allocate the tuple to bind x. *)
+
+match (3, 2, 1) with
+| ((_, 3, _) as x)
+| ((1, _, _) as x) -> ignore x; true
+| _ -> false
+;;
+[%%expect{|
+(let
+  (*match*/95 = 3
+   *match*/96 = 2
+   *match*/97 = 1
+   *match*/98 = (makeblock 0 *match*/95 *match*/96 *match*/97))
+  (catch
+    (catch
+      (let (*match*/99 =a (field 0 *match*/98))
+        (catch
+          (let (*match*/100 =a (field 1 *match*/98))
+            (if (!= *match*/100 3) (exit 7)
+              (let (*match*/101 =a (field 2 *match*/98)) (exit 5 *match*/98))))
+         with (7)
+          (if (!= *match*/99 1) (exit 6)
+            (let
+              (*match*/103 =a (field 2 *match*/98)
+               *match*/102 =a (field 1 *match*/98))
+              (exit 5 *match*/98)))))
+     with (6) 0a)
+   with (5 x/93) (seq (ignore x/93) 1a)))
+- : bool = false
+|}];;
+

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -65,6 +65,8 @@ module Pattern_head : sig
   val loc : t -> Location.t
   val typ : t -> Types.type_expr
 
+  val arity : t -> int
+
   (** [deconstruct p] returns the head of [p] and the list of sub patterns.
 
       @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
@@ -145,6 +147,16 @@ end = struct
     let desc, pats = deconstruct_desc q.pat_desc in
     { desc; typ = q.pat_type; loc = q.pat_loc;
       env = q.pat_env; attributes = q.pat_attributes }, pats
+
+  let arity t =
+    match t.desc with
+      | Any -> 0
+      | Constant _ -> 0
+      | Construct c -> c.cstr_arity
+      | Tuple n | Array n -> n
+      | Record l -> List.length l
+      | Variant { has_arg; _ } -> if has_arg then 1 else 0
+      | Lazy -> 1
 
   let to_omega_pattern t =
     let pat_desc =

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -20,6 +20,7 @@ open Asttypes
 open Types
 open Typedtree
 
+
 (*************************************)
 (* Utilities for building patterns   *)
 (*************************************)
@@ -30,180 +31,22 @@ let make_pat desc ty tenv =
    pat_attributes = [];
   }
 
-let omega = make_pat Tpat_any Ctype.none Env.empty
+let omega = Patterns.omega
+let omegas = Patterns.omegas
+let omega_list = Patterns.omega_list
 
 let extra_pat =
   make_pat
     (Tpat_var (Ident.create_local "+", mknoloc "+"))
     Ctype.none Env.empty
 
-let rec omegas i =
-  if i <= 0 then [] else omega :: omegas (i-1)
-
-let omega_list l = List.map (fun _ -> omega) l
-
-module Pattern_head : sig
-  type desc =
-    | Any
-    | Construct of constructor_description
-    | Constant of constant
-    | Tuple of int
-    | Record of label_description list
-    | Variant of
-        { tag: label; has_arg: bool;
-          cstr_row: row_desc ref;
-          type_row : unit -> row_desc; }
-          (* the row of the type may evolve if [close_variant] is called,
-             hence the (unit -> ...) delay *)
-    | Array of int
-    | Lazy
-
-  type t
-
-  val desc : t -> desc
-  val env : t -> Env.t
-  val loc : t -> Location.t
-  val typ : t -> Types.type_expr
-
-  val arity : t -> int
-
-  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
-
-      @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
-
-  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
-  val to_omega_pattern : t -> pattern
-
-  val make
-    :  loc:Location.t
-    -> typ:Types.type_expr
-    -> env:Env.t
-    -> desc
-    -> t
-
-  val omega : t
-
-end = struct
-  type desc =
-    | Any
-    | Construct of constructor_description
-    | Constant of constant
-    | Tuple of int
-    | Record of label_description list
-    | Variant of
-        { tag: label;
-          has_arg: bool;
-          cstr_row: row_desc ref;
-          type_row: unit -> row_desc; }
-    | Array of int
-    | Lazy
-
-  type t = {
-    desc: desc;
-    typ : Types.type_expr;
-    loc : Location.t;
-    env : Env.t;
-    attributes : attributes;
-  }
-
-  let desc { desc } = desc
-  let env { env } = env
-  let loc { loc } = loc
-  let typ { typ } = typ
-
-  let deconstruct q =
-    let rec deconstruct_desc = function
-      | Tpat_any
-      | Tpat_var _ -> Any, []
-      | Tpat_constant c -> Constant c, []
-      | Tpat_alias (p,_,_) -> deconstruct_desc p.pat_desc
-      | Tpat_tuple args ->
-          Tuple (List.length args), args
-      | Tpat_construct (_, c, args) ->
-          Construct c, args
-      | Tpat_variant (tag, arg, cstr_row) ->
-          let has_arg, pats =
-            match arg with
-            | None -> false, []
-            | Some a -> true, [a]
-          in
-          let type_row () =
-            match Ctype.expand_head q.pat_env q.pat_type with
-              | {desc = Tvariant type_row} -> Btype.row_repr type_row
-              | _ -> assert false
-          in
-          Variant {tag; has_arg; cstr_row; type_row}, pats
-      | Tpat_array args ->
-          Array (List.length args), args
-      | Tpat_record (largs, _) ->
-          let lbls = List.map (fun (_,lbl,_) -> lbl) largs in
-          let pats = List.map (fun (_,_,pat) -> pat) largs in
-          Record lbls, pats
-      | Tpat_lazy p ->
-          Lazy, [p]
-      | Tpat_or _ -> invalid_arg "Parmatch.Pattern_head.deconstruct: (P | Q)"
-    in
-    let desc, pats = deconstruct_desc q.pat_desc in
-    { desc; typ = q.pat_type; loc = q.pat_loc;
-      env = q.pat_env; attributes = q.pat_attributes }, pats
-
-  let arity t =
-    match t.desc with
-      | Any -> 0
-      | Constant _ -> 0
-      | Construct c -> c.cstr_arity
-      | Tuple n | Array n -> n
-      | Record l -> List.length l
-      | Variant { has_arg; _ } -> if has_arg then 1 else 0
-      | Lazy -> 1
-
-  let to_omega_pattern t =
-    let pat_desc =
-      match t.desc with
-      | Any -> Tpat_any
-      | Lazy -> Tpat_lazy omega
-      | Constant c -> Tpat_constant c
-      | Tuple n -> Tpat_tuple (omegas n)
-      | Array n -> Tpat_array (omegas n)
-      | Construct c ->
-          let lid_loc = Location.mkloc (Longident.Lident c.cstr_name) t.loc in
-          Tpat_construct (lid_loc, c, omegas c.cstr_arity)
-      | Variant { tag; has_arg; cstr_row } ->
-          let arg_opt = if has_arg then Some omega else None in
-          Tpat_variant (tag, arg_opt, cstr_row)
-      | Record lbls ->
-          let lst =
-            List.map (fun lbl ->
-              let lid_loc =
-                Location.mkloc (Longident.Lident lbl.lbl_name) t.loc
-              in
-              (lid_loc, lbl, omega)
-            ) lbls
-          in
-          Tpat_record (lst, Closed)
-    in
-    { pat_desc; pat_type = t.typ; pat_loc = t.loc; pat_extra = [];
-      pat_env = t.env; pat_attributes = t.attributes }
-
-  let make ~loc ~typ ~env desc =
-    { desc; loc; typ; env; attributes = [] }
-
-  let omega =
-    { desc = Any
-    ; loc = Location.none
-    ; typ = Ctype.none
-    ; env = Env.empty
-    ; attributes = []
-    }
-end
 
 (*
   Normalize a pattern ->
    all arguments are omega (simple pattern) and no more variables
 *)
 
-let normalize_pat p = Pattern_head.(to_omega_pattern @@ fst @@ deconstruct p)
+let normalize_pat p = Patterns.Head.(to_omega_pattern @@ fst @@ deconstruct p)
 
 (*******************)
 (* Coherence check *)
@@ -282,7 +125,7 @@ let normalize_pat p = Pattern_head.(to_omega_pattern @@ fst @@ deconstruct p)
 *)
 let all_coherent column =
   let coherent_heads hp1 hp2 =
-    match Pattern_head.desc hp1, Pattern_head.desc hp2 with
+    match Patterns.Head.desc hp1, Patterns.Head.desc hp2 with
     | Construct c, Construct c' ->
       c.cstr_consts = c'.cstr_consts
       && c.cstr_nonconsts = c'.cstr_nonconsts
@@ -316,7 +159,7 @@ let all_coherent column =
   in
   match
     List.find (fun head_pat ->
-      match Pattern_head.desc head_pat with
+      match Patterns.Head.desc head_pat with
       | Any -> false
       | _ -> true
     ) column
@@ -397,7 +240,7 @@ let first_column simplified_matrix =
 let is_absent tag row = Btype.row_field tag !row = Rabsent
 
 let is_absent_pat d =
-  match Pattern_head.desc d with
+  match Patterns.Head.desc d with
   | Variant { tag; cstr_row; _ } -> is_absent tag cstr_row
   | _ -> false
 
@@ -517,7 +360,7 @@ let get_constructor_type_path ty tenv =
 
 (* Check top matching *)
 let simple_match d h =
-  match Pattern_head.desc d, Pattern_head.desc h with
+  match Patterns.Head.desc d, Patterns.Head.desc h with
   | Construct c1, Construct c2 ->
       Types.equal_tag c1.cstr_tag c2.cstr_tag
   | Variant { tag = t1; _ }, Variant { tag = t2 } ->
@@ -533,7 +376,7 @@ let simple_match d h =
 
 
 (* extract record fields as a whole *)
-let record_arg ph = match Pattern_head.desc ph with
+let record_arg ph = match Patterns.Head.desc ph with
 | Any -> []
 | Record args -> args
 | _ -> fatal_error "Parmatch.as_record"
@@ -548,7 +391,7 @@ let extract_fields lbls arg =
   List.map (fun lbl -> get_field lbl.lbl_pos arg) lbls
 
 (* Build argument list when p2 >= p1, where p1 is a simple pattern *)
-let simple_match_args discr head args = match Pattern_head.desc head with
+let simple_match_args discr head args = match Patterns.Head.desc head with
 | Constant _ -> []
 | Construct _
 | Variant _
@@ -557,7 +400,7 @@ let simple_match_args discr head args = match Pattern_head.desc head with
 | Lazy -> args
 | Record lbls ->  extract_fields (record_arg discr) (List.combine lbls args)
 | Any ->
-    begin match Pattern_head.desc discr with
+    begin match Patterns.Head.desc discr with
     | Construct cstr -> omegas cstr.cstr_arity
     | Variant { has_arg = true }
     | Lazy -> [omega]
@@ -600,7 +443,7 @@ let discr_pat q pss =
   let rec refine_pat acc = function
     | [] -> acc
     | ((head, _), _) :: rows ->
-      match Pattern_head.desc head with
+      match Patterns.Head.desc head with
       | Any -> refine_pat acc rows
       | Tuple _ | Lazy -> head
       | Record lbls ->
@@ -619,14 +462,14 @@ let discr_pat q pss =
           ) lbls (record_arg acc)
         in
         let d =
-          let open Pattern_head in
+          let open Patterns.Head in
           make ~loc:(loc head) ~typ:(typ head) ~env:(env head) (Record fields)
         in
         refine_pat d rows
       | _ -> acc
   in
-  let q, _ = Pattern_head.deconstruct q in
-  match Pattern_head.desc q with
+  let q, _ = Patterns.Head.deconstruct q in
+  match Patterns.Head.desc q with
   (* short-circuiting: clearly if we have anything other than [Record] or
      [Any] to start with, we're not going to be able refine at all. So
      there's no point going over the matrix. *)
@@ -726,10 +569,10 @@ let simplify_head_pat ~add_column p ps k =
     match p.pat_desc with
     | Tpat_alias (p,_,_) ->
         (* We have to handle aliases here, because there can be or-patterns
-           underneath, that [Pattern_head.deconstruct] won't handle. *)
+           underneath, that [Patterns.Head.deconstruct] won't handle. *)
         simplify_head_pat p ps k
     | Tpat_or (p1,p2,_) -> simplify_head_pat p1 ps (simplify_head_pat p2 ps k)
-    | _ -> add_column (Pattern_head.deconstruct p) ps k
+    | _ -> add_column (Patterns.Head.deconstruct p) ps k
   in simplify_head_pat p ps k
 
 let rec simplify_first_col = function
@@ -763,7 +606,7 @@ let build_specialized_submatrix ~extend_row discr pss =
 *)
 type 'matrix specialized_matrices = {
   default : 'matrix;
-  constrs : (Pattern_head.t * 'matrix) list;
+  constrs : (Patterns.Head.t * 'matrix) list;
 }
 
 (* Consider a pattern matrix whose first column has been simplified
@@ -811,13 +654,13 @@ let build_specialized_submatrices ~extend_row discr rows =
 
   (* insert a row of head omega into all groups *)
   let insert_omega r env =
-    List.map (fun (q0,rs) -> extend_group q0 Pattern_head.omega [] r rs) env
+    List.map (fun (q0,rs) -> extend_group q0 Patterns.Head.omega [] r rs) env
   in
 
   let rec form_groups constr_groups omega_tails = function
     | [] -> (constr_groups, omega_tails)
     | ((head, args), tail) :: rest ->
-        match Pattern_head.desc head with
+        match Patterns.Head.desc head with
         | Any ->
             (* note that calling insert_omega here would be wrong
                as some groups may not have been formed yet, if the
@@ -830,7 +673,7 @@ let build_specialized_submatrices ~extend_row discr rows =
 
   let constr_groups, omega_tails =
     let initial_constr_group =
-      match Pattern_head.desc discr with
+      match Patterns.Head.desc discr with
       | Record _ | Tuple _ | Lazy ->
         (* [discr] comes from [discr_pat], and in this case subsumes any of the
            patterns we could find on the first column of [rows]. So it is better
@@ -857,14 +700,14 @@ let set_last a =
     | x::l -> x :: loop l
   in
   function
-  | (_, []) -> (Pattern_head.deconstruct a, [])
+  | (_, []) -> (Patterns.Head.deconstruct a, [])
   | (first, row) -> (first, loop row)
 
 (* mark constructor lines for failure when they are incomplete *)
 let mark_partial =
   let zero = make_pat (Tpat_constant (Const_int 0)) Ctype.none Env.empty in
   List.map (fun ((hp, _), _ as ps) ->
-    match Pattern_head.desc hp with
+    match Patterns.Head.desc hp with
     | Any -> ps
     | _ -> set_last zero ps
   )
@@ -897,7 +740,7 @@ let close_variant env row =
 let full_match closing env =  match env with
 | [] -> false
 | (discr, _) :: _ ->
-  match Pattern_head.desc discr with
+  match Patterns.Head.desc discr with
   | Any -> assert false
   | Construct { cstr_tag = Cstr_extension _ ; _ } -> false
   | Construct c -> List.length env = c.cstr_consts + c.cstr_nonconsts
@@ -905,7 +748,7 @@ let full_match closing env =  match env with
       let fields =
         List.map
           (fun (d, _) ->
-            match Pattern_head.desc d with
+            match Patterns.Head.desc d with
             | Variant { tag } -> tag
             | _ -> assert false)
           env
@@ -942,10 +785,10 @@ let should_extend ext env = match ext with
 | Some ext -> begin match env with
   | [] -> assert false
   | (p,_)::_ ->
-      begin match Pattern_head.desc p with
+      begin match Patterns.Head.desc p with
       | Construct {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)} ->
           let path =
-            get_constructor_type_path (Pattern_head.typ p) (Pattern_head.env p)
+            get_constructor_type_path (Patterns.Head.typ p) (Patterns.Head.env p)
           in
           Path.same path ext
       | Construct {cstr_tag=(Cstr_extension _)} -> false
@@ -998,7 +841,7 @@ let rec orify_many = function
 
 (* build an or-pattern from a constructor list *)
 let pat_of_constrs ex_pat cstrs =
-  let ex_pat = Pattern_head.to_omega_pattern ex_pat in
+  let ex_pat = Patterns.Head.to_omega_pattern ex_pat in
   if cstrs = [] then raise Empty else
   orify_many (List.map (pat_of_constr ex_pat) cstrs)
 
@@ -1044,9 +887,9 @@ let rec get_variant_constructors env ty =
 
 (* Sends back a pattern that complements constructor tags all_tag *)
 let complete_constrs p all_tags =
-  let c = match Pattern_head.desc p with Construct c -> c | _ -> assert false in
+  let c = match Patterns.Head.desc p with Construct c -> c | _ -> assert false in
   let not_tags = complete_tags c.cstr_consts c.cstr_nonconsts all_tags in
-  let constrs = get_variant_constructors (Pattern_head.env p) c.cstr_res in
+  let constrs = get_variant_constructors (Patterns.Head.env p) c.cstr_res in
   let others =
     List.filter
       (fun cnstr -> ConstructorTagHashtbl.mem not_tags cnstr.cstr_tag)
@@ -1056,10 +899,10 @@ let complete_constrs p all_tags =
   const @ nonconst
 
 let build_other_constrs env p =
-  match Pattern_head.desc p with
+  match Patterns.Head.desc p with
   | Construct { cstr_tag = Cstr_constant _ | Cstr_block _ } ->
       let get_tag q =
-        match Pattern_head.desc q with
+        match Patterns.Head.desc q with
         | Construct c -> c.cstr_tag
         | _ -> fatal_error "Parmatch.get_tag" in
       let all_tags =  List.map (fun (p,_) -> get_tag p) env in
@@ -1070,16 +913,16 @@ let complete_constrs p all_tags =
   (* This wrapper is here for [Matching], which (indirectly) calls this function
      from [combine_constructor], and nowhere else.
      So we know patterns have been fully simplified. *)
-  complete_constrs (fst @@ Pattern_head.deconstruct p) all_tags
+  complete_constrs (fst @@ Patterns.Head.deconstruct p) all_tags
 
 (* Auxiliary for build_other *)
 
 let build_other_constant proj make first next p env =
-  let all = List.map (fun (p, _) -> proj (Pattern_head.desc p)) env in
+  let all = List.map (fun (p, _) -> proj (Patterns.Head.desc p)) env in
   let rec try_const i =
     if List.mem i all
     then try_const (next i)
-    else make_pat (make i) (Pattern_head.typ p) (Pattern_head.env p)
+    else make_pat (make i) (Patterns.Head.typ p) (Patterns.Head.env p)
   in try_const first
 
 (*
@@ -1093,19 +936,19 @@ let build_other ext env =
   match env with
   | [] -> omega
   | (d, _) :: _ ->
-      match Pattern_head.desc d with
+      match Patterns.Head.desc d with
       | Construct { cstr_tag = Cstr_extension _ } ->
           (* let c = {c with cstr_name = "*extension*"} in *) (* PR#7330 *)
           make_pat
             (Tpat_var (Ident.create_local "*extension*",
-                       {txt="*extension*"; loc = Pattern_head.loc d}))
+                       {txt="*extension*"; loc = Patterns.Head.loc d}))
             Ctype.none Env.empty
       | Construct _ ->
           begin match ext with
           | Some ext ->
               if Path.same ext
                    (get_constructor_type_path
-                      (Pattern_head.typ d) (Pattern_head.env d))
+                      (Patterns.Head.typ d) (Patterns.Head.env d))
               then
                 extra_pat
               else
@@ -1117,7 +960,7 @@ let build_other ext env =
           let tags =
             List.map
               (fun (d, _) ->
-                match Pattern_head.desc d with
+                match Patterns.Head.desc d with
                 | Variant { tag } -> tag
                 | _ -> assert false)
               env
@@ -1125,7 +968,7 @@ let build_other ext env =
             let make_other_pat tag const =
               let arg = if const then None else Some omega in
               make_pat (Tpat_variant(tag, arg, cstr_row))
-                (Pattern_head.typ d) (Pattern_head.env d)
+                (Patterns.Head.typ d) (Patterns.Head.env d)
             in
             let row = type_row () in
             begin match
@@ -1150,13 +993,13 @@ let build_other ext env =
                 List.fold_left
                   (fun p_res pat ->
                     make_pat (Tpat_or (pat, p_res, None))
-                      (Pattern_head.typ d) (Pattern_head.env d))
+                      (Patterns.Head.typ d) (Patterns.Head.env d))
                   pat other_pats
             end
       | Constant Const_char _ ->
           let all_chars =
             List.map
-              (fun (p,_) -> match Pattern_head.desc p with
+              (fun (p,_) -> match Patterns.Head.desc p with
               | Constant (Const_char c) -> c
               | _ -> assert false)
               env
@@ -1169,7 +1012,7 @@ let build_other ext env =
                 find_other (i+1) imax
               else
                 make_pat (Tpat_constant (Const_char ci))
-                  (Pattern_head.typ d) (Pattern_head.env d)
+                  (Patterns.Head.typ d) (Patterns.Head.env d)
           in
           let rec try_chars = function
             | [] -> omega
@@ -1219,7 +1062,7 @@ let build_other ext env =
       | Array _ ->
           let all_lengths =
             List.map
-              (fun (p,_) -> match Pattern_head.desc p with
+              (fun (p,_) -> match Patterns.Head.desc p with
               | Array len -> len
               | _ -> assert false)
               env in
@@ -1228,7 +1071,7 @@ let build_other ext env =
             else
               make_pat
                 (Tpat_array (omegas l))
-                (Pattern_head.typ d) (Pattern_head.env d) in
+                (Patterns.Head.typ d) (Patterns.Head.env d) in
           try_arrays 0
       | _ -> omega
 
@@ -1294,13 +1137,13 @@ let rec satisfiable pss qs = match pss with
               (fun (p,pss) ->
                  not (is_absent_pat p) &&
                  satisfiable pss
-                   (simple_match_args p Pattern_head.omega [] @ qs))
+                   (simple_match_args p Patterns.Head.omega [] @ qs))
               constrs
         end
     | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> false
     | q::qs ->
         let pss = simplify_first_col pss in
-        let hq, qargs = Pattern_head.deconstruct q in
+        let hq, qargs = Patterns.Head.deconstruct q in
         if not (all_coherent (hq :: first_column pss)) then
           false
         else begin
@@ -1353,15 +1196,15 @@ let rec list_satisfying_vectors pss qs =
                       else
                         let witnesses =
                           list_satisfying_vectors pss
-                            (simple_match_args p Pattern_head.omega [] @ qs)
+                            (simple_match_args p Patterns.Head.omega [] @ qs)
                         in
-                        let p = Pattern_head.to_omega_pattern p in
+                        let p = Patterns.Head.to_omega_pattern p in
                         List.map (set_args p) witnesses
                     ) constrs
                   )
                 in
                 if full_match false constrs then for_constrs () else
-                begin match Pattern_head.desc p with
+                begin match Patterns.Head.desc p with
                 | Construct _ ->
                     (* activate this code for checking non-gadt constructors *)
                     wild default (build_other_constrs constrs p)
@@ -1372,13 +1215,13 @@ let rec list_satisfying_vectors pss qs =
           end
       | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> []
       | q::qs ->
-          let hq, qargs = Pattern_head.deconstruct q in
+          let hq, qargs = Patterns.Head.deconstruct q in
           let pss = simplify_first_col pss in
           if not (all_coherent (hq :: first_column pss)) then
             []
           else begin
             let q0 = discr_pat q pss in
-            List.map (set_args (Pattern_head.to_omega_pattern q0))
+            List.map (set_args (Patterns.Head.to_omega_pattern q0))
               (list_satisfying_vectors
                  (build_specialized_submatrix ~extend_row:(@) q0 pss)
                  (simple_match_args q0 hq qargs @ qs))
@@ -1413,7 +1256,7 @@ let rec do_match pss qs = match qs with
       (* [q] is generated by us, it doesn't come from the source. So we know
          it's not of the form [P as name].
          Therefore there is no risk of [deconstruct] raising. *)
-      let q0, qargs = Pattern_head.deconstruct q in
+      let q0, qargs = Patterns.Head.deconstruct q in
       let pss = simplify_first_col pss in
       (* [pss] will (or won't) match [q0 :: qs] regardless of the coherence of
          its first column. *)
@@ -1492,7 +1335,7 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
           (* first column of pss is made of variables only *)
           begin match exhaust ext default (n-1) with
           | Witnesses r ->
-              let q0 = Pattern_head.to_omega_pattern q0 in
+              let q0 = Patterns.Head.to_omega_pattern q0 in
               Witnesses (List.map (fun row -> q0::row) r)
           | r -> r
         end
@@ -1504,11 +1347,11 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
               match
                 exhaust
                   ext pss
-                  (List.length (simple_match_args p Pattern_head.omega [])
+                  (List.length (simple_match_args p Patterns.Head.omega [])
                    + n - 1)
               with
               | Witnesses r ->
-                  let p = Pattern_head.to_omega_pattern p in
+                  let p = Patterns.Head.to_omega_pattern p in
                   Witnesses (List.map (set_args p) r)
               | r       -> r in
           let before = try_many try_non_omega constrs in
@@ -1601,7 +1444,7 @@ let rec pressure_variants tdefs = function
               | [], _
               | _, None -> ()
               | (d, _) :: _, Some env ->
-                match Pattern_head.desc d with
+                match Patterns.Head.desc d with
                 | Variant { type_row; _ } ->
                   let row = type_row () in
                   if Btype.row_fixed row
@@ -1803,7 +1646,7 @@ let rec every_satisfiables pss qs = match qs.active with
     | _ ->
 (* standard case, filter matrix *)
         let pss = simplify_first_usefulness_col pss in
-        let huq, args = Pattern_head.deconstruct uq in
+        let huq, args = Patterns.Head.deconstruct uq in
         (* The handling of incoherent matrices is kept in line with
            [satisfiable] *)
         if not (all_coherent (huq :: first_column pss)) then
@@ -2457,12 +2300,12 @@ let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
       let rest_of_the_row =
         { row = ps; varsets = Ident.Set.add x head_bound_variables :: varsets; }
       in
-      add_column (Pattern_head.deconstruct omega) rest_of_the_row k
+      add_column (Patterns.Head.deconstruct omega) rest_of_the_row k
     | Tpat_or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps
         (simpl head_bound_variables varsets p2 ps k)
     | _ ->
-      add_column (Pattern_head.deconstruct p)
+      add_column (Patterns.Head.deconstruct p)
         { row = ps; varsets = head_bound_variables :: varsets; } k
   in simpl head_bound_variables varsets p ps k
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -570,13 +570,10 @@ and set_args_erase_mutable q r = do_set_args ~erase_mutable:true q r
  *)
 let simplify_head_pat ~add_column p ps k =
   let rec simplify_head_pat p ps k =
-    match p.pat_desc with
-    | Tpat_alias (p,_,_) ->
-        (* We have to handle aliases here, because there can be or-patterns
-           underneath, that [Patterns.Head.deconstruct] won't handle. *)
-        simplify_head_pat p ps k
-    | Tpat_or (p1,p2,_) -> simplify_head_pat p1 ps (simplify_head_pat p2 ps k)
-    | _ -> add_column (Patterns.Head.deconstruct p) ps k
+    match Patterns.General.(view p |> strip_vars).pat_desc with
+    | `Or (p1,p2,_) -> simplify_head_pat p1 ps (simplify_head_pat p2 ps k)
+    | #Patterns.Simple.view as view ->
+       add_column (Patterns.Head.deconstruct { p with pat_desc = view }) ps k
   in simplify_head_pat p ps k
 
 let rec simplify_first_col = function
@@ -701,7 +698,7 @@ let build_specialized_submatrices ~extend_row discr rows =
 let set_last a =
   let rec loop = function
     | [] -> assert false
-    | [_] -> [a]
+    | [_] -> [Patterns.General.erase a]
     | x::l -> x :: loop l
   in
   function
@@ -710,7 +707,7 @@ let set_last a =
 
 (* mark constructor lines for failure when they are incomplete *)
 let mark_partial =
-  let zero = make_pat (Tpat_constant (Const_int 0)) Ctype.none Env.empty in
+  let zero = make_pat (`Constant (Const_int 0)) Ctype.none Env.empty in
   List.map (fun ((hp, _), _ as ps) ->
     match hp.pat_desc with
     | Patterns.Head.Any -> ps
@@ -1119,39 +1116,40 @@ let rec satisfiable pss qs = match pss with
 | _  ->
     match qs with
     | [] -> false
-    | {pat_desc = Tpat_or(q1,q2,_)}::qs ->
-        satisfiable pss (q1::qs) || satisfiable pss (q2::qs)
-    | {pat_desc = Tpat_alias(q,_,_)}::qs ->
-          satisfiable pss (q::qs)
-    | {pat_desc = (Tpat_any | Tpat_var(_))}::qs ->
-        let pss = simplify_first_col pss in
-        if not (all_coherent (first_column pss)) then
-          false
-        else begin
-          let { default; constrs } =
-            let q0 = discr_pat omega pss in
-            build_specialized_submatrices ~extend_row:(@) q0 pss in
-          if not (full_match false constrs) then
-            satisfiable default qs
-          else
-            List.exists
-              (fun (p,pss) ->
-                 not (is_absent_pat p) &&
-                 satisfiable pss
-                   (simple_match_args p Patterns.Head.omega [] @ qs))
-              constrs
-        end
-    | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> false
     | q::qs ->
-        let pss = simplify_first_col pss in
-        let hq, qargs = Patterns.Head.deconstruct q in
-        if not (all_coherent (hq :: first_column pss)) then
-          false
-        else begin
-          let q0 = discr_pat q pss in
-          satisfiable (build_specialized_submatrix ~extend_row:(@) q0 pss)
-            (simple_match_args q0 hq qargs @ qs)
-        end
+       match Patterns.General.(view q |> strip_vars).pat_desc with
+       | `Or(q1,q2,_) ->
+          satisfiable pss (q1::qs) || satisfiable pss (q2::qs)
+       | `Any ->
+          let pss = simplify_first_col pss in
+          if not (all_coherent (first_column pss)) then
+            false
+          else begin
+            let { default; constrs } =
+              let q0 = discr_pat Patterns.Simple.omega pss in
+              build_specialized_submatrices ~extend_row:(@) q0 pss in
+            if not (full_match false constrs) then
+              satisfiable default qs
+            else
+              List.exists
+                (fun (p,pss) ->
+                   not (is_absent_pat p) &&
+                   satisfiable pss
+                     (simple_match_args p Patterns.Head.omega [] @ qs))
+                constrs
+          end
+       | `Variant (l,_,r) when is_absent l r -> false
+       | #Patterns.Simple.view as view ->
+          let q = { q with pat_desc = view } in
+          let pss = simplify_first_col pss in
+          let hq, qargs = Patterns.Head.deconstruct q in
+          if not (all_coherent (hq :: first_column pss)) then
+            false
+          else begin
+              let q0 = discr_pat q pss in
+              satisfiable (build_specialized_submatrix ~extend_row:(@) q0 pss)
+                (simple_match_args q0 hq qargs @ qs)
+            end
 
 (* While [satisfiable] only checks whether the last row of [pss + qs] is
    satisfiable, this function returns the (possibly empty) list of vectors [es]
@@ -1169,53 +1167,54 @@ let rec list_satisfying_vectors pss qs =
   | _  ->
       match qs with
       | [] -> []
-      | {pat_desc = Tpat_or(q1,q2,_)}::qs ->
-          list_satisfying_vectors pss (q1::qs) @
-          list_satisfying_vectors pss (q2::qs)
-      | {pat_desc = Tpat_alias(q,_,_)}::qs ->
-          list_satisfying_vectors pss (q::qs)
-      | {pat_desc = (Tpat_any | Tpat_var(_))}::qs ->
-          let pss = simplify_first_col pss in
-          if not (all_coherent (first_column pss)) then
-            []
-          else begin
-            let q0 = discr_pat omega pss in
-            let wild default_matrix p =
-              List.map (fun qs -> p::qs)
-                (list_satisfying_vectors default_matrix qs)
-            in
-            match build_specialized_submatrices ~extend_row:(@) q0 pss with
-            | { default; constrs = [] } ->
-                (* first column of pss is made of variables only *)
-                wild default omega
-            | { default; constrs = ((p,_)::_ as constrs) } ->
-                let for_constrs () =
-                  List.flatten (
-                    List.map (fun (p,pss) ->
-                      if is_absent_pat p then
-                        []
-                      else
-                        let witnesses =
-                          list_satisfying_vectors pss
-                            (simple_match_args p Patterns.Head.omega [] @ qs)
-                        in
-                        let p = Patterns.Head.to_omega_pattern p in
-                        List.map (set_args p) witnesses
-                    ) constrs
-                  )
-                in
-                if full_match false constrs then for_constrs () else
-                begin match p.pat_desc with
-                | Construct _ ->
-                    (* activate this code for checking non-gadt constructors *)
-                    wild default (build_other_constrs constrs p)
-                    @ for_constrs ()
-                | _ ->
-                    wild default Patterns.omega
-                end
+      | q :: qs ->
+         match Patterns.General.(view q |> strip_vars).pat_desc with
+         | `Or(q1,q2,_) ->
+            list_satisfying_vectors pss (q1::qs) @
+            list_satisfying_vectors pss (q2::qs)
+         | `Any ->
+            let pss = simplify_first_col pss in
+            if not (all_coherent (first_column pss)) then
+              []
+            else begin
+              let q0 = discr_pat Patterns.Simple.omega pss in
+              let wild default_matrix p =
+                List.map (fun qs -> p::qs)
+                  (list_satisfying_vectors default_matrix qs)
+              in
+              match build_specialized_submatrices ~extend_row:(@) q0 pss with
+              | { default; constrs = [] } ->
+                  (* first column of pss is made of variables only *)
+                  wild default omega
+              | { default; constrs = ((p,_)::_ as constrs) } ->
+                  let for_constrs () =
+                    List.flatten (
+                      List.map (fun (p,pss) ->
+                        if is_absent_pat p then
+                          []
+                        else
+                          let witnesses =
+                            list_satisfying_vectors pss
+                              (simple_match_args p Patterns.Head.omega [] @ qs)
+                          in
+                          let p = Patterns.Head.to_omega_pattern p in
+                          List.map (set_args p) witnesses
+                      ) constrs
+                    )
+                  in
+                  if full_match false constrs then for_constrs () else
+                  begin match p.pat_desc with
+                  | Construct _ ->
+                      (* activate this code for checking non-gadt constructors *)
+                      wild default (build_other_constrs constrs p)
+                      @ for_constrs ()
+                  | _ ->
+                      wild default Patterns.omega
+                  end
           end
-      | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> []
-      | q::qs ->
+      | `Variant (l, _, r) when is_absent l r -> []
+      | #Patterns.Simple.view as view ->
+          let q = { q with pat_desc = view } in
           let hq, qargs = Patterns.Head.deconstruct q in
           let pss = simplify_first_col pss in
           if not (all_coherent (hq :: first_column pss)) then
@@ -1244,19 +1243,17 @@ let rec do_match pss qs = match qs with
     | []::_ -> true
     | _ -> false
     end
-| q::qs -> match q with
-  | {pat_desc = Tpat_or (q1,q2,_)} ->
+| q::qs -> match Patterns.General.(view q |> strip_vars).pat_desc with
+  | `Or (q1,q2,_) ->
       do_match pss (q1::qs) || do_match pss (q2::qs)
-  | {pat_desc = Tpat_any} ->
+  | `Any ->
       let rec remove_first_column = function
         | (_::ps)::rem -> ps::remove_first_column rem
         | _ -> []
       in
       do_match (remove_first_column pss) qs
-  | _ ->
-      (* [q] is generated by us, it doesn't come from the source. So we know
-         it's not of the form [P as name].
-         Therefore there is no risk of [deconstruct] raising. *)
+  | #Patterns.Simple.view as view ->
+      let q = { q with pat_desc = view } in
       let q0, qargs = Patterns.Head.deconstruct q in
       let pss = simplify_first_col pss in
       (* [pss] will (or won't) match [q0 :: qs] regardless of the coherence of
@@ -1330,7 +1327,7 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
          If [exhaust] has been called by [do_check_fragile], then it is possible
          we might fail to warn the user that the matching is fragile. See for
          example testsuite/tests/warnings/w04_failure.ml. *)
-      let q0 = discr_pat omega pss in
+      let q0 = discr_pat Patterns.Simple.omega pss in
       match build_specialized_submatrices ~extend_row:(@) q0 pss with
       | { default; constrs = [] } ->
           (* first column of pss is made of variables only *)
@@ -1410,7 +1407,7 @@ let rec pressure_variants tdefs = function
       if not (all_coherent (first_column pss)) then
         true
       else begin
-        let q0 = discr_pat omega pss in
+        let q0 = discr_pat Patterns.Simple.omega pss in
         match build_specialized_submatrices ~extend_row:(@) q0 pss with
         | { default; constrs = [] } -> pressure_variants tdefs default
         | { default; constrs } ->
@@ -1501,15 +1498,10 @@ let make_row ps = {ors=[] ; no_ors=[]; active=ps}
 let make_rows pss = List.map make_row pss
 
 
-(* Useful to detect and expand  or pats inside as pats *)
-let rec unalias p = match p.pat_desc with
-| Tpat_alias (p,_,_) -> unalias p
-| _ -> p
-
-
-let is_var p = match (unalias p).pat_desc with
-| Tpat_any|Tpat_var _ -> true
-| _                   -> false
+(* Useful to detect and expand or pats inside as pats *)
+let is_var p = match Patterns.General.(view p |> strip_vars).pat_desc with
+| `Any -> true
+| _    -> false
 
 let is_var_column rs =
   List.for_all
@@ -1623,41 +1615,41 @@ let rec every_satisfiables pss qs = match qs.active with
           Used
     end
 | q::rem ->
-    let uq = unalias q in
-    begin match uq.pat_desc with
-    | Tpat_any | Tpat_var _ ->
+    begin match Patterns.General.(view q |> strip_vars).pat_desc with
+    | `Any ->
         if is_var_column pss then
-(* forget about ``all-variable''  columns now *)
+          (* forget about ``all-variable''  columns now *)
           every_satisfiables (remove_column pss) (remove qs)
         else
-(* otherwise this is direct food for satisfiable *)
+          (* otherwise this is direct food for satisfiable *)
           every_satisfiables (push_no_or_column pss) (push_no_or qs)
-    | Tpat_or (q1,q2,_) ->
+    | `Or (q1,q2,_) ->
         if
           q1.pat_loc.Location.loc_ghost &&
           q2.pat_loc.Location.loc_ghost
         then
-(* syntactically generated or-pats should not be expanded *)
+          (* syntactically generated or-pats should not be expanded *)
           every_satisfiables (push_no_or_column pss) (push_no_or qs)
         else
-(* this is a real or-pattern *)
+          (* this is a real or-pattern *)
           every_satisfiables (push_or_column pss) (push_or qs)
-    | Tpat_variant (l,_,r) when is_absent l r -> (* Ah Jacques... *)
+    | `Variant (l,_,r) when is_absent l r -> (* Ah Jacques... *)
         Unused
-    | _ ->
-(* standard case, filter matrix *)
+    | #Patterns.Simple.view as view ->
+        let q = { q with pat_desc = view } in
+        (* standard case, filter matrix *)
         let pss = simplify_first_usefulness_col pss in
-        let huq, args = Patterns.Head.deconstruct uq in
+        let hq, args = Patterns.Head.deconstruct q in
         (* The handling of incoherent matrices is kept in line with
            [satisfiable] *)
-        if not (all_coherent (huq :: first_column pss)) then
+        if not (all_coherent (hq :: first_column pss)) then
           Unused
         else begin
           let q0 = discr_pat q pss in
           every_satisfiables
             (build_specialized_submatrix q0 pss
               ~extend_row:(fun ps r -> { r with active = ps @ r.active }))
-            {qs with active=simple_match_args q0 huq args @ rem}
+            {qs with active=simple_match_args q0 hq args @ rem}
         end
     end
 
@@ -2294,19 +2286,19 @@ type amb_row = { row : pattern list ; varsets : Ident.Set.t list; }
 
 let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
   let rec simpl head_bound_variables varsets p ps k =
-    match p.pat_desc with
-    | Tpat_alias (p,x,_) ->
+    match (Patterns.General.view p).pat_desc with
+    | `Alias (p,x,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
-    | Tpat_var (x,_) ->
+    | `Var (x, _) ->
       let rest_of_the_row =
         { row = ps; varsets = Ident.Set.add x head_bound_variables :: varsets; }
       in
-      add_column (Patterns.Head.deconstruct omega) rest_of_the_row k
-    | Tpat_or (p1,p2,_) ->
+      add_column (Patterns.Head.deconstruct Patterns.Simple.omega) rest_of_the_row k
+    | `Or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps
         (simpl head_bound_variables varsets p2 ps k)
-    | _ ->
-      add_column (Patterns.Head.deconstruct p)
+    | #Patterns.Simple.view as view ->
+      add_column (Patterns.Head.deconstruct { p with pat_desc = view })
         { row = ps; varsets = head_bound_variables :: varsets; } k
   in simpl head_bound_variables varsets p ps k
 
@@ -2408,7 +2400,7 @@ let rec matrix_stable_vars m = match m with
             let extend_row columns = function
               | Negative r -> Negative (columns @ r)
               | Positive r -> Positive { r with row = columns @ r.row } in
-            let q0 = discr_pat omega m in
+            let q0 = discr_pat Patterns.Simple.omega m in
             let { default; constrs } =
               build_specialized_submatrices ~extend_row q0 m in
             let non_default = List.map snd constrs in

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -124,8 +124,9 @@ let normalize_pat p = Patterns.Head.(to_omega_pattern @@ fst @@ deconstruct p)
    check that every other head pattern in the column is coherent with that one.
 *)
 let all_coherent column =
+  let open Patterns.Head in
   let coherent_heads hp1 hp2 =
-    match Patterns.Head.desc hp1, Patterns.Head.desc hp2 with
+    match hp1.pat_desc, hp2.pat_desc with
     | Construct c, Construct c' ->
       c.cstr_consts = c'.cstr_consts
       && c.cstr_nonconsts = c'.cstr_nonconsts
@@ -158,11 +159,11 @@ let all_coherent column =
     | _, _ -> false
   in
   match
-    List.find (fun head_pat ->
-      match Patterns.Head.desc head_pat with
-      | Any -> false
-      | _ -> true
-    ) column
+    List.find
+      (function
+       | { pat_desc = Any } -> false
+       | _ -> true)
+      column
   with
   | exception Not_found ->
     (* only omegas on the column: the column is coherent. *)
@@ -240,8 +241,8 @@ let first_column simplified_matrix =
 let is_absent tag row = Btype.row_field tag !row = Rabsent
 
 let is_absent_pat d =
-  match Patterns.Head.desc d with
-  | Variant { tag; cstr_row; _ } -> is_absent tag cstr_row
+  match d.pat_desc with
+  | Patterns.Head.Variant { tag; cstr_row; _ } -> is_absent tag cstr_row
   | _ -> false
 
 let const_compare x y =
@@ -360,7 +361,8 @@ let get_constructor_type_path ty tenv =
 
 (* Check top matching *)
 let simple_match d h =
-  match Patterns.Head.desc d, Patterns.Head.desc h with
+  let open Patterns.Head in
+  match d.pat_desc, h.pat_desc with
   | Construct c1, Construct c2 ->
       Types.equal_tag c1.cstr_tag c2.cstr_tag
   | Variant { tag = t1; _ }, Variant { tag = t2 } ->
@@ -376,10 +378,12 @@ let simple_match d h =
 
 
 (* extract record fields as a whole *)
-let record_arg ph = match Patterns.Head.desc ph with
-| Any -> []
-| Record args -> args
-| _ -> fatal_error "Parmatch.as_record"
+let record_arg ph =
+  let open Patterns.Head in
+  match ph.pat_desc with
+  | Any -> []
+  | Record args -> args
+  | _ -> fatal_error "Parmatch.as_record"
 
 
 let extract_fields lbls arg =
@@ -391,26 +395,28 @@ let extract_fields lbls arg =
   List.map (fun lbl -> get_field lbl.lbl_pos arg) lbls
 
 (* Build argument list when p2 >= p1, where p1 is a simple pattern *)
-let simple_match_args discr head args = match Patterns.Head.desc head with
-| Constant _ -> []
-| Construct _
-| Variant _
-| Tuple _
-| Array _
-| Lazy -> args
-| Record lbls ->  extract_fields (record_arg discr) (List.combine lbls args)
-| Any ->
-    begin match Patterns.Head.desc discr with
-    | Construct cstr -> omegas cstr.cstr_arity
-    | Variant { has_arg = true }
-    | Lazy -> [omega]
-    | Record lbls ->  omega_list lbls
-    | Array len
-    | Tuple len -> omegas len
-    | Variant { has_arg = false }
-    | Any
-    | Constant _ -> []
-    end
+let simple_match_args discr head args =
+  let open Patterns.Head in
+  match head.pat_desc with
+  | Constant _ -> []
+  | Construct _
+  | Variant _
+  | Tuple _
+  | Array _
+  | Lazy -> args
+  | Record lbls ->  extract_fields (record_arg discr) (List.combine lbls args)
+  | Any ->
+      begin match discr.pat_desc with
+      | Construct cstr -> Patterns.omegas cstr.cstr_arity
+      | Variant { has_arg = true }
+      | Lazy -> [Patterns.omega]
+      | Record lbls ->  omega_list lbls
+      | Array len
+      | Tuple len -> Patterns.omegas len
+      | Variant { has_arg = false }
+      | Any
+      | Constant _ -> []
+      end
 
 (* Consider a pattern matrix whose first column has been simplified to contain
    only _ or a head constructor
@@ -440,10 +446,11 @@ let simple_match_args discr head args = match Patterns.Head.desc head with
    stop and return our accumulator.
 *)
 let discr_pat q pss =
+  let open Patterns.Head in
   let rec refine_pat acc = function
     | [] -> acc
     | ((head, _), _) :: rows ->
-      match Patterns.Head.desc head with
+      match head.pat_desc with
       | Any -> refine_pat acc rows
       | Tuple _ | Lazy -> head
       | Record lbls ->
@@ -461,15 +468,12 @@ let discr_pat q pss =
               lbl :: r
           ) lbls (record_arg acc)
         in
-        let d =
-          let open Patterns.Head in
-          make ~loc:(loc head) ~typ:(typ head) ~env:(env head) (Record fields)
-        in
+        let d = { head with pat_desc = Record fields } in
         refine_pat d rows
       | _ -> acc
   in
-  let q, _ = Patterns.Head.deconstruct q in
-  match Patterns.Head.desc q with
+  let q, _ = deconstruct q in
+  match q.pat_desc with
   (* short-circuiting: clearly if we have anything other than [Record] or
      [Any] to start with, we're not going to be able refine at all. So
      there's no point going over the matrix. *)
@@ -660,8 +664,8 @@ let build_specialized_submatrices ~extend_row discr rows =
   let rec form_groups constr_groups omega_tails = function
     | [] -> (constr_groups, omega_tails)
     | ((head, args), tail) :: rest ->
-        match Patterns.Head.desc head with
-        | Any ->
+        match head.pat_desc with
+        | Patterns.Head.Any ->
             (* note that calling insert_omega here would be wrong
                as some groups may not have been formed yet, if the
                first row with this head pattern comes after in the list *)
@@ -673,7 +677,8 @@ let build_specialized_submatrices ~extend_row discr rows =
 
   let constr_groups, omega_tails =
     let initial_constr_group =
-      match Patterns.Head.desc discr with
+      let open Patterns.Head in
+      match discr.pat_desc with
       | Record _ | Tuple _ | Lazy ->
         (* [discr] comes from [discr_pat], and in this case subsumes any of the
            patterns we could find on the first column of [rows]. So it is better
@@ -707,8 +712,8 @@ let set_last a =
 let mark_partial =
   let zero = make_pat (Tpat_constant (Const_int 0)) Ctype.none Env.empty in
   List.map (fun ((hp, _), _ as ps) ->
-    match Patterns.Head.desc hp with
-    | Any -> ps
+    match hp.pat_desc with
+    | Patterns.Head.Any -> ps
     | _ -> set_last zero ps
   )
 
@@ -740,7 +745,8 @@ let close_variant env row =
 let full_match closing env =  match env with
 | [] -> false
 | (discr, _) :: _ ->
-  match Patterns.Head.desc discr with
+  let open Patterns.Head in
+  match discr.pat_desc with
   | Any -> assert false
   | Construct { cstr_tag = Cstr_extension _ ; _ } -> false
   | Construct c -> List.length env = c.cstr_consts + c.cstr_nonconsts
@@ -748,7 +754,7 @@ let full_match closing env =  match env with
       let fields =
         List.map
           (fun (d, _) ->
-            match Patterns.Head.desc d with
+            match d.pat_desc with
             | Variant { tag } -> tag
             | _ -> assert false)
           env
@@ -785,11 +791,10 @@ let should_extend ext env = match ext with
 | Some ext -> begin match env with
   | [] -> assert false
   | (p,_)::_ ->
-      begin match Patterns.Head.desc p with
+      let open Patterns.Head in
+      begin match p.pat_desc with
       | Construct {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)} ->
-          let path =
-            get_constructor_type_path (Patterns.Head.typ p) (Patterns.Head.env p)
-          in
+          let path = get_constructor_type_path p.pat_type p.pat_env in
           Path.same path ext
       | Construct {cstr_tag=(Cstr_extension _)} -> false
       | Constant _ | Tuple _ | Variant _ | Record _ | Array _ | Lazy -> false
@@ -887,9 +892,10 @@ let rec get_variant_constructors env ty =
 
 (* Sends back a pattern that complements constructor tags all_tag *)
 let complete_constrs p all_tags =
-  let c = match Patterns.Head.desc p with Construct c -> c | _ -> assert false in
+  let open Patterns.Head in
+  let c = match p.pat_desc with Construct c -> c | _ -> assert false in
   let not_tags = complete_tags c.cstr_consts c.cstr_nonconsts all_tags in
-  let constrs = get_variant_constructors (Patterns.Head.env p) c.cstr_res in
+  let constrs = get_variant_constructors p.pat_env c.cstr_res in
   let others =
     List.filter
       (fun cnstr -> ConstructorTagHashtbl.mem not_tags cnstr.cstr_tag)
@@ -899,10 +905,11 @@ let complete_constrs p all_tags =
   const @ nonconst
 
 let build_other_constrs env p =
-  match Patterns.Head.desc p with
+  let open Patterns.Head in
+  match p.pat_desc with
   | Construct { cstr_tag = Cstr_constant _ | Cstr_block _ } ->
       let get_tag q =
-        match Patterns.Head.desc q with
+        match q.pat_desc with
         | Construct c -> c.cstr_tag
         | _ -> fatal_error "Parmatch.get_tag" in
       let all_tags =  List.map (fun (p,_) -> get_tag p) env in
@@ -918,11 +925,11 @@ let complete_constrs p all_tags =
 (* Auxiliary for build_other *)
 
 let build_other_constant proj make first next p env =
-  let all = List.map (fun (p, _) -> proj (Patterns.Head.desc p)) env in
+  let all = List.map (fun (p, _) -> proj p.pat_desc) env in
   let rec try_const i =
     if List.mem i all
     then try_const (next i)
-    else make_pat (make i) (Patterns.Head.typ p) (Patterns.Head.env p)
+    else make_pat (make i) p.pat_type p.pat_env
   in try_const first
 
 (*
@@ -936,19 +943,18 @@ let build_other ext env =
   match env with
   | [] -> omega
   | (d, _) :: _ ->
-      match Patterns.Head.desc d with
+      let open Patterns.Head in
+      match d.pat_desc with
       | Construct { cstr_tag = Cstr_extension _ } ->
           (* let c = {c with cstr_name = "*extension*"} in *) (* PR#7330 *)
           make_pat
             (Tpat_var (Ident.create_local "*extension*",
-                       {txt="*extension*"; loc = Patterns.Head.loc d}))
+                       {txt="*extension*"; loc = d.pat_loc}))
             Ctype.none Env.empty
       | Construct _ ->
           begin match ext with
           | Some ext ->
-              if Path.same ext
-                   (get_constructor_type_path
-                      (Patterns.Head.typ d) (Patterns.Head.env d))
+              if Path.same ext (get_constructor_type_path d.pat_type d.pat_env)
               then
                 extra_pat
               else
@@ -960,15 +966,14 @@ let build_other ext env =
           let tags =
             List.map
               (fun (d, _) ->
-                match Patterns.Head.desc d with
+                match d.pat_desc with
                 | Variant { tag } -> tag
                 | _ -> assert false)
               env
             in
             let make_other_pat tag const =
-              let arg = if const then None else Some omega in
-              make_pat (Tpat_variant(tag, arg, cstr_row))
-                (Patterns.Head.typ d) (Patterns.Head.env d)
+              let arg = if const then None else Some Patterns.omega in
+              make_pat (Tpat_variant(tag, arg, cstr_row)) d.pat_type d.pat_env
             in
             let row = type_row () in
             begin match
@@ -992,14 +997,13 @@ let build_other ext env =
             | pat::other_pats ->
                 List.fold_left
                   (fun p_res pat ->
-                    make_pat (Tpat_or (pat, p_res, None))
-                      (Patterns.Head.typ d) (Patterns.Head.env d))
+                    make_pat (Tpat_or (pat, p_res, None)) d.pat_type d.pat_env)
                   pat other_pats
             end
       | Constant Const_char _ ->
           let all_chars =
             List.map
-              (fun (p,_) -> match Patterns.Head.desc p with
+              (fun (p,_) -> match p.pat_desc with
               | Constant (Const_char c) -> c
               | _ -> assert false)
               env
@@ -1011,11 +1015,10 @@ let build_other ext env =
               if List.mem ci all_chars then
                 find_other (i+1) imax
               else
-                make_pat (Tpat_constant (Const_char ci))
-                  (Patterns.Head.typ d) (Patterns.Head.env d)
+                make_pat (Tpat_constant (Const_char ci)) d.pat_type d.pat_env
           in
           let rec try_chars = function
-            | [] -> omega
+            | [] -> Patterns.omega
             | (c1,c2) :: rest ->
                 try
                   find_other (Char.code c1) (Char.code c2)
@@ -1062,18 +1065,16 @@ let build_other ext env =
       | Array _ ->
           let all_lengths =
             List.map
-              (fun (p,_) -> match Patterns.Head.desc p with
+              (fun (p,_) -> match p.pat_desc with
               | Array len -> len
               | _ -> assert false)
               env in
           let rec try_arrays l =
             if List.mem l all_lengths then try_arrays (l+1)
             else
-              make_pat
-                (Tpat_array (omegas l))
-                (Patterns.Head.typ d) (Patterns.Head.env d) in
+              make_pat (Tpat_array (omegas l)) d.pat_type d.pat_env in
           try_arrays 0
-      | _ -> omega
+      | _ -> Patterns.omega
 
 let rec has_instance p = match p.pat_desc with
   | Tpat_variant (l,_,r) when is_absent l r -> false
@@ -1204,13 +1205,13 @@ let rec list_satisfying_vectors pss qs =
                   )
                 in
                 if full_match false constrs then for_constrs () else
-                begin match Patterns.Head.desc p with
+                begin match p.pat_desc with
                 | Construct _ ->
                     (* activate this code for checking non-gadt constructors *)
                     wild default (build_other_constrs constrs p)
                     @ for_constrs ()
                 | _ ->
-                    wild default omega
+                    wild default Patterns.omega
                 end
           end
       | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> []
@@ -1444,7 +1445,7 @@ let rec pressure_variants tdefs = function
               | [], _
               | _, None -> ()
               | (d, _) :: _, Some env ->
-                match Patterns.Head.desc d with
+                match d.pat_desc with
                 | Variant { type_row; _ } ->
                   let row = type_row () in
                   if Btype.row_fixed row

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -28,6 +28,48 @@ val omegas : int -> pattern list
 val omega_list : 'a list -> pattern list
 (** [List.map (fun _ -> omega)] *)
 
+module Pattern_head : sig
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+          (* the row of the type may evolve if [close_variant] is called,
+             hence the (unit -> ...) delay *)
+    | Array of int
+    | Lazy
+
+  type t
+
+  val desc : t -> desc
+  val env : t -> Env.t
+  val loc : t -> Location.t
+  val typ : t -> Types.type_expr
+
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
+
+      @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
+  val deconstruct : pattern -> t * pattern list
+
+  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
+  val to_omega_pattern : t -> pattern
+
+  val make
+    :  loc:Location.t
+    -> typ:Types.type_expr
+    -> env:Env.t
+    -> desc
+    -> t
+
+  val omega : t
+
+end
+
 val normalize_pat : pattern -> pattern
 (** Keep only the "head" of a pattern: all arguments are replaced by [omega], so
     are variables. *)

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -51,6 +51,8 @@ module Pattern_head : sig
   val loc : t -> Location.t
   val typ : t -> Types.type_expr
 
+  val arity : t -> int
+
   (** [deconstruct p] returns the head of [p] and the list of sub patterns.
 
       @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -19,7 +19,7 @@ open Asttypes
 open Typedtree
 open Types
 
-val normalize_pat : pattern -> pattern
+val normalize_pat : Patterns.Simple.pattern -> pattern
 (** Keep only the "head" of a pattern: all arguments are replaced by [omega], so
     are variables. *)
 
@@ -71,7 +71,7 @@ val set_args_erase_mutable : pattern -> pattern list -> pattern list
 
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :
-    pattern -> constructor_tag list -> constructor_description  list
+    Patterns.Simple.pattern -> constructor_tag list -> constructor_description  list
 
 (** [ppat_of_type] builds an untyped pattern from its expected type,
     for explosion of wildcard patterns in Typecore.type_pat.

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -19,59 +19,6 @@ open Asttypes
 open Typedtree
 open Types
 
-val omega : pattern
-(** aka. "Tpat_any" or "_"  *)
-
-val omegas : int -> pattern list
-(** [List.init (fun _ -> omega)] *)
-
-val omega_list : 'a list -> pattern list
-(** [List.map (fun _ -> omega)] *)
-
-module Pattern_head : sig
-  type desc =
-    | Any
-    | Construct of constructor_description
-    | Constant of constant
-    | Tuple of int
-    | Record of label_description list
-    | Variant of
-        { tag: label; has_arg: bool;
-          cstr_row: row_desc ref;
-          type_row : unit -> row_desc; }
-          (* the row of the type may evolve if [close_variant] is called,
-             hence the (unit -> ...) delay *)
-    | Array of int
-    | Lazy
-
-  type t
-
-  val desc : t -> desc
-  val env : t -> Env.t
-  val loc : t -> Location.t
-  val typ : t -> Types.type_expr
-
-  val arity : t -> int
-
-  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
-
-      @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
-
-  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
-  val to_omega_pattern : t -> pattern
-
-  val make
-    :  loc:Location.t
-    -> typ:Types.type_expr
-    -> env:Env.t
-    -> desc
-    -> t
-
-  val omega : t
-
-end
-
 val normalize_pat : pattern -> pattern
 (** Keep only the "head" of a pattern: all arguments are replaced by [omega], so
     are variables. *)

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -47,6 +47,8 @@ module Simple = struct
   ]
 
   type pattern = view pattern_data
+
+  let omega = { omega with pat_desc = `Any }
 end
 
 module Half_simple = struct
@@ -108,6 +110,17 @@ module General = struct
 
   let erase p : Typedtree.pattern =
     { p with pat_desc = erase_desc p.pat_desc }
+
+  let rec strip_vars (p : pattern) : Half_simple.pattern =
+    match p.pat_desc with
+    | `Alias (p, _, _) -> strip_vars (view p)
+    | `Var _ -> { p with pat_desc = `Any }
+    | #Half_simple.view as view -> { p with pat_desc = view }
+
+  let assert_simple (p : pattern) : Simple.pattern =
+    match strip_vars p with
+    | {pat_desc = `Or _; _} -> failwith "Patterns.assert_simple"
+    | {pat_desc = #Simple.view; _} as p -> p
 end
 
 (* the head constructor of a simple pattern *)
@@ -130,10 +143,8 @@ module Head : sig
 
   val arity : t -> int
 
-  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
-
-      @raises [Invalid_arg _] if [p] is an or-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns. *)
+  val deconstruct : Simple.pattern -> t * pattern list
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern
@@ -157,17 +168,15 @@ end = struct
 
   type t = desc pattern_data
 
-  let deconstruct q =
-    let rec deconstruct_desc = function
-      | Tpat_any
-      | Tpat_var _ -> Any, []
-      | Tpat_constant c -> Constant c, []
-      | Tpat_alias (p,_,_) -> deconstruct_desc p.pat_desc
-      | Tpat_tuple args ->
+  let deconstruct (q : Simple.pattern) =
+    let deconstruct_desc = function
+      | `Any -> Any, []
+      | `Constant c -> Constant c, []
+      | `Tuple args ->
           Tuple (List.length args), args
-      | Tpat_construct (_, c, args) ->
+      | `Construct (_, c, args) ->
           Construct c, args
-      | Tpat_variant (tag, arg, cstr_row) ->
+      | `Variant (tag, arg, cstr_row) ->
           let has_arg, pats =
             match arg with
             | None -> false, []
@@ -179,15 +188,14 @@ end = struct
               | _ -> assert false
           in
           Variant {tag; has_arg; cstr_row; type_row}, pats
-      | Tpat_array args ->
+      | `Array args ->
           Array (List.length args), args
-      | Tpat_record (largs, _) ->
+      | `Record (largs, _) ->
           let lbls = List.map (fun (_,lbl,_) -> lbl) largs in
           let pats = List.map (fun (_,_,pat) -> pat) largs in
           Record lbls, pats
-      | Tpat_lazy p ->
+      | `Lazy p ->
           Lazy, [p]
-      | Tpat_or _ -> invalid_arg "Parmatch.Pattern_head.deconstruct: (P | Q)"
     in
     let desc, pats = deconstruct_desc q.pat_desc in
     { q with pat_desc = desc }, pats

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -1,0 +1,172 @@
+open Asttypes
+open Types
+open Typedtree
+
+let omega = {
+  pat_desc = Tpat_any;
+  pat_loc = Location.none;
+  pat_extra = [];
+  pat_type = Ctype.none;
+  pat_env = Env.empty;
+  pat_attributes = [];
+}
+
+let rec omegas i =
+  if i <= 0 then [] else omega :: omegas (i-1)
+
+let omega_list l = List.map (fun _ -> omega) l
+
+module Head : sig
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+    | Array of int
+    | Lazy
+
+  type t
+
+  val desc : t -> desc
+  val env : t -> Env.t
+  val loc : t -> Location.t
+  val typ : t -> Types.type_expr
+
+  val arity : t -> int
+
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
+
+      @raises [Invalid_arg _] if [p] is an or-pattern.  *)
+  val deconstruct : pattern -> t * pattern list
+
+  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
+  val to_omega_pattern : t -> pattern
+
+  val make
+    :  loc:Location.t
+    -> typ:Types.type_expr
+    -> env:Env.t
+    -> desc
+    -> t
+
+  val omega : t
+
+end = struct
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+          (* the row of the type may evolve if [close_variant] is called,
+             hence the (unit -> ...) delay *)
+    | Array of int
+    | Lazy
+
+  type t = {
+    desc: desc;
+    typ : Types.type_expr;
+    loc : Location.t;
+    env : Env.t;
+    attributes : attributes;
+  }
+
+  let desc { desc } = desc
+  let env { env } = env
+  let loc { loc } = loc
+  let typ { typ } = typ
+
+  let deconstruct q =
+    let rec deconstruct_desc = function
+      | Tpat_any
+      | Tpat_var _ -> Any, []
+      | Tpat_constant c -> Constant c, []
+      | Tpat_alias (p,_,_) -> deconstruct_desc p.pat_desc
+      | Tpat_tuple args ->
+          Tuple (List.length args), args
+      | Tpat_construct (_, c, args) ->
+          Construct c, args
+      | Tpat_variant (tag, arg, cstr_row) ->
+          let has_arg, pats =
+            match arg with
+            | None -> false, []
+            | Some a -> true, [a]
+          in
+          let type_row () =
+            match Ctype.expand_head q.pat_env q.pat_type with
+              | {desc = Tvariant type_row} -> Btype.row_repr type_row
+              | _ -> assert false
+          in
+          Variant {tag; has_arg; cstr_row; type_row}, pats
+      | Tpat_array args ->
+          Array (List.length args), args
+      | Tpat_record (largs, _) ->
+          let lbls = List.map (fun (_,lbl,_) -> lbl) largs in
+          let pats = List.map (fun (_,_,pat) -> pat) largs in
+          Record lbls, pats
+      | Tpat_lazy p ->
+          Lazy, [p]
+      | Tpat_or _ -> invalid_arg "Parmatch.Pattern_head.deconstruct: (P | Q)"
+    in
+    let desc, pats = deconstruct_desc q.pat_desc in
+    { desc; typ = q.pat_type; loc = q.pat_loc;
+      env = q.pat_env; attributes = q.pat_attributes }, pats
+
+  let arity t =
+    match t.desc with
+      | Any -> 0
+      | Constant _ -> 0
+      | Construct c -> c.cstr_arity
+      | Tuple n | Array n -> n
+      | Record l -> List.length l
+      | Variant { has_arg; _ } -> if has_arg then 1 else 0
+      | Lazy -> 1
+
+  let to_omega_pattern t =
+    let pat_desc =
+      match t.desc with
+      | Any -> Tpat_any
+      | Lazy -> Tpat_lazy omega
+      | Constant c -> Tpat_constant c
+      | Tuple n -> Tpat_tuple (omegas n)
+      | Array n -> Tpat_array (omegas n)
+      | Construct c ->
+          let lid_loc = Location.mkloc (Longident.Lident c.cstr_name) t.loc in
+          Tpat_construct (lid_loc, c, omegas c.cstr_arity)
+      | Variant { tag; has_arg; cstr_row } ->
+          let arg_opt = if has_arg then Some omega else None in
+          Tpat_variant (tag, arg_opt, cstr_row)
+      | Record lbls ->
+          let lst =
+            List.map (fun lbl ->
+              let lid_loc =
+                Location.mkloc (Longident.Lident lbl.lbl_name) t.loc
+              in
+              (lid_loc, lbl, omega)
+            ) lbls
+          in
+          Tpat_record (lst, Closed)
+    in
+    { pat_desc; pat_type = t.typ; pat_loc = t.loc; pat_extra = [];
+      pat_env = t.env; pat_attributes = t.attributes }
+
+  let make ~loc ~typ ~env desc =
+    { desc; loc; typ; env; attributes = [] }
+
+  let omega =
+    { desc = Any
+    ; loc = Location.none
+    ; typ = Ctype.none
+    ; env = Env.empty
+    ; attributes = []
+    }
+end

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -30,12 +30,7 @@ module Head : sig
     | Array of int
     | Lazy
 
-  type t
-
-  val desc : t -> desc
-  val env : t -> Env.t
-  val loc : t -> Location.t
-  val typ : t -> Types.type_expr
+  type t = desc pattern_
 
   val arity : t -> int
 
@@ -47,15 +42,7 @@ module Head : sig
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern
 
-  val make
-    :  loc:Location.t
-    -> typ:Types.type_expr
-    -> env:Env.t
-    -> desc
-    -> t
-
   val omega : t
-
 end = struct
   type desc =
     | Any
@@ -72,18 +59,7 @@ end = struct
     | Array of int
     | Lazy
 
-  type t = {
-    desc: desc;
-    typ : Types.type_expr;
-    loc : Location.t;
-    env : Env.t;
-    attributes : attributes;
-  }
-
-  let desc { desc } = desc
-  let env { env } = env
-  let loc { loc } = loc
-  let typ { typ } = typ
+  type t = desc pattern_
 
   let deconstruct q =
     let rec deconstruct_desc = function
@@ -118,11 +94,10 @@ end = struct
       | Tpat_or _ -> invalid_arg "Parmatch.Pattern_head.deconstruct: (P | Q)"
     in
     let desc, pats = deconstruct_desc q.pat_desc in
-    { desc; typ = q.pat_type; loc = q.pat_loc;
-      env = q.pat_env; attributes = q.pat_attributes }, pats
+    { q with pat_desc = desc }, pats
 
   let arity t =
-    match t.desc with
+    match t.pat_desc with
       | Any -> 0
       | Constant _ -> 0
       | Construct c -> c.cstr_arity
@@ -133,14 +108,15 @@ end = struct
 
   let to_omega_pattern t =
     let pat_desc =
-      match t.desc with
+      let mkloc x = Location.mkloc x t.pat_loc in
+      match t.pat_desc with
       | Any -> Tpat_any
       | Lazy -> Tpat_lazy omega
       | Constant c -> Tpat_constant c
       | Tuple n -> Tpat_tuple (omegas n)
       | Array n -> Tpat_array (omegas n)
       | Construct c ->
-          let lid_loc = Location.mkloc (Longident.Lident c.cstr_name) t.loc in
+          let lid_loc = mkloc (Longident.Lident c.cstr_name) in
           Tpat_construct (lid_loc, c, omegas c.cstr_arity)
       | Variant { tag; has_arg; cstr_row } ->
           let arg_opt = if has_arg then Some omega else None in
@@ -148,25 +124,16 @@ end = struct
       | Record lbls ->
           let lst =
             List.map (fun lbl ->
-              let lid_loc =
-                Location.mkloc (Longident.Lident lbl.lbl_name) t.loc
-              in
+              let lid_loc = mkloc (Longident.Lident lbl.lbl_name) in
               (lid_loc, lbl, omega)
             ) lbls
           in
           Tpat_record (lst, Closed)
     in
-    { pat_desc; pat_type = t.typ; pat_loc = t.loc; pat_extra = [];
-      pat_env = t.env; pat_attributes = t.attributes }
-
-  let make ~loc ~typ ~env desc =
-    { desc; loc; typ; env; attributes = [] }
-
-  let omega =
-    { desc = Any
-    ; loc = Location.none
-    ; typ = Ctype.none
-    ; env = Env.empty
-    ; attributes = []
+    { t with
+      pat_desc;
+      pat_extra = [];
     }
+
+  let omega = { omega with pat_desc = Any }
 end

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -2,6 +2,8 @@ open Asttypes
 open Types
 open Typedtree
 
+(* useful pattern auxiliary functions *)
+
 let omega = {
   pat_desc = Tpat_any;
   pat_loc = Location.none;
@@ -15,6 +17,95 @@ let rec omegas i =
   if i <= 0 then [] else omega :: omegas (i-1)
 
 let omega_list l = List.map (fun _ -> omega) l
+
+(* "views" on patterns are polymorphic variants
+   that allow to restrict the set of pattern constructors
+   statically allowed at a particular place *)
+
+type simple_view = [
+  | `Any
+  | `Constant of constant
+  | `Tuple of pattern list
+  | `Construct of Longident.t loc * constructor_description * pattern list
+  | `Variant of label * pattern option * row_desc ref
+  | `Record of (Longident.t loc * label_description * pattern) list * closed_flag
+  | `Array of pattern list
+  | `Lazy of pattern
+]
+
+type half_simple_view = [
+  | simple_view
+  | `Or of pattern * pattern * row_desc option
+]
+type general_view = [
+  | half_simple_view
+  | `Var of Ident.t * string loc
+  | `Alias of pattern * Ident.t * string loc
+]
+
+module Non_empty_row = struct
+  type 'a t = 'a * Typedtree.pattern list
+
+  let of_initial = function
+    | [] -> assert false
+    | pat :: patl -> (pat, patl)
+
+  let map_first f (p, patl) = (f p, patl)
+end
+
+module General : sig
+  type pattern = general_view pattern_data
+  
+  val view : Typedtree.pattern -> pattern
+  val erase : [< general_view ] pattern_data -> Typedtree.pattern
+end = struct
+  type pattern = general_view pattern_data
+  
+  let view_desc = function
+    | Tpat_any ->
+       `Any
+    | Tpat_var (id, str) ->
+       `Var (id, str)
+    | Tpat_alias (p, id, str) ->
+       `Alias (p, id, str)
+    | Tpat_constant cst ->
+       `Constant cst
+    | Tpat_tuple ps ->
+       `Tuple ps
+    | Tpat_construct (cstr, cstr_descr, args) ->
+       `Construct (cstr, cstr_descr, args)
+    | Tpat_variant (cstr, arg, row_desc) ->
+       `Variant (cstr, arg, row_desc)
+    | Tpat_record (fields, closed) ->
+       `Record (fields, closed)
+    | Tpat_array ps -> `Array ps
+    | Tpat_or (p, q, row_desc) -> `Or (p, q, row_desc)
+    | Tpat_lazy p -> `Lazy p
+
+  let view p : pattern =
+    { p with pat_desc = view_desc p.pat_desc }
+
+  let erase_desc = function
+    | `Any -> Tpat_any
+    | `Var (id, str) -> Tpat_var (id, str)
+    | `Alias (p, id, str) -> Tpat_alias (p, id, str)
+    | `Constant cst -> Tpat_constant cst
+    | `Tuple ps -> Tpat_tuple ps
+    | `Construct (cstr, cst_descr, args) ->
+       Tpat_construct (cstr, cst_descr, args)
+    | `Variant (cstr, arg, row_desc) ->
+       Tpat_variant (cstr, arg, row_desc)
+    | `Record (fields, closed) ->
+       Tpat_record (fields, closed)
+    | `Array ps -> Tpat_array ps
+    | `Or (p, q, row_desc) -> Tpat_or (p, q, row_desc)
+    | `Lazy p -> Tpat_lazy p
+
+  let erase p =
+    { p with pat_desc = erase_desc p.pat_desc }
+end
+
+(* the head constructor of a simple pattern *)
 
 module Head : sig
   type desc =
@@ -30,7 +121,7 @@ module Head : sig
     | Array of int
     | Lazy
 
-  type t = desc pattern_
+  type t = desc pattern_data
 
   val arity : t -> int
 
@@ -59,7 +150,7 @@ end = struct
     | Array of int
     | Lazy
 
-  type t = desc pattern_
+  type t = desc pattern_data
 
   let deconstruct q =
     let rec deconstruct_desc = function

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -1,0 +1,56 @@
+open Asttypes
+open Typedtree
+open Types
+
+val omega : pattern
+(** aka. "Tpat_any" or "_"  *)
+
+val omegas : int -> pattern list
+(** [List.init (fun _ -> omega)] *)
+
+val omega_list : 'a list -> pattern list
+(** [List.map (fun _ -> omega)] *)
+
+module Head : sig
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+          (* the row of the type may evolve if [close_variant] is called,
+             hence the (unit -> ...) delay *)
+    | Array of int
+    | Lazy
+
+  type t
+
+  val desc : t -> desc
+  val env : t -> Env.t
+  val loc : t -> Location.t
+  val typ : t -> Types.type_expr
+
+  val arity : t -> int
+
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
+
+      @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
+  val deconstruct : pattern -> t * pattern list
+
+  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
+  val to_omega_pattern : t -> pattern
+
+  val make
+    :  loc:Location.t
+    -> typ:Types.type_expr
+    -> env:Env.t
+    -> desc
+    -> t
+
+  val omega : t
+
+end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -34,6 +34,8 @@ module Simple : sig
     | `Lazy of pattern
   ]
   type pattern = view pattern_data
+
+  val omega : [> view ] pattern_data
 end
 
 module Half_simple : sig
@@ -54,6 +56,10 @@ module General : sig
 
   val view : Typedtree.pattern -> pattern
   val erase : [< view ] pattern_data -> Typedtree.pattern
+
+  val strip_vars : pattern -> Half_simple.pattern
+
+  val assert_simple : pattern -> Simple.pattern
 end
 
 module Head : sig
@@ -79,7 +85,7 @@ module Head : sig
   (** [deconstruct p] returns the head of [p] and the list of sub patterns.
 
       @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
+  val deconstruct : Simple.pattern -> t * pattern list
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -11,27 +11,6 @@ val omegas : int -> pattern list
 val omega_list : 'a list -> pattern list
 (** [List.map (fun _ -> omega)] *)
 
-type simple_view = [
-  | `Any
-  | `Constant of constant
-  | `Tuple of pattern list
-  | `Construct of Longident.t loc * constructor_description * pattern list
-  | `Variant of label * pattern option * row_desc ref
-  | `Record of (Longident.t loc * label_description * pattern) list * closed_flag
-  | `Array of pattern list
-  | `Lazy of pattern
-]
-
-type half_simple_view = [
-  | simple_view
-  | `Or of pattern * pattern * row_desc option
-]
-type general_view = [
-  | half_simple_view
-  | `Var of Ident.t * string loc
-  | `Alias of pattern * Ident.t * string loc
-]
-
 module Non_empty_row : sig
   type 'a t = 'a * Typedtree.pattern list
 
@@ -41,11 +20,40 @@ module Non_empty_row : sig
   val map_first : ('a -> 'b) -> 'a t -> 'b t
 end
 
+module Simple : sig
+  type view = [
+    | `Any
+    | `Constant of constant
+    | `Tuple of pattern list
+    | `Construct of
+        Longident.t loc * constructor_description * pattern list
+    | `Variant of label * pattern option * row_desc ref
+    | `Record of
+        (Longident.t loc * label_description * pattern) list * closed_flag
+    | `Array of pattern list
+    | `Lazy of pattern
+  ]
+  type pattern = view pattern_data
+end
+
+module Half_simple : sig
+  type view = [
+    | Simple.view
+    | `Or of pattern * pattern * row_desc option
+  ]
+  type pattern = view pattern_data
+end
+
 module General : sig
-  type pattern = general_view pattern_data
+  type view = [
+    | Half_simple.view
+    | `Var of Ident.t * string loc
+    | `Alias of pattern * Ident.t * string loc
+  ]
+  type pattern = view pattern_data
 
   val view : Typedtree.pattern -> pattern
-  val erase : [< general_view ] pattern_data -> Typedtree.pattern
+  val erase : [< view ] pattern_data -> Typedtree.pattern
 end
 
 module Head : sig

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -27,12 +27,7 @@ module Head : sig
     | Array of int
     | Lazy
 
-  type t
-
-  val desc : t -> desc
-  val env : t -> Env.t
-  val loc : t -> Location.t
-  val typ : t -> Types.type_expr
+  type t = desc pattern_
 
   val arity : t -> int
 
@@ -43,13 +38,6 @@ module Head : sig
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern
-
-  val make
-    :  loc:Location.t
-    -> typ:Types.type_expr
-    -> env:Env.t
-    -> desc
-    -> t
 
   val omega : t
 

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -11,6 +11,43 @@ val omegas : int -> pattern list
 val omega_list : 'a list -> pattern list
 (** [List.map (fun _ -> omega)] *)
 
+type simple_view = [
+  | `Any
+  | `Constant of constant
+  | `Tuple of pattern list
+  | `Construct of Longident.t loc * constructor_description * pattern list
+  | `Variant of label * pattern option * row_desc ref
+  | `Record of (Longident.t loc * label_description * pattern) list * closed_flag
+  | `Array of pattern list
+  | `Lazy of pattern
+]
+
+type half_simple_view = [
+  | simple_view
+  | `Or of pattern * pattern * row_desc option
+]
+type general_view = [
+  | half_simple_view
+  | `Var of Ident.t * string loc
+  | `Alias of pattern * Ident.t * string loc
+]
+
+module Non_empty_row : sig
+  type 'a t = 'a * Typedtree.pattern list
+
+  val of_initial : Typedtree.pattern list -> Typedtree.pattern t
+  (** 'assert false' on empty rows *)
+
+  val map_first : ('a -> 'b) -> 'a t -> 'b t
+end
+
+module General : sig
+  type pattern = general_view pattern_data
+
+  val view : Typedtree.pattern -> pattern
+  val erase : [< general_view ] pattern_data -> Typedtree.pattern
+end
+
 module Head : sig
   type desc =
     | Any
@@ -27,7 +64,7 @@ module Head : sig
     | Array of int
     | Lazy
 
-  type t = desc pattern_
+  type t = desc pattern_data
 
   val arity : t -> int
 


### PR DESCRIPTION
This is a continuation of the work @gasche and I started last summer (cf. #8766, #8768, #8850, #8851, #8861 and #8869).

We are about to send another wave of small(ish) PRs containing code that we wrote back then, and we thought it would be nice for reviewers to also have the whole diff of our current changes, which this PR contains, to have a idea of where things are going.

The main focus at this point is to introduce dedicated types to represent pattern matches (and patterns themselves) at various points of the pipeline, thus eliminating a good number of `assert false`.

