### PR TITLE
EINTR-based signals, again

### DIFF
--- a/Changes
+++ b/Changes
@@ -94,6 +94,16 @@ Working version
    when using mutually recursive functions.
    (Jacques-Henri Jourdan, review François Bobot)
 
+* #1128, #7503, #9036, #9722: EINTR-based signal handling.
+  When a signal arrives, avoid running its OCaml handler in the middle
+  of a blocking section. Instead, allow control to return quickly to
+  a polling point where the signal handler can safely run, ensuring that
+  I/O locks are not held while it runs. A polling point was removed from
+  caml_leave_blocking_section, and one added to caml_raise.
+  (Stephen Dolan, review by Goswin von Brederlow, Xavier Leroy, Damien
+   Doligez, Anil Madhavapeddy, Guillaume Munch-Maccagnoni and Jacques-
+   Henri Jourdan)
+
 ### Code generation and optimizations:
 
 - #9551: ocamlc no longer loads DLLs at link time to check that

--- a/ocamltest/run_stubs.c
+++ b/ocamltest/run_stubs.c
@@ -71,8 +71,10 @@ static void logToChannel(void *voidchannel, const char *fmt, va_list ap)
     if (text == NULL) return;
     if (vsnprintf(text, length, fmt, ap) != length) goto end;
   }
+  Lock(channel);
   caml_putblock(channel, text, length);
   caml_flush(channel);
+  Unlock(channel);
 end:
   free(text);
 }

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -437,6 +437,8 @@ value caml_thread_sigmask(value cmd, value sigs) /* ML */
   retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
   st_check_error(retcode, "Thread.sigmask");
+  /* Run any handlers for just-unmasked pending signals */
+  caml_process_pending_actions();
   return st_encode_sigset(&oldset);
 }
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -253,15 +253,6 @@ static void caml_thread_leave_blocking_section(void)
   caml_thread_restore_runtime_state();
 }
 
-static int caml_thread_try_leave_blocking_section(void)
-{
-  /* Disable immediate processing of signals (PR#3659).
-     try_leave_blocking_section always fails, forcing the signal to be
-     recorded and processed at the next leave_blocking_section or
-     polling. */
-  return 0;
-}
-
 /* Hooks for I/O locking */
 
 static void caml_io_mutex_free(struct channel *chan)
@@ -496,7 +487,6 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   caml_scan_roots_hook = caml_thread_scan_roots;
   caml_enter_blocking_section_hook = caml_thread_enter_blocking_section;
   caml_leave_blocking_section_hook = caml_thread_leave_blocking_section;
-  caml_try_leave_blocking_section_hook = caml_thread_try_leave_blocking_section;
 #ifdef NATIVE_CODE
   caml_termination_hook = st_thread_exit;
 #endif

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -71,6 +71,8 @@ CAMLprim value unix_sigprocmask(value vaction, value vset)
   caml_enter_blocking_section();
   retcode = caml_sigmask_hook(how, &set, &oldset);
   caml_leave_blocking_section();
+  /* Run any handlers for just-unmasked pending signals */
+  caml_process_pending_actions();
   if (retcode != 0) unix_error(retcode, "sigprocmask", Nothing);
   return encode_sigset(&oldset);
 }

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -386,6 +386,7 @@ static void read_main_debug_info(struct debug_info *di)
   if (caml_seek_optional_section(fd, &trail, "DBUG") != -1) {
     chan = caml_open_descriptor_in(fd);
 
+    Lock(chan);
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
 
@@ -401,6 +402,7 @@ static void read_main_debug_info(struct debug_info *di)
       /* Record event list */
       Store_field(events, i, evl);
     }
+    Unlock(chan);
 
     caml_close_channel(chan);
 

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -264,7 +264,6 @@
 #define something_to_do caml_something_to_do
 #define enter_blocking_section_hook caml_enter_blocking_section_hook
 #define leave_blocking_section_hook caml_leave_blocking_section_hook
