### PR TITLE
Light syntax for first class polymorphism

### DIFF
--- a/testsuite/tests/typing-poly/poly_expr.ml
+++ b/testsuite/tests/typing-poly/poly_expr.ml
@@ -2,16 +2,16 @@
    * expect
 *)
 
-type nat = < poly : 'a. ('a -> 'a) -> ('a -> 'a) >
+type nat = < app : 'a. ('a -> 'a) -> ('a -> 'a) >
 type 'a nat' = ('a -> 'a) -> 'a -> 'a
 [%%expect{|
-type nat = < poly : 'a. ('a -> 'a) -> 'a -> 'a >
+type nat = < app : 'a. ('a -> 'a) -> 'a -> 'a >
 type 'a nat' = ('a -> 'a) -> 'a -> 'a
 |}]
 
 let zero : nat = [%poly (fun f x -> x : _ nat')]
 let one : nat = [%poly (fun f x -> f x : _ nat')]
-let suc : nat -> nat = fun n -> [%poly fun f x -> n#poly f (f x)]
+let suc : nat -> nat = fun n -> [%poly fun f x -> n#app f (f x)]
 [%%expect{|
 val zero : nat = <obj>
 val one : nat = <obj>
@@ -21,7 +21,7 @@ val suc : nat -> nat = <fun>
 let rec of_int' n f x =
   if n <= 0 then x else of_int' (n-1) f (f x)
 let of_int n : nat = [%poly of_int' n]
-let to_int (n : nat) = n#poly succ 0
+let to_int (n : nat) = n#app succ 0
 [%%expect{|
 val of_int' : int -> ('a -> 'a) -> 'a -> 'a = <fun>
 val of_int : int -> nat = <fun>
@@ -29,13 +29,13 @@ val to_int : nat -> int = <fun>
 |}]
 
 let add (m : nat) (n : nat) : nat =
-  [%poly fun f x -> m#poly f (n#poly f x)]
+  [%poly fun f x -> m#app f (n#app f x)]
 
 let mul : nat -> nat -> nat =
-  fun m n -> [%poly fun f -> m#poly (n#poly f)]
+  fun m n -> [%poly fun f -> m#app (n#app f)]
 
 let pow : nat -> nat -> nat =
-  fun m n -> [%poly n#poly m#poly]
+  fun m n -> [%poly n#app m#app]
 [%%expect{|
 val add : nat -> nat -> nat = <fun>
 val mul : nat -> nat -> nat = <fun>
@@ -54,30 +54,30 @@ let choose x y = if true then x else y
 let a2 () = choose id
 let a2' = choose [%poly id]
 let a3 = choose [] ids
-let auto (x : <poly : 'a. 'a -> 'a>) = x#poly x
-let auto' (x : <poly : 'a. 'a -> 'a>) = x#poly x#poly
+let auto (x : <app : 'a. 'a -> 'a>) = x#app x
+let auto' (x : <app : 'a. 'a -> 'a>) = x#app x#app
 let a5 = id auto
 let a6 () = id auto'
 let a6' = id [%poly auto']
 let a7 = choose id auto
-let poly (id : <poly: 'a. 'a -> 'a>) = id#poly 1, id#poly true
+let poly (id : <app : 'a. 'a -> 'a>) = id#app 1, id#app true
 let a10 = poly [%poly id]
 let a11 = poly [%poly fun x -> x]
 let a12 = id poly [%poly fun x -> x]
 [%%expect{|
 val id : 'a -> 'a = <fun>
-val ids : < poly : 'a. 'a -> 'a > list = [<obj>]
+val ids : < app : 'a. 'a -> 'a > list = [<obj>]
 val choose : 'a -> 'a -> 'a = <fun>
 val a2 : unit -> ('a -> 'a) -> 'a -> 'a = <fun>
-val a2' : < poly : 'a. 'a -> 'a > -> < poly : 'b. 'b -> 'b > = <fun>
-val a3 : < poly : 'a. 'a -> 'a > list = []
-val auto : < poly : 'a. 'a -> 'a > -> < poly : 'a. 'a -> 'a > = <fun>
-val auto' : < poly : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
-val a5 : < poly : 'a. 'a -> 'a > -> < poly : 'a. 'a -> 'a > = <fun>
-val a6 : unit -> < poly : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
-val a6' : < poly : 'b. < poly : 'a. 'a -> 'a > -> 'b -> 'b > = <obj>
-val a7 : < poly : 'a. 'a -> 'a > -> < poly : 'a. 'a -> 'a > = <fun>
-val poly : < poly : 'a. 'a -> 'a > -> int * bool = <fun>
+val a2' : < app : 'a. 'a -> 'a > -> < app : 'b. 'b -> 'b > = <fun>
+val a3 : < app : 'a. 'a -> 'a > list = []
+val auto : < app : 'a. 'a -> 'a > -> < app : 'a. 'a -> 'a > = <fun>
+val auto' : < app : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
+val a5 : < app : 'a. 'a -> 'a > -> < app : 'a. 'a -> 'a > = <fun>
+val a6 : unit -> < app : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
+val a6' : < app : 'b. < app : 'a. 'a -> 'a > -> 'b -> 'b > = <obj>
+val a7 : < app : 'a. 'a -> 'a > -> < app : 'a. 'a -> 'a > = <fun>
+val poly : < app : 'a. 'a -> 'a > -> int * bool = <fun>
 val a10 : int * bool = (1, true)
 val a11 : int * bool = (1, true)
 val a12 : int * bool = (1, true)

--- a/testsuite/tests/typing-poly/poly_expr.ml
+++ b/testsuite/tests/typing-poly/poly_expr.ml
@@ -1,0 +1,48 @@
+(* TEST
+   * expect
+*)
+
+type nat = < poly : 'a. ('a -> 'a) -> ('a -> 'a) >
+type 'a nat' = ('a -> 'a) -> 'a -> 'a
+[%%expect{|
+type nat = < poly : 'a. ('a -> 'a) -> 'a -> 'a >
+type 'a nat' = ('a -> 'a) -> 'a -> 'a
+|}]
+
+let zero : nat = [%poly (fun f x -> x : _ nat')]
+let one : nat = [%poly (fun f x -> f x : _ nat')]
+let suc : nat -> nat = fun n -> [%poly fun f x -> n#poly f (f x)]
+[%%expect{|
+val zero : nat = <obj>
+val one : nat = <obj>
+val suc : nat -> nat = <fun>
+|}]
+
+let rec of_int' n f x =
+  if n <= 0 then x else of_int' (n-1) f (f x)
+let of_int n : nat = [%poly of_int' n]
+let to_int (n : nat) = n#poly succ 0
+[%%expect{|
+val of_int' : int -> ('a -> 'a) -> 'a -> 'a = <fun>
+val of_int : int -> nat = <fun>
+val to_int : nat -> int = <fun>
+|}]
+
+let add (m : nat) (n : nat) : nat =
+  [%poly fun f x -> m#poly f (n#poly f x)]
+
+let mul : nat -> nat -> nat =
+  fun m n -> [%poly fun f -> m#poly (n#poly f)]
+
+let pow : nat -> nat -> nat =
+  fun m n -> [%poly n#poly m#poly]
+[%%expect{|
+val add : nat -> nat -> nat = <fun>
+val mul : nat -> nat -> nat = <fun>
+val pow : nat -> nat -> nat = <fun>
+|}]
+
+let test1 = to_int (pow (of_int 2) (of_int 3))
+[%%expect{|
+val test1 : int = 8
+|}]

--- a/testsuite/tests/typing-poly/poly_expr.ml
+++ b/testsuite/tests/typing-poly/poly_expr.ml
@@ -9,8 +9,8 @@ type nat = < poly : 'a. ('a -> 'a) -> 'a -> 'a >
 type 'a nat' = ('a -> 'a) -> 'a -> 'a
 |}]
 
-let zero : nat = [%poly (fun f x -> x : _ nat')]
-let one : nat = [%poly (fun f x -> f x : _ nat')]
+let zero : nat = [%poly fun f x -> x]
+let one : nat = [%poly fun f x -> f x]
 let suc : nat -> nat = fun n -> [%poly fun f x -> n#poly f (f x)]
 [%%expect{|
 val zero : nat = <obj>

--- a/testsuite/tests/typing-poly/poly_expr.ml
+++ b/testsuite/tests/typing-poly/poly_expr.ml
@@ -9,8 +9,8 @@ type nat = < poly : 'a. ('a -> 'a) -> 'a -> 'a >
 type 'a nat' = ('a -> 'a) -> 'a -> 'a
 |}]
 
-let zero : nat = [%poly fun f x -> x]
-let one : nat = [%poly fun f x -> f x]
+let zero : nat = [%poly (fun f x -> x : _ nat')]
+let one : nat = [%poly (fun f x -> f x : _ nat')]
 let suc : nat -> nat = fun n -> [%poly fun f x -> n#poly f (f x)]
 [%%expect{|
 val zero : nat = <obj>
@@ -45,4 +45,40 @@ val pow : nat -> nat -> nat = <fun>
 let test1 = to_int (pow (of_int 2) (of_int 3))
 [%%expect{|
 val test1 : int = 8
+|}]
+
+
+let id x = x
+let ids = [[%poly id]]
+let choose x y = if true then x else y
+let a2 () = choose id
+let a2' = choose [%poly id]
+let a3 = choose [] ids
+let auto (x : <poly : 'a. 'a -> 'a>) = x#poly x
+let auto' (x : <poly : 'a. 'a -> 'a>) = x#poly x#poly
+let a5 = id auto
+let a6 () = id auto'
+let a6' = id [%poly auto']
+let a7 = choose id auto
+let poly (id : <poly: 'a. 'a -> 'a>) = id#poly 1, id#poly true
+let a10 = poly [%poly id]
+let a11 = poly [%poly fun x -> x]
+let a12 = id poly [%poly fun x -> x]
+[%%expect{|
+val id : 'a -> 'a = <fun>
+val ids : < poly : 'a. 'a -> 'a > list = [<obj>]
+val choose : 'a -> 'a -> 'a = <fun>
+val a2 : unit -> ('a -> 'a) -> 'a -> 'a = <fun>
+val a2' : < poly : 'a. 'a -> 'a > -> < poly : 'b. 'b -> 'b > = <fun>
+val a3 : < poly : 'a. 'a -> 'a > list = []
+val auto : < poly : 'a. 'a -> 'a > -> < poly : 'a. 'a -> 'a > = <fun>
+val auto' : < poly : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
+val a5 : < poly : 'a. 'a -> 'a > -> < poly : 'a. 'a -> 'a > = <fun>
+val a6 : unit -> < poly : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
+val a6' : < poly : 'b. < poly : 'a. 'a -> 'a > -> 'b -> 'b > = <obj>
+val a7 : < poly : 'a. 'a -> 'a > -> < poly : 'a. 'a -> 'a > = <fun>
+val poly : < poly : 'a. 'a -> 'a > -> int * bool = <fun>
+val a10 : int * bool = (1, true)
+val a11 : int * bool = (1, true)
+val a12 : int * bool = (1, true)
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3675,7 +3675,7 @@ and type_expect_
             match (expand_head env xty).desc with
             | Tobject (fi, _) ->
                 begin match (repr fi).desc with
-                | Tfield ("poly", _, t, _) ->
+                | Tfield ("app", _, t, _) ->
                     begin match (repr t).desc with
                     | Tpoly (t, vars) ->
                         (* Need also to check principality *)
@@ -3700,13 +3700,13 @@ and type_expect_
           generalize ty;
           let ty_poly = reify_univars env ty in
           let ty_self =
-            newgenty (Tobject (newgenty (Tfield ("poly", Fpresent, ty_poly,
+            newgenty (Tobject (newgenty (Tfield ("app", Fpresent, ty_poly,
                                                  newgenty Tnil)),
                                ref None)) in
           let csig =
             {csig_self = ty_self;
              csig_vars = Vars.empty;
-             csig_concr = Concr.singleton "poly";
+             csig_concr = Concr.singleton "app";
              csig_inher = []} in
           let pat () =
             {pat_desc = Tpat_any;
@@ -3731,9 +3731,9 @@ and type_expect_
             {cstr_self = pat ();
              cstr_type = csig;
              cstr_meths =
-               Meths.add "poly" (Ident.create_local "poly") Meths.empty;
+               Meths.add "app" (Ident.create_local "app") Meths.empty;
              cstr_fields = [{cf_desc = Tcf_method
-                               (Location.mknoloc "poly", Public,
+                               (Location.mknoloc "app", Public,
                                 Tcfk_concrete (Fresh, met));
                              cf_loc = exp.exp_loc;
                              cf_attributes = []} ]} in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3665,6 +3665,61 @@ and type_expect_
       | _ ->
           raise (Error (loc, env, Invalid_extension_constructor_payload))
       end
+
+  | Pexp_extension ({ txt = ("ocaml.poly"|"poly"); _ },
+                    payload) ->
+      begin match payload with
+      | PStr [ { pstr_desc = Pstr_eval (sexp, attrs) } ] ->
+          begin_def();
+          let exp = type_exp env sexp in
+          end_def();
+          let ty = exp.exp_type in
+          generalize ty;
+          let ty_poly = reify_univars env ty in
+          let ty_self =
+            newgenty (Tobject (newgenty (Tfield ("poly", Fpresent, ty_poly,
+                                                 newgenty Tnil)),
+                               ref None)) in
+          let csig =
+            {csig_self = ty_self;
+             csig_vars = Vars.empty;
+             csig_concr = Concr.singleton "poly";
+             csig_inher = []} in
+          let pat () =
+            {pat_desc = Tpat_any;
+             pat_loc = Location.none;
+             pat_extra = [];
+             pat_type = instance ty_self;
+             pat_env = env;
+             pat_attributes = []} in
+          let pat_arg = pat () in
+          let met =
+            {exp_desc = Texp_function
+               {arg_label = Nolabel; param = Ident.create_local "*none*";
+                cases = [{c_lhs = pat_arg; c_guard = None; c_rhs = exp}];
+                partial = Total};
+             exp_loc = exp.exp_loc;
+             exp_extra = [];
+             exp_type = newgenty
+               (Tarrow (Nolabel, pat_arg.pat_type, ty_poly, Cok));
+             exp_env = env;
+             exp_attributes = []} in
+          let cstruct =
+            {cstr_self = pat ();
+             cstr_type = csig;
+             cstr_meths =
+               Meths.add "poly" (Ident.create_local "poly") Meths.empty;
+             cstr_fields = [{cf_desc = Tcf_method
+                               (Location.mknoloc "poly", Public,
+                                Tcfk_concrete (Fresh, met));
+                             cf_loc = exp.exp_loc;
+                             cf_attributes = []} ]} in
+          rue {met with exp_desc = Texp_object (cstruct, []);
+               exp_type = instance ty_self; exp_attributes = attrs}
+      | _ ->
+          raise (Error (loc, env, Invalid_extension_constructor_payload))
+      end
+
   | Pexp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3670,7 +3670,7 @@ and type_expect_
                     payload) ->
       begin match payload with
       | PStr [ { pstr_desc = Pstr_eval (sexp, attrs) } ] ->
-          let xty = instance ty_expected in
+          (*let xty = instance ty_expected in
           let xpl =
             match (expand_head env xty).desc with
             | Tobject (fi, _) ->
@@ -3685,14 +3685,14 @@ and type_expect_
                 | _ -> None
                 end
             | _ -> None
-          in
+          in*)
           begin_def();
           let exp =
-            match xpl with
+            (*match xpl with
             | Some (t, vars) ->
                 let (_, xty) = instance_poly true vars t in
                 type_expect env sexp (mk_expected xty)
-            | None ->
+            | None ->*)
                 type_exp env sexp
           in
           end_def();


### PR DESCRIPTION
Use the syntax `[%poly <expr>]` as a shorthand for
```ocaml
object method poly : <polytype> = < expr> end
```
where `<polytype>` is inferred.

This is just a proof of concept.