### PR TITLE
Garbage collector colours change

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,8 +20,8 @@ Working version
 
 - #9756: garbage collector colors change
   removes the gray color from the major gc
-  (Sadiq Jaffer and Stephen Dolan reviewed by Xavier Leroy, 
-  KC Sivaramakrishnan, Damien Doligez and Jacques-Henri Jourdan) 
+  (Sadiq Jaffer and Stephen Dolan reviewed by Xavier Leroy,
+  KC Sivaramakrishnan, Damien Doligez and Jacques-Henri Jourdan)
 
 - #1795, #9543: modernize signal handling on Linux i386, PowerPC, and s390x,
   adding support for Musl ppc64le along the way.

--- a/Changes
+++ b/Changes
@@ -20,7 +20,8 @@ Working version
 
 - #9756: garbage collector colors change
   removes the gray color from the major gc
-  (Sadiq Jaffer and Stephen Dolan reviewed by)
+  (Sadiq Jaffer and Stephen Dolan reviewed by Xavier Leroy, 
+  KC Sivaramakrishnan, Damien Doligez and Jacques-Henri Jourdan) 
 
 - #1795, #9543: modernize signal handling on Linux i386, PowerPC, and s390x,
   adding support for Musl ppc64le along the way.

--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ Working version
 
 ### Runtime system:
 
+- #9756: garbage collector colors change
+  removes the gray color from the major gc
+  (Sadiq Jaffer and Stephen Dolan reviewed by)
+
 - #1795, #9543: modernize signal handling on Linux i386, PowerPC, and s390x,
   adding support for Musl ppc64le along the way.
   (Xavier Leroy and Anil Madhavapeddy, review by Stephen Dolan)

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -36,6 +36,9 @@ DOMAIN_STATE(struct caml_ephe_ref_table*, ephe_ref_table)
 DOMAIN_STATE(struct caml_custom_table*, custom_table)
 /* See minor_gc.c */
 
+DOMAIN_STATE(struct mark_stack*, mark_stack)
+/* See major_gc.c */
+
 DOMAIN_STATE(value*, stack_low)
 DOMAIN_STATE(value*, stack_high)
 DOMAIN_STATE(value*, stack_threshold)

--- a/runtime/caml/gc.h
+++ b/runtime/caml/gc.h
@@ -20,7 +20,6 @@
 #include "mlvalues.h"
 
 #define Caml_white (0 << 8)
-#define Caml_gray  (1 << 8)
 #define Caml_blue  (2 << 8)
 #define Caml_black (3 << 8)
 
@@ -29,12 +28,10 @@
 #define Color_val(val) (Color_hd (Hd_val (val)))
 
 #define Is_white_hd(hd) (Color_hd (hd) == Caml_white)
-#define Is_gray_hd(hd) (Color_hd (hd) == Caml_gray)
 #define Is_blue_hd(hd) (Color_hd (hd) == Caml_blue)
 #define Is_black_hd(hd) (Color_hd (hd) == Caml_black)
 
 #define Whitehd_hd(hd) (((hd)  & ~Caml_black)/*| Caml_white*/)
-#define Grayhd_hd(hd)  (((hd)  & ~Caml_black)  | Caml_gray)
 #define Blackhd_hd(hd) (((hd)/*& ~Caml_black*/)| Caml_black)
 #define Bluehd_hd(hd)  (((hd)  & ~Caml_black)  | Caml_blue)
 
@@ -68,7 +65,6 @@ extern uintnat caml_spacetime_my_profinfo(struct ext_table**, uintnat);
 #endif
 
 #define Is_white_val(val) (Color_val(val) == Caml_white)
-#define Is_gray_val(val) (Color_val(val) == Caml_gray)
 #define Is_blue_val(val) (Color_val(val) == Caml_blue)
 #define Is_black_val(val) (Color_val(val) == Caml_black)
 

--- a/runtime/caml/gc.h
+++ b/runtime/caml/gc.h
@@ -20,6 +20,7 @@
 #include "mlvalues.h"
 
 #define Caml_white (0 << 8)
+#define Caml_gray  (1 << 8)
 #define Caml_blue  (2 << 8)
 #define Caml_black (3 << 8)
 
@@ -28,10 +29,12 @@
 #define Color_val(val) (Color_hd (Hd_val (val)))
 
 #define Is_white_hd(hd) (Color_hd (hd) == Caml_white)
