### PR TITLE
regression test for #9701

### DIFF
--- a/testsuite/tests/backtrace/toplevel_script_backtrace.ml
+++ b/testsuite/tests/backtrace/toplevel_script_backtrace.ml
@@ -1,0 +1,22 @@
+(* TEST
+   ocaml_script_as_argument = "true"
+   ocaml_exit_status = "2"
+ * toplevel
+*)
+
+(* Make the test reproducible regardless of whether OCAMLRUNPARAM=b or not *)
+Printexc.record_backtrace true;;
+
+let () =
+  (* regression test for #9701 *)
+  Format.pp_print_text Format.std_formatter
+    "This test is currently not working at expected: \
+     it does not include proper backtrace locations for \
+     the exception raised in the ocaml script file. \
+     See 'Called from unknown location' in \
+     toplevel_script_backtrace.ocaml.reference";
+  Format.printf "@."
+
+let f () = failwith "test"
+let proc () = f ()
+let () = proc ()

--- a/testsuite/tests/backtrace/toplevel_script_backtrace.ocaml.reference
+++ b/testsuite/tests/backtrace/toplevel_script_backtrace.ocaml.reference
@@ -1,0 +1,8 @@
+This test is currently not working at expected: it does not include proper
+backtrace locations for the exception raised in the ocaml script file. See
+'Called from unknown location' in
+toplevel_script_backtrace.ocaml.reference
+Exception: Failure "test".
+Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+Called from unknown location
+Called from Toploop.load_lambda in file "toplevel/toploop.ml", line 212, characters 17-27


### PR DESCRIPTION
I tried to build a test that checks that unhandled exceptions in OCaml scripts show a proper backtrace. It works on my machine, but seems to be failing on some configurations:

>  ... testing 'toplevel_script_backtrace.ml' with 1 (toplevel) =>
> failed (Running toplevel_script_backtrace.ml in bytecode toplevel
> (expected exit status: 2): command
> /home/barsac/ci/builds/workspace/extra-checks/runtime/ocamlrun
> /home/barsac/ci/builds/workspace/extra-checks/ocaml -noinit -no-version -noprompt -nostdlib -I
> /home/barsac/ci/builds/workspace/extra-checks/stdlib -I
> /home/barsac/ci/builds/workspace/extra-checks/toplevel
> toplevel_script_backtrace.ml failed with exit code 1)
