### PR TITLE
pattern-matching refactoring: merge the two matchers

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,8 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #9493: refactor the pattern-matching compiler
+  (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 ### Build system:
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2049,6 +2049,13 @@ let make_record_matching ~scopes head all_labels def = function
           in
           (access, str) :: make_args (pos + 1)
       in
+      (* There is some redundancy in the expansions here, [head] is
+         expanded here and again in matcher. Without the expansion
+         here there would be a risk of the arity being computed
+         incorrectly by Default_environment.specialize. It would be
+         nicer to have a type-level distinction between expanded heads
+         and non-expanded heads, to be able to reason confidently on
+         when expansions must happen. *)
       let head = expand_record_head head in
       let def = Default_environment.specialize head def in
       { cases = []; args = make_args 0; default = def }

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -485,7 +485,7 @@ module Context : sig
 
   val eprintf : t -> unit
 
-  val specialize : pattern -> t -> t
+  val specialize : Pattern_head.t -> t -> t
 
   val lshift : t -> t
 
@@ -564,8 +564,7 @@ end = struct
 
   let combine ctx = List.map Row.combine ctx
 
-  let specialize q ctx =
-    let qh = fst (Pattern_head.deconstruct q) in
+  let specialize head ctx =
     let non_empty = function
       | { Row.left = _; right = [] } ->
           fatal_error "Matching.Context.specialize"
@@ -583,9 +582,12 @@ end = struct
           | `Var _ -> filter_rec ((left, omega, right) :: rem)
           | #simple_view as view -> (
               let p = { p with pat_desc = view } in
-              match matcher qh p right with
+              match matcher head p right with
               | exception NoMatch -> filter_rec rem
-              | right -> { Row.left = q :: left; right } :: filter_rec rem
+              | right ->
+                  let left = Pattern_head.to_omega_pattern head :: left in
+                  { Row.left; right }
+                  :: filter_rec rem
             )
         )
     in
@@ -1137,9 +1139,10 @@ let pm_free_variables { cases } =
     cases Ident.Set.empty
 
 (* Basic grouping predicates *)
-let pat_as_constr = function
-  | { pat_desc = Tpat_construct (_, cstr, _) } -> cstr
-  | _ -> fatal_error "Matching.pat_as_constr"
+let head_as_constr head =
+  match Pattern_head.desc head with
+  | Construct cstr -> cstr
+  | _ -> fatal_error "Matching.head_as_constr"
 
 let can_group discr pat =
   match (Pattern_head.desc discr, Pattern_head.desc (Simple.head pat)) with
@@ -1613,7 +1616,7 @@ let split_and_precompile ~arg_id ~arg_lambda pm =
 type cell = {
   pm : initial_clause pattern_matching;
   ctx : Context.t;
-  discr : pattern
+  discr : Pattern_head.t
 }
 (** a submatrix after specializing by discriminant pattern;
     [ctx] is the context shared by all rows. *)
@@ -1639,8 +1642,9 @@ let add_in_div make_matching_fun eq_key key patl_action division =
 let divide make eq_key get_key get_args ctx
     (pm : Simple.clause pattern_matching) =
   let add ((p, patl), action) division =
+    let ph = Simple.head p in
     let p = General.erase p in
-    add_in_div (make p pm.default ctx) eq_key (get_key p)
+    add_in_div (make ph pm.default ctx) eq_key (get_key p)
       (get_args p patl, action)
       division
   in
@@ -1679,17 +1683,12 @@ let get_key_constant caller = function
 
 let get_args_constant _ rem = rem
 
-let matcher_of_pattern p = fst (Pattern_head.deconstruct p)
-
-let make_constant_matching p def ctx = function
+let make_constant_matching head def ctx = function
   | [] -> fatal_error "Matching.make_constant_matching"
   | _ :: argl ->
-      let def = Default_environment.specialize (matcher_of_pattern p) def
-      and ctx = Context.specialize p ctx in
-      { pm = { cases = []; args = argl; default = def };
-        ctx;
-        discr = normalize_pat p
-      }
+      let def = Default_environment.specialize head def
+      and ctx = Context.specialize head ctx in
+      { pm = { cases = []; args = argl; default = def }; ctx; discr = head }
 
 let divide_constant ctx m =
   divide make_constant_matching
@@ -1717,10 +1716,11 @@ let get_args_constr p rem =
   | { pat_desc = Tpat_construct (_, _, args) } -> args @ rem
   | _ -> assert false
 
-let make_constr_matching ~scopes p def ctx = function
+let make_constr_matching ~scopes head def ctx = function
   | [] -> fatal_error "Matching.make_constr_matching"
   | (arg, _mut) :: argl ->
-      let cstr = pat_as_constr p in
+      let cstr = head_as_constr head in
+      let loc = of_location ~scopes (Pattern_head.loc head) in
       let newargs =
         if cstr.cstr_inlined <> None then
           (arg, Alias) :: argl
@@ -1728,20 +1728,18 @@ let make_constr_matching ~scopes p def ctx = function
           match cstr.cstr_tag with
           | Cstr_constant _
           | Cstr_block _ ->
-              make_field_args (of_location ~scopes p.pat_loc)
-                Alias arg 0 (cstr.cstr_arity - 1) argl
+              make_field_args loc Alias arg 0 (cstr.cstr_arity - 1) argl
           | Cstr_unboxed -> (arg, Alias) :: argl
           | Cstr_extension _ ->
-              make_field_args (of_location ~scopes p.pat_loc)
-                Alias arg 1 cstr.cstr_arity argl
+              make_field_args loc Alias arg 1 cstr.cstr_arity argl
       in
       { pm =
           { cases = [];
             args = newargs;
-            default = Default_environment.specialize (matcher_of_pattern p) def
+            default = Default_environment.specialize head def
           };
-        ctx = Context.specialize p ctx;
-        discr = normalize_pat p
+        ctx = Context.specialize head ctx;
+        discr = head
       }
 
 let divide_constructor ~scopes ctx pm =
@@ -1750,30 +1748,26 @@ let divide_constructor ~scopes ctx pm =
 
 (* Matching against a variant *)
 
-let make_variant_matching_constant p def ctx = function
+let make_variant_matching_constant head def ctx = function
   | [] -> fatal_error "Matching.make_variant_matching_constant"
   | _ :: argl ->
-      let def = Default_environment.specialize (matcher_of_pattern p) def
-      and ctx = Context.specialize p ctx in
-      { pm = { cases = []; args = argl; default = def };
-        ctx;
-        discr = normalize_pat p
-      }
+      let def = Default_environment.specialize head def
+      and ctx = Context.specialize head ctx in
+      { pm = { cases = []; args = argl; default = def }; ctx; discr = head }
 
-let make_variant_matching_nonconst ~scopes p def ctx = function
+let make_variant_matching_nonconst ~scopes head def ctx = function
   | [] -> fatal_error "Matching.make_variant_matching_nonconst"
   | (arg, _mut) :: argl ->
-      let def = Default_environment.specialize (matcher_of_pattern p) def
-      and ctx = Context.specialize p ctx
-      and loc = of_location ~scopes p.pat_loc in
+      let def = Default_environment.specialize head def
+      and loc = of_location ~scopes (Pattern_head.loc head)
+      and ctx = Context.specialize head ctx in
       { pm =
           { cases = [];
-            args = (Lprim (Pfield 1, [ arg ], loc), Alias)
-                   :: argl;
+            args = (Lprim (Pfield 1, [ arg ], loc), Alias) :: argl;
             default = def
           };
         ctx;
-        discr = normalize_pat p
+        discr = head
       }
 
 let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
@@ -1786,7 +1780,7 @@ let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
           | `Variant (lab, pato, _) -> lab, pato
           | _ -> assert false
         in
-        let p = General.erase p in
+        let head = Simple.head p in
         let variants = divide rem in
         if
           try Btype.row_field_repr (List.assoc lab row.row_fields) = Rabsent
@@ -1798,11 +1792,11 @@ let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
           match pato with
           | None ->
               add_in_div
-                (make_variant_matching_constant p def ctx)
+                (make_variant_matching_constant head def ctx)
                 ( = ) (Cstr_constant tag) (patl, action) variants
           | Some pat ->
               add_in_div
-                (make_variant_matching_nonconst ~scopes p def ctx)
+                (make_variant_matching_nonconst ~scopes head def ctx)
                 ( = ) (Cstr_block tag)
                 (pat :: patl, action)
                 variants
@@ -1826,7 +1820,8 @@ let make_var_matching def = function
       }
 
 let divide_var ctx pm =
