### PR TITLE
Add a macro for out-of-heap block header

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
   (KC Sivaramakrishnan, review by David Allsopp, Xavier Leroy, Mark Shinwell
   and Leo White)
 
+- #9564: Add a macro to construct out-of-heap block header.
+	(KC Sivaramakrishnan, review by Stephen Dolan, Gabriel Scherer, and Xavier
+	Leroy)
+
 ### Code generation and optimizations:
 
 - #9441: Add RISC-V RV64G native-code backend.

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -379,6 +379,15 @@ extern value caml_global_data;
 
 CAMLextern value caml_set_oo_id(value obj);
 
+/* Header for out-of-heap blocks. */
+
+#define Caml_out_of_heap_header(wosize, tag)                                  \
+      (/*CAMLassert ((wosize) <= Max_wosize),*/                               \
+       ((header_t) (((header_t) (wosize) << 10)                               \
+                    + (3 << 8) /* matches [Caml_black]. See [gc.h] */         \
+                    + (tag_t) (tag)))                                         \
+      )
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Following up on #9534, we need a way to allow the users to create a valid header for out of heap objects while migrating away from using naked pointers. This was raised by @garrigue in the [discussion](https://github.com/ocaml/ocaml/pull/9534#issuecomment-624077284) on #9534. This PR adds a macro definition:

```c
#define Caml_out_of_heap_header ((header_t)(3 << 8)) /* matches [Caml_black] */
```

to `caml/mlvalues.h`. The GC in naked pointer mode examines the header, and if it is `Caml_black`, it does not scan the object. 

The idea is to use this header for out of heap objects. For example,

```c
#include "caml/mlvalues.h"

struct {
  value h;
  int i;
  double j;
  void* v;
} s = {Caml_out_of_heap_header, 42, 0.0, NULL};

value get_struct_as_value (value v) {
  return (value)&s.i;
}
```

Multicore OCaml uses a different GC colour scheme, but has a `NOT_MARKABLE` colour whose bit pattern is the same as `Caml_black`. When the GC colour scheme is updated, this API can remain the same.

It would be nice to get this change in 4.11 as we can suggest this as the solution for out of heap pointers. 
