### PR TITLE
Specify C compiler flags correctly in win32unix Makefile

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,7 +40,7 @@ Working version
 
 ### Build system:
 
-- #9332: Cease storing C dependencies in the codebase. C dependencies are
+- #9332, #9518: Cease storing C dependencies in the codebase. C dependencies are
   generated on-the-fly in development mode. For incremental compilation, the
   MSVC ports require GCC to be present.
   (David Allsopp, review by Sébastien Hinderer, YAML-fu by Stephen Dolan)

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -26,7 +26,7 @@ CAMLC := $(BEST_OCAMLC) -nostdlib -I $(ROOTDIR)/stdlib
 CAMLOPT := $(BEST_OCAMLOPT) -nostdlib -I $(ROOTDIR)/stdlib
 
 OC_CFLAGS += $(SHAREDLIB_CFLAGS) $(EXTRACFLAGS)
-OC_CPPFLAGS += -I$(ROOTDIR)/runtime
+OC_CPPFLAGS += -I$(ROOTDIR)/runtime $(EXTRACPPFLAGS)
 
 # Compilation options
 COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
@@ -41,6 +41,7 @@ MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 # but have sensible default values:
 COBJS ?=
 EXTRACFLAGS ?=
+EXTRACPPFLAGS ?=
 EXTRACAMLFLAGS ?=
 LINKOPTS ?=
 LDOPTS ?=

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -164,7 +164,7 @@ endif
 	@
 
 $(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(DEP_CC) $(OC_CPPFLAGS) $(basename $*).c -MG -MT '$*.$(O)' -MF $@
+	$(DEP_CC) $(OC_CPPFLAGS) $(basename $*).c -MT '$*.$(O)' -MF $@
 
 .PHONY: depend
 depend:

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -46,7 +46,7 @@ CAMLOBJS=unix.cmo unixLabels.cmo
 WIN32_LIBS=$(call SYSLIB,ws2_32) $(call SYSLIB,advapi32)
 LINKOPTS=$(addprefix -cclib ,$(WIN32_LIBS))
 EXTRACAMLFLAGS=-nolabels
-EXTRACFLAGS=-I../unix
+EXTRACPPFLAGS=-I../unix
 HEADERS=unixsupport.h socketaddr.h
 
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -419,5 +419,7 @@ ifeq "$(COMPUTE_DEPS)" "true"
 include $(addprefix $(DEPDIR)/, $(DEP_FILES))
 endif
 
+# -MG ensures that the dependencies are generated even if the files listed in
+# $(GENERATED_HEADERS) haven't been assembled yet.
 $(DEPDIR)/%.$(D): %.c | $(DEPDIR)
 	$(DEP_CC) $(OC_CPPFLAGS) $(basename $*).c -MG -MT '$*.$(O)' -MF $@

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -55,25 +55,27 @@ function set_configuration {
         mingw)
             build='--build=i686-pc-cygwin'
             host='--host=i686-w64-mingw32'
+            dep='--disable-dependency-generation'
         ;;
         msvc)
             build='--build=i686-pc-cygwin'
             host='--host=i686-pc-windows'
+            dep='--disable-dependency-generation'
         ;;
         msvc64)
             build='--build=x86_64-unknown-cygwin'
             host='--host=x86_64-pc-windows'
+            # Explicitly test dependency generation on msvc64
+            dep='--enable-dependency-generation'
         ;;
     esac
 
     mkdir -p "$CACHE_DIRECTORY"
     ./configure --cache-file="$CACHE_DIRECTORY/config.cache-$1" \
-                --disable-dependency-generation \
-                $build $host --prefix="$2" --enable-ocamltest || ( \
+                $dep $build $host --prefix="$2" --enable-ocamltest || ( \
       rm -f "$CACHE_DIRECTORY/config.cache-$1" ; \
       ./configure --cache-file="$CACHE_DIRECTORY/config.cache-$1" \
-                  --disable-dependency-generation \
-                  $build $host --prefix="$2" --enable-ocamltest )
+                  $dep $build $host --prefix="$2" --enable-ocamltest )
 
     FILE=$(pwd | cygpath -f - -m)/Makefile.config
     echo "Edit $FILE to turn C compiler warnings into errors"


### PR DESCRIPTION
This PR fixes a developer-only regression in #9332 spotted in #8753. There are three commits:

- It was accidentally the case that there was no _Windows_ CI check in #9332 for msvc64 without `--enable-dependency-generation`, which is responsible for this regression creeping in while the code was being restructured during review. The first commit makes AppVeyor msvc64 test `--enable-dependency-generation` and a run on my AppVeyor on my fork [confirms this catches the regression](https://ci.appveyor.com/project/dra27/ocaml/builds/32577375).
- The underlying bug is that the otherlibs general `Makefile` defines `EXTRACFLAGS` which `otherlibs/win32unix/Makefile` then uses, but in reality this should be `EXTRACPPFLAGS`, since `-I` options should also be passed to the pre-processor. I've introduced `EXTRACPPFLAGS` to `otherlibs/Makefile.otherlibs.common` which means that `-I../unix` now gets passed to the pre-processor, as it should be.
- Normally if a header specified in a C file is missing, `gcc -MM` fails. `-MG` tells gcc to assume that the header is generated by the build system, so emit a dependency without warning. This is needed in `runtime/Makefile` for the 3 headers in the `GENERATED_HEADERS` variable. It was redundantly still in `otherlibs/systhreads/Makefile`. However, the 3 generated headers are in fact used very locally in the runtime - i.e. they're used by specific C objects, not other headers. I tested the build system by adding a special `noop` target to the `Makefiles`s so that I could do `make noop` after `./configure` and simply ensure that the `Makefile`s load (so this exactly tested the generation of the C dependency information). This confirms, as I suspected, that no other C objects depend on generated .h files. I've therefore removed the `-MG` from `otherlibs/systhreads/Makefile`. The rationale is that it should be consciously added when a generated header is required, not mask an error (say a mistyped header) during dependency generation. The alternative is simply to put `-MM -MG` in the definition of `DEP_CC` in `Makefile.build_config.in`

On the basis that `make alldepend` is presently broken on `trunk`, I propose to merge this if CI passes.