### PR TITLE
testsuite: in typing-warnings, use .opt binaries for the "slow" tests

### DIFF
--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -18,7 +18,7 @@ Here is an example of a case that is not matched:
 val f : 'a option * 'b option -> int = <fun>
 |}]
 
-(* Exhaustiveness check is very slow *)
+(* Unused cases *)
 type _ t =
   A : int t | B : bool t | C : char t | D : float t
 type (_,_,_,_) u = U : (int, int, int, int) u
@@ -30,31 +30,7 @@ type (_, _, _, _) u = U : (int, int, int, int) u
 type v = E | F | G
 |}]
 
-let f : type a b c d e f g.
-      a t * b t * c t * d t * e t * f t * g t * v
-       * (a,b,c,d) u * (e,f,g,g) u -> int =
- function A, A, A, A, A, A, A, _, U, U -> 1
-   | _, _, _, _, _, _, _, G, _, _ -> 1
-   (*| _ -> _ *)
-;;
-[%%expect {|
-Lines 4-5, characters 1-38:
-4 | .function A, A, A, A, A, A, A, _, U, U -> 1
-5 |    | _, _, _, _, _, _, _, G, _, _ -> 1
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(A, A, A, A, A, A, B, (E|F), _, _)
-Line 5, characters 5-33:
-5 |    | _, _, _, _, _, _, _, G, _, _ -> 1
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 56: this match case is unreachable.
-Consider replacing it with a refutation case '<pat> -> .'
-val f :
-  'a t * 'b t * 'c t * 'd t * 'e t * 'f t * 'g t * v * ('a, 'b, 'c, 'd) u *
-  ('e, 'f, 'g, 'g) u -> int = <fun>
-|}]
 
-(* Unused cases *)
 let f (x : int t) = match x with A -> 1 | _ -> 2;; (* warn *)
 [%%expect {|
 Line 1, characters 20-48:

--- a/testsuite/tests/typing-warnings/exhaustiveness_slow.compilers.reference
+++ b/testsuite/tests/typing-warnings/exhaustiveness_slow.compilers.reference
@@ -1,0 +1,11 @@
+File "exhaustiveness_slow.ml", lines 18-19, characters 1-38:
+18 | .function A, A, A, A, A, A, A, _, U, U -> 1
+19 |    | _, _, _, _, _, _, _, G, _, _ -> 1
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(A, A, A, A, A, A, B, (E|F), _, _)
+File "exhaustiveness_slow.ml", line 19, characters 5-33:
+19 |    | _, _, _, _, _, _, _, G, _, _ -> 1
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 56: this match case is unreachable.
+Consider replacing it with a refutation case '<pat> -> .'

--- a/testsuite/tests/typing-warnings/exhaustiveness_slow.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness_slow.ml
@@ -1,0 +1,21 @@
+(* TEST
+   * setup-ocamlc.opt-build-env
+   ** ocamlc.opt
+   flags = " -w A -strict-sequence "
+   *** check-ocamlc.opt-output
+*)
+
+(* Exhaustiveness check is very slow *)
+type _ t =
+  A : int t | B : bool t | C : char t | D : float t
+type (_,_,_,_) u = U : (int, int, int, int) u
+type v = E | F | G
+;;
+
+let f : type a b c d e f g.
+      a t * b t * c t * d t * e t * f t * g t * v
+       * (a,b,c,d) u * (e,f,g,g) u -> int =
+ function A, A, A, A, A, A, A, _, U, U -> 1
+   | _, _, _, _, _, _, _, G, _, _ -> 1
+   (*| _ -> _ *)
+;;


### PR DESCRIPTION
exhaustiveness.ml contains a mix of tricky
examples (checking correctness of the typer) and "slow"
examples (that have exponential checking time due to
a search explosion). Everything is run using expect_test, which uses
the bytecode type-checker, so the "slow" examples are very slow.

This PR separates out the "slow" example in their own file
exhaustiveness_slow.ml which is not an expect-style test, but checked using
ocamlc.opt.

On my machine
    make one DIR=tests/typing-warnings
goes from 14s to 2.3s.

This would be important in the future if we want to add more "slow"
tests (in particular this would be useful for #9511).

(No change entry needed.)