### PR TITLE
Better backtraces for lazy values

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,6 +127,9 @@ Working version
 
 ### Bug fixes:
 
+- #9469: Better backtraces for lazy values
+  (Leo White, review by Nicolás Ojeda Bär)
+
 - #9521, #9522: correctly fail when comparing functions
   with Closure and Infix tags.
   (Gabriel Scherer and Jeremy Yallop and Xavier Leroy,

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -679,7 +679,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
                            loc),
                      Lprim(Praise Raise_reraise, [raise_arg], loc)))
   | Lazy_force, [arg] ->
-      Matching.inline_lazy_force arg Loc_unknown
+      Matching.inline_lazy_force arg loc
   | Loc kind, [] ->
       lambda_of_loc kind loc
   | Loc kind, [arg] ->

--- a/testsuite/tests/backtrace/lazy.ml
+++ b/testsuite/tests/backtrace/lazy.ml
@@ -1,0 +1,28 @@
+(* TEST
+   flags = "-g"
+   compare_programs = "false"
+   * native
+*)
+
+
+let l1 : unit lazy_t = lazy (raise Not_found)
+
+let test1 () =
+  let () = Lazy.force l1 in ()
+
+let l2 : unit lazy_t = lazy (raise Not_found)
+
+let test2 () =
+  let (lazy ()) = l2 in ()
+
+let run test =
+  try
+    test ();
+  with exn ->
+    Printf.printf "Uncaught exception %s\n" (Printexc.to_string exn);
+    Printexc.print_backtrace stdout
+
+let () =
+  Printexc.record_backtrace true;
+  run test1;
+  run test2

--- a/testsuite/tests/backtrace/lazy.reference
+++ b/testsuite/tests/backtrace/lazy.reference
@@ -1,0 +1,11 @@
+Uncaught exception Not_found
+Raised at Lazy.l1 in file "lazy.ml", line 8, characters 28-45
+Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
+Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Called from Lazy.run in file "lazy.ml", line 20, characters 4-11
+Uncaught exception Not_found
+Raised at Lazy.l2 in file "lazy.ml", line 13, characters 28-45
+Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
+Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Called from Lazy.test2 in file "lazy.ml", line 16, characters 6-15
+Called from Lazy.run in file "lazy.ml", line 20, characters 4-11

--- a/testsuite/tests/backtrace/lazy.reference
+++ b/testsuite/tests/backtrace/lazy.reference
@@ -2,6 +2,7 @@ Uncaught exception Not_found
 Raised at Lazy.l1 in file "lazy.ml", line 8, characters 28-45
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
 Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
+Called from Lazy.test1 in file "lazy.ml", line 11, characters 11-24
 Called from Lazy.run in file "lazy.ml", line 20, characters 4-11
 Uncaught exception Not_found
 Raised at Lazy.l2 in file "lazy.ml", line 13, characters 28-45


### PR DESCRIPTION
Currently code like:
```ocaml
let l1 : unit lazy_t = lazy (raise Not_found)

let test1 () =
  let () = Lazy.force l1 in ()

let () = test1 ()
```
produces a backtrace that does not include any location in the `test1` function. Similarly,
```ocaml
let l2 : unit lazy_t = lazy (raise Not_found)

let test2 () =
  let (lazy ()) = l2 in ()

let () = test2 ()
```
produces a backtrace that does not include any location in the `test2` function.

This PR fixes that by making sure that the code generated for forcing lazy values is given the location of the call or pattern that produced it.