### PR TITLE
Cmm refactoring: merge `Clet` and `Clet_mut`

### DIFF
--- a/Changes
+++ b/Changes
@@ -66,7 +66,8 @@ Working version
 - #9280: Micro-optimise allocations on amd64 to save a register.
   (Stephen Dolan, review by Xavier Leroy)
 
-- #9316, #9443: Use typing information from Clambda for mutable Cmm variables.
+- #9316, #9443, #9467: Use typing information from Clambda
+  for mutable Cmm variables.
   (Stephen Dolan, review by Vincent Laviron, Guillaume Bury, Xavier Leroy,
   and Gabriel Scherer)
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -85,6 +85,12 @@ val new_label: unit -> label
 
 type rec_flag = Nonrecursive | Recursive
 
+type let_kind =
+  | Immutable
+  (** for immutable let-bindings, the type is inferred from the definition *)
+  | Mutable of machtype
+  (** mutable let-bindings need to agree on a type for all future updates *)
+
 type phantom_defining_expr =
   (* CR-soon mshinwell: Convert this to [Targetint.OCaml.t] (or whatever the
      representation of "target-width OCaml integers of type [int]"
@@ -158,9 +164,7 @@ and expression =
   | Cconst_natpointer of nativeint * Debuginfo.t
   | Cblockheader of nativeint * Debuginfo.t
   | Cvar of Backend_var.t
-  | Clet of Backend_var.With_provenance.t * expression * expression
-  | Clet_mut of Backend_var.With_provenance.t * machtype
-                * expression * expression
+  | Clet of let_kind * Backend_var.With_provenance.t * expression * expression
   | Cphantom_let of Backend_var.With_provenance.t
       * phantom_defining_expr option * expression
   (* Cassign must refer to a variable bound by Clet_mut *)

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -154,26 +154,26 @@ let rec expr ppf = function
   | Cconst_pointer (n, _dbg) -> fprintf ppf "%ia" n
   | Cconst_natpointer (n, _dbg) -> fprintf ppf "%sa" (Nativeint.to_string n)
   | Cvar id -> V.print ppf id
-  | Clet(id, def, (Clet(_, _, _) as body)) ->
+  | Clet(Immutable, id, def, (Clet(Immutable, _, _, _) as body)) ->
       let print_binding id ppf def =
         fprintf ppf "@[<2>%a@ %a@]"
           VP.print id expr def in
       let rec in_part ppf = function
-        | Clet(id, def, body) ->
+        | Clet(Immutable, id, def, body) ->
             fprintf ppf "@ %a" (print_binding id) def;
             in_part ppf body
         | exp -> exp in
       fprintf ppf "@[<2>(let@ @[<1>(%a" (print_binding id) def;
       let exp = in_part ppf body in
       fprintf ppf ")@]@ %a)@]" sequence exp
-  | Clet(id, def, body) ->
+  | Clet(Immutable, id, def, body) ->
      fprintf ppf
       "@[<2>(let@ @[<2>%a@ %a@]@ %a)@]"
       VP.print id expr def sequence body
-  | Clet_mut(id, kind, def, body) ->
+  | Clet(Mutable mty, id, def, body) ->
     fprintf ppf
       "@[<2>(let_mut@ @[<2>%a: %a@ %a@]@ %a)@]"
-      VP.print id machtype kind expr def sequence body
+      VP.print id machtype mty expr def sequence body
   | Cphantom_let(var, def, (Cphantom_let(_, _, _) as body)) ->
       let print_binding var ppf def =
         fprintf ppf "@[<2>%a@ %a@]" VP.print var

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -79,11 +79,11 @@ module Make(I:I) = struct
       Cop(Cload (Word_int, Asttypes.Mutable),
         [Cop(Cadda,[str;Cconst_int(Arch.size_int*ind, dbg)], dbg)],
         dbg) in
-    Clet(id, cell, body)
+    Clet(Immutable, id, cell, body)
 
   let mk_let_size id str body =
     let size = I.string_block_length str in
-    Clet(id, size, body)
+    Clet(Immutable, id, size, body)
 
   let mk_cmp_gen cmp_op id nat ifso ifnot =
     let dbg = Debuginfo.none in

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -24,14 +24,14 @@ let rec make_letdef def body =
     [] -> body
   | (id, def) :: rem ->
       unbind_ident id;
-      Clet(id, def, make_letdef rem body)
+      Clet(Immutable, id, def, make_letdef rem body)
 
 let rec make_letmutdef def body =
   match def with
     [] -> body
   | (id, ty, def) :: rem ->
       unbind_ident id;
-      Clet_mut(id, ty, def, make_letmutdef rem body)
+      Clet(Mutable ty, id, def, make_letmutdef rem body)
 
 let make_switch n selector caselist =
   let index = Array.make n 0 in


### PR DESCRIPTION
This refactoring was suggested by the bug #9316 fixed in #9443 -- a fragile pattern-matching handled `Clet` but not `Clet_mut` and this introduced a deoptimization.

(cc @stedolan @mshinwell)

The change is mostly automatic (and a bit noisy in places that use Clet or Clet_mut for code production, apologies).

The non-automatic parts are as follows:

- in Cmm_helpers, `remove_unit` and `low_32` had fragile pattern matching
  that looked like they should have handled Clet_mut and Cphantom_let as well;
  I extended them to do this. I made `remove_unit` non-fragile, but I left `low_32`
  fragile. (I wonder if it wouldn't be possible to improve these functions by using `map_shallow` or something on the control-flow constructs.)

- in Selectgen I refactored `bind_let` and `bind_let_mut` (in a second commit). I have a minor question for reviewers there, about a divergence between the two implementations.

I considered factoring the printing of Clet nodes in Printcmm, but ultimately decided to leave it alone (the code could be made nicer, but I don't think there is any bug or missed opportunity there, and I guess some stuff can be impacted by a change in printed output).