### PR TITLE
[RFC] Dynamic check for naked pointers

### DIFF
--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -11,7 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%"]
+  ["./configure" "--prefix=%{prefix}%" "--disable-naked-pointers"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -73,3 +73,6 @@ DOMAIN_STATE(intnat, stat_top_heap_wsz)
 DOMAIN_STATE(intnat, stat_compactions)
 DOMAIN_STATE(intnat, stat_heap_chunks)
 /* See gc_ctrl.c */
+
+DOMAIN_STATE(void*, checking_pointer_pc)
+/* See major_gc.c */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -80,4 +80,6 @@ void caml_init_domain ()
   Caml_state->local_roots = NULL;
   Caml_state->requested_major_slice = 0;
   Caml_state->requested_minor_gc = 0;
+
+  Caml_state->checking_pointer_pc = NULL;
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -150,38 +150,41 @@ static void realloc_gray_vals (void)
 
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
 
-#if defined(__clang__)
-#define OPTNONE __attribute__((optnone))
-#elif defined(__GNUC__)
-#define OPTNONE __attribute__((optimize("O0")))
-#else
-#error "Naked pointer checker unsupported for this platform"
-#endif
+static inline int safe_load (header_t * addr, /*out*/ header_t * contents)
+{
+  int ok;
+  header_t h;
+  intnat tmp;
 
-static int OPTNONE is_pointer_safe (value v, value *p)
+  asm volatile(
+      "leaq 1f(%%rip), %[tmp] \n\t"
+      "movq %[tmp], 0(%[handler]) \n\t"
+      "xorl %[ok], %[ok] \n\t"
+      "movq 0(%[addr]), %[h] \n\t"
+      "movl $1, %[ok] \n\t"
+  "1: \n\t"
+      "xorq %[tmp], %[tmp] \n\t"
+      "movq %[tmp], 0(%[handler])"
+      : [tmp] "=&r" (tmp), [ok] "=&r" (ok), [h] "=&r" (h)
+      : [addr] "r" (addr),
+        [handler] "r" (&(Caml_state->checking_pointer_pc)));
+  *contents = h;
+  return ok;
+}
+
+static int is_pointer_safe (value v, value *p)
 {
   header_t h;
   tag_t t;
 
-  Caml_state->checking_pointer_pc = &&on_segfault;
+  if (! safe_load(&Hd_val(v), &h)) goto on_segfault;
 
-  /* This conditional is only needed so that clang does not miscompile the use
-   * of first-class label above. [Caml_state->young_ptr] will never be [42],
-   * but the use of [goto] is sufficient to force clang to get the right
-   * address of [on_segfault] label. */
-  if (Caml_state->young_ptr == (void*)42)
-    goto *Caml_state->checking_pointer_pc;
-
-  h = Hd_val(v);
-  Caml_state->checking_pointer_pc = NULL;
-
-  t = Tag_val(v);
-  if (t == Infix_tag){
-    v -= Infix_offset_val(v);
-    h = Hd_val (v);
+  t = Tag_hd(h);
+  if (t == Infix_tag) {
+    v -= Infix_offset_hd(h);
+    if (! safe_load(&Hd_val(v), &h)) goto on_segfault;
     t = Tag_hd(h);
   }
-
 
   /* For the pointer to be considered safe, either the given pointer is in heap
    * or the (out of heap) pointer has a black header and its size is < 2 ** 40
@@ -199,10 +202,9 @@ static int OPTNONE is_pointer_safe (value v, value *p)
   }
   return 0;
 
-on_segfault:
-  Caml_state->checking_pointer_pc = NULL;
+ on_segfault:
   fprintf (stderr, "Out-of-heap pointer at %p of value %p. "
-                   "Cannot read head.\n", p, (void*)v);
+           "Cannot read head.\n", p, (void*)v);
   return 0;
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -150,10 +150,10 @@ static void realloc_gray_vals (void)
 
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
 
-#if defined(__GNUC__)
-#define OPTNONE __attribute__((optimize("O0")))
-#elif defined(__clang__)
+#if defined(__clang__)
 #define OPTNONE __attribute__((optnone))
+#elif defined(__GNUC__)
+#define OPTNONE __attribute__((optimize("O0")))
 #else
 #error "Naked pointer checker unsupported for this platform"
 #endif
@@ -164,6 +164,14 @@ static int OPTNONE is_pointer_safe (value v, value *p)
   tag_t t;
 
   Caml_state->checking_pointer_pc = &&on_segfault;
+
+  /* This conditional is only needed so that clang does not miscompile the use
+   * of first-class label above. [Caml_state->young_ptr] will never be [42],
+   * but the use of [goto] is sufficient to force clang to get the right
+   * address of [on_segfault] label. */
+  if (Caml_state->young_ptr == (void*)42)
+    goto *Caml_state->checking_pointer_pc;
+
   h = Hd_val(v);
   Caml_state->checking_pointer_pc = NULL;
 
@@ -173,6 +181,7 @@ static int OPTNONE is_pointer_safe (value v, value *p)
     h = Hd_val (v);
     t = Tag_hd(h);
   }
+
 
   /* For the pointer to be considered safe, either the given pointer is in heap
    * or the (out of heap) pointer has a black header and its size is < 2 ** 40

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -148,10 +148,55 @@ static void realloc_gray_vals (void)
   }
 }
 
+#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+
+static int is_pointer_safe (value v, value *p)
+{
+  header_t h;
+  tag_t t;
+  volatile int ret_val = 0;
+
+  Caml_state->checking_pointer_pc = &&on_segfault;
+  h = Hd_val(v);
+  Caml_state->checking_pointer_pc = NULL;
+
+  t = Tag_val(v);
+  if (t == Infix_tag){
+    v -= Infix_offset_val(v);
+    h = Hd_val (v);
+    t = Tag_hd(h);
+  }
+
+  /* For the pointer to be considered safe, either the given pointer is in heap
+   * or the (out of heap) pointer has a black head or the size of the object is
+   * 0. If not, we report a warning. */
+  if (Is_in_heap (v) || Is_black_hd(h) || Wosize_val(v) == 0)
+    return 1;
+
+on_segfault:
+  if (Caml_state->checking_pointer_pc == NULL) {
+    fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
+                    "non-black head (tag=%d)\n", p, (void*)v, t);
+  } else {
+    fprintf (stderr, "Out-of-heap pointer at %p of value %p. "
+                     "Cannot read head.\n", p, (void*)v);
+  }
+  return ret_val;
+}
+
+#endif
+
 void caml_darken (value v, value *p /* not used */)
 {
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
-  if (Is_block (v) && !Is_young (v) && Wosize_val (v) > 0) {
+  if (Is_block (v) && !Is_young (v)) {
+
+    if (!is_pointer_safe(v,p)) return;
+
+    /* Atoms never need to be marked. */
+    if (Wosize_val (v) == 0)
+      return;
+
 #else
   if (Is_block (v) && Is_in_heap (v)) {
 #endif
@@ -244,12 +289,18 @@ static inline value* mark_slice_darken(value *gray_vals_ptr,
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
   if (Is_block (child)
         && ! Is_young (child)
-        && Wosize_val (child) > 0  /* Atoms never need to be marked. */
         /* Closure blocks contain code pointers at offsets that cannot
            be reliably determined, so we always use the page table when
            marking such values. */
         && (!(Tag_val (v) == Closure_tag || Tag_val (v) == Infix_tag) ||
             Is_in_heap (child))) {
+
+    if (!is_pointer_safe(child, &Field(v,i)))
+      return gray_vals_ptr;
+
+    /* Atoms never need to be marked. */
+    if (Wosize_val (child) == 0)
+      return gray_vals_ptr;
 #else
   if (Is_block (child) && Is_in_heap (child)) {
 #endif

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -150,9 +150,17 @@ static void realloc_gray_vals (void)
 
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
 
-static int is_pointer_safe (value v, value *p)
+#if defined(__GNUC__)
+#define OPTNONE __attribute__((optimize("O0")))
+#elif defined(__clang__)
+#define OPTNONE __attribute__((optnone))
+#else
+#error "Naked pointer checker unsupported for this platform"
+#endif
+
+static int OPTNONE is_pointer_safe (value v, value *p)
 {
-  volatile header_t h;
+  header_t h;
   tag_t t;
 
   Caml_state->checking_pointer_pc = &&on_segfault;
@@ -172,21 +180,20 @@ static int is_pointer_safe (value v, value *p)
   if (Is_in_heap (v) || (Is_black_hd(h) && Wosize_hd(h) < (1ul << 40)))
     return 1;
 
-on_segfault:
-  if (Caml_state->checking_pointer_pc == NULL) {
-    if (!Is_black_hd(h)) {
-      fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
-                      "non-black head (tag=%d)\n", p, (void*)v, t);
-    } else {
-      fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
-                       "suspiciously large size: %lu words\n",
-               p, (void*)v, Wosize_hd(h));
-    }
+  if (!Is_black_hd(h)) {
+    fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
+                    "non-black head (tag=%d)\n", p, (void*)v, t);
   } else {
-    Caml_state->checking_pointer_pc = NULL;
-    fprintf (stderr, "Out-of-heap pointer at %p of value %p. "
-                     "Cannot read head.\n", p, (void*)v);
+    fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
+                      "suspiciously large size: %lu words\n",
+              p, (void*)v, Wosize_hd(h));
   }
+  return 0;
+
+on_segfault:
+  Caml_state->checking_pointer_pc = NULL;
+  fprintf (stderr, "Out-of-heap pointer at %p of value %p. "
+                   "Cannot read head.\n", p, (void*)v);
   return 0;
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -152,9 +152,8 @@ static void realloc_gray_vals (void)
 
 static int is_pointer_safe (value v, value *p)
 {
-  header_t h;
+  volatile header_t h;
   tag_t t;
-  volatile int ret_val = 0;
 
   Caml_state->checking_pointer_pc = &&on_segfault;
   h = Hd_val(v);
@@ -168,20 +167,27 @@ static int is_pointer_safe (value v, value *p)
   }
 
   /* For the pointer to be considered safe, either the given pointer is in heap
-   * or the (out of heap) pointer has a black head or the size of the object is
-   * 0. If not, we report a warning. */
-  if (Is_in_heap (v) || Is_black_hd(h) || Wosize_val(v) == 0)
+   * or the (out of heap) pointer has a black header and its size is < 2 ** 40
+   * words (128 GB). If not, we report a warning. */
+  if (Is_in_heap (v) || (Is_black_hd(h) && Wosize_hd(h) < (1ul << 40)))
     return 1;
 
 on_segfault:
   if (Caml_state->checking_pointer_pc == NULL) {
-    fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
-                    "non-black head (tag=%d)\n", p, (void*)v, t);
+    if (!Is_black_hd(h)) {
+      fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
+                      "non-black head (tag=%d)\n", p, (void*)v, t);
+    } else {
+      fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
+                       "suspiciously large size: %lu words\n",
+               p, (void*)v, Wosize_hd(h));
+    }
   } else {
+    Caml_state->checking_pointer_pc = NULL;
     fprintf (stderr, "Out-of-heap pointer at %p of value %p. "
                      "Cannot read head.\n", p, (void*)v);
   }
-  return ret_val;
+  return 0;
 }
 
 #endif

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -240,6 +240,12 @@ DECLARE_SIGNAL_HANDLER(segv_handler)
 #endif
     caml_raise_stack_overflow();
 #endif
+  } else if (Caml_state->checking_pointer_pc) {
+#ifdef CONTEXT_PC
+    CONTEXT_PC = (context_reg)Caml_state->checking_pointer_pc;
+#else
+#error "CONTEXT_PC must be defined if RETURN_AFTER_STACK_OVERFLOW is"
+#endif
   } else {
     /* Otherwise, deactivate our exception handler and return,
        causing fatal signal to be generated at point of error. */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -60,9 +60,9 @@ void caml_init_atom_table(void)
 
   for(i = 0; i < 256; i++) {
 #ifdef NATIVE_CODE
-    caml_atom_table[i] = Make_header_allocated_here(0, i, Caml_white);
+    caml_atom_table[i] = Make_header_allocated_here(0, i, Caml_black);
 #else
-    caml_atom_table[i] = Make_header(0, i, Caml_white);
+    caml_atom_table[i] = Make_header(0, i, Caml_black);
 #endif
   }
   if (caml_page_table_add(In_static_data,

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -561,6 +561,9 @@ let exit retcode =
 
 let _ = register_named_value "Pervasives.do_at_exit" do_at_exit
 
+external major : unit -> unit = "caml_gc_major"
+let _ = at_exit major
+
 (*MODULE_ALIASES*)
 module Arg          = Arg
 module Array        = Array


### PR DESCRIPTION
**Note: This PR is not for merging, but to aid discussion**

This PR adds the ability to dynamically identify naked pointers to 4.10.0 compiler. A naked pointer is identified during a GC if the pointer is either

1. not in heap and reading the head value triggers a segfault or
2. not in heap, points to a non-zero-sized block and is not black

If the block is zero-sized or marked black, then the GC would not have to scan this object and can be safely skipped. Of course, this technique will have false negatives since the bit pattern in the field where the header is expected to be may look like a zero-sized block or marked black.

When a naked pointer is found, a warning is output to `stderr` and the program continues.

## OPAM remote

You can install this compiler using this [opam repo](https://github.com/kayceesrk/opam-repo):

```bash
opam switch create 4.10.0+nnp+check --repositories=nnp=git+https://github.com/kayceesrk/opam-repo.git,default
```

## Example

```c
/* cstub.c */
#include "caml/mlvalues.h"

value make_block (value header, value size) {
  int64_t* p = (int64_t*)malloc(sizeof(int64_t) * (Int64_val(size) + 1));
  p[0] = Int64_val(header);
  return (value)&p[1];
}

value get_raw_pointer (value v) {
  return (value)Int64_val(v);
}
```

```ocaml
(* test.ml *)
external make_block : int64 -> int64 -> Obj.t = "make_block"                        
external get_raw_pointer : int64 -> Obj.t = "get_raw_pointer"                       
                                                                                    
(* See runtime/caml/gc.h *)                                                         
let white = 0L                                                                      
let gray = 1L                                                                       
let blue = 2L                                                                       
let black = 3L                                                                      
                                                                                    
(* See runtime/caml/mlvalues.h *)                                                   
let mk_header tag colour size =                                                     
  let open Int64 in                                                                 
  assert (colour >= 0L && colour <= 3L);                                            
  assert (tag >= 0L && tag <= 255L);        
  assert (size >=0L);
  logor (shift_left size 10) (logor (shift_left colour 8) tag)

let do_gc () =
  print_endline "**** Begin full major GC ****";
  Gc.full_major ();
  print_endline "**** End full major GC ****"

(* External object with black header is accepted. GC doesn't scan black
 * objects. *)
let ex1 =
  let h = mk_header 0L black 1000L in
  let e = make_block h 1000L in
  let o = Obj.new_block 0 1 in
  Obj.set_field o 0 e;
  o

let _ = do_gc ()

(* External object with size 0 is accepted. GC doesn't scan 0 sized objects. *)
let ex2 =
  (* The header may be non-black for 0 sized object *)
  let h = mk_header 0L white 0L in
  (* The actual size of the object in memory may be different *)
  let e = make_block h 1000L in
  let o = Obj.new_block 0 1 in
  Obj.set_field o 0 e;
  o

let _ = do_gc ()

(* A non-zero-sized external object cannot be non-black. *)
let ex3 =
  let h = mk_header 0L white 1000L in
  let e = make_block h 1000L in
  let o = Obj.new_block 0 1 in
  Obj.set_field o 0 e;
  o

let _ = do_gc ()

(* If external pointers point to unallocated memory, a warning is generated *)
let ex3 =
  let o = Obj.new_block 0 1 in
  Obj.set_field o 0 (get_raw_pointer 42L);
  o

let _ = do_gc ()

let _ = [ex1; ex2; ex3]
```

```bash
$ ocamlopt.opt -g test.ml cstub.c
$ ./a.out 
**** Begin full major GC ****
**** End full major GC ****
**** Begin full major GC ****
**** End full major GC ****
**** Begin full major GC ****
Out-of-heap pointer at 0x7feaf8083ff8 of value 0x55e0ff10aa38 has non-black head (tag=0)
**** End full major GC ****
**** Begin full major GC ****
Out-of-heap pointer at 0x7feaf800c2e0 of value 0x55e0ff10aa38 has non-black head (tag=0)
Out-of-heap pointer at 0x7feaf800c2e0 of value 0x55e0ff10aa38 has non-black head (tag=0)
Out-of-heap pointer at 0x7feaf8083ff8 of value 0x2a. Cannot read head.
**** End full major GC ****
Out-of-heap pointer at 0x7feaf800c2e0 of value 0x55e0ff10aa38 has non-black head (tag=0)
Out-of-heap pointer at 0x7feaf800c2f0 of value 0x2a. Cannot read head.
```

## Finding the source of the naked pointers

Given that the naked pointers are discovered during the GC, how does one find the source of the problem? [`rr`](https://github.com/mozilla/rr) makes it quite easy. Let's look at a debugging a naked pointer on a real project:

```bash
$ opam install frama-c
$ rr frama-c
rr: Saving execution to trace directory `/home/kc/.local/share/rr/frama-c-5'.
Out-of-heap pointer at 0x55fc1e2754d8 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e275600 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e2754d8 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e275600 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e2754d8 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e275600 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e2754d8 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e275600 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e2754d8 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e275600 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e2754d8 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
Out-of-heap pointer at 0x55fc1e275600 of value 0x55fc1e3a0cc0 has non-black head (tag=144)
$ rr replay
(rr) watch *(value*)0x55fc1e2754d8
Hardware watchpoint 1: *(value*)0x55fc1e2754d8
(rr) c
Continuing.

Hardware watchpoint 1: *(value*)0x55fc1e2754d8

Old value = 1
New value = 94541327240384
0x000055fc1dab48f8 in camlUnmarshal__entry () at src/libraries/datatype/unmarshal.ml:72
72      src/libraries/datatype/unmarshal.ml: No such file or directory.
```

This corresponds to the naked pointer at https://github.com/Frama-C/Frama-C-snapshot/blob/master/src/libraries/datatype/unmarshal.ml#L72. 

## Limitations

* Tested only on `amd64` on Linux. 
* Uses `rr` for locating the allocation point. There may be clever ways to use `gdb` to do the same. 