### PR TITLE
Prefix ocamldebug modules to minimize clashes

### DIFF
--- a/.depend
+++ b/.depend
@@ -2180,11 +2180,11 @@ asmcomp/afl_instrument.cmi : \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi
 asmcomp/arch.cmo : \
-    utils/config.cmi \
-    utils/clflags.cmi
+    lambda/debuginfo.cmi \
+    utils/config.cmi
 asmcomp/arch.cmx : \
-    utils/config.cmx \
-    utils/clflags.cmx
+    lambda/debuginfo.cmx \
+    utils/config.cmx
 asmcomp/asmgen.cmo : \
     lambda/translmod.cmi \
     asmcomp/split.cmi \
@@ -2623,14 +2623,8 @@ asmcomp/deadcode.cmx : \
 asmcomp/deadcode.cmi : \
     asmcomp/mach.cmi
 asmcomp/emit.cmo : \
-    asmcomp/x86_proc.cmi \
-    asmcomp/x86_masm.cmi \
-    asmcomp/x86_gas.cmi \
-    asmcomp/x86_dsl.cmi \
-    asmcomp/x86_ast.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
-    utils/numbers.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/linear.cmi \
@@ -2646,14 +2640,8 @@ asmcomp/emit.cmo : \
     asmcomp/arch.cmo \
     asmcomp/emit.cmi
 asmcomp/emit.cmx : \
-    asmcomp/x86_proc.cmx \
-    asmcomp/x86_masm.cmx \
-    asmcomp/x86_gas.cmx \
-    asmcomp/x86_dsl.cmx \
-    asmcomp/x86_ast.cmi \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
-    utils/numbers.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/linear.cmx \
@@ -2897,21 +2885,21 @@ asmcomp/printmach.cmi : \
     asmcomp/reg.cmi \
     asmcomp/mach.cmi
 asmcomp/proc.cmo : \
-    asmcomp/x86_proc.cmi \
     asmcomp/reg.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
+    utils/ccomp.cmi \
     asmcomp/arch.cmo \
     asmcomp/proc.cmi
 asmcomp/proc.cmx : \
-    asmcomp/x86_proc.cmx \
     asmcomp/reg.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
+    utils/ccomp.cmx \
     asmcomp/arch.cmx \
     asmcomp/proc.cmi
 asmcomp/proc.cmi : \
@@ -2932,18 +2920,10 @@ asmcomp/reg.cmi : \
 asmcomp/reload.cmo : \
     asmcomp/reloadgen.cmi \
     asmcomp/reg.cmi \
-    asmcomp/mach.cmi \
-    asmcomp/cmm.cmi \
-    utils/clflags.cmi \
-    asmcomp/arch.cmo \
     asmcomp/reload.cmi
 asmcomp/reload.cmx : \
     asmcomp/reloadgen.cmx \
     asmcomp/reg.cmx \
-    asmcomp/mach.cmx \
-    asmcomp/cmm.cmx \
-    utils/clflags.cmx \
-    asmcomp/arch.cmx \
     asmcomp/reload.cmi
 asmcomp/reload.cmi : \
     asmcomp/mach.cmi
@@ -3028,7 +3008,7 @@ asmcomp/selectgen.cmi : \
     asmcomp/arch.cmo
 asmcomp/selection.cmo : \
     asmcomp/selectgen.cmi \
-    asmcomp/proc.cmi \
+    asmcomp/reg.cmi \
     asmcomp/mach.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
@@ -3036,7 +3016,7 @@ asmcomp/selection.cmo : \
     asmcomp/selection.cmi
 asmcomp/selection.cmx : \
     asmcomp/selectgen.cmx \
-    asmcomp/proc.cmx \
+    asmcomp/reg.cmx \
     asmcomp/mach.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \

--- a/.depend
+++ b/.depend
@@ -2180,11 +2180,11 @@ asmcomp/afl_instrument.cmi : \
     lambda/debuginfo.cmi \
     asmcomp/cmm.cmi
 asmcomp/arch.cmo : \
-    lambda/debuginfo.cmi \
-    utils/config.cmi
+    utils/config.cmi \
+    utils/clflags.cmi
 asmcomp/arch.cmx : \
-    lambda/debuginfo.cmx \
-    utils/config.cmx
+    utils/config.cmx \
+    utils/clflags.cmx
 asmcomp/asmgen.cmo : \
     lambda/translmod.cmi \
     asmcomp/split.cmi \
