### PR TITLE
Restore ocamloptp

### DIFF
--- a/Changes
+++ b/Changes
@@ -289,6 +289,9 @@ OCaml 4.11
   on length of Sys.command argument.
   (Xavier Leroy, report by Jérémie Dimino, review by David Allsopp)
 
+- #9552: restore ocamloptp build and installation
+  (Florian Angeletti, review by David Allsopp and Xavier Leroy)
+
 ### Manual and documentation:
 
 - #9141: beginning of the ocamltest reference manual

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,7 +29,7 @@ DESTDIR ?=
 # Setup GNU make variables storing per-target source and target,
 # a list of installed tools, and a function to quote a filename for
 # the shell.
-override installed_tools := ocamldep ocamlprof ocamlcp \
+override installed_tools := ocamldep ocamlprof ocamlcp ocamloptp \
                    ocamlmktop ocamlmklib ocamlobjinfo
 
 install_files :=
@@ -125,6 +125,7 @@ ocamlcp_cmos = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
                main_args.cmo
 
 $(call byte_and_opt,ocamlcp,$(ocamlcp_cmos) ocamlcp.cmo,)
+$(call byte_and_opt,ocamloptp,$(ocamlcp_cmos) ocamloptp.cmo,)
 
 opt:: profiling.cmx
 


### PR DESCRIPTION
The build and installation of ocamloptp has been disabled since the removal of gprof support in #2314 in 4.09. This was an accident: ocamloptp is unrelated to gprof and the discussion in the above PR explicitly mentions that it should be not disabled.