### PR TITLE
ocamltest: do not overwrite user-defined variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -139,6 +139,10 @@ Working version
   them to system linker, ppx contexts, etc.
   (Nicolás Ojeda Bär, review by Jérémie Dimino and Gabriel Scherer)
 
+- #9633: ocamltest: fix a bug when certain variables set in test scripts would
+  be ignored (eg `ocamlrunparam`).
+  (Nicolás Ojeda Bär, review by Sébastien Hinderer)
+
 OCaml 4.11
 ----------
 

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -224,7 +224,7 @@ let initialize_test_exit_status_variables _log env =
   ] env
 
 let _ =
-  Environments.register_initializer
+  Environments.register_initializer Environments.Post
     "test_exit_status_variables" initialize_test_exit_status_variables;
   List.iter register
   [

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -95,18 +95,31 @@ let dump log environment =
 
 (* Initializers *)
 
+type kind = Pre | Post
+
 type env_initializer = out_channel -> t -> t
 
-let (initializers : (string, env_initializer) Hashtbl.t) = Hashtbl.create 10
+type initializers =
+  {
+    pre: (string, env_initializer) Hashtbl.t;
+    post: (string, env_initializer) Hashtbl.t;
+  }
 
-let register_initializer name code = Hashtbl.add initializers name code
+let initializers = {pre = Hashtbl.create 10; post = Hashtbl.create 10}
+
+let get_initializers = function
+  | Pre -> initializers.pre
+  | Post -> initializers.post
+
+let register_initializer kind name code =
+  Hashtbl.add (get_initializers kind) name code
 
 let apply_initializer _log _name code env =
   code _log env
 
-let initialize log env =
+let initialize kind log env =
   let f = apply_initializer log in
-  Hashtbl.fold f initializers env
+  Hashtbl.fold f (get_initializers kind) env
 
 (* Modifiers *)
 

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -43,11 +43,13 @@ val dump : out_channel -> t -> unit
 
 (* Initializers *)
 
+type kind = Pre | Post
+
 type env_initializer = out_channel -> t -> t
 
-val register_initializer : string -> env_initializer -> unit
+val register_initializer : kind -> string -> env_initializer -> unit
 
-val initialize : env_initializer
+val initialize : kind -> env_initializer
 
 (* Modifiers *)
 

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -187,10 +187,12 @@ let test_file test_filename =
                test_build_directory_prefix;
              Builtin_variables.promote, promote;
            ] in
-       let root_environment =
+       let rootenv =
+         Environments.initialize Environments.Pre log initial_environment in
+       let rootenv =
          interprete_environment_statements
-           initial_environment rootenv_statements in
-       let rootenv = Environments.initialize log root_environment in
+           rootenv rootenv_statements in
+       let rootenv = Environments.initialize Environments.Post log rootenv in
        let common_prefix = " ... testing '" ^ test_basename ^ "' with" in
        let initial_status =
          if skip_test then Skip_all_tests else Run rootenv

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1365,8 +1365,10 @@ let run_ocamldoc =
   end
 
 let _ =
