### PR TITLE
Always permit triplet-prefixed ld in PACKLD

### DIFF
--- a/Changes
+++ b/Changes
@@ -187,6 +187,11 @@ Working version
 
 ### Build system:
 
+- #7121, #9558: Always the autoconf-discovered ld in PACKLD. For
+  cross-compilation, this means the triplet-prefixed version will always be
+  used.
+  (David Allsopp, report by Adrian Nader, review by Sébastien Hinderer)
+
 - #9332, #9518, #9529: Cease storing C dependencies in the codebase. C
   dependencies are generated on-the-fly in development mode. For incremental
   compilation, the MSVC ports require GCC to be present.

--- a/configure
+++ b/configure
@@ -14034,28 +14034,31 @@ else
 fi
 
 if test -z "$PARTIALLD"; then :
+  case "$arch,$CC,$system,$model" in #(
+  amd64,gcc*,macosx,*) :
+    PACKLD_FLAGS=' -arch x86_64' ;; #(
+  amd64,gcc*,solaris,*) :
+    PACKLD_FLAGS=' -m elf_x86_64' ;; #(
+  power,gcc*,elf,ppc) :
+    PACKLD_FLAGS=' -m elf32ppclinux' ;; #(
+  power,gcc*,elf,ppc64) :
+    PACKLD_FLAGS=' -m elf64ppc' ;; #(
+  power,gcc*,elf,ppc64le) :
+    PACKLD_FLAGS=' -m elf64lppc' ;; #(
+  *) :
+    PACKLD_FLAGS='' ;;
+esac
   # The string for PACKLD must be capable of being concatenated with the
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick).
-  case "$arch,$CC,$system,$model" in #(
-  amd64,gcc*,macosx,*) :
-    PACKLD='ld -r -arch x86_64 -o $(EMPTY)' ;; #(
-  amd64,gcc*,solaris,*) :
-    PACKLD='ld -r -m elf_x86_64 -o $(EMPTY)' ;; #(
-  power,gcc*,elf,ppc) :
-    PACKLD='ld -r -m elf32ppclinux -o $(EMPTY)' ;; #(
-  power,gcc*,elf,ppc64) :
-    PACKLD='ld -r -m elf64ppc -o $(EMPTY)' ;; #(
-  power,gcc*,elf,ppc64le) :
-    PACKLD='ld -r -m elf64lppc -o $(EMPTY)' ;; #(
+   if test x"$CC" = "xcl"; then :
   # For the Microsoft C compiler there must be no space at the end of the
     # string.
-    *,cl,*,*) :
-    PACKLD="link -lib -nologo $machine -out:" ;; #(
-  *) :
-    PACKLD="$DIRECT_LD -r -o \$(EMPTY)" ;;
-esac
+    PACKLD="link -lib -nologo $machine -out:"
+else
+  PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o \$(EMPTY)"
+fi
 else
   PACKLD="$PARTIALLD -o \$(EMPTY)"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1020,20 +1020,22 @@ AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 
 AC_CHECK_TOOL([DIRECT_LD],[ld])
 AS_IF([test -z "$PARTIALLD"],
+  [AS_CASE(["$arch,$CC,$system,$model"],
+    [amd64,gcc*,macosx,*], [PACKLD_FLAGS=' -arch x86_64'],
+    [amd64,gcc*,solaris,*], [PACKLD_FLAGS=' -m elf_x86_64'],
+    [power,gcc*,elf,ppc], [PACKLD_FLAGS=' -m elf32ppclinux'],
+    [power,gcc*,elf,ppc64], [PACKLD_FLAGS=' -m elf64ppc'],
+    [power,gcc*,elf,ppc64le], [PACKLD_FLAGS=' -m elf64lppc'],
+    [PACKLD_FLAGS=''])
   # The string for PACKLD must be capable of being concatenated with the
   # output filename. Don't assume that all C compilers understand GNU -ofoo
   # form, so ensure that the definition includes a space at the end (which is
   # achieved using the $(EMPTY) expansion trick).
-  [AS_CASE(["$arch,$CC,$system,$model"],
-    [amd64,gcc*,macosx,*], [PACKLD='ld -r -arch x86_64 -o $(EMPTY)'],
-    [amd64,gcc*,solaris,*], [PACKLD='ld -r -m elf_x86_64 -o $(EMPTY)'],
-    [power,gcc*,elf,ppc], [PACKLD='ld -r -m elf32ppclinux -o $(EMPTY)'],
-    [power,gcc*,elf,ppc64], [PACKLD='ld -r -m elf64ppc -o $(EMPTY)'],
-    [power,gcc*,elf,ppc64le], [PACKLD='ld -r -m elf64lppc -o $(EMPTY)'],
+   AS_IF([test x"$CC" = "xcl"],
     # For the Microsoft C compiler there must be no space at the end of the
     # string.
-    [*,cl,*,*], [PACKLD="link -lib -nologo $machine -out:"],
-    [PACKLD="$DIRECT_LD -r -o \$(EMPTY)"])],
+    [PACKLD="link -lib -nologo $machine -out:"],
+    [PACKLD="$DIRECT_LD -r$PACKLD_FLAGS -o \$(EMPTY)"])],
   [PACKLD="$PARTIALLD -o \$(EMPTY)"])
 
 AS_IF([test $arch != "none" && $arch64 ],


### PR DESCRIPTION
#7121 was mostly addressed by the switch to autoconf except for the cases where flags were being added to the `ld` invocation where `ld -r` was still hard-coded. This PR fixes that by instead defining `PACKLD_FLAGS` containing the extra flags which are then included in the working definition.

In order to allow libtool to initialise on msvc, we have this for `$LD`:
https://github.com/ocaml/ocaml/blob/f81e2b6a59a09ca070d809c63e6eefc4b2436802/configure.ac#L417
and then later:
https://github.com/ocaml/ocaml/blob/f81e2b6a59a09ca070d809c63e6eefc4b2436802/configure.ac#L1004
so on non-MSVC systems `$LD` and `$DIRECT_LD` are the same thing. The reason for `DIRECT_LD` is to ensure that on a broken system, we don't accidentally using `link`

Precheck job [#380](https://ci.inria.fr/ocaml/job/precheck/380/) (full pass)