### PR TITLE
[RFC] output-complete-exe: embed debug info in C file

### DIFF
--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -104,6 +104,9 @@ CAMLprim value caml_record_backtrace(value vflag);
 /* Path to the file containing debug information, if any, or NULL. */
 CAMLextern char_os * caml_cds_file;
 
+CAMLextern char * caml_embedded_debug_info;
+CAMLextern unsigned int caml_embedded_debug_info_len;
+
 /* Primitive called _only_ by runtime to record unwinded frames to
  * backtrace.  A similar primitive exists for native code, but with a
  * different prototype. */


### PR DESCRIPTION
This is an **experiment** trying to embed the debug info for `-output-complete-exe` binaries directly in the C file in order to have backtraces again in such binaries (see #9368).

The debug info is embedded as a static string literal in the generated code, with each byte encoded as `\xhh` in hex.

The problem is that the resulting C file is quite large; for `ocamopt` the generated file is about 105M.

Does anyone know of a trick to embed binary data in a C file in a more compact manner than escaping every byte?

I also experimented using `objcopy` to copy the debug info directly to the generated `.o` which is much more efficient, but much less portable.

Note: for debugging, I disabled the deletion of the temporary C file that gets generated, so if you use `-verbose` and `-output-complete-exe` you can find out the name of the temporary file and inspect it.