### PR TITLE
Reproducible env summaries

### DIFF
--- a/Changes
+++ b/Changes
@@ -342,6 +342,9 @@ Working version
 - #9274, avoid reading cmi file while printing types
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #9307, #9345: reproducible env summaries for reproducible compilation
+  (Florian Angeletti, review by Leo White)
+
 - #9309, #9318: Fix exhaustivity checking with empty types
   (Florian Angeletti, Stefan Muenzel and Thomas Refis, review by Gabriel Scherer
   and Thomas Refis)

--- a/testsuite/tests/reproducibility/cmis_on_file_system.ml
+++ b/testsuite/tests/reproducibility/cmis_on_file_system.ml
@@ -1,0 +1,26 @@
+(* TEST
+  files = "cmis_on_file_system.ml cmis_on_file_system_companion.mli"
+  * setup-ocamlc.byte-build-env
+  ** ocamlc.byte
+  compile_only = "true"
+  module = "cmis_on_file_system.ml"
+  flags="-bin-annot"
+  *** script
+  script= "mv cmis_on_file_system.cmt lone.cmt"
+  **** ocamlc.byte
+  module = "cmis_on_file_system_companion.mli"
+  compile_only="true"
+  ***** ocamlc.byte
+  compile_only = "true"
+  flags="-bin-annot"
+  module="cmis_on_file_system.ml"
+  ****** compare-native-programs
+  program="cmis_on_file_system.cmt"
+  program2="lone.cmt"
+*)
+
+
+(** Test that we are not recording the cmis present on the file system
+    at a given point in time *)
+type t = int
+let () = ()

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -696,9 +696,16 @@ let find_name_module ~mark name tbl =
 let add_persistent_structure id env =
   if not (Ident.persistent id) then invalid_arg "Env.add_persistent_structure";
   if not (Current_unit_name.is_name_of id) then
+    let summary =
+      match
+        IdTbl.find_name wrap_module ~mark:false (Ident.name id) env.modules
+      with
+      | exception Not_found | _, Mod_persistent -> env.summary
+      | _ -> Env_persistent (env.summary, id)
+    in
     { env with
       modules = IdTbl.add id Mod_persistent env.modules;
-      summary = Env_persistent (env.summary, id);
+      summary
     }
   else
     env


### PR DESCRIPTION
Closes #9307 

Since the refactoring of the initial environment, in #2041, the environment summary contains the list of the available cmis in the load paths. This creates an issue for reproducible builds since those summaries end up snapshoting the state of the file system at the time of the build which is unstable for parallel builds.

However, after #2235, the presence of those cmis in the environment is only an optimization once the standard library has been opened: if a module is missing in the environment, the type checker will look for a corresponding cmi on the file system even if no cmi have been recorded with this name.

Since this is only an optimisation, the present PR proposes to solve the reproducibility issue by not storing at all the present cmi files in the environment summary. The second commit in this PR goes a little further and removes the `Env_persistent` entries from the summary type because they were essentially unused. 
