### PR TITLE
Add Obj.null

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -153,7 +153,7 @@ static void realloc_gray_vals (void)
 void caml_darken (value v, value *p /* not used */)
 {
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
-  if (Is_block (v) && !Is_young (v) && Wosize_val (v) > 0) {
+  if (v && Is_block (v) && !Is_young (v) && Wosize_val (v) > 0) {
 #else
   if (Is_block (v) && Is_in_heap (v)) {
 #endif
@@ -237,7 +237,8 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
   child = Field (v, i);
 
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
-  if (Is_block (child)
+  if (child /* Obj.null */
+        && Is_block (child)
         && ! Is_young (child)
         && Wosize_val (child) > 0  /* Atoms never need to be marked. */
         /* Closure blocks contain code pointers at offsets that cannot

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -153,7 +153,9 @@ static void realloc_gray_vals (void)
 void caml_darken (value v, value *p /* not used */)
 {
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
-  if (v && Is_block (v) && !Is_young (v) && Wosize_val (v) > 0) {
+  if (v /* not Obj.null (== NULL) */
+        && Is_block (v) && !Is_young (v)
+        && Wosize_val (v) > 0) {
 #else
   if (Is_block (v) && Is_in_heap (v)) {
 #endif
@@ -237,7 +239,7 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
   child = Field (v, i);
 
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
-  if (child /* Obj.null */
+  if (child /* not Obj.null (== NULL) */
         && Is_block (child)
         && ! Is_young (child)
         && Wosize_val (child) > 0  /* Atoms never need to be marked. */

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -66,7 +66,7 @@ Caml_inline int Is_Dead_during_clean(value x)
 {
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_clean);
-  return Is_block (x) && !Is_young (x) && Is_white_val(x);
+  return x /* Obj.null */ && Is_block (x) && !Is_young (x) && Is_white_val(x);
 }
 /** The minor heap doesn't have to be marked, outside they should
     already be black
@@ -75,7 +75,7 @@ Caml_inline int Must_be_Marked_during_mark(value x)
 {
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_mark);
-  return Is_block (x) && !Is_young (x);
+  return x /* Obj.null */ && Is_block (x) && !Is_young (x);
 }
 #else
 Caml_inline int Is_Dead_during_clean(value x)

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -68,6 +68,8 @@ let int_tag = 1000
 let out_of_heap_tag = 1001
 let unaligned_tag = 1002
 
+let null = field (repr 0L) 1
+
 module Extension_constructor =
 struct
   type t = extension_constructor

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -90,6 +90,8 @@ val int_tag : int
 val out_of_heap_tag : int
 val unaligned_tag : int   (* should never happen @since 3.11.0 *)
 
+val null : t
+
 module Extension_constructor :
 sig
   type t = extension_constructor


### PR DESCRIPTION
This PR adds a distinguished `null` value to the `Obj` module that has the same bit pattern as `NULL` in C (all bits set to 0 according to C99 standard). 

## The need for `Obj.null`

C bindings and low-level code sometimes have the need to represent a value that is [either `NULL` or is a valid OCaml value](https://github.com/ocaml/ocaml/pull/9534#issuecomment-624071403). This is permitted by the OCaml compiler as the GC uses the page table to identify that `NULL` is outside the heap and skips following the object. However, with `no-naked-pointers` mode, where the GC only consults the page table for code pointers, `NULL` value to be a value on the major heap i.e, `Is_block(NULL) && !Is_young(NULL)` holds. This would lead to a crash if the GC follows the `NULL` pointer.

## Implementation

In the naked pointer mode, the only places where the GC decides whether to follow a pointer is in `caml_darken` and `mark_slice_darken`. We add a check to see if the value is non-NULL before following it. 

**edit:** In `weak.c`, the checks in `Must_be_Marked_during_mark` and `Is_Dead_during_clean` now check for `NULL` value. 

## Interaction with Multicore OCaml

This scheme is also compatible with the multicore compiler. Multicore currently uses a parallel minor GC, and `Obj.null` poses no special issues. The alternative concurrent minor GC uses a fast read barrier test to decide whether a pointer is in a foreign minor heap arena. See section 4.3.2 in the [multicore GC paper](https://arxiv.org/pdf/2004.11663.pdf).

Assuming a similar 16-bit address space, the precondition we need is that `PQ(bx) != 0 /\ PQ(bx) != 1`.

```c
/* ax == 0 /\ PQ(bx) != 0 /\ PQ(bx) != 1 */
xor %bx , %ax
/* ax == bx /\ PQ(ax) != 0 /\ PQ(ax) != 1 */
sub 0x0010 , %ax
/* PQ(ax) != 0 */
test 0xff01 , %ax
/* ZF not set */
```

It is unlikely that the minor heap area gets allocated between at the very beginning of the virtual memory area. If we get unlucky, we'll just reserve that space and request another contiguous virtual memory chunk. In the worst case, on 64-bit address space, with the current multicore settings for the number of domains (128 max) with each domain having a maximum 16MB of minor heap arena, we may have to reserve (not allocate) 8GB of virtual address space. @stedolan. 
