### PR TITLE
More efficient management of code fragments

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,11 @@ Working version
 - #9634: Allow initial and repeated commas in `OCAMLRUNPARAM`.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)
 
+- #9654: More efficient management of code fragments.
+  (Xavier Leroy, review by Jacques-Henri Jourdan, Damien Doligez, and
+  Stephen Dolan)
+
+
 ### Code generation and optimizations:
 
 - #9441: Add RISC-V RV64G native-code backend.

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -26,7 +26,7 @@ BYTECODE_C_SOURCES := $(addsuffix .c, \
   floats str array io extern intern hash sys meta parsing gc_ctrl md5 obj \
   lexing callback debugger weak compact finalise custom dynlink \
   spacetime_byt afl $(UNIX_OR_WIN32) bigarray main memprof domain \
-  skiplist)
+  skiplist codefrag)
 
 NATIVE_C_SOURCES := $(addsuffix .c, \
   startup_aux startup_nat main fail_nat roots_nat signals \
@@ -35,7 +35,7 @@ NATIVE_C_SOURCES := $(addsuffix .c, \
   lexing $(UNIX_OR_WIN32) printexc callback weak compact finalise custom \
   globroots backtrace_nat backtrace dynlink_nat debugger meta \
   dynlink clambda_checks spacetime_nat spacetime_snapshot afl bigarray \
-  memprof domain skiplist)
+  memprof domain skiplist codefrag)
 
 GENERATED_HEADERS := caml/opnames.h caml/version.h caml/jumptbl.h
 CONFIG_HEADERS := caml/m.h caml/s.h

