### PR TITLE
Ensure stdlib documentation index refers to Stdlib

### DIFF
--- a/Changes
+++ b/Changes
@@ -346,6 +346,9 @@ OCaml 4.11
   warnings for consistency.
   (Muskan Garg, review by Gabriel Scherer and Florian Angeletti)
 
+- #7708, #9580: Ensure Stdlib documentation index refers to Stdlib.
+  (Stephen Dolan, review by Florian Angeletti, report by Hannes Mehnert)
+
 ### Compiler user-interface and warnings:
 
 - GPR#1664: make -output-complete-obj link the runtime native c libraries when

--- a/manual/manual/library/core.etex
+++ b/manual/manual/library/core.etex
@@ -27,7 +27,7 @@ indexed at the end of this report.
 \section{s:stdlib-module}{Module {\tt Stdlib}: the initially opened module}
 \begin{links}
 \item \ahref{libref/Stdlib.html}{Module \texttt{Stdlib}: the initially opened module}
-\item \ahref{libref/Pervasives.html}{Module \texttt{Pervasives}: deprecated alias for Stdlib}
+\item Module \texttt{Pervasives}: deprecated alias for Stdlib
 \end{links}
 \else
 {

--- a/ocamldoc/Makefile.docfiles
+++ b/ocamldoc/Makefile.docfiles
@@ -42,7 +42,7 @@ DOC_COMPILERLIBS_INCLUDES = $(addprefix -I $(SRC)/, $(DOC_COMPILERLIBS_DIRS))
 DOC_ALL_INCLUDES = $(DOC_STDLIB_INCLUDES) $(DOC_COMPILERLIBS_INCLUDES)
 
 STDLIB_MOD_WP = $(filter-out stdlib__pervasives, $(STDLIB_MODULES))
-STDLIB_MLI0 = $(SRC)/stdlib/pervasives.ml $(STDLIB_MOD_WP:%=$(SRC)/stdlib/%.mli)
+STDLIB_MLI0 = $(STDLIB_MOD_WP:%=$(SRC)/stdlib/%.mli)
 STDLIB_MLIS=\
   $(STDLIB_MLI0:$(SRC)/stdlib/stdlib__%=$(SRC)/stdlib/%) \
   $(STR_MLIS) \

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -2394,12 +2394,12 @@ class html =
     (** A method to create index files. *)
     method generate_elements_index :
         'a.
-        ?strip_stdlib:bool ->
+        ?strip_libname:bool ->
           'a list ->
             ('a -> Odoc_info.Name.t) ->
               ('a -> Odoc_info.info option) ->
                 ('a -> string) -> string -> string -> unit =
-    fun ?(strip_stdlib=false) elements name info target title simple_file ->
+    fun ?(strip_libname=false) elements name info target title simple_file ->
       try
         let chanout = open_out (Filename.concat !Global.target_dir simple_file) in
         let b = new_buf () in
@@ -2419,7 +2419,10 @@ class html =
         let f_ele e =
           let simple_name = Name.simple (name e) in
           let father_name = Name.father (name e) in
-          if strip_stdlib && father_name = "Stdlib" && father_name <> simple_name then
+          if strip_libname &&
+               !Odoc_global.library_namespace <> "" &&
+                 father_name = !Odoc_global.library_namespace &&
+                   father_name <> simple_name then
             (* avoid duplicata *) ()
           else
             begin
@@ -2840,7 +2843,7 @@ class html =
     (** Generate the modules index in the file [index_modules.html]. *)
     method generate_modules_index _module_list =
       self#generate_elements_index
-        ~strip_stdlib:true
+        ~strip_libname:true
         self#list_modules
         (fun m -> m.m_name)
         (fun m -> m.m_info)

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -2394,11 +2394,12 @@ class html =
     (** A method to create index files. *)
     method generate_elements_index :
         'a.
-        'a list ->
-          ('a -> Odoc_info.Name.t) ->
-            ('a -> Odoc_info.info option) ->
-              ('a -> string) -> string -> string -> unit =
-    fun elements name info target title simple_file ->
+        ?strip_stdlib:bool ->
+          'a list ->
+            ('a -> Odoc_info.Name.t) ->
+              ('a -> Odoc_info.info option) ->
+                ('a -> string) -> string -> string -> unit =
+    fun ?(strip_stdlib=false) elements name info target title simple_file ->
       try
         let chanout = open_out (Filename.concat !Global.target_dir simple_file) in
         let b = new_buf () in
@@ -2418,7 +2419,7 @@ class html =
         let f_ele e =
           let simple_name = Name.simple (name e) in
           let father_name = Name.father (name e) in
-          if father_name = "Stdlib" && father_name <> simple_name then
+          if strip_stdlib && father_name = "Stdlib" && father_name <> simple_name then
             (* avoid duplicata *) ()
           else
             begin
@@ -2839,6 +2840,7 @@ class html =
     (** Generate the modules index in the file [index_modules.html]. *)
     method generate_modules_index _module_list =
       self#generate_elements_index
+        ~strip_stdlib:true
         self#list_modules
         (fun m -> m.m_name)
         (fun m -> m.m_info)


### PR DESCRIPTION
The [library manual](http://caml.inria.fr/pub/docs/manual-ocaml/libref/) contains various indices (of modules, types, etc.). However, all of the references to Stdlib are missing: values defined in Stdlib refer to the now-undocumented Pervasives module instead, and most of the exceptions don't show up at all.

The issue is [this line in ocamldoc](https://github.com/ocaml/ocaml/blob/trunk/ocamldoc/odoc_html.ml#L2421), which I think is meant to filter out `Stdlib`'s module aliases which otherwise show up as duplicates, but actually filters out every reference to `Stdlib`.

This patch makes the filtering specific to the index of modules, and remove Pervasives from the documentation so its definitions do not appear as duplicates in the index.

Fixes #7708 