### PR TITLE
Fix5987

### DIFF
--- a/manual/manual/refman/typedecl.etex
+++ b/manual/manual/refman/typedecl.etex
@@ -55,7 +55,7 @@ field-decl:
           ['mutable'] field-name ':' poly-typexpr
 ;
 type-constraint:
-    'constraint' "'" ident '=' typexpr
+    'constraint' typexpr '=' typexpr
 \end{syntax}
 \ikwd{mutable\@\texttt{mutable}}
 \ikwd{constraint\@\texttt{constraint}}


### PR DESCRIPTION
Fix the manual as suggested in #5987:
Type constraints are
```
constraint typexpr = typexpr
```
not only
```
constraint 'a = typexpr
```
(This was already the case for class constraints)