### PR TITLE
Add locations to docstring attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -284,6 +284,9 @@ Working version
 - #2324: Replace caml_int_compare and caml_float_compare with primitives.
   (Greta Yorsh, review by Stephen Dolan and Vincent Laviron)
 
+- #9452: Add locations to docstring attributes
+  (Leo White, review by Gabriel Scherer)
+
 ### Build system:
 
 - #9250: Add --disable-ocamltest to configure and disable building for

--- a/parsing/docstrings.ml
+++ b/parsing/docstrings.ml
@@ -89,18 +89,20 @@ let doc_loc = {txt = "ocaml.doc"; loc = Location.none}
 
 let docs_attr ds =
   let open Parsetree in
+  let body = ds.ds_body in
+  let loc = ds.ds_loc in
   let exp =
-    { pexp_desc = Pexp_constant (Pconst_string(ds.ds_body, ds.ds_loc, None));
-      pexp_loc = ds.ds_loc;
+    { pexp_desc = Pexp_constant (Pconst_string(body, loc, None));
+      pexp_loc = loc;
       pexp_loc_stack = [];
       pexp_attributes = []; }
   in
   let item =
-    { pstr_desc = Pstr_eval (exp, []); pstr_loc = exp.pexp_loc }
+    { pstr_desc = Pstr_eval (exp, []); pstr_loc = loc }
   in
   { attr_name = doc_loc;
     attr_payload = PStr [item];
-    attr_loc = Location.none }
+    attr_loc = loc }
 
 let add_docs_attrs docs attrs =
   let attrs =
@@ -139,18 +141,20 @@ let text_loc = {txt = "ocaml.text"; loc = Location.none}
 
 let text_attr ds =
   let open Parsetree in
+  let body = ds.ds_body in
+  let loc = ds.ds_loc in
   let exp =
-    { pexp_desc = Pexp_constant (Pconst_string(ds.ds_body, ds.ds_loc, None));
-      pexp_loc = ds.ds_loc;
+    { pexp_desc = Pexp_constant (Pconst_string(body, loc, None));
+      pexp_loc = loc;
       pexp_loc_stack = [];
       pexp_attributes = []; }
   in
   let item =
-    { pstr_desc = Pstr_eval (exp, []); pstr_loc = exp.pexp_loc }
+    { pstr_desc = Pstr_eval (exp, []); pstr_loc = loc }
   in
   { attr_name = text_loc;
     attr_payload = PStr [item];
-    attr_loc = Location.none }
+    attr_loc = loc }
 
 let add_text_attrs dsl attrs =
   let fdsl = List.filter (function {ds_body=""} -> false| _ ->true) dsl in


### PR DESCRIPTION
When locations were added to attributes the ones that come from docstrings were given `Location.none` rather than the location of the docstring. This is apparently mildly annoying for some tools, so this PR fixes it.