### PR TITLE
stdlib: provide a sequential implementation of the Atomic module from Multicore

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,10 @@ Working version
 
 ### Language features:
 
+- #9570: Provide an Atomic module with a trivial purely-sequential
+  implementation, to help write code that is compatible with Multicore
+  OCaml.
+  (Gabriel Scherer, review by Xavier Leroy)
 
 ### Runtime system:
 

--- a/manual/manual/library/stdlib-blurb.etex
+++ b/manual/manual/library/stdlib-blurb.etex
@@ -60,6 +60,7 @@ the above 4 modules \\
 "Lazy" & p.~\pageref{Lazy} & delayed evaluation \\
 "Weak" & p.~\pageref{Weak} & references that don't prevent objects
 from being garbage-collected \\
+"Atomic" & p.~\pageref{Atomic} & atomic references (for compatibility with concurrent runtimes) \\
 "Ephemeron" & p.~\pageref{Ephemeron} & ephemerons and weak hash tables \\
 "Bigarray" & p.~\pageref{Bigarray} & large, multi-dimensional, numerical arrays
 \end{tabular}
@@ -110,6 +111,7 @@ be called from C \\
 \item \ahref{libref/Arg.html}{Module \texttt{Arg}: parsing of command line arguments}
 \item \ahref{libref/Array.html}{Module \texttt{Array}: array operations}
 \item \ahref{libref/ArrayLabels.html}{Module \texttt{ArrayLabels}: array operations (with labels)}
+\item \ahref{libref/Atomic.html}{Module \texttt{Atomic}: atomic references}
 \item \ahref{libref/Bigarray.html}{Module \texttt{Bigarray}: large, multi-dimensional, numerical arrays}
 \item \ahref{libref/Bool.html}{Module \texttt{Bool}: boolean values}
 \item \ahref{libref/Buffer.html}{Module \texttt{Buffer}: extensible buffers}
@@ -165,6 +167,7 @@ be called from C \\
 \input{Arg.tex}
 \input{Array.tex}
 \input{ArrayLabels.tex}
+\input{Atomic.tex}
 \input{Bigarray.tex}
 \input{Bool.tex}
 \input{Buffer.tex}

--- a/manual/tests/check-stdlib-modules
+++ b/manual/tests/check-stdlib-modules
@@ -13,7 +13,7 @@ for i in `cat $TMPDIR/stdlib-$$-modules`; do
     Stdlib | Camlinternal* | *Labels | Obj | Pervasives) continue;;
   esac
   grep -q -e '"'$i'" & p\.~\\pageref{'$i'} &' $1/manual/manual/library/stdlib-blurb.etex || {
-    echo "Module $i is missing from stdlib-blurb.etex." >&2
+    echo "Module $i is missing from library/stdlib-blurb.etex." >&2
     exitcode=2
   }
 done

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -31,6 +31,11 @@ stdlib__arrayLabels.cmx : \
     stdlib__arrayLabels.cmi
 stdlib__arrayLabels.cmi : \
     stdlib__seq.cmi
+stdlib__atomic.cmo : \
+    stdlib__atomic.cmi
+stdlib__atomic.cmx : \
+    stdlib__atomic.cmi
+stdlib__atomic.cmi :
 stdlib__bigarray.cmo : \
     stdlib__sys.cmi \
     stdlib__complex.cmi \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -36,7 +36,7 @@ STDLIB_MODS=\
   camlinternalFormat printf arg printexc fun gc digest random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \
   filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
