### PR TITLE
Allow `[@tailcall true]` and `[@tailcall false]`

### DIFF
--- a/.depend
+++ b/.depend
@@ -2803,7 +2803,6 @@ asmcomp/scheduling.cmx : \
 asmcomp/scheduling.cmi : \
     asmcomp/linear.cmi
 asmcomp/selectgen.cmo : \
-    lambda/simplif.cmi \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
     utils/numbers.cmi \
@@ -2817,7 +2816,6 @@ asmcomp/selectgen.cmo : \
     asmcomp/arch.cmo \
     asmcomp/selectgen.cmi
 asmcomp/selectgen.cmx : \
-    lambda/simplif.cmx \
     asmcomp/reg.cmx \
     asmcomp/proc.cmx \
     utils/numbers.cmx \

--- a/Changes
+++ b/Changes
@@ -364,6 +364,10 @@ Working version
   (Xavier Van de Woestyne, report by whitequark, review by Florian Angeletti
   and Gabriel Scherer)
 
+- #9754: allow [@tailcall true] (equivalent to [@tailcall]) and
+  [@tailcall false] (warns if on a tailcall)
+  (Gabriel Scherer, review by Nicolás Ojeda Bär)
+
 - #9657: Warnings can now be referred to by their mnemonic name. The names are
   displayed using `-warn-help` and can be utilized anywhere where a warning list
   specification is expected, e.g. `[@@@ocaml.warning ...]`.

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1177,18 +1177,5 @@ method emit_fundecl f =
 
 end
 
-(* Tail call criterion (estimated).  Assumes:
-- all arguments are of type "int" (always the case for OCaml function calls)
-- one extra argument representing the closure environment (conservative).
-*)
-
-let is_tail_call nargs =
-  let ty = Array.make (nargs + 1) Int in
-  let (_loc_arg, stack_ofs) = Proc.loc_arguments ty in
-  stack_ofs = 0
-
-let _ =
-  Simplif.is_tail_native_heuristic := is_tail_call
-
 let reset () =
   current_function_name := ""

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -212,8 +212,9 @@ type structured_constant =
   | Const_immstring of string
 
 type tailcall_attribute =
-  | Tailcall_expectation of bool (* [@tailcall true] and [@tailcall] have [true],
-                                    [@tailcall false] has [false] *)
+  | Tailcall_expectation of bool
+    (* [@tailcall] and [@tailcall true] have [true],
+       [@tailcall false] has [false] *)
   | Default_tailcall (* no [@tailcall] attribute *)
 
 type inline_attribute =

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -212,7 +212,8 @@ type structured_constant =
   | Const_immstring of string
 
 type tailcall_attribute =
-  | Should_be_tailcall (* [@tailcall] *)
+  | Tailcall_expectation of bool (* [@tailcall true] and [@tailcall] have [true],
+                                    [@tailcall false] has [false] *)
   | Default_tailcall (* no [@tailcall] attribute *)
 
 type inline_attribute =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -203,7 +203,8 @@ type structured_constant =
   | Const_immstring of string
 
 type tailcall_attribute =
-  | Should_be_tailcall (* [@tailcall] *)
+  | Tailcall_expectation of bool (* [@tailcall true] and [@tailcall] have [true],
+                                    [@tailcall false] has [false] *)
   | Default_tailcall (* no [@tailcall] attribute *)
 
 type inline_attribute =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -203,8 +203,9 @@ type structured_constant =
   | Const_immstring of string
 
 type tailcall_attribute =
-  | Tailcall_expectation of bool (* [@tailcall true] and [@tailcall] have [true],
-                                    [@tailcall false] has [false] *)
+  | Tailcall_expectation of bool
+    (* [@tailcall] and [@tailcall true] have [true],
+       [@tailcall false] has [false] *)
   | Default_tailcall (* no [@tailcall] attribute *)
 
 type inline_attribute =

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -475,8 +475,10 @@ let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
 
 let apply_tailcall_attribute ppf = function
   | Default_tailcall -> ()
-  | Should_be_tailcall ->
+  | Tailcall_expectation true ->
     fprintf ppf " tailcall"
+  | Tailcall_expectation false ->
+    fprintf ppf " tailcall(false)"
 
 let apply_inlined_attribute ppf = function
   | Default_inline -> ()

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -608,20 +608,22 @@ let rec emit_tail_infos is_tail lambda =
   | Lvar _ -> ()
   | Lconst _ -> ()
   | Lapply ap ->
