### PR TITLE
Configure: improve selection of GCC options

### DIFF
--- a/Changes
+++ b/Changes
@@ -69,6 +69,9 @@ Working version
 - #9316: Use typing information from Clambda for mutable Cmm variables.
   (Stephen Dolan, review by Vincent Laviron, Guillaume Bury and Xavier Leroy)
 
+- #9426: build the Mingw ports with higher levels of GCC optimization
+  (Xavier Leroy, review by Sébastien Hinderer)
+
 ### Code generation and optimizations:
 
 - #8637, #8805, #9247, #9296: Record debug info for each allocation.
@@ -284,6 +287,10 @@ Working version
 - #7696, #6608: Record expression deleted when all fields specified
   (Jacques Garrigue, report by Jeremy Yallop)
 
+- #7917, #9426: Use GCC option -fexcess-precision=standard when available,
+  avoiding a problem with x87 excess precision in Float.round.
+  (Xavier Leroy, review by Sébastien Hinderer)
+
 - #9064: Relax the level handling when unifying row fields
   (Leo White, review by Jacques Garrigue)
 
@@ -322,6 +329,7 @@ Working version
 - #9428: Fix truncated exception backtrace for C->OCaml callbacks
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
+
 
 OCaml 4.10 maintenance branch
 -----------------------------

--- a/configure
+++ b/configure
@@ -12499,12 +12499,20 @@ esac
 # in the macro itself, too
 case $host in #(
   *-*-mingw32) :
+    case $ocaml_cv_cc_vendor in #(
+  gcc-01234-*) :
+    as_fn_error $? "This version of Mingw GCC is too old.
+          Please use GCC version 5 or above." "$LINENO" 5 ;; #(
+  gcc-*) :
     internal_cflags="-Wno-unused $gcc_warnings"
-    # TODO: see whether the code can be fixed to avoid -Wno-unused
-    common_cflags="-O -mms-bitfields"
-    internal_cppflags='-DUNICODE -D_UNICODE'
-    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+        # TODO: see whether the code can be fixed to avoid -Wno-unused
+        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+        internal_cppflags='-DUNICODE -D_UNICODE'
+        internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+        internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+  *) :
+    as_fn_error $? "Unsupported C compiler for a Mingw build" "$LINENO" 5 ;;
+esac ;; #(
   *) :
     case $ocaml_cv_cc_vendor in #(
   clang-*) :

--- a/configure
+++ b/configure
@@ -12506,7 +12506,8 @@ case $host in #(
   gcc-*) :
     internal_cflags="-Wno-unused $gcc_warnings"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+        common_cflags="-O2 -fno-strict-aliasing -fwrapv \
+-fexcess-precision=standard -mms-bitfields"
         internal_cppflags='-DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
@@ -12534,12 +12535,18 @@ $as_echo "$as_me: WARNING: This version of GCC is rather old.
 $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       common_cflags="-std=gnu99 -O";
       internal_cflags="$gcc_warnings" ;; #(
-  gcc-4-*) :
-    common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
+  gcc-4-234) :
+    # No -fexcess-precision option before GCC 4.5
+      common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
       internal_cflags="$gcc_warnings" ;; #(
+  gcc-4-*) :
+    common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
+-fno-builtin-memcmp -fexcess-precision=standard";
+      internal_cflags="$gcc_warnings" ;; #(
   gcc-*) :
-    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+    common_cflags="-O2 -fno-strict-aliasing -fwrapv \
+-fexcess-precision=standard";
       internal_cflags="$gcc_warnings -fno-common" ;; #(
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD"

--- a/configure
+++ b/configure
@@ -12500,7 +12500,7 @@ esac
 case $host in #(
   *-*-mingw32) :
     case $ocaml_cv_cc_vendor in #(
-  gcc-01234-*) :
+  gcc-[01234]-*) :
     as_fn_error $? "This version of Mingw GCC is too old.
           Please use GCC version 5 or above." "$LINENO" 5 ;; #(
   gcc-*) :
@@ -12519,12 +12519,12 @@ esac ;; #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$gcc_warnings -fno-common" ;; #(
-  gcc-012-*) :
+  gcc-[012]-*) :
     # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
       as_fn_error $? "This version of GCC is too old.
         Please use GCC version 4.2 or above." "$LINENO" 5 ;; #(
