### PR TITLE
Bind arguments of integer and float compare in cmmgen

### DIFF
--- a/Changes
+++ b/Changes
@@ -101,6 +101,10 @@ Working version
   (Gabriel Scherer and Jeremy Yallop and Xavier Leroy,
    report by Twitter user @st_toHKR through Jun Furuse)
 
+- #9613: correctly handle arguments of integer and float compare that
+  have side-effects after inlining and un-anf.
+  (Greta Yorsh and Stephen Dolan, review by Leo White and Gabriel Scherer)
+
 OCaml 4.11
 ----------
 

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -271,7 +271,6 @@ let mk_not dbg cmm =
       (* 1 -> 3, 3 -> 1 *)
       Cop(Csubi, [Cconst_int (4, dbg); c], dbg)
 
-
 let mk_compare_ints dbg a1 a2 =
   match (a1,a2) with
   | Cconst_int (c1, _), Cconst_int (c2, _) ->
@@ -289,6 +288,25 @@ let mk_compare_ints dbg a1 a2 =
           let op2 = Cop(Ccmpi(Clt), [a1; a2], dbg) in
           tag_int(sub_int op1 op2 dbg) dbg))
     end
+
+let mk_compare_floats dbg a1 a2 =
+  bind "float_cmp" a1 (fun a1 ->
+    bind "float_cmp" a2 (fun a2 ->
+      let op1 = Cop(Ccmpf(CFgt), [a1; a2], dbg) in
+      let op2 = Cop(Ccmpf(CFlt), [a1; a2], dbg) in
+      let op3 = Cop(Ccmpf(CFeq), [a1; a1], dbg) in
+      let op4 = Cop(Ccmpf(CFeq), [a2; a2], dbg) in
+      (* If both operands a1 and a2 are not NaN, then op3 = op4 = 1,
+         and the result is op1 - op2.
+         If at least one of the operands is NaN,
+         then op1 = op2 = 0, and the result is op3 - op4,
+         which orders NaN before other values.
+         To detect if the operand is NaN, we use the property:
+         for all x, NaN is not equal to x, even if x is NaN.
+         Therefore, op3 is 0 if and only if a1 is NaN,
+         and op4 is 0 if and only if a2 is NaN.
+         See also caml_float_compare_unboxed in runtime/floats.c  *)
+      tag_int (add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg) dbg))
 
 let create_loop body dbg =
   let cont = Lambda.next_raise_count () in

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -283,9 +283,11 @@ let mk_compare_ints dbg a1 a2 =
   | Cconst_natint (c1, _), Cconst_int (c2, _) ->
      int_const dbg Nativeint.(compare c1 (of_int c2))
   | a1, a2 -> begin
-      let op1 = Cop(Ccmpi(Cgt), [a1; a2], dbg) in
-      let op2 = Cop(Ccmpi(Clt), [a1; a2], dbg) in
-      tag_int(sub_int op1 op2 dbg) dbg
+      bind "int_cmp" a1 (fun a1 ->
+        bind "int_cmp" a2 (fun a2 ->
+          let op1 = Cop(Ccmpi(Cgt), [a1; a2], dbg) in
+          let op2 = Cop(Ccmpi(Clt), [a1; a2], dbg) in
+          tag_int(sub_int op1 op2 dbg) dbg))
     end
 
 let create_loop body dbg =

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -153,8 +153,9 @@ val mk_if_then_else :
 (** Boolean negation *)
 val mk_not : Debuginfo.t -> expression -> expression
 
-(** Integer comparison that returns int not bool *)
+(** Integer and float comparison that returns int not bool *)
 val mk_compare_ints : Debuginfo.t -> expression -> expression -> expression
