### PR TITLE
PowerPC, System Z: do not reset backtrace_pos in caml_raise_exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -310,6 +310,11 @@ Working version
 - #9367: Make bytecode and native-code backtraces agree.
   (Stephen Dolan, review by Gabriel Scherer)
 
+- #9428: Fix truncated exception backtrace for C->OCaml callbacks
+  on Power and Z System
+  (Xavier Leroy, review by Nicolás Ojeda Bär)
+
+
 OCaml 4.10 maintenance branch
 -----------------------------
 

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -410,8 +410,6 @@ FUNCTION(caml_raise_exception)
     /* Branch to handler */
         bctr
 .L121:
-        li      0, 0
-        stg     0, Caml_state(backtrace_pos)
         mr      27, 3           /* preserve exn bucket in callee-save reg */
                                 /* arg1: exception bucket, already in r3 */
         lg      4, Caml_state(last_return_address) /* arg2: PC of raise */

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -183,8 +183,6 @@ caml_raise_exception:
     /* Branch to handler */
         br      %r1;
 .L112:
-        lgfi    %r0, 0
-        stg     %r0, Caml_state(backtrace_pos)
         ldgr    %f15,%r2        /* preserve exn bucket in callee-save reg */
                                 /* arg1: exception bucket, already in r2 */
         lg      %r3, Caml_state(last_return_address) /* arg2: PC of raise */


### PR DESCRIPTION
On PowerPC and System Z, caml_raise_exception would set backtrace_pos
to 0 before calling caml_stash_backtrace.

This caused the backtrace to be truncated in situations like the following:
C code calls back into OCaml code, which raises an exception
(-> backtrace is saved thanks to caml_raise_exn calling caml_stash_backtrace)
then caml_callback raises the exception again via caml_raise_exception.

The test lib-dynlink-initializers/test10_main.ml exhibited the problem.
The backtrace was wrong, and is now correct after this patch.

Other ports do not reset backtrace_pos in caml_raise_exception.
This may have been code from an early implementation of native-code
backtraces that was left over (by mistake) in the PowerPC port,
which served as a basis for the System Z port.