### PR TITLE
Memprof: disable sampling when memprof is suspended.

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
 - #9466: Memprof: optimize random samples generation.
   (Jacques-Henri Jourdan review by Xavier Leroy and Stephen Dolan)
 
+- #9628: Memprof: disable sampling when memprof is suspended.
+  (Jacques-Henri Jourdan review by Gabriel Scherer and Stephen Dolan)
+
 - #9508: Remove support for FreeBSD prior to 4.0R, that required explicit
   floating-point initialization to behave like IEEE standard
   (Hannes Mehnert, review by David Allsopp)

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -22,7 +22,7 @@
 #include "mlvalues.h"
 #include "roots.h"
 
-extern int caml_memprof_suspended;
+extern void caml_memprof_set_suspended(int);
 
 extern value caml_memprof_handle_postponed_exn(void);
 

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -146,7 +146,7 @@ void caml_fatal_uncaught_exception(value exn)
      memprof's callback could raise an exception while
      [handle_uncaught_exception] is running, so that the printing of
      the exception fails. */
-  caml_memprof_suspended = 1;
+  caml_memprof_set_suspended(1);
 
   if (handle_uncaught_exception != NULL)
     /* [Printexc.handle_uncaught_exception] does not raise exception. */


### PR DESCRIPTION
When a Memprof callback is running, allocations are no longer sampled. However, in the current implementation, minor allocations occurring during a callback are still sampled, but the samples are ignored.

This opens the possibility of an optimization: disabling the minor sampling engine during callbacks. This is what is done in this PR.

When the sampling rate is low, this should only have minor impact since the sampling engine have negingible performance impact in this case. However, doing this optmizations actually simplifies the code a bit, and it can have major impact when the sampling rate is high. For example, when running this following example code on my machine:

```ocaml
let samples = ref 0

let rec recur n f = match n with 0 -> f () | n -> recur (n-1) f + 1

let () =
  Gc.Memprof.start
    ~sampling_rate:0.1
    ~callstack_size:0
    { Gc.Memprof.null_tracker with
      alloc_minor = fun _ ->
        incr samples;
        for i = 0 to 100 do
          ignore (Sys.opaque_identity (ref 42))
        done;
        None };

  for i = 1 to 10_000_000 do
    let d = recur 20 (fun () ->
      Array.make 20 0 |> ignore; ref 42 |> Sys.opaque_identity |> ignore; 0) in
    assert (d = 20)
  done;

  Printf.printf "%d\n" !samples
``` 

the running time goes from about 3s to 11s.