### PR TITLE
Printtyped: change printing of "extra" nodes

### DIFF
--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -234,11 +234,12 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   line i ppf "pattern %a\n" fmt_location x.pat_loc;
   attributes i ppf x.pat_attributes;
   let i = i+1 in
-  match x.pat_extra with
-    | extra :: rem ->
-        pattern_extra i ppf extra;
-        pattern i ppf { x with pat_extra = rem }
-    | [] ->
+  begin match x.pat_extra with
+  | [] -> ()
+  | extra ->
+    line i ppf "extra\n";
+    List.iter (pattern_extra (i+1) ppf) extra;
+  end;
   match x.pat_desc with
   | Tpat_any -> line i ppf "Tpat_any\n";
   | Tpat_var (s,_) -> line i ppf "Tpat_var \"%a\"\n" fmt_ident s;
@@ -297,7 +298,7 @@ and pattern_extra i ppf (extra_pat, _, attrs) =
      line i ppf "Tpat_extra_open %a\n" fmt_path id;
      attributes i ppf attrs;
 
-and expression_extra i ppf x attrs =
+and expression_extra i ppf (x,_,attrs) =
   match x with
   | Texp_constraint ct ->
       line i ppf "Texp_constraint\n";
@@ -319,11 +320,13 @@ and expression_extra i ppf x attrs =
 and expression i ppf x =
   line i ppf "expression %a\n" fmt_location x.exp_loc;
   attributes i ppf x.exp_attributes;
-  let i =
-    List.fold_left (fun i (extra,_,attrs) ->
-                      expression_extra i ppf extra attrs; i+1)
-      (i+1) x.exp_extra
-  in
+  let i = i+1 in
+  begin match x.exp_extra with
+  | [] -> ()
+  | extra ->
+    line i ppf "extra\n";
+    List.iter (expression_extra (i+1) ppf) extra;
+  end;
   match x.exp_desc with
   | Texp_ident (li,_,_) -> line i ppf "Texp_ident %a\n" fmt_path li;
   | Texp_instvar (_, li,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -294,7 +294,7 @@ and pattern_extra i ppf (extra_pat, _, attrs) =
      line i ppf "Tpat_extra_type %a\n" fmt_path id;
      attributes i ppf attrs;
   | Tpat_open (id,_,_) ->
-     line i ppf "Tpat_extra_open \"%a\"\n" fmt_path id;
+     line i ppf "Tpat_extra_open %a\n" fmt_path id;
      attributes i ppf attrs;
 
 and expression_extra i ppf x attrs =
@@ -407,7 +407,7 @@ and expression i ppf x =
       expression i ppf e
   | Texp_new (li, _, _) -> line i ppf "Texp_new %a\n" fmt_path li;
   | Texp_setinstvar (_, s, _, e) ->
-      line i ppf "Texp_setinstvar \"%a\"\n" fmt_path s;
+      line i ppf "Texp_setinstvar %a\n" fmt_path s;
       expression i ppf e;
   | Texp_override (_, l) ->
       line i ppf "Texp_override\n";


### PR DESCRIPTION
Compared to the `Parsetree`, some nodes in the `Typedtree` which have no effect on the translator are removed from the main tree:
- [pattern extra](https://github.com/ocaml/ocaml/blob/trunk/typing/typedtree.mli#L56)
- [expression extra](https://github.com/ocaml/ocaml/blob/trunk/typing/typedtree.mli#L151)

However the printer in `Printtyped` does not reflect this representation but rather try mimic the shape of the original `Parsetree`. This is a minor difference, but it puzzled in a Merlin test which prints that tree representation during traversal. So I thought it was a bug but it was just the printer displaying nodes without actual representation. I propose to change the printing to better reflect the representation by putting extra nodes in a "sub-field" of the main node.

Given test.ml:
```ocaml
let Int.((_ : int)) : int = (5 : int :> int)
```

Here is the difference in the formatting using `ocamlopt -dtypedtree -c test.ml`:
- before
  ```
  [
    structure_item (t.ml[1,0+0]..t.ml[1,0+44])
      Tstr_value Nonrec
      [
        <def>
          pattern (t.ml[1,0+10]..t.ml[1,0+11])
            Tpat_extra_constraint
            core_type (t.ml[1,0+22]..t.ml[1,0+25])
              Ttyp_constr "int/1!"
              []
            pattern (t.ml[1,0+10]..t.ml[1,0+11])
              Tpat_extra_open ""Stdlib!.Int""
              pattern (t.ml[1,0+10]..t.ml[1,0+11])
                Tpat_extra_constraint
                core_type (t.ml[1,0+14]..t.ml[1,0+17])
                  Ttyp_constr "int/1!"
                  []
                pattern (t.ml[1,0+10]..t.ml[1,0+11])
                  Tpat_any
          expression (t.ml[1,0+29]..t.ml[1,0+30])
            Texp_coerce
            Some
              core_type (t.ml[1,0+33]..t.ml[1,0+36])
                Ttyp_constr "int/1!"
                []
            core_type (t.ml[1,0+40]..t.ml[1,0+43])
              Ttyp_constr "int/1!"
              []
              Texp_constant Const_int 5
      ]
  ]
  ```

- after
  ```
  [
    structure_item (t.ml[1,0+0]..t.ml[1,0+44])
      Tstr_value Nonrec
      [
        <def>
          pattern (t.ml[1,0+10]..t.ml[1,0+11])
            extra
              Tpat_extra_constraint
              core_type (t.ml[1,0+22]..t.ml[1,0+25])
                Ttyp_constr "int/1!"
                []
              Tpat_extra_open "Stdlib!.Int"
              Tpat_extra_constraint
              core_type (t.ml[1,0+14]..t.ml[1,0+17])
                Ttyp_constr "int/1!"
                []
            Tpat_any
          expression (t.ml[1,0+29]..t.ml[1,0+30])
            extra
              Texp_coerce
              Some
                core_type (t.ml[1,0+33]..t.ml[1,0+36])
                  Ttyp_constr "int/1!"
                  []
              core_type (t.ml[1,0+40]..t.ml[1,0+43])
                Ttyp_constr "int/1!"
                []
            Texp_constant Const_int 5
      ]
  ]
  ```
