### PR TITLE
[WIP] pattern-matching: Cannot_flatten, maybe we can?

### DIFF
--- a/Changes
+++ b/Changes
@@ -19,6 +19,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #9650: keep refactoring the pattern-matching compiler
+  (Gabriel Scherer, review by Thomas Refis)
+
 ### Build system:
 
 ### Bug fixes:

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3753,41 +3753,27 @@ let do_for_multiple_match ~scopes loc paraml pat_act_list partial =
       } )
   in
   try
-    match split_and_precompile ~arg pm1 with
-    | exception Cannot_flatten ->
-        (* One pattern binds the whole tuple, flattening is not possible.
-           We need to allocate the scrutinee. *)
-        let lambda, total =
-          compile_match ~scopes None partial (Context.start 1) pm1 in
-        begin match partial with
-        | Partial ->
-            check_total ~scopes loc ~failer:Raise_match_failure
-              total lambda raise_num
-        | Total ->
-            assert (Jumps.is_empty total);
-            lambda
-        end
-    | next, nexts ->
-        let size = List.length paraml
-        and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
-        let args = List.map (fun id -> (Lvar id, Alias)) idl in
-        let flat_next = flatten_precompiled size args next
-        and flat_nexts =
-          List.map (fun (e, pm) -> (e, flatten_precompiled size args pm)) nexts
-        in
-        let lam, total =
-          comp_match_handlers (compile_flattened ~scopes repr) partial
-            (Context.start size) flat_next flat_nexts
-        in
-        List.fold_right2 (bind Strict) idl paraml
-          ( match partial with
-          | Partial ->
-              check_total ~scopes loc ~failer:Raise_match_failure
-                total lam raise_num
-          | Total ->
-              assert (Jumps.is_empty total);
-              lam
-          )
+    let next, nexts = split_and_precompile ~arg pm1 in
+    let size = List.length paraml
+    and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
+    let args = List.map (fun id -> (Lvar id, Alias)) idl in
+    let flat_next = flatten_precompiled size args next
+    and flat_nexts =
+      List.map (fun (e, pm) -> (e, flatten_precompiled size args pm)) nexts
+    in
+    let lam, total =
+      comp_match_handlers (compile_flattened ~scopes repr) partial
+        (Context.start size) flat_next flat_nexts
+    in
+    List.fold_right2 (bind Strict) idl paraml
+      ( match partial with
+      | Partial ->
+          let failer = Raise_match_failure in
+          check_total ~scopes loc ~failer total lam raise_num
+      | Total ->
+          assert (Jumps.is_empty total);
+          lam
+      )
   with Unused -> assert false
 
 (* ; partial_function loc () *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3757,7 +3757,9 @@ let do_for_multiple_match ~scopes loc paraml pat_act_list partial =
   try
     let next, nexts = split_and_precompile ~arg pm1 in
     let size = List.length paraml
-    and idl = List.map (fun _ -> Ident.create_local "*match*") paraml in
+    and idl = List.map (function
+      | Lvar id -> id
+      | _ -> Ident.create_local "*match*") paraml in
     let args = List.map (fun id -> (Lvar id, Alias)) idl in
     let flat_next = flatten_precompiled size args next
     and flat_nexts =

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -134,9 +134,10 @@ let _ = fun a b -> match a, b with
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
-(* here flattening is an optimisation,
-   as we avoid allocating the tuple in the first case,
-   and only allocate in the second case *)
+(* here flattening is an optimisation: the allocation is moved as an
+   alias within each branch, and in the first branch it is unused and
+   will be removed by simplification, so the final code
+   (see the -dlambda output) will not allocate in the first branch. *)
 let _ = fun a b -> match a, b with
 | (true as x, _) as _p -> x, (true, true)
 | (false as x, _) as p -> x, p

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -1,6 +1,23 @@
 (* TEST
-   flags = "-drawlambda"
+   flags = "-drawlambda -dlambda"
    * expect
+*)
+
+(* Note: the tests below contain *both* the -drawlambda and
+   the -dlambda intermediate representations:
+   -drawlambda is the Lambda code generated directly by the
+     pattern-matching compiler; it contain "alias" bindings or static
+     exits that are unused, and will be removed by simplification, or
+     that are used only once, and will be inlined by simplification.
+   -dlambda is the Lambda code resulting from simplification.
+
+  The -drawlambda output more closely matches what the
+  pattern-compiler produces, and the -dlambda output more closely
+  matches the final generated code.
+
+  In this test we decided to show both to notice that some allocations
+  are "optimized away" during simplification (see "here flattening is
+  an optimization" below).
 *)
 
 match (3, 2, 1) with
@@ -15,6 +32,9 @@ match (3, 2, 1) with
       (catch (if (!= *match*/89 3) (exit 3) (exit 1)) with (3)
         (if (!= *match*/88 1) (exit 2) (exit 1)))
      with (2) 0)
+   with (1) 1))
+(let (*match*/88 = 3 *match*/89 = 2 *match*/90 = 1)
+  (catch (if (!= *match*/89 3) (if (!= *match*/88 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
 |}];;
@@ -40,6 +60,13 @@ match (3, 2, 1) with
             (exit 4 x/96))))
      with (5) 0)
    with (4 x/91) (seq (ignore x/91) 1)))
