### PR TITLE
call_linker now returns exit_code for better user response on linking_error, fixes #7141

### DIFF
--- a/Changes
+++ b/Changes
@@ -797,6 +797,9 @@ OCaml 4.10.0
 - #9261: Fix a soundness bug in Rec_check, new in 4.10 (from #8908)
   (Vincent Laviron, review by Jeremy Yallop and Gabriel Scherer)
 
+- #9389: returns exit_code for better user response on linking_error
+  (Anukriti Kumar, review by Gabriel Scherer and sliquister)
+
 OCaml 4.09 maintenance branch:
 ------------------------------
 

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -29,7 +29,7 @@ type error =
   | Inconsistent_interface of modname * filepath * filepath
   | Inconsistent_implementation of modname * filepath * filepath
   | Assembler_error of filepath
-  | Linking_error
+  | Linking_error of int
   | Multiple_definition of modname * filepath * filepath
   | Missing_cmx of filepath * modname
 
@@ -280,8 +280,9 @@ let make_shared_startup_file ~ppf_dump units =
   Emit.end_assembly ()
 
 let call_linker_shared file_list output_name =
-  if not (Ccomp.call_linker Ccomp.Dll output_name file_list "")
-  then raise(Error Linking_error)
+  let exitcode = Ccomp.call_linker Ccomp.Dll output_name file_list "" in
+  if not (exitcode = 0)
+  then raise(Error(Linking_error (exitcode)))
 
 let link_shared ~ppf_dump objfiles output_name =
   Profile.record_call output_name (fun () ->
@@ -333,8 +334,9 @@ let call_linker file_list startup_file output_name =
     else if !Clflags.output_c_object then Ccomp.Partial
     else Ccomp.Exe
   in
-  if not (Ccomp.call_linker mode output_name files c_lib)
-  then raise(Error Linking_error)
+  let exitcode = Ccomp.call_linker mode output_name files c_lib in
+  if not (exitcode = 0)
+  then raise(Error(Linking_error (exitcode)))
 
 (* Main entry point *)
 
@@ -414,8 +416,8 @@ let report_error ppf = function
        intf
   | Assembler_error file ->
       fprintf ppf "Error while assembling %a" Location.print_filename file
-  | Linking_error ->
-      fprintf ppf "Error during linking"
+  | Linking_error exitcode ->
+      fprintf ppf "Error during linking (exit code %d)" exitcode
   | Multiple_definition(modname, file1, file2) ->
       fprintf ppf
         "@[<hov>Files %a@ and %a@ both define a module named %s@]"

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -282,7 +282,7 @@ let make_shared_startup_file ~ppf_dump units =
 let call_linker_shared file_list output_name =
   let exitcode = Ccomp.call_linker Ccomp.Dll output_name file_list "" in
   if not (exitcode = 0)
-  then raise(Error(Linking_error (exitcode)))
+  then raise(Error(Linking_error exitcode))
 
 let link_shared ~ppf_dump objfiles output_name =
   Profile.record_call output_name (fun () ->
@@ -336,7 +336,7 @@ let call_linker file_list startup_file output_name =
   in
   let exitcode = Ccomp.call_linker mode output_name files c_lib in
   if not (exitcode = 0)
-  then raise(Error(Linking_error (exitcode)))
+  then raise(Error(Linking_error exitcode))
 
 (* Main entry point *)
 

--- a/asmcomp/asmlink.mli
+++ b/asmcomp/asmlink.mli
@@ -36,7 +36,7 @@ type error =
   | Inconsistent_interface of modname * filepath * filepath
   | Inconsistent_implementation of modname * filepath * filepath
   | Assembler_error of filepath
-  | Linking_error
+  | Linking_error of int
   | Multiple_definition of modname * filepath * filepath
   | Missing_cmx of filepath * modname
 

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -141,11 +141,11 @@ let make_package_object ~ppf_dump members targetobj targetname coercion
       List.map
         (fun m -> Filename.remove_extension m.pm_file ^ Config.ext_obj)
         (List.filter (fun m -> m.pm_kind <> PM_intf) members) in
-    let ok =
-      Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) "" = 0
+    let exitcode =
+      Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) ""
     in
     remove_file objtemp;
-    if not ok then raise(Error Linking_error)
+    if not (exitcode = 0) then raise(Error Linking_error)
   )
 
 (* Make the .cmx file for the package *)

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -142,7 +142,7 @@ let make_package_object ~ppf_dump members targetobj targetname coercion
         (fun m -> Filename.remove_extension m.pm_file ^ Config.ext_obj)
         (List.filter (fun m -> m.pm_kind <> PM_intf) members) in
     let ok =
-      Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) ""
+      Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) "" = 0
     in
     remove_file objtemp;
     if not ok then raise(Error Linking_error)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -577,7 +577,7 @@ let build_custom_runtime prim_name exec_name =
       [] in
   Ccomp.call_linker Ccomp.Exe exec_name
     (debug_prefix_map @ [prim_name] @ List.rev !Clflags.ccobjs @ [runtime_lib])
-    (Clflags.std_include_flag "-I" ^ " " ^ Config.bytecomp_c_libraries)
+    (Clflags.std_include_flag "-I" ^ " " ^ Config.bytecomp_c_libraries) = 0
 
 let append_bytecode bytecode_name exec_name =
   let oc = open_out_gen [Open_wronly; Open_append; Open_binary] 0 exec_name in
@@ -703,7 +703,7 @@ let link objfiles output_name =
                    else "-lcamlrun" ^ !Clflags.runtime_variant in
                  Ccomp.call_linker mode output_name
                    ([obj_file] @ List.rev !Clflags.ccobjs @ [runtime_lib])
-                   c_libs
+                   c_libs = 0
                ) then raise (Error Custom_runtime);
            end
          end;

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -575,9 +575,12 @@ let build_custom_runtime prim_name exec_name =
       [Printf.sprintf "-fdebug-prefix-map=%s=camlprim.c" prim_name]
     else
       [] in
+  let exitcode =
+    (Clflags.std_include_flag "-I" ^ " " ^ Config.bytecomp_c_libraries)
+  in
   Ccomp.call_linker Ccomp.Exe exec_name
     (debug_prefix_map @ [prim_name] @ List.rev !Clflags.ccobjs @ [runtime_lib])
-    (Clflags.std_include_flag "-I" ^ " " ^ Config.bytecomp_c_libraries) = 0
+    exitcode = 0
 
 let append_bytecode bytecode_name exec_name =
   let oc = open_out_gen [Open_wronly; Open_append; Open_binary] 0 exec_name in

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -211,5 +211,5 @@ let call_linker mode output_name files extra =
           (quote_files files)
           extra
     in
-    command cmd = 0
+    command cmd
   )

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -36,4 +36,4 @@ type link_mode =
   | MainDll
   | Partial
 
-val call_linker: link_mode -> string -> string list -> string -> bool
+val call_linker: link_mode -> string -> string list -> string -> int


### PR DESCRIPTION
Created additional error `Linking_error_c_compiler` fixes #7141