### PR TITLE
Naked pointers and the bytecode interpreter

### DIFF
--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -304,7 +304,7 @@ code_t caml_next_frame_pointer(value ** sp, value ** trsp)
     if (Is_long(*spv)) continue;
     p = (code_t*) spv;
     if(&Trap_pc(*trsp) == p) {
-      *trsp = Trap_link(*trsp);
+      *trsp = *trsp + Long_val(Trap_link_offset(*trsp));
       continue;
     }
 

--- a/runtime/caml/stacks.h
+++ b/runtime/caml/stacks.h
@@ -33,7 +33,7 @@
 #define caml_trap_barrier (Caml_state_field(trap_barrier))
 
 #define Trap_pc(tp) (((code_t *)(tp))[0])
-#define Trap_link(tp) (((value **)(tp))[1])
+#define Trap_link_offset(tp) (((value *)(tp))[1])
 
 void caml_init_stack (uintnat init_max_size);
 void caml_realloc_stack (asize_t required_size);

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -850,7 +850,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(PUSHTRAP):
       sp -= 4;
       Trap_pc(sp) = pc + *pc;
-      Trap_link(sp) = Caml_state->trapsp;
+      Trap_link_offset(sp) = Val_long(Caml_state->trapsp - sp);
       sp[2] = env;
       sp[3] = Val_long(extra_args);
       Caml_state->trapsp = sp;
@@ -865,7 +865,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         pc--; /* restart the POPTRAP after processing the signal */
         goto process_actions;
       }
-      Caml_state->trapsp = Trap_link(sp);
+      Caml_state->trapsp = sp + Long_val(Trap_link_offset(sp));
       sp += 4;
       Next;
 
@@ -898,7 +898,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       }
       sp = Caml_state->trapsp;
       pc = Trap_pc(sp);
-      Caml_state->trapsp = Trap_link(sp);
+      Caml_state->trapsp = sp + Long_val(Trap_link_offset(sp));
       env = sp[2];
       extra_args = Long_val(sp[3]);
       sp += 4;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -538,7 +538,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
         Alloc_small(accu, num_args + 3, Closure_tag);
         Field(accu, 2) = env;
         for (i = 0; i < num_args; i++) Field(accu, i + 3) = sp[i];
-        CAMLassert(!Is_in_value_area(pc-3));
         Code_val(accu) = pc - 3; /* Point to the preceding RESTART instr. */
         Closinfo_val(accu) = Make_closinfo(0, 2);
         sp += num_args;
@@ -567,7 +566,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
       }
       /* The code pointer is not in the heap, so no need to go through
          caml_initialize. */
-      CAMLassert(!Is_in_value_area(pc + *pc));
       Code_val(accu) = pc + *pc;
       Closinfo_val(accu) = Make_closinfo(0, 2);
       pc++;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -35,12 +35,6 @@
 #include "caml/memprof.h"
 #include "caml/eventlog.h"
 