+(let (*match*/93 = 3 *match*/94 = 2 *match*/95 = 1)
+  (catch
+    (if (!= *match*/94 3)
+      (if (!= *match*/93 1) 0
+        (exit 4 (makeblock 0 *match*/93 *match*/94 *match*/95)))
+      (exit 4 (makeblock 0 *match*/93 *match*/94 *match*/95)))
+   with (4 x/91) (seq (ignore x/91) 1)))
 - : bool = false
 |}];;
 
@@ -49,6 +76,7 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
+(function a/98 b/99 0)
 (function a/98 b/99 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
@@ -69,6 +97,7 @@ let _ = fun a b -> match a, b with
 (* outside, trivial *)
 [%%expect {|
 (function a/102 b/103 (let (p/104 =a (makeblock 0 a/102 b/103)) p/104))
+(function a/102 b/103 (makeblock 0 a/102 b/103))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -78,6 +107,7 @@ let _ = fun a b -> match a, b with
 (* inside, trivial *)
 [%%expect{|
 (function a/106 b/107 (let (p/108 =a (makeblock 0 a/106 b/107)) p/108))
+(function a/106 b/107 (makeblock 0 a/106 b/107))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -89,6 +119,7 @@ let _ = fun a b -> match a, b with
 (function a/112 b/113
   (let (x/114 =a a/112 p/115 =a (makeblock 0 a/112 b/113))
     (makeblock 0 x/114 p/115)))
+(function a/112 b/113 (makeblock 0 a/112 (makeblock 0 a/112 b/113)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -100,6 +131,7 @@ let _ = fun a b -> match a, b with
 (function a/118 b/119
   (let (x/120 =a a/118 p/121 =a (makeblock 0 a/118 b/119))
     (makeblock 0 x/120 p/121)))
+(function a/118 b/119 (makeblock 0 a/118 (makeblock 0 a/118 b/119)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -114,6 +146,9 @@ let _ = fun a b -> match a, b with
       (makeblock 0 x/130 p/131))
     (let (x/132 =a b/129 p/133 =a (makeblock 0 a/128 b/129))
       (makeblock 0 x/132 p/133))))
+(function a/128 b/129
+  (if a/128 (makeblock 0 a/128 (makeblock 0 a/128 b/129))
+    (makeblock 0 b/129 (makeblock 0 a/128 b/129))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -130,6 +165,11 @@ let _ = fun a b -> match a, b with
         (exit 10 x/142 p/143))
       (let (x/140 =a b/135 p/141 =a (makeblock 0 a/134 b/135))
         (exit 10 x/140 p/141)))
+   with (10 x/136 p/137) (makeblock 0 x/136 p/137)))
+(function a/134 b/135
+  (catch
+    (if a/134 (exit 10 a/134 (makeblock 0 a/134 b/135))
+      (exit 10 b/135 (makeblock 0 a/134 b/135)))
    with (10 x/136 p/137) (makeblock 0 x/136 p/137)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
@@ -149,6 +189,9 @@ let _ = fun a b -> match a, b with
       (makeblock 0 x/146 [0: 1 1]))
     (let (x/148 =a a/144 p/149 =a (makeblock 0 a/144 b/145))
       (makeblock 0 x/148 p/149))))
+(function a/144 b/145
+  (if a/144 (makeblock 0 a/144 [0: 1 1])
+    (makeblock 0 a/144 (makeblock 0 a/144 b/145))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -160,11 +203,13 @@ let _ = fun a b -> match a, b with
 (function a/150 b/151
   (let (x/152 =a a/150 p/153 =a (makeblock 0 a/150 b/151))
     (makeblock 0 x/152 p/153)))
+(function a/150 b/151 (makeblock 0 a/150 (makeblock 0 a/150 b/151)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
 type 'a tuplist = Nil | Cons of ('a * 'a tuplist)
 [%%expect{|
+0
 0
 type 'a tuplist = Nil | Cons of ('a * 'a tuplist)
 |}]
@@ -180,6 +225,9 @@ let _ =fun a b -> match a, b with
     (if a/163 (if b/164 (let (p/165 =a (field 0 b/164)) p/165) (exit 12))
       (exit 12))
    with (12) (let (p/166 =a (makeblock 0 a/163 b/164)) p/166)))
+(function a/163 b/164
+  (catch (if a/163 (if b/164 (field 0 b/164) (exit 12)) (exit 12)) with (12)
+    (makeblock 0 a/163 b/164)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -195,6 +243,12 @@ let _ = fun a b -> match a, b with
         (if b/168 (let (p/172 =a (field 0 b/168)) (exit 13 p/172)) (exit 14))
         (exit 14))
      with (14) (let (p/171 =a (makeblock 0 a/167 b/168)) (exit 13 p/171)))
+   with (13 p/169) p/169))
+(function a/167 b/168
+  (catch
+    (catch
+      (if a/167 (if b/168 (exit 13 (field 0 b/168)) (exit 14)) (exit 14))
+     with (14) (exit 13 (makeblock 0 a/167 b/168)))
    with (13 p/169) p/169))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -9,17 +9,11 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let
-  (*match*/88 = 3
-   *match*/89 = 2
-   *match*/90 = 1
-   *match*/91 = *match*/88
-   *match*/92 = *match*/89
-   *match*/93 = *match*/90)
+(let (*match*/88 = 3 *match*/89 = 2 *match*/90 = 1)
   (catch
     (catch
-      (catch (if (!= *match*/92 3) (exit 3) (exit 1)) with (3)
-        (if (!= *match*/91 1) (exit 2) (exit 1)))
+      (catch (if (!= *match*/89 3) (exit 3) (exit 1)) with (3)
+        (if (!= *match*/88 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
 - : bool = false
@@ -33,25 +27,19 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let
-  (*match*/96 = 3
-   *match*/97 = 2
-   *match*/98 = 1
-   *match*/103 = *match*/96
-   *match*/104 = *match*/97
-   *match*/105 = *match*/98)
+(let (*match*/93 = 3 *match*/94 = 2 *match*/95 = 1)
   (catch
     (catch
       (catch
-        (if (!= *match*/104 3) (exit 6)
-          (let (x/102 =a (makeblock 0 *match*/96 *match*/97 *match*/98))
-            (exit 4 x/102)))
+        (if (!= *match*/94 3) (exit 6)
+          (let (x/99 =a (makeblock 0 *match*/93 *match*/94 *match*/95))
+            (exit 4 x/99)))
        with (6)
-        (if (!= *match*/103 1) (exit 5)
-          (let (x/100 =a (makeblock 0 *match*/96 *match*/97 *match*/98))
-            (exit 4 x/100))))
+        (if (!= *match*/93 1) (exit 5)
+          (let (x/97 =a (makeblock 0 *match*/93 *match*/94 *match*/95))
+            (exit 4 x/97))))
      with (5) 0)
-   with (4 x/94) (seq (ignore x/94) 1)))
+   with (4 x/91) (seq (ignore x/91) 1)))
 - : bool = false
 |}];;
 
@@ -61,7 +49,7 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/106 b/107 (let (*match*/110 = a/106 *match*/111 = b/107) 0))
+(function a/100 b/101 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -80,12 +68,7 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/112 b/113
-  (let
-    (*match*/116 = a/112
-     *match*/117 = b/113
-     p/114 =a (makeblock 0 a/112 b/113))
-    p/114))
+(function a/104 b/105 (let (p/106 =a (makeblock 0 a/104 b/105)) p/106))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -94,12 +77,7 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/118 b/119
-  (let
-    (*match*/126 = a/118
-     *match*/127 = b/119
-     p/120 =a (makeblock 0 a/118 b/119))
-    p/120))
+(function a/108 b/109 (let (p/110 =a (makeblock 0 a/108 b/109)) p/110))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -108,13 +86,9 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/128 b/129
-  (let
-    (*match*/134 = a/128
-     *match*/135 = b/129
-     x/130 =a *match*/134
-     p/131 =a (makeblock 0 a/128 b/129))
-    (makeblock 0 x/130 p/131)))
+(function a/116 b/117
+  (let (x/118 =a a/116 p/119 =a (makeblock 0 a/116 b/117))
+    (makeblock 0 x/118 p/119)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -123,13 +97,9 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/136 b/137
-  (let
-    (*match*/148 = a/136
-     *match*/149 = b/137
-     x/138 =a *match*/148
-     p/139 =a (makeblock 0 a/136 b/137))
-    (makeblock 0 x/138 p/139)))
+(function a/122 b/123
+  (let (x/124 =a a/122 p/125 =a (makeblock 0 a/122 b/123))
+    (makeblock 0 x/124 p/125)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -138,13 +108,12 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/150 b/151
-  (let (*match*/156 = a/150 *match*/157 = b/151)
-    (if *match*/156
-      (let (x/152 =a *match*/156 p/153 =a (makeblock 0 a/150 b/151))
-        (makeblock 0 x/152 p/153))
-      (let (x/154 =a *match*/157 p/155 =a (makeblock 0 a/150 b/151))
-        (makeblock 0 x/154 p/155)))))
+(function a/134 b/135
+  (if a/134
+    (let (x/136 =a a/134 p/137 =a (makeblock 0 a/134 b/135))
+      (makeblock 0 x/136 p/137))
+    (let (x/138 =a b/135 p/139 =a (makeblock 0 a/134 b/135))
+      (makeblock 0 x/138 p/139))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -154,15 +123,14 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/158 b/159
-  (let (*match*/170 = a/158 *match*/171 = b/159)
-    (catch
-      (if *match*/170
-        (let (x/167 =a *match*/170 p/169 =a (makeblock 0 a/158 b/159))
-          (exit 10 x/167 p/169))
-        (let (x/164 =a *match*/171 p/166 =a (makeblock 0 a/158 b/159))
-          (exit 10 x/164 p/166)))
-     with (10 x/160 p/161) (makeblock 0 x/160 p/161))))
+(function a/140 b/141
+  (catch
+    (if a/140
+      (let (x/149 =a a/140 p/151 =a (makeblock 0 a/140 b/141))
+        (exit 10 x/149 p/151))
+      (let (x/146 =a b/141 p/148 =a (makeblock 0 a/140 b/141))
+        (exit 10 x/146 p/148)))
+   with (10 x/142 p/143) (makeblock 0 x/142 p/143)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -174,13 +142,12 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/172 b/173
-  (let (*match*/178 = a/172 *match*/179 = b/173)
-    (if *match*/178
-      (let (x/174 =a *match*/178 _p/175 =a (makeblock 0 a/172 b/173))
-        (makeblock 0 x/174 [0: 1 1]))
-      (let (x/176 =a *match*/178 p/177 =a (makeblock 0 a/172 b/173))
-        (makeblock 0 x/176 p/177)))))
+(function a/152 b/153
+  (if a/152
+    (let (x/154 =a a/152 _p/155 =a (makeblock 0 a/152 b/153))
+      (makeblock 0 x/154 [0: 1 1]))
+    (let (x/156 =a a/152 p/157 =a (makeblock 0 a/152 b/153))
+      (makeblock 0 x/156 p/157))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -189,13 +156,9 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/180 b/181
-  (let
-    (*match*/192 = a/180
-     *match*/193 = b/181
-     x/182 =a *match*/192
-     p/183 =a (makeblock 0 a/180 b/181))
-    (makeblock 0 x/182 p/183)))
+(function a/158 b/159
+  (let (x/160 =a a/158 p/161 =a (makeblock 0 a/158 b/159))
+    (makeblock 0 x/160 p/161)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -211,14 +174,11 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/197 b/198
-  (let (*match*/201 = a/197 *match*/202 = b/198)
-    (catch
-      (if *match*/201
-        (if *match*/202 (let (p/199 =a (field 0 *match*/202)) p/199)
-          (exit 12))
-        (exit 12))
-     with (12) (let (p/200 =a (makeblock 0 a/197 b/198)) p/200))))
+(function a/173 b/174
+  (catch
+    (if a/173 (if b/174 (let (p/175 =a (field 0 b/174)) p/175) (exit 12))
+      (exit 12))
+   with (12) (let (p/176 =a (makeblock 0 a/173 b/174)) p/176)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -227,15 +187,13 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/203 b/204
-  (let (*match*/210 = a/203 *match*/211 = b/204)
+(function a/177 b/178
+  (catch
     (catch
-      (catch
-        (if *match*/210
-          (if *match*/211
-            (let (p/209 =a (field 0 *match*/211)) (exit 13 p/209)) (exit 14))
-          (exit 14))
-       with (14) (let (p/208 =a (makeblock 0 a/203 b/204)) (exit 13 p/208)))
-     with (13 p/205) p/205)))
+      (if a/177
+        (if b/178 (let (p/183 =a (field 0 b/178)) (exit 13 p/183)) (exit 14))
+        (exit 14))
+     with (14) (let (p/182 =a (makeblock 0 a/177 b/178)) (exit 13 p/182)))
+   with (13 p/179) p/179))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -32,12 +32,12 @@ match (3, 2, 1) with
     (catch
       (catch
         (if (!= *match*/94 3) (exit 6)
-          (let (x/99 =a (makeblock 0 *match*/93 *match*/94 *match*/95))
-            (exit 4 x/99)))
+          (let (x/97 =a (makeblock 0 *match*/93 *match*/94 *match*/95))
+            (exit 4 x/97)))
        with (6)
         (if (!= *match*/93 1) (exit 5)
-          (let (x/97 =a (makeblock 0 *match*/93 *match*/94 *match*/95))
-            (exit 4 x/97))))
+          (let (x/96 =a (makeblock 0 *match*/93 *match*/94 *match*/95))
+            (exit 4 x/96))))
      with (5) 0)
    with (4 x/91) (seq (ignore x/91) 1)))
 - : bool = false
@@ -49,7 +49,7 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function a/100 b/101 0)
+(function a/98 b/99 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -68,7 +68,7 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function a/104 b/105 (let (p/106 =a (makeblock 0 a/104 b/105)) p/106))
+(function a/102 b/103 (let (p/104 =a (makeblock 0 a/102 b/103)) p/104))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -77,7 +77,7 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function a/108 b/109 (let (p/110 =a (makeblock 0 a/108 b/109)) p/110))
+(function a/106 b/107 (let (p/108 =a (makeblock 0 a/106 b/107)) p/108))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -86,9 +86,9 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function a/116 b/117
-  (let (x/118 =a a/116 p/119 =a (makeblock 0 a/116 b/117))
-    (makeblock 0 x/118 p/119)))
+(function a/112 b/113
+  (let (x/114 =a a/112 p/115 =a (makeblock 0 a/112 b/113))
+    (makeblock 0 x/114 p/115)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -97,9 +97,9 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function a/122 b/123
-  (let (x/124 =a a/122 p/125 =a (makeblock 0 a/122 b/123))
-    (makeblock 0 x/124 p/125)))
+(function a/118 b/119
+  (let (x/120 =a a/118 p/121 =a (makeblock 0 a/118 b/119))
+    (makeblock 0 x/120 p/121)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -108,12 +108,12 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function a/134 b/135
-  (if a/134
-    (let (x/136 =a a/134 p/137 =a (makeblock 0 a/134 b/135))
-      (makeblock 0 x/136 p/137))
-    (let (x/138 =a b/135 p/139 =a (makeblock 0 a/134 b/135))
-      (makeblock 0 x/138 p/139))))
+(function a/128 b/129
+  (if a/128
+    (let (x/130 =a a/128 p/131 =a (makeblock 0 a/128 b/129))
+      (makeblock 0 x/130 p/131))
+    (let (x/132 =a b/129 p/133 =a (makeblock 0 a/128 b/129))
+      (makeblock 0 x/132 p/133))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -123,14 +123,14 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function a/140 b/141
+(function a/134 b/135
   (catch
-    (if a/140
-      (let (x/149 =a a/140 p/151 =a (makeblock 0 a/140 b/141))
-        (exit 10 x/149 p/151))
-      (let (x/146 =a b/141 p/148 =a (makeblock 0 a/140 b/141))
-        (exit 10 x/146 p/148)))
-   with (10 x/142 p/143) (makeblock 0 x/142 p/143)))
+    (if a/134
+      (let (x/142 =a a/134 p/143 =a (makeblock 0 a/134 b/135))
+        (exit 10 x/142 p/143))
+      (let (x/140 =a b/135 p/141 =a (makeblock 0 a/134 b/135))
+        (exit 10 x/140 p/141)))
+   with (10 x/136 p/137) (makeblock 0 x/136 p/137)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -142,12 +142,12 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function a/152 b/153
-  (if a/152
-    (let (x/154 =a a/152 _p/155 =a (makeblock 0 a/152 b/153))
-      (makeblock 0 x/154 [0: 1 1]))
-    (let (x/156 =a a/152 p/157 =a (makeblock 0 a/152 b/153))
-      (makeblock 0 x/156 p/157))))
+(function a/144 b/145
+  (if a/144
+    (let (x/146 =a a/144 _p/147 =a (makeblock 0 a/144 b/145))
+      (makeblock 0 x/146 [0: 1 1]))
+    (let (x/148 =a a/144 p/149 =a (makeblock 0 a/144 b/145))
+      (makeblock 0 x/148 p/149))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -156,9 +156,9 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function a/158 b/159
-  (let (x/160 =a a/158 p/161 =a (makeblock 0 a/158 b/159))
-    (makeblock 0 x/160 p/161)))
+(function a/150 b/151
+  (let (x/152 =a a/150 p/153 =a (makeblock 0 a/150 b/151))
+    (makeblock 0 x/152 p/153)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -174,11 +174,11 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function a/173 b/174
+(function a/163 b/164
   (catch
-    (if a/173 (if b/174 (let (p/175 =a (field 0 b/174)) p/175) (exit 12))
+    (if a/163 (if b/164 (let (p/165 =a (field 0 b/164)) p/165) (exit 12))
       (exit 12))
-   with (12) (let (p/176 =a (makeblock 0 a/173 b/174)) p/176)))
+   with (12) (let (p/166 =a (makeblock 0 a/163 b/164)) p/166)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -187,13 +187,13 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function a/177 b/178
+(function a/167 b/168
   (catch
     (catch
-      (if a/177
-        (if b/178 (let (p/183 =a (field 0 b/178)) (exit 13 p/183)) (exit 14))
+      (if a/167
+        (if b/168 (let (p/172 =a (field 0 b/168)) (exit 13 p/172)) (exit 14))
         (exit 14))
-     with (14) (let (p/182 =a (makeblock 0 a/177 b/178)) (exit 13 p/182)))
-   with (13 p/179) p/179))
+     with (14) (let (p/171 =a (makeblock 0 a/167 b/168)) (exit 13 p/171)))
+   with (13 p/169) p/169))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -57,3 +57,196 @@ match (3, 2, 1) with
    with (5 x/94) (seq (ignore x/94) 1)))
 - : bool = false
 |}];;
+
+(* Regression test for #3780 *)
+let _ = fun a b ->
+  match a, b with
+  | ((true, _) as _g)
+  | ((false, _) as _g) -> ()
+[%%expect{|
+(function a/105 b/106 (let (*match*/109 = a/105 *match*/110 = b/106) 0))
+- : bool -> 'a -> unit = <fun>
+|}];;
+
+(* More complete tests.
+
+   The current strategy of the compiler is to determine whether
+   flattening of tuple patterns is possible during precompilation,
+   after the pattern has been half-simplified (toplevel alias
+   patterns are gone), during simplification (explosion of
+   or-patterns). Flattening fail if there is an alias pattern found
+   under an or-pattern during explosion.
+
+   The test cases below compare the compiler output on alias patterns
+   that are outside an or-pattern (handled during
+   half-simplification, then flattened) or inside an or-pattern
+   (handled during simplification, blocks flattening).
+
+   TL;DR:
+   - outside: flattening happens, good code generated
+   - inside: raises Cannot_flatten, worse code generated
+*)
+let _ = fun a b -> match a, b with
+| (true, _) as p -> p
+| (false, _) as p -> p
+(* outside, trivial *)
+[%%expect {|
+(function a/111 b/112
+  (let
+    (*match*/115 = a/111
+     *match*/116 = b/112
+     p/113 =a (makeblock 0 a/111 b/112))
+    p/113))
+- : bool -> 'a -> bool * 'a = <fun>
+|}]
+
+let _ = fun a b -> match a, b with
+| ((true, _) as p)
+| ((false, _) as p) -> p
+(* inside, trivial *)
+[%%expect{|
+(function a/117 b/118
+  (let (*match*/121 = (makeblock 0 a/117 b/118) p/119 =a *match*/121) p/119))
+- : bool -> 'a -> bool * 'a = <fun>
+|}];;
+
+let _ = fun a b -> match a, b with
+| (true as x, _) as p -> x, p
+| (false as x, _) as p -> x, p
+(* outside, simple *)
+[%%expect {|
+(function a/125 b/126
+  (let
+    (*match*/131 = a/125
+     *match*/132 = b/126
+     x/127 =a *match*/131
+     p/128 =a (makeblock 0 a/125 b/126))
+    (makeblock 0 x/127 p/128)))
+- : bool -> 'a -> bool * (bool * 'a) = <fun>
+|}]
+
+let _ = fun a b -> match a, b with
+| ((true as x, _) as p)
+| ((false as x, _) as p) -> x, p
+(* inside, simple *)
+[%%expect {|
+(function a/133 b/134
+  (let
+    (*match*/140 = (makeblock 0 a/133 b/134)
+     x/135 =a (field 0 *match*/140)
+     p/136 =a *match*/140)
+    (makeblock 0 x/135 p/136)))
+- : bool -> 'a -> bool * (bool * 'a) = <fun>
+|}]
+
+let _ = fun a b -> match a, b with
+| (true as x, _) as p -> x, p
+| (false, x) as p -> x, p
+(* outside, complex *)
+[%%expect{|
+(function a/145 b/146
+  (let (*match*/151 = a/145 *match*/152 = b/146)
+    (if *match*/151
+      (let (x/147 =a *match*/151 p/148 =a (makeblock 0 a/145 b/146))
+        (makeblock 0 x/147 p/148))
+      (let (x/149 =a *match*/152 p/150 =a (makeblock 0 a/145 b/146))
+        (makeblock 0 x/149 p/150)))))
+- : bool -> bool -> bool * (bool * bool) = <fun>
+|}]
+
+let _ = fun a b -> match a, b with
+| ((true as x, _) as p)
+| ((false, x) as p)
+  -> x, p
+(* inside, complex *)
+[%%expect{|
+(function a/153 b/154
+  (let (*match*/160 = (makeblock 0 a/153 b/154))
+    (catch
+      (let (x/162 =a (field 0 *match*/160))
+        (if x/162
+          (let (*match*/163 =a (field 1 *match*/160))
+            (exit 14 x/162 *match*/160))
+          (let (x/161 =a (field 1 *match*/160)) (exit 14 x/161 *match*/160))))
+     with (14 x/155 p/156) (makeblock 0 x/155 p/156))))
+- : bool -> bool -> bool * (bool * bool) = <fun>
+|}]
+
+(* here flattening is an optimisation,
+   as we avoid allocating the tuple in the first case,
+   and only allocate in the second case *)
+
+let _ = fun a b -> match a, b with
+| (true as x, _) as _p -> x, (true, true)
+| (false as x, _) as p -> x, p
+(* outside, onecase *)
+[%%expect {|
+(function a/164 b/165
+  (let (*match*/170 = a/164 *match*/171 = b/165)
+    (if *match*/170
+      (let (x/166 =a *match*/170 _p/167 =a (makeblock 0 a/164 b/165))
+        (makeblock 0 x/166 [0: 1 1]))
+      (let (x/168 =a *match*/170 p/169 =a (makeblock 0 a/164 b/165))
+        (makeblock 0 x/168 p/169)))))
+- : bool -> bool -> bool * (bool * bool) = <fun>
+|}]
+
+let _ = fun a b -> match a, b with
+| ((true as x, _) as p)
+| ((false as x, _) as p) -> x, p
+(* inside, onecase *)
+[%%expect{|
+(function a/172 b/173
+  (let
+    (*match*/179 = (makeblock 0 a/172 b/173)
+     x/174 =a (field 0 *match*/179)
+     p/175 =a *match*/179)
+    (makeblock 0 x/174 p/175)))
+- : bool -> 'a -> bool * (bool * 'a) = <fun>
+|}]
+
+type 'a tuplist = Nil | Cons of ('a * 'a tuplist)
+[%%expect{|
+0
+type 'a tuplist = Nil | Cons of ('a * 'a tuplist)
+|}]
+
+(* another example where we avoid an allocation in the first case *)
+let _ =fun a b -> match a, b with
+| (true, Cons p) -> p
+| (_, _) as p -> p
+(* outside, tuplist *)
+[%%expect {|
+(function a/187 b/188
+  (let (*match*/191 = a/187 *match*/192 = b/188)
+    (catch
+      (if *match*/191
+        (if *match*/192 (let (p/189 =a (field 0 *match*/192)) p/189)
+          (exit 17))
+        (exit 17))
+     with (17) (let (p/190 =a (makeblock 0 a/187 b/188)) p/190))))
+- : bool -> bool tuplist -> bool * bool tuplist = <fun>
+|}]
+
+(* if we cannot flatten, we generate worse code *)
+let _ = fun a b -> match a, b with
+| (true, Cons p)
+| ((_, _) as p) -> p
+(* inside, tuplist *)
+[%%expect{|
+(function a/193 b/194
+  (let (*match*/197 = (makeblock 0 a/193 b/194))
+    (catch
+      (let (*match*/199 =a (field 0 *match*/197))
+        (catch
+          (if *match*/199
+            (let (*match*/200 =a (field 1 *match*/197))
+              (if *match*/200
+                (let (p/198 =a (field 0 *match*/200)) (exit 19 p/198))
+                (exit 20)))
+            (exit 20))
+         with (20)
+          (let (*match*/201 =a (field 1 *match*/197)) (exit 19 *match*/197))))
+     with (19 p/195) p/195)))
+- : bool -> bool tuplist -> bool * bool tuplist = <fun>
+|}]


### PR DESCRIPTION
This PR implements a new approach to "flattening" pattern-matching compilation (`do_for_multiple_match`) for source programs of the form `match foo, bar, baz with ...`. (The pattern-matching compiler is trying to avoid allocating a tuple if possible, that is if the patterns do not use the name of the tuple. The point of this PR is to change the details of how this is implemented.)

The goal of getting rid of the `Cannot_flatten` exception is to simplify reasoning on the codebase. It looks like we actually produce better code, but this was not the intent -- the examples where we see a different are relatively artificial and may not exist in real codebases.

This PR is only a Work-in-Progress, because the "simplify the reasoning" part is only half-achieved. We do not have `Cannot_flatten` anymore, so the control flow is simpler, but the correctness reasoning for the `flatten_*` functions has become more subtle: whereas we knew before that they would never encounter (and throw away) as-patterns, they can now reach as-patterns, but only in usage modes (default environments, provenance) where (I believe that) variables do not matter anyway, so ignoring them is fine.

(cc @maranget, @trefis, @Octachron)