--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -1,0 +1,80 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cambium, INRIA Paris                  */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* A table of all code fragments (main program and dynlinked modules) */
+
+#ifndef CAML_CODEFRAG_H
+#define CAML_CODEFRAG_H
+
+#ifdef CAML_INTERNALS
+
+enum digest_status {
+  DIGEST_LATER,    /* computed on demand */
+  DIGEST_NOW,      /* computed by caml_register_code_fragment */
+  DIGEST_PROVIDED, /* passed by caller of caml_register_code_fragment */
+  DIGEST_IGNORE    /* this code fragment is private and cannot be
+                      identified by its digest */
+};
+
+struct code_fragment {
+  char *code_start;
+  char *code_end;
+  int fragnum;
+  unsigned char digest[16];
+  enum digest_status digest_status;
+};
+
+/* Register a code fragment for addresses [start] (included)
+   to [end] (excluded).  This range of addresses is assumed
+   disjoint from all currently-registered code fragments.
+
+   [digest_kind] explains what digest is to be associated to the code
+   fragment.  If [digest_kind == DIGEST_PROVIDED], the [opt_digest]
+   parameter points to the 16-byte digest of the code.
+   For all other values of [digest_kind], [opt_digest] is ignored
+   and should be [NULL].
+
+   The returned integer is the fragment number (fragnum) associated
+   with the new code fragment. */
+extern int caml_register_code_fragment(char * start, char * end,
+                                       enum digest_status digest_kind,
+                                       unsigned char * opt_digest);
+
+/* Un-register a code fragment. */
+extern void caml_remove_code_fragment(struct code_fragment * cf);
+
+/* Find the code fragment whose range of addresses contains [pc].
+   Returns NULL if none exists. */
+extern struct code_fragment * caml_find_code_fragment_by_pc(char *pc);
+
+/* Find the code fragment whose fragment number is [fragnum].
+   Returns NULL if none exists. */
+extern struct code_fragment * caml_find_code_fragment_by_num(int fragnum);
+
+/* Find the code fragment whose digest is equal to the given digest.
+   Returns NULL if none exists. */
+extern struct code_fragment *
+   caml_find_code_fragment_by_digest(unsigned char digest[16]);
+
+/* Return the digest of the given code fragment.
+   If the code fragment was registered in [DIGEST_LATER] mode
+   and if the digest was not computed yet, it is obtained by hashing
+   the bytes between [code_start] and [code_end].
+   Returns NULL if the code fragment was registered with [DIGEST_IGNORE]. */
+extern unsigned char * caml_digest_of_code_fragment(struct code_fragment *);
+
+#endif
+
+#endif

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -430,18 +430,6 @@ extern int caml_snwprintf(wchar_t * buf,
 #  endif
 #endif
 
-/* A table of all code fragments (main program and dynlinked modules) */
-struct code_fragment {
-  char *code_start;
-  char *code_end;
-  unsigned char digest[16];
-  char digest_computed;
-};
-
-extern struct ext_table caml_code_fragments_table;
-
-int caml_find_code_fragment(char *pc, int *index, struct code_fragment **cf);
-
 #endif /* CAML_INTERNALS */
 
 /* The [backtrace_slot] type represents values stored in

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -57,7 +57,7 @@ int caml_register_code_fragment(char * start, char * end,
   caml_skiplist_insert(&code_fragments_by_pc,
                        (uintnat) start, (uintnat) cf);
   caml_skiplist_insert(&code_fragments_by_num,
-                       cf->fragnum, (uintnat) cf);
+                       (uintnat) cf->fragnum, (uintnat) cf);
   return cf->fragnum;
 }
 
@@ -76,7 +76,8 @@ struct code_fragment * caml_find_code_fragment_by_pc(char *pc)
   if (caml_skiplist_find_below(&code_fragments_by_pc,
                                (uintnat) pc, &key, &data)) {
     cf = (struct code_fragment *) data;
-    if (cf->code_start <= pc && pc < cf->code_end) return cf;
+    CAMLassert(cf->code_start <= pc);
+    if (pc < cf->code_end) return cf;
   }
   return NULL;
 }

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -1,0 +1,126 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cambium, INRIA Paris                  */
+/*                                                                        */
+/*   Copyright 2020 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+/* A table of all code fragments (main program and dynlinked modules) */
+
+#include <string.h>
+#include <stddef.h>
+#include "caml/codefrag.h"
+#include "caml/misc.h"
+#include "caml/md5.h"
+#include "caml/memory.h"
+#include "caml/skiplist.h"
+
+static struct skiplist caml_code_fragments_list = SKIPLIST_STATIC_INITIALIZER;
+
+static struct ext_table caml_code_fragments_table = {0, 0, NULL};
+
+int caml_register_code_fragment(char * start, char * end,
+                                enum digest_status digest_kind,
+                                unsigned char * opt_digest)
+{
+  int pos;
+  struct code_fragment * cf = caml_stat_alloc(sizeof(struct code_fragment));
+
+  cf->code_start = start;
+  cf->code_end = end;
+  switch (digest_kind) {
+  case DIGEST_LATER:
+    break;
+  case DIGEST_NOW:
+    caml_md5_block(cf->digest, cf->code_start, cf->code_end - cf->code_start);
+    digest_kind = DIGEST_PROVIDED;
+    break;
+  case DIGEST_PROVIDED:
+    memcpy(cf->digest, opt_digest, 16);
+    break;
+  case DIGEST_IGNORE:
+    break;
+  }
+  cf->digest_status = digest_kind;
+  caml_skiplist_insert(&caml_code_fragments_list,
+                       (uintnat) start, (uintnat) cf);
+  if (caml_code_fragments_table.capacity == 0) {
+    caml_ext_table_init(&caml_code_fragments_table, 8);
+  }
+  pos = caml_ext_table_add(&caml_code_fragments_table, cf);
+  cf->fragnum = pos;
+  return pos;
+}
+
+void caml_remove_code_fragment(struct code_fragment * cf)
+{
+  struct code_fragment * c;
+  int i;
+
+  caml_skiplist_remove(&caml_code_fragments_list, (uintnat) cf->code_start);
+  /* Remove cf from the table, maintaining the invariant that
+     if c is the i-th element of the table, c->fragnum is equal to i. */
+  for (i = cf->fragnum; i < caml_code_fragments_table.size - 1; i++) {
+    c = caml_code_fragments_table.contents[i + 1];
+    caml_code_fragments_table.contents[i] = c;
+    c->fragnum = i;
+  }
+  caml_code_fragments_table.size--;
+  caml_stat_free(cf);
+}
+
+struct code_fragment * caml_find_code_fragment_by_pc(char *pc)
+{
+  struct code_fragment * cf;
+  uintnat key, data;
+
+  if (caml_skiplist_find_below(&caml_code_fragments_list,
+                               (uintnat) pc, &key, &data)) {
+    cf = (struct code_fragment *) data;
+    if (cf->code_start <= pc && pc < cf->code_end) return cf;
+  }
+  return NULL;
+}
+
+struct code_fragment * caml_find_code_fragment_by_num(int fragnum)
+{
+  if (0 <= fragnum && fragnum < caml_code_fragments_table.size) {
+    return caml_code_fragments_table.contents[fragnum];
+  } else {
+    return NULL;
+  }
+}
+
+unsigned char * caml_digest_of_code_fragment(struct code_fragment * cf)
+{
+  if (cf->digest_status == DIGEST_IGNORE)
+    return NULL;
+  if (cf->digest_status == DIGEST_LATER) {
+    caml_md5_block(cf->digest, cf->code_start, cf->code_end - cf->code_start);
+    cf->digest_status = DIGEST_PROVIDED;
+  }
+  return cf->digest;
+}
+
+struct code_fragment *
+   caml_find_code_fragment_by_digest(unsigned char digest[16])
+{
+  int i;
+
+  for (i = caml_code_fragments_table.size - 1; i >= 0; i--) {
+    struct code_fragment * cf = caml_code_fragments_table.contents[i];
+    unsigned char * d = caml_digest_of_code_fragment(cf);
+    if (d != NULL && memcmp(digest, d, 16) == 0) return cf;
+  }
+  return NULL;
+}

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -64,18 +64,18 @@ int caml_register_code_fragment(char * start, char * end,
 
 void caml_remove_code_fragment(struct code_fragment * cf)
 {
-  struct code_fragment * c;
-  int i;
-
   caml_skiplist_remove(&caml_code_fragments_list, (uintnat) cf->code_start);
-  /* Remove cf from the table, maintaining the invariant that
-     if c is the i-th element of the table, c->fragnum is equal to i. */
-  for (i = cf->fragnum; i < caml_code_fragments_table.size - 1; i++) {
-    c = caml_code_fragments_table.contents[i + 1];
-    caml_code_fragments_table.contents[i] = c;
-    c->fragnum = i;
+  /* Currently, caml_remove_code_fragment is used only to remove
+     the fragment most recently inserted, so optimize for this case. */
+  if (cf->fragnum == caml_code_fragments_table.size - 1) {
+    caml_code_fragments_table.size--;
+  } else {
+    /* Just mark the table entry invalid.  Later, we could maintain
+       a free list of empty entries in caml_code_fragments_table
+       so as to reuse them on the next caml_register_code_fragment.
+       Or replace the table by a skiplist. */
+    caml_code_fragments_table.contents[cf->fragnum] = NULL;
   }
-  caml_code_fragments_table.size--;
   caml_stat_free(cf);
 }
 

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -20,6 +20,7 @@
 #include "caml/memory.h"
 #include "caml/stack.h"
 #include "caml/callback.h"
+#include "caml/codefrag.h"
 #include "caml/alloc.h"
 #include "caml/intext.h"
 #include "caml/osdeps.h"
@@ -100,7 +101,6 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
   CAMLlocal1 (result);
   void *sym,*sym2;
   void* handle = Handle_val(handle_v);
-  struct code_fragment * cf;
 
 #define optsym(n) getsym(handle,unit,n)
   const char *unit;
@@ -128,11 +128,8 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
   sym2 = optsym("__code_end");
   if (NULL != sym && NULL != sym2) {
     caml_page_table_add(In_code_area, sym, sym2);
-    cf = caml_stat_alloc(sizeof(struct code_fragment));
-    cf->code_start = (char *) sym;
-    cf->code_end = (char *) sym2;
-    cf->digest_computed = 0;
-    caml_ext_table_add(&caml_code_fragments_table, cf);
+    caml_register_code_fragment((char *) sym, (char *) sym2,
+                                DIGEST_LATER, NULL);
   }
 
   if( caml_natdynlink_hook != NULL ) caml_natdynlink_hook(handle,unit);

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -25,11 +25,11 @@
 #include <io.h>
 #endif
 
+#include "caml/codefrag.h"
 #include "caml/debugger.h"
 #include "caml/fix_code.h"
 #include "caml/instruct.h"
 #include "caml/intext.h"
-#include "caml/md5.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
@@ -37,20 +37,14 @@
 
 code_t caml_start_code;
 asize_t caml_code_size;
-struct ext_table caml_code_fragments_table;
 
 /* Read the main bytecode block from a file */
 
 void caml_init_code_fragments(void) {
-  struct code_fragment * cf;
-  /* Register the code in the table of code fragments */
-  cf = caml_stat_alloc(sizeof(struct code_fragment));
-  cf->code_start = (char *) caml_start_code;
-  cf->code_end = (char *) caml_start_code + caml_code_size;
-  caml_md5_block(cf->digest, caml_start_code, caml_code_size);
-  cf->digest_computed = 1;
-  caml_ext_table_init(&caml_code_fragments_table, 8);
-  caml_ext_table_add(&caml_code_fragments_table, cf);
+  /* Register the main bytecode block in the table of code fragments */
+  caml_register_code_fragment((char *) caml_start_code,
+                              (char *) caml_start_code + caml_code_size,
+                              DIGEST_NOW, NULL);
 }
 
 void caml_load_code(int fd, asize_t len)

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/backtrace_prim.h"
+#include "caml/codefrag.h"
 #include "caml/config.h"
 #include "caml/debugger.h"
 #include "caml/fail.h"
@@ -93,25 +94,26 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
 {
   CAMLparam3(ls_prog, debuginfo, digest_opt);
   CAMLlocal3(clos, bytecode, retval);
-  struct code_fragment * cf = caml_stat_alloc(sizeof(struct code_fragment));
   code_t prog;
   asize_t len;
+  enum digest_status digest_kind;
+  unsigned char * digest;
+  int fragnum;
 
   prog = (code_t)buffer_of_bytes_array(ls_prog, &len);
   caml_add_debug_info(prog, Val_long(len), debuginfo);
-  cf->code_start = (char *) prog;
-  cf->code_end = (char *) prog + len;
   /* match (digest_opt : string option) with */
   if (Is_block(digest_opt)) {
     /* | Some digest -> */
-    memcpy(cf->digest, String_val(Field(digest_opt, 0)), 16);
-    cf->digest_computed = 1;
+    digest_kind = DIGEST_PROVIDED;
+    digest = (unsigned char *) String_val(Field(digest_opt, 0));
   } else {
     /* | None -> */
-    cf->digest_computed = 0;
+    digest_kind = DIGEST_LATER;
+    digest = NULL;
   }
-  caml_ext_table_add(&caml_code_fragments_table, cf);
-
+  fragnum = caml_register_code_fragment((char *) prog, (char *) prog + len,
+                                        digest_kind, digest);
 #ifdef ARCH_BIG_ENDIAN
   caml_fixup_endianness((code_t) prog, len);
 #endif
@@ -121,7 +123,7 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
   caml_prepare_bytecode((code_t) prog, len);
 
   /* Notify debugger after fragment gets added and reified. */
-  caml_debugger(CODE_LOADED, Val_long(caml_code_fragments_table.size - 1));
+  caml_debugger(CODE_LOADED, Val_long(fragnum));
 
   clos = caml_alloc_small (1, Closure_tag);
   Code_val(clos) = (code_t) prog;
@@ -142,21 +144,19 @@ CAMLprim value caml_static_release_bytecode(value bc)
 {
   code_t prog;
   asize_t len;
-  int found, index;
   struct code_fragment *cf;
 
   prog = Bytecode_val(bc)->prog;
   len = Bytecode_val(bc)->len;
   caml_remove_debug_info(prog);
 
-  found = caml_find_code_fragment((char*) prog, &index, &cf);
-  /* Not matched with a caml_reify_bytecode call; impossible. */
-  CAMLassert(found); (void) found; /* Silence unused variable warning. */
+  cf = caml_find_code_fragment_by_pc((char *) prog);
+  CAMLassert(cf != NULL);
 
   /* Notify debugger before the fragment gets destroyed. */
-  caml_debugger(CODE_UNLOADED, Val_long(index));
+  caml_debugger(CODE_UNLOADED, Val_long(cf->fragnum));
 
-  caml_ext_table_remove(&caml_code_fragments_table, cf);
+  caml_remove_code_fragment(cf);
 
 #ifndef NATIVE_CODE
   caml_release_bytecode(prog, len);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -205,19 +205,3 @@ int caml_runtime_warnings_active(void)
   }
   return 1;
 }
-
-int caml_find_code_fragment(char *pc, int *index, struct code_fragment **cf)
-{
-  struct code_fragment *cfi;
-  int i;
-
-  for (i = 0; i < caml_code_fragments_table.size; i++) {
-    cfi = (struct code_fragment *) caml_code_fragments_table.contents[i];
-    if ((char*) pc >= cfi->code_start && (char*) pc < cfi->code_end) {
-      if (index != NULL) *index = i;
-      if (cf != NULL) *cf = cfi;
-      return 1;
-    }
-  }
-  return 0;
-}

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -22,6 +22,7 @@
 #include "caml/callback.h"
 #include "caml/backtrace.h"
 #include "caml/custom.h"
+#include "caml/codefrag.h"
 #include "caml/debugger.h"
 #include "caml/domain.h"
 #include "caml/eventlog.h"
@@ -47,7 +48,6 @@
 
 extern int caml_parser_trace;
 char * caml_code_area_start, * caml_code_area_end;
-struct ext_table caml_code_fragments_table;
 
 /* Initialize the atom table and the static data and code area limits. */
 
@@ -57,7 +57,6 @@ static void init_static(void)
 {
   extern struct segment caml_data_segments[], caml_code_segments[];
   int i;
-  struct code_fragment * cf;
 
   caml_init_atom_table ();
 
@@ -79,12 +78,9 @@ static void init_static(void)
       caml_code_area_end = caml_code_segments[i].end;
   }
   /* Register the code in the table of code fragments */
-  cf = caml_stat_alloc(sizeof(struct code_fragment));
-  cf->code_start = caml_code_area_start;
-  cf->code_end = caml_code_area_end;
-  cf->digest_computed = 0;
-  caml_ext_table_init(&caml_code_fragments_table, 8);
-  caml_ext_table_add(&caml_code_fragments_table, cf);
+  caml_register_code_fragment(caml_code_area_start,
+                              caml_code_area_end,
+                              DIGEST_LATER, NULL);
 }
 
 /* These are termination hooks used by the systhreads library */


### PR DESCRIPTION
The OCaml runtime system keeps track of "code fragments", that is, areas of memory containing byte- or native- compiled code.  Typically, there is one fragment for the main, statically-linked program, and one fragment for each dynamically-loaded module.

Cdoe fragments play a role in marshaling and unmarshaling of function closures, but also in the interface with the bytecode debugger.  Future uses are being considered for hashing (https://github.com/ocaml/ocaml/pull/9648#issuecomment-640590514) and for scanning the bytecode interpreter stack.

Currently, the management of code fragments is spread over several runtime modules, and uses inefficient data structures (extensible arrays) with search time linear in the number of code fragments.

This PR groups together all operations on code fragments in a new runtime module `codefrag.c` with a well-defined interface in `<caml/codefrag.h>`.  It uses the new `skiplist.c` module to implement "search code fragment by PC" in logarithmic time.

As usual, this PR is best reviewed commit by commit.