### PR TITLE
List.fold_assoc_{left,right} + Hashtbl.fold_pair

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -220,6 +220,16 @@ let rec remove_assq x = function
   | [] -> []
   | (a, _ as pair) :: l -> if a == x then l else pair :: remove_assq x l
 
+let rec fold_assoc_left f accu l =
+  match l with
+  | [] -> accu
+  | (k, v) :: l -> fold_assoc_left f (f accu k v) l
+
+let rec fold_assoc_right f l accu =
+  match l with
+  | [] -> accu
+  | (k, v) :: l -> f k v (fold_assoc_right f l accu)
+
 let rec find p = function
   | [] -> raise Not_found
   | x :: l -> if p x then x else find p l

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -187,6 +187,8 @@ let rec memq x = function
     [] -> false
   | a::l -> a == x || memq x l
 
+let cons_assoc k v l = (k, v) :: l
+
 let rec assoc x = function
     [] -> raise Not_found
   | (a,b)::l -> if compare a x = 0 then b else assoc x l

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -220,6 +220,11 @@ let rec remove_assq x = function
   | [] -> []
   | (a, _ as pair) :: l -> if a == x then l else pair :: remove_assq x l
 
+let rec iter_assoc f l =
+  match l with
+  | [] -> ()
+  | (k, v) :: l -> f k v; iter_assoc f l
+
 let rec fold_assoc_left f accu l =
   match l with
   | [] -> accu

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -276,8 +276,6 @@ val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
 
 
 (** {1 Association lists} *)
-
-
 val assoc : 'a -> ('a * 'b) list -> 'b
 (** [assoc a l] returns the value associated with key [a] in the list of
    pairs [l]. That is,
@@ -320,6 +318,10 @@ val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
 val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!List.remove_assoc}, but uses physical equality instead
    of structural equality to compare keys.  Not tail-recursive. *)
+
+val cons_assoc : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
+(** [cons_assoc k v li] is [(k, v) :: li]. This function is useful
+    to populate association lists *)
 
 val iter_assoc : ('k -> 'v -> unit) -> ('k * 'v) list -> unit
 (** [List.iter_assoc f [(k1, v1); (k2, v2); ...; (kn, vn)]] is

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -321,6 +321,13 @@ val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!List.remove_assoc}, but uses physical equality instead
    of structural equality to compare keys.  Not tail-recursive. *)
 
+val iter_assoc : ('k -> 'v -> unit) -> ('k * 'v) list -> unit
+(** [List.iter_assoc f [(k1, v1); (k2, v2); ...; (kn, vn)]] is
+    [f k1 v1; f k2 v2; ...; f kn vn].
+
+    @since 4.12.0
+*)
+
 val fold_assoc_left : ('a -> 'k -> 'v -> 'a) -> 'a -> ('k * 'v) list -> 'a
 (** [List.fold_assoc_left f a [(k1,v1); ...; (kn,vn)]] is
     [f (... (f (f a k1 v1) k2 v2) ...) kn vn].

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -321,6 +321,19 @@ val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!List.remove_assoc}, but uses physical equality instead
    of structural equality to compare keys.  Not tail-recursive. *)
 
+val fold_assoc_left : ('a -> 'k -> 'v -> 'a) -> 'a -> ('k * 'v) list -> 'a
+(** [List.fold_assoc_left f a [(k1,v1); ...; (kn,vn)]] is
+    [f (... (f (f a k1 v1) k2 v2) ...) kn vn].
+
+    @since 4.12.0
+*)
+
+val fold_assoc_right : ('k -> 'v -> 'b -> 'b) -> ('k * 'v) list -> 'b -> 'b
+(** [List.fold_assoc_right f [(k1,v1); ...; (kn,vn)] b] is
+   [f k1 v1 (f k2 v2 (... (f kn vn b) ...))].  Not tail-recursive.
+
+    @since 4.12.0
+*)
 
 (** {1 Lists of pairs} *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -373,6 +373,13 @@ val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
    of structural equality to compare keys. Not tail-recursive.
  *)
 
