### PR TITLE
testsuite: remove a slow exhaustiveness check

### DIFF
--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -18,7 +18,6 @@ Here is an example of a case that is not matched:
 val f : 'a option * 'b option -> int = <fun>
 |}]
 
-(* Exhaustiveness check is very slow *)
 type _ t =
   A : int t | B : bool t | C : char t | D : float t
 type (_,_,_,_) u = U : (int, int, int, int) u
@@ -28,30 +27,6 @@ type v = E | F | G
 type _ t = A : int t | B : bool t | C : char t | D : float t
 type (_, _, _, _) u = U : (int, int, int, int) u
 type v = E | F | G
-|}]
-
-let f : type a b c d e f g.
-      a t * b t * c t * d t * e t * f t * g t * v
-       * (a,b,c,d) u * (e,f,g,g) u -> int =
- function A, A, A, A, A, A, A, _, U, U -> 1
-   | _, _, _, _, _, _, _, G, _, _ -> 1
-   (*| _ -> _ *)
-;;
-[%%expect {|
-Lines 4-5, characters 1-38:
-4 | .function A, A, A, A, A, A, A, _, U, U -> 1
-5 |    | _, _, _, _, _, _, _, G, _, _ -> 1
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(A, A, A, A, A, A, B, (E|F), _, _)
-Line 5, characters 5-33:
-5 |    | _, _, _, _, _, _, _, G, _, _ -> 1
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 56: this match case is unreachable.
-Consider replacing it with a refutation case '<pat> -> .'
-val f :
-  'a t * 'b t * 'c t * 'd t * 'e t * 'f t * 'g t * v * ('a, 'b, 'c, 'd) u *
-  ('e, 'f, 'g, 'g) u -> int = <fun>
 |}]
 
 (* Unused cases *)


### PR DESCRIPTION
The test takes 14s to run every time we run the checksuite, and it
does not seem to serve an easily identifiable purpose. In theory
similar tests could help detect a performance regression in
exhaustiveness checking, but this test seems to only degrade in
constant factor (#9512  proposed to use ocamlc.opt instead of ocamlc to
run it, but it was declined as "hiding" potential problems, which
suggests constant-factor differences). We do not monitor the testsuite
for 10s timing difference, so it is unlikely that we would notice
a constant-factor difference during automated testing.
