### PR TITLE
pattern-matching refactoring: keep going

### DIFF
--- a/Changes
+++ b/Changes
@@ -261,7 +261,8 @@ Working version
   (Gabriel Scherer, Thomas Refis, Florian Angeletti and Jacques Garrigue,
    reviewing each other without self-loops)
 
-- #9321, #9322, #9359, #9361, #9417: refactor the pattern-matching compiler
+- #9321, #9322, #9359, #9361, #9417, #9447: refactor the
+  pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 - #9211, #9215, #9222: fix Makefile dependencies in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3190,17 +3190,7 @@ and compile_match_nonempty repr partial ctx
       let m = { m with args; cases } in
       let first_match, rem =
         split_and_precompile_half_simplified ~arg:(Some v) m in
-      let lam, total =
-        comp_match_handlers
-          (( if dbg then
-             do_compile_matching_pr
-           else
-             do_compile_matching
-           )
-             repr)
-          partial ctx first_match rem
-      in
-      (bind_check str v arg lam, total)
+      combine_handlers repr partial ctx (v, str, arg) first_match rem
   | _ -> assert false
 
 and compile_match_simplified repr partial ctx
@@ -3211,18 +3201,21 @@ and compile_match_simplified repr partial ctx
       let args = (arg, Alias) :: argl in
       let m = { m with args } in
       let first_match, rem = split_and_precompile_simplified m in
-      let lam, total =
-        comp_match_handlers
-          (( if dbg then
-             do_compile_matching_pr
-           else
-             do_compile_matching
-           )
-             repr)
-          partial ctx first_match rem
-      in
-      (bind_check str v arg lam, total)
+      combine_handlers repr partial ctx (v, str, arg) first_match rem
   | _ -> assert false
+
+and combine_handlers repr partial ctx (v, str, arg) first_match rem =
+  let lam, total =
+    comp_match_handlers
+      (( if dbg then
+         do_compile_matching_pr
+       else
+         do_compile_matching
+       )
+         repr)
+      partial ctx first_match rem
+  in
+  (bind_check str v arg lam, total)
 
 (* verbose version of do_compile_matching, for debug *)
 and do_compile_matching_pr repr partial ctx x =


### PR DESCRIPTION
This is the next bit of the big pattern-matching refactoring change (#9321) after #9417 has been merged. This one is a series of small commits that iterate simple refactorings; they should be reviewed independently.

(Internal: there was a bit of rebase work due to the (nice!) change of arguments of the `split_and_precompile_*` function from `args` to `~arg` suggested by @Octachron during the review of #9322.)