### PR TITLE
Restore the slow exhaustiveness check as an optional test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -103,6 +103,7 @@ otherlibs/win32unix/symlink.c     typo.long-line
 
 stdlib/hashbang     typo.white-at-eol typo.missing-lf
 
+testsuite/developer/**                                  typo.missing-header typo.long-line=may
 testsuite/tests/**                                      typo.missing-header typo.long-line=may
 testsuite/tests/lib-bigarray-2/bigarrf.f                typo.tab
 testsuite/tests/lib-unix/win-stat/fakeclock.c           typo.missing-header=false
@@ -114,6 +115,7 @@ testsuite/tools/*.asm                                   typo.missing-header
 testsuite/typing                                        typo.missing-header
 
 # prune testsuite reference files
+testsuite/developer/**/*.reference               typo.prune
 testsuite/tests/**/*.reference               typo.prune
 
 # Expect tests with overly long lines of expected output

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -135,7 +135,7 @@ check-failstamp:
 
 .PHONY: all-%
 all-%: lib tools
-	@for dir in tests/$**; do \
+	@for dir in tests/$** developer/$**; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
 	done 2>&1 | tee $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) retries
@@ -175,7 +175,7 @@ parallel-%: lib tools
 	 || (echo "Your 'parallel' tool seems incompatible with GNU parallel.";\
 	     echo "This target requires GNU parallel.";\
 	     exit 1)
-	@for dir in tests/$**; do echo $$dir; done \
+	@for dir in tests/$** developer/$**; do echo $$dir; done \
 	 | parallel --gnu --no-notice --keep-order \
 	     "$(MAKE) $(NO_PRINT) exec-one DIR={} 2>&1" \
 	 | tee $(TESTLOG)

--- a/testsuite/developer/HACKING.adoc
+++ b/testsuite/developer/HACKING.adoc
@@ -1,0 +1,6 @@
+== Developer Tests
+
+This directory contains tests which are not run in the full testsuite but which
+are selected either explicitly (e.g. with make one) or via a make all-* target.
+
+At present, it is used solely for slow-running tests.

--- a/testsuite/developer/typing-warnings/exhaustiveness.ml
+++ b/testsuite/developer/typing-warnings/exhaustiveness.ml
@@ -1,0 +1,38 @@
+(* TEST
+   flags = " -w A -strict-sequence "
+   * expect
+*)
+
+(* Exhaustiveness check is very slow *)
+type _ t =
+  A : int t | B : bool t | C : char t | D : float t
+type (_,_,_,_) u = U : (int, int, int, int) u
+type v = E | F | G
+;;
+
+let f : type a b c d e f g.
+      a t * b t * c t * d t * e t * f t * g t * v
+       * (a,b,c,d) u * (e,f,g,g) u -> int =
+ function A, A, A, A, A, A, A, _, U, U -> 1
+   | _, _, _, _, _, _, _, G, _, _ -> 1
+   (*| _ -> _ *)
+;;
+[%%expect {|
+type _ t = A : int t | B : bool t | C : char t | D : float t
+type (_, _, _, _) u = U : (int, int, int, int) u
+type v = E | F | G
+Lines 10-11, characters 1-38:
+10 | .function A, A, A, A, A, A, A, _, U, U -> 1
+11 |    | _, _, _, _, _, _, _, G, _, _ -> 1
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(A, A, A, A, A, A, B, (E|F), _, _)
+Line 11, characters 5-33:
+11 |    | _, _, _, _, _, _, _, G, _, _ -> 1
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 56: this match case is unreachable.
+Consider replacing it with a refutation case '<pat> -> .'
+val f :
+  'a t * 'b t * 'c t * 'd t * 'e t * 'f t * 'g t * v * ('a, 'b, 'c, 'd) u *
+  ('e, 'f, 'g, 'g) u -> int = <fun>
+|}]


### PR DESCRIPTION
There ~is~was a very slow exhaustiveness check in `tests/typing-warnings/exhaustiveness.ml` which has been removed to speed up the testsuite (see #9512 and #9555).

We used to have interactive tests which were removed in #8666, principally because they suffered from bitrot too easily. However, in https://github.com/ocaml/ocaml/pull/9555#issuecomment-627803098, @garrigue notes that he regularly runs the slow test, so bitrot is not at present a concern, even if performance is for everyone else.

I have introduced `testsuite/developer` as a second test tree containing this old test. It is not run by default (i.e. with `make -C testsuite`) but it is selected with `make -C testsuite all-typing` which means that we can satisfy both @garrigue and @xavierleroy & @gasche!

This allows the test to remain for those for whom it is useful until there is some kind of actual performance testing in place.

Another thought for bitrot, Xavier, is that there could be a mode where these tests are checked weekly/monthly for bitrot or perhaps the `main` job could execute them (i.e. on merges)? Or the test can be tagged with a developer responsible for maintaining them?