### PR TITLE
 pattern-matching refactoring: clarify usage of the Cannot_flatten exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -114,7 +114,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- #9493, #9520, #9563, #9599: refactor the pattern-matching compiler
+- #9493, #9520, #9563, #9599, #9608: refactor the pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 - #9604: refactoring of the ocamltest codebase.

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3583,11 +3583,17 @@ let flatten_pattern size p =
   | Tpat_any -> Patterns.omegas size
   | _ -> raise Cannot_flatten
 
+let flatten_simple_pattern size (p : Simple.pattern) =
+  match p.pat_desc with
+  | `Tuple args -> args
+  | `Any -> Patterns.omegas size
+  | _ -> raise Cannot_flatten
+
 let flatten_cases size cases =
   List.map
     (function
       | (p, []), action -> (
-          match flatten_pattern size (General.erase p) with
+          match flatten_simple_pattern size p with
           | p :: ps -> ((p, ps), action)
           | [] -> assert false
         )

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3587,7 +3587,22 @@ let flatten_simple_pattern size (p : Simple.pattern) =
   match p.pat_desc with
   | `Tuple args -> args
   | `Any -> Patterns.omegas size
-  | _ -> raise Cannot_flatten
+  | `Array _
+  | `Variant _
+  | `Record _
+  | `Lazy _
+  | `Construct _
+  | `Constant _ ->
+      (* All calls to this function originate from [do_for_multiple_match],
+         where we know that the scrutinee is a tuple literal.
+
+         Since the PM is well typed, none of these cases are possible. *)
+      let msg =
+        Format.fprintf Format.str_formatter
+          "Matching.flatten_pattern: got '%a'" top_pretty (General.erase p);
+        Format.flush_str_formatter ()
+      in
+      fatal_error msg
 
 let flatten_cases size cases =
   List.map

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -1,0 +1,59 @@
+(* TEST
+   flags = "-drawlambda"
+   * expect
+*)
+
+(* Successful flattening *)
+
+match (3, 2, 1) with
+| (_, 3, _)
+| (1, _, _) -> true
+| _ -> false
+;;
+[%%expect{|
+(let
+  (*match*/88 = 3
+   *match*/89 = 2
+   *match*/90 = 1
+   *match*/91 = *match*/88
+   *match*/92 = *match*/89
+   *match*/93 = *match*/90)
+  (catch
+    (catch
+      (catch (if (!= *match*/92 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/91 1) (exit 2) (exit 1)))
+     with (2) 0)
+   with (1) 1))
+- : bool = false
+|}];;
+
+(* Failed flattening: we need to allocate the tuple to bind x. *)
+
+match (3, 2, 1) with
+| ((_, 3, _) as x)
+| ((1, _, _) as x) -> ignore x; true
+| _ -> false
+;;
+[%%expect{|
+(let
+  (*match*/96 = 3
+   *match*/97 = 2
+   *match*/98 = 1
+   *match*/99 = (makeblock 0 *match*/96 *match*/97 *match*/98))
+  (catch
+    (catch
+      (let (*match*/100 =a (field 0 *match*/99))
+        (catch
+          (let (*match*/101 =a (field 1 *match*/99))
+            (if (!= *match*/101 3) (exit 7)
+              (let (*match*/102 =a (field 2 *match*/99)) (exit 5 *match*/99))))
+         with (7)
+          (if (!= *match*/100 1) (exit 6)
+            (let
+              (*match*/104 =a (field 2 *match*/99)
+               *match*/103 =a (field 1 *match*/99))
+              (exit 5 *match*/99)))))
+     with (6) 0)
+   with (5 x/94) (seq (ignore x/94) 1)))
+- : bool = false
+|}];;


### PR DESCRIPTION
This is the next bit of the big pattern-matching refactoring change (#9321) after #9599  has been merged. This patchset clarifies the usage of the `Cannot_flatten` exception in `do_for_multiple_match`.

(cc @trefis @Octachron)

For now this is only a "dynamic check" clarification (we are thinking hard about the control flow and turning an exception into a fatal error in some cases where it would be a programming error if it happened), not a static enforcement of the corresponding discipline. I thought a bit about how to do the latter, but it is not easy¹. Suggestions are welcome, but I think that any change of this nature should go in a separate PR.

¹: We would like to "learn" some static fact from whether an exception is raised or not, but preferably without rewriting the whole call stack to use explicit results instead. Another option would be to pass a failure continuation instead of raising an exception, but it is unclear that this would be better. Yet another option would be to remove the `option` character of `arg_id` with two different entry points depending on whether we know we need to flatten or not; with some clever factorization to avoid having to duplicate the implementation.