### PR TITLE
dune: temporarily remove use of new primitive before building

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -45,6 +45,7 @@
      gc_ctrl.c  md5.c obj.c
    lexing.c callback.c debugger.c weak.c compact.c finalise.c custom.c dynlink.c
    spacetime_byt.c afl.c unix.c win32.c bigarray.c main.c memprof.c domain.c
+   skiplist.c codefrag.c
  )
  (action
    (progn

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -24,8 +24,11 @@
  (preprocess
    (per_module
      ((action
-        (run awk -v dune_wrapped=true
-               -f %{dep:expand_module_aliases.awk} %{input-file}))
+        (progn
+          ; FIXME: remove after 4.12
+          (run sed -i s/loc_FUNCTION/loc_POS/ %{input-file})
+          (run awk -v dune_wrapped=true
+                 -f %{dep:expand_module_aliases.awk} %{input-file})))
       stdlib))))
 
 (rule


### PR DESCRIPTION
The dune build started failing recently after the addition of a new primitive: that's because the stdlib can't be build with a compiler that doesn't know that primitive.
Until dune uses such a compiler, it removes the only occurrence of the primitive that appears in the stdlib.

This fixes the build of the `@libs` alias. `@world` (e.g. linking of executables) is still broken for a different reason.