### PR TITLE
Naked pointers and the bytecode interpreter, alternative approach

### DIFF
--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -304,7 +304,7 @@ code_t caml_next_frame_pointer(value ** sp, value ** trsp)
     if (Is_long(*spv)) continue;
     p = (code_t*) spv;
     if(&Trap_pc(*trsp) == p) {
-      *trsp = Trap_link(*trsp);
+      *trsp = *trsp + Long_val(Trap_link_offset(*trsp));
       continue;
     }
 

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -75,7 +75,8 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   Caml_state->extern_sp -= narg + 4;
   for (i = 0; i < narg; i++) Caml_state->extern_sp[i] = args[i]; /* arguments */
 #ifndef LOCAL_CALLBACK_BYTECODE
-  Caml_state->extern_sp[narg] = (value)(callback_code + 4); /* return address */
+  Caml_state->extern_sp[narg] = Val_foreign_ptr(callback_code + 4);
+                                                 /* return address */
   Caml_state->extern_sp[narg + 1] = Val_unit;    /* environment */
   Caml_state->extern_sp[narg + 2] = Val_long(0); /* extra args */
   Caml_state->extern_sp[narg + 3] = closure;
@@ -85,7 +86,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   res = caml_interprete(callback_code, sizeof(callback_code));
 #else /*have LOCAL_CALLBACK_BYTECODE*/
   /* return address */
-  Caml_state->extern_sp[narg] = (value) (local_callback_code + 4);
+  Caml_state->extern_sp[narg] = Val_foreign_ptr(local_callback_code + 4);
   Caml_state->extern_sp[narg + 1] = Val_unit;    /* environment */
   Caml_state->extern_sp[narg + 2] = Val_long(0); /* extra args */
   Caml_state->extern_sp[narg + 3] = closure;

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -88,6 +88,30 @@ typedef uintnat mark_t;
 #define Is_exception_result(v) (((v) & 3) == 2)
 #define Extract_exception(v) ((v) & ~3)
 
+/* Pointers outside the OCaml heap that are used as values.
+   (E.g. code pointers.)  Must be 2-aligned. */
+
+Caml_inline value Val_foreign_ptr(void * p)
+{
+  CAMLassert(((value) p & 1) == 0);
+#ifdef NO_NAKED_POINTERS
+  return (value) p + 1;
+#else
+  return (value) p;
+#endif
+}
+
+Caml_inline void * Foreign_ptr_val(value v)
+{
+#ifdef NO_NAKED_POINTERS
+  CAMLassert((v & 1) == 1);
+  return (void *) (v - 1);
+#else
+  CAMLassert((v & 1) == 0);
+  return (void *) v;
+#endif
+}
+
 /* Structure of the header:
 
 For 16-bit and 32-bit architectures:

--- a/runtime/caml/stacks.h
+++ b/runtime/caml/stacks.h
@@ -33,7 +33,7 @@
 #define caml_trap_barrier (Caml_state_field(trap_barrier))
 
 #define Trap_pc(tp) (((code_t *)(tp))[0])
-#define Trap_link(tp) (((value **)(tp))[1])
+#define Trap_link_offset(tp) (((value *)(tp))[1])
 
 void caml_init_stack (uintnat init_max_size);
 void caml_realloc_stack (asize_t required_size);

--- a/runtime/caml/stacks.h
+++ b/runtime/caml/stacks.h
@@ -32,7 +32,7 @@
 #define caml_trapsp (Caml_state_field(trapsp))
 #define caml_trap_barrier (Caml_state_field(trap_barrier))
 
-#define Trap_pc(tp) (((code_t *)(tp))[0])
+#define Trap_pc(tp) (((value *)(tp))[0])
 #define Trap_link_offset(tp) (((value *)(tp))[1])
 
 void caml_init_stack (uintnat init_max_size);

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -344,7 +344,7 @@ void caml_debugger_code_unloaded(int index)
   })
 }
 
-#define Pc(sp) ((code_t)((sp)[0]))
+#define Pc(sp) ((code_t) Foreign_ptr_val((sp)[0]))
 #define Env(sp) ((sp)[1])
 #define Extra_args(sp) (Long_val(((sp)[2])))
 #define Locals(sp) ((sp) + 3)

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -850,7 +850,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(PUSHTRAP):
       sp -= 4;
       Trap_pc(sp) = pc + *pc;
-      Trap_link(sp) = Caml_state->trapsp;
+      Trap_link_offset(sp) = Val_long(Caml_state->trapsp - sp);
       sp[2] = env;
       sp[3] = Val_long(extra_args);
       Caml_state->trapsp = sp;
@@ -865,7 +865,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         pc--; /* restart the POPTRAP after processing the signal */
         goto process_actions;
       }
