### PR TITLE
Make systhread mutexes errorcheck

### DIFF
--- a/Changes
+++ b/Changes
@@ -84,6 +84,15 @@ Working version
    which has never existed.
   (Jacques-Henri Jourdan, review by Xavier Leroy)
 
+* #9757: With systhread, mutexes now raise an exception when
+  attempting to lock recursively, instead of deadlocking. This is
+  meant to improve the failure mode when locking a mutex or a channel
+  in a finaliser or a signal handler, that are already locked by the
+  thread. On Windows, mutexes used to be accidentally recursive, so
+  this might break Windows-specific programs that relied on this
+  behaviour.
+  (Guillaume Munch-Maccagnoni, review by)
+
 ### Code generation and optimizations:
 
 - #9620: Limit the number of parameters for an uncurried or untupled

--- a/otherlibs/systhreads/mutex.mli
+++ b/otherlibs/systhreads/mutex.mli
@@ -36,7 +36,8 @@ val lock : t -> unit
 (** Lock the given mutex. Only one thread can have the mutex locked
    at any time. A thread that attempts to lock a mutex already locked
    by another thread will suspend until the other thread unlocks
-   the mutex. *)
+   the mutex. Attempting to lock the mutex from a thread that already
+   owns the lock results in a [Sys_error] exception. *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if

--- a/testsuite/tests/lib-threads/mutex_errorcheck.ml
+++ b/testsuite/tests/lib-threads/mutex_errorcheck.ml
@@ -1,0 +1,36 @@
+(* TEST
+
+* hassysthreads
+include systhreads
+** bytecode
+** native
+
+*)
+
+let m = Mutex.create ()
+
+let on = ref true
+
+let create_finalised () =
+  let r = ref 0 in
+  Gc.finalise (fun _ -> if !on then begin
+    Mutex.lock m ;
+    print_endline "finalised!" ;
+    Mutex.unlock m
+  end) r;
+  r
+
+let () =
+  print_endline "start" ;
+  begin
+    try
+      while true do
+        Mutex.lock m ;
+        let x = create_finalised () in
+        Mutex.unlock m ;
+        ignore (Sys.opaque_identity x)
+      done
+    with
+      e -> (on := false ; print_endline (Printexc.to_string e))
+  end;
+  print_endline "end";

--- a/testsuite/tests/lib-threads/mutex_errorcheck.reference
+++ b/testsuite/tests/lib-threads/mutex_errorcheck.reference
@@ -1,0 +1,3 @@
+start
+Sys_error("Mutex.lock: Resource deadlock avoided")
+end


### PR DESCRIPTION
From the commit log:

This means that an exception is raised when attempting to lock a mutex
locked from the same thread, e.g. from an asynchronous callback.

This changes the behaviour on Windows where mutexes were recursive.

Add test for deadlock inside asynchronous callbacks.

---

The main motivation is the detection of deadlocks caused by locking from an asynchronous callback, since this is a "bug at a distance" that can surprise users and be hard to debug. This has occurred many times: #5141, #5299, #7503, #8794...

This PR changes both `Mutex` and the channel locks. This is orthogonal to #9722 which aims to unlock channels before running asynchronous callbacks, and can be considered separately.

For POSIX, this converts a deadlock into a `Sys_error` exception, so this preserves compatibility.

There is a danger of breaking code for people who wrote win32-only programs and relied on the recursive behaviour of win32 mutexes. Unfortunately, the documentation of `Mutex` is ambiguous about the non-recursive nature of mutexes. If there is a risk to break programs, it may be preferable to leave the windows behaviour unchanged; otherwise to clarify the documentation. 

Optionally, I can make the runtime lock errorcheck too. At #5299, it was previously discussed to make it recursive, and it was decided against it, and in particular the current windows behaviour is incorrect. This is easy to fix in the same way if desired.

For obvious reasons the Win32 code has not yet been tested. I will rely on CI for compilation and further help is welcome.

(I believe this can interest @xavierleroy and @stedolan.)