### PR TITLE
Unbox Unix.gettimeofday and Unix.time

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ Working version
 - #9075: define to_rev_seq in Set and Map modules.
   (Sébastien Briais, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #9561: Unbox Unix.gettimeofday and Unix.time
+  (Stephen Dolan, review by David Allsopp)
+
 - #9571: Make at_exit and Printexc.register_printer thread-safe.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)
 

--- a/otherlibs/unix/gettimeofday.c
+++ b/otherlibs/unix/gettimeofday.c
@@ -17,22 +17,17 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include "unixsupport.h"
-
-#ifdef HAS_GETTIMEOFDAY
-
 #include <sys/types.h>
 #include <sys/time.h>
 
-CAMLprim value unix_gettimeofday(value unit)
+double unix_gettimeofday_unboxed(value unit)
 {
   struct timeval tp;
-  if (gettimeofday(&tp, NULL) == -1) uerror("gettimeofday", Nothing);
-  return caml_copy_double((double) tp.tv_sec + (double) tp.tv_usec / 1e6);
+  gettimeofday(&tp, NULL);
+  return ((double) tp.tv_sec + (double) tp.tv_usec / 1e6);
 }
 
-#else
-
 CAMLprim value unix_gettimeofday(value unit)
-{ caml_invalid_argument("gettimeofday not implemented"); }
-
-#endif
+{
+  return caml_copy_double(unix_gettimeofday_unboxed(unit));
+}

--- a/otherlibs/unix/time.c
+++ b/otherlibs/unix/time.c
@@ -18,7 +18,12 @@
 #include <caml/alloc.h>
 #include "unixsupport.h"
 
+double unix_time_unboxed(value unit)
+{
+  return ((double) time((time_t *) NULL));
+}
+
 CAMLprim value unix_time(value unit)
 {
-  return caml_copy_double((double) time((time_t *) NULL));
+  return caml_copy_double(unix_time_unboxed(unit));
 }

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -497,8 +497,10 @@ type tm =
     tm_yday : int;
     tm_isdst : bool }
 
-external time : unit -> float = "unix_time"
-external gettimeofday : unit -> float = "unix_gettimeofday"
+external time : unit -> (float [@unboxed]) =
+  "unix_time" "unix_time_unboxed" [@@noalloc]
+external gettimeofday : unit -> (float [@unboxed]) =
+  "unix_gettimeofday" "unix_gettimeofday_unboxed" [@@noalloc]
 external gmtime : float -> tm = "unix_gmtime"
 external localtime : float -> tm = "unix_localtime"
 external mktime : tm -> float * tm = "unix_mktime"

--- a/otherlibs/win32unix/gettimeofday.c
+++ b/otherlibs/win32unix/gettimeofday.c
@@ -22,7 +22,7 @@
 /* Unix epoch as a Windows timestamp in hundreds of ns */
 #define epoch_ft 116444736000000000.0;
 
-CAMLprim value unix_gettimeofday(value unit)
+double unix_gettimeofday_unboxed(value unit)
 {
   FILETIME ft;
   double tm;
@@ -36,5 +36,10 @@ CAMLprim value unix_gettimeofday(value unit)
 #else
   tm = *(uint64_t *)&ft - epoch_ft; /* shift to Epoch-relative time */
 #endif
-  return caml_copy_double(tm * 1e-7);  /* tm is in 100ns */
+  return (tm * 1e-7);  /* tm is in 100ns */
+}
+
+CAMLprim value unix_gettimeofday(value unit)
+{
+  return caml_copy_double(unix_gettimeofday_unboxed(unit));
 }

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -566,8 +566,10 @@ type tm =
     tm_yday : int;
     tm_isdst : bool }
 
-external time : unit -> float = "unix_time"
-external gettimeofday : unit -> float = "unix_gettimeofday"
+external time : unit -> (float [@unboxed]) =
+  "unix_time" "unix_time_unboxed" [@@noalloc]
+external gettimeofday : unit -> (float [@unboxed]) =
+  "unix_gettimeofday" "unix_gettimeofday_unboxed" [@@noalloc]
 external gmtime : float -> tm = "unix_gmtime"
 external localtime : float -> tm = "unix_localtime"
 external mktime : tm -> float * tm = "unix_mktime"


### PR DESCRIPTION
This patch makes Unix.time and Unix.gettimeofday be unboxed and `@noalloc`, which makes them about 20% faster (as measured by a stupid benchmark that does them many times in a loop).

This removes the fallback and error-handling paths from gettimeofday. I don't think they're needed: gettimeofday was in the 1994 Single Unix Specification and every subsequent POSIX release, and POSIX specifies that it has no errors (and no portable way to detect errors) if the timezone argument is null.

(Resolves #7446)