### PR TITLE
Add a "stale" Github action to process inactive issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "15 4 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been open one year with no activity.  Consequently, it is being marked with the "stale" label.  What this means is that the issue will be automatically closed in 30 days unless more comments are added or the "stale" label is removed.  Comments that provide new information on the issue are especially welcome: is it still reproducible? did it appear in other contexts? how critical is it? etc.'
+        days-before-stale: 366
+        days-before-close: 30


### PR DESCRIPTION
As discussed among the core OCaml developers, and following the example set by the OPAM repository (https://github.com/ocaml/opam-repository/pull/16250), this commit adds a Github action that "pings" issues that have been inactive for one year and schedules them for closing 30 days later if no action has been taken.

The action is scheduled to run once per day.  According to @avsm, the "stale" action can process only 30 issues or so per run because of API rate limitations.  We turn this limitation into a feature: by processing a limited number of issues every day, we give the core OCaml developers a bit of time to have a quick look at the issues before they are closed.
