### PR TITLE
Modernize signal handling on Linux i386, PowerPC, and s390x

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,10 @@ Working version
 
 ### Runtime system:
 
+- #1795, #9543: modernize signal handling on Linux i386, PowerPC, and s390x,
+  adding support for Musl ppc64le along the way.
+  (Xavier Leroy and Anil Madhavapeddy, review by Stephen Dolan)
+
 - #9508: Remove support for FreeBSD prior to 4.0R, that required explicit
   floating-point initialization to behave like IEEE standard
   (Hannes Mehnert, review by David Allsopp)

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -17,7 +17,10 @@
 
 /* Signal handling, code specific to the native-code compiler */
 
-#if defined (SYS_linux)
+#if defined(TARGET_amd64) && defined (SYS_linux)
+#define _GNU_SOURCE
+#endif
+#if defined(TARGET_i386) && defined (SYS_linux_elf)
 #define _GNU_SOURCE
 #endif
 #include <signal.h>

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -17,7 +17,7 @@
 
 /* Signal handling, code specific to the native-code compiler */
 
-#if defined(TARGET_amd64) && defined (SYS_linux)
+#if defined (SYS_linux)
 #define _GNU_SOURCE
 #endif
 #include <signal.h>

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -323,18 +323,19 @@
 #elif defined(TARGET_power) && defined(SYS_elf)
 
   #define DECLARE_SIGNAL_HANDLER(name) \
-    static void name(int sig, struct sigcontext * context)
+    static void name(int sig, siginfo_t * info, ucontext_t * context)
 
   #define SET_SIGACT(sigact,name) \
-     sigact.sa_handler = (void (*)(int)) (name); \
-     sigact.sa_flags = 0
+     sigact.sa_sigaction = (void (*)(int,siginfo_t *,void *)) (name); \
+     sigact.sa_flags = SA_SIGINFO
 
   typedef unsigned long context_reg;
-  #define CONTEXT_PC (context->regs->nip)
-  #define CONTEXT_EXCEPTION_POINTER (context->regs->gpr[29])
-  #define CONTEXT_YOUNG_LIMIT (context->regs->gpr[30])
-  #define CONTEXT_YOUNG_PTR (context->regs->gpr[31])
-  #define CONTEXT_SP (context->regs->gpr[1])
+  #define CONTEXT_PC (context->uc_mcontext.regs->nip)
+  #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.regs->gpr[29])
+  #define CONTEXT_YOUNG_LIMIT (context->uc_mcontext.regs->gpr[30])
+  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.regs->gpr[31])
+  #define CONTEXT_SP (context->uc_mcontext.regs->gpr[1])
+  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
 /****************** PowerPC, NetBSD */
 

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -381,18 +381,19 @@
 #elif defined(TARGET_s390x) && defined(SYS_elf)
 
   #define DECLARE_SIGNAL_HANDLER(name) \
-    static void name(int sig, struct sigcontext * context)
+    static void name(int sig, siginfo_t * info, ucontext_t * context)
 
   #define SET_SIGACT(sigact,name) \
-     sigact.sa_handler = (void (*)(int)) (name); \
-     sigact.sa_flags = 0
+     sigact.sa_sigaction = (void (*)(int,siginfo_t *,void *)) (name); \
+     sigact.sa_flags = SA_SIGINFO
 
   typedef unsigned long context_reg;
-  #define CONTEXT_PC (context->sregs->regs.psw.addr)
-  #define CONTEXT_EXCEPTION_POINTER (context->sregs->regs.gprs[13])
-  #define CONTEXT_YOUNG_LIMIT (context->sregs->regs.gprs[10])
-  #define CONTEXT_YOUNG_PTR (context->sregs->regs.gprs[11])
-  #define CONTEXT_SP (context->sregs->regs.gprs[15])
+  #define CONTEXT_PC (context->uc_mcontext.psw.addr)
+  #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.gregs[13])
+  #define CONTEXT_YOUNG_LIMIT (context->uc_mcontext.gregs[10])
+  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[11])
+  #define CONTEXT_SP (context->uc_mcontext.gregs[15])
+  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
 /******************** Default */
 

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -318,7 +318,25 @@
   #define CONTEXT_SP (CONTEXT_STATE.CONTEXT_REG(r1))
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
-/****************** PowerPC, ELF (Linux) */
+/****************** PowerPC 32 bits, ELF (Linux) */
+
+#elif defined(TARGET_power) && defined(MODEL_ppc) && defined(SYS_elf)
+
+  #define DECLARE_SIGNAL_HANDLER(name) \
+    static void name(int sig, struct sigcontext * context)
+
+  #define SET_SIGACT(sigact,name) \
+     sigact.sa_handler = (void (*)(int)) (name); \
+     sigact.sa_flags = 0
+
+  typedef unsigned long context_reg;
+  #define CONTEXT_PC (context->regs->nip)
+  #define CONTEXT_EXCEPTION_POINTER (context->regs->gpr[29])
+  #define CONTEXT_YOUNG_LIMIT (context->regs->gpr[30])
+  #define CONTEXT_YOUNG_PTR (context->regs->gpr[31])
+  #define CONTEXT_SP (context->regs->gpr[1])
+
+/****************** PowerPC 64 bits, ELF (Linux) */
 
 #elif defined(TARGET_power) && defined(SYS_elf)
 
