### PR TITLE
Reimplement output_value using a hash table to detect sharing

### DIFF
--- a/Changes
+++ b/Changes
@@ -73,6 +73,12 @@ Working version
 - #9426: build the Mingw ports with higher levels of GCC optimization
   (Xavier Leroy, review by Sébastien Hinderer)
 
+- #9353: Reimplement `output_value` and the `Marshal.to_*` functions
+  using a hash table to detect sharing, instead of temporary in-place
+  modifications.  This is a prerequisite for Multicore OCaml.
+  (Xavier Leroy and Basile Clément, review by Gabriel Scherer and
+  Stephen Dolan)
+
 ### Code generation and optimizations:
 
 - #8637, #8805, #9247, #9296: Record debug info for each allocation.

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -48,23 +48,6 @@ enum {
 
 static int extern_flags;        /* logical or of some of the flags above */
 
-/* Trail mechanism to undo forwarding pointers put inside objects */
-
-struct trail_entry {
-  value obj;    /* address of object + initial color in low 2 bits */
-  value field0; /* initial contents of field 0 */
-};
-
-struct trail_block {
-  struct trail_block * previous;
-  struct trail_entry entries[ENTRIES_PER_TRAIL_BLOCK];
-};
-
-static struct trail_block extern_trail_first;
-static struct trail_block * extern_trail_block;
-static struct trail_entry * extern_trail_cur, * extern_trail_limit;
-
-
 /* Stack for pending values to marshal */
 
 struct extern_item { value * v; mlsize_t count; };
@@ -77,6 +60,43 @@ static struct extern_item extern_stack_init[EXTERN_STACK_INIT_SIZE];
 static struct extern_item * extern_stack = extern_stack_init;
 static struct extern_item * extern_stack_limit = extern_stack_init
                                                    + EXTERN_STACK_INIT_SIZE;
+
+/* Hash table to record already-marshaled objects and their positions */
+
+struct object_position { value obj; uintnat pos; };
+
+/* The hash table uses open addressing, linear probing, and a redundant
+   representation:
+   - a bitvector [present] records which entries of the table are occupied;
+   - an array [entries] records (object, position) pairs for the entries
+     that are occupied.
+   The bitvector is much smaller than the array (1/128th on 64-bit
+   platforms, 1/64th on 32-bit platforms), so it has better locality,
+   making it faster to determine that an object is not in the table.
+   Also, it makes it faster to empty or initialize a table: only the
+   [present] bitvector needs to be filled with zeros, the [entries]
+   array can be left uninitialized.
+*/
+
+struct position_table {
+  int shift;
+  mlsize_t size;                    /* size == 1 << (wordsize - shift) */
+  mlsize_t mask;                    /* mask == size - 1 */
+  mlsize_t threshold;               /* threshold == a fixed fraction of size */
+  uintnat * present;                /* [Bitvect_size(size)] */
+  struct object_position * entries; /* [size]  */
+};
+
+#define Bits_word (8 * sizeof(uintnat))
+#define Bitvect_size(n) (((n) + Bits_word - 1) / Bits_word)
+
+#define POS_TABLE_INIT_SIZE_LOG2 8
+#define POS_TABLE_INIT_SIZE (1 << POS_TABLE_INIT_SIZE_LOG2)
+
+static uintnat pos_table_present_init[Bitvect_size(POS_TABLE_INIT_SIZE)];
+static struct object_position pos_table_entries_init[POS_TABLE_INIT_SIZE];
+
+static struct position_table pos_table;
 
 /* Forward declarations */
 
@@ -96,7 +116,6 @@ CAMLnoreturn_start
 static void extern_stack_overflow(void)
 CAMLnoreturn_end;
 
-static void extern_replay_trail(void);
 static void free_extern_output(void);
 
 /* Free the extern stack if needed */
@@ -132,68 +151,148 @@ static struct extern_item * extern_resize_stack(struct extern_item * sp)
   return newstack + sp_offset;
 }
 
-/* Initialize the trail */
+/* Multiplicative Fibonacci hashing
+   (Knuth, TAOCP vol 3, section 6.4, page 518).
+   HASH_FACTOR is (sqrt(5) - 1) / 2 * 2^wordsize. */
+#ifdef ARCH_SIXTYFOUR
+#define HASH_FACTOR 11400714819323198486UL
+#else
+#define HASH_FACTOR 2654435769UL
+#endif
+#define Hash(v) (((uintnat)(v) * HASH_FACTOR) >> pos_table.shift)
 
