### PR TITLE
New format for the OCaml version string

### DIFF
--- a/Changes
+++ b/Changes
@@ -525,6 +525,13 @@ OCaml 4.11
 - #9486: Fix configuration for the Haiku operating system
   (Sylvain Kerjean, review by David Allsopp and Sébastien Hinderer)
 
+- #9712: Update the version format to allow "~".
+  The new format is "major.minor[.patchlevel][(+|~)additional-info]",
+  for instance "4.12.0~beta1+flambda".
+  This is a documentation-only change for the 4.11 branch, the new format
+  will be used starting with the 4.12 branch.
+  (Florian Angeletti, review by Damien Doligez and Xavier Leroy)
+
 ### Internal/compiler-libs changes:
 
  - #463: a new Misc.Magic_number module for user-friendly parsing

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -320,10 +320,12 @@ val catch_break : bool -> unit
 
 val ocaml_version : string
 (** [ocaml_version] is the version of OCaml.
-    It is a string of the form ["major.minor[.patchlevel][+additional-info]"],
+    It is a string of the form
+      ["major.minor[.patchlevel][(+|~)additional-info]"],
     where [major], [minor], and [patchlevel] are integers, and
-    [additional-info] is an arbitrary string. The [[.patchlevel]] and
-    [[+additional-info]] parts may be absent. *)
+    [additional-info] is an arbitrary string.
+    The [[.patchlevel]] part is absent for versions anterior to 3.08.0.
+    The [[(+|~)additional-info]] part may be absent. *)
 
 
 val enable_runtime_warnings: bool -> unit

--- a/tools/make-version-header.sh
+++ b/tools/make-version-header.sh
@@ -41,7 +41,7 @@ esac
 major="`echo "$version" | sed -n -e '1s/^\([0-9]*\)\..*/\1/p'`"
 minor="`echo "$version" | sed -n -e '1s/^[0-9]*\.0*\([0-9]*\).*/\1/p'`"
 patchlvl="`echo "$version" | sed -n -e '1s/^[0-9]*\.[0-9]*\.\([0-9]*\).*/\1/p'`"
-suffix="`echo "$version" | sed -n -e '1s/^[^+]*+\(.*\)/\1/p'`"
+suffix="`echo "$version" | sed -n -e '1s/^[^+~]*[+~]\(.*\)/\1/p'`"
 
 echo "#define OCAML_VERSION_MAJOR $major"
 printf '#define OCAML_VERSION_MINOR %d\n' "$minor"


### PR DESCRIPTION
This PR proposes to change the specification of the OCaml version string to allow "~" with the Debian semantic.
The new format is `major.minor[.patchlevel][(+|~)additional-info]`, for instance `4.12.0~beta1+flambda`.

This change will make possible to use Debian ordering for pre-release version (alpha, beta, and rcs)
```
4.12.0~alpha1 < 4.12.0 < 4.12.0+trunk
```
For now, this is only a documentation change, and we propose to postpone any use of the new format to 4.12 and later.