+val fold_assoc_left : f:('a -> 'k -> 'v -> 'a) -> init:'a -> ('k * 'v) list -> 'a
+(** [List.fold_assoc_left f a [(k1,v1); ...; (kn,vn)]] is
+    [f (... (f (f a k1 v1) k2 v2) ...) kn vn]. *)
+
+val fold_assoc_right : f:('k -> 'v -> 'b -> 'b) -> ('k * 'v) list -> init:'b -> 'b
+(** [List.fold_assoc_right f [(k1,v1); ...; (kn,vn)] b] is
+   [f k1 v1 (f k2 v2 (... (f kn vn b) ...))].  Not tail-recursive. *)
 
 (** {1 Lists of pairs} *)
 

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -125,28 +125,8 @@ module HofM (M: Map.S) : Hashtbl.S with type key = M.key =
   struct
     type key = M.key
     type 'a t = (key, 'a) Hashtbl.t
-    let create s = Hashtbl.create s
-    let clear = Hashtbl.clear
-    let reset = Hashtbl.reset
-    let copy = Hashtbl.copy
-    let add = Hashtbl.add
-    let remove = Hashtbl.remove
-    let find = Hashtbl.find
-    let find_opt = Hashtbl.find_opt
-    let find_all = Hashtbl.find_all
-    let replace = Hashtbl.replace
-    let mem = Hashtbl.mem
-    let iter = Hashtbl.iter
-    let fold = Hashtbl.fold
-    let length = Hashtbl.length
-    let stats = Hashtbl.stats
-    let filter_map_inplace = Hashtbl.filter_map_inplace
-    let to_seq = Hashtbl.to_seq
-    let to_seq_keys = Hashtbl.to_seq_keys
-    let to_seq_values = Hashtbl.to_seq_values
-    let of_seq = Hashtbl.of_seq
-    let add_seq = Hashtbl.add_seq
-    let replace_seq = Hashtbl.replace_seq
+    include (Hashtbl : module type of Hashtbl with type ('a, 'b) t := ('a, 'b) Hashtbl.t)
+    let create n = create ?random:None n
   end
 
 module HS1 = HofM(MS)

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -61,6 +61,10 @@ let () =
   assert (
     let f a b = a + b, string_of_int b in
     List.fold_left_map f 0 l = (45, sl));
+  assert (List.fold_assoc_left (fun a k v -> (k,v+1)::a) [] [(1,2); (3,4)]
+         = [(3, 5); (1, 3)]);
+  assert (List.fold_assoc_right (fun k v a -> (k,v+1)::a) [(1,2); (3,4)] []
+         = [(1, 3); (3, 5)]);
   ()
 ;;
 

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -61,6 +61,10 @@ let () =
   assert (
     let f a b = a + b, string_of_int b in
     List.fold_left_map f 0 l = (45, sl));
+  assert ((let li = ref [] in
+           List.iter_assoc (fun k v -> li := (k, v) :: !li) [(1,2); (3,4)];
+           !li)
+         = [(3, 4); (1, 2)]);
   assert (List.fold_assoc_left (fun a k v -> (k,v+1)::a) [] [(1,2); (3,4)]
          = [(3, 5); (1, 3)]);
   assert (List.fold_assoc_right (fun k v a -> (k,v+1)::a) [(1,2); (3,4)] []


### PR DESCRIPTION
```
val List.fold_assoc_left : ('a -> 'k -> 'v -> 'a) -> 'a -> ('k * 'v) list -> 'a
val List.fold_assoc_right : ('k -> 'v -> 'a -> 'a) -> ('k * 'v) list -> 'a -> 'a
val Hashtbl.fold_pair : ('k * 'v -> 'a -> 'a) -> ('k, 'v) Hashtbl.t -> 'a -> 'a
```

These functions were born from the ashes of @nojb's #2236 (Hashtbl.{to,of}_list). The `List.fold_assoc*` can build an associative collection (`Hashtbl`, `Map`) from an associative list easily.

```
List.fold_assoc_right Hashtbl.add bindings table
```

`Hashtbl.fold_pair` can build a non-associative collection (`List`, `Stack`, `Queue`...) from a hashtable easily.

```
Hashtbl.fold_pair Queue.add tbl (Queue.create ())
```

Remark: instead of such functions, one could consider using generic currying and uncurrying combinators, as proposed in the defunct #9425. One argument in favor of the approach in the current PR is that uses of the new functions are readable in a fairly natural/accessible, even to people who are not already aware of the concept of currification.

Remark: other associative collections, in particular Map, would benefit from a `fold_pair` for the same reason. One thing at a time!

Remark: this would go in the direction of exposing two generic export functions for datastructures, a fold (here `fold_pair`), and a sequence. This corresponds to exposing a "generator" and an "iterator" in the language of [this blog post](http://gallium.inria.fr/blog/generators-iterators-control-and-continuations/) that argues that those are extremal points in the design space.