+val mk_compare_floats : Debuginfo.t -> expression -> expression -> expression
 
 (** Loop construction (while true do expr done).
     Used to be represented as Cloop. *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -915,23 +915,23 @@ and transl_prim_2 env p arg1 arg2 dbg =
       let a2 = transl_unbox_int dbg env bi arg2 in
       mk_compare_ints dbg a1 a2
   | Pcompare_floats ->
-      let a1 = transl_unbox_float dbg env arg1 in
-      let a2 = transl_unbox_float dbg env arg2 in
-      let op1 = Cop(Ccmpf(CFgt), [a1; a2], dbg) in
-      let op2 = Cop(Ccmpf(CFlt), [a1; a2], dbg) in
-      let op3 = Cop(Ccmpf(CFeq), [a1; a1], dbg) in
-      let op4 = Cop(Ccmpf(CFeq), [a2; a2], dbg) in
-      (* If both operands a1 and a2 are not NaN, then op3 = op4 = 1,
-         and the result is op1 - op2.
-         If at least one of the operands is NaN,
-         then op1 = op2 = 0, and the result is op3 - op4,
-         which orders NaN before other values.
-         To detect if the operand is NaN, we use the property:
-         for all x, NaN is not equal to x, even if x is NaN.
-         Therefore, op3 is 0 if and only if a1 is NaN,
-         and op4 is 0 if and only if a2 is NaN.
-         See also caml_float_compare_unboxed in runtime/floats.c  *)
-      tag_int (add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg) dbg
+      bind "float_cmp" (transl_unbox_float dbg env arg1) (fun a1 ->
+      bind "float_cmp" (transl_unbox_float dbg env arg2) (fun a2 ->
+        let op1 = Cop(Ccmpf(CFgt), [a1; a2], dbg) in
+        let op2 = Cop(Ccmpf(CFlt), [a1; a2], dbg) in
+        let op3 = Cop(Ccmpf(CFeq), [a1; a1], dbg) in
+        let op4 = Cop(Ccmpf(CFeq), [a2; a2], dbg) in
+        (* If both operands a1 and a2 are not NaN, then op3 = op4 = 1,
+           and the result is op1 - op2.
+           If at least one of the operands is NaN,
+           then op1 = op2 = 0, and the result is op3 - op4,
+           which orders NaN before other values.
+           To detect if the operand is NaN, we use the property:
+           for all x, NaN is not equal to x, even if x is NaN.
+           Therefore, op3 is 0 if and only if a1 is NaN,
+           and op4 is 0 if and only if a2 is NaN.
+           See also caml_float_compare_unboxed in runtime/floats.c  *)
+        tag_int (add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg) dbg))
   | Pisout ->
       transl_isout (transl env arg1) (transl env arg2) dbg
   (* Float operations *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -915,23 +915,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
       let a2 = transl_unbox_int dbg env bi arg2 in
       mk_compare_ints dbg a1 a2
   | Pcompare_floats ->
-      bind "float_cmp" (transl_unbox_float dbg env arg1) (fun a1 ->
-      bind "float_cmp" (transl_unbox_float dbg env arg2) (fun a2 ->
-        let op1 = Cop(Ccmpf(CFgt), [a1; a2], dbg) in
-        let op2 = Cop(Ccmpf(CFlt), [a1; a2], dbg) in
-        let op3 = Cop(Ccmpf(CFeq), [a1; a1], dbg) in
-        let op4 = Cop(Ccmpf(CFeq), [a2; a2], dbg) in
-        (* If both operands a1 and a2 are not NaN, then op3 = op4 = 1,
-           and the result is op1 - op2.
-           If at least one of the operands is NaN,
-           then op1 = op2 = 0, and the result is op3 - op4,
-           which orders NaN before other values.
-           To detect if the operand is NaN, we use the property:
-           for all x, NaN is not equal to x, even if x is NaN.
-           Therefore, op3 is 0 if and only if a1 is NaN,
-           and op4 is 0 if and only if a2 is NaN.
-           See also caml_float_compare_unboxed in runtime/floats.c  *)
-        tag_int (add_int (sub_int op1 op2 dbg) (sub_int op3 op4 dbg) dbg) dbg))
+      let a1 = transl_unbox_float dbg env arg1 in
+      let a2 = transl_unbox_float dbg env arg2 in
+      mk_compare_floats dbg a1 a2
   | Pisout ->
       transl_isout (transl env arg1) (transl env arg2) dbg
   (* Float operations *)

--- a/testsuite/tests/asmcomp/compare.ml
+++ b/testsuite/tests/asmcomp/compare.ml
@@ -1,0 +1,10 @@
+(* TEST
+   * native
+*)
+let[@inline never] float () = print_string "hello\n"; 42.
+let[@inline never] f () = compare (float ()) 0.5;;
+let _ = f ()
+
+let[@inline never] myint () = print_string "bye\n"; 42
+let[@inline never] g () = compare (myint ()) 5;;
+let _ = g ()

--- a/testsuite/tests/asmcomp/compare.reference
+++ b/testsuite/tests/asmcomp/compare.reference
@@ -1,0 +1,2 @@
+hello
+bye


### PR DESCRIPTION
Fix a bug in PR #2324 when an argument of compare has a side-effect after inlining and un-anf.  The expression generated for integer and float compare primitives in native code uses the arguments of compare twice, so it needs a "bind".