### PR TITLE
pattern-matching refactoring: simplify `Default_env.specialize_matrix` by avoiding the OrPat exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -274,7 +274,7 @@ Working version
   (Gabriel Scherer, Thomas Refis, Florian Angeletti and Jacques Garrigue,
    reviewing each other without self-loops)
 
-- #9321, #9322, #9359, #9361, #9417, #9447: refactor the
+- #9321, #9322, #9359, #9361, #9417, #9447, #9464: refactor the
   pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -589,8 +589,6 @@ end = struct
   let union pss qss = get_mins Row.le (pss @ qss)
 end
 
-exception OrPat
-
 let rec flatten_pat_line size p k =
   match p.pat_desc with
   | Tpat_any -> omegas size :: k
@@ -672,15 +670,10 @@ end = struct
           match p.pat_desc with
           | Tpat_alias (p, _, _) -> filter_rec ((p :: ps) :: rem)
           | Tpat_var _ -> filter_rec ((omega :: ps) :: rem)
+          | Tpat_or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
           | _ -> (
               match matcher p ps with
               | exception NoMatch -> filter_rec rem
-              | exception OrPat -> (
-                  match p.pat_desc with
-                  | Tpat_or (p1, p2, _) ->
-                      filter_rec ((p1 :: ps) :: (p2 :: ps) :: rem)
-                  | _ -> assert false
-                )
               | specialized ->
                   assert (List.length specialized = List.length ps + arity);
                   specialized :: filter_rec rem
@@ -690,6 +683,69 @@ end = struct
       | _ ->
           pretty_matrix Format.err_formatter pss;
           fatal_error "Matching.Default_environment.specialize_matrix"
+
+    (* Filter just one row, without a `rem` accumulator
+       of further rows to process.
+       The following equality holds:
+         filter_rec ((p :: ps) :: rem)
+         = filter_one p ps @ filter_rec rem
+    *)
+    and filter_one p ps =
+      filter_rec [ p :: ps ]
+
+    and filter_rec_or p1 p2 ps rem =
+      match arity with
+      | 0 -> (
+          (* if K has arity 0, specializing ((K|K)::rem) returns just (rem):
+             if either sides works (filters into a non-empty list),
+             no need to keep the other. *)
+          match filter_one p1 ps with
+          | [] -> filter_rec ((p2 :: ps) :: rem)
+          | matches -> matches @ filter_rec rem
+        )
+      | 1 -> (
+          (* if K has arity 1, ((K p | K q) :: rem) can be expressed
+             as ((p | q) :: rem): even if both sides of an or-pattern
+             match, we can compress the output in a single row,
+             instead of duplicating the row.
+
+             In particular, filtering a single row (the filter_one calls)
+             returns a result that respects the following properties:
+             - "row count": the result is either an empty list or a single row
+             - "row shape": if there is a row in the result, it contains one
+               pattern consed to the tail [ps] of our input row; in particular
+               the row is not empty. *)
+          match (filter_one p1 ps, filter_one p2 ps) with
+          | [], row
+          | row, [] ->
+              row @ filter_rec rem
+          | [ (arg1 :: _) ], [ (arg2 :: _) ] ->
+              (* By the row shape property,
+                 the wildcard patterns can only be ps. *)
+              (* The output below is a single row,
+                  respecting the row count property. *)
+              ({ arg1 with
+                 pat_desc = Tpat_or (arg1, arg2, None);
+                 pat_loc = Location.none
+               }
+              :: ps
+              )
+              :: filter_rec rem
+          | (_ :: _ :: _), _
+          | _, (_ :: _ :: _) ->
+              (* Cannot happen from the row count property. *)
+              assert false
+          | [ [] ], _
+          | _, [ [] ] ->
+              (* Cannot happen from the row shape property. *)
+              assert false
+        )
+      | _ ->
+          (* we cannot preserve the or-pattern as in the arity-1 case,
+             because we cannot express
+                (K (p1, .., pn) | K (q1, .. qn))
+             as (p1 .. pn | q1 .. qn) *)
+          filter_rec ((p1 :: ps) :: (p2 :: ps) :: rem)
     in
     filter_rec pss
 
@@ -1569,8 +1625,7 @@ let divide_line make_ctx make get_args discr ctx
 
    - matcher functions are arguments to Default_environment.specialize (for
    default handlers)
-   They may raise NoMatch or OrPat and perform the full
-   matching (selection + arguments).
+   They may raise NoMatch and perform the full matching (selection + arguments).
 
    - get_args and get_key are for the compiled matrices, note that
    selection and getting arguments are separated.
@@ -1579,11 +1634,8 @@ let divide_line make_ctx make get_args discr ctx
    new  ``pattern_matching'' records.
 *)
 
