### PR TITLE
fix doc comment for unit type

### DIFF
--- a/stdlib/unit.mli
+++ b/stdlib/unit.mli
@@ -19,7 +19,7 @@
 
 (** {1:unit The unit type} *)
 
-type t = unit = ()
+type t = unit = () (**)
 (** The unit type.
 
     The constructor [()] is included here so that it has a path,


### PR DESCRIPTION
Hi,

Currently [the doc](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Stdlib.Unit.html) is broken. This should fix it.

Cheers.