### PR TITLE
pattern-matching refactoring: move pattern types to a new module typing/Patterns

### DIFF
--- a/.depend
+++ b/.depend
@@ -771,6 +771,7 @@ typing/parmatch.cmo : \
     typing/subst.cmi \
     typing/printpat.cmi \
     typing/predef.cmi \
+    typing/patterns.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     utils/misc.cmi \
@@ -793,6 +794,7 @@ typing/parmatch.cmx : \
     typing/subst.cmx \
     typing/printpat.cmx \
     typing/predef.cmx \
+    typing/patterns.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     utils/misc.cmx \
@@ -821,6 +823,32 @@ typing/path.cmx : \
     typing/path.cmi
 typing/path.cmi : \
     typing/ident.cmi
+typing/patterns.cmo : \
+    typing/types.cmi \
+    typing/typedtree.cmi \
+    parsing/longident.cmi \
+    parsing/location.cmi \
+    typing/env.cmi \
+    typing/ctype.cmi \
+    typing/btype.cmi \
+    parsing/asttypes.cmi \
+    typing/patterns.cmi
+typing/patterns.cmx : \
+    typing/types.cmx \
+    typing/typedtree.cmx \
+    parsing/longident.cmx \
+    parsing/location.cmx \
+    typing/env.cmx \
+    typing/ctype.cmx \
+    typing/btype.cmx \
+    parsing/asttypes.cmi \
+    typing/patterns.cmi
+typing/patterns.cmi : \
+    typing/types.cmi \
+    typing/typedtree.cmi \
+    parsing/location.cmi \
+    typing/env.cmi \
+    parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \
     utils/misc.cmi \
@@ -3270,6 +3298,7 @@ lambda/matching.cmo : \
     lambda/printlambda.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
+    typing/patterns.cmi \
     typing/parmatch.cmi \
     utils/misc.cmi \
     parsing/longident.cmi \
@@ -3291,6 +3320,7 @@ lambda/matching.cmx : \
     lambda/printlambda.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
+    typing/patterns.cmx \
     typing/parmatch.cmx \
     utils/misc.cmx \
     parsing/longident.cmx \

--- a/.depend
+++ b/.depend
@@ -811,6 +811,7 @@ typing/parmatch.cmx : \
 typing/parmatch.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
+    typing/patterns.cmi \
     parsing/parsetree.cmi \
     parsing/location.cmi \
     typing/env.cmi \
@@ -828,6 +829,7 @@ typing/patterns.cmo : \
     typing/typedtree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    typing/ident.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     typing/btype.cmi \
@@ -838,6 +840,7 @@ typing/patterns.cmx : \
     typing/typedtree.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    typing/ident.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     typing/btype.cmx \
@@ -846,8 +849,8 @@ typing/patterns.cmx : \
 typing/patterns.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
-    parsing/location.cmi \
-    typing/env.cmi \
+    parsing/longident.cmi \
+    typing/ident.cmi \
     parsing/asttypes.cmi
 typing/persistent_env.cmo : \
     utils/warnings.cmi \

--- a/Changes
+++ b/Changes
@@ -49,7 +49,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #9493, #9520: refactor the pattern-matching compiler
+- #9493, #9520, #9563: refactor the pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 ### Build system:

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -57,7 +57,7 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/tast_iterator.cmo typing/tast_mapper.cmo typing/stypes.cmo \
   file_formats/cmt_format.cmo typing/cmt2annot.cmo typing/untypeast.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/printpat.cmo \
-  typing/parmatch.cmo \
+  typing/patterns.cmo typing/parmatch.cmo \
   typing/typedecl_properties.cmo typing/typedecl_variance.cmo \
   typing/typedecl_unboxed.cmo typing/typedecl_immediacy.cmo \
   typing/typedecl_separability.cmo \

--- a/dune
+++ b/dune
@@ -59,7 +59,8 @@
    cmi_format persistent_env env type_immediacy
    typedtree printtyped ctype printtyp includeclass mtype envaux includecore
    tast_iterator tast_mapper cmt_format untypeast includemod
-   typetexp printpat parmatch stypes typedecl typeopt rec_check typecore
+   typetexp patterns printpat parmatch stypes typedecl typeopt rec_check
+   typecore
    typeclass typemod typedecl_variance typedecl_properties typedecl_immediacy
    typedecl_unboxed typedecl_separability cmt2annot
    ; manual update: mli only files

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -168,7 +168,7 @@ module Non_empty_clause = struct
     | [], _ -> assert false
     | pat :: patl, act -> ((pat, patl), act)
 
