### PR TITLE
Fewer ocamltest cleanups

### DIFF
--- a/Changes
+++ b/Changes
@@ -83,6 +83,9 @@ Working version
 - #9493, #9520, #9563, #9599: refactor the pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
+- #9604: refactoring of the ocamltest codebase.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer and Sébastien Hinderer)
+
 ### Build system:
 
 - #9332, #9518, #9529: Cease storing C dependencies in the codebase. C

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -221,10 +221,12 @@ ocaml_directories.cmi :
 ocaml_files.cmo : \
     ocamltest_stdlib.cmi \
     ocamltest_config.cmi \
+    ocaml_directories.cmi \
     ocaml_files.cmi
 ocaml_files.cmx : \
     ocamltest_stdlib.cmx \
     ocamltest_config.cmx \
+    ocaml_directories.cmx \
     ocaml_files.cmi
 ocaml_files.cmi :
 ocaml_filetypes.cmo : \

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -63,8 +63,7 @@ let files env = words_of_variable env Builtin_variables.files
 let setup_symlinks test_source_directory build_directory files =
   let symlink filename =
     let src = Filename.concat test_source_directory filename in
-    let cmd = "ln -sf " ^ src ^" " ^ build_directory in
-    Sys.run_system_command cmd in
+    Sys.run_system_command "ln" ["-sf"; src; build_directory] in
   let copy filename =
     let src = Filename.concat test_source_directory filename in
     let dst = Filename.concat build_directory filename in

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -68,7 +68,7 @@ let setup_symlinks test_source_directory build_directory files =
     let src = Filename.concat test_source_directory filename in
     let dst = Filename.concat build_directory filename in
     Sys.copy_file src dst in
-  let f = if Sys.os_type="Win32" then copy else symlink in
+  let f = if Sys.win32 then copy else symlink in
   Sys.make_directory build_directory;
   List.iter f files
 
@@ -121,7 +121,7 @@ let run_cmd
   in
   let lst = List.concat (List.map String.words cmd) in
   let quoted_lst =
-    if Sys.os_type="Win32"
+    if Sys.win32
     then List.map Filename.maybe_quote lst
     else lst in
   let cmd' = String.concat " " quoted_lst in

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -138,11 +138,8 @@ let compare_files ?(tool = default_comparison_tool) files =
         files.reference_filename;
         files.output_filename
       ] in
-      let dev_null = match Sys.os_type with
-        | "Win32" -> "NUL"
-        | _ -> "/dev/null" in
       let settings = Run_command.settings_of_commandline
-        ~stdout_fname:dev_null ~stderr_fname:dev_null commandline in
+        ~stdout_fname:Filename.null ~stderr_fname:Filename.null commandline in
       let status = Run_command.run settings in
       result_of_exitcode commandline status
   | Internal ignore ->

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -161,11 +161,11 @@ let test_file test_filename =
   let summary = Sys.with_chdir test_build_directory_prefix
     (fun () ->
        let log =
-         if !Options.log_to_stderr then stderr else begin
+         if Options.log_to_stderr then stderr else begin
            let log_filename = test_prefix ^ ".log" in
            open_out log_filename
          end in
-       let promote = string_of_bool !Options.promote in
+       let promote = string_of_bool Options.promote in
        let install_hook name =
          let hook_name = Filename.make_filename hookname_prefix name in
          if Sys.file_exists hook_name then begin
@@ -198,13 +198,13 @@ let test_file test_filename =
        let summary =
          run_test_trees log common_prefix "" initial_status test_trees in
        Actions.clear_all_hooks();
-       if not !Options.log_to_stderr then close_out log;
+       if not Options.log_to_stderr then close_out log;
        summary
     ) in
   begin match summary with
   | Some_failure -> ()
   | No_failure ->
-      if not !Options.keep_test_dir_on_success then
+      if not Options.keep_test_dir_on_success then
         clean_test_build_directory ()
   end
 
