### PR TITLE
Parmatch.exhaust: single-row optimization

### DIFF
--- a/Changes
+++ b/Changes
@@ -131,6 +131,9 @@ Working version
   (Gabriel Scherer, review by Luc Maranget, Thomas Refis and Florian Angeletti,
    report by Alex Fedoseev through Hongbo Zhang)
 
+- #9514: optimize pattern-matching exhaustivity analysis in the single-row case
+  (Gabriel Scherer, review by Stephen DOlan)
+
 ### Build system:
 
 - #9332, #9518, #9529: Cease storing C dependencies in the codebase. C


### PR DESCRIPTION
This PR implements an optimization to pattern-matching exhaustivity checking that compresses exhaustivity counter-examples on certain "single-row" patterns which may occur naturally in user code written to avoid fragile pattern matching. For example:

```ocaml
let map4 f = function
  | (Some x1, Some x2, Some x3, Some x4) -> Some (f x1 x2 x3 x4)
  | (Some _ | None), (Some _ | None), (Some _ | None), (Some _ | None) -> None
```

The first line matches "all `Some`", the second line matches "at least one `None`" in a non-fragile way. (This is a bit silly for option which is not going to gain a new constructor overnight, but you get the idea for user-defined datatypes.)

Now let's consider that you make a mistake and use `Some _` instead of `(Some _ | None)` in the last element of the tuple:

```ocaml
let wrong_map4 f = function
  | (Some x1, Some x2, Some x3, Some x4) -> Some (f x1 x2 x3 x4)
  | (Some _ | None), (Some _ | None), (Some _ | None), (Some _ (* None missing*)) -> None
```

In the current trunk the counter-example generator will generate 2^(N-1) counter-examples, corresponding to all possible explosions of the or-patterns in the second row.

```
let wrong_map4 f = function
    | (Some x1, Some x2, Some x3, Some x4) -> Some (f x1 x2 x3 x4)
    | (Some _ | None), (Some _ | None), (Some _ | None), (Some _ (* None missing*)) -> None
  ;;
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
((Some _, Some _, Some _, None)|(Some _, Some _, None, None)|
(Some _, None, Some _, None)|(Some _, None, None, None)|
(None, Some _, Some _, None)|(None, Some _, None, None)|
(None, None, Some _, None)|(None, None, None, None))
```

In particular there is a risk of exponential blowup of the exhaustiveness checker or fragility checker, which is the cause of #9498 (a Stack Overflow in user-written code that exhibits exactly this pattern). The mistake (forgetting the `None` in the last element of the tuple) is not necessary to experience the blowup, it also occurs when `warning "+4"` is activated or in related examples involving GADTs (see https://github.com/ocaml/ocaml/pull/9511#issuecomment-620854130).

With the present PR, a new optimization is added to the exhaustivity checker that matches a "single-row" scenario (we are asking for exhaustivity counter-examples to a matrix with a single row) that in particular captures this class of user examples. There is now a single counter-example generated, because the or-patterns are not exploded:

```
let wrong_map4 f = function
    | (Some x1, Some x2, Some x3, Some x4) -> Some (f x1 x2 x3 x4)
    | (Some _ | None), (Some _ | None), (Some _ | None), (Some _ (* None missing*)) -> None
  ;;
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
((Some _|None), (Some _|None), (Some _|None), None)
```

In particular, this PR fixes #9498.

You may be wondering how this PR compares to #9511 which I also submitted this morning and also fixes #9498 ?

- The two changes are orthogonal: #9511 is good at avoiding blowups when many counter-examples are generated (by being more lazy in how we traverse them), this PR removes the blowup in a particular case. Other cases will still blow up, so I think we still want to have #9511, but in this particular case the counter-example generated are much nicer with this PR. Presently I think that the best would be to have both PRs merged.

- #9511 is the result of a discussion with @maranget, @trefis and @Octachron, and in particular I am sure that the technical approach is sound. I am confident about the present PR but @maranget may still find a reason why it is in fact completely wrong (that's what he does). @trefis also wanted to keep the exhaustivity-checker (critical for soundness) as simple as possible, this would also be a reason to not merge the present PR.

- On the other hand, #9511 makes the choice to drop counter-examples in some cases, which may be controversial with some users or maintainers. This PR only acts on a particular case, and then it clearly improves the counter-example provided.

- The present PR is less invasive than the previous one. Assuming that they are both approved and merged, this one is easier to backport. (However, I think that from the point of view of Bucklescript, the other PR gives the nicer guarantee that many other blowup cases will be handled better, so you probably still want both.)