### PR TITLE
pattern-matching refactoring: refine the type of `complete_constrs`

### DIFF
--- a/.depend
+++ b/.depend
@@ -811,7 +811,6 @@ typing/parmatch.cmx : \
 typing/parmatch.cmi : \
     typing/types.cmi \
     typing/typedtree.cmi \
-    typing/patterns.cmi \
     parsing/parsetree.cmi \
     parsing/location.cmi \
     typing/env.cmi \

--- a/Changes
+++ b/Changes
@@ -76,7 +76,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #9493, #9520, #9563: refactor the pattern-matching compiler
+- #9493, #9520, #9563, #9599: refactor the pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 ### Build system:

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -67,7 +67,7 @@ val set_args_erase_mutable : pattern -> pattern list -> pattern list
 
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :
-    Patterns.Simple.pattern ->
+    constructor_description pattern_data ->
     constructor_tag list ->
     constructor_description list
 


### PR DESCRIPTION
This is an offspring of #9563 (the n-th piece of the big pattern-matching refactoring #9321) that was suggested by @Octachron during review.

We change the amount of information carried about variant constructors during pattern-matching compilation, to be able to refine the type of the function `complete_constrs` that sits at the Matching/Parmatch boundary, which would previously accept any pattern statically, and do a dynamic check that fails unless it is in fact a variant constructor pattern.