### PR TITLE
fix doc comment for seq type

### DIFF
--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -33,7 +33,7 @@ type 'a t = unit -> 'a node
 
 and +'a node =
   | Nil
-  | Cons of 'a * 'a t
+  | Cons of 'a * 'a t (**)
 (** A fully-evaluated list node, either empty or containing an element
     and a delayed tail. *)
 


### PR DESCRIPTION
Hi,

Same as #9373 but for `Seq.t` - as it was mentioned there.

Cheers.