### PR TITLE
remove caml_init_ieee_floats()

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ Working version
 
 ### Runtime system:
 
+- #9508: Remove support for FreeBSD prior to 4.0R, that required explicit
+  floating-point initialization to behave like IEEE standard
+  (Hannes Mehnert, review by David Allsopp)
 
 ### Code generation and optimizations:
 

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -1047,23 +1047,3 @@ CAMLprim value caml_classify_float(value vd)
 {
   return caml_classify_float_unboxed(Double_val(vd));
 }
-
-/* The [caml_init_ieee_float] function should initialize floating-point hardware
-   so that it behaves as much as possible like the IEEE standard.
-   In particular, return special numbers like Infinity and NaN instead
-   of signalling exceptions.  Currently, everyone is in IEEE mode
-   at program startup, except FreeBSD prior to 4.0R. */
-
-#ifdef __FreeBSD__
-#include <osreldate.h>
-#if (__FreeBSD_version < 400017)
-#include <floatingpoint.h>
-#endif
-#endif
-
-void caml_init_ieee_floats(void)
-{
-#if defined(__FreeBSD__) && (__FreeBSD_version < 400017)
-  fpsetmask(0);
-#endif
-}

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -318,8 +318,6 @@ static int parse_command_line(char_os **argv)
   return i;
 }
 
-extern void caml_init_ieee_floats (void);
-
 #ifdef _WIN32
 extern void caml_signal_thread(void * lpParam);
 #endif
@@ -361,9 +359,6 @@ CAMLexport void caml_main(char_os **argv)
   if (!caml_startup_aux(/* pooling */ caml_cleanup_on_exit))
     return;
 
-  /* Machine-dependent initialization of the floating-point hardware
-     so that it behaves as much as possible as specified in IEEE */
-  caml_init_ieee_floats();
   caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
@@ -501,7 +496,6 @@ CAMLexport value caml_startup_code_exn(
   if (!caml_startup_aux(pooling))
     return Val_unit;
 
-  caml_init_ieee_floats();
   caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -91,7 +91,6 @@ struct longjmp_buffer caml_termination_jmpbuf;
 void (*caml_termination_hook)(void *) = NULL;
 
 extern value caml_start_program (caml_domain_state*);
-extern void caml_init_ieee_floats (void);
 extern void caml_init_signals (void);
 #ifdef _WIN32
 extern void caml_win32_overflow_detection (void);
@@ -128,7 +127,6 @@ value caml_startup_common(char_os **argv, int pooling)
   caml_spacetime_initialize();
 #endif
   caml_init_frame_descriptors();
-  caml_init_ieee_floats();
   caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();


### PR DESCRIPTION
this used to call fpsetmask(0) on FreeBSD systems (< 4). FreeBSD 4 is not
anymore supported since 2007, it is safe to remove this code now.