### PR TITLE
Reimplement Unix.create_process and related functions without Unix.fork

### DIFF
--- a/Changes
+++ b/Changes
@@ -52,6 +52,10 @@ Working version
   (Xavier Leroy, review by Florian Angeletti, Guillaume Munch-Maccagnoni,
    and Gabriel Scherer)
 
+- #9573: reimplement Unix.create_process and related functions without
+  Unix.fork, for better efficiency and compatibility with threads.
+  (Xavier Leroy, review by Gabriel Scherer and Anil Madhavapeddy)
+
 - #9575: Add Unix.is_inet6_addr
   (Nicolás Ojeda Bär, review by Xavier Leroy)
 

--- a/configure
+++ b/configure
@@ -15578,6 +15578,24 @@ if test "x$ac_cv_func_execvpe" = xyes; then :
 fi
 
 
+## posix_spawn
+
+ac_fn_c_check_header_mongrel "$LINENO" "spawn.h" "ac_cv_header_spawn_h" "$ac_includes_default"
+if test "x$ac_cv_header_spawn_h" = xyes; then :
+  ac_fn_c_check_func "$LINENO" "posix_spawn" "ac_cv_func_posix_spawn"
+if test "x$ac_cv_func_posix_spawn" = xyes; then :
+  ac_fn_c_check_func "$LINENO" "posix_spawnp" "ac_cv_func_posix_spawnp"
+if test "x$ac_cv_func_posix_spawnp" = xyes; then :
+  $as_echo "#define HAS_POSIX_SPAWN 1" >>confdefs.h
+
+fi
+
+fi
+
+fi
+
+
+
 ## ffs or _BitScanForward
 
 ac_fn_c_check_func "$LINENO" "ffs" "ac_cv_func_ffs"

--- a/configure.ac
+++ b/configure.ac
@@ -1559,6 +1559,12 @@ AC_CHECK_FUNC([getauxval], [AC_DEFINE([HAS_GETAUXVAL])])
 
 AC_CHECK_FUNC([execvpe], [AC_DEFINE([HAS_EXECVPE])])
 
+## posix_spawn
+
+AC_CHECK_HEADER([spawn.h],
+  [AC_CHECK_FUNC([posix_spawn],
+    [AC_CHECK_FUNC([posix_spawnp], [AC_DEFINE([HAS_POSIX_SPAWN])])])])
+
 ## ffs or _BitScanForward
 
 AC_CHECK_FUNC([ffs], [AC_DEFINE([HAS_FFS])])

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -36,7 +36,7 @@ COBJS=accept.o access.o addrofstr.o alarm.o bind.o channels.o chdir.o \
   readdir.o readlink.o rename.o rewinddir.o rmdir.o select.o sendrecv.o \
   setgid.o setgroups.o setsid.o setuid.o shutdown.o signals.o \
   sleep.o socket.o socketaddr.o \
-  socketpair.o sockopt.o stat.o strofaddr.o symlink.o termios.o \
+  socketpair.o sockopt.o spawn.o stat.o strofaddr.o symlink.o termios.o \
   time.o times.o truncate.o umask.o unixsupport.o unlink.o \
   utimes.o wait.o write.o
 

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -14,6 +14,7 @@
 /**************************************************************************/
 
 #define _GNU_SOURCE  /* helps to find execvpe() */
+#include <string.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #define CAML_INTERNALS
@@ -36,32 +37,126 @@ CAMLprim value unix_execvp(value path, value args)
                                     /* from smart compilers */
 }
 
-#ifdef HAS_EXECVPE
+#ifndef HAS_EXECVPE
+int unix_execvpe_emulation(const char * name,
+                           char * const argv[],
+                           char * const envp[]);
+#endif
 
 CAMLprim value unix_execvpe(value path, value args, value env)
 {
   char_os ** argv;
   char_os ** envp;
   char_os * wpath;
+  int err;
   caml_unix_check_path(path, "execvpe");
   argv = cstringvect(args, "execvpe");
   envp = cstringvect(env, "execvpe");
   wpath = caml_stat_strdup_to_os(String_val(path));
+#ifdef HAS_EXECVPE
   (void) execvpe_os((const char_os *)wpath, EXECV_CAST argv, EXECV_CAST envp);
+  err = errno;
+#else
+  err = unix_execvpe_emulation(wpath, argv, envp);
+#endif
   caml_stat_free(wpath);
   cstringvect_free(argv);
   cstringvect_free(envp);
-  uerror("execvpe", path);
+  unix_error(err, "execvpe", path);
   return Val_unit;                  /* never reached, but suppress warnings */
                                     /* from smart compilers */
 }
 
