### PR TITLE
Link std_exit.cmo into binaries compiled with -output-complete-exe

### DIFF
--- a/Changes
+++ b/Changes
@@ -448,6 +448,11 @@ OCaml 4.10 maintenance branch
 - #9165: Add missing -function-sections and -O3 flags in Makefiles.
   (Greta Yorsh, review by David Allsopp)
 
+- #9495: fix a bug where bytecode binaries compiled with `-output-complete-exe`
+  would not execute `at_exit` hooks at program termination (in particular,
+  output channels would not be flushed).
+  (Nicolás Ojeda Bär, review by David Allsopp)
+
 OCaml 4.10.0 (21 February 2020)
 -------------------------------
 

--- a/testsuite/tests/output-complete-obj/puts.c
+++ b/testsuite/tests/output-complete-obj/puts.c
@@ -4,5 +4,6 @@
 value caml_puts(value s)
 {
   puts(String_val(s));
+  fflush(stdout);
   return Val_unit;
 }

--- a/testsuite/tests/output-complete-obj/test2.ml
+++ b/testsuite/tests/output-complete-obj/test2.ml
@@ -16,6 +16,8 @@ program = "./test2"
 
 external puts: string -> unit = "caml_puts"
 
+let _ = at_exit (fun () -> print_endline "Program terminated")
+
 let () =
   Unix.putenv "FOO" "Hello OCaml!";
   puts (Unix.getenv "FOO")

--- a/testsuite/tests/output-complete-obj/test2.reference
+++ b/testsuite/tests/output-complete-obj/test2.reference
@@ -1,1 +1,2 @@
 Hello OCaml!
+Program terminated


### PR DESCRIPTION
What it says. This brings in line the finalization logic for normal bytecode binaries and those compiled with `-output-complete-exe`.

This is a bug fix and should be included in 4.11.