-  gcc-3-*|gcc-4-01) :
+  gcc-3-*|gcc-4-[01]) :
     # No -fwrapv option before GCC 3.4.
       # Known problems with -fwrapv fixed in 4.2 only.
       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of GCC is rather old.
@@ -12535,7 +12535,7 @@ $as_echo "$as_me: WARNING: This version of GCC is rather old.
 $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       common_cflags="-std=gnu99 -O";
       internal_cflags="$gcc_warnings" ;; #(
-  gcc-4-234) :
+  gcc-4-[234]) :
     # No -fexcess-precision option before GCC 4.5
       common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";

--- a/configure
+++ b/configure
@@ -12501,8 +12501,7 @@ case $host in #(
   *-*-mingw32) :
     case $ocaml_cv_cc_vendor in #(
   gcc-[01234]-*) :
-    as_fn_error $? "This version of Mingw GCC is too old.
-          Please use GCC version 5 or above." "$LINENO" 5 ;; #(
+    as_fn_error $? "This version of Mingw GCC is too old. Please use GCC version 5 or above." "$LINENO" 5 ;; #(
   gcc-*) :
     internal_cflags="-Wno-unused $gcc_warnings"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
@@ -12522,15 +12521,12 @@ esac ;; #(
   gcc-[012]-*) :
     # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
-      as_fn_error $? "This version of GCC is too old.
-        Please use GCC version 4.2 or above." "$LINENO" 5 ;; #(
+      as_fn_error $? "This version of GCC is too old. Please use GCC version 4.2 or above." "$LINENO" 5 ;; #(
   gcc-3-*|gcc-4-[01]) :
     # No -fwrapv option before GCC 3.4.
       # Known problems with -fwrapv fixed in 4.2 only.
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of GCC is rather old.
-        Reducing optimization level.\"" >&5
-$as_echo "$as_me: WARNING: This version of GCC is rather old.
-        Reducing optimization level.\"" >&2;};
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of GCC is rather old. Reducing optimization level.\"" >&5
+$as_echo "$as_me: WARNING: This version of GCC is rather old. Reducing optimization level.\"" >&2;};
       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Consider using GCC version 4.2 or above." >&5
 $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       common_cflags="-std=gnu99 -O";