-  let map_head f ((p, patl), act) = ((f p, patl), act)
+  let map_first f ((p, patl), act) = ((f p, patl), act)
 end
 
 type simple_view =
@@ -1116,7 +1116,7 @@ let safe_before ((p, ps), act_p) l =
 
 let half_simplify_nonempty ~arg (cls : Typedtree.pattern Non_empty_clause.t) :
     Half_simple.clause =
-  cls |> Non_empty_clause.map_head General.view |> Half_simple.of_clause ~arg
+  cls |> Non_empty_clause.map_first General.view |> Half_simple.of_clause ~arg
 
 let half_simplify_clause ~arg (cls : Typedtree.pattern list clause) =
   cls |> Non_empty_clause.of_initial |> half_simplify_nonempty ~arg

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -161,14 +161,18 @@ let head_loc ~scopes head =
 
 type 'a clause = 'a * lambda
 
-module Non_empty_clause = struct
-  type 'a t = ('a * Typedtree.pattern list) clause
+let map_on_row f (row, action) = (f row, action)
+
+let map_on_rows f = List.map (map_on_row f)
+
+module Non_empty_row = struct
+  type 'a t = 'a * Typedtree.pattern list
 
   let of_initial = function
-    | [], _ -> assert false
-    | pat :: patl, act -> ((pat, patl), act)
+    | [] -> assert false
+    | pat :: patl -> (pat, patl)
 
-  let map_first f ((p, patl), act) = ((f p, patl), act)
+  let map_first f (p, patl) = (f p, patl)
 end
 
 type simple_view =
@@ -193,7 +197,7 @@ type general_view =
 module General : sig
   type pattern = general_view pattern_data
 
-  type clause = pattern Non_empty_clause.t
+  type nonrec clause = pattern Non_empty_row.t clause
 
   val view : Typedtree.pattern -> pattern
 
@@ -201,7 +205,7 @@ module General : sig
 end = struct
   type pattern = general_view pattern_data
 