-  Environments.register_initializer Environments.Post "find_source_modules" find_source_modules;
-  Environments.register_initializer Environments.Pre "config_variables" config_variables;
+  Environments.register_initializer Environments.Post
+    "find_source_modules" find_source_modules;
+  Environments.register_initializer Environments.Pre
+    "config_variables" config_variables;
   List.iter register
   [
     setup_ocamlc_byte_build_env;

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1365,8 +1365,8 @@ let run_ocamldoc =
   end
 
 let _ =
-  Environments.register_initializer "find_source_modules" find_source_modules;
-  Environments.register_initializer "config_variables" config_variables;
+  Environments.register_initializer Environments.Post "find_source_modules" find_source_modules;
+  Environments.register_initializer Environments.Pre "config_variables" config_variables;
   List.iter register
   [
     setup_ocamlc_byte_build_env;

--- a/testsuite/tests/backtrace/backtrace.ml
+++ b/testsuite/tests/backtrace/backtrace.ml
@@ -19,5 +19,4 @@ let g msg =
      | Error "c" -> raise (Error "c")
 
 let _ =
-  Printexc.record_backtrace true;
   ignore (g Sys.argv.(1))

--- a/testsuite/tests/backtrace/backtrace.reference
+++ b/testsuite/tests/backtrace/backtrace.reference
@@ -9,10 +9,10 @@ Called from Backtrace.f in file "backtrace.ml", line 12, characters 42-53
 Called from Backtrace.f in file "backtrace.ml", line 12, characters 42-53
 Called from Backtrace.g in file "backtrace.ml", line 16, characters 4-11
 Re-raised at Backtrace.g in file "backtrace.ml", line 18, characters 62-71
-Called from Backtrace in file "backtrace.ml", line 23, characters 9-25
+Called from Backtrace in file "backtrace.ml", line 22, characters 9-25
 Fatal error: exception Backtrace.Error("c")
 Raised at Backtrace.g in file "backtrace.ml", line 19, characters 20-37
-Called from Backtrace in file "backtrace.ml", line 23, characters 9-25
+Called from Backtrace in file "backtrace.ml", line 22, characters 9-25
 Fatal error: exception Backtrace.Error("d")
 Raised at Backtrace.f in file "backtrace.ml", line 12, characters 16-32
 Called from Backtrace.f in file "backtrace.ml", line 12, characters 42-53
@@ -21,6 +21,6 @@ Called from Backtrace.f in file "backtrace.ml", line 12, characters 42-53
 Called from Backtrace.f in file "backtrace.ml", line 12, characters 42-53
 Called from Backtrace.f in file "backtrace.ml", line 12, characters 42-53
 Called from Backtrace.g in file "backtrace.ml", line 16, characters 4-11
-Called from Backtrace in file "backtrace.ml", line 23, characters 9-25
+Called from Backtrace in file "backtrace.ml", line 22, characters 9-25
 Fatal error: exception Invalid_argument("index out of bounds")
-Raised by primitive operation at Backtrace in file "backtrace.ml", line 23, characters 12-24
+Raised by primitive operation at Backtrace in file "backtrace.ml", line 22, characters 12-24

--- a/testsuite/tests/backtrace/backtrace2.ml
+++ b/testsuite/tests/backtrace/backtrace2.ml
@@ -66,7 +66,6 @@ let run g args =
     Printexc.print_backtrace stdout
 
 let _ =
-  Printexc.record_backtrace true;
   run test_Error [| "a" |];
   run test_Error [| "b" |];
   run test_Error [| "c" |];

--- a/testsuite/tests/backtrace/backtrace3.ml
+++ b/testsuite/tests/backtrace/backtrace3.ml
@@ -53,7 +53,6 @@ let run args =
     Printexc.print_backtrace stdout
 
 let _ =
-  Printexc.record_backtrace true;
   run [| "a" |];
   run [| "b" |];
   run [| "c" |];

--- a/testsuite/tests/backtrace/backtrace_deprecated.ml
+++ b/testsuite/tests/backtrace/backtrace_deprecated.ml
@@ -36,7 +36,6 @@ let run args =
         trace
 
 let _ =
-  Printexc.record_backtrace true;
   run [| "a" |];
   run [| "b" |];
   run [| "c" |];

--- a/testsuite/tests/backtrace/backtrace_or_exception.ml
+++ b/testsuite/tests/backtrace/backtrace_or_exception.ml
@@ -44,7 +44,6 @@ let run f =
     Printf.printf "---------------------------\n%!"
 
 let _ =
-  Printexc.record_backtrace true;
   run without_reraise;
   run with_reraise;
   run trickier

--- a/testsuite/tests/backtrace/backtrace_slots.ml
+++ b/testsuite/tests/backtrace/backtrace_slots.ml
@@ -58,7 +58,6 @@ let run args =
           | Some line -> print_endline line)
 
 let _ =
-  Printexc.record_backtrace true;
   run [| "a" |];
   run [| "b" |];
   run [| "c" |];

--- a/testsuite/tests/backtrace/backtraces_and_finalizers.ml
+++ b/testsuite/tests/backtrace/backtraces_and_finalizers.ml
@@ -5,8 +5,6 @@
    * native
 *)
 
-let () = Printexc.record_backtrace true
-
 let finaliser _ = try raise Exit with _ -> ()
 
 let create () =

--- a/testsuite/tests/backtrace/inline_test.ml
+++ b/testsuite/tests/backtrace/inline_test.ml
@@ -25,5 +25,4 @@ let i x =
   if h x = () then ()
 
 let () =
-  Printexc.record_backtrace true;
   i ()

--- a/testsuite/tests/backtrace/inline_test.reference
+++ b/testsuite/tests/backtrace/inline_test.reference
@@ -11,5 +11,5 @@ inline_test.ml
 line 25
 characters 5-8
 inline_test.ml