-#if defined (NATIVE_CODE) && defined (NO_NAKED_POINTERS)
-#define NATIVE_CODE_AND_NO_NAKED_POINTERS
-#else
-#undef NATIVE_CODE_AND_NO_NAKED_POINTERS
-#endif
-
 #ifdef _MSC_VER
 Caml_inline double fmin(double a, double b) {
   return (a < b) ? a : b;
@@ -152,7 +146,7 @@ static void realloc_gray_vals (void)
 
 void caml_darken (value v, value *p /* not used */)
 {
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
   if (Is_block (v) && !Is_young (v)) {
 #else
   if (Is_block (v) && Is_in_heap (v)) {
@@ -164,7 +158,7 @@ void caml_darken (value v, value *p /* not used */)
       h = Hd_val (v);
       t = Tag_hd (h);
     }
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
     /* We insist that naked pointers to outside the heap point to things that
        look like values with headers coloured black.  This isn't always
        strictly necessary but is essential in certain cases---in particular
@@ -236,7 +230,7 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
 
   child = Field (v, i);
 
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
   if (Is_block (child) && ! Is_young (child)) {
 #else
   if (Is_block (child) && Is_in_heap (child)) {
@@ -270,7 +264,7 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
       child -= Infix_offset_val(child);
       chd = Hd_val(child);
     }
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
     /* See [caml_darken] for a description of this assertion. */
     CAMLassert (Is_in_heap (child) || Is_black_hd (chd));
 #endif

--- a/runtime/stacks.c
+++ b/runtime/stacks.c
@@ -47,7 +47,6 @@ void caml_realloc_stack(asize_t required_space)
 {
   asize_t size;
   value * new_low, * new_high, * new_sp;
-  value * p;
 
   CAMLassert(Caml_state->extern_sp >= Caml_state->stack_low);
   size = Caml_state->stack_high - Caml_state->stack_low;
@@ -72,8 +71,6 @@ void caml_realloc_stack(asize_t required_space)
   caml_stat_free(Caml_state->stack_low);
   Caml_state->trapsp = (value *) shift(Caml_state->trapsp);
   Caml_state->trap_barrier = (value *) shift(Caml_state->trap_barrier);
-  for (p = Caml_state->trapsp; p < new_high; p = Trap_link(p))
-    Trap_link(p) = (value *) shift(Trap_link(p));
   Caml_state->stack_low = new_low;
   Caml_state->stack_high = new_high;
   Caml_state->stack_threshold =


### PR DESCRIPTION
This is the next installment in the "make no-naked-pointers mode work in preparation for Multicore OCaml" series.  The hero of today's episode is the bytecode interpreter.

The stack of the bytecode interpreter is an interesting mix of
- OCaml values (tagged integers or heap pointers), for values of local variables and for intermediate evaluation results;
- code pointers, for return addresses into calling functions;
- pointers within the stack, for chaining of exception handlers.

The latter two are "naked" pointers outside the heap, so in no-naked-pointers mode something must be done so that the [edited] major GC never sees them.

There are at least 4 solutions:

1. Don't store naked pointers inside the bytecode interpreter stack
  1a. Set the low bit to 1 so that the (aligned) pointer looks like an integer
  1b. Store an offset (a relative address) instead of a pointer (an absolute address), encoding the offset as an OCaml tagged integer.

2. Skip over the naked pointers when scanning the stack during a [edit] major GC
  2a. Use metadata (like the frame descriptors in native-code) to know where the values are and where the other pointers are in the stack
  2b. Use tests such as `caml_find_code_fragment_by_pc` to identify code pointers, and comparisons with the bounds of the stack to identify pointers within the stack.

Multicore OCaml currently uses 1a (encapsulated pointers) for code pointers and [edited] 1b (offsets) for pointers within the stack, see https://github.com/ocaml-multicore/ocaml-multicore/blob/parallel_minor_gc/runtime/interp.c.

It's a fine solution [edit: modulo a problem with imprecise stack backtraces]  but a fairly big patch.  In this PR I explore another possibility:
- Approach 1b for chaining exception handlers: the pointer to the next handler is replaced by an offset.  This has the additional benefit that the chaining of handlers no longer needs updating when the bytecode stack is reallocated.  (Oleg Kiselyov told me so a long time ago; I should have listened.)
- Approach 2b to identify and exclude code pointers during [edited] major GC stack scanning.

The diff is quite small, but suffices to make no-naked-pointers mode work in bytecode.  (Before this PR, it was active only in native code.)

A note about performance: `caml_find_code_fragment_by_pc` is not cheap, even with the nifty skiplist-based implementation; however, the slowdown on `caml_do_local_roots` appears very small -- I was not able to measure it yet.  This is because the call stack is rarely very deep, and `caml_do_local_roots` is called only at the beginning of a major GC cycle, i.e. quite rarely.  The scanning function that is called at every minor GC, `caml_oldify_local_roots`, does not need to worry about code pointers, because it excludes everything that is not a pointer in the minor heap.

For the record: I also have an implementation of approach 1a if it is deemed preferable. [edit: see #9687] But it is a bigger change.
