### PR TITLE
Prohibit signature local types with constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -349,6 +349,9 @@ Working version
 - #9367: Make bytecode and native-code backtraces agree.
   (Stephen Dolan, review by Gabriel Scherer)
 
+* #9388: Prohibit signature local types with constraints
+  (Leo White, review by Jacques Garrigue)
+
 - #9406, #9409: fix an error with packed module types from missing
   cmis.
   (Florian Angeletti, report by Thomas Leonard, review by Gabriel Radanne

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -101,3 +101,19 @@ Line 3, characters 11-12:
                ^
 Error: Unbound type constructor t
 |}]
+
+type ('a, 'b) foo = Foo
+
+type 'a s = 'b list constraint 'a = (int, 'b) foo
+
+module type S = sig
+  type 'a t := 'a s * bool
+  type 'a bar = (int, 'a) foo
+  val x : string bar t
+end
+[%%expect{|
+type ('a, 'b) foo = Foo
+type 'a s = 'b list constraint 'a = (int, 'b) foo
+Uncaught exception: Ctype.Cannot_apply
+
+|}]

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -114,6 +114,10 @@ end
 [%%expect{|
 type ('a, 'b) foo = Foo
 type 'a s = 'b list constraint 'a = (int, 'b) foo
-Uncaught exception: Ctype.Cannot_apply
-
+Line 6, characters 2-26:
+6 |   type 'a t := 'a s * bool
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Destructive substitutions are not supported for constrained
+       types (other than when replacing a type constructor with
+       a type constructor with the same arguments).
 |}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1237,10 +1237,13 @@ and transl_signature env sg =
                  td.typ_private = Private
               then
                 raise (Error (td.typ_loc, env, Invalid_type_subst_rhs));
+              let params = td.typ_type.type_params in
+              if params_are_constrained params
+              then raise(Error(loc, env, With_cannot_remove_constrained_type));
               let info =
                   let subst =
                     Subst.add_type_function (Pident td.typ_id)
-                      ~params:td.typ_type.type_params
+                      ~params
                       ~body:(Option.get td.typ_type.type_manifest)
                       Subst.identity
                   in


### PR DESCRIPTION
This PR prevents signature local types having constrained parameters. This is needed because they are implemented using `Subst.add_type_function` which does not support constrained types, leading to problems like:

```ocaml
type ('a, 'b) foo = Foo

type 'a s = 'b list constraint 'a = (int, 'b) foo

module type S = sig
  type 'a t := 'a s * bool
  type 'a bar = (int, 'a) foo
  val x : string bar t
end
[%%expect{|
type ('a, 'b) foo = Foo
type 'a s = 'b list constraint 'a = (int, 'b) foo
Uncaught exception: Ctype.Cannot_apply
|}]
```

We already place this restriction on ordinary destructive substitutions, and I have simply reused that check and error message.

Note that there is nothing fundamental about this restriction, it simply requires more implementation work to get a version that can work with constrained parameters. See the discussion in #792 for more details.