### PR TITLE
[experiment] optimize some string idioms ?

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -130,7 +130,8 @@ let preserve_tailcall_for_prim = function
   | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
+  | Pstringappend ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -143,6 +143,7 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
+  | Pstringappend
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -152,6 +152,7 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
+  | Pstringappend
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -343,6 +343,7 @@ let primitive ppf = function
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
   | Popaque -> fprintf ppf "opaque"
+  | Pstringappend -> fprintf ppf "stringappend"
 
 let name_of_primitive = function
   | Pidentity -> "Pidentity"
@@ -449,6 +450,7 @@ let name_of_primitive = function
   | Pbbswap _ -> "Pbbswap"
   | Pint_as_pointer -> "Pint_as_pointer"
   | Popaque -> "Popaque"
+  | Pstringappend -> "Pstringappend"
 
 let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
   if is_a_functor then

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -358,6 +358,7 @@ let primitives_table =
     "%greaterequal", Comparison(Greater_equal, Compare_generic);
     "%greaterthan", Comparison(Greater_than, Compare_generic);
     "%compare", Comparison(Compare, Compare_generic);
+    "%stringappend", Primitive (Pstringappend, 2)
   ]
 
 
@@ -757,7 +758,7 @@ let lambda_primitive_needs_event_after = function
   | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_64 _
   | Pbigstring_load_16 _ | Pbigstring_load_32 _ | Pbigstring_load_64 _
   | Pbigstring_set_16 _ | Pbigstring_set_32 _ | Pbigstring_set_64 _
-  | Pbbswap _ -> true
+  | Pbbswap _ | Pstringappend -> true
 
   | Pidentity | Pbytes_to_string | Pbytes_of_string | Pignore | Psetglobal _
   | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -150,6 +150,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pidentity
   | Pgetglobal _
   | Psetglobal _
+  | Pstringappend
     ->
       Misc.fatal_errorf "lambda primitive %a can't be converted to \
                          clambda primitive"

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -297,6 +297,8 @@ let toplevel_substitution_named = "toplevel_substitution_named"
 let unbox_free_vars_of_closures = "unbox_free_vars_of_closures"
 let unit = "unit"
 let zero = "zero"
+let pstringappend = "Pstringappend"
+let pstringappend_arg = "Pstringappend_arg"
 
 let anon_fn_with_loc (sloc: Lambda.scoped_location) =
   let loc = Debuginfo.Scoped_location.to_location sloc in
@@ -414,6 +416,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
   | Popaque -> popaque
+  | Pstringappend -> pstringappend
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pidentity -> pidentity_arg
@@ -520,3 +523,4 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
   | Popaque -> popaque_arg
+  | Pstringappend -> pstringappend_arg

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -472,3 +472,80 @@ CAMLprim value caml_bytes_of_string(value bv)
 {
   return bv;
 }