-  divide_line Context.lshift make_var_matching get_args_var omega ctx pm
+  divide_line Context.lshift make_var_matching get_args_var Pattern_head.omega
+    ctx pm
 
 (* Matching and forcing a lazy value *)
 
@@ -1969,12 +1964,12 @@ let inline_lazy_force arg loc =
          tables (~ 250 elts); conditionals are better *)
     inline_lazy_force_cond arg loc
 
-let make_lazy_matching p def = function
+let make_lazy_matching head def = function
   | [] -> fatal_error "Matching.make_lazy_matching"
   | (arg, _mut) :: argl ->
       { cases = [];
         args = (inline_lazy_force arg Loc_unknown, Strict) :: argl;
-        default = Default_environment.specialize (matcher_of_pattern p) def
+        default = Default_environment.specialize head def
       }
 
 let divide_lazy p ctx pm =
@@ -1989,9 +1984,11 @@ let get_args_tuple arity p rem =
   | { pat_desc = Tpat_tuple args } -> args @ rem
   | _ -> assert false
 
-let make_tuple_matching p loc arity def = function
+let make_tuple_matching ~scopes head def = function
   | [] -> fatal_error "Matching.make_tuple_matching"
   | (arg, _mut) :: argl ->
+      let loc = of_location ~scopes (Pattern_head.loc head) in
+      let arity = Pattern_head.arity head in
       let rec make_args pos =
         if pos >= arity then
           argl