-  stdLabels spacetime bigarray
+  stdLabels spacetime bigarray atomic
 
 STDLIB_MODULES=\
   $(foreach module, $(STDLIB_MODS), $(call add_stdlib_prefix,$(module)))

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -1,0 +1,43 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Gabriel Scherer, projet Partout, INRIA Paris-Saclay        *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* We are not reusing ('a ref) directly to make it easier to reason
+   about atomicity if we wish to: even in a sequential implementation,
+   signals and other asynchronous callbacks might break atomicity. *)
+type 'a t = {mutable v: 'a}
+
+let make v = {v}
+let get r = r.v
+let set r v = r.v <- v
+
+let exchange r v =
+  let cur = r.v in
+  r.v <- v;
+  cur
+
+let compare_and_set r seen v =
+  let cur = r.v in
+  if cur == seen then
+    (r.v <- v; true)
+  else
+    false
+
+let fetch_and_add r n =
+  let cur = r.v in
+  r.v <- (cur + n);
+  cur
+
+let incr r = ignore (fetch_and_add r 1)
+let decr r = ignore (fetch_and_add r (-1))

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -1,0 +1,59 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Stephen Dolan, University of Cambridge                     *)
+(*             Gabriel Scherer, projet Partout, INRIA Paris-Saclay        *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This module provides a purely sequential implementation of the
+    concurrent atomic references provided by the Multicore OCaml
+    standard library:
+
+    https://github.com/ocaml-multicore/ocaml-multicore/blob/parallel_minor_gc/stdlib/atomic.mli
+
+    This sequential implementation is provided in the interest of
+    compatibility: when people will start writing code to run on
+    Multicore, it would be nice if their use of Atomic was
+    backward-compatible with older versions of OCaml without having to
+    import additional compatibility layers. *)
+
+(** An atomic (mutable) reference to a value of type ['a]. *)
+type 'a t
+
+(** Create an atomic reference. *)
+val make : 'a -> 'a t
+
+(** Get the current value of the atomic reference. *)
+val get : 'a t -> 'a
+
+(** Set a new value for the atomic reference. *)
+val set : 'a t -> 'a -> unit
+
+(** Set a new value for the atomic reference, and return the current value. *)
+val exchange : 'a t -> 'a -> 'a
+
+(** [compare_and_set r seen v] sets the new value of [r] to [v] only
+    if its current value is physically equal to [seen] -- the
+    comparison and the set occur atomically. Returns [true] if the
+    comparison succeeded (so the set happened) and [false]
+    otherwise. *)
+val compare_and_set : 'a t -> 'a -> 'a -> bool
+
+(** [fetch_and_add r n] atomically increments the value of [r] by [n],
+    and returns the current value (before the increment). *)
+val fetch_and_add : int t -> int -> int
+
+(** [incr r] atomically increments the value of [r] by [1]. *)
+val incr : int t -> unit
+
+(** [decr r] atomically decrements the value of [r] by [1]. *)
+val decr : int t -> unit

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -566,6 +566,7 @@ let _ = register_named_value "Pervasives.do_at_exit" do_at_exit
 module Arg          = Arg
 module Array        = Array
 module ArrayLabels  = ArrayLabels
+module Atomic       = Atomic
 module Bigarray     = Bigarray
 module Bool         = Bool
 module Buffer       = Buffer

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1335,6 +1335,7 @@ val do_at_exit : unit -> unit
 module Arg          = Arg
 module Array        = Array
 module ArrayLabels  = ArrayLabels
+module Atomic       = Atomic
 module Bigarray     = Bigarray
 module Bool         = Bool
 module Buffer       = Buffer

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -1,75 +1,75 @@
 [
-  structure_item (test_locations.ml[42,1260+0]..[44,1298+34])
+  structure_item (test_locations.ml[42,1324+0]..[44,1362+34])
     Pstr_value Rec
     [
       <def>
-        pattern (test_locations.ml[42,1260+8]..[42,1260+11])
-          Ppat_var "fib" (test_locations.ml[42,1260+8]..[42,1260+11])
-        expression (test_locations.ml[42,1260+14]..[44,1298+34])
+        pattern (test_locations.ml[42,1324+8]..[42,1324+11])
+          Ppat_var "fib" (test_locations.ml[42,1324+8]..[42,1324+11])
+        expression (test_locations.ml[42,1324+14]..[44,1362+34])
           Pexp_function
           [
             <case>
-              pattern (test_locations.ml[43,1283+4]..[43,1283+9])
+              pattern (test_locations.ml[43,1347+4]..[43,1347+9])
                 Ppat_or
-                pattern (test_locations.ml[43,1283+4]..[43,1283+5])
+                pattern (test_locations.ml[43,1347+4]..[43,1347+5])
                   Ppat_constant PConst_int (0,None)
-                pattern (test_locations.ml[43,1283+8]..[43,1283+9])
+                pattern (test_locations.ml[43,1347+8]..[43,1347+9])
                   Ppat_constant PConst_int (1,None)
-              expression (test_locations.ml[43,1283+13]..[43,1283+14])
+              expression (test_locations.ml[43,1347+13]..[43,1347+14])
                 Pexp_constant PConst_int (1,None)
             <case>
-              pattern (test_locations.ml[44,1298+4]..[44,1298+5])
-                Ppat_var "n" (test_locations.ml[44,1298+4]..[44,1298+5])
-              expression (test_locations.ml[44,1298+9]..[44,1298+34])
+              pattern (test_locations.ml[44,1362+4]..[44,1362+5])
+                Ppat_var "n" (test_locations.ml[44,1362+4]..[44,1362+5])
+              expression (test_locations.ml[44,1362+9]..[44,1362+34])
                 Pexp_apply
-                expression (test_locations.ml[44,1298+21]..[44,1298+22])
-                  Pexp_ident "+" (test_locations.ml[44,1298+21]..[44,1298+22])
+                expression (test_locations.ml[44,1362+21]..[44,1362+22])
+                  Pexp_ident "+" (test_locations.ml[44,1362+21]..[44,1362+22])
                 [
                   <arg>
                   Nolabel
-                    expression (test_locations.ml[44,1298+9]..[44,1298+20])
+                    expression (test_locations.ml[44,1362+9]..[44,1362+20])
                       Pexp_apply
-                      expression (test_locations.ml[44,1298+9]..[44,1298+12])
-                        Pexp_ident "fib" (test_locations.ml[44,1298+9]..[44,1298+12])
+                      expression (test_locations.ml[44,1362+9]..[44,1362+12])
+                        Pexp_ident "fib" (test_locations.ml[44,1362+9]..[44,1362+12])
                       [
                         <arg>
                         Nolabel
-                          expression (test_locations.ml[44,1298+13]..[44,1298+20])
+                          expression (test_locations.ml[44,1362+13]..[44,1362+20])
                             Pexp_apply
-                            expression (test_locations.ml[44,1298+16]..[44,1298+17])
-                              Pexp_ident "-" (test_locations.ml[44,1298+16]..[44,1298+17])
+                            expression (test_locations.ml[44,1362+16]..[44,1362+17])
+                              Pexp_ident "-" (test_locations.ml[44,1362+16]..[44,1362+17])
                             [
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1298+14]..[44,1298+15])
-                                  Pexp_ident "n" (test_locations.ml[44,1298+14]..[44,1298+15])
+                                expression (test_locations.ml[44,1362+14]..[44,1362+15])
+                                  Pexp_ident "n" (test_locations.ml[44,1362+14]..[44,1362+15])
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1298+18]..[44,1298+19])
+                                expression (test_locations.ml[44,1362+18]..[44,1362+19])
                                   Pexp_constant PConst_int (1,None)
                             ]
                       ]
                   <arg>
                   Nolabel
-                    expression (test_locations.ml[44,1298+23]..[44,1298+34])
+                    expression (test_locations.ml[44,1362+23]..[44,1362+34])
                       Pexp_apply
-                      expression (test_locations.ml[44,1298+23]..[44,1298+26])
-                        Pexp_ident "fib" (test_locations.ml[44,1298+23]..[44,1298+26])
+                      expression (test_locations.ml[44,1362+23]..[44,1362+26])
+                        Pexp_ident "fib" (test_locations.ml[44,1362+23]..[44,1362+26])
                       [
                         <arg>
                         Nolabel
-                          expression (test_locations.ml[44,1298+27]..[44,1298+34])
+                          expression (test_locations.ml[44,1362+27]..[44,1362+34])
                             Pexp_apply
-                            expression (test_locations.ml[44,1298+30]..[44,1298+31])
-                              Pexp_ident "-" (test_locations.ml[44,1298+30]..[44,1298+31])
+                            expression (test_locations.ml[44,1362+30]..[44,1362+31])
+                              Pexp_ident "-" (test_locations.ml[44,1362+30]..[44,1362+31])
                             [
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1298+28]..[44,1298+29])
-                                  Pexp_ident "n" (test_locations.ml[44,1298+28]..[44,1298+29])
+                                expression (test_locations.ml[44,1362+28]..[44,1362+29])
+                                  Pexp_ident "n" (test_locations.ml[44,1362+28]..[44,1362+29])
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1298+32]..[44,1298+33])
+                                expression (test_locations.ml[44,1362+32]..[44,1362+33])
                                   Pexp_constant PConst_int (2,None)
                             ]
                       ]
