### PR TITLE
fix an environment problem in merge_constraint

### DIFF
--- a/Changes
+++ b/Changes
@@ -605,6 +605,10 @@ OCaml 4.11
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
 
+- #9623: fix typing environments in Typedecl.transl_with_constraint
+  (Gabriel Scherer, review by Jacques Garrigue and Leo White,
+   report by Hugo Heuzard)
+
 OCaml 4.10 maintenance branch
 -----------------------------
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -1,26 +1,115 @@
 (* TEST
    * expect *)
 
-module type Sig = sig
-  type t
-  type u = t
+module RhsScopeCheck = struct
+  module type Sig1 = sig
+    type t
+    type u = t
+  end
+
+  (* A scoping error here is intentional:
+     with-constraints "with <lhs> = <rhs>"
+     have their <rhs> evaluated in the current
+     typing environment, not within the signature
+     that they are constraining. [t] is unbound
+     in the current environment, so [with u = t]
+     must be rejected. *)
+  module type Check1 = Sig1
+    with type u = t
 end
 [%%expect{|
-module type Sig = sig type t type u = t end
+Line 15, characters 18-19:
+15 |     with type u = t
+                       ^
+Error: Unbound type constructor t
 |}]
 
-(* A scoping error here is intentional:
-   with-constraints "with <lhs> = <rhs>"
-   have their <rhs> evaluated in the current
-   typing environment, not within the signature
-   that they are constraining. [t] is unbound
-   in the current environment, so [with u = t]
-   must be rejected. *)
-module type Problem = Sig
-   with type u = t
+
+module VarianceEnv = struct
+  module type Sig = sig
+    type +'a abstract
+    type +'a user = Foo of 'a abstract
+  end
+
+  module type Problem = sig
+    include Sig
+    module M : Sig
+      with type 'a abstract = 'a abstract
+       and type 'a user = 'a user
+
+    (* the variance annotation of [+'a foo] should be accepted, which
+       would not be the case if the with-constraint [and type 'a
+       user = 'a user] had its variance type-checked in the wrong typing
+       environment: see #9624 *)
+    type +'a foo = 'a M.user
+  end
+end
 [%%expect{|
-Line 2, characters 17-18:
-2 |    with type u = t
-                     ^
-Error: Unbound type constructor t
+module VarianceEnv :
+  sig
+    module type Sig =
+      sig type +'a abstract type 'a user = Foo of 'a abstract end
+    module type Problem =
+      sig
+        type +'a abstract
+        type 'a user = Foo of 'a abstract
+        module M :
+          sig
+            type 'a abstract = 'a abstract
+            type 'a user = 'a user = Foo of 'a abstract
+          end
+        type 'a foo = 'a M.user
+      end
+  end
+|}]
+
+module UnboxedEnv = struct
+  module type Sig = sig
+    type 'a ind = 'a * int
+    type t = T : 'e ind -> t [@@unboxed]
+  end
+
+  module type Problem = sig
+    include Sig
+    module type ReboundSig = Sig
+      with type 'a ind = 'a ind
+       and type t = t
+    (* the with-definition [and type t = t] above should be accepted,
+       which would not be the case if its definition had separability
+       checked in the wrong typing environment: see #9624 *)
+  end
+end
+[%%expect{|
+module UnboxedEnv :
+  sig
+    module type Sig =
+      sig type 'a ind = 'a * int type t = T : 'e ind -> t [@@unboxed] end
+    module type Problem =
+      sig
+        type 'a ind = 'a * int
+        type t = T : 'e ind -> t [@@unboxed]
+        module type ReboundSig =
+          sig
+            type 'a ind = 'a ind
+            type t = t/2 = T : 'a ind -> t/1 [@@unboxed]
+          end
+      end
+  end
+|}]
+
+module ParamsUnificationEnv = struct
+  module type Sig =
+    sig type 'a u = 'a list type +'a t = 'b constraint 'a = 'b u end
+  type +'a t = 'b constraint 'a = 'b list
+  module type Sig2 = Sig with type 'a t = 'a t
+end
+[%%expect{|
+module ParamsUnificationEnv :
+  sig
+    module type Sig =
+      sig type 'a u = 'a list type +'a t = 'b constraint 'a = 'b u end
+    type +'a t = 'b constraint 'a = 'b list
+    module type Sig2 =
+      sig type 'a u = 'a list type 'a t = 'a t constraint 'a = 'b u end
+  end
 |}]

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -1,0 +1,26 @@
+(* TEST
+   * expect *)
+
+module type Sig = sig
+  type t
+  type u = t
+end
+[%%expect{|
+module type Sig = sig type t type u = t end
+|}]
+
+(* A scoping error here is intentional:
+   with-constraints "with <lhs> = <rhs>"
+   have their <rhs> evaluated in the current
+   typing environment, not within the signature
+   that they are constraining. [t] is unbound
+   in the current environment, so [with u = t]
+   must be rejected. *)
+module type Problem = Sig
+   with type u = t
+[%%expect{|
+Line 2, characters 17-18:
+2 |    with type u = t
+                     ^
+Error: Unbound type constructor t
+|}]

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -39,25 +39,15 @@ module type Sunderscore = sig type (_, 'a) t = int * 'a end
 |}]
 
 
-(* Valid substitutions in a recursive module may fail due to the ordering of
-   the modules. *)
-
+(* Valid substitutions in a recursive module used to fail
+   due to the ordering of the modules. This is fixed since #9623. *)
 module type S0 = sig
   module rec M : sig type t = M2.t end
   and M2 : sig type t = int end
 end with type M.t = int
 [%%expect {|
-Lines 1-4, characters 17-23:
-1 | .................sig
-2 |   module rec M : sig type t = M2.t end
-3 |   and M2 : sig type t = int end
-4 | end with type M.t = int
-Error: In this `with' constraint, the new definition of M.t
-       does not match its original definition in the constrained signature:
-       Type declarations do not match:
-         type t = int
-       is not included in
-         type t = M2.t
+module type S0 =
+  sig module rec M : sig type t = int end and M2 : sig type t = int end end
 |}]
 
 

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -39,8 +39,10 @@ val transl_value_decl:
     Parsetree.value_description -> Typedtree.value_description * Env.t
 
 val transl_with_constraint:
-    Env.t -> Ident.t -> Path.t option -> Types.type_declaration ->
-    Parsetree.type_declaration -> Typedtree.type_declaration
+    Ident.t -> Path.t option ->
+    sig_env:Env.t -> sig_decl:Types.type_declaration ->
+    outer_env:Env.t -> Parsetree.type_declaration ->
+    Typedtree.type_declaration
 
 val abstract_type_decl: int -> type_declaration
 val approx_type_decl:


### PR DESCRIPTION
This is a preliminary fix for an uncaught `Not_found` exception in the type-checker, from my analysis of the reproduction case provided by @hhugo in https://github.com/ocaml/ocaml/pull/9609#issuecomment-636710146 .

The patch includes a reproduction case:

```ocaml
module type Sig = sig
  type 'a ind = 'a * int
  type t = T : 'e ind -> t [@@unboxed]
end

module type Problem = sig
  include Sig
  module type ReboundSig = Sig
    with type 'a ind = 'a ind
     and type t = t
end
```

Without the patch, checking `type t = t` (which results in a recomputation of the validity of the `[@@unboxed]` attribute in the resulting signature) raises a `Not_found` exception during the lookup of a `Tconstr` path in the typing environment. (The code assumes that all type-constructor paths are bound in the typing environment.)

The patch fixes the issue by bluntly replacing a use of `initial_env` in `merge_constraint` by `env`. I suspect however that the patch is incorrect or incomplete. The authors of `merge_constraint` took care to separate the initial and partially-checked environments, I suppose there is a reason for it -- I would welcome an explanation. If using `env` was the correct change, then many other occurrences of `initial_env` should be modified.

(cc @garrigue and, somewhat randomly, @lpw25  @trefis @Octachron)