### PR TITLE
Fix docs: runtime warnings are not enabled by default

### DIFF
--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -330,7 +330,7 @@ val enable_runtime_warnings: bool -> unit
 (** Control whether the OCaml runtime system can emit warnings
     on stderr.  Currently, the only supported warning is triggered
     when a channel created by [open_*] functions is finalized without
-    being closed.  Runtime warnings are enabled by default.
+    being closed.  Runtime warnings are disabled by default.
 
     @since 4.03.0 *)
 


### PR DESCRIPTION
The docs on this are out of date: they say runtime warnings are enabled by
default, but the source code has a commit 6c90da4 pointing to
https://github.com/ocaml/ocaml/pull/210 that disables them by default.

Itt seems like enabling runtime warnings by default never made its way into a
release and the docs could just be updated to say that runtime warnings are
disabled by default.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>