-let rec matcher_const cst p rem =
+let matcher_const cst p rem =
   match p.pat_desc with
-  | Tpat_or (p1, p2, _) -> (
-      try matcher_const cst p1 rem with NoMatch -> matcher_const cst p2 rem
-    )
   | Tpat_constant c1 when const_compare c1 cst = 0 -> rem
   | Tpat_any -> rem
   | _ -> raise NoMatch
@@ -1643,64 +1695,12 @@ let get_args_constr p rem =
        This comparison is performed by Types.may_equal_constr.
 *)
 
-let matcher_constr cstr =
-  match cstr.cstr_arity with
-  | 0 ->
-      let rec matcher_rec q rem =
-        match q.pat_desc with
-        | Tpat_or (p1, p2, _) -> (
-            try matcher_rec p1 rem with NoMatch -> matcher_rec p2 rem
-          )
-        | Tpat_construct (_, cstr', []) when Types.may_equal_constr cstr cstr'
-          ->
-            rem
-        | Tpat_any -> rem
-        | _ -> raise NoMatch
-      in
-      matcher_rec
-  | 1 ->
-      let rec matcher_rec q rem =
-        match q.pat_desc with
-        | Tpat_or (p1, p2, _) -> (
-            (* if both sides of the or-pattern match the head constructor,
-            (K p1 | K p2) :: rem
-          return (p1 | p2) :: rem *)
-            let r1 = try Some (matcher_rec p1 rem) with NoMatch -> None
-            and r2 = try Some (matcher_rec p2 rem) with NoMatch -> None in
-            match (r1, r2) with
-            | None, None -> raise NoMatch
-            | Some r1, None -> r1
-            | None, Some r2 -> r2
-            | Some (a1 :: _), Some (a2 :: _) ->
-                { a1 with
-                  pat_loc = Location.none;
-                  pat_desc = Tpat_or (a1, a2, None)
-                }
-                :: rem
-            | _, _ -> assert false
-          )
-        | Tpat_construct (_, cstr', [ arg ])
-          when Types.may_equal_constr cstr cstr' ->
-            arg :: rem
-        | Tpat_any -> omega :: rem
-        | _ -> raise NoMatch
-      in
-      matcher_rec
-  | _ -> (
-      fun q rem ->
-        match q.pat_desc with
-        | Tpat_or (_, _, _) ->
-            (* we cannot preserve the or-pattern as in the arity-1 case,
-               because we cannot express
-                 (K (p1, .., pn) | K (q1, .. qn))
-               as (p1 .. pn | q1 .. qn) *)
-            raise OrPat
-        | Tpat_construct (_, cstr', args)
-          when Types.may_equal_constr cstr cstr' ->
-            args @ rem
-        | Tpat_any -> Parmatch.omegas cstr.cstr_arity @ rem
-        | _ -> raise NoMatch
-    )
+let matcher_constr cstr q rem =
+  match q.pat_desc with
+  | Tpat_construct (_, cstr', args) when Types.may_equal_constr cstr cstr' ->
+      args @ rem
+  | Tpat_any -> Parmatch.omegas cstr.cstr_arity @ rem
+  | _ -> raise NoMatch
 
 let make_constr_matching p def ctx = function
   | [] -> fatal_error "Matching.make_constr_matching"
@@ -1734,12 +1734,8 @@ let divide_constructor ctx pm =
 
 (* Matching against a variant *)
 
-let rec matcher_variant_const lab p rem =
+let matcher_variant_const lab p rem =
   match p.pat_desc with
-  | Tpat_or (p1, p2, _) -> (
-      try matcher_variant_const lab p1 rem
-      with NoMatch -> matcher_variant_const lab p2 rem
-    )
   | Tpat_variant (lab1, _, _) when lab1 = lab -> rem
   | Tpat_any -> rem
   | _ -> raise NoMatch
@@ -1757,7 +1753,6 @@ let make_variant_matching_constant p lab def ctx = function
 
 let matcher_variant_nonconst lab p rem =
   match p.pat_desc with
-  | Tpat_or (_, _, _) -> raise OrPat
   | Tpat_variant (lab1, Some arg, _) when lab1 = lab -> arg :: rem
   | Tpat_any -> omega :: rem
   | _ -> raise NoMatch
@@ -1839,7 +1834,6 @@ let get_arg_lazy p rem =
 
 let matcher_lazy p rem =
   match p.pat_desc with
-  | Tpat_or (_, _, _) -> raise OrPat
   | Tpat_any
   | Tpat_var _ ->
       omega :: rem
@@ -2000,7 +1994,6 @@ let get_args_tuple arity p rem =
 
 let matcher_tuple arity p rem =
   match p.pat_desc with
-  | Tpat_or (_, _, _) -> raise OrPat
   | Tpat_any
   | Tpat_var _ ->
       omegas arity @ rem
@@ -2043,7 +2036,6 @@ let get_args_record num_fields p rem =
 
 let matcher_record num_fields p rem =
   match p.pat_desc with
-  | Tpat_or (_, _, _) -> raise OrPat
   | Tpat_any
   | Tpat_var _ ->
       record_matching_line num_fields [] @ rem
@@ -2103,7 +2095,6 @@ let get_args_array p rem =
 
 let matcher_array len p rem =
   match p.pat_desc with
-  | Tpat_or (_, _, _) -> raise OrPat
   | Tpat_array args when List.length args = len -> args @ rem
   | Tpat_any -> Parmatch.omegas len @ rem
   | _ -> raise NoMatch

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -65,6 +65,8 @@ module Pattern_head : sig
   val loc : t -> Location.t
   val typ : t -> Types.type_expr
 
+  val arity : t -> int
+
   (** [deconstruct p] returns the head of [p] and the list of sub patterns.
 
       @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
@@ -145,6 +147,16 @@ end = struct
     let desc, pats = deconstruct_desc q.pat_desc in
     { desc; typ = q.pat_type; loc = q.pat_loc;
       env = q.pat_env; attributes = q.pat_attributes }, pats
+
+  let arity t =
+    match t.desc with
+      | Any -> 0
+      | Constant _ -> 0
+      | Construct c -> c.cstr_arity
+      | Tuple n | Array n -> n
+      | Record l -> List.length l
+      | Variant { has_arg; _ } -> if has_arg then 1 else 0
+      | Lazy -> 1
 
   let to_omega_pattern t =
     let pat_desc =

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -51,6 +51,8 @@ module Pattern_head : sig
   val loc : t -> Location.t
   val typ : t -> Types.type_expr
 
+  val arity : t -> int
+
   (** [deconstruct p] returns the head of [p] and the list of sub patterns.
 
       @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)


### PR DESCRIPTION
This is the next bit of the big pattern-matching refactoring change (#9321) after #9447 has been merged.

(cc @trefis @Octachron)

This patchset contains a bugfix, and a (tricky) refactoring that clarifies and simplifies the `specialize_matrix` logic by getting rid of the `OrPat` exception used in a higher-order way. Instead it uses an arity-based criterion to implement the same logic, which lets us do it once in the specializer, instead of having to implement it in each matcher. As a result, the compiler improves a bit as it will push or-patterns down during specialization in valid situations that were not implemented before. For example, `lazy p | lazy q` is turned into `lazy (p | q)` -- same non-constant polymorphic variants, etc..