@@ -80,78 +80,78 @@
 
 let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
-  structure_item (test_locations.ml[42,1260+0]..test_locations.ml[44,1298+34])
+  structure_item (test_locations.ml[42,1324+0]..test_locations.ml[44,1362+34])
     Tstr_value Rec
     [
       <def>
-        pattern (test_locations.ml[42,1260+8]..test_locations.ml[42,1260+11])
-          Tpat_var "fib/80"
-        expression (test_locations.ml[42,1260+14]..test_locations.ml[44,1298+34])
+        pattern (test_locations.ml[42,1324+8]..test_locations.ml[42,1324+11])
+          Tpat_var "fib"
+        expression (test_locations.ml[42,1324+14]..test_locations.ml[44,1362+34])
           Texp_function
           Nolabel
           [
             <case>
-              pattern (test_locations.ml[43,1283+4]..test_locations.ml[43,1283+9])
+              pattern (test_locations.ml[43,1347+4]..test_locations.ml[43,1347+9])
                 Tpat_or
-                pattern (test_locations.ml[43,1283+4]..test_locations.ml[43,1283+5])
+                pattern (test_locations.ml[43,1347+4]..test_locations.ml[43,1347+5])
                   Tpat_constant Const_int 0
-                pattern (test_locations.ml[43,1283+8]..test_locations.ml[43,1283+9])
+                pattern (test_locations.ml[43,1347+8]..test_locations.ml[43,1347+9])
                   Tpat_constant Const_int 1
-              expression (test_locations.ml[43,1283+13]..test_locations.ml[43,1283+14])
+              expression (test_locations.ml[43,1347+13]..test_locations.ml[43,1347+14])
                 Texp_constant Const_int 1
             <case>
-              pattern (test_locations.ml[44,1298+4]..test_locations.ml[44,1298+5])
-                Tpat_var "n/81"
-              expression (test_locations.ml[44,1298+9]..test_locations.ml[44,1298+34])
+              pattern (test_locations.ml[44,1362+4]..test_locations.ml[44,1362+5])
+                Tpat_var "n"
+              expression (test_locations.ml[44,1362+9]..test_locations.ml[44,1362+34])
                 Texp_apply
-                expression (test_locations.ml[44,1298+21]..test_locations.ml[44,1298+22])
+                expression (test_locations.ml[44,1362+21]..test_locations.ml[44,1362+22])
                   Texp_ident "Stdlib!.+"
                 [
                   <arg>
                     Nolabel
-                    expression (test_locations.ml[44,1298+9]..test_locations.ml[44,1298+20])
+                    expression (test_locations.ml[44,1362+9]..test_locations.ml[44,1362+20])
                       Texp_apply
-                      expression (test_locations.ml[44,1298+9]..test_locations.ml[44,1298+12])
-                        Texp_ident "fib/80"
+                      expression (test_locations.ml[44,1362+9]..test_locations.ml[44,1362+12])
+                        Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
-                          expression (test_locations.ml[44,1298+13]..test_locations.ml[44,1298+20])
+                          expression (test_locations.ml[44,1362+13]..test_locations.ml[44,1362+20])
                             Texp_apply
-                            expression (test_locations.ml[44,1298+16]..test_locations.ml[44,1298+17])
+                            expression (test_locations.ml[44,1362+16]..test_locations.ml[44,1362+17])
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1298+14]..test_locations.ml[44,1298+15])
-                                  Texp_ident "n/81"
+                                expression (test_locations.ml[44,1362+14]..test_locations.ml[44,1362+15])
+                                  Texp_ident "n"
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1298+18]..test_locations.ml[44,1298+19])
+                                expression (test_locations.ml[44,1362+18]..test_locations.ml[44,1362+19])
                                   Texp_constant Const_int 1
                             ]
                       ]
                   <arg>
                     Nolabel
