### PR TITLE
Improve recursive module usage warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -226,6 +226,9 @@ Working version
   from intermediate-representation dumps (-dfoo).
   (Gabriel Scherer, review by Vincent Laviron)
 
+- #9393: Improve recursive module usage warnings
+  (Leo White, review by Thomas Refis)
+
 - #2141: generate .annot files from cmt data; deprecate -annot.
   (Nicolás Ojeda Bär, review by Alain Frisch, Gabriel Scherer and Damien
   Doligez)

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -316,9 +316,9 @@ module type S' =
   end
 module Asc : sig type t = int val compare : int -> int -> int end
 module Desc : sig type t = int val compare : int -> int -> int end
-Line 15, characters 16-64:
+Line 15, characters 0-69:
 15 | module rec M1 : S' with module Term0 := Asc and module T := Desc = M1;;
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
        Constructors do not match:
          E of (MkT(M.T).t, MkT(M.T).t) eq

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -23,9 +23,9 @@ module type S = sig type x type y type t = E of x type u = t = E of y end
 
 module rec M1 : S with type x = int and type y = bool = M1;;
 [%%expect{|
-Line 1, characters 16-53:
+Line 1, characters 0-58:
 1 | module rec M1 : S with type x = int and type y = bool = M1;;
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M1.t
        Constructors do not match:
          E of M1.x
@@ -75,9 +75,9 @@ let (E eq : M1.u) = (E Eq : M1.t);;
 let cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x;;
 cast eq 3;;
 [%%expect{|
-Line 1, characters 16-53:
+Line 1, characters 0-58:
 1 | module rec M1 : S with type x = int and type y = bool = M1;;
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M1.t
        Constructors do not match:
          E of (M1.x, M1.x) eq

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -6,8 +6,8 @@
 
 module rec T : sig type t = T.t end = T;;
 [%%expect{|
-Line 1, characters 15-35:
+Line 1, characters 0-39:
 1 | module rec T : sig type t = T.t end = T;;
-                   ^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation T.t is cyclic
 |}]

--- a/testsuite/tests/typing-recmod/t01bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t01bad.compilers.reference
@@ -1,4 +1,4 @@
-File "t01bad.ml", line 10, characters 15-35:
+File "t01bad.ml", line 10, characters 0-61:
 10 | module rec A : sig type t = A.t end = struct type t = A.t end;;
-                    ^^^^^^^^^^^^^^^^^^^^
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation A.t is cyclic

--- a/testsuite/tests/typing-recmod/t02bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t02bad.compilers.reference
@@ -1,5 +1,5 @@
-File "t02bad.ml", line 10, characters 15-35:
+File "t02bad.ml", line 10, characters 0-61:
 10 | module rec A : sig type t = B.t end = struct type t = B.t end
-                    ^^^^^^^^^^^^^^^^^^^^
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
        B.t

--- a/testsuite/tests/typing-recmod/t04bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t04bad.compilers.reference
@@ -1,5 +1,5 @@
-File "t04bad.ml", line 10, characters 15-41:
+File "t04bad.ml", line 10, characters 0-73:
 10 | module rec A : sig type t = int * A.t end = struct type t = int * A.t end;;
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
        int * A.t

--- a/testsuite/tests/typing-recmod/t05bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t05bad.compilers.reference
@@ -1,5 +1,5 @@
-File "t05bad.ml", line 10, characters 15-42:
+File "t05bad.ml", line 10, characters 0-75:
 10 | module rec A : sig type t = B.t -> int end = struct type t = B.t -> int end
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of A.t contains a cycle:
        B.t -> int

--- a/testsuite/tests/typing-recmod/t07bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t07bad.compilers.reference
@@ -1,6 +1,6 @@
-File "t07bad.ml", line 10, characters 15-51:
+File "t07bad.ml", lines 10-11, characters 0-54:
 10 | module rec A : sig type 'a t = <m: 'a list A.t> end
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 |              = struct type 'a t = <m: 'a list A.t> end..
 Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t

--- a/testsuite/tests/typing-recmod/t08bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t08bad.compilers.reference
@@ -1,6 +1,6 @@
-File "t08bad.ml", line 10, characters 15-68:
+File "t08bad.ml", lines 10-11, characters 0-71:
 10 | module rec A : sig type 'a t = <m: 'a list B.t; n: 'a array B.t> end
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 |              = struct type 'a t = <m: 'a list B.t; n: 'a array B.t> end
 Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t

--- a/testsuite/tests/typing-recmod/t09bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t09bad.compilers.reference
@@ -1,6 +1,6 @@
-File "t09bad.ml", line 10, characters 15-41:
+File "t09bad.ml", lines 10-11, characters 0-44:
 10 | module rec A : sig type 'a t = 'a B.t end
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 |              = struct type 'a t = 'a B.t end
 Error: This recursive type is not regular.
        The type constructor A.t is defined as
          type 'a A.t

--- a/testsuite/tests/typing-recmod/t11bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t11bad.compilers.reference
@@ -1,6 +1,6 @@
-File "t11bad.ml", line 12, characters 15-52:
-12 |        and B : sig type 'a t = <m: 'a array B.t> end
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+File "t11bad.ml", lines 12-13, characters 7-55:
+12 | .......and B : sig type 'a t = <m: 'a array B.t> end
+13 |              = struct type 'a t = <m: 'a array B.t> end..
 Error: This recursive type is not regular.
        The type constructor B.t is defined as
          type 'a B.t

--- a/testsuite/tests/typing-recmod/t12bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t12bad.compilers.reference
@@ -1,9 +1,14 @@
-File "t12bad.ml", lines 11-15, characters 4-7:
-11 | ....sig
+File "t12bad.ml", lines 10-21, characters 0-7:
+10 | module rec M :
+11 |     sig
 12 |       class ['a] c : 'a -> object
 13 |         method map : ('a -> 'b) -> 'b M.c
 14 |       end
-15 |     end
+...
+18 |         method map : 'b. ('a -> 'b) -> 'b M.c
+19 |           = fun f -> new M.c (f x)
+20 |       end
+21 |     end..
 Error: This recursive type is not regular.
        The type constructor M.c is defined as
          type 'a M.c

--- a/testsuite/tests/typing-recmod/t14bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t14bad.compilers.reference
@@ -1,5 +1,5 @@
-File "t14bad.ml", line 23, characters 17-39:
+File "t14bad.ml", line 23, characters 2-43:
 23 |   module rec U : T with type D.t = U'.t = U
-                      ^^^^^^^^^^^^^^^^^^^^^^
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of U.D.t contains a cycle:
        U'.t

--- a/testsuite/tests/typing-recmod/t15bad.compilers.reference
+++ b/testsuite/tests/typing-recmod/t15bad.compilers.reference
@@ -1,4 +1,4 @@
-File "t15bad.ml", line 11, characters 15-35:
+File "t15bad.ml", line 11, characters 0-61:
 11 | module rec M : S' with type t = M.t = struct type t = M.t end;;
-                    ^^^^^^^^^^^^^^^^^^^^
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation M.t is cyclic

--- a/testsuite/tests/typing-warnings/unused_recmodule.ml
+++ b/testsuite/tests/typing-warnings/unused_recmodule.ml
@@ -1,0 +1,38 @@
+(* TEST
+   * expect
+*)
+
+[@@@ocaml.warning "+a"]
+
+module M : sig end = struct
+  module rec Foo : sig
+    type t
+    val create : Bar.t -> t
+  end = struct
+    type t = unit
+
+    let create _ = ()
+  end
+
+  and Bar : sig
+    type t
+  end = struct
+    type t = unit
+  end
+
+  let _ = Foo.create
+end;;
+[%%expect{|
+Line 14, characters 4-10:
+14 |     type t
+         ^^^^^^
+Warning 34: unused type t.
+Lines 13-17, characters 2-5:
+13 | ..and Bar : sig
+14 |     type t
+15 |   end = struct
+16 |     type t = unit
+17 |   end
+Warning 60: unused module Bar.
+module M : sig end
+|}];;

--- a/testsuite/tests/typing-warnings/unused_recmodule.ml
+++ b/testsuite/tests/typing-warnings/unused_recmodule.ml
@@ -27,12 +27,5 @@ Line 14, characters 4-10:
 14 |     type t
          ^^^^^^
 Warning 34: unused type t.
-Lines 13-17, characters 2-5:
-13 | ..and Bar : sig
-14 |     type t
-15 |   end = struct
-16 |     type t = unit
-17 |   end
-Warning 60: unused module Bar.
 module M : sig end
 |}];;


### PR DESCRIPTION
Usage warnings are broken for recursive modules where a module or one of its components are only used in the signatures of other modules. For example,
```ocaml
module M : sig end = struct
  module rec Foo : sig
    type t
    val create : Bar.t -> t
  end = struct
    type t = unit

    let create _ = ()
  end

  and Bar : sig
    type t
  end = struct
    type t = unit
  end

  let _ = Foo.create
end;;
[%%expect{|
Line 14, characters 4-10:
14 |     type t
         ^^^^^^
Warning 34: unused type t.
Lines 13-17, characters 2-5:
13 | ..and Bar : sig
14 |     type t
15 |   end = struct
16 |     type t = unit
17 |   end
Warning 60: unused module Bar.
module M : sig end
```

This PR fixes the problem for the recursive modules themselves. The problem remains for the components of recursive modules. (i.e. the unused module warning above is fixed but the unused type warning is not).