### PR TITLE
Keep Sys.opaque_identity in Cmm and Mach

### DIFF
--- a/Changes
+++ b/Changes
@@ -1175,6 +1175,9 @@ OCaml 4.11.0 (19 August 2020)
 - #9392: Visit registers at most once in Coloring.iter_preferred.
   (Stephen Dolan, review by Pierre Chambart and Xavier Leroy)
 
+- #9412: Keep Sys.opaque_identity in Cmm and Mach
+  (Stephen Dolan, review by Mark Shinwell and Gabriel Scherer)
+
 - #9549, #9557: Make -flarge-toc the default for PowerPC and introduce
   -fsmall-toc to enable the previous behaviour.
   (David Allsopp, report by Nathaniel Wesley Filardo, review by Xavier Leroy)

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -223,7 +223,7 @@ method class_of_operation op =
   | Imove | Ispill | Ireload -> assert false   (* treated specially *)
   | Iconst_int _ | Iconst_float _ | Iconst_symbol _ -> Op_pure
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ -> assert false                 (* treated specially *)
+  | Iextcall _ | Iopaque -> assert false       (* treated specially *)
   | Istackoffset _ -> Op_other
   | Iload(_,_) -> Op_load
   | Istore(_,_,asg) -> Op_store asg
@@ -276,6 +276,9 @@ method private cse n i =
          could be kept, but won't be usable for CSE as one of their
          arguments is always a memory load.  For simplicity, we
          just forget everything. *)
+      {i with next = self#cse empty_numbering i.next}
+  | Iop Iopaque ->
+      (* Assume arbitrary side effects from Iopaque *)
       {i with next = self#cse empty_numbering i.next}
   | Iop (Ialloc _) ->
       (* For allocations, we must avoid extending the live range of a

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -695,6 +695,8 @@ let emit_instr fallthrough i =
       I.cvtsi2sd  (arg i 0)  (res i 0)
   | Lop(Iintoffloat) ->
       I.cvttsd2si (arg i 0) (res i 0)
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
   | Lop(Ispecific(Ilea addr)) ->
       I.lea (addressing addr NONE i 0) (res i 0)
   | Lop(Ispecific(Istore_int(n, addr, _))) ->

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -354,7 +354,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Ilea _|Isextend32|Izextend32) -> true
   | Ispecific _ -> false
   | _ -> true

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -721,6 +721,8 @@ let emit_instr i =
     | Lop(Iintoffloat) ->
         `	ftosizd	s14, {emit_reg i.arg.(0)}\n`;
         `	fmrs	{emit_reg i.res.(0)}, s14\n`; 2
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc); 0
     | Lop(Iaddf | Isubf | Imulf | Idivf | Ispecific Inegmulf as op) ->
         let instr = (match op with
                        Iaddf              -> "faddd"

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -335,7 +335,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _)
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -517,6 +517,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Iintop_imm _) -> 1
     | Lop (Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf) -> 1
     | Lop (Iaddf | Isubf | Imulf | Idivf | Ispecific Inegmulf) -> 1