-      begin match ap.ap_tailcall with
-      | Default_tailcall -> ()
-      | Should_be_tailcall ->
-          (* Note: is_tail does not take backend-specific logic into
-             account (maximum number of parameters, etc.)  so it may
-             over-approximate tail-callness.
+      begin
+        (* Note: is_tail does not take backend-specific logic into
+           account (maximum number of parameters, etc.)  so it may
+           over-approximate tail-callness.
 
-             Trying to do something more fine-grained would result in
-             different warnings depending on whether the native or
-             bytecode compiler is used. *)
-          if not is_tail
-          && Warnings.is_active Warnings.Tailcall_expected
-          then Location.prerr_warning (to_location ap.ap_loc)
-                 Warnings.Tailcall_expected;
+           Trying to do something more fine-grained would result in
+           different warnings depending on whether the native or
+           bytecode compiler is used. *)
+        let maybe_warn ~is_tail ~expect_tail =
+          if is_tail <> expect_tail then
+            Location.prerr_warning (to_location ap.ap_loc)
+              (Warnings.Wrong_tailcall_expectation expect_tail) in
+        match ap.ap_tailcall with
+        | Default_tailcall -> ()
+        | Tailcall_expectation expect_tail ->
+            maybe_warn ~is_tail ~expect_tail
       end;
       emit_tail_infos false ap.ap_func;
       list_emit_tail_infos false ap.ap_args
@@ -887,6 +889,7 @@ let simplify_lambda lam =
     |> simplify_exits
     |> simplify_lets
   in
-  if !Clflags.annotations || Warnings.is_active Warnings.Tailcall_expected
-    then emit_tail_infos true lam;
+  if !Clflags.annotations
+     || Warnings.is_active (Warnings.Wrong_tailcall_expectation true)
+  then emit_tail_infos true lam;
   lam

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -603,9 +603,6 @@ let simplify_lets lam =
 
 (* Tail call info in annotation files *)
 
-let is_tail_native_heuristic : (int -> bool) ref =
-  ref (fun _ -> true)
-
 let rec emit_tail_infos is_tail lambda =
   match lambda with
   | Lvar _ -> ()
@@ -614,10 +611,13 @@ let rec emit_tail_infos is_tail lambda =
       begin match ap.ap_tailcall with
       | Default_tailcall -> ()
       | Should_be_tailcall ->
-          (* Note: we may want to instead check the call_kind,
-             which takes [is_tail_native_heuristic] into account.
-             But then this means getting different warnings depending
-             on whether the native or bytecode compiler is used. *)
+          (* Note: is_tail does not take backend-specific logic into
+             account (maximum number of parameters, etc.)  so it may
+             over-approximate tail-callness.
+
+             Trying to do something more fine-grained would result in
+             different warnings depending on whether the native or
+             bytecode compiler is used. *)
           if not is_tail
           && Warnings.is_active Warnings.Tailcall_expected
           then Location.prerr_warning (to_location ap.ap_loc)

--- a/lambda/simplif.mli
+++ b/lambda/simplif.mli
@@ -38,7 +38,3 @@ val split_default_wrapper
   -> attr:function_attribute
   -> loc:Lambda.scoped_location
   -> (Ident.t * lambda) list
