### PR TITLE
Fix #9695: no error when opening an alias to a missing module

### DIFF
--- a/Changes
+++ b/Changes
@@ -712,8 +712,8 @@ OCaml 4.11
   (Gabriel Scherer, review by Jacques Garrigue and Leo White,
    report by Hugo Heuzard)
 
-- #9695: no error when opening an alias to a missing module
-  (Jacques Garrigue, report by Gabriel Scherer)
+- #9695, #9702: no error when opening an alias to a missing module
+  (Jacques Garrigue, report and review by Gabriel Scherer)
 
 OCaml 4.10 maintenance branch
 -----------------------------

--- a/Changes
+++ b/Changes
@@ -712,6 +712,9 @@ OCaml 4.11
   (Gabriel Scherer, review by Jacques Garrigue and Leo White,
    report by Hugo Heuzard)
 
+- #9695: no error when opening an alias to a missing module
+  (Jacques Garrigue, report by Gabriel Scherer)
+
 OCaml 4.10 maintenance branch
 -----------------------------
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1782,9 +1782,9 @@ let get_mod_field modname field =
        Env.add_persistent_structure mod_ident Env.initial_safe_string
      in
      match Env.open_pers_signature modname env with
-     | exception Not_found ->
+     | Error `Not_found ->
          fatal_error ("Module " ^ modname ^ " unavailable.")
-     | env -> (
+     | Ok env -> (
          match Env.find_value_by_name (Longident.Lident field) env with
          | exception Not_found ->
              fatal_error ("Primitive " ^ modname ^ "." ^ field ^ " not found.")

--- a/testsuite/tests/typing-modules-bugs/pr9695_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr9695_bad.compilers.reference
@@ -1,0 +1,4 @@
+File "pr9695_bad.ml", line 10, characters 18-19:
+10 | let () = let open A in x
+                       ^
+Error: This is an alias for module MissingModule, which is missing

--- a/testsuite/tests/typing-modules-bugs/pr9695_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr9695_bad.ml
@@ -1,0 +1,10 @@
+(* TEST
+flags = " -w a -no-alias-deps"
+ocamlc_byte_exit_status = "2"
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** check-ocamlc.byte-output
+*)
+
+module A = MissingModule
+let () = let open A in x

--- a/testsuite/tests/typing-modules/pr9695.ml
+++ b/testsuite/tests/typing-modules/pr9695.ml
@@ -1,0 +1,12 @@
+(* TEST
+   * expect
+*)
+
+module Test (S : sig module type S end) (M : S.S) =
+  struct open M (* should not succeed silently *) end
+[%%expect{|
+Line 2, characters 14-15:
+2 |   struct open M (* should not succeed silently *) end
+                  ^
+Error: This module is not a structure; it has type S.S
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2002,9 +2002,10 @@ let add_components slot root env0 comps =
   }
 
 let open_signature slot root env0 =
-  match get_components (find_module_components root env0) with
-  | Functor_comps _ -> None
-  | Structure_comps comps ->
+  match get_components_res (find_module_components root env0) with
+  | Error _
+  | Ok (Functor_comps _) -> None
+  | Ok (Structure_comps comps) ->
     Some (add_components slot root env0 comps)
 
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2001,20 +2001,22 @@ let add_components slot root env0 comps =
     modules;
   }
 
-let open_signature slot root env0 =
+let open_signature slot root env0 : (_,_) result =
   match get_components_res (find_module_components root env0) with
-  | Error _
-  | Ok (Functor_comps _) -> None
+  | Error _ -> Error `Not_found
+  | exception Not_found -> Error `Not_found
+  | Ok (Functor_comps _) -> Error `Functor
   | Ok (Structure_comps comps) ->
-    Some (add_components slot root env0 comps)
+    Ok (add_components slot root env0 comps)
 
 
 (* Open a signature from a file *)
 
 let open_pers_signature name env =
   match open_signature None (Pident(Ident.create_persistent name)) env with
-  | Some env -> env
-  | None -> assert false (* a compilation unit cannot refer to a functor *)
+  | (Ok _ | Error `Not_found as res) -> res
+  | Error `Functor -> assert false
+        (* a compilation unit cannot refer to a functor *)
 
 let open_signature
     ?(used_slot = ref false)

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -306,9 +306,9 @@ val open_signature:
     ?used_slot:bool ref ->
     ?loc:Location.t -> ?toplevel:bool ->
     Asttypes.override_flag -> Path.t ->
-      t -> t option
+    t -> (t, [`Not_found | `Functor]) result
 
-val open_pers_signature: string -> t -> t
+val open_pers_signature: string -> t -> (t, [`Not_found]) result
 
 (* Insertion by name *)
 

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -64,9 +64,9 @@ let rec env_from_summary sum subst =
           let env = env_from_summary s subst in
           let path' = Subst.module_path subst path in
           begin match Env.open_signature Asttypes.Override path' env with
-          | Some env -> env
-          | None -> assert false
-          | exception Not_found -> raise (Error (Module_not_found path'))
+          | Ok env -> env
+          | Error `Functor -> assert false
+          | Error `Not_found -> raise (Error (Module_not_found path'))
           end
       | Env_functor_arg(Env_module(s, id, pres, desc), id')
             when Ident.same id id' ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -134,8 +134,8 @@ let extract_sig_open env loc mty =
 let type_open_ ?used_slot ?toplevel ovf env loc lid =
   let path = Env.lookup_module_path ~load:true ~loc:lid.loc lid.txt env in
   match Env.open_signature ~loc ?used_slot ?toplevel ovf path env with
-  | Some env -> path, env
-  | None ->
+  | Ok env -> path, env
+  | Error _ ->
       let md = Env.find_module path env in
       ignore (extract_sig_open env lid.loc md.md_type);
       assert false


### PR DESCRIPTION
Fix #9695, which was caused by using `Env.get_components` without checking for errors.
Fortunately `Env.get_components_res` does returns errors.