### PR TITLE
ocamltest: use -output-complete-exe instead of -custom

### DIFF
--- a/testsuite/tests/backtrace/callstack.ml
+++ b/testsuite/tests/backtrace/callstack.ml
@@ -5,7 +5,8 @@
    compare_programs = "false"
    ** no-flambda
    *** native
-   *** bytecode
+   *** shared-libraries
+   **** bytecode
 *)
 
 let[@inline never] f0 () =

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -1,15 +1,15 @@
 main thread:
-Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 12, characters 38-66
-Called from Callstack.f1 in file "callstack.ml", line 13, characters 27-32
-Called from Callstack.f2 in file "callstack.ml", line 14, characters 27-32
-Called from Callstack.f3 in file "callstack.ml", line 15, characters 27-32
-Called from Callstack in file "callstack.ml", line 18, characters 9-14
+Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 13, characters 38-66
+Called from Callstack.f1 in file "callstack.ml", line 14, characters 27-32
+Called from Callstack.f2 in file "callstack.ml", line 15, characters 27-32
+Called from Callstack.f3 in file "callstack.ml", line 16, characters 27-32
+Called from Callstack in file "callstack.ml", line 19, characters 9-14
 from finalizer:
-Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 12, characters 38-66
-Called from Callstack in file "callstack.ml", line 23, characters 2-18
+Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 13, characters 38-66
+Called from Callstack in file "callstack.ml", line 24, characters 2-18
 new thread:
-Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 12, characters 38-66
-Called from Callstack.f1 in file "callstack.ml", line 13, characters 27-32
-Called from Callstack.f2 in file "callstack.ml", line 14, characters 27-32
-Called from Callstack.f3 in file "callstack.ml", line 15, characters 27-32
+Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 13, characters 38-66
+Called from Callstack.f1 in file "callstack.ml", line 14, characters 27-32
+Called from Callstack.f2 in file "callstack.ml", line 15, characters 27-32
+Called from Callstack.f3 in file "callstack.ml", line 16, characters 27-32
 Called from Thread.create.(fun) in file "thread.ml", line 39, characters 8-14

--- a/testsuite/tests/embedded/cmcaml.ml
+++ b/testsuite/tests/embedded/cmcaml.ml
@@ -1,5 +1,7 @@
 (* TEST
    modules = "cmstub.c cmmain.c"
+
+* native
 *)
 
 (* OCaml part of the code *)

--- a/testsuite/tests/lib-dynlink-bytecode/main.ml
+++ b/testsuite/tests/lib-dynlink-bytecode/main.ml
@@ -45,7 +45,7 @@ reference = "${test_source_directory}/static.reference"
 
 ******** ocamlc.byte
 program = "${test_build_directory}/custom.exe"
-flags = "-custom -linkall -I ."
+flags = "-output-complete-exe -linkall -I . -ccopt -I${ocamlsrcdir}/runtime"
 all_modules = "registry.cmo plug2.cma plug1.cma"
 use_runtime = "false"
 ********* run

--- a/testsuite/tests/lib-threads/delayintr.ml
+++ b/testsuite/tests/lib-threads/delayintr.ml
@@ -11,10 +11,10 @@ files = "sigint.c"
 
 program = "${test_build_directory}/delayintr.byte"
 
-**** ocamlc.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlc.byte
 
@@ -29,10 +29,10 @@ all_modules = "delayintr.ml"
 
 program = "${test_build_directory}/delayintr.opt"
 
-**** ocamlopt.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlopt.byte
 

--- a/testsuite/tests/lib-threads/signal.ml
+++ b/testsuite/tests/lib-threads/signal.ml
@@ -11,10 +11,10 @@ files = "sigint.c"
 
 program = "${test_build_directory}/signal.byte"
 
-**** ocamlc.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlc.byte
 
@@ -29,10 +29,10 @@ all_modules = "signal.ml"
 
 program = "${test_build_directory}/signal.opt"
 
-**** ocamlopt.byte
+**** cc
 
 program = "sigint"
-all_modules = "sigint.c"
+modules = "sigint.c"
 
 ***** ocamlopt.byte
 


### PR DESCRIPTION
This PR (extracted from #9236 for easier reviewing) switches `ocamltest` to use `-output-complete-exe` instead of `-custom`. For info, `-custom` is currently used when 1) C files are being linked with the main program, or 2) libraries with stubs are being used and shared libraries are not supported.

A few adaptations are necessary (both in `ocamltest` and the `testsuite`) because `-output-complete-exe` does not behave the same as `-custom`.

#### `ocamltest` changes

- Disable program comparison when using `-output-complete-exe` (with `-custom` program comparison was possible because the bytecode was accessible to the `cmpbyt` program).

- Do not pass the flag when not linking the program (passing both `-output-complete-exe` and `-c` is an error).

#### `testsuite` changes

Here the main point is that with `-custom` the `main` function came from the `libcamlrun` library, so it was possible to override with a user-provided one. This is no longer possible with `-output-complete-exe` because the `main` function is generated in the main program.

- `embedded/cmcaml.ml`: this test contains a program that links C and OCaml code and depends on the above "feature" of `-custom`. One solution could be to use `-output-complete-obj` for the OCaml part and link everything together at the end. However, convincing `ocamltest` to do this proved too much for me. Instead I disable the test on `bytecode`.

- `lib-threads/{signal,delayintr}.ml`: these two tests also depend on the above "feature" of `-custom`. The difference with `cmcaml.ml` is that the programs being compiled consist only of C code, so it is simpler to just call the C compiler directly.

- `lib-dynlink-bytecode/main.ml`: this test used `-custom` in the test script itself. Switched it to `-output-complete-exe`.

- `backtrace/callstack.ml`: debug info is not available for `-output-complete-exe` binaries. Thus, disable this test on bytecode when shared libraries are not supported.