### PR TITLE
Allow ',' at the start of OCAMLRUNPARAM

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,9 @@ Working version
   (Nicolás Ojeda Bär, review by Stephen Dolan, Gabriel Scherer, Mark Shinwell,
   and Xavier Leroy)
 
+- #9634: Allow initial and repeated commas in `OCAMLRUNPARAM`.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 - #9441: Add RISC-V RV64G native-code backend.

--- a/manual/manual/cmds/runtime.etex
+++ b/manual/manual/cmds/runtime.etex
@@ -98,6 +98,8 @@ The following environment variables are also consulted:
   (If "OCAMLRUNPARAM" is not set, "CAMLRUNPARAM" will be used instead.)
   This variable must be a sequence of parameter specifications separated
   by commas.
+  For convenience, commas at the beginning of the variable are ignored,
+  and multiple runs of commas are interpreted as a single one.
   A parameter specification is an option letter followed by an "="
   sign, a decimal number (or an hexadecimal number prefixed by "0x"),
   and an optional multiplier.  The options are documented below;

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -135,6 +135,7 @@ void caml_parse_ocamlrunparam(void)
       case 'v': scanmult (opt, &caml_verb_gc); break;
       case 'w': scanmult (opt, &caml_init_major_window); break;
       case 'W': scanmult (opt, &caml_runtime_warnings); break;
+      case ',': continue;
       }
       while (*opt != '\0'){
         if (*opt++ == ',') break;


### PR DESCRIPTION
Currently the idiom `OCAMLRUNPARAM=$OCAMLRUNPARAM,b=1` doesn't work if `$OCAMLRUNPARAM` is empty, as the `OCAMLRUNPARAM` parsing code is not able to handle the initial comma. This PR makes it so that any number of initial commas, or repeated commas in general are skipped over.