### PR TITLE
Correct implementation of --disable-stdlib-manpages

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,6 +328,10 @@ Working version
   (Florian Angeletti, Stefan Muenzel and Thomas Refis, review by Gabriel Scherer
   and Thomas Refis)
 
+- #9335: actually have --disable-stdlib-manpages not build the manpages
+  (implementation conflicted with #8837 which wasn't picked up in review)
+  (David Allsopp, review by Florian Angeletti and Sébastien Hinderer)
+
 - #9343: Re-enable `-short-paths` for some error messages
   (Leo White, review by Florian Angeletti)
 

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ opt.opt: checknative
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
 	  $(OCAMLTEST_OPT)
-ifneq "$(WITH_OCAMLDOC)" ""
+ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif
 
@@ -264,7 +264,7 @@ all: coreall
 	$(MAKE) ocaml
 	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) \
          $(WITH_OCAMLTEST)
-ifneq "$(WITH_OCAMLDOC)" ""
+ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
 	$(MAKE) manpages
 endif
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -185,14 +185,8 @@ LIBCMOFILES = $(CMOFILES)
 LIBCMXFILES = $(LIBCMOFILES:.cmo=.cmx)
 LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
 
-ifeq "$(STDLIB_MANPAGES)" "true"
-DOCS_TARGET = manpages
-else
-DOCS_TARGET =
-endif
-
 .PHONY: all
-all: lib exe generators $(DOCS_TARGET)
+all: lib exe generators
 
 .PHONY: exe
 exe: $(OCAMLDOC)


### PR DESCRIPTION
The implementation of #8835 was accidentally broken by #8837. I think this PR amends #8835 to work in the spirit of the change made in #8837 (which was to make the building of manpages explicit). It means that `make -C ocamldoc all` now never builds the manpages, which I think is OK? As things presently stand, I think the manpages target would have been being called twice.

cc @gasche