### PR TITLE
Fix the polymorphic recursion problem of #9603

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,7 +120,7 @@ OCaml 4.11
   (Gabriel Radanne, Leo White, Gabriel Scherer and Pieter Goetschalckx,
    request by Bikal Lem)
 
-- #6673, #1132: Relax the handling of explicit polymorphic types
+- #6673, #1132, #9617: Relax the handling of explicit polymorphic types
   (Leo White, review by Jacques Garrigue and Gabriel Scherer)
 
 - #9232: allow any class type paths in #-types,

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -816,11 +816,10 @@ let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 Lines 1-2, characters 4-15:
 1 | ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
 2 |   fun Eq o -> o..............
-Error: This expression has type
-         'a 'b. ('a, 'b) eq -> ([< `A of 'b & 'a | `B ] as 'c) -> 'c
-       but an expression was expected of type
-         'a 'b. ('a, 'b) eq -> ([< `A of 'b & 'e | `B ] as 'd) -> 'd
-       The universal variable 'a would escape its scope
+Error: This definition has type
+         'c. ('d, 'c) eq -> ([< `A of 'c & 'f & 'd | `B ] as 'e) -> 'e
+       which is less general than
+         'a 'b. ('a, 'b) eq -> ([< `A of 'b & 'h | `B ] as 'g) -> 'g
 |}];;
 
 let f : type a b. (a,b) eq -> [`A of a | `B] -> [`A of b | `B] =

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1780,3 +1780,13 @@ class c : object method m : ?x:int -> unit -> int method n : int end
 class d :
   object method m : ?x:int -> unit -> int method n : int method n' : int end
 |}]
+
+(* #1132 *)
+let rec foo : 'a . 'a -> 'd = fun x -> x
+[%%expect{|
+Line 1, characters 30-40:
+1 | let rec foo : 'a . 'a -> 'd = fun x -> x
+                                  ^^^^^^^^^^
+Error: This definition has type 'b -> 'b which is less general than
+         'a. 'a -> 'c
+|}]

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -16,8 +16,8 @@ val error :
 |}]
 
 (* Known problem with polymorphic methods *)
-let foo : 
-  < m : 'left 'right. <left:'left; right:'right> pair > 
+let foo :
+  < m : 'left 'right. <left:'left; right:'right> pair >
    -> < m : 'left 'right. <left:'left; right:'right> pair >
 = fun x -> x
 

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -1,0 +1,48 @@
+(* TEST
+   * expect
+*)
+
+type 'p pair = 'a * 'b constraint 'p = < left:'a; right:'b>
+
+(* New in 4.11 *)
+let error: 'left 'right.
+  <left:'left; right:'right> pair -> <left:'right; right:'left> pair =
+  fun (x,y) -> (y,x)
+[%%expect{|
+type 'c pair = 'a * 'b constraint 'c = < left : 'a; right : 'b >
+val error :
+  < left : 'left; right : 'right > pair ->
+  < left : 'right; right : 'left > pair = <fun>
+|}]
+
+(* Known problem with polymorphic methods *)
+let foo : 
+  < m : 'left 'right. <left:'left; right:'right> pair > 
+   -> < m : 'left 'right. <left:'left; right:'right> pair >
+= fun x -> x
+
+[%%expect{|
+Line 4, characters 11-12:
+4 | = fun x -> x
+               ^
+Error: This expression has type
+         < m : 'left 'right. < left : 'left; right : 'right > pair >
+       but an expression was expected of type
+         < m : 'left 'right. < left : 'left; right : 'right > pair >
+       Type < left : 'left; right : 'right > pair = 'a * 'b
+       is not compatible with type < left : 'left0; right : 'right0 > pair
+       The method left has type 'a, but the expected method type was 'left
+       The universal variable 'left would escape its scope
+|}, Principal{|
+Line 4, characters 6-7:
+4 | = fun x -> x
+          ^
+Error: This pattern matches values of type
+         < m : 'left 'right. < left : 'left; right : 'right > pair >
+       but a pattern was expected which matches values of type
+         < m : 'left 'right. < left : 'left; right : 'right > pair >
+       Type < left : 'left; right : 'right > pair = 'a * 'b
+       is not compatible with type < left : 'left0; right : 'right0 > pair
+       The method left has type 'a, but the expected method type was 'left
+       The universal variable 'left would escape its scope
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1408,7 +1408,9 @@ let rec copy_sep cleanup_scope fixed free bound visited ty =
       match ty.desc with
         Tarrow _ | Ttuple _ | Tvariant _ | Tconstr _ | Tobject _ | Tpackage _ ->
           (ty,(t,bound)) :: visited
-      | _ -> visited in
+      | Tvar _ | Tfield _ | Tnil | Tpoly _ | Tunivar _ | Tlink _ | Tsubst _ ->
+          visited
+    in
     let copy_rec = copy_sep cleanup_scope fixed free bound visited in
     t.desc <-
       begin match ty.desc with
@@ -1418,7 +1420,7 @@ let rec copy_sep cleanup_scope fixed free bound visited ty =
           (* We shall really check the level on the row variable *)
           let keep = is_Tvar more && more.level <> generic_level in
           let more' = copy_rec more in
-          let fixed' = fixed && is_Tvar (repr more') in
+          let fixed' = fixed && (is_Tvar more || is_Tunivar more) in
           let row = copy_row copy_rec fixed' row keep more' in
           Tvariant row
       | Tpoly (t1, tl) ->


### PR DESCRIPTION
#1132 , by relying on unification of polytypes, introduced a limitation to polymorphic recursion.

#9603 is an open problem about unification of polytypes.
This PR fixes the polymorphic recursion case, by removing the reliance on unification.