### PR TITLE
Update documentation for the Thread module and deprecate some functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,11 @@ Working version
 
 ### Other libraries:
 
+* #9206, #9419: update documentation of the threads library;
+  deprecate Thread.kill, Thread.wait_read, Thread.wait_write,
+  and the whole ThreadUnix module.
+  (Xavier Leroy, review by Florian Angeletti, Guillaume Munch-Maccagnoni,
+   and Gabriel Scherer)
 
 ### Tools:
 

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -30,7 +30,7 @@ COMPILER_LIBS_INTF = Asthelper.tex Astmapper.tex Asttypes.tex \
   $(COMPILER_LIBS_PLUGIN_HOOKS)
 
 OTHERLIB_INTF = Unix.tex UnixLabels.tex Str.tex \
-  Thread.tex Mutex.tex Condition.tex Event.tex ThreadUnix.tex \
+  Thread.tex Mutex.tex Condition.tex Event.tex \
   Dynlink.tex Bigarray.tex
 
 INTF = $(CORE_INTF) $(STDLIB_INTF) $(COMPILER_LIBS_INTF) $(OTHERLIB_INTF)

--- a/manual/manual/library/libthreads.etex
+++ b/manual/manual/library/libthreads.etex
@@ -2,36 +2,23 @@
 \label{c:threads}\cutname{threads.html}
 %HEVEA\cutname{libthreads.html}
 
-\textbf{Warning:} the "threads" library is deprecated since version
-4.08.0 of OCaml. Please switch to system threads, which have the same
-API. Lightweight threads with VM-level scheduling are provided by
-third-party libraries such as Lwt, but with a different API.
-
 The "threads" library allows concurrent programming in OCaml.
 It provides multiple threads of control (also called lightweight
 processes) that execute concurrently in the same memory space. Threads
 communicate by in-place modification of shared data structures, or by
 sending and receiving data on communication channels.
 
-The "threads" library is implemented by time-sharing on a single
-processor. It will not take advantage of multi-processor machines.
-Using this library will therefore never make programs run
-faster. However, many programs are easier to write when structured as
-several communicating processes.
+The "threads" library is implemented on top of the threading
+facilities provided by the operating system: POSIX 1003.1c threads for
+Linux, MacOS, and other Unix-like systems; Win32 threads for Windows.
+Only one thread at a time is allowed to run OCaml code, hence
+opportunities for parallelism are limited to the parts of the program
+that run system or C library code.  However, threads provide
+concurrency and can be used to structure programs as several
+communicating processes.  Threads also efficiently support concurrent,
+overlapping I/O operations.
 
-Two implementations of the "threads" library are available, depending
-on the capabilities of the operating system:
-\begin{itemize}
-\item System threads.  This implementation builds on the OS-provided threads
-facilities: POSIX 1003.1c threads for Unix, and Win32 threads for
-Windows.  When available, system threads support both bytecode and
-native-code programs.
-\item VM-level threads.  This implementation performs time-sharing and
-context switching at the level of the OCaml virtual machine (bytecode
-interpreter).  It is available on Unix systems, and supports only
-bytecode programs.  It cannot be used with native-code programs.
-\end{itemize}
-Programs that use system threads must be linked as follows:
+Programs that use threads must be linked as follows:
 \begin{alltt}
         ocamlc -I +threads \var{other options} unix.cma threads.cma \var{other files}
         ocamlopt -I +threads \var{other options} unix.cmxa threads.cmxa \var{other files}
@@ -45,12 +32,10 @@ the "-I +threads" option (see chapter~\ref{c:camlc}).
 \item \ahref{libref/Mutex.html}{Module \texttt{Mutex}: locks for mutual exclusion}
 \item \ahref{libref/Condition.html}{Module \texttt{Condition}: condition variables to synchronize between threads}
 \item \ahref{libref/Event.html}{Module \texttt{Event}: first-class synchronous communication}
-\item \ahref{libref/ThreadUnix.html}{Module \texttt{ThreadUnix}: thread-compatible system calls}
 \end{links}
 \else
 \input{Thread.tex}
 \input{Mutex.tex}
 \input{Condition.tex}
 \input{Event.tex}
-\input{ThreadUnix.tex}
 \fi

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -34,7 +34,7 @@ val create : ('a -> 'b) -> 'a -> t
    directly accessible to the parent thread. *)
 
 val self : unit -> t
