### PR TITLE
configure: support bfd on FreeBSD

### DIFF
--- a/Changes
+++ b/Changes
@@ -52,6 +52,9 @@ Working version
   MSVC ports require GCC to be present.
   (David Allsopp, review by Sébastien Hinderer, YAML-fu by Stephen Dolan)
 
+- #9531: fix support for the BFD library on FreeBSD
+  (Hannes Mehnert, review by Gabriel Scherer and David Allsopp)
+
 ### Bug fixes:
 
 

--- a/configure
+++ b/configure
@@ -16340,7 +16340,7 @@ fi
       if test -z "$BFD_LIB_DIR"; then :
   BFD_LIB_DIR="/opt/local/lib"
 fi ;; #(
-  *-*openbsd*) :
+  *-*-openbsd*|*-*-freebsd*) :
     if test -z "$BFD_INCLUDE_DIR"; then :
   BFD_INCLUDE_DIR="/usr/local/include"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1638,7 +1638,7 @@ AS_IF([test x"$with_bfd" != "xno"],
         [BFD_INCLUDE_DIR="/opt/local/include"])
       AS_IF([test -z "$BFD_LIB_DIR"],
         [BFD_LIB_DIR="/opt/local/lib"])],
-    [*-*openbsd*],
+    [*-*-openbsd*|*-*-freebsd*],
       [AS_IF([test -z "$BFD_INCLUDE_DIR"],
         [BFD_INCLUDE_DIR="/usr/local/include"])
       AS_IF([test -z "$BFD_LIB_DIR"],


### PR DESCRIPTION
On FreeBSD, libbfd is - similarly to OpenBSD - not installed by default, but
can be added via the devel/libbfd port. This will install libbfd into the
/usr/local prefix, thus configure needs to look there for include and library