-#define try_leave_blocking_section_hook caml_try_leave_blocking_section_hook
 #define enter_blocking_section caml_enter_blocking_section
 #define leave_blocking_section caml_leave_blocking_section
 #define convert_signal_number caml_convert_signal_number

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -64,8 +64,15 @@ enum {
      [offset] is the absolute position of the logical end of the buffer, [max].
 */
 
-/* Functions and macros that can be called from C.  Take arguments of
-   type struct channel *.  The channel must be locked before calling these. */
+/* Creating and closing channels from C */
+
+CAMLextern struct channel * caml_open_descriptor_in (int);
+CAMLextern struct channel * caml_open_descriptor_out (int);
+CAMLextern void caml_close_channel (struct channel *);
+
+
+/* I/O on channels from C. The channel must be locked (see below) before
+   calling any of the functions and macros below */
 
 #define caml_putch(channel, ch) do{                                       \
   if ((channel)->curr >= (channel)->end) caml_flush_partial(channel);     \
@@ -77,11 +84,8 @@ enum {
    ? caml_refill(channel)                                                   \
    : (unsigned char) *((channel)->curr)++)
 
-CAMLextern struct channel * caml_open_descriptor_in (int);
-CAMLextern struct channel * caml_open_descriptor_out (int);
-CAMLextern void caml_close_channel (struct channel *);
-CAMLextern int caml_channel_binary_mode (struct channel *);
 CAMLextern value caml_alloc_channel(struct channel *chan);
+CAMLextern int caml_channel_binary_mode (struct channel *);
 
 CAMLextern int caml_flush_partial (struct channel *);
 CAMLextern void caml_flush (struct channel *);

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -65,7 +65,7 @@ enum {
 */
 
 /* Functions and macros that can be called from C.  Take arguments of
-   type struct channel *.  No locking is performed. */
+   type struct channel *.  The channel must be locked before calling these. */
 
 #define caml_putch(channel, ch) do{                                       \
   if ((channel)->curr >= (channel)->end) caml_flush_partial(channel);     \

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -30,12 +30,16 @@ extern unsigned short caml_win32_revision;
 #include "misc.h"
 #include "memory.h"
 
+#define Io_interrupted (-1)
+
 /* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
    [flags] indicates whether [fd] is a socket
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
    Return number of bytes read.
-   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
+   In case of error, raises [Sys_error] or [Sys_blocked_io].
+   If interrupted by a signal and no bytes where read, returns
+   Io_interrupted without raising. */
 extern int caml_read_fd(int fd, int flags, void * buf, int n);
 
 /* Write at most [n] bytes from buffer [buf] onto file descriptor [fd].
@@ -43,7 +47,9 @@ extern int caml_read_fd(int fd, int flags, void * buf, int n);
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
    Return number of bytes written.
-   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
+   In case of error, raises [Sys_error] or [Sys_blocked_io].
+   If interrupted by a signal and no bytes were written, returns
+   Io_interrupted without raising. */
 extern int caml_write_fd(int fd, int flags, void * buf, int n);
 
 /* Decompose the given path into a list of directories, and add them

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -31,6 +31,7 @@ extern "C" {
 #endif
 
 CAMLextern void caml_enter_blocking_section (void);
+CAMLextern void caml_enter_blocking_section_no_pending (void);
 CAMLextern void caml_leave_blocking_section (void);
 
 CAMLextern void caml_process_pending_actions (void);
@@ -38,6 +39,9 @@ CAMLextern void caml_process_pending_actions (void);
    minor and major collections, signal handlers, finalisers, and
    Memprof callbacks. Assumes that the runtime lock is held. Can raise
    exceptions asynchronously into OCaml code. */
+
+CAMLextern int caml_check_pending_actions (void);
+/* Returns 1 if there are pending actions, 0 otherwise. */
 
 CAMLextern value caml_process_pending_actions_exn (void);
 /* Same as [caml_process_pending_actions], but returns the exception

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -86,7 +86,6 @@ void caml_setup_stack_overflow_detection(void);
 
 CAMLextern void (*caml_enter_blocking_section_hook)(void);
 CAMLextern void (*caml_leave_blocking_section_hook)(void);
-CAMLextern int (*caml_try_leave_blocking_section_hook)(void);
 #ifdef POSIX_SIGNALS
 CAMLextern int (*caml_sigmask_hook)(int, const sigset_t *, sigset_t *);
 #endif

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -141,6 +141,12 @@ static void open_connection(void)
 #endif
   dbg_in = caml_open_descriptor_in(dbg_socket);
   dbg_out = caml_open_descriptor_out(dbg_socket);
+  /* The code in this file does not bracket channel I/O operations with
+     Lock and Unlock, so fail if those are not no-ops. */
+  if (caml_channel_mutex_lock != NULL ||
+      caml_channel_mutex_unlock != NULL ||
+      caml_channel_mutex_unlock_exn != NULL)
+    caml_fatal_error("debugger does not support channel locks");
   if (!caml_debugger_in_use) caml_putword(dbg_out, -1); /* first connection */
 #ifdef _WIN32
   caml_putword(dbg_out, _getpid());

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -34,6 +34,8 @@
 CAMLexport void caml_raise(value v)
 {
   Unlock_exn();
+  CAMLassert(!Is_exception_result(v));
+  v = caml_process_pending_actions_with_root(v);
   Caml_state->exn_bucket = v;
   if (Caml_state->external_raise == NULL) caml_fatal_uncaught_exception(v);
   siglongjmp(Caml_state->external_raise->buf, 1);

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -62,6 +62,10 @@ CAMLno_asan
 void caml_raise(value v)
 {
   Unlock_exn();
+
+  CAMLassert(!Is_exception_result(v));
+  v = caml_process_pending_actions_with_root(v);
+
   if (Caml_state->exception_pointer == NULL) caml_fatal_uncaught_exception(v);
 
   while (Caml_state->local_roots != NULL &&

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -163,6 +163,11 @@ CAMLexport void caml_enter_blocking_section(void)
   }
 }
 
+CAMLexport void caml_enter_blocking_section_no_pending(void)
+{
+  caml_enter_blocking_section_hook ();
+}
+
 CAMLexport void caml_leave_blocking_section(void)
 {
   int saved_errno;
@@ -183,7 +188,7 @@ CAMLexport void caml_leave_blocking_section(void)
      [signals_are_pending] is 0 but the signal needs to be
      handled at this point. */
   signals_are_pending = 1;
-  caml_raise_if_exception(caml_process_pending_signals_exn());
+  //caml_raise_if_exception(caml_process_pending_signals_exn());
 
   errno = saved_errno;
 }
@@ -320,6 +325,12 @@ Caml_inline value process_pending_actions_with_root_exn(value extra_root)
     CAMLdrop;
   }
   return extra_root;
+}
+
+CAMLno_tsan /* The access to [caml_something_to_do] is not synchronized. */
+int caml_check_pending_actions()
+{
+  return caml_something_to_do;
 }
 
 value caml_process_pending_actions_with_root(value extra_root)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -136,33 +136,18 @@ CAMLno_tsan void caml_record_signal(int signal_number)
 
 /* Management of blocking sections. */
 
-static intnat volatile caml_async_signal_mode = 0;
-
 static void caml_enter_blocking_section_default(void)
 {
-  CAMLassert (caml_async_signal_mode == 0);
-  caml_async_signal_mode = 1;
 }
 
 static void caml_leave_blocking_section_default(void)
 {
-  CAMLassert (caml_async_signal_mode == 1);
-  caml_async_signal_mode = 0;
-}
-
-static int caml_try_leave_blocking_section_default(void)
-{
-  intnat res;
-  Read_and_clear(res, caml_async_signal_mode);
-  return res;
 }
 
 CAMLexport void (*caml_enter_blocking_section_hook)(void) =
    caml_enter_blocking_section_default;
 CAMLexport void (*caml_leave_blocking_section_hook)(void) =
    caml_leave_blocking_section_default;
-CAMLexport int (*caml_try_leave_blocking_section_hook)(void) =
-   caml_try_leave_blocking_section_default;
 
 CAMLno_tsan /* The read of [caml_something_to_do] is not synchronized. */
 CAMLexport void caml_enter_blocking_section(void)

--- a/runtime/signals_byt.c
+++ b/runtime/signals_byt.c
@@ -46,12 +46,7 @@ static void handle_signal(int signal_number)
   signal(signal_number, handle_signal);
 #endif
   if (signal_number < 0 || signal_number >= NSIG) return;
-  if (caml_try_leave_blocking_section_hook()) {
-    caml_raise_if_exception(caml_execute_signal_exn(signal_number, 1));
-    caml_enter_blocking_section_hook();
-  }else{
-    caml_record_signal(signal_number);
-  }
+  caml_record_signal(signal_number);
   errno = saved_errno;
 }
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -99,19 +99,14 @@ DECLARE_SIGNAL_HANDLER(handle_signal)
   signal(sig, handle_signal);
 #endif
   if (sig < 0 || sig >= NSIG) return;