-(** Return the thread currently executing. *)
+(** Return the handle for the thread currently executing. *)
 
 val id : t -> int
 (** Return the identifier of the given thread. A thread identifier
@@ -45,7 +45,11 @@ val exit : unit -> unit
 (** Terminate prematurely the currently executing thread. *)
 
 val kill : t -> unit
-(** Terminate prematurely the thread whose handle is given. *)
+  [@@ocaml.deprecated "Not implemented, do not use"]
+(** This function was supposed to terminate prematurely the thread
+    whose handle is given.  It is not currently implemented due to
+    problems with cleanup handlers on many POSIX 1003.1c implementations.
+    It always raises the [Invalid_argument] exception. *)
 
 (** {1 Suspending threads} *)
 
@@ -58,49 +62,59 @@ val join : t -> unit
 (** [join th] suspends the execution of the calling thread
    until the thread [th] has terminated. *)
 
+val yield : unit -> unit
+(** Re-schedule the calling thread without suspending it.
+   This function can be used to give scheduling hints,
+   telling the scheduler that now is a good time to
+   switch to other threads. *)
+
+(** {1 Waiting for file descriptors or processes} *)
+
+(** The functions below are leftovers from an earlier, VM-based threading
+    system.  The {!Unix} module provides equivalent functionality, in
+    a more general and more standard-conformant manner.  It is recommended
+    to use {!Unix} functions directly. *)
+
 val wait_read : Unix.file_descr -> unit
-(** See {!Thread.wait_write}.*)
+  [@@ocaml.deprecated "This function no longer does anything"]
+(** This function does nothing in the current implementation of the threading
+    library and can be removed from all user programs. *)
 
 val wait_write : Unix.file_descr -> unit
-(** This function does nothing in this implementation. *)
+  [@@ocaml.deprecated "This function no longer does anything"]
+(** This function does nothing in the current implementation of the threading
+    library and can be removed from all user programs. *)
 
 val wait_timed_read : Unix.file_descr -> float -> bool
 (** See {!Thread.wait_timed_write}.*)
 
 val wait_timed_write : Unix.file_descr -> float -> bool
 (** Suspend the execution of the calling thread until at least
-   one character or EOF is available for reading ([wait_read]) or
-   one character can be written without blocking ([wait_write])
+   one character or EOF is available for reading ([wait_timed_read]) or
+   one character can be written without blocking ([wait_timed_write])
    on the given Unix file descriptor. Wait for at most
    the amount of time given as second argument (in seconds).
    Return [true] if the file descriptor is ready for input/output
    and [false] if the timeout expired.
-
-   These functions return immediately [true] in the Win32
-   implementation. *)
+   The same functionality can be achieved with {!Unix.select}.
+*)
 
 val select :
   Unix.file_descr list -> Unix.file_descr list ->
   Unix.file_descr list -> float ->
     Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
-(** Suspend the execution of the calling thread until input/output
+(** Same function as {!Unix.select}.
+   Suspend the execution of the calling thread until input/output
    becomes possible on the given Unix file descriptors.
    The arguments and results have the same meaning as for
-   [Unix.select].
-   This function is not implemented yet under Win32. *)
+   {!Unix.select}. *)
 
 val wait_pid : int -> int * Unix.process_status
-(** [wait_pid p] suspends the execution of the calling thread
+(** Same function as {!Unix.waitpid}.
+   [wait_pid p] suspends the execution of the calling thread
    until the process specified by the process identifier [p]
    terminates. Returns the pid of the child caught and
-   its termination status, as per [Unix.wait].
-   This function is not implemented under MacOS. *)
-
-val yield : unit -> unit
-(** Re-schedule the calling thread without suspending it.
-   This function can be used to give scheduling hints,
-   telling the scheduler that now is a good time to
-   switch to other threads. *)
+   its termination status, as per {!Unix.wait}. *)
 
 (** {1 Management of signals} *)
 

--- a/otherlibs/systhreads/threadUnix.mli
+++ b/otherlibs/systhreads/threadUnix.mli
@@ -21,6 +21,8 @@
    (block the calling thread, if required, but do not block all threads
    in the process).  *)
 
+[@@@ocaml.deprecated "Use the Unix module instead of ThreadUnix"]
+
 (** {1 Process handling} *)
 
 val execv : string -> string array -> unit


### PR DESCRIPTION
As pointed out in #9206, the documentation for the thread library is out of date.  This PR updates it as follows:
- Deprecate `Thread.kill`, `Thread.wait_read`, `Thread.wait_write`, `Thread.select`, `Thread.wait_pid` for reasons explained in the documentation comments.
- Update documentation comments for several `Thread` functions.
- In the manual, remove leftover mentions of the VM threads  implementation; focus on the system threads implementation.
