### PR TITLE
don't include stdio.h in caml/misc.h

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,11 @@ Working version
   (Florian Angeletti, review by Alain Frisch, Gabriel Radanne, Gabriel Scherer
   and Leo White)
 
+* #9483: Remove accidental #inclusion of <stdio.h> in caml/misc.h
+  The only release with the inclusion of stdio.h has been 10.0
+  (Christopher Zimmermann, review by Xavier Leroy and David Allsopp)
+
+
 
 ### Runtime system:
 

--- a/Changes
+++ b/Changes
@@ -29,12 +29,6 @@ Working version
   (Florian Angeletti, review by Alain Frisch, Gabriel Radanne, Gabriel Scherer
   and Leo White)
 
-* #9483: Remove accidental #inclusion of <stdio.h> in caml/misc.h
-  The only release with the inclusion of stdio.h has been 10.0
-  (Christopher Zimmermann, review by Xavier Leroy and David Allsopp)
-
-
-
 ### Runtime system:
 
 - #9119: Make [caml_stat_resize_noexc] compatible with the [realloc]
@@ -77,6 +71,10 @@ Working version
 
 - #9426: build the Mingw ports with higher levels of GCC optimization
   (Xavier Leroy, review by Sébastien Hinderer)
+  
+* #9483: Remove accidental inclusion of <stdio.h> in <caml/misc.h>
+  The only release with the inclusion of stdio.h has been 4.10.0
+  (Christopher Zimmermann, review by Xavier Leroy and David Allsopp)
 
 ### Code generation and optimizations:
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -33,10 +33,6 @@
 
 typedef size_t asize_t;
 
-#ifndef NULL
-#define NULL 0
-#endif
-
 #if defined(__GNUC__) || defined(__clang__)
   /* Supported since at least GCC 3.1 */
   #define CAMLdeprecated_typedef(name, type) \

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -27,7 +27,6 @@
 
 #include <stddef.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdarg.h>
 
 /* Basic types and constants */

--- a/testsuite/tests/compatibility/stub.c
+++ b/testsuite/tests/compatibility/stub.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <caml/minor_gc.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>


### PR DESCRIPTION
On OpenBSD, `stderr` and `stdout` are macros defined in `stdio.h`
ppx_expect uses `stderr` and `stdout` as identifiers in
`collector/expect_test_collector_stubs.c` where `caml/misc.h` is included.
This confuses the C compiler, because the macro will get expanded where an identifier is expected.
There is no need to include `stdio.h` in `caml/misc.h`
Build error log of ppx_expect is [here](https://www.gmerlin.de/ppx_expect.txt)
This seems to have happened by accident in commit cddec18fde8