### PR TITLE
Minor fixes to the marshaler (output_value)

### DIFF
--- a/Changes
+++ b/Changes
@@ -313,10 +313,12 @@ Working version
 - #9367: Make bytecode and native-code backtraces agree.
   (Stephen Dolan, review by Gabriel Scherer)
 
+- #9420: Fix memory leak when `caml_output_value_to_block` raises an exception
+  (Xavier Leroy, review by Guillaume Munch-Maccagnoni)
+
 - #9428: Fix truncated exception backtrace for C->OCaml callbacks
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
-
 
 OCaml 4.10 maintenance branch
 -----------------------------

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -794,7 +794,7 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
   int header_len;
   intnat data_len;
   char * res;
-  struct output_block * blk;
+  struct output_block * blk, * nextblk;
 
   init_extern_output();
   data_len = extern_value(v, flags, header, &header_len);
@@ -804,12 +804,13 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
   *len = header_len + data_len;
   memcpy(res, header, header_len);
   res += header_len;
-  for (blk = extern_output_first; blk != NULL; blk = blk->next) {
+  for (blk = extern_output_first; blk != NULL; blk = nextblk) {
     intnat n = blk->end - blk->data;
     memcpy(res, blk->data, n);
     res += n;
+    nextblk = blk->next;
+    caml_stat_free(blk);
   }
-  free_extern_output();
 }
 
 /* Functions for writing user-defined marshallers */

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -231,12 +231,13 @@ static void free_extern_output(void)
 {
   struct output_block * blk, * nextblk;
 
-  if (extern_userprovided_output != NULL) return;
-  for (blk = extern_output_first; blk != NULL; blk = nextblk) {
-    nextblk = blk->next;
-    caml_stat_free(blk);
+  if (extern_userprovided_output == NULL) {
+    for (blk = extern_output_first; blk != NULL; blk = nextblk) {
+      nextblk = blk->next;
+      caml_stat_free(blk);
+    }
+    extern_output_first = NULL;
   }
-  extern_output_first = NULL;
   extern_free_stack();
 }
 


### PR DESCRIPTION
This PR is best reviewed commit by commit.

Commit 2ba3f2ef9 fixes a rare memory leak: if `caml_output_value_to_block` fails and raises an exception, the stack of the marshaler is not freed.

Commit 1d43c55b3 changes the way the output buffer is freed in `caml_output_value_to_malloc` to use the same pattern as `caml_output_val` and `caml_output_value_to_bytes`.  The current implementation is not buggy, however I prefer the new implementation offered here for reasons explained in the commit message.