+    | Lop (Iopaque) -> 0
     | Lop (Ispecific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
     | Lop (Ispecific (Ishiftarith _)) -> 1
     | Lop (Ispecific (Imuladd | Imulsub)) -> 1
@@ -846,6 +847,8 @@ let emit_instr i =
                      | Inegmulsubf -> "fnmsub"
                      | _ -> assert false) in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}, {emit_reg i.arg.(0)}\n`
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific(Ishiftarith(op, shift))) ->
         let instr = (match op with
                        Ishiftadd    -> "add"

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -286,7 +286,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _)
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true
 

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -165,6 +165,7 @@ and operation =
   | Ccmpf of float_comparison
   | Craise of Lambda.raise_kind
   | Ccheckbound
+  | Copaque
 
 type expression =
     Cconst_int of int * Debuginfo.t

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -162,6 +162,7 @@ and operation =
                    then the index.
                    It results in a bounds error if the index is greater than
                    or equal to the bound. *)
+  | Copaque (* Sys.opaque_identity *)
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1329,6 +1329,9 @@ let check_bound safety access_size dbg length a2 k =
       in
       Csequence(make_checkbound dbg [max_or_zero a1 dbg; a2], k)
 
+let opaque e dbg =
+  Cop(Copaque, [e], dbg)
+
 let unaligned_set size ptr idx newval dbg =
   match (size : Clambda_primitives.memory_access_size) with
   | Sixteen -> unaligned_set_16 ptr idx newval dbg

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -318,6 +318,9 @@ val check_bound :
   expression -> expression -> expression ->
   expression
 
+(** Sys.opaque_identity *)
+val opaque : expression -> Debuginfo.t -> expression
+
 (** Generic application functions *)
 
 (** Get the symbol for the generic application with [n] arguments, and

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -785,7 +785,7 @@ and transl_prim_1 env p arg dbg =
   match p with
   (* Generic operations *)
     Popaque ->
-      transl env arg
+      opaque (transl env arg) dbg
   (* Heap operations *)
   | Pfield n ->
       get_field env (transl env arg) n dbg

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -731,6 +731,8 @@ let emit_instr fallthrough i =
       I.add (int 8) esp;
       cfi_adjust_cfa_offset (-8);
       stack_offset := !stack_offset + 8
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
   | Lop(Ispecific(Ilea addr)) ->
       I.lea (addressing addr DWORD i 0) (reg i.res.(0))
   | Lop(Ispecific(Istore_int(n, addr, _))) ->

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -232,7 +232,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Ilea _) -> true
   | Ispecific _ -> false
   | _ -> true

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -58,6 +58,7 @@ type operation =
   | Iintop_imm of integer_operation * int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat
+  | Iopaque
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -59,6 +59,7 @@ type operation =
   | Iintop_imm of integer_operation * int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf
   | Ifloatofint | Iintoffloat
+  | Iopaque
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -496,6 +496,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf) -> 1
     | Lop(Ifloatofint) -> 9
     | Lop(Iintoffloat) -> 4
+    | Lop(Iopaque) -> 0
     | Lop(Ispecific _) -> 1
     | Lop (Iname_for_debugger _) -> 0
     | Lreloadretaddr -> 2
@@ -855,6 +856,8 @@ let emit_instr i =
           `	lwz	{emit_reg i.res.(0)}, 4(1)\n`;
           `	addi	1, 1, 16\n`
         end
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific sop) ->
         let instr = name_for_specific sop in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -325,7 +325,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
   | Ispecific _ -> false
   | _ -> true

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -156,6 +156,7 @@ let operation d = function
   | Ccmpf c -> Printf.sprintf "%sf" (float_comparison c)
   | Craise k -> Lambda.raise_kind k ^ location d
   | Ccheckbound -> "checkbound" ^ location d
+  | Copaque -> "opaque"
 
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -144,6 +144,7 @@ let operation op arg ppf res =
   | Idivf -> fprintf ppf "%a /f %a" reg arg.(0) reg arg.(1)
   | Ifloatofint -> fprintf ppf "floatofint %a" reg arg.(0)
   | Iintoffloat -> fprintf ppf "intoffloat %a" reg arg.(0)
+  | Iopaque -> fprintf ppf "opaque %a" reg arg.(0)
   | Iname_for_debugger { ident; which_parameter; } ->
     fprintf ppf "name_for_debugger %a%s=%a"
       V.print ident

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -70,6 +70,10 @@ method reload_operation op arg res =
       | _ ->
           (arg, res)
       end
+  | Iopaque ->
+      (* arg = result, can be on stack or register *)
+      assert (arg.(0).stamp = res.(0).stamp);
+      (arg, res)
   | _ ->
       (self#makeregs arg, self#makeregs res)
 

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -438,6 +438,8 @@ let emit_instr i =
       `	fcvt.d.l	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
   | Lop(Iintoffloat) ->
       `	fcvt.l.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, rtz\n`
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
   | Lop(Ispecific sop) ->
       let instr = name_for_specific sop in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -539,6 +539,8 @@ let emit_instr i =
     | Lop(Iintoffloat) ->
         (* rounding method #5 = round toward 0 *)
         `	cgdbr	{emit_reg i.res.(0)}, 5, {emit_reg i.arg.(0)}\n`
+    | Lop(Iopaque) ->
+        assert (i.arg.(0).loc = i.res.(0).loc)
     | Lop(Ispecific sop) ->
         assert (i.arg.(2).loc = i.res.(0).loc);
         let instr = name_for_specific sop in

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -215,7 +215,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
   | _ -> true
 

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -85,6 +85,7 @@ let oper_result_type = function
   | Cintoffloat -> typ_int
   | Craise _ -> typ_void
   | Ccheckbound -> typ_void
+  | Copaque -> typ_val
 
 (* Infer the size in bytes of the result of an expression whose evaluation
    may be deferred (cf. [emit_parts]). *)
@@ -322,7 +323,7 @@ method is_simple_expr = function
   | Cop(op, args, _) ->
       begin match op with
         (* The following may have side effects *)
-      | Capply _ | Cextcall _ | Calloc | Cstore _ | Craise _ -> false
+      | Capply _ | Cextcall _ | Calloc | Cstore _ | Craise _ | Copaque -> false
         (* The remaining operations are simple if their args are *)
       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
@@ -361,7 +362,7 @@ method effects_of exp =
   | Cop (op, args, _) ->
     let from_op =
       match op with
-      | Capply _ | Cextcall _ -> EC.arbitrary
+      | Capply _ | Cextcall _ | Copaque -> EC.arbitrary
       | Calloc -> EC.none
       | Cstore _ -> EC.effect_only Effect.Arbitrary
       | Craise _ | Ccheckbound -> EC.effect_only Effect.Raise
@@ -674,6 +675,13 @@ method emit_expr (env:environment) exp =
           dbg, Cconst_int (1, dbg),
           dbg, Cconst_int (0, dbg),
           dbg))
