### PR TITLE
Stdlib: add Fun.curry and Fun.uncurry

### DIFF
--- a/Changes
+++ b/Changes
@@ -115,6 +115,9 @@ Working version
 - #9365: Set.filter_map and Map.filter_map
   (Gabriel Scherer, review by Stephen Dolan and Nicolás Ojeda Bär)
 
+- #9425: Add Fun.curry and Fun.uncurry
+  (Craig Ferguson)
+
 ### Other libraries:
 
 - #9106: Register printer for Unix_error in win32unix, as in unix.

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -16,6 +16,8 @@
 external id : 'a -> 'a = "%identity"
 let const c _ = c
 let flip f x y = f y x
+let curry f x y = f (x, y)
+let uncurry f (x, y) = f x y
 let negate p v = not (p v)
 
 exception Finally_raised of exn

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -30,6 +30,16 @@ val flip : ('a -> 'b -> 'c) -> ('b -> 'a -> 'c)
 (** [flip f] reverses the argument order of the binary function
     [f]. For any arguments [x] and [y], [(flip f) x y] is [f y x]. *)
 
+val curry : (('a * 'b) -> 'c) -> ('a -> 'b -> 'c)
+(** [curry f] is the curried form of the uncurried function [f]. For any
+    arguments [x] and [y], [(curry f) x y] is [f (x, y)].
+    @since 4.11.0 *)
+
+val uncurry : ('a -> 'b -> 'c) -> (('a * 'b) -> 'c)
+(** [uncurry f] is the uncurried form of the curried function [f]. For any
+    arguments [x] and [y], [(uncurry f) (x, y)] is [f x y].
+    @since 4.11.0 *)
+
 val negate : ('a -> bool) -> ('a -> bool)
 (** [negate p] is the negation of the predicate function [p]. For any
     argument [x], [(negate p) x] is [not (p x)]. *)

--- a/testsuite/tests/lib-fun/test.ml
+++ b/testsuite/tests/lib-fun/test.ml
@@ -19,6 +19,14 @@ let test_flip () =
   assert (Fun.flip List.cons [2] 1 = [1;2]);
   ()
 
+let test_curry () =
+  assert (Fun.curry fst 1 2 = 1);
+  ()
+
+let test_uncurry () =
+  assert (Fun.uncurry Int.add (1, 1) = 2);
+  ()
+
 let test_negate () =
   assert (Fun.negate (Bool.equal true) true = false);
   assert (Fun.negate (Bool.equal true) false = true);
@@ -42,6 +50,8 @@ let tests () =
   test_id ();
   test_const ();
   test_flip ();
+  test_curry ();
+  test_uncurry ();
   test_negate ();
   test_protect ();
   ()


### PR DESCRIPTION
I find myself defining these functions whenever I chain operations on pairs. They seem appropriate for the standard library.

See equivalents in Haskell's [Prelude](https://hackage.haskell.org/package/base-4.12.0.0/docs/Prelude.html#g:3) and Scala's [Function](https://www.scala-lang.org/api/current/scala/Function$.html).