### PR TITLE
Do not print options in usage messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -216,6 +216,9 @@ Working version
   non-development builds.
   (David Allsopp, review by Sébastien Hinderer)
 
+- #9341: Do not print option documentation in usage messages.
+    (Andrew Jeffery, review by ...)
+
 ### Bug fixes:
 
 - #7683, #1499: Fixes one case where the evaluation order in native-code

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -216,7 +216,7 @@ let main () =
                                 ("camldebug" ^ (Int.to_string (Unix.getpid ())))
       );
     begin try
-      Arg.parse speclist anonymous "";
+      Arg.parse speclist anonymous "" "";
       Arg.usage speclist
         "No program name specified\n\
          Usage: ocamldebug [options] <program> [arguments]\n\

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -16,7 +16,10 @@
 open Clflags
 open Compenv
 
-let usage = "Usage: ocamlc <options> <files>\nOptions are:"
+let err_usage = "Usage: ocamlc <options> <files>\n\
+                 Try 'ocamlc --help' for more information."
+
+let help_usage = "Usage: ocamlc <options> <files>\nOptions are:"
 
 (* Error messages to standard error formatter *)
 let ppf = Format.err_formatter
@@ -30,7 +33,7 @@ let main () =
      "<options> Compute dependencies (use 'ocamlc -depend -help' for details)"];
   try
     readenv ppf Before_args;
-    Clflags.parse_arguments anonymous usage;
+    Clflags.parse_arguments anonymous err_usage help_usage;
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
       fatal "-plugin is only supported up to OCaml 4.08.0";
@@ -44,7 +47,7 @@ let main () =
     with Arg.Bad msg ->
       begin
         prerr_endline msg;
-        Clflags.print_arguments usage;
+        Clflags.print_arguments help_usage;
         exit 2
       end
     end;

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -634,11 +634,17 @@ let main () =
          "<file> Read additional NUL separated command line arguments from \n\
          \      <file>"
   ];
-  let usage =
+  let err_usage =
+    let basename = Filename.basename Sys.argv.(0) in
+    Printf.sprintf "Usage: %s [options] <source files>\n\
+      Try '%s --help' for more information."
+                   basename basename
+  in
+  let help_usage =
     Printf.sprintf "Usage: %s [options] <source files>\nOptions are:"
                    (Filename.basename Sys.argv.(0))
   in
-  Clflags.parse_arguments file_dependencies usage;
+  Clflags.parse_arguments file_dependencies err_usage help_usage;
   Compenv.readenv ppf Before_link;
   if !sort_files then sort_files_by_dependencies !files
   else List.iter print_file_dependencies (List.sort compare !files);

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -34,7 +34,10 @@ module Backend = struct
 end
 let backend = (module Backend : Backend_intf.S)
 
-let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
+let err_usage = "Usage: ocamlopt <options> <files>\
+               \nTry 'ocamlopt --help' for more information."
+
+let help_usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 
 module Options = Main_args.Make_optcomp_options (Main_args.Default.Optmain)
 let main () =
@@ -47,7 +50,7 @@ let main () =
       ["-depend", Arg.Unit Makedepend.main_from_option,
        "<options> Compute dependencies \
         (use 'ocamlopt -depend -help' for details)"];
-    Clflags.parse_arguments anonymous usage;
+    Clflags.parse_arguments anonymous err_usage help_usage;
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
       fatal "-plugin is only supported up to OCaml 4.08.0";
@@ -61,7 +64,7 @@ let main () =
     with Arg.Bad msg ->
       begin
         prerr_endline msg;
-        Clflags.print_arguments usage;
+        Clflags.print_arguments help_usage;
         exit 2
       end
     end;

--- a/lex/main.ml
+++ b/lex/main.ml
@@ -45,15 +45,9 @@ let specs =
    "-vnum",  Arg.Unit print_version_num, " Print version number and exit";
   ]
 
-let _ =
-  Arg.parse
-    specs
-    (fun name -> source_name := Some name)
-    usage
-
+let _ = Arg.parse specs (fun name -> source_name := Some name) usage usage
 
 let main () =
-
   let source_name = match !source_name with
   | None -> Arg.usage specs usage ; exit 2
   | Some name -> name in

--- a/manual/tests/cross_reference_checker.ml
+++ b/manual/tests/cross_reference_checker.ml
@@ -235,7 +235,7 @@ let args =
 
 let () =
   let m = ref Refs.empty in
