### PR TITLE
pattern-matching refactoring: refactor the `make_<foo>_matching` functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,7 +46,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #9493: refactor the pattern-matching compiler
+- #9493, #9520: refactor the pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 ### Build system:


### PR DESCRIPTION
This is the next bit of the big pattern-matching refactoring change (#9321) after #9493 has been merged.

(cc @trefis @Octachron)

Before, each head construction had a `make_<foo>_matching` construct that
was responsible for three things:
- consuming the argument from the argument list
  (the "argument" is a piece of lambda code to access
   the value of the current scrutinee)
- building arguments for the subpatterns of the scrutinee
  and pushing them to the argument list
- building a `cell` structure out of this, representing a head group
  during compilation

Only the second point is really specific to each construction.

This refactoring turns this second point into a construct-specific
`get_expr_args_<foo>` function (similarly to `get_pat_args_<foo>`),
and moves the first and third point to a generic `make_matching`
function.

Note: this PR contains a minor improvement to the location used to
force (lazy ..) arguments, and also removes the redundant expansion
that was discussed in the last PR. (The latter is a separate commit
to ease separate reviewing.)