### PR TITLE
[WIP][Typing/typecore.ml]: Added warning 68, matching a function type

### DIFF
--- a/testsuite/tests/typing-warnings/arrowcheck.ml
+++ b/testsuite/tests/typing-warnings/arrowcheck.ml
@@ -1,0 +1,14 @@
+(* TEST
+   flags = " -w A -strict-sequence "
+   * expect
+*)
+
+(* Ignore OCAMLRUNPARAM=b to be reproducible *)
+match List.find with _ -> true;;
+[%%expect {|
+Line 1, characters 0-30:
+1 | match List.find with _ -> true;;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 68: Trying to match a function type.
+- : bool = true
+|}]

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -92,6 +92,7 @@ type t =
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
   | Unused_functor_parameter of string      (* 67 *)
+  | Matching_function_type                  (* 68 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -170,9 +171,10 @@ let number = function
   | Redefining_unit _ -> 65
   | Unused_open_bang _ -> 66
   | Unused_functor_parameter _ -> 67
+  | Matching_function_type -> 68 
 ;;
 
-let last_warning_number = 67
+let last_warning_number = 68
 ;;
 
 (* Must be the max number returned by the [number] function. *)
@@ -631,6 +633,8 @@ let message = function
          which shadows the existing one.\n\
          Hint: Did you mean 'type %s = unit'?" name
   | Unused_functor_parameter s -> "unused functor parameter " ^ s ^ "."
+  | Matching_function_type ->
+      "Trying to match a function type."
 ;;
 
 let nerrors = ref 0;;
@@ -775,6 +779,8 @@ let descriptions =
    64, "-unsafe used with a preprocessor returning a syntax tree";
    65, "Type declaration defining a new '()' constructor";
    66, "Unused open! statement";
+   (* 67, "ask octachron" *)
+   68, "matching function type";
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -94,6 +94,7 @@ type t =
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
   | Unused_functor_parameter of string      (* 67 *)
+  | Matching_function_type                      (* 68 *)
 ;;
 
 type alert = {kind:string; message:string; def:loc; use:loc}


### PR DESCRIPTION
#6881
@Octachron 
- This test case seems to be the problem now.
<pre>
# match fun x -> x with x -> x, x;;  
Warning 68: Trying to match a function type.
- : ('a -> 'a) * ('b -> 'b) = (<fun>, <fun>)
</pre>

- For now I have added a very basic test case, will add more after your suggestions.
- The descriptions and name associated to the newly added warning 68 needs to be discussed.
I will improve the code structure and add the Changes files once the PR reaches to its working state.

Thanks a lot for all the help 