### PR TITLE
Build programs with the $(EXE) extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,8 +247,8 @@ _build
 /tools/ocamlmklib.opt
 /tools/ocamlmklibconfig.ml
 /tools/objinfo_helper
-/tools/read_cmt
-/tools/read_cmt.opt
+/tools/ocamlcmt
+/tools/ocamlcmt.opt
 /tools/cmpbyt
 /tools/cmpbyt.opt
 /tools/stripdebug

--- a/.gitignore
+++ b/.gitignore
@@ -222,7 +222,6 @@ _build
 
 /tools/ocamldep
 /tools/ocamldep.opt
-/tools/ocamldep.bak
 /tools/ocamlprof
 /tools/ocamlprof.opt
 /tools/opnames.ml
@@ -233,7 +232,6 @@ _build
 /tools/ocamlobjinfo.opt
 /tools/cvt_emit
 /tools/cvt_emit.opt
-/tools/cvt_emit.bak
 /tools/cvt_emit.ml
 /tools/ocamlcp
 /tools/ocamlcp.opt

--- a/Makefile
+++ b/Makefile
@@ -1055,7 +1055,7 @@ depend: beforedepend
 
 .PHONY: distclean
 distclean: clean
-	rm -f boot/ocamlrun boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
+	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader \
 	boot/*.cm* boot/libcamlrun.a boot/libcamlrun.lib boot/ocamlc.opt
 	rm -f Makefile.config Makefile.build_config
 	rm -f runtime/caml/m.h runtime/caml/s.h

--- a/Makefile
+++ b/Makefile
@@ -152,10 +152,13 @@ core:
 	$(MAKE) coreall
 
 # Check if fixpoint reached
+
+CMPBYT := $(CAMLRUN) tools/cmpbyt
+
 .PHONY: compare
 compare:
-	@if $(CAMLRUN) tools/cmpbyt boot/ocamlc ocamlc \
-         && $(CAMLRUN) tools/cmpbyt boot/ocamllex lex/ocamllex; \
+	@if $(CMPBYT) boot/ocamlc ocamlc \
+         && $(CMPBYT) boot/ocamllex lex/ocamllex; \
 	then echo "Fixpoint reached, bootstrap succeeded."; \
 	else \
 	  echo "Fixpoint not reached, try one more bootstrapping cycle."; \

--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ install:
 	  VERSION \
 	  "$(INSTALL_LIBDIR)"
 	$(MAKE) -C runtime install
-	$(INSTALL_PROG) ocaml$(EXE) "$(INSTALL_BINDIR)/ocaml$(EXE)"
+	$(INSTALL_PROG) ocaml$(EXE) "$(INSTALL_BINDIR)"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	$(INSTALL_PROG) ocamlc$(EXE) "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
 endif
@@ -362,7 +362,7 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	$(INSTALL_PROG) lex/ocamllex$(EXE) \
 	  "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
 endif
-	$(INSTALL_PROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
+	$(INSTALL_PROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)"
 	$(INSTALL_DATA) \
 	   utils/*.cmi \
 	   parsing/*.cmi \
@@ -391,7 +391,7 @@ endif
 	$(INSTALL_DATA) \
 	   $(BYTESTART) $(TOPLEVELSTART) \
 	   "$(INSTALL_COMPLIBDIR)"
-	$(INSTALL_PROG) $(expunge) "$(INSTALL_LIBDIR)/$(expunge)"
+	$(INSTALL_PROG) $(expunge) "$(INSTALL_LIBDIR)"
 	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmi \
 	   "$(INSTALL_LIBDIR)"
@@ -420,7 +420,7 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 	  $(MAKE) install-flexdll; \
 	fi
 endif
-	$(INSTALL_DATA) Makefile.config "$(INSTALL_LIBDIR)/Makefile.config"
+	$(INSTALL_DATA) Makefile.config "$(INSTALL_LIBDIR)"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt$(EXE); then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
@@ -511,11 +511,9 @@ endif
 
 .PHONY: installoptopt
 installoptopt:
-	$(INSTALL_PROG) ocamlc.opt$(EXE) "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
-	$(INSTALL_PROG) ocamlopt.opt$(EXE) \
-	  "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
-	$(INSTALL_PROG) \
-	  lex/ocamllex.opt$(EXE) "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
+	$(INSTALL_PROG) ocamlc.opt$(EXE) "$(INSTALL_BINDIR)"
+	$(INSTALL_PROG) ocamlopt.opt$(EXE) "$(INSTALL_BINDIR)"
+	$(INSTALL_PROG) lex/ocamllex.opt$(EXE) "$(INSTALL_BINDIR)"
 	cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.opt$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
@@ -538,8 +536,7 @@ installoptopt:
 	   $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
 	   "$(INSTALL_COMPLIBDIR)"
 	if test -f ocamlnat$(EXE) ; then \
-	  $(INSTALL_PROG) \
-	    ocamlnat$(EXE) "$(INSTALL_BINDIR)/ocamlnat$(EXE)"; \
+	  $(INSTALL_PROG) ocamlnat$(EXE) "$(INSTALL_BINDIR)"; \
 	  $(INSTALL_DATA) \
 	     toplevel/opttopdirs.cmi \
 	     "$(INSTALL_LIBDIR)"; \

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,7 @@ coreall: runtime
 
 # Build the core system: the minimum needed to make depend and bootstrap
 .PHONY: core
-core:
-	$(MAKE) coldstart
+core: coldstart
 	$(MAKE) coreall
 
 # Check if fixpoint reached

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 include stdlib/StdlibModules
 
 CAMLC=$(BOOT_OCAMLC) -g -nostdlib -I boot -use-prims runtime/primitives
-CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink
+CAMLOPT=$(CAMLRUN) ./ocamlopt$(EXE) -g -nostdlib -I stdlib -I otherlibs/dynlink
 ARCHES=amd64 i386 arm arm64 power s390x riscv
 INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
         -I lambda -I middle_end -I middle_end/closure \
@@ -77,7 +77,7 @@ LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
 COMPLIBDIR=$(LIBDIR)/compiler-libs
 
 TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
-RUNTOP=./runtime/ocamlrun ./ocaml \
+RUNTOP=./runtime/ocamlrun$(EXE) ./ocaml$(EXE) \
   -nostdlib -I stdlib \
   -noinit $(TOPFLAGS) $(TOPINCLUDES)
 NATRUNTOP=./ocamlnat$(EXE) \
@@ -96,10 +96,13 @@ FLEXDLL_SUBMODULE_PRESENT := $(wildcard flexdll/Makefile)
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
   BOOT_FLEXLINK_CMD =
 else
-  BOOT_FLEXLINK_CMD = FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
+  BOOT_FLEXLINK_CMD = \
+    FLEXLINK_CMD="../boot/ocamlrun$(EXE) ../flexdll/flexlink.exe"
 endif
 else
 endif
+
+expunge := expunge$(EXE)
 
 # targets for the compilerlibs/*.{cma,cmxa} archives
 include compilerlibs/Makefile.compilerlibs
@@ -129,6 +132,10 @@ partialclean::
 .PHONY: beforedepend
 beforedepend:: utils/config.ml utils/domainstate.ml utils/domainstate.mli
 
+programs := expunge ocaml ocamlc ocamlc.opt ocamlnat ocamlopt ocamlopt.opt
+
+$(foreach program, $(programs), $(eval $(call PROGRAM_SYNONYM,$(program))))
+
 # Start up the system from the distribution compiler
 .PHONY: coldstart
 coldstart:
@@ -152,12 +159,12 @@ core: coldstart
 
 # Check if fixpoint reached
 
-CMPBYT := $(CAMLRUN) tools/cmpbyt
+CMPBYT := $(CAMLRUN) tools/cmpbyt$(EXE)
 
 .PHONY: compare
 compare:
-	@if $(CMPBYT) boot/ocamlc ocamlc \
-         && $(CMPBYT) boot/ocamllex lex/ocamllex; \
+	@if $(CMPBYT) boot/ocamlc ocamlc$(EXE) \
+         && $(CMPBYT) boot/ocamllex lex/ocamllex$(EXE); \
 	then echo "Fixpoint reached, bootstrap succeeded."; \
 	else \
 	  echo "Fixpoint not reached, try one more bootstrapping cycle."; \
@@ -170,8 +177,8 @@ PROMOTE ?= cp
 
 .PHONY: promote-common
 promote-common:
-	$(PROMOTE) ocamlc boot/ocamlc
-	$(PROMOTE) lex/ocamllex boot/ocamllex
+	$(PROMOTE) ocamlc$(EXE) boot/ocamlc
+	$(PROMOTE) lex/ocamllex$(EXE) boot/ocamllex
 	cd stdlib; cp $(LIBFILES) ../boot
 
 # Promote the newly compiled system to the rank of cross compiler
@@ -231,7 +238,7 @@ coreboot:
 # Rebuild the library (using runtime/ocamlrun ./ocamlc)
 	$(MAKE) library-cross
 # Promote the new compiler and the new runtime
-	$(MAKE) CAMLRUN=runtime/ocamlrun promote
+	$(MAKE) CAMLRUN=runtime/ocamlrun$(EXE) promote
 # Rebuild the core system
 	$(MAKE) partialclean
 	$(MAKE) core
@@ -293,6 +300,7 @@ flexdll: flexdll/Makefile flexlink
              MSVC_DETECT=0 CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false support
 
 # Bootstrapping flexlink - leaves a bytecode image of flexlink.exe in flexdll/
+FLEXLINK_OCAMLOPT = ../boot/ocamlrun$(EXE) ../boot/ocamlc -nostdlib -I ../boot
 .PHONY: flexlink
 flexlink: flexdll/Makefile
 	$(MAKE) -C runtime BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
@@ -302,7 +310,7 @@ flexlink: flexdll/Makefile
 	cd stdlib && cp $(LIBFILES) ../boot/
 	$(MAKE) -C flexdll MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
 	  CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
-	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -nostdlib -I ../boot" \
+	  OCAMLOPT="$(FLEXLINK_OCAMLOPT)" \
 	  flexlink.exe
 	$(MAKE) -C runtime clean
 	$(MAKE) partialclean
@@ -311,9 +319,9 @@ flexlink: flexdll/Makefile
 flexlink.opt:
 	cd flexdll && \
 	mv flexlink.exe flexlink && \
-	($(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
-	           OCAML_CONFIG_FILE=../Makefile.config \
-	           OCAMLOPT="../ocamlopt.opt -nostdlib -I ../stdlib" \
+	($(MAKE) OCAML_FLEXLINK="../boot/ocamlrun$(EXE) ./flexlink" \
+	           MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
+	           OCAMLOPT="../ocamlopt.opt$(EXE) -nostdlib -I ../stdlib" \
 	           flexlink.exe || \
 	 (mv flexlink flexlink.exe && false)) && \
 	mv flexlink.exe flexlink.opt && \
@@ -345,13 +353,14 @@ install:
 	  VERSION \
 	  "$(INSTALL_LIBDIR)"
 	$(MAKE) -C runtime install
-	$(INSTALL_PROG) ocaml "$(INSTALL_BINDIR)/ocaml$(EXE)"
+	$(INSTALL_PROG) ocaml$(EXE) "$(INSTALL_BINDIR)/ocaml$(EXE)"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	$(INSTALL_PROG) ocamlc "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
+	$(INSTALL_PROG) ocamlc$(EXE) "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
 endif
 	$(MAKE) -C stdlib install
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	$(INSTALL_PROG) lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
+	$(INSTALL_PROG) lex/ocamllex$(EXE) \
+	  "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
 endif
 	$(INSTALL_PROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
 	$(INSTALL_DATA) \
@@ -382,7 +391,7 @@ endif
 	$(INSTALL_DATA) \
 	   $(BYTESTART) $(TOPLEVELSTART) \
 	   "$(INSTALL_COMPLIBDIR)"
-	$(INSTALL_PROG) expunge "$(INSTALL_LIBDIR)/expunge$(EXE)"
+	$(INSTALL_PROG) $(expunge) "$(INSTALL_LIBDIR)/$(expunge)"
 	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmi \
 	   "$(INSTALL_LIBDIR)"
@@ -413,13 +422,13 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 endif
 	$(INSTALL_DATA) Makefile.config "$(INSTALL_LIBDIR)/Makefile.config"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	if test -f ocamlopt; then $(MAKE) installopt; else \
+	if test -f ocamlopt$(EXE); then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	fi
 else
-	if test -f ocamlopt; then $(MAKE) installopt; fi
+	if test -f ocamlopt$(EXE); then $(MAKE) installopt; fi
 endif
 
 # Installation of the native-code compiler
@@ -427,7 +436,7 @@ endif
 installopt:
 	$(MAKE) -C runtime installopt
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	$(INSTALL_PROG) ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
+	$(INSTALL_PROG) ocamlopt$(EXE) "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
 endif
 	$(MAKE) -C stdlib installopt
 	$(INSTALL_DATA) \
@@ -485,27 +494,28 @@ endif
 	  $(MAKE) -C otherlibs/$$i installopt || exit $$?; \
 	done
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
-	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; else \
+	if test -f ocamlopt.opt$(EXE); then $(MAKE) installoptopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamlopt.byte$(EXE) ocamlopt$(EXE); \
 	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	fi
 else
-	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; fi
+	if test -f ocamlopt.opt$(EXE); then $(MAKE) installoptopt; fi
 endif
 	$(MAKE) -C tools installopt
-	if test -f ocamlopt.opt -a -f flexdll/flexlink.opt ; then \
+	if test -f ocamlopt.opt$(EXE) -a -f flexdll/flexlink.opt ; then \
 	  $(INSTALL_PROG) \
 	    flexdll/flexlink.opt "$(INSTALL_BINDIR)/flexlink$(EXE)" ; \
 	fi
 
 .PHONY: installoptopt
 installoptopt:
-	$(INSTALL_PROG) ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
-	$(INSTALL_PROG) ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
+	$(INSTALL_PROG) ocamlc.opt$(EXE) "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
+	$(INSTALL_PROG) ocamlopt.opt$(EXE) \
+	  "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
 	$(INSTALL_PROG) \
-	  lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
+	  lex/ocamllex.opt$(EXE) "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
 	cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.opt$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
@@ -575,23 +585,25 @@ manual-pregen: opt.opt
 
 # The clean target
 clean:: partialclean
+	rm -f $(programs) $(programs:=.exe)
 
 # The bytecode compiler
 
-ocamlc: compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma $(BYTESTART)
+ocamlc$(EXE): compilerlibs/ocamlcommon.cma \
+              compilerlibs/ocamlbytecomp.cma $(BYTESTART)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o $@ $^
 
 partialclean::
-	rm -rf ocamlc
+	rm -rf ocamlc$(EXE)
 
 # The native-code compiler
 
-ocamlopt: compilerlibs/ocamlcommon.cma compilerlibs/ocamloptcomp.cma \
+ocamlopt$(EXE): compilerlibs/ocamlcommon.cma compilerlibs/ocamloptcomp.cma \
           $(OPTSTART)
 	$(CAMLC) $(LINKFLAGS) -o $@ $^
 
 partialclean::
-	rm -f ocamlopt
+	rm -f ocamlopt$(EXE)
 
 # The toplevel
 
@@ -604,11 +616,11 @@ ocaml_dependencies := \
 ocaml.tmp: $(ocaml_dependencies)
 	$(CAMLC) $(LINKFLAGS) -linkall -o $@ $^
 
-ocaml: expunge ocaml.tmp
+ocaml$(EXE): $(expunge) ocaml.tmp
 	- $(CAMLRUN) $^ $@ $(PERVASIVES)
 
 partialclean::
-	rm -f ocaml
+	rm -f ocaml$(EXE)
 
 .PHONY: runtop
 runtop:
@@ -644,21 +656,23 @@ beforedepend:: parsing/lexer.ml
 
 # The bytecode compiler compiled with the native-code compiler
 
-ocamlc.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlbytecomp.cmxa \
-            $(BYTESTART:.cmo=.cmx)
+ocamlc.opt$(EXE): compilerlibs/ocamlcommon.cmxa \
+                  compilerlibs/ocamlbytecomp.cmxa $(BYTESTART:.cmo=.cmx)
 	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
 
 partialclean::
-	rm -f ocamlc.opt
+	rm -f ocamlc.opt$(EXE)
 
 # The native-code compiler compiled with itself
 
-ocamlopt.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
-              $(OPTSTART:.cmo=.cmx)
+ocamlopt.opt$(EXE): \
+                    compilerlibs/ocamlcommon.cmxa \
+                    compilerlibs/ocamloptcomp.cmxa \
+                    $(OPTSTART:.cmo=.cmx)
 	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^
 
 partialclean::
-	rm -f ocamlopt.opt
+	rm -f ocamlopt.opt$(EXE)
 
 # The predefined exceptions and primitives
 
@@ -696,9 +710,11 @@ asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
 
 # Preprocess the code emitters
 
-asmcomp/emit.ml: asmcomp/$(ARCH)/emit.mlp tools/cvt_emit
+cvt_emit := tools/cvt_emit$(EXE)
+
+asmcomp/emit.ml: asmcomp/$(ARCH)/emit.mlp $(cvt_emit)
 	echo \# 1 \"$(ARCH)/emit.mlp\" > $@
-	$(CAMLRUN) tools/cvt_emit < $< >> $@ \
+	$(CAMLRUN) $(cvt_emit) < $< >> $@ \
 	|| { rm -f $@; exit 2; }
 
 partialclean::
@@ -706,17 +722,17 @@ partialclean::
 
 beforedepend:: asmcomp/emit.ml
 
-tools/cvt_emit: tools/cvt_emit.mll
+$(cvt_emit): tools/cvt_emit.mll
 	$(MAKE) -C tools cvt_emit
 
 # The "expunge" utility
 
-expunge: compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
+$(expunge): compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
          toplevel/expunge.cmo
 	$(CAMLC) $(LINKFLAGS) -o $@ $^
 
 partialclean::
-	rm -f expunge
+	rm -f $(expunge)
 
 # The runtime system for the bytecode compiler
 
@@ -766,7 +782,8 @@ library: ocamlc
 
 .PHONY: library-cross
 library-cross:
-	$(MAKE) -C stdlib $(BOOT_FLEXLINK_CMD) CAMLRUN=../runtime/ocamlrun all
+	$(MAKE) -C stdlib \
+	  $(BOOT_FLEXLINK_CMD) CAMLRUN=../runtime/ocamlrun$(EXE) all
 
 .PHONY: libraryopt
 libraryopt:
@@ -983,14 +1000,6 @@ endif
 
 # The native toplevel
 
-# When the native toplevel executable has an extension (e.g. ".exe"),
-# provide a phony 'ocamlnat' synonym
-
-ifneq ($(EXE),)
-.PHONY: ocamlnat
-ocamlnat: ocamlnat$(EXE)
-endif
-
 ocamlnat$(EXE): compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
     compilerlibs/ocamlbytecomp.cmxa \
     otherlibs/dynlink/dynlink.cmxa \
@@ -1005,13 +1014,15 @@ toplevel/opttoploop.cmx: otherlibs/dynlink/dynlink.cmxa
 
 # The numeric opcodes
 
-bytecomp/opcodes.ml: runtime/caml/instruct.h tools/make_opcodes
-	runtime/ocamlrun tools/make_opcodes -opcodes < $< > $@
+make_opcodes := tools/make_opcodes$(EXE)
+
+bytecomp/opcodes.ml: runtime/caml/instruct.h $(make_opcodes)
+	runtime/ocamlrun$(EXE) $(make_opcodes) -opcodes < $< > $@
 
 bytecomp/opcodes.mli: bytecomp/opcodes.ml
 	$(CAMLC) -i $< > $@
 
-tools/make_opcodes: tools/make_opcodes.mll
+$(make_opcodes): tools/make_opcodes.mll
 	$(MAKE) -C tools make_opcodes
 
 partialclean::
@@ -1065,7 +1076,6 @@ distclean: clean
 	rm -f config.log config.status libtool
 	rm -f tools/eventlog_metadata
 	rm -f tools/*.bak
-	rm -f ocaml ocamlc
 	rm -f testsuite/_log*
 
 include .depend

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -34,10 +34,10 @@ or rebuilding it (or `touch`-ing it) if you want it used.), \
     ok)
 
 choose_best = $(strip $(if \
-   $(and $(wildcard $(ROOTDIR)/$1.opt),$(strip \
-      $(call check_not_stale,$1,$1.opt))), \
-    $(ROOTDIR)/$1.opt, \
-    $(CAMLRUN) $(ROOTDIR)/$1))
+   $(and $(wildcard $(ROOTDIR)/$1.opt$(EXE)),$(strip \
+      $(call check_not_stale,$1$(EXE),$1.opt$(EXE)))), \
+    $(ROOTDIR)/$1.opt$(EXE), \
+    $(CAMLRUN) $(ROOTDIR)/$1$(EXE)))
 
 BEST_OCAMLC := $(call choose_best,ocamlc)
 BEST_OCAMLOPT := $(call choose_best,ocamlopt)
@@ -50,7 +50,7 @@ BEST_OCAMLLEX := $(call choose_best,lex/ocamllex)
 # bootrap-compiler and host-compiler object files, as ocamldep only
 # produces text output.
 BEST_OCAMLDEP := $(strip $(if \
-   $(and $(wildcard $(ROOTDIR)/ocamlc.opt),$(strip \
-      $(call check_not_stale,boot/ocamlc,ocamlc.opt))), \
-    $(ROOTDIR)/ocamlc.opt -depend, \
+   $(and $(wildcard $(ROOTDIR)/ocamlc.opt$(EXE)),$(strip \
+      $(call check_not_stale,boot/ocamlc,ocamlc.opt$(EXE)))), \
+    $(ROOTDIR)/ocamlc.opt$(EXE) -depend, \
     $(BOOT_OCAMLC) -depend))

--- a/Makefile.common
+++ b/Makefile.common
@@ -40,7 +40,7 @@ FLEXDLL_SUBMODULE_PRESENT =
 endif
 
 # Use boot/ocamlc.opt if available
-CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
+CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
 ifeq (0,$(shell \
   test $(ROOTDIR)/boot/ocamlc.opt -nt $(ROOTDIR)/boot/ocamlc; \
   echo $$?))
@@ -117,3 +117,12 @@ endif
 
 $(DEPDIR):
 	$(MKDIR) $@
+
+# When executable files have an extension (e.g. ".exe"),
+# provide phony synonyms
+define PROGRAM_SYNONYM
+ifneq ($(EXE),)
+.PHONY: $(1)
+$(1): $(1)$(EXE)
+endif
+endef # PROGRAM_SYNONYM

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -77,7 +77,7 @@ else
   CUSTOM =
 endif
 
-OCAML=$(OCAMLRUN) $(OTOPDIR)/ocaml $(OCFLAGS) -noinit
+OCAML=$(OCAMLRUN) $(OTOPDIR)/ocaml$(EXE) $(OCFLAGS) -noinit
 ifeq "$(FLEXLINK)" ""
   FLEXLINK_PREFIX=
 else
@@ -85,24 +85,24 @@ else
     FLEXLINK_PREFIX=
   else
     EMPTY=
-    FLEXLINK_PREFIX=OCAML_FLEXLINK="$(WINTOPDIR)/boot/ocamlrun \
+    FLEXLINK_PREFIX=OCAML_FLEXLINK="$(WINTOPDIR)/boot/ocamlrun$(EXE) \
 	                            $(WINTOPDIR)/flexdll/flexlink.exe" $(EMPTY)
   endif
 endif
-OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc $(CUSTOM) $(OCFLAGS) \
-       $(RUNTIME_VARIANT)
-OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt $(OCFLAGS) \
+OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc$(EXE) \
+       $(CUSTOM) $(OCFLAGS) $(RUNTIME_VARIANT)
+OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt$(EXE) $(OCFLAGS) \
          $(RUNTIME_VARIANT)
-OCAMLDOC=$(OCAMLRUN) $(OTOPDIR)/ocamldoc/ocamldoc
-OCAMLLEX=$(OCAMLRUN) $(OTOPDIR)/lex/ocamllex
-OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
+OCAMLDOC=$(OCAMLRUN) $(OTOPDIR)/ocamldoc/ocamldoc$(EXE)
+OCAMLLEX=$(OCAMLRUN) $(OTOPDIR)/lex/ocamllex$(EXE)
+OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib$(EXE) \
            -ocamlc "$(OTOPDIR)/runtime/ocamlrun$(USE_RUNTIME)$(EXE) \
-                    $(OTOPDIR)/ocamlc $(OCFLAGS) $(RUNTIME_VARIANT)" \
+                    $(OTOPDIR)/ocamlc$(EXE) $(OCFLAGS) $(RUNTIME_VARIANT)" \
            -ocamlopt "$(OTOPDIR)/runtime/ocamlrun$(USE_RUNTIME)$(EXE) \
-                      $(OTOPDIR)/ocamlopt $(OCFLAGS) $(RUNTIME_VARIANT)"
+                      $(OTOPDIR)/ocamlopt$(EXE) $(OCFLAGS) $(RUNTIME_VARIANT)"
 OCAMLYACC=$(TOPDIR)/yacc/ocamlyacc$(EXE)
-DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tools/dumpobj
-OBJINFO=$(OCAMLRUN) $(OTOPDIR)/tools/ocamlobjinfo
+DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tools/dumpobj$(EXE)
+OBJINFO=$(OCAMLRUN) $(OTOPDIR)/tools/ocamlobjinfo$(EXE)
 
 #FORTRAN_COMPILER=
 #FORTRAN_LIBRARY=

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -60,7 +60,7 @@ ocamldebug$(EXE): $(libraries) $(all_objects)
 	$(CAMLC) $(LINKFLAGS) -o $@ -linkall $^
 
 install:
-	$(INSTALL_PROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"
+	$(INSTALL_PROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)"
 
 clean::
 	rm -f ocamldebug ocamldebug.exe

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -42,10 +42,10 @@ allopt: ocamllex.opt
 opt.opt: allopt
 
 ocamllex: $(OBJS)
-	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamllex $(OBJS)
+	$(CAMLC) $(LINKFLAGS) -compat-32 -o $@ $^
 
 ocamllex.opt: $(OBJS:.cmo=.cmx)
-	$(CAMLOPT_CMD) -o ocamllex.opt $(OBJS:.cmo=.cmx)
+	$(CAMLOPT_CMD) -o $@ $^
 
 clean::
 	rm -f ocamllex ocamllex.opt

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -19,11 +19,11 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.common
 
-CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
+CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 
 CAMLC = $(BOOT_OCAMLC) -strict-sequence -nostdlib \
         -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
-CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
+CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
             -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS =
@@ -36,19 +36,23 @@ DEPINCLUDES =
 OBJS=cset.cmo syntax.cmo parser.cmo lexer.cmo table.cmo lexgen.cmo \
      compact.cmo common.cmo output.cmo outputbis.cmo main.cmo
 
+programs := ocamllex ocamllex.opt
+
+$(foreach program, $(programs), $(eval $(call PROGRAM_SYNONYM,$(program))))
+
 .PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
 all: ocamllex
 allopt: ocamllex.opt
 opt.opt: allopt
 
-ocamllex: $(OBJS)
+ocamllex$(EXE): $(OBJS)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o $@ $^
 
-ocamllex.opt: $(OBJS:.cmo=.cmx)
+ocamllex.opt$(EXE): $(OBJS:.cmo=.cmx)
 	$(CAMLOPT_CMD) -o $@ $^
 
 clean::
-	rm -f ocamllex ocamllex.opt
+	rm -f $(programs) $(programs:=.exe)
 	rm -f *.cmo *.cmi *.cmx *.cmt *.cmti *.o *.obj
 
 parser.ml parser.mli: parser.mly

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -294,7 +294,7 @@ install:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
 	$(MKDIR) "$(INSTALL_MANODIR)"
-	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)"
+	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)"
 	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
 	  "$(INSTALL_LIBDIR)/ocamldoc"
@@ -321,8 +321,7 @@ installopt:
 installopt_really:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
-	$(INSTALL_PROG) \
-	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)"
+	$(INSTALL_PROG) $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)"
 	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBCMIS) \
 	  "$(INSTALL_LIBDIR)/ocamldoc"

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -18,8 +18,8 @@ ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
-OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
+OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
+OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
@@ -32,8 +32,10 @@ OCAMLLEX = $(BEST_OCAMLLEX)
 ##############
 
 CP=cp
-OCAMLDOC=ocamldoc
-OCAMLDOC_OPT=$(OCAMLDOC).opt
+OCAMLDOC=ocamldoc$(EXE)
+OCAMLDOC_OPT=ocamldoc.opt$(EXE)
+
+programs := ocamldoc ocamldoc.opt
 
 # TODO: clarify whether the following really needs to be that complicated
 ifeq "$(UNIX_OR_WIN32)" "unix"
@@ -202,8 +204,12 @@ OCAMLDOC_LIBRARIES = ocamlcommon unix str dynlink
 OCAMLDOC_BCLIBRARIES = $(OCAMLDOC_LIBRARIES:%=%.cma)
 OCAMLDOC_NCLIBRARIES = $(OCAMLDOC_LIBRARIES:%=%.cmxa)
 
+$(eval $(call PROGRAM_SYNONYM,ocamldoc))
+
 $(OCAMLDOC): $(EXECMOFILES)
 	$(OCAMLC) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_BCLIBRARIES) $^
+
+$(eval $(call PROGRAM_SYNONYM,ocamldoc.opt))
 
 $(OCAMLDOC_OPT): $(EXECMXFILES)
 	$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
@@ -288,7 +294,7 @@ install:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
 	$(MKDIR) "$(INSTALL_MANODIR)"
-	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
+	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)"
 	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
 	  "$(INSTALL_LIBDIR)/ocamldoc"
@@ -316,7 +322,7 @@ installopt_really:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
 	$(INSTALL_PROG) \
-	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
+	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)"
 	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBCMIS) \
 	  "$(INSTALL_LIBDIR)/ocamldoc"
@@ -487,7 +493,8 @@ odoc:
 .PHONY: clean
 clean:
 	rm -f \#*\#
-	rm -f $(OCAMLDOC) $(OCAMLDOC_OPT) *.cma *.cmxa *.cmo *.cmi *.cmx *.cmt *.cmti *.a *.lib *.o *.obj
+	rm -f $(programs) $(programs:=.exe)
+	rm -f *.cma *.cmxa *.cmo *.cmi *.cmx *.cmt *.cmti *.a *.lib *.o *.obj
 	rm -f odoc_parser.output odoc_text_parser.output
 	rm -f odoc_lexer.ml odoc_text_lexer.ml odoc_see_lexer.ml odoc_ocamlhtml.ml
 	rm -f odoc_parser.ml odoc_parser.mli odoc_text_parser.ml odoc_text_parser.mli

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -346,8 +346,10 @@ ocamltest_config.cmx : \
     ocamltest_config.cmi
 ocamltest_config.cmi :
 ocamltest_stdlib.cmo : \
+    ocamltest_config.cmi \
     ocamltest_stdlib.cmi
 ocamltest_stdlib.cmx : \
+    ocamltest_config.cmx \
     ocamltest_stdlib.cmi
 ocamltest_stdlib.cmi :
 options.cmo : \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -260,6 +260,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	    $(call SUBST,SO) \
 	    $(call SUBST_STRING,CSC) \
 	    $(call SUBST_STRING,CSCFLAGS) \
+	    $(call SUBST_STRING,EXE) \
 	    $(call SUBST_STRING,MKDLL) \
 	    $(call SUBST_STRING,mkexe) \
 	    $(call SUBST_STRING,BYTECCLIBS) \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -195,7 +195,7 @@ depincludes :=
 
 ocamllex := $(BEST_OCAMLLEX)
 
-ocamlyacc := $(ROOTDIR)/yacc/ocamlyacc
+ocamlyacc := $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 
 ocamlcdefaultflags :=
 
@@ -213,11 +213,15 @@ compdeps_paths=$(addprefix $(ROOTDIR)/compilerlibs/,$(compdeps_names))
 compdeps_byte=$(addsuffix .cma,$(compdeps_paths))
 compdeps_opt=$(addsuffix .cmxa,$(compdeps_paths))
 
+$(eval $(call PROGRAM_SYNONYM,ocamltest))
+
 ocamltest$(EXE): $(compdeps_byte) $(bytecode_modules)
 	$(ocamlc_cmd) -custom -o $@ $^
 
 %.cmo: %.ml $(compdeps_byte)
 	$(ocamlc) -c $<
+
+$(eval $(call PROGRAM_SYNONYM,ocamltest.opt))
 
 ocamltest.opt$(EXE): $(compdeps_opt) $(native_modules)
 	$(ocamlopt_cmd) -o $@ $^

--- a/ocamltest/ocaml_files.ml
+++ b/ocamltest/ocaml_files.ml
@@ -37,25 +37,26 @@ let ocamlrun =
   Filename.make_path [Ocaml_directories.srcdir; "runtime"; ocamlrunfile]
 
 let ocamlc =
-  Filename.make_path [Ocaml_directories.srcdir; "ocamlc"]
+  Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocamlc"]
 
 let ocaml =
-  Filename.make_path [Ocaml_directories.srcdir; "ocaml"]
+  Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocaml"]
 
 let ocamlc_dot_opt =
-  Filename.make_path [Ocaml_directories.srcdir; "ocamlc.opt"]
+  Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocamlc.opt"]
 
 let ocamlopt =
-  Filename.make_path [Ocaml_directories.srcdir; "ocamlopt"]
+  Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocamlopt"]
 
 let ocamlopt_dot_opt =
-  Filename.make_path [Ocaml_directories.srcdir; "ocamlopt.opt"]
+  Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocamlopt.opt"]
 
 let ocamlnat =
   Filename.make_path [Ocaml_directories.srcdir; Filename.mkexe "ocamlnat"]
 
 let cmpbyt =
-  Filename.make_path [Ocaml_directories.srcdir; "tools"; "cmpbyt"]
+  Filename.make_path
+    [Ocaml_directories.srcdir; "tools"; Filename.mkexe "cmpbyt"]
 
 let expect_test =
   Filename.make_path
@@ -63,27 +64,32 @@ let expect_test =
      Filename.mkexe "expect_test"]
 
 let ocamllex =
-  Filename.make_path [Ocaml_directories.srcdir; "lex"; "ocamllex"]
+  Filename.make_path
+    [Ocaml_directories.srcdir; "lex"; Filename.mkexe "ocamllex"]
 
 let ocamlyacc =
   Filename.make_path
     [Ocaml_directories.srcdir; "yacc"; Filename.mkexe "ocamlyacc"]
 
 let ocamldoc =
-  Filename.make_path [Ocaml_directories.srcdir; "ocamldoc"; "ocamldoc"]
+  Filename.make_path
+    [Ocaml_directories.srcdir; "ocamldoc"; Filename.mkexe "ocamldoc"]
 
 let ocamldebug =
   Filename.make_path
     [Ocaml_directories.srcdir; "debugger"; Filename.mkexe "ocamldebug"]
 
 let ocamlobjinfo =
-  Filename.make_path [Ocaml_directories.srcdir; "tools"; "ocamlobjinfo"]
+  Filename.make_path
+    [Ocaml_directories.srcdir; "tools"; Filename.mkexe "ocamlobjinfo"]
 
 let ocamlmklib =
-  Filename.make_path [Ocaml_directories.srcdir; "tools"; "ocamlmklib"]
+  Filename.make_path
+    [Ocaml_directories.srcdir; "tools"; Filename.mkexe "ocamlmklib"]
 
 let codegen =
-  Filename.make_path [Ocaml_directories.srcdir; "testsuite"; "tools"; "codegen"]
+  Filename.make_path
+    [Ocaml_directories.srcdir; "testsuite"; "tools"; Filename.mkexe "codegen"]
 
 let asmgen_archmod =
   let objname =

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -70,6 +70,8 @@ let csc = "%%CSC%%"
 
 let csc_flags = "%%CSCFLAGS%%"
 
+let exe = "%%EXE%%"
+
 let mkdll = "%%MKDLL%%"
 let mkexe = "%%mkexe%%"
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -100,6 +100,9 @@ val csc : string
 val csc_flags : string
 (** Flags for the CSharp compiler *)
 
+val exe : string
+(** Extension of executable files *)
+
 val mkdll : string
 val mkexe : string
 

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -42,10 +42,7 @@ module Filename = struct
 
   let make_path components = List.fold_left Filename.concat "" components
 
-  let mkexe =
-    if Sys.win32
-    then fun name -> make_filename name "exe"
-    else fun name -> name
+  let mkexe filename = filename ^ Ocamltest_config.exe
 end
 
 module List = struct

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -30,7 +30,7 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime $(EXTRACPPFLAGS)
 # Compilation options
 COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
           -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
-MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
+MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
 
 # Variables that must be defined by individual libraries:
 # LIBNAME

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -86,8 +86,7 @@ lib$(CLIBNAME).$(A): $(COBJS)
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
 	  $(INSTALL_PROG) \
-	    dll$(CLIBNAME)$(EXT_DLL) \
-	    "$(INSTALL_STUBLIBDIR)/"; \
+	    dll$(CLIBNAME)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
 ifneq "$(STUBSLIB)" ""
 	$(INSTALL_DATA) $(STUBSLIB) "$(INSTALL_LIBDIR)/"
@@ -113,7 +112,7 @@ installopt:
 	   "$(INSTALL_LIBDIR)/"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) $(LIBNAME).a
 	if test -f $(LIBNAME).cmxs; then \
-	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)/"; \
+	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)"; \
 	fi
 
 partialclean:

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -241,8 +241,7 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	  dynlink.cmti dynlink.mli \
 	  "$(INSTALL_LIBDIR)"
 endif
-	$(INSTALL_PROG) \
-	  $(extract_crc) "$(INSTALL_LIBDIR)/$(extract_crc)"
+	$(INSTALL_PROG) $(extract_crc) "$(INSTALL_LIBDIR)"
 
 installopt:
 	if $(NATDYNLINK); then \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -24,7 +24,7 @@ ROOTDIR = ../..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
+CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
 
 OCAMLC=$(BEST_OCAMLC) -g -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLOPT=$(BEST_OCAMLOPT) -g -nostdlib -I $(ROOTDIR)/stdlib
@@ -201,7 +201,9 @@ native/dynlink_compilerlibs.cmx: $(COMPILERLIBS_CMX)
 
 # The main dynlink rules start here.
 
-all: dynlink.cma extract_crc
+extract_crc := extract_crc$(EXE)
+
+all: dynlink.cma $(extract_crc)
 
 allopt: dynlink.cmxa
 
@@ -225,7 +227,9 @@ dynlink.cmxa: $(NATOBJS)
 dynlink_platform_intf.mli: dynlink_platform_intf.ml
 	cp $< $@
 
-extract_crc: dynlink.cma byte/dynlink_compilerlibs.cmo extract_crc.cmo
+$(eval $(call PROGRAM_SYNONYM,extract_crc))
+
+$(extract_crc): dynlink.cma byte/dynlink_compilerlibs.cmo extract_crc.cmo
 	$(OCAMLC) -o $@ $^
 
 install:
@@ -238,7 +242,7 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	  "$(INSTALL_LIBDIR)"
 endif
 	$(INSTALL_PROG) \
-	  extract_crc "$(INSTALL_LIBDIR)/extract_crc$(EXE)"
+	  $(extract_crc) "$(INSTALL_LIBDIR)/$(extract_crc)"
 
 installopt:
 	if $(NATDYNLINK); then \
@@ -249,13 +253,14 @@ installopt:
 	fi
 
 partialclean:
-	rm -f extract_crc *.cm[ioaxt] *.cmti *.cmxa \
+	rm -f $(extract_crc) *.cm[ioaxt] *.cmti *.cmxa \
 	      byte/*.cm[iot] byte/*.cmti \
 	      native/*.cm[ixt] native/*.cmti native/*.o native/*.obj \
 	      $(LOCAL_SRC)/*.cm[ioaxt] $(LOCAL_SRC)/*.cmti \
         $(LOCAL_SRC)/*.o $(LOCAL_SRC)/*.obj
 
 clean: partialclean
+	rm -f extract_crc extract_crc.exe
 	rm -f *.a *.lib *.o *.obj *.so *.dll dynlink_platform_intf.mli \
 	      $(LOCAL_SRC)/*.ml $(LOCAL_SRC)/*.mli $(LOCAL_SRC)/Makefile \
 	      $(LOCAL_SRC)/.depend byte/dynlink.mli native/dynlink.mli

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -32,7 +32,7 @@ LIBS = -nostdlib -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
 CAMLC=$(BEST_OCAMLC) $(LIBS)
 CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
 
-MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
+MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
 COMPFLAGS=-w +33..39 -warn-error A -g -bin-annot -safe-string
 
 LIBNAME=threads

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -109,8 +109,7 @@ INSTALL_THREADSLIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
 
 install:
 	if test -f dllthreads$(EXT_DLL); then \
-	  $(INSTALL_PROG) \
-	    dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)/dllthreads$(EXT_DLL)"; \
+	  $(INSTALL_PROG) dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
 	$(INSTALL_DATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreads.$(A)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -19,12 +19,12 @@ include $(ROOTDIR)/Makefile.common
 
 TARGET_BINDIR ?= $(BINDIR)
 
-COMPILER=$(ROOTDIR)/ocamlc
+COMPILER=$(ROOTDIR)/ocamlc$(EXE)
 CAMLC=$(CAMLRUN) $(COMPILER)
 COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
           -g -warn-error A -bin-annot -nostdlib \
           -safe-string -strict-formats
-OPTCOMPILER=$(ROOTDIR)/ocamlopt
+OPTCOMPILER=$(ROOTDIR)/ocamlopt$(EXE)
 CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(BOOT_OCAMLC) -depend
 DEPFLAGS=-slash

--- a/tools/.depend
+++ b/tools/.depend
@@ -135,8 +135,10 @@ ocamlmklib.cmx : \
 ocamlmklibconfig.cmo :
 ocamlmklibconfig.cmx :
 ocamlmktop.cmo : \
+    ../utils/config.cmi \
     ../utils/ccomp.cmi
 ocamlmktop.cmx : \
+    ../utils/config.cmx \
     ../utils/ccomp.cmx
 ocamloptp.cmo : \
     ../driver/main_args.cmi

--- a/tools/.depend
+++ b/tools/.depend
@@ -116,6 +116,30 @@ objinfo.cmx : \
     ../file_formats/cmo_format.cmi \
     ../file_formats/cmi_format.cmx \
     ../bytecomp/bytesections.cmx
+ocamlcmt.cmo : \
+    ../typing/untypeast.cmi \
+    ../typing/stypes.cmi \
+    ../parsing/pprintast.cmi \
+    ../parsing/location.cmi \
+    ../utils/load_path.cmi \
+    ../typing/envaux.cmi \
+    ../driver/compmisc.cmi \
+    ../file_formats/cmt_format.cmi \
+    ../typing/cmt2annot.cmo \
+    ../utils/clflags.cmi \
+    ../typing/annot.cmi
+ocamlcmt.cmx : \
+    ../typing/untypeast.cmx \
+    ../typing/stypes.cmx \
+    ../parsing/pprintast.cmx \
+    ../parsing/location.cmx \
+    ../utils/load_path.cmx \
+    ../typing/envaux.cmx \
+    ../driver/compmisc.cmx \
+    ../file_formats/cmt_format.cmx \
+    ../typing/cmt2annot.cmx \
+    ../utils/clflags.cmx \
+    ../typing/annot.cmi
 ocamlcp.cmo : \
     ../driver/main_args.cmi
 ocamlcp.cmx : \
@@ -169,30 +193,6 @@ profiling.cmo : \
 profiling.cmx : \
     profiling.cmi
 profiling.cmi :
-read_cmt.cmo : \
-    ../typing/untypeast.cmi \
-    ../typing/stypes.cmi \
-    ../parsing/pprintast.cmi \
-    ../parsing/location.cmi \
-    ../utils/load_path.cmi \
-    ../typing/envaux.cmi \
-    ../driver/compmisc.cmi \
-    ../file_formats/cmt_format.cmi \
-    ../typing/cmt2annot.cmo \
-    ../utils/clflags.cmi \
-    ../typing/annot.cmi
-read_cmt.cmx : \
-    ../typing/untypeast.cmx \
-    ../typing/stypes.cmx \
-    ../parsing/pprintast.cmx \
-    ../parsing/location.cmx \
-    ../utils/load_path.cmx \
-    ../typing/envaux.cmx \
-    ../driver/compmisc.cmx \
-    ../file_formats/cmt_format.cmx \
-    ../typing/cmt2annot.cmx \
-    ../utils/clflags.cmx \
-    ../typing/annot.cmi
 stripdebug.cmo : \
     ../utils/misc.cmi \
     ../bytecomp/bytesections.cmi

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -188,19 +188,18 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	do \
 	  $(INSTALL_PROG) "$$i$(EXE)" "$(INSTALL_BINDIR)/$$i.byte$(EXE)"; \
 	  if test -f "$$i".opt$(EXE); then \
-	    $(INSTALL_PROG) "$$i.opt$(EXE)" \
-	      "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
-	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	    $(INSTALL_PROG) "$$i.opt$(EXE)" "$(INSTALL_BINDIR)" && \
+	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  else \
-	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 else
 	for i in $(install_files); \
 	do \
 	  if test -f "$$i".opt$(EXE); then \
-	    $(INSTALL_PROG) "$$i.opt$(EXE)" "$(INSTALL_BINDIR)/$$i.opt$(EXE)"; \
-	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	    $(INSTALL_PROG) "$$i.opt$(EXE)" "$(INSTALL_BINDIR)"; \
+	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 endif
@@ -235,9 +234,8 @@ install::
 	  $(INSTALL_PROG)\
 	    ocamlcmt.opt$(EXE) "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	else \
-	  $(INSTALL_PROG) ocamlcmt$(EXE) "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	  $(INSTALL_PROG) ocamlcmt$(EXE) "$(INSTALL_BINDIR)"; \
 	fi
-
 
 # The bytecode disassembler
 
@@ -292,8 +290,7 @@ OBJINFO=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 $(call byte_and_opt,ocamlobjinfo,$(OBJINFO),objinfo_helper$(EXE))
 
 install::
-	$(INSTALL_PROG) \
-	  objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
+	$(INSTALL_PROG) objinfo_helper$(EXE) "$(INSTALL_LIBDIR)"
 
 primreq=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
         $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -98,12 +98,8 @@ $(call byte_and_opt,ocamldep,$(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ),)
 ocamldep: depend.cmi
 ocamldep.opt: depend.cmi
 
-# ocamldep is precious: sometimes we are stuck in the middle of a
-# bootstrap and we need to remake the dependencies
 clean::
-	if test -f ocamldep; then mv -f ocamldep ocamldep.bak; else :; fi
-	rm -f ocamldep.opt
-
+	rm -f ocamldep ocamldep.exe ocamldep.opt ocamldep.opt.exe
 
 # The profiler
 
@@ -211,14 +207,8 @@ CVT_EMIT=cvt_emit.cmo
 cvt_emit: $(CVT_EMIT)
 	$(CAMLC) $(LINKFLAGS) -o cvt_emit $(CVT_EMIT)
 
-# cvt_emit is precious: sometimes we are stuck in the middle of a
-# bootstrap and we need to remake the dependencies
-.PRECIOUS: cvt_emit
 clean::
-	if test -f cvt_emit; then mv -f cvt_emit cvt_emit.bak; else :; fi
-
-clean::
-	rm -f cvt_emit.ml
+	rm -f cvt_emit.ml cvt_emit cvt_emit.exe
 
 beforedepend:: cvt_emit.ml
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -46,10 +46,14 @@ define byte_and_opt_
 # This check is defensive programming
 $(and $(filter-out 1,$(words $1)),$(error \
    cannot build file with whitespace in name))
-$1: $3 $2
+$(call PROGRAM_SYNONYM, $1)
+
+$1$(EXE): $3 $2
 	$$(CAMLC) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ $2
 
-$1.opt: $3 $$(call byte2native,$2)
+$(call PROGRAM_SYNONYM, $1.opt)
+
+$1.opt$(EXE): $3 $$(call byte2native,$2)
 	$$(CAMLOPT_CMD) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ \
 	                $$(call byte2native,$2)
 
@@ -61,7 +65,7 @@ ifeq '$(filter $(installed_tools),$1)' '$1'
 install_files += $1
 endif
 clean::
-	rm -f -- $1 $1.opt
+	rm -f -- $1 $1.opt $1.exe $1.opt.exe
 
 endef
 
@@ -73,7 +77,7 @@ endef
 
 CAMLC = $(BOOT_OCAMLC) -g -nostdlib -I $(ROOTDIR)/boot \
         -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
-CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt -g -nostdlib -I $(ROOTDIR)/stdlib
+CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -g -nostdlib -I $(ROOTDIR)/stdlib
 CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp \
                        middle_end middle_end/closure middle_end/flambda \
@@ -93,10 +97,10 @@ CAMLDEP_OBJ=ocamldep.cmo
 CAMLDEP_IMPORTS= \
   $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
   $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma
-ocamldep: LINKFLAGS += -compat-32
+ocamldep$(EXE): LINKFLAGS += -compat-32
 $(call byte_and_opt,ocamldep,$(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ),)
-ocamldep: depend.cmi
-ocamldep.opt: depend.cmi
+ocamldep$(EXE): depend.cmi
+ocamldep.opt$(EXE): depend.cmi
 
 clean::
 	rm -f ocamldep ocamldep.exe ocamldep.opt ocamldep.opt.exe
@@ -182,9 +186,10 @@ install::
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	for i in $(install_files); \
 	do \
-	  $(INSTALL_PROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)"; \
-	  if test -f "$$i".opt; then \
-	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
+	  $(INSTALL_PROG) "$$i$(EXE)" "$(INSTALL_BINDIR)/$$i.byte$(EXE)"; \
+	  if test -f "$$i".opt$(EXE); then \
+	    $(INSTALL_PROG) "$$i.opt$(EXE)" \
+	      "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  else \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
@@ -193,8 +198,8 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 else
 	for i in $(install_files); \
 	do \
-	  if test -f "$$i".opt; then \
-	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)"; \
+	  if test -f "$$i".opt$(EXE); then \
+	    $(INSTALL_PROG) "$$i.opt$(EXE)" "$(INSTALL_BINDIR)/$$i.opt$(EXE)"; \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
@@ -202,10 +207,12 @@ endif
 
 # The preprocessor for asm generators
 
-CVT_EMIT=cvt_emit.cmo
+cvt_emit := cvt_emit$(EXE)
 
-cvt_emit: $(CVT_EMIT)
-	$(CAMLC) $(LINKFLAGS) -o cvt_emit $(CVT_EMIT)
+$(eval $(call PROGRAM_SYNONYM,cvt_emit))
+
+$(cvt_emit): cvt_emit.cmo
+	$(CAMLC) $(LINKFLAGS) -o $@ $^
 
 clean::
 	rm -f cvt_emit.ml cvt_emit cvt_emit.exe
@@ -214,20 +221,21 @@ beforedepend:: cvt_emit.ml
 
 # Reading cmt files
 
-READ_CMT= \
+ocamlcmt_objects= \
           $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
           $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
           \
-          read_cmt.cmo
+          ocamlcmt.cmo
 
 # Reading cmt files
-$(call byte_and_opt,read_cmt,$(READ_CMT),)
+$(call byte_and_opt,ocamlcmt,$(ocamlcmt_objects),)
 
 install::
-	if test -f read_cmt.opt; then \
-	  $(INSTALL_PROG) read_cmt.opt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	if test -f ocamlcmt.opt$(EXE); then \
+	  $(INSTALL_PROG)\
+	    ocamlcmt.opt$(EXE) "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	else \
-	  $(INSTALL_PROG) read_cmt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	  $(INSTALL_PROG) ocamlcmt$(EXE) "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	fi
 
 
@@ -241,14 +249,18 @@ DUMPOBJ= \
 
 $(call byte_and_opt,dumpobj,$(DUMPOBJ),)
 
-make_opcodes: make_opcodes.ml
-	$(CAMLC) make_opcodes.ml -o $@
+make_opcodes := make_opcodes$(EXE)
 
-opnames.ml: $(ROOTDIR)/runtime/caml/instruct.h make_opcodes
-	$(ROOTDIR)/runtime/ocamlrun make_opcodes -opnames < $< > $@
+$(eval $(call PROGRAM_SYNONYM,make_opcodes))
+
+$(make_opcodes): make_opcodes.ml
+	$(CAMLC) $< -o $@
+
+opnames.ml: $(ROOTDIR)/runtime/caml/instruct.h $(make_opcodes)
+	$(ROOTDIR)/runtime/ocamlrun$(EXE) $(make_opcodes) -opnames < $< > $@
 
 clean::
-	rm -f opnames.ml make_opcodes make_opcodes.ml
+	rm -f opnames.ml make_opcodes make_opcodes.exe make_opcodes.ml
 
 beforedepend:: opnames.ml
 
@@ -296,11 +308,12 @@ LINTAPIDIFF=$(ROOTDIR)/compilerlibs/ocamlcommon.cmxa \
 	$(ROOTDIR)/otherlibs/str/str.cmxa \
 	lintapidiff.cmx
 
-lintapidiff.opt: INCLUDES+= -I $(ROOTDIR)/otherlibs/str
-lintapidiff.opt: $(LINTAPIDIFF)
+lintapidiff.opt$(EXE): INCLUDES+= -I $(ROOTDIR)/otherlibs/str
+lintapidiff.opt$(EXE): $(LINTAPIDIFF)
 	$(CAMLOPT_CMD) $(LINKFLAGS) -I $(ROOTDIR) -o $@ $(LINTAPIDIFF)
 clean::
-	rm -f -- lintapidiff.opt lintapidiff.cm? lintapidiff.o lintapidiff.obj
+	rm -f -- lintapidiff.opt lintapidiff.opt.exe
+	rm -f lintapidiff.cm? lintapidiff.o lintapidiff.obj
 
 
 clean::
@@ -330,28 +343,31 @@ CMPBYT=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 
 $(call byte_and_opt,cmpbyt,$(CMPBYT),)
 
-CAMLTEX= $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
-	$(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
-	$(ROOTDIR)/compilerlibs/ocamltoplevel.cma \
-	$(ROOTDIR)/otherlibs/str/str.cma \
-	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.cma \
-	caml_tex.ml
+caml_tex_files := \
+  $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+  $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
+  $(ROOTDIR)/compilerlibs/ocamltoplevel.cma \
+  $(ROOTDIR)/otherlibs/str/str.cma \
+  $(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.cma \
+  caml_tex.ml
 
 #Scan latex files, and run ocaml code examples
 
-caml-tex: INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str $(UNIXLIB))
-caml-tex: $(CAMLTEX)
-	$(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlc -nostdlib \
+caml_tex := caml-tex$(EXE)
+
+$(caml_tex): INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str $(UNIXLIB))
+$(caml_tex): $(caml_tex_files)
+	$(ROOTDIR)/runtime/ocamlrun$(EXE) $(ROOTDIR)/ocamlc$(EXE) -nostdlib \
 	                            -I $(ROOTDIR)/stdlib $(LINKFLAGS) -linkall \
-	                            -o $@ -no-alias-deps $(CAMLTEX)
+	                            -o $@ -no-alias-deps $^
 
 # we need str and unix which depend on the bytecode version of other tools
 # thus we delay building caml-tex to the opt.opt stage
 ifneq "$(WITH_CAMLTEX)" ""
-opt.opt:caml-tex
+opt.opt: $(caml_tex)
 endif
 clean::
-	rm -f -- caml-tex caml_tex.cm?
+	rm -f -- caml-tex caml-tex.exe caml_tex.cm?
 
 # Common stuff
 

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -244,7 +244,8 @@ let dump_byte ic =
     toc
 
 let find_dyn_offset filename =
-  let helper = Filename.concat Config.standard_library "objinfo_helper" in
+  let helper_name = "objinfo_helper" ^ Config.ext_exe in
+  let helper = Filename.concat Config.standard_library helper_name in
   let tempfile = Filename.temp_file "objinfo" ".out" in
   match
     Fun.protect

--- a/tools/objinfo_helper.c
+++ b/tools/objinfo_helper.c
@@ -111,7 +111,7 @@ int main(int argc, char ** argv)
   long value;
 
   if (argc != 2)
-    error(NULL, "Usage: objinfo_helper <dynamic library>");
+    error(NULL, "Usage: %s <dynamic library>", argv[0]);
 
   fd = bfd_openr(argv[1], "default");
   if (!fd)

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -41,7 +41,7 @@ let arg_list = Arg.align [
   ]
 
 let arg_usage =
-  "read_cmt [OPTIONS] FILE.cmt : read FILE.cmt and print related information"
+  "ocamlcmt [OPTIONS] FILE.cmt : read FILE.cmt and print related information"
 
 let dummy_crc = String.make 32 '-'
 

--- a/tools/ocamlmktop.ml
+++ b/tools/ocamlmktop.ml
@@ -20,9 +20,8 @@ let _ =
      cmd.exe has special quoting rules (see 'cmd.exe /?' for details).
      Short version: if the string passed to cmd.exe starts with '"',
      the first and last '"' are removed *)
-  let ocamlc,extra_quote =
-    if Sys.win32 then "ocamlc.exe","\"" else "ocamlc",""
-  in
+  let ocamlc = "ocamlc" ^ Config.ext_exe in
+  let extra_quote = if Sys.win32 then "\"" else "" in
   let ocamlc = Filename.(quote (concat (dirname ocamlmktop) ocamlc)) in
   let cmdline =
     extra_quote ^ ocamlc ^ " -I +compiler-libs -linkall ocamlcommon.cma " ^

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -170,6 +170,11 @@ val ext_lib: string
 val ext_dll: string
 (** Extension for dynamically-loaded libraries, e.g. [.so] under Unix.*)
 
+val ext_exe: string
+(** Extension for executable programs, e.g. [.exe] under Windows.
+
+    @since 4.12.0 *)
+
 val default_executable_name: string
 (** Name of executable produced by linking if none is given with -o,
     e.g. [a.out] under Unix. *)


### PR DESCRIPTION
This PR aims at fixing issue #7312.

In addition to what has already been implemented, a few other things
could be included here.

- `bytecomp/bytelink.ml` defines a `fix_exec_name` function. Rather than
  looking at `Sys.os_type`, this function could just check whether the
  provided name ends with the defined extension, leave it
  unchanged in that case and add the extension otherwise.

- In `tools/ocamlmktop.ml`, the code that computes `ocamlc,extra_quote`
  could be modified so that the computation of ocamlc becomes something
  like `"ocamlc" ^ Config.ext_exe`.

- But, at the moment, `tools/ocamlmktop.ml` does not depend on the
  configuration module. So, wouldn't it be worth making `ext_exe` also
  available e.g. from the Sys module?

- Finally, in `utils/config.mlp`, the computation of
  `default_executable_name` could also be reworked so that just the
  basename depends on the OS type but the `ext_exe` extension then gets
  systematically added.

Shall I go ahead and add all these changes to this PR?

Also, there is the case of the `tools/read_cmt` tool which gets
currently installed as `ocamlcmt`. Shall I change the PR so that this
program, too, gets built using the name it will have when installed?

Most lileky this PR breaks the dune build, in case somebody wants to
work on it, e.g. @trefis
