### PR TITLE
Document base case of List.for_all and List.exists

### DIFF
--- a/Changes
+++ b/Changes
@@ -141,7 +141,7 @@ Working version
 
 - #9255, #9300: reference chapter, split the expression grammar
   (Florian Angeletti, report by Harrison Ainsworth, review by Gabriel Scherer)
-  
+
 - #9325: documented base case for `List.for_all` and `List.exists`
   (Glenn Slotte, review by Florian Angeletti)
 

--- a/Changes
+++ b/Changes
@@ -141,6 +141,9 @@ Working version
 
 - #9255, #9300: reference chapter, split the expression grammar
   (Florian Angeletti, report by Harrison Ainsworth, review by Gabriel Scherer)
+  
+- #9325: documented base case for `List.for_all` and `List.exists`
+  (Glenn Slotte, review by Florian Angeletti)
 
 ### Compiler user-interface and warnings:
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -202,7 +202,7 @@ val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
 val for_all : ('a -> bool) -> 'a list -> bool
 (** [for_all p [a1; ...; an]] checks if all elements of the list
    satisfy the predicate [p]. That is, it returns
-   [(p a1) && (p a2) && ... && (p an)]] for a non-empty list and
+   [(p a1) && (p a2) && ... && (p an)] for a non-empty list and
    [true] if the list is empty. *)
 
 val exists : ('a -> bool) -> 'a list -> bool

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -202,14 +202,14 @@ val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
 val for_all : ('a -> bool) -> 'a list -> bool
 (** [for_all p [a1; ...; an]] checks if all elements of the list
    satisfy the predicate [p]. That is, it returns
-   [(p a1) && (p a2) && ... && (p an)]. Return [true] if list is
-   empty. *)
+   [(p a1) && (p a2) && ... && (p an)]] for a non-empty list and
+   [true] if the list is empty. *)
 
 val exists : ('a -> bool) -> 'a list -> bool
 (** [exists p [a1; ...; an]] checks if at least one element of
    the list satisfies the predicate [p]. That is, it returns
-   [(p a1) || (p a2) || ... || (p an)]. Return [false] if list
-   is empty. *)
+   [(p a1) || (p a2) || ... || (p an)] for a non-empty list and
+   [false] if the list is empty. *)
 
 val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -202,12 +202,14 @@ val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
 val for_all : ('a -> bool) -> 'a list -> bool
 (** [for_all p [a1; ...; an]] checks if all elements of the list
    satisfy the predicate [p]. That is, it returns
-   [(p a1) && (p a2) && ... && (p an)]. *)
+   [(p a1) && (p a2) && ... && (p an)]. Return [true] if list is
+   empty. *)
 
 val exists : ('a -> bool) -> 'a list -> bool
 (** [exists p [a1; ...; an]] checks if at least one element of
    the list satisfies the predicate [p]. That is, it returns
-   [(p a1) || (p a2) || ... || (p an)]. *)
+   [(p a1) || (p a2) || ... || (p an)]. Return [false] if list
+   is empty. *)
 
 val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.


### PR DESCRIPTION
The base case of `List.for_all` is not immediately obvious to me, so I think it'd be nice to have it documented. And while the base case of `List.exists` is much more obvious just from its name, I documented the base case of that as well, just for consistency.