-  type clause = pattern Non_empty_clause.t
+  type nonrec clause = pattern Non_empty_row.t clause
 
   let view_desc = function
     | Tpat_any -> `Any
@@ -260,13 +264,13 @@ module Half_simple : sig
 
   type pattern = half_simple_view pattern_data
 
-  type clause = pattern Non_empty_clause.t
+  type nonrec clause = pattern Non_empty_row.t clause
 
   val of_clause : arg:lambda -> General.clause -> clause
 end = struct
   type pattern = half_simple_view pattern_data
 
-  type clause = pattern Non_empty_clause.t
+  type nonrec clause = pattern Non_empty_row.t clause
 
   let rec simpl_under_orpat p =
     match p.pat_desc with
@@ -325,7 +329,7 @@ exception Cannot_flatten
 module Simple : sig
   type pattern = simple_view pattern_data
 
-  type clause = pattern Non_empty_clause.t
+  type nonrec clause = pattern Non_empty_row.t clause
 
   val head : pattern -> Patterns.Head.t
 
@@ -339,7 +343,7 @@ module Simple : sig
 end = struct
   type pattern = simple_view pattern_data
 
-  type clause = pattern Non_empty_clause.t
+  type nonrec clause = pattern Non_empty_row.t clause
 
   let head p =
     fst (Patterns.Head.deconstruct (General.erase (p :> General.pattern)))
@@ -957,7 +961,7 @@ type handler = {
 }
 
 type 'head_pat pm_or_compiled = {
-  body : 'head_pat Non_empty_clause.t pattern_matching;
+  body : 'head_pat Non_empty_row.t clause pattern_matching;
   handlers : handler list;
   or_matrix : matrix
 }
@@ -1114,12 +1118,16 @@ let safe_before ((p, ps), act_p) l =
       || not (may_compats (General.erase p :: ps) (General.erase q :: qs)))
     l
 
-let half_simplify_nonempty ~arg (cls : Typedtree.pattern Non_empty_clause.t) :
-    Half_simple.clause =
-  cls |> Non_empty_clause.map_first General.view |> Half_simple.of_clause ~arg
+let half_simplify_nonempty ~arg (cls : Typedtree.pattern Non_empty_row.t clause)
+  : Half_simple.clause =
+  cls
+  |> map_on_row (Non_empty_row.map_first General.view)
+  |> Half_simple.of_clause ~arg
 
 let half_simplify_clause ~arg (cls : Typedtree.pattern list clause) =
-  cls |> Non_empty_clause.of_initial |> half_simplify_nonempty ~arg
+  cls
+  |> map_on_row Non_empty_row.of_initial
+  |> half_simplify_nonempty ~arg
 
 (* Once matchings are *fully* simplified, one can easily find
    their nature. *)
@@ -3148,10 +3156,10 @@ let rec compile_match ~scopes repr partial ctx
         (event_branch repr action, Jumps.empty)
   | nonempty_cases ->
       compile_match_nonempty ~scopes repr partial ctx
-        { m with cases = List.map Non_empty_clause.of_initial nonempty_cases }
+        { m with cases = map_on_rows Non_empty_row.of_initial nonempty_cases }
 
 and compile_match_nonempty ~scopes repr partial ctx
-    (m : Typedtree.pattern Non_empty_clause.t pattern_matching) =
+    (m : Typedtree.pattern Non_empty_row.t clause pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
   | { args = (arg, str) :: argl } ->
@@ -3654,7 +3662,7 @@ let flatten_handler size handler =
 
 type pm_flattened =
   | FPmOr of pattern pm_or_compiled
-  | FPm of pattern Non_empty_clause.t pattern_matching
+  | FPm of pattern Non_empty_row.t clause pattern_matching
 
 let flatten_precompiled size args pmh =
   match pmh with

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2499,7 +2499,12 @@ let rec list_as_pat = function
 
 let complete_pats_constrs = function
   | p :: _ as pats ->
-      let p_simple = General.(view p |> assert_simple) in
+      (* We (indirectly) call this function
+         from [combine_constructor], and nowhere else.
+         So we know patterns have been fully simplified. *)
+      let p_simple = match (Patterns.General.view p).pat_desc with
+        | #Patterns.Simple.view as simple -> { p with pat_desc = simple }
+        | _ -> invalid_arg "complete_pats_constrs" in
       List.map (pat_of_constr p)
         (complete_constrs p_simple (List.map get_key_constr pats))
   | _ -> assert false

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -165,79 +165,18 @@ let map_on_row f (row, action) = (f row, action)
 
 let map_on_rows f = List.map (map_on_row f)
 
-module Non_empty_row = struct
-  type 'a t = 'a * Typedtree.pattern list
+module Non_empty_row = Patterns.Non_empty_row
 
-  let of_initial = function
-    | [] -> assert false
-    | pat :: patl -> (pat, patl)
+type simple_view = Patterns.simple_view
 
-  let map_first f (p, patl) = (f p, patl)
-end
+type half_simple_view = Patterns.half_simple_view
 
-type simple_view =
-  [ `Any
-  | `Constant of constant
-  | `Tuple of pattern list
-  | `Construct of Longident.t loc * constructor_description * pattern list
-  | `Variant of label * pattern option * row_desc ref
-  | `Record of
-    (Longident.t loc * label_description * pattern) list * closed_flag
-  | `Array of pattern list
-  | `Lazy of pattern ]
+type general_view = Patterns.general_view
 
-type half_simple_view =
-  [ simple_view | `Or of pattern * pattern * row_desc option ]
-
-type general_view =
-  [ half_simple_view
-  | `Var of Ident.t * string loc
-  | `Alias of pattern * Ident.t * string loc ]
-
-module General : sig
-  type pattern = general_view pattern_data
+module General = struct
+  include Patterns.General
 
   type nonrec clause = pattern Non_empty_row.t clause
