### PR TITLE
parmatch: cut the list of valid exhaustivity witnesses

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,10 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #9498, #9499: make the fragile-pattern check more robust
+  to or-pattern explosion
+  (Gabriel Scherer, review by ???, report by Alex Fedoseev through Hongbo Zhang)
+
 
 ### Build system:
 

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -14,7 +14,7 @@ Lines 1-3, characters 8-23:
 3 |   | Some _, Some _ -> 2..
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-((Some _, None)|(None, Some _))
+(Some _, None)
 val f : 'a option * 'b option -> int = <fun>
 |}]
 
@@ -149,7 +149,7 @@ Line 1, characters 8-47:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-({left=Box 0; right=Box 0}|{left=Box 1; right=Box _})
+{left=Box 0; right=Box 0}
 val f : int box pair -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-warnings/fragile_matching.ml
+++ b/testsuite/tests/typing-warnings/fragile_matching.ml
@@ -1,0 +1,108 @@
+(* TEST *)
+
+(* Tests for stack-overflow crashes caused by a combinatorial
+   explosition in fragile pattern checking. *)
+
+[@@@warning "+4"]
+
+module SyntheticTest = struct
+  (* from Luc Maranget *)
+  type t = A | B
+
+  let f = function
+    | A,A,A,A,A, A,A,A,A,A, A,A,A,A,A, A,A,A -> 1
+    | (A|B),(A|B),(A|B),(A|B),(A|B),
+      (A|B),(A|B),(A|B),(A|B),(A|B),
+      (A|B),(A|B),(A|B),(A|B),(A|B),
+      (A|B),(A|B),(A|B) ->  2
+end
+
+module RealCodeTest = struct
+  (* from Alex Fedoseev *)
+
+  type visibility = Shown | Hidden
+
+  type ('outputValue, 'message) fieldStatus =
+  | Pristine
+  | Dirty of ('outputValue, 'message) result * visibility
+
+  type message = string
+
+  type fieldsStatuses = {
+    iaasStorageConfigurations :
+      iaasStorageConfigurationFieldsStatuses array;
+  }
+
+  and iaasStorageConfigurationFieldsStatuses = {
+    startDate : (int, message) fieldStatus;
+    term : (int, message) fieldStatus;
+    rawStorageCapacity : (int, message) fieldStatus;
+    diskType : (string option, message) fieldStatus;
+    connectivityMethod : (string option, message) fieldStatus;
+    getRequest : (int option, message) fieldStatus;
+    getRequestUnit : (string option, message) fieldStatus;
+    putRequest : (int option, message) fieldStatus;
+    putRequestUnit : (string option, message) fieldStatus;
+    transferOut : (int option, message) fieldStatus;
+    transferOutUnit : (string option, message) fieldStatus;
+    region : (string option, message) fieldStatus;
+    cloudType : (string option, message) fieldStatus;
+    description : (string option, message) fieldStatus;
+    features : (string array, message) fieldStatus;
+    accessTypes : (string array, message) fieldStatus;
+    certifications : (string array, message) fieldStatus;
+    additionalRequirements : (string option, message) fieldStatus;
+  }
+
+  type interface = { dirty : unit -> bool }
+
+  let useForm () = {
+    dirty = fun () ->
+      Array.for_all
+        (fun item ->
+          match item with
+          | {
+              additionalRequirements = Pristine;
+              certifications = Pristine;
+              accessTypes = Pristine;
+              features = Pristine;
+              description = Pristine;
+              cloudType = Pristine;
+              region = Pristine;
+              transferOutUnit = Pristine;
+              transferOut = Pristine;
+              putRequestUnit = Pristine;
+              putRequest = Pristine;
+              getRequestUnit = Pristine;
+              getRequest = Pristine;
+              connectivityMethod = Pristine;
+              diskType = Pristine;
+              rawStorageCapacity = Pristine;
+              term = Pristine;
+              startDate = Pristine;
+            } ->
+            false
+          | {
+              additionalRequirements = Pristine | Dirty (_, _);
+              certifications = Pristine | Dirty (_, _);
+              accessTypes = Pristine | Dirty (_, _);
+              features = Pristine | Dirty (_, _);
+              description = Pristine | Dirty (_, _);
+              cloudType = Pristine | Dirty (_, _);
+              region = Pristine | Dirty (_, _);
+              transferOutUnit = Pristine | Dirty (_, _);
+              transferOut = Pristine | Dirty (_, _);
+              putRequestUnit = Pristine | Dirty (_, _);
+              putRequest = Pristine | Dirty (_, _);
+              getRequestUnit = Pristine | Dirty (_, _);
+              getRequest = Pristine | Dirty (_, _);
+              connectivityMethod = Pristine | Dirty (_, _);
+              diskType = Pristine | Dirty (_, _);
+              rawStorageCapacity = Pristine | Dirty (_, _);
+              term = Pristine | Dirty (_, _);
+              startDate = Pristine | Dirty (_, _);
+            } ->
+            true)
+        [||]
+  }
+end


### PR DESCRIPTION
This PR is on top of #9499. It cuts the list of valid exhaustivity counter-examples to some bound to avoid blowup in exhaustivity or fragility checking time.

(cc @maranget @trefis)

I previously believed that implementing this would require changing the interface of `Typecore.partial_pred`, but in fact this is very simple, we just have to `filter_map` the predicate on the sequence of witnesses and keep the valid ones.

This is a Draft PR and I am not sure that we want it. Some upsides and downsides:

- It does speedup type-checking a lot in some pathological scenarios, such as the non-exhaustive match example that Luc used in https://github.com/ocaml/ocaml/pull/9499#issuecomment-619566679 . For example with N=15, trunk ocamlc.opt takes 4.2s and then Stack Overflows, the ocamlc.opt from #9499 takes 6s to return the result, and this PR's ocamlc.opt takes 0.1s.

- But I can still observe exponential behavior with the current patch (only you need larger N for programs to become slow). The problem is that `exhaust` is still strict, it is only generating a lazy list of witnesses, and its own traversal of the problem space remain exponential. Unless we decide to also change this, we are only enlarging the "feasible space" for pathological programs, and this may be silly if we don't have evidence that real-world user programs are currently blowing up and wouldn't with the change. (One problem is that exhaustiveness blows up in this way on non-exhaustive programs, which users typically don't keep in their code, they notice the issue and they fix it; so they may have encountered bad behaviors on intermediate non-exhaustive version of their code, and fixed it without telling us.)

- When printing an exhaustivity warning, there are some "sub-warnings" that are displayed based on some criterion on the counter-examples (is one of them matched by a guard clause, is one of them using an extensible variant). With the current version of the patch, those criterion are only checked on the cut list, not the whole list; this means that there may be false-negative scenarios where the sub-warnings are not shown while they should have. On the other hand, forcing the whole list to check those criterion defeats the purpose of the "optimization" (which is to be more robust to pathogological cases). I am not completely sure what is more important here, (relative) completeness of the sub-warnings or resilience to pathological inputs.