### PR TITLE
Memprof: fatal error if thread is stopped from a callback.

### DIFF
--- a/Changes
+++ b/Changes
@@ -103,8 +103,8 @@ OCaml 4.11
   API when the old block is NULL.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
-- #8920, #9238, #9239, #9254: New API for statistical memory profiling in
-  Memprof.Gc. The new version does no longer use ephemerons and allows
+- #8920, #9238, #9239, #9254, #9458: New API for statistical memory profiling
+  in Memprof.Gc. The new version does no longer use ephemerons and allows
   registering callbacks for promotion and deallocation of memory
   blocks.
   The new API no longer gives the block tags to the allocation callback.

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -25,7 +25,6 @@
 extern int caml_memprof_suspended;
 
 extern value caml_memprof_handle_postponed_exn(void);
-extern void caml_memprof_check_action_pending(void);
 
 extern void caml_memprof_track_alloc_shr(value block);
 extern void caml_memprof_track_young(uintnat wosize, int from_caml,
@@ -42,6 +41,14 @@ extern void caml_memprof_update_clean_phase(void);
 extern void caml_memprof_invert_tracked(void);
 
 extern void caml_memprof_shutdown(void);
+
+struct caml_memprof_th_ctx {
+  int suspended, callback_running;
+};
+extern void caml_memprof_init_th_ctx(struct caml_memprof_th_ctx* ctx);
+extern void caml_memprof_stop_th_ctx(struct caml_memprof_th_ctx* ctx);
+extern void caml_memprof_save_th_ctx(struct caml_memprof_th_ctx* ctx);
+extern void caml_memprof_restore_th_ctx(const struct caml_memprof_th_ctx* ctx);
 
 #endif
 

--- a/testsuite/tests/statmemprof/thread_exit_in_callback.ml
+++ b/testsuite/tests/statmemprof/thread_exit_in_callback.ml
@@ -1,0 +1,18 @@
+(* TEST
+modules = "thread_exit_in_callback_stub.c"
+exit_status = "42"
+* hassysthreads
+include systhreads
+** bytecode
+** native
+*)
+
+(* We cannot tell Ocamltest that this program is supposed to stop with
+   a fatal error. Instead, we install a fatal error hook and call exit(42) *)
+external install_fatal_error_hook : unit -> unit = "install_fatal_error_hook"
+
+let _ =
+  install_fatal_error_hook ();
+  Gc.Memprof.(start ~callstack_size:10 ~sampling_rate:1.
+    { null_tracker with alloc_minor = fun _ -> Thread.exit (); None });
+  ignore (Sys.opaque_identity (ref 1))

--- a/testsuite/tests/statmemprof/thread_exit_in_callback.reference
+++ b/testsuite/tests/statmemprof/thread_exit_in_callback.reference
@@ -1,0 +1,1 @@
+Fatal error hook: Thread.exit called from a memprof callback.

--- a/testsuite/tests/statmemprof/thread_exit_in_callback_stub.c
+++ b/testsuite/tests/statmemprof/thread_exit_in_callback_stub.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include "caml/misc.h"
+#include "caml/mlvalues.h"
+
+void fatal_error_hook_exit_3 (char *msg, va_list args) {
+  fprintf(stderr, "Fatal error hook: ");
+  vfprintf(stderr, msg, args);
+  fprintf(stderr, "\n");
+  exit(42);
+}
+
+
+value install_fatal_error_hook (value unit) {
+  caml_fatal_error_hook = fatal_error_hook_exit_3;
+  return Val_unit;
+}


### PR DESCRIPTION
This is specified as undefined behavior in gc.mli.

These are the two first commits of #9449. They do not deserve a Changes entry.

I don't think we need a test for this either.

I addressed @gadmm's concern:

> This can also be set in caml_fatal_uncaught_exception, in that case the error message would be misleading.
>
> The use of suspended in caml_fatal_uncaught_exception is replaced by a proper mask at https://github.com/ocaml/ocaml/pull/8961/files#diff-7daa060567fae8578a3e27866a93d610R143 so the problem fixes itself eventually, but not immediately. Do you have an idea of something that could be done in the meantime?

Two different flags are now used for that purpose.

I would like this to be merged in 4.11. But this can be considered as a bugfix, since it protects against potential segfaults if `Thread.exit` is called from a callback.