-
-  val view : Typedtree.pattern -> pattern
-
-  val erase : [< general_view ] pattern_data -> Typedtree.pattern
-end = struct
-  type pattern = general_view pattern_data
-
-  type nonrec clause = pattern Non_empty_row.t clause
-
-  let view_desc = function
-    | Tpat_any -> `Any
-    | Tpat_var (id, str) -> `Var (id, str)
-    | Tpat_alias (p, id, str) -> `Alias (p, id, str)
-    | Tpat_constant cst -> `Constant cst
-    | Tpat_tuple ps -> `Tuple ps
-    | Tpat_construct (cstr, cstr_descr, args) ->
-        `Construct (cstr, cstr_descr, args)
-    | Tpat_variant (cstr, arg, row_desc) -> `Variant (cstr, arg, row_desc)
-    | Tpat_record (fields, closed) -> `Record (fields, closed)
-    | Tpat_array ps -> `Array ps
-    | Tpat_or (p, q, row_desc) -> `Or (p, q, row_desc)
-    | Tpat_lazy p -> `Lazy p
-
-  let view p : pattern = { p with pat_desc = view_desc p.pat_desc }
-
-  let erase_desc = function
-    | `Any -> Tpat_any
-    | `Var (id, str) -> Tpat_var (id, str)
-    | `Alias (p, id, str) -> Tpat_alias (p, id, str)
-    | `Constant cst -> Tpat_constant cst
-    | `Tuple ps -> Tpat_tuple ps
-    | `Construct (cstr, cst_descr, args) ->
-        Tpat_construct (cstr, cst_descr, args)
-    | `Variant (cstr, arg, row_desc) -> Tpat_variant (cstr, arg, row_desc)
-    | `Record (fields, closed) -> Tpat_record (fields, closed)
-    | `Array ps -> Tpat_array ps
-    | `Or (p, q, row_desc) -> Tpat_or (p, q, row_desc)
-    | `Lazy p -> Tpat_lazy p
-
-  let erase p = { p with pat_desc = erase_desc p.pat_desc }
 end
 
 module Half_simple : sig

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1198,7 +1198,8 @@ let rec list_satisfying_vectors pss qs =
                   if full_match false constrs then for_constrs () else
                   begin match p.pat_desc with
                   | Construct _ ->
-                      (* activate this code for checking non-gadt constructors *)
+                      (* activate this code
+                         for checking non-gadt constructors *)
                       wild default (build_other_constrs constrs p)
                       @ for_constrs ()
                   | _ ->
@@ -2283,10 +2284,7 @@ let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
     | `Alias (p,x,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
     | `Var (x, _) ->
-      let rest_of_the_row =
-        { row = ps; varsets = Ident.Set.add x head_bound_variables :: varsets; }
-      in
-      add_column (Patterns.Head.deconstruct Patterns.Simple.omega) rest_of_the_row k
+      simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k
     | `Or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps
         (simpl head_bound_variables varsets p2 ps k)

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -907,10 +907,13 @@ let build_other_constrs env p =
   | _ -> extra_pat
 
 let complete_constrs p all_tags =
-  (* This wrapper is here for [Matching], which (indirectly) calls this function
-     from [combine_constructor], and nowhere else.
-     So we know patterns have been fully simplified. *)
-  complete_constrs (fst @@ Patterns.Head.deconstruct p) all_tags
+  (* This wrapper is here for [Matching].
+
+     TODO: instead of a simple pattern, it would be nicer to pass
+     a constructor payload directly:
+     [Types.constructor_description pattern_data].
+  *)
+  complete_constrs (fst (Patterns.Head.deconstruct p)) all_tags
 
 (* Auxiliary for build_other *)
 

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -19,59 +19,6 @@ open Asttypes
 open Typedtree
 open Types
 
-val omega : pattern
-(** aka. "Tpat_any" or "_"  *)
-
-val omegas : int -> pattern list
-(** [List.init (fun _ -> omega)] *)
-
-val omega_list : 'a list -> pattern list
-(** [List.map (fun _ -> omega)] *)
-
-module Pattern_head : sig
-  type desc =
-    | Any
-    | Construct of constructor_description
-    | Constant of constant
-    | Tuple of int
-    | Record of label_description list
-    | Variant of
-        { tag: label; has_arg: bool;
-          cstr_row: row_desc ref;
-          type_row : unit -> row_desc; }
-          (* the row of the type may evolve if [close_variant] is called,
-             hence the (unit -> ...) delay *)
-    | Array of int
-    | Lazy
-
-  type t
-
-  val desc : t -> desc
-  val env : t -> Env.t
-  val loc : t -> Location.t
-  val typ : t -> Types.type_expr
-
-  val arity : t -> int
-
-  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
-
-      @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
-
-  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
-  val to_omega_pattern : t -> pattern
-
-  val make
-    :  loc:Location.t
-    -> typ:Types.type_expr
-    -> env:Env.t
-    -> desc
-    -> t
-
-  val omega : t
-
-end
-
 val const_compare : constant -> constant -> int
 (** [const_compare c1 c2] compares the actual values represented by [c1] and
     [c2], while simply using [Stdlib.compare] would compare the

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -67,7 +67,7 @@ val set_args_erase_mutable : pattern -> pattern list -> pattern list
 
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :
-    pattern -> constructor_tag list -> constructor_description  list
+    Patterns.Simple.pattern -> constructor_tag list -> constructor_description  list
 
 (** [ppat_of_type] builds an untyped pattern from its expected type,
     for explosion of wildcard patterns in Typecore.type_pat.

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -67,7 +67,9 @@ val set_args_erase_mutable : pattern -> pattern list -> pattern list
 
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :
-    Patterns.Simple.pattern -> constructor_tag list -> constructor_description  list
+    Patterns.Simple.pattern ->
+    constructor_tag list ->
+    constructor_description list
 
 (** [ppat_of_type] builds an untyped pattern from its expected type,
     for explosion of wildcard patterns in Typecore.type_pat.

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -1,3 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Gabriel Scherer, projet Partout, INRIA Paris-Saclay           *)
+(*          Thomas Refis, Jane Street Europe                              *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 open Asttypes
 open Types
 open Typedtree
@@ -67,7 +83,7 @@ module General = struct
     | `Alias of pattern * Ident.t * string loc
   ]
   type pattern = view pattern_data
