### PR TITLE
forbid optional arguments reordering with -nolabels

### DIFF
--- a/Changes
+++ b/Changes
@@ -291,7 +291,7 @@ Working version
 - #2324: Replace caml_int_compare and caml_float_compare with primitives.
   (Greta Yorsh, review by Stephen Dolan and Vincent Laviron)
 
-- #9411: type_args: merge sargs and more_sargs
+* #9411: forbid optional arguments reordering with -nolabels
   (Thomas Refis, review by Frédéric Bour and Jacques Garrigue)
 
 - #9452: Add locations to docstring attributes

--- a/Changes
+++ b/Changes
@@ -291,6 +291,9 @@ Working version
 - #2324: Replace caml_int_compare and caml_float_compare with primitives.
   (Greta Yorsh, review by Stephen Dolan and Vincent Laviron)
 
+- #9411: type_args: merge sargs and more_sargs
+  (Thomas Refis, review by Frédéric Bour and Jacques Garrigue)
+
 - #9452: Add locations to docstring attributes
   (Leo White, review by Gabriel Scherer)
 

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -37,6 +37,7 @@ Line 2, characters 13-17:
 Error: The function applied to this argument has type
          ?x:'a -> a:'b -> ?y:'c -> z:'d -> unit
 This argument cannot be applied with label ?y
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 
 let f (g: ?x:_ -> _) = g ~y:None ?x:None; g ?x:None ()
@@ -47,6 +48,7 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: The function applied to this argument has type ?x:'a -> 'b
 This argument cannot be applied with label ~y
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 
 (** Show that optional arguments can be commuted, to some degree. *)
@@ -69,6 +71,7 @@ Line 1, characters 7-8:
 Error: The function applied to this argument has type
          ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
 This argument cannot be applied with label ~c
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 ;;
 
@@ -83,6 +86,7 @@ Line 1, characters 14-15:
 Error: The function applied to this argument has type
          ?c:int -> x:int -> int -> int
 This argument cannot be applied without label
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 ;;
 
@@ -94,6 +98,7 @@ Line 1, characters 12-13:
 Error: The function applied to this argument has type
          ?b:int -> ?c:int -> x:int -> int -> int
 This argument cannot be applied with label ~c
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 ;;
 
@@ -105,6 +110,7 @@ Line 1, characters 7-8:
 Error: The function applied to this argument has type
          ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
 This argument cannot be applied with label ~b
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 ;;
 
@@ -125,5 +131,6 @@ Line 1, characters 5-6:
 Error: The function applied to this argument has type
          ?x:'a -> ?y:'b -> unit -> unit
 This argument cannot be applied with label ~y
+  Since OCaml 4.11, optional arguments do not commute when -nolabels is given
 |}]
 ;;

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -63,7 +63,12 @@ val f : int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int = <fun>
 
 f 3 ~c:2 ~a:1 ~b:0 ~x:4 5;;
 [%%expect{|
-- : int = 15
+Line 1, characters 22-23:
+1 | f 3 ~c:2 ~a:1 ~b:0 ~x:4 5;;
+                          ^
+Error: The function applied to this argument has type
+         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
+This argument cannot be applied with label ~x
 |}]
 ;;
 
@@ -76,7 +81,7 @@ Line 1, characters 14-15:
 1 | f 3 ~a:1 ~b:2 5 ~c:0 ~x:4;;
                   ^
 Error: The function applied to this argument has type
-         ?c:int -> x:int -> int -> int
+         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
 This argument cannot be applied without label
 |}]
 ;;
@@ -87,7 +92,7 @@ Line 1, characters 14-15:
 1 | f 3 ~a:1 ~c:2 5 ~b:0 ~x:4;;
                   ^
 Error: The function applied to this argument has type
-         ?b:int -> ?c:int -> x:int -> int -> int
+         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
 This argument cannot be applied without label
 |}]
 ;;
@@ -98,7 +103,7 @@ Line 1, characters 14-15:
 1 | f 3 ~b:1 ~c:2 5 ~a:0 ~x:4;;
                   ^
 Error: The function applied to this argument has type
