### PR TITLE
manual: fix attribute examples

### DIFF
--- a/Changes
+++ b/Changes
@@ -984,6 +984,9 @@ OCaml 4.09.0 (19 September 2019):
 - #8515: manual, precise constraints on reexported types
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #9327, #9401: manual, fix infix attribute examples
+  (Florian Angeletti, report by David Cadé, review by Gabriel Scherer)
+
 ### Tools:
 
 - #2221: ocamldep will now correctly allow a .ml file in an include directory

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1501,7 +1501,7 @@ It is also possible to specify attributes using an infix syntax. For instance:
 
 \begin{verbatim}
 let[@foo] x = 2 in x + 1          === (let x = 2 [@@foo] in x + 1)
-begin[@foo][@bar x] ... end       === (begin ... end)[@foo][@@bar x]
+begin[@foo][@bar x] ... end       === (begin ... end)[@foo][@bar x]
 module[@foo] M = ...              === module M = ... [@@foo]
 type[@foo] t = T                  === type t = T [@@foo]
 method[@foo] m = ...              === method m = ... [@@foo]
@@ -1512,7 +1512,7 @@ For "let", the attributes are applied to each bindings:
 \begin{verbatim}
 let[@foo] x = 2 and y = 3 in x + y === (let x = 2 [@@foo] and y = 3 in x + y)
 let[@foo] x = 2
-and[@bar] y = 3 in x + y           === (let x = 2 [@@foo] and y = 3 [@bar] in x + y)
+and[@bar] y = 3 in x + y           === (let x = 2 [@@foo] and y = 3 [@@bar] in x + y)
 \end{verbatim}
 
 


### PR DESCRIPTION
This PR fixes few attribute examples that were inadvertently mixing algebraic and item attributes.

closes #9327  