@@ -2623,8 +2623,14 @@ asmcomp/deadcode.cmx : \
 asmcomp/deadcode.cmi : \
     asmcomp/mach.cmi
 asmcomp/emit.cmo : \
+    asmcomp/x86_proc.cmi \
+    asmcomp/x86_masm.cmi \
+    asmcomp/x86_gas.cmi \
+    asmcomp/x86_dsl.cmi \
+    asmcomp/x86_ast.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
+    utils/numbers.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     asmcomp/linear.cmi \
@@ -2640,8 +2646,14 @@ asmcomp/emit.cmo : \
     asmcomp/arch.cmo \
     asmcomp/emit.cmi
 asmcomp/emit.cmx : \
+    asmcomp/x86_proc.cmx \
+    asmcomp/x86_masm.cmx \
+    asmcomp/x86_gas.cmx \
+    asmcomp/x86_dsl.cmx \
+    asmcomp/x86_ast.cmi \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
+    utils/numbers.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     asmcomp/linear.cmx \
@@ -2885,21 +2897,21 @@ asmcomp/printmach.cmi : \
     asmcomp/reg.cmi \
     asmcomp/mach.cmi
 asmcomp/proc.cmo : \
+    asmcomp/x86_proc.cmi \
     asmcomp/reg.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
-    utils/ccomp.cmi \
     asmcomp/arch.cmo \
     asmcomp/proc.cmi
 asmcomp/proc.cmx : \
+    asmcomp/x86_proc.cmx \
     asmcomp/reg.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
-    utils/ccomp.cmx \
     asmcomp/arch.cmx \
     asmcomp/proc.cmi
 asmcomp/proc.cmi : \
@@ -2920,10 +2932,18 @@ asmcomp/reg.cmi : \
 asmcomp/reload.cmo : \
     asmcomp/reloadgen.cmi \
     asmcomp/reg.cmi \
+    asmcomp/mach.cmi \
+    asmcomp/cmm.cmi \
+    utils/clflags.cmi \
+    asmcomp/arch.cmo \
     asmcomp/reload.cmi
 asmcomp/reload.cmx : \
     asmcomp/reloadgen.cmx \
     asmcomp/reg.cmx \
+    asmcomp/mach.cmx \
+    asmcomp/cmm.cmx \
+    utils/clflags.cmx \
+    asmcomp/arch.cmx \
     asmcomp/reload.cmi
 asmcomp/reload.cmi : \
     asmcomp/mach.cmi
@@ -3008,7 +3028,7 @@ asmcomp/selectgen.cmi : \
     asmcomp/arch.cmo
 asmcomp/selection.cmo : \
     asmcomp/selectgen.cmi \
-    asmcomp/reg.cmi \
+    asmcomp/proc.cmi \
     asmcomp/mach.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
@@ -3016,7 +3036,7 @@ asmcomp/selection.cmo : \
     asmcomp/selection.cmi
 asmcomp/selection.cmx : \
     asmcomp/selectgen.cmx \
-    asmcomp/reg.cmx \
+    asmcomp/proc.cmx \
     asmcomp/mach.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \

--- a/Changes
+++ b/Changes
@@ -79,6 +79,9 @@ Working version
   until the program creates a thread for the first time, then fail cleanly.
   (Xavier Leroy, report by @anentropic, review by Gabriel Scherer)
 
+- #9621: Pack the ocamldebug modules to minimize clashes
+  (Raphael Sousa Santos, review by Vincent Laviron)
+
 ### Manual and documentation:
 
 - #7812, #10475: reworded the description of the behaviors of

--- a/Changes
+++ b/Changes
@@ -80,7 +80,7 @@ Working version
   (Xavier Leroy, report by @anentropic, review by Gabriel Scherer)
 
 - #9621: Pack the ocamldebug modules to minimize clashes
-  (Raphael Sousa Santos, review by Vincent Laviron)
+  (Raphael Sousa Santos, review by Vincent Laviron and Gabriel Scherer)
 
 ### Manual and documentation:
 

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -349,6 +349,10 @@ main.cmx : \
     ../file_formats/cmi_format.cmx \
     ../utils/clflags.cmx \
     checkpoints.cmx
