### PR TITLE
Remove Is_in_code_area and registration of code in page table

### DIFF
--- a/Changes
+++ b/Changes
@@ -65,6 +65,10 @@ Working version
 - #9675: Remove the caml_static_{alloc,free,resize} primitives, now unused.
   (Xavier Leroy, review by Gabriel Scherer)
 
+* #9697: Remove the Is_in_code_area macro and the registration of DLL code
+  areas in the page table, subsumed by the new code fragment management API
+  (Xavier Leroy, review by Jacques-Henri Jourdan)
+
 ### Code generation and optimizations:
 
 - #9620: Limit the number of parameters for an uncurried or untupled

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -77,11 +77,6 @@
 #define Is_in_value_area(a)                                     \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
 
-#define Is_in_code_area(pc) \
- (    ((char *)(pc) >= caml_code_area_start && \
-       (char *)(pc) <= caml_code_area_end)     \
-   || (Classify_addr(pc) & In_code_area) )
-
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
 
 /***********************************************************************/
@@ -93,7 +88,6 @@ extern char * caml_code_area_start, * caml_code_area_end;
 #define In_heap 1
 #define In_young 2
 #define In_static_data 4
-#define In_code_area 8
 
 #ifdef ARCH_SIXTYFOUR
 

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -126,11 +126,9 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
 
   sym = optsym("__code_begin");
   sym2 = optsym("__code_end");
-  if (NULL != sym && NULL != sym2) {
-    caml_page_table_add(In_code_area, sym, sym2);
+  if (NULL != sym && NULL != sym2)
     caml_register_code_fragment((char *) sym, (char *) sym2,
                                 DIGEST_LATER, NULL);
-  }
 
   if( caml_natdynlink_hook != NULL ) caml_natdynlink_hook(handle,unit);
 


### PR DESCRIPTION
Previously, code areas from native-code DLLs were registered in the page table and could be queried with the `Is_in_code_area` macro.

Following commit e4bf109d1 (#9682), the runtime system no longer queries the page table for code areas (it uses the table of code fragments instead).

A grep through OPAM package sources shows no uses of `Is_in_code_area` macro or the `In_code_area flag` for pages.  So there is no need to provide an alternate implementation of `Is_in_code_area`.

This commit simply removes the `Is_in_code_area macro` and the registration of code areas in the page table.
