### PR TITLE
Re-enable `-short-paths` for some error messages

### DIFF
--- a/Changes
+++ b/Changes
@@ -244,6 +244,9 @@ Working version
   (Florian Angeletti, Stefan Muenzel and Thomas Refis, review by Gabriel Scherer
   and Thomas Refis)
 
+- #9343: Re-enable `-short-paths` for some error messages
+  (Leo White, review by Florian Angeletti)
+
 OCaml 4.10.0
 ------------
 

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -14,7 +14,7 @@ type t = M.t
 Line 5, characters 14-15:
 5 | let x : M.t = S
                   ^
-Error: This variant expression is expected to have type M.t
+Error: This variant expression is expected to have type t
        The constructor S does not belong to type M.t
 |}]
 
@@ -31,6 +31,6 @@ type c = M.c
 Line 7, characters 9-18:
 7 | let () = (new M.c)#bar
              ^^^^^^^^^
-Error: This expression has type M.c
+Error: This expression has type c
        It has no method bar
 |}]

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -15,7 +15,7 @@ Line 5, characters 14-15:
 5 | let x : M.t = S
                   ^
 Error: This variant expression is expected to have type t
-       The constructor S does not belong to type M.t
+       The constructor S does not belong to type t
 |}]
 
 module M = struct

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -1,0 +1,36 @@
+(* TEST
+   flags = " -short-paths "
+   * expect
+*)
+
+module M = struct type t = T end
+
+type t = M.t
+
+let x : M.t = S
+[%%expect {|
+module M : sig type t = T end
+type t = M.t
+Line 5, characters 14-15:
+5 | let x : M.t = S
+                  ^
+Error: This variant expression is expected to have type M.t
+       The constructor S does not belong to type M.t
+|}]
+
+module M = struct
+  class c = object method foo = 3 end
+end
+
+type c = M.c
+
+let () = (new M.c)#bar
+[%%expect {|
+module M : sig class c : object method foo : int end end
+type c = M.c
+Line 7, characters 9-18:
+7 | let () = (new M.c)#bar
+             ^^^^^^^^^
+Error: This expression has type M.c
+       It has no method bar
+|}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1119,6 +1119,12 @@ and type_sch ppf ty = typexp true ppf ty
 
 and type_scheme ppf ty = reset_and_mark_loops ty; typexp true ppf ty
 
+let type_path ppf p =
+  let (p', s) = best_type_path p in
+  let p = if (s = Id) then p' else p in
+  let t = tree_of_path Type p in
+  !Oprint.out_ident ppf t
+
 (* Maxence *)
 let type_scheme_max ?(b_reset_names=true) ppf ty =
   if b_reset_names then reset_names () ;

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -25,6 +25,10 @@ val tree_of_path: Path.t -> out_ident
 val path: formatter -> Path.t -> unit
 val string_of_path: Path.t -> string
 
+val type_path: formatter -> Path.t -> unit
+(** Print a type path taking account of [-short-paths].
+    Calls should be within [wrap_printing_env]. *)
+
 module Out_name: sig
   val create: string -> out_name
   val print: out_name -> string
@@ -87,7 +91,6 @@ module Conflicts: sig
 
   val reset: unit -> unit
 end
-
 
 val reset: unit -> unit
 val mark_loops: type_expr -> unit

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5007,7 +5007,8 @@ let spellcheck_idents ppf unbound valid_idents =
   spellcheck ppf (Ident.name unbound) (List.map Ident.name valid_idents)
 
 open Format
-open Printtyp
+
+let longident = Printtyp.longident
 
 (* Returns the first diff of the trace *)
 let type_clash_of_trace trace =
@@ -5155,10 +5156,10 @@ let report_error ~loc env = function
           Location.errorf ~loc
             "@[<v>@[<2>This function has type@ %a@]\
              @ @[It is applied to too many arguments;@ %s@]@]"
-            type_expr typ "maybe you forgot a `;'.";
+            Printtyp.type_expr typ "maybe you forgot a `;'.";
       | _ ->
           Location.errorf ~loc "@[<v>@[<2>This expression has type@ %a@]@ %s@]"
-            type_expr typ
+            Printtyp.type_expr typ
             "This is not a function; it cannot be applied."
       end
   | Apply_wrong_label (l, ty) ->
@@ -5169,7 +5170,7 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "@[<v>@[<2>The function applied to this argument has type@ %a@]@.\
          This argument cannot be applied %a@]"
-        type_expr ty print_label l
+        Printtyp.type_expr ty print_label l
   | Label_multiply_defined s ->
       Location.errorf ~loc "The record field label %s is defined several times"
         s
@@ -5182,29 +5183,30 @@ let report_error ~loc env = function
       Location.errorf ~loc "The record field %a is not mutable" longident lid
   | Wrong_name (eorp, ty_expected, { type_path; kind; name; valid_names; }) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        let { ty; explanation } = ty_expected in
-        if Path.is_constructor_typath type_path then begin
-          fprintf ppf
-            "@[The field %s is not part of the record \
-             argument for the %a constructor@]"
-            name.txt
-            path type_path;
-        end else begin
-          fprintf ppf
-            "@[@[<2>%s type@ %a%t@]@ \
-             The %s %s does not belong to type %a@]"
-            eorp type_expr ty
-            (report_type_expected_explanation_opt explanation)
-            (Datatype_kind.label_name kind)
-            name.txt (*kind*) path type_path;
-        end;
-        spellcheck ppf name.txt valid_names
-      ) ()
+        Printtyp.wrap_printing_env ~error:true env (fun () ->
+          let { ty; explanation } = ty_expected in
+          if Path.is_constructor_typath type_path then begin
+            fprintf ppf
+              "@[The field %s is not part of the record \
+               argument for the %a constructor@]"
+              name.txt
+              Printtyp.path type_path;
+          end else begin
+            fprintf ppf
+              "@[@[<2>%s type@ %a%t@]@ \
+               The %s %s does not belong to type %a@]"
+              eorp Printtyp.type_expr ty
+              (report_type_expected_explanation_opt explanation)
+              (Datatype_kind.label_name kind)
+              name.txt (*kind*) Printtyp.path type_path;
+          end;
+          spellcheck ppf name.txt valid_names
+      )) ()
   | Name_type_mismatch (kind, lid, tp, tpl) ->
       let type_name = Datatype_kind.type_name kind in
       let name = Datatype_kind.label_name kind in
       Location.error_of_printer ~loc (fun ppf () ->
-        report_ambiguous_type_error ppf env tp tpl
+        Printtyp.report_ambiguous_type_error ppf env tp tpl
           (function ppf ->
              fprintf ppf "The %s %a@ belongs to the %s type"
                name longident lid type_name)
@@ -5219,14 +5221,15 @@ let report_error ~loc env = function
       Location.errorf ~loc "%s" msg
   | Undefined_method (ty, me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        fprintf ppf
-          "@[<v>@[This expression has type@;<1 2>%a@]@,\
-           It has no method %s@]" type_expr ty me;
-        begin match valid_methods with
-          | None -> ()
-          | Some valid_methods -> spellcheck ppf me valid_methods
-        end
-      ) ()
+        Printtyp.wrap_printing_env ~error:true env (fun () ->
+          fprintf ppf
+            "@[<v>@[This expression has type@;<1 2>%a@]@,\
+             It has no method %s@]" Printtyp.type_expr ty me;
+          begin match valid_methods with
+            | None -> ()
+            | Some valid_methods -> spellcheck ppf me valid_methods
+          end
+      )) ()
   | Undefined_inherited_method (me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
         fprintf ppf "This expression has no method %s" me;
@@ -5244,7 +5247,7 @@ let report_error ~loc env = function
       Location.errorf ~loc "The instance variable %s is not mutable" v
   | Not_subtype(tr1, tr2) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        report_subtyping_error ppf env tr1 "is not a subtype of" tr2
+        Printtyp.report_subtyping_error ppf env tr1 "is not a subtype of" tr2
       ) ()
   | Outside_class ->
       Location.errorf ~loc
