### PR TITLE
Fix PR#7817: Unsound inclusion check for polymorphic variant

### DIFF
--- a/Changes
+++ b/Changes
@@ -435,6 +435,9 @@ OCaml 4.11
 - #7696, #6608: Record expression deleted when all fields specified
   (Jacques Garrigue, report by Jeremy Yallop)
 
+- #7817, #9546: Unsound inclusion check for polymorphic variant
+  (Jacques Garrigue, report by Mikhail Mandrykin, review by Leo White)
+
 - #7917, #9426: Use GCC option -fexcess-precision=standard when available,
   avoiding a problem with x87 excess precision in Float.round.
   (Xavier Leroy, review by Sébastien Hinderer)

--- a/Changes
+++ b/Changes
@@ -436,7 +436,7 @@ OCaml 4.11
   (Jacques Garrigue, report by Jeremy Yallop)
 
 - #7817, #9546: Unsound inclusion check for polymorphic variant
-  (Jacques Garrigue, report by Mikhail Mandrykin, review by Leo White)
+  (Jacques Garrigue, report by Mikhail Mandrykin, review by Gabriel Scherer)
 
 - #7917, #9426: Use GCC option -fexcess-precision=standard when available,
   avoiding a problem with x87 excess precision in Float.round.

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -1,0 +1,29 @@
+(* TEST
+   * expect
+*)
+
+let r = ref None
+
+module M : sig
+  val write : ([< `A of string | `B of int ] -> unit)
+end = struct
+  let write x =
+    match x with `A _ | `B _ -> r := Some x
+end
+[%%expect{|
+val r : '_weak1 option ref = {contents = None}
+Lines 5-8, characters 6-3:
+5 | ......struct
+6 |   let write x =
+7 |     match x with `A _ | `B _ -> r := Some x
+8 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit end
+       is not included in
+         sig val write : [< `A of string | `B of int ] -> unit end
+       Values do not match:
+         val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit
+       is not included in
+         val write : [< `A of string | `B of int ] -> unit
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3196,11 +3196,7 @@ let moregen_occur env level ty =
     if ty.level > level then begin
       if is_Tvar ty && ty.level >= generic_level - 1 then raise Occur;
       ty.level <- pivot_level - ty.level;
-      match ty.desc with
-        Tvariant row when static_row row ->
-          iter_row occur row
-      | _ ->
-          iter_type_expr occur ty
+      iter_type_expr occur ty
     end
   in
   begin try


### PR DESCRIPTION
Fixed #7817 .
The problem was that `Btype.static_row` was applied on a partial row, which is incorrect.
Since we now set the row to `Tnil` for static rows, the check was unnecessary anyway.