@@ -2000,13 +1997,13 @@ let make_tuple_matching p loc arity def = function
       in
       { cases = [];
         args = make_args 0;
-        default = Default_environment.specialize (matcher_of_pattern p) def
+        default = Default_environment.specialize head def
       }
 
-let divide_tuple ~scopes arity p ctx pm =
-  divide_line (Context.specialize p)
-    (make_tuple_matching p (of_location ~scopes p.pat_loc) arity)
-    (get_args_tuple arity) p ctx pm
+let divide_tuple ~scopes head ctx pm =
+  let arity = Pattern_head.arity head in
+  divide_line (Context.specialize head) (make_tuple_matching ~scopes head)
+    (get_args_tuple arity) head ctx pm
 
 (* Matching against a record pattern *)
 
@@ -2022,9 +2019,10 @@ let get_args_record num_fields p rem =
       record_matching_line num_fields lbl_pat_list @ rem
   | _ -> assert false
 
-let make_record_matching p loc all_labels def = function
+let make_record_matching ~scopes head all_labels def = function
   | [] -> fatal_error "Matching.make_record_matching"
   | (arg, _mut) :: argl ->
+      let loc = of_location ~scopes (Pattern_head.loc head) in
       let rec make_args pos =
         if pos >= Array.length all_labels then
           argl
@@ -2047,15 +2045,15 @@ let make_record_matching p loc all_labels def = function
           in
           (access, str) :: make_args (pos + 1)
       in
-      let p = expand_record p in
-      let def = Default_environment.specialize (matcher_of_pattern p) def in
+      let head = expand_record_head head in
+      let def = Default_environment.specialize head def in
       { cases = []; args = make_args 0; default = def }
 
-let divide_record ~scopes all_labels p ctx pm =
+let divide_record ~scopes all_labels head ctx pm =
   let get_args = get_args_record (Array.length all_labels) in
-  divide_line (Context.specialize p)
-    (make_record_matching p (of_location ~scopes p.pat_loc) all_labels)
-    get_args p ctx pm
+  divide_line (Context.specialize head)
+    (make_record_matching ~scopes head all_labels)
+    get_args head ctx pm
 
 (* Matching against an array pattern *)
 
@@ -2068,10 +2066,15 @@ let get_args_array p rem =
   | { pat_desc = Tpat_array patl } -> patl @ rem
   | _ -> assert false
 
-let make_array_matching ~scopes kind p def ctx = function
+let make_array_matching ~scopes kind head def ctx = function
   | [] -> fatal_error "Matching.make_array_matching"
   | (arg, _mut) :: argl ->
-      let len = get_key_array p in
+      let len =
+        match Pattern_head.desc head with
+        | Array len -> len
+        | _ -> assert false
+      in
+      let loc = of_location ~scopes (Pattern_head.loc head) in
       let rec make_args pos =
         if pos >= len then
           argl
@@ -2079,15 +2082,15 @@ let make_array_matching ~scopes kind p def ctx = function
           ( Lprim
               ( Parrayrefu kind,
                 [ arg; Lconst (Const_base (Const_int pos)) ],
-                (of_location ~scopes p.pat_loc) ),
+                loc ),
             StrictOpt )
           :: make_args (pos + 1)
       in
-      let def = Default_environment.specialize (matcher_of_pattern p) def
-      and ctx = Context.specialize p ctx in
+      let def = Default_environment.specialize head def
+      and ctx = Context.specialize head ctx in
       { pm = { cases = []; args = make_args 0; default = def };
         ctx;
-        discr = normalize_pat p
+        discr = head
       }
 
 let divide_array ~scopes kind ctx pm =
