### PR TITLE
Protect against bad rounding of mtime / atime / ctime stats

### DIFF
--- a/Changes
+++ b/Changes
@@ -191,6 +191,11 @@ OCaml 4.11
   of dynlinked modules.
   (Nicolás Ojeda Bär, review by Xavier Clerc and Gabriel Scherer)
 
+- #9490, #9505: ensure proper rounding of file times returned by
+  Unix.stat, Unix.lstat, Unix.fstat.
+  (Xavier Leroy and Guillaume Melquiond, report by David Brown,
+   review by Gabriel Scherer and David Allsopp)
+
 ### Tools:
 
 - #9057: aid debugging the debugger by preserving backtraces of unhandled

--- a/otherlibs/unix/stat.c
+++ b/otherlibs/unix/stat.c
@@ -16,6 +16,7 @@
 #define CAML_INTERNALS
 
 #include <errno.h>
+#include <math.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <caml/mlvalues.h>
@@ -47,18 +48,36 @@ static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };
 
+/* Transform a (seconds, nanoseconds) time stamp (in the style of
+   struct timespec) to a number of seconds in floating-point.
+   Make sure the integer part of the result is always equal to [seconds]
+   (issue #9490). */
+
+static double stat_timestamp(time_t sec, long nsec)
+{
+  /* The conversion of sec to FP is exact for the foreseeable future.
+     (It starts rounding when sec > 2^53, i.e. in 285 million years.) */
+  double s = (double) sec;
+  /* The conversion of nsec to fraction of seconds can round.
+     Still, we have 0 <= n < 1.0. */
+  double n = (double) nsec / 1e9;
+  /* The sum s + n can round up, hence s <= t + <= s + 1.0 */
+  double t = s + n;
+  /* Detect the "round up to s + 1" case and decrease t so that
+     its integer part is s. */
+  if (t == s + 1.0) t = nextafter(t, s);
+  return t;
+}
+
 static value stat_aux(int use_64, struct stat *buf)
 {
   CAMLparam0();
   CAMLlocal5(atime, mtime, ctime, offset, v);
 
   #include "nanosecond_stat.h"
-  atime = caml_copy_double((double) buf->st_atime
-                           + (NSEC(buf, a) / 1000000000.0));
-  mtime = caml_copy_double((double) buf->st_mtime
-                           + (NSEC(buf, m) / 1000000000.0));
-  ctime = caml_copy_double((double) buf->st_ctime
-                           + (NSEC(buf, c) / 1000000000.0));
+  atime = caml_copy_double(stat_timestamp(buf->st_atime, NSEC(buf, a)));
+  mtime = caml_copy_double(stat_timestamp(buf->st_mtime, NSEC(buf, m)));
+  ctime = caml_copy_double(stat_timestamp(buf->st_ctime, NSEC(buf, c)));
   #undef NSEC
   offset = use_64 ? Val_file_offset(buf->st_size) : Val_int (buf->st_size);
   v = caml_alloc_small(12, 0);

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -15,7 +15,14 @@
 #define CAML_INTERNALS
 
 #include <errno.h>
+#ifdef _MSC_VER 
 #include <float.h>
+#ifndef nextafter
+#define nextafter _nextafter
+#endif
+#else
+#include <math.h>
+#endif
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -55,10 +62,6 @@
 static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };
-
-#ifndef nextafter
-#define nextafter _nextafter
-#endif
 
 /* Transform a timestamp expressed in units of 100ns
    to a number of seconds in floating-point.

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -15,7 +15,7 @@
 #define CAML_INTERNALS
 
 #include <errno.h>
-#ifdef _MSC_VER 
+#ifdef _MSC_VER
 #include <float.h>
 #ifndef nextafter
 #define nextafter _nextafter

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -15,6 +15,7 @@
 #define CAML_INTERNALS
 
 #include <errno.h>
+#include <float.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -55,6 +56,38 @@ static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };
 
+#ifndef nextafter
+#define nextafter _nextafter
+#endif
+
+/* Transform a timestamp expressed in units of 100ns
+   to a number of seconds in floating-point.
+   Make sure the integer part of the result is always equal to
+   the timestamp divided by 10^7 (issue #9490).
+   Use the same algorithm as for the Unix implementation
+   (in ../unix/stat.c) in the hope of getting the same result
+   when the same file is accessed either from Windows or from Linux.
+ */
+
+static double stat_timestamp(__time64_t tm)
+{
+  /* Split the timestamp into seconds and remaining 100ns units */
+  __int64 sec = tm / 10000000;  /* 10^7 */
+  int n100sec = tm % 10000000;
+  /* The conversion of sec to FP is exact for the foreseeable future.
+     (It starts rounding when sec > 2^53, i.e. in 285 million years.) */
+  double s = (double) sec;
+  /* The conversion of n100sec to fraction of seconds can round.
+     Still, we have 0 <= n100sec < 1.0. */
+  double n = (double) n100sec / 1e7;
+  /* The sum s + n can round up, hence s <= t + <= s + 1.0 */
+  double t = s + n;
+  /* Detect the "round up to s + 1" case and decrease t so that
+     its integer part is s. */
+  if (t == s + 1.0) t = nextafter(t, s);
+  return t;
+}
+
 static value stat_aux(int use_64, __int64 st_ino, struct _stat64 *buf)
 {
   CAMLparam0 ();
@@ -72,9 +105,9 @@ static value stat_aux(int use_64, __int64 st_ino, struct _stat64 *buf)
   Store_field (v, 7, Val_int (buf->st_rdev));
   Store_field (v, 8,
                use_64 ? caml_copy_int64(buf->st_size) : Val_int (buf->st_size));
-  Store_field (v, 9, caml_copy_double((double) buf->st_atime / 10000000.0));
-  Store_field (v, 10, caml_copy_double((double) buf->st_mtime / 10000000.0));
-  Store_field (v, 11, caml_copy_double((double) buf->st_ctime / 10000000.0));
+  Store_field (v, 9, caml_copy_double(stat_timestamp(buf->st_atime)));
+  Store_field (v, 10, caml_copy_double(stat_timestamp(buf->st_mtime)));
+  Store_field (v, 11, caml_copy_double(stat_timestamp(buf->st_ctime)));
   CAMLreturn (v);
 }
 


### PR DESCRIPTION
Some file systems maintain time stamps with sub-second resolution, up
to nanosecond resolution.  When converting from a "(seconds, nanoseconds)"
timestamp to a floating-point timestamp, rounding to nearest can produce
"seconds + 1" as a result, i.e. the integer part of the FP timestamp
is not equal to "seconds".  As described in #9490, this is a problem
in some cases.

This PR implements a more careful conversion of "(seconds,
nanoseconds)" pairs to FP timestamps so that the integer part of the
FP result is always "seconds".

The FP trickery is explained in comments and was discussed as part of #9490.
