### PR TITLE
Add closure-info field when reifying bytecode

### DIFF
--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -125,8 +125,9 @@ CAMLprim value caml_reify_bytecode(value ls_prog,
   /* Notify debugger after fragment gets added and reified. */
   caml_debugger(CODE_LOADED, Val_long(fragnum));
 
-  clos = caml_alloc_small (1, Closure_tag);
+  clos = caml_alloc_small (2, Closure_tag);
   Code_val(clos) = (code_t) prog;
+  Closinfo_val(clos) = Make_closinfo(0, 2);
   bytecode = caml_alloc_small (2, Abstract_tag);
   Bytecode_val(bytecode)->prog = prog;
   Bytecode_val(bytecode)->len = len;


### PR DESCRIPTION
In `caml_reify_bytecode` a block with a `Closure_tag` and of size 1 is allocated. This patch adds the closure-info field that I think was missed in [PR#9619](https://github.com/ocaml/ocaml/pull/9619). 

Right now [this code](https://github.com/ocaml/ocaml/blob/trunk/runtime/major_gc.c#L395) in the major GC ends up reading the header of the next object to work out arity. This trips the [assert](https://github.com/ocaml/ocaml/blob/trunk/runtime/major_gc.c#L399) when the testsuite is built with no naked pointers.