### PR TITLE
configure: move -fexcess-precision=standard to the internal cflags

### DIFF
--- a/configure
+++ b/configure
@@ -12497,10 +12497,10 @@ case $host in #(
   gcc-[01234]-*) :
     as_fn_error $? "This version of Mingw GCC is too old. Please use GCC version 5 or above." "$LINENO" 5 ;; #(
   gcc-*) :
-    internal_cflags="-Wno-unused $gcc_warnings"
+    internal_cflags="-Wno-unused $gcc_warnings \
+-fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv \
--fexcess-precision=standard -mms-bitfields"
+        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
         internal_cppflags='-DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
@@ -12532,12 +12532,12 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       internal_cflags="$gcc_warnings" ;; #(
   gcc-4-*) :
     common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
--fno-builtin-memcmp -fexcess-precision=standard";
-      internal_cflags="$gcc_warnings" ;; #(
+-fno-builtin-memcmp";
+      internal_cflags="$gcc_warnings -fexcess-precision=standard" ;; #(
   gcc-*) :
-    common_cflags="-O2 -fno-strict-aliasing -fwrapv \
--fexcess-precision=standard";
-      internal_cflags="$gcc_warnings -fno-common" ;; #(
+    common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+      internal_cflags="$gcc_warnings -fno-common \
+-fexcess-precision=standard" ;; #(
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"

--- a/configure.ac
+++ b/configure.ac
@@ -555,10 +555,10 @@ AS_CASE([$host],
         [AC_MSG_ERROR(m4_normalize([This version of Mingw GCC is too old.
           Please use GCC version 5 or above.]))],
       [gcc-*],
-        [internal_cflags="-Wno-unused $gcc_warnings"
+        [internal_cflags="-Wno-unused $gcc_warnings \
+-fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
-        common_cflags="-O2 -fno-strict-aliasing -fwrapv \
--fexcess-precision=standard -mms-bitfields"
+        common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
         internal_cppflags='-DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
@@ -587,12 +587,12 @@ AS_CASE([$host],
       internal_cflags="$gcc_warnings"],
     [gcc-4-*],
       [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
--fno-builtin-memcmp -fexcess-precision=standard";
-      internal_cflags="$gcc_warnings"],
+-fno-builtin-memcmp";
+      internal_cflags="$gcc_warnings -fexcess-precision=standard"],
     [gcc-*],
-      [common_cflags="-O2 -fno-strict-aliasing -fwrapv \
--fexcess-precision=standard";
-      internal_cflags="$gcc_warnings -fno-common"],
+      [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
+      internal_cflags="$gcc_warnings -fno-common \
+-fexcess-precision=standard"],
     [msvc-*],
       [common_cflags="-nologo -O2 -Gy- -MD"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"


### PR DESCRIPTION
Follow-up to  issue #7917 and PR  #9426.

The GCC option `-fexcess=precision` is supported for C but not for C++.

Some users use `ocamlc -c` or `ocamlopt -c` to compile C++ source files, causing errors since `-fexcess-precision=standard` was added to the common C flags in commit c5afa9303.

This commit moves `-fexcess-precision=standard` to the internal C flags, so that `ocamlc -c` and `ocamlopt -c` will not apply it to C / C++ source files.