### PR TITLE
Update link options for PowerPC 32 bits Linux

### DIFF
--- a/configure
+++ b/configure
@@ -12827,6 +12827,8 @@ fi ;; #(
      oc_ldflags="-brtl -bexpfull"
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
+  gcc*,powerpc-*-linux*) :
+    oc_ldflags="-mbss-plt" ;; #(
   *) :
      ;;
 esac
@@ -13649,7 +13651,12 @@ esac ;; #(
   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
     sharedlib_cflags="-fPIC"
-      mksharedlib="$CC -shared"
+       case $CC,$host in #(
+  gcc*,powerpc-*-linux*) :
+    mksharedlib="$CC -shared -mbss-plt" ;; #(
+  *) :
+    mksharedlib="$CC -shared" ;;
+esac
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"

--- a/configure.ac
+++ b/configure.ac
@@ -725,6 +725,8 @@ AS_CASE([$CC,$host],
     [mkexe="$mkexe "
      oc_ldflags="-brtl -bexpfull"
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
+  [gcc*,powerpc-*-linux*],
+    [oc_ldflags="-mbss-plt"],
 )
 
 
@@ -852,7 +854,9 @@ AS_IF([test x"$enable_shared" != "xno"],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
-      mksharedlib="$CC -shared"
+       AS_CASE([$CC,$host],
+           [gcc*,powerpc-*-linux*], [mksharedlib="$CC -shared -mbss-plt"],
+           [mksharedlib="$CC -shared"])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"


### PR DESCRIPTION
On PowerPC 32 bits Linux, recent versions of GCC produce "secure PLT" relocatable code by default, while ocamlopt still generates "BSS PLT" relocatable code.  This causes a warning at link-time when "BSS PLT" object files (produced by ocamlopt) are being linked.

This PR makes sure that "-mbss-plt" is added to the OC_LDFLAGS variable on PowerPC 32 bits Linux.
