### PR TITLE
Parmatch: make `exhaust` (exhaustivity and fragility checking) lazy

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,6 +86,12 @@ Working version
 - #9604: refactoring of the ocamltest codebase.
   (Nicolás Ojeda Bär, review by Gabriel Scherer and Sébastien Hinderer)
 
+- #9498, #9511: make the pattern-matching analyzer more robust to
+  or-pattern explosion, by stopping after the first counter-example to
+  exhaustivity
+  (Gabriel Scherer, review by Luc Maranget, Thomas Refis and Florian Angeletti,
+   report by Alex Fedoseev through Hongbo Zhang)
+
 ### Build system:
 
 - #9332, #9518, #9529: Cease storing C dependencies in the codebase. C

--- a/testsuite/tests/basic-more/morematch.compilers.reference
+++ b/testsuite/tests/basic-more/morematch.compilers.reference
@@ -49,7 +49,7 @@ File "morematch.ml", lines 1050-1053, characters 8-10:
 1053 |   | C -> 2
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(A `D|B (`B, (`A|`C)))
+A `D
 File "morematch.ml", line 1084, characters 5-51:
 1084 |   |  _, _, _, _, _, A, _, _, _, _, B, _, _, _, _, _ -> "11"
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -19,7 +19,7 @@ Lines 7-9, characters 43-24:
 9 |     | Two, Two -> "four"
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(Two, One)
+(One, Two)
 module Add :
   functor (T : sig type two end) ->
     sig

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -115,7 +115,7 @@ Lines 24-26, characters 6-30:
 26 |         | Bar _, Bar _ -> true
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(Bar _, Foo _)
+(Foo _, Bar _)
 module Nonexhaustive :
   sig
     type 'a u = C1 : int -> int u | C2 : bool -> bool u

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -62,7 +62,7 @@ Lines 5-7, characters 39-23:
 7 |   | IntLit , 6 -> false
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(IntLit, 0)
+(BoolLit, true)
 val check : 's t * 's -> bool = <fun>
 |}];;
 
@@ -80,6 +80,6 @@ Lines 3-5, characters 45-38:
 5 |   | {fst = IntLit ; snd =  6} -> false
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-{fst=IntLit; snd=0}
+{fst=BoolLit; snd=true}
 val check : ('s t, 's) pair -> bool = <fun>
 |}];;

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -13,7 +13,7 @@ Lines 1-3, characters 8-23:
 3 |   | Some _, Some _ -> 2..
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(Some _, None)
+(None, Some _)
 val f : 'a option * 'b option -> int = <fun>
 |}]
 

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -3,7 +3,6 @@
    * expect
 *)
 
-(* Warn about all relevant cases when possible *)
 let f = function
     None, None -> 1
   | Some _, Some _ -> 2;;
@@ -14,7 +13,7 @@ Lines 1-3, characters 8-23:
 3 |   | Some _, Some _ -> 2..
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-((Some _, None)|(None, Some _))
+(Some _, None)
 val f : 'a option * 'b option -> int = <fun>
 |}]
 
@@ -124,7 +123,7 @@ Line 1, characters 8-47:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-({left=Box 0; right=Box 0}|{left=Box 1; right=Box _})
+{left=Box 0; right=Box 0}
 val f : int box pair -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-warnings/fragile_matching.ml
+++ b/testsuite/tests/typing-warnings/fragile_matching.ml
@@ -1,0 +1,108 @@
+(* TEST *)
+
+(* Tests for stack-overflow crashes caused by a combinatorial
+   explosition in fragile pattern checking. *)
+
+[@@@warning "+4"]
+
+module SyntheticTest = struct
+  (* from Luc Maranget *)
+  type t = A | B
+
+  let f = function
+    | A,A,A,A,A, A,A,A,A,A, A,A,A,A,A, A,A,A -> 1
+    | (A|B),(A|B),(A|B),(A|B),(A|B),
+      (A|B),(A|B),(A|B),(A|B),(A|B),
+      (A|B),(A|B),(A|B),(A|B),(A|B),
+      (A|B),(A|B),(A|B) ->  2
+end
+
+module RealCodeTest = struct
+  (* from Alex Fedoseev *)
+
+  type visibility = Shown | Hidden
+
+  type ('outputValue, 'message) fieldStatus =
+  | Pristine
+  | Dirty of ('outputValue, 'message) result * visibility
+
+  type message = string
+
+  type fieldsStatuses = {
+    iaasStorageConfigurations :
+      iaasStorageConfigurationFieldsStatuses array;
+  }
+
+  and iaasStorageConfigurationFieldsStatuses = {
+    startDate : (int, message) fieldStatus;
+    term : (int, message) fieldStatus;
+    rawStorageCapacity : (int, message) fieldStatus;
+    diskType : (string option, message) fieldStatus;
+    connectivityMethod : (string option, message) fieldStatus;
+    getRequest : (int option, message) fieldStatus;
+    getRequestUnit : (string option, message) fieldStatus;
+    putRequest : (int option, message) fieldStatus;
+    putRequestUnit : (string option, message) fieldStatus;
+    transferOut : (int option, message) fieldStatus;
+    transferOutUnit : (string option, message) fieldStatus;
+    region : (string option, message) fieldStatus;
+    cloudType : (string option, message) fieldStatus;
+    description : (string option, message) fieldStatus;
+    features : (string array, message) fieldStatus;
+    accessTypes : (string array, message) fieldStatus;
+    certifications : (string array, message) fieldStatus;
+    additionalRequirements : (string option, message) fieldStatus;
+  }
+
+  type interface = { dirty : unit -> bool }
+
+  let useForm () = {
+    dirty = fun () ->
+      Array.for_all
+        (fun item ->
+          match item with
+          | {
+              additionalRequirements = Pristine;
+              certifications = Pristine;
+              accessTypes = Pristine;
+              features = Pristine;
+              description = Pristine;
+              cloudType = Pristine;
+              region = Pristine;
+              transferOutUnit = Pristine;
+              transferOut = Pristine;
+              putRequestUnit = Pristine;
+              putRequest = Pristine;
+              getRequestUnit = Pristine;
+              getRequest = Pristine;
+              connectivityMethod = Pristine;
+              diskType = Pristine;
+              rawStorageCapacity = Pristine;
+              term = Pristine;
+              startDate = Pristine;
+            } ->
+            false
+          | {
+              additionalRequirements = Pristine | Dirty (_, _);
+              certifications = Pristine | Dirty (_, _);
+              accessTypes = Pristine | Dirty (_, _);
+              features = Pristine | Dirty (_, _);
+              description = Pristine | Dirty (_, _);
+              cloudType = Pristine | Dirty (_, _);
+              region = Pristine | Dirty (_, _);
+              transferOutUnit = Pristine | Dirty (_, _);
+              transferOut = Pristine | Dirty (_, _);
+              putRequestUnit = Pristine | Dirty (_, _);
+              putRequest = Pristine | Dirty (_, _);
+              getRequestUnit = Pristine | Dirty (_, _);
+              getRequest = Pristine | Dirty (_, _);
+              connectivityMethod = Pristine | Dirty (_, _);
+              diskType = Pristine | Dirty (_, _);
+              rawStorageCapacity = Pristine | Dirty (_, _);
+              term = Pristine | Dirty (_, _);
+              startDate = Pristine | Dirty (_, _);
+            } ->
+            true)
+        [||]
+  }
+end

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1250,22 +1250,6 @@ let rec do_match pss qs = match qs with
         (build_specialized_submatrix ~extend_row:(@) q0 pss)
         (qargs @ qs)
 
-
-type 'a exhaust_result =
-  | No_matching_value
-  | Witnesses of 'a list
-
-let rappend r1 r2 =
-  match r1, r2 with
-  | No_matching_value, _ -> r2
-  | _, No_matching_value -> r1
-  | Witnesses l1, Witnesses l2 -> Witnesses (l1 @ l2)
-
-let rec try_many  f = function
-  | [] -> No_matching_value
-  | (p,pss)::rest ->
-      rappend (f (p, pss)) (try_many f rest)
-
 (*
 let print_pat pat =
   let rec string_of_pat pat =
@@ -1296,14 +1280,14 @@ let print_pat pat =
   This function should be called for exhaustiveness check only.
 *)
 let rec exhaust (ext:Path.t option) pss n = match pss with
-| []    ->  Witnesses [omegas n]
-| []::_ ->  No_matching_value
+| []    ->  Seq.return (omegas n)
+| []::_ ->  Seq.empty
 | pss   ->
     let pss = simplify_first_col pss in
     if not (all_coherent (first_column pss)) then
       (* We're considering an ill-typed branch, we won't actually be able to
          produce a well typed value taking that branch. *)
-      No_matching_value
+      Seq.empty
     else begin
       (* Assuming the first column is ill-typed but considered coherent, we
          might end up producing an ill-typed witness of non-exhaustivity
@@ -1319,61 +1303,53 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
       match build_specialized_submatrices ~extend_row:(@) q0 pss with
       | { default; constrs = [] } ->
           (* first column of pss is made of variables only *)
-          begin match exhaust ext default (n-1) with
-          | Witnesses r ->
-              let q0 = Patterns.Head.to_omega_pattern q0 in
-              Witnesses (List.map (fun row -> q0::row) r)
-          | r -> r
-        end
+          let sub_witnesses = exhaust ext default (n-1) in
+          let q0 = Patterns.Head.to_omega_pattern q0 in
+          Seq.map (fun row -> q0::row) sub_witnesses
       | { default; constrs } ->
           let try_non_omega (p,pss) =
             if is_absent_pat p then
-              No_matching_value
+              Seq.empty
             else
-              match
+              let sub_witnesses =
                 exhaust
                   ext pss
                   (List.length (simple_match_args p Patterns.Head.omega [])
                    + n - 1)
-              with
-              | Witnesses r ->
-                  let p = Patterns.Head.to_omega_pattern p in
-                  Witnesses (List.map (set_args p) r)
-              | r       -> r in
-          let before = try_many try_non_omega constrs in
-          if
-            full_match false constrs && not (should_extend ext constrs)
-          then
-            before
-          else
-            let r =  exhaust ext default (n-1) in
-            match r with
-            | No_matching_value -> before
-            | Witnesses r ->
-                try
-                  let p = build_other ext constrs in
-                  let dug = List.map (fun tail -> p :: tail) r in
-                  match before with
-                  | No_matching_value -> Witnesses dug
-                  | Witnesses x -> Witnesses (x @ dug)
-                with
-        (* cannot occur, since constructors don't make a full signature *)
-                | Empty -> fatal_error "Parmatch.exhaust"
-  end
+              in
+              let p = Patterns.Head.to_omega_pattern p in
+              Seq.map (set_args p) sub_witnesses
+          in
+          let try_omega () =
+            if full_match false constrs && not (should_extend ext constrs) then
+              Seq.empty
+            else
+              let sub_witnesses = exhaust ext default (n-1) in
+              match build_other ext constrs with
+              | exception Empty ->
+                  (* cannot occur, since constructors don't make
+                     a full signature *)
+                  fatal_error "Parmatch.exhaust"
+              | p ->
+                  Seq.map (fun tail -> p :: tail) sub_witnesses
+          in
+          (* Lazily compute witnesses for all constructor submatrices
+             (Some constr_mat) then the default submatrix (None).
+             Note that the call to [try_omega ()] is delayed to after
+             all constructor matrices have been traversed. *)
+          List.map (fun constr_mat -> Some constr_mat) constrs @ [None]
+          |> List.to_seq
+          |> Seq.flat_map
+            (function
+              | Some constr_mat -> try_non_omega constr_mat
+              | None -> try_omega ())
+    end
 
 let exhaust ext pss n =
-  let ret = exhaust ext pss n in
-  match ret with
-    No_matching_value -> No_matching_value
-  | Witnesses lst ->
-      let singletons =
-        List.map
-          (function
-              [x] -> x
-            | _ -> assert false)
-          lst
-      in
-      Witnesses [orify_many singletons]
+  exhaust ext pss n
+  |> Seq.map (function
+     | [x] -> x
+     | _ -> assert false)
 
 (*
    Another exhaustiveness check, enforcing variant typing.
@@ -1931,6 +1907,10 @@ let ppat_of_type env ty =
       let (ppat, constrs, labels) = Conv.conv (orify_many pats) in
       PT_pattern (PE_gadt_cases, ppat, constrs, labels)
 
+let typecheck ~pred p =
+  let (pattern,constrs,labels) = Conv.conv p in
+  pred constrs labels pattern
+
 let do_check_partial ~pred loc casel pss = match pss with
 | [] ->
         (*
@@ -1949,48 +1929,34 @@ let do_check_partial ~pred loc casel pss = match pss with
     end ;
     Partial
 | ps::_  ->
-    begin match exhaust None pss (List.length ps) with
-    | No_matching_value -> Total
-    | Witnesses [u] ->
-        let v =
-          let (pattern,constrs,labels) = Conv.conv u in
-          let u' = pred constrs labels pattern in
-          (* pretty_pat u;
-          begin match u' with
-            None -> prerr_endline ": impossible"
-          | Some _ -> prerr_endline ": possible"
-          end; *)
-          u'
+    let counter_examples =
+      exhaust None pss (List.length ps)
+      |> Seq.filter_map (typecheck ~pred) in
+    match counter_examples () with
+    | Seq.Nil -> Total
+    | Seq.Cons (v, _rest) ->
+      if Warnings.is_active (Warnings.Partial_match "") then begin
+        let errmsg =
+          try
+            let buf = Buffer.create 16 in
+            let fmt = Format.formatter_of_buffer buf in
+            Printpat.top_pretty fmt v;
+            if do_match (initial_only_guarded casel) [v] then
+              Buffer.add_string buf
+                "\n(However, some guarded clause may match this value.)";
+            if contains_extension v then
+              Buffer.add_string buf
+                "\nMatching over values of extensible variant types \
+                   (the *extension* above)\n\
+              must include a wild card pattern in order to be exhaustive."
+            ;
+            Buffer.contents buf
+          with _ ->
+            ""
         in
-        begin match v with
-          None -> Total
-        | Some v ->
-            if Warnings.is_active (Warnings.Partial_match "") then begin
-              let errmsg =
-                try
-                  let buf = Buffer.create 16 in
-                  let fmt = Format.formatter_of_buffer buf in
-                  Printpat.top_pretty fmt v;
-                  if do_match (initial_only_guarded casel) [v] then
-                    Buffer.add_string buf
-                      "\n(However, some guarded clause may match this value.)";
-                  if contains_extension v then
-                    Buffer.add_string buf
-                      "\nMatching over values of extensible variant types \
-                         (the *extension* above)\n\
-                    must include a wild card pattern in order to be exhaustive."
-                  ;
-                  Buffer.contents buf
-                with _ ->
-                  ""
-              in
-                Location.prerr_warning loc (Warnings.Partial_match errmsg)
-            end;
-            Partial
-        end
-    | _ ->
-        fatal_error "Parmatch.check_partial"
-    end
+        Location.prerr_warning loc (Warnings.Partial_match errmsg)
+      end;
+      Partial
 
 (*****************)
 (* Fragile check *)
@@ -2054,12 +2020,13 @@ let do_check_fragile loc casel pss =
     | ps::_ ->
         List.iter
           (fun ext ->
-            match exhaust (Some ext) pss (List.length ps) with
-            | No_matching_value ->
+            let witnesses = exhaust (Some ext) pss (List.length ps) in
+            match witnesses () with
+            | Seq.Nil ->
                 Location.prerr_warning
                   loc
                   (Warnings.Fragile_match (Path.name ext))
-            | Witnesses _ -> ())
+            | Seq.Cons _ -> ())
           exts
 
 (********************************)


### PR DESCRIPTION
This PR fixes #9498 (a Stack Overflow when checking for fragile pattern matching in a hand-written user program) and subsumes #9499 and #9502, which were earlier approaches that made witness/counter-example generation partially lazy.

(cc @maranget, @trefis and @Octachron, with which I discussed the design space; we decided on this approach together, see https://github.com/ocaml/ocaml/pull/9502#issuecomment-620684482 )

## Design

With this PR, the `exhaust` function is completely lazy (it returns a `Seq.t` of non-matched patterns), and we only keep the first output that passes the type-checker (the `pred` function provided by Typecore). Before, the type-checke would decide (through the `type_pat` splitting mode) whether to keep only the first example (Backtrack_or) or to keep more examples (Refine_or); in particular, in some cases we show simpler, shorter reports to users, with only one counter-example to exhaustivity instead of an or-pattern of many examples.

Before:

```
# function (true,true,true,true) -> ();;
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
((true, true, true, false)|(true, true, false, _)|(true, false, _, _)|
(false, _, _, _))
```

After:

```
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
(true, true, true, false)
```

We could decide to show more than one counter-example, but there isn't a clear choice of bound/cutoff (if we show all of them, we are back to an exponential behavior); I don't think this would be a good idea.

On the other hand, we could decide to show the wildcard-group counter-example before the constructor-group counter-examples, which would show `(false, _, _, _)` in this case. This seems nicer to me (I would assume that wildcard-group counter-examples are typically broader: "the difference more to the left") and I would be interested in @maranget's opinion, it sounds like something he would have intuitions about.

## Performance impact

Besides fixing a real-world bug (a stack overflow on a human-written program, #9498), basically the hope is that this is the end-game in terms of avoiding or-pattern blowups resulting from the `Parmatch.exhaust` function. On the family of exponential examples provided by @maranget in https://github.com/ocaml/ocaml/pull/9499#issuecomment-619566679, all examples now run in linear time (instantaneous).

For previous iterations of this PR, I suspected that they could increase compilation time in common cases (it used an lazy sequence but would often force it fully in the end). This new version should be just as fast or faster than trunk in the common case, because we stop the traversal after the first valid counter-example is found. (If there is only one example, then the cost is very small anyway; if there are many, we save time by giving less work to the type-checker.) I expect that the difference will not be noticeable on most programs.

Edit: I realized later that this reasoning does not hold in the case of exhaustiveness checking. In the common case, a function definitive exhaustive, which means that we have to traverse all counter-example candidates to check that none of them are valid (so in particular we fully force the sequence). In this common use-case we do expect a constant-factor slowdown due to the use of a lazy rather than strict sequence; but in practice I was unable to observe a noticeable performance difference, even on hand-crafted worst-case examples.

## Code style

I rewrote the PR with non-invasiveness in mind, and also the goal of not using any additional function missing from the `Seq` module. In particular I inlined my `pop : 'a Seq.t -> ('a * 'a Seq.t) option` function, and I rewrote one part in a slightly less natural form to use just `Seq.flat_map` instead of `Seq.append`. This avoids the question of where to store the `Seq` additions (locally in the function, or at the beginning of Parmatch, or in utils/misc.ml?), and should make it easier for our Bucklescript friends to rebase to old OCaml versions if they want to.
