### PR TITLE
Revised handing of calling conventions for external C functions

### DIFF
--- a/.depend
+++ b/.depend
@@ -2271,6 +2271,7 @@ asmcomp/cmm.cmo : \
     lambda/debuginfo.cmi \
     middle_end/backend_var.cmi \
     parsing/asttypes.cmi \
+    asmcomp/arch.cmo \
     asmcomp/cmm.cmi
 asmcomp/cmm.cmx : \
     utils/targetint.cmx \
@@ -2278,6 +2279,7 @@ asmcomp/cmm.cmx : \
     lambda/debuginfo.cmx \
     middle_end/backend_var.cmx \
     parsing/asttypes.cmi \
+    asmcomp/arch.cmx \
     asmcomp/cmm.cmi
 asmcomp/cmm.cmi : \
     utils/targetint.cmi \
@@ -2728,7 +2730,8 @@ asmcomp/proc.cmx : \
     asmcomp/proc.cmi
 asmcomp/proc.cmi : \
     asmcomp/reg.cmi \
-    asmcomp/mach.cmi
+    asmcomp/mach.cmi \
+    asmcomp/cmm.cmi
 asmcomp/reg.cmo : \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \

--- a/Changes
+++ b/Changes
@@ -84,6 +84,11 @@ Working version
    partially curried or tupled.
    (Xavier Leroy, review by Mark Shinwell)
 
