### PR TITLE
Memprof: getting rid of caml_memprof_shutdown

### DIFF
--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -40,8 +40,6 @@ extern void caml_memprof_do_roots(scanning_action f);
 extern void caml_memprof_update_clean_phase(void);
 extern void caml_memprof_invert_tracked(void);
 
-extern void caml_memprof_shutdown(void);
-
 struct caml_memprof_th_ctx {
   int suspended, callback_running;
 };

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -926,22 +926,6 @@ static void caml_memprof_init(void) {
   xoshiro_init();
 }
 
-void caml_memprof_shutdown(void) {
-  init = 0;
-  started = 0;
-  lambda = 0.;
-  suspended = 0;
-  callback_running = 0;
-  trackst.len = 0;
-  trackst.callback = trackst.young = trackst.delete = 0;
-  caml_stat_free(trackst.entries);
-  trackst.entries = NULL;
-  trackst.alloc_len = 0;
-  caml_stat_free(callstack_buffer);
-  callstack_buffer = NULL;
-  callstack_buffer_len = 0;
-}
-
 CAMLprim value caml_memprof_start(value lv, value szv, value tracker_param)
 {
   CAMLparam3(lv, szv, tracker_param);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -191,7 +191,6 @@ CAMLexport void caml_shutdown(void)
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
   caml_finalise_heap();
-  caml_memprof_shutdown();
   caml_free_locale();
 #ifndef NATIVE_CODE
   caml_free_shared_libs();


### PR DESCRIPTION
This function is not needed since there is no requirement that the OCaml runtime be able to restart once shut down.

Indeed, in `startup_aux.c`, there is the following code, which witnesses the fact that the shutdown functions are not meant to allow the runtime to be restarted:
```C
  if (shutdown_happened == 1)
    caml_fatal_error("caml_startup was called after the runtime "
                     "was shut down with caml_shutdown");
```

The `caml_memprof_shutdown` function was initially introduced following a comment by @gasche stating the contrary (https://github.com/ocaml/ocaml/pull/8920#discussion_r358799535).