### PR TITLE
 [Ocamldep] [TOOLS] : -nocwd argument to not include current dir to search path

### DIFF
--- a/Changes
+++ b/Changes
@@ -139,6 +139,9 @@ Working version
   to the toplevel.
   (Gabriel Scherer, review by Armaël Guéneau)
 
+- #6969: Argument -nocwd added to ocamldep
+  (Muskan Garg, review by Florian Angeletti)
+
 - #9207, #9210: fix ocamlyacc to work correctly with up to 255 entry
   points to the grammar.
   (Andreas Abel, review by Xavier Leroy)

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -31,6 +31,7 @@ let bytecode_only = ref false
 let raw_dependencies = ref false
 let sort_files = ref false
 let all_dependencies = ref false
+let nocwd = ref false
 let one_line = ref false
 let files =
   ref ([] : (string * file_kind * String.Set.t * string list) list)
@@ -406,10 +407,12 @@ let mli_file_dependencies source_file =
 let process_file_as process_fun def source_file =
   Compenv.readenv ppf (Before_compile source_file);
   load_path := [];
+  let cwd = if !nocwd then [] else [Filename.current_dir_name] in
   List.iter add_to_load_path (
       (!Compenv.last_include_dirs @
        !Clflags.include_dirs @
-       !Compenv.first_include_dirs
+       !Compenv.first_include_dirs @
+       cwd
       ));
   Location.input_name := source_file;
   try
@@ -574,7 +577,6 @@ let print_version_num () =
 
 let main () =
   Clflags.classic := false;
-  add_to_list first_include_dirs Filename.current_dir_name;
   Compenv.readenv ppf Before_args;
   Clflags.reset_arguments (); (* reset arguments from ocamlc/ocamlopt *)
   Clflags.add_arguments __LOC__ [
@@ -591,6 +593,9 @@ let main () =
         " Dump the delayed dependency map for each map file";
      "-I", Arg.String (add_to_list Clflags.include_dirs),
         "<dir>  Add <dir> to the list of include directories";
+     "-nocwd", Arg.Set nocwd,
+        " Do not add current working directory to \
+          the list of include directories";
      "-impl", Arg.String (file_dependencies_as ML),
         "<f>  Process <f> as a .ml file";
      "-intf", Arg.String (file_dependencies_as MLI),

--- a/man/ocamldep.m
+++ b/man/ocamldep.m
@@ -95,6 +95,9 @@ the same
 .B \-I
 options that are passed to the compiler.
 .TP
+.B \-nocwd
+Do not add current working directory to the list of include directories.
+.TP
 .BI \-impl \ file
 Process
 .IR file

--- a/manual/manual/cmds/ocamldep.etex
+++ b/manual/manual/cmds/ocamldep.etex
@@ -65,6 +65,9 @@ and no dependencies are generated. For programs that span multiple
 directories, it is recommended to pass "ocamldep" the same "-I" options
 that are passed to the compiler.
 
+\item["-nocwd"]
+Do not add current working directory to the list of include directories.
+
 \item["-impl" \var{file}]
 Process \var{file} as a ".ml" file.
 


### PR DESCRIPTION
Work in progress
@gasche @Octachron 
Please review for issue #6969 