@@ -250,7 +250,7 @@ let list_tests dir =
 let () =
   init_tests_to_skip()
 
-let main () =
+let () =
   let failed = ref false in
   let work_done = ref false in
   let list_tests dir =
@@ -260,10 +260,8 @@ let main () =
   in
   let find_test_dirs dir = List.iter print_endline (find_test_dirs dir) in
   let doit f x = work_done := true; f x in
-  List.iter (doit find_test_dirs) !Options.find_test_dirs;
-  List.iter (doit list_tests) !Options.list_tests;
-  List.iter (doit test_file) !Options.files_to_test;
+  List.iter (doit find_test_dirs) Options.find_test_dirs;
+  List.iter (doit list_tests) Options.list_tests;
+  List.iter (doit test_file) Options.files_to_test;
   if not !work_done then print_usage();
   if !failed || not !work_done then exit 1
-
-let _ = main()

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -127,9 +127,6 @@ let init_tests_to_skip () =
   tests_to_skip := String.words (Sys.safe_getenv "OCAMLTEST_SKIP_TESTS")
 
 let test_file test_filename =
-  (* Printf.printf "# reading test file %s\n%!" test_filename; *)
-  (* Save current working directory *)
-  let cwd = Sys.getcwd() in
   let skip_test = List.mem test_filename !tests_to_skip in
   let tsl_block = tsl_block_of_file_safe test_filename in
   let (rootenv_statements, test_trees) = test_trees_of_tsl_block tsl_block in
@@ -204,8 +201,6 @@ let test_file test_filename =
        if not !Options.log_to_stderr then close_out log;
        summary
     ) in
-  (* Restore current working directory  *)
-  Sys.chdir cwd;
   begin match summary with
   | Some_failure -> ()
   | No_failure ->

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -852,16 +852,14 @@ let really_compare_programs backend comparison_tool log env =
       "flambda temporarily disables comparison of native programs" in
     (Result.pass_with_reason reason, env)
   end else
-  if backend = Ocaml_backends.Native &&
-    (Sys.os_type="Win32" || Sys.os_type="Cygwin")
+  if backend = Ocaml_backends.Native && (Sys.win32 || Sys.cygwin)
   then begin
     let reason =
       "comparison of native programs temporarily disabled under Windows" in
     (Result.pass_with_reason reason, env)
   end else begin
     let comparison_tool =
-      if backend=Ocaml_backends.Native &&
-        (Sys.os_type="Win32" || Sys.os_type="Cygwin")
+      if backend=Ocaml_backends.Native && (Sys.win32 || Sys.cygwin)
         then
           let bytes_to_ignore = 512 (* comparison_start_address program *) in
           Filecompare.(make_cmp_tool ~ignore:{bytes=bytes_to_ignore; lines=0})

--- a/ocamltest/ocaml_commands.ml
+++ b/ocamltest/ocaml_commands.ml
@@ -15,31 +15,31 @@
 
 (* Helper functions to build OCaml-related commands *)
 
-let ocamlrun ocamlsrcdir program =
-  (Ocaml_files.ocamlrun ocamlsrcdir) ^ " " ^ (program ocamlsrcdir)
+let ocamlrun program =
+  Ocaml_files.ocamlrun ^ " " ^ program
 
-let ocamlrun_ocamlc ocamlsrcdir = ocamlrun ocamlsrcdir Ocaml_files.ocamlc
+let ocamlrun_ocamlc = ocamlrun Ocaml_files.ocamlc
 
-let ocamlrun_ocamlopt ocamlsrcdir = ocamlrun ocamlsrcdir Ocaml_files.ocamlopt
+let ocamlrun_ocamlopt = ocamlrun Ocaml_files.ocamlopt
 
-let ocamlrun_ocaml ocamlsrcdir = ocamlrun ocamlsrcdir Ocaml_files.ocaml
+let ocamlrun_ocaml = ocamlrun Ocaml_files.ocaml
 
