### PR TITLE
Warning 68 for instantiation of external variable in GADT pattern matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
         -I driver -I toplevel
 
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
-	  -warn-error A \
+	  -warn-error A-68 \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -116,7 +116,7 @@ INCLUDES_NODEP=\
 DEPINCLUDES=$(INCLUDES_DEP)
 INCLUDES=$(INCLUDES_DEP) $(INCLUDES_NODEP)
 
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A-68 \
   -safe-string -strict-sequence -strict-formats -bin-annot -principal
 
 LINKFLAGS=$(INCLUDES) -nostdlib

--- a/testsuite/tests/basic/switch_opts.compilers.reference
+++ b/testsuite/tests/basic/switch_opts.compilers.reference
@@ -1,0 +1,4 @@
+File "switch_opts.ml", line 275, characters 8-10:
+275 |       | Ag -> 1
+              ^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -713,6 +713,10 @@ let bad_location =
 [%%expect{|
 val bad_location : 'a GADT_ordering.is_point -> 'a -> int = <fun>
 |}, Principal{|
+Line 4, characters 11-19:
+4 |       let+ Is_point = is_point
+               ^^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 6-10:
 4 |       let+ Is_point = is_point
           ^^^^

--- a/testsuite/tests/typing-gadts/omega07.ml
+++ b/testsuite/tests/typing-gadts/omega07.ml
@@ -582,6 +582,10 @@ type (_, _) ctxt =
       (red, 'n) ctxt -> (black, 'n) ctxt
   | CBlk : int * dir * ('c1, 'n) sub_tree *
       (black, 'n succ) ctxt -> ('c, 'n) ctxt
+Line 22, characters 4-19:
+22 |     Rnode (l, e, r) -> Bnode (l, e, r)
+         ^^^^^^^^^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 val blacken : (red, 'a) sub_tree -> (black, 'a succ) sub_tree = <fun>
 |}];;
 
@@ -636,6 +640,10 @@ let rotate d1 pE sib d2 gE uncle (Rnode (x, e, y)) =
   | RightD, LeftD  -> Bnode (Rnode (uncle, gE, x), e, Rnode (y, pE, sib))
 ;;
 [%%expect{|
+Line 1, characters 33-50:
+1 | let rotate d1 pE sib d2 gE uncle (Rnode (x, e, y)) =
+                                     ^^^^^^^^^^^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 val rotate :
   dir ->
   int ->

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -18,6 +18,25 @@ let trivial t =
 ;;
 
 [%%expect{|
+Line 3, characters 4-10:
+3 |   | IntLit -> ()
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-11:
+4 |   | BoolLit -> ()
+        ^^^^^^^
+Error: This pattern matches values of type bool t
+       but a pattern was expected which matches values of type int t
+       Type bool is not compatible with type int
+|}, Principal{|
+Line 3, characters 4-10:
+3 |   | IntLit -> ()
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-11:
+4 |   | BoolLit -> ()
+        ^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-11:
 4 |   | BoolLit -> ()
         ^^^^^^^
@@ -43,6 +62,10 @@ let trivial_merged t =
 ;;
 
 [%%expect{|
+Line 3, characters 4-10:
+3 |   | IntLit
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-11:
 4 |   | BoolLit -> ()
         ^^^^^^^
@@ -118,6 +141,10 @@ let simple t a =
 ;;
 
 [%%expect{|
+Line 3, characters 4-10:
+3 |   | IntLit, 3 -> ()
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-11:
 4 |   | BoolLit, true -> ()
         ^^^^^^^
@@ -125,6 +152,14 @@ Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
 |}, Principal{|
+Line 3, characters 4-10:
+3 |   | IntLit, 3 -> ()
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-11:
+4 |   | BoolLit, true -> ()
+        ^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-17:
 4 |   | BoolLit, true -> ()
         ^^^^^^^^^^^^^
@@ -152,6 +187,10 @@ let simple_merged t a =
 ;;
 
 [%%expect{|
+Line 3, characters 4-10:
+3 |   | IntLit, 3
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-11:
 4 |   | BoolLit, true -> ()
         ^^^^^^^
@@ -386,6 +425,10 @@ let noop t a =
 ;;
 
 [%%expect{|
+Line 3, characters 4-10:
+3 |   | IntLit, x -> x
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-11:
 4 |   | BoolLit, x -> x
         ^^^^^^^
@@ -393,6 +436,14 @@ Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
 |}, Principal{|
+Line 3, characters 4-10:
+3 |   | IntLit, x -> x
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-11:
+4 |   | BoolLit, x -> x
+        ^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-14:
 4 |   | BoolLit, x -> x
         ^^^^^^^^^^
@@ -418,6 +469,10 @@ let noop_merged t a =
 ;;
 
 [%%expect{|
+Line 3, characters 4-10:
+3 |   | IntLit, x
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-11:
 4 |   | BoolLit, x -> x
         ^^^^^^^
@@ -453,6 +508,25 @@ let trivial2 t2 =
 ;;
 
 [%%expect{|
+Line 3, characters 4-9:
+3 |   | Int _ -> ()
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-10:
+4 |   | Bool _ -> ()
+        ^^^^^^
+Error: This pattern matches values of type bool t2
+       but a pattern was expected which matches values of type int t2
+       Type bool is not compatible with type int
+|}, Principal{|
+Line 3, characters 4-9:
+3 |   | Int _ -> ()
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-10:
+4 |   | Bool _ -> ()
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-10:
 4 |   | Bool _ -> ()
         ^^^^^^
@@ -478,6 +552,10 @@ let trivial2_merged t2 =
 ;;
 
 [%%expect{|
+Line 3, characters 4-9:
+3 |   | Int _
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-10:
 4 |   | Bool _ -> ()
         ^^^^^^
@@ -504,6 +582,25 @@ let extract t2 =
 ;;
 
 [%%expect{|
+Line 3, characters 4-9:
+3 |   | Int _ -> x
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-10:
+4 |   | Bool _ -> x
+        ^^^^^^
+Error: This pattern matches values of type bool t2
+       but a pattern was expected which matches values of type int t2
+       Type bool is not compatible with type int
+|}, Principal{|
+Line 3, characters 4-9:
+3 |   | Int _ -> x
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 4, characters 4-10:
+4 |   | Bool _ -> x
+        ^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-10:
 4 |   | Bool _ -> x
         ^^^^^^
@@ -529,6 +626,10 @@ let extract_merged t2 =
 ;;
 
 [%%expect{|
+Line 3, characters 4-9:
+3 |   | Int x
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-10:
 4 |   | Bool x -> x
         ^^^^^^
@@ -634,6 +735,10 @@ let not_annotated x =
 ;;
 
 [%%expect{|
+Line 3, characters 4-5:
+3 |   | A | B -> 3
+        ^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 val not_annotated : int t3 -> int = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -44,6 +44,10 @@ type ('a, 'result, 'visit_action) context =
 Line 15, characters 4-9:
 15 |   | Local -> fun _ -> raise Exit
          ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 15, characters 4-9:
+15 |   | Local -> fun _ -> raise Exit
+         ^^^^^
 Error: This pattern matches values of type
          ($0, $0 * insert, visit_action) context
        The type constructor $0 would escape its scope
@@ -65,6 +69,10 @@ Error: This pattern matches values of type
          ($'a, $'a * insert, visit_action) context
        The type constructor $'a would escape its scope
 |}, Principal{|
+Line 4, characters 4-9:
+4 |   | Local -> fun _ -> raise Exit
+        ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 4, characters 4-9:
 4 |   | Local -> fun _ -> raise Exit
         ^^^^^

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -24,8 +24,16 @@ let get1' = function
   | (Cons (x, _) : (_ * 'a, 'a) t) -> x
   | Nil -> assert false ;; (* ok *)
 [%%expect{|
+Line 3, characters 4-7:
+3 |   | Nil -> assert false ;; (* ok *)
+        ^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 val get1' : ('b * 'a as 'a, 'a) t -> 'b = <fun>
 |}, Principal{|
+Line 3, characters 4-7:
+3 |   | Nil -> assert false ;; (* ok *)
+        ^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 3, characters 4-7:
 3 |   | Nil -> assert false ;; (* ok *)
         ^^^

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -13,6 +13,10 @@ type _ t =
     Int : int -> int t
   | String : string -> string t
   | Same : 'l t -> 'l t
+Line 3, characters 21-26:
+3 | let rec f = function Int x -> x | Same s -> f s;;
+                         ^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 val f : int t -> int = <fun>
 Lines 4-5, characters 0-77:
 4 | type 'a tt = 'a t =

--- a/testsuite/tests/typing-gadts/pr7222.ml
+++ b/testsuite/tests/typing-gadts/pr7222.ml
@@ -34,6 +34,10 @@ type (_, _) elt =
     Elt_fine : 'nat n -> ('l, 'nat * 'l) elt
   | Elt : 'nat n -> ('l, 'nat -> 'l) elt
 type _ t = Nil : nil t | Cons : ('x, 'fx) elt * 'x t -> 'fx t
+Line 9, characters 11-18:
+9 |   let Cons(Elt dim, _) = sh in ()
+               ^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 9, characters 6-22:
 9 |   let Cons(Elt dim, _) = sh in ()
           ^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-gadts/pr7390.ml
+++ b/testsuite/tests/typing-gadts/pr7390.ml
@@ -21,6 +21,10 @@ type 'fill either =
 let f (* : filled either -> string *) =
   fun (Either (Y a, N)) -> a;;
 [%%expect{|
+Line 2, characters 15-18:
+2 |   fun (Either (Y a, N)) -> a;;
+                   ^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 2, characters 2-28:
 2 |   fun (Either (Y a, N)) -> a;;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -64,6 +64,14 @@ module List =
   end
 ;;
 [%%expect{|
+Line 9, characters 10-20:
+9 |         | Cons (a,b) -> a
+              ^^^^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 12, characters 10-20:
+12 |         | Cons (a,b) -> b
+               ^^^^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 module List :
   sig
     type zero

--- a/testsuite/tests/typing-misc/pattern_open.ml
+++ b/testsuite/tests/typing-misc/pattern_open.ml
@@ -190,6 +190,10 @@ module S :
 let test_separation = function
   | S.(Sep), (S.(Sep,Sep), Sep) -> ();;
 [%%expect {|
+Line 2, characters 7-10:
+2 |   | S.(Sep), (S.(Sep,Sep), Sep) -> ();;
+           ^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 2, characters 27-30:
 2 |   | S.(Sep), (S.(Sep,Sep), Sep) -> ();;
                                ^^^
@@ -206,6 +210,10 @@ Error: Unbound constructor Ex
 let test_separation_3 = function
   | S.(Sep) -> s;;
 [%%expect {|
+Line 2, characters 7-10:
+2 |   | S.(Sep) -> s;;
+           ^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 2, characters 15-16:
 2 |   | S.(Sep) -> s;;
                    ^

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -423,6 +423,25 @@ let x  = function
 
 [%%expect{|
 type 'a x = X : [> `azdwbie ] x | Y : [> `c7diagq ] x
+Line 6, characters 4-5:
+6 |   | X -> ()
+        ^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 7, characters 4-5:
+7 |   | Y  -> ()
+        ^
+Error: Variant tags `azdwbie and `c7diagq have the same hash value.
+       Change one of them.
+|}, Principal{|
+type 'a x = X : [> `azdwbie ] x | Y : [> `c7diagq ] x
+Line 6, characters 4-5:
+6 |   | X -> ()
+        ^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
+Line 7, characters 4-5:
+7 |   | Y  -> ()
+        ^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 Line 7, characters 4-5:
 7 |   | Y  -> ()
         ^

--- a/testsuite/tests/typing-multifile/pr6372.compilers.reference
+++ b/testsuite/tests/typing-multifile/pr6372.compilers.reference
@@ -1,0 +1,4 @@
+File "e.ml", line 1, characters 15-22:
+1 | open D;; let f (C {f}) = ()
+                   ^^^^^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.

--- a/testsuite/tests/typing-objects/pr5619_bad.ml
+++ b/testsuite/tests/typing-objects/pr5619_bad.ml
@@ -26,6 +26,10 @@ class foo =
   end
 ;;
 [%%expect{|
+Line 6, characters 10-13:
+6 |           Foo -> (self :> <foo : string>)
+              ^^^
+Warning 68: This GADT pattern-matching instantiated an external type variable.
 class foo :
   object method cast : foo_t name -> < foo : string > method foo : string end
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1561,7 +1561,8 @@ and type_pat_aux
       in
       let expected_ty = instance expected_ty in
       let expected_fvs =
-        if mode = Normal && constr.cstr_generalized && not !already_warned_gadt
+        if mode = Normal && constr.cstr_generalized && no_existentials = None
+        && not !already_warned_gadt
         then free_variables expected_ty else []
       in
       (* PR#7214: do not use gadt unification for toplevel lets *)

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -824,7 +824,7 @@ let split_pattern pat =
     (* The third parameter of [Tpat_or] is [Some _] only for "#typ"
        patterns, which we do *not* expand. Hence we can put [None] here. *)
     { pat with pat_desc = Tpat_or (p1, p2, None) } in
-  let rec split_pattern cpat =
+  let rec split_pattern (cpat : computation general_pattern) =
     match cpat.pat_desc with
     | Tpat_value p ->
         Some p, None

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -92,6 +92,7 @@ type t =
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
   | Unused_functor_parameter of string      (* 67 *)
+  | Instantiate_by_gadt                     (* 68 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -170,9 +171,10 @@ let number = function
   | Redefining_unit _ -> 65
   | Unused_open_bang _ -> 66
   | Unused_functor_parameter _ -> 67
+  | Instantiate_by_gadt -> 68
 ;;
 
-let last_warning_number = 67
+let last_warning_number = 68
 ;;
 
 (* Must be the max number returned by the [number] function. *)
@@ -631,6 +633,8 @@ let message = function
          which shadows the existing one.\n\
          Hint: Did you mean 'type %s = unit'?" name
   | Unused_functor_parameter s -> "unused functor parameter " ^ s ^ "."
+  | Instantiate_by_gadt ->
+      "This GADT pattern-matching instantiated an external type variable."
 ;;
 
 let nerrors = ref 0;;
@@ -776,6 +780,7 @@ let descriptions =
    65, "Type declaration defining a new '()' constructor.";
    66, "Unused open! statement.";
    67, "Unused functor parameter.";
+   68, "GADT pattern matching instantiated a type variable."
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -94,6 +94,7 @@ type t =
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
   | Unused_functor_parameter of string      (* 67 *)
+  | Instantiate_by_gadt                     (* 68 *)
 ;;
 
 type alert = {kind:string; message:string; def:loc; use:loc}


### PR DESCRIPTION
Proof of concept implementation of a warning when instantiating an external type variable during GADT pattern matching.
This is an answer to @fpottier 's comment that the behavior of the type-checker can be confusing in that case.