@@ -5257,10 +5260,10 @@ let report_error ~loc env = function
       Location.error_of_printer ~loc (fun ppf () ->
         Printtyp.report_unification_error ppf env trace
           (function ppf ->
-             let ty, ty' = prepare_expansion (ty, ty') in
+             let ty, ty' = Printtyp.prepare_expansion (ty, ty') in
              fprintf ppf "This expression cannot be coerced to type@;<1 2>%a;@ \
                           it has type"
-             (type_expansion ty) ty')
+             (Printtyp.type_expansion ty) ty')
           (function ppf ->
              fprintf ppf "but is here used with type");
         if b then
@@ -5274,13 +5277,13 @@ let report_error ~loc env = function
         Location.errorf ~loc
           "This function expects too many arguments,@ \
            it should have type@ %a%t"
-          type_expr ty
+          Printtyp.type_expr ty
           (report_type_expected_explanation_opt explanation)
       end else begin
         Location.errorf ~loc
           "This expression should not be a function,@ \
            the expected type is@ %a%t"
-          type_expr ty
+          Printtyp.type_expr ty
           (report_type_expected_explanation_opt explanation)
       end
   | Abstract_wrong_label (l, ty, explanation) ->
@@ -5290,24 +5293,24 @@ let report_error ~loc env = function
                        (prefixed_label_name l) in
       Location.errorf ~loc
         "@[<v>@[<2>This function should have type@ %a%t@]@,%s@]"
