### PR TITLE
use [raw_field] primitives in camlinternalMod

### DIFF
--- a/Changes
+++ b/Changes
@@ -205,6 +205,11 @@ Working version
   be ignored (eg `ocamlrunparam`).
   (Nicolás Ojeda Bär, review by Sébastien Hinderer)
 
+- #9681, #9690, #9693: small runtime changes
+  for the new closure representation (#9619)
+  (Xavier Leroy, Sadiq Jaffer, Gabriel Scherer,
+   review by Xavier Leroy and Jacques-Henri Jourdan)
+
 OCaml 4.11
 ----------
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -90,39 +90,49 @@ CAMLprim value caml_obj_block(value tag, value size)
    * pointer to a block of custom operations. Without initialisation, hashing,
    * finalising or serialising this custom object will lead to crashes. See
    * GPR#9513 for more details.
+   *
+   * Note: we fail here before the allocation happens, to ensure that
+   * no ill-formed block is created even in the failure case. This would
+   * cause a segfault when the GC will try to use the custom finalization operation
+   * when it notices the value is dead.
    */
   if (tg == Custom_tag)
     caml_invalid_argument ("Obj.new_block");
 
   /* When [tg < No_scan_tag], [caml_alloc] returns an object whose fields are
    * initialised to [Val_unit]. Otherwise, the fields are uninitialised. We aim
-   * to avoid inconsistent states in other cases.
-   *
-   * For [Abstract_tag], [Double_tag] and [Double_array_tag], the initial
-   * content is irrelevant. [Custom_tag] objects are disallowed.
-   *
-   * For [String_tag], the initial contents do no matter. However, the length
-   * of the string is encoded using the last byte of the block. For this
-   * reason, the blocks with [String_tag] cannot be of size [0]. We initialise
-   * the last byte to [0] such that the length returned by [String.length] and
-   * [Bytes.length] is non-negative number.
-   *
-   * [Closure_tag] is below [no_scan_tag], but closures have more
-   * structure with in particular a "closure information" that
-   * indicates where the environment start. We initialize this to
-   * a sane value, as it may be accessed by runtime functions.
-   */
+   * to avoid inconsistent states in other cases. */
   res = caml_alloc(sz, tg);
 
-  if (tg == String_tag) {
-    if (sz == 0) caml_invalid_argument ("Obj.new_block");
-    Field (res, sz - 1) = 0;
-  }
-
-  if (tg == Closure_tag) {
-    /* Closinfo_val is the seconnd field, so we need size at least 2 */
+  switch (tg) {
+  case Closure_tag: {
+    /* [Closure_tag] is below [no_scan_tag], but closures have more
+       structure with in particular a "closure information" that
+       indicates where the environment starts. We initialize this to
+       a sane value, as it may be accessed by runtime functions. */
+    /* Closinfo_val is the second field, so we need size at least 2 */
     if (sz < 2) caml_invalid_argument ("Obj.new_block");
     Closinfo_val(res) = Make_closinfo(0, 2);
+    break;
+  }
+  case Abstract_tag:
+  case Double_tag:
+  case Double_array_tag: {
+   /* For [Abstract_tag], [Double_tag] and [Double_array_tag], the initial
+      content is irrelevant. */
+    break;
+  }
+  case String_tag: {
+    /* For [String_tag], the initial content does not matter. However,
+       the length of the string is encoded using the last byte of the
+       block. For this reason, the blocks with [String_tag] cannot be
+       of size [0]. We initialise the last byte to [0] such that the
+       length returned by [String.length] and [Bytes.length] is
+       a non-negative number. */
+    if (sz == 0) caml_invalid_argument ("Obj.new_block");
+    Field (res, sz - 1) = 0;
+    break;
+  }
   }
 
   return res;

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -106,12 +106,23 @@ CAMLprim value caml_obj_block(value tag, value size)
    * reason, the blocks with [String_tag] cannot be of size [0]. We initialise
    * the last byte to [0] such that the length returned by [String.length] and
    * [Bytes.length] is non-negative number.
+   *
+   * [Closure_tag] is below [no_scan_tag], but closures have more
+   * structure with in particular a "closure information" that
+   * indicates where the environment start. We initialize this to
+   * a sane value, as it may be accessed by runtime functions.
    */
   res = caml_alloc(sz, tg);
 
   if (tg == String_tag) {
     if (sz == 0) caml_invalid_argument ("Obj.new_block");
     Field (res, sz - 1) = 0;
+  }
+
+  if (tg == Closure_tag) {
+    /* Closinfo_val is the seconnd field, so we need size at least 2 */
+    if (sz < 2) caml_invalid_argument ("Obj.new_block");
+    Closinfo_val(res) = Make_closinfo(0, 2);
   }
 
   return res;

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -146,12 +146,14 @@ camlinternalLazy.cmi :
 camlinternalMod.cmo : \
     stdlib__sys.cmi \
     stdlib__obj.cmi \
+    stdlib__nativeint.cmi \
     camlinternalOO.cmi \
     stdlib__array.cmi \
     camlinternalMod.cmi
 camlinternalMod.cmx : \
     stdlib__sys.cmx \
     stdlib__obj.cmx \
+    stdlib__nativeint.cmx \
     camlinternalOO.cmx \
     stdlib__array.cmx \
     camlinternalMod.cmi
@@ -441,11 +443,13 @@ stdlib__nativeint.cmx : \
 stdlib__nativeint.cmi :
 stdlib__obj.cmo : \
     stdlib__sys.cmi \
+    stdlib__nativeint.cmi \
     stdlib__marshal.cmi \
     stdlib__int32.cmi \
     stdlib__obj.cmi
 stdlib__obj.cmx : \
     stdlib__sys.cmx \
+    stdlib__nativeint.cmx \
     stdlib__marshal.cmx \
     stdlib__int32.cmx \
     stdlib__obj.cmi

--- a/stdlib/camlinternalMod.ml
+++ b/stdlib/camlinternalMod.ml
@@ -28,6 +28,38 @@ let overwrite o n =
     Obj.set_field o i (Obj.field n i)
   done
 
+let overwrite_closure o n =
+  (* We need to use the [raw_field] functions at least on the code
+     pointer, which is not a valid value in -no-naked-pointers
+     mode. *)
+  assert (Obj.tag n = Obj.closure_tag);
+  assert (Obj.size o >= Obj.size n);
+  let n_start_env = Obj.Closure.((info n).start_env) in
+  let o_start_env = Obj.Closure.((info o).start_env) in
+  (* if the environment of n starts before the one of o,
+     clear the raw fields in between. *)
+  for i = n_start_env to o_start_env - 1 do
+    Obj.set_raw_field o i Nativeint.one
+  done;
+  (* if the environment of o starts before the one of n,
+     clear the environment fields in between. *)
+  for i = o_start_env to n_start_env - 1 do
+    Obj.set_field o i (Obj.repr ())
+  done;
+  for i = 0 to n_start_env - 1 do
+    (* code pointers, closure info fields, infix headers *)
+    Obj.set_raw_field o i (Obj.raw_field n i)
+  done;
+  for i = n_start_env to Obj.size n - 1 do
+    (* environment fields *)
+    Obj.set_field o i (Obj.field n i)
+  done;
+  for i = Obj.size n to Obj.size o - 1 do
+    (* clear the leftover space *)
+    Obj.set_field o i (Obj.repr ())
+  done;
+  ()
+
 let rec init_mod loc shape =
   match shape with
   | Function ->
@@ -37,7 +69,7 @@ let rec init_mod loc shape =
       let template =
         Obj.repr (fun _ -> raise (Undefined_recursive_module loc))
       in
-      overwrite closure template;
+      overwrite_closure closure template;
       closure
   | Lazy ->
       Obj.repr (lazy (raise (Undefined_recursive_module loc)))
@@ -61,8 +93,8 @@ let rec update_mod shape o n =
       && (Obj.size n = Obj.size o
           || (Sys.backend_type = Sys.Native
               && Obj.size n <= Obj.size o))
-      then begin overwrite o n end
-      else overwrite o (Obj.repr (fun x -> (Obj.obj n : _ -> _) x))
+      then begin overwrite_closure o n end
+      else overwrite_closure o (Obj.repr (fun x -> (Obj.obj n : _ -> _) x))
   | Lazy ->
       if Obj.tag n = Obj.lazy_tag then
         Obj.set_field o 0 (Obj.field n 0)

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -74,6 +74,33 @@ let int_tag = 1000
 let out_of_heap_tag = 1001
 let unaligned_tag = 1002
 
+module Closure = struct
+  type info = {
+    arity: int;
+    start_env: int;
+  }
+
+  let info_of_raw (info : nativeint) =
+    let open Nativeint in
+    let arity =
+      (* signed: negative for tupled functions *)
+      if Sys.word_size = 64 then
+        to_int (shift_right info 56)
+      else
+        to_int (shift_right info 24)
+    in
+    let start_env =
+      (* start_env is unsigned, but we know it can always fit an OCaml
+         integer so we use [to_int] instead of [unsigned_to_int]. *)
+      to_int (shift_right_logical (shift_left info 8) 9) in
+    { arity; start_env }
+
+  (* note: we expect a closure, not an infix pointer *)
+  let info (obj : t) =
+    assert (tag obj = closure_tag);
+    info_of_raw (raw_field obj 1)
+end
+
 module Extension_constructor =
 struct
   type t = extension_constructor

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -99,6 +99,14 @@ val int_tag : int
 val out_of_heap_tag : int
 val unaligned_tag : int   (* should never happen @since 3.11.0 *)
 
+module Closure : sig
+  type info = {
+    arity: int;
+    start_env: int;
+  }
+  val info : t -> info
+end
+
 module Extension_constructor :
 sig
   type t = extension_constructor


### PR DESCRIPTION
Looking at #9690 (changes to caml_{alloc,update}_dummy for the new closure representation of #9619), I have the impression that camlinternalMod.update_mod needs to be updated as well. Here is a naive proposal.

(cc @xavierleroy @jhjourdan)