### PR TITLE
List.equal, List.compare

### DIFF
--- a/Changes
+++ b/Changes
@@ -192,6 +192,11 @@ Working version
 - #9663: Extend Printexc API for raw backtrace entries.
   (Stephen Dolan, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
+* #9668: List.equal, List.compare
+  (This could break code using "open List" by shadowing
+   Stdlib.{equal,compare}.)
+  (Gabriel Scherer, review by Nicolás Ojeda Bär, Daniel Bünzli and Alain Frisch)
+
 - #9763: Add function Hashtbl.rebuild to convert from old hash table
   formats (that may have been saved to persistent storage) to the
   current hash table format.  Remove leftover support for the hash

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -549,6 +549,29 @@ let rec compare_length_with l n =
       compare_length_with l (n-1)
 ;;
 
+(** {1 Comparison} *)
+
+(* Note: we are *not* shortcutting the list by using
+   [List.compare_lengths] first; this may be slower on long lists
+   immediately start with distinct elements. It is also incorrect for
+   [compare] below, and it is better (principle of least surprise) to
+   use the same approach for both functions. *)
+let rec equal eq l1 l2 =
+  match l1, l2 with
+  | [], [] -> true
+  | [], _::_ | _::_, [] -> false
+  | a1::l1, a2::l2 -> eq a1 a2 && equal eq l1 l2
+
+let rec compare cmp l1 l2 =
+  match l1, l2 with
+  | [], [] -> 0
+  | [], _::_ -> -1
+  | _::_, [] -> 1
+  | a1::l1, a2::l2 ->
+    let c = cmp a1 a2 in
+    if c <> 0 then c
+    else compare cmp l1 l2
+
 (** {1 Iterators} *)
 
 let to_seq l =

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -102,6 +102,39 @@ val flatten : 'a list list -> 'a list
 (** An alias for [concat]. *)
 
 
+(** {1 Comparison} *)
+
+val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+(** [equal eq [a1; ...; an] [b1; ..; bm]] holds when
+    the two input lists have the same length, and for each
+    pair of elements [ai], [bi] at the same position we have
+    [eq ai bi].
+
+    Note: the [eq] function may be called even if the
+    lists have different length. If you know your equality
+    function is costly, you may want to check {!compare_lengths}
+    first.
+
+    @since 4.12.0
+*)
+
+val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+(** [compare cmp l1 l2] performs a lexicographic comparison
+    of the two input lists, using the same ['a -> 'a -> int]
+    interface as {!Stdlib.compare}.
+
+    - [a1 :: l1] is smaller than [a2 :: l2]
+      if [a1] is smaller than [a2], or if they are equal
+      and [l1] is smaller than [l2].
+    - the empty list [[]] is strictly smaller than non-empty lists.
+
+    Note: the [cmp] function will be called even if the lists have
+    different lengths. A shorter list is not necessarily smaller,
+    for example [List.compare [3] [2; 1] > 0].
+
+    @since 4.12.0
+*)
+
 (** {1 Iterators} *)
 
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -123,6 +123,38 @@ val flatten : 'a list list -> 'a list
  *)
 
 
+(** {1 Comparison} *)
+
+val equal : eq:('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+(** [equal eq [a1; ...; an] [b1; ..; bm]] holds when
+    the two input lists have the same length, and for each
+    pair of elements [ai], [bi] at the same position we have
+    [eq ai bi].
+
+    Note: the [eq] function may be called even if the
+    lists have different length. If you know your equality
+    function is costly, you may want to check {!compare_lengths}
+    first.
+
+    @since 4.12.0
+*)
+
+val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
+(** [compare cmp [a1; ...; an] [b1; ...; bm]] performs
+    a lexicographic comparison of the two input lists,
+    using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
+
+    - [a1 :: l1] is smaller than [a2 :: l2] (negative result)
+      if [a1] is smaller than [a2], or if they are equal (0 result)
+      and [l1] is smaller than [l2]
+    - the empty list [[]] is strictly smaller than non-empty lists
+
+    Note: the [cmp] function will be called even if the lists have
+    different lengths.
+
+    @since 4.12.0
+*)
+
 (** {1 Iterators} *)
 
 

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -35,6 +35,24 @@ let () =
   assert (not (List.exists (fun a -> a > 9) l));
   assert (List.exists (fun _ -> true) l);
 
+  assert (List.equal (=) [1; 2; 3] [1; 2; 3]);
+  assert (not (List.equal (=) [1; 2; 3] [1; 2]));
+  assert (not (List.equal (=) [1; 2; 3] [1; 3; 2]));
+
+  (* The current implementation of List.equal calls the comparison
+     function even for different-size lists. This is not part of the
+     specification, so it would be valid to change this behavior, but
+     we don't want to change it without noticing so here is a test for
+     it. *)
+  assert (let c = ref 0 in
+          not (List.equal (fun _ _ -> incr c; true) [1; 2] [1; 2; 3])
+          && !c = 2);
+
+  assert (List.compare compare [1; 2; 3] [1; 2; 3] = 0);
+  assert (List.compare compare [1; 2; 3] [1; 2] > 0);
+  assert (List.compare compare [1; 2; 3] [1; 3; 2] < 0);
+  assert (List.compare compare [3] [2; 1] > 0);
+
   begin
     let f ~limit a = if a >= limit then Some (a, limit) else None in
     assert (List.find_map (f ~limit:3) [] = None);

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -152,7 +152,7 @@
               (function f param (apply f (field 0 param) (field 1 param)))
             map =
               (function f l
-                (apply (field 16 (global Stdlib__list!)) (apply uncurry f) l)))
+                (apply (field 18 (global Stdlib__list!)) (apply uncurry f) l)))
            (makeblock 0
              (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
              (apply map
@@ -190,7 +190,7 @@
                     (apply f (field 0 param) (field 1 param)))
                 map =
                   (function f l
-                    (apply (field 16 (global Stdlib__list!))
+                    (apply (field 18 (global Stdlib__list!))
                       (apply uncurry f) l)))
                (makeblock 0
                  (makeblock 0 (apply map eta_gen_cmp vec)


### PR DESCRIPTION
`List.equal f foo bar` is nicer than
`List.length foo = List.length bar && List.for_all2 f foo bar`.

Note: with List.compare there is a risk of users having opened the
List module, and then using 'compare' from the stdlib unqualified. For
example:

    List.(sort compare foo bar)

Such code will break (type error), and has to be fixed by using
Stdlib.compare. Stdlib is available since OCaml 4.07; people wishing
to support both 4.12 and older releases would have to avoid opening
List, or rebind 'compare' locally.