### PR TITLE
--enable-warn-error configure option

### DIFF
--- a/configure
+++ b/configure
@@ -913,6 +913,7 @@ enable_flambda_invariants
 with_target_bindir
 enable_reserved_header_bits
 enable_stdlib_manpages
+enable_warn_error
 enable_force_safe_string
 enable_flat_float_array
 enable_function_sections
@@ -1593,6 +1594,7 @@ Optional Features:
                           headers for profiling info
   --disable-stdlib-manpages
                           do not build or install the library man pages
+  --enable-warn-error     treat C compiler warnings as errors
   --disable-force-safe-string
                           do not force strings to be safe
   --disable-flat-float-array
@@ -3248,6 +3250,12 @@ fi
 # Check whether --enable-stdlib-manpages was given.
 if test "${enable_stdlib_manpages+set}" = set; then :
   enableval=$enable_stdlib_manpages;
+fi
+
+
+# Check whether --enable-warn-error was given.
+if test "${enable_warn_error+set}" = set; then :
+  enableval=$enable_warn_error;
 fi
 
 
@@ -12610,20 +12618,25 @@ fi
 
 case $ocaml_cv_cc_vendor in #(
   xlc-*) :
-    outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i" ;; #(
+    outputobj='-o $(EMPTY)'
+    warn_error_flag=''
+    gcc_warnings='-qflag=i:i' ;; #(
   # all warnings enabled
   msvc-*) :
-    outputobj=-Fo; gcc_warnings="" ;; #(
+    outputobj='-Fo'
+    warn_error_flag='-WX'
+    gcc_warnings='' ;; #(
   *) :
     outputobj='-o $(EMPTY)'
-  gcc_warnings='-Wall -Wdeclaration-after-statement'
-  case 4.12.0+dev0-2020-04-22 in #(
-  *+dev*) :
-    gcc_warnings="$gcc_warnings -Werror" ;; #(
+  warn_error_flag='-Werror'
+  gcc_warnings='-Wall -Wdeclaration-after-statement' ;;
+esac
+
+case $enable_warn_error,4.12.0+dev0-2020-04-22 in #(
+  yes,*|,*+dev*) :
+    gcc_warnings="$gcc_warnings $warn_error_flag" ;; #(
   *) :
      ;;
-esac
-   ;;
 esac
 
 # We select high optimization levels, provided we can turn off:
@@ -12689,7 +12702,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       internal_cflags="$gcc_warnings -fno-common \
 -fexcess-precision=standard" ;; #(
   msvc-*) :
-    common_cflags="-nologo -O2 -Gy- -MD"
+    common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="

--- a/configure
+++ b/configure
@@ -12620,21 +12620,21 @@ case $ocaml_cv_cc_vendor in #(
   xlc-*) :
     outputobj='-o $(EMPTY)'
     warn_error_flag=''
-    gcc_warnings='-qflag=i:i' ;; #(
+    cc_warnings='-qflag=i:i' ;; #(
   # all warnings enabled
   msvc-*) :
     outputobj='-Fo'
     warn_error_flag='-WX'
-    gcc_warnings='' ;; #(
+    cc_warnings='' ;; #(
   *) :
     outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  gcc_warnings='-Wall -Wdeclaration-after-statement' ;;
+  cc_warnings='-Wall -Wdeclaration-after-statement' ;;
 esac
 
 case $enable_warn_error,4.12.0+dev0-2020-04-22 in #(
   yes,*|,*+dev*) :
-    gcc_warnings="$gcc_warnings $warn_error_flag" ;; #(
+    cc_warnings="$cc_warnings $warn_error_flag" ;; #(
   *) :
      ;;
 esac
@@ -12660,7 +12660,7 @@ case $host in #(
   gcc-[01234]-*) :
     as_fn_error $? "This version of Mingw GCC is too old. Please use GCC version 5 or above." "$LINENO" 5 ;; #(
   gcc-*) :
-    internal_cflags="-Wno-unused $gcc_warnings \
+    internal_cflags="-Wno-unused $cc_warnings \
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
         common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
@@ -12674,7 +12674,7 @@ esac ;; #(
     case $ocaml_cv_cc_vendor in #(
   clang-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common" ;; #(
+      internal_cflags="$cc_warnings -fno-common" ;; #(
   gcc-[012]-*) :
     # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
@@ -12687,29 +12687,29 @@ $as_echo "$as_me: WARNING: This version of GCC is rather old. Reducing optimizat
       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Consider using GCC version 4.2 or above." >&5
 $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
       common_cflags="-std=gnu99 -O";
