### PR TITLE
Further C dependency fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,9 +51,9 @@ Working version
 
 ### Build system:
 
-- #9332, #9518: Cease storing C dependencies in the codebase. C dependencies are
-  generated on-the-fly in development mode. For incremental compilation, the
-  MSVC ports require GCC to be present.
+- #9332, #9518, #9529: Cease storing C dependencies in the codebase. C
+  dependencies are generated on-the-fly in development mode. For incremental
+  compilation, the MSVC ports require GCC to be present.
   (David Allsopp, review by Sébastien Hinderer, YAML-fu by Stephen Dolan)
 
 ### Bug fixes:

--- a/Makefile.common
+++ b/Makefile.common
@@ -81,6 +81,7 @@ OCAMLLEX_FLAGS ?= -q
 # general (it supports both .o and .obj)
 
 ifneq "$(COMPUTE_DEPS)" "false"
+RUNTIME_HEADERS :=
 REQUIRED_HEADERS :=
 else
 RUNTIME_HEADERS := $(wildcard $(ROOTDIR)/runtime/caml/*.tbl) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -89,7 +89,7 @@ RUNTIME_HEADERS := $(wildcard $(ROOTDIR)/runtime/caml/*.tbl) \
 REQUIRED_HEADERS := $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
 
-%.$(O): %.c $(RUNTIME_HEADERS) $(wildcard *.h)
+%.$(O): %.c $(REQUIRED_HEADERS)
 	$(CC) -c $(OC_CFLAGS) $(OC_CPPFLAGS) $(OUTPUTOBJ)$@ $<
 
 $(DEPDIR):

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -156,15 +156,14 @@ include $(addprefix $(DEPDIR)/, $(DEP_FILES))
 endif
 
 %.n.$(O): OC_CPPFLAGS += $(NATIVE_CPPFLAGS)
+%.n.$(D): OC_CPPFLAGS += $(NATIVE_CPPFLAGS)
 
-%.b.c: %.c
-	@
+define GEN_RULE
+$(DEPDIR)/%.$(1).$(D): %.c | $(DEPDIR)
+	$$(DEP_CC) $$(OC_CPPFLAGS) $$< -MT '$$*.$(1).$(O)' -MF $$@
+endef
 
-%.n.c: %.c
-	@
-
-$(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(DEP_CC) $(OC_CPPFLAGS) $(basename $*).c -MT '$*.$(O)' -MF $@
+$(foreach object_type, b n, $(eval $(call GEN_RULE,$(object_type))))
 
 .PHONY: depend
 depend:

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -37,15 +37,6 @@ NATIVE_C_SOURCES := $(addsuffix .c, \
   dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray \
   memprof domain)
 
-# The other_files variable stores the list of files whose dependencies
-# should be computed by `make depend` although they do not need to be
-# compiled on the current build system
-ifeq "$(UNIX_OR_WIN32)" "win32"
-other_files := unix.c
-else
-other_files := win32.c
-endif
-
 GENERATED_HEADERS := caml/opnames.h caml/version.h caml/jumptbl.h
 CONFIG_HEADERS := caml/m.h caml/s.h
 
@@ -409,8 +400,7 @@ i386nt.obj: i386nt.asm domain_state32.inc
 
 # Dependencies
 
-DEP_FILES := $(addsuffix .b, $(basename $(BYTECODE_C_SOURCES) \
-                                        instrtrace $(other_files)))
+DEP_FILES := $(addsuffix .b, $(basename $(BYTECODE_C_SOURCES) instrtrace))
 ifneq "$(NATIVE_COMPILER)" "false"
 DEP_FILES += $(addsuffix .n, $(basename $(NATIVE_C_SOURCES)))
 endif

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -351,10 +351,10 @@ libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
 define COMPILE_C_FILE
 ifneq "$(COMPUTE_DEPS)" "false"
 ifneq "$(1)" "%"
-# This rule states that, for example, sys.b.c is sys.c and is needed for the
-# dependency generation pattern rule.
-$(1).c: %.c
-	@
+# -MG ensures that the dependencies are generated even if the files listed in
+# $$(GENERATED_HEADERS) haven't been assembled yet.
+$(DEPDIR)/$(1).$(D): %.c | $(DEPDIR)
+	$$(DEP_CC) $$(OC_CPPFLAGS) $$< -MG -MT '$$*$(subst %,,$(1)).$(O)' -MF $$@
 endif
 $(1).$(O): %.c
 else
@@ -418,8 +418,3 @@ DEP_FILES := $(addsuffix .$(D), $(DEP_FILES))
 ifeq "$(COMPUTE_DEPS)" "true"
 include $(addprefix $(DEPDIR)/, $(DEP_FILES))
 endif
-
-# -MG ensures that the dependencies are generated even if the files listed in
-# $(GENERATED_HEADERS) haven't been assembled yet.
-$(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(DEP_CC) $(OC_CPPFLAGS) $(basename $*).c -MG -MT '$*.$(O)' -MF $@

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -351,10 +351,14 @@ libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
 define COMPILE_C_FILE
 ifneq "$(COMPUTE_DEPS)" "false"
 ifneq "$(1)" "%"
-# -MG ensures that the dependencies are generated even if the files listed in
-# $$(GENERATED_HEADERS) haven't been assembled yet.
-$(DEPDIR)/$(1).$(D): %.c | $(DEPDIR)
-	$$(DEP_CC) $$(OC_CPPFLAGS) $$< -MG -MT '$$*$(subst %,,$(1)).$(O)' -MF $$@
+# -MG would ensure that the dependencies are generated even if the files listed
+# in $$(GENERATED_HEADERS) haven't been assembled yet. However, this goes subtly
+# wrong if the user has the headers installed, as gcc will pick up a dependency
+# on those instead and the local ones will not be generated. For this reason, we
+# don't use -MG and instead include $(GENERATED_HEADERS) in the order only
+# dependencies to ensure that they exist before dependencies are computed.
+$(DEPDIR)/$(1).$(D): %.c | $(DEPDIR) $(GENERATED_HEADERS)
+	$$(DEP_CC) $$(OC_CPPFLAGS) $$< -MT '$$*$(subst %,,$(1)).$(O)' -MF $$@
 endif
 $(1).$(O): %.c
 else

--- a/tools/ci/inria/bootstrap
+++ b/tools/ci/inria/bootstrap
@@ -125,7 +125,7 @@ set -ex
 # default values
 make=make
 instdir="$HOME/ocaml-tmp-install"
-confoptions="--enable-ocamltest --disable-dependency-generation \
+confoptions="--enable-ocamltest --enable-dependency-generation \
 ${OCAML_CONFIGURE_OPTIONS}"
 make_native=true
 cleanup=false

--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -149,7 +149,7 @@ git clean -q -f -d -x
 # We cannot give the sanitizer options as part of -cc because
 # then various autoconfiguration tests fail.
 # Instead, we'll fix OC_CFLAGS a posteriori.
-./configure CC=clang-9 --disable-stdlib-manpages --disable-dependency-generation
+./configure CC=clang-9 --disable-stdlib-manpages --enable-dependency-generation
 
 # These are the undefined behaviors we want to check
 # Others occur on purpose e.g. signed arithmetic overflow
@@ -200,7 +200,7 @@ echo "======== clang 9, thread sanitizer =========="
 
 git clean -q -f -d -x
 
-./configure CC=clang-9 --disable-stdlib-manpages --disable-dependency-generation
+./configure CC=clang-9 --disable-stdlib-manpages --enable-dependency-generation
 
 # Select thread sanitizer
 # Don't optimize too much to get better backtraces of errors

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -125,7 +125,7 @@ host=''
 conffile=Makefile.config
 make=make
 instdir="$HOME/ocaml-tmp-install"
-confoptions="--enable-ocamltest --disable-dependency-generation \
+confoptions="--enable-ocamltest --enable-dependency-generation \
 ${OCAML_CONFIGURE_OPTIONS}"
 make_native=true
 cleanup=false


### PR DESCRIPTION
macOS still installs a 14 year old version of GNU make (3.81). It turns out that the changes in #9332 need a feature added a decade ago in GNU make 3.82. The fix I propose here is to remove the virtual rule in `runtime/Makefile` and `otherlibs/systhreads/Makefile` which were supposed to allow `make` to realise that it's OK for sys.b.c not to exist and instead to generate the dependency rules for each case (in `runtime/Makefile` this is virtually identical; in `otherlibs/systhreads/Makefile` it takes nearly the same number of lines, as it happens).

Triggered by #9528, various fixes:

- It is readily apparent both from #9528 and #9518 that the CI strategy for `--disable-dependency-generation` was wrong - Travis and AppVeyor both do a test using it, and now Inria's CI does virtually all of its tests with `--enable-dependency-generation`. This is also more logical, as it tests more diverse tools than the `--disable-dependency-generation` which only tests GNU `make`, and in a very obvious way.
- There was a missing blank definition of `RUNTIME_HEADERS` in `Makefile.common` which has been added to satisfy the warning.
- In the flurry of renamings at the end of #9332, the wrong variable was used at the bottom of `Makefile.common` so in `--disable-dependency-generation` mode, C files depended on the runtime headers only - they now depend on runtime headers *and* the local headers
- Switching Inria's CI to `--enable-dependency-generation` revealed the expected failure on macOS from #9528, but also failed the ARM32 and ARM64 builds. It turns out those workers have OCaml installed on them, which revealed that using `-MG` is completely flawed (cf. #9518) and this is removed here. Doing that also revealed that the old `$(otherfiles)` (which was previously used to cause Unix builds to generate the dependency information for `win32.o` and vice versa) was still there, even though that's never needed.

An earlier version of this branch has already been through precheck, but this exact branch is presently [precheck#371](https://ci.inria.fr/ocaml/job/precheck/371/)