-  Arg.parse args (OCaml_refs.from_file m) usage;
+  Arg.parse args (OCaml_refs.from_file m) usage usage;
   match !aux_file with
   | None -> print_error No_aux_file; exit 2
   |  Some aux ->

--- a/ocamldoc/odoc_args.ml
+++ b/ocamldoc/odoc_args.ml
@@ -379,6 +379,7 @@ let parse () =
   let options = !options @ !help_options in
   Arg.parse (Arg.align ~limit:13 options)
       anonymous
+      (M.usage^M.options_are)
       (M.usage^M.options_are);
   (* we sort the hidden modules by name, to be sure that for example,
      A.B is before A, so we will match against A.B before A in

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -76,3 +76,4 @@ let usage = "Usage: " ^ Sys.argv.(0) ^ " options files to test"
 
 let _ =
   Arg.parse (Arg.align commandline_options) (add_to_list files_to_test) usage
+    usage

--- a/otherlibs/dynlink/extract_crc.ml
+++ b/otherlibs/dynlink/extract_crc.ml
@@ -80,7 +80,7 @@ let main () =
   Arg.parse
     ["-I", Arg.String(fun dir -> load_path := !load_path @ [dir]),
            "<dir>  Add <dir> to the list of include directories"]
-    print_crc usage;
+    print_crc usage usage;
   print_string "\n]\n"
 
 let _ = main(); exit 0

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -72,11 +72,13 @@ type spec =
 type key = string
 type doc = string
 type usage_msg = string
+type err_msg = string
+type help_msg = string
 type anon_fun = (string -> unit)
 
 val parse :
-  (key * spec * doc) list -> anon_fun -> usage_msg -> unit
-(** [Arg.parse speclist anon_fun usage_msg] parses the command line.
+  (key * spec * doc) list -> anon_fun -> err_msg -> help_msg -> unit
+(** [Arg.parse speclist anon_fun err_msg help_msg] parses the command line.
     [speclist] is a list of triples [(key, spec, doc)].
     [key] is the option keyword, it must start with a ['-'] character.
     [spec] gives the option type and the function to call when this option
@@ -89,22 +91,22 @@ val parse :
     If an error occurs, [Arg.parse] exits the program, after printing
     to standard error an error message as follows:
 -   The reason for the error: unknown option, invalid or missing argument, etc.
--   [usage_msg]
--   The list of options, each followed by the corresponding [doc] string.
-    Beware: options that have an empty [doc] string will not be included in the
-    list.
+-   [err_msg] or [help_msg] depending on the error
+-   Optionally the list of options, if help was asked for, each followed by the
+    corresponding [doc] string. Beware: options that have an empty [doc] string
+    will not be included in the list.
 
     For the user to be able to specify anonymous arguments starting with a
     [-], include for example [("-", String anon_fun, doc)] in [speclist].
 
     By default, [parse] recognizes two unit options, [-help] and [--help],
-    which will print to standard output [usage_msg] and the list of
+    which will print to standard output [help_msg] and the list of
     options, and exit the program.  You can override this behaviour
     by specifying your own [-help] and [--help] options in [speclist].
 *)
 
 val parse_dynamic :
-  (key * spec * doc) list ref -> anon_fun -> usage_msg -> unit
+  (key * spec * doc) list ref -> anon_fun -> err_msg -> help_msg -> unit
 (** Same as {!Arg.parse}, except that the [speclist] argument is a reference
     and may be updated during the parsing. A typical use for this feature
     is to parse command lines of the form:
@@ -114,8 +116,8 @@ val parse_dynamic :
 *)
 
 val parse_argv : ?current: int ref -> string array ->
-  (key * spec * doc) list -> anon_fun -> usage_msg -> unit
-(** [Arg.parse_argv ~current args speclist anon_fun usage_msg] parses
+  (key * spec * doc) list -> anon_fun -> err_msg -> help_msg -> unit
+(** [Arg.parse_argv ~current args speclist anon_fun err_msg help_msg] parses
   the array [args] as if it were the command line.  It uses and updates
   the value of [~current] (if given), or {!Arg.current}.  You must set
   it before calling [parse_argv].  The initial value of [current]
@@ -127,7 +129,7 @@ val parse_argv : ?current: int ref -> string array ->
 *)
 
 val parse_argv_dynamic : ?current:int ref -> string array ->
-  (key * spec * doc) list ref -> anon_fun -> string -> unit
+  (key * spec * doc) list ref -> anon_fun -> err_msg -> help_msg -> unit
 (** Same as {!Arg.parse_argv}, except that the [speclist] argument is a
     reference and may be updated during the parsing.
     See {!Arg.parse_dynamic}.
@@ -135,7 +137,7 @@ val parse_argv_dynamic : ?current:int ref -> string array ->
 *)
 
 val parse_and_expand_argv_dynamic : int ref -> string array ref ->
-  (key * spec * doc) list ref -> anon_fun -> string -> unit
+  (key * spec * doc) list ref -> anon_fun -> err_msg -> help_msg -> unit
 (** Same as {!Arg.parse_argv_dynamic}, except that the [argv] argument is a
     reference and may be updated during the parsing of [Expand] arguments.
     See {!Arg.parse_argv_dynamic}.
@@ -143,7 +145,7 @@ val parse_and_expand_argv_dynamic : int ref -> string array ref ->
 *)
 
 val parse_expand:
-  (key * spec * doc) list -> anon_fun -> usage_msg -> unit
+  (key * spec * doc) list -> anon_fun -> err_msg -> help_msg -> unit
 (** Same as {!Arg.parse}, except that the [Expand] arguments are allowed and
     the {!current} reference is not updated.
     @since 4.05.0

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -93,7 +93,7 @@ let test spec argv =
   r_int := 0;
   r_float := 0.0;
   accum := [];
-  Arg.parse_and_expand_argv_dynamic current argv (ref spec) f_anon "usage";
+  Arg.parse_and_expand_argv_dynamic current argv (ref spec) f_anon "usage" "usage";
   let result = List.rev !accum in
   let reference = [
       "anon(anon1)";

--- a/testsuite/tests/lib-arg/testerror.ml
+++ b/testsuite/tests/lib-arg/testerror.ml
@@ -10,8 +10,8 @@ let usage= "Arg module testing"
 
 let test total i (spec,anon,argv) =
   let argv = Array.of_list ("testerror" :: argv) in
-  try Arg.parse_argv ~current:(ref 0) argv spec anon usage with
-  | Arg.Bad s-> Printf.printf "(%d/%d) Bad:\n%s\n" (i+1) total s
+  try Arg.parse_argv ~current:(ref 0) argv spec anon usage usage with
+  | Arg.Bad s -> Printf.printf "(%d/%d) Bad:\n%s\n" (i+1) total s
   | Arg.Help s -> Printf.printf "(%d/%d) Help:\n%s\n" (i+1) total s
 
 

--- a/testsuite/tests/lib-arg/testerror.reference
+++ b/testsuite/tests/lib-arg/testerror.reference
@@ -1,16 +1,10 @@
 (1/10) Bad:
 testerror: option '-s' needs an argument.
 Arg module testing
-  -s missing arg
-  -help  Display this list of options
-  --help  Display this list of options
 
 (2/10) Bad:
 testerror: wrong argument 'true'; option '-set=true' expects no argument.
 Arg module testing
-  -set no argument expected
-  -help  Display this list of options
-  --help  Display this list of options
 
 (3/10) Help:
 Arg module testing
@@ -20,46 +14,28 @@ Arg module testing
 (4/10) Bad:
 testerror: wrong argument 'not_an_int'; option '-int' expects an integer.
 Arg module testing
-  -int wrong argument type
-  -help  Display this list of options
-  --help  Display this list of options
 
 (5/10) Bad:
 testerror: unknown option '-an-unknown-option'.
 Arg module testing
-  -help  Display this list of options
-  --help  Display this list of options
 
 (6/10) Bad:
 testerror: User-raised error.
 Arg module testing
-  -help  Display this list of options
-  --help  Display this list of options
 
 (7/10) Bad:
 testerror: User-raised error bis.
 Arg module testing
-  -error user raised error
-  -help  Display this list of options
-  --help  Display this list of options
 
 (8/10) Bad:
 testerror: wrong argument '1'; option '-rest=1' expects no argument.
 Arg module testing
-  -rest help
-  -help  Display this list of options
-  --help  Display this list of options
 
 (9/10) Bad:
 testerror: wrong argument '1'; option '-tuple=1' expects no argument.
 Arg module testing
-  -tuple help
-  -help  Display this list of options
-  --help  Display this list of options
 
 (10/10) Bad:
 testerror: wrong argument '1'; option '-unit=1' expects no argument.
 Arg module testing
-  -help  Display this list of options
-  --help  Display this list of options
 

--- a/testsuite/tests/lib-unix/common/reflector.ml
+++ b/testsuite/tests/lib-unix/common/reflector.ml
@@ -47,4 +47,4 @@ let () =
   set_binary_mode_in stdin true;
   set_binary_mode_out stdout true;
   set_binary_mode_out stderr true;
-  Arg.parse options report_bad_argument  ""
+  Arg.parse options report_bad_argument  "" ""

--- a/testsuite/tests/misc/sorts.ml
+++ b/testsuite/tests/misc/sorts.ml
@@ -4346,7 +4346,7 @@ let options = [
 let anonymous x = raise (Arg.Bad ("unrecognised option "^x));;
 
 let main () =
-  Arg.parse options anonymous usage;
+  Arg.parse options anonymous usage usage;
 
   Printf.printf "Command line arguments are:";
   for i = 1 to Array.length Sys.argv - 1 do

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -72,7 +72,7 @@ let main() =
      "-dscheduling", Arg.Set dump_scheduling, "";
      "-dlinear", Arg.Set dump_linear, "";
      "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
-    ] compile_file usage
+    ] compile_file usage usage
 
 let () =
   main ();

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -364,7 +364,7 @@ let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
 let () =
   Clflags.color := Some Misc.Color.Never;
   try
-    Arg.parse args main usage;
+    Arg.parse args main usage usage;
     Printf.eprintf "expect_test: no input file\n";
     exit 2
   with exn ->

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -251,6 +251,7 @@ let () =
              "-v", Arg.Bool (fun b -> verbose := b ), "output result on stderr"
             ]
     (fun s -> files := s :: !files)
+    "caml-tex: "
     "caml-tex: ";
   Toplevel.init ()
 

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -556,7 +556,12 @@ let arg_list = [
      "<file> Read additional NUL separated command line arguments from \n\
      \      <file>";
 ]
-let arg_usage =
+
+let arg_help_usage =
+  Printf.sprintf "%s [OPTIONS] FILES : dump content of bytecode files"
+                 Sys.argv.(0)
+
+let arg_err_usage =
   Printf.sprintf "%s [OPTIONS] FILES : dump content of bytecode files"
                  Sys.argv.(0)
 
@@ -576,7 +581,7 @@ let arg_fun filename =
   printf "## end of ocaml dump of %S\n%!" filename
 
 let main() =
-  Arg.parse_expand arg_list arg_fun arg_usage;
+  Arg.parse_expand arg_list arg_fun arg_err_usage arg_help_usage;
     exit 0
 
 let _ = main ()

--- a/tools/make_opcodes.mll
+++ b/tools/make_opcodes.mll
@@ -37,7 +37,8 @@ and opnames = parse
         "-opcodes", Arg.Set print_opcodes, " Dump opcode numbers";
       ]
     in
-    Arg.parse (Arg.align spec) ignore "Extract opcode info from instruct.h";
+    let usage = "Extract opcode info from instruct.h" in
+    Arg.parse (Arg.align spec) ignore usage usage;
     let lexbuf = Lexing.from_channel stdin in
     let id, opnames = find_enum lexbuf in
     if !print_opnames then begin

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -409,7 +409,7 @@ let arg_usage =
    Printf.sprintf "%s [OPTIONS] FILES : give information on files" Sys.argv.(0)
 
 let main() =
-  Arg.parse_expand arg_list dump_obj arg_usage;
+  Arg.parse_expand arg_list dump_obj arg_usage arg_usage;
   exit 0
 
 let _ = main ()

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -66,7 +66,7 @@ let optlist =
     :: ("-p", Arg.String add_profarg, "[afilmt]  Same as option -P")
     :: Main_args.options_with_command_line_syntax Options.list rev_compargs
 in
-Arg.parse_expand optlist anon usage;
+Arg.parse_expand optlist anon usage usage;
 if !with_impl && !with_intf then begin
   fprintf stderr "ocamlcp cannot deal with both \"-impl\" and \"-intf\"\n";
   fprintf stderr "please compile interfaces and implementations separately\n";

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -67,7 +67,7 @@ let optlist =
         \032     t  try ... with")
     :: Main_args.options_with_command_line_syntax Options.list rev_compargs
 in
-Arg.parse_expand optlist anon usage;
+Arg.parse_expand optlist anon usage usage;
 if !with_impl && !with_intf then begin
   fprintf stderr "ocamloptp cannot deal with both \"-impl\" and \"-intf\"\n";
   fprintf stderr "please compile interfaces and implementations separately\n";

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -516,7 +516,7 @@ let main () =
        "-args0", Arg.Expand Arg.read_arg0,
            "<file> Read additional NUL separated command line arguments from \n\
            \      <file>"
-    ] process_anon_file usage;
+    ] process_anon_file usage usage;
     exit 0
   with
   | Profiler msg ->