-  
+
   let view_desc = function
     | Tpat_any ->
        `Any

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -47,6 +47,8 @@ module Simple = struct
   ]
 
   type pattern = view pattern_data
+
+  let omega = { omega with pat_desc = `Any }
 end
 
 module Half_simple = struct
@@ -108,6 +110,17 @@ module General = struct
 
   let erase p : Typedtree.pattern =
     { p with pat_desc = erase_desc p.pat_desc }
+
+  let rec strip_vars (p : pattern) : Half_simple.pattern =
+    match p.pat_desc with
+    | `Alias (p, _, _) -> strip_vars (view p)
+    | `Var _ -> { p with pat_desc = `Any }
+    | #Half_simple.view as view -> { p with pat_desc = view }
+
+  let assert_simple (p : pattern) : Simple.pattern =
+    match strip_vars p with
+    | {pat_desc = `Or _; _} -> failwith "Patterns.assert_simple"
+    | {pat_desc = #Simple.view; _} as p -> p
 end
 
 (* the head constructor of a simple pattern *)
@@ -130,10 +143,8 @@ module Head : sig
 
   val arity : t -> int
 
-  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
-
-      @raises [Invalid_arg _] if [p] is an or-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns. *)
+  val deconstruct : Simple.pattern -> t * pattern list
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern
@@ -157,17 +168,15 @@ end = struct
 
   type t = desc pattern_data
 
-  let deconstruct q =
-    let rec deconstruct_desc = function
-      | Tpat_any
-      | Tpat_var _ -> Any, []
-      | Tpat_constant c -> Constant c, []
-      | Tpat_alias (p,_,_) -> deconstruct_desc p.pat_desc
-      | Tpat_tuple args ->
+  let deconstruct (q : Simple.pattern) =
+    let deconstruct_desc = function
+      | `Any -> Any, []
+      | `Constant c -> Constant c, []
+      | `Tuple args ->
           Tuple (List.length args), args
-      | Tpat_construct (_, c, args) ->
+      | `Construct (_, c, args) ->
           Construct c, args
-      | Tpat_variant (tag, arg, cstr_row) ->
+      | `Variant (tag, arg, cstr_row) ->
           let has_arg, pats =
             match arg with
             | None -> false, []
@@ -179,15 +188,14 @@ end = struct
               | _ -> assert false
           in
           Variant {tag; has_arg; cstr_row; type_row}, pats
-      | Tpat_array args ->
+      | `Array args ->
           Array (List.length args), args
-      | Tpat_record (largs, _) ->
+      | `Record (largs, _) ->
           let lbls = List.map (fun (_,lbl,_) -> lbl) largs in
           let pats = List.map (fun (_,_,pat) -> pat) largs in
           Record lbls, pats
-      | Tpat_lazy p ->
+      | `Lazy p ->
           Lazy, [p]
