### PR TITLE
Fix module_coercion test on no-flat-floatarray mode

### DIFF
--- a/testsuite/tests/translprim/module_coercion.compilers.no-flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.no-flat.reference
@@ -11,7 +11,7 @@
           (function prim prim prim stub (array.set[int] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[int] prim prim prim))
-          (function prim prim stub (caml_int_compare prim prim))
+          (function prim prim stub (compare_ints prim prim))
           (function prim prim stub (== prim prim))
           (function prim prim stub (!= prim prim))
           (function prim prim stub (< prim prim))
@@ -25,7 +25,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_float_compare prim prim))
+          (function prim prim stub (compare_floats prim prim))
           (function prim prim stub (==. prim prim))
           (function prim prim stub (!=. prim prim))
           (function prim prim stub (<. prim prim))
@@ -53,7 +53,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_int32_compare prim prim))
+          (function prim prim stub (compare_bints int32 prim prim))
           (function prim prim stub (Int32.== prim prim))
           (function prim prim stub (Int32.!= prim prim))
           (function prim prim stub (Int32.< prim prim))
@@ -67,7 +67,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_int64_compare prim prim))
+          (function prim prim stub (compare_bints int64 prim prim))
           (function prim prim stub (Int64.== prim prim))
           (function prim prim stub (Int64.!= prim prim))
           (function prim prim stub (Int64.< prim prim))
@@ -81,7 +81,7 @@
           (function prim prim prim stub (array.set[addr] prim prim prim))
           (function prim prim prim stub
             (array.unsafe_set[addr] prim prim prim))
-          (function prim prim stub (caml_nativeint_compare prim prim))
+          (function prim prim stub (compare_bints nativeint prim prim))
           (function prim prim stub (Nativeint.== prim prim))
           (function prim prim stub (Nativeint.!= prim prim))
           (function prim prim stub (Nativeint.< prim prim))


### PR DESCRIPTION
When testing #9445 on 4.11, I noticed one other test that fails on no-flat-floatarray mode.

The fix is trivial, I'll merge and cherry-pick to 4.11 once CI is happy.