-static void init_extern_trail(void)
+/* When the table becomes 2/3 full, its size is increased. */
+#define Threshold(sz) (((sz) * 2) / 3)
+
+/* Initialize the position table */
+
+static void extern_init_position_table(void)
 {
-  extern_trail_block = &extern_trail_first;
-  extern_trail_cur = extern_trail_block->entries;
-  extern_trail_limit = extern_trail_block->entries + ENTRIES_PER_TRAIL_BLOCK;
-}
-
-/* Replay the trail, undoing the in-place modifications
-   performed on objects */
-
-static void extern_replay_trail(void)
-{
-  struct trail_block * blk, * prevblk;
-  struct trail_entry * ent, * lim;
-
-  blk = extern_trail_block;
-  lim = extern_trail_cur;
-  while (1) {
-    for (ent = &(blk->entries[0]); ent < lim; ent++) {
-      value obj = ent->obj;
-      color_t colornum = obj & 3;
-      obj = obj & ~3;
-      Hd_val(obj) = Coloredhd_hd(Hd_val(obj), colornum);
-      Field(obj, 0) = ent->field0;
-    }
-    if (blk == &extern_trail_first) break;
-    prevblk = blk->previous;
-    caml_stat_free(blk);
-    blk = prevblk;
-    lim = &(blk->entries[ENTRIES_PER_TRAIL_BLOCK]);
-  }
-  /* Protect against a second call to extern_replay_trail */
-  extern_trail_block = &extern_trail_first;
-  extern_trail_cur = extern_trail_block->entries;
-}
-
-/* Set forwarding pointer on an object and add corresponding entry
-   to the trail. */
-
-static void extern_record_location(value obj)
-{
-  header_t hdr;
-
   if (extern_flags & NO_SHARING) return;
-  if (extern_trail_cur == extern_trail_limit) {
-    struct trail_block * new_block =
-      caml_stat_alloc_noexc(sizeof(struct trail_block));
-    if (new_block == NULL) extern_out_of_memory();
-    new_block->previous = extern_trail_block;
-    extern_trail_block = new_block;
-    extern_trail_cur = extern_trail_block->entries;
-    extern_trail_limit = extern_trail_block->entries + ENTRIES_PER_TRAIL_BLOCK;
+  pos_table.size = POS_TABLE_INIT_SIZE;
+  pos_table.shift = 8 * sizeof(value) - POS_TABLE_INIT_SIZE_LOG2;
+  pos_table.mask = POS_TABLE_INIT_SIZE - 1;
+  pos_table.threshold = Threshold(POS_TABLE_INIT_SIZE);
+  pos_table.present = pos_table_present_init;
+  pos_table.entries = pos_table_entries_init;
+  memset(pos_table_present_init, 0, sizeof(pos_table_present_init));
+}
+
+/* Free the position table */
+
+static void extern_free_position_table(void)
+{
+  if (pos_table.present != pos_table_present_init) {
+    caml_stat_free(pos_table.present);
+    caml_stat_free(pos_table.entries);
+    /* Protect against repeated calls to extern_free_position_table */
+    pos_table.present = pos_table_present_init;
   }
-  hdr = Hd_val(obj);
-  extern_trail_cur->obj = obj | Colornum_hd(hdr);
-  extern_trail_cur->field0 = Field(obj, 0);
-  extern_trail_cur++;
-  Hd_val(obj) = Bluehd_hd(hdr);
-  Field(obj, 0) = (value) obj_counter;
+}
+
+/* Accessing bitvectors */
+
+Caml_inline uintnat bitvect_test(uintnat * bv, uintnat i)
+{
+  return bv[i / Bits_word] & ((uintnat) 1 << (i & (Bits_word - 1)));
+}
+
+Caml_inline void bitvect_set(uintnat * bv, uintnat i)
+{
+  bv[i / Bits_word] |= ((uintnat) 1 << (i & (Bits_word - 1)));
+}
+
+/* Grow the position table */
+
+static void extern_resize_position_table(void)
+{
+  mlsize_t new_size, new_byte_size;
+  int new_shift;
+  uintnat * new_present;
+  struct object_position * new_entries;
+  uintnat i, h;
+  struct position_table old = pos_table;
+
+  /* Grow the table quickly (x 8) up to 10^6 entries,
+     more slowly (x 2) afterwards. */
+  if (old.size < 1000000) {
+    new_size = 8 * old.size;
+    new_shift = old.shift - 3;
+  } else {
+    new_size = 2 * old.size;
+    new_shift = old.shift - 1;
+  }
+  if (new_size == 0
+      || caml_umul_overflow(new_size, sizeof(struct object_position),
+                            &new_byte_size))
+    extern_out_of_memory();
+  new_entries = caml_stat_alloc_noexc(new_byte_size);
+  if (new_entries == NULL) extern_out_of_memory();
+  new_present =
+    caml_stat_calloc_noexc(Bitvect_size(new_size), sizeof(uintnat));
+  if (new_present == NULL) {
+    caml_stat_free(new_entries);
+    extern_out_of_memory();
+  }
+  pos_table.size = new_size;
+  pos_table.shift = new_shift;
+  pos_table.mask = new_size - 1;
+  pos_table.threshold = Threshold(new_size);
+  pos_table.present = new_present;
+  pos_table.entries = new_entries;
+
+  /* Insert every entry of the old table in the new table */
+  for (i = 0; i < old.size; i++) {
+    if (! bitvect_test(old.present, i)) continue;
+    h = Hash(old.entries[i].obj);
+    while (bitvect_test(new_present, h)) {
+      h = (h + 1) & pos_table.mask;
+    }
+    bitvect_set(new_present, h);
+    new_entries[h] = old.entries[i];
+  }
+
+  /* Free the old tables if not statically allocated */
+  if (old.present != pos_table_present_init) {
+    caml_stat_free(old.present);
+    caml_stat_free(old.entries);
+  }
+}
+
+/* Determine whether the given object [obj] is in the hash table.
+   If so, set [*pos_out] to its position in the output and return 1.
+   If not, set [*h_out] to the hash value appropriate for
+   [extern_record_location] and return 0. */
+
+Caml_inline int extern_lookup_position(value obj,
+                                       uintnat * pos_out, uintnat * h_out)
+{
+  uintnat h = Hash(obj);
+  while (1) {
+    if (! bitvect_test(pos_table.present, h)) {
+      *h_out = h;
+      return 0;
+    }
+    if (pos_table.entries[h].obj == obj) {
+      *pos_out = pos_table.entries[h].pos;
+      return 1;
+    }
+    h = (h + 1) & pos_table.mask;
+  }
+}
+
+/* Record the output position for the given object [obj]. */
+/* The [h] parameter is the index in the hash table where the object
+   must be inserted.  It was determined during lookup. */
+
+static void extern_record_location(value obj, uintnat h)
+{
+  if (extern_flags & NO_SHARING) return;
+  bitvect_set(pos_table.present, h);
+  pos_table.entries[h].obj = obj;
+  pos_table.entries[h].pos = obj_counter;
   obj_counter++;
+  if (obj_counter >= pos_table.threshold) extern_resize_position_table();
 }
 
 /* To buffer the output */
@@ -239,6 +338,7 @@ static void free_extern_output(void)
     extern_output_first = NULL;
   }
   extern_free_stack();
