### PR TITLE
Turn off PIE for Alpine Linux on platforms other than amd64 and s390x

### DIFF
--- a/Changes
+++ b/Changes
@@ -292,6 +292,11 @@ Working version
 
 ### Bug fixes:
 
+- #7562, #9456: ocamlopt-generated code crashed on Alpine Linux on
+  ppc64le, arm, and i386.  Fixed by turning PIE off for musl-based Linux
+  systems except amd64 (x86_64) and s390x.
+  (Xavier Leroy, review by Gabriel Scherer)
+
 - #7683, #1499: Fixes one case where the evaluation order in native-code
   may not match the one in bytecode.
   (Nicolás Ojeda Bär, report by Pierre Chambart, review by Gabriel Scherer)

--- a/configure
+++ b/configure
@@ -13865,6 +13865,31 @@ if test $arch != "none" && $arch64 ; then :
   otherlibraries="$otherlibraries raw_spacetime_lib"
 fi
 
+# Disable PIE at link time when ocamlopt does not produce position-independent
+# code and the system produces PIE executables by default and demands PIC
+# object files to do so.
+# This issue does not affect amd64 (x86_64) and s390x (Z systems),
+# since ocamlopt produces PIC object files by default.
+# Currently the problem is known for Alpine Linux on platforms other
+# than amd64 and s390x (issue #7562), and probably affects all Linux
+# distributions that use the musl standard library and dynamic loader.
+# Other systems have PIE by default but can cope with non-PIC object files,
+# e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
+
+case $arch in #(
+  amd64|s390x|none) :
+    # ocamlopt generates PIC code or doesn't generate code at all
+     ;; #(
+  *) :
+    case $host in #(
+  *-linux-musl) :
+    # Alpine and other musl-based Linux distributions
+       common_cflags="-no-pie $common_cflags" ;; #(
+  *) :
+     ;;
+esac ;;
+esac
+
 # Assembler
 
 if test -n "$host_alias"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -987,6 +987,27 @@ AS_IF([test -z "$PARTIALLD"],
 AS_IF([test $arch != "none" && $arch64 ],
   [otherlibraries="$otherlibraries raw_spacetime_lib"])
 
+# Disable PIE at link time when ocamlopt does not produce position-independent
+# code and the system produces PIE executables by default and demands PIC
+# object files to do so.
+# This issue does not affect amd64 (x86_64) and s390x (Z systems),
+# since ocamlopt produces PIC object files by default.
+# Currently the problem is known for Alpine Linux on platforms other
+# than amd64 and s390x (issue #7562), and probably affects all Linux
+# distributions that use the musl standard library and dynamic loader.
+# Other systems have PIE by default but can cope with non-PIC object files,
+# e.g. Ubuntu >= 17.10 for i386, which uses the glibc dynamic loader.
+
+AS_CASE([$arch],
+  [amd64|s390x|none],
+    # ocamlopt generates PIC code or doesn't generate code at all
+    [],
+  [AS_CASE([$host],
+    [*-linux-musl],
+       # Alpine and other musl-based Linux distributions
+       [common_cflags="-no-pie $common_cflags"],
+    [])])
+
 # Assembler
 
 AS_IF([test -n "$host_alias"], [toolpref="${host_alias}-"], [toolpref=""])


### PR DESCRIPTION
This is a fix for issue #7562.

Alpine Linux produces position-independent executables (PIEs) by default. If non-PIC object files are given to the linker, it silently produces a wrong executable that crashes when run.  This is the case for  camlopt-generated code, which by default is not PIC except on amd64 (x86_64) and s390x (Z systems).

The fix is to special-case Alpine, or more exactly the `-linux-musl` system name that characterizes Linux systems using the Musl standard library, like Alpine, and add `-no-pie` to the C compiler options, except on amd64 and s390x.

It's on purpose that this fix is minimal and specific to Alpine.  For instance, I thought about adding `-no-pie` for all targets except amd64 and s390x, but decided not to:
1. `-no-pie` is not always necessary.  E.g. Ubuntu >= 17.10 produces PIE by default, yet has no problems with non-PIC i386 code produced by ocamlopt, probably because the dynamic loader of Glibc is more clever than that of Musl.
2. PIE is a security feature, so we should not turn it off until provably needed.

