### PR TITLE
#9739: recursively occuring types are not always variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -664,6 +664,11 @@ OCaml 4.12.0
   (Xavier Leroy, Sadiq Jaffer, Gabriel Scherer,
    review by Xavier Leroy and Jacques-Henri Jourdan)
 
+- #9739, ???: Avoid calling type variables types that are not variables in
+  recursive occurence error messages
+  (for instance, "Type variable int occurs inside int list")
+  (Florian Angeletti, report by Stephen Dolan, review by ???)
+
 - #9759, #9767: Spurious GADT ambiguity without -principal
   (Jacques Garrigue, report by Thomas Refis,
    review by Thomas Refis and Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -664,10 +664,10 @@ OCaml 4.12.0
   (Xavier Leroy, Sadiq Jaffer, Gabriel Scherer,
    review by Xavier Leroy and Jacques-Henri Jourdan)
 
-- #9739, ???: Avoid calling type variables types that are not variables in
+- #9739, #9747: Avoid calling type variables, types that are not variables in
   recursive occurence error messages
   (for instance, "Type variable int occurs inside int list")
-  (Florian Angeletti, report by Stephen Dolan, review by ???)
+  (Florian Angeletti, report by Stephen Dolan, review by Armaël Guéneau)
 
 - #9759, #9767: Spurious GADT ambiguity without -principal
   (Jacques Garrigue, report by Thomas Refis,

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -99,3 +99,21 @@ Error: This expression has type t1 but an expression was expected of type t2
        but the expected method type was 'a. 'a * ('a * < m : 'a. 'b >) as 'b
        The universal variable 'a would escape its scope
 |}]
+
+(* #9739
+   Recursive occurence checks are only done on type variables.
+   However, we are not guaranteed to still have a type variable when printing.
+*)
+
+let rec foo () = [42]
+and bar () =
+  let x = foo () in
+  x |> List.fold_left max 0 x
+[%%expect {|
+Line 4, characters 7-29:
+4 |   x |> List.fold_left max 0 x
+           ^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type int but an expression was expected of type
+         int list -> 'a
+       The type int occurs inside int list -> 'a
+|}]

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -115,5 +115,4 @@ Line 4, characters 7-29:
            ^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type int but an expression was expected of type
          int list -> 'a
-       The type int occurs inside int list -> 'a
 |}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2097,9 +2097,12 @@ let explanation intro prev env = function
                  marked_type_expr x marked_type_expr y)
       | _ ->
           (* We had a delayed unification of the type variable with
-           *  a non-variable after the occur check *)
-          Some(dprintf "@,@[<hov>The type %a occurs inside@ %a@]"
-                 marked_type_expr x marked_type_expr y)
+             a non-variable after the occur check. *)
+          Some ignore
+           (* There is no need to search further for an explanation, but
+              we don't want to print a message of the form:
+                {[ The type int occurs inside int list -> 'a |}
+           *)
       end
 
 let mismatch intro env trace =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2091,8 +2091,16 @@ let explanation intro prev env = function
   | Trace.Obj o -> explain_object o
   | Trace.Rec_occur(x,y) ->
       reset_and_mark_loops y;
-      Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
-            marked_type_expr x marked_type_expr y)
+      begin match x.desc with
+      | Tvar _ | Tunivar _  ->
+          Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
+                 marked_type_expr x marked_type_expr y)
+      | _ ->
+          (* We had a delayed unification of the type variable with
+           *  a non-variable after the occur check *)
+          Some(dprintf "@,@[<hov>The type %a occurs inside@ %a@]"
+                 marked_type_expr x marked_type_expr y)
+      end
 
 let mismatch intro env trace =
   Trace.explain trace (fun ~prev h -> explanation intro prev env h)


### PR DESCRIPTION
Types variables with recursive occurrences can be unified to non-variables before their printing happens.
This can yield to head-scratching error messages like
```ocaml
let rec f () = 1 and l =  [[f ()]; f()]
``` 
>```
>Error: ...
>       The type variable int occurs inside int list
>```

This PR fixes this issue by checking that we still have a type variable at this point of time before using the term "type variable".
Note that we could remove the error message entirely in the non-variable cases, but the refined error message seemed slightly useful in complex cases
```ocaml
2 | and g () = let y = f() in y |> List.fold_left (fun f g y -> f (g y)) Fun.id y
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
>```
>Error: This expression has type int -> int
>       but an expression was expected of type (int -> int) list -> 'a
>       The type int occurs inside (int -> int) list
>```

Close #9739 