-      internal_cflags="$gcc_warnings" ;; #(
+      internal_cflags="$cc_warnings" ;; #(
   gcc-4-[234]) :
     # No -fexcess-precision option before GCC 4.5
       common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
-      internal_cflags="$gcc_warnings" ;; #(
+      internal_cflags="$cc_warnings" ;; #(
   gcc-4-*) :
     common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
-      internal_cflags="$gcc_warnings -fexcess-precision=standard" ;; #(
+      internal_cflags="$cc_warnings -fexcess-precision=standard" ;; #(
   gcc-*) :
     common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common \
+      internal_cflags="$cc_warnings -fno-common \
 -fexcess-precision=standard" ;; #(
   msvc-*) :
-    common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
+    common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
   xlc-*) :
     common_cflags="-O5 -qtune=balanced -qnoipa -qinline $CFLAGS";
-      internal_cflags="$gcc_warnings" ;; #(
+      internal_cflags="$cc_warnings" ;; #(
   *) :
     common_cflags="-O" ;;
 esac ;;

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,10 @@ AC_ARG_ENABLE([stdlib-manpages],
   [AS_HELP_STRING([--disable-stdlib-manpages],
     [do not build or install the library man pages])])
 
+AC_ARG_ENABLE([warn-error],
+  [AS_HELP_STRING([--enable-warn-error],
+    [treat C compiler warnings as errors])])
+
 AC_ARG_VAR([WINDOWS_UNICODE_MODE],
   [how to handle Unicode under Windows: ansi, compatible])
 
@@ -556,15 +560,20 @@ AS_IF(
 
 AS_CASE([$ocaml_cv_cc_vendor],
   [xlc-*],
-    [outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i"], # all warnings enabled
+    [outputobj='-o $(EMPTY)'
+    warn_error_flag=''
+    gcc_warnings='-qflag=i:i'], # all warnings enabled
   [msvc-*],
-    [outputobj=-Fo; gcc_warnings=""],
+    [outputobj='-Fo'
+    warn_error_flag='-WX'
+    gcc_warnings=''],
   [outputobj='-o $(EMPTY)'
-  gcc_warnings='-Wall -Wdeclaration-after-statement'
-  AS_CASE([AC_PACKAGE_VERSION],
-    [*+dev*],
-      [gcc_warnings="$gcc_warnings -Werror"])
-  ])
+  warn_error_flag='-Werror'
+  gcc_warnings='-Wall -Wdeclaration-after-statement'])
+
+AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
+  [yes,*|,*+dev*],
+    [gcc_warnings="$gcc_warnings $warn_error_flag"])
 
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)
@@ -627,7 +636,7 @@ AS_CASE([$host],
       internal_cflags="$gcc_warnings -fno-common \
 -fexcess-precision=standard"],
     [msvc-*],