+  extern_free_position_table();
 }
 
 static void grow_extern_output(intnat required)
@@ -281,21 +381,18 @@ static intnat extern_output_length(void)
 
 static void extern_out_of_memory(void)
 {
-  extern_replay_trail();
   free_extern_output();
   caml_raise_out_of_memory();
 }
 
 static void extern_invalid_argument(char *msg)
 {
-  extern_replay_trail();
   free_extern_output();
   caml_invalid_argument(msg);
 }
 
 static void extern_failwith(char *msg)
 {
-  extern_replay_trail();
   free_extern_output();
   caml_failwith(msg);
 }
@@ -303,7 +400,6 @@ static void extern_failwith(char *msg)
 static void extern_stack_overflow(void)
 {
   caml_gc_message (0x04, "Stack overflow in marshaling value\n");
-  extern_replay_trail();
   free_extern_output();
   caml_raise_out_of_memory();
 }
@@ -392,6 +488,10 @@ static void extern_rec(value v)
 {
   struct code_fragment * cf;
   struct extern_item * sp;
+  uintnat h = 0;
+  uintnat pos = 0;
+
+  extern_init_position_table();
   sp = extern_stack;
 
   while(1) {
@@ -448,21 +548,23 @@ static void extern_rec(value v)
       }
       goto next_item;
     }