-let ocamlrun_expect_test ocamlsrcdir =
-  ocamlrun ocamlsrcdir Ocaml_files.expect_test
+let ocamlrun_expect_test =
+  ocamlrun Ocaml_files.expect_test
 
-let ocamlrun_ocamllex ocamlsrcdir = ocamlrun ocamlsrcdir Ocaml_files.ocamllex
+let ocamlrun_ocamllex = ocamlrun Ocaml_files.ocamllex
 
-let ocamlrun_ocamldoc ocamlsrcdir =
-  ocamlrun ocamlsrcdir Ocaml_files.ocamldoc
+let ocamlrun_ocamldoc =
+  ocamlrun Ocaml_files.ocamldoc
 
-let ocamlrun_ocamldebug ocamlsrcdir =
-  ocamlrun ocamlsrcdir Ocaml_files.ocamldebug
+let ocamlrun_ocamldebug =
+  ocamlrun Ocaml_files.ocamldebug
 
-let ocamlrun_ocamlobjinfo ocamlsrcdir =
-  ocamlrun ocamlsrcdir Ocaml_files.ocamlobjinfo
+let ocamlrun_ocamlobjinfo =
+  ocamlrun Ocaml_files.ocamlobjinfo
 
-let ocamlrun_ocamlmklib ocamlsrcdir =
-  ocamlrun ocamlsrcdir Ocaml_files.ocamlmklib
+let ocamlrun_ocamlmklib =
+  ocamlrun Ocaml_files.ocamlmklib
 
-let ocamlrun_codegen ocamlsrcdir =
-  ocamlrun ocamlsrcdir Ocaml_files.codegen
+let ocamlrun_codegen =
+  ocamlrun Ocaml_files.codegen

--- a/ocamltest/ocaml_commands.mli
+++ b/ocamltest/ocaml_commands.mli
@@ -15,21 +15,21 @@
 
 (* Helper functions to build OCaml-related commands *)
 
-val ocamlrun_ocamlc : string -> string
+val ocamlrun_ocamlc : string
 
-val ocamlrun_ocamlopt : string -> string
+val ocamlrun_ocamlopt : string
 
-val ocamlrun_ocaml : string -> string
+val ocamlrun_ocaml : string
 
-val ocamlrun_expect_test : string -> string
+val ocamlrun_expect_test : string
 
-val ocamlrun_ocamllex : string -> string
+val ocamlrun_ocamllex : string
 
-val ocamlrun_ocamldoc : string -> string
+val ocamlrun_ocamldoc : string
 
-val ocamlrun_ocamldebug : string -> string
+val ocamlrun_ocamldebug : string
 
-val ocamlrun_ocamlobjinfo : string -> string
+val ocamlrun_ocamlobjinfo : string
 
-val ocamlrun_ocamlmklib : string -> string
-val ocamlrun_codegen : string -> string
+val ocamlrun_ocamlmklib : string
+val ocamlrun_codegen : string

--- a/ocamltest/ocaml_compilers.ml
+++ b/ocamltest/ocaml_compilers.ml
@@ -18,7 +18,7 @@
 open Ocamltest_stdlib
 
 class compiler
-  ~(name : string -> string)
+  ~(name : string)
   ~(flags : string)
   ~(directory : string)
   ~(exit_status_variable : Variables.t)

--- a/ocamltest/ocaml_compilers.mli
+++ b/ocamltest/ocaml_compilers.mli
@@ -16,7 +16,7 @@
 (* Descriptions of the OCaml compilers *)
 
 class compiler :
-  name : (string -> string) ->
+  name : string ->
   flags : string ->
   directory : string ->
   exit_status_variable : Variables.t ->

--- a/ocamltest/ocaml_directories.ml
+++ b/ocamltest/ocaml_directories.ml
@@ -17,21 +17,21 @@
 
 open Ocamltest_stdlib
 
-let srcdir () =
+let srcdir =
   Sys.getenv_with_default_value "OCAMLSRCDIR" Ocamltest_config.ocamlsrcdir
 
