### PR TITLE
Report full major collections in Gc stats

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,9 @@ Working version
   (Xavier Leroy, review by Jacques-Henri Jourdan, Damien Doligez, and
   Stephen Dolan)
 
+- #9670: Report full major collections in Gc stats.
+  (Leo White, review by Gabriel Scherer)
+
 - #9675: Remove the caml_static_{alloc,free,resize} primitives, now unused.
   (Xavier Leroy, review by Gabriel Scherer)
 

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -71,6 +71,7 @@ DOMAIN_STATE(intnat, stat_major_collections)
 DOMAIN_STATE(intnat, stat_heap_wsz)
 DOMAIN_STATE(intnat, stat_top_heap_wsz)
 DOMAIN_STATE(intnat, stat_compactions)
+DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(intnat, stat_heap_chunks)
 /* See gc_ctrl.c */
 

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -562,6 +562,7 @@ void caml_compact_heap_maybe (void)
     caml_gc_message (0x200, "Automatic compaction triggered.\n");
     caml_empty_minor_heap ();  /* minor heap must be empty for compaction */
     caml_finish_major_cycle ();
+    ++ Caml_state->stat_forced_major_collections;
 
     fw = caml_fl_cur_wsz;
     fp = 100.0 * fw / (Caml_state->stat_heap_wsz - fw);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -69,6 +69,7 @@ void caml_init_domain ()
   Caml_state->stat_heap_wsz = 0;
   Caml_state->stat_top_heap_wsz = 0;
   Caml_state->stat_compactions = 0;
+  Caml_state->stat_forced_major_collections = 0;
   Caml_state->stat_heap_chunks = 0;
 
   Caml_state->backtrace_active = 0;

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -130,6 +130,7 @@ CAMLprim value caml_sys_exit(value retcode_v)
     intnat heap_chunks = Caml_state->stat_heap_chunks;
     intnat top_heap_words = Caml_state->stat_top_heap_wsz;
     intnat cpct = Caml_state->stat_compactions;
+    intnat forcmajcoll = Caml_state->stat_forced_major_collections;
     caml_gc_message(0x400, "allocated_words: %.0f\n", allocated_words);
     caml_gc_message(0x400, "minor_words: %.0f\n", minwords);
     caml_gc_message(0x400, "promoted_words: %.0f\n", prowords);
@@ -146,6 +147,9 @@ CAMLprim value caml_sys_exit(value retcode_v)
                     top_heap_words);
     caml_gc_message(0x400, "compactions: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                     cpct);
+    caml_gc_message(0x400,
+                    "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+                    forcmajcoll);
   }
 
 #ifndef NATIVE_CODE

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -31,6 +31,7 @@ type stat = {
   compactions : int;
   top_heap_words : int;
   stack_size : int;
+  forced_major_collections: int;
 }
 
 type control = {
@@ -70,9 +71,10 @@ open Printf
 
 let print_stat c =
   let st = stat () in
-  fprintf c "minor_collections: %d\n" st.minor_collections;
-  fprintf c "major_collections: %d\n" st.major_collections;
-  fprintf c "compactions:       %d\n" st.compactions;
+  fprintf c "minor_collections:      %d\n" st.minor_collections;
+  fprintf c "major_collections:      %d\n" st.major_collections;
+  fprintf c "compactions:            %d\n" st.compactions;
+  fprintf c "forced_major_collections: %d\n" st.forced_major_collections;
   fprintf c "\n";
   let l1 = String.length (sprintf "%.0f" st.minor_words) in
   fprintf c "minor_words:    %*.0f\n" l1 st.minor_words;

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -72,6 +72,10 @@ type stat =
 
     stack_size: int;
     (** Current size of the stack, in words. @since 3.12.0 *)
+
+    forced_major_collections: int;
+    (** Number of forced full major collections completed since the program
+        was started. @since 4.12.0 *)
 }
 (** The memory management counters are returned in a [stat] record.
 


### PR DESCRIPTION
Full major collections, where the entire major collection cycle happens at once, can cause a big spike in latency. It's easy for them to take multiple seconds with a large heap. They are not only triggered by `Gc.full_major ()` -- they also happen automatically if the garbage collector suspects that it might need to do a compaction. These automatic full majors can be disabled by disabling compaction.

Unlike other causes of latency spikes -- e.g. actual compactions -- there is no obvious indication that this has happened. This is repeatedly causing issues for our developers -- giving them performance issues they cannot easily debug.

This PR attempts to address this issue by reporting full major collections as a statistic in the output of `Gc.stat`. The full major collections counter is incremented in locations where `caml_finish_major_cycle` is called and the previous cycle just finished.