### PR TITLE
Functions from weak are breaking all marking invariants on ephemerons

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Working version
 
 ### Runtime system:
 
+* #9391, #9424: Fix failed assertion in runtime due to ephemerons *set_* and
+  *blit_* function during Mark phase
+  (François Bobot, reported by Stephen Dolan, reviewed by Damien Doligez)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -43,6 +43,7 @@ extern uintnat caml_allocated_words;
 extern double caml_extra_heap_resources;
 extern uintnat caml_dependent_size, caml_dependent_allocated;
 extern uintnat caml_fl_wsz_at_phase_change;
+extern int caml_ephe_list_pure;
 
 #define Phase_mark 0
 #define Phase_clean 1

--- a/testsuite/tests/misc/ephe_issue9391.ml
+++ b/testsuite/tests/misc/ephe_issue9391.ml
@@ -1,5 +1,4 @@
 (* TEST
-   exit_status = "-6"
 *)
 
 let debug = false

--- a/testsuite/tests/misc/ephe_issue9391.ml
+++ b/testsuite/tests/misc/ephe_issue9391.ml
@@ -1,0 +1,68 @@
+(* TEST
+   exit_status = "-6"
+*)
+
+let debug = false
+
+open Printf
+open Ephemeron
+
+let empty = ref 0
+let make_ra ~size = Array.init size (fun _ -> ref 1) [@@inline never]
+let make_ephes ~size = Array.init size (fun _ -> Ephemeron.K1.create ()) [@@inline never]
+
+let test ~size ~slice =
+  let keys1 = make_ra ~size in
+  let keys2 = make_ra ~size in
+  let datas1 = make_ra ~size in
+  let datas2 = make_ra ~size in
+  let ephe1 = make_ephes ~size in
+  let ephe2 = make_ephes ~size in
+  if debug then Gc.set { (Gc.get ()) with Gc.verbose = 0x3 };
+  (** Fill ephe.(i )from key.(i) to data.(i) *)
+  for i=0 to size-1 do Ephemeron.K1.set_key  ephe1.(i) keys1.(i); done;
+  for i=0 to size-1 do Ephemeron.K1.set_data ephe1.(i) datas1.(i); done;
+  for i=0 to size-1 do Ephemeron.K1.set_key  ephe2.(i) keys2.(i); done;
+  for i=0 to size-1 do Ephemeron.K1.set_data ephe2.(i) datas2.(i); done;
+  (** Push everything in the major heap *)
+  if debug then Printf.eprintf "Start minor major\n%!";
+  Gc.minor ();
+  Gc.major ();
+  if debug then Printf.eprintf "start emptying\n%!";
+  for i=0 to size-1 do keys1.(i) <- empty; done;
+  for i=0 to size-1 do datas1.(i) <- empty; done;
+  (** The emptying is done during a major so keys and data are kept alive by the
+     assignments. Restart a new major *)
+  Gc.major ();
+  if debug then Printf.eprintf "Start checking state\n%!";
+  (** Fill the ephemeron with an alive key *)
+  if debug then Printf.eprintf "Start replacing dead key into alive one\n%!";
+  (* Printf.eprintf "put in set (2) %i\n%!" (Gc.major_slice (10*4*slice*6)); *)
+  for i=0 to size-1 do
+    ignore (Gc.major_slice (4));
+    if debug then Printf.eprintf "@%!";
+    Ephemeron.K1.blit_data ephe1.(i) ephe2.(i);
+    if debug && 0 = i mod (size / 10) then Printf.eprintf "done %5i/%i\n%!" i size;
+  done;
+  if debug then   Printf.eprintf "end\n%!";
+  (** Finish all, assertion in clean phase should not find a dangling data *)
+  Gc.full_major ();
+  let r = ref 0 in
+  if debug then
+    for i=0 to size-1 do
+      if Ephemeron.K1.check_data ephe2.(size-1-i) then incr r;
+      if 0 = i mod (size / 10) then Printf.eprintf "done %5i/%i %i\n%!" i size !r;
+    done;
+  (* keep the arrays alive *)
+  assert (Array.length keys1 = size);
+  assert (Array.length keys2 = size);
+  assert (Array.length datas1 = size);
+  assert (Array.length datas2 = size);
+  assert (Array.length ephe1 = size);
+  assert (Array.length ephe2 = size)
+[@@inline never]
+
+let () =
+  test ~size:1000 ~slice:5;
+  test ~size:1000 ~slice:10;
+  test ~size:1000 ~slice:15

--- a/testsuite/tests/misc/ephe_issue9391.reference
+++ b/testsuite/tests/misc/ephe_issue9391.reference
@@ -1,0 +1,1 @@
+file caml/weak.h; line 211 ### Assertion failed: !Is_white_val (child)

--- a/testsuite/tests/misc/ephe_issue9391.reference
+++ b/testsuite/tests/misc/ephe_issue9391.reference
@@ -1,1 +1,0 @@
-file caml/weak.h; line 211 ### Assertion failed: !Is_white_val (child)


### PR DESCRIPTION
The marking of ephemerons follow the invariants describe in `major_gc.c`:

```
   Ephemerons:
   During mark phase the list caml_ephe_list_head of ephemerons
   is iterated by different pointers that follow the invariants:
   caml_ephe_list_head ->* ephes_checked_if_pure ->* ephes_to_check ->* null
                        |                         |                  |
                       (1)                       (2)                (3)

    At the start of mark phase, (1) and (2) are empty.

    In mark phase:
      - An ephemeron in (1) have a data alive (grey/black if in the heap)
        or none (nb: new ephemerons are added in this part by weak.c)
      - An ephemeron in (2):
         - is in any state if ephe_list_pure is false
         - otherwise has at least a white key or is white or its data is black or none.
           The third case can happen only using a set_* of weak.c
      - the ephemerons in (3) are in an unknown state and must be checked

    At the end of mark phase, (3) is empty and ephe_list_pure is true.
    The ephemeron in (1) and (2) will be cleaned (white keys and data
    replaced by none or the ephemeron is removed from the list if it is white)
    in clean phase.
```

During the addition of the cleaning phase, which fixes some behavior inconsistencies in weak pointers, I started to think the clean phase as a magical bullet which avoided the `set_*` functions from weak to take care of the `mark` phase. It is clearly wrong as #9391 shows.

This MR fixes that by:
  - ensuring that functions that modify the data of ephemerons doesn't break the property that ephemerons in the set `(1)` should follow
 - ensuring that functions that modify the keys of ephemerons doesn't break the property that ephemerons in the set `(2)` should follow

There are different possible fixes:
 - put back the ephemerons in the set `(3)` when modified, but it makes the marking possibly non terminating;
- always blacken the data, but it could defeat the purpose of ephemerons;
- detect in which set the ephemerons is, in order to do nothing in 2 of the 3 cases, but it is complicated to keep track of this information and it is just an optimization;
- detect by looking at all the keys, if the ephemerons can be in set (2) or (3), but it could lead to bad performance as #9259 shown.

The intermediary choice in this implementation is to blacken the data except when:
- in case of data modification:
   - it is sure it is not before the modification in set `(1)`: the old data was white.
- in case of key modification:
   - after the modification it verifies the property of the set `(2)`, the ephemeron is white or one of the setted keys is white (EDIT: now additionnally, "or the data is marked")

TODO:
 - [x]  add tests that are consistently failing before the fix, and check the fix.
 - [x] handle infix tag