### PR TITLE
Adapt caml_alloc_dummy_infix to new closure representation

### DIFF
--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -138,8 +138,11 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
     for (i = 0; i < sz; i++) Field(res, i) = Field(arg, i);
   } else {
     res = caml_alloc_shr(sz, tg);
+    /* It is safe to use [caml_initialize] even if [tag == Closure_tag]
+       and some of the "values" being copied are actually code pointers.
+       That's because the new "value" does not point to the minor heap. */
     for (i = 0; i < sz; i++) caml_initialize(&Field(res, i), Field(arg, i));
-    // Give gc a chance to run, and run memprof callbacks
+    /* Give gc a chance to run, and run memprof callbacks */
     caml_process_pending_actions();
   }
   CAMLreturn (res);


### PR DESCRIPTION
As noticed by @jhjourdan in https://github.com/ocaml/ocaml/pull/9619#issuecomment-645177697, the first closure info field must be valid.

Also document two other places where no change is needed because of the new closure representation, but for non-obvious reasons.