-         ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
+         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
 This argument cannot be applied without label
 |}]
 ;;

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -48,3 +48,57 @@ Line 1, characters 28-32:
 Error: The function applied to this argument has type ?x:'a -> 'b
 This argument cannot be applied with label ~y
 |}]
+
+(** Show that optional arguments can be commuted, to some degree. *)
+
+let f i ?(a=0) ?(b=0) ?(c=0) ~x j =
+  i + a + b + c + x + j
+;;
+[%%expect{|
+val f : int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int = <fun>
+|}]
+;;
+
+(* [a], [b] and [c] can be commuted without issues *)
+
+f 3 ~c:2 ~a:1 ~b:0 ~x:4 5;;
+[%%expect{|
+- : int = 15
+|}]
+;;
+
+(* Now, for all of the following, the error appears on the first non optional
+   argument, but compare the reported function types: *)
+
+f 3 ~a:1 ~b:2 5 ~c:0 ~x:4;;
+[%%expect{|
+Line 1, characters 14-15:
+1 | f 3 ~a:1 ~b:2 5 ~c:0 ~x:4;;
+                  ^
+Error: The function applied to this argument has type
+         ?c:int -> x:int -> int -> int
+This argument cannot be applied without label
+|}]
+;;
+
+f 3 ~a:1 ~c:2 5 ~b:0 ~x:4;;
+[%%expect{|
+Line 1, characters 14-15:
+1 | f 3 ~a:1 ~c:2 5 ~b:0 ~x:4;;
+                  ^
+Error: The function applied to this argument has type
+         ?b:int -> ?c:int -> x:int -> int -> int
+This argument cannot be applied without label
+|}]
+;;
+
+f 3 ~b:1 ~c:2 5 ~a:0 ~x:4;;
+[%%expect{|
+Line 1, characters 14-15:
+1 | f 3 ~b:1 ~c:2 5 ~a:0 ~x:4;;
+                  ^
+Error: The function applied to this argument has type
+         ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
+This argument cannot be applied without label
+|}]
+;;

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -63,12 +63,12 @@ val f : int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int = <fun>
 
 f 3 ~c:2 ~a:1 ~b:0 ~x:4 5;;
 [%%expect{|
-Line 1, characters 22-23:
+Line 1, characters 7-8:
 1 | f 3 ~c:2 ~a:1 ~b:0 ~x:4 5;;
-                          ^
+           ^
 Error: The function applied to this argument has type
-         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
-This argument cannot be applied with label ~x
+         ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
+This argument cannot be applied with label ~c
 |}]
 ;;
 
@@ -81,30 +81,30 @@ Line 1, characters 14-15:
 1 | f 3 ~a:1 ~b:2 5 ~c:0 ~x:4;;
                   ^
 Error: The function applied to this argument has type
-         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
+         ?c:int -> x:int -> int -> int
 This argument cannot be applied without label
 |}]
 ;;
 
 f 3 ~a:1 ~c:2 5 ~b:0 ~x:4;;
 [%%expect{|
-Line 1, characters 14-15:
+Line 1, characters 12-13:
 1 | f 3 ~a:1 ~c:2 5 ~b:0 ~x:4;;
-                  ^
+                ^
 Error: The function applied to this argument has type
-         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
-This argument cannot be applied without label
+         ?b:int -> ?c:int -> x:int -> int -> int
+This argument cannot be applied with label ~c
 |}]
 ;;
 
 f 3 ~b:1 ~c:2 5 ~a:0 ~x:4;;
 [%%expect{|
-Line 1, characters 14-15:
+Line 1, characters 7-8:
 1 | f 3 ~b:1 ~c:2 5 ~a:0 ~x:4;;
-                  ^
+           ^
 Error: The function applied to this argument has type
-         int -> ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
-This argument cannot be applied without label
+         ?a:int -> ?b:int -> ?c:int -> x:int -> int -> int
+This argument cannot be applied with label ~b
 |}]
 ;;
 
@@ -119,6 +119,6 @@ val f : ?x:'a -> ?y:'b -> unit -> unit = <fun>
 
 f ~y:3;;
 [%%expect{|
-- : ?x:'a -> unit -> unit = <fun>
+- : unit -> unit = <fun>
 |}]
 ;;

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -102,3 +102,18 @@ Error: The function applied to this argument has type
 This argument cannot be applied without label
 |}]
 ;;
