### PR TITLE
Added JSON output to ocamldep

### DIFF
--- a/Changes
+++ b/Changes
@@ -289,12 +289,6 @@ OCaml 4.11
   on length of Sys.command argument.
   (Xavier Leroy, report by Jérémie Dimino, review by David Allsopp)
 
-<<<<<<< HEAD
-- #9552: restore ocamloptp build and installation
-  (Florian Angeletti, review by David Allsopp and Xavier Leroy)
-
-=======
->>>>>>> 8fda485... Added: Documentation for -json
 - #7560: Argument -json added to ocamldep, using this the output
   for ocamldep -modules can be printed in JSON format.
   (Muskan Garg, review by Florian Angeletti and Gabiel Scherer)

--- a/Changes
+++ b/Changes
@@ -289,6 +289,16 @@ OCaml 4.11
   on length of Sys.command argument.
   (Xavier Leroy, report by Jérémie Dimino, review by David Allsopp)
 
+<<<<<<< HEAD
+- #9552: restore ocamloptp build and installation
+  (Florian Angeletti, review by David Allsopp and Xavier Leroy)
+
+=======
+>>>>>>> 8fda485... Added: Documentation for -json
+- #7560: Argument -json added to ocamldep, using this the output
+  for ocamldep -modules can be printed in JSON format.
+  (Muskan Garg, review by Florian Angeletti and Gabiel Scherer)
+
 ### Manual and documentation:
 
 - #9141: beginning of the ocamltest reference manual

--- a/man/ocamldep.m
+++ b/man/ocamldep.m
@@ -135,6 +135,9 @@ by
 but can be post-processed by other tools such as
 .BR Omake (1).
 .TP
+.B \-json
+Print module dependencies in JSON format only supported with -modules for now.
+.TP
 .BI \-native
 Generate dependencies for a pure native-code program (no bytecode
 version).  When an implementation file (.ml file) has no explicit

--- a/manual/manual/cmds/ocamldep.etex
+++ b/manual/manual/cmds/ocamldep.etex
@@ -95,6 +95,9 @@ units referenced within the file "filename", but these names are not
 resolved to source file names.  Such raw dependencies cannot be used
 by "make", but can be post-processed by other tools such as "Omake".
 
+\item["-json"]
+Print module dependencies in JSON format only supported with -modules for now.
+
 \item["-native"]
 Generate dependencies for a pure native-code program (no bytecode
 version).  When an implementation file (".ml" file) has no explicit

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -178,6 +178,16 @@ module Stdlib : sig
   external compare : 'a -> 'a -> int = "%compare"
 end
 
+module Json : sig
+  type t =
+    [
+      | `String of string
+      | `Assoc of (string * t) list
+      | `List of t list
+    ]
+  val print : Format.formatter -> t -> unit
+end
+
 val find_in_path: string list -> string -> string
         (* Search a file in a list of directories. *)
 val find_in_path_rel: string list -> string -> string


### PR DESCRIPTION
Closes #7560
 an example of the output format is:
<pre>
[{"source": "stdlib/arg.ml",
  "depends_on": ["Array", "Buffer", "List", "Printf", "String", "Sys"]
 },
 {"source": "stdlib/array.ml", "depends_on": ["Seq"]},
 {"source": "stdlib/format.ml",
  "depends_on":
     ["Buffer",
      "CamlinternalFormat",
      "CamlinternalFormatBasics",
      "Int",
      "List",
      "Queue",
      "Stack",
      "Stdlib",
      "String"
     ]
 },
 {"source": "stdlib/fun.mli", "depends_on": []},
 {"source": "stdlib/printf.mli", "depends_on": ["Buffer"]}
]
</pre>