### PR TITLE
Clean without deps: reworking CAN_BE_UNCONFIGURED

### DIFF
--- a/Changes
+++ b/Changes
@@ -52,6 +52,10 @@ Working version
   compilation, the MSVC ports require GCC to be present.
   (David Allsopp, review by Sébastien Hinderer, YAML-fu by Stephen Dolan)
 
+- #9527: stop including configuration when running 'clean' rules
+  to avoid C dependency recomputation.
+  (Gabriel Scherer, review by David Allsopp)
+
 ### Bug fixes:
 
 

--- a/Makefile
+++ b/Makefile
@@ -1068,10 +1068,7 @@ distclean: clean
 
 include .depend
 
-
-ifneq "$(REQUIRES_CONFIGURATION)" ""
 Makefile.config Makefile.build_config: config.status
-
 config.status:
 	@echo "Please refer to the installation instructions:"
 	@echo "- In file INSTALL for Unix systems."
@@ -1083,4 +1080,3 @@ config.status:
 	@echo "	make install"
 	@echo "should work."
 	@false
-endif

--- a/Makefile
+++ b/Makefile
@@ -951,6 +951,10 @@ partialclean::
 
 ## Test compilation of backend-specific parts
 
+ARCH_SPECIFIC =\
+  asmcomp/arch.ml asmcomp/proc.ml asmcomp/CSE.ml asmcomp/selection.ml \
+  asmcomp/scheduling.ml asmcomp/reload.ml
+
 partialclean::
 	rm -f $(ARCH_SPECIFIC)
 

--- a/Makefile
+++ b/Makefile
@@ -16,20 +16,6 @@
 # The main Makefile
 
 ROOTDIR = .
-
-# The configure and *clean targets can all be run without running ./configure
-# first.
-# If no goals were specified (i.e. `make`), add defaultentry (since it requires
-# ./configure to be run)
-CAN_BE_UNCONFIGURED := $(strip \
-  $(filter-out partialclean clean distclean configure, \
-	$(if $(MAKECMDGOALS),$(MAKECMDGOALS),defaultentry)))
-
-ifeq "$(CAN_BE_UNCONFIGURED)" ""
--include Makefile.build_config
-else
-include Makefile.build_config
-endif
 include Makefile.common
 
 .PHONY: defaultentry
@@ -1083,7 +1069,7 @@ distclean: clean
 include .depend
 
 
-ifneq "$(strip $(CAN_BE_UNCONFIGURED))" ""
+ifneq "$(CAN_BE_UNCONFIGURED)" ""
 Makefile.config Makefile.build_config: config.status
 
 config.status:

--- a/Makefile
+++ b/Makefile
@@ -1069,7 +1069,7 @@ distclean: clean
 include .depend
 
 
-ifneq "$(CAN_BE_UNCONFIGURED)" ""
+ifneq "$(REQUIRES_CONFIGURATION)" ""
 Makefile.config Makefile.build_config: config.status
 
 config.status:

--- a/Makefile.common
+++ b/Makefile.common
@@ -15,7 +15,22 @@
 
 # This makefile contains common definitions and rules shared by
 # other Makefiles
-# We assume that Makefile.config has already been included
+
+# Some special targets ('*clean' and 'configure') do not require configuration.
+# CAN_BE_UNCONFIGURED is empty if only those targets are requested,
+# and non-empty if configuration is required.
+CAN_BE_UNCONFIGURED := $(strip \
+  $(filter-out partialclean clean distclean configure, \
+	$(if $(MAKECMDGOALS),$(MAKECMDGOALS),defaultentry)))
+# If no goals were specified (i.e. `make`), we add defaultentry
+# (since it requires ./configure to be run) so that
+# CAN_BE_UNCONFIGURED is non-empty.
+
+ifeq "$(CAN_BE_UNCONFIGURED)" ""
+-include $(ROOTDIR)/Makefile.build_config
+else
+include $(ROOTDIR)/Makefile.build_config
+endif
 
 # %(DEPDIR) must be kept in sync with entries in .gitignore
 DEPDIR=.dep

--- a/Makefile.common
+++ b/Makefile.common
@@ -16,19 +16,7 @@
 # This makefile contains common definitions and rules shared by
 # other Makefiles
 
-# Some special targets ('*clean' and 'configure') do not require configuration.
-# REQUIRES_CONFIGURATION is empty if only those targets are requested,
-# and non-empty if configuration is required.
-REQUIRES_CONFIGURATION := $(strip \
-  $(filter-out partialclean clean distclean configure, \
-	$(if $(MAKECMDGOALS),$(MAKECMDGOALS),defaultentry)))
-# If no goals were specified (i.e. `make`), we add defaultentry
-# (since it requires ./configure to be run) so that
-# REQUIRES_CONFIGURATION is non-empty.
-
-ifneq "$(REQUIRES_CONFIGURATION)" ""
-include $(ROOTDIR)/Makefile.build_config
-endif
+include $(ROOTDIR)/Makefile.config_if_required
 
 # %(DEPDIR) must be kept in sync with entries in .gitignore
 DEPDIR=.dep