@@ -2972,7 +2975,9 @@ let compile_list compile_fun division =
             let c_rem, total, new_discrs =
               c_rec (Jumps.map Context.combine total1 :: totals) rem
             in
-            ((key, lambda1) :: c_rem, total, cell.discr :: new_discrs)
+            ( (key, lambda1) :: c_rem,
+              total,
+              Pattern_head.to_omega_pattern cell.discr :: new_discrs )
           with Unused -> c_rec totals rem
       )
   in
@@ -3223,14 +3228,14 @@ and do_compile_matching ~scopes repr partial ctx pmh =
       let ploc = Pattern_head.loc ph in
       match Pattern_head.desc ph with
       | Any ->
-         compile_no_test ~scopes divide_var Context.rshift repr partial ctx pm
-      | Tuple l ->
-          compile_no_test ~scopes (divide_tuple ~scopes l pomega)
+          compile_no_test ~scopes divide_var Context.rshift repr partial ctx pm
+      | Tuple _ ->
+          compile_no_test ~scopes (divide_tuple ~scopes ph)
             Context.combine repr partial ctx pm
       | Record [] -> assert false
       | Record (lbl :: _) ->
           compile_no_test ~scopes
-            (divide_record ~scopes lbl.lbl_all pomega)
+            (divide_record ~scopes lbl.lbl_all ph)
             Context.combine repr partial ctx pm
       | Constant cst ->
           compile_test
@@ -3254,7 +3259,7 @@ and do_compile_matching ~scopes repr partial ctx pmh =
             ctx pm
       | Lazy ->
           compile_no_test ~scopes
-            (divide_lazy pomega)
+            (divide_lazy ph)
             Context.combine repr partial ctx pm
       | Variant { cstr_row = row } ->
           compile_test

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -639,7 +639,8 @@ module Default_environment : sig
 
   val cons : matrix -> int -> t -> t
 
-  val specialize : int -> (pattern -> pattern list -> pattern list) -> t -> t
+  val specialize :
+    int -> (Simple.pattern -> pattern list -> pattern list) -> t -> t
 
   val pop_column : t -> t
 
@@ -667,12 +668,15 @@ end = struct
 
   let specialize_matrix arity matcher pss =
     let rec filter_rec = function
