### PR TITLE
RISC-V: Update C calling conventions to use the ELF psABI

### DIFF
--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -283,8 +283,10 @@ let emit_instr i =
         match (src, dst) with
         | {loc = Reg _; typ = (Val | Int | Addr)}, {loc = Reg _} ->
             `	mv      {emit_reg dst}, {emit_reg src}\n`
-        | {loc = Reg _; typ = Float}, {loc = Reg _} ->
+        | {loc = Reg _; typ = Float}, {loc = Reg _; typ = Float} ->
             `	fmv.d   {emit_reg dst}, {emit_reg src}\n`
+        | {loc = Reg _; typ = Float}, {loc = Reg _; typ = (Val | Int | Addr)} ->
+            `	fmv.x.d {emit_reg dst}, {emit_reg src}\n`
         | {loc = Reg _; typ = (Val | Int | Addr)}, {loc = Stack s} ->
             let ofs = slot_offset s (register_class dst) in
             emit_store src ofs

--- a/asmcomp/riscv/proc.ml
+++ b/asmcomp/riscv/proc.ml
@@ -187,6 +187,8 @@ let loc_results res =
      first integer args in a0 .. a7
      first float args in fa0 .. fa7
      remaining args on stack.
+   A FP argument can be passed in an integer register if all FP registers
+   are exhausted but integer registers remain.
    Return values in a0 .. a1 or fa0 .. fa1. *)
 
 let external_calling_conventions
@@ -202,8 +204,7 @@ let external_calling_conventions
         | Val | Int | Addr as ty ->
             if !int <= last_int then begin
               loc.(i) <- [| phys_reg !int |];
-              incr int;
-              incr float;
+              incr int
             end else begin
               loc.(i) <- [| stack_slot (make_stack !ofs) ty |];
               ofs := !ofs + size_int
@@ -211,8 +212,10 @@ let external_calling_conventions
         | Float ->
             if !float <= last_float then begin
               loc.(i) <- [| phys_reg !float |];
-              incr float;
-              incr int;
+              incr float
+            end else if !int <= last_int then begin
+              loc.(i) <- [| phys_reg !int |];
+              incr int
             end else begin
               loc.(i) <- [| stack_slot (make_stack !ofs) Float |];
               ofs := !ofs + size_float


### PR DESCRIPTION
The original implementation of `loc_external_arguments` and `loc_external_results` was following an older ABI, where an FP argument passed in an FP register "burns" an integer register.

In the ELF psABI, integer registers and FP registers are used independently,as in the OCaml calling convention.

Fixes: #9515