--- a/tools/primreq.ml
+++ b/tools/primreq.ml
@@ -84,6 +84,7 @@ let main() =
      "<file> Read additional NUL separated command line arguments from \n\
      \      <file>";]
     scan_obj
+    "Usage: primreq [options] <.cmo and .cma files>\nOptions are:"
     "Usage: primreq [options] <.cmo and .cma files>\nOptions are:";
   if String.length !exclude_file > 0 then exclude !exclude_file;
   String.Set.iter

--- a/tools/read_cmt.ml
+++ b/tools/read_cmt.ml
@@ -117,7 +117,7 @@ let main () =
                      "Error: the file's extension must be .cmt or .cmti.\n%!";
       Arg.usage arg_list arg_usage
     end
-  ) arg_usage
+  ) arg_usage arg_usage
 
 
 let () =

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -15,8 +15,11 @@
 
 open Clflags
 
-let usage =
-   "Usage: ocamlnat <options> <object-files> [script-file]\noptions are:"
+let err_usage = "Usage: ocamlnat <options> <object-files> [script-file \
+                 [arguments]]\nTry 'ocamlnat --help' for more information."
+
+let help_usage = "Usage: ocamlnat <options> <object-files> [script-file \
+                  [arguments]]\nOptions are:"
 
 let preload_objects = ref []
 