-      [common_cflags="-nologo -O2 -Gy- -MD"
+      [common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="

--- a/configure.ac
+++ b/configure.ac
@@ -562,18 +562,18 @@ AS_CASE([$ocaml_cv_cc_vendor],
   [xlc-*],
     [outputobj='-o $(EMPTY)'
     warn_error_flag=''
-    gcc_warnings='-qflag=i:i'], # all warnings enabled
+    cc_warnings='-qflag=i:i'], # all warnings enabled
   [msvc-*],
     [outputobj='-Fo'
     warn_error_flag='-WX'
-    gcc_warnings=''],
+    cc_warnings=''],
   [outputobj='-o $(EMPTY)'
   warn_error_flag='-Werror'
-  gcc_warnings='-Wall -Wdeclaration-after-statement'])
+  cc_warnings='-Wall -Wdeclaration-after-statement'])
 
 AS_CASE([$enable_warn_error,AC_PACKAGE_VERSION],
   [yes,*|,*+dev*],
-    [gcc_warnings="$gcc_warnings $warn_error_flag"])
+    [cc_warnings="$cc_warnings $warn_error_flag"])
 
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)
@@ -597,7 +597,7 @@ AS_CASE([$host],
         [AC_MSG_ERROR(m4_normalize([This version of Mingw GCC is too old.
           Please use GCC version 5 or above.]))],
       [gcc-*],
-        [internal_cflags="-Wno-unused $gcc_warnings \
+        [internal_cflags="-Wno-unused $cc_warnings \
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
         common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
@@ -608,7 +608,7 @@ AS_CASE([$host],
   [AS_CASE([$ocaml_cv_cc_vendor],
     [clang-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common"],
+      internal_cflags="$cc_warnings -fno-common"],
     [gcc-[[012]]-*],
       # Some versions known to miscompile OCaml, e,g, 2.7.2.1, some 2.96.
       # Plus: C99 support unknown.
@@ -621,29 +621,29 @@ AS_CASE([$host],
         Reducing optimization level."]));
       AC_MSG_WARN([Consider using GCC version 4.2 or above.]);
       common_cflags="-std=gnu99 -O";
-      internal_cflags="$gcc_warnings"],
+      internal_cflags="$cc_warnings"],
     [gcc-4-[[234]]],
       # No -fexcess-precision option before GCC 4.5
       [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
-      internal_cflags="$gcc_warnings"],
+      internal_cflags="$cc_warnings"],
     [gcc-4-*],
       [common_cflags="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
 -fno-builtin-memcmp";
-      internal_cflags="$gcc_warnings -fexcess-precision=standard"],
+      internal_cflags="$cc_warnings -fexcess-precision=standard"],
     [gcc-*],
       [common_cflags="-O2 -fno-strict-aliasing -fwrapv";
-      internal_cflags="$gcc_warnings -fno-common \
+      internal_cflags="$cc_warnings -fno-common \
 -fexcess-precision=standard"],
     [msvc-*],
-      [common_cflags="-nologo -O2 -Gy- -MD $gcc_warnings"
+      [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
       internal_cppflags='-DUNICODE -D_UNICODE'
       internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
       internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
     [xlc-*],
       [common_cflags="-O5 -qtune=balanced -qnoipa -qinline $CFLAGS";
-      internal_cflags="$gcc_warnings"],
+      internal_cflags="$cc_warnings"],
     [common_cflags="-O"])])
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -49,7 +49,6 @@ function run {
 # Takes 3 arguments
 # $1:the Windows port. Recognized values: mingw, msvc and msvc64
 # $2: the prefix to use to install
-# $3: C compiler flags to use to turn warnings into errors
 function set_configuration {
     case "$1" in
         mingw)
@@ -77,9 +76,7 @@ function set_configuration {
       ./configure --cache-file="$CACHE_DIRECTORY/config.cache-$1" \
                   $dep $build $host --prefix="$2" --enable-ocamltest )
 
-    FILE=$(pwd | cygpath -f - -m)/Makefile.config
-    echo "Edit $FILE to turn C compiler warnings into errors"
-    sed -i -e '/^ *OC_CFLAGS *=/s/\r\?$/ '"$3"'\0/' "$FILE"
+#    FILE=$(pwd | cygpath -f - -m)/Makefile.config
 #    run "Content of $FILE" cat Makefile.config
 }
 
@@ -110,7 +107,7 @@ case "$1" in
   msvc32-only)
     cd "$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX-msvc32"
 
-    set_configuration msvc "$OCAMLROOT-msvc32" -WX
+    set_configuration msvc "$OCAMLROOT-msvc32"
 
     run "$MAKE world" $MAKE world
     run "$MAKE runtimeopt" $MAKE runtimeopt
@@ -163,9 +160,9 @@ case "$1" in
     fi
 
     if [[ $PORT = 'msvc64' ]] ; then
-      set_configuration msvc64 "$OCAMLROOT" -WX
+      set_configuration msvc64 "$OCAMLROOT"
     else
-      set_configuration mingw "$OCAMLROOT-mingw32" -Werror
+      set_configuration mingw "$OCAMLROOT-mingw32"
     fi
 
     cd "$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX-$PORT"


### PR DESCRIPTION
This PR does two things:

- It extends the logic in `configure` which turns on `-Werror` for GCC (and mingw-w64) to specify the MSVC-equivalent `-WX`, which removes the need for a legacy hack in the AppVeyor scripts
- It adds a new option `--enable-warn-error`/`--disable-warn-error` which allows the default detection to be overridden (at present, `--enable-warn-error` is assumed if `VERSION` contains `+dev`)

The multicore team will use this option, as we want to turn `-Werror` on in CI (detecting `+multicore` in `VERSION`, as we can't add `+dev`) while using `--disable-warn-error` in the opam package for `ocaml-variants.4.10.0+multicore`

Given that GCC and MSVC have different names for the parameter, I chose `--enable-warn-error` since it's what `ocamlopt` uses!

cc @ctk21