-      Caml_state->trapsp = Trap_link(sp);
+      Caml_state->trapsp = sp + Long_val(Trap_link_offset(sp));
       sp += 4;
       Next;
 
@@ -898,7 +898,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       }
       sp = Caml_state->trapsp;
       pc = Trap_pc(sp);
-      Caml_state->trapsp = Trap_link(sp);
+      Caml_state->trapsp = sp + Long_val(Trap_link_offset(sp));
       env = sp[2];
       extra_args = Long_val(sp[3]);
       sp += 4;

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -540,7 +540,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
         Alloc_small(accu, num_args + 3, Closure_tag);
         Field(accu, 2) = env;
         for (i = 0; i < num_args; i++) Field(accu, i + 3) = sp[i];
-        CAMLassert(!Is_in_value_area(pc-3));
         Code_val(accu) = pc - 3; /* Point to the preceding RESTART instr. */
         Closinfo_val(accu) = Make_closinfo(0, 2);
         sp += num_args;
@@ -569,7 +568,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
       }
       /* The code pointer is not in the heap, so no need to go through
          caml_initialize. */
-      CAMLassert(!Is_in_value_area(pc + *pc));
       Code_val(accu) = pc + *pc;
       Closinfo_val(accu) = Make_closinfo(0, 2);
       pc++;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -35,12 +35,6 @@
 #include "caml/memprof.h"
 #include "caml/eventlog.h"
 
-#if defined (NATIVE_CODE) && defined (NO_NAKED_POINTERS)
-#define NATIVE_CODE_AND_NO_NAKED_POINTERS
-#else
-#undef NATIVE_CODE_AND_NO_NAKED_POINTERS
-#endif
-
 #ifdef _MSC_VER
 Caml_inline double fmin(double a, double b) {
   return (a < b) ? a : b;
@@ -152,7 +146,7 @@ static void realloc_gray_vals (void)
 
 void caml_darken (value v, value *p /* not used */)
 {
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
   if (Is_block (v) && !Is_young (v)) {
 #else
   if (Is_block (v) && Is_in_heap (v)) {
@@ -164,7 +158,7 @@ void caml_darken (value v, value *p /* not used */)
       h = Hd_val (v);
       t = Tag_hd (h);
     }
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
     /* We insist that naked pointers to outside the heap point to things that
        look like values with headers coloured black.  This isn't always
        strictly necessary but is essential in certain cases---in particular
@@ -236,7 +230,7 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
 
   child = Field (v, i);
 
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
   if (Is_block (child) && ! Is_young (child)) {
 #else
   if (Is_block (child) && Is_in_heap (child)) {
@@ -270,7 +264,7 @@ Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
       child -= Infix_offset_val(child);
       chd = Hd_val(child);
     }
-#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+#ifdef NO_NAKED_POINTERS
     /* See [caml_darken] for a description of this assertion. */
     CAMLassert (Is_in_heap (child) || Is_black_hd (chd));
 #endif

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -232,7 +232,7 @@ CAMLprim value caml_invoke_traced_function(value codeptr, value env, value arg)
   Caml_state->extern_sp -= 4;
   nsp = Caml_state->extern_sp;
   for (i = 0; i < 7; i++) nsp[i] = osp[i];
-  nsp[7] = (value) Nativeint_val(codeptr);
+  nsp[7] = Val_foreign_ptr((char *) Nativeint_val(codeptr));
   nsp[8] = env;
   nsp[9] = Val_int(0);
   nsp[10] = arg;

--- a/runtime/stacks.c
+++ b/runtime/stacks.c
@@ -47,7 +47,6 @@ void caml_realloc_stack(asize_t required_space)
 {
   asize_t size;
   value * new_low, * new_high, * new_sp;
-  value * p;
 
   CAMLassert(Caml_state->extern_sp >= Caml_state->stack_low);
   size = Caml_state->stack_high - Caml_state->stack_low;
@@ -72,8 +71,6 @@ void caml_realloc_stack(asize_t required_space)
   caml_stat_free(Caml_state->stack_low);
   Caml_state->trapsp = (value *) shift(Caml_state->trapsp);
   Caml_state->trap_barrier = (value *) shift(Caml_state->trap_barrier);
-  for (p = Caml_state->trapsp; p < new_high; p = Trap_link(p))
-    Trap_link(p) = (value *) shift(Trap_link(p));
   Caml_state->stack_low = new_low;
   Caml_state->stack_high = new_high;
   Caml_state->stack_threshold =


### PR DESCRIPTION
This is an alternative to #9680 (please see for context) where code pointers in the stack of the bytecode interpreter follow approach 1a (encapsulation by setting the low bit to 1) instead of 2b (special tests at scanning time).  
