### PR TITLE
Make -flarge-toc the default for PowerPC

### DIFF
--- a/Changes
+++ b/Changes
@@ -227,6 +227,10 @@ OCaml 4.11
   (Guillaume Munch-Maccagnoni, review by Daniel Bünzli, Gabriel Radanne,
    and Gabriel Scherer)
 
+- #9549, #9557: Make -flarge-toc the default for PowerPC and introduce
+  -fsmall-toc to enable the previous behaviour.
+  (David Allsopp, report by Nathaniel Wesley Filardo, review by Xavier Leroy)
+
 ### Other libraries:
 
 - #9106: Register printer for Unix_error in win32unix, as in unix.

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -34,11 +34,13 @@ let abi =
 
 (* Machine-specific command-line options *)
 
-let big_toc = ref false
+let big_toc = ref true
 
 let command_line_options = [
   "-flarge-toc", Arg.Set big_toc,
-     " Support TOC (table of contents) greater than 64 kbytes"
+     " Support TOC (table of contents) greater than 64 kbytes (default)";
+  "-fsmall-toc", Arg.Clear big_toc,
+     " TOC (table of contents) is limited to 64 kbytes"
 ]
 
 (* Specific operations *)

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -728,6 +728,19 @@ Generate position-independent machine code.  This is the default.
 .B \-fno\-PIC
 Generate position-dependent machine code.
 
+.SH OPTIONS FOR THE POWER ARCHITECTURE
+
+The PowerPC code generator supports the following additional options:
+.TP
+.B \-flarge\-toc
+Enables the PowerPC large model allowing the TOC (table of contents) to be
+arbitrarily large.  This is the default since 4.11.
+.TP
+.B \-fsmall\-toc
+Enables the PowerPC small model allowing the TOC to be up to 64 kbytes per
+compilation unit.  Prior to 4.11 this was the default behaviour.
+\end{options}
+
 .SH OPTIONS FOR THE ARM ARCHITECTURE
 The ARM code generator supports the following additional options:
 .TP

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -138,6 +138,17 @@ the default.
 \item["-fno-PIC"] Generate position-dependent machine code.
 \end{options}
 
+\paragraph{Options for the PowerPC architecture}
+The PowerPC code generator supports the following additional options:
+
+\begin{options}
+\item["-flarge-toc"] Enables the PowerPC large model allowing the TOC (table of
+contents) to be arbitrarily large.  This is the default since 4.11.
+\item["-fsmall-toc"] Enables the PowerPC small model allowing the TOC to be up
+to 64 kbytes per compilation unit.  Prior to 4.11 this was the default
+behaviour.
+\end{options}
+
 \paragraph{Contextual control of command-line options}
 
 The compiler command line can be modified ``from the outside''


### PR DESCRIPTION
Introduce `-fsmall-toc` in order to access the previous behaviour and document both options in the manual and ocamlopt manpage.

Addresses #9549