### PR TITLE
Fix #mod_use in toplevel

### DIFF
--- a/Changes
+++ b/Changes
@@ -176,7 +176,7 @@ Working version
   points to the grammar.
   (Andreas Abel, review by Xavier Leroy)
 
-- #9283: add a new toplevel directive `#use_output "<command>"` to
+- #9283, #9455, #9457: add a new toplevel directive `#use_output "<command>"` to
   run a command and evaluate its output.
   (Jérémie Dimino, review by David Allsopp)
 

--- a/testsuite/tests/tool-toplevel/mod.ml
+++ b/testsuite/tests/tool-toplevel/mod.ml
@@ -1,0 +1,1 @@
+let answer = 42

--- a/testsuite/tests/tool-toplevel/mod_use.ml
+++ b/testsuite/tests/tool-toplevel/mod_use.ml
@@ -1,0 +1,9 @@
+(* TEST
+   files = "mod.ml"
+   * expect
+*)
+
+#mod_use "mod.ml"
+[%%expect {|
+module Mod : sig val answer : int end
+|}];;

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -490,16 +490,16 @@ let use_output ppf command =
          fprintf ppf "Command exited with code %d.@." n;
          false)
 
-let use_file ppf wrap_mode name =
+let use_file ppf wrap_mod name =
   match name with
   | "" ->
-    use_channel ppf wrap_mode stdin name "(stdin)"
+    use_channel ppf wrap_mod stdin name "(stdin)"
   | _ ->
     match Load_path.find name with
     | filename ->
       let ic = open_in_bin filename in
       Misc.try_finally ~always:(fun () -> close_in ic)
-        (fun () -> use_channel ppf false ic name filename)
+        (fun () -> use_channel ppf wrap_mod ic name filename)
     | exception Not_found ->
       fprintf ppf "Cannot find file %s.@." name;
       false

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -436,16 +436,16 @@ let use_output ppf command =
          fprintf ppf "Command exited with code %d.@." n;
          false)
 
-let use_file ppf wrap_mode name =
+let use_file ppf wrap_mod name =
   match name with
   | "" ->
-    use_channel ppf wrap_mode stdin name "(stdin)"
+    use_channel ppf wrap_mod stdin name "(stdin)"
   | _ ->
     match Load_path.find name with
     | filename ->
       let ic = open_in_bin filename in
       Misc.try_finally ~always:(fun () -> close_in ic)
-        (fun () -> use_channel ppf wrap_mode ic name filename)
+        (fun () -> use_channel ppf wrap_mod ic name filename)
     | exception Not_found ->
       fprintf ppf "Cannot find file %s.@." name;
       false

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -445,7 +445,7 @@ let use_file ppf wrap_mode name =
     | filename ->
       let ic = open_in_bin filename in
       Misc.try_finally ~always:(fun () -> close_in ic)
-        (fun () -> use_channel ppf false ic name filename)
+        (fun () -> use_channel ppf wrap_mode ic name filename)
     | exception Not_found ->
       fprintf ppf "Cannot find file %s.@." name;
       false

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -394,7 +394,7 @@ let preprocess_phrase ppf phr =
   if !Clflags.dump_source then Pprintast.top_phrase ppf phr;
   phr
 
-let use_channel ppf wrap_mod ic name filename =
+let use_channel ppf ~wrap_in_module ic name filename =
   let lb = Lexing.from_channel ic in
   Warnings.reset_fatal ();
   Location.init lb filename;
@@ -408,7 +408,7 @@ let use_channel ppf wrap_mod ic name filename =
         (fun ph ->
           let ph = preprocess_phrase ppf ph in
           if not (execute_phrase !use_print_results ppf ph) then raise Exit)
-        (if wrap_mod then
+        (if wrap_in_module then
            parse_mod_use_file name lb
          else
            !parse_use_file lb);
@@ -431,27 +431,30 @@ let use_output ppf command =
        | 0 ->
          let ic = open_in_bin fn in
          Misc.try_finally ~always:(fun () -> close_in ic)
-           (fun () -> use_channel ppf false ic "" "(command-output)")
+           (fun () ->
+              use_channel ppf ~wrap_in_module:false ic "" "(command-output)")
        | n ->
          fprintf ppf "Command exited with code %d.@." n;
          false)
 
-let use_file ppf wrap_mod name =
+let use_file ppf ~wrap_in_module name =
   match name with
   | "" ->
-    use_channel ppf wrap_mod stdin name "(stdin)"
+    use_channel ppf ~wrap_in_module stdin name "(stdin)"
   | _ ->
     match Load_path.find name with
     | filename ->
       let ic = open_in_bin filename in
       Misc.try_finally ~always:(fun () -> close_in ic)
-        (fun () -> use_channel ppf wrap_mod ic name filename)
+        (fun () -> use_channel ppf ~wrap_in_module ic name filename)
     | exception Not_found ->
       fprintf ppf "Cannot find file %s.@." name;
       false
 
-let mod_use_file ppf name = use_file ppf true name
-let use_file ppf name = use_file ppf false name
+let mod_use_file ppf name =
+  use_file ppf ~wrap_in_module:true name
+let use_file ppf name =
+  use_file ppf ~wrap_in_module:false name
 
 let use_silently ppf name =
   protect_refs [ R (use_print_results, false) ] (fun () -> use_file ppf name)


### PR DESCRIPTION
Regression from #9283. Fixes #9455.

This is an absolute show-stopper for 4.11!