### PR TITLE
Some uses of Filename.quote_command for better quoting

### DIFF
--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -166,13 +166,12 @@ let check_file ?(tool = default_comparison_tool) files =
 
 let diff files =
   let temporary_file = Filename.temp_file "ocamltest" "diff" in
-  let diff_commandline = String.concat " "
-  [
-    "diff -u";
-    files.reference_filename;
-    files.output_filename;
-    "> " ^ temporary_file
-  ] in
+  let diff_commandline =
+    Filename.quote_command "diff" ~stdout:temporary_file
+      [ "-u";
+        files.reference_filename;
+        files.output_filename ]
+  in
   let result =
     if (Sys.command diff_commandline) = 2 then Stdlib.Error "diff"
     else Ok (Sys.string_of_file temporary_file)

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -155,7 +155,10 @@ let test_file test_filename =
   let test_build_directory_prefix =
     get_test_build_directory_prefix test_directory in
   let clean_test_build_directory () =
-    ignore (Sys.command ("rm -rf " ^ test_build_directory_prefix)) in
+    ignore
+      (Sys.command
+         (Filename.quote_command "rm" ["-rf"; test_build_directory_prefix]))
+  in
   clean_test_build_directory ();
   Sys.make_directory test_build_directory_prefix;
   let summary = Sys.with_chdir test_build_directory_prefix

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -102,8 +102,7 @@ module Sys = struct
 
   let mkdir dir =
     if not (Sys.file_exists dir) then
-      let quoted_dir = "\"" ^ dir ^ "\"" in
-      run_system_command ("mkdir " ^ quoted_dir)
+      run_system_command (Filename.quote_command "mkdir" [dir])
 
   let rec make_directory dir =
     if Sys.file_exists dir then ()

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -250,10 +250,10 @@ let find_dyn_offset filename =
     Fun.protect
       ~finally:(fun () -> remove_file tempfile)
       (fun () ->
-         let rc = Sys.command (sprintf "%s %s > %s"
-                                 (Filename.quote helper)
-                                 (Filename.quote filename)
-                                 tempfile) in
+         let rc =
+           Sys.command
+             (Filename.quote_command helper ~stdout:tempfile [filename])
+         in
          if rc <> 0 then failwith "cannot read";
          let tc = Scanf.Scanning.from_file tempfile in
          Fun.protect


### PR DESCRIPTION
The change in `filecompare.ml` fixes an actual bug. The rest look potentially problematic.
