### PR TITLE
Remove Const_pointer

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -91,7 +91,7 @@ and instrument = function
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _
-  | Cconst_symbol _ | Cconst_pointer _ | Cconst_natpointer _
+  | Cconst_symbol _
   | Cblockheader _ | Cvar _ as c -> c
 
 let instrument_function c dbg =

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -176,10 +176,6 @@ method! select_store is_assign addr exp =
   | (Cblockheader(n, _dbg))
       when self#is_immediate_natint n && not Config.spacetime ->
       (Ispecific(Istore_int(n, addr, is_assign)), Ctuple [])
-  | Cconst_pointer (n, _dbg) when self#is_immediate n ->
-      (Ispecific(Istore_int(Nativeint.of_int n, addr, is_assign)), Ctuple [])
-  | Cconst_natpointer (n, _dbg) when self#is_immediate_natint n ->
-      (Ispecific(Istore_int(n, addr, is_assign)), Ctuple [])
   | _ ->
       super#select_store is_assign addr exp
 

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -147,8 +147,6 @@ type expression =
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
   | Cconst_symbol of string * Debuginfo.t
-  | Cconst_pointer of int * Debuginfo.t
-  | Cconst_natpointer of nativeint * Debuginfo.t
   | Cblockheader of nativeint * Debuginfo.t
   | Cvar of Backend_var.t
   | Clet of Backend_var.With_provenance.t * expression * expression
@@ -237,8 +235,6 @@ let iter_shallow_tail f = function
   | Cconst_natint _
   | Cconst_float _
   | Cconst_symbol _
-  | Cconst_pointer _
-  | Cconst_natpointer _
   | Cblockheader _
   | Cvar _
   | Cassign _
@@ -276,8 +272,6 @@ let rec map_tail f = function
   | Cconst_natint _
   | Cconst_float _
   | Cconst_symbol _
-  | Cconst_pointer _
-  | Cconst_natpointer _
   | Cblockheader _
   | Cvar _
   | Cassign _
@@ -315,8 +309,6 @@ let map_shallow f = function
   | Cconst_natint _
   | Cconst_float _
   | Cconst_symbol _
-  | Cconst_pointer _
-  | Cconst_natpointer _
   | Cblockheader _
   | Cvar _
     as c ->

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -154,8 +154,6 @@ and expression =
   | Cconst_natint of nativeint * Debuginfo.t
   | Cconst_float of float * Debuginfo.t
   | Cconst_symbol of string * Debuginfo.t
-  | Cconst_pointer of int * Debuginfo.t
-  | Cconst_natpointer of nativeint * Debuginfo.t
   | Cblockheader of nativeint * Debuginfo.t
   | Cvar of Backend_var.t
   | Clet of Backend_var.With_provenance.t * expression * expression

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -180,8 +180,8 @@ let transl_constant dbg = function
       int_const dbg n
   | Uconst_ptr n ->
       if n <= max_repr_int && n >= min_repr_int
-      then Cconst_pointer((n lsl 1) + 1, dbg)
-      else Cconst_natpointer
+      then Cconst_int((n lsl 1) + 1, dbg)
+      else Cconst_natint
               (Nativeint.add (Nativeint.shift_left (Nativeint.of_int n) 1) 1n,
                dbg)
   | Uconst_ref (label, _) ->
@@ -810,8 +810,8 @@ and transl_prim_1 env p arg dbg =
   | Pnot ->
       transl_if env Then_false_else_true
         dbg arg
-        dbg (Cconst_pointer (1, dbg))
-        dbg (Cconst_pointer (3, dbg))
+        dbg (Cconst_int (1, dbg))
+        dbg (Cconst_int (3, dbg))
   (* Test integer/block *)
   | Pisint ->
       tag_int(Cop(Cand, [transl env arg; Cconst_int (1, dbg)], dbg)) dbg
@@ -870,8 +870,8 @@ and transl_prim_2 env p arg1 arg2 dbg =
       transl_sequand env Then_true_else_false
         dbg arg1
         dbg' arg2
-        dbg (Cconst_pointer (3, dbg))
-        dbg' (Cconst_pointer (1, dbg))
+        dbg (Cconst_int (3, dbg))
+        dbg' (Cconst_int (1, dbg))
       (* let id = V.create_local "res1" in
       Clet(id, transl env arg1,
            Cifthenelse(test_bool dbg (Cvar id), transl env arg2, Cvar id)) *)
@@ -880,8 +880,8 @@ and transl_prim_2 env p arg1 arg2 dbg =
       transl_sequor env Then_true_else_false
         dbg arg1
         dbg' arg2
-        dbg (Cconst_pointer (3, dbg))
-        dbg' (Cconst_pointer (1, dbg))
+        dbg (Cconst_int (3, dbg))
+        dbg' (Cconst_int (1, dbg))
   (* Integer operations *)
   | Paddint ->
       add_int_caml (transl env arg1) (transl env arg2) dbg

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -196,10 +196,6 @@ method! select_store is_assign addr exp =
       (Ispecific(Istore_int(Nativeint.of_int n, addr, is_assign)), Ctuple [])
   | (Cconst_natint (n, _) | Cblockheader (n, _)) ->
       (Ispecific(Istore_int(n, addr, is_assign)), Ctuple [])
-  | Cconst_pointer (n, _) ->
-      (Ispecific(Istore_int(Nativeint.of_int n, addr, is_assign)), Ctuple [])
-  | Cconst_natpointer (n, _) ->
-      (Ispecific(Istore_int(n, addr, is_assign)), Ctuple [])
   | Cconst_symbol (s, _) ->
       (Ispecific(Istore_symbol(s, addr, is_assign)), Ctuple [])
   | _ ->
