### PR TITLE
Fix tools/check-typo for mawk 1.3.4

### DIFF
--- a/tools/check-typo
+++ b/tools/check-typo
@@ -170,9 +170,8 @@ IGNORE_DIRS="
 # is faster to optimistically run check-typo on them (and maybe get
 # out in the middle) than to first check then run.
 
-TEST_AWK='BEGIN {if ("a{1}" ~ /a{1}/) exit 0}'
-if $OCAML_CT_AWK "$TEST_AWK" ; then
-  TEST_AWK='BEGIN {if ("a" ~ /a{1}/) exit 0}'
+TEST_AWK='BEGIN {if ("a{1}" ~ /a{1}$/) exit 1}'
+if ! $OCAML_CT_AWK "$TEST_AWK" ; then
   if $OCAML_CT_AWK --re-interval "$TEST_AWK" 2>/dev/null ; then
     OCAML_CT_AWK="$OCAML_CT_AWK --re-interval"
   else


### PR DESCRIPTION
On Ubuntu 19.10:

```
dra@eoan:~$ mawk -W version
mawk 1.3.3 Nov 1996, Copyright (C) Michael D. Brennan

compiled limits:
max NF             32767
sprintf buffer      2040
```

On Ubuntu 20.04:

```
dra@focal:~$ mawk -W version
mawk 1.3.4 20200120
Copyright 2008-2019,2020, Thomas E. Dickey
Copyright 1991-1996,2014, Michael D. Brennan

random-funcs:       srandom/random
regex-funcs:        internal
compiled limits:
sprintf buffer      8192
maximum-integer     2147483647
```

For whatever reason, in 2012 `--re-interval` along with a few other gawk options was altered to display the warning but not do exit(2) as [noted in the CHANGES file](https://invisible-island.net/mawk/CHANGES.html#index-t20121129).

This PR fixes both... happy check-typo'ing

Fixes #9643