### PR TITLE
x86 asm: handle unit names with special characters

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1146,7 +1146,7 @@ let end_assembly() =
     };
 
   if system = S_linux then begin
-    let frametable = Compilenv.make_symbol (Some "frametable") in
+    let frametable = emit_symbol (Compilenv.make_symbol (Some "frametable")) in
     D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
   end;
 

--- a/testsuite/tests/asmcomp/0-!@#%.compilers.reference
+++ b/testsuite/tests/asmcomp/0-!@#%.compilers.reference
@@ -1,0 +1,2 @@
+File "0-!@#%.ml", line 1:
+Warning 24: bad source file name: "0-!@#%" is not a valid module name.

--- a/testsuite/tests/asmcomp/0-!@#%.ml
+++ b/testsuite/tests/asmcomp/0-!@#%.ml
@@ -1,0 +1,10 @@
+(* TEST *)
+
+(* We could not include the following characters the file name:
+
+   - '$' : this character is interpreted specially by [ocamltest] (as it uses
+     [Buffer.add_substitute] on the filenames).
+
+   - '^' : this character causes problems under Windows if not properly
+     quoted. In particular, flexlink needed to be adapted.
+*)


### PR DESCRIPTION
Fixes #9461 