### PR TITLE
Add new flag for non-elevated symbolic links and test for Developer Mode on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -154,7 +154,6 @@ build-aux/missing text eol=lf
 ocamldoc/remove_DEBUG text eol=lf
 ocamltest/getocamloptdefaultflags text eol=lf
 ocamltest/ocamltest.org typo.long-line=may typo.missing-header
-ocamltest/ocamltest_stdlib_stubs.c typo.long-line
 stdlib/Compflags text eol=lf
 stdlib/sharpbang text eol=lf
 tools/autogen text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -154,6 +154,7 @@ build-aux/missing text eol=lf
 ocamldoc/remove_DEBUG text eol=lf
 ocamltest/getocamloptdefaultflags text eol=lf
 ocamltest/ocamltest.org typo.long-line=may typo.missing-header
+ocamltest/ocamltest_stdlib_stubs.c typo.long-line
 stdlib/Compflags text eol=lf
 stdlib/sharpbang text eol=lf
 tools/autogen text eol=lf

--- a/Changes
+++ b/Changes
@@ -64,6 +64,7 @@ Working version
 
 - #9593: Use new flag for non-elevated symbolic links and test for Developer
   Mode on Windows
+  (Manuel Hornung, review by David Allsopp and Nicolás Ojeda Bär)
 
 * #9601: Return EPERM for EUNKNOWN -1314 in win32unix (principally affects
   error handling when Unix.symlink is unavailable)

--- a/Changes
+++ b/Changes
@@ -62,6 +62,9 @@ Working version
 - #9575: Add Unix.is_inet6_addr
   (Nicolás Ojeda Bär, review by Xavier Leroy)
 
+- #9593: Use new flag for non-elevated symbolic links and test for Developer
+  Mode on Windows
+
 * #9601: Return EPERM for EUNKNOWN -1314 in win32unix (principally affects
   error handling when Unix.symlink is unavailable)
   (David Allsopp, review by Xavier Leroy)