@@ -105,7 +108,8 @@ let main () =
   let list = ref Options.list in
   begin
     try
-      Arg.parse_and_expand_argv_dynamic current argv list file_argument usage;
+      Arg.parse_and_expand_argv_dynamic current argv list file_argument
+        err_usage help_usage;
     with
     | Arg.Bad msg -> Format.fprintf Format.err_formatter "%s%!" msg; exit 2
     | Arg.Help msg -> Format.fprintf Format.std_formatter "%s%!" msg; exit 0

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -15,8 +15,12 @@
 
 open Compenv
 
-let usage = "Usage: ocaml <options> <object-files> [script-file [arguments]]\n\
-             options are:"
+let err_usage = "Usage: ocaml <options> <object-files> [script-file \
+                 [arguments]]\nTry 'ocaml --help' for more information."
+
+let help_usage = "Usage: ocaml <options> <object-files> \
+                  [script-file [arguments]]\nOptions are:"
+
 
 let preload_objects = ref []
 
@@ -109,7 +113,8 @@ let main () =
   let list = ref Options.list in
   begin
     try
-      Arg.parse_and_expand_argv_dynamic current argv list file_argument usage;
+      Arg.parse_and_expand_argv_dynamic current argv list file_argument
+        err_usage help_usage;
     with
     | Arg.Bad msg -> Printf.eprintf "%s" msg; exit 2
     | Arg.Help msg -> Printf.printf "%s" msg; exit 0

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -494,11 +494,11 @@ let print_arguments usage =
 (* This function is almost the same as [Arg.parse_expand], except
    that [Arg.parse_expand] could not be used because it does not take a
    reference for [arg_spec].*)