@@ -330,11 +348,11 @@
      sigact.sa_flags = SA_SIGINFO
 
   typedef unsigned long context_reg;
-  #define CONTEXT_PC (context->uc_mcontext.regs->nip)
-  #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.regs->gpr[29])
-  #define CONTEXT_YOUNG_LIMIT (context->uc_mcontext.regs->gpr[30])
-  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.regs->gpr[31])
-  #define CONTEXT_SP (context->uc_mcontext.regs->gpr[1])
+  #define CONTEXT_PC (context->uc_mcontext.gp_regs[32])
+  #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.gp_regs[29])
+  #define CONTEXT_YOUNG_LIMIT (context->uc_mcontext.gp_regs[30])
+  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gp_regs[31])
+  #define CONTEXT_SP (context->uc_mcontext.gp_regs[1])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
 
 /****************** PowerPC, NetBSD */

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -186,15 +186,16 @@
 #elif defined(TARGET_i386) && defined(SYS_linux_elf)
 
   #define DECLARE_SIGNAL_HANDLER(name) \
-    static void name(int sig, struct sigcontext context)
+    static void name(int sig, siginfo_t * info, ucontext_t * context)
 
   #define SET_SIGACT(sigact,name) \
-     sigact.sa_handler = (void (*)(int)) (name); \
-     sigact.sa_flags = 0
+     sigact.sa_sigaction = (void (*)(int,siginfo_t *,void *)) (name); \
+     sigact.sa_flags = SA_SIGINFO
 
-  #define CONTEXT_FAULTING_ADDRESS ((char *) context.cr2)
-  #define CONTEXT_PC (context.eip)
-  #define CONTEXT_SP (context.esp)
+  typedef greg_t context_reg;
+  #define CONTEXT_PC (context->uc_mcontext.gregs[REG_RIP])
+  #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
+  #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.gregs[REG_CR2])
 
 /****************** I386, BSD_ELF */
 

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -193,9 +193,9 @@
      sigact.sa_flags = SA_SIGINFO
 
   typedef greg_t context_reg;
-  #define CONTEXT_PC (context->uc_mcontext.gregs[REG_RIP])
-  #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
-  #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.gregs[REG_CR2])
+  #define CONTEXT_PC (context->uc_mcontext.gregs[REG_EIP])
+  #define CONTEXT_SP (context->uc_mcontext.gregs[REG_ESP])
+  #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.cr2)
 
 /****************** I386, BSD_ELF */
 


### PR DESCRIPTION
OCaml's signal handlers need to know the state of the processor when the signal was received.  The approach standardized by the Single Unix specification is tu use 3-argument signal handing functions and the `SA_SIGINFO` flag to `sigaction`.  However, as the Linux man page for `sigaction` says,

Undocumented:
      Before the introduction of SA_SIGINFO, it was also possible to get some
       additional information, namely by using  a  sa_handler  with  a  second
       argument  of  type  struct  sigcontext.   See the relevant Linux kernel
       sources for details.  This use is obsolete now.

For historical reasons, the i386, PowerPC and s390x Linux ports of OCaml still use the undocumented, obsolete approach, while the other Linux ports use the modern `SA_SIGINFO` approach.  [EDIT: added PowerPC and s390x to the list.]

For consistency and future-proofing, this PR updates the i386 Linux port to use the modern approach to signal handling.  [EDIT:] And also the PowerPC 64 bits and s390x ports.
