### PR TITLE
Visit registers at most once in Coloring.iter_preferred

### DIFF
--- a/Changes
+++ b/Changes
@@ -78,6 +78,9 @@ Working version
 - #9193: Make tuple matching optimisation apply to Lswitch and Lstringswitch.
   (Stephen Dolan, review by Thomas Refis and Gabriel Scherer)
 
+- #9392: Visit registers at most once in Coloring.iter_preferred.
+  (Stephen Dolan, review by Pierre Chambart and Xavier Leroy)
+
 ### Standard library:
 
 - #9077: Add Seq.cons and Seq.append

--- a/asmcomp/coloring.ml
+++ b/asmcomp/coloring.ml
@@ -74,18 +74,13 @@ let allocate_registers() =
   (* Iterate over all registers preferred by the given register (transitive) *)
   let iter_preferred f reg =
     let rec walk r w =
-      if not r.visited then begin
+      if not (Reg.is_visited r) then begin
+        Reg.mark_visited r;
         f r w;
-        begin match r.prefer with
-            [] -> ()
-          | p  -> r.visited <- true;
-                  List.iter (fun (r1, w1) -> walk r1 (min w w1)) p;
-                  r.visited <- false
-        end
+        List.iter (fun (r1, w1) -> walk r1 (min w w1)) r.prefer
       end in
-    reg.visited <- true;
     List.iter (fun (r, w) -> walk r w) reg.prefer;
-    reg.visited <- false in
+    Reg.clear_visited_marks () in
 
   (* Where to start the search for a suitable register.
      Used to introduce some "randomness" in the choice between registers

--- a/asmcomp/reg.ml
+++ b/asmcomp/reg.ml
@@ -45,7 +45,7 @@ type t =
     mutable prefer: (t * int) list;
     mutable degree: int;
     mutable spill_cost: int;
-    mutable visited: bool }
+    mutable visited: int }
 
 and location =
     Unknown
@@ -62,16 +62,30 @@ type reg = t
 let dummy =
   { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown;
     spill = false; interf = []; prefer = []; degree = 0; spill_cost = 0;
-    visited = false; part = None;
+    visited = 0; part = None;
   }
 
 let currstamp = ref 0
 let reg_list = ref([] : t list)
 
+
+let visit_generation = ref 1
+
+let mark_visited r =
+  r.visited <- !visit_generation
+
+let is_visited r =
+  r.visited = !visit_generation
+
+let clear_visited_marks () =
+  incr visit_generation
+
+let unvisited () = !visit_generation - 1
+
 let create ty =
   let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
             loc = Unknown; spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = false; part = None; } in
+            spill_cost = 0; visited = unvisited (); part = None; } in
   reg_list := r :: !reg_list;
   incr currstamp;
   r
@@ -96,7 +110,7 @@ let clone r =
 let at_location ty loc =
   let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
             spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = false; part = None; } in
+            spill_cost = 0; visited = unvisited (); part = None; } in
   incr currstamp;
   r
 

--- a/asmcomp/reg.ml
+++ b/asmcomp/reg.ml
@@ -67,9 +67,12 @@ let dummy =
 
 let currstamp = ref 0
 let reg_list = ref([] : t list)
-
+let hw_reg_list = ref ([] : t list)
 
 let visit_generation = ref 1
+
+(* Any visited value not equal to !visit_generation counts as "unvisited" *)
+let unvisited = 0
 
 let mark_visited r =
   r.visited <- !visit_generation
@@ -80,12 +83,11 @@ let is_visited r =
 let clear_visited_marks () =
   incr visit_generation
 
-let unvisited () = !visit_generation - 1
 
 let create ty =
   let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
             loc = Unknown; spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = unvisited (); part = None; } in
+            spill_cost = 0; visited = unvisited; part = None; } in
   reg_list := r :: !reg_list;
   incr currstamp;
   r
@@ -110,7 +112,8 @@ let clone r =
 let at_location ty loc =
   let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
             spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = unvisited (); part = None; } in
+            spill_cost = 0; visited = unvisited; part = None; } in
+  hw_reg_list := r :: !hw_reg_list;
   incr currstamp;
   r
 
@@ -140,9 +143,15 @@ let reset() =
      all hard pseudo-registers that have been allocated by Proc, so
      remember it and use it as the base stamp for allocating
      soft pseudo-registers *)
-  if !first_virtual_reg_stamp = -1 then first_virtual_reg_stamp := !currstamp;
+  if !first_virtual_reg_stamp = -1 then begin
+    first_virtual_reg_stamp := !currstamp;
+    assert (!reg_list = []) (* Only hard regs created before now *)
+  end;
   currstamp := !first_virtual_reg_stamp;
-  reg_list := []
+  reg_list := [];
+  visit_generation := 1;
+  !hw_reg_list |> List.iter (fun r ->
+    r.visited <- unvisited)
 
 let all_registers() = !reg_list
 let num_registers() = !currstamp

--- a/asmcomp/reg.mli
+++ b/asmcomp/reg.mli
@@ -31,7 +31,7 @@ type t =
     mutable prefer: (t * int) list;     (* Preferences for other regs *)
     mutable degree: int;                (* Number of other regs live sim. *)
     mutable spill_cost: int;            (* Estimate of spilling cost *)
-    mutable visited: bool }             (* For graph walks *)
+    mutable visited: int }              (* For graph walks *)
 
 and location =
     Unknown
@@ -68,3 +68,7 @@ val reset: unit -> unit
 val all_registers: unit -> t list
 val num_registers: unit -> int
 val reinit: unit -> unit
+
+val mark_visited : t -> unit
+val is_visited : t -> bool
+val clear_visited_marks : unit -> unit


### PR DESCRIPTION
The current implementation of Coloring.iter_preferred may visit registers multiple times, because the visit marks are set and cleared each time a node is reached. This means that the algorithm has worst-case exponential complexity when the graph of preferences is not a tree, as happened recently on the flambda2 branch.

This patch changes the traversal to a linear-time DFS.

cc @chambart 