+#define Is_gray_hd(hd) (Color_hd (hd) == Caml_gray)
 #define Is_blue_hd(hd) (Color_hd (hd) == Caml_blue)
 #define Is_black_hd(hd) (Color_hd (hd) == Caml_black)
 
 #define Whitehd_hd(hd) (((hd)  & ~Caml_black)/*| Caml_white*/)
+#define Grayhd_hd(hd)  (((hd)  & ~Caml_black)  | Caml_gray)
 #define Blackhd_hd(hd) (((hd)/*& ~Caml_black*/)| Caml_black)
 #define Bluehd_hd(hd)  (((hd)  & ~Caml_black)  | Caml_blue)
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -26,12 +26,19 @@ typedef struct {
   asize_t alloc;         /* in bytes, used for compaction */
   asize_t size;          /* in bytes */
   char *next;
+  int requires_redarken;
+  value* redarken_start;  /* first block in chunk to redarken */
+  value* redarken_end;    /* last block in chunk that needs redarkening */
 } heap_chunk_head;
 
 #define Chunk_size(c) (((heap_chunk_head *) (c)) [-1]).size
 #define Chunk_alloc(c) (((heap_chunk_head *) (c)) [-1]).alloc
 #define Chunk_next(c) (((heap_chunk_head *) (c)) [-1]).next
 #define Chunk_block(c) (((heap_chunk_head *) (c)) [-1]).block
+#define Chunk_requires_redarken(c) \
+                          ((((heap_chunk_head *) (c)) [-1]).requires_redarken)
+#define Chunk_redarken_start(c) (((heap_chunk_head *) (c)) [-1]).redarken_start
+#define Chunk_redarken_end(c) (((heap_chunk_head *) (c)) [-1]).redarken_end
 
 extern int caml_gc_phase;
 extern int caml_gc_subphase;

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -84,6 +84,7 @@ void caml_init_major_heap (asize_t);           /* size in bytes */
 asize_t caml_clip_heap_chunk_wsz (asize_t wsz);
 void caml_darken (value, value *);
 void caml_major_collection_slice (intnat);
+void caml_shrink_mark_stack ();
 void major_collection (void);
 void caml_finish_major_cycle (void);
 void caml_set_major_window (int);

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -26,7 +26,6 @@ typedef struct {
   asize_t alloc;         /* in bytes, used for compaction */
   asize_t size;          /* in bytes */
   char *next;
-  int requires_redarken;
   value* redarken_start;  /* first block in chunk to redarken */
   value* redarken_end;    /* last block in chunk that needs redarkening */
 } heap_chunk_head;
@@ -35,8 +34,6 @@ typedef struct {
 #define Chunk_alloc(c) (((heap_chunk_head *) (c)) [-1]).alloc
 #define Chunk_next(c) (((heap_chunk_head *) (c)) [-1]).next
 #define Chunk_block(c) (((heap_chunk_head *) (c)) [-1]).block
-#define Chunk_requires_redarken(c) \
-                          ((((heap_chunk_head *) (c)) [-1]).requires_redarken)
 #define Chunk_redarken_start(c) (((heap_chunk_head *) (c)) [-1]).redarken_start
 #define Chunk_redarken_end(c) (((heap_chunk_head *) (c)) [-1]).redarken_end
 

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -365,6 +365,9 @@ static void do_compaction (intnat new_allocation_policy)
     }
   }
   ++ Caml_state->stat_compactions;
+
+  caml_shrink_mark_stack();
+
   caml_gc_message (0x10, "done.\n");
 }
 

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -32,10 +32,6 @@
 #include "caml/memprof.h"
 #include "caml/eventlog.h"
 
-#define Caml_gray (1 << 8)
-#define Is_gray_hd(hd) (Color_hd (hd) == Caml_gray)
-#define Grayhd_hd(hd)  (((hd)  & ~Caml_black)  | Caml_gray)
-
 extern uintnat caml_percent_free;                   /* major_gc.c */
 extern void caml_shrink_heap (char *);              /* memory.c */
 

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -32,6 +32,10 @@
 #include "caml/memprof.h"
 #include "caml/eventlog.h"
 
+#define Caml_gray (1 << 8)
+#define Is_gray_hd(hd) (Color_hd (hd) == Caml_gray)
+#define Grayhd_hd(hd)  (((hd)  & ~Caml_black)  | Caml_gray)
+
 extern uintnat caml_percent_free;                   /* major_gc.c */
 extern void caml_shrink_heap (char *);              /* memory.c */
 

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -1639,7 +1639,6 @@ static header_t *bf_merge_block (value bp, char *limit)
     switch (Color_val (cur)){
     case Caml_white: goto white;
     case Caml_blue: bf_remove (cur); goto next;
-    case Caml_gray:
     case Caml_black:
       goto end_of_run;
     }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -173,7 +173,7 @@ static value heap_stats (int returnstats)
           }
         }
         break;