+ocamldebug_entry.cmo : \
+    $(UNIXDIR)/unix.cmi
+ocamldebug_entry.cmx : \
+    $(UNIXDIR)/unix.cmx
 parameters.cmo : \
     ../utils/load_path.cmi \
     ../typing/envaux.cmi \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -65,7 +65,7 @@ clean::
 	rm -f ocamldebug ocamldebug.exe
 	rm -f *.cmo *.cmi
 
-ocamldebug_entry.cmo: ocamldebug_entry.ml
+ocamldebug_entry.cmo: ocamldebug_entry.ml ocamldebug.cmo
 	$(CAMLC) -c $(COMPFLAGS) $<
 
 %.cmo: %.ml

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -52,7 +52,10 @@ libraries = $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 
 all: ocamldebug$(EXE)
 
-ocamldebug$(EXE): $(libraries) $(all_objects)
+Ocamldebug.cmo: $(all_objects)
+	$(CAMLC) -pack $(COMPFLAGS) -o $@ $^
+
+ocamldebug$(EXE): $(libraries) Ocamldebug.cmo
 	$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
 
 install:
@@ -63,10 +66,10 @@ clean::
 	rm -f *.cmo *.cmi
 
 %.cmo: %.ml
-	$(CAMLC) -c $(COMPFLAGS) $<
+	$(CAMLC) -c $(COMPFLAGS) -for-pack Ocamldebug $<
 
 %.cmi: %.mli
