### PR TITLE
Fix tail-call optimisation with a mutable ref

### DIFF
--- a/Changes
+++ b/Changes
@@ -66,7 +66,7 @@ Working version
 - #9280: Micro-optimise allocations on amd64 to save a register.
   (Stephen Dolan, review by Xavier Leroy)
 
-- #9316: Use typing information from Clambda for mutable Cmm variables.
+- #9316, #9443: Use typing information from Clambda for mutable Cmm variables.
   (Stephen Dolan, review by Vincent Laviron, Guillaume Bury and Xavier Leroy)
 
 - #9426: build the Mingw ports with higher levels of GCC optimization

--- a/Changes
+++ b/Changes
@@ -67,7 +67,8 @@ Working version
   (Stephen Dolan, review by Xavier Leroy)
 
 - #9316, #9443: Use typing information from Clambda for mutable Cmm variables.
-  (Stephen Dolan, review by Vincent Laviron, Guillaume Bury and Xavier Leroy)
+  (Stephen Dolan, review by Vincent Laviron, Guillaume Bury, Xavier Leroy,
+  and Gabriel Scherer)
 
 - #9426: build the Mingw ports with higher levels of GCC optimization
   (Xavier Leroy, review by Sébastien Hinderer)

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -687,11 +687,7 @@ method emit_expr (env:environment) exp =
   | Clet_mut(v, k, e1, e2) ->
       begin match self#emit_expr env e1 with
         None -> None
-      | Some r1 ->
-        let rv = Reg.createv k in
-        name_regs v rv;
-        self#insert_moves env r1 rv;
-        self#emit_expr (env_add ~mut:Mutable v rv env) e2
+      | Some r1 -> self#emit_expr (self#bind_let_mut env v k r1) e2
       end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_expr env body
@@ -911,6 +907,12 @@ method private bind_let (env:environment) v r1 =
     env_add v rv env
   end
 
+method private bind_let_mut (env:environment) v k r1 =
+  let rv = Reg.createv k in
+  name_regs v rv;
+  self#insert_moves env r1 rv;
+  env_add ~mut:Mutable v rv env
+
 (* The following two functions, [emit_parts] and [emit_parts_list], force
    right-to-left evaluation order as required by the Flambda [Un_anf] pass
    (and to be consistent with the bytecode compiler). *)
@@ -1070,6 +1072,11 @@ method emit_tail (env:environment) exp =
         None -> ()
       | Some r1 -> self#emit_tail (self#bind_let env v r1) e2
       end
+  | Clet_mut (v, k, e1, e2) ->
+     begin match self#emit_expr env e1 with
+       None -> ()
+     | Some r1 -> self#emit_tail (self#bind_let_mut env v k r1) e2
+     end
   | Cphantom_let (_var, _defining_expr, body) ->
       self#emit_tail env body
   | Cop((Capply ty) as op, args, dbg) ->
@@ -1205,8 +1212,14 @@ method emit_tail (env:environment) exp =
           self#insert_moves env r1 loc;
           self#insert env Ireturn loc [||]
       end
-  | _ ->
-      self#emit_return env exp
+  | Cop _
+  | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
+  | Cconst_pointer _ | Cconst_natpointer _ | Cblockheader _
+  | Cvar _
+  | Cassign _
+  | Ctuple _
+  | Cexit _ ->
+    self#emit_return env exp
 
 method private emit_tail_sequence env exp =
   let s = {< instr_seq = dummy_instr >} in

--- a/testsuite/tests/regression/pr9443/pr9443.ml
+++ b/testsuite/tests/regression/pr9443/pr9443.ml
@@ -1,0 +1,11 @@
+(* TEST *)
+
+(* Test tail call optimisation with an elided mutable cell *)
+let rec loop n =
+  if n = 0 then () else begin
+    let last = ref 0 in
+    last := 0;
+    loop (n-1)
+  end
+
+let () = loop 1_000_000


### PR DESCRIPTION
There's a bug in #9316 - it breaks tail call optimisation on functions containing elided local references.