### PR TITLE
#9148 extension constructor printing discrepancy in REPL

### DIFF
--- a/Changes
+++ b/Changes
@@ -385,6 +385,10 @@ Working version
 - #9421, #9427: fix printing of (::) in ocamldoc
   (Florian Angeletti, report by Yawar Amin, review by Damien Doligez)
 
+- #9440: for a type extension constructor with parameterised arguments,
+  REPL displayed <poly> for each as opposed to the concrete values used.
+  (Christian Quinn, review by Gabriel Scherer)
+
 - #9469: Better backtraces for lazy values
   (Leo White, review by Nicolás Ojeda Bär)
 

--- a/testsuite/tests/tool-toplevel/printval.ml
+++ b/testsuite/tests/tool-toplevel/printval.ml
@@ -1,0 +1,60 @@
+(* TEST
+   * expect
+*)
+
+(* Test a success case *)
+type 'a t = T of 'a
+;;
+T 123
+[%%expect {|
+type 'a t = T of 'a
+- : int t = T 123
+|}]
+
+(* no <poly> after fix *)
+type _ t = ..
+type 'a t += T of 'a
+;;
+T 123
+[%%expect {|
+type _ t = ..
+type 'a t += T of 'a
+- : int t = T 123
+|}]
+
+
+(* GADT with fixed arg type *)
+type _ t += T: char -> int t
+;;
+T 'x'
+[%%expect {|
+type _ t += T : char -> int t
+- : int t = T 'x'
+|}]
+
+
+(* GADT with poly arg type.... and the expected T <poly> *)
+type _ t += T: 'a -> int t
+;;
+T 'x'
+[%%expect {|
+type _ t += T : 'a -> int t
+- : int t = T <poly>
+|}]
+
+(* the rest are expected without <poly> *)
+type _ t += T: 'a * bool -> 'a t
+;;
+T ('x',true)
+[%%expect {|
+type _ t += T : 'a * bool -> 'a t
+- : char t = T ('x', true)
+|}]
+
+type _ t += T: 'a -> ('a * bool) t
+;;
+T 'x'
+[%%expect {|
+type _ t += T : 'a -> ('a * bool) t
+- : (char * bool) t = T 'x'
+|}]


### PR DESCRIPTION
for a type extension constructor with parameterised arguments,
REPL displayed ```<poly>``` for each as opposed to the concrete values used.
patch copies over code used for variant constructors.