@@ -289,9 +285,6 @@ method select_push exp =
   match exp with
     Cconst_int (n, _) -> (Ispecific(Ipush_int(Nativeint.of_int n)), Ctuple [])
   | Cconst_natint (n, _) -> (Ispecific(Ipush_int n), Ctuple [])
-  | Cconst_pointer (n, _) ->
-      (Ispecific(Ipush_int(Nativeint.of_int n)), Ctuple [])
-  | Cconst_natpointer (n, _) -> (Ispecific(Ipush_int n), Ctuple [])
   | Cconst_symbol (s, _) -> (Ispecific(Ipush_symbol s), Ctuple [])
   | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -151,8 +151,6 @@ let rec expr ppf = function
       (Nativeint.to_string n) (location d)
   | Cconst_float (n, _dbg) -> fprintf ppf "%F" n
   | Cconst_symbol (s, _dbg) -> fprintf ppf "\"%s\"" s
-  | Cconst_pointer (n, _dbg) -> fprintf ppf "%ia" n
-  | Cconst_natpointer (n, _dbg) -> fprintf ppf "%sa" (Nativeint.to_string n)
   | Cvar id -> V.print ppf id
   | Clet(id, def, (Clet(_, _, _) as body)) ->
       let print_binding id ppf def =

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -88,7 +88,7 @@ module Make(I:I) = struct
   let mk_cmp_gen cmp_op id nat ifso ifnot =
     let dbg = Debuginfo.none in
     let test =
-      Cop (Ccmpi cmp_op, [ Cvar id; Cconst_natpointer (nat, dbg) ], dbg)
+      Cop (Ccmpi cmp_op, [ Cvar id; Cconst_natint (nat, dbg) ], dbg)
     in
     Cifthenelse (test, dbg, ifso, dbg, ifnot, dbg)
 

--- a/testsuite/tests/asmgen/soli.cmm
+++ b/testsuite/tests/asmgen/soli.cmm
@@ -72,7 +72,7 @@ arguments = "-DUNIT_INT -DFUN=solitaire main.c"
                                  (intaset (addraref "board" i1) j1 1)
                                  (intaset (addraref "board" i2) j2 2)
                                  (if (app "solve" (+ m 1) int)
-                                     (raise_notrace 0a)
+                                     (raise_notrace 0)
                                    [])
                                  (intaset (addraref "board" i) j 2)
                                  (intaset (addraref "board" i1) j1 2)

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.clambda.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.clambda.reference
@@ -26,6 +26,6 @@ cmm:
 (function camlTest_locations__entry ()
  (let clos "camlTest_locations__1"
    (store val(root-init) "camlTest_locations" clos))
- 1a)
+ 1)
 
 (data)

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.flambda.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.flambda.reference
@@ -33,6 +33,6 @@ cmm:
  "camlTest_locations":
  addr "camlTest_locations__fib_5_closure")
 (data)
-(function camlTest_locations__entry () 1a)
+(function camlTest_locations__entry () 1)
 
 (data)

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.clambda.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.clambda.reference
@@ -23,6 +23,6 @@ cmm:
 (function camlTest_locations__entry ()
  (let clos "camlTest_locations__1"
    (store val(root-init) "camlTest_locations" clos))
- 1a)
+ 1)
 
 (data)

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.flambda.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlopt.flambda.reference
@@ -25,6 +25,6 @@ cmm:
  "camlTest_locations":
  addr "camlTest_locations__fib_5_closure")
 (data)
-(function camlTest_locations__entry () 1a)
+(function camlTest_locations__entry () 1)
 
 (data)

--- a/testsuite/tools/lexcmm.mll
+++ b/testsuite/tools/lexcmm.mll
@@ -191,9 +191,6 @@ rule token = parse
   | '-'? (['0'-'9']+ | "0x" ['0'-'9' 'a'-'f' 'A'-'F']+
                      | "0o" ['0'-'7']+ | "0b" ['0'-'1']+)
       { INTCONST(int_of_string(Lexing.lexeme lexbuf)) }
-  | '-'? ['0'-'9']+ 'a'
-      { let s = Lexing.lexeme lexbuf in
-        POINTER(int_of_string(String.sub s 0 (String.length s - 1))) }
   | '-'? ['0'-'9']+ ('.' ['0'-'9']*)? (['e' 'E'] ['+' '-']? ['0'-'9']+)?
       { FLOATCONST(Lexing.lexeme lexbuf) }
   | ['A'-'Z' 'a'-'z' '\223'-'\246' '\248'-'\255' ]

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -133,7 +133,6 @@ let access_array base numelt size =
 %token NLEF
 %token NLTF
 %token OR
-%token <int> POINTER
 %token PROJ
 %token <Lambda.raise_kind> RAISE
 %token RBRACKET
@@ -211,7 +210,6 @@ expr:
     INTCONST    { Cconst_int ($1, debuginfo ()) }
   | FLOATCONST  { Cconst_float (float_of_string $1, debuginfo ()) }
   | STRING      { Cconst_symbol ($1, debuginfo ()) }
-  | POINTER     { Cconst_pointer ($1, debuginfo ()) }
   | IDENT       { Cvar(find_ident $1) }
   | LBRACKET RBRACKET { Ctuple [] }
   | LPAREN LET letdef sequence RPAREN { make_letdef $3 $4 }


### PR DESCRIPTION
Since #9316 was merged, `Cconst_pointer` is compiled in exactly the same way as `Cconst_int`. This patch removes the now-redundant `Cconst_pointer`.

cc @mshinwell