### PR TITLE
revert c1a7ace (originally c545e04)

### DIFF
--- a/Changes
+++ b/Changes
@@ -281,6 +281,9 @@ Working version
   may not match the one in bytecode.
   (Nicolás Ojeda Bär, report by Pierre Chambart, review by Gabriel Scherer)
 
+- #7696, #6608: Record expression deleted when all fields specified
+  (Jacques Garrigue, report by Jeremy Yallop)
+
 - #9064: Relax the level handling when unifying row fields
   (Leo White, review by Jacques Garrigue)
 

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -112,7 +112,7 @@ val x : 'a option -> unit = <fun>
 val y : 'a list -> unit = <fun>
 |}];;
 
-(* this is accepted as all fields are overridden *)
+(* used to be accepted, see PR#7696 *)
 let rec x = { x with contents = 3 }  [@ocaml.warning "-23"];;
 [%%expect{|
 Line 1, characters 12-35:

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -115,7 +115,10 @@ val y : 'a list -> unit = <fun>
 (* this is accepted as all fields are overridden *)
 let rec x = { x with contents = 3 }  [@ocaml.warning "-23"];;
 [%%expect{|
-val x : int ref = {contents = 3}
+Line 1, characters 12-35:
+1 | let rec x = { x with contents = 3 }  [@ocaml.warning "-23"];;
+                ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
 
 (* this is rejected as `c` will be dereferenced during the copy,

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -165,6 +165,17 @@ Error: This expression has type string t
        Type string is not compatible with type int
 |}]
 
+(* PR#7696 *)
+let r = { (assert false) with contents = 1 } ;;
+[%%expect{|
+Line 1, characters 8-44:
+1 | let r = { (assert false) with contents = 1 } ;;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 23: all the fields are explicitly listed in this record:
+the 'with' clause is useless.
+Exception: Assert_failure ("", 1, 10).
+|}]
+
 (* reexport *)
 
 type ('a,'b) def = { x:int } constraint 'b = [> `A]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2906,11 +2906,8 @@ and type_expect_
       let num_fields =
         match lbl_exp_list with [] -> assert false
         | (_, lbl,_)::_ -> Array.length lbl.lbl_all in
-      let opt_exp =
-        if opt_sexp <> None && List.length lid_sexp_list = num_fields then
-          (Location.prerr_warning loc Warnings.Useless_record_with; None)
-        else opt_exp
-      in
+      if opt_sexp <> None && List.length lid_sexp_list = num_fields then
+        Location.prerr_warning loc Warnings.Useless_record_with;
       let label_descriptions, representation =
         let (_, { lbl_all; lbl_repres }, _) = List.hd lbl_exp_list in
         lbl_all, lbl_repres


### PR DESCRIPTION
Fix #7696 by reverting c1a7ace.
(A wrong ordering happened with #6608, so that this commit was first introduced and reverted, and then reintroduced later)