-
-(* To be filled by asmcomp/selectgen.ml *)
-val is_tail_native_heuristic: (int -> bool) ref
-                          (* # arguments -> can tailcall *)

--- a/lambda/translattribute.ml
+++ b/lambda/translattribute.ml
@@ -57,16 +57,33 @@ let is_unrolled = function
   | {txt="inline"|"ocaml.inline"|"inlined"|"ocaml.inlined"} -> false
   | _ -> assert false
 
-let get_id_payload =
+let get_payload get_from_exp =
   let open Parsetree in
   function
-  | PStr [] -> Some ""
-  | PStr [{pstr_desc = Pstr_eval ({pexp_desc},[])}] ->
-      begin match pexp_desc with
-      | Pexp_ident { txt = Longident.Lident id } -> Some id
-      | _ -> None
-      end
-  | _ -> None
+  | PStr [{pstr_desc = Pstr_eval (exp, [])}] -> get_from_exp exp
+  | _ -> Result.Error ()
+
+let get_optional_payload get_from_exp =
+  let open Parsetree in
+  function
+  | PStr [] -> Result.Ok None
+  | other -> Result.map Option.some (get_payload get_from_exp other)
+
+let get_id_from_exp =
+  let open Parsetree in
+  function
+  | { pexp_desc = Pexp_ident { txt = Longident.Lident id } } -> Result.Ok id
+  | _ -> Result.Error ()
+
+let get_int_from_exp =
+  let open Parsetree in
+  function
+    | { pexp_desc = Pexp_constant (Pconst_integer(s, None)) } ->
+        begin match Misc.Int_literal_converter.int s with
+        | n -> Result.Ok n
+        | exception (Failure _) -> Result.Error ()
+        end
+    | _ -> Result.Error ()
 
 let parse_id_payload txt loc ~default ~empty cases payload =
   let[@local] warn () =
@@ -80,10 +97,10 @@ let parse_id_payload txt loc ~default ~empty cases payload =
     Location.prerr_warning loc (Warnings.Attribute_payload (txt, msg));
     default
   in
-  match get_id_payload payload with
-  | Some "" -> empty
-  | None -> warn ()
-  | Some id ->
+  match get_optional_payload get_id_from_exp payload with
+  | Error () -> warn ()
+  | Ok None -> empty
+  | Ok (Some id) ->
       match List.assoc_opt id cases with
       | Some r -> r
       | None -> warn ()
@@ -92,27 +109,14 @@ let parse_inline_attribute attr =
   match attr with
   | None -> Default_inline
   | Some {Parsetree.attr_name = {txt;loc} as id; attr_payload = payload} ->
-    let open Parsetree in
     if is_unrolled id then begin
       (* the 'unrolled' attributes must be used as [@unrolled n]. *)
       let warning txt = Warnings.Attribute_payload
           (txt, "It must be an integer literal")
       in
-      match payload with
-      | PStr [{pstr_desc = Pstr_eval ({pexp_desc},[])}] -> begin
-          match pexp_desc with
-          | Pexp_constant (Pconst_integer(s, None)) -> begin
-              try
-                Unroll (Misc.Int_literal_converter.int s)
-              with Failure _ ->
-                Location.prerr_warning loc (warning txt);
-                Default_inline
-            end
-          | _ ->
-            Location.prerr_warning loc (warning txt);
-            Default_inline
-        end
-      | _ ->
+      match get_payload get_int_from_exp payload with
+      | Ok n -> Unroll n
+      | Error () ->
         Location.prerr_warning loc (warning txt);
         Default_inline
     end else

--- a/testsuite/tests/warnings/w51.compilers.reference
+++ b/testsuite/tests/warnings/w51.compilers.reference
@@ -1,4 +1,0 @@
-File "w51.ml", line 14, characters 13-37:
-14 |   | n -> n * (fact [@tailcall]) (n-1)
-                  ^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 51 [tailcall-expected]: expected tailcall

--- a/testsuite/tests/warnings/w51.ml
+++ b/testsuite/tests/warnings/w51.ml
@@ -1,15 +1,16 @@
 (* TEST
-
-flags = "-w A"
-
-* setup-ocamlc.byte-build-env
-** ocamlc.byte
-compile_only = "true"
-*** check-ocamlc.byte-output
-
+   flags = "-w A"
+   * expect
 *)
 
 let rec fact = function
   | 1 -> 1
   | n -> n * (fact [@tailcall]) (n-1)
 ;;
+[%%expect {|
+Line 3, characters 13-37:
+3 |   | n -> n * (fact [@tailcall]) (n-1)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 51 [tailcall-expected]: expected tailcall
+val fact : int -> int = <fun>
+|}]

--- a/testsuite/tests/warnings/w51.ml
+++ b/testsuite/tests/warnings/w51.ml
@@ -11,6 +11,54 @@ let rec fact = function
 Line 3, characters 13-37:
 3 |   | n -> n * (fact [@tailcall]) (n-1)
                  ^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 51 [tailcall-expected]: expected tailcall
+Warning 51 [wrong-tailcall-expectation]: expected tailcall
 val fact : int -> int = <fun>
+|}]
+
+let rec fact = function
+  | 1 -> 1
+  | n -> n * (fact [@tailcall true]) (n-1)
+;;
+[%%expect {|
+Line 3, characters 13-42:
+3 |   | n -> n * (fact [@tailcall true]) (n-1)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 51 [wrong-tailcall-expectation]: expected tailcall
+val fact : int -> int = <fun>
+|}]
+
+let rec fact = function
+  | 1 -> 1
+  | n -> n * (fact [@tailcall false]) (n-1)
+;;
+[%%expect {|
+val fact : int -> int = <fun>
+|}]
+
+let rec fact_tail acc = function
+  | 1 -> acc
+  | n -> (fact_tail [@tailcall]) (n * acc) (n - 1)
+;;
+[%%expect{|
+val fact_tail : int -> int -> int = <fun>
+|}]
+
+let rec fact_tail acc = function
+  | 1 -> acc
+  | n -> (fact_tail [@tailcall true]) (n * acc) (n - 1)
+;;
+[%%expect{|
+val fact_tail : int -> int -> int = <fun>
+|}]
+
+let rec fact_tail acc = function
+  | 1 -> acc
+  | n -> (fact_tail [@tailcall false]) (n * acc) (n - 1)
+;;
+[%%expect{|
+Line 3, characters 9-56:
+3 |   | n -> (fact_tail [@tailcall false]) (n * acc) (n - 1)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 51 [wrong-tailcall-expectation]: expected non-tailcall
+val fact_tail : int -> int -> int = <fun>
 |}]