-      | Tpat_or _ -> invalid_arg "Parmatch.Pattern_head.deconstruct: (P | Q)"
     in
     let desc, pats = deconstruct_desc q.pat_desc in
     { q with pat_desc = desc }, pats

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -132,11 +132,6 @@ module General = struct
     | `Alias (p, _, _) -> strip_vars (view p)
     | `Var _ -> { p with pat_desc = `Any }
     | #Half_simple.view as view -> { p with pat_desc = view }
-
-  let assert_simple (p : pattern) : Simple.pattern =
-    match strip_vars p with
-    | {pat_desc = `Or _; _} -> failwith "Patterns.assert_simple"
-    | {pat_desc = #Simple.view; _} as p -> p
 end
 
 (* the head constructor of a simple pattern *)

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -1,0 +1,172 @@
+open Asttypes
+open Types
+open Typedtree
+
+let omega = {
+  pat_desc = Tpat_any;
+  pat_loc = Location.none;
+  pat_extra = [];
+  pat_type = Ctype.none;
+  pat_env = Env.empty;
+  pat_attributes = [];
+}
+
+let rec omegas i =
+  if i <= 0 then [] else omega :: omegas (i-1)
+
+let omega_list l = List.map (fun _ -> omega) l
+
+module Head : sig
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+    | Array of int
+    | Lazy
+
+  type t
+
+  val desc : t -> desc
+  val env : t -> Env.t
+  val loc : t -> Location.t
+  val typ : t -> Types.type_expr
+
+  val arity : t -> int
+
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
+
+      @raises [Invalid_arg _] if [p] is an or-pattern.  *)
+  val deconstruct : pattern -> t * pattern list
+
+  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
+  val to_omega_pattern : t -> pattern
+
+  val make
+    :  loc:Location.t
+    -> typ:Types.type_expr
+    -> env:Env.t
+    -> desc
+    -> t
+
+  val omega : t
+
+end = struct
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+          (* the row of the type may evolve if [close_variant] is called,
+             hence the (unit -> ...) delay *)
+    | Array of int
+    | Lazy
+
+  type t = {
+    desc: desc;
+    typ : Types.type_expr;
+    loc : Location.t;
+    env : Env.t;
+    attributes : attributes;
+  }
+
+  let desc { desc } = desc
+  let env { env } = env
+  let loc { loc } = loc
+  let typ { typ } = typ
+
+  let deconstruct q =
+    let rec deconstruct_desc = function
+      | Tpat_any
+      | Tpat_var _ -> Any, []
+      | Tpat_constant c -> Constant c, []
+      | Tpat_alias (p,_,_) -> deconstruct_desc p.pat_desc
+      | Tpat_tuple args ->
+          Tuple (List.length args), args
+      | Tpat_construct (_, c, args) ->
+          Construct c, args
+      | Tpat_variant (tag, arg, cstr_row) ->
+          let has_arg, pats =
+            match arg with
+            | None -> false, []
+            | Some a -> true, [a]
+          in
+          let type_row () =
+            match Ctype.expand_head q.pat_env q.pat_type with
+              | {desc = Tvariant type_row} -> Btype.row_repr type_row
+              | _ -> assert false
+          in
+          Variant {tag; has_arg; cstr_row; type_row}, pats
+      | Tpat_array args ->
+          Array (List.length args), args
+      | Tpat_record (largs, _) ->
+          let lbls = List.map (fun (_,lbl,_) -> lbl) largs in
+          let pats = List.map (fun (_,_,pat) -> pat) largs in
+          Record lbls, pats
+      | Tpat_lazy p ->
+          Lazy, [p]
+      | Tpat_or _ -> invalid_arg "Parmatch.Pattern_head.deconstruct: (P | Q)"
+    in
+    let desc, pats = deconstruct_desc q.pat_desc in
+    { desc; typ = q.pat_type; loc = q.pat_loc;
+      env = q.pat_env; attributes = q.pat_attributes }, pats
+
+  let arity t =
+    match t.desc with
+      | Any -> 0
+      | Constant _ -> 0
+      | Construct c -> c.cstr_arity
+      | Tuple n | Array n -> n
+      | Record l -> List.length l
+      | Variant { has_arg; _ } -> if has_arg then 1 else 0
+      | Lazy -> 1
+
+  let to_omega_pattern t =
+    let pat_desc =
+      match t.desc with
+      | Any -> Tpat_any
+      | Lazy -> Tpat_lazy omega
+      | Constant c -> Tpat_constant c
+      | Tuple n -> Tpat_tuple (omegas n)
+      | Array n -> Tpat_array (omegas n)
+      | Construct c ->
+          let lid_loc = Location.mkloc (Longident.Lident c.cstr_name) t.loc in
+          Tpat_construct (lid_loc, c, omegas c.cstr_arity)
+      | Variant { tag; has_arg; cstr_row } ->
+          let arg_opt = if has_arg then Some omega else None in
+          Tpat_variant (tag, arg_opt, cstr_row)
+      | Record lbls ->
+          let lst =
+            List.map (fun lbl ->
+              let lid_loc =
+                Location.mkloc (Longident.Lident lbl.lbl_name) t.loc
+              in
+              (lid_loc, lbl, omega)
+            ) lbls
+          in
+          Tpat_record (lst, Closed)
+    in
+    { pat_desc; pat_type = t.typ; pat_loc = t.loc; pat_extra = [];
+      pat_env = t.env; pat_attributes = t.attributes }
+
+  let make ~loc ~typ ~env desc =
+    { desc; loc; typ; env; attributes = [] }
+
+  let omega =
+    { desc = Any
+    ; loc = Location.none
+    ; typ = Ctype.none
+    ; env = Env.empty
+    ; attributes = []
+    }
+end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -11,6 +11,43 @@ val omegas : int -> pattern list
 val omega_list : 'a list -> pattern list
 (** [List.map (fun _ -> omega)] *)
 
