### PR TITLE
pattern-matching refactoring: first-order representation for failure handlers

### DIFF
--- a/Changes
+++ b/Changes
@@ -193,7 +193,8 @@ Working version
 - #9216: add Lambda.duplicate which refreshes bound identifiers
   (Gabriel Scherer, review by Pierre Chambart and Vincent Laviron)
 
-- #9493, #9520, #9563, #9599, #9608: refactor the pattern-matching compiler
+- #9493, #9520, #9563, #9599, #9608, #9647: refactor
+  the pattern-matching compiler
   (Thomas Refis and Gabriel Scherer, review by Florian Angeletti)
 
 - #9604: refactoring of the ocamltest codebase.

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3391,9 +3391,18 @@ let for_function ~scopes loc repr param pat_act_list partial =
   compile_matching ~scopes repr f param pat_act_list partial
 
 (* In the following two cases, exhaustiveness info is not available! *)
-let for_trywith ~scopes param pat_act_list =
+let for_trywith ~scopes loc param pat_act_list =
+  (* Note: the failure action of [for_trywith] corresponds
+     to an exception that is not matched by a try..with handler,
+     and is thus reraised for the next handler in the stack.
+
+     It is important to *not* include location information in
+     the reraise (hence the [Loc_unknown]) to avoid seeing this
+     silent reraise in exception backtraces. *)
   compile_matching ~scopes None
-    (fun () -> Lprim (Praise Raise_reraise, [ param ], Loc_unknown))
+    (fun () ->
+       ignore loc;
+       Lprim (Praise Raise_reraise, [ param ], Loc_unknown))
     param pat_act_list Partial
 
 let simple_for_let ~scopes loc param pat body =

--- a/lambda/matching.mli
+++ b/lambda/matching.mli
@@ -25,7 +25,7 @@ val for_function:
         int ref option -> lambda -> (pattern * lambda) list -> partial ->
         lambda
 val for_trywith:
-        scopes:scopes ->
+        scopes:scopes -> Location.t ->
         lambda -> (pattern * lambda) list ->
         lambda
 val for_let:

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -292,7 +292,7 @@ and transl_exp0 ~scopes e =
   | Texp_try(body, pat_expr_list) ->
       let id = Typecore.name_cases "exn" pat_expr_list in
       Ltrywith(transl_exp ~scopes body, id,
-               Matching.for_trywith ~scopes (Lvar id)
+               Matching.for_trywith ~scopes e.exp_loc (Lvar id)
                  (transl_cases_try ~scopes pat_expr_list))
   | Texp_tuple el ->
       let ll, shape = transl_list_with_shape ~scopes el in
@@ -1035,7 +1035,7 @@ and transl_match ~scopes e arg pat_expr_list partial =
     let static_exception_id = next_raise_count () in
     Lstaticcatch
       (Ltrywith (Lstaticraise (static_exception_id, body), id,
-                 Matching.for_trywith ~scopes (Lvar id) exn_cases),
+                 Matching.for_trywith ~scopes e.exp_loc (Lvar id) exn_cases),
        (static_exception_id, val_ids),
        handler)
   in


### PR DESCRIPTION
This PR was not initially planned in #9321, but once you get started...

(cc @trefis @Octachron)

`compile_matching` uses higher-order functions to decide what code to generate for match failure. The present PR uses a proper datastructure to represent the possible cases, which simplifies the code slightly.

~~The PR also contains a related improvement to the location used in `Matching.for_trywith`.~~