-let stdlib ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "stdlib"]
+let stdlib =
+  Filename.make_path [srcdir; "stdlib"]
 
-let libunix ocamlsrcdir =
+let libunix =
   let subdir = if Sys.os_type="Win32" then "win32unix" else "unix" in
-  Filename.make_path [ocamlsrcdir; "otherlibs"; subdir]
+  Filename.make_path [srcdir; "otherlibs"; subdir]
 
-let toplevel ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "toplevel"]
+let toplevel =
+  Filename.make_path [srcdir; "toplevel"]
 
-let runtime ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "runtime"]
+let runtime =
+  Filename.make_path [srcdir; "runtime"]
 
-let tools ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "tools"]
+let tools =
+  Filename.make_path [srcdir; "tools"]

--- a/ocamltest/ocaml_directories.ml
+++ b/ocamltest/ocaml_directories.ml
@@ -24,7 +24,7 @@ let stdlib =
   Filename.make_path [srcdir; "stdlib"]
 
 let libunix =
-  let subdir = if Sys.os_type="Win32" then "win32unix" else "unix" in
+  let subdir = if Sys.win32 then "win32unix" else "unix" in
   Filename.make_path [srcdir; "otherlibs"; subdir]
 
 let toplevel =

--- a/ocamltest/ocaml_directories.mli
+++ b/ocamltest/ocaml_directories.mli
@@ -15,14 +15,14 @@
 
 (* Locations of directories in the OCaml source tree *)
 
-val srcdir : unit -> string
+val srcdir : string
 
-val stdlib : string -> string
+val stdlib : string
 
-val libunix : string -> string
+val libunix : string
 
-val toplevel : string -> string
+val toplevel : string
 
-val runtime : string -> string
+val runtime : string
 
-val tools : string -> string
+val tools : string

--- a/ocamltest/ocaml_files.ml
+++ b/ocamltest/ocaml_files.ml
@@ -28,62 +28,65 @@ let runtime_variant() =
   else if use_runtime="i" then Instrumented
   else Normal
 
-let ocamlrun ocamlsrcdir =
+let ocamlrun =
   let runtime = match runtime_variant () with
     | Normal -> "ocamlrun"
     | Debug -> "ocamlrund"
     | Instrumented -> "ocamlruni" in
   let ocamlrunfile = Filename.mkexe runtime in
-  Filename.make_path [ocamlsrcdir; "runtime"; ocamlrunfile]
+  Filename.make_path [Ocaml_directories.srcdir; "runtime"; ocamlrunfile]
 
-let ocamlc ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "ocamlc"]
+let ocamlc =
+  Filename.make_path [Ocaml_directories.srcdir; "ocamlc"]
 
-let ocaml ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "ocaml"]
+let ocaml =
+  Filename.make_path [Ocaml_directories.srcdir; "ocaml"]
 
-let ocamlc_dot_opt ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "ocamlc.opt"]
+let ocamlc_dot_opt =
+  Filename.make_path [Ocaml_directories.srcdir; "ocamlc.opt"]
 
-let ocamlopt ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "ocamlopt"]
+let ocamlopt =
+  Filename.make_path [Ocaml_directories.srcdir; "ocamlopt"]
 
-let ocamlopt_dot_opt ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "ocamlopt.opt"]
+let ocamlopt_dot_opt =
+  Filename.make_path [Ocaml_directories.srcdir; "ocamlopt.opt"]
 
-let ocamlnat ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; Filename.mkexe "ocamlnat"]
+let ocamlnat =
+  Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocamlnat"]
 
-let cmpbyt ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "tools"; "cmpbyt"]
+let cmpbyt =
+  Filename.make_path [Ocaml_directories.srcdir; "tools"; "cmpbyt"]
 
-let expect_test ocamlsrcdir =
+let expect_test =
   Filename.make_path
-    [ocamlsrcdir; "testsuite"; "tools"; Filename.mkexe "expect_test"]
+    [Ocaml_directories.srcdir; "testsuite"; "tools";
+     Filename.mkexe "expect_test"]
 
