### PR TITLE
Memprof: provide the guarantee that an allocation callback is always run in the same thread the allocation takes place.

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,11 @@ Working version
   (Nicolás Ojeda Bär, review by Stephen Dolan, Gabriel Scherer, Mark Shinwell,
   and Xavier Leroy)
 
+- #9449: Memprof: guarantee that an allocation callback is always run
+   in the same thread the allocation takes place.
+  (Jacques-Henri Jourdan, review by Stephen Dolan and
+   Guillaume Munch-Maccagnoni)
+
 ### Code generation and optimizations:
 
 - #9441: Add RISC-V RV64G native-code backend.
@@ -173,6 +178,8 @@ OCaml 4.11
   registering callbacks for promotion and deallocation of memory
   blocks.
   The new API no longer gives the block tags to the allocation callback.
+  It provides the guarantee that allocation callbacks are run in the
+  same thread as the allocation.
   (Stephen Dolan and Jacques-Henri Jourdan, review by Damien Doligez
    and Gabriel Scherer)
 

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -44,6 +44,7 @@ extern void caml_memprof_shutdown(void);
 
 struct caml_memprof_th_ctx {
   int suspended, callback_running;
+  uintnat first_alloc_callback_idx;
 };
 extern void caml_memprof_init_th_ctx(struct caml_memprof_th_ctx* ctx);
 extern void caml_memprof_stop_th_ctx(struct caml_memprof_th_ctx* ctx);

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1055,11 +1055,6 @@ CAMLprim value caml_memprof_stop(value unit)
 
   if (!started) caml_failwith("Gc.Memprof.stop: not started.");
 
