### PR TITLE
Make at_exit and Printexc.register_printer thread-safe

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ Working version
 - #9075: define to_rev_seq in Set and Map modules.
   (Sébastien Briais, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #9571: Make at_exit and Printexc.register_printer thread-safe.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)
+
 ### Other libraries:
 
 * #9206, #9419: update documentation of the threads library;

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -482,6 +482,7 @@ stdlib__printexc.cmo : \
     stdlib__printf.cmi \
     stdlib__obj.cmi \
     stdlib__buffer.cmi \
+    stdlib__atomic.cmi \
     stdlib__array.cmi \
     stdlib__printexc.cmi
 stdlib__printexc.cmx : \
@@ -489,6 +490,7 @@ stdlib__printexc.cmx : \
     stdlib__printf.cmx \
     stdlib__obj.cmx \
     stdlib__buffer.cmx \
+    stdlib__atomic.cmx \
     stdlib__array.cmx \
     stdlib__printexc.cmi
 stdlib__printexc.cmi :

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -18,6 +18,10 @@ case $1 in
   stdlib.cm[iox])
       echo ' -nopervasives -no-alias-deps -w -49' \
            ' -pp "$AWK -f ./expand_module_aliases.awk"';;
+  # stdlib dependencies
+  camlinternalFormatBasics*.cm[iox]) echo ' -nopervasives';;
+  stdlib__atomic*.cm[iox]) echo ' -nopervasives';;
+  # end stdlib dependencies
   camlinternalOO.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
   camlinternalLazy.cmx) echo ' -afl-inst-ratio 0';;
     # never instrument camlinternalOO or camlinternalLazy (PR#7725)
@@ -25,7 +29,6 @@ case $1 in
                            # make sure add_char is inlined (PR#5872)
   stdlib__buffer.cm[io]) echo ' -w A';;
   camlinternalFormat.cm[io]) echo ' -w Ae';;
-  camlinternalFormatBasics*.cm[iox]) echo ' -nopervasives';;
   stdlib__printf.cm[io]|stdlib__format.cm[io]|stdlib__scanf.cm[io])
       echo ' -w Ae';;
   stdlib__scanf.cmx) echo ' -inline 9';;

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -34,7 +34,8 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 include StdlibModules
 
 OBJS=$(addsuffix .cmo,$(STDLIB_MODULES))
-OTHERS=$(filter-out camlinternalFormatBasics.cmo stdlib.cmo,$(OBJS))
+NOSTDLIB= camlinternalFormatBasics.cmo stdlib__atomic.cmo stdlib.cmo
+OTHERS=$(filter-out $(NOSTDLIB),$(OBJS))
 
 PREFIXED_OBJS=$(filter stdlib__%.cmo,$(OBJS))
 UNPREFIXED_OBJS=$(PREFIXED_OBJS:stdlib__%.cmo=%)

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -30,11 +30,11 @@ endef
 
 # Modules should be listed in dependency order.
 STDLIB_MODS=\
-  camlinternalFormatBasics stdlib pervasives seq option result bool char uchar \
+  camlinternalFormatBasics atomic \
+  stdlib pervasives seq option result bool char uchar \
   sys list bytes string unit marshal obj array float int int32 int64 nativeint \
   lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
-  camlinternalFormat printf arg atomic \
-  printexc fun gc digest random hashtbl weak \
+  camlinternalFormat printf arg printexc fun gc digest random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \
   filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
   stdLabels spacetime bigarray

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -33,10 +33,11 @@ STDLIB_MODS=\
   camlinternalFormatBasics stdlib pervasives seq option result bool char uchar \
   sys list bytes string unit marshal obj array float int int32 int64 nativeint \
   lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
-  camlinternalFormat printf arg printexc fun gc digest random hashtbl weak \
+  camlinternalFormat printf arg atomic \
+  printexc fun gc digest random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \
   filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
-  stdLabels spacetime bigarray atomic
+  stdLabels spacetime bigarray
 
 STDLIB_MODULES=\
   $(foreach module, $(STDLIB_MODS), $(call add_stdlib_prefix,$(module)))

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -13,6 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* Atomic is a dependency of Stdlib, so it is compiled with
+   -nopervasives. *)
+external ( == ) : 'a -> 'a -> bool = "%eq"
+external ( + ) : int -> int -> int = "%addint"
+external ignore : 'a -> unit = "%ignore"
+
 (* We are not reusing ('a ref) directly to make it easier to reason
    about atomicity if we wish to: even in a sequential implementation,
    signals and other asynchronous callbacks might break atomicity. *)

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -18,7 +18,8 @@
    (exit_module std_exit)
    (internal_modules Camlinternal*)
    (modules_before_stdlib
-     camlinternalFormatBasics))
+     camlinternalFormatBasics
+     stdlib__atomic))
  (flags (:standard -w -9 -nolabels))
  (preprocess
    (per_module

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -17,7 +17,7 @@ open Printf
 
 type t = exn = ..
 
-let printers = ref []
+let printers = Atomic.make []
 
 let locfmt = format_of_string "File \"%s\", line %d, characters %d-%d: %s"
 
@@ -50,7 +50,7 @@ let use_printers x =
          | None | exception _ -> conv tl
          | Some s -> Some s)
     | [] -> None in
-  conv !printers
+  conv (Atomic.get printers)
 
 let to_string_default = function
   | Out_of_memory -> "Out of memory"
@@ -260,8 +260,11 @@ let get_backtrace () = raw_backtrace_to_string (get_raw_backtrace ())
 external record_backtrace: bool -> unit = "caml_record_backtrace"
 external backtrace_status: unit -> bool = "caml_backtrace_status"
 
-let register_printer fn =
-  printers := fn :: !printers
+let rec register_printer fn =
+  let old_printers = Atomic.get printers in
+  let new_printers = fn :: old_printers in
+  let success = Atomic.compare_and_set printers old_printers new_printers in
+  if not success then register_printer fn
 
 external get_callstack: int -> raw_backtrace = "caml_get_current_callstack"
 


### PR DESCRIPTION
This PR lives on top of #9570. (In particular it is best read per-commit.)

The first proper commit fixes data races in `at_exit` and `Printexc.register_printer` under systhreads using respectively a manual implementation and the new atomics. Using atomics for `at_exit` would cause dependency issues.

The second proper commit makes `Atomic` a dependency of `Stdlib` to implement `at_exit` with atomics. It took me _a while_ to manage to make it compile, and it seemed that I needed to redo the bootstrap, so please tell me in case the bootstrap is not supposed to be needed, I may have further issues with the build process.