-  if (caml_try_leave_blocking_section_hook ()) {
-    caml_raise_if_exception(caml_execute_signal_exn(sig, 1));
-    caml_enter_blocking_section_hook();
-  } else {
-    caml_record_signal(sig);
+  caml_record_signal(sig);
   /* Some ports cache [Caml_state->young_limit] in a register.
      Use the signal context to modify that register too, but only if
      we are inside OCaml code (not inside C code). */
 #if defined(CONTEXT_PC) && defined(CONTEXT_YOUNG_LIMIT)
-    if (caml_find_code_fragment_by_pc((char *) CONTEXT_PC) != NULL)
-      CONTEXT_YOUNG_LIMIT = (context_reg) Caml_state->young_limit;
+  if (caml_find_code_fragment_by_pc((char *) CONTEXT_PC) != NULL)
+    CONTEXT_YOUNG_LIMIT = (context_reg) Caml_state->young_limit;
 #endif
-  }
   errno = saved_errno;
 }
 

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -444,7 +444,9 @@ CAMLexport void caml_main(char_os **argv)
   /* Load the globals */
   caml_seek_section(fd, &trail, "DATA");
   chan = caml_open_descriptor_in(fd);
+  Lock(chan);
   caml_global_data = caml_input_val(chan);
+  Unlock(chan);
   caml_close_channel(chan); /* this also closes fd */
   caml_stat_free(trail.section);
   /* Ensure that the globals are in the major heap. */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -87,7 +87,7 @@ int caml_read_fd(int fd, int flags, void * buf, int n)
 {
   int retcode;
   if ((flags & CHANNEL_FLAG_FROM_SOCKET) == 0) {
-    caml_enter_blocking_section();
+    caml_enter_blocking_section_no_pending();
     retcode = read(fd, buf, n);
     /* Large reads from console can fail with ENOMEM.  Reduce requested size
        and try again. */
@@ -97,7 +97,7 @@ int caml_read_fd(int fd, int flags, void * buf, int n)
     caml_leave_blocking_section();
     if (retcode == -1) caml_sys_io_error(NO_ARG);
   } else {
-    caml_enter_blocking_section();
+    caml_enter_blocking_section_no_pending();
     retcode = recv((SOCKET) _get_osfhandle(fd), buf, n, 0);
     caml_leave_blocking_section();
     if (retcode == -1) caml_win32_sys_error(WSAGetLastError());
@@ -114,7 +114,7 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
     retcode = write(fd, buf, n);
   } else {
 #endif
-    caml_enter_blocking_section();
+    caml_enter_blocking_section_no_pending();
     retcode = write(fd, buf, n);
     caml_leave_blocking_section();
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
@@ -122,7 +122,7 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
 #endif
     if (retcode == -1) caml_sys_io_error(NO_ARG);
   } else {
-    caml_enter_blocking_section();
+    caml_enter_blocking_section_no_pending();
     retcode = send((SOCKET) _get_osfhandle(fd), buf, n, 0);
     caml_leave_blocking_section();
     if (retcode == -1) caml_win32_sys_error(WSAGetLastError());

--- a/testsuite/tests/lib-systhreads/eintr.ml
+++ b/testsuite/tests/lib-systhreads/eintr.ml
@@ -1,0 +1,91 @@
+(* TEST
+
+* hassysthreads
+include systhreads
+** not-windows
+*** bytecode
+*** native
+*)
+
+let signals_requested = Atomic.make 0
+let signal_delay = 0.1
+let _ = Thread.create (fun () ->
+  let signals_sent = ref 0 in
+  ignore (Thread.sigmask Unix.SIG_BLOCK [Sys.sigint]);
+  while true do
+    if Atomic.get signals_requested > !signals_sent then begin
+      Thread.delay signal_delay;
+      Unix.kill (Unix.getpid ()) Sys.sigint;
+      incr signals_sent
+    end else begin
+      Thread.yield ()
+    end
+  done) ()
+let request_signal () = Atomic.incr signals_requested
+
+let () =
+  let (rd, wr) = Unix.pipe () in
+  Sys.catch_break true;
+  request_signal ();
+  begin match Unix.read rd (Bytes.make 1 'a') 0 1 with
+  | _ -> assert false
+  | exception Sys.Break -> print_endline "break: ok" end;
+  Sys.catch_break false;
+  Unix.close rd;
+  Unix.close wr
+
+let () =
+  let (rd, wr) = Unix.pipe () in
+  Sys.set_signal Sys.sigint (Signal_handle (fun _ -> Gc.full_major ()));
+  request_signal ();
+  begin match Unix.read rd (Bytes.make 1 'a') 0 1 with
+  | _ -> assert false
+  | exception Unix.Unix_error(Unix.EINTR, "read", _) ->
+     print_endline "eintr: ok" end;
+  Sys.set_signal Sys.sigint Signal_default;
+  Unix.close rd;
+  Unix.close wr
+
+
+(* Doing I/O on stdout would be more realistic, but seeking has the
+   same locking & scheduling effects, without actually producing any
+   output *)
+let poke_stdout () =
+  match out_channel_length stdout with
+  | _ -> ()
+  | exception Sys_error _ -> ()
+
+let () =
+  let r = Atomic.make true in
+  Sys.set_signal Sys.sigint (Signal_handle (fun _ ->
+    poke_stdout (); Atomic.set r false));
+  request_signal ();
+  while Atomic.get r do
+    poke_stdout ()
+  done;
+  Sys.set_signal Sys.sigint Signal_default;
+  print_endline "chan: ok"
+
+let () =
+  let mklist () = List.init 1000 (fun i -> (i, i)) in
+  let before = Sys.opaque_identity (ref (mklist ())) in
+  let during = Atomic.make (Sys.opaque_identity (mklist ())) in
+  let siglist = ref [] in
+  Sys.set_signal Sys.sigint (Signal_handle (fun _ ->
+    Gc.full_major (); poke_stdout (); Gc.compact ();
+    siglist := mklist ();
+    raise Sys.Break));
+  request_signal ();
+  begin match
+    while true do
+      poke_stdout ();
+      Atomic.set during (mklist ())
+    done
+  with
+  | () -> assert false
+  | exception Sys.Break -> () end;
+  let expected = Sys.opaque_identity (mklist ()) in
+  assert (!before = expected);
+  assert (Atomic.get during = expected);
+  assert (!siglist = expected);
+  print_endline "gc: ok"

--- a/testsuite/tests/lib-systhreads/eintr.reference
+++ b/testsuite/tests/lib-systhreads/eintr.reference
@@ -1,0 +1,4 @@
+break: ok
+eintr: ok
+chan: ok
+gc: ok


### PR DESCRIPTION
This is a (greatly simplified) reimplementation of #1128, to solve a collection of tricky locking and signal-handling issues.

In trunk, when a signal arrives it is handled:

  - at the next polling point, if not in a blocking section
  - If in a blocking section, then:
      * immediately, if the `systhreads` library has *not* been linked
      * at the next polling point, if the `systhreads` library has been linked

Polling points include all allocations in OCaml and calls to `caml_process_pending_actions` from C. (Before #8691 / #9027 / #8897, all allocations in C were also polling points, but no longer)

There are a number of problems with the current behaviour:

  - It is odd for the responsiveness of a program to signals to depend on whether `systhreads` has been linked.

  - (#5141, #7503) When they interrupt code using mutexes, the signal handlers run under an unknown collection of locks, which can cause deadlocks. This is particularly bad for signal handlers that write a message to stdout or stderr, as io.c maintains mutexes on those channels.

  - If a signal is handled immediately during a blocking section that was executing a non-async-signal-safe function, arbitrary corruption can occur. (It is possible to write a blocking section that only uses async-signal-safe functions, but this requires care, and various blocking sections even in the stdlib are not async-signal-safe).

  - If a signal is handled immediately during a blocking section, then any progress made by that blocking section is discarded if the handler raises. Specifically, a signal may occur after a system call has *successfully returned* but before the blocking section has ended, and its return value was lost. There is in general no way to recover from this in the case of say, writing to a pipe.

This patch fixes these issues by:

  - Always waiting for the next polling point, and never handling signals immediately (regardless of whether `systhreads` is linked)

  - Modifying the blocking `read` and `write` calls in `io.c` to insert a polling point (and hence handle signals) before retrying a system call on receipt of an EINTR.

If a signal arrives during a blocking system call, instead of handling the signal then and there, we mark the pending signal and rely on the OS to make the system call fail with EINTR, at which point we check for pending signals before retrying the operation.

Compared with the previous EINTR patch (#1128), this one is much simpler. When #1128 was written, there was no easy way to delay handling of a signal to a convenient point, and so that patch included some gymnastics to ensure it was always safe to handle one.

Since #8691 / #9027 / #8897, polling points are less frequent in C code, and delaying a signal until convenient is easier. To allow this, the C API is modified by:

  - Adding `caml_check_pending_actions`, which checks for pending actions without yet running them
  - Adding `caml_enter_blocking_section_no_pending`, which enters a blocking section without checking for pending actions
  - Never checking for pending actions in `caml_leave_blocking_section`

(This PR is best read commit-by-commit)

TODO:

  - [x] There's currently a `signals_are_pending = 1` in `caml_leave_blocking_section`, which might cause unnecessary work. I'll investigate.
  -  ~Windows support~ (left until after #1408 is merged)