### PR TITLE
Bootstrapping FlexDLL when new primitives have been added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,13 +300,17 @@ flexdll: flexdll/Makefile flexlink
              MSVC_DETECT=0 CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false support
 
 # Bootstrapping flexlink - leaves a bytecode image of flexlink.exe in flexdll/
-FLEXLINK_OCAMLOPT = ../boot/ocamlrun$(EXE) ../boot/ocamlc -nostdlib -I ../boot
+FLEXLINK_OCAMLOPT = \
+   ../boot/ocamlrun$(EXE) ../boot/ocamlc \
+   -use-prims ../runtime/primitives -nostdlib -I ../boot
+
 .PHONY: flexlink
 flexlink: flexdll/Makefile
 	$(MAKE) -C runtime BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
-	$(MAKE) -C stdlib COMPILER=../boot/ocamlc \
-	                  $(filter-out *.cmi,$(LIBFILES))
+	$(MAKE) -C stdlib \
+                COMPILER="../boot/ocamlc -use-prims ../runtime/primitives" \
+                $(filter-out *.cmi,$(LIBFILES))
 	cd stdlib && cp $(LIBFILES) ../boot/
 	$(MAKE) -C flexdll MSVC_DETECT=0 OCAML_CONFIG_FILE=../Makefile.config \
 	  CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \


### PR DESCRIPTION
Under Windows, it is possible to build FlexDLL from sources while OCaml is building from sources too.  This is used for our Appveyor CI, in particular.

However, the current build procedure assumes that the OCaml bootstrap is stable, and in particular that boot/ocamlc knows about all the primitives defined by runtime/ocamlrun and used in stdlib.

This commit lifts this assumption and enables FlexDLL to be bootstrapped even if the OCaml bootstrap is not there yet.  This unblocks Appveyor CI in this case.

Developed and tested with help from @Octachron.
