### PR TITLE
The end of the page table is near

### DIFF
--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -74,8 +74,12 @@
 
 #define Is_in_heap_or_young(a) (Classify_addr(a) & (In_heap | In_young))
 
+#ifdef NO_NAKED_POINTERS
+#define Is_in_value_area(a) 1
+#else
 #define Is_in_value_area(a)                                     \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
+#endif
 
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
 

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -84,9 +84,9 @@
 #define Is_in_value_area(a)                                     \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
 
-#endif
-
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
+
+#endif
 
 /***********************************************************************/
 /* The rest of this file is private and may change without notice. */

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -72,13 +72,18 @@
 
 #define Is_in_heap(a) (Classify_addr(a) & In_heap)
 
+#ifdef NO_NAKED_POINTERS
+
+#define Is_in_heap_or_young(a) 1
+#define Is_in_value_area(a) 1
+
+#else
+
 #define Is_in_heap_or_young(a) (Classify_addr(a) & (In_heap | In_young))
 
-#ifdef NO_NAKED_POINTERS
-#define Is_in_value_area(a) 1
-#else
 #define Is_in_value_area(a)                                     \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
+
 #endif
 
 #define Is_in_static_data(a) (Classify_addr(a) & In_static_data)

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -176,7 +176,7 @@ Caml_inline void caml_ephe_clean_partial (value v,
     child = Field (v, i);
   ephemeron_again:
     if (child != caml_ephe_none
-        && Is_block (child) && Is_in_heap_or_young (child)){
+        && Is_block (child) && Is_in_value_area (child)){
       if (Tag_val (child) == Forward_tag){
         value f = Forward_val (child);
         if (Is_block (f)) {

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -127,11 +127,9 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (Is_long(v2))
         return Long_val(v1) - Long_val(v2);
       /* Subtraction above cannot overflow and cannot result in UNORDERED */
-#ifndef NO_NAKED_POINTERS
       if (!Is_in_value_area(v2))
         return LESS;
-#endif
-        switch (Tag_val(v2)) {
+      switch (Tag_val(v2)) {
         case Forward_tag:
           v2 = Forward_val(v2);
           continue;
@@ -150,11 +148,9 @@ static intnat do_compare_val(struct compare_stack* stk,
       return LESS;                /* v1 long < v2 block */
     }
     if (Is_long(v2)) {
-#ifndef NO_NAKED_POINTERS
       if (!Is_in_value_area(v1))
         return GREATER;
-#endif
-        switch (Tag_val(v1)) {
+      switch (Tag_val(v1)) {
         case Forward_tag:
           v1 = Forward_val(v1);
           continue;
@@ -172,7 +168,6 @@ static intnat do_compare_val(struct compare_stack* stk,
         }
       return GREATER;            /* v1 block > v2 long */
     }
-#ifndef NO_NAKED_POINTERS
     /* If one of the objects is outside the heap (but is not an atom),
        use address comparison. Since both addresses are 2-aligned,
        shift lsb off to avoid overflow in subtraction. */
@@ -181,7 +176,6 @@ static intnat do_compare_val(struct compare_stack* stk,
       return (v1 >> 1) - (v2 >> 1);
       /* Subtraction above cannot result in UNORDERED */
     }
-#endif
     t1 = Tag_val(v1);
     t2 = Tag_val(v2);
     if (t1 != t2) {

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -698,13 +698,11 @@ static void extern_rec(value v)
   if (Is_long(v)) {
     extern_int(Long_val(v));
   }
-#ifndef NO_NAKED_POINTERS
   else if (! (Is_in_value_area(v) || caml_extern_allow_out_of_heap)) {
     /* Naked pointer outside the heap: try to marshal it as a code pointer,
        otherwise fail. */
     extern_code_pointer((char *) v);
   }
-#endif
   else {
     header_t hd = Hd_val(v);
     tag_t tag = Tag_hd(hd);
@@ -1144,13 +1142,12 @@ CAMLprim value caml_obj_reachable_words(value v)
   while (1) {
     if (Is_long(v)) {
       /* Tagged integers contribute 0 to the size, nothing to do */
-#ifndef NO_NAKED_POINTERS
     } else if (! Is_in_heap_or_young(v)) {
       /* Out-of-heap blocks contribute 0 to the size, nothing to do */
-      /* However, once we get rid of the page table, we will no longer
-         be able to distinguish major heap blocks and out-of-heap blocks,
-         so we will need to count out-of-heap blocks too. */
-#endif
+      /* However, in no-naked-pointers mode, we don't distinguish
+         between major heap blocks and out-of-heap blocks,
+         and the test above is always false,
+         so we end up counting out-of-heap blocks too. */
     } else if (extern_lookup_position(v, &pos, &h)) {
       /* Already seen and counted, nothing to do */
     } else {

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -205,14 +205,12 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
       h = caml_hash_mix_intnat(h, v);
       num--;
     }
-#ifndef NO_NAKED_POINTERS
     else if (!Is_in_value_area(v)) {
       /* v is a pointer outside the heap, probably a code pointer.
          Shall we count it?  Let's say yes by compatibility with old code. */
       h = caml_hash_mix_intnat(h, v);
       num--;
     }
-#endif
     else {
       switch (Tag_val(v)) {
       case String_tag:
@@ -344,14 +342,12 @@ static void hash_aux(struct hash_state* h, value obj)
     Combine(Long_val(obj));
     return;
   }
-#ifndef NO_NAKED_POINTERS
   if (! Is_in_value_area(obj)) {
     /* obj is a pointer outside the heap, to an object with
        a priori unknown structure. Use its physical address as hash key. */
     Combine((intnat) obj);
     return;
   }
-#endif
   /* Pointers into the heap are well-structured blocks. So are atoms.
      We can inspect the block contents. */
   /* The code needs reindenting later. Leaving as is to facilitate review. */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -295,7 +295,13 @@ static value* mark_ephe_aux (value *gray_vals_ptr, intnat *work,
   CAMLassert(Tag_val (v) == Abstract_tag);
   data = Field(v,CAML_EPHE_DATA_OFFSET);
   if ( data != caml_ephe_none &&
-       Is_block (data) && Is_in_heap (data) && Is_white_val (data)){
+       Is_block (data) &&
+#ifdef NO_NAKED_POINTERS
+       !Is_young(data) &&
+#else
+       Is_in_heap (data) &&
+#endif
+       Is_white_val (data)){
 
     int alive_data = 1;
 
@@ -308,7 +314,13 @@ static value* mark_ephe_aux (value *gray_vals_ptr, intnat *work,
       key = Field (v, i);
     ephemeron_again:
       if (key != caml_ephe_none &&
-          Is_block (key) && Is_in_heap (key)){
+          Is_block (key) &&
+#ifdef NO_NAKED_POINTERS
+          !Is_young(key)
+#else
+          Is_in_heap(key)
+#endif
+          ){
         if (Tag_val (key) == Forward_tag){
           value f = Forward_val (key);
           if (Is_long (f) ||

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -386,7 +386,7 @@ CAMLexport int caml_ephemeron_get_key_copy(value ar, mlsize_t offset,
     if(is_ephe_key_none(ar, offset)) CAMLreturn(0);
     v = Field (ar, offset);
     /** Don't copy custom_block #7279 */
-    if(!(Is_block (v) && Is_in_heap_or_young(v)  && Tag_val(v) != Custom_tag)) {
+    if(!(Is_block (v) && Is_in_value_area(v) && Tag_val(v) != Custom_tag)) {
       if ( caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(v) ){
         caml_darken (v, NULL);
       };
@@ -445,7 +445,7 @@ CAMLexport int caml_ephemeron_get_data_copy (value ar, value *data)
     v = Field (ar, CAML_EPHE_DATA_OFFSET);
     if (v == caml_ephe_none) CAMLreturn(0);
     /** Don't copy custom_block #7279 */
-    if (!(Is_block (v) && Is_in_heap_or_young(v) && Tag_val(v) != Custom_tag)) {
+    if (!(Is_block (v) && Is_in_value_area(v) && Tag_val(v) != Custom_tag)) {
       if ( caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(v) ){
         caml_darken (v, NULL);
       };

--- a/testsuite/tests/asmcomp/is_static.ml
+++ b/testsuite/tests/asmcomp/is_static.ml
@@ -1,6 +1,7 @@
 (* TEST
    modules = "is_in_static_data.c"
-   * native
+   * naked_pointers
+   ** native
 *)
 
 (* Data that should be statically allocated by the compiler (all versions) *)


### PR DESCRIPTION
(Let's see if a click bait title attracts more reviews...)

This pull request eliminates some more uses of the page table in the runtime system when built in no-naked-pointers mode, in preparation for Multicore OCaml, which has no page table.

In the end, only one use remains in the code of the runtime system (file compact.c), plus a number of uses in assertions in debug mode.  

The 5 commits in this PR are well documented in their commit messages.  Before reviewing, it can be helpful to re-read the description of the pointer classification macros in https://github.com/ocaml/ocaml/blob/trunk/runtime/caml/address_class.h.  

The first commit is the continuation of #9680 by other means.

#9678 must be merged before this one, hence the "draft" status.