### PR TITLE
Share the strings representing scopes

### DIFF
--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -64,6 +64,17 @@ module Scoped_location = struct
     | [] -> "<unknown>"
     | scopes -> String.concat "" (to_strings [] scopes)
 
+  let string_of_scopes =
+    let module StringSet = Set.Make (String) in
+    let repr = ref StringSet.empty in
+    fun scopes ->
+      let res = string_of_scopes scopes in
+      match StringSet.find_opt res !repr with
+      | Some x -> x
+      | None ->
+        repr := StringSet.add res !repr;
+        res
+
   let enter_anonymous_function ~scopes =
     Sc_anonymous_function :: scopes
   let enter_value_definition ~scopes id =


### PR DESCRIPTION
After https://github.com/ocaml/ocaml/pull/9096, we noticed that the total size of `cmo` and `cma` files
was up by 17% in our tree. This pull request tweaks `Debuginfo`
so that strings representing scopes (which are marshaled into
`cmo` and `cma` files) are shared.