### PR TITLE
Add Stdlib.Ref

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -540,6 +540,13 @@ stdlib__random.cmi : \
     stdlib__nativeint.cmi \
     stdlib__int64.cmi \
     stdlib__int32.cmi
+stdlib__ref.cmo : \
+    stdlib__fun.cmi \
+    stdlib__ref.cmi
+stdlib__ref.cmx : \
+    stdlib__fun.cmx \
+    stdlib__ref.cmi
+stdlib__ref.cmi :
 stdlib__result.cmo : \
     stdlib__seq.cmi \
     stdlib__result.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -34,7 +34,7 @@ STDLIB_MODS=\
   stdlib pervasives seq option result bool char uchar \
   sys list bytes string unit marshal obj array float int int32 int64 nativeint \
   lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
-  camlinternalFormat printf arg printexc fun gc digest random hashtbl weak \
+  camlinternalFormat printf arg printexc fun ref gc digest random hashtbl weak \
   format scanf callback camlinternalOO oo camlinternalMod genlex ephemeron \
   filename complex arrayLabels listLabels bytesLabels stringLabels moreLabels \
   stdLabels spacetime bigarray

--- a/stdlib/ref.ml
+++ b/stdlib/ref.ml
@@ -1,0 +1,35 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Nicolas Ojeda Bar, LexiFi                       *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a t = 'a ref = {mutable contents : 'a}
+
+external ref : 'a -> 'a t = "%makemutable"
+
+external get : 'a t -> 'a = "%field0"
+
+external set : 'a t -> 'a -> unit = "%setfield0"
+
+let with_ref r x f =
+  let oldx = !r in
+  r := x;
+  Fun.protect ~finally:(fun () -> r := oldx) f
+
+external equal : 'a t -> 'a t -> bool = "%eq"
+
+external incr : int t -> unit = "%incr"
+
+external decr : int t -> unit = "%decr"
+
+let add_to_list r x = set r (x :: get r)

--- a/stdlib/ref.mli
+++ b/stdlib/ref.mli
@@ -1,0 +1,49 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Nicolas Ojeda Bar, LexiFi                       *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** References.
+
+    References are mutable indirection cells containing a value of a given type.
+
+    @since 4.12 *)
+
+type 'a t = 'a ref = {mutable contents : 'a}
+(** The type of references of type ['a]. *)
+
+val ref : 'a -> 'a t
+(** [ref x] creates a new reference with initial value [x]. *)
+
+val get : 'a t -> 'a
+(** [get r] returns the value stored in [r]. *)
+
+val set : 'a t -> 'a -> unit
+(** [set r x] sets the value stored in [r] to [x]. *)
+
+val with_ref : 'a t -> 'a -> (unit -> 'b) -> 'b
+(** [with_ref r x f] sets [r] to [x], and returns the result of [f], after
+    restoring [r] to its previous value (even if an exception is raised by
+    [f]. *)
+
+val equal : 'a t -> 'a t -> bool
+(** [equal r r'] is [r == r']. *)
+
+val incr : int t -> unit
+(** [incr r] is [set r (get r + 1)]. *)
+
+val decr : int t -> unit
+(** [decr r] is [set r (get r - 1)]. *)
+
+val add_to_list : 'a list t -> 'a -> unit
+(** [add_to_list r x] is [set r (x :: get r)]. *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -607,6 +607,7 @@ module Printexc     = Printexc
 module Printf       = Printf
 module Queue        = Queue
 module Random       = Random
+module Ref          = Ref
 module Result       = Result
 module Scanf        = Scanf
 module Seq          = Seq

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1377,6 +1377,7 @@ module Printexc     = Printexc
 module Printf       = Printf
 module Queue        = Queue
 module Random       = Random
+module Ref          = Ref
 module Result       = Result
 module Scanf        = Scanf
 module Seq          = Seq


### PR DESCRIPTION
After writing `with_ref` and `add_to_list` for Nth time, I wondered why we don't have them in the stdlib.

What do you think?