-                    expression (test_locations.ml[44,1298+23]..test_locations.ml[44,1298+34])
+                    expression (test_locations.ml[44,1362+23]..test_locations.ml[44,1362+34])
                       Texp_apply
-                      expression (test_locations.ml[44,1298+23]..test_locations.ml[44,1298+26])
-                        Texp_ident "fib/80"
+                      expression (test_locations.ml[44,1362+23]..test_locations.ml[44,1362+26])
+                        Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
-                          expression (test_locations.ml[44,1298+27]..test_locations.ml[44,1298+34])
+                          expression (test_locations.ml[44,1362+27]..test_locations.ml[44,1362+34])
                             Texp_apply
-                            expression (test_locations.ml[44,1298+30]..test_locations.ml[44,1298+31])
+                            expression (test_locations.ml[44,1362+30]..test_locations.ml[44,1362+31])
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1298+28]..test_locations.ml[44,1298+29])
-                                  Texp_ident "n/81"
+                                expression (test_locations.ml[44,1362+28]..test_locations.ml[44,1362+29])
+                                  Texp_ident "n"
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1298+32]..test_locations.ml[44,1298+33])
+                                expression (test_locations.ml[44,1362+32]..test_locations.ml[44,1362+33])
                                   Texp_constant Const_int 2
                             ]
                       ]