-let ocamllex ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "lex"; "ocamllex"]
+let ocamllex =
+  Filename.make_path [Ocaml_directories.srcdir; "lex"; "ocamllex"]
 
-let ocamlyacc ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "yacc"; Filename.mkexe "ocamlyacc"]
+let ocamlyacc =
+  Filename.make_path
+    [Ocaml_directories.srcdir; "yacc"; Filename.mkexe "ocamlyacc"]
 
-let ocamldoc ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "ocamldoc"; "ocamldoc"]
+let ocamldoc =
+  Filename.make_path [Ocaml_directories.srcdir; "ocamldoc"; "ocamldoc"]
 
-let ocamldebug ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "debugger"; Filename.mkexe "ocamldebug"]
+let ocamldebug =
+  Filename.make_path
+    [Ocaml_directories.srcdir; "debugger"; Filename.mkexe "ocamldebug"]
 
-let ocamlobjinfo ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "tools"; "ocamlobjinfo"]
+let ocamlobjinfo =
+  Filename.make_path [Ocaml_directories.srcdir; "tools"; "ocamlobjinfo"]
 
-let ocamlmklib ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "tools"; "ocamlmklib"]
+let ocamlmklib =
+  Filename.make_path [Ocaml_directories.srcdir; "tools"; "ocamlmklib"]
 
-let codegen ocamlsrcdir =
-  Filename.make_path [ocamlsrcdir; "testsuite"; "tools"; "codegen"]
+let codegen =
+  Filename.make_path [Ocaml_directories.srcdir; "testsuite"; "tools"; "codegen"]
 
-let asmgen_archmod ocamlsrcdir =
+let asmgen_archmod =
   let objname =
     "asmgen_" ^ Ocamltest_config.arch ^ "." ^ Ocamltest_config.objext
   in
-  Filename.make_path [ocamlsrcdir; "testsuite"; "tools"; objname]
+  Filename.make_path [Ocaml_directories.srcdir; "testsuite"; "tools"; objname]

--- a/ocamltest/ocaml_files.mli
+++ b/ocamltest/ocaml_files.mli
@@ -22,32 +22,32 @@ type runtime_variant =
 
 val runtime_variant : unit -> runtime_variant
 
-val ocamlrun : string -> string
+val ocamlrun : string
 
-val ocamlc : string -> string
+val ocamlc : string
 
-val ocaml : string -> string
+val ocaml : string
 
-val ocamlc_dot_opt : string -> string
+val ocamlc_dot_opt : string
 
-val ocamlopt : string -> string
+val ocamlopt : string
 
-val ocamlopt_dot_opt : string -> string
+val ocamlopt_dot_opt : string
 
-val ocamlnat : string -> string
+val ocamlnat : string
 
-val cmpbyt : string -> string
+val cmpbyt : string
 
-val expect_test : string -> string
+val expect_test : string
 
-val ocamllex : string -> string
+val ocamllex : string
 
-val ocamlyacc : string -> string
+val ocamlyacc : string
 
-val ocamldoc : string -> string
-val ocamldebug : string -> string
-val ocamlobjinfo : string -> string
-val ocamlmklib : string -> string
-val codegen : string -> string
+val ocamldoc : string
+val ocamldebug : string
+val ocamlobjinfo : string
+val ocamlmklib : string
+val codegen : string
 
-val asmgen_archmod : string -> string
+val asmgen_archmod : string

--- a/ocamltest/ocaml_flags.ml
+++ b/ocamltest/ocaml_flags.ml
@@ -15,15 +15,15 @@
 
 (* Flags used in OCaml commands *)
 
-let stdlib ocamlsrcdir =
-  let stdlib_path = Ocaml_directories.stdlib ocamlsrcdir in
+let stdlib =
+  let stdlib_path = Ocaml_directories.stdlib in
   "-nostdlib -I " ^ stdlib_path
 
