### PR TITLE
bug report https://github.com/ocaml/ocaml/issues/9418

### DIFF
--- a/Changes
+++ b/Changes
@@ -280,6 +280,9 @@ Working version
 
 ### Bug fixes:
 
+- #9148: for a type extension constructor with parameterised arguments,
+  REPL displayed <poly> for each as opposed to the concrete values used.
+
 - #7683, #1499: Fixes one case where the evaluation order in native-code
   may not match the one in bytecode.
   (Nicolás Ojeda Bär, report by Pierre Chambart, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -280,9 +280,6 @@ Working version
 
 ### Bug fixes:
 
-- #9148: for a type extension constructor with parameterised arguments,
-  REPL displayed <poly> for each as opposed to the concrete values used.
-
 - #7683, #1499: Fixes one case where the evaluation order in native-code
   may not match the one in bytecode.
   (Nicolás Ojeda Bär, report by Pierre Chambart, review by Gabriel Scherer)
@@ -332,6 +329,9 @@ Working version
 - #9428: Fix truncated exception backtrace for C->OCaml callbacks
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
+
+- #9439: for a type extension constructor with parameterised arguments,
+  REPL displayed <poly> for each as opposed to the concrete values used.
 
 
 OCaml 4.10 maintenance branch


### PR DESCRIPTION
putting printing of extensions into alignment with regular variants.