### PR TITLE
Fix #7520: Odd behaviour of refutation cases with polymorphic variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -424,7 +424,7 @@ OCaml 4.11
 ### Bug fixes:
 
 - #7520: Odd behaviour of refutation cases with polymorphic variants
-  (Jacques Garrigue, report by Leo White)
+  (Jacques Garrigue, report by Leo White, reviews by Gabriel Scherer and Leo)
 
 - #7562, #9456: ocamlopt-generated code crashed on Alpine Linux on
   ppc64le, arm, and i386.  Fixed by turning PIE off for musl-based Linux

--- a/Changes
+++ b/Changes
@@ -423,7 +423,7 @@ OCaml 4.11
 
 ### Bug fixes:
 
-- #7520: Odd behaviour of refutation cases with polymorphic variants
+- #7520, #9547: Odd behaviour of refutation cases with polymorphic variants
   (Jacques Garrigue, report by Leo White, reviews by Gabriel Scherer and Leo)
 
 - #7562, #9456: ocamlopt-generated code crashed on Alpine Linux on

--- a/Changes
+++ b/Changes
@@ -423,6 +423,9 @@ OCaml 4.11
 
 ### Bug fixes:
 
+- #7520: Odd behaviour of refutation cases with polymorphic variants
+  (Jacques Garrigue, report by Leo White)
+
 - #7562, #9456: ocamlopt-generated code crashed on Alpine Linux on
   ppc64le, arm, and i386.  Fixed by turning PIE off for musl-based Linux
   systems except amd64 (x86_64) and s390x.

--- a/testsuite/tests/typing-gadts/pr7520.ml
+++ b/testsuite/tests/typing-gadts/pr7520.ml
@@ -1,0 +1,13 @@
+(* TEST
+   * expect
+*)
+
+type ('a, 'b) eq = Refl : ('a, 'a) eq
+type empty = (int, string) eq
+
+let f = function `Foo (_ : empty) -> .
+[%%expect{|
+type ('a, 'b) eq = Refl : ('a, 'a) eq
+type empty = (int, string) eq
+val f : [< `Foo of empty ] -> 'a = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2498,15 +2498,6 @@ let unify_package env unify_list lv1 p1 n1 tl1 lv2 p2 n2 tl2 =
 (* force unification in Reither when one side has a non-conjunctive type *)
 let rigid_variants = ref false
 
-(* drop not force unification in Reither, even in fixed case
-   (not sound, only use it when checking exhaustiveness) *)
-let passive_variants = ref false
-let with_passive_variants f x =
-  if !passive_variants then f x else
-  match passive_variants := true; f x with
-  | r           -> passive_variants := false; r
-  | exception e -> passive_variants := false; raise e
-
 let unify_eq t1 t2 =
   t1 == t2 ||
   match !umode with
@@ -2966,7 +2957,6 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
         List.iter2 (unify env) tl1 tl2
       end
       else let redo =
-        not !passive_variants &&
         (m1 || m2 || either_fixed ||
          !rigid_variants && (List.length tl1 = 1 || List.length tl2 = 1)) &&
         begin match tl1 @ tl2 with [] -> false
@@ -2992,7 +2982,6 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
         [], [] -> ()
       | (tu1::tlu1), _ :: _ ->
           (* Attempt to merge all the types containing univars *)
-          if not !passive_variants then
           List.iter (unify env tu1) (tlu1@tlu2)
       | (tu::_, []) | ([], tu::_) -> occur_univar !env tu
       end;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -242,8 +242,6 @@ val unify_gadt:
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)
-val with_passive_variants: ('a -> 'b) -> ('a -> 'b)
-        (* Call [f] in passive_variants mode, for exhaustiveness check. *)
 val filter_arrow: Env.t -> type_expr -> arg_label -> type_expr * type_expr
         (* A special case of unification (with l:'a -> 'b). *)
 val filter_method: Env.t -> string -> private_flag -> type_expr -> type_expr

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1846,11 +1846,7 @@ let partial_pred ~lev ~splitting_mode ?(explode=0)
       } in
   try
     reset_pattern None true;
-    let typed_p =
-      Ctype.with_passive_variants
-        (type_pat Value ~lev ~mode env p)
-        expected_ty
-    in
+    let typed_p = type_pat Value ~lev ~mode env p expected_ty in
     set_state state env;
     (* types are invalidated but we don't need them here *)
     Some typed_p


### PR DESCRIPTION
Fixes #7520.
Removes the `Ctype.passive_variants` flag, which was introduced to fix #7269, and used to relax polymorphic variant unification during exhaustiveness check, but is no longer needed since we always use GADT unification.