-      case Caml_gray: case Caml_black:
+      case Caml_black:
         CAMLassert (Wosize_hd (cur_hd) > 0);
         ++ live_blocks;
         live_words += Whsize_hd (cur_hd);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -321,7 +321,8 @@ void caml_shrink_mark_stack () {
   if (shrunk_stack != NULL) {
     stk->stack = shrunk_stack;
     stk->size = MARK_STACK_INIT_SIZE;
-    return;
+  }else{
+    caml_gc_message (0x08, "Mark stack shrinking failed");
   }
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -304,11 +304,14 @@ void caml_darken (value v, value *p /* not used */)
   }
 }
 
-/* This function adds blocks in the passed heap chunk [heap_chunk] to the mark
-   stack. It may return 0 if doing so would cause the mark stack to grow more
-   than a quarter full. This is to lower the chance of triggering another
-   overflow, which would be wasteful. Subsequent calls will continue progress.
-   It will return 1 when the supplied chunk has no more range to redarken. */
+/* This function adds blocks in the passed heap chunk [heap_chunk] to
+   the mark stack. It returns 1 when the supplied chunk has no more
+   range to redarken.  It returns 0 if there are still blocks in the
+   chunk that need redarkening because pushing them onto the stack
+   would make it grow more than a quarter full. This is to lower the
+   chance of triggering another overflow, which would be
+   wasteful. Subsequent calls will continue progress.
+ */
 static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
   value* p = (value*)Chunk_redarken_start(heap_chunk);
   value* end = (value*)Chunk_redarken_end(heap_chunk);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -425,8 +425,7 @@ Caml_inline void mark_slice_darken(struct mark_stack* stk, value v, mlsize_t i,
       Hd_val (child) = Blackhd_hd (chd);
       if( Tag_hd(chd) < No_scan_tag ) {
         mark_stack_push(stk, child, 0, work);
-      }
-      else {
+      } else {
         *work -= 1; /* Account for header */
       }
     }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -209,8 +209,8 @@ static void realloc_mark_stack (struct mark_stack* stk)
   mark_stack_prune(stk);
 }
 
-/* This function pushes the provided mark_entry [me] on to the current mark
-   stk [stk]. It first checks, if the block is small enough, whether there
+/* This function pushes the provided mark_entry [me] onto the current mark
+   stack [stk]. It first checks, if the block is small enough, whether there
    are any fields we would actually do mark work on. If so then it enqueues
    the entry. */
 Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -546,6 +546,9 @@ static void mark_slice (intnat work)
     if (work <= 0) {
       if( can_mark ) {
         mark_stack_push(stk, me, NULL);
+        CAML_EVENTLOG_DO({
+          CAML_EV_COUNTER(EV_C_MAJOR_MARK_SLICE_REMAIN, me_end - me.offset);
+        });
       }
       break;
     }
@@ -559,6 +562,10 @@ static void mark_slice (intnat work)
                                               &slice_pointers, &work);
 
       work--;
+
+      CAML_EVENTLOG_DO({
+        slice_fields++;
+      });
 
       if( me.offset == me_end ) {
         work--; /* Include header word */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -165,8 +165,6 @@ static void mark_stack_prune (struct mark_stack* stk)
         Chunk_redarken_end(chunk_addr) = block_op;
       }
 
-      Chunk_requires_redarken(chunk_addr) = 1;
-
       if( redarken_first_chunk == NULL
           || redarken_first_chunk > (char*)chunk_addr ) {
         redarken_first_chunk = (char*)chunk_addr;
@@ -322,7 +320,6 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
     p += Whsize_hp(Hp_op(p));
   }
 
-  Chunk_requires_redarken(heap_chunk) = 0;
   Chunk_redarken_start(heap_chunk) =
       (value*)(heap_chunk + Chunk_size(heap_chunk));
 