@@ -162,15 +162,15 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 
 (setglobal Test_locations!
   (letrec
-    (fib/80
-       (function n/81[int] : int
-         (funct-body Test_locations.fib test_locations.ml(42):1274-1332
-           (if (isout 1 n/81)
-             (before Test_locations.fib test_locations.ml(44):1307-1332
+    (fib
+       (function n[int] : int
+         (funct-body Test_locations.fib test_locations.ml(42):1338-1396
+           (if (isout 1 n)
+             (before Test_locations.fib test_locations.ml(44):1371-1396
                (+
-                 (after Test_locations.fib test_locations.ml(44):1307-1318
-                   (apply fib/80 (- n/81 1)))
-                 (after Test_locations.fib test_locations.ml(44):1321-1332
-                   (apply fib/80 (- n/81 2)))))
-             (before Test_locations.fib test_locations.ml(43):1296-1297 1)))))
-    (pseudo <unknown location> (makeblock 0 fib/80))))
+                 (after Test_locations.fib test_locations.ml(44):1371-1382
+                   (apply fib (- n 1)))
+                 (after Test_locations.fib test_locations.ml(44):1385-1396
+                   (apply fib (- n 2)))))
+             (before Test_locations.fib test_locations.ml(43):1360-1361 1)))))
+    (pseudo <unknown location> (makeblock 0 fib))))

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.clambda.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.clambda.reference
@@ -4,7 +4,7 @@ cmm:
 (data
  int 3063
  "camlTest_locations__1":
- addr "camlTest_locations__fib_80"
+ addr "camlTest_locations__fib_81"
  int 3)
 (data int 1792 global "camlTest_locations" "camlTest_locations": int 1)
 (data
@@ -12,20 +12,20 @@ cmm:
  "camlTest_locations__gc_roots":
  addr "camlTest_locations"
  int 0)
-(function{test_locations.ml:42,14-72} camlTest_locations__fib_80 (n/81: val)
- (if (<a 3 n/81)
+(function{test_locations.ml:42,14-72} camlTest_locations__fib_81 (n: val)
+ (if (<a 3 n)
    (+
      (+
-       (app{test_locations.ml:44,9-20} "camlTest_locations__fib_80"
-         (+ n/81 -2) val)
-       (app{test_locations.ml:44,23-34} "camlTest_locations__fib_80"
-         (+ n/81 -4) val))
+       (app{test_locations.ml:44,9-20} "camlTest_locations__fib_81" (+ n -2)
+         val)
+       (app{test_locations.ml:44,23-34} "camlTest_locations__fib_81" 
+         (+ n -4) val))
      -1)
    3))
 
 (function camlTest_locations__entry ()
- (let clos/84 "camlTest_locations__1"
-   (store val(root-init) "camlTest_locations" clos/84))
+ (let clos "camlTest_locations__1"
+   (store val(root-init) "camlTest_locations" clos))
  1a)
 
 (data)

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.flambda.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.flambda.reference
@@ -13,17 +13,17 @@ cmm:
  global "camlTest_locations__gc_roots"
  "camlTest_locations__gc_roots":
  int 0)