-	$(CAMLC) -c $(COMPFLAGS) $<
+	$(CAMLC) -c $(COMPFLAGS) -for-pack Ocamldebug $<
 
 depend: beforedepend
 	$(CAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mli *.ml \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -52,10 +52,10 @@ libraries = $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 
 all: ocamldebug$(EXE)
 
-Ocamldebug.cmo: $(all_objects)
+ocamldebug.cmo: $(all_objects)
 	$(CAMLC) -pack $(COMPFLAGS) -o $@ $^
 
-ocamldebug$(EXE): $(libraries) Ocamldebug.cmo
+ocamldebug$(EXE): $(libraries) ocamldebug.cmo ocamldebug_entry.cmo
 	$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
 
 install:
@@ -65,11 +65,14 @@ clean::
 	rm -f ocamldebug ocamldebug.exe
 	rm -f *.cmo *.cmi
 
+ocamldebug_entry.cmo: ocamldebug_entry.ml
+	$(CAMLC) -c $(COMPFLAGS) $<
+
 %.cmo: %.ml
-	$(CAMLC) -c $(COMPFLAGS) -for-pack Ocamldebug $<
+	$(CAMLC) -c $(COMPFLAGS) -for-pack ocamldebug $<
 
 %.cmi: %.mli
-	$(CAMLC) -c $(COMPFLAGS) -for-pack Ocamldebug $<
+	$(CAMLC) -c $(COMPFLAGS) -for-pack ocamldebug $<
 
 depend: beforedepend
 	$(CAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mli *.ml \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -43,19 +43,19 @@ debugger_modules := \
   show_source time_travel program_management frames eval \
   show_information loadprinter debugger_parser command_line main
 
-all_modules := $(compiler_modules) $(debugger_modules)
+compiler_objects := $(addsuffix .cmo,$(compiler_modules))
 
-all_objects := $(addsuffix .cmo,$(all_modules))
+debugger_objects := $(addsuffix .cmo,$(debugger_modules))
 
 libraries = $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
   $(UNIXDIR)/unix.cma $(DYNLINKDIR)/dynlink.cma
 
 all: ocamldebug$(EXE)
 
-ocamldebug.cmo: $(all_objects)
+ocamldebug.cmo: $(debugger_objects)
 	$(CAMLC) -pack $(COMPFLAGS) -o $@ $^
 
-ocamldebug$(EXE): $(libraries) ocamldebug.cmo ocamldebug_entry.cmo
+ocamldebug$(EXE): $(libraries) $(compiler_objects) ocamldebug.cmo ocamldebug_entry.cmo
 	$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
 
 install:

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -55,7 +55,8 @@ all: ocamldebug$(EXE)
 ocamldebug.cmo: $(debugger_objects)
 	$(CAMLC) -pack $(COMPFLAGS) -o $@ $^
 
-ocamldebug$(EXE): $(libraries) $(compiler_objects) ocamldebug.cmo ocamldebug_entry.cmo
+ocamldebug$(EXE): $(libraries) $(compiler_objects) ocamldebug.cmo \
+    ocamldebug_entry.cmo
 	$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
 
 install:

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -244,6 +244,3 @@ let main () =
   | Cmi_format.Error e ->
       report Cmi_format.report_error e;
       exit 2
-
-let _ =
-  Unix.handle_unix_error main ()

--- a/debugger/ocamldebug_entry.ml
+++ b/debugger/ocamldebug_entry.ml
@@ -1,0 +1,2 @@
+let _ =
+  Unix.handle_unix_error Ocamldebug.Main.main ()

--- a/testsuite/tests/tool-debugger/module_named_main/input_script
+++ b/testsuite/tests/tool-debugger/module_named_main/input_script
@@ -1,0 +1,7 @@
+load_printer main.cmo
+install_printer Main.Submodule.pp
+goto 0
+break @ Main 26
+run
+print value
+quit

--- a/testsuite/tests/tool-debugger/module_named_main/main.ml
+++ b/testsuite/tests/tool-debugger/module_named_main/main.ml
@@ -1,0 +1,30 @@
+(* TEST
+flags += " -g "
+ocamldebug_script = "${test_source_directory}/input_script"
+* debugger
+** shared-libraries
+*** setup-ocamlc.byte-build-env
+**** ocamlc.byte
+***** check-ocamlc.byte-output
+****** ocamldebug
+******* check-program-output
+*)
+
+module Submodule = struct
+
+  type t = unit
+
+  let value = ()
+
+  let pp (fmt : Format.formatter) (_ : t) : unit =
+    Format.fprintf fmt "DEBUG: Aux.Submodule.pp"
+
+end
+
+let debug () =
+  let value = Submodule.value in
+  ignore value
+
+;;
+
+debug ();

--- a/testsuite/tests/tool-debugger/module_named_main/main.reference
+++ b/testsuite/tests/tool-debugger/module_named_main/main.reference
@@ -1,0 +1,6 @@
+File main.cmo loaded
+Loading program... done.
+Beginning of program.
+Breakpoint: 1
+26   <|b|>ignore value
+value: unit = DEBUG: Aux.Submodule.pp

--- a/testsuite/tests/tool-debugger/printer/printer.ml
+++ b/testsuite/tests/tool-debugger/printer/printer.ml
@@ -2,7 +2,7 @@ let p : Format.formatter -> int -> unit = fun fmt n ->
   (* We use `max_printer_depth` to tweak the output so that
      this test shows that the printer not only compiles
      against the debugger's code, but also uses its state. *)
-  for _i = 1 to min n !Printval.max_printer_depth do
+  for _i = 1 to min n !Ocamldebug.Printval.max_printer_depth do
     Format.pp_print_string fmt "S ";
   done;
   Format.pp_print_string fmt "O"


### PR DESCRIPTION
This adresses issue #9156.

Three things were discussed to be done on that issue:

1. Prefix ocamldebug modules (manually, packing or with dune-style aliases)
2. Catch the error to prevent the segmentation fault and provide a better error message
3. Unifying the mechanisms that the toplevel and the debugger use to deal with this (such as using expunge on ocamldebug)

This PR intends to address the first and the second. I would propose to do the third on a separate PR.

About the first: I skipped doing the dune-style aliases, because I thought it would rely on too much complexity on the Makefile. This PR adds prefixes manually as I find that's the more transparent change. Packing would have been the minimal change. It requires only a small modification to the Makefile:

```
59c59
< ocamldebug$(EXE): $(libraries) Ocamldebug.cmo
---
> ocamldebug$(EXE): $(libraries) $(all_objects)
72,74d71
< Ocamldebug.cmo: $(all_objects)
< 	$(CAMLC) -pack $(COMPFLAGS) -o $@ $(all_objects)
< 
76c73
< 	$(CAMLC) -c $(COMPFLAGS) -for-pack Ocamldebug $<
---
> 	$(CAMLC) -c $(COMPFLAGS) -for-pack Ocamldebug $<
```
The problem is that the `tools-debugger/printer` test breaks in a way that requires a bigger change. The problem is that it uses a module from a ocamldebug that, after being packed, is never seen as fully initialized. Looking at the debugger section of the manual, it doesn't seem like this is officially supported, so maybe just removing the reference to the internal ocamldebug module would have been ok. Let me know if you'd rather have me do that and use packing.

About the second: work in progress. The segmentation fault only happens with the actual 'Main' module and not with the others. I imagine that is because the 'Main' module is the one running (not fully initialized)