### PR TITLE
Treat `open struct` as `include struct` in toplevel

### DIFF
--- a/Changes
+++ b/Changes
@@ -383,6 +383,9 @@ Working version
   (Florian Angeletti, report by Thomas Leonard, review by Gabriel Radanne
    and Gabriel Scherer)
 
+- #9415: Treat `open struct` as `include struct` in toplevel
+  (Leo White, review by Thomas Refis)
+
 - #9420: Fix memory leak when `caml_output_value_to_block` raises an exception
   (Xavier Leroy, review by Guillaume Munch-Maccagnoni)
 

--- a/testsuite/tests/generalized-open/accepted_expect.ml
+++ b/testsuite/tests/generalized-open/accepted_expect.ml
@@ -4,6 +4,49 @@
 
 open Set.Make(String);;
 [%%expect{|
+type elt = String.t
+type t = Set.Make(String).t
+val empty : t = <abstr>
+val is_empty : t -> bool = <fun>
+val mem : elt -> t -> bool = <fun>
+val add : elt -> t -> t = <fun>
+val singleton : elt -> t = <fun>
+val remove : elt -> t -> t = <fun>
+val union : t -> t -> t = <fun>
+val inter : t -> t -> t = <fun>
+val disjoint : t -> t -> bool = <fun>
+val diff : t -> t -> t = <fun>
+val compare : t -> t -> int = <fun>
+val equal : t -> t -> bool = <fun>
+val subset : t -> t -> bool = <fun>
+val iter : (elt -> unit) -> t -> unit = <fun>
+val map : (elt -> elt) -> t -> t = <fun>
+val fold : (elt -> 'a -> 'a) -> t -> 'a -> 'a = <fun>
+val for_all : (elt -> bool) -> t -> bool = <fun>
+val exists : (elt -> bool) -> t -> bool = <fun>
+val filter : (elt -> bool) -> t -> t = <fun>
+val filter_map : (elt -> elt option) -> t -> t = <fun>
+val partition : (elt -> bool) -> t -> t * t = <fun>
+val cardinal : t -> int = <fun>
+val elements : t -> elt list = <fun>
+val min_elt : t -> elt = <fun>
+val min_elt_opt : t -> elt option = <fun>
+val max_elt : t -> elt = <fun>
+val max_elt_opt : t -> elt option = <fun>
+val choose : t -> elt = <fun>
+val choose_opt : t -> elt option = <fun>
+val split : elt -> t -> t * bool * t = <fun>
+val find : elt -> t -> elt = <fun>
+val find_opt : elt -> t -> elt option = <fun>
+val find_first : (elt -> bool) -> t -> elt = <fun>
+val find_first_opt : (elt -> bool) -> t -> elt option = <fun>
+val find_last : (elt -> bool) -> t -> elt = <fun>
+val find_last_opt : (elt -> bool) -> t -> elt option = <fun>
+val of_list : elt list -> t = <fun>
+val to_seq_from : elt -> t -> elt Seq.t = <fun>
+val to_seq : t -> elt Seq.t = <fun>
+val add_seq : elt Seq.t -> t -> t = <fun>
+val of_seq : elt Seq.t -> t = <fun>
 |}]
 
 let e = empty;;
@@ -15,6 +58,7 @@ open struct
   let x = singleton "hidden"
 end;;
 [%%expect{|
+val x : t = <abstr>
 |}];;
 
 elements (union x (of_list ["a"; "b"]));;
@@ -49,6 +93,7 @@ val hd : 'a -> unit = <fun>
 
 open (List : sig val map : ('a -> 'b) -> 'a list -> 'b list end);;
 [%%expect{|
+val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 |}]
 
 let l = map succ [0;1;2;3]

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -87,6 +87,9 @@ open struct
   let current () = !counter
 end
 [%%expect{|
+val inc : unit -> unit = <fun>
+val dec : unit -> unit = <fun>
+val current : unit -> int = <fun>
 |}]
 
 let () =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2100,16 +2100,23 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
       Env.enter_signature ~scope (extract_sig_open env md.mod_loc md.mod_type)
         env
     in
-    List.iter (Signature_names.check_sig_item ~info:`From_open names loc) sg;
+    let info, visibility =
+      match toplevel with
+      | Some false | None -> Some `From_open, Hidden
+      | Some true -> None, Exported
+    in
+    List.iter (Signature_names.check_sig_item ?info names loc) sg;
     let sg =
       List.map (function
-        | Sig_value(id, vd, _) -> Sig_value(id, vd, Hidden)
-        | Sig_type(id, td, rs, _) -> Sig_type(id, td, rs, Hidden)
-        | Sig_typext(id, ec, et, _) -> Sig_typext(id, ec, et, Hidden)
-        | Sig_module(id, mp, md, rs, _) -> Sig_module(id, mp, md, rs, Hidden)
-        | Sig_modtype(id, mtd, _) -> Sig_modtype(id, mtd, Hidden)
-        | Sig_class(id, cd, rs, _) -> Sig_class(id, cd, rs, Hidden)
-        | Sig_class_type(id, ctd, rs, _) -> Sig_class_type(id, ctd, rs, Hidden)
+        | Sig_value(id, vd, _) -> Sig_value(id, vd, visibility)
+        | Sig_type(id, td, rs, _) -> Sig_type(id, td, rs, visibility)
+        | Sig_typext(id, ec, et, _) -> Sig_typext(id, ec, et, visibility)
+        | Sig_module(id, mp, md, rs, _) ->
+            Sig_module(id, mp, md, rs, visibility)
+        | Sig_modtype(id, mtd, _) -> Sig_modtype(id, mtd, visibility)
+        | Sig_class(id, cd, rs, _) -> Sig_class(id, cd, rs, visibility)
+        | Sig_class_type(id, ctd, rs, _) ->
+            Sig_class_type(id, ctd, rs, visibility)
       ) sg
     in
     let open_descr = {


### PR DESCRIPTION
Currently `open struct` behaves slightly strangely in the toplevel. It is checked as if the types it introduces are going out of scope even though they are not:
```
# open struct type t = T end
  let x = T;;
  Line 1, characters 0-26:
1 | open struct type t = T end
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: The type t/89 introduced by this open appears in the signature
       Line 2, characters 6-7:
         The value x has no valid type if t/89 is hidden
```
It also crashes the toplevel in flambda `ocamlnat`:
```
# open struct let x = 5 end;;
# x + 5;;
>> Fatal error: Unknown ident: x_88
Fatal error: exception Misc.Fatal_error
Raised at file "utils/misc.ml", line 22, characters 14-31
Called from file "toplevel/opttoploop.ml", line 83, characters 19-36
Called from file "set.ml", line 381, characters 34-55
Called from file "toplevel/opttoploop.ml", line 82, characters 2-270
Called from file "toplevel/opttoploop.ml", line 652, characters 12-41
Re-raised at file "parsing/location.ml", line 925, characters 14-25
Called from file "toplevel/opttoploop.ml", line 657, characters 11-42
Called from file "toplevel/opttopstart.ml", line 16, characters 8-25
```
This PR fixes both issues by making `open struct` behave like `include struct` when used at top-level.