### PR TITLE
Remove sudo:false in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@
 #**************************************************************************
 
 dist: xenial
-sudo: false
 language: c
 git:
   submodules: false

--- a/Changes
+++ b/Changes
@@ -159,6 +159,9 @@ Working version
   run a command and evaluate its output.
   (Jérémie Dimino, review by David Allsopp)
 
+- #9402: Remove `sudo:false` from .travis.yml
+  (Hikaru Yoshimura)
+
 ### Manual and documentation:
 
 - #9141: beginning of the ocamltest reference manual


### PR DESCRIPTION
- Travis CI requires to remove `sudo:false` option to move into Linux infrastructure. See also:
    - [Upcoming Required Linux Infrastructure Migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
- The official document says that Container-based infrastructure has been fully deprecated
    - https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure
- So I dropped `sudo: false`
- I think that other repositories in this organization(for example https://github.com/ocaml/dune) are also using `sudo:false`, it would be better to do the same fix. May I submit the same PR to other https://github.com/ocaml repositories?