### PR TITLE
documented OCAMLRUNPARAM settings, fixes #8697

### DIFF
--- a/Changes
+++ b/Changes
@@ -2424,6 +2424,9 @@ OCaml 4.07.0 (10 July 2018)
 - #1779: integrate the Bigarray documentation into the main manual.
   (Perry E. Metzger, review by Florian Angeletti and Xavier Clerc)
 
+- #9398: updated man page for ocamlrun command line options
+  (Anukriti Kumar, review by David Allsopp, Gabriel Scherer)
+
 ### Type system:
 
 - #7611, #1491: reject the use of generative functors as applicative.

--- a/man/ocamlrun.m
+++ b/man/ocamlrun.m
@@ -74,10 +74,21 @@ Search the directory
 .I dir
 for dynamically-loaded libraries, in addition to the standard search path.
 .TP
+.B \-m
+Print the magic number of the bytecode executable given as argument and
+exit.
+.TP
+.B \-M
+Print the magic number expected for bytecode executable by this version
+of the runtime and exit.
+.TP
 .B \-p
 Print the names of the primitives known to this version of
 .BR ocamlrun (1)
 and exit.
+.TP
+.B \-t
+Increments the trace level for the debug runtime (ignored otherwise).
 .TP
 .B \-v
 Direct the memory manager to print verbose messages on standard error.
@@ -145,8 +156,20 @@ Turn on randomization of all hash tables by default (see the
 module of the standard library). This option takes no
 argument.
 .TP
+.BR H
+Allocates heap chunks by mmapping huge pages. Huge pages are locked into
+memory, and are not swapped.
+.TP
 .BR h
 The initial size of the major heap (in words).
+.TP
+.BR w
+Sets size of window used by major GC for smoothing out variations in
+its workload. This is an integer between 1 and 50. (Default: 1)
+.TP
+.BR W
+Activates runtime warnings (such as Channel opened on file dies without
+being closed, unflushed data, etc.)
 .TP
 .BR a \ (allocation_policy)
 The policy used for allocating in the OCaml heap.  Possible values

--- a/man/ocamlrun.m
+++ b/man/ocamlrun.m
@@ -69,6 +69,11 @@ set.  This option is equivalent to setting the
 .B b
 flag in the OCAMLRUNPARAM environment variable (see below).
 .TP
+.B \-c
+(cleanup_on_exit) Shut the runtime down gracefully on exit. The option
+also enables pooling (as in caml_startup_pooled). This mode can be used
+to detect leaks with a third-party memory debugger.
+.TP
 .BI \-I \ dir
 Search the directory
 .I dir

--- a/manual/manual/cmds/runtime.etex
+++ b/manual/manual/cmds/runtime.etex
@@ -65,10 +65,13 @@ section~\ref{s:ocamlrun-dllpath}).
 Print the magic number of the bytecode executable given as argument
 and exit.
 \item["-M"]
-Print the magic number expected by this version of the runtime and exit.
+Print the magic number expected for bytecode executable by this version
+of the runtime and exit.
 \item["-p"]
 Print the names of the primitives known to this version of
 "ocamlrun" and exit.
+\item["-t"]
+Increments the trace level for the debug runtime (ignored otherwise).
 \item["-v"]
 Direct the memory manager to print some progress messages on
 standard error.  This is equivalent to setting "v=63" in the
@@ -124,7 +127,13 @@ The following environment variables are also consulted:
   section~\ref{Hashtbl}).
 \fi
         This option takes no argument.
+  \item[H] Allocates heap chunks by mmapping huge pages. Huge pages are locked into
+    memory, and are not swapped.
   \item[h] The initial size of the major heap (in words).
+  \item[w] Sets size of window used by major GC for smoothing out variations in
+    its workload. This is an integer between 1 and 50. (Default: 1)
+  \item[W] Activates runtime warnings (such as Channel opened on file dies without
+    being closed, unflushed data, etc.)
   \item[a] ("allocation_policy")
     The policy used for allocating in the OCaml heap. Possible values
     are "0" for the next-fit policy, "1" for the first-fit


### PR DESCRIPTION
Added missing OCAMLRUNPARAM settings, as mentioned in #8697 
-n flag is still missing, I'm not sure what it exactly does it sets minor_max_bsz, in config.h right before where Custom_minor_max_bsz_def is defined, this is commented:
`Default setting for maximum size of custom objects counted as garbage in the minor heap. Documented in gc.mli`
Let me know about accommodating changes.