### PR TITLE
configure: use cc as assembler with clang and for all FreeBSD platforms

### DIFF
--- a/Changes
+++ b/Changes
@@ -294,6 +294,9 @@ Working version
 - #9064: Relax the level handling when unifying row fields
   (Leo White, review by Jacques Garrigue)
 
+- #9068, #9437: ocamlopt -output-complete-obj failure on FreeBSD 12
+  (Xavier Leroy, report by Hannes Mehnert, review by Sébastien Hinderer)
+
 - #9097: Do not emit references to dead labels introduced by #2321 (spacetime).
   (Greta Yorsh, review by Mark Shinwell)
 

--- a/configure
+++ b/configure
@@ -13916,22 +13916,20 @@ esac ;; #(
   s390x,elf) :
     default_as="${toolpref}as -m 64 -march=$model"
     default_aspp="${toolpref}gcc -c -Wa,-march=$model" ;; #(
-  arm,freebsd|arm64,freebsd) :
-    default_as="${toolpref}cc -c"
-    default_aspp="${toolpref}cc -c" ;; #(
+  *,freebsd) :
+    default_as="${toolpref}cc -c -Wno-trigraphs"
+    default_aspp="${toolpref}cc -c -Wno-trigraphs" ;; #(
   *,dragonfly) :
     default_as="${toolpref}as"
     default_aspp="${toolpref}cc -c" ;; #(
-  *,freebsd) :
-    default_as="${toolpref}as"
-    default_aspp="${toolpref}cc -c" ;; #(
   amd64,*|arm,*|arm64,*|i386,*) :
-    default_as="${toolpref}as"
     case $ocaml_cv_cc_vendor in #(
   clang-*) :
-    default_aspp="${toolpref}clang -c -Wno-trigraphs" ;; #(
+    default_as="${toolpref}clang -c -Wno-trigraphs"
+                  default_aspp="${toolpref}clang -c -Wno-trigraphs" ;; #(
   *) :
-    default_aspp="${toolpref}gcc -c" ;;
+    default_as="${toolpref}as"
+      default_aspp="${toolpref}gcc -c" ;;
 esac ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1029,20 +1029,18 @@ AS_CASE(["$arch,$system"],
   [s390x,elf],
     [default_as="${toolpref}as -m 64 -march=$model"
     default_aspp="${toolpref}gcc -c -Wa,-march=$model"],
-  [arm,freebsd|arm64,freebsd],
-    [default_as="${toolpref}cc -c"
-    default_aspp="${toolpref}cc -c"],
+  [*,freebsd],
+    [default_as="${toolpref}cc -c -Wno-trigraphs"
+    default_aspp="${toolpref}cc -c -Wno-trigraphs"],
   [*,dragonfly],
     [default_as="${toolpref}as"
     default_aspp="${toolpref}cc -c"],
-  [*,freebsd],
-    [default_as="${toolpref}as"
-    default_aspp="${toolpref}cc -c"],
   [amd64,*|arm,*|arm64,*|i386,*],
-    [default_as="${toolpref}as"
-    AS_CASE([$ocaml_cv_cc_vendor],
-      [clang-*], [default_aspp="${toolpref}clang -c -Wno-trigraphs"],
-      [default_aspp="${toolpref}gcc -c"])])
+    [AS_CASE([$ocaml_cv_cc_vendor],
+      [clang-*], [default_as="${toolpref}clang -c -Wno-trigraphs"
+                  default_aspp="${toolpref}clang -c -Wno-trigraphs"],
+      [default_as="${toolpref}as"
+      default_aspp="${toolpref}gcc -c"])])
 
 AS_IF([test "$with_pic"],
   [fpic=true


### PR DESCRIPTION
In recent FreeBSD, `cc` is Clang and `ld` is LLD, the LLVM linker, but
`as` is still GNU binutils.  Moreover, Clang contains its own
assembler and does not call `as`.  Consequently, object files produced
by invoking `as` directly are slightly different from those produced
by `cc`.

This can cause obscure errors such as issue #9068: `ld -r` fails when
combining objects produced by `as` and objects produced by `cc`.

The workaround is to use `cc` as the assembler.  We already did that
for the ARM and ARM64 targets, but #9068 shows that it is necessary
for AMD64 too.  Just use `cc` as assembler for all FreeBSD targets.

Similar issues were reported under Linux when clang and LLD are used
instead of GCC and binutils.  We already used clang as the preprocessed
assembler in this case.  Also use clang as the assembler in this case.