--- a/configure.ac
+++ b/configure.ac
@@ -556,8 +556,8 @@ AS_CASE([$host],
   [*-*-mingw32],
     [AS_CASE([$ocaml_cv_cc_vendor],
       [gcc-[[01234]]-*],
-        [AC_MSG_ERROR([This version of Mingw GCC is too old.
-          Please use GCC version 5 or above.])],
+        [AC_MSG_ERROR(m4_normalize([This version of Mingw GCC is too old.
+          Please use GCC version 5 or above.]))],
       [gcc-*],
         [internal_cflags="-Wno-unused $gcc_warnings"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
@@ -574,13 +574,13 @@ AS_CASE([$host],
     [gcc-[[012]]-*],
       # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
-      [AC_MSG_ERROR([This version of GCC is too old.
-        Please use GCC version 4.2 or above.])],
+      [AC_MSG_ERROR(m4_normalize([This version of GCC is too old.
+        Please use GCC version 4.2 or above.]))],
     [gcc-3-*|gcc-4-[[01]]],
       # No -fwrapv option before GCC 3.4.
       # Known problems with -fwrapv fixed in 4.2 only.
-      [AC_MSG_WARN([This version of GCC is rather old.
-        Reducing optimization level."]);
+      [AC_MSG_WARN(m4_normalize([This version of GCC is rather old.
+        Reducing optimization level."]));
       AC_MSG_WARN([Consider using GCC version 4.2 or above.]);
       common_cflags="-std=gnu99 -O";
       internal_cflags="$gcc_warnings"],

--- a/configure.ac
+++ b/configure.ac
@@ -561,7 +561,8 @@ AS_CASE([$host],
       [gcc-*],
         [internal_cflags="-Wno-unused $gcc_warnings"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+        common_cflags="-O2 -fno-strict-aliasing -fwrapv \
+-fexcess-precision=standard -mms-bitfields"
         internal_cppflags='-DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
@@ -583,12 +584,18 @@ AS_CASE([$host],
       AC_MSG_WARN([Consider using GCC version 4.2 or above.]);
       common_cflags="-std=gnu99 -O";
       internal_cflags="$gcc_warnings"],
-    [gcc-4-*],
+    [gcc-4-[234]],
+      # No -fexcess-precision option before GCC 4.5
       [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
       internal_cflags="$gcc_warnings"],
+    [gcc-4-*],
+      [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
+-fno-builtin-memcmp -fexcess-precision=standard";
+      internal_cflags="$gcc_warnings"],
     [gcc-*],
-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+      [common_cflags="-O2 -fno-strict-aliasing -fwrapv \
+-fexcess-precision=standard";
       internal_cflags="$gcc_warnings -fno-common"],
     [msvc-*],
       [common_cflags="-nologo -O2 -Gy- -MD"

--- a/configure.ac
+++ b/configure.ac
@@ -554,12 +554,18 @@ AS_CASE([$ocaml_cv_cc_vendor],
 # in the macro itself, too
 AS_CASE([$host],
   [*-*-mingw32],
-    [internal_cflags="-Wno-unused $gcc_warnings"
-    # TODO: see whether the code can be fixed to avoid -Wno-unused
-    common_cflags="-O -mms-bitfields"
-    internal_cppflags='-DUNICODE -D_UNICODE'
-    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+    [AS_CASE([$ocaml_cv_cc_vendor],
+      [gcc-[01234]-*],
+        [AC_MSG_ERROR([This version of Mingw GCC is too old.
+          Please use GCC version 5 or above.])],
+      [gcc-*],
+        [internal_cflags="-Wno-unused $gcc_warnings"
+        # TODO: see whether the code can be fixed to avoid -Wno-unused
+        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
+        internal_cppflags='-DUNICODE -D_UNICODE'
+        internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+        internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+      [AC_MSG_ERROR([Unsupported C compiler for a Mingw build])])],
   [AS_CASE([$ocaml_cv_cc_vendor],
     [clang-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";

--- a/configure.ac
+++ b/configure.ac
@@ -555,7 +555,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
 AS_CASE([$host],
   [*-*-mingw32],
     [AS_CASE([$ocaml_cv_cc_vendor],
-      [gcc-[01234]-*],
+      [gcc-[[01234]]-*],
         [AC_MSG_ERROR([This version of Mingw GCC is too old.
           Please use GCC version 5 or above.])],
       [gcc-*],
@@ -571,12 +571,12 @@ AS_CASE([$host],
     [clang-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
       internal_cflags="$gcc_warnings -fno-common"],
-    [gcc-[012]-*],
+    [gcc-[[012]]-*],
       # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
       [AC_MSG_ERROR([This version of GCC is too old.
         Please use GCC version 4.2 or above.])],
-    [gcc-3-*|gcc-4-[01]],
+    [gcc-3-*|gcc-4-[[01]]],
       # No -fwrapv option before GCC 3.4.
       # Known problems with -fwrapv fixed in 4.2 only.
       [AC_MSG_WARN([This version of GCC is rather old.
@@ -584,7 +584,7 @@ AS_CASE([$host],
       AC_MSG_WARN([Consider using GCC version 4.2 or above.]);
       common_cflags="-std=gnu99 -O";
       internal_cflags="$gcc_warnings"],
-    [gcc-4-[234]],
+    [gcc-4-[[234]]],
       # No -fexcess-precision option before GCC 4.5
       [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";


### PR DESCRIPTION
Commit 3cf529ee4 affects the MinGW port.  It gives GCC the same optimization and standard-conformance options used for the other ports.  This should improve performance of the MinGW port. To simplify the configuration logic, the MinGW port requires GCC version >= 5.0.

Commit 6a36c0b5e addresses issue #7917 and should also help with https://github.com/coq/coq/pull/11432 .  It adds the `-fexcess-precision=standard` option for GCC version >= 4.5.  This makes sure that FP results stored or passed as double precision are not kept in extended precision, like GCC enjoys doing on x86 32 bits with x87 floating-point operations.  
