### PR TITLE
typedecl_separability: compute the same separability signatures in either "(no) flat float" modes

### DIFF
--- a/Changes
+++ b/Changes
@@ -139,7 +139,7 @@ OCaml 4.11
   For instance, "val f: #F(X).t -> unit" is now allowed.
   (Florian Angeletti, review by Gabriel Scherer, suggestion by Leo White)
 
-- #7364, #2188, #9609: improvement of the unboxability check for types
+- #7364, #2188, #9592, #9609: improvement of the unboxability check for types
   with a single constructor. Mutually-recursive type declarations can
   now contain unboxed types. This is based on the paper
     https://arxiv.org/abs/1811.02300


### PR DESCRIPTION
In -no-flat-float-array mode, instead of always returning
`best_msig` (the most permissive signature), we first compute the
flat-float-array separability signature -- falling back to `best_msig`
if it fails.

This discipline is conservative: it never rejects -no-flat-float-array
programs. At the same time it guarantees that, for any program that is
also accepted in -flat-float-array mode, the same separability will be
inferred in the two modes. In particular, the same .cmi files and
digests will be produced.

Before we introduced this hack, the production of different .cmi files
would break the build system of the compiler itself, when trying to
build a -no-flat-float-array system from a bootstrap compiler itself
using -flat-float-array. See #9291.