### PR TITLE
ocamlopt: add -asm option to specify assembler command

### DIFF
--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -355,7 +355,9 @@ let prologue_required fd =
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " " ^
+  Ccomp.command ((match !Clflags.asm_compiler with
+                  | Some asm -> asm
+                  | None -> Config.asm) ^ " " ^
                  (String.concat " " (Misc.debug_prefix_map_flags ())) ^
                  " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -262,7 +262,9 @@ let prologue_required fd =
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " " ^
+  Ccomp.command ((match !Clflags.asm_compiler with
+                  | Some asm -> asm
+                  | None -> Config.asm) ^ " " ^
                  (String.concat " " (Misc.debug_prefix_map_flags ())) ^
                  " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -362,7 +362,9 @@ let prologue_required fd =
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " " ^
+  Ccomp.command ((match !Clflags.asm_compiler with
+                  | Some asm -> asm
+                  | None -> Config.asm) ^ " " ^
                  (String.concat " " (Misc.debug_prefix_map_flags ())) ^
                  " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -236,7 +236,9 @@ let prologue_required fd =
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " " ^
+  Ccomp.command ((match !Clflags.asm_compiler with
+                  | Some asm -> asm
+                  | None -> Config.asm) ^ " " ^
                  (String.concat " " (Misc.debug_prefix_map_flags ())) ^
                  " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -241,11 +241,15 @@ let binary_content = ref None
 
 let compile infile outfile =
   if masm then
-    Ccomp.command (Config.asm ^
+    Ccomp.command ((match !Clflags.asm_compiler with
+                    | Some asm -> asm
+                    | None -> Config.asm) ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
                    (if !Clflags.verbose then "" else ">NUL"))
   else
-    Ccomp.command (Config.asm ^ " " ^
+    Ccomp.command ((match !Clflags.asm_compiler with
+                    | Some asm -> asm
+                    | None -> Config.asm) ^ " " ^
                    (String.concat " " (Misc.debug_prefix_map_flags ())) ^
                    " -o " ^ Filename.quote outfile ^ " " ^
                    Filename.quote infile)

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -246,6 +246,7 @@ let read_one_param ppf position name v =
   |  "s" ->
     set "s" [ Clflags.keep_asm_file ; Clflags.keep_startup_file ] v
   |  "S" -> set "S" [ Clflags.keep_asm_file ] v
+  |  "asm" -> asm_compiler := Some v
   |  "dstartup" -> set "dstartup" [ Clflags.keep_startup_file ] v
 
   (* warn-errors *)

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -486,6 +486,10 @@ let mk_S f =
   "-S", Arg.Unit f, " Keep intermediate assembly file"
 ;;
 
+let mk_asm f =
+  "-asm", Arg.String f, "<command>  Use <command> as the assembler"
+;;
+
 let mk_safe_string f =
   "-safe-string", Arg.Unit f,
   if Config.safe_string then " (was set when configuring the compiler)"
@@ -1101,6 +1105,7 @@ module type Optcomp_options = sig
   val _p : unit -> unit
   val _pp : string -> unit
   val _S : unit -> unit
+  val _asm : string -> unit
   val _shared : unit -> unit
   val _afl_instrument : unit -> unit
   val _afl_inst_ratio : int -> unit
@@ -1112,6 +1117,7 @@ module type Opttop_options = sig
   include Optcommon_options
   val _verbose : unit -> unit
   val _S : unit -> unit
+  val _asm : string -> unit
 end;;
 
 module type Ocamldoc_options = sig
@@ -1392,6 +1398,7 @@ struct
     mk_with_runtime F._with_runtime;
     mk_without_runtime F._without_runtime;
     mk_S F._S;
+    mk_asm F._asm;
     mk_safe_string F._safe_string;
     mk_shared F._shared;
     mk_short_paths F._short_paths;
@@ -1509,6 +1516,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_no_rectypes F._no_rectypes;
     mk_remove_unused_arguments F._remove_unused_arguments;
     mk_S F._S;
+    mk_asm F._asm;
     mk_safe_string F._safe_string;
     mk_short_paths F._short_paths;
     mk_stdin F._stdin;
@@ -1716,6 +1724,7 @@ module Default = struct
 
   module Native = struct
     let _S = set keep_asm_file
+    let _asm s = asm_compiler := (Some s)
     let _clambda_checks () = clambda_checks := true
     let _classic_inlining () = classic_inlining := true
     let _compact = clear optimize_for_speed

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -230,6 +230,7 @@ module type Optcomp_options = sig
   val _p : unit -> unit
   val _pp : string -> unit
   val _S : unit -> unit
+  val _asm : string -> unit
   val _shared : unit -> unit
   val _afl_instrument : unit -> unit
   val _afl_inst_ratio : int -> unit
@@ -241,6 +242,7 @@ module type Opttop_options = sig
   include Optcommon_options
   val _verbose : unit -> unit
   val _S : unit -> unit
+  val _asm : string -> unit
 end;;
 
 module type Ocamldoc_options = sig

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -191,6 +191,11 @@ compilation. Source code files are turned into compiled files, but no
 executable file is produced. This option is useful to
 compile modules separately.
 .TP
+.BI \-asm \ as
+Use
+.I as
+as the assembler for assembling generated assembly files.
+.TP
 .BI \-cc \ ccomp
 Use
 .I ccomp

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -101,6 +101,11 @@ and as the C compiler for compiling ".c" source files.
 }%notop
 
 \notop{%
+\item["-asm" \var{as}]
+Use \var{as} as the assembler for assembling object files.
+}%notop
+
+\notop{%
 \item["-cclib" "-l"\var{libname}]
 Pass the "-l"\var{libname} option to the \comp{C} linker
 \comp{when linking in ``custom runtime'' mode (see the "-custom" option)}.

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -112,6 +112,7 @@ and dump_instr = ref false              (* -dinstr *)
 and keep_camlprimc_file = ref false     (* -dcamlprimc *)
 
 let keep_asm_file = ref false           (* -S *)
+let asm_compiler = ref (None: string option) (* -asm *)
 let optimize_for_speed = ref true       (* -compact *)
 and opaque = ref false                  (* -opaque *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -137,6 +137,7 @@ val dump_flambda_let : int option ref
 val dump_instr : bool ref
 val keep_camlprimc_file : bool ref
 val keep_asm_file : bool ref
+val asm_compiler : string option ref
 val optimize_for_speed : bool ref
 val dump_cmm : bool ref
 val dump_selection : bool ref


### PR DESCRIPTION
Option -asm to choose the assembler used with ocamlopt.