-#else
+#ifndef HAS_EXECVPE
 
-CAMLprim value unix_execvpe(value path, value args, value env)
+static int unix_execve_script(const char * path,
+                              char * const argv[],
+                              char * const envp[])
 {
-  unix_error(ENOSYS, "execvpe", path);
-  return Val_unit;
+  size_t argc, i;
+  char ** new_argv;
+
+  /* Try executing directly.  Will not return if it succeeds. */
+  execve(path, argv, envp);
+  if (errno != ENOEXEC) return errno;
+  /* Try executing as a shell script. */
+  for (argc = 0; argv[argc] != NULL; argc++) /*skip*/;
+  /* The new argument vector is
+            {"/bin/sh", path, argv[1], ..., argv[argc-1], NULL} */
+  new_argv = calloc(argc + 3, sizeof (char *));
+  if (new_argv == NULL) return ENOMEM;
+  new_argv[0] = "/bin/sh";
+  new_argv[1] = (char *) path;
+  for (i = 1; i < argc; i++) new_argv[i + 1] = argv[i];
+  new_argv[argc + 1] = NULL;
+  /* Execute the shell with the new argument vector.
+     Will not return if it succeeds. */
+  execve(new_argv[0], new_argv, envp);
+  /* Shell execution failed. */
+  free(new_argv);
+  return errno;
+}
+
+int unix_execvpe_emulation(const char * name,
+                           char * const argv[],
+                           char * const envp[])
+{
+  char * searchpath, * p, * q, * fullname;
+  size_t namelen, dirlen;
+  int r, got_eacces;
+
+  /* If name contains a '/', do not search in path */
+  if (index(name, '/') != NULL) return unix_execve_script(name, argv, envp);
+  /* Determine search path */
+  searchpath = getenv("PATH");
+  if (searchpath == NULL) searchpath = "/bin:/usr/bin";
+  if (searchpath[0] == 0) return ENOENT;
+  namelen = strlen(name);
+  got_eacces = 0;
+  p = searchpath;
+  while (1) {
+    /* End of path component is next ':' or end of string */
+    for (q = p; *q != 0 && *q != ':'; q++) /*skip*/;
+    /* Path component is between p (included) and q (excluded) */
+    dirlen = q - p;
+    if (dirlen == 0) {
+      /* An empty path component means "current working directory" */
+      r = unix_execve_script(name, argv, envp);
+    } else {
+      /* Construct the string "directory/name" */
+      fullname = malloc(dirlen + 1 + namelen + 1);
+      if (fullname == NULL) return ENOMEM;
+      memcpy(fullname, p, dirlen);   /* copy directory from path */
+      fullname[dirlen] = '/';        /* add separator */
+      memcpy(fullname + dirlen + 1, name, namelen + 1);
+                                     /* add name, including final 0 */
+      r = unix_execve_script(fullname, argv, envp);
+      free(fullname);
+    }
+    switch (r) {
+    case EACCES:
+      /* Record that we got a "Permission denied" error and continue. */
+      got_eacces = 1; break;
+    case ENOENT: case ENOTDIR:
+      /* The file was not found.  Continue the search. */
+      break;
+    case EISDIR: case ELOOP:
+    case ENODEV: case ETIMEDOUT:
+      /* Strange, unexpected error.  Continue the search. */
+      break;
+    default:
+      /* Serious error.  We found an executable file but could not
+         execute it.  Stop the search and return the error. */
+      return r;
+    }
+    /* Continue with next path component, if any */
+    if (*q == 0) break;
+    p = q + 1;                  /* skip ':' */
+  }
+  /* If we found a file but had insufficient permissions, return
+     EACCES to our caller.  Otherwise, say we did not find a file
+     (ENOENT). */
+  return got_eacces ? EACCES : ENOENT;
 }
 
 #endif

