### PR TITLE
PR extension constructor rebind pprint 4.11

### DIFF
--- a/Changes
+++ b/Changes
@@ -362,6 +362,9 @@ Working version
 -  #9591: fix pprint of polyvariants that start with a core_type, closed,
    not low (Chet Murthy, review by Florian Angeletti)
 
+-  #9590: fix pprint of extension constructors (and exceptions) that rebind
+   (Chet Murthy, review by octachron@)
+
 ### Build system:
 
 - #7121, #9558: Always the autoconf-discovered ld in PACKLD. For

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1587,9 +1587,9 @@ and extension_constructor ctxt f x =
   | Pext_decl(l, r) ->
       constructor_declaration ctxt f (x.pext_name.txt, l, r, x.pext_attributes)
   | Pext_rebind li ->
-      pp f "%s%a@;=@;%a" x.pext_name.txt
-        (attributes ctxt) x.pext_attributes
+      pp f "%s@;=@;%a%a" x.pext_name.txt
         longident_loc li
+        (attributes ctxt) x.pext_attributes
 
 and case_list ctxt f l : unit =
   let aux f {pc_lhs; pc_guard; pc_rhs} =

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -171,11 +171,14 @@ and[@foo] y = x
 type%foo[@foo] t = int
 and[@foo] t = int
 type%foo[@foo] t += T
+type t += A = M.A[@a]
+type t += B = M.A[@b] | C = M.A[@c][@@t]
 
 class%foo[@foo] x = x
 class type%foo[@foo] x = x
 external%foo[@foo] x : _  = ""
 exception%foo[@foo] X
+exception A = M.A[@a]
 
 module%foo[@foo] M = M
 module%foo[@foo] rec M : S = M


### PR DESCRIPTION
This little patch fixes the pretty-printing of "rebind" extension-constructors (and also rebind exceptions) so that it matches the parser.  With tests.  a rebind extension like
```
type t  += A = M.A [@a]
```
was pretty-printed as
```
type t += A[@a] = M.A
```
[obviously wrong, also not accepted by parser]

With tests for extension-constructors and exceptions.