+type simple_view = [
+  | `Any
+  | `Constant of constant
+  | `Tuple of pattern list
+  | `Construct of Longident.t loc * constructor_description * pattern list
+  | `Variant of label * pattern option * row_desc ref
+  | `Record of (Longident.t loc * label_description * pattern) list * closed_flag
+  | `Array of pattern list
+  | `Lazy of pattern
+]
+
+type half_simple_view = [
+  | simple_view
+  | `Or of pattern * pattern * row_desc option
+]
+type general_view = [
+  | half_simple_view
+  | `Var of Ident.t * string loc
+  | `Alias of pattern * Ident.t * string loc
+]
+
+module Non_empty_row : sig
+  type 'a t = 'a * Typedtree.pattern list
+
+  val of_initial : Typedtree.pattern list -> Typedtree.pattern t
+  (** 'assert false' on empty rows *)
+
+  val map_first : ('a -> 'b) -> 'a t -> 'b t
+end
+
+module General : sig
+  type pattern = general_view pattern_data
+
+  val view : Typedtree.pattern -> pattern
+  val erase : [< general_view ] pattern_data -> Typedtree.pattern
+end
+
 module Head : sig
   type desc =
     | Any

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -1,0 +1,56 @@
+open Asttypes
+open Typedtree
+open Types
+
+val omega : pattern
+(** aka. "Tpat_any" or "_"  *)
+
+val omegas : int -> pattern list
+(** [List.init (fun _ -> omega)] *)
+
+val omega_list : 'a list -> pattern list
+(** [List.map (fun _ -> omega)] *)
+
+module Head : sig
+  type desc =
+    | Any
+    | Construct of constructor_description
+    | Constant of constant
+    | Tuple of int
+    | Record of label_description list
+    | Variant of
+        { tag: label; has_arg: bool;
+          cstr_row: row_desc ref;
+          type_row : unit -> row_desc; }
+          (* the row of the type may evolve if [close_variant] is called,
+             hence the (unit -> ...) delay *)
+    | Array of int
+    | Lazy
+
+  type t
+
+  val desc : t -> desc
+  val env : t -> Env.t
+  val loc : t -> Location.t
+  val typ : t -> Types.type_expr
+
+  val arity : t -> int
+
+  (** [deconstruct p] returns the head of [p] and the list of sub patterns.
+
+      @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
+  val deconstruct : pattern -> t * pattern list
+
+  (** reconstructs a pattern, putting wildcards as sub-patterns. *)
+  val to_omega_pattern : t -> pattern
+
+  val make
+    :  loc:Location.t
+    -> typ:Types.type_expr
+    -> env:Env.t
+    -> desc
+    -> t
+
+  val omega : t
+
+end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -34,6 +34,8 @@ module Simple : sig
     | `Lazy of pattern
   ]
   type pattern = view pattern_data
+
+  val omega : [> view ] pattern_data
 end
 
 module Half_simple : sig
@@ -54,6 +56,10 @@ module General : sig
 
   val view : Typedtree.pattern -> pattern
   val erase : [< view ] pattern_data -> Typedtree.pattern