-  /* This call to [caml_memprof_stop] will discard all the previously
-     tracked blocks. We try one last time to call the postponed
-     callbacks. */
-  caml_raise_if_exception(caml_memprof_handle_postponed_exn());
-
   /* Discard the tracked blocks. */
   for (i = 0; i < trackst.len; i++)
     if (trackst.entries[i].idx_ptr != NULL)

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -358,16 +358,17 @@ static struct tracking_state {
 
 /* Reallocate the [trackst] array if it is either too small or too
    large.
+   [grow] is the number of free cells needed.
    Returns 1 if reallocation succeeded --[trackst.alloc_len] is at
    least [trackst.len]--, and 0 otherwise. */
-static int realloc_trackst(void) {
-  uintnat new_alloc_len;
+static int realloc_trackst(uintnat grow) {
+  uintnat new_alloc_len, new_len = trackst.len + grow;
   struct tracked* new_entries;
-  if (trackst.len <= trackst.alloc_len &&
-     (4*trackst.len >= trackst.alloc_len ||
+  if (new_len <= trackst.alloc_len &&
+     (4*new_len >= trackst.alloc_len ||
       trackst.alloc_len == MIN_TRACKST_ALLOC_LEN))
     return 1;
-  new_alloc_len = trackst.len * 2;
+  new_alloc_len = new_len * 2;
   if (new_alloc_len < MIN_TRACKST_ALLOC_LEN)
     new_alloc_len = MIN_TRACKST_ALLOC_LEN;
   new_entries = caml_stat_resize_noexc(trackst.entries,
@@ -383,11 +384,9 @@ Caml_inline uintnat new_tracked(uintnat n_samples, uintnat wosize,
                                 value block, value user_data)
 {
   struct tracked *t;
-  trackst.len++;
-  if (!realloc_trackst()) {
-    trackst.len--;
+  if (!realloc_trackst(1))
     return Invalid_index;
-  }
+  trackst.len++;
   t = &trackst.entries[trackst.len - 1];
   t->block = block;
   t->n_samples = n_samples;
@@ -538,7 +537,7 @@ static void flush_deleted(void)
   trackst.delete = trackst.len = j;
   CAMLassert(trackst.callback <= trackst.len);
   CAMLassert(trackst.young <= trackst.len);
-  realloc_trackst();
+  realloc_trackst(0);
 }
 
 static void check_action_pending(void) {

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -490,6 +490,9 @@ module Memprof :
        to keep for minor blocks, and ['major] the type of metadata
        for major blocks.
 
+       When using threads, it is guaranteed that allocation callbacks are
+       always run in the thread where the allocation takes place.
+
        If an allocation-tracking or promotion-tracking function returns [None],
        memprof stops tracking the corresponding value.
      *)

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -535,11 +535,10 @@ module Memprof :
     val stop : unit -> unit
     (** Stop the sampling. Fails if sampling is not active.
 
-        This function does not allocate memory, but tries to run the
-        postponed callbacks for already allocated memory blocks (of
-        course, these callbacks may allocate).
+        This function does not allocate memory.
 
-        All the already tracked blocks are discarded.
+        All the already tracked blocks are discarded. If there are
+        pending postponed callbacks, they may be discarded.
 
         Calling [stop] when a callback is running can lead to
         callbacks not being called even though some events happened. *)

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -12,4 +12,4 @@ Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 12, c
 Called from Callstack.f1 in file "callstack.ml", line 13, characters 27-32
 Called from Callstack.f2 in file "callstack.ml", line 14, characters 27-32
 Called from Callstack.f3 in file "callstack.ml", line 15, characters 27-32
-Called from Thread.create.(fun) in file "thread.ml", line 39, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14

--- a/testsuite/tests/statmemprof/blocking_in_callback.ml
+++ b/testsuite/tests/statmemprof/blocking_in_callback.ml
@@ -6,8 +6,7 @@ include systhreads
 *)
 
 let cnt = ref 0
-let alloc_num = ref 0
-let alloc_tot = 100000
+let alloc_thread = 50000
 
 let (rd1, wr1) = Unix.pipe ()
 let (rd2, wr2) = Unix.pipe ()
@@ -15,20 +14,26 @@ let (rd2, wr2) = Unix.pipe ()
 let main_thread = Thread.self ()
 let cb_main = ref 0 and cb_other = ref 0
 let stopped = ref false
-let minor_alloc_callback _ =
+let alloc_callback alloc =
   if !stopped then
     None
   else begin
-    let do_stop = !cb_main + !cb_other >= alloc_tot in
-    if do_stop then stopped := true;
     let t = Thread.self () in
     if t == main_thread then begin
+      assert (alloc.Gc.Memprof.size < 10 || alloc.Gc.Memprof.size mod 2 = 0);
+      let do_stop = !cb_main >= alloc_thread in
+      if do_stop then stopped := true;
       incr cb_main;
+
       assert (Unix.write wr2 (Bytes.make 1 'a') 0 1 = 1);
       if not do_stop then
         assert (Unix.read rd1 (Bytes.make 1 'a') 0 1 = 1)
     end else begin
+      assert (alloc.Gc.Memprof.size < 10 || alloc.Gc.Memprof.size mod 2 = 1);
+      let do_stop = !cb_other >= alloc_thread in
+      if do_stop then stopped := true;
       incr cb_other;
+
       assert (Unix.write wr1 (Bytes.make 1 'a') 0 1 = 1);
       if not do_stop then
         assert (Unix.read rd2 (Bytes.make 1 'a') 0 1 = 1)
@@ -39,31 +44,34 @@ let minor_alloc_callback _ =
 let mut = Mutex.create ()
 let () = Mutex.lock mut
 
-let rec go () =
+let rec go alloc_num tid =
   Mutex.lock mut;
   Mutex.unlock mut;
-  if !alloc_num < alloc_tot then begin
-    alloc_num := !alloc_num + 1;
-    Sys.opaque_identity (Bytes.make (Random.int 300) 'a') |> ignore;
-    go ()
+  if alloc_num < alloc_thread then begin
+    let len = 2 * (Random.int 200 + 1) + tid in
+    Sys.opaque_identity (Array.make len 0) |> ignore;
+    go (alloc_num + 1) tid
   end else begin
     cnt := !cnt + 1;
     if !cnt < 2 then begin
       Gc.minor ();    (* check for callbacks *)
       Thread.yield ();
-      go ()
+      go alloc_num tid
     end else begin
       Gc.minor ()    (* check for callbacks *)
     end
   end
 
 let () =
-  let t = Thread.create go () in
+  let t = Thread.create (fun () -> go 0 1) () in
   Gc.Memprof.(start ~callstack_size:10 ~sampling_rate:1.
-    { null_tracker with alloc_minor = minor_alloc_callback; });
+    { null_tracker with
+      alloc_minor = alloc_callback;
+      alloc_major = alloc_callback });
   Mutex.unlock mut;
-  go ();
+  go 0 0;
   Thread.join t;
   Gc.Memprof.stop ();
-  assert (abs (!cb_main - !cb_other) <= 1);
-  assert (!cb_main + !cb_other >= alloc_tot)
+  assert (!cb_main >= alloc_thread);
+  assert (!cb_other >= alloc_thread);
+  assert (abs (!cb_main - !cb_other) <= 1)

--- a/testsuite/tests/statmemprof/minor_no_postpone.ml
+++ b/testsuite/tests/statmemprof/minor_no_postpone.ml
@@ -32,5 +32,6 @@ let () =
   ignore (Sys.opaque_identity (alloc_stub ()));
   assert(not !callback_done);
   callback_ok := true;
-  stop ();
-  assert(!callback_done)
+  ignore (Sys.opaque_identity (ref ()));
+  assert(!callback_done);
+  stop ()


### PR DESCRIPTION
This is done by maintaining a bag of pending allocation callbacks for each thread, in the form of an linked list.

We also change the behavior of `Memprof.stop`, so that it does no longer try to run pending callbacks. This is only effective in native mode, since function calls in bytecode mode will trigger polling and hence run pending callbacks.

This MR is rather large, but only one commit actually has non-trivial content. Reviewing should be easier by reading one commit after the other.