### PR TITLE
Skip lists to the rescue of the debugger (issue #9606)

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,10 @@ Working version
 
 ### Tools:
 
+- #9606, #9635, #9637: fix performance regression in the debugger
+  (behaviors quadratic in the size of the debugged program)
+  (Xavier Leroy, report by Jacques Garrigue and Virgile Prevosto,
+  review by David Allsopp and Jacques-Henri Jourdan)
 
 ### Manual and documentation:
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -25,7 +25,8 @@ BYTECODE_C_SOURCES := $(addsuffix .c, \
   signals_byt printexc backtrace_byt backtrace compare ints eventlog \
   floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
   lexing callback debugger weak compact finalise custom dynlink \
-  spacetime_byt afl $(UNIX_OR_WIN32) bigarray main memprof domain)
+  spacetime_byt afl $(UNIX_OR_WIN32) bigarray main memprof domain \
+  skiplist)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
   startup_aux startup_nat main fail_nat roots_nat signals \
@@ -34,7 +35,7 @@ NATIVE_C_SOURCES := $(addsuffix .c, \
   lexing $(UNIX_OR_WIN32) printexc callback weak compact finalise custom \
   globroots backtrace_nat backtrace dynlink_nat debugger meta \
   dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray \
-  memprof domain)
+  memprof domain skiplist)
 
 GENERATED_HEADERS := caml/opnames.h caml/version.h caml/jumptbl.h
 CONFIG_HEADERS := caml/m.h caml/s.h

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cambium, INRIA Paris                  */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* A dictionary data structure implemented as skip lists */
+
+/* Keys and associated data are natural-width integers (type [uintnat]).
+   Pointers can be used too, modulo conversion to [uintnat]. */
+
+#ifndef CAML_SKIPLIST_H
+#define CAML_SKIPLIST_H
+
+#ifdef CAML_INTERNALS
+
+#include "config.h"
+
+#define NUM_LEVELS 17
+
+/* The head of a skip list */
+
+struct skiplist {
+  uintnat reserved1, reserved2; /* dummy values for layout compatibility
+                                   with struct skipcell below */
+  struct skipcell * forward[NUM_LEVELS]; /* forward chaining */
+  int level;                    /* max level used */
+};
+
+/* The cells of a skip list */
+
+struct skipcell {
+  uintnat key;
+  uintnat data;
+#if (__STDC_VERSION__ >= 199901L)
+  struct skipcell * forward[];  /* variable-length array */
+#else
+  struct skipcell * forward[1]; /* variable-length array */
+#endif
+};
+
+/* Initialize a skip list, statically */
+#define SKIPLIST_STATIC_INITIALIZER { 0, 0, {0, }, 0 }
+
+/* Initialize a skip list, dynamically */
+extern void caml_skiplist_init(struct skiplist * sk);
+
+/* Search a skip list.
+   If [key] is found, store associated data in [*data] and return 1.
+   If [key] is not found, return 0 and leave [*data] unchanged. */
+extern int caml_skiplist_find(struct skiplist * sk, uintnat key,
+                              /*out*/ uintnat * data);
+
+/* Search the entry of the skip list that has the largest key less than
+   or equal to [k].
+   If such an entry exists, store its key in [*key], the associated data in
+   [*data], and return 1.
+   If no such entry exists (all keys in the skip list are strictly greater
+   than [k]), return 0 and leave [*key] and [*data] unchanged. */
+extern int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
+                                    /*out*/ uintnat * key,
+                                    /*out*/ uintnat * data);
+
+/* Insertion in a skip list.
+   If [key] was already there, change the associated data and return 1.
+   If [key] was not there, insert new [key, data] binding and return 0. */
+extern int caml_skiplist_insert(struct skiplist * sk,
+                                uintnat key, uintnat data);
+
+/* Deletion in a skip list.
+   If [key] was there, remove it and return 1.
+   If [key] was not there, leave the skip list unchanged and return 0. */
+extern int caml_skiplist_remove(struct skiplist * sk, uintnat key);
+
+/* Empty an already initialized skip list. */
+extern void caml_skiplist_empty(struct skiplist * sk);
+
+/* Iterate over a skip list, in increasing order of keys.
+   [var] designates the current element.
+   [action] can refer to [var->key] and [var->data].
+   [action] can safely remove the current element, i.e. call
+   [caml_skiplist_remove] on [var->key].  The traversal will
+   continue with the skiplist element following the removed element.
+   Other operations performed over the skiplist during its traversal have
+   unspecified effects on the traversal. */
+
+#define FOREACH_SKIPLIST_ELEMENT(var,sk,action) \
+  { struct skipcell * var, * caml__next; \
+    for (var = (sk)->forward[0]; var != NULL; var = caml__next) \
+    { caml__next = (var)->forward[0]; action; } \
+  }
+
+#endif
+
+#endif

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -1,0 +1,207 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cambium, INRIA Paris                  */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+/* A dictionary data structure implemented as skip lists
+   (see William Pugh, "Skip lists: a probabilistic alternative to
+   balanced binary trees", Comm. ACM 33(6), 1990). */
+
+#include <stddef.h>
+#include "caml/config.h"
+#include "caml/memory.h"
+#include "caml/misc.h"
+#include "caml/skiplist.h"
+
+/* Size of struct skipcell, in bytes, without the forward array */
+#if (__STDC_VERSION__ >= 199901L)
+#define SIZEOF_SKIPCELL sizeof(struct skipcell)
+#else
+#define SIZEOF_SKIPCELL (sizeof(struct skipcell) - sizeof(struct skipcell *))
+#endif
+
+/* Generate a random level for a new node: 0 with probability 3/4,
+   1 with probability 3/16, 2 with probability 3/64, etc.
+   We use a simple linear congruential PRNG (see Knuth vol 2) instead
+   of random(), because we need exactly 32 bits of pseudo-random data
+   (i.e. 2 * (NUM_LEVELS - 1)).  Moreover, the congruential PRNG
+   is faster and guaranteed to be deterministic (to reproduce bugs). */
+
+static uint32_t random_seed = 0;
+
+static int random_level(void)
+{
+  uint32_t r;
+  int level = 0;
+
+  /* Linear congruence with modulus = 2^32, multiplier = 69069
+     (Knuth vol 2 p. 106, line 15 of table 1), additive = 25173. */
+  r = random_seed = random_seed * 69069 + 25173;
+  /* Knuth (vol 2 p. 13) shows that the least significant bits are
+     "less random" than the most significant bits with a modulus of 2^m,
+     so consume most significant bits first */
+  while ((r & 0xC0000000U) == 0xC0000000U) { level++; r = r << 2; }
+  CAMLassert(level < NUM_LEVELS);
+  return level;
+}
+
+/* Initialize a skip list */
+
+void caml_skiplist_init(struct skiplist * sk)
+{
+  int i;
+  for (i = 0; i < NUM_LEVELS; i++) sk->forward[i] = NULL;
+  sk->level = 0;
+}
+
+/* Search a skip list */
+
+int caml_skiplist_find(struct skiplist * sk, uintnat key, uintnat * data)
+{
+  int i;
+  struct skipcell * e, * f;
+
+  e = (struct skipcell *) sk;
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e->forward[i];
+      if (f == NULL || f->key >= key) break;
+      e = f;
+    }
+  }
+  e = e->forward[0];
+  if (e != NULL && e->key == key) {
+    *data = e->data;
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
+                             uintnat * key, uintnat * data)
+{
+  int i;
+  struct skipcell * e, * f;
+
+  e = (struct skipcell *) sk;
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e->forward[i];
+      if (f == NULL || f->key > k) break;
+      e = f;
+    }
+  }
+  if (e == (struct skipcell *) sk) {
+    return 0;
+  } else {
+    *key = e-> key; *data = e->data; return 1;
+  }
+}
+
+/* Insertion in a skip list */
+
+int caml_skiplist_insert(struct skiplist * sk,
+                         uintnat key, uintnat data)
+{
+  struct skipcell * update[NUM_LEVELS];
+  struct skipcell * e, * f;
+  int i, new_level;
+
+  /* Init "cursor" to list head */
+  e = (struct skipcell *) sk;
+  /* Find place to insert new node */
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e->forward[i];
+      if (f == NULL || f->key >= key) break;
+      e = f;
+    }
+    update[i] = e;
+  }
+  e = e->forward[0];
+  /* If already present, update data */
+  if (e != NULL && e->key == key) {
+    e->data = data;
+    return 1;
+  }
+  /* Insert additional element, updating list level if necessary */
+  new_level = random_level();
+  if (new_level > sk->level) {
+    for (i = sk->level + 1; i <= new_level; i++)
+      update[i] = (struct skipcell *) sk;
+    sk->level = new_level;
+  }
+  e = caml_stat_alloc(SIZEOF_SKIPCELL +
+                      (new_level + 1) * sizeof(struct skipcell *));
+  e->key = key;
+  e->data = data;
+  for (i = 0; i <= new_level; i++) {
+    e->forward[i] = update[i]->forward[i];
+    update[i]->forward[i] = e;
+  }
+  return 0;
+}
+
+/* Deletion in a skip list */
+
+int caml_skiplist_remove(struct skiplist * sk, uintnat key)
+{
+  struct skipcell * update[NUM_LEVELS];
+  struct skipcell * e, * f;
+  int i;
+
+  /* Init "cursor" to list head */
+  e = (struct skipcell *) sk;
+  /* Find element in list */
+  for (i = sk->level; i >= 0; i--) {
+    while (1) {
+      f = e->forward[i];
+      if (f == NULL || f->key >= key) break;
+      e = f;
+    }
+    update[i] = e;
+  }
+  e = e->forward[0];
+  /* If not found, nothing to do */
+  if (e == NULL || e->key != key) return 0;
+  /* Rebuild list without node */
+  for (i = 0; i <= sk->level; i++) {
+    if (update[i]->forward[i] == e)
+      update[i]->forward[i] = e->forward[i];
+  }
+  /* Reclaim list element */
+  caml_stat_free(e);
+  /* Down-correct list level */
+  while (sk->level > 0 &&
+         sk->forward[sk->level] == NULL)
+    sk->level--;
+  return 1;
+}
+
+/* Empty a skip list */
+
+void caml_skiplist_empty(struct skiplist * sk)
+{
+  struct skipcell * e, * next;
+  int i;
+
+  for (e = sk->forward[0]; e != NULL; e = next) {
+    next = e->forward[0];
+    caml_stat_free(e);
+  }
+  for (i = 0; i <= sk->level; i++) sk->forward[i] = NULL;
+  sk->level = 0;
+}


