### PR TITLE
replaced fib example with gcd in coreexample.etex

### DIFF
--- a/Changes
+++ b/Changes
@@ -1571,6 +1571,9 @@ OCaml 4.08.0 (13 June 2019)
 - #8508: refresh \moduleref macro
   (Florian Angeletti, review by Gabriel Scherer)
 
+- 9410: replaced fibonacci example with gcd of coreexamples manual
+  (Anukriti Kumar, review by San Vu Ngoc, Florian Angeletti, Léo Andrès)
+
 ### Code generation and optimizations:
 
 - #7725, #1754: improve AFL instrumentation for objects and lazy values.

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -941,15 +941,18 @@ source files created for use with OCaml compilers, but can be helpful
 to mark the end of a top-level expression unambiguously even when
 there are syntax errors.
 Here is a
-sample standalone program to print Fibonacci numbers:
+sample standalone program to print the greatest common divisor
+(gcd) of two numbers:
 \begin{verbatim}
-(* File fib.ml *)
-let rec fib n =
-  if n < 2 then 1 else fib (n-1) + fib (n-2);;
+(* File gcd.ml *)
+let rec gcd a b =
+  if b = 0 then a
+  else gcd b (a mod b);;
+
 let main () =
-  let arg = int_of_string Sys.argv.(1) in
-  print_int (fib arg);
-  print_newline ();
+  let a = int_of_string Sys.argv.(1) in
+  let b = int_of_string Sys.argv.(2) in
+  Printf.printf "%d\n" (gcd a b);
   exit 0;;
 main ();;
 \end{verbatim}
@@ -958,11 +961,11 @@ parameters. "Sys.argv.(1)" is thus the first command-line parameter.
 The program above is compiled and executed with the following shell
 commands:
 \begin{verbatim}
-$ ocamlc -o fib fib.ml
-$ ./fib 10
-89
-$ ./fib 20
-10946
+$ ocamlc -o gcd gcd.ml
+$ ./gcd 6 9
+3
+$ ./fib 7 11
+1
 \end{verbatim}
 
 More complex standalone OCaml programs are typically composed of


### PR DESCRIPTION
New gcd example, fixes #9351 
```ocaml
let rec gcd a b =
  if b = 0 then a
  else gcd b (a mod b);;

let main () =
  let a = int_of_string Sys.argv.(1) in
  let b = int_of_string Sys.argv.(2) in
  Printf.printf "%d\n" (gcd a b);
  exit 0;;
main ();;
```