--- a/testsuite/tests/warnings/w51.ml
+++ b/testsuite/tests/warnings/w51.ml
@@ -62,3 +62,15 @@ Line 3, characters 9-56:
 Warning 51 [wrong-tailcall-expectation]: expected non-tailcall
 val fact_tail : int -> int -> int = <fun>
 |}]
+
+
+(* explicitly test the "invalid payload" case *)
+let rec test x = (test[@tailcall foobar]) x;;
+[%%expect{|
+Line 1, characters 24-32:
+1 | let rec test x = (test[@tailcall foobar]) x;;
+                            ^^^^^^^^
+Warning 47 [attribute-payload]: illegal payload for attribute 'tailcall'.
+Only an optional boolean literal is supported.
+val test : 'a -> 'b = <fun>
+|}]

--- a/testsuite/tests/warnings/w51_bis.compilers.reference
+++ b/testsuite/tests/warnings/w51_bis.compilers.reference
@@ -1,4 +1,4 @@
 File "w51_bis.ml", line 15, characters 12-48:
 15 |         try (foldl [@tailcall]) op (op x acc) xs
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 51 [tailcall-expected]: expected tailcall
+Warning 51 [wrong-tailcall-expectation]: expected tailcall

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -75,7 +75,7 @@ type t =
   | Eliminated_optional_arguments of string list (* 48 *)
   | No_cmi_file of string * string option   (* 49 *)
   | Unexpected_docstring of bool            (* 50 *)
-  | Tailcall_expected                       (* 51 *)
+  | Wrong_tailcall_expectation of bool      (* 51 *)
   | Fragile_literal_pattern                 (* 52 *)
   | Misplaced_attribute of string           (* 53 *)
   | Duplicated_attribute of string          (* 54 *)
@@ -153,7 +153,7 @@ let number = function
   | Eliminated_optional_arguments _ -> 48
   | No_cmi_file _ -> 49
   | Unexpected_docstring _ -> 50
-  | Tailcall_expected -> 51
+  | Wrong_tailcall_expectation _ -> 51
   | Fragile_literal_pattern -> 52
   | Misplaced_attribute _ -> 53
   | Duplicated_attribute _ -> 54
@@ -295,8 +295,8 @@ let descriptions =
     ["no-cmi-file"];
     50, "Unexpected documentation comment.",
     ["unexpected-docstring"];
-    51, "Warning on non-tail calls if @tailcall present.",
-    ["tailcall-expected"];
+    51, "Function call annotated with an incorrect @tailcall attribute",
+    ["wrong-tailcall-expectation"];
     52, "Fragile constant pattern.",
     ["fragile-literal-pattern"];
     53, "Attribute cannot appear in this context.",
@@ -744,8 +744,9 @@ let message = function
   | Unexpected_docstring unattached ->
       if unattached then "unattached documentation comment (ignored)"
       else "ambiguous documentation comment"
-  | Tailcall_expected ->
-      Printf.sprintf "expected tailcall"
+  | Wrong_tailcall_expectation b ->
+      Printf.sprintf "expected %s"
+        (if b then "tailcall" else "non-tailcall")
   | Fragile_literal_pattern ->
       Printf.sprintf
         "Code should not depend on the actual values of\n\

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -77,7 +77,7 @@ type t =
   | Eliminated_optional_arguments of string list (* 48 *)
   | No_cmi_file of string * string option   (* 49 *)
   | Unexpected_docstring of bool            (* 50 *)
-  | Tailcall_expected                       (* 51 *)
+  | Wrong_tailcall_expectation of bool      (* 51 *)
   | Fragile_literal_pattern                 (* 52 *)
   | Misplaced_attribute of string           (* 53 *)
   | Duplicated_attribute of string          (* 54 *)


### PR DESCRIPTION
`[@tailcall true]` is equivalent to `[@tailcall]`, and `[@tailcall false]` warns if the call is in tail-call position.

This is build-up work for the upcoming "TRMC Reborn" PR, which will use these attributes to drive some parts of the TRMC transformation.