### PR TITLE
Fix #7741: Failure to report escaping type variable

### DIFF
--- a/Changes
+++ b/Changes
@@ -533,6 +533,9 @@ OCaml 4.11
 - #7696, #6608: Record expression deleted when all fields specified
   (Jacques Garrigue, report by Jeremy Yallop)
 
+- #7741: Failure to report escaping type variable
+  (Jacques Garrigue, report by Gabriel Radanne, review by Gabriel Scherer)
+
 - #7817, #9546: Unsound inclusion check for polymorphic variant
   (Jacques Garrigue, report by Mikhail Mandrykin, review by Gabriel Scherer)
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1816,3 +1816,39 @@ Error: This expression has type < x : 'b. 'b s list >
        'a list
        The universal variable 'b would escape its scope
 |}]
+
+type u = < m : 'a. 'a s list * (< m : 'b. 'a s list * 'c > as 'c) >
+type v = < m : 'a. 'a s list * 'c > as 'c
+[%%expect{|
+type u = < m : 'a. 'a s list * (< m : 'a s list * 'b > as 'b) >
+type v = < m : 'a. 'a s list * 'b > as 'b
+|}]
+let f (x : u) = (x : v)
+[%%expect{|
+Line 1, characters 17-18:
+1 | let f (x : u) = (x : v)
+                     ^
+Error: This expression has type u but an expression was expected of type v
+       The method m has type 'a s list * < m : 'b > as 'b,
+       but the expected method type was 'a. 'a s list * < m : 'a. 'b > as 'b
+       The universal variable 'a would escape its scope
+|}]
+
+type 'a s = private int
+[%%expect{|
+type 'a s = private int
+|}]
+let x : 'a c = object
+  method x : 'b . 'b s list = []
+end
+[%%expect{|
+Lines 1-3, characters 15-3:
+1 | ...............object
+2 |   method x : 'b . 'b s list = []
+3 | end
+Error: This expression has type < x : 'b. 'b s list >
+       but an expression was expected of type 'a c
+       The method x has type 'b. 'b s list, but the expected method type was
+       'a list
+       The universal variable 'b would escape its scope
+|}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1790,3 +1790,29 @@ Line 1, characters 30-40:
 Error: This definition has type 'b -> 'b which is less general than
          'a. 'a -> 'c
 |}]
+
+(* #7741 *)
+type 'a s = S
+
+class type ['x] c = object
+  method x : 'x list
+end
+[%%expect{|
+type 'a s = S
+class type ['x] c = object method x : 'x list end
+|}]
+
+let x : 'a c = object
+  method x : 'b . 'b s list = [S]
+end
+[%%expect{|
+Lines 1-3, characters 15-3:
+1 | ...............object
+2 |   method x : 'b . 'b s list = [S]
+3 | end
+Error: This expression has type < x : 'b. 'b s list >
+       but an expression was expected of type 'a c
+       The method x has type 'b. 'b s list, but the expected method type was
+       'a list
+       The universal variable 'b would escape its scope
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1919,7 +1919,9 @@ let occur_univar env ty =
                    corresponds to type variables that do not occur in the
                    definition (expansion would erase them completely).
                    The type-checker consistently ignores type expressions
-                   in this position. *)
+                   in this position. Physical expansion, as done in `occur`,
+                   would be costly here, since we need to check inside
+                   object and variant types too. *)
                 if not Variance.(eq v null) then occur_rec bound t)
               tl td.type_variance
           with Not_found ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1915,7 +1915,7 @@ let occur_univar env ty =
             let td = Env.find_type p env in
             List.iter2
               (fun t v ->
-                if Variance.(mem May_pos v || mem May_neg v)
+                if Variance.(mem May_pos v || mem May_neg v || mem Inj v)
                 then occur_rec bound t)
               tl td.type_variance
           with Not_found ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1917,9 +1917,8 @@ let occur_univar env ty =
               (fun t v ->
                 (* Optimization: rather than expanding the type definition
                    for abbreviations, use the inferred presence information.
-                   Only public abbreviations may make this formula false. *)
-                if Variance.(mem May_pos v || mem May_neg v || mem Inj v)
-                then occur_rec bound t)
+                   Only public abbreviations may have a null variance. *)
+                if not Variance.(eq v null) then occur_rec bound t)
               tl td.type_variance
           with Not_found ->
             List.iter (occur_rec bound) tl
@@ -1968,8 +1967,7 @@ let univars_escape env univar_pairs vl ty =
             List.iter2
               (fun t v ->
                 (* Optimization: see occur_univar *)
-                if Variance.(mem May_pos v || mem May_neg v || mem Inj v)
-                then occur t)
+                if not Variance.(eq v null) then occur t)
               tl td.type_variance
           with Not_found ->
             List.iter occur tl

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1915,9 +1915,11 @@ let occur_univar env ty =
             let td = Env.find_type p env in
             List.iter2
               (fun t v ->
-                (* Optimization: rather than expanding the type definition
-                   for abbreviations, use the inferred presence information.
-                   Only public abbreviations may have a null variance. *)
+                (* The null variance only occurs in type abbreviations and
+                   corresponds to type variables that do not occur in the
+                   definition (expansion would erase them completely).
+                   The type-checker consistently ignores type expressions
+                   in this position. *)
                 if not Variance.(eq v null) then occur_rec bound t)
               tl td.type_variance
           with Not_found ->
@@ -1965,9 +1967,8 @@ let univars_escape env univar_pairs vl ty =
           begin try
             let td = Env.find_type p env in
             List.iter2
-              (fun t v ->
-                (* Optimization: see occur_univar *)
-                if not Variance.(eq v null) then occur t)
+              (* see occur_univar *)
+              (fun t v -> if not Variance.(eq v null) then occur t)
               tl td.type_variance
           with Not_found ->
             List.iter occur tl

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1915,6 +1915,9 @@ let occur_univar env ty =
             let td = Env.find_type p env in
             List.iter2
               (fun t v ->
+                (* Optimization: rather than expanding the type definition
+                   for abbreviations, use the inferred presence information.
+                   Only public abbreviations may make this formula false. *)
                 if Variance.(mem May_pos v || mem May_neg v || mem Inj v)
                 then occur_rec bound t)
               tl td.type_variance
@@ -1964,7 +1967,9 @@ let univars_escape env univar_pairs vl ty =
             let td = Env.find_type p env in
             List.iter2
               (fun t v ->
-                if Variance.(mem May_pos v || mem May_neg v) then occur t)
+                (* Optimization: see occur_univar *)
+                if Variance.(mem May_pos v || mem May_neg v || mem Inj v)
+                then occur t)
               tl td.type_variance
           with Not_found ->
             List.iter occur tl


### PR DESCRIPTION
This is a fix for #7741.
Forgot to check for the `Inj` flag in `Ctype.occur_univar`.