### PR TITLE
The manual is now hosted on ocaml.org

### DIFF
--- a/manual/manual/allfiles.etex
+++ b/manual/manual/allfiles.etex
@@ -22,17 +22,16 @@
 \cleardoublepage
 \setcounter{page}{1}
 
-
 \begin{htmlonly}
 \begin{quote}
 \rule{}{}
 This manual is also available in
-\ahref{http://caml.inria.fr/distrib/ocaml-\ocamlversion/ocaml-\ocamlversion-refman.pdf}{PDF}.
-\ahref{http://caml.inria.fr/distrib/ocaml-\ocamlversion/ocaml-\ocamlversion-refman.txt}{plain text},
+\ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman.pdf}{PDF}.
+\ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman.txt}{plain text},
 as a
-\ahref{http://caml.inria.fr/distrib/ocaml-\ocamlversion/ocaml-\ocamlversion-refman-html.tar.gz}{bundle of HTML files},
+\ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman-html.tar.gz}{bundle of HTML files},
 and as a
-\ahref{http://caml.inria.fr/distrib/ocaml-\ocamlversion/ocaml-\ocamlversion-refman.info.tar.gz}{bundle of Emacs Info files}.
+\ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman.info.tar.gz}{bundle of Emacs Info files}.
 \rule{}{}
 \end{quote}
 \end{htmlonly}

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -296,10 +296,8 @@ containing the C code.  The standard OCaml runtime system "ocamlrun"
 then loads dynamically these libraries, and resolves references to the
 required primitives, before executing the bytecode.
 
-This facility is currently supported and known to work well under
-Linux, MacOS, and Windows.  It is supported, but not
-fully tested yet, under FreeBSD, Tru64, Solaris and Irix.  It is not
-supported yet under other Unixes.
+This facility is currently available on all platforms supported by
+OCaml except Cygwin 64 bits.
 
 To dynamically link C code with OCaml code, the C code must first be
 compiled into a shared library (under Unix) or DLL (under Windows).

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -297,7 +297,7 @@ then loads dynamically these libraries, and resolves references to the
 required primitives, before executing the bytecode.
 
 This facility is currently supported and known to work well under
-Linux, MacOS~X, and Windows.  It is supported, but not
+Linux, MacOS, and Windows.  It is supported, but not
 fully tested yet, under FreeBSD, Tru64, Solaris and Irix.  It is not
 supported yet under other Unixes.
 

--- a/manual/manual/foreword.etex
+++ b/manual/manual/foreword.etex
@@ -27,7 +27,7 @@ this manual that are specific to one operating system are presented as
 shown below:
 
 \begin{unix} This is material specific to the Unix family of operating
-systems, including Linux and \hbox{MacOS~X}.
+systems, including Linux and macOS.
 \end{unix}
 
 \begin{windows} This is material specific to Microsoft Windows

--- a/manual/manual/foreword.etex
+++ b/manual/manual/foreword.etex
@@ -67,13 +67,13 @@ The OCaml documentation and user's manual is licensed under a
 \section*{availability}{Availability}
 
 \begin{latexonly}
-The complete OCaml distribution can be accessed via the Web
-site \url{https://ocaml.org/}.  This site contains a lot of additional
+The complete OCaml distribution can be accessed via the website
+\url{https://ocaml.org/}.  This site contains a lot of additional
 information on OCaml.
 \end{latexonly}
 
 \begin{htmlonly}
 The complete OCaml distribution can be accessed via the
-\href{https://ocaml.org/}{ocaml.org Web site}.
+\href{https://ocaml.org/}{ocaml.org website}.
 This site contains a lot of additional information on OCaml.
 \end{htmlonly}

--- a/manual/manual/foreword.etex
+++ b/manual/manual/foreword.etex
@@ -68,14 +68,12 @@ The OCaml documentation and user's manual is licensed under a
 
 \begin{latexonly}
 The complete OCaml distribution can be accessed via the Web
-sites \url{http://www.ocaml.org/} and \url{http://caml.inria.fr/}.
-The former Web site contains a lot of additional information on OCaml.
+site \url{https://ocaml.org/}.  This site contains a lot of additional
+information on OCaml.
 \end{latexonly}
 
 \begin{htmlonly}
 The complete OCaml distribution can be accessed via the
-\href{http://www.ocaml.org/}{community Caml Web site} and the
-\href{http://caml.inria.fr/}{older Caml Web site}.
-The \href{http://www.ocaml.org/}{community Caml Web site}
-contains a lot of additional information on OCaml.
+\href{https://ocaml.org/}{ocaml.org Web site}.
+This site contains a lot of additional information on OCaml.
 \end{htmlonly}

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -208,8 +208,6 @@
 \def\versionspecific#1{\begin{quote}\textsf{#1:}\quad}
 \def\unix{\versionspecific{Unix}}
 \def\endunix{\end{quote}}
-\def\macos{\versionspecific{MacOS~9}}
-\def\endmacos{\end{quote}}
 \def\windows{\versionspecific{Windows}}
 \def\endwindows{\end{quote}}
 

--- a/manual/manual/macros.tex
+++ b/manual/manual/macros.tex
@@ -70,8 +70,6 @@
 
 \def\unix{\versionspecific{Unix}}
 \def\endunix{\end{description}}
-%\def\macos{\versionspecific{MacOS 9}}
-%\def\endmacos{\end{description}}
 \def\windows{\versionspecific{Windows}}
 \def\endwindows{\end{description}}
 

--- a/manual/manual/manual.inf
+++ b/manual/manual/manual.inf
@@ -66,8 +66,6 @@
 
 \def\unix{\versionspecific{Unix}}
 \def\endunix{\end{quote}}
-\def\macos{\versionspecific{MacOS}}
-\def\endmacos{\end{quote}}
 \def\windows{\versionspecific{Windows}}
 \def\endwindows{\end{quote}}
 


### PR DESCRIPTION
Following up on https://github.com/ocaml/ocaml.org/pull/1110 :
- Point to ocaml.org instead of caml.inria.fr for the various versions of the manual (PDF, etc)
- Remove other mentions of caml.inria.fr; ocaml.org is now the place to go.

Unrelated but it was about time:
- MacOS X is now called MacOS, and MacOS 9 is no more.