@@ -569,10 +566,7 @@ static void mark_slice (intnat work)
       /* There are chunks that need to be redarkened because we
          overflowed our mark stack */
       if( redarken_chunk(redarken_first_chunk, stk) ) {
-        do {
-          redarken_first_chunk = Chunk_next(redarken_first_chunk);
-        } while( redarken_first_chunk != NULL
-                  && !Chunk_requires_redarken(redarken_first_chunk) );
+        redarken_first_chunk = Chunk_next(redarken_first_chunk);
       }
     } else if (caml_gc_subphase == Subphase_mark_roots) {
       work = caml_darken_all_roots_slice (work);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -153,10 +153,8 @@ static void mark_stack_prune (struct mark_stack* stk)
     value* block_op = Op_val(me.block);
     uintnat chunk_addr = 0, chunk_addr_below = 0;
 
-    caml_skiplist_find_below(&chunk_sklist, (uintnat)me.block, &chunk_addr,
-                              &chunk_addr_below);
-
-    if( chunk_addr != 0 && me.block >= chunk_addr
+    if( caml_skiplist_find_below(&chunk_sklist, (uintnat)me.block,
+          &chunk_addr, &chunk_addr_below)
         && me.block < chunk_addr_below ) {
 
       if( Chunk_redarken_start(chunk_addr) > block_op ) {

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -525,7 +525,7 @@ static void mark_ephe_aux (struct mark_stack *stk, intnat *work,
 
 static void mark_slice (intnat work)
 {
-  mark_entry me = {0};
+  mark_entry me = {0, 0};
   mlsize_t me_end = 0;
 #ifdef CAML_INSTR
   int slice_fields = 0; /** eventlog counters */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -221,13 +221,15 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
   if (Tag_val(me.block) == Closure_tag) {
     /* Skip the code pointers and integers at beginning of closure;
         start scanning at the first word of the environment part. */
-  /* It might be the case that [mark_stack_push] has been called 
+  /* It might be the case that [mark_stack_push] has been called
       while we are traversing a closure block but have not enough
       budget to finish the block. In that specific case, we should not
       update [m.offset] */
     if (me.offset == 0)
       me.offset = Start_env_closinfo(Closinfo_val(me.block));
-    CAMLassert(me.offset <= Wosize_val(me.block) && me.offset >= Start_env_closinfo(Closinfo_val(me.block)));
+
+    CAMLassert(me.offset <= Wosize_val(me.block)
+      && me.offset >= Start_env_closinfo(Closinfo_val(me.block)));
   }
 #endif
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -212,7 +212,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
                                   intnat* work)
 {
   value v;
-  int i, block_end = Wosize_val(me.block), end;
+  int i, block_wsz = Wosize_val(me.block), end;
 
   CAMLassert(Is_block(me.block) && Is_in_heap (me.block) && Is_black_val(me.block));
   CAMLassert(Tag_val(me.block) != Infix_tag);
@@ -227,7 +227,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
   }
 #endif
 
-  end = (block_end < 8 ? block_end : 8);
+  end = (block_wsz < 8 ? block_wsz : 8);
 
   /* Optimisation to avoid pushing small, unmarkable objects such as [Some 42]
    * into the mark stack. */
@@ -239,11 +239,11 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
       break;
   }
 
-  if (i == block_end) {
+  if (i == block_wsz) {
     /* nothing left to mark */
     if( work != NULL ) {
       /* we should take credit for it though */
-      *work -= Whsize_wosize(block_end - me.offset);
+      *work -= Whsize_wosize(block_wsz - me.offset);
     }
     return;
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -184,7 +184,7 @@ static void realloc_mark_stack (struct mark_stack* stk)
   mark_entry* new;
   uintnat mark_stack_bsize = stk->size * sizeof(mark_entry);
 
-  if ( Wsize_bsize(mark_stack_bsize) < Caml_state->stat_heap_wsz / 32 ) {
+  if ( Wsize_bsize(mark_stack_bsize) < Caml_state->stat_heap_wsz / 64 ) {
     caml_gc_message (0x08, "Growing mark stack to %"
                            ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
                      (intnat) mark_stack_bsize * 2 / 1024);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -186,8 +186,7 @@ static void realloc_mark_stack (struct mark_stack* stk)
   mark_entry* new;
   uintnat mark_stack_bsize = stk->size * sizeof(mark_entry);
 
-  if ( mark_stack_bsize < Caml_state->stat_heap_wsz / 32
-      || mark_stack_bsize < MARK_STACK_INIT_SIZE*sizeof(mark_entry) ) {
+  if ( mark_stack_bsize < Caml_state->stat_heap_wsz / 32 ) {
     caml_gc_message (0x08, "Growing mark stack to %"
                            ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
                      (intnat) mark_stack_bsize * 2 / 1024);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -148,8 +148,6 @@ static void mark_stack_prune (struct mark_stack* stk)
     heap_chunk = Chunk_next(heap_chunk);
   } while( heap_chunk != NULL );
 
-  heap_chunk = caml_heap_start;
-
   for( entry = 0; entry < mark_stack_count ; entry++ ) {
     mark_entry me = mark_stack[entry];
     value* block_op = Op_val(me.block);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -455,9 +455,7 @@ static void mark_ephe_aux (struct mark_stack *stk, intnat *work,
     int alive_data = 1;
 
     /* The liveness of the ephemeron is one of the condition */
-    if (Is_white_hd (hd)) {
-      alive_data = 0;
-    }
+    if (Is_white_hd (hd)) alive_data = 0;
 
     /* The liveness of the keys not caml_ephe_none is the other condition */
     size = Wosize_hd (hd);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1008,9 +1008,8 @@ void caml_init_major_heap (asize_t heap_size)
   Caml_state->mark_stack->stack =
     caml_stat_alloc_noexc(MARK_STACK_INIT_SIZE * sizeof(mark_entry));
 
-  if(Caml_state->mark_stack->stack == NULL) {
+  if(Caml_state->mark_stack->stack == NULL)
     caml_fatal_error("not enough memory for the mark stack");
-  }
 
   Caml_state->mark_stack->count = 0;
   Caml_state->mark_stack->size = MARK_STACK_INIT_SIZE;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -219,10 +219,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
   value v;
   int i, block_end = Wosize_val(me.block), end;
 
-  CAMLassert (Is_in_heap (me.block) || Is_black_hd (Hd_val(me.block)));
-
-  CAMLassert(Is_black_val(me.block));
-  CAMLassert(Is_block(me.block));
+  CAMLassert(Is_block(me.block) && Is_in_heap (me.block) && Is_black_val(me.block));
   CAMLassert(Tag_val(me.block) != Infix_tag);
   CAMLassert(Tag_val(me.block) < No_scan_tag);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -212,7 +212,8 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
   value v;
   int i, block_wsz = Wosize_val(me.block), end;
 
-  CAMLassert(Is_block(me.block) && Is_in_heap (me.block) && Is_black_val(me.block));
+  CAMLassert(Is_block(me.block) && Is_in_heap (me.block)
+            && Is_black_val(me.block));
   CAMLassert(Tag_val(me.block) != Infix_tag);
   CAMLassert(Tag_val(me.block) < No_scan_tag);
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -221,7 +221,12 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
   if (Tag_val(me.block) == Closure_tag) {
     /* Skip the code pointers and integers at beginning of closure;
         start scanning at the first word of the environment part. */
-    me.offset = Start_env_closinfo(Closinfo_val(me.block));
+  /* It might be the case that [mark_stack_push] has been called 
+      while we are traversing a closure block but have not enough
+      budget to finish the block. In that specific case, we should not
+      update [m.offset] */
+    if (me.offset == 0)
+      me.offset = Start_env_closinfo(Closinfo_val(me.block));
     CAMLassert(me.offset <= Wosize_val(me.block));
   }
 #endif

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -488,10 +488,8 @@ static void mark_ephe_aux (struct mark_stack *stk, intnat *work,
     *work -= Whsize_wosize(i);
 
     if (alive_data){
-      mark_slice_darken(stk, v,
-                                        CAML_EPHE_DATA_OFFSET,
-                                        /*in_ephemeron=*/1,
-                                        slice_pointers, work);
+      mark_slice_darken(stk, v, CAML_EPHE_DATA_OFFSET, /*in_ephemeron=*/1,
+                          slice_pointers, work);
     } else { /* not triggered move to the next one */
       ephes_to_check = &Field(v,CAML_EPHE_LINK_OFFSET);
       return;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -561,8 +561,8 @@ static void mark_slice (intnat work)
 
     if( can_mark ) {
       CAMLassert(Is_block(me.block) &&
-                Is_black_val (me.block) &&
-                Tag_val(me.block) < No_scan_tag);
+                 Is_black_val (me.block) &&
+                 Tag_val(me.block) < No_scan_tag);
 
       mark_slice_darken(stk, me.block, me.offset++, /*in_ephemeron=*/ 0,
                                               &slice_pointers, &work);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -140,9 +140,7 @@ static void mark_stack_prune (struct mark_stack* stk)
   mark_entry* mark_stack = stk->stack;
 
   char* heap_chunk = caml_heap_start;
-  struct skiplist chunk_sklist = {0};
-
-  caml_skiplist_init(&chunk_sklist);
+  struct skiplist chunk_sklist = SKIPLIST_STATIC_INITIALIZER;
 
   do {
     caml_skiplist_insert(&chunk_sklist, (uintnat)heap_chunk,

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -186,7 +186,7 @@ static void realloc_mark_stack (struct mark_stack* stk)
   mark_entry* new;
   uintnat mark_stack_bsize = stk->size * sizeof(mark_entry);
 
-  if ( mark_stack_bsize < Caml_state->stat_heap_wsz / 32 ) {
+  if ( Wsize_bsize(mark_stack_bsize) < Caml_state->stat_heap_wsz / 32 ) {
     caml_gc_message (0x08, "Growing mark stack to %"
                            ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
                      (intnat) mark_stack_bsize * 2 / 1024);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -570,7 +570,9 @@ static void mark_slice (intnat work)
         redarken_first_chunk = Chunk_next(redarken_first_chunk);
       }
     } else if (caml_gc_subphase == Subphase_mark_roots) {
+      CAML_EV_BEGIN(EV_MAJOR_MARK_ROOTS);
       work = caml_darken_all_roots_slice (work);
+      CAML_EV_END(EV_MAJOR_MARK_ROOTS);
       if (work > 0){
         caml_gc_subphase = Subphase_mark_main;
       }
@@ -586,6 +588,7 @@ static void mark_slice (intnat work)
       case Subphase_mark_main: {
           /* Subphase_mark_main is done.
              Mark finalised values. */
+          CAML_EV_BEGIN(EV_MAJOR_MARK_MAIN);
           caml_final_update_mark_phase ();
           /* Complete the marking */
           ephes_to_check = ephes_checked_if_pure;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -227,7 +227,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, mark_entry me,
       update [m.offset] */
     if (me.offset == 0)
       me.offset = Start_env_closinfo(Closinfo_val(me.block));
-    CAMLassert(me.offset <= Wosize_val(me.block));
+    CAMLassert(me.offset <= Wosize_val(me.block) && me.offset >= Start_env_closinfo(Closinfo_val(me.block)));
   }
 #endif
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -340,7 +340,7 @@ static void start_cycle (void)
   CAMLassert (caml_gc_phase == Phase_idle);
   CAMLassert (Caml_state->mark_stack->count == 0);
   CAMLassert (redarken_first_chunk == NULL);
-  caml_gc_message (0x01, "starting new major GC cycle\n");
+  caml_gc_message (0x01, "Starting new major GC cycle\n");
   caml_darken_all_roots_start ();
   caml_gc_phase = Phase_mark;
   caml_gc_subphase = Subphase_mark_roots;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -547,9 +547,7 @@ static void mark_slice (intnat work)
         me_end = Wosize_val(me.block);
         can_mark = 1;
       }
-    }
-    else
-    {
+    } else {
       can_mark = 1;
     }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -313,8 +313,8 @@ void caml_darken (value v, value *p /* not used */)
    wasteful. Subsequent calls will continue progress.
  */
 static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
-  value* p = (value*)Chunk_redarken_start(heap_chunk);
-  value* end = (value*)Chunk_redarken_end(heap_chunk);
+  value* p = Chunk_redarken_start(heap_chunk);
+  value* end = Chunk_redarken_end(heap_chunk);
 
   while (p <= end) {
     header_t hd = Hd_op(p);

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -262,8 +262,8 @@ char *caml_alloc_for_heap (asize_t request)
     mem = (char *) block + sizeof (heap_chunk_head);
     Chunk_size (mem) = size - sizeof (heap_chunk_head);
     Chunk_block (mem) = block;
-    Chunk_redarken_start(mem) = (value*)(-1);
-    Chunk_redarken_end(mem) = 0;
+    Chunk_redarken_start(mem) = (value*)(mem + Chunk_size(mem));
+    Chunk_redarken_end(mem) = (value*)mem;
     return mem;
 #else
     return NULL;
@@ -279,8 +279,8 @@ char *caml_alloc_for_heap (asize_t request)
     mem += sizeof (heap_chunk_head);
     Chunk_size (mem) = request;
     Chunk_block (mem) = block;
-    Chunk_redarken_start(mem) = (value*)(-1);
-    Chunk_redarken_end(mem) = 0;
+    Chunk_redarken_start(mem) = (value*)(mem + Chunk_size(mem));
+    Chunk_redarken_end(mem) = (value*)mem;
     return mem;
   }
 }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -262,7 +262,7 @@ char *caml_alloc_for_heap (asize_t request)
     mem = (char *) block + sizeof (heap_chunk_head);
     Chunk_size (mem) = size - sizeof (heap_chunk_head);
     Chunk_block (mem) = block;
-    Chunk_redarken_start(mem) = (value*)(mem + size);
+    Chunk_redarken_start(mem) = (value*)(-1);
     Chunk_redarken_end(mem) = 0;
     return mem;
 #else
@@ -279,7 +279,7 @@ char *caml_alloc_for_heap (asize_t request)
     mem += sizeof (heap_chunk_head);
     Chunk_size (mem) = request;
     Chunk_block (mem) = block;
-    Chunk_redarken_start(mem) = (value*)(mem + request);
+    Chunk_redarken_start(mem) = (value*)(-1);
     Chunk_redarken_end(mem) = 0;
     return mem;
   }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -262,6 +262,9 @@ char *caml_alloc_for_heap (asize_t request)
     mem = (char *) block + sizeof (heap_chunk_head);
     Chunk_size (mem) = size - sizeof (heap_chunk_head);
     Chunk_block (mem) = block;
+    Chunk_requires_redarken(mem) = 0;
+    Chunk_redarken_start(mem) = (value*)(mem + size);
+    Chunk_redarken_end(mem) = 0;
     return mem;
 #else
     return NULL;
@@ -277,6 +280,9 @@ char *caml_alloc_for_heap (asize_t request)
     mem += sizeof (heap_chunk_head);
     Chunk_size (mem) = request;
     Chunk_block (mem) = block;
+    Chunk_requires_redarken(mem) = 0;
+    Chunk_redarken_start(mem) = (value*)(mem + request);
+    Chunk_redarken_end(mem) = 0;
     return mem;
   }
 }
@@ -404,6 +410,7 @@ static value *expand_heap (mlsize_t request)
     }
   }
   CAMLassert (Wosize_hp (mem) >= request);
+
   if (caml_add_to_heap ((char *) mem) != 0){
     caml_free_for_heap ((char *) mem);
     return NULL;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -408,7 +408,6 @@ static value *expand_heap (mlsize_t request)
     }
   }
   CAMLassert (Wosize_hp (mem) >= request);
-
   if (caml_add_to_heap ((char *) mem) != 0){
     caml_free_for_heap ((char *) mem);
     return NULL;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -262,7 +262,6 @@ char *caml_alloc_for_heap (asize_t request)
     mem = (char *) block + sizeof (heap_chunk_head);
     Chunk_size (mem) = size - sizeof (heap_chunk_head);
     Chunk_block (mem) = block;
-    Chunk_requires_redarken(mem) = 0;
     Chunk_redarken_start(mem) = (value*)(mem + size);
     Chunk_redarken_end(mem) = 0;
     return mem;
@@ -280,7 +279,6 @@ char *caml_alloc_for_heap (asize_t request)
     mem += sizeof (heap_chunk_head);
     Chunk_size (mem) = request;
     Chunk_block (mem) = block;
-    Chunk_requires_redarken(mem) = 0;
     Chunk_redarken_start(mem) = (value*)(mem + request);
     Chunk_redarken_end(mem) = 0;
     return mem;


### PR DESCRIPTION
This PR makes a change to the garbage collector colour scheme in the major collector. It removes the existing gray colour to match the scheme used by the multicore major collector.

This note covers the differences between trunk and multicore&#39;s major GC behaviour with respect to colours and overflow, then it lays out how this PR aims to remove the gray colour to aid merging the multicore collector whilst minimising trunk behaviour changes.

### GC Colours

On trunk we currently have:

- **White** - blocks that we haven&#39;t seen referenced by any live ( **black** ) major heap blocks yet
- **Gray** - blocks that have been referenced by a live ( **black** ) major heap block but whose fields we haven&#39;t yet marked
- **Black** - blocks that have been marked as live and whose fields we have also marked

For the purposes of marking, multicore only has the two states of **UNMARKED** and **MARKED** which correspond to the **White** and **Black** trunk states above. This is because marking is concurrent and idempotent. Additionally marking and sweeping by different domains can overlap which is enabled by the new GC colour scheme. For more details: https://arxiv.org/abs/2004.11663

In terms of how these affect the different runtimes:

On trunk when a block is processed it is marked **Gray** and then added to a list of _gray values_ to be later visited.

On multicore when a block is processed it is **MARKED** and then each field is pushed on to the _mark stack_ to be later visited and marked.

### Different strategies for dealing with overflow

Both of these schemes need a way to deal with the _mark stack_ or _gray values_ overflowing. That is when their sizes grow to become greater than some proportion of the major heap - in both cases 1/32th.

On trunk when _gray values_ overflows it discards some of its entries and marks the heap as _impure_ which later in the marking loop causes the heap to be rescanned for gray blocks so that they can be marked.

On multicore when the _mark stack_ overflows it goes through a process whereby entries are scanned to find the minimum number of pools that will result in a 20% reduction in the size of the stack. These pools are then marked as needing a redarken at a later point in time and their entries removed from the stack.

### Differences in gray values and mark stack

_Gray values_ on trunk and the _mark stack_ on multicore differ in their representation slightly. While _gray values_ on trunk is an array of values that are marked gray on multicore the _mark stack_ is stored as an array of _mark entry_ structs which represent a block currently being scanned, an offset index into the object which will be marked next and the maximum number of fields (_Wosize_) for the block.

### Differences in marking behaviour

A subtle difference between trunk and multicore is their behaviour in marking the object graph.

In trunk this goes as follows:

- A value is taken from the _gray values_
- Each of its fields is iterated
  - The field is marked _gray_ and added to _gray values_

In multicore:

- An entry _e_ is taken from the mark stack
- The offset in the entry _e_ is used to construct a new entry _child_
- The entry _e_&#39;s offset is incremented and it is pushed back on to the mark stack
- _e_ is set to _child_ and we continue from step 2

i.e trunk pushes all fields on to the stack first and then descends whereas multicore descends through each field in turn.

This may lead to different overflow behaviours on the same object graph.

### This PR

#### Mark stack

In this PR we remove the gray value from trunk and we replace the _gray values_ array with multicore&#39;s _mark stack_. One slight change from multicore is that we no longer store the _end_ (_Wosize)_ in the _mark stack_ &#39;s entry as it seems there is no performance benefit from doing so.

#### Marking behaviour

We retain trunk&#39;s marking behaviour.

#### Overflow behaviour

We deviate here from multicore&#39;s existing strategy. All heap chunks are added to a skiplist and the _mark stack_ entries are iterated. For each chunk we build up a range in the chunk that needs to be redarkened at a later time. We do this for all _mark stack_ entries and prune the whole mark stack.

Later when the marking loop exhausts the _mark stack_ we iterate through chunks and redarken blocks with black headers that have any non-black fields. This process will only populate up to a quarter of the mark stack, to prevent subsequent overflows. It is incremental and can be called again when the mark stack empties.

Initially we ported multicore&#39;s _addrmap_ based implementation ([https://github.com/ocaml-multicore/ocaml-multicore/blob/parallel\_minor\_gc/runtime/major\_gc.c#L1385](https://github.com/ocaml-multicore/ocaml-multicore/blob/parallel_minor_gc/runtime/major_gc.c#L1385)) and broke the major heap in to _heap ranges_ as heap chunks can vary in size. This actually didn&#39;t offer a performance advantage over the much simpler skiplist-based approach.

#### Performance

The following are a set of macro benchmarks from the Sandmark suite:

![image](https://user-images.githubusercontent.com/631805/85889208-ecb50680-b7e2-11ea-822a-93f36a914878.png)

Of the macro benchmarks, matrix multiply and the two zarith benchmarks show performance regressions. From profiling all three spend nearly all their time in a few hot loops and next to no time in marking. Re-running on a machine with layout randomization shows no difference in performance between this PR and trunk, which points to a loop layout-related effect.

Below are some existing microbenchmarks in the Sandmark suite that did manage to overflow their mark stack. Overall there seems to be little negative impact on them.

![image](https://user-images.githubusercontent.com/631805/85889225-f2125100-b7e2-11ea-8513-3bf8fb56c131.png)

### Considerations

#### Overflow algorithm

In theory the simple overflow algorithm should be O(n logc) where n is the number of entries in the mark stack and c is the number of heap chunks. This could be a problem for very large heaps, as the mark stack is a proportion of the heap size though the size of heap chunks also grows rapidly as the heap grows in size.

#### Initial mark stack size

We currently have an initial mark stack size of 2048 mark stack entries. At 16 bytes per entry on 64-bit archs, that is 32k. Should this be a parameter tunable through OCAMLRUNPARAM? An alternative is to set the initial mark stack size much lower but allow it to grow beyond 1/32th of the heap up to a certain size.