### PR TITLE
Add Hint when a module is used in place of a module type

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,6 +133,12 @@ Working version
   corresponding core_type.
   (Etienne Millon, review by Thomas Refis)
 
+- #6633, #9673: Add hint when a module is used instead of a module type or
+  when a module type is used instead of a module or when a class type is used
+  instead of a class.
+  (Xavier Van de Woestyne, report by whitequark, review by Florian Angeletti
+  and Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #9493, #9520, #9563, #9599, #9608: refactor the pattern-matching compiler

--- a/testsuite/tests/typing-modules/pr6633.ml
+++ b/testsuite/tests/typing-modules/pr6633.ml
@@ -1,0 +1,69 @@
+(* TEST
+   * expect
+*)
+
+
+(* If a module is used as a module type it should trigger the hint. *)
+module Equal = struct end
+module Foo = functor (E : Equal) -> struct end;;
+[%%expect{|
+module Equal : sig end
+Line 2, characters 26-31:
+2 | module Foo = functor (E : Equal) -> struct end;;
+                              ^^^^^
+Error: Unbound module type Equal
+Hint: There is a module named Equal, but modules are not module types
+|}]
+
+(* If there is a typo in the module type name it should trigger the
+   spellcheck.
+*)
+module type Equals = sig end
+module Foo = functor (E : EqualF) -> struct end;;
+[%%expect{|
+module type Equals = sig end
+Line 2, characters 26-32:
+2 | module Foo = functor (E : EqualF) -> struct end;;
+                              ^^^^^^
+Error: Unbound module type EqualF
+Hint: Did you mean Equals?
+|}]
+
+(* If a module is used as a module type it should trigger the hint
+   (even it is a typo). *)
+module type Equal = sig end
+module EqualF = struct end
+module Foo = functor (E : EqualF) -> struct end;;
+[%%expect{|
+module type Equal = sig end
+module EqualF : sig end
+Line 3, characters 26-32:
+3 | module Foo = functor (E : EqualF) -> struct end;;
+                              ^^^^^^
+Error: Unbound module type EqualF
+Hint: There is a module named EqualF, but modules are not module types
+|}]
+
+(* If a module type is used as a module it should trigger the hint. *)
+module type S = sig type t val show: t -> string end
+let f (x: S.t ) = ();;
+[%%expect{|
+module type S = sig type t val show : t -> string end
+Line 2, characters 10-13:
+2 | let f (x: S.t ) = ();;
+              ^^^
+Error: Unbound module S
+Hint: There is a module type named S, but module types are not modules
+|}]
+
+(* If a class type is used as a class it should trigger the hint. *)
+class type ct = object method m: int end
+class c = object inherit ct end
+[%%expect{|
+class type ct = object method m : int end
+Line 2, characters 25-27:
+2 | class c = object inherit ct end
+                             ^^
+Error: Unbound class ct
+Hint: There is a class type named ct, but classes are not class types
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3063,21 +3063,45 @@ let report_lookup_error _loc env ppf = function
   | Unbound_type lid ->
       fprintf ppf "Unbound type constructor %a" !print_longident lid;
       spellcheck ppf extract_types env lid;
-  | Unbound_module lid ->
+  | Unbound_module lid -> begin
       fprintf ppf "Unbound module %a" !print_longident lid;
-      spellcheck ppf extract_modules env lid;
+       match find_modtype_by_name lid env with
+      | exception Not_found -> spellcheck ppf extract_modules env lid;
+      | _ ->
+         fprintf ppf
+           "@.@[%s %a, %s@]"
+           "Hint: There is a module type named"
+           !print_longident lid
+           "but module types are not modules"
+    end
   | Unbound_constructor lid ->
       fprintf ppf "Unbound constructor %a" !print_longident lid;
       spellcheck ppf extract_constructors env lid;
   | Unbound_label lid ->
       fprintf ppf "Unbound record field %a" !print_longident lid;
       spellcheck ppf extract_labels env lid;
-  | Unbound_class lid ->
+  | Unbound_class lid -> begin
       fprintf ppf "Unbound class %a" !print_longident lid;
-      spellcheck ppf extract_classes env lid;
-  | Unbound_modtype lid ->
+      match find_cltype_by_name lid env with
+      | exception Not_found -> spellcheck ppf extract_classes env lid;
+      | _ ->
+         fprintf ppf
+           "@.@[%s %a, %s@]"
+           "Hint: There is a class type named"
+           !print_longident lid
+           "but classes are not class types"
+    end
+  | Unbound_modtype lid -> begin
       fprintf ppf "Unbound module type %a" !print_longident lid;
-      spellcheck ppf extract_modtypes env lid;
+      match find_module_by_name lid env with
+      | exception Not_found -> spellcheck ppf extract_modtypes env lid;
+      | _ ->
+         fprintf ppf
+           "@.@[%s %a, %s@]"
+           "Hint: There is a module named"
+           !print_longident lid
+           "but modules are not module types"
+    end
   | Unbound_cltype lid ->
       fprintf ppf "Unbound class type %a" !print_longident lid;
       spellcheck ppf extract_cltypes env lid;


### PR DESCRIPTION
Attempt to fix #6633 
The patch add an Hint if a module is used in place of a module type. For example:
```ocaml
module Equal = struct
  module type Equal = sig ... end
end
module Foo = functor (E : Equal) -> struct end;;
```
Will add to the error:

```
Line 5, characters 26-31:
5 | module Foo = functor (E : Equal) -> struct end;;
                              ^^^^^
Error: Unbound module type Equal
```
The following Hint: 

```
Hint: There is a module called [Equal] but it is not a module type
```
If there is namesake the hint is not displayed.