+      | [] -> []
       | (p :: ps) :: rem -> (
+          let p = General.view p in
           match p.pat_desc with
-          | Tpat_alias (p, _, _) -> filter_rec ((p :: ps) :: rem)
-          | Tpat_var _ -> filter_rec ((omega :: ps) :: rem)
-          | Tpat_or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
-          | _ -> (
+          | `Alias (p, _, _) -> filter_rec ((p :: ps) :: rem)
+          | `Var _ -> filter_rec ((omega :: ps) :: rem)
+          | `Or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
+          | #simple_view as view -> (
+              let p = { p with pat_desc = view } in
               match matcher p ps with
               | exception NoMatch -> filter_rec rem
               | specialized ->
@@ -680,7 +684,6 @@ end = struct
                   specialized :: filter_rec rem
             )
         )
-      | [] -> []
       | _ ->
           pretty_matrix Format.err_formatter pss;
           fatal_error "Matching.Default_environment.specialize_matrix"
@@ -767,7 +770,7 @@ end = struct
 
   let pop_compat p def =
     let compat_matcher q rem =
-      if may_compat p q then
+      if may_compat p (General.erase q) then
         rem
       else
         raise NoMatch
@@ -1637,8 +1640,8 @@ let divide_line make_ctx make get_args discr ctx
 
 let matcher_const cst p rem =
   match p.pat_desc with
-  | Tpat_constant c1 when const_compare c1 cst = 0 -> rem
-  | Tpat_any -> rem
+  | `Constant c1 when const_compare c1 cst = 0 -> rem
+  | `Any -> rem
   | _ -> raise NoMatch
 
 let get_key_constant caller = function
@@ -1698,9 +1701,9 @@ let get_args_constr p rem =
 
 let matcher_constr cstr q rem =
   match q.pat_desc with
-  | Tpat_construct (_, cstr', args) when Types.may_equal_constr cstr cstr' ->
+  | `Construct (_, cstr', args) when Types.may_equal_constr cstr cstr' ->
       args @ rem
-  | Tpat_any -> Parmatch.omegas cstr.cstr_arity @ rem
+  | `Any -> Parmatch.omegas cstr.cstr_arity @ rem
   | _ -> raise NoMatch
 
 let make_constr_matching ~scopes p def ctx = function
@@ -1740,8 +1743,8 @@ let divide_constructor ~scopes ctx pm =
 
 let matcher_variant_const lab p rem =
   match p.pat_desc with
-  | Tpat_variant (lab1, _, _) when lab1 = lab -> rem
-  | Tpat_any -> rem
+  | `Variant (lab1, _, _) when lab1 = lab -> rem
+  | `Any -> rem
   | _ -> raise NoMatch
 
 let make_variant_matching_constant p lab def ctx = function
@@ -1757,8 +1760,8 @@ let make_variant_matching_constant p lab def ctx = function
 
 let matcher_variant_nonconst lab p rem =
   match p.pat_desc with
-  | Tpat_variant (lab1, Some arg, _) when lab1 = lab -> arg :: rem
-  | Tpat_any -> omega :: rem
+  | `Variant (lab1, Some arg, _) when lab1 = lab -> arg :: rem
+  | `Any -> omega :: rem
   | _ -> raise NoMatch
 
 let make_variant_matching_nonconst ~scopes p lab def ctx = function
@@ -1840,10 +1843,8 @@ let get_arg_lazy p rem =
 
 let matcher_lazy p rem =
   match p.pat_desc with
-  | Tpat_any
-  | Tpat_var _ ->
-      omega :: rem
-  | Tpat_lazy arg -> arg :: rem
+  | `Any -> omega :: rem
+  | `Lazy arg -> arg :: rem
   | _ -> raise NoMatch
 
 (* Inlining the tag tests before calling the primitive that works on
@@ -2000,10 +2001,8 @@ let get_args_tuple arity p rem =
 
 let matcher_tuple arity p rem =
   match p.pat_desc with
-  | Tpat_any
-  | Tpat_var _ ->
-      omegas arity @ rem
-  | Tpat_tuple args when List.length args = arity -> args @ rem
+  | `Any -> omegas arity @ rem
+  | `Tuple args when List.length args = arity -> args @ rem
   | _ -> raise NoMatch
 
 let make_tuple_matching loc arity def = function
@@ -2042,11 +2041,9 @@ let get_args_record num_fields p rem =
 
 let matcher_record num_fields p rem =
   match p.pat_desc with
-  | Tpat_any
-  | Tpat_var _ ->
-      record_matching_line num_fields [] @ rem
-  | Tpat_record ([], _) when num_fields = 0 -> rem
-  | Tpat_record (((_, lbl, _) :: _ as lbl_pat_list), _)
+  | `Any -> record_matching_line num_fields [] @ rem
+  | `Record ([], _) when num_fields = 0 -> rem
+  | `Record (((_, lbl, _) :: _ as lbl_pat_list), _)
     when Array.length lbl.lbl_all = num_fields ->
       record_matching_line num_fields lbl_pat_list @ rem
   | _ -> raise NoMatch
@@ -2101,8 +2098,8 @@ let get_args_array p rem =
 
 let matcher_array len p rem =
   match p.pat_desc with
-  | Tpat_array args when List.length args = len -> args @ rem
-  | Tpat_any -> Parmatch.omegas len @ rem
+  | `Array args when List.length args = len -> args @ rem
+  | `Any -> Parmatch.omegas len @ rem
   | _ -> raise NoMatch
 
 let make_array_matching ~scopes kind p def ctx = function

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -198,13 +198,6 @@ end = struct
     }
 end
 
-(*
-  Normalize a pattern ->
-   all arguments are omega (simple pattern) and no more variables
-*)
-
-let normalize_pat p = Pattern_head.(to_omega_pattern @@ fst @@ deconstruct p)
-
 (*******************)
 (* Coherence check *)
 (*******************)

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -72,10 +72,6 @@ module Pattern_head : sig
 
 end
 
-val normalize_pat : pattern -> pattern
-(** Keep only the "head" of a pattern: all arguments are replaced by [omega], so
-    are variables. *)
-
 val const_compare : constant -> constant -> int
 (** [const_compare c1 c2] compares the actual values represented by [c1] and
     [c2], while simply using [Stdlib.compare] would compare the


### PR DESCRIPTION
This is the next bit of the big pattern-matching refactoring change (#9321) after #9464  has been merged.

(cc @trefis @Octachron)

It is a series of refactoring with two highlights:
- In the compilation part, we move from a series of `matcher_*` functions to a single `matcher` on a head. This is similar in spirit to the move from the `group_*` functions to a single `can_group` function on a head in acd44f90afd8dd9e0c2fa9313ea26460c55e241b ( #9417 ).
- We merge the resulting matcher function (for compilation) with the `ctx_matcher` function from Context (for optimization), which deduplicates the matching logic. 

As previously, this is best reviewed commit-by-commit.