### PR TITLE
Tweak Makefile variables

### DIFF
--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -105,7 +105,6 @@ BYTECOMP_CMI=
 ARCH_SPECIFIC =\
   asmcomp/arch.ml asmcomp/proc.ml asmcomp/CSE.ml asmcomp/selection.ml \
   asmcomp/scheduling.ml asmcomp/reload.ml
-ARCH_SPECIFIC_CMI=
 
 INTEL_ASM=\
   asmcomp/x86_proc.cmo \
@@ -116,6 +115,7 @@ INTEL_ASM_CMI=\
   asmcomp/x86_ast.cmi
 
 ARCH_SPECIFIC_ASMCOMP=
+ARCH_SPECIFIC_ASMCOMP_CMI=
 ifeq ($(ARCH),i386)
 ARCH_SPECIFIC_ASMCOMP=$(INTEL_ASM)
 ARCH_SPECIFIC_ASMCOMP_CMI=$(INTEL_ASM_CMI)


### PR DESCRIPTION
Gets rid of an unneeded variable (`ARCH_SPECIFIC_CMI`) and fixes a warning about undefined variable (`ARCH_SPECIFIC_ASMCOMP_CMI`).