### PR TITLE
Avoid looking up nonexistent Comballoc debuginfo

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,7 +41,7 @@ Working version
 - #9233: Restore the bytecode stack after an allocation.
   (Stephen Dolan, review by Gabriel Scherer and Jacques-Henri Jourdan)
 
-- #9230: Memprof support for native allocations.
+- #9230, #9362: Memprof support for native allocations.
   (Jacques-Henri Jourdan and Stephen Dolan, review by Gabriel Scherer)
 
 - #9249: restore definition of ARCH_ALIGN_INT64 in m.h if the architecture

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -135,8 +135,12 @@ intnat caml_collect_current_callstack(value** ptrace, intnat* plen,
     debuginfo info;
     if (descr == NULL) return 0;
     info = debuginfo_extract(descr, alloc_idx);
-    CAMLassert(((uintnat)info & 3) == 0);
-    (*ptrace)[trace_pos++] = Val_backtrace_slot(Slot_debuginfo(info));
+    if (info != NULL) {
+      CAMLassert(((uintnat)info & 3) == 0);
+      (*ptrace)[trace_pos++] = Val_backtrace_slot(Slot_debuginfo(info));
+    } else {
+      (*ptrace)[trace_pos++] = Val_backtrace_slot(Slot_frame_descr(descr));
+    }
   }
 
   while (trace_pos < max_frames) {


### PR DESCRIPTION
This is a minor bugfix for #9230. For allocations subject to combining, #9230 stores a pointer to the debuginfo instead of the frametable in backtraces, because the same frametable entry might refer to several allocations from different locations that have been combined.

The bug is that there might not be a debuginfo! In such cases, we should store the frametable entry, to at least get a unique ID for the allocation site rather than a null pointer.

Even when everything is compiled with `-g`, this still occurs for internally-generated functions (`caml_apply2`, etc.), for which no debuginfo is generated.

cc @jhjourdan, @gasche 