### PR TITLE
Remove temporary num-related hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,10 +398,6 @@ endif
 	for i in $(OTHERLIBRARIES); do \
 	  $(MAKE) -C otherlibs/$$i install || exit $$?; \
 	done
-# Transitional: findlib 1.7.3 is confused if leftover num.cm? files remain
-# from an previous installation of OCaml before otherlibs/num was removed.
-	rm -f "$(INSTALL_LIBDIR)"/num.cm?
-# End transitional
 ifneq "$(WITH_OCAMLDOC)" ""
 	$(MAKE) -C ocamldoc install
 endif

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -55,17 +55,8 @@ endif
 allopt: stdlib.cmxa std_exit.cmx
 opt.opt: allopt
 
-LEGACY_OBJS=$(patsubst stdlib__%,"$(INSTALL_LIBDIR)/%", \
-                                  $(filter stdlib__%,$(OBJS)))
 .PHONY: install
 install::
-# Transitional: when upgrading from 4.06 -> 4.07, module M is in stdlib__m.cm*,
-# while previously it was in m.cm*, which confuses the compiler.
-	rm -f $(LEGACY_OBJS)
-# Remove "old" pervasives.* and bigarray.* to avoid getting confused with the
-# Stdlib versions.
-	rm -f "$(INSTALL_LIBDIR)/pervasives.*" "$(INSTALL_LIBDIR)/bigarray.*"
-# End transitional
 	$(INSTALL_DATA) \
 	  stdlib.cma std_exit.cmo *.cmi camlheader_ur \
 	  "$(INSTALL_LIBDIR)"


### PR DESCRIPTION
This is a follow-up to commit 3de0115bfec

In that commit, @xavierleroy suggested that the hack he introduced
to make the transition towards the independent Num package easier
could be removed e.g. in 4.07.

How about doing that, five releases later?