### PR TITLE
Make substitution of type functions more robust

### DIFF
--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -189,7 +189,7 @@ let rec typexp copy_scope s ty =
          | exception Not_found -> Tconstr(type_path s p, args, ref Mnil)
          | Path _ -> Tconstr(type_path s p, args, ref Mnil)
          | Type_function { params; body } ->
-            (!ctype_apply_env_empty params body args).desc
+            Tlink (!ctype_apply_env_empty params body args)
          end
       | Tpackage(p, n, tl) ->
           Tpackage(modtype_path s p, n, List.map (typexp copy_scope s) tl)


### PR DESCRIPTION
When substituting a "type function" for something like:

```ocaml
sig val x : int t end with type 'a t := 'a * 'a
```

the type-checker will create a fresh type node to replace `int t` with, then it will create an instance of the substituted type (i.e. `int * int`). Then it mutates the fresh type node to have the same type description as the instance. This is fine as long as the instance is itself a fresh type node, but that isn't true for things like:

```ocaml
sig val x : 'a t -> 'a t end with type 'a t := 'a
```
This PR changes that code so that the fresh type node is mutated to be a `Tlink` that points to the instance.

I don't think this issue is currently exposed as a proper bug, because the instance always happens to be a `Tlink` node itself. But this is clearly not something we guarantee -- so we shouldn't rely on it.