### PR TITLE
Switch Travis testing from Xenial to Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 #*                                                                        *
 #**************************************************************************
 
-dist: xenial
+dist: bionic
 language: c
 git:
   submodules: false
@@ -25,12 +25,7 @@ matrix:
     addons:
       apt:
         packages:
-        - gcc:i386
-        - cpp:i386
-        - binutils:i386
-        - binutils-dev:i386
-        - libx11-dev:i386
-        - libc6-dev:i386
+        - gcc-multilib
   - env: CI_KIND=build XARCH=x64
     addons:
       apt:

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -119,8 +119,9 @@ EOF
     ./configure $configure_flags
     ;;
   i386)
-    ./configure --build=x86_64-pc-linux-gnu --host=i386-pc-linux-gnu \
-      AS='as' ASPP='gcc -c' \
+    ./configure --build=x86_64-pc-linux-gnu --host=i386-linux \
+      CC='gcc -m32' AS='as --32' ASPP='gcc -m32 -c' \
+      PARTIALLD='ld -r -melf_i386' \
       $configure_flags
     ;;
   *)


### PR DESCRIPTION
I couldn't get the x86 versions of the tools to work in the same way on Bionic as they did in Xenial, so this is using multilib instead for the 32-bit test.