### PR TITLE
Toplevel: allow -- to set Sys.argv for interactive use

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -886,6 +886,11 @@ let mk__ f =
   "<file>  Treat <file> as a file name (even if it starts with `-')"
 ;;
 
+let mk___ f =
+  "--", Arg.Rest f,
+  "Stop interpreting arguments and fill Sys.argv with remaining arguments"
+;;
+
 module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
@@ -1008,6 +1013,7 @@ module type Toplevel_options = sig
   val _args0 : string -> string array
   val _color : string -> unit
   val _error_style : string -> unit
+  val rest_arg : string -> unit
 end
 ;;
 
@@ -1303,6 +1309,8 @@ struct
 
     mk_args F._args;
     mk_args0 F._args0;
+
+    mk___ F.rest_arg;
   ]
 end;;
 
@@ -1560,6 +1568,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dump_pass F._dump_pass;
+    mk___ F.rest_arg;
   ]
 end;;
 
@@ -1891,6 +1900,7 @@ module Default = struct
     let _stdin () = (* placeholder: file_argument ""*) ()
     let _version () = print_version ()
     let _vnum () = print_version_num ()
+    let rest_arg _ = ()
   end
 
   module Topmain = struct

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -137,6 +137,7 @@ module type Toplevel_options = sig
   val _args0 : string -> string array
   val _color : string -> unit
   val _error_style : string -> unit
+  val rest_arg : string -> unit
 end
 ;;
 

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -625,11 +625,19 @@ let set_paths () =
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()
 
+external caml_sys_modify_argv : string array -> unit =
+  "caml_sys_modify_argv"
+
+let override_sys_argv new_argv =
+  caml_sys_modify_argv new_argv;
+  Arg.current := 0
+
 (* The interactive loop *)
 
 exception PPerror
 
-let loop ppf =
+let loop ppf rest_args =
+  Option.iter override_sys_argv rest_args;
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
     fprintf ppf "        OCaml version %s - native toplevel@.@." Config.version;
@@ -659,13 +667,6 @@ let loop ppf =
     | PPerror -> ()
     | x -> Location.report_exception ppf x; Btype.backtrack snap
   done
-
-external caml_sys_modify_argv : string array -> unit =
-  "caml_sys_modify_argv"
-
-let override_sys_argv new_argv =
-  caml_sys_modify_argv new_argv;
-  Arg.current := 0
 
 (* Execute a script.  If [name] is "", read the script from stdin. *)
 

--- a/toplevel/opttoploop.mli
+++ b/toplevel/opttoploop.mli
@@ -21,7 +21,7 @@ val set_paths : unit -> unit
 
 (* The interactive toplevel loop *)
 
-val loop : formatter -> unit
+val loop : formatter -> string array option -> unit
 
 (* Read and execute a script from the given file *)
 

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -84,12 +84,15 @@ let wrap_expand f s =
   expand_position start (Array.length arr);
   arr
 
+let rest_args = ref None
+
 module Options = Main_args.Make_opttop_options (struct
     include Main_args.Default.Opttopmain
     let _stdin () = file_argument ""
     let _args = wrap_expand Arg.read_arg
     let _args0 = wrap_expand Arg.read_arg0
     let anonymous s = file_argument s
+    let rest_arg s := rest_args := Some (s :: Option.value ~default:[] !rest_args)
 end);;
 
 let () =
@@ -113,4 +116,5 @@ let main () =
   Compmisc.read_clflags_from_env ();
   if not (prepare Format.err_formatter) then exit 2;
   Compmisc.init_path ();
-  Opttoploop.loop Format.std_formatter
+  let rest_args = Option.map (fun l -> Array.of_list (List.rev l)) !rest_args in
+  Opttoploop.loop Format.std_formatter rest_args

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -578,11 +578,19 @@ let set_paths () =
 let initialize_toplevel_env () =
   toplevel_env := Compmisc.initial_env()
 
+external caml_sys_modify_argv : string array -> unit =
+  "caml_sys_modify_argv"
+
+let override_sys_argv new_argv =
+  caml_sys_modify_argv new_argv;
+  Arg.current := 0
+
 (* The interactive loop *)
 
 exception PPerror
 
-let loop ppf =
+let loop ppf rest_args =
+  Option.iter override_sys_argv rest_args;
   Clflags.debug := true;
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
@@ -619,13 +627,6 @@ let loop ppf =
     | PPerror -> ()
     | x -> Location.report_exception ppf x; Btype.backtrack snap
   done
-
-external caml_sys_modify_argv : string array -> unit =
-  "caml_sys_modify_argv"
-
-let override_sys_argv new_argv =
-  caml_sys_modify_argv new_argv;
-  Arg.current := 0
 
 (* Execute a script.  If [name] is "", read the script from stdin. *)
 

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -27,7 +27,7 @@ val set_paths : unit -> unit
 
 (* The interactive toplevel loop *)
 
-val loop : formatter -> unit
+val loop : formatter -> string array option -> unit
 
 (* Read and execute a script from the given file *)
 

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -87,12 +87,15 @@ let wrap_expand f s =
   expand_position start (Array.length arr);
   arr
 
+let rest_args = ref None
+
 module Options = Main_args.Make_bytetop_options (struct
     include Main_args.Default.Topmain
     let _stdin () = file_argument ""
     let _args = wrap_expand Arg.read_arg
     let _args0 = wrap_expand Arg.read_arg0
     let anonymous s = file_argument s
+    let rest_arg s = rest_args := Some (s :: Option.value ~default:[] !rest_args)
 end);;
 
 let () =
@@ -118,4 +121,5 @@ let main () =
   Compmisc.read_clflags_from_env ();
   if not (prepare ppf) then exit 2;
   Compmisc.init_path ();
-  Toploop.loop Format.std_formatter
+  let rest_args = Option.map (fun l -> Array.of_list (List.rev l)) !rest_args in
+  Toploop.loop Format.std_formatter rest_args


### PR DESCRIPTION
Closes: #4671 

```
$ echo "Array.iter print_endline Sys.argv;;" | ocaml -noprompt
        OCaml version 4.12.0+dev0-2020-04-22

./ocaml
-noprompt
- : unit = ()
$ echo "Array.iter print_endline Sys.argv;;" | ocaml -noprompt -- a b c
        OCaml version 4.12.0+dev0-2020-04-22

a
b
c
- : unit = ()
```
Unfortunately, `Arg.Rest` does not offer a way to detect when `--` is passed but no arguments are passed after it (ie to have an empty `Sys.argv`):
```
$ echo "Array.iter print_endline Sys.argv;;" | ocaml -noprompt --
        OCaml version 4.12.0+dev0-2020-04-22

./ocaml
-noprompt
--
- : unit = ()
```