### PR TITLE
Refactor skiplist to avoid UB casts

### DIFF
--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -30,8 +30,6 @@
 /* The head of a skip list */
 
 struct skiplist {
-  uintnat reserved1, reserved2; /* dummy values for layout compatibility
-                                   with struct skipcell below */
   struct skipcell * forward[NUM_LEVELS]; /* forward chaining */
   int level;                    /* max level used */
 };
@@ -49,7 +47,7 @@ struct skipcell {
 };
 
 /* Initialize a skip list, statically */
-#define SKIPLIST_STATIC_INITIALIZER { 0, 0, {0, }, 0 }
+#define SKIPLIST_STATIC_INITIALIZER { {0, }, 0 }
 
 /* Initialize a skip list, dynamically */
 extern void caml_skiplist_init(struct skiplist * sk);

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -71,43 +71,42 @@ void caml_skiplist_init(struct skiplist * sk)
 int caml_skiplist_find(struct skiplist * sk, uintnat key, uintnat * data)
 {
   int i;
-  struct skipcell * e, * f;
+  struct skipcell ** e, * f;
 
-  e = (struct skipcell *) sk;
+  e = sk->forward;
   for (i = sk->level; i >= 0; i--) {
     while (1) {
-      f = e->forward[i];
-      if (f == NULL || f->key >= key) break;
-      e = f;
+      f = e[i];
+      if (f == NULL || f->key > key) break;
+      if (f->key == key) {
+        *data = f->data;
+        return 1;
+      }
+      e = f->forward;
     }
   }
-  e = e->forward[0];
-  if (e != NULL && e->key == key) {
-    *data = e->data;
-    return 1;
-  } else {
-    return 0;
-  }
+  return 0;
 }
 
 int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
                              uintnat * key, uintnat * data)
 {
   int i;
-  struct skipcell * e, * f;
+  struct skipcell ** e, * f, * last = NULL;
 
-  e = (struct skipcell *) sk;
+  e = sk->forward;
   for (i = sk->level; i >= 0; i--) {
     while (1) {
-      f = e->forward[i];
+      f = e[i];
       if (f == NULL || f->key > k) break;
-      e = f;
+      last = f;
+      e = f->forward;
     }
   }
-  if (e == (struct skipcell *) sk) {
+  if (!last) {
     return 0;
   } else {
-    *key = e-> key; *data = e->data; return 1;
+    *key = last-> key; *data = last->data; return 1;
   }
 }
 
@@ -116,41 +115,41 @@ int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
 int caml_skiplist_insert(struct skiplist * sk,
                          uintnat key, uintnat data)
 {
-  struct skipcell * update[NUM_LEVELS];
-  struct skipcell * e, * f;
+  struct skipcell ** update[NUM_LEVELS];
+  struct skipcell ** e, * f;
   int i, new_level;
 
   /* Init "cursor" to list head */
-  e = (struct skipcell *) sk;
+  e = sk->forward;
   /* Find place to insert new node */
   for (i = sk->level; i >= 0; i--) {
     while (1) {
-      f = e->forward[i];
+      f = e[i];
       if (f == NULL || f->key >= key) break;
-      e = f;
+      e = f->forward;
     }
-    update[i] = e;
+    update[i] = &e[i];
   }
-  e = e->forward[0];
+  f = e[0];
   /* If already present, update data */
-  if (e != NULL && e->key == key) {
-    e->data = data;
+  if (f != NULL && f->key == key) {
+    f->data = data;
     return 1;
   }
   /* Insert additional element, updating list level if necessary */
   new_level = random_level();
   if (new_level > sk->level) {
     for (i = sk->level + 1; i <= new_level; i++)
-      update[i] = (struct skipcell *) sk;
+      update[i] = &sk->forward[i];
     sk->level = new_level;
   }
-  e = caml_stat_alloc(SIZEOF_SKIPCELL +
+  f = caml_stat_alloc(SIZEOF_SKIPCELL +
                       (new_level + 1) * sizeof(struct skipcell *));
-  e->key = key;
-  e->data = data;
+  f->key = key;
+  f->data = data;
   for (i = 0; i <= new_level; i++) {
-    e->forward[i] = update[i]->forward[i];
-    update[i]->forward[i] = e;
+    f->forward[i] = *update[i];
+    *update[i] = f;
   }
   return 0;
 }
@@ -159,31 +158,31 @@ int caml_skiplist_insert(struct skiplist * sk,
 
 int caml_skiplist_remove(struct skiplist * sk, uintnat key)
 {
-  struct skipcell * update[NUM_LEVELS];
-  struct skipcell * e, * f;
+  struct skipcell ** update[NUM_LEVELS];
+  struct skipcell ** e, * f;
   int i;
 
   /* Init "cursor" to list head */
-  e = (struct skipcell *) sk;
+  e = sk->forward;
   /* Find element in list */
   for (i = sk->level; i >= 0; i--) {
     while (1) {
-      f = e->forward[i];
+      f = e[i];
       if (f == NULL || f->key >= key) break;
-      e = f;
+      e = f->forward;
     }
-    update[i] = e;
+    update[i] = &e[i];
   }
-  e = e->forward[0];
+  f = e[0];
   /* If not found, nothing to do */
-  if (e == NULL || e->key != key) return 0;
+  if (f == NULL || f->key != key) return 0;
   /* Rebuild list without node */
   for (i = 0; i <= sk->level; i++) {
-    if (update[i]->forward[i] == e)
-      update[i]->forward[i] = e->forward[i];
+    if (*update[i] == f)
+      *update[i] = f->forward[i];
   }
   /* Reclaim list element */
-  caml_stat_free(e);
+  caml_stat_free(f);
   /* Down-correct list level */
   while (sk->level > 0 &&
          sk->forward[sk->level] == NULL)


### PR DESCRIPTION
This patch removes casts between `struct skiplist *` and `struct skipcell *`, and removes the "layout compatibility" fields in `skiplist` that were there to enable these casts.

Such casts are UB in C99, due to strict aliasing. We compile with `-fno-strict-aliasing` on GCC and Clang, so this is probably fine there, but it's [still scary](https://blog.regehr.org/archives/1307).

I've tried to make the change as minimal as possible. The only algorithmic difference is that `caml_skiplist_find` is now "stop-at" (see [discussion here](https://github.com/ocaml/ocaml/pull/9635#discussion_r436061208)), as this was slightly easier to write in the no-cast style. The new implementation never touches more cells than the old, usually touches 0-1 fewer cells, and on a really good day touches log n fewer cells.