+
+(* Example given by Jacques when reviewing
+   https://github.com/ocaml/ocaml/pull/9411 *)
+
+let f ?x ?y () = ();;
+[%%expect{|
+val f : ?x:'a -> ?y:'b -> unit -> unit = <fun>
+|}]
+;;
+
+f ~y:3;;
+[%%expect{|
+- : ?x:'a -> unit -> unit = <fun>
+|}]
+;;

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -119,6 +119,11 @@ val f : ?x:'a -> ?y:'b -> unit -> unit = <fun>
 
 f ~y:3;;
 [%%expect{|
-- : unit -> unit = <fun>
+Line 1, characters 5-6:
+1 | f ~y:3;;
+         ^
+Error: The function applied to this argument has type
+         ?x:'a -> ?y:'b -> unit -> unit
+This argument cannot be applied with label ~y
 |}]
 ;;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -691,10 +691,12 @@ let prefixed_label_name = function
   | Optional s -> "?" ^ s
 
 let rec extract_label_aux hd l = function
-    [] -> raise Not_found
+  | [] -> None
   | (l',t as p) :: ls ->
-      if label_name l' = l then (l', t, List.rev hd, ls)
-      else extract_label_aux (p::hd) l ls
+      if label_name l' = l then
+        Some (l', t, hd <> [], List.rev_append hd ls)
+      else
+        extract_label_aux (p::hd) l ls
 
 let extract_label l ls = extract_label_aux [] l ls
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -205,8 +205,11 @@ val prefixed_label_name : arg_label -> label
 
 val extract_label :
     label -> (arg_label * 'a) list ->
-    arg_label * 'a * (arg_label * 'a) list * (arg_label * 'a) list
-    (* actual label, value, before list, after list *)
+    (arg_label * 'a * bool * (arg_label * 'a) list) option
+(* actual label,
+   value,
+   whether (label, value) was at the head of the list,
+   list without the extracted (label, value) *)
 
 (**** Utilities for backtracking ****)
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1113,10 +1113,7 @@ and class_expr_aux cl_num val_env met_env scl =
                 match sargs with
                 | [] -> assert false
                 | (l', sarg0) :: sargs ->
-                    if !did_commute then
-                      raise(Error(sarg0.pexp_loc, val_env,
-                                  Apply_wrong_label l'))
-                    else if l <> l' && l' <> Nolabel then
+                    if !did_commute || (l <> l' && l' <> Nolabel) then
                       raise(Error(sarg0.pexp_loc, val_env,
                                   Apply_wrong_label l'))
                     else

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1106,13 +1106,6 @@ and class_expr_aux cl_num val_env met_env scl =
         match ty_fun, ty_fun0 with
         | Cty_arrow (l, ty, ty_fun), Cty_arrow (_, ty0, ty_fun0)
           when sargs <> [] ->
-            let extract_label name sargs =
-              match Btype.extract_label name sargs with
-              | exception Not_found -> None
-              | (l, arg, commuted, in_order) ->
-                  if commuted <> [] then did_commute := true;
-                  Some (l, arg, commuted @ in_order)
-            in
             let name = Btype.label_name l
             and optional = Btype.is_optional l in
             let sargs, arg =
@@ -1129,8 +1122,9 @@ and class_expr_aux cl_num val_env met_env scl =
                     else
                       (sargs, Some (type_argument val_env sarg0 ty ty0))
               end else
-                match extract_label name sargs with
-                | Some (l', sarg0, sargs) ->
+                match Btype.extract_label name sargs with
+                | Some (l', sarg0, commuted, sargs) ->
+                    did_commute := commuted;
                     if not optional && Btype.is_optional l' then
                       Location.prerr_warning sarg0.pexp_loc
                         (Warnings.Nonoptional_label

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1101,61 +1101,60 @@ and class_expr_aux cl_num val_env met_env scl =
           true
         end
       in
-      let rec type_args args omitted ty_fun ty_fun0 sargs more_sargs =
+      let did_commute = ref false in
+      let rec type_args args omitted ty_fun ty_fun0 sargs =
         match ty_fun, ty_fun0 with
         | Cty_arrow (l, ty, ty_fun), Cty_arrow (_, ty0, ty_fun0)
-          when sargs <> [] || more_sargs <> [] ->
+          when sargs <> [] ->
+            let extract_label name sargs =
+              match Btype.extract_label name sargs with
+              | exception Not_found -> None
+              | (l, arg, commuted, in_order) ->
+                  if commuted <> [] then did_commute := true;
+                  Some (l, arg, commuted @ in_order)
+            in
             let name = Btype.label_name l
             and optional = Btype.is_optional l in
-            let sargs, more_sargs, arg =
+            let sargs, arg =
               if ignore_labels && not (Btype.is_optional l) then begin
-                match sargs, more_sargs with
-                  (l', sarg0)::_, _ ->
-                    raise(Error(sarg0.pexp_loc, val_env, Apply_wrong_label l'))
-                | _, (l', sarg0)::more_sargs ->
-                    if l <> l' && l' <> Nolabel then
+                match sargs with
+                | [] -> assert false
+                | (l', sarg0) :: sargs ->
+                    if !did_commute then
                       raise(Error(sarg0.pexp_loc, val_env,
                                   Apply_wrong_label l'))
-                    else ([], more_sargs,
-                          Some (type_argument val_env sarg0 ty ty0))
-                | _ ->
-                    assert false
-              end else try
-                let (l', sarg0, sargs, more_sargs) =
-                  try
-                    let (l', sarg0, sargs1, sargs2) =
-                      Btype.extract_label name sargs
-                    in (l', sarg0, sargs1 @ sargs2, more_sargs)
-                  with Not_found ->
-                    let (l', sarg0, sargs1, sargs2) =
-                      Btype.extract_label name more_sargs
-                    in (l', sarg0, sargs @ sargs1, sargs2)
-                in
-                if not optional && Btype.is_optional l' then
-                  Location.prerr_warning sarg0.pexp_loc
-                    (Warnings.Nonoptional_label (Printtyp.string_of_label l));
-                sargs, more_sargs,
-                if not optional || Btype.is_optional l' then
-                  Some (type_argument val_env sarg0 ty ty0)
-                else
-                  let ty' = extract_option_type val_env ty
-                  and ty0' = extract_option_type val_env ty0 in
-                  let arg = type_argument val_env sarg0 ty' ty0' in
-                  Some (option_some val_env arg)
-              with Not_found ->
-                sargs, more_sargs,
-                if Btype.is_optional l
-                   && (List.mem_assoc Nolabel sargs
-                       || List.mem_assoc Nolabel more_sargs)
-                then
-                  Some (option_none val_env ty0 Location.none)
-                else None
+                    else if l <> l' && l' <> Nolabel then
+                      raise(Error(sarg0.pexp_loc, val_env,
+                                  Apply_wrong_label l'))
+                    else
+                      (sargs, Some (type_argument val_env sarg0 ty ty0))
+              end else
+                match extract_label name sargs with
+                | Some (l', sarg0, sargs) ->
+                    if not optional && Btype.is_optional l' then
+                      Location.prerr_warning sarg0.pexp_loc
+                        (Warnings.Nonoptional_label
+                           (Printtyp.string_of_label l));
+                    sargs,
+                    if not optional || Btype.is_optional l' then
+                      Some (type_argument val_env sarg0 ty ty0)
+                    else
+                      let ty' = extract_option_type val_env ty
+                      and ty0' = extract_option_type val_env ty0 in
+                      let arg = type_argument val_env sarg0 ty' ty0' in
+                      Some (option_some val_env arg)
+                | None ->
+                    sargs,
+                    if Btype.is_optional l && List.mem_assoc Nolabel sargs then
+                      Some (option_none val_env ty0 Location.none)
+                    else
+                      None
             in
             let omitted = if arg = None then (l,ty0) :: omitted else omitted in
             type_args ((l,arg)::args) omitted ty_fun ty_fun0
-              sargs more_sargs
+              sargs
         | _ ->
-            match sargs @ more_sargs with
+            match sargs with
               (l, sarg0)::_ ->
                 if omitted <> [] then
                   raise(Error(sarg0.pexp_loc, val_env, Apply_wrong_label l))
@@ -1169,10 +1168,7 @@ and class_expr_aux cl_num val_env met_env scl =
       in
       let (args, cty) =
         let (_, ty_fun0) = Ctype.instance_class [] cl.cl_type in
-        if ignore_labels then
-          type_args [] [] cl.cl_type ty_fun0 [] sargs
-        else
-          type_args [] [] cl.cl_type ty_fun0 sargs []
+        type_args [] [] cl.cl_type ty_fun0 sargs
       in
       rc {cl_desc = Tcl_apply (cl, args);
           cl_loc = scl.pcl_loc;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4282,9 +4282,12 @@ and type_application env funct sargs =
             | (l', sarg) :: remaining_sargs ->
                 if name = label_name l' || (not optional && l' = Nolabel) then
                   (remaining_sargs, use_arg sarg l')
-                else if optional &&
-                        not (List.exists (fun (l, _) -> name = label_name l)
-                               remaining_sargs)
+                else if
+                  optional &&
+                  not (List.exists (fun (l, _) -> name = label_name l)
+                         remaining_sargs) &&
+                  List.exists (function (Nolabel, _) -> true | _ -> false)
+                    sargs
                 then
                   (sargs, eliminate_optional_arg ())
                 else

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4247,7 +4247,7 @@ and type_application env funct sargs =
     end
   in
   let warned = ref false in
-  let rec type_args args omitted ty_fun ty_fun0 ty_old sargs =
+  let rec type_args args omitted ty_fun ty_fun0 sargs =
     match expand_head env ty_fun, expand_head env ty_fun0 with
       {desc=Tarrow (l, ty, ty_fun, com); level=lv} as ty_fun',
       {desc=Tarrow (_, ty0, ty_fun0, _)}
@@ -4319,9 +4319,7 @@ and type_application env funct sargs =
         in
         let omitted =
           if arg = None then (l,ty,lv) :: omitted else omitted in
-        let ty_old = if sargs = [] then ty_fun else ty_old in
-        type_args ((l,arg)::args) omitted ty_fun ty_fun0
-          ty_old sargs
+        type_args ((l,arg)::args) omitted ty_fun ty_fun0 sargs
     | _ -> type_unknown_args args omitted ty_fun0 sargs
   in
   let is_ignore funct =
@@ -4343,7 +4341,7 @@ and type_application env funct sargs =
       ([Nolabel, Some exp], ty_res)
   | _ ->
     let ty = funct.exp_type in
-    type_args [] [] ty (instance ty) ty sargs
+    type_args [] [] ty (instance ty) sargs
 
 and type_construct env loc lid sarg ty_expected_explained attrs =
   let { ty = ty_expected; explanation } = ty_expected_explained in

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -139,7 +139,7 @@ type error =
       Ctype.Unification_trace.t * type_forcing_context option
       * Typedtree.expression_desc option
   | Apply_non_function of type_expr
-  | Apply_wrong_label of arg_label * type_expr
+  | Apply_wrong_label of arg_label * type_expr * bool
   | Label_multiply_defined of string
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t


### PR DESCRIPTION
Foreword: IMHO this is a fairly low-key "cleanup" PR. I hope to send some more PRs of that sort (on that particular bit of code) in the coming days, so I would ask potential reviewers to not spend to long suggesting further changes / clean-ups / simplification to this part of the code.

Of course that's only a suggestion, and if people disagree then I can come back in a few days with a bigger (and likely harder to review) PR :)

---

If I understood correctly, the split between `sargs` and `more_sargs` (which I spent a while trying to find meaningful names for, to no avail) exists only to be able to raise an error when an argument gets commuted even though `-nolabels` was passed.
I believe this can only happen for optional parameters, as in this example:
```ocaml
let f x ?(y=2) z = x + y + z;;

let _ = f 3 4 ~y:1;;
```

It is still unclear to me why optional parameters are handled in that way in this mode. Note: I understand that unlike named parameters, they cannot be applied without a label. But I believe (perhaps wrongly) that the implementation could be more obvious in that regard.
Anyway, as I said, that's a discussion for another day!