### PR TITLE
Fix name of a struct field in comment

### DIFF
--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -879,7 +879,7 @@ static int bf_small_map = 0;
 /* Small free blocks have only one pointer to the next block.
    Large free blocks have 5 fields:
    tree fields:
-     - node flag
+     - isnode flag
      - left son
      - right son
    list fields:

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -14,6 +14,7 @@
 /**************************************************************************/
 
 #define CAML_INTERNALS
+
 #define FREELIST_DEBUG 0
 #if FREELIST_DEBUG
 #include <stdio.h>

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -14,7 +14,6 @@
 /**************************************************************************/
 
 #define CAML_INTERNALS
-
 #define FREELIST_DEBUG 0
 #if FREELIST_DEBUG
 #include <stdio.h>
@@ -880,8 +879,8 @@ static int bf_small_map = 0;
    Large free blocks have 5 fields:
    tree fields:
      - isnode flag
-     - left son
-     - right son
+     - left child
+     - right child
    list fields:
      - next
      - prev


### PR DESCRIPTION
Fix the name in the documentation of the field `isnode` in the struct `large_free_block`.

No change entry needed