--- a/otherlibs/unix/spawn.c
+++ b/otherlibs/unix/spawn.c
@@ -1,0 +1,165 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*   Xavier Leroy, projet Cambium, Collège de France and INRIA Paris      */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define _GNU_SOURCE  /* helps to find execvpe() */
+#include <errno.h>
+#include <sys/types.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include "unixsupport.h"
+
+#ifdef HAS_POSIX_SPAWN
+
+#include <spawn.h>
+
+extern char ** environ;
+
+/* Implementation based on posix_spawn() */
+
+CAMLprim value unix_spawn(value executable, /* string */
+                          value args,       /* string array */
+                          value optenv,     /* string array option */
+                          value usepath,    /* bool */
+                          value redirect)   /* int array (size 3) */
+{
+  char ** argv;
+  char ** envp;
+  const char * path;
+  pid_t pid;
+  int src, dst, r, i;
+  posix_spawn_file_actions_t act;
+
+  caml_unix_check_path(executable, "create_process");
+  path = String_val(executable);
+  argv = cstringvect(args, "create_process");
+  if (Is_block(optenv)) {
+    envp = cstringvect(Field(optenv, 0), "create_process");
+  } else {
+    envp = environ;
+  }
+  /* Prepare the redirections for stdin, stdout, stderr */
+  posix_spawn_file_actions_init(&act);
+  for (dst = 0; dst <= 2; dst++) {
+    /* File descriptor [redirect.(dst)] becomes file descriptor [dst] */
+    src = Int_val(Field(redirect, dst));
+    if (src != dst) {
+      r = posix_spawn_file_actions_adddup2(&act, src, dst);
+      if (r != 0) goto error;
+      /* Close [src] if this is its last use */
+      for (i = dst + 1; i <= 2; i++) {
+        if (src == Int_val(Field(redirect, i))) goto dontclose;
+      }
+      r = posix_spawn_file_actions_addclose(&act, src);
+      if (r != 0) goto error;
+    dontclose:
+      /*skip*/;
+    }
+  }
+  /* Spawn the new process */
+  if (Bool_val(usepath)) {
+    r = posix_spawnp(&pid, path, &act, NULL, argv, envp);
+  } else {
+    r = posix_spawn(&pid, path, &act, NULL, argv, envp);
+  }
+ error:
+  posix_spawn_file_actions_destroy(&act);
+  cstringvect_free(argv);
+  if (Is_block(optenv)) cstringvect_free(envp);
+  if (r != 0) unix_error(r, "create_process", executable);
+  return Val_long(pid);
+}
+
+#else
+
+/* Fallback implementation based on fork() and exec() */
+
+#ifndef HAS_EXECVPE
+extern int unix_execvpe_emulation(const char * name,
+                                  char * const argv[],
+                                  char * const envp[]);
+#endif
+
+/* Exit code used for the child process to report failure to exec */
+/* This is consistent with system() and allowed by posix_spawn() specs */
+
+#define ERROR_EXIT_STATUS 127
+
+CAMLprim value unix_spawn(value executable, /* string */
+                          value args,       /* string array */
+                          value optenv,     /* string array option */
+                          value usepath,    /* bool */
+                          value redirect)   /* int array (size 3) */
+{
+  char ** argv;
+  char ** envp;
+  const char * path;
+  pid_t pid;
+  int src, dst, i;
+
+  caml_unix_check_path(executable, "create_process");
+  path = String_val(executable);
+  argv = cstringvect(args, "create_process");
+  if (Is_block(optenv)) {
+    envp = cstringvect(Field(optenv, 0), "create_process");
+  } else {
+    envp = NULL;
+  }
+  pid = fork();
+  if (pid != 0) {
+    /* This is the parent process */
+    cstringvect_free(argv);
+    if (envp != NULL) cstringvect_free(envp);
+    if (pid == -1) uerror("create_process", executable);
+    return Val_long(pid);
+  }
+  /* This is the child process */
+  /* Perform the redirections for stdin, stdout, stderr */
+  for (dst = 0; dst <= 2; dst++) {
+    /* File descriptor [redirect.(dst)] becomes file descriptor [dst] */
+    src = Int_val(Field(redirect, dst));
+    if (src != dst) {
+      if (dup2(src, dst) == -1) _exit(ERROR_EXIT_STATUS);
+      /* Close [src] if this is its last use */
+      for (i = dst + 1; i <= 2; i++) {
+        if (src == Int_val(Field(redirect, i))) goto dontclose;
+      }
+      if (close(src) == -1) _exit(ERROR_EXIT_STATUS);
+    dontclose:
+      /*skip*/;
+    }
+  }
+  /* Transfer control to the executable */
+  if (Bool_val(usepath)) {
+    if (envp == NULL) {
+      execvp(path, argv);
+    } else {
+#ifdef HAS_EXECVPE
+      execvpe(path, argv, envp);
+#else
+      unix_execvpe_emulation(path, argv, envp);
+#endif
+    }
+  } else {
+    if (envp == NULL) {
+      execv(path, argv);
+    } else {
+      execve(path, argv, envp);
+    }
+  }
+  /* If we get here, the exec*() call failed. */
+  _exit(ERROR_EXIT_STATUS);
+}
+
+#endif

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -205,67 +205,7 @@ type wait_flag =
 external execv : string -> string array -> 'a = "unix_execv"
 external execve : string -> string array -> string array -> 'a = "unix_execve"
 external execvp : string -> string array -> 'a = "unix_execvp"
