### PR TITLE
Mark new macros change as potentially breaking

### DIFF
--- a/Changes
+++ b/Changes
@@ -38,8 +38,10 @@ Working version
   (KC Sivaramakrishnan, review by Stephen Dolan, Gabriel Scherer,
    and Xavier Leroy)
 
-- #9569: Add `Val_none`, `Some_val`, `Is_none`, `Is_some`, `caml_alloc_some`,
-  and `Tag_some`.
+* #5154, #9569, #9734: Add `Val_none`, `Some_val`, `Is_none`, `Is_some`,
+  `caml_alloc_some`, and `Tag_some`. As these macros are sometimes defined by
+  authors of C bindings, this change may cause warnings/errors in case of
+  redefinition.
   (Nicolás Ojeda Bär, review by Stephen Dolan, Gabriel Scherer, Mark Shinwell,
   and Xavier Leroy)
 


### PR DESCRIPTION
If an OCaml C library already defines some of the new `Val_none`,
`Some_val`, `Is_none`, `Is_some`, `caml_alloc_some`, or `Tag_some`
macros; then the C compiler will likely warn for macro redefinition,
even if the macro definition are identical. In some setups that always
turn warnings to errors, this will block the compilation of the
library.

This problem happens in [ocaml-mccs][1].

The proposed [fix][2] for libraries is to only define the macros when
compiling with OCaml strictly older than 4.12, i.e.:

    #if OCAML_VERSION < 41200
    #define ...
    #endif

[1]: https://github.com/AltGr/ocaml-mccs/pull/30
[2]: https://github.com/ocaml/ocaml/issues/5154#issuecomment-644283763