### PR DESCRIPTION
The OCaml runtime system needs efficient data structures.  As an example of what can go wrong, #9606 reports a performance bug in the runtime/debugger interface caused by the use of arrays with linear search.

There are some efficient data structures in the runtime: hash tables in memory.c and extern.c, splay trees in freelist.c, skip lists in globroots.c.  However, they are not reusable and specialized to one usage.

This PR extricates the skip list implementation from globroots.c, turning it into a reusable finite set and finite map implementation, with documented interface in `<caml/skiplist.h>`.  Keys and data are unsigned integers or pointers.  It then uses skip lists in debugger.c to fix the performance bug #9606.

I have other uses in mind once this PR is merged, such as a more efficient management of bytecode fragments.  So, I would appreciate if it was reviewed promptly.

The PR is best reviewed commit by commit:
- 9f671e413 introduce skiplist.c and caml/skiplist.h
- 847392887 uses the generic implementation in globroots.c, deleting much old code
- 7cb9e23b1 uses skiplists in debugger.c

To speed up reviewing, here are answers to the obvious question "why skip lists and not hash tables / balanced search trees / my favorite data structure ?"
- The code for skip lists was already written and tested.
- All operations (find, insert, delete) are efficient:  O (log n) with probability 1.
- No rebalancing needed, saving much C code.
- Deletion is as easy as insertion (unlike linear hash tables).
- Underneath any skip list there is a singly-linked list, making traversals a breeze.
- It supports an efficient "find node with key equal or immediately below the given key" that could be useful later.  (Has htables cannot do this.)