+
+CAMLprim value caml_string_append2(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLlocal1(buf);
+
+  int l1 = caml_string_length(v1);
+  int l2 = caml_string_length(v2);
+
+  buf = caml_alloc_string(l1 + l2);
+
+  memmove(&Byte(buf, 0), &Byte(v1, 0), l1);
+  memmove(&Byte(buf, l1), &Byte(v2, 0), l2);
+
+  CAMLreturn(buf);
+}
+
+CAMLprim value caml_string_append3(value v1, value v2, value v3)
+{
+  CAMLparam3(v1, v2, v3);
+  CAMLlocal1(buf);
+
+  int l1 = caml_string_length(v1);
+  int l2 = caml_string_length(v2);
+  int l3 = caml_string_length(v3);
+
+  buf = caml_alloc_string(l1 + l2 + l3);
+
+  memmove(&Byte(buf, 0), &Byte(v1, 0), l1);
+  memmove(&Byte(buf, l1), &Byte(v2, 0), l2);
+  memmove(&Byte(buf, l1 + l2), &Byte(v3, 0), l3);
+
+  CAMLreturn(buf);
+}
+
+CAMLprim value caml_string_append4(value v1, value v2, value v3, value v4)
+{
+  CAMLparam4(v1, v2, v3, v4);
+  CAMLlocal1(buf);
+
+  int l1 = caml_string_length(v1);
+  int l2 = caml_string_length(v2);
+  int l3 = caml_string_length(v3);
+  int l4 = caml_string_length(v4);
+
+  buf = caml_alloc_string(l1 + l2 + l3 + l4);
+
+  memmove(&Byte(buf, 0), &Byte(v1, 0), l1);
+  memmove(&Byte(buf, l1), &Byte(v2, 0), l2);
+  memmove(&Byte(buf, l1 + l2), &Byte(v3, 0), l3);
+  memmove(&Byte(buf, l1 + l2 + l3), &Byte(v4, 0), l4);
+
+  CAMLreturn(buf);
+}
+
+CAMLprim value caml_string_append5(value v1, value v2, value v3, value v4,
+                                   value v5)
+{
+  CAMLparam5(v1, v2, v3, v4, v5);
+  CAMLlocal1(buf);
+
+  int l1 = caml_string_length(v1);
+  int l2 = caml_string_length(v2);
+  int l3 = caml_string_length(v3);
+  int l4 = caml_string_length(v4);
+  int l5 = caml_string_length(v5);
+
+  buf = caml_alloc_string(l1 + l2 + l3 + l4 + l5);
+
+  memmove(&Byte(buf, 0), &Byte(v1, 0), l1);
+  memmove(&Byte(buf, l1), &Byte(v2, 0), l2);
+  memmove(&Byte(buf, l1 + l2), &Byte(v3, 0), l3);
+  memmove(&Byte(buf, l1 + l2 + l3), &Byte(v4, 0), l4);
+  memmove(&Byte(buf, l1 + l2 + l3 + l4), &Byte(v5, 0), l5);
+
+  CAMLreturn(buf);
+}

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -549,3 +549,24 @@ CAMLprim value caml_string_append5(value v1, value v2, value v3, value v4,
 
   CAMLreturn(buf);
 }
+
+CAMLprim value caml_string_appendn(value v)
+{
+  CAMLparam1(v);
+  CAMLlocal1(buf);
+  int i, len, off;
+
+  for (i = 0, len = 0; i < caml_array_length(v); i++) {
+    len += caml_string_length(Field(v, i));
+  }
+
+  buf = caml_alloc_string(len);
+
+  for (i = 0, off = 0; i < caml_array_length(v); i++) {
+    int len = caml_string_length(Field(v, i));
+    memmove(&Byte(buf, off), &Byte(Field(v, i), 0), len);
+    off += len;
+  }
+
+  CAMLreturn(buf);
+}


### PR DESCRIPTION
Following #6426 this PR proposes an optimization that recognizes nested applications of `^` operator (a common idiom) and compiles them efficiently (by allocating a single buffer and blitting all the given strings into it).

Technically, this is done by introducing a new primitive `%stringappend` which is eliminated during `Simplif`.

An alternative could be to the rewriting at the level of the typed tree, but this way looked a bit simpler.

What do you think?

**Example:** the function
```
external ( ^ ) : string -> string -> string = "%stringappend"

let f a b c d = (a ^ b) ^ c ^ (d ^ d)
```
is compiled down to:
```
(setglobal A!
  (let
    (f/81 =
       (function a/83 b/84 c/85 d/86
         (let
           (len/89 =[int] (string.length a/83)
            len/90 =[int] (string.length b/84)
            len/91 =[int] (string.length c/85)
            off/92 =[int] (+ len/89 len/90)
            len/93 =[int] (string.length d/86)
            off/94 =[int] (+ off/92 len/91)
            len/95 =[int] (string.length d/86)
            off/96 =[int] (+ off/94 len/93)
            buf/97 = (caml_create_bytes (+ off/96 len/95)))
           (seq (caml_blit_string a/83 0 buf/97 0 len/89)
             (caml_blit_string b/84 0 buf/97 len/89 len/90)
             (caml_blit_string c/85 0 buf/97 off/92 len/91)
             (caml_blit_string d/86 0 buf/97 off/94 len/93)
             (caml_blit_string d/86 0 buf/97 off/96 len/95)
             (bytes_to_string buf/97)))))
    (makeblock 0 f/81)))
```

cc @alainfrisch 