### PR TITLE
Map ERROR_PRIVILEGE_NOT_HELD to EPERM in win32unix

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,10 @@ Working version
 - #9575: Add Unix.is_inet6_addr
   (Nicolás Ojeda Bär, review by Xavier Leroy)
 
+* #9601: Return EPERM for EUNKNOWN -1314 in win32unix (principally affects
+  error handling when Unix.symlink is unavailable)
+  (David Allsopp, review by Xavier Leroy)
+
 ### Tools:
 
 

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -141,6 +141,7 @@ static struct error_entry win_error_table[] = {
   { ERROR_WRITE_PROTECT,
     ERROR_SHARING_BUFFER_EXCEEDED - ERROR_WRITE_PROTECT,
     EACCES },
+  { ERROR_PRIVILEGE_NOT_HELD, 0, EPERM},
   { WSAEINVAL, 0, EINVAL },
   { WSAEACCES, 0, EACCES },
   { WSAEBADF, 0, EBADF },


### PR DESCRIPTION
While looking at #9593, I spotted that when `Unix.symlink` is called when it's not available, you get an `EUNKNOWN -1314` which is unfortunate. #9593 increases the small window of opportunity to see this exception (enable Developer Mode, don't restart).

I propose mapping `ERROR_PRIVILEGE_NOT_HELD` (1314) to `EPERM`. Searching GitHub, the only reference I could find to matching on `EUNKNOWNERR(-1314, _, _)` was #7217, though it is technically a breaking change.

Posix doesn't define `EPERM`, so it remains Windows-specific. This seems to me to be a plus - it of course implies that the code has failed to take Windows odd treatment of the symlink privilege into account (i.e. I don't think we should map `ERROR_PRIVILEGE_NOT_HELD` to `EACCES`)