--- a/ocamltest/ocamltest_stdlib_stubs.c
+++ b/ocamltest/ocamltest_stdlib_stubs.c
@@ -47,21 +47,21 @@
 static BOOL IsDeveloperModeEnabled()
 {
   HKEY hKey;
-  LSTATUS openKeyError, queryValueError;
+  LSTATUS status;
   DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
 
-  openKeyError = RegOpenKeyExW(
+  status = RegOpenKeyExW(
     HKEY_LOCAL_MACHINE,
     L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
     0,
     KEY_READ | KEY_WOW64_64KEY,
     &hKey
   );
-  if (openKeyError != ERROR_SUCCESS) {
+  if (status != ERROR_SUCCESS) {
     return FALSE;
   }
 
-  queryValueError = RegQueryValueExW(
+  status = RegQueryValueExW(
     hKey,
     L"AllowDevelopmentWithoutDevLicense",
     NULL,
@@ -70,7 +70,7 @@ static BOOL IsDeveloperModeEnabled()
     &dwordSize
   );
   RegCloseKey(hKey);
-  if (queryValueError != ERROR_SUCCESS) {
+  if (status != ERROR_SUCCESS) {
     return FALSE;
   }
   return developerModeRegistryValue != 0;

--- a/ocamltest/ocamltest_stdlib_stubs.c
+++ b/ocamltest/ocamltest_stdlib_stubs.c
@@ -43,19 +43,32 @@
 #include <sys/types.h>
 
 // Developer Mode allows the creation of symlinks without elevation - see
-// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw#symbolic_link_flag_allow_unprivileged_create
+// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
 static BOOL IsDeveloperModeEnabled()
 {
   HKEY hKey;
   LSTATUS openKeyError, queryValueError;
   DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
 
-  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+  openKeyError = RegOpenKeyExW(
+    HKEY_LOCAL_MACHINE,
+    L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
+    0,
+    KEY_READ | KEY_WOW64_64KEY,
+    &hKey
+  );
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }
-  
-  queryValueError = RegQueryValueExW(hKey, L"AllowDevelopmentWithoutDevLicense", NULL, NULL, (LPBYTE)&developerModeRegistryValue, &dwordSize);
+ 
+  queryValueError = RegQueryValueExW(
+    hKey,
+    L"AllowDevelopmentWithoutDevLicense",
+    NULL,
+    NULL,
+    (LPBYTE)&developerModeRegistryValue,
+    &dwordSize
+  );
   RegCloseKey(hKey);
   if (queryValueError != ERROR_SUCCESS) {
     return FALSE;

--- a/ocamltest/ocamltest_stdlib_stubs.c
+++ b/ocamltest/ocamltest_stdlib_stubs.c
@@ -44,13 +44,13 @@
 
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw#symbolic_link_flag_allow_unprivileged_create
-BOOL IsDeveloperModeEnabled()
+static BOOL IsDeveloperModeEnabled()
 {
   HKEY hKey;
   LSTATUS openKeyError, queryValueError;
   DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
 
-  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ, &hKey);
+  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }

--- a/ocamltest/ocamltest_stdlib_stubs.c
+++ b/ocamltest/ocamltest_stdlib_stubs.c
@@ -60,7 +60,7 @@ static BOOL IsDeveloperModeEnabled()
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }
- 
+
   queryValueError = RegQueryValueExW(
     hKey,
     L"AllowDevelopmentWithoutDevLicense",

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -57,7 +57,7 @@ static BOOL IsDeveloperModeEnabled()
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }
-  
+
   queryValueError = RegQueryValueExW(
     hKey,
     L"AllowDevelopmentWithoutDevLicense",

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -88,10 +88,9 @@ again:
   }
 
   if (!pCreateSymbolicLink) {
-    pCreateSymbolicLink = (LPFN_CREATESYMBOLICLINK)GetProcAddress(GetModuleHandle(L"kernel32"), "CreateSymbolicLinkW");
-    no_symlink = !pCreateSymbolicLink;
-
-    if (!no_symlink && IsDeveloperModeEnabled()) {
+    if (!(pCreateSymbolicLink = (LPFN_CREATESYMBOLICLINK)GetProcAddress(GetModuleHandle(L"kernel32"), "CreateSymbolicLinkW"))) {
+      no_symlink = 1;
+    } else if (IsDeveloperModeEnabled()) {
       additional_symlink_flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
     }
 

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -96,6 +96,7 @@ again:
       additional_symlink_flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
     }
 
+    is_initialized = TRUE;
     goto again;
   }
 

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -73,20 +73,20 @@ again:
   CAMLreturn(Val_unit);
 }
 
-#define luid_eq(l, r) (l.LowPart == r.LowPart && l.HighPart == r.HighPart)
-
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw#symbolic_link_flag_allow_unprivileged_create
-BOOL IsDeveloperModeEnabled() {
+BOOL IsDeveloperModeEnabled()
+{
   HKEY hKey;
-  LSTATUS openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ, &hKey);
+  LSTATUS openKeyError, queryValueError;
+  DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
+
+  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ, &hKey);
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }
   
-  DWORD developerModeRegistryValue;
-  DWORD dwordSize = sizeof(DWORD);
-  LSTATUS queryValueError = RegQueryValueExW(hKey, L"AllowDevelopmentWithoutDevLicense", NULL, NULL, (LPBYTE)&developerModeRegistryValue, &dwordSize);
+  queryValueError = RegQueryValueExW(hKey, L"AllowDevelopmentWithoutDevLicense", NULL, NULL, (LPBYTE)&developerModeRegistryValue, &dwordSize);
   RegCloseKey(hKey);
   if (queryValueError != ERROR_SUCCESS) {
     return FALSE;
@@ -94,16 +94,18 @@ BOOL IsDeveloperModeEnabled() {
   return developerModeRegistryValue != 0;
 }
 
+#define luid_eq(l, r) (l.LowPart == r.LowPart && l.HighPart == r.HighPart)
+
 CAMLprim value unix_has_symlink(value unit)
 {
   CAMLparam1(unit);
 
+  HANDLE hProcess = GetCurrentProcess();
+  BOOL result = FALSE;
+
   if (IsDeveloperModeEnabled()) {
     CAMLreturn(Val_true);
   }
-
-  HANDLE hProcess = GetCurrentProcess();
-  BOOL result = FALSE;
 
   if (OpenProcessToken(hProcess, TOKEN_READ, &hProcess)) {
     LUID seCreateSymbolicLinkPrivilege;

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -40,19 +40,32 @@ static BOOL no_symlinks_available = FALSE;
 static DWORD additional_symlink_flags = 0;
 
 // Developer Mode allows the creation of symlinks without elevation - see
-// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw#symbolic_link_flag_allow_unprivileged_create
+// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
 static BOOL IsDeveloperModeEnabled()
 {
   HKEY hKey;
   LSTATUS openKeyError, queryValueError;
   DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
 
-  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
+  openKeyError = RegOpenKeyExW(
+    HKEY_LOCAL_MACHINE,
+    L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
+    0,
+    KEY_READ | KEY_WOW64_64KEY,
+    &hKey
+  );
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }
   
-  queryValueError = RegQueryValueExW(hKey, L"AllowDevelopmentWithoutDevLicense", NULL, NULL, (LPBYTE)&developerModeRegistryValue, &dwordSize);
+  queryValueError = RegQueryValueExW(
+    hKey,
+    L"AllowDevelopmentWithoutDevLicense",
+    NULL,
+    NULL,
+    (LPBYTE)&developerModeRegistryValue,
+    &dwordSize
+  );
   RegCloseKey(hKey);
   if (queryValueError != ERROR_SUCCESS) {
     return FALSE;

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -44,21 +44,21 @@ static DWORD additional_symlink_flags = 0;
 static BOOL IsDeveloperModeEnabled()
 {
   HKEY hKey;
-  LSTATUS openKeyError, queryValueError;
+  LSTATUS status;
   DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
 
-  openKeyError = RegOpenKeyExW(
+  status = RegOpenKeyExW(
     HKEY_LOCAL_MACHINE,
     L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock",
     0,
     KEY_READ | KEY_WOW64_64KEY,
     &hKey
   );
-  if (openKeyError != ERROR_SUCCESS) {
+  if (status != ERROR_SUCCESS) {
     return FALSE;
   }
 
-  queryValueError = RegQueryValueExW(
+  status = RegQueryValueExW(
     hKey,
     L"AllowDevelopmentWithoutDevLicense",
     NULL,
@@ -67,7 +67,7 @@ static BOOL IsDeveloperModeEnabled()
     &dwordSize
   );
   RegCloseKey(hKey);
-  if (queryValueError != ERROR_SUCCESS) {
+  if (status != ERROR_SUCCESS) {
     return FALSE;
   }
   return developerModeRegistryValue != 0;

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -28,15 +28,21 @@
 #include <caml/osdeps.h>
 #include "unixsupport.h"
 
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE (0x2)
+#endif
+
 typedef BOOLEAN (WINAPI *LPFN_CREATESYMBOLICLINK) (LPWSTR, LPWSTR, DWORD);
 
+static BOOL is_initialized = FALSE;
 static LPFN_CREATESYMBOLICLINK pCreateSymbolicLink = NULL;
-static int no_symlink = 0;
+static BOOL no_symlinks_available = FALSE;
+static DWORD additional_symlink_flags = 0;
 
 CAMLprim value unix_symlink(value to_dir, value osource, value odest)
 {
   CAMLparam3(to_dir, osource, odest);
-  DWORD flags = (Bool_val(to_dir) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0) | SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+  DWORD flags;
   BOOLEAN result;
   LPWSTR source;
   LPWSTR dest;
@@ -44,15 +50,22 @@ CAMLprim value unix_symlink(value to_dir, value osource, value odest)
   caml_unix_check_path(odest, "symlink");
 
 again:
-  if (no_symlink) {
+  if (no_symlinks_available) {
     caml_invalid_argument("symlink not available");
   }
 
-  if (!pCreateSymbolicLink) {
+  if (!is_initialized) {
     pCreateSymbolicLink = (LPFN_CREATESYMBOLICLINK)GetProcAddress(GetModuleHandle(L"kernel32"), "CreateSymbolicLinkW");
-    no_symlink = !pCreateSymbolicLink;
+    no_symlinks_available = !pCreateSymbolicLink;
+
+    if (!no_symlinks_available && IsDeveloperModeEnabled()) {
+      additional_symlink_flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+    }
+
     goto again;
   }
+
+  flags = (Bool_val(to_dir) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0) | additional_symlink_flags;
 
   /* Copy source and dest outside the OCaml heap */
   source = caml_stat_strdup_to_utf16(String_val(osource));
@@ -75,13 +88,13 @@ again:
 
 // Developer Mode allows the creation of symlinks without elevation - see
 // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw#symbolic_link_flag_allow_unprivileged_create
-BOOL IsDeveloperModeEnabled()
+static BOOL IsDeveloperModeEnabled()
 {
   HKEY hKey;
   LSTATUS openKeyError, queryValueError;
   DWORD developerModeRegistryValue, dwordSize = sizeof(DWORD);
 
-  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ, &hKey);
+  openKeyError = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock", 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
   if (openKeyError != ERROR_SUCCESS) {
     return FALSE;
   }
@@ -99,7 +112,6 @@ BOOL IsDeveloperModeEnabled()
 CAMLprim value unix_has_symlink(value unit)
 {
   CAMLparam1(unit);
-
   HANDLE hProcess = GetCurrentProcess();
   BOOL result = FALSE;
 


### PR DESCRIPTION
This should solve #8680.

I ran the corresponding test scenarios (/lib-unix/win-symlink) in all relevant environments:
1. cygwin shell launched from a **non-admin** powershell with **Developer Mode disabled**
	```
	MUN-MANE+manuhornung@mun-mane /cygdrive/c/ocaml
	$ make -C testsuite one DIR=tests/lib-unix/win-symlink
	make: Entering directory '/cygdrive/c/ocaml/testsuite'
	Running tests from 'tests/lib-unix/win-symlink' ...
	running correct symlink code for windows ... testing 'test.ml' with 1 (libwin32u
	nix) => passed
	 ... testing 'test.ml' with 1.1 (has_symlink) => skipped (symlinks not available
	)
	 ... testing 'test.ml' with 1.1.1 (bytecode) => n/a
	 ... testing 'test.ml' with 1.1.2 (native) => n/a
	make[1]: Entering directory '/cygdrive/c/ocaml/testsuite'
	make[1]: Leaving directory '/cygdrive/c/ocaml/testsuite'
	make: Leaving directory '/cygdrive/c/ocaml/testsuite'
	```
1. cygwin shell launched from a **non-admin** powershell with **Developer Mode enabled**
	```
	MUN-MANE+manuhornung@mun-mane /cygdrive/c/ocaml
	$ make -C testsuite one DIR=tests/lib-unix/win-symlink
	make: Entering directory '/cygdrive/c/ocaml/testsuite'
	Running tests from 'tests/lib-unix/win-symlink' ...
	running correct symlink code for windows ... testing 'test.ml' with 1 (libwin32u
	nix) => passed
	 ... testing 'test.ml' with 1.1 (has_symlink) => passed
	 ... testing 'test.ml' with 1.1.1 (bytecode) => passed
	 ... testing 'test.ml' with 1.1.2 (native) => passed
	make[1]: Entering directory '/cygdrive/c/ocaml/testsuite'
	make[1]: Leaving directory '/cygdrive/c/ocaml/testsuite'
	make: Leaving directory '/cygdrive/c/ocaml/testsuite'
	```
1. cygwin shell launched from an **admin** powershell with **Developer Mode disabled**
	```
	MUN-MANE+manuhornung@mun-mane /cygdrive/c/ocaml
	$ make -C testsuite one DIR=tests/lib-unix/win-symlink
	make: Entering directory '/cygdrive/c/ocaml/testsuite'
	Running tests from 'tests/lib-unix/win-symlink' ...
	running correct symlink code for windows ... testing 'test.ml' with 1 (libwin32u
	nix) => passed
	 ... testing 'test.ml' with 1.1 (has_symlink) => passed
	 ... testing 'test.ml' with 1.1.1 (bytecode) => passed
	 ... testing 'test.ml' with 1.1.2 (native) => passed
	make[1]: Entering directory '/cygdrive/c/ocaml/testsuite'
	make[1]: Leaving directory '/cygdrive/c/ocaml/testsuite'
	make: Leaving directory '/cygdrive/c/ocaml/testsuite'
	```
1. cygwin shell launched from an **admin** powershell with **Developer Mode enabled**
	```
	MUN-MANE+manuhornung@mun-mane /cygdrive/c/ocaml
	$ make -C testsuite one DIR=tests/lib-unix/win-symlink
	make: Entering directory '/cygdrive/c/ocaml/testsuite'
	Running tests from 'tests/lib-unix/win-symlink' ...
	running correct symlink code for windows ... testing 'test.ml' with 1 (libwin32u
	nix) => passed
	 ... testing 'test.ml' with 1.1 (has_symlink) => passed
	 ... testing 'test.ml' with 1.1.1 (bytecode) => passed
	 ... testing 'test.ml' with 1.1.2 (native) => passed
	make[1]: Entering directory '/cygdrive/c/ocaml/testsuite'
	make[1]: Leaving directory '/cygdrive/c/ocaml/testsuite'
	make: Leaving directory '/cygdrive/c/ocaml/testsuite'
	```
As far as I can tell, all results are as expected: Symlinks with an admin shell still work outside of developer mode and it is now also possible to create symlinks in an non-admin shell if Developer Mode is enabled.

Please let me know what you think!

Closes: #8680 