-line 29
+line 28
 characters 2-6

--- a/testsuite/tests/backtrace/inline_traversal_test.ml
+++ b/testsuite/tests/backtrace/inline_traversal_test.ml
@@ -26,7 +26,6 @@ let i x =
 
 let () =
   let open Printexc in
-  record_backtrace true;
   try i ()
   with _ ->
     let trace = get_raw_backtrace () in

--- a/testsuite/tests/backtrace/inline_traversal_test.reference
+++ b/testsuite/tests/backtrace/inline_traversal_test.reference
@@ -2,4 +2,4 @@ inline_traversal_test.ml:16
 inline_traversal_test.ml:19
 inline_traversal_test.ml:22
 inline_traversal_test.ml:25
-inline_traversal_test.ml:30
+inline_traversal_test.ml:29

--- a/testsuite/tests/backtrace/pr6920_why_at.ml
+++ b/testsuite/tests/backtrace/pr6920_why_at.ml
@@ -13,5 +13,4 @@ let f () =
   () [@@inline never]
 
 let () =
-  Printexc.record_backtrace true;
   f ()

--- a/testsuite/tests/backtrace/pr6920_why_at.reference
+++ b/testsuite/tests/backtrace/pr6920_why_at.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
 Raised at Pr6920_why_at.why in file "pr6920_why_at.ml", line 9, characters 35-45
 Called from Pr6920_why_at.f in file "pr6920_why_at.ml", line 11, characters 2-11
-Called from Pr6920_why_at in file "pr6920_why_at.ml", line 17, characters 2-6
+Called from Pr6920_why_at in file "pr6920_why_at.ml", line 16, characters 2-6

--- a/testsuite/tests/backtrace/pr6920_why_swallow.ml
+++ b/testsuite/tests/backtrace/pr6920_why_swallow.ml
@@ -15,5 +15,4 @@ let f () =
   () [@@inline never]
 
 let () =
-  Printexc.record_backtrace true;
   f ()

--- a/testsuite/tests/backtrace/pr6920_why_swallow.reference
+++ b/testsuite/tests/backtrace/pr6920_why_swallow.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
 Raised at Pr6920_why_swallow.why in file "pr6920_why_swallow.ml", line 9, characters 35-45
 Called from Pr6920_why_swallow.f in file "pr6920_why_swallow.ml", line 12, characters 4-13
-Called from Pr6920_why_swallow in file "pr6920_why_swallow.ml", line 19, characters 2-6
+Called from Pr6920_why_swallow in file "pr6920_why_swallow.ml", line 18, characters 2-6

--- a/testsuite/tests/backtrace/raw_backtrace.ml
+++ b/testsuite/tests/backtrace/raw_backtrace.ml
@@ -54,7 +54,6 @@ let run args =
       flush stdout
 
 let _ =
-  Printexc.record_backtrace true;
   run [| "a" |];
   run [| "b" |];
   run [| "c" |];


### PR DESCRIPTION
Fixes a bug discovered when reviewing #9469 : certain user-defined `ocamltest` variables (such as `ocamlrunparam`) will be overwritten by what is defined in the system environment (or set to empty if not set). This problem is present in the testsuite where `ocamlrunparam = ...` is systematically ignored and was being "fixed" by also calling `Printexc.record_backtrace true`.

The reason for the bug is that the `ocamltest` environment is computed in two steps:

1. User-defined variables (as written in the script) are processed: https://github.com/ocaml/ocaml/blob/abb8db459d8aa3440380a19d979dcb17222b7e19/ocamltest/main.ml#L190-L192

2. Certain variables that come from the system environment are also added: see https://github.com/ocaml/ocaml/blob/abb8db459d8aa3440380a19d979dcb17222b7e19/ocamltest/main.ml#L193 `Environment.initialize` ends up calling
https://github.com/ocaml/ocaml/blob/abb8db459d8aa3440380a19d979dcb17222b7e19/ocamltest/ocaml_actions.ml#L1095-L1122
which overwrites a number of variables, including `ocamlrunparam`.

~~This PR inverts the order of 1. and 2., hopefully fixing the issue.~~ UPDATE: it turns out this doesn't work because inverting the two calls breaks the logic that deals with the `modules` variable (at least). As a minimal fix, I changed it instead so that variables coming from the system environment are added only when the same variable is not already defined by the user.

As a test, the explicit calls to `Printexc.record_backtrace` are removed from the relevant tests.