### PR TITLE
globroots.c: adapt to no-naked-pointers mode

### DIFF
--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -91,8 +91,10 @@ static enum gc_root_class classify_gc_root(value v)
 {
   if(!Is_block(v)) return UNTRACKED;
   if(Is_young(v)) return YOUNG;
-  if(Is_in_heap(v)) return OLD;
-  return UNTRACKED;
+#ifndef NO_NAKED_POINTERS
+  if(!Is_in_heap(v)) return UNTRACKED;
+#endif
+  return OLD;
 }
 
 /* Register a global C root of the generational kind */


### PR DESCRIPTION
Global roots management has a special case for out-of-heap pointers. This is not compatible with a future removal of the page table. However, this is just an optimization that can safely be turned off.

This PR treats out-of-heap pointers as major-heap pointers in no-naked-pointers mode.