-let parse_arguments f msg =
+let parse_arguments f errmsg helpmsg =
   try
     let argv = ref Sys.argv in
     let current = ref (!Arg.current) in
-    Arg.parse_and_expand_argv_dynamic current argv arg_spec f msg
+    Arg.parse_and_expand_argv_dynamic current argv arg_spec f errmsg helpmsg
   with
   | Arg.Bad msg -> Printf.eprintf "%s" msg; exit 2
   | Arg.Help msg -> Printf.printf "%s" msg; exit 0

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -254,10 +254,10 @@ val arg_spec : (string * Arg.spec * string) list ref
    added. *)
 val add_arguments : string -> (string * Arg.spec * string) list -> unit
 
-(* [parse_arguments anon_arg usage] will parse the arguments, using
-  the arguments provided in [Clflags.arg_spec].
+(* [parse_arguments anon_arg err_usage help_usage] will parse the arguments,
+   using the arguments provided in [Clflags.arg_spec].
 *)
-val parse_arguments : Arg.anon_fun -> string -> unit
+val parse_arguments : Arg.anon_fun -> Arg.err_msg -> Arg.help_msg -> unit
 
 (* [print_arguments usage] print the standard usage message *)
 val print_arguments : string -> unit


### PR DESCRIPTION
See #9295 for motivation.

This changes the building of usage messages to only include help and option descriptions when explicitly asked for.  `usage_b` now takes an optional `help` parameter (defaulting to `true`). `usage_b` now only prints the `speclist` if `help` is `true`.

