### PR TITLE
Use different symbol names for caml_do_local_roots on bytecode and native

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,6 +48,9 @@ Working version
   (Nicolás Ojeda Bär, review by Stephen Dolan, Gabriel Scherer, Mark Shinwell,
   and Xavier Leroy)
 
+- #8807, #9503: Use different symbols for do_local_roots on bytecode and native
+  (Stephen Dolan, review by David Allsopp and Xavier Leroy)
+
 - #9619: Change representation of function closures so that code pointers
   can be easily distinguished from environment variables
   (Xavier Leroy, review by Mark Shinwell and Damien Doligez)

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -29,12 +29,15 @@ intnat caml_darken_all_roots_slice (intnat);
 void caml_do_roots (scanning_action, int);
 extern uintnat caml_incremental_roots_count;
 #ifndef NATIVE_CODE
-CAMLextern void caml_do_local_roots (scanning_action, value *, value *,
-                                     struct caml__roots_block *);
+CAMLextern void caml_do_local_roots_byt (scanning_action, value *, value *,
+                                         struct caml__roots_block *);
+#define caml_do_local_roots caml_do_local_roots_byt
 #else
-CAMLextern void caml_do_local_roots(scanning_action f, char * c_bottom_of_stack,
-                                    uintnat last_retaddr, value * v_gc_regs,
-                                    struct caml__roots_block * gc_local_roots);
+CAMLextern void caml_do_local_roots_nat (
+                     scanning_action f, char * c_bottom_of_stack,
+                     uintnat last_retaddr, value * v_gc_regs,
+                     struct caml__roots_block * gc_local_roots);
+#define caml_do_local_roots caml_do_local_roots_nat
 #endif
 
 CAMLextern void (*caml_scan_roots_hook) (scanning_action);

--- a/runtime/roots_byt.c
+++ b/runtime/roots_byt.c
@@ -92,8 +92,8 @@ void caml_do_roots (scanning_action f, int do_globals)
   CAML_EV_END(EV_MAJOR_ROOTS_GLOBAL);
   /* The stack and the local C roots */
   CAML_EV_BEGIN(EV_MAJOR_ROOTS_LOCAL);
-  caml_do_local_roots(f, Caml_state->extern_sp, Caml_state->stack_high,
-                      Caml_state->local_roots);
+  caml_do_local_roots_byt(f, Caml_state->extern_sp, Caml_state->stack_high,
+                          Caml_state->local_roots);
   CAML_EV_END(EV_MAJOR_ROOTS_LOCAL);
   /* Global C roots */
   CAML_EV_BEGIN(EV_MAJOR_ROOTS_C);
@@ -113,9 +113,9 @@ void caml_do_roots (scanning_action f, int do_globals)
   CAML_EV_END(EV_MAJOR_ROOTS_HOOK);
 }
 
-CAMLexport void caml_do_local_roots (scanning_action f, value *stack_low,
-                                     value *stack_high,
-                                     struct caml__roots_block *local_roots)
+CAMLexport void caml_do_local_roots_byt (scanning_action f, value *stack_low,
+                                         value *stack_high,
+                                         struct caml__roots_block *local_roots)
 {
   register value * sp;
   struct caml__roots_block *lr;

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -423,9 +423,9 @@ void caml_do_roots (scanning_action f, int do_globals)
   CAML_EV_END(EV_MAJOR_ROOTS_DYNAMIC_GLOBAL);
   /* The stack and local roots */
   CAML_EV_BEGIN(EV_MAJOR_ROOTS_LOCAL);
-  caml_do_local_roots(f, Caml_state->bottom_of_stack,
-                      Caml_state->last_return_address, Caml_state->gc_regs,
-                      Caml_state->local_roots);
+  caml_do_local_roots_nat(f, Caml_state->bottom_of_stack,
+                          Caml_state->last_return_address, Caml_state->gc_regs,
+                          Caml_state->local_roots);
   CAML_EV_END(EV_MAJOR_ROOTS_LOCAL);
   /* Global C roots */
   CAML_EV_BEGIN(EV_MAJOR_ROOTS_C);
@@ -445,9 +445,9 @@ void caml_do_roots (scanning_action f, int do_globals)
   CAML_EV_END(EV_MAJOR_ROOTS_HOOK);
 }
 
-void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
-                         uintnat last_retaddr, value * gc_regs,
-                         struct caml__roots_block * local_roots)
+void caml_do_local_roots_nat(scanning_action f, char * bottom_of_stack,
+                             uintnat last_retaddr, value * gc_regs,
+                             struct caml__roots_block * local_roots)
 {
   char * sp;
   uintnat retaddr;


### PR DESCRIPTION
In #8807, a custom Makefile that manually linked the threads library and the runtime built a binary that failed with a mysterious segfault. The problem turned out to be that the bytecode version of systhreads was being linked against the native runtime.

This should have been a link error, but since the two runtimes use the same name for the `caml_do_local_roots` function there was no error. Since the signatures are different, it segfaulted at runtime.

This PR contains a tiny patch to ensure that bytecode and native use different symbol names for this function.