### PR TITLE
Fix dune build after using Atomic in Stdlib

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -32,8 +32,10 @@ stdlib__arrayLabels.cmx : \
 stdlib__arrayLabels.cmi : \
     stdlib__seq.cmi
 stdlib__atomic.cmo : \
+    camlinternalAtomic.cmi \
     stdlib__atomic.cmi
 stdlib__atomic.cmx : \
+    camlinternalAtomic.cmx \
     stdlib__atomic.cmi
 stdlib__atomic.cmi :
 stdlib__bigarray.cmo : \
@@ -103,6 +105,11 @@ stdlib__callback.cmx : \
     stdlib__obj.cmx \
     stdlib__callback.cmi
 stdlib__callback.cmi :
+camlinternalAtomic.cmo : \
+    camlinternalAtomic.cmi
+camlinternalAtomic.cmx : \
+    camlinternalAtomic.cmi
+camlinternalAtomic.cmi :
 camlinternalFormat.cmo : \
     stdlib__sys.cmi \
     stdlib__string.cmi \
@@ -687,9 +694,11 @@ stdlib__weak.cmi : \
     stdlib__hashtbl.cmi
 stdlib.cmo : \
     camlinternalFormatBasics.cmi \
+    camlinternalAtomic.cmi \
     stdlib.cmi
 stdlib.cmx : \
     camlinternalFormatBasics.cmx \
+    camlinternalAtomic.cmx \
     stdlib.cmi
 stdlib.cmi : \
     camlinternalFormatBasics.cmi

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -20,7 +20,7 @@ case $1 in
            ' -pp "$AWK -f ./expand_module_aliases.awk"';;
   # stdlib dependencies
   camlinternalFormatBasics*.cm[iox]) echo ' -nopervasives';;
-  stdlib__atomic*.cm[iox]) echo ' -nopervasives';;
+  camlinternalAtomic.cm[iox]) echo ' -nopervasives';;
   # end stdlib dependencies
   camlinternalOO.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
   camlinternalLazy.cmx) echo ' -afl-inst-ratio 0';;

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -34,7 +34,7 @@ OC_CPPFLAGS += -I$(ROOTDIR)/runtime
 include StdlibModules
 
 OBJS=$(addsuffix .cmo,$(STDLIB_MODULES))
-NOSTDLIB= camlinternalFormatBasics.cmo stdlib__atomic.cmo stdlib.cmo
+NOSTDLIB= camlinternalFormatBasics.cmo camlinternalAtomic.cmo stdlib.cmo
 OTHERS=$(filter-out $(NOSTDLIB),$(OBJS))
 
 PREFIXED_OBJS=$(filter stdlib__%.cmo,$(OBJS))

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -30,11 +30,12 @@ endef
 
 # Modules should be listed in dependency order.
 STDLIB_MODS=\
-  camlinternalFormatBasics atomic \
+  camlinternalFormatBasics camlinternalAtomic \
   stdlib pervasives seq option result bool char uchar \
   sys list bytes string unit marshal obj array float int int32 int64 nativeint \
   lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
-  camlinternalFormat printf arg printexc fun gc digest random hashtbl weak \
+  camlinternalFormat printf arg atomic \
+  printexc fun gc digest random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \
   filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
   stdLabels spacetime bigarray

--- a/stdlib/camlinternalAtomic.mli
+++ b/stdlib/camlinternalAtomic.mli
@@ -2,6 +2,7 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
+(*                 Stephen Dolan, University of Cambridge                 *)
 (*          Guillaume Munch-Maccagnoni, projet Gallinette, INRIA          *)
 (*                                                                        *)
 (*   Copyright 2020 Institut National de Recherche en Informatique et     *)
@@ -13,4 +14,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-include CamlinternalAtomic
+(* The documentation is in atomic.mli. CamlinternalAtomic exists in
+   order to be a dependency of Stdlib. More precisely, the option
+   modules_before_stdlib used in stdlib/dune does not support the
+   Stdlib__ prefix trick. *)
+
+type 'a t
+val make : 'a -> 'a t
+val get : 'a t -> 'a
+val set : 'a t -> 'a -> unit
+val exchange : 'a t -> 'a -> 'a
+val compare_and_set : 'a t -> 'a -> 'a -> bool
+val fetch_and_add : int t -> int -> int
+val incr : int t -> unit
+val decr : int t -> unit

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -19,7 +19,7 @@
    (internal_modules Camlinternal*)
    (modules_before_stdlib
      camlinternalFormatBasics
-     stdlib__atomic))
+     camlinternalAtomic))
  (flags (:standard -w -9 -nolabels))
  (preprocess
    (per_module

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -543,10 +543,10 @@ let ( ^^ ) (Format (fmt1, str1)) (Format (fmt2, str2)) =
 
 external sys_exit : int -> 'a = "caml_sys_exit"
 
-let exit_function = Stdlib__atomic.make flush_all
+let exit_function = CamlinternalAtomic.make flush_all
 
 let rec at_exit f =
-  let module Atomic = Stdlib__atomic in
+  let module Atomic = CamlinternalAtomic in
   (* MPR#7253, MPR#7796: make sure "f" is executed only once *)
   let f_yet_to_run = Atomic.make true in
   let old_exit = Atomic.get exit_function in
@@ -557,7 +557,7 @@ let rec at_exit f =
   let success = Atomic.compare_and_set exit_function old_exit new_exit in
   if not success then at_exit f
 
-let do_at_exit () = (Stdlib__atomic.get exit_function) ()
+let do_at_exit () = (CamlinternalAtomic.get exit_function) ()
 
 let exit retcode =
   do_at_exit ();


### PR DESCRIPTION
From the commit log:

Introduce CamlinternalAtomic since Stdlib cannot refer to Stdlib__-prefixed modules without breaking the dune build.

No change entry required.

---

This was reported at #9571. Two files are introduced to work around the limitation of the dune option `modules_before_stdlib` which does not seem to handle the `stdlib__` prefix. This is a heavy solution, and a better option might be to fix this at the level of dune, if not too complicated.