-(function{test_locations.ml:42,14-72} camlTest_locations__fib_5 (n/84: val)
- (if (<a 3 n/84)
+(function{test_locations.ml:42,14-72} camlTest_locations__fib_5 (n: val)
+ (if (<a 3 n)
    (let
-     Paddint_arg/91
-       (app{test_locations.ml:44,23-34} "camlTest_locations__fib_5"
-         (+ n/84 -4) val)
+     Paddint_arg
+       (app{test_locations.ml:44,23-34} "camlTest_locations__fib_5" (+ n -4)
+         val)
      (+
        (+
-         (app{test_locations.ml:44,9-20} "camlTest_locations__fib_5"
-           (+ n/84 -2) val)
-         Paddint_arg/91)
+         (app{test_locations.ml:44,9-20} "camlTest_locations__fib_5" 
+           (+ n -2) val)
+         Paddint_arg)
        -1))
    3))
 

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -85,7 +85,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
     [
       <def>
         pattern 
-          Tpat_var "fib/80"
+          Tpat_var "fib"
         expression 
           Texp_function
           Nolabel
@@ -101,7 +101,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 Texp_constant Const_int 1
             <case>
               pattern 
-                Tpat_var "n/81"
+                Tpat_var "n"
               expression 
                 Texp_apply
                 expression 
@@ -112,7 +112,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression 
                       Texp_apply
                       expression 
-                        Texp_ident "fib/80"
+                        Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
@@ -124,7 +124,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                               <arg>
                                 Nolabel
                                 expression 
-                                  Texp_ident "n/81"
+                                  Texp_ident "n"
                               <arg>
                                 Nolabel
                                 expression 
@@ -136,7 +136,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                     expression 
                       Texp_apply
                       expression 
-                        Texp_ident "fib/80"
+                        Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
@@ -148,7 +148,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                               <arg>
                                 Nolabel
                                 expression 
-                                  Texp_ident "n/81"
+                                  Texp_ident "n"
                               <arg>
                                 Nolabel
                                 expression 
@@ -162,8 +162,7 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 
 (setglobal Test_locations!
   (letrec
-    (fib/80
-       (function n/81[int] : int
-         (if (isout 1 n/81)
-           (+ (apply fib/80 (- n/81 1)) (apply fib/80 (- n/81 2))) 1)))
-    (makeblock 0 fib/80)))
+    (fib
+       (function n[int] : int
+         (if (isout 1 n) (+ (apply fib (- n 1)) (apply fib (- n 2))) 1)))
+    (makeblock 0 fib)))

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.clambda.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.clambda.reference
@@ -4,7 +4,7 @@ cmm:
 (data
  int 3063
  "camlTest_locations__1":
- addr "camlTest_locations__fib_80"
+ addr "camlTest_locations__fib_81"
  int 3)
 (data int 1792 global "camlTest_locations" "camlTest_locations": int 1)
 (data
@@ -12,17 +12,17 @@ cmm:
  "camlTest_locations__gc_roots":
  addr "camlTest_locations"
  int 0)
