### PR TITLE
Non-fix for a non-bug in debuginfo processing

### DIFF
--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -161,6 +161,10 @@ static debuginfo debuginfo_extract(frame_descr* d, int alloc_idx)
   unsigned char* infoptr;
   uint32_t debuginfo_offset;
 
+  /* The special frames marking the top of an ML stack chunk are never
+     returned by caml_next_frame_descriptor, so should never reach here. */
+  CAMLassert(d->frame_size != 0xffff);
+
   if ((d->frame_size & 1) == 0) {
     return NULL;
   }


### PR DESCRIPTION
I just wasted a bunch of time being convinced there was a bug in the backtrace logic, because the magical frame tables for `caml_start_program` that indicate the end of an ML stack chunk were not being specially handled in `debuginfo_extract`.

Turns out there's no bug here: these frametables are filtered out before they can reach that function. This patch adds an assertion to that effect. Seeing it there would have saved me some time this morning and will save some time for the next person to touch this.