-external execvpe_c :
-            string -> string array -> string array -> 'a = "unix_execvpe"
-
-let execvpe_ml name args env =
-  (* Try to execute the given file *)
-  let exec file =
-    try
-      execve file args env
-    with Unix_error(ENOEXEC, _, _) ->
-      (* Assume this is a script and try to execute through the shell *)
-      let argc = Array.length args in
-      (* Drop the original args.(0) if it is there *)
-      let new_args = Array.append
-        [| shell; file |]
-        (if argc = 0 then args else Array.sub args 1 (argc - 1)) in
-      execve new_args.(0) new_args env in
-  (* Try each path element in turn *)
-  let rec scan_dir eacces = function
-  | [] ->
-      (* No matching file was found (if [eacces = false]) or
-         a matching file was found but we got a "permission denied"
-         error while trying to execute it (if [eacces = true]).
-         Raise the error appropriate to each case. *)
-      raise (Unix_error((if eacces then EACCES else ENOENT),
-                        "execvpe", name))
-  | dir :: rem ->
-      let dir =  (* an empty path element means the current directory *)
-        if dir = "" then Filename.current_dir_name else dir in
-      try
-        exec (Filename.concat dir name)
-      with Unix_error(err, _, _) as exn ->
-        match err with
-        (* The following errors are treated as nonfatal, meaning that
-           we will ignore them and continue searching in the path.
-           Among those errors, EACCES is recorded specially so as
-           to produce the correct exception in the end.
-           To determine which errors are nonfatal, we looked at the
-           execvpe() sources in Glibc and in OpenBSD. *)
-        | EACCES ->
-            scan_dir true rem
-        | EISDIR|ELOOP|ENAMETOOLONG|ENODEV|ENOENT|ENOTDIR|ETIMEDOUT ->
-            scan_dir eacces rem
-        (* Other errors, e.g. E2BIG, are fatal and abort the search. *)
-        | _ ->
-            raise exn in
-  if String.contains name '/' then
-    (* If the command name contains "/" characters, don't search in path *)
-    exec name
-  else
-    (* Split path into elements and search in these elements *)
-    (try unsafe_getenv "PATH" with Not_found -> "/bin:/usr/bin")
-    |> String.split_on_char ':'
-    |> scan_dir false
-      (* [unsafe_getenv] and not [getenv] to be consistent with [execvp],
-         which looks up the PATH environment variable whether SUID or not. *)
-
-let execvpe name args env =
-  try
-    execvpe_c name args env
-  with Unix_error(ENOSYS, _, _) ->
-    execvpe_ml name args env
+external execvpe : string -> string array -> string array -> 'a = "unix_execvpe"
 
 external fork : unit -> int = "unix_fork"
 external wait : unit -> int * process_status = "unix_wait"

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -880,18 +880,13 @@ let rec waitpid_non_intr pid =
 
 external sys_exit : int -> 'a = "caml_sys_exit"
 
-let system cmd =
-  match fork() with
-     0 -> begin try
-            execv shell [| shell; "-c"; cmd |]
-          with _ ->
-            sys_exit 127
-          end
-  | id -> snd(waitpid_non_intr id)
-
 external spawn : string -> string array -> string array option ->
                  bool -> int array -> int
                = "unix_spawn"
+
+let system cmd =
+  let pid = spawn shell [| shell; "-c"; cmd |] None false [| 0; 1; 2 |] in
+  snd(waitpid_non_intr pid)
 
 let create_process_gen usepath cmd args optenv
                        new_stdin new_stdout new_stderr =

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -243,6 +243,8 @@
 
 #undef HAS_EXECVPE
 
+#undef HAS_POSIX_SPAWN
+
 #undef HAS_FFS
 #undef HAS_BITSCANFORWARD
 

--- a/testsuite/tests/lib-unix/common/redirections.ml
+++ b/testsuite/tests/lib-unix/common/redirections.ml
@@ -96,6 +96,22 @@ let test_swap12 () =    (* swapping stdout and stderr *)
   if status <> Unix.WEXITED 0 then
     out Unix.stdout "!!! reflector exited with an error\n"
 
+let test_12tofile () =   (* > file 2>&1 *)
+  let f =
+    Unix.(openfile "./tmpout.txt" [O_WRONLY;O_TRUNC;O_CREAT;O_CLOEXEC] 0o600) in
+  let pid =
+    Unix.create_process
+       refl
+       [| refl; "-o"; "123"; "-e"; "456"; "-o"; "789" |]
+       Unix.stdin f f in
+  let (_, status) = Unix.waitpid [] pid in
+  Unix.close f;
+  if status <> Unix.WEXITED 0 then
+    out Unix.stdout "!!! reflector exited with an error\n";
+  out Unix.stdout "---- File tmpout.txt\n";
+  cat "./tmpout.txt";
+  Sys.remove "./tmpout.txt"
+
 let test_open_process_in () =
   let ic = Unix.open_process_in (refl ^ " -o 123 -o 456") in
   out Unix.stdout (input_line ic ^ "\n");
@@ -139,6 +155,8 @@ let _ =
   test_2ampsup1();
   out Unix.stdout "** create_process swap 1-2\n";
   test_swap12();
+  out Unix.stdout "** create_process >file 2>&1\n";
+  test_12tofile();
   out Unix.stdout "** open_process_in\n";
   test_open_process_in();
   out Unix.stdout "** open_process_out\n";

--- a/testsuite/tests/lib-unix/common/redirections.reference
+++ b/testsuite/tests/lib-unix/common/redirections.reference
@@ -13,6 +13,11 @@ bbbb
 789
 ** create_process swap 1-2
 123
+** create_process >file 2>&1
+---- File tmpout.txt
+123
+456
+789
 ** open_process_in
 123
 456


### PR DESCRIPTION
Currently, under POSIX, the high-level process creation functions from module Unix (`create_process`, `system`, `open_process_*`) are implemented with `Unix.fork` and `Unix.execv*`, in classic Unix manner.

This implementation will probably be a problem for Multicore OCaml (see https://github.com/ocaml-multicore/ocaml-multicore/pull/241).  Plus, it has some strange behaviors in today's multithreaded programs (e.g. a finalizer can run in the child process before the exec).  Finally, a more efficient implementation is possible on systems that support `posix_spawn`.

This PR reimplements the high-level process creation functions on top of a new `spawn` C primitive, which is implemented with `posix_spawn` when available, or with `fork()` and `execv*()` as a fallback.  Note that the fallback implementation guarantees that no OCaml code runs in the child process before the `exec`, hence should work fine with threads.  The `posix_spawn` implementation should be noticeably more efficient under Linux/Glibc at least.

An unfortunate consequence of this work is that another part of the Unix library, currently implemented in OCaml, must be reimplemented in C: the emulation of the `execvpe` system call when it's not available.  PR #1414 introduced the emulation written in OCaml.  However, the new `spawn` C primitive needs to call `execvpe` from C, hence if it's not available, a C emulation must be used.

This PR is best reviewed commit per commit:  the first commit (559c9bb0c) deals with the `execvpe` emulation, the following commits introduce `spawn` and use it in Unix.

The test suite already contained good tests for `Unix.create_process` and for `Unix.execvpe`.  CI precheck testing is in progress.
