### PR TITLE
fix build for Android

### DIFF
--- a/configure
+++ b/configure
@@ -16348,6 +16348,8 @@ if test "x$ax_pthread_ok" = "xyes"; then
     pthread_link="-lpthread -lposix4" ;; #(
   *-*-haiku*) :
     pthread_link="" ;; #(
+  *-*-android*) :
+    pthread_link="" ;; #(
   *) :
     pthread_link="-lpthread" ;;
 esac

--- a/configure
+++ b/configure
@@ -12998,13 +12998,6 @@ if test "x$ac_cv_header_stdint_h" = xyes; then :
 fi
 
 
-ac_fn_c_check_header_mongrel "$LINENO" "sys/shm.h" "ac_cv_header_sys_shm_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_shm_h" = xyes; then :
-  $as_echo "#define HAS_SYS_SHM_H 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_header_compile "$LINENO" "dirent.h" "ac_cv_header_dirent_h" "#include <sys/types.h>
 "
 if test "x$ac_cv_header_dirent_h" = xyes; then :
@@ -15602,6 +15595,23 @@ if test "x$ac_cv_func_getauxval" = xyes; then :
   $as_echo "#define HAS_GETAUXVAL 1" >>confdefs.h
 
 fi
+
+
+## shmat
+ac_fn_c_check_header_mongrel "$LINENO" "sys/shm.h" "ac_cv_header_sys_shm_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_shm_h" = xyes; then :
+
+    $as_echo "#define HAS_SYS_SHM_H 1" >>confdefs.h
+
+    ac_fn_c_check_func "$LINENO" "shmat" "ac_cv_func_shmat"
+if test "x$ac_cv_func_shmat" = xyes; then :
+  $as_echo "#define HAS_SHMAT 1" >>confdefs.h
+
+fi
+
+
+fi
+
 
 
 ## execvpe

--- a/configure.ac
+++ b/configure.ac
@@ -1630,6 +1630,7 @@ AS_IF([test x"$enable_systhreads" = "xno"],
       AS_CASE([$host],
         [*-*-solaris*], [pthread_link="-lpthread -lposix4"],
         [*-*-haiku*], [pthread_link=""],
+        [*-*-android*], [pthread_link=""],
         [pthread_link="-lpthread"])
       common_cppflags="$common_cppflags -D_REENTRANT"
       AC_MSG_NOTICE([the POSIX threads library is supported])

--- a/configure.ac
+++ b/configure.ac
@@ -740,7 +740,6 @@ AS_IF([test "x$ac_cv_lib_m_cos" = xyes ], [mathlib="-lm"], [mathlib=""])
 AC_CHECK_HEADER([math.h])
 AC_CHECK_HEADERS([unistd.h],[AC_DEFINE([HAS_UNISTD])])
 AC_CHECK_HEADER([stdint.h],[AC_DEFINE([HAS_STDINT_H])])
-AC_CHECK_HEADER([sys/shm.h],[AC_DEFINE([HAS_SYS_SHM_H])])
 AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],
   [#include <sys/types.h>])
 
@@ -1563,6 +1562,13 @@ AC_CHECK_FUNC([accept4], [AC_DEFINE([HAS_ACCEPT4])])
 ## getauxval
 
 AC_CHECK_FUNC([getauxval], [AC_DEFINE([HAS_GETAUXVAL])])
+
+## shmat
+AC_CHECK_HEADER([sys/shm.h],
+  [
+    AC_DEFINE([HAS_SYS_SHM_H])
+    AC_CHECK_FUNC([shmat], [AC_DEFINE([HAS_SHMAT])])
+  ])
 
 ## execvpe
 

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -15,7 +15,7 @@
 /* Runtime support for afl-fuzz */
 #include "caml/config.h"
 
-#if !defined(HAS_SYS_SHM_H)
+#if !defined(HAS_SYS_SHM_H) || !defined(HAS_SHMAT)
 
 #include "caml/mlvalues.h"
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -245,6 +245,8 @@
 
 #undef HAS_SYS_SHM_H
 
+#undef HAS_SHMAT
+
 #undef HAS_EXECVPE
 
 #undef HAS_POSIX_SPAWN


### PR DESCRIPTION
### Configure

Stop using `-lpthread` for Android, as it's not required(same as haiku and beos).
Add a new flag `HAS_SHMAT` to check if shmat is available in the linker

### AFL

As AFL uses `shmat` it can only be enabled when `HAS_SHMAT` is true, so check on that