+
+  val strip_vars : pattern -> Half_simple.pattern
+
+  val assert_simple : pattern -> Simple.pattern
 end
 
 module Head : sig
@@ -79,7 +85,7 @@ module Head : sig
   (** [deconstruct p] returns the head of [p] and the list of sub patterns.
 
       @raises [Invalid_arg _] if [p] is an or- or an exception-pattern.  *)
-  val deconstruct : pattern -> t * pattern list
+  val deconstruct : Simple.pattern -> t * pattern list
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -11,27 +11,6 @@ val omegas : int -> pattern list
 val omega_list : 'a list -> pattern list
 (** [List.map (fun _ -> omega)] *)
 
-type simple_view = [
-  | `Any
-  | `Constant of constant
-  | `Tuple of pattern list
-  | `Construct of Longident.t loc * constructor_description * pattern list
-  | `Variant of label * pattern option * row_desc ref
-  | `Record of (Longident.t loc * label_description * pattern) list * closed_flag
-  | `Array of pattern list
-  | `Lazy of pattern
-]
-
-type half_simple_view = [
-  | simple_view
-  | `Or of pattern * pattern * row_desc option
-]
-type general_view = [
-  | half_simple_view
-  | `Var of Ident.t * string loc
-  | `Alias of pattern * Ident.t * string loc
-]
-
 module Non_empty_row : sig
   type 'a t = 'a * Typedtree.pattern list
 
@@ -41,11 +20,40 @@ module Non_empty_row : sig
   val map_first : ('a -> 'b) -> 'a t -> 'b t
 end
 
+module Simple : sig
+  type view = [
+    | `Any
+    | `Constant of constant
+    | `Tuple of pattern list
+    | `Construct of
+        Longident.t loc * constructor_description * pattern list
+    | `Variant of label * pattern option * row_desc ref
+    | `Record of
+        (Longident.t loc * label_description * pattern) list * closed_flag
+    | `Array of pattern list
+    | `Lazy of pattern
+  ]
+  type pattern = view pattern_data
+end
+
+module Half_simple : sig
+  type view = [
+    | Simple.view
+    | `Or of pattern * pattern * row_desc option
+  ]
+  type pattern = view pattern_data
+end
+
 module General : sig
-  type pattern = general_view pattern_data
+  type view = [
+    | Half_simple.view
+    | `Var of Ident.t * string loc
+    | `Alias of pattern * Ident.t * string loc
+  ]
+  type pattern = view pattern_data
 
   val view : Typedtree.pattern -> pattern
-  val erase : [< general_view ] pattern_data -> Typedtree.pattern
+  val erase : [< view ] pattern_data -> Typedtree.pattern
 end
 
 module Head : sig

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -1,3 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Gabriel Scherer, projet Partout, INRIA Paris-Saclay           *)
+(*          Thomas Refis, Jane Street Europe                              *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 open Asttypes
 open Typedtree
 open Types

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -27,12 +27,7 @@ module Head : sig
     | Array of int
     | Lazy
 
-  type t
-
-  val desc : t -> desc
-  val env : t -> Env.t
-  val loc : t -> Location.t
-  val typ : t -> Types.type_expr
+  type t = desc pattern_data
 
   val arity : t -> int
 
@@ -43,13 +38,6 @@ module Head : sig
 
   (** reconstructs a pattern, putting wildcards as sub-patterns. *)
   val to_omega_pattern : t -> pattern
-
-  val make
-    :  loc:Location.t
-    -> typ:Types.type_expr
-    -> env:Env.t
-    -> desc
-    -> t
 
   val omega : t
 

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -74,8 +74,6 @@ module General : sig
   val erase : [< view ] pattern_data -> Typedtree.pattern
 
   val strip_vars : pattern -> Half_simple.pattern
-
-  val assert_simple : pattern -> Simple.pattern
 end
 
 module Head : sig


### PR DESCRIPTION
This is the next bit of the big pattern-matching refactoring change (#9321) after #9520  has been merged.

(cc @trefis @Octachron)

By now we have grown interesting static types to describe patterns and use in patterns-decomposition algoriths: "heads" in Parmatch, and "(half-)simple" polymorphic variants in Matching. This PR moves these two categories into a shared compilation unit typing/Patterns, for use in both modules.

As usual, it is best reviewed commit-by-commit.