### PR TITLE
Fix package constraints for module aliases

### DIFF
--- a/Changes
+++ b/Changes
@@ -232,6 +232,9 @@ Working version
 - #9163: Treat loops properly in un_anf
   (Leo White, review by Mark Shinwell, Pierre Chambart and Vincent Laviron)
 
+- #9433: Fix package constraints for module aliases
+  (Leo White, review by Jacques Garrigue)
+
 - #9469: Better backtraces for lazy values
   (Leo White, review by Nicolás Ojeda Bär)
 

--- a/testsuite/tests/typing-fstclassmod/aliases.ml
+++ b/testsuite/tests/typing-fstclassmod/aliases.ml
@@ -18,8 +18,5 @@ let h x = (x : (module S with type t = int) :> (module T))
 module M : sig end
 module type S = sig module Alias = M type t end
 module type T = sig module Alias = M type t = int end
-Line 11, characters 10-58:
-11 | let h x = (x : (module S with type t = int) :> (module T))
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type (module S with type t = int) is not a subtype of (module T)
+val h : (module S with type t = int) -> (module T) = <fun>
 |}]

--- a/testsuite/tests/typing-fstclassmod/aliases.ml
+++ b/testsuite/tests/typing-fstclassmod/aliases.ml
@@ -1,0 +1,25 @@
+(* TEST
+   * expect
+*)
+
+module M = struct end
+
+module type S = sig
+  module Alias = M
+
+  type t
+end
+
+module type T = S with type t = int
+
+let h x = (x : (module S with type t = int) :> (module T))
+;;
+[%%expect {|
+module M : sig end
+module type S = sig module Alias = M type t end
+module type T = sig module Alias = M type t = int end
+Line 11, characters 10-58:
+11 | let h x = (x : (module S with type t = int) :> (module T))
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type (module S with type t = int) is not a subtype of (module T)
+|}]

--- a/testsuite/tests/typing-missing-cmi-3/middle.ml
+++ b/testsuite/tests/typing-missing-cmi-3/middle.ml
@@ -3,3 +3,6 @@ type 'a t = 'a Original.t = T
 let f: (module Original.T with type t = int) -> unit = fun _ -> ()
 let x = (module struct type t end: Original.T )
 let g: (module Original.T) -> unit = fun _ -> ()
+type pack1 = (module Original.T with type t = int)
+module type T = sig module M : Original.T end
+type pack2 = (module T with type M.t = int)

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -53,7 +53,7 @@ let foo (x : Middle.pack1) =
 Line 2, characters 17-24:
 2 |   let module M = (val x) in
                      ^^^^^^^
-Error: This module type is not a signature
+Error: The type of this packed module refers to Original.T, which is missing
 |}]
 
 let foo (x : Middle.pack2) =
@@ -63,21 +63,27 @@ let foo (x : Middle.pack2) =
 Line 2, characters 17-24:
 2 |   let module M = (val x) in
                      ^^^^^^^
-Error: This module type is not a signature
+Error: The type of this packed module refers to Original.T, which is missing
 |}]
 
 module type T1 = sig type t = int end
 let foo x = (x : Middle.pack1 :> (module T1))
 [%%expect {|
 module type T1 = sig type t = int end
-File "_none_", line 1:
-Error: This module type is not a signature
+Line 2, characters 12-45:
+2 | let foo x = (x : Middle.pack1 :> (module T1))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type Middle.pack1 = (module Original.T with type t = int)
+       is not a subtype of (module T1)
 |}]
 
 module type T2 = sig module M : sig type t = int end end
 let foo x = (x : Middle.pack2 :> (module T2))
 [%%expect {|
 module type T2 = sig module M : sig type t = int end end
-File "_none_", line 1:
-Error: This module type is not a signature
+Line 2, characters 12-45:
+2 | let foo x = (x : Middle.pack2 :> (module T2))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type Middle.pack2 = (module Middle.T with type M.t = int)
+       is not a subtype of (module T2)
 |}]

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -45,3 +45,39 @@ Line 1, characters 26-36:
 Error: Signature mismatch:
        Modules do not match: sig end is not included in Original.T
 |}]
+
+let foo (x : Middle.pack1) =
+  let module M = (val x) in
+  ()
+[%%expect {|
+Line 2, characters 17-24:
+2 |   let module M = (val x) in
+                     ^^^^^^^
+Error: This module type is not a signature
+|}]
+
+let foo (x : Middle.pack2) =
+  let module M = (val x) in
+  ()
+[%%expect {|
+Line 2, characters 17-24:
+2 |   let module M = (val x) in
+                     ^^^^^^^
+Error: This module type is not a signature
+|}]
+
+module type T1 = sig type t = int end
+let foo x = (x : Middle.pack1 :> (module T1))
+[%%expect {|
+module type T1 = sig type t = int end
+File "_none_", line 1:
+Error: This module type is not a signature
+|}]
+
+module type T2 = sig module M : sig type t = int end end
+let foo x = (x : Middle.pack2 :> (module T2))
+[%%expect {|
+module type T2 = sig module M : sig type t = int end end
+File "_none_", line 1:
+Error: This module type is not a signature
+|}]

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -127,6 +127,7 @@ type error =
   | Recursive_module_require_explicit_type
   | Apply_generative
   | Cannot_scrape_alias of Path.t
+  | Cannot_scrape_package_type of Path.t
   | Badly_formed_signature of string * Typedecl.error
   | Cannot_hide_id of hiding_error
   | Invalid_type_subst_rhs


### PR DESCRIPTION
There is a small bug in the code that compares first-class module types:
```ocaml
module M = struct end

module type S = sig
  module Alias = M

  type t
end

module type T = S with type t = int

let h x = (x : (module S with type t = int) :> (module T))
;;
[%%expect {|
module M : sig end
module type S = sig module Alias = M type t end
module type T = sig module Alias = M type t = int end
Line 11, characters 10-58:
11 | let h x = (x : (module S with type t = int) :> (module T))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Type (module S with type t = int) is not a subtype of (module T)
|}]
```

This is caused by the `package_constraints` function setting all the sub-module presences to `Mp_present` even if that sub-module is a module alias. This PR changes the code so that it leaves the presences unchanged.

This is only correct if the recursive call to `package_constraints` cannot change a module alias to something else, which is true but not immediately obvious because it relies on the fact that `constrs` is always `[]` for a module alias. So I also changed the code to make it obviously true by always explicit leaving module aliases alone. This change also makes it clearer that we don't have a soundness bug due to weakening module aliases inappropriately.