### PR TITLE
ocamldoc: fix the printing of (::)

### DIFF
--- a/Changes
+++ b/Changes
@@ -373,6 +373,9 @@ Working version
 - #8747, #9709: incorrect principality warning on functional updates of records
   (Jacques Garrigue, report and review by Thomas Refis)
 
+- #9421, #9427: fix printing of (::) in ocamldoc
+  (Florian Angeletti, report by Yawar Amin, review by Damien Doligez)
+
 - #9469: Better backtraces for lazy values
   (Leo White, review by Nicolás Ojeda Bär)
 

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -388,8 +388,14 @@ module Analyser =
               | Cstr_record l ->
                   Cstr_record (List.map (get_field env name_comment_list) l)
             in
+            let vc_name = match constructor_name with
+              | "::" ->
+                  (* The only infix constructor is always printed (::) *)
+                  "(::)"
+              | s -> s
+            in
             {
-              vc_name = constructor_name ;
+              vc_name;
               vc_args;
               vc_ret =  Option.map (Odoc_env.subst_type env) ret_type;
               vc_text = comment_opt


### PR DESCRIPTION
Currently,
```ocaml
type t = (::)
```
is printed by ocamldoc as
```ocaml
type t = ::
```
This small PR fixes this issue in all ocamldoc backends by using directly `(::)` in the ocamldoc description of variant constructors.

Closes #9421 .

(There is no parentheses needed for the four other non-UIDENT constructors: true, false, [] and () )