-        type_expr ty
+        Printtyp.type_expr ty
         (report_type_expected_explanation_opt explanation)
         (label_mark l)
   | Scoping_let_module(id, ty) ->
       Location.errorf ~loc
         "This `let module' expression has type@ %a@ \
          In this type, the locally bound module name %s escapes its scope"
-        type_expr ty id
+        Printtyp.type_expr ty id
   | Private_type ty ->
       Location.errorf ~loc "Cannot create values of the private type %a"
-        type_expr ty
+        Printtyp.type_expr ty
   | Private_label (lid, ty) ->
       Location.errorf ~loc "Cannot assign field %a of the private type %a"
-        longident lid type_expr ty
+        longident lid Printtyp.type_expr ty
   | Private_constructor (constr, ty) ->
       Location.errorf ~loc
         "Cannot use private constructor %s to create values of type %a"
-        constr.cstr_name type_expr ty
+        constr.cstr_name Printtyp.type_expr ty
   | Not_a_variant_type lid ->
       Location.errorf ~loc "The type %a@ is not a variant type" longident lid
   | Incoherent_label_order ->
@@ -5327,7 +5330,7 @@ let report_error ~loc env = function
   | Not_a_packed_module ty ->
       Location.errorf ~loc
         "This expression is packed module, but the expected type is@ %a"
-        type_expr ty
+        Printtyp.type_expr ty
   | Unexpected_existential (reason, name, types) ->
       let reason_str =
         match reason with
@@ -5427,7 +5430,7 @@ let report_error ~loc env = function
           fprintf ppf "but bindings were expected of type")
 
 let report_error ~loc env err =
-  wrap_printing_env ~error:true env (fun () -> report_error ~loc env err)
+  Printtyp.wrap_printing_env ~error:true env (fun () -> report_error ~loc env err)
 
 let () =
   Location.register_error_of_exn

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5190,7 +5190,7 @@ let report_error ~loc env = function
               "@[The field %s is not part of the record \
                argument for the %a constructor@]"
               name.txt
-              Printtyp.path type_path;
+              Printtyp.type_path type_path;
           end else begin
             fprintf ppf
               "@[@[<2>%s type@ %a%t@]@ \
@@ -5198,7 +5198,7 @@ let report_error ~loc env = function
               eorp Printtyp.type_expr ty
               (report_type_expected_explanation_opt explanation)
               (Datatype_kind.label_name kind)
-              name.txt (*kind*) Printtyp.path type_path;
+              name.txt (*kind*) Printtyp.type_path type_path;
           end;
           spellcheck ppf name.txt valid_names
       )) ()
@@ -5430,7 +5430,8 @@ let report_error ~loc env = function
           fprintf ppf "but bindings were expected of type")
 
 let report_error ~loc env err =
-  Printtyp.wrap_printing_env ~error:true env (fun () -> report_error ~loc env err)
+  Printtyp.wrap_printing_env ~error:true env
+    (fun () -> report_error ~loc env err)
 
 let () =
   Location.register_error_of_exn


### PR DESCRIPTION
This PR has two parts.

The first is either a bug fix for `-short-paths`, or an object lesson in why global state and `with_foo` functions make for bad bug-prone interfaces, depending on how you look at it.

The second part just applies `-short-paths` when printing a type path in an error message that previously always printed the long path.

A new test is added in the first commit and updated in the second and third commits. This should make it clear what is being fixed by each part.