### PR TITLE
Convert Travis Changes test to GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,6 +52,7 @@ tools/mantis2gh_stripped.csv typo.missing-header
 *.adoc                   typo.long-line=may
 
 /.github/ISSUE_TEMPLATE/config.yml typo.missing-header
+/.github/workflows/*.yml typo.missing-header typo.long-line
 /.mailmap                typo.long-line typo.missing-header typo.non-ascii
 /.merlin                 typo.missing-header
 /Changes                 typo.utf8 typo.missing-header

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,15 @@
+name: Changes Log
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  build:
+    name: Check entry present in Changes file
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-change-entry-needed') }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: dra27/ocaml-changes@v1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
       XARCH=x64
       CONFIG_ARG=--enable-dependency-generation
       MAKE_ARG=-j
-  - env: CI_KIND=changes
   - env: CI_KIND=manual
   - env: CI_KIND=check-typo
 #  - env: CI_KIND=tests

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -182,38 +182,6 @@ EOF
   test -z "$(git ls-files --others -i --exclude-standard)"
 }
 
-CheckChangesModified () {
-  cat<<EOF
-------------------------------------------------------------------------
-This test checks that the Changes file has been modified by the pull
-request. Most contributions should come with a message in the Changes
-file, as described in our contributor documentation:
-
-  https://github.com/ocaml/ocaml/blob/trunk/CONTRIBUTING.md#changelog
-
-Some very minor changes (typo fixes for example) may not need
-a Changes entry. In this case, you may explicitly disable this test by
-adding the code word "No change entry needed" (on a single line) to
-a commit message of the PR, or using the "no-change-entry-needed" label
-on the github pull request.
-------------------------------------------------------------------------
-EOF
-  # check that Changes has been modified
-  git diff "$TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD" --name-only --exit-code \
-    Changes > /dev/null && CheckNoChangesMessage || echo pass
-}
-
-CheckNoChangesMessage () {
-  API_URL=https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/labels
-  if [[ -n $(git log --grep='[Nn]o [Cc]hange.* needed' --max-count=1 \
-    "$TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD") ]]
-  then echo pass
-  elif [[ -n $(curl "$API_URL" | grep 'no-change-entry-needed') ]]
-  then echo pass
-  else exit 1
-  fi
-}
-
 CheckManual () {
       cat<<EOF
 --------------------------------------------------------------------------
@@ -343,10 +311,6 @@ CheckTypo () {
 
 case $CI_KIND in
 build) BuildAndTest;;
-changes)
-    case $TRAVIS_EVENT_TYPE in
-        pull_request) CheckChangesModified;;
-    esac;;
 manual)
     CheckManual;;
 tests)


### PR DESCRIPTION
Assuming it works correctly, moving it from my personal fork, there are three major benefits to this:

- The API doesn't have to be queried by the scripts so there should be no more failures of this test owing to API rate exceeding (that said, that doesn't seem to have been a problem recently)
- The Action displays separately from the main Travis tests, and any future workflows we may define would also display separately. This permanently addresses @xavierleroy's complaint that the Travis workflow mixes testing with process
- The Action triggers automatically if the `no-change-entry-needed` label is applied or removed, which is possibly the most exciting thing I've seen today, but then I did have to write some JavaScript to do this, so my threshold is low.

It appears to be sensible to put your GitHub actions in a separate repo - this action is presently hosted in https://github.com/dra27/ocaml-changes. That should be moved, either to a new org or to ocaml/ before this can be merged. It contains an adapted version of the code deleted from the Travis shell script below with the necessary JavaScript boilerplate to invoke it.