### PR TITLE
Introduce and use an `Is_naked_pointer(v)` macro in the runtime

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,7 +48,6 @@ Working version
   (Xavier Leroy, review by Jacques-Henri Jourdan, Damien Doligez, and
   Stephen Dolan)
 
-
 ### Code generation and optimizations:
 
 - #9441: Add RISC-V RV64G native-code backend.
@@ -153,6 +152,10 @@ Working version
 - #9442: refactor the implementation of the [@tailcall] attribute
   to allow for a structured attribute payload
   (Gabriel Scherer, review by Vladimir Keleshev and Nicolás Ojeda Bär)
+
+- #9685: introduce and use an Is_naked_pointer(v) macro for runtime code
+  to work in either naked-pointers or no-naked-pointers mode.
+  (Gabriel Scherer, review by ???)
 
 ### Build system:
 

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -297,7 +297,7 @@ CAMLprim value caml_make_vect(value len, value init)
     res = Atom(0);
 #ifdef FLAT_FLOAT_ARRAY
   } else if (Is_block(init)
-           && Is_in_value_area(init)
+           && !Is_naked_pointer(init)
            && Tag_val(init) == Double_tag) {
     mlsize_t wsize;
     double d;
@@ -371,7 +371,7 @@ CAMLprim value caml_make_array(value init)
   } else {
     v = Field(init, 0);
     if (Is_long(v)
-        || ! Is_in_value_area(v)
+        || Is_naked_pointer(v)
         || Tag_val(v) != Double_tag) {
       CAMLreturn (init);
     } else {

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -44,6 +44,14 @@
 
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
 
+#ifndef NO_NAKED_POINTERS
+/* We overapproximate naked pointers by any pointer not in the value area,
+   which *may* be a naked pointer. */
+#define Is_naked_pointer(a) (!(Is_in_value_area(a)))
+#else
+#define Is_naked_pointer(a) 0
+#endif
+
 /***********************************************************************/
 /* The rest of this file is private and may change without notice. */
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -127,11 +127,9 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (Is_long(v2))
         return Long_val(v1) - Long_val(v2);
       /* Subtraction above cannot overflow and cannot result in UNORDERED */
-#ifndef NO_NAKED_POINTERS
-      if (!Is_in_value_area(v2))
+      if (Is_naked_pointer(v2))
         return LESS;
-#endif
-        switch (Tag_val(v2)) {
+      switch (Tag_val(v2)) {
         case Forward_tag:
           v2 = Forward_val(v2);
           continue;
@@ -150,11 +148,9 @@ static intnat do_compare_val(struct compare_stack* stk,
       return LESS;                /* v1 long < v2 block */
     }
     if (Is_long(v2)) {
-#ifndef NO_NAKED_POINTERS
-      if (!Is_in_value_area(v1))
+      if (Is_naked_pointer(v1))
         return GREATER;
-#endif
-        switch (Tag_val(v1)) {
+      switch (Tag_val(v1)) {
         case Forward_tag:
           v1 = Forward_val(v1);
           continue;
@@ -172,16 +168,14 @@ static intnat do_compare_val(struct compare_stack* stk,
         }
       return GREATER;            /* v1 block > v2 long */
     }
-#ifndef NO_NAKED_POINTERS
     /* If one of the objects is outside the heap (but is not an atom),
        use address comparison. Since both addresses are 2-aligned,
        shift lsb off to avoid overflow in subtraction. */
-    if (! Is_in_value_area(v1) || ! Is_in_value_area(v2)) {
+    if (Is_naked_pointer(v1) || Is_naked_pointer(v2)) {
       if (v1 == v2) goto next_item;
       return (v1 >> 1) - (v2 >> 1);
       /* Subtraction above cannot result in UNORDERED */
     }
-#endif
     t1 = Tag_val(v1);
     t2 = Tag_val(v2);
     if (t1 != t2) {

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -711,7 +711,8 @@ static void extern_rec(value v)
     if (tag == Forward_tag) {
       value f = Forward_val (v);
       if (Is_block (f)
-          && (!Is_in_value_area(f) || Tag_val (f) == Forward_tag
+          && (Is_naked_pointer(f)
+              || Tag_val (f) == Forward_tag
               || Tag_val (f) == Lazy_tag
 #ifdef FLAT_FLOAT_ARRAY
               || Tag_val (f) == Double_tag

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -698,13 +698,11 @@ static void extern_rec(value v)
   if (Is_long(v)) {
     extern_int(Long_val(v));
   }
-#ifndef NO_NAKED_POINTERS
-  else if (! (Is_in_value_area(v) || caml_extern_allow_out_of_heap)) {
+  else if (Is_naked_pointer(v) && !caml_extern_allow_out_of_heap) {
     /* Naked pointer outside the heap: try to marshal it as a code pointer,
        otherwise fail. */
     extern_code_pointer((char *) v);
   }
-#endif
   else {
     header_t hd = Hd_val(v);
     tag_t tag = Tag_hd(hd);

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -236,7 +236,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
            Forward_tag links being followed */
         for (i = MAX_FORWARD_DEREFERENCE; i > 0; i--) {
           v = Forward_val(v);
-          if (Is_long(v) || !Is_in_value_area(v) || Tag_val(v) != Forward_tag)
+          if (Is_long(v) || Is_naked_pointer(v) || Tag_val(v) != Forward_tag)
             goto again;
         }
         /* Give up on this object and move to the next */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -247,7 +247,8 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
       value f = Forward_val (child);
       if ((in_ephemeron && Is_long(f)) ||
           (Is_block (f)
-           && (!Is_in_value_area(f) || Tag_val (f) == Forward_tag
+           && (Is_naked_pointer(f)
+               || Tag_val (f) == Forward_tag
                || Tag_val (f) == Lazy_tag
 #ifdef FLAT_FLOAT_ARRAY
                || Tag_val (f) == Double_tag
@@ -319,7 +320,8 @@ static value* mark_ephe_aux (value *gray_vals_ptr, intnat *work,
           value f = Forward_val (key);
           if (Is_long (f) ||
               (Is_block (f) &&
-               (!Is_in_value_area(f) || Tag_val (f) == Forward_tag
+               (Is_naked_pointer(f)
+                || Tag_val (f) == Forward_tag
                 || Tag_val (f) == Lazy_tag
 #ifdef FLAT_FLOAT_ARRAY
                 || Tag_val (f) == Double_tag

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -246,13 +246,15 @@ void caml_oldify_one (value v, value *p)
             vv = 1;
             ft = Tag_val (Hd_val (f) == 0 ? Field (f, 0) : f);
           }else{
-            vv = Is_in_value_area(f);
+            vv = !Is_naked_pointer(f);
             if (vv){
               ft = Tag_val (f);
             }
           }
         }
-        if (!vv || ft == Forward_tag || ft == Lazy_tag
+        if (!vv
+            || ft == Forward_tag
+            || ft == Lazy_tag
 #ifdef FLAT_FLOAT_ARRAY
             || ft == Double_tag
 #endif

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -221,7 +221,7 @@ CAMLprim value caml_obj_add_offset (value v, value offset)
 
 CAMLprim value caml_lazy_follow_forward (value v)
 {
-  if (Is_block (v) && Is_in_value_area(v)
+  if (Is_block (v) && !Is_naked_pointer(v)
       && Tag_val (v) == Forward_tag){
     return Forward_val (v);
   }else{


### PR DESCRIPTION
This macro is defined as `!(Is_in_value_arena(v))` in naked-pointers mode, and `0` otherwise. Using it allowed me to get rid of a number of `#ifdef NO_NAKED_POINTERS` conditionals, which makes the code more pleasant to read and thus more maintainable. I also used it in a couple places that were *not* using such conditionals before, and are now automagically faster in no-naked-pointers mode.

This last category of changes is of course where bugs may lie, because for those we have a change of behavior: for some uses of `Is_in_value_arena(v)` it would be invalid to remove the check even in no-naked-pointers mode (typically I did not touch hash.c, which is written in such a way that a code pointer may end up there, at least before #9648 gets merged.)

(The PR is best reviewed commit by commit. For reviewers: the comments proposed in #9684 may help read this PR, at least they helped me write it, so maybe go check that first.)

(cc @xavierleroy)