-    /* Check if already seen */
-    if (Color_hd(hd) == Caml_blue) {
-      uintnat d = obj_counter - (uintnat) Field(v, 0);
-      if (d < 0x100) {
-        writecode8(CODE_SHARED8, d);
-      } else if (d < 0x10000) {
-        writecode16(CODE_SHARED16, d);
+    /* Check if object already seen */
+    if (! (extern_flags & NO_SHARING)) {
+      if (extern_lookup_position(v, &pos, &h)) {
+        uintnat d = obj_counter - pos;
+        if (d < 0x100) {
+          writecode8(CODE_SHARED8, d);
+        } else if (d < 0x10000) {
+          writecode16(CODE_SHARED16, d);
 #ifdef ARCH_SIXTYFOUR
-      } else if (d >= (uintnat)1 << 32) {
-        writecode64(CODE_SHARED64, d);
+        } else if (d >= (uintnat)1 << 32) {
+          writecode64(CODE_SHARED64, d);
 #endif
-      } else {
-        writecode32(CODE_SHARED32, d);
+        } else {
+          writecode32(CODE_SHARED32, d);
+        }
+        goto next_item;
       }
-      goto next_item;
     }
 
     /* Output the contents of the object */
@@ -489,7 +591,7 @@ static void extern_rec(value v)
       writeblock(String_val(v), len);
       size_32 += 1 + (len + 4) / 4;
       size_64 += 1 + (len + 8) / 8;
-      extern_record_location(v);
+      extern_record_location(v, h);
       break;
     }
     case Double_tag: {
@@ -499,7 +601,7 @@ static void extern_rec(value v)
       writeblock_float8((double *) v, 1);
       size_32 += 1 + 2;
       size_64 += 1 + 1;
-      extern_record_location(v);
+      extern_record_location(v, h);
       break;
     }
     case Double_array_tag: {
@@ -525,7 +627,7 @@ static void extern_rec(value v)
       writeblock_float8((double *) v, nfloats);
       size_32 += 1 + nfloats * 2;
       size_64 += 1 + nfloats;
-      extern_record_location(v);
+      extern_record_location(v, h);
       break;
     }
     case Abstract_tag:
@@ -569,7 +671,7 @@ static void extern_rec(value v)
       }
       size_32 += 2 + ((sz_32 + 3) >> 2);  /* header + ops + data */
       size_64 += 2 + ((sz_64 + 7) >> 3);
-      extern_record_location(v);
+      extern_record_location(v, h);
       break;
     }
     default: {
@@ -597,7 +699,7 @@ static void extern_rec(value v)
       size_32 += 1 + sz;
       size_64 += 1 + sz;
       field0 = Field(v, 0);
-      extern_record_location(v);
+      extern_record_location(v, h);
       /* Remember that we still have to serialize fields 1 ... sz - 1 */
       if (sz > 1) {
         sp++;
@@ -628,6 +730,7 @@ static void extern_rec(value v)
     if (sp == extern_stack) {
         /* We are done.   Cleanup the stack and leave the function */
         extern_free_stack();
+        extern_free_position_table();
         return;
     }
     v = *((sp->v)++);
@@ -646,7 +749,6 @@ static intnat extern_value(value v, value flags,
   /* Parse flag list */
   extern_flags = caml_convert_flag_list(flags, extern_flag_values);
   /* Initializations */
-  init_extern_trail();
   obj_counter = 0;
   size_32 = 0;
   size_64 = 0;
@@ -654,8 +756,6 @@ static intnat extern_value(value v, value flags,
   extern_rec(v);
   /* Record end of output */
   close_extern_output();
-  /* Undo the modifications done on externed blocks */
-  extern_replay_trail();
   /* Write the header */
   res_len = extern_output_length();
 #ifdef ARCH_SIXTYFOUR


### PR DESCRIPTION
Marshaling (`output_value` and related stdlib functions) needs to detect and preserve sharing in the OCaml value being serialized (unless the `Marshal.No_sharing` flag is given).

Until 2004 this was done by recording the addresses and output positions of already-seen blocks in a separate hash table.

In 2004, commit 1945d7890, I wrote a more efficient implementation that modifies in-place the OCaml value to record already-seen blocks, then undoes the modifications at exit.

Now it's 2020, Multicore OCaml knocks at the door, and wants its hash table back, because those in-place modifications are incompatible with a concurrent GC.

This PR reimplements the pre-2004 solution, with a twist to the hash table implementation (using a bit vector to determine more quicky whether a hash table entry is empty) that improves performance a bit.

Performance is comparable with that of the current implementation for small values, but degrades sharply (3-4 times slower) for large values, when the hash table becomes large enough that nearly every access misses in all the caches.  (A single load instruction, corresponding to the first probe in the table, can account for 30% of the total running time of marshaling!)  

Here are some figures: `Marshal.to_bytes` of a perfect binary tree of depth N, with no internal sharing
```
 N  Old impl    New impl    Ratio
 2: 1.05e-07s   1.16e-07s   1.10 
 4: 2.91e-07s   3.17e-07s   1.09 
 8: 4.21e-06s   5.87e-06s   1.40 
12: 7.07e-05s   1.13e-04s   1.60 
16: 1.27e-03s   3.40e-03s   2.68 
20: 3.29e-02s   1.13e-01s   3.43 
24: 7.07e-01s   2.41e+00s   3.40 
```

The slowdown is not due to excessive collisions in the hash table: on this test, hashing is nearly perfect, > 99% of hash table accesses hit on the first probe, 100% on the first or second probe.

Even though `output_value` becomes slower, it remains quite efficient overall.  In particular, there was no observable slowdown on `make world.opt`, despite ocamlc and ocamlopt using `output_value` to produce .cmi and .cmx files.