+- #9752: Revised handling of calling conventions for external C functions.
+   Provide a more precise description of the types of unboxed arguments,
+   so that the ARM64 iOS/macOS calling conventions can be honored.
+   (Xavier Leroy, review by Mark Shinwell and Github user @EduardoRFS)
+
 ### Standard library:
 
 * #9554: add primitive __FUNCTION__ that returns the name of the current method

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -103,7 +103,7 @@ let instrument_initialiser c dbg =
      calls *)
   with_afl_logging
     (Csequence
-       (Cop (Cextcall ("caml_setup_afl", typ_int, false, None),
+       (Cop (Cextcall ("caml_setup_afl", typ_int, [], false, None),
              [Cconst_int (0, dbg ())],
              dbg ()),
         c))

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -165,7 +165,7 @@ let calling_conventions first_int last_int first_float last_float make_stack
   let float = ref first_float in
   let ofs = ref 0 in
   for i = 0 to Array.length arg - 1 do
-    match arg.(i).typ with
+    match arg.(i) with
     | Val | Int | Addr as ty ->
         if !int <= last_int then begin
           loc.(i) <- phys_reg !int;
@@ -234,7 +234,7 @@ let win64_loc_external_arguments arg =
   let reg = ref 0
   and ofs = ref 32 in
   for i = 0 to Array.length arg - 1 do
-    match arg.(i).typ with
+    match arg.(i) with
     | Val | Int | Addr as ty ->
         if !reg < 4 then begin
           loc.(i) <- phys_reg win64_int_external_arguments.(!reg);
@@ -254,15 +254,14 @@ let win64_loc_external_arguments arg =
   done;
   (loc, Misc.align !ofs 16)  (* keep stack 16-aligned *)
 
-let loc_external_arguments arg =
-  let arg =
-    Array.map (fun regs -> assert (Array.length regs = 1); regs.(0)) arg
-  in
-  let loc, alignment =
-    if win64 then win64_loc_external_arguments arg
+let loc_external_arguments ty_args =
+  let arg = Cmm.machtype_of_exttype_list ty_args in
+  let loc, stack_ofs =
+    if win64
+    then win64_loc_external_arguments arg
     else unix_loc_external_arguments arg
   in
-  Array.map (fun reg -> [|reg|]) loc, alignment
+  Array.map (fun reg -> [|reg|]) loc, stack_ofs
 
 let loc_exn_bucket = rax
 

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -135,7 +135,7 @@ method is_immediate_natint n = n <= 0x7FFFFFFFn && n >= -0x80000000n
 
 method! is_simple_expr e =
   match e with
-  | Cop(Cextcall (fn, _, _, _), args, _)
+  | Cop(Cextcall (fn, _, _, _, _), args, _)
     when List.mem fn inline_ops ->
       (* inlined ops are simple if their arguments are *)
       List.for_all self#is_simple_expr args
@@ -144,7 +144,7 @@ method! is_simple_expr e =
 
 method! effects_of e =
   match e with
-  | Cop(Cextcall(fn, _, _, _), args, _)
+  | Cop(Cextcall(fn, _, _, _, _), args, _)
     when List.mem fn inline_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | _ ->
@@ -197,7 +197,7 @@ method! select_operation op args dbg =
       self#select_floatarith true Imulf Ifloatmul args
   | Cdivf ->
       self#select_floatarith false Idivf Ifloatdiv args
-  | Cextcall("sqrt", _, false, _) ->
+  | Cextcall("sqrt", _, _, false, _) ->
      begin match args with
        [Cop(Cload ((Double|Double_u as chunk), _), [loc], _dbg)] ->
          let (addr, arg) = self#select_addressing chunk loc in
@@ -217,12 +217,12 @@ method! select_operation op args dbg =
       | _ ->
           super#select_operation op args dbg
       end
-  | Cextcall("caml_bswap16_direct", _, _, _) ->
+  | Cextcall("caml_bswap16_direct", _, _, _, _) ->
       (Ispecific (Ibswap 16), args)
-  | Cextcall("caml_int32_direct_bswap", _, _, _) ->
+  | Cextcall("caml_int32_direct_bswap", _, _, _, _) ->
       (Ispecific (Ibswap 32), args)
-  | Cextcall("caml_int64_direct_bswap", _, _, _)
-  | Cextcall("caml_nativeint_direct_bswap", _, _, _) ->
+  | Cextcall("caml_int64_direct_bswap", _, _, _, _)
+  | Cextcall("caml_nativeint_direct_bswap", _, _, _, _) ->
       (Ispecific (Ibswap 64), args)
   (* AMD64 does not support immediate operands for multiply high signed *)
   | Cmulhi ->

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -19,6 +19,17 @@
 
 open Format
 
+type abi =
+  | AAPCS64     (* ARM's Procedure Call Standard for AArch64 *)
+  | AppleABI    (* Apple's variant for iOS and macOS *)
+
+let abi =
+  match Config.system with
+  | "macosx" -> AppleABI
+  | _        -> AAPCS64
+
+(* Machine-specific command-line options *)
+
 let command_line_options = []
 
 (* Addressing modes *)
@@ -56,6 +67,7 @@ type specific_operation =
   | Inegmulsubf   (* floating-point negate, multiply and subtract *)
   | Isqrtf        (* floating-point square root *)
   | Ibswap of int (* endianness conversion *)
+  | Imove32       (* 32-bit integer move *)
 
 and arith_operation =
     Ishiftadd
@@ -65,7 +77,7 @@ let spacetime_node_hole_pointer_is_live_before = function
   | Ifar_alloc _ | Ifar_intop_checkbound _ | Ifar_intop_imm_checkbound _
   | Ishiftarith _ | Ishiftcheckbound _ | Ifar_shiftcheckbound _ -> false
   | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
-  | Inegmulsubf | Isqrtf | Ibswap _ -> false
+  | Inegmulsubf | Isqrtf | Ibswap _ | Imove32 -> false
 
 (* Sizes, endianness *)
 
@@ -169,4 +181,7 @@ let print_specific_operation printreg op ppf arg =
         printreg arg.(0)
   | Ibswap n ->
       fprintf ppf "bswap%i %a" n
+        printreg arg.(0)
+  | Imove32 ->
+      fprintf ppf "move32 %a"
         printreg arg.(0)

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -19,14 +19,7 @@
 
 open Format
 
-type abi =
-  | AAPCS64     (* ARM's Procedure Call Standard for AArch64 *)
-  | AppleABI    (* Apple's variant for iOS and macOS *)
-
-let abi =
-  match Config.system with
-  | "macosx" -> AppleABI
-  | _        -> AAPCS64
+let macosx = (Config.system = "macosx")
 
 (* Machine-specific command-line options *)
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -481,6 +481,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Imuladd | Imulsub)) -> 1
     | Lop (Ispecific (Ibswap 16)) -> 2
     | Lop (Ispecific (Ibswap _)) -> 1
+    | Lop (Ispecific Imove32) -> 1
     | Lop (Iname_for_debugger _) -> 0
     | Lreloadretaddr -> 0
     | Lreturn -> epilogue_size ()
@@ -603,6 +604,19 @@ let emit_instr i =
               `	str	{emit_reg src}, {emit_stack dst}\n`
           | {loc = Stack _}, {loc = Reg _} ->
               `	ldr	{emit_reg dst}, {emit_stack src}\n`
+          | _ ->
+              assert false
+        end
+    | Lop(Ispecific Imove32) ->
+        let src = i.arg.(0) and dst = i.res.(0) in
+        if src.loc <> dst.loc then begin
+          match (src, dst) with
+          | {loc = Reg _}, {loc = Reg _} ->
+              `	mov	{emit_wreg dst}, {emit_wreg src}\n`
+          | {loc = Reg _}, {loc = Stack _} ->
+              `	str	{emit_wreg src}, {emit_stack dst}\n`
+          | {loc = Stack _}, {loc = Reg _} ->
+              `	ldr	{emit_wreg dst}, {emit_stack src}\n`
           | _ ->
               assert false
         end

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -109,6 +109,36 @@ let loc_spacetime_node_hole = Reg.dummy  (* Spacetime unsupported *)
 
 (* Calling conventions *)
 
+let loc_int last_int make_stack int ofs =
+  if !int <= last_int then begin
+    let l = phys_reg !int in
+    incr int; l
+  end else begin
+    ofs := Misc.align !ofs size_int;
+    let l = stack_slot (make_stack !ofs) Int in
+    ofs := !ofs + size_int; l
+  end
+
+let loc_float last_float make_stack float ofs =
+  if !float <= last_float then begin
+    let l = phys_reg !float in
+    incr float; l
+  end else begin
+    ofs := Misc.align !ofs size_float;
+    let l = stack_slot (make_stack !ofs) Float in
+    ofs := !ofs + size_float; l
+  end
+
+let loc_int32 last_int make_stack int ofs =
+  if !int <= last_int then begin
+    let l = phys_reg !int in
+    incr int; l
+  end else begin
+    let l = stack_slot (make_stack !ofs) Int in
+    ofs := !ofs + (if macosx then 4 else 8);
+    l
+  end
+
 let calling_conventions
     first_int last_int first_float last_float make_stack arg =
   let loc = Array.make (Array.length arg) Reg.dummy in
@@ -117,22 +147,10 @@ let calling_conventions
   let ofs = ref 0 in
   for i = 0 to Array.length arg - 1 do
     match arg.(i) with
-    | Val | Int | Addr as ty ->
-        if !int <= last_int then begin
-          loc.(i) <- phys_reg !int;
-          incr int
-        end else begin
-          loc.(i) <- stack_slot (make_stack !ofs) ty;
-          ofs := !ofs + size_int
-        end
+    | Val | Int | Addr ->
+        loc.(i) <- loc_int last_int make_stack int ofs
     | Float ->
-        if !float <= last_float then begin
-          loc.(i) <- phys_reg !float;
-          incr float
-        end else begin
-          loc.(i) <- stack_slot (make_stack !ofs) Float;
-          ofs := !ofs + size_float
-        end
+        loc.(i) <- loc_float last_float make_stack float ofs
   done;
   (loc, Misc.align !ofs 16)  (* keep stack 16-aligned *)
 
@@ -159,12 +177,30 @@ let loc_results res =
      first integer args in r0...r7
      first float args in d0...d7
      remaining args on stack.
+   macOS/iOS peculiarity: int32 arguments passed on stack occupy 4 bytes,
+   while the AAPCS64 says 8 bytes.
    Return values in r0...r1 or d0. *)
 
-let loc_external_arguments arg =
-  let tyarg = Cmm.machtype_of_exttype_list arg in
-  let loc, stack_ofs = calling_conventions 0 7 100 107 outgoing tyarg in
-  Array.map (fun reg -> [|reg|]) loc, stack_ofs
+let external_calling_conventions
+    first_int last_int first_float last_float make_stack ty_args =
+  let loc = Array.make (List.length ty_args) [| Reg.dummy |] in
+  let int = ref first_int in
+  let float = ref first_float in
+  let ofs = ref 0 in
+  List.iteri (fun i ty_arg ->
+    begin match ty_arg with
+    | XInt | XInt64 ->
+        loc.(i) <- [| loc_int last_int make_stack int ofs |]
+    | XInt32 ->
+        loc.(i) <- [| loc_int32 last_int make_stack int ofs |]
+    | XFloat ->
+        loc.(i) <- [| loc_float last_float make_stack float ofs |]
+    end)
+    ty_args;
+  (loc, Misc.align !ofs 16)  (* keep stack 16-aligned *)
+
+let loc_external_arguments ty_args =
+  external_calling_conventions 0 7 100 107 outgoing ty_args
 
 let loc_external_results res =
   let (loc, _) = calling_conventions 0 1 100 100 not_supported res in loc

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -116,7 +116,7 @@ let calling_conventions
   let float = ref first_float in
   let ofs = ref 0 in
   for i = 0 to Array.length arg - 1 do
-    match arg.(i).typ with
+    match arg.(i) with
     | Val | Int | Addr as ty ->
         if !int <= last_int then begin
           loc.(i) <- phys_reg !int;
@@ -162,11 +162,10 @@ let loc_results res =
    Return values in r0...r1 or d0. *)
 
 let loc_external_arguments arg =
-  let arg =
-    Array.map (fun regs -> assert (Array.length regs = 1); regs.(0)) arg
-  in
-  let loc, alignment = calling_conventions 0 7 100 107 outgoing arg in
-  Array.map (fun reg -> [|reg|]) loc, alignment
+  let tyarg = Cmm.machtype_of_exttype_list arg in
+  let loc, stack_ofs = calling_conventions 0 7 100 107 outgoing tyarg in
+  Array.map (fun reg -> [|reg|]) loc, stack_ofs
+
 let loc_external_results res =
   let (loc, _) = calling_conventions 0 1 100 100 not_supported res in loc
 

--- a/asmcomp/arm64/reload.ml
+++ b/asmcomp/arm64/reload.ml
@@ -15,5 +15,26 @@
 
 (* Reloading for the ARM 64 bits *)
 
+open Reg
+
+class reload = object (self)
+
+inherit Reloadgen.reload_generic as super
+
+method! reload_operation op arg res =
+  match op with
+  | Ispecific Imove32 ->
+      (* Like Imove: argument or result can be on stack but not both *)
+      begin match arg.(0), res.(0) with
+      | {loc = Stack s1}, {loc = Stack s2} when s1 <> s2 ->
+          ([| self#makereg arg.(0) |], res)
+      | _ ->
+          (arg, res)
+      end
+   | _ ->
+      super#reload_operation op arg res
+
+end
+
 let fundecl f num_stack_slots =
-  (new Reloadgen.reload_generic)#fundecl f num_stack_slots
+  (new reload)#fundecl f num_stack_slots

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -85,6 +85,11 @@ let inline_ops =
 let use_direct_addressing _symb =
   not !Clflags.dlcode
 
+let is_stack_slot rv =
+  Reg.(match rv with
+        | [| { loc = Stack _ } |] -> true
+        | _ -> false)
+
 (* Instruction selection *)
 
 class selector = object(self)
@@ -98,13 +103,13 @@ method is_immediate n =
 
 method! is_simple_expr = function
   (* inlined floating-point ops are simple if their arguments are *)
-  | Cop(Cextcall (fn, _, _, _), args, _) when List.mem fn inline_ops ->
+  | Cop(Cextcall (fn, _, _, _, _), args, _) when List.mem fn inline_ops ->
       List.for_all self#is_simple_expr args
   | e -> super#is_simple_expr e
 
 method! effects_of e =
   match e with
-  | Cop(Cextcall (fn, _, _, _), args, _) when List.mem fn inline_ops ->
+  | Cop(Cextcall (fn, _, _, _, _), args, _) when List.mem fn inline_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | e -> super#effects_of e
 
@@ -228,15 +233,15 @@ method! select_operation op args dbg =
           super#select_operation op args dbg
       end
   (* Recognize floating-point square root *)
-  | Cextcall("sqrt", _, _, _) ->
+  | Cextcall("sqrt", _, _, _, _) ->
       (Ispecific Isqrtf, args)
   (* Recognize bswap instructions *)
-  | Cextcall("caml_bswap16_direct", _, _, _) ->
+  | Cextcall("caml_bswap16_direct", _, _, _, _) ->
       (Ispecific(Ibswap 16), args)
-  | Cextcall("caml_int32_direct_bswap", _, _, _) ->
+  | Cextcall("caml_int32_direct_bswap", _, _, _, _) ->
       (Ispecific(Ibswap 32), args)
   | Cextcall(("caml_int64_direct_bswap"|"caml_nativeint_direct_bswap"),
-              _, _, _) ->
+              _, _, _, _) ->
       (Ispecific (Ibswap 64), args)
   (* Other operations are regular *)
   | _ ->
@@ -250,6 +255,10 @@ method select_logical op = function
   | args ->
       (Iintop op, args)
 
+method! insert_move_extcall_arg env ty_arg src dst =
+  if ty_arg = XInt32 && abi = AppleABI && is_stack_slot dst
+  then self#insert env (Iop (Ispecific Imove32)) src dst
+  else self#insert_moves env src dst
 end
 
 let fundecl f = (new selector)#emit_fundecl f

--- a/asmcomp/arm64/selection.ml
+++ b/asmcomp/arm64/selection.ml
@@ -256,7 +256,7 @@ method select_logical op = function
       (Iintop op, args)
 
 method! insert_move_extcall_arg env ty_arg src dst =
-  if ty_arg = XInt32 && abi = AppleABI && is_stack_slot dst
+  if macosx && ty_arg = XInt32 && is_stack_slot dst
   then self#insert env (Iop (Ispecific Imove32)) src dst
   else self#insert_moves env src dst
 end

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -77,6 +77,21 @@ let ge_component comp1 comp2 =
   | Float, (Int | Addr | Val) ->
     assert false
 
+type exttype =
+  | XInt
+  | XInt32
+  | XInt64
+  | XFloat
+
+let machtype_of_exttype = function
+  | XInt -> typ_int
+  | XInt32 -> typ_int
+  | XInt64 -> if Arch.size_int = 4 then [|Int;Int|] else typ_int
+  | XFloat -> typ_float
+
+let machtype_of_exttype_list xtl =
+  Array.concat (List.map machtype_of_exttype xtl)
+
 type integer_comparison = Lambda.integer_comparison =
   | Ceq | Cne | Clt | Cgt | Cle | Cge
 
@@ -124,7 +139,7 @@ type memory_chunk =
 
 and operation =
     Capply of machtype
-  | Cextcall of string * machtype * bool * label option
+  | Cextcall of string * machtype * exttype list * bool * label option
     (** If specified, the given label will be placed immediately after the
         call (at the same place as any frame descriptor would reference). *)
   | Cload of memory_chunk * Asttypes.mutable_flag

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -68,6 +68,17 @@ val ge_component
   -> machtype_component
   -> bool
 
+type exttype =
+  | XInt                                (**r OCaml value, word-sized integer *)
+  | XInt32                              (**r 32-bit integer *)
+  | XInt64                              (**r 64-bit integer  *)
+  | XFloat                              (**r double-precision FP number  *)
+(** A variant of [machtype] used to describe arguments
+    to external C functions *)
+
+val machtype_of_exttype: exttype -> machtype
+val machtype_of_exttype_list: exttype list -> machtype
+
 type integer_comparison = Lambda.integer_comparison =
   | Ceq | Cne | Clt | Cgt | Cle | Cge
 
@@ -127,7 +138,10 @@ type memory_chunk =
 
 and operation =
     Capply of machtype
-  | Cextcall of string * machtype * bool * label option
+  | Cextcall of string * machtype * exttype list * bool * label option
+      (** The [machtype] is the machine type of the result.
+          The [exttype list] describes the unboxing types of the arguments.
+          An empty list means "all arguments are machine words [XInt]". *)
   | Cload of memory_chunk * Asttypes.mutable_flag
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -613,8 +613,8 @@ let rec remove_unit = function
       Clet(id, c1, remove_unit c2)
   | Cop(Capply _mty, args, dbg) ->
       Cop(Capply typ_void, args, dbg)
-  | Cop(Cextcall(proc, _mty, alloc, label_after), args, dbg) ->
-      Cop(Cextcall(proc, typ_void, alloc, label_after), args, dbg)
+  | Cop(Cextcall(proc, _ty_res, ty_args, alloc, label_after), args, dbg) ->
+      Cop(Cextcall(proc, typ_void, ty_args, alloc, label_after), args, dbg)
   | Cexit (_,_) as c -> c
   | Ctuple [] as c -> c
   | c -> Csequence(c, Ctuple [])
@@ -736,10 +736,10 @@ let float_array_ref arr ofs dbg =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
 
 let addr_array_set arr ofs newval dbg =
-  Cop(Cextcall("caml_modify", typ_void, false, None),
+  Cop(Cextcall("caml_modify", typ_void, [], false, None),
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
-  Cop(Cextcall("caml_initialize", typ_void, false, None),
+  Cop(Cextcall("caml_initialize", typ_void, [], false, None),
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let int_array_set arr ofs newval dbg =
   Cop(Cstore (Word_int, Lambda.Assignment),
@@ -775,7 +775,7 @@ let bigstring_length ba dbg =
 
 let lookup_tag obj tag dbg =
   bind "tag" tag (fun tag ->
-    Cop(Cextcall("caml_get_public_method", typ_val, false, None),
+    Cop(Cextcall("caml_get_public_method", typ_val, [], false, None),
         [obj; tag],
         dbg))
 
@@ -805,14 +805,14 @@ let make_alloc_generic set_fn dbg tag wordsize args =
     | e1::el -> Csequence(set_fn (Cvar id) (Cconst_int (idx, dbg)) e1 dbg,
                           fill_fields (idx + 2) el) in
     Clet(VP.create id,
-         Cop(Cextcall("caml_alloc", typ_val, true, None),
+         Cop(Cextcall("caml_alloc", typ_val, [], true, None),
                  [Cconst_int (wordsize, dbg); Cconst_int (tag, dbg)], dbg),
          fill_fields 1 args)
   end
 
 let make_alloc dbg tag args =
   let addr_array_init arr ofs newval dbg =
-    Cop(Cextcall("caml_initialize", typ_void, false, None),
+    Cop(Cextcall("caml_initialize", typ_void, [], false, None),
         [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
   in
   make_alloc_generic addr_array_init dbg tag (List.length args) args
@@ -2147,18 +2147,18 @@ let arraylength kind arg dbg =
       Cop(Cor, [float_array_length_shifted hdr dbg; Cconst_int (1, dbg)], dbg)
 
 let bbswap bi arg dbg =
-  let prim = match (bi : Primitive.boxed_integer) with
-    | Pnativeint -> "nativeint"
-    | Pint32 -> "int32"
-    | Pint64 -> "int64"
+  let prim, tyarg = match (bi : Primitive.boxed_integer) with
+    | Pnativeint -> "nativeint", XInt
+    | Pint32 -> "int32", XInt32
+    | Pint64 -> "int64", XInt64
   in
   Cop(Cextcall(Printf.sprintf "caml_%s_direct_bswap" prim,
-               typ_int, false, None),
+               typ_int, [tyarg], false, None),
       [arg],
       dbg)
 
 let bswap16 arg dbg =
-  (Cop(Cextcall("caml_bswap16_direct", typ_int, false, None),
+  (Cop(Cextcall("caml_bswap16_direct", typ_int, [], false, None),
        [arg],
        dbg))
 
@@ -2183,15 +2183,15 @@ let assignment_kind
 let setfield n ptr init arg1 arg2 dbg =
   match assignment_kind ptr init with
   | Caml_modify ->
-      return_unit dbg (Cop(Cextcall("caml_modify", typ_void, false, None),
-                      [field_address arg1 n dbg;
-                       arg2],
-                      dbg))
+      return_unit dbg
+        (Cop(Cextcall("caml_modify", typ_void, [], false, None),
+             [field_address arg1 n dbg; arg2],
+             dbg))
   | Caml_initialize ->
-      return_unit dbg (Cop(Cextcall("caml_initialize", typ_void, false, None),
-                      [field_address arg1 n dbg;
-                       arg2],
-                      dbg))
+      return_unit dbg
+        (Cop(Cextcall("caml_initialize", typ_void, [], false, None),
+             [field_address arg1 n dbg; arg2],
+             dbg))
   | Simple ->
       return_unit dbg (set_field arg1 n arg2 init dbg)
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -726,7 +726,7 @@ and transl_catch env nfail ids body handler dbg =
 and transl_make_array dbg env kind args =
   match kind with
   | Pgenarray ->
-      Cop(Cextcall("caml_make_array", typ_val, true, None),
+      Cop(Cextcall("caml_make_array", typ_val, [], true, None),
           [make_alloc dbg 0 (List.map (transl env) args)], dbg)
   | Paddrarray | Pintarray ->
       make_alloc dbg 0 (List.map (transl env) args)
@@ -737,20 +737,32 @@ and transl_make_array dbg env kind args =
 and transl_ccall env prim args dbg =
   let transl_arg native_repr arg =
     match native_repr with
-    | Same_as_ocaml_repr -> transl env arg
-    | Unboxed_float -> transl_unbox_float dbg env arg
-    | Unboxed_integer bi -> transl_unbox_int dbg env bi arg
-    | Untagged_int -> untag_int (transl env arg) dbg
+    | Same_as_ocaml_repr ->
+        (XInt, transl env arg)
+    | Unboxed_float ->
+        (XFloat, transl_unbox_float dbg env arg)
+    | Unboxed_integer bi ->
+        let xty =
+          match bi with
+          | Pnativeint -> XInt
+          | Pint32 -> XInt32
+          | Pint64 -> XInt64 in
+        (xty, transl_unbox_int dbg env bi arg)
+    | Untagged_int ->
+        (XInt, untag_int (transl env arg) dbg)
   in
   let rec transl_args native_repr_args args =
     match native_repr_args, args with
     | [], args ->
         (* We don't require the two lists to be of the same length as
            [default_prim] always sets the arity to [0]. *)
-        List.map (transl env) args
-    | _, [] -> assert false
+        (List.map (fun _ -> XInt) args, List.map (transl env) args)
+    | _, [] ->
+        assert false
     | native_repr :: native_repr_args, arg :: args ->
-        transl_arg native_repr arg :: transl_args native_repr_args args
+        let (ty1, arg') = transl_arg native_repr arg in
+        let (tys, args') = transl_args native_repr_args args in
+        (ty1 :: tys, arg' :: args')
   in
   let typ_res, wrap_result =
     match prim.prim_native_repr_res with
@@ -761,10 +773,10 @@ and transl_ccall env prim args dbg =
     | Unboxed_integer bi -> (typ_int, box_int dbg bi)
     | Untagged_int -> (typ_int, (fun i -> tag_int i dbg))
   in
-  let args = transl_args prim.prim_native_repr_args args in
+  let typ_args, args = transl_args prim.prim_native_repr_args args in
   wrap_result
     (Cop(Cextcall(Primitive.native_name prim,
-                  typ_res, prim.prim_alloc, None), args, dbg))
+                  typ_res, typ_args, prim.prim_alloc, None), args, dbg))
 
 and transl_prim_1 env p arg dbg =
   match p with
@@ -1304,7 +1316,7 @@ and transl_letrec env bindings cont =
       bindings
   in
   let op_alloc prim args =
-    Cop(Cextcall(prim, typ_val, true, None), args, dbg) in
+    Cop(Cextcall(prim, typ_val, [], true, None), args, dbg) in
   let rec init_blocks = function
     | [] -> fill_nonrec bsz
     | (id, _exp, RHS_block sz) :: rem ->
@@ -1330,7 +1342,7 @@ and transl_letrec env bindings cont =
     | [] -> cont
     | (id, exp, (RHS_block _ | RHS_infix _ | RHS_floatblock _)) :: rem ->
         let op =
-          Cop(Cextcall("caml_update_dummy", typ_void, false, None),
+          Cop(Cextcall("caml_update_dummy", typ_void, [], false, None),
               [Cvar (VP.var id); transl env exp], dbg) in
         Csequence(op, fill_blocks rem)
     | (_id, _exp, RHS_nonrec) :: rem ->

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -121,7 +121,7 @@ let calling_conventions first_int last_int first_float last_float make_stack
   let float = ref first_float in
   let ofs = ref (-64) in
   for i = 0 to Array.length arg - 1 do
-    match arg.(i).typ with
+    match arg.(i) with
       Val | Int | Addr as ty ->
         if !int <= last_int then begin
           loc.(i) <- phys_reg !int;
@@ -158,7 +158,7 @@ let loc_external_arguments _arg =
   fatal_error "Proc.loc_external_arguments"
 let loc_external_results res =
   match res with
-  | [|{typ=Int};{typ=Int}|] -> [|eax; edx|]
+  | [| Int; Int |] -> [|eax; edx|]
   | _ ->
       let (loc, _ofs) = calling_conventions 0 0 100 100 not_supported res in loc
 

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -89,7 +89,7 @@ let rec float_needs = function
       let n1 = float_needs arg1 in
       let n2 = float_needs arg2 in
       if n1 = n2 then 1 + n1 else if n1 > n2 then n1 else n2
-  | Cop(Cextcall(fn, _ty_res, _alloc, _label), args, _dbg)
+  | Cop(Cextcall(fn, _ty_res, _ty_args, _alloc, _label), args, _dbg)
     when !fast_math && List.mem fn inline_float_ops ->
       begin match args with
         [arg] -> float_needs arg
@@ -162,7 +162,7 @@ method is_immediate (_n : int) = true
 
 method! is_simple_expr e =
   match e with
-  | Cop(Cextcall(fn, _, _alloc, _), args, _)
+  | Cop(Cextcall(fn, _, _, _, _), args, _)
     when !fast_math && List.mem fn inline_float_ops ->
       (* inlined float ops are simple if their arguments are *)
       List.for_all self#is_simple_expr args
@@ -171,7 +171,7 @@ method! is_simple_expr e =
 
 method! effects_of e =
   match e with
-  | Cop(Cextcall(fn, _, _, _), args, _)
+  | Cop(Cextcall(fn, _, _, _, _), args, _)
     when !fast_math && List.mem fn inline_float_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | _ ->
@@ -233,7 +233,7 @@ method! select_operation op args dbg =
           super#select_operation op args dbg
       end
   (* Recognize inlined floating point operations *)
-  | Cextcall(fn, _ty_res, false, _label)
+  | Cextcall(fn, _ty_res, _ty_args, false, _label)
     when !fast_math && List.mem fn inline_float_ops ->
       (Ispecific(Ifloatspecial fn), args)
   (* i386 does not support immediate operands for multiply high signed *)
@@ -297,7 +297,7 @@ method select_push exp =
 method! mark_c_tailcall =
   contains_calls := true
 
-method! emit_extcall_args env args =
+method! emit_extcall_args env _ty_args args =
   let rec size_pushes = function
   | [] -> 0
   | e :: el -> Selectgen.size_expr env e + size_pushes el in

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -50,7 +50,9 @@ type operation =
   | Icall_imm of { func : string; label_after : label; }
   | Itailcall_ind of { label_after : label; }
   | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Iextcall of { func : string;
+                  ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
+                  alloc : bool; label_after : label; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -57,7 +57,9 @@ type operation =
   | Icall_imm of { func : string; label_after : label; }
   | Itailcall_ind of { label_after : label; }
   | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Iextcall of { func : string;
+                  ty_res : Cmm.machtype; ty_args : Cmm.exttype list;
+                  alloc : bool; label_after : label; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -39,6 +39,21 @@ let machtype ppf mty =
            fprintf ppf "*%a" machtype_component mty.(i)
          done
 
+let exttype ppf = function
+  | XInt -> fprintf ppf "int"
+  | XInt32 -> fprintf ppf "int32"
+  | XInt64 -> fprintf ppf "int64"
+  | XFloat -> fprintf ppf "float"
+
+let extcall_signature ppf (ty_res, ty_args) =
+  begin match ty_args with
+  | [] -> ()
+  | ty_arg1 :: ty_args ->
+      exttype ppf ty_arg1;
+      List.iter (fun ty -> fprintf ppf ",%a" exttype ty) ty_args
+  end;
+  fprintf ppf "->%a" machtype ty_res
+
 let integer_comparison = function
   | Ceq -> "=="
   | Cne -> "!="
@@ -101,7 +116,7 @@ let location d =
 
 let operation d = function
   | Capply _ty -> "app" ^ location d
-  | Cextcall(lbl, _ty, _alloc, _) ->
+  | Cextcall(lbl, _ty_res, _ty_args, _alloc, _) ->
       Printf.sprintf "extcall \"%s\"%s" lbl (location d)
   | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
   | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
@@ -207,7 +222,8 @@ let rec expr ppf = function
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       begin match op with
       | Capply mty -> fprintf ppf "@ %a" machtype mty
-      | Cextcall(_, mty, _, _) -> fprintf ppf "@ %a" machtype mty
+      | Cextcall(_, ty_res, ty_args, _, _) ->
+          fprintf ppf "@ %a" extcall_signature (ty_res, ty_args)
       | _ -> ()
       end;
       fprintf ppf ")@]"

--- a/asmcomp/printcmm.mli
+++ b/asmcomp/printcmm.mli
@@ -19,7 +19,9 @@ open Format
 
 val rec_flag : formatter -> Cmm.rec_flag -> unit
 val machtype_component : formatter -> Cmm.machtype_component -> unit
-val machtype : formatter -> Cmm.machtype_component array -> unit
+val machtype : formatter -> Cmm.machtype -> unit
+val exttype : formatter -> Cmm.exttype -> unit
+val extcall_signature : formatter -> Cmm.machtype * Cmm.exttype list -> unit
 val integer_comparison : Cmm.integer_comparison -> string
 val float_comparison : Cmm.float_comparison -> string
 val chunk : Cmm.memory_chunk -> string

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -28,16 +28,14 @@ val phys_reg: int -> Reg.t
 val rotate_registers: bool
 
 (* Calling conventions *)
-val loc_arguments: Reg.t array -> Reg.t array * int
-val loc_results: Reg.t array -> Reg.t array
-val loc_parameters: Reg.t array -> Reg.t array
+val loc_arguments: Cmm.machtype -> Reg.t array * int
+val loc_results: Cmm.machtype -> Reg.t array
+val loc_parameters: Cmm.machtype -> Reg.t array
 (* For argument number [n] split across multiple registers, the target-specific
    implementation of [loc_external_arguments] must return [regs] such that
-   [regs.(n).(0)] is to hold the part of the value at the lowest address.
-   (All that matters for the input to [loc_external_arguments] is the pattern
-   of lengths and register types of the various supplied arrays.) *)
-val loc_external_arguments: Reg.t array array -> Reg.t array array * int
-val loc_external_results: Reg.t array -> Reg.t array
+   [regs.(n).(0)] is to hold the part of the value at the lowest address. *)
+val loc_external_arguments: Cmm.exttype list -> Reg.t array array * int
+val loc_external_results: Cmm.machtype -> Reg.t array
 val loc_exn_bucket: Reg.t
 val loc_spacetime_node_hole: Reg.t
 

--- a/asmcomp/reg.ml
+++ b/asmcomp/reg.ml
@@ -117,6 +117,9 @@ let at_location ty loc =
   incr currstamp;
   r
 
+let typv rv =
+  Array.map (fun r -> r.typ) rv
+
 let anonymous t =
   match Raw_name.to_string t.raw_name with
   | None -> true

--- a/asmcomp/reg.mli
+++ b/asmcomp/reg.mli
@@ -49,7 +49,7 @@ val createv: Cmm.machtype -> t array
 val createv_like: t array -> t array
 val clone: t -> t
 val at_location: Cmm.machtype_component -> location -> t
-
+val typv: t array -> Cmm.machtype
 val anonymous : t -> bool
 
 (* Name for printing *)

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -105,7 +105,7 @@ let calling_conventions
   let float = ref first_float in
   let ofs = ref stack_ofs in
   for i = 0 to Array.length arg - 1 do
-    match arg.(i).typ with
+    match arg.(i) with
     | Val | Int | Addr as ty ->
         if !int <= last_int then begin
           loc.(i) <- phys_reg !int;
@@ -145,11 +145,9 @@ let loc_results res =
      Always reserve 160 bytes at bottom of stack, plus whatever is needed
      to hold the overflow arguments. *)
 
-let loc_external_arguments arg =
-  let arg =
-    Array.map (fun regs -> assert (Array.length regs = 1); regs.(0)) arg in
-  let (loc, ofs) =
-    calling_conventions 0 4 100 103 outgoing 160 arg in
+let loc_external_arguments ty_args =
+  let arg = Cmm.machtype_of_exttype_list ty_args in
+  let (loc, ofs) = calling_conventions 0 4 100 103 outgoing 160 arg in
   (Array.map (fun reg -> [|reg|]) loc, ofs)
 
 (* Results are in GPR 2 and FPR 0 *)

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -66,7 +66,7 @@ let env_empty = {
 
 let oper_result_type = function
     Capply ty -> ty
-  | Cextcall(_s, ty, _alloc, _) -> ty
+  | Cextcall(_s, ty_res, _ty_args, _alloc, _) -> ty_res
   | Cload (c, _) ->
       begin match c with
       | Word_val -> typ_val
@@ -445,13 +445,13 @@ method select_operation op args _dbg =
   | (Capply _, _) ->
     let label_after = Cmm.new_label () in
     (Icall_ind { label_after; }, args)
-  | (Cextcall(func, _ty, alloc, label_after), _) ->
+  | (Cextcall(func, ty_res, ty_args, alloc, label_after), _) ->
     let label_after =
       match label_after with
       | None -> Cmm.new_label ()
       | Some label_after -> label_after
     in
-    Iextcall { func; alloc; label_after; }, args
+    Iextcall { func; ty_res; ty_args; alloc; label_after; }, args
   | (Cload (chunk, _mut), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
       (Iload(chunk, addr), [eloc])
@@ -717,8 +717,8 @@ method emit_expr (env:environment) exp =
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let rd = self#regs_for ty in
-              let (loc_arg, stack_ofs) = Proc.loc_arguments rarg in
-              let loc_res = Proc.loc_results rd in
+              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
+              let loc_res = Proc.loc_results (Reg.typv rd) in
               let spacetime_reg =
                 self#about_to_emit_call env (Iop new_op) [| r1.(0) |] dbg
               in
@@ -731,8 +731,8 @@ method emit_expr (env:environment) exp =
           | Icall_imm _ ->
               let r1 = self#emit_tuple env new_args in
               let rd = self#regs_for ty in
-              let (loc_arg, stack_ofs) = Proc.loc_arguments r1 in
-              let loc_res = Proc.loc_results rd in
+              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
+              let loc_res = Proc.loc_results (Reg.typv rd) in
               let spacetime_reg =
                 self#about_to_emit_call env (Iop new_op) [| |] dbg
               in
@@ -741,16 +741,16 @@ method emit_expr (env:environment) exp =
               self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
               self#insert_move_results env loc_res rd stack_ofs;
               Some rd
-          | Iextcall _ ->
+          | Iextcall { ty_args; _} ->
               let spacetime_reg =
-                self#about_to_emit_call env (Iop new_op) [| |] dbg
-              in
-              let (loc_arg, stack_ofs) = self#emit_extcall_args env new_args in
+                self#about_to_emit_call env (Iop new_op) [| |] dbg in
+              let (loc_arg, stack_ofs) =
+                self#emit_extcall_args env ty_args new_args in
               self#maybe_emit_spacetime_move env ~spacetime_reg;
               let rd = self#regs_for ty in
               let loc_res =
                 self#insert_op_debug env new_op dbg
-                  loc_arg (Proc.loc_external_results rd) in
+                  loc_arg (Proc.loc_external_results (Reg.typv rd)) in
               self#insert_move_results env loc_res rd stack_ofs;
               Some rd
           | Ialloc { bytes = _; spacetime_index; label_after_call_gc; } ->
@@ -998,19 +998,26 @@ method private emit_tuple_not_flattened env exp_list =
 method private emit_tuple env exp_list =
   Array.concat (self#emit_tuple_not_flattened env exp_list)
 
-method emit_extcall_args env args =
+method emit_extcall_args env ty_args args =
   let args = self#emit_tuple_not_flattened env args in
-  let arg_hard_regs, stack_ofs =
-    Proc.loc_external_arguments (Array.of_list args)
-  in
-  (* Flattening [args] and [arg_hard_regs] causes parts of values split
-     across multiple registers to line up correctly, by virtue of the
-     semantics of [split_int64_for_32bit_target] in cmmgen.ml, and the
-     required semantics of [loc_external_arguments] (see proc.mli). *)
-  let args = Array.concat args in
-  let arg_hard_regs = Array.concat (Array.to_list arg_hard_regs) in
-  self#insert_move_args env args arg_hard_regs stack_ofs;
-  arg_hard_regs, stack_ofs
+  let ty_args =
+    if ty_args = [] then List.map (fun _ -> XInt) args else ty_args in
+  let locs, stack_ofs = Proc.loc_external_arguments ty_args in
+  let ty_args = Array.of_list ty_args in
+  if stack_ofs <> 0 then
+    self#insert env (Iop(Istackoffset stack_ofs)) [||] [||];
+  List.iteri
+    (fun i arg ->
+      self#insert_move_extcall_arg env ty_args.(i) arg locs.(i))
+    args;
+  Array.concat (Array.to_list locs), stack_ofs
+
+method insert_move_extcall_arg env _ty_arg src dst =
+  (* The default implementation is one or two ordinary moves.
+     (Two in the case of an int64 argument on a 32-bit platform.)
+     It can be overriden to use special move instructions,
+     for example a "32-bit move" instruction for int32 arguments. *)
+  self#insert_moves env src dst
 
 method emit_stores env data regs_addr =
   let a =
@@ -1042,7 +1049,7 @@ method private emit_return (env:environment) exp =
   match self#emit_expr env exp with
     None -> ()
   | Some r ->
-      let loc = Proc.loc_results r in
+      let loc = Proc.loc_results (Reg.typv r) in
       self#insert_moves env r loc;
       self#insert env Ireturn loc [||]
 
@@ -1069,7 +1076,7 @@ method emit_tail (env:environment) exp =
             Icall_ind { label_after; } ->
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
-              let (loc_arg, stack_ofs) = Proc.loc_arguments rarg in
+              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv rarg) in
               if stack_ofs = 0 then begin
                 let call = Iop (Itailcall_ind { label_after; }) in
                 let spacetime_reg =
@@ -1081,7 +1088,7 @@ method emit_tail (env:environment) exp =
                             (Array.append [|r1.(0)|] loc_arg) [||];
               end else begin
                 let rd = self#regs_for ty in
-                let loc_res = Proc.loc_results rd in
+                let loc_res = Proc.loc_results (Reg.typv rd) in
                 let spacetime_reg =
                   self#about_to_emit_call env (Iop new_op) [| r1.(0) |] dbg
                 in
@@ -1094,7 +1101,7 @@ method emit_tail (env:environment) exp =
               end
           | Icall_imm { func; label_after; } ->
               let r1 = self#emit_tuple env new_args in
-              let (loc_arg, stack_ofs) = Proc.loc_arguments r1 in
+              let (loc_arg, stack_ofs) = Proc.loc_arguments (Reg.typv r1) in
               if stack_ofs = 0 then begin
                 let call = Iop (Itailcall_imm { func; label_after; }) in
                 let spacetime_reg =
@@ -1105,7 +1112,7 @@ method emit_tail (env:environment) exp =
                 self#insert_debug env call dbg loc_arg [||];
               end else if func = !current_function_name then begin
                 let call = Iop (Itailcall_imm { func; label_after; }) in
-                let loc_arg' = Proc.loc_parameters r1 in
+                let loc_arg' = Proc.loc_parameters (Reg.typv r1) in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| |] dbg
                 in
@@ -1114,7 +1121,7 @@ method emit_tail (env:environment) exp =
                 self#insert_debug env call dbg loc_arg' [||];
               end else begin
                 let rd = self#regs_for ty in
-                let loc_res = Proc.loc_results rd in
+                let loc_res = Proc.loc_results (Reg.typv rd) in
                 let spacetime_reg =
                   self#about_to_emit_call env (Iop new_op) [| |] dbg
                 in
@@ -1189,7 +1196,7 @@ method emit_tail (env:environment) exp =
       begin match opt_r1 with
         None -> ()
       | Some r1 ->
-          let loc = Proc.loc_results r1 in
+          let loc = Proc.loc_results (Reg.typv r1) in
           self#insert_moves env r1 loc;
           self#insert env Ireturn loc [||]
       end
@@ -1224,7 +1231,7 @@ method emit_fundecl f =
       (fun (id, ty) -> let r = self#regs_for ty in name_regs id r; r)
       f.Cmm.fun_args in
   let rarg = Array.concat rargs in
-  let loc_arg = Proc.loc_parameters rarg in
+  let loc_arg = Proc.loc_parameters (Reg.typv rarg) in
   (* To make it easier to add the Spacetime instrumentation code, we
      first emit the body and extract the resulting instruction sequence;
      then we emit the prologue followed by any Spacetime instrumentation.  The
@@ -1268,9 +1275,8 @@ end
 *)
 
 let is_tail_call nargs =
-  assert (Reg.dummy.typ = Int);
-  let args = Array.make (nargs + 1) Reg.dummy in
-  let (_loc_arg, stack_ofs) = Proc.loc_arguments args in
+  let ty = Array.make (nargs + 1) Int in
+  let (_loc_arg, stack_ofs) = Proc.loc_arguments ty in
   stack_ofs = 0
 
 let _ =

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -97,8 +97,13 @@ class virtual selector_generic : object
       -> Reg.t array -> Reg.t array
     (* Can be overridden to deal with 2-address instructions
        or instructions with hardwired input/output registers *)
+  method insert_move_extcall_arg :
+    environment -> Cmm.exttype -> Reg.t array -> Reg.t array -> unit
+    (* Can be overriden to deal with unusual unboxed calling conventions,
+       e.g. on a 64-bit platform, passing unboxed 32-bit arguments
+       in 32-bit stack slots. *)
   method emit_extcall_args :
-    environment -> Cmm.expression list -> Reg.t array * int
+    environment -> Cmm.exttype list -> Cmm.expression list -> Reg.t array * int
     (* Can be overridden to deal with stack-based calling conventions *)
   method emit_stores :
     environment -> Cmm.expression list -> Reg.t array -> unit

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -111,7 +111,7 @@ let code_for_function_prologue ~function_name ~fun_dbg:dbg ~node_hole =
           Clet (VP.create is_new_node,
             Clet (VP.create pc, cconst_symbol function_name,
               Cop (Cextcall ("caml_spacetime_allocate_node",
-                  [| Int |], false, None),
+                  typ_int, [], false, None),
                 [cconst_int (1 (* header *) + !index_within_node);
                 Cvar pc;
                 Cvar node_hole;
@@ -151,7 +151,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
        the latter table to be used for resolving a program counter at such
        a point to a location.
     *)
-    Cop (Cextcall ("caml_spacetime_generate_profinfo", [| Int |],
+    Cop (Cextcall ("caml_spacetime_generate_profinfo", typ_int, [],
         false, Some label),
       [Cvar address_of_profinfo;
        cconst_int (index_within_node + 1)],
@@ -272,7 +272,7 @@ let code_for_call ~node ~callee ~is_tail ~label dbg =
         else cconst_int 1  (* [Val_unit] *)
       in
       Cop (Cextcall ("caml_spacetime_indirect_node_hole_ptr",
-          [| Int |], false, None),
+           typ_int, [], false, None),
         [callee; Cvar place_within_node; caller_node],
         dbg))
 
@@ -336,7 +336,7 @@ class virtual instruction_selection = object (self)
         assert (Array.length arg = 1);
         self#instrument_indirect_call ~env ~callee:arg.(0)
           ~is_tail:true ~label_after dbg
-      | M.Iop (M.Iextcall { func; alloc = true; label_after; }) ->
+      | M.Iop (M.Iextcall { func; alloc = true; label_after; _}) ->
         (* N.B. No need to instrument "noalloc" external calls. *)
         assert (Array.length arg = 0);
         self#instrument_direct_call ~env ~func ~is_tail:false ~label_after dbg

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -218,7 +218,8 @@ expr:
   | LPAREN APPLY location expr exprlist machtype RPAREN
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall($3, $5, false, None), List.rev $4, debuginfo ())}
+               {Cop(Cextcall($3, $5, [], false, None),
+                    List.rev $4, debuginfo ())}
   | LPAREN ALLOC exprlist RPAREN { Cop(Calloc, List.rev $3, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }


### PR DESCRIPTION
## Executive summary

This PR changes the way calling conventions for external C functions are described for every ocamlopt target architecture, and the way code is generated to call external C functions.  The motivation is to support iOS/macOS running on ARM 64 bits, whose calling conventions cannot be described with the current ocamlopt code but fits easily in the proposed approach.  This fixes a problem that blocks the merge of #9699.

##  C calling conventions

The calling conventions for external functions implemented in C are more complex than those for internal functions implemented in OCaml, because 1- we don't get to choose our conventions and must adapt to those of the target platform, and 2- external C functions take a greater variety of unboxed numerical arguments: unboxed double-precision FP numbers, but also 64-bit, 32-bit, and platform-native unboxed integers.  

The two problematic cases are:
- Passing an unboxed 64-bit integer on a 32-bit platform.  The argument must be split across two integer registers, or stored in an 8-byte stack slot.  This case was addressed by @jeremiedimino in 2015, commit e7593340c104084ad8ef521c0baa9b9ae6e78af0.
- Passing an unboxed 32-bit integer on ARM64 / iOS.  On this 64-bit platform, 32-bit integer arguments passed in stack are passed in 4-byte stack words, not 8-byte stack words as on any other 64-bit platform we currently support.  This case cannot be addressed with the current code base, and demands a new approach.

## Proposed approach

The first commit of this PR changes the way external C functions are called, as follows:
- Introduce the type `Cmm.exttype` to precisely describe arguments to external C functions, especially unboxed numerical arguments: 32-bit integers, 64-bit integers, native integers, or double FP numbers.
- Annotate `Cmm.Cextcall` with the types of the arguments (`Cmm.exttype list`). An empty list means "all arguments have default type `XInt`", which is the most common case.
- Annotate `Mach.Iextcall` with the type of the result (`Cmm.machtype`) and the types of the arguments (`Cmm.exttype list`).  (The asymmetry between the result types and the argument types is intended.  The result type describes a value in words the OCaml runtime system understands, distinguishing e.g. well-formed values from raw integers.  The argument types describe arguments in words the C compiler understands.)
- Change (slightly) the API for describing calling conventions in Proc:
  - `loc_external_arguments` now takes a `Cmm.exttype list`,   in order to know more precisely the types of the arguments.
  - `loc_arguments`, `loc_parameters`, `loc_results`, `loc_external_results`  now take a `Cmm.machype` instead of an array of pseudoregisters.   (Only the types of the pseudoregisters mattered anyway.)
- Update the implementations of module Proc accordingly, in every port.
  - For most 64-bit platforms, a single `calling_conventions` function suffices, modulo a conversion from `Cmm.exttype list` to `Cmm.machtype`
  - For other platforms, two different functions handle OCaml calling conventions and C calling conventions, but I managed to share many auxiliary functions between the two functions.
- Introduce a new overridable method in `Selectgen`, named `insert_move_extcall_arg`, to produce the code that moves an argument of an external C function to the locations returned by `Proc.loc_external_arguments`.
- Revise the selection of external calls accordingly (method `emit_extcall_args` in `Selectgen`).

The second commit reaps the benefits of the new approach.  It modifies the ARM64 port to support the iOS calling conventions properly.  To this end, a new `Imove32` specific operation is introduced, and generated in `insert_move_extcall_arg` when an `XInt32` argument is passed on stack.
 
