### PR TITLE
Fix statmemprof tests in `-disable-flat-float-array` mode

### DIFF
--- a/testsuite/tests/statmemprof/callstacks.ml
+++ b/testsuite/tests/statmemprof/callstacks.ml
@@ -43,10 +43,10 @@ let alloc_closure () =
   let x = Sys.opaque_identity 1 in
   ignore (Sys.opaque_identity (fun () -> x))
 
-let floatarray = [| 1.; 2. |]
-let[@inline never] get0 a = a.(0)
+let floatarray = Float.Array.make 2 42.
+external float_get : Float.Array.t -> int -> float = "%floatarray_safe_get"
 let getfloatfield () =
-  ignore (Sys.opaque_identity (get0 floatarray))
+  ignore (Sys.opaque_identity (float_get floatarray 0))
 
 let marshalled =
   Marshal.to_string [Sys.opaque_identity 1] []

--- a/testsuite/tests/statmemprof/callstacks.reference
+++ b/testsuite/tests/statmemprof/callstacks.reference
@@ -50,8 +50,7 @@ Called from file "callstacks.ml", line 84, characters 2-10
 Called from file "list.ml", line 110, characters 12-15
 Called from file "callstacks.ml", line 91, characters 2-27
 -----------
-Raised by primitive operation at file "callstacks.ml", line 47, characters 28-33
-Called from file "callstacks.ml", line 49, characters 30-47
+Raised by primitive operation at file "callstacks.ml", line 49, characters 30-54
 Called from file "callstacks.ml", line 84, characters 2-10
 Called from file "list.ml", line 110, characters 12-15
 Called from file "callstacks.ml", line 91, characters 2-27


### PR DESCRIPTION
One of the statmemprof test tests allocating during access to a float array. This doesn't allocate when configured with `-disable-flat-float-array`, so the test fails.