### PR TITLE
Add stdlib List.iota

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -91,7 +91,7 @@ let iota ?(start = 0) ?(step = 1) len =
   if len < 0 then invalid_arg "List.iota" else
     let rec loop n l =
       if n = len then rev l else
-        loop (n + 1) (((start + n) * step) :: l)
+        loop (n + 1) ((start + (n * step)) :: l)
     in loop 0 [] ;;
 
 let rec map f = function

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -87,6 +87,13 @@ let rec flatten = function
 
 let concat = flatten
 
+let iota ?(start = 0) ?(step = 1) len =
+  if len < 0 then invalid_arg "List.iota" else
+    let rec loop n l =
+      if n = len then rev l else
+        loop (n + 1) (((start + n) * step) :: l)
+    in loop 0 [] ;;
+
 let rec map f = function
     [] -> []
   | a::l -> let r = f a in r :: map f l

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -90,9 +90,10 @@ let concat = flatten
 let iota ?(start = 0) ?(step = 1) len =
   if len < 0 then invalid_arg "List.iota" else
     let rec loop n l =
-      if n = len then rev l else
-        loop (n + 1) ((start + (n * step)) :: l)
-    in loop 0 [] ;;
+      if n = 0 then l else
+        let n1 = n - 1 in
+        loop n1 ((start + (n1 * step)) :: l)
+    in loop len []
 
 let rec map f = function
     [] -> []

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -104,7 +104,8 @@ val flatten : 'a list list -> 'a list
 val iota : ?start:int -> ?step:int -> int -> int list
 (** [List.iota ?start ?step len] returns a list containing the elements
     [[start; start+step; ...; start+(len-1)*step]], where [start] and [step]
-     default to [0] and [1], respectively. *)
+    default to [0] and [1], respectively.
+    Raise [Invalid_argument "List.nth"] if [n] is negative. *)
 
 (** {1 Iterators} *)
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -101,6 +101,10 @@ val concat : 'a list list -> 'a list
 val flatten : 'a list list -> 'a list
 (** An alias for [concat]. *)
 
+val iota : ?start:int -> ?step:int -> int -> int list
+(** [List.iota ?start ?step len] returns a list containing the elements
+    [[start; start+step; ...; start+(len-1)*step]], where [start] and [step]
+     default to [0] and [1], respectively. *)
 
 (** {1 Iterators} *)
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -105,7 +105,7 @@ val iota : ?start:int -> ?step:int -> int -> int list
 (** [List.iota ?start ?step len] returns a list containing the elements
     [[start; start+step; ...; start+(len-1)*step]], where [start] and [step]
     default to [0] and [1], respectively.
-    Raise [Invalid_argument "List.nth"] if [n] is negative. *)
+    Raise [Invalid_argument "List.iota"] if [n] is negative. *)
 
 (** {1 Iterators} *)
 

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -12,8 +12,8 @@ let () =
   let l = List.init 10 (fun x -> x) in
   let sl = List.init 10 string_of_int in
   assert (List.iota 3 = [0; 1; 2]);
-  assert (List.iota 5 ~start:1 = [1; 2; 3; 4; 5]);
-  assert (List.iota 5 ~start:10 ~step:2 = [10; 12; 14; 16; 18]);
+  assert (List.iota ~start:1 5 = [1; 2; 3; 4; 5]);
+  assert (List.iota ~start:10 ~step:2 5 = [10; 12; 14; 16; 18]);
   assert (List.exists (fun a -> a < 10) l);
   assert (List.exists (fun a -> a > 0) l);
   assert (List.exists (fun a -> a = 0) l);

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -13,7 +13,7 @@ let () =
   let sl = List.init 10 string_of_int in
   assert (List.iota 3 = [0; 1; 2]);
   assert (List.iota 5 ~start:1 = [1; 2; 3; 4; 5]);
-  assert (List.iota 5 ~start:10 ~step:2 = [20; 22; 24; 26; 28]);
+  assert (List.iota 5 ~start:10 ~step:2 = [10; 12; 14; 16; 18]);
   assert (List.exists (fun a -> a < 10) l);
   assert (List.exists (fun a -> a > 0) l);
   assert (List.exists (fun a -> a = 0) l);

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -11,6 +11,9 @@ let string_of_even_opt x =
 let () =
   let l = List.init 10 (fun x -> x) in
   let sl = List.init 10 string_of_int in
+  assert (List.iota 3 = [0; 1; 2]);
+  assert (List.iota 5 ~start:1 = [1; 2; 3; 4; 5]);
+  assert (List.iota 5 ~start:10 ~step:2 = [20; 22; 24; 26; 28]);
   assert (List.exists (fun a -> a < 10) l);
   assert (List.exists (fun a -> a > 0) l);
   assert (List.exists (fun a -> a = 0) l);


### PR DESCRIPTION
Hello,

since I recently read that also mere mortals might contribute even to the stdlib, I thought about trying it.

Content of this PR is adding the `iota` function of [SRFI-1 fame](https://srfi.schemers.org/srfi-1/srfi-1.html) to the `List` module, as it's simple enough and still very useful for anyone ever came to knew it.

I added the implementation to the .ml, the signature plus the documentation to the .mli, a few simple tests to the respective test file, ran the tests and checked the documentation - looks fine for me, but I might very well have missed something.

Thanks for all your work on that great language, Frank
