### PR TITLE
unboxed-primitive-args: test does not require unix

### DIFF
--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -1,22 +1,19 @@
 (* TEST
 
-* hasunix
-include unix
-
 files = "common.mli common.ml test_common.c test_common.h"
 
-** setup-ocamlopt.byte-build-env
-*** ocaml
+* setup-ocamlopt.byte-build-env
+** ocaml
 test_file = "${test_source_directory}/gen_test.ml"
 ocaml_script_as_argument = "true"
 arguments = "c"
 compiler_output = "stubs.c"
-**** ocaml
+*** ocaml
 arguments = "ml"
 compiler_output = "main.ml"
-***** ocamlopt.byte
+**** ocamlopt.byte
 all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
-****** run
-******* check-program-output
+***** run
+****** check-program-output
 
 *)


### PR DESCRIPTION
The `unix` dependency (it seems due to a historic dependency on `Bigarray`) appears to keep this test from being run in platforms where shared libraries are supported.