### PR TITLE
Stdlib.Arg: a new Rest_all spec, similar to Rest, that passes all arguments at once

### DIFF
--- a/Changes
+++ b/Changes
@@ -67,6 +67,11 @@ Working version
 - #9571: Make at_exit and Printexc.register_printer thread-safe.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)
 
+- #9587: Arg: new Rest_all spec to get all rest arguments in a list
+  (this is similar to Rest, but makes it possible to detect when there
+   are no arguments (an empty list) after the rest marker)
+  (Gabriel Scherer, review by Nicolás Ojeda Bär and David Allsopp)
+
 ### Other libraries:
 
 * #9206, #9419: update documentation of the threads library;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1624,6 +1624,7 @@ let options_with_command_line_syntax_inner r after_rest =
       if not !after_rest then (after_rest := true; option ());
       arg a
     in
+    let rest_all a = option (); List.iter arg a in
     match spec with
     | Unit f -> Unit (fun a -> f a; option ())
     | Bool f -> Bool (fun a -> f a; option_with_arg (string_of_bool a))
@@ -1641,6 +1642,7 @@ let options_with_command_line_syntax_inner r after_rest =
        Tuple (loop ~name_opt hd :: List.map (loop ~name_opt:None) tl)
     | Symbol (l, f) -> Symbol (l, (fun a -> f a; option_with_arg a))
     | Rest f -> Rest (fun a -> f a; rest a)
+    | Rest_all f -> Rest_all (fun a -> f a; rest_all a)
     | Expand f -> Expand f
   in
   loop

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -36,6 +36,9 @@ type spec =
                                   call the function with the symbol. *)
   | Rest of (string -> unit)   (* Stop interpreting keywords and call the
                                   function with each remaining argument *)
+  | Rest_all of (string list -> unit)
+                               (* Stop interpreting keywords and call the
+                                  function with all remaining arguments. *)
   | Expand of (string -> string array) (* If the remaining arguments to process
                                           are of the form
                                           [["-foo"; "arg"] @ rest] where "foo"
@@ -251,6 +254,14 @@ let parse_and_expand_argv_dynamic_aux allow_expand current argv speclist anonfun
               f !argv.(!current + 1);
               consume_arg ();
             done;
+        | Rest_all f ->
+            no_arg ();
+            let acc = ref [] in
+            while !current < Array.length !argv - 1 do
+              acc := !argv.(!current + 1) :: !acc;
+              consume_arg ();
+            done;
+            f (List.rev !acc)
         | Expand f ->
             if not allow_expand then
               raise (Invalid_argument "Arg.Expand is is only allowed with \

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -23,9 +23,13 @@
     An option is a keyword alone or followed by an argument.
     The types of keywords are: [Unit], [Bool], [Set], [Clear],
     [String], [Set_string], [Int], [Set_int], [Float], [Set_float],
-    [Tuple], [Symbol], and [Rest].
-    [Unit], [Set] and [Clear] keywords take no argument. A [Rest]
-    keyword takes the remaining of the command line as arguments.
+    [Tuple], [Symbol], [Rest], [Rest_all] and [Expand].
+
+    [Unit], [Set] and [Clear] keywords take no argument.
+
+    A [Rest] or [Rest_all] keyword takes the remainder of the command line
+    as arguments. (More explanations below.)
+
     Every other keyword takes the following word on the command line
     as argument.  For compatibility with GNU getopt_long, [keyword=arg]
     is also allowed.
@@ -39,6 +43,14 @@
 -   [cmd a b c           ](three anonymous arguments: ["a"], ["b"], and ["c"])
 -   [cmd a b -- c d      ](two anonymous arguments and a rest option with
                            two arguments)
+
+    [Rest] takes a function that is called repeatedly for each
+    remaining command line argument. [Rest_all] takes a function that
+    is called once, with the list of all remaining arguments.
+
+    Note that if no arguments follow a [Rest] keyword then the function
+    is not called at all whereas the function for a [Rest_all] keyword
+    is called with an empty list.
 *)
 
 type spec =
@@ -59,6 +71,9 @@ type spec =
                                    call the function with the symbol *)
   | Rest of (string -> unit)   (** Stop interpreting keywords and call the
                                    function with each remaining argument *)
+  | Rest_all of (string list -> unit)
+                               (** Stop interpreting keywords and call the
+                                   function with all remaining arguments *)
   | Expand of (string -> string array) (** If the remaining arguments to process
                                            are of the form
                                            [["-foo"; "arg"] @ rest] where "foo"

--- a/testsuite/tests/lib-arg/test_rest_all.ml
+++ b/testsuite/tests/lib-arg/test_rest_all.ml
@@ -1,0 +1,80 @@
+(* TEST
+   * expect
+*)
+
+type arg = AString of string | ARest of string | ARest_all of string list
+
+let push acc s =
+  acc := s :: !acc
+
+let f_str acc s = push acc (AString s)
+
+let f_rest acc s = push acc (ARest s)
+
+let f_rest_all acc ss = push acc (ARest_all ss)
+
+let test args =
+  let acc = ref [] in
+  Arg.parse_argv ~current:(ref 0) args Arg.[
+    "-str", String (f_str acc), "String (1)";
+    "-rest", Rest (f_rest acc), "Rest (*)";
+    "-rest-all", Rest_all (f_rest_all acc), "Rest_all (*)";
+  ] failwith "";
+  List.rev !acc
+
+[%%expect{|
+type arg = AString of string | ARest of string | ARest_all of string list
+val push : 'a list ref -> 'a -> unit = <fun>
+val f_str : arg list ref -> string -> unit = <fun>
+val f_rest : arg list ref -> string -> unit = <fun>
+val f_rest_all : arg list ref -> string list -> unit = <fun>
+val test : string array -> arg list = <fun>
+|}];;
+
+let _ = test [|
+  "prog";
+  "-str"; "foo";
+  "-str"; "bar";
+  "-rest";
+  "foobar";
+  "-str"; "foobaz"
+|];;
+[%%expect{|
+- : arg list =
+[AString "foo"; AString "bar"; ARest "foobar"; ARest "-str"; ARest "foobaz"]
+|}];;
+
+let _ = test [|
+  "prog";
+  "-str"; "foo";
+  "-str"; "bar";
+  "-rest-all";
+  "foobar";
+  "-str"; "foobaz"
+|];;
+[%%expect{|
+- : arg list =
+[AString "foo"; AString "bar"; ARest_all ["foobar"; "-str"; "foobaz"]]
+|}];;
+
+(* Rest does nothing when there are no following arguments *)
+let _ = test [|
+  "prog";
+  "-str"; "foo";
+  "-str"; "bar";
+  "-rest";
+|];;
+[%%expect{|
+- : arg list = [AString "foo"; AString "bar"]
+|}];;
+
+(* Rest_all lets us detect that there were no rest arguments *)
+let _ = test [|
+  "prog";
+  "-str"; "foo";
+  "-str"; "bar";
+  "-rest-all";
+|];;
+[%%expect{|
+- : arg list = [AString "foo"; AString "bar"; ARest_all []]
+|}];;


### PR DESCRIPTION
In particular this allow to detect a Rest_all keyword followed by no
arguments at all (an empty list).

cc @nojb #9586