### PR TITLE
fixed fibonacci example of coreexamples manual

### DIFF
--- a/Changes
+++ b/Changes
@@ -1571,6 +1571,9 @@ OCaml 4.08.0 (13 June 2019)
 - #8508: refresh \moduleref macro
   (Florian Angeletti, review by Gabriel Scherer)
 
+- 9410: fixed fibonacci example of coreexamples manual
+  (Anukriti Kumar, review by sanette, Octachron, zapashcanon)
+
 ### Code generation and optimizations:
 
 - #7725, #1754: improve AFL instrumentation for objects and lazy values.

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -941,15 +941,22 @@ source files created for use with OCaml compilers, but can be helpful
 to mark the end of a top-level expression unambiguously even when
 there are syntax errors.
 Here is a
-sample standalone program to print Fibonacci numbers:
+sample standalone program to print Fibonacci numbers from 0 to n:
 \begin{verbatim}
 (* File fib.ml *)
-let rec fib n =
-  if n < 2 then 1 else fib (n-1) + fib (n-2);;
+let fib n =
+  let previous_ref = ref (0, 1) in
+  Printf.printf "fib(0) = 0\n";
+  for i = 1 to n do
+    let (a, b) = !previous_ref in
+    let next = a + b in
+    previous_ref := (next, a);
+    Printf.printf "fib(%d) = %d\n" i next
+  done
+
 let main () =
   let arg = int_of_string Sys.argv.(1) in
-  print_int (fib arg);
-  print_newline ();
+  fib arg;
   exit 0;;
 main ();;
 \end{verbatim}


### PR DESCRIPTION
fixes #9351

This Fibonacci is linear time (so can easily compute fib(50))
As well as for Fib(0) it gives 0 Fib(1) = 1 Fib(2) = 2 as per wikipedia. It also prints every every fibonacci it computes like a table to make the code readability simpler.
```ocaml
let fib (n) =
  let previous_ref = ref (0, 1) in
  Printf.printf "fib(0) = 0\n";
  for i = 1 to n do
    let (a, b) = !previous_ref in
    let next = a + b in
    previous_ref := (next, a);
    Printf.printf "fib(%d) = %d\n" i next
  done

let main () =
  let arg = int_of_string Sys.argv.(1) in
  fib (arg);
  exit 0;;
main ();;
```

Output:
![image](https://user-images.githubusercontent.com/31126248/78090282-4e81f200-73e7-11ea-9d0e-3ca64e2b6b0b.png)
