### PR TITLE
Fix #9640: regression introduced by #9623

### DIFF
--- a/Changes
+++ b/Changes
@@ -618,7 +618,7 @@ OCaml 4.11
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
 
-- #9623: fix typing environments in Typedecl.transl_with_constraint
+- #9623, #9640: fix typing environments in Typedecl.transl_with_constraint
   (Gabriel Scherer, review by Jacques Garrigue and Leo White,
    report by Hugo Heuzard)
 

--- a/Changes
+++ b/Changes
@@ -618,7 +618,7 @@ OCaml 4.11
   on Power and Z System
   (Xavier Leroy, review by Nicolás Ojeda Bär)
 
-- #9623, #9640: fix typing environments in Typedecl.transl_with_constraint
+- #9623, #9642: fix typing environments in Typedecl.transl_with_constraint
   (Gabriel Scherer, review by Jacques Garrigue and Leo White,
    report by Hugo Heuzard)
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -220,3 +220,29 @@ module type Iobuf_packet =
         end
   end
 |}]
+
+(* Simpler example by @gasche *)
+module type S = sig
+  type t
+  type u = t
+end
+module type Pack = sig
+  module M : S
+end
+[%%expect{|
+module type S = sig type t type u = t end
+module type Pack = sig module M : S end
+|}]
+module type Weird = sig
+  module M : S
+  module P : Pack
+    with type M.t = M.t
+    with type M.u = M.u
+end
+[%%expect{|
+module type Weird =
+  sig
+    module M : S
+    module P : sig module M : sig type t = M.t type u = M.u end end
+  end
+|}]


### PR DESCRIPTION
In `merge_constraint`, #9623 was precomputing a common `sig_env` for the whole signature, but forgot to do so recursively.
This PR fixes #9640.