### PR TITLE
compare: correctly compare a Closure_tag with an Infix_tag

### DIFF
--- a/Changes
+++ b/Changes
@@ -58,6 +58,10 @@ Working version
 
 ### Bug fixes:
 
+- #9521, #9522: correctly fail when comparing functions
+  with Closure and Infix tags.
+  (Gabriel Scherer and Jeremy Yallop and Xavier Leroy,
+   report by Twitter user @st_toHKR through Jun Furuse)
 
 OCaml 4.11
 ----------

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -184,12 +184,28 @@ static intnat do_compare_val(struct compare_stack* stk,
 #endif
     t1 = Tag_val(v1);
     t2 = Tag_val(v2);
-    if (t1 == Forward_tag) { v1 = Forward_val (v1); continue; }
-    if (t2 == Forward_tag) { v2 = Forward_val (v2); continue; }
-    if (t1 == Infix_tag) t1 = Closure_tag;
-    if (t2 == Infix_tag) t2 = Closure_tag;
-    if (t1 != t2) return (intnat)t1 - (intnat)t2;
+    if (t1 != t2) {
+        /* Besides long/block comparisons, the only forms of
+           heterogeneous comparisons we support are:
+           - Forward_tag pointers, which may point to values of any type, and
+           - comparing Infix_tag and Closure_tag functions (#9521).
+
+           Other heterogeneous cases may still happen due to
+           existential types, and we just compare the tags.
+        */
+        if (t1 == Forward_tag) { v1 = Forward_val (v1); continue; }
+        if (t2 == Forward_tag) { v2 = Forward_val (v2); continue; }
+        if (t1 == Infix_tag) t1 = Closure_tag;
+        if (t2 == Infix_tag) t2 = Closure_tag;
+        if (t1 != t2)
+            return (intnat)t1 - (intnat)t2;
+    }
     switch(t1) {
+    case Forward_tag: {
+        v1 = Forward_val (v1);
+        v2 = Forward_val (v2);
+        continue;
+    }
     case String_tag: {
       mlsize_t len1, len2;
       int res;
@@ -240,6 +256,7 @@ static intnat do_compare_val(struct compare_stack* stk,
       compare_free_stack(stk);
       caml_invalid_argument("compare: abstract value");
     case Closure_tag:
+    case Infix_tag:
       compare_free_stack(stk);
       caml_invalid_argument("compare: functional value");
     case Object_tag: {

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -186,6 +186,8 @@ static intnat do_compare_val(struct compare_stack* stk,
     t2 = Tag_val(v2);
     if (t1 == Forward_tag) { v1 = Forward_val (v1); continue; }
     if (t2 == Forward_tag) { v2 = Forward_val (v2); continue; }
+    if (t1 == Infix_tag) t1 = Closure_tag;
+    if (t2 == Infix_tag) t2 = Closure_tag;
     if (t1 != t2) return (intnat)t1 - (intnat)t2;
     switch(t1) {
     case String_tag: {
@@ -238,7 +240,6 @@ static intnat do_compare_val(struct compare_stack* stk,
       compare_free_stack(stk);
       caml_invalid_argument("compare: abstract value");
     case Closure_tag:
-    case Infix_tag:
       compare_free_stack(stk);
       caml_invalid_argument("compare: functional value");
     case Object_tag: {

--- a/testsuite/tests/basic/equality.ml
+++ b/testsuite/tests/basic/equality.ml
@@ -12,6 +12,11 @@ let eqtrue (b:bool) = b
 let eqftffff =
   function (false,true,false,false,false,false) -> true | _ -> false
 
+let eqfun delayed_check =
+  match delayed_check () with
+  | exception Invalid_argument _ -> true
+  | _ -> false
+
 let x = [1;2;3]
 
 let f x = 1 :: 2 :: 3 :: x
@@ -32,6 +37,9 @@ let mkleftlist len =
   let l = ref Nil in
   for i = 1 to len do l := Cons(!l, i) done;
   !l
+
+(* use an existential to check equality with different tags *)
+type any = Any : 'a -> any
 
 let _ =
   test 1 eq0 (compare 0 0);
@@ -103,4 +111,25 @@ let _ =
   test 52 eqtrue (testcmpfloat 0.0 nan);
   test 53 eqtrue (testcmpfloat 0.0 0.0);
   test 54 eqtrue (testcmpfloat 1.0 0.0);
-  test 55 eqtrue (testcmpfloat 0.0 1.0)
+  test 55 eqtrue (testcmpfloat 0.0 1.0);
+  test 56 eqfun (fun () -> compare (fun x -> x) (fun x -> x));
+  test 57 eqfun (fun () ->
+    (* #9521 *)
+    let rec f x = g x and g x = f x in compare f g);
+
+  (* this is the current behavior of comparison
+     with values of incoherent types (packed below
+     an existential), but it may not be the only specification. *)
+  test 58 eqm1
+    (compare (Any 0) (Any 2));
+  begin
+    (* comparing two function fails *)
+    test 59 eqfun (fun () ->
+      compare (Any (fun x -> x)) (Any (fun x -> x + 1)));
+    (* comparing a function and a non-function succeeds *)
+    test 60 (Fun.negate eq0)
+      (compare (Any (fun x -> x)) (Any 0));
+    test 61 (Fun.negate eq0)
+      (compare (Any 0) (Any (fun x -> x)));
+  end;
+  ()

--- a/testsuite/tests/basic/equality.reference
+++ b/testsuite/tests/basic/equality.reference
@@ -47,3 +47,9 @@ Test 52 passed.
 Test 53 passed.
 Test 54 passed.
 Test 55 passed.
+Test 56 passed.
+Test 57 passed.
+Test 58 passed.
+Test 59 passed.
+Test 60 passed.
+Test 61 passed.


### PR DESCRIPTION
Currently comparing a Closure_tag with an Infix_tag (which are both valid tags for function values) will succeed with an address comparison, instead of raising `Invalid_argument "compare: functional value"` as expected.

Fixes #9521 .

There is a small performance cost to this optimization, which adds a new test (that rarely succeeds) in the hot path, but the hot path is already rather long and the test is just basic comparisons so I thought it would be fine.

The fact that Infix_tag were handled in the swtch below indicates to me that the intent was to behave correctly on these values.

@camlspotter what is a full name (in latin characters) I should use for the original reporter of the issue?