### PR TITLE
Cast `getpid()` to `long long` before printing

### DIFF
--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -248,8 +248,8 @@ static int handle_process_termination(
   if (WIFEXITED(status)) return WEXITSTATUS(status);
 
   if ( !WIFSIGNALED(status) )
-    error("Process %d neither terminated normally nor received a" \
-          "signal!?", pid);
+    error("Process %lld neither terminated normally nor received a" \
+          "signal!?", (long long) pid);
 
   /* From here we know that the process terminated due to a signal */
   signal = WTERMSIG(status);
@@ -258,8 +258,8 @@ static int handle_process_termination(
 #endif /* WCOREDUMP */
   corestr = core ? "" : "no ";
   fprintf(stderr,
-    "Process %d got signal %d(%s), %score dumped\n",
-    pid, signal, strsignal(signal), corestr
+    "Process %lld got signal %d(%s), %score dumped\n",
+    (long long) pid, signal, strsignal(signal), corestr
   );
 
   if (core)
@@ -273,7 +273,7 @@ static int handle_process_termination(
         fprintf(stderr, "Out of memory while processing core file.\n");
       else {
         snprintf(corefile, corefile_len,
-          "%s.%d.core", corefilename_prefix, pid);
+          "%s.%lld.core", corefilename_prefix, (long long) pid);
         if ( rename(COREFILENAME, corefile) == -1)
           fprintf(stderr, "The core file exists but could not be renamed.\n");
         else


### PR DESCRIPTION
Follow-up to commit 41441a65f.
That commit fixed the issue in runtime/ .
The present commit fixes the issue in ocamltest/ . 
The ocamltest issue was reported in #9436 .
