### PR TITLE
Named text sections for caml_system__code_begin/end symbols

### DIFF
--- a/Changes
+++ b/Changes
@@ -498,6 +498,9 @@ OCaml 4.12.0
 - #9963: Centralized tracking of frontend's global state
   (Frédéric Bour and Thomas Refis, review by Gabriel Scherer)
 
+- #9631: Named text sections for caml_system__code_begin/end symbols
+  (Greta Yorsh, review by Frédéric Bour)
+
 ### Build system:
 
 - #7121, #9558: Always the autoconf-discovered ld in PACKLD. For

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -58,7 +58,7 @@
 #define GREL(r) r@GOTPCREL
 #define GCALL(r) r@PLT
 #if defined(FUNCTION_SECTIONS)
-#define TEXT_SECTION(name) .section .text.##name,"ax",%progbits
+#define TEXT_SECTION(name) .section .text.caml.##name,"ax",%progbits
 #else
 #define TEXT_SECTION(name)
 #endif
@@ -66,7 +66,7 @@
 #define EIGHT_ALIGN 8
 #define SIXTEEN_ALIGN 16
 #define FUNCTION(name) \
-        TEXT_SECTION(caml.##name); \
+        TEXT_SECTION(name); \
         .globl name; \
         .type name,@function; \
         .align FUNCTION_ALIGN; \
@@ -292,6 +292,8 @@
 #define C_ARG_4 %rcx
 #endif
 
+        .text
+
 #if defined(FUNCTION_SECTIONS)
         TEXT_SECTION(caml_hot__code_begin)
         .globl  G(caml_hot__code_begin)
@@ -302,8 +304,7 @@ G(caml_hot__code_begin):
 G(caml_hot__code_end):
 #endif
 
-        .text
-
+        TEXT_SECTION(caml_system__code_begin)
         .globl  G(caml_system__code_begin)
 G(caml_system__code_begin):
         ret  /* just one instruction, so that debuggers don't display
@@ -658,6 +659,7 @@ CFI_STARTPROC
 CFI_ENDPROC
 ENDFUNCTION(G(caml_ml_array_bound_error))
 
+        TEXT_SECTION(caml_system__code_end)
         .globl  G(caml_system__code_end)
 G(caml_system__code_end):
 

--- a/runtime/arm.S
+++ b/runtime/arm.S
@@ -100,13 +100,13 @@ domain_state_ptr  .req    r11
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-#define TEXT_SECTION(name) .section .text.##name,"ax",%progbits
+#define TEXT_SECTION(name) .section .text.caml.##name,"ax",%progbits
 #else
 #define TEXT_SECTION(name)
 #endif
 
 #define FUNCTION(name) \
-        TEXT_SECTION(caml.##name); \
+        TEXT_SECTION(name); \
         .align 2; \
         .globl name; \
         .type name, %function; \
@@ -132,6 +132,7 @@ caml_hot__code_end:
 #define Caml_state(var) [domain_state_ptr, 8*domain_field_caml_##var]
 
 /* Allocation functions and GC interface */
+        TEXT_SECTION(caml_system__code_begin)
         .globl  caml_system__code_begin
 caml_system__code_begin:
 
@@ -424,6 +425,7 @@ FUNCTION(caml_ml_array_bound_error)
         CFI_ENDPROC
         .size   caml_ml_array_bound_error, .-caml_ml_array_bound_error
 
+        TEXT_SECTION(caml_system__code_end)
         .globl  caml_system__code_end
 caml_system__code_end:
 

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -95,7 +95,7 @@
 #endif
 
 #if defined(FUNCTION_SECTIONS)
-#define TEXT_SECTION(name) .section .text.##name,"ax",%progbits
+#define TEXT_SECTION(name) .section .text.caml.##name,"ax",%progbits
 #else
 #define TEXT_SECTION(name)
 #endif
@@ -114,7 +114,7 @@ G(caml_hot__code_end):
 
 #define FUNCTION(name) FUNCTION name
         .macro FUNCTION name
-        TEXT_SECTION(caml.##G(\name))
+        TEXT_SECTION(G(\name))
         .align 2
         .globl G(\name)
 G(\name):
@@ -133,7 +133,7 @@ G(\name):
 #else
 
 #define FUNCTION(name) \
-        TEXT_SECTION(caml.##name); \
+        TEXT_SECTION(name); \
         .align  2; \
         .globl  G(name); \
         .type   G(name), %function; \
@@ -152,6 +152,7 @@ G(name):
 #endif
 
 /* Allocation functions and GC interface */
+        TEXT_SECTION(caml_system__code_begin)
         .globl  G(caml_system__code_begin)
 G(caml_system__code_begin):
 
@@ -507,6 +508,7 @@ FUNCTION(caml_ml_array_bound_error)
         CFI_ENDPROC
         END_FUNCTION(caml_ml_array_bound_error)
 
+         TEXT_SECTION(caml_system__code_end)
         .globl  G(caml_system__code_end)
 G(caml_system__code_end):
 

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -48,14 +48,14 @@
 #if defined(SYS_macosx) || defined(SYS_mingw) || defined(SYS_cygwin)
 #define TEXT_SECTION(name)
 #else
-#define TEXT_SECTION(name) .section .text.##name,"ax",%progbits
+#define TEXT_SECTION(name) .section .text.caml.##name,"ax",%progbits
 #endif
 #else
 #define TEXT_SECTION(name)
 #endif
 
 #define FUNCTION(name) \
-        TEXT_SECTION(caml.##name); \
+        TEXT_SECTION(name); \
         .globl G(name); \
         .align FUNCTION_ALIGN; \
         G(name):
@@ -96,6 +96,7 @@
 #define ALIGN_STACK(amount) subl $ amount, %esp ; CFI_ADJUST(amount)
 #define UNDO_ALIGN_STACK(amount) addl $ amount, %esp ; CFI_ADJUST(-amount)
 
+        .text
 #if defined(FUNCTION_SECTIONS)
         TEXT_SECTION(caml_hot__code_begin)
         .globl  G(caml_hot__code_begin)
@@ -107,7 +108,7 @@ G(caml_hot__code_end):
 #endif
 
 /* Allocation */
-        .text
+        TEXT_SECTION(caml_system__code_begin)
         .globl  G(caml_system__code_begin)
 G(caml_system__code_begin):
 
@@ -416,6 +417,7 @@ FUNCTION(caml_ml_array_bound_error)
         CFI_ENDPROC
         ENDFUNCTION(caml_ml_array_bound_error)
 
+        TEXT_SECTION(caml_system__code_end)
         .globl  G(caml_system__code_end)
 G(caml_system__code_end):
 


### PR DESCRIPTION
Place the symbols `caml_system__code_begin` and `caml_system__code_end` into their own named text sections `.text.caml.caml_system__code_begin` and `.text.caml.caml_system__code_end`, respectively, when function sections are enabled.  Other symbols that mark begin and end of code segments are already placed their own named text sections.

Note that this PR changes the section names for `caml_hot__code_begin` and `caml_hot__code_begin` symbols: they are prefixed with `.text.caml` instead of `.text` only. The new names are consistent with the section names for other code segment markers. Linker scripts that use `caml_hot__*` symbols will need to be adjusted, but it's probably only used by ocamlfdo. 

With these changes, the symbols appear in the correct order in the executable:
```
caml_hot__code_begin
caml_hot__code_end
caml_system__code_begin
caml_call_gc
...
```
instead of
```
caml_system__code_begin
caml_hot__code_begin
caml_hot__code_end
caml_call_gc
...
```
when linked with default linkers on Linux systems.
It makes debuggers happy again, as originally intended here:
https://github.com/ocaml/ocaml/blob/ca64723db3bd3c8a2d6d6614e7e50671fa1c975f/runtime/amd64.S#L308-L310)