-let include_toplevel_directory ocamlsrcdir =
-  "-I " ^ (Ocaml_directories.toplevel ocamlsrcdir)
+let include_toplevel_directory =
+  "-I " ^ Ocaml_directories.toplevel
 
-let c_includes ocamlsrcdir =
-  let dir = Ocaml_directories.runtime ocamlsrcdir in
+let c_includes =
+  let dir = Ocaml_directories.runtime in
   "-ccopt -I" ^ dir
 
 let runtime_variant_flags () = match Ocaml_files.runtime_variant() with
@@ -31,9 +31,9 @@ let runtime_variant_flags () = match Ocaml_files.runtime_variant() with
   | Ocaml_files.Debug -> " -runtime-variant d"
   | Ocaml_files.Instrumented -> " -runtime-variant i"
 
-let runtime_flags ocamlsrcdir env backend c_files =
+let runtime_flags env backend c_files =
   let runtime_library_flags = "-I " ^
-    (Ocaml_directories.runtime ocamlsrcdir) in
+    Ocaml_directories.runtime in
   let rt_flags = match backend with
     | Ocaml_backends.Native -> runtime_variant_flags ()
     | Ocaml_backends.Bytecode ->
@@ -46,16 +46,16 @@ let runtime_flags ocamlsrcdir env backend c_files =
           in
           if use_runtime = Some false
           then ""
-          else "-use-runtime " ^ (Ocaml_files.ocamlrun ocamlsrcdir)
+          else "-use-runtime " ^ Ocaml_files.ocamlrun
         end
       end in
   rt_flags ^ " " ^ runtime_library_flags
 
 let toplevel_default_flags = "-noinit -no-version -noprompt"
 
-let ocamldebug_default_flags ocamlsrcdir =
+let ocamldebug_default_flags =
   "-no-version -no-prompt -no-time -no-breakpoint-message " ^
-  ("-I " ^ (Ocaml_directories.stdlib ocamlsrcdir) ^ " ") ^
-  ("-topdirs-path " ^ (Ocaml_directories.toplevel ocamlsrcdir))
+  ("-I " ^ Ocaml_directories.stdlib ^ " ") ^
+  ("-topdirs-path " ^ Ocaml_directories.toplevel)
 
 let ocamlobjinfo_default_flags = "-null-crc"

--- a/ocamltest/ocaml_flags.mli
+++ b/ocamltest/ocaml_flags.mli
@@ -15,17 +15,17 @@
 
 (* Flags used in OCaml commands *)
 
-val stdlib : string -> string
+val stdlib : string
 
-val include_toplevel_directory : string -> string
+val include_toplevel_directory : string
 
-val c_includes : string -> string
+val c_includes : string
 
 val runtime_flags :
-  string -> Environments.t -> Ocaml_backends.t -> bool -> string
+  Environments.t -> Ocaml_backends.t -> bool -> string
 
 val toplevel_default_flags : string
 
-val ocamldebug_default_flags : string -> string
+val ocamldebug_default_flags : string
 
 val ocamlobjinfo_default_flags : string

--- a/ocamltest/ocaml_modifiers.ml
+++ b/ocamltest/ocaml_modifiers.ml
@@ -79,7 +79,7 @@ let testing = make_library_modifier
 let tool_ocaml_lib = make_module_modifier
   "lib" (compiler_subdir ["testsuite"; "lib"])
 
-let unixlibdir = if Sys.os_type="Win32" then "win32unix" else "unix"
+let unixlibdir = if Sys.win32 then "win32unix" else "unix"
 
 let unix = make_library_modifier
   "unix" (compiler_subdir ["otherlibs"; unixlibdir])

--- a/ocamltest/ocaml_tools.ml
+++ b/ocamltest/ocaml_tools.ml
@@ -18,7 +18,7 @@
 open Ocamltest_stdlib
 
 class tool
-  ~(name : string -> string)
+  ~(name : string)
   ~(family : string)
   ~(flags : string)
   ~(directory : string)