--- a/Makefile.common
+++ b/Makefile.common
@@ -17,16 +17,16 @@
 # other Makefiles
 
 # Some special targets ('*clean' and 'configure') do not require configuration.
-# CAN_BE_UNCONFIGURED is empty if only those targets are requested,
+# REQUIRES_CONFIGURATION is empty if only those targets are requested,
 # and non-empty if configuration is required.
-CAN_BE_UNCONFIGURED := $(strip \
+REQUIRES_CONFIGURATION := $(strip \
   $(filter-out partialclean clean distclean configure, \
 	$(if $(MAKECMDGOALS),$(MAKECMDGOALS),defaultentry)))
 # If no goals were specified (i.e. `make`), we add defaultentry
 # (since it requires ./configure to be run) so that
-# CAN_BE_UNCONFIGURED is non-empty.
+# REQUIRES_CONFIGURATION is non-empty.
 
-ifeq "$(CAN_BE_UNCONFIGURED)" ""
+ifeq "$(REQUIRES_CONFIGURATION)" ""
 -include $(ROOTDIR)/Makefile.build_config
 else
 include $(ROOTDIR)/Makefile.build_config

--- a/Makefile.common
+++ b/Makefile.common
@@ -26,9 +26,7 @@ REQUIRES_CONFIGURATION := $(strip \
 # (since it requires ./configure to be run) so that
 # REQUIRES_CONFIGURATION is non-empty.
 
-ifeq "$(REQUIRES_CONFIGURATION)" ""
--include $(ROOTDIR)/Makefile.build_config
-else
+ifneq "$(REQUIRES_CONFIGURATION)" ""
 include $(ROOTDIR)/Makefile.build_config
 endif
 

--- a/Makefile.config_if_required
+++ b/Makefile.config_if_required
@@ -13,15 +13,17 @@
 #*                                                                        *
 #**************************************************************************
 
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS += defaultentry
+endif
+
+CLEAN_TARGET_NAMES=clean partialclean distclean
+
 # Some special targets ('*clean' and 'configure') do not require configuration.
 # REQUIRES_CONFIGURATION is empty if only those targets are requested,
 # and non-empty if configuration is required.
 REQUIRES_CONFIGURATION := $(strip \
-  $(filter-out partialclean clean distclean configure, \
-	$(if $(MAKECMDGOALS),$(MAKECMDGOALS),defaultentry)))
-# If no goals were specified (i.e. `make`), we add defaultentry
-# (since it requires ./configure to be run) so that
-# REQUIRES_CONFIGURATION is non-empty.
+  $(filter-out $(CLEAN_TARGET_NAMES) configure, $(MAKECMDGOALS)))
 
 ifneq "$(REQUIRES_CONFIGURATION)" ""
 include $(ROOTDIR)/Makefile.build_config

--- a/Makefile.config_if_required
+++ b/Makefile.config_if_required
@@ -1,0 +1,28 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*            Gabriel Scherer, projet Parsifal, INRIA Saclay              *
+#*                                                                        *
+#*   Copyright 2020 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# Some special targets ('*clean' and 'configure') do not require configuration.
+# REQUIRES_CONFIGURATION is empty if only those targets are requested,
+# and non-empty if configuration is required.
+REQUIRES_CONFIGURATION := $(strip \
+  $(filter-out partialclean clean distclean configure, \
+	$(if $(MAKECMDGOALS),$(MAKECMDGOALS),defaultentry)))
+# If no goals were specified (i.e. `make`), we add defaultentry
+# (since it requires ./configure to be run) so that
+# REQUIRES_CONFIGURATION is non-empty.
+
+ifneq "$(REQUIRES_CONFIGURATION)" ""
+include $(ROOTDIR)/Makefile.build_config
+endif

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -47,7 +47,9 @@ SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
 #   variable. Note that for Windows we add Unix-syntax directory names in
 #   PATH, and Cygwin will translate it to Windows syntax.
 
--include $(TOPDIR)/Makefile.config
+# TOPDIR is legacy, our makefiles should use ROOTDIR now
+ROOTDIR=$(TOPDIR)
+include $(ROOTDIR)/Makefile.config_if_required
 
 # Make sure USE_RUNTIME is defined
 USE_RUNTIME ?=

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -102,10 +102,6 @@ BYTECOMP=bytecomp/instruct.cmo bytecomp/bytegen.cmo \
   driver/errors.cmo driver/compile.cmo
 BYTECOMP_CMI=
 
-ARCH_SPECIFIC =\
-  asmcomp/arch.ml asmcomp/proc.ml asmcomp/CSE.ml asmcomp/selection.ml \
-  asmcomp/scheduling.ml asmcomp/reload.ml
-
 INTEL_ASM=\
   asmcomp/x86_proc.cmo \
   asmcomp/x86_dsl.cmo \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -15,7 +15,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -17,7 +17,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 
 CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -15,7 +15,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -17,7 +17,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -79,7 +79,17 @@ endif
 
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime -DCAML_INTERNALS
 
-run := run_$(UNIX_OR_WIN32)
+ifdef UNIX_OR_WIN32
+run_source := run_$(UNIX_OR_WIN32).c
+else
+ifneq "$(filter-out $(CLEAN_TARGET_NAMES), $(MAKECMDGOALS))" ""
+$(warning The variable UNIX_OR_WIN32 is not defined. \
+  It must be set (usually by $(ROOTDIR)/configure), \
+  or only clean rules are supported.)
+endif
+# If we are in a 'clean' rule, we ask for both versions to be cleaned.
+run_source := run_unix.c run_win32.c
+endif
 
 # List of source files from which ocamltest is compiled
 # (all the different sorts of files are derived from this)
@@ -88,8 +98,7 @@ run := run_$(UNIX_OR_WIN32)
 # which is actually built into the tool but clearly separated from its core
 
 core := \
-  $(run).c \
-  run_stubs.c \
+  $(run_source) run_stubs.c \
   ocamltest_stdlib_stubs.c \
   ocamltest_config.mli ocamltest_config.ml.in \
   ocamltest_stdlib.mli ocamltest_stdlib.ml \
@@ -279,7 +288,6 @@ ocamltest.html: ocamltest.org
 clean:
 	rm -rf ocamltest ocamltest.exe ocamltest.opt ocamltest.opt.exe
 	rm -rf $(c_files:.c=.o) $(c_files:.c=.obj)
-	rm -rf run_unix.o run_win32.o run_win32.obj
 	rm -rf $(ml_files:.ml=.o) $(ml_files:.ml=.obj)
 	rm -rf $(cmi_files)
 	rm -rf $(cmo_files)

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -14,7 +14,6 @@
 #**************************************************************************
 
 ROOTDIR=..
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 
 OTHERLIBRARIES ?= bigarray dynlink raw_spacetime_lib str systhreads \

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -16,7 +16,6 @@
 # Common Makefile for otherlibs
 
 ROOTDIR=../..
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -21,7 +21,6 @@
 
 ROOTDIR = ../..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -15,7 +15,6 @@
 
 ROOTDIR=../..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -15,7 +15,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 
 # Lists of source files

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -15,7 +15,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 
 TARGET_BINDIR ?= $(BINDIR)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -238,7 +238,6 @@ $(OTHERS:.cmo=.cmx) std_exit.cmx: stdlib.cmx
 
 clean::
 	rm -f *.cm* *.o *.obj *.a *.lib *.odoc
-	rm -f camlheader*
 
 include .depend
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -16,7 +16,6 @@
 MAKEFLAGS := -r -R
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 
 ifeq ($(SYSTEM),unix)

--- a/yacc/Makefile
+++ b/yacc/Makefile
@@ -17,7 +17,6 @@
 
 ROOTDIR = ..
 
--include $(ROOTDIR)/Makefile.build_config
 include $(ROOTDIR)/Makefile.common
 
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime


### PR DESCRIPTION
This PR is a non-trivial rework of the CAN_BE_UNCONFIGURED logic to fix a build performance regression caused by #9332: in the current trunk, `make clean` starts by recomputing the C dependencies, adding about 8 seconds of useless work.

(If you wonder what `CAN_BE_UNCONFIGURED` is: it is the list of the current Makefile targets which *require* `./configure` to have been executed first (this excludes `*clean` and `configure`). Yes, this doesn't make complete sense, and this PR renames it to `REQUIRES_CONFIGURATION`. The point is that our Makefiles check if the list is empty, and then go into warrior mode to work correctly without configuration.)

We fix this in two daring steps:
1. Move the inclusion of `Makefile.build_config` into `Makefile.common`
    (This simplifies all makefiles slightly: the two files were always included in this order.)
2. When `CAN_BE_UNCONFIGURED` is empty, do *not* include `Makefile.build_config`
    (previously we would `-include`, which would tolerate the absence without failing)

The risky part is the second one, and it needs a careful review -- but it should be safe as we supported not having the file at all before, right?

As a result of the second change, the `.dep` logic is not included when there are no REQUIRES_CONFIGURATION target, and in particular `make clean` does not try to compute C dependencies anymore.

On my machine, `make distclean` goes from 8.5s to 0.5s with this PR.

(cc @dra27 @shindere)