-(function camlTest_locations__fib_80 (n/81: val)
- (if (<a 3 n/81)
+(function camlTest_locations__fib_81 (n: val)
+ (if (<a 3 n)
    (+
-     (+ (app "camlTest_locations__fib_80" (+ n/81 -2) val)
-       (app "camlTest_locations__fib_80" (+ n/81 -4) val))
+     (+ (app "camlTest_locations__fib_81" (+ n -2) val)
+       (app "camlTest_locations__fib_81" (+ n -4) val))
      -1)
    3))
 
 (function camlTest_locations__entry ()
- (let clos/84 "camlTest_locations__1"
-   (store val(root-init) "camlTest_locations" clos/84))
+ (let clos "camlTest_locations__1"
+   (store val(root-init) "camlTest_locations" clos))
  1a)
 
 (data)

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.flambda.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.flambda.reference
@@ -13,11 +13,10 @@ cmm:
  global "camlTest_locations__gc_roots"
  "camlTest_locations__gc_roots":
  int 0)
-(function camlTest_locations__fib_5 (n/84: val)
- (if (<a 3 n/84)
-   (let Paddint_arg/91 (app "camlTest_locations__fib_5" (+ n/84 -4) val)
-     (+ (+ (app "camlTest_locations__fib_5" (+ n/84 -2) val) Paddint_arg/91)
-       -1))
+(function camlTest_locations__fib_5 (n: val)
+ (if (<a 3 n)
+   (let Paddint_arg (app "camlTest_locations__fib_5" (+ n -4) val)
+     (+ (+ (app "camlTest_locations__fib_5" (+ n -2) val) Paddint_arg) -1))
    3))
 
 (data

--- a/testsuite/tests/formatting/test_locations.ml
+++ b/testsuite/tests/formatting/test_locations.ml
@@ -3,14 +3,14 @@ compile_only="true"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
-flags="-g -dno-locations -dsource -dparsetree -dtypedtree -dlambda"
+flags="-g -dno-unique-ids -dno-locations -dsource -dparsetree -dtypedtree -dlambda"
 *** check-ocamlc.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dno-locations.ocamlc.reference"
 
 * setup-ocamlopt.byte-build-env
 ** ocamlopt.byte
-flags="-g -dno-locations -dcmm"
+flags="-g -dno-unique-ids -dno-locations -dcmm"
 *** no-flambda
 **** check-ocamlopt.byte-output
 compiler_reference =
@@ -22,14 +22,14 @@ compiler_reference =
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
-flags="-g -dlocations -dsource -dparsetree -dtypedtree -dlambda"
+flags="-g -dno-unique-ids -dlocations -dsource -dparsetree -dtypedtree -dlambda"
 *** check-ocamlc.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dlocations.ocamlc.reference"
 
 * setup-ocamlopt.byte-build-env
 ** ocamlopt.byte
-flags="-g -dlocations -dcmm"
+flags="-g -dno-unique-ids -dlocations -dcmm"
 *** no-flambda
 **** check-ocamlopt.byte-output
 compiler_reference =

--- a/testsuite/tests/generalized-open/gpr1506.ml
+++ b/testsuite/tests/generalized-open/gpr1506.ml
@@ -103,9 +103,9 @@ include struct open struct type t = T end let x = T end
 Line 1, characters 15-41:
 1 | include struct open struct type t = T end let x = T end
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The type t/149 introduced by this open appears in the signature
+Error: The type t/150 introduced by this open appears in the signature
        Line 1, characters 46-47:
-         The value x has no valid type if t/149 is hidden
+         The value x has no valid type if t/150 is hidden
 |}];;
 
 module A = struct
@@ -123,9 +123,9 @@ Lines 3-6, characters 4-7:
 4 |       type t = T
 5 |       let x = T
 6 |     end
-Error: The type t/154 introduced by this open appears in the signature
+Error: The type t/155 introduced by this open appears in the signature
        Line 7, characters 8-9:
-         The value y has no valid type if t/154 is hidden
+         The value y has no valid type if t/155 is hidden
 |}];;
 
 module A = struct
@@ -142,9 +142,9 @@ Lines 3-5, characters 4-7:
 3 | ....open struct
 4 |       type t = T
 5 |     end
-Error: The type t/159 introduced by this open appears in the signature
+Error: The type t/160 introduced by this open appears in the signature
        Line 6, characters 8-9:
