### PR TITLE
Fix copy scope bugs

### DIFF
--- a/Changes
+++ b/Changes
@@ -600,6 +600,9 @@ OCaml 4.11
 - #9375, #9477: add forgotten substitution when compiling anonymous modules
   (Thomas Refis, review by Frédéric Bour, report by Andreas Hauptmann)
 
+- #9384, #9385: Fix copy scope bugs in substitutions
+  (Leo White, review by Thomas Refis, report by Nick Roberts)
+
 * #9388: Prohibit signature local types with constraints
   (Leo White, review by Jacques Garrigue)
 

--- a/testsuite/tests/typing-modules/pr9384.ml
+++ b/testsuite/tests/typing-modules/pr9384.ml
@@ -1,0 +1,44 @@
+(* TEST
+   * expect
+*)
+
+module M : sig
+  type 'a t := [< `A ] as 'a
+  val f : 'a -> 'a t
+end = struct
+  let f x = x
+end;;
+[%%expect{|
+Line 2, characters 2-28:
+2 |   type 'a t := [< `A ] as 'a
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Destructive substitutions are not supported for constrained
+       types (other than when replacing a type constructor with
+       a type constructor with the same arguments).
+|}]
+
+type foo = { foo : 'a. ([< `A] as 'a) -> 'a }
+
+module Foo (X : sig type 'a t := [< `A ] as 'a type foo2 = foo = { foo : 'a. 'a t -> 'a t } end) = struct
+    let f { X.foo } = foo
+end;;
+[%%expect{|
+type foo = { foo : 'a. ([< `A ] as 'a) -> 'a; }
+Line 3, characters 20-46:
+3 | module Foo (X : sig type 'a t := [< `A ] as 'a type foo2 = foo = { foo : 'a. 'a t -> 'a t } end) = struct
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Destructive substitutions are not supported for constrained
+       types (other than when replacing a type constructor with
+       a type constructor with the same arguments).
+|}]
+
+type bar = { bar : 'a. ([< `A] as 'a) -> 'a }
+
+module Bar (X : sig type 'a t := 'a type bar2 = bar = { bar : 'a. ([< `A] as 'a) t -> 'a t } end) = struct
+  let f { X.bar } = bar
+end;;
+[%%expect{|
+type bar = { bar : 'a. ([< `A ] as 'a) -> 'a; }
+Uncaught exception: File "typing/ctype.ml", line 1443, characters 11-17: Assertion failed
+
+|}]

--- a/testsuite/tests/typing-modules/pr9384.ml
+++ b/testsuite/tests/typing-modules/pr9384.ml
@@ -39,6 +39,8 @@ module Bar (X : sig type 'a t := 'a type bar2 = bar = { bar : 'a. ([< `A] as 'a)
 end;;
 [%%expect{|
 type bar = { bar : 'a. ([< `A ] as 'a) -> 'a; }
-Uncaught exception: File "typing/ctype.ml", line 1443, characters 11-17: Assertion failed
-
+module Bar :
+  functor
+    (X : sig type bar2 = bar = { bar : 'a. ([< `A ] as 'a) -> 'a; } end) ->
+    sig val f : X.bar2 -> ([< `A ] as 'a) -> 'a end
 |}]

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -506,8 +506,9 @@ and signature_item' copy_scope scoping s comp =
   | Sig_class_type(id, d, rs, vis) ->
       Sig_class_type(id, cltype_declaration' copy_scope s d, rs, vis)
 
-and signature_item s comp =
-  For_copy.with_scope (fun copy_scope -> signature_item' copy_scope s comp)
+and signature_item scoping s comp =
+  For_copy.with_scope
+    (fun copy_scope -> signature_item' copy_scope scoping s comp)
 
 and module_declaration scoping s decl =
   {
@@ -538,9 +539,10 @@ let merge_path_maps f m1 m2 =
 let type_replacement s = function
   | Path p -> Path (type_path s p)
   | Type_function { params; body } ->
-     let params = List.map (type_expr s) params in
-     let body = type_expr s body in
-     Type_function { params; body }
+    For_copy.with_scope (fun copy_scope ->
+     let params = List.map (typexp copy_scope s) params in
+     let body = typexp copy_scope s body in
+     Type_function { params; body })
 
 (* Composition of substitutions:
      apply (compose s1 s2) x = apply s2 (apply s1 x) *)


### PR DESCRIPTION
There were two bugs in the handling of `copy_scope`s in `Subst` which lead to #9384 and the bugs from the comments on #9384.

One bug is the classic `with_foo` currying bug. The other uses separate copy_states for the parameters and body of a type constructor -- losing sharing between the two.