### PR TITLE
Extend Printexc API for raw backtrace entries

### DIFF
--- a/Changes
+++ b/Changes
@@ -116,7 +116,7 @@ Working version
   Alain Frisch)
 
 - #9663: Extend Printexc API for raw backtrace entries.
-  (Stephen Dolan, review by Nicolás Ojeda Bär)
+  (Stephen Dolan, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
 ### Other libraries:
 

--- a/Changes
+++ b/Changes
@@ -115,6 +115,9 @@ Working version
   (Bernhard Schommer, review by Daniel Bünzli, Gabriel Scherer and
   Alain Frisch)
 
+- #9663: Extend Printexc API for raw backtrace entries.
+  (Stephen Dolan, review by Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 * #9206, #9419: update documentation of the threads library;

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -294,7 +294,7 @@ let uncaught_exception_handler = ref default_uncaught_exception_handler
 
 let set_uncaught_exception_handler fn = uncaught_exception_handler := fn
 
-let empty_backtrace : raw_backtrace = Obj.obj (Obj.new_block Obj.abstract_tag 0)
+let empty_backtrace : raw_backtrace = [| |]
 
 let try_get_raw_backtrace () =
   try

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -95,6 +95,8 @@ type raw_backtrace_slot
 type raw_backtrace_entry = private int
 type raw_backtrace = raw_backtrace_entry array
 
+let raw_backtrace_entries bt = bt
+
 external get_raw_backtrace:
   unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -92,7 +92,8 @@ let catch fct arg =
     exit 2
 
 type raw_backtrace_slot
-type raw_backtrace
+type raw_backtrace_entry = private int
+type raw_backtrace = raw_backtrace_entry array
 
 external get_raw_backtrace:
   unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
@@ -234,6 +235,9 @@ let backtrace_slots raw_backtrace =
       then Some backtrace
       else None
 
+let backtrace_slots_of_raw_entry entry =
+  backtrace_slots [| entry |]
+
 module Slot = struct
   type t = backtrace_slot
   let format = format_backtrace_slot
@@ -243,8 +247,7 @@ module Slot = struct
   let name = backtrace_slot_defname
 end
 
-external raw_backtrace_length :
-  raw_backtrace -> int = "caml_raw_backtrace_length" [@@noalloc]
+let raw_backtrace_length bt = Array.length bt
 
 external get_raw_backtrace_slot :
   raw_backtrace -> int -> raw_backtrace_slot = "caml_raw_backtrace_slot"

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -123,7 +123,7 @@ type raw_backtrace = private raw_backtrace_entry array
     A [raw_backtrace_entry] can be converted to a usable form using
     [backtrace_slots_of_raw_entry] below. Note that, due to inlining, a
     single [raw_backtrace_entry] may convert to several [backtrace_slot]s.
-    Since the values of a [raw_bcaktrace_entry] are not stable, they cannot
+    Since the values of a [raw_backtrace_entry] are not stable, they cannot
     be marshalled. If they are to be converted, the conversion must be done
     by the process that generated them.
 

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -109,20 +109,35 @@ val use_printers: exn -> string option
 
 (** {1 Raw backtraces} *)
 
-type raw_backtrace
-(** The abstract type [raw_backtrace] stores a backtrace in
-    a low-level format, instead of directly exposing them as string as
-    the [get_backtrace()] function does.
+type raw_backtrace_entry = private int
+(** @since 4.12.0 *)
 
-    This allows delaying the formatting of backtraces to when they are
-    actually printed, which may be useful if you record more
-    backtraces than you print.
+type raw_backtrace = private raw_backtrace_entry array
+(** The type [raw_backtrace] stores a backtrace in a low-level format,
+    as an array of [raw_backtrace_entry] values.
 
-    Raw backtraces cannot be marshalled. If you need marshalling, you
-    should use the array returned by the [backtrace_slots] function of
-    the next section.
+    Each [raw_backtrace_entry] is an opaque integer, whose value is not stable
+    between different programs, or even between different runs of the same
+    binary.
+
+    A [raw_backtrace_entry] can be converted to a usable form using
+    [backtrace_slots_of_raw_entry] below. Note that, due to inlining, a
+    single [raw_backtrace_entry] may convert to several [backtrace_slot]s.
+    Since the values of a [raw_bcaktrace_entry] are not stable, they cannot
+    be marshalled. If they are to be converted, the conversion must be done
+    by the process that generated them.
+
+    Again due to inlining, there may be multiple distinct raw_backtrace_entry
+    values that convert to equal [backtrace_slot]s. However, if two
+    [raw_backtrace_entry]s are equal as integers, then they represent the same
+    [backtrace_slot]s.
+
+    Converting backtraces to [backtrace_slot]s is slower than capturing the
+    backtraces. If an application processes many backtraces, it can be useful
+    to use [raw_backtrace] to avoid or delay conversion.
 
     @since 4.01.0
+    @since 4.12.0 (definition as raw_backtrace_entry array)
 *)
 
 val get_raw_backtrace: unit -> raw_backtrace
@@ -224,6 +239,16 @@ val backtrace_slots : raw_backtrace -> backtrace_slot array option
     @since 4.02.0
 *)
 
+val backtrace_slots_of_raw_entry :
+  raw_backtrace_entry -> backtrace_slot array option
+(** Returns the slots of a single raw backtrace entry, or [None] if this
+    entry lacks debug information.
+
+    Slots are returned in the same order as [backtrace_slots]: the slot
+    at index [0] is the most recent call, raise, or primitive, and
+    subsequent slots represent callers. *)
+
+
 type location = {
   filename : string;
   line_number : int;
@@ -296,17 +321,17 @@ end
 (** {1 Raw backtrace slots} *)
 
 type raw_backtrace_slot
-(** This type allows direct access to raw backtrace slots, without any
-    conversion in an OCaml-usable data-structure. Being
-    process-specific, they must absolutely not be marshalled, and are
-    unsafe to use for this reason (marshalling them may not fail, but
-    un-marshalling and using the result will result in
-    undefined behavior).
+(** This type is used to iterate over the slots of a [raw_backtrace_entry].
+    For most purposes, [backtrace_slots_of_raw_entry] is easier to use.
 
-    Elements of this type can still be compared and hashed: when two
-    elements are equal, then they represent the same source location
-    (the converse is not necessarily true in presence of inlining,
-    for example).
+    Like [raw_backtrace_entry], values of this type are process-specific and
+    must absolutely not be marshalled, and are unsafe to use for this reason
+    (marshalling them may not fail, but un-marshalling and using the result
+    will result in undefined behavior).
+
+    Elements of this type can still be compared and hashed: when two elements
+    are equal, then they represent the same source location (the converse is not
+    necessarily true in presence of inlining, for example).
 
     @since 4.02.0
 *)

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -109,12 +109,20 @@ val use_printers: exn -> string option
 
 (** {1 Raw backtraces} *)
 
-type raw_backtrace_entry = private int
-(** @since 4.12.0 *)
-
-type raw_backtrace = private raw_backtrace_entry array
+type raw_backtrace
 (** The type [raw_backtrace] stores a backtrace in a low-level format,
-    as an array of [raw_backtrace_entry] values.
+    which can be converted to usable form using [raw_backtrace_entries]
+    and [backtrace_slots_of_raw_entry] below.
+
+    Converting backtraces to [backtrace_slot]s is slower than capturing the
+    backtraces. If an application processes many backtraces, it can be useful
+    to use [raw_backtrace] to avoid or delay conversion.
+
+    @since 4.01.0
+*)
+
+type raw_backtrace_entry = private int
+(** A [raw_backtrace_entry] is an element of a [raw_backtrace].
 
     Each [raw_backtrace_entry] is an opaque integer, whose value is not stable
     between different programs, or even between different runs of the same
@@ -132,13 +140,10 @@ type raw_backtrace = private raw_backtrace_entry array
     [raw_backtrace_entry]s are equal as integers, then they represent the same
     [backtrace_slot]s.
 
-    Converting backtraces to [backtrace_slot]s is slower than capturing the
-    backtraces. If an application processes many backtraces, it can be useful
-    to use [raw_backtrace] to avoid or delay conversion.
+    @since 4.12.0 *)
 
-    @since 4.01.0
-    @since 4.12.0 (definition as raw_backtrace_entry array)
-*)
+val raw_backtrace_entries : raw_backtrace -> raw_backtrace_entry array
+(** @since 4.12.0 *)
 
 val get_raw_backtrace: unit -> raw_backtrace
 (** [Printexc.get_raw_backtrace ()] returns the same exception
@@ -321,7 +326,7 @@ end
 (** {1 Raw backtrace slots} *)
 
 type raw_backtrace_slot
-(** This type is used to iterate over the slots of a [raw_backtrace_entry].
+(** This type is used to iterate over the slots of a [raw_backtrace].
     For most purposes, [backtrace_slots_of_raw_entry] is easier to use.
 
     Like [raw_backtrace_entry], values of this type are process-specific and

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -118,6 +118,10 @@ type raw_backtrace
     backtraces. If an application processes many backtraces, it can be useful
     to use [raw_backtrace] to avoid or delay conversion.
 
+    Raw backtraces cannot be marshalled. If you need marshalling, you
+    should use the array returned by the [backtrace_slots] function of
+    the next section.
+
     @since 4.01.0
 *)
 
@@ -251,7 +255,10 @@ val backtrace_slots_of_raw_entry :
 
     Slots are returned in the same order as [backtrace_slots]: the slot
     at index [0] is the most recent call, raise, or primitive, and
-    subsequent slots represent callers. *)
+    subsequent slots represent callers.
+
+    @since 4.12
+*)
 
 
 type location = {


### PR DESCRIPTION
The `raw_backtrace` / `raw_backtrace_slot` API is tricky to use, and doesn't expose enough to allow efficient comparison of backtraces.

This patch exposes the type `raw_backtrace` as a `private raw_backtrace_entry array`, where `raw_backtrace_entry` is a `private int` which can be later converted to a `backtrace_slot array option`. 

This allows much more efficient access to backtraces. For instance, with this API it's possible to find the common suffix of two backtraces without calling `debuginfo_extract` on every item. (I ran into this use-case when writing [`memtrace`](github.com/janestreet/memtrace), which processes a lot of backtraces).

It's also easier to use correctly - getting the backtrace info from a `raw_backtrace_slot` at the moment requires manually iterating over the subslots using `get_raw_backtrace_next_slot`.