-         The value y has no valid type if t/159 is hidden
+         The value y has no valid type if t/160 is hidden
 |}]
 
 (* It was decided to not allow this anymore. *)

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -1,0 +1,39 @@
+(* TEST *)
+
+let r = Atomic.make 1
+let () = assert (Atomic.get r = 1)
+
+let () = Atomic.set r 2
+let () = assert (Atomic.get r = 2)
+
+let () = assert (Atomic.exchange r 3 = 2)
+
+let () = assert (Atomic.compare_and_set r 3 4 = true)
+let () = assert (Atomic.get r = 4)
+
+let () = assert (Atomic.compare_and_set r 3 (-4) = false)
+let () = assert (Atomic.get r = 4 )
+
+let () = assert (Atomic.compare_and_set r 3 4 = false)
+
+let () = assert (Atomic.fetch_and_add r 2 = 4)
+let () = assert (Atomic.get r = 6)
+
+let () = assert (Atomic.fetch_and_add r (-2) = 6)
+let () = assert (Atomic.get r = 4)
+
+let () = assert ((Atomic.incr r; Atomic.get r) = 5)
+
+let () = assert ((Atomic.decr r; Atomic.get r) = 4)
+
+let () =
+  let r = Atomic.make 0 in
+  let cur = Atomic.get r in
+  ignore (Atomic.set r (cur + 1), Atomic.set r (cur - 1));
+  assert (Atomic.get r <> cur)
+
+let () =
+  let r = Atomic.make 0 in
+  let cur = Atomic.get r in
+  ignore (Atomic.incr r, Atomic.decr r);
+  assert (Atomic.get r = cur)

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
@@ -1,15 +1,15 @@
 [
-  structure_item (stop_after_typing_impl.ml[13,349+0]..stop_after_typing_impl.ml[13,349+37])
+  structure_item (stop_after_typing_impl.ml[13,365+0]..stop_after_typing_impl.ml[13,365+37])
     Tstr_primitive
-    value_description apply/80 (stop_after_typing_impl.ml[13,349+0]..stop_after_typing_impl.ml[13,349+37])
-      core_type (stop_after_typing_impl.ml[13,349+16]..stop_after_typing_impl.ml[13,349+26])
+    value_description apply (stop_after_typing_impl.ml[13,365+0]..stop_after_typing_impl.ml[13,365+37])
+      core_type (stop_after_typing_impl.ml[13,365+16]..stop_after_typing_impl.ml[13,365+26])
         Ttyp_arrow
         Nolabel
-        core_type (stop_after_typing_impl.ml[13,349+16]..stop_after_typing_impl.ml[13,349+19])
-          Ttyp_constr "int/1!"
+        core_type (stop_after_typing_impl.ml[13,365+16]..stop_after_typing_impl.ml[13,365+19])
+          Ttyp_constr "int!"
           []
-        core_type (stop_after_typing_impl.ml[13,349+23]..stop_after_typing_impl.ml[13,349+26])
-          Ttyp_constr "int/1!"
+        core_type (stop_after_typing_impl.ml[13,365+23]..stop_after_typing_impl.ml[13,365+26])
+          Ttyp_constr "int!"
           []
       [
         "%apply"

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.ml
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.ml
@@ -1,7 +1,7 @@
 (* TEST
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
-    flags = "-stop-after typing -dtypedtree"
+    flags = "-stop-after typing -dno-unique-ids -dtypedtree"
     ocamlc_byte_exit_status = "0"
 *** check-ocamlc.byte-output
 *)

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -24,11 +24,11 @@ end
 Line 3, characters 2-36:
 3 |   include Comparable with type t = t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/97 by t/101
+Error: Illegal shadowing of included type t/98 by t/102
        Line 2, characters 2-19:
-         Type t/97 came from this include
+         Type t/98 came from this include
        Line 3, characters 2-23:
-         The value print has no valid type if t/97 is shadowed
+         The value print has no valid type if t/98 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
This module provides a purely sequential implementation of the
concurrent atomic references provided by the Multicore OCaml
standard library:

https://github.com/ocaml-multicore/ocaml-multicore/blob/parallel_minor_gc/stdlib/atomic.mli

This sequential implementation is provided in the interest of
compatibility: when people will start writing code to run on
Multicore, it would be nice if their use of Atomic was
backward-compatible with older versions of OCaml without having to
import additional compatibility layers. *)

(fixes #7043)