### PR TITLE
Add precheck GH action

### DIFF
--- a/.github/workflows/precheck.yml
+++ b/.github/workflows/precheck.yml
@@ -1,0 +1,26 @@
+name: "Trigger precheck"
+on:
+  issue_comment:
+    types:
+    - created
+
+jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Install jq
+      run: sudo apt-get install jq
+    - name: run script
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ISSUE_URL: ${{ github.event.issue.url }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
+        PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
+        JENKINS_USER: ${{ secrets.JENKINS_USER }}
+        JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+        CAML_DEVEL_TOKEN: ${{ secrets.CAML_DEVEL_TOKEN }}
+      run: bash ./tools/ci/precheck.sh

--- a/tools/ci/precheck.sh
+++ b/tools/ci/precheck.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -x
+
+PRECHECK_URL="https://ci.inria.fr/ocaml/job/precheck"
+
+# A filename used to pipe data between commands
+OUTPUT="out.txt"
+
+# Bail out if comment is not trigger
+
+if test "${COMMENT_BODY}" != "/precheck"; then exit 0; fi
+
+# Bail out if not in a PR
+
+if test -z "${PULL_REQUEST_URL}"; then exit 0; fi
+
+# Check that the user belongs to caml-devel
+
+## Retrieve team URL
+
+curl -s \
+     -H "Authorization: Bearer ${CAML_DEVEL_TOKEN}" \
+     -H "Content-type: application/json" \
+     https://api.github.com/orgs/ocaml/teams/caml-devel | jq -r '.url' | tee ${OUTPUT}
+
+read CAML_DEVEL_URL < ${OUTPUT}
+
+echo "CAML_DEVEL_URL=${CAML_DEVEL_URL}"
+echo "COMMENT_USER_LOGIN=${COMMENT_USER_LOGIN}"
+
+## Retrieve the list of members of caml-devel
+
+curl -s \
+     -H "Authorization: Bearer ${CAML_DEVEL_TOKEN}" \
+     -H "Content-type: application/json" \
+     ${CAML_DEVEL_URL}/members | jq -r '.[].login' > ${OUTPUT}
+
+## Check whether comment author belongs to caml-devel
+
+if ! grep -Fxq "${COMMENT_USER_LOGIN}" ${OUTPUT}
+then
+    MESSAGE="Sorry, only members of the developer team may trigger precheck."
+    echo "$MESSAGE" | jq -R -s '{body: .}' | \
+        curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+             -H "Content-type: application/json" \
+             ${ISSUE_URL}/comments -d @-
+    exit 0
+fi
+
+# Retrieve PR repo and branch
+
+curl -s ${PULL_REQUEST_URL} | jq -r '"\(.head.ref) \(.head.repo.html_url)"' | tee ${OUTPUT}
+
+read BRANCH REPO_URL < ${OUTPUT}
+
+echo "BRANCH=${BRANCH}"
+echo "REPO_URL=${REPO_URL}"
+
+# Trigger Jenkins build
+
+echo "Triggering Jenkins build"
+
+curl -s -i -u "${JENKINS_USER}:${JENKINS_TOKEN}" \
+     -F "REPO_URL=${REPO_URL}" -F "BRANCH=${BRANCH}" \
+     ${PRECHECK_URL}/buildWithParameters | tee ${OUTPUT}
+
+# Get Jenkins queue URL
+
+read JENKINS_QUEUE_URL < <(grep -i '^Location:' ${OUTPUT} | cut -d' ' -f 2 | tr -d '[:space:]')
+
+echo "JENKINS_QUEUE_URL=${JENKINS_QUEUE_URL}"
+
+# Get Jenkins job URL by polling queue URL
+
+echo "Getting Jenkins job URL"
+
+JENKINS_JOB_URL=
+
+for i in {1..10}
+do
+    echo "Polling for 10s (${i})..."
+
+    sleep 10
+
+    curl -s -u "${JENKINS_USER}:${JENKINS_TOKEN}" \
+         ${JENKINS_QUEUE_URL}api/json | jq -r '.executable.url' | tee ${OUTPUT}
+
+    read JENKINS_JOB_URL < ${OUTPUT}
+
+    if test -n "${JENKINS_JOB_URL}"
+    then
+        break
+    fi
+done
+
+echo "JENKINS_JOB_URL=${JENKINS_JOB_URL}"
+
+# Post message saying that the build has started
+
+if test -z "${JENKINS_JOB_URL}"
+then
+    MESSAGE="Build requested, but could not retrieve Jenkins job URL :("
+else
+    MESSAGE="Precheck started: ${JENKINS_JOB_URL}"
+fi
+
+echo "$MESSAGE" | jq -R -s '{body: .}' | \
+    curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+         -H "Content-type: application/json" \
+         ${ISSUE_URL}/comments -d @-


### PR DESCRIPTION
This is an experiment adding a GH action that allows to trigger the precheck CI by simply adding  an issue comment to a PR with the text `/precheck`. After a few moments (around ~20 seconds), a bot posts a follow-up comment with the precheck URL.

For security, only members of `caml-devel` are allowed to trigger it.

Personally, I like precheck quite a bit because it is much faster than the Travis/AppVeyor CIs, but I feel I lose a lot of time just getting to the right page to launch it (and copy-pasting the repository and branch name, etc.)

I can explain the details if there is interest. It won't work here because it needs to be merged for the hook to trigger, but you can play with it in my fork: https://github.com/nojb/ocaml/pull/4

The script is pretty amateurish and a bash expert would be able to improve on it.