--- a/ocamltest/ocaml_tools.mli
+++ b/ocamltest/ocaml_tools.mli
@@ -16,7 +16,7 @@
 (* Descriptions of the OCaml tools *)
 
 class tool :
-  name : (string -> string) ->
+  name : string ->
   family : string ->
   flags : string ->
   directory : string ->
@@ -24,7 +24,7 @@ class tool :
   reference_variable : Variables.t ->
   output_variable : Variables.t ->
 object
-  method name : string -> string
+  method name : string
   method family : string
   method flags : string
   method directory : string

--- a/ocamltest/ocaml_toplevels.ml
+++ b/ocamltest/ocaml_toplevels.ml
@@ -18,7 +18,7 @@
 open Ocamltest_stdlib
 
 class toplevel
-  ~(name : string -> string)
+  ~(name : string)
   ~(flags : string)
   ~(directory : string)
   ~(exit_status_variable : Variables.t)

--- a/ocamltest/ocaml_toplevels.mli
+++ b/ocamltest/ocaml_toplevels.mli
@@ -16,7 +16,7 @@
 (* Descriptions of the OCaml toplevels *)
 
 class toplevel :
-  name : (string -> string) ->
+  name : string ->
   flags : string ->
   directory : string ->
   exit_status_variable : Variables.t ->

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -28,7 +28,7 @@ end
 
 module Filename = struct
   include Filename
-  let path_sep = if Sys.os_type="Win32" then ";" else ":"
+  let path_sep = if Sys.win32 then ";" else ":"
   (* This function comes from otherlibs/win32unix/unix.ml *)
   let maybe_quote f =
     if String.contains f ' ' ||
@@ -43,7 +43,7 @@ module Filename = struct
   let make_path components = List.fold_left Filename.concat "" components
 
   let mkexe =
-    if Sys.os_type="Win32"
+    if Sys.win32
     then fun name -> make_filename name "exe"
     else fun name -> name
 end

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -92,7 +92,7 @@ module Sys = struct
     match Sys.command command with
     | 0 -> ()
     | _ as exitcode ->
-      Printf.eprintf "Sysem command %s failed with status %d\n%!"
+      Printf.eprintf "System command %s failed with status %d\n%!"
         command exitcode;
       exit 3
 

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -93,7 +93,9 @@ module Sys = struct
     close_in ic;
     filesize = 0
 
-  let run_system_command command = match Sys.command command with
+  let run_system_command prog args =
+    let command = Filename.quote_command prog args in
+    match Sys.command command with
     | 0 -> ()
     | _ as exitcode ->
       Printf.eprintf "Sysem command %s failed with status %d\n%!"
@@ -102,7 +104,7 @@ module Sys = struct
 
   let mkdir dir =
     if not (Sys.file_exists dir) then
-      run_system_command (Filename.quote_command "mkdir" [dir])
+      run_system_command "mkdir" [dir]
 
   let rec make_directory dir =
     if Sys.file_exists dir then ()

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -46,7 +46,7 @@ end
 module Sys : sig
   include module type of Sys
   val file_is_empty : string -> bool
-  val run_system_command : string -> unit
+  val run_system_command : string -> string list -> unit
   val make_directory : string -> unit
   val string_of_file : string -> string
   val copy_chan : in_channel -> out_channel -> unit

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -56,4 +56,6 @@ module Sys : sig
   val with_chdir : string -> (unit -> 'a) -> 'a
   val getenv_with_default_value : string -> string -> string
   val safe_getenv : string -> string
+  val with_input_file : ?bin:bool -> string -> (in_channel -> 'a) -> 'a
+  val with_output_file : ?bin:bool -> string -> (out_channel -> 'a) -> 'a
 end

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -78,5 +78,12 @@ let files_to_test = ref []
 
 let usage = "Usage: " ^ Sys.argv.(0) ^ " options files to test"
 
-let _ =
+let () =
   Arg.parse (Arg.align commandline_options) (add_to_list files_to_test) usage
+
+let log_to_stderr = !log_to_stderr
+let files_to_test = !files_to_test
+let promote = !promote
+let find_test_dirs = !find_test_dirs
+let list_tests = !list_tests
+let keep_test_dir_on_success = !keep_test_dir_on_success

--- a/ocamltest/options.mli
+++ b/ocamltest/options.mli
@@ -15,16 +15,16 @@
 
 (* Description of ocamltest's command-line options *)
 
-val log_to_stderr : bool ref
+val log_to_stderr : bool
 
-val files_to_test : string list ref
+val files_to_test : string list
 
-val promote : bool ref
+val promote : bool
 
 val usage : string
 
-val find_test_dirs : string list ref
+val find_test_dirs : string list
 
-val list_tests : string list ref
+val list_tests : string list
 
-val keep_test_dir_on_success : bool ref
+val keep_test_dir_on_success : bool

--- a/ocamltest/run_command.ml
+++ b/ocamltest/run_command.ml
@@ -32,7 +32,7 @@ type settings = {
 let settings_of_commandline ?(stdout_fname="") ?(stderr_fname="") commandline =
   let words = String.words commandline in
   let quoted_words =
-    if Sys.os_type="Win32"
+    if Sys.win32
     then List.map Filename.maybe_quote words
     else words in
   {

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -36,7 +36,7 @@ rule token = parse
   | "*/" { TSL_END_C_STYLE }
   | "(*" blank* "TEST" { TSL_BEGIN_OCAML_STYLE }
   | "*)" { TSL_END_OCAML_STYLE }
-  | "," { COMA }
+  | "," { COMMA }
   | '*'+ { TEST_DEPTH (String.length (Lexing.lexeme lexbuf)) }
   | "+=" { PLUSEQUAL }
   | "=" { EQUAL }

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -33,7 +33,7 @@ let mkenvstmt envstmt =
 
 %token TSL_BEGIN_C_STYLE TSL_END_C_STYLE
 %token TSL_BEGIN_OCAML_STYLE TSL_END_OCAML_STYLE
-%token COMA
+%token COMMA
 %token <int> TEST_DEPTH
 %token EQUAL PLUSEQUAL
 /* %token COLON */
@@ -67,7 +67,7 @@ with_environment_modifiers:
 
 opt_environment_modifiers:
 | { [] }
-| opt_environment_modifiers COMA identifier { $3::$1 }
+| opt_environment_modifiers COMMA identifier { $3::$1 }
 
 env_item:
 | identifier EQUAL string


### PR DESCRIPTION
This series of minor refactoring commits is a rebase of @nojb's #9597 without changes to the object-oriented machinery for the definition of OCaml compiler tools. (I didn't have the access rights to force-push to the previous PR.) I have reviewed the changes previously (see my comments in #9597 and #9596), and I approve of them: I believe they are good to merge.

cc @shindere, whose opinion would be very nice, and also @Armael who seemed interested.

This PR is best reviewed commit by commit. It is of manageable size and each change is clearly a good idea.

@nojb to be precise, I got rid of three commits of #9597:
- The controversial [commit](https://github.com/ocaml/ocaml/pull/9597/commits/e1196955d0cd81d602e031006329568caff6777e) that removes the object-oriented machinery.
- The [commit](https://github.com/ocaml/ocaml/pull/9597/commits/388f3a5be4850087c3d9f33a630cbec7e9f029b1) that simplifies the reference logic for the toplevel -- I know I was the one to suggest it in the first place. I believe that the current code is too complex and also wrong, but thinking about it slightly more I would rather have a reference file that works for both ocaml and ocamlnat (.toplevels?), so I left this one for later. (Also it is linked to the object-oriented machinery aspect.)
- Your commit called [Better indentation](https://github.com/ocaml/ocaml/pull/9597/commits/bb029a2cb8c46eec22dc272db839b72f1587ed32) that did not pass my bar of "obviously a good idea". I think it's an improvement, but other people may disagree and I think it is not worth spending time on.