+  | Cop(Copaque, args, dbg) ->
+      begin match self#emit_parts_list env args with
+        None -> None
+      | Some (simple_args, env) ->
+         let rs = self#emit_tuple env simple_args in
+         Some (self#insert_op_debug env Iopaque dbg rs rs)
+      end
   | Cop(op, args, dbg) ->
       begin match self#emit_parts_list env args with
         None -> None

--- a/testsuite/tests/lib-sys/opaque.ml
+++ b/testsuite/tests/lib-sys/opaque.ml
@@ -29,10 +29,9 @@ let[@inline never] dead_alloc a =
   ignore (Sys.opaque_identity (a, a));
   let mw3 = Gc.minor_words () in
   Printf.printf "dead: %.0f\n" ((mw3 -. mw2) -. (mw2 -. mw1))
-  
+
 
 let () =
   float_unboxing 50. (fun _ -> ());
   lifetimes ();
   dead_alloc 10
-          

--- a/testsuite/tests/lib-sys/opaque.ml
+++ b/testsuite/tests/lib-sys/opaque.ml
@@ -1,0 +1,38 @@
+(* TEST *)
+
+let[@inline never] float_unboxing s f =
+  let x = Sys.opaque_identity (s +. 1.) in
+  let mw1 = Gc.minor_words () in
+  let mw2 = Gc.minor_words () in
+  f x;
+  let mw3 = Gc.minor_words () in
+  Printf.printf "unbox: %.0f\n" ((mw3 -. mw2) -. (mw2 -. mw1))
+
+let[@inline never] lifetimes () =
+  let final = ref false in
+  let go () =
+    let r = ref 42 in
+    Gc.finalise (fun _ -> final := true) r;
+    let f1 = !final in
+    Gc.full_major ();
+    let f2 = !final in
+    ignore (Sys.opaque_identity r);
+    (f1, f2) in
+  let (f1, f2) = go () in
+  Gc.full_major ();
+  let f3 = !final in
+  Printf.printf "lifetime: %b %b %b\n" f1 f2 f3
+
+let[@inline never] dead_alloc a =
+  let mw1 = Gc.minor_words () in
+  let mw2 = Gc.minor_words () in
+  ignore (Sys.opaque_identity (a, a));
+  let mw3 = Gc.minor_words () in
+  Printf.printf "dead: %.0f\n" ((mw3 -. mw2) -. (mw2 -. mw1))
+  
+
+let () =
+  float_unboxing 50. (fun _ -> ());
+  lifetimes ();
+  dead_alloc 10
+          

--- a/testsuite/tests/lib-sys/opaque.reference
+++ b/testsuite/tests/lib-sys/opaque.reference
@@ -1,0 +1,3 @@
+unbox: 0
+lifetime: false false true
+dead: 3


### PR DESCRIPTION
`Sys.opaque_identity` inhibits optimisations, and is useful when writing tests and benchmarks. Its documented semantics are that of an unknown function with arbitrary side-effects, which at runtime happens to simply return its argument. The fact that the compiler can't see that it's the identity inhibits optimisations, preventing the compiler from e.g. simplifying a benchmark away to nothing.

However, there are a couple of cases where it's not effective:

  - Float unboxing/reboxing still occurs: `Sys.opaque_identity (x +. 1.)` might still be unboxed and later reboxed.
  - Liveness sees through it: `Sys.opaque_identity x` is not enough to keep `x` from being GC'd.

These optimisations have effects observable using the `Gc` module (by counting allocations and using finalisers, respectively), and in these cases `Sys.opaque_identity` differs from an identity function written in C. I think this is a bug - optimisations that are inhibited by an external C identity function should already be inhibited by Sys.opaque_identity.

The issue is that `opaque_identity` is discarded after `Clambda`, so optimisations that operate on Cmm/Mach ignore it. The fix is to add a `Copaque`/`Iopaque` operation to those languages - it generates no code, but participates in unboxing analysis / liveness computation / etc.