### PR TITLE
Add -warn-json flag to produce warnings in JSON format [experiment]

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -635,6 +635,10 @@ let mk_warn_help f =
   "-warn-help", Arg.Unit f, " Show description of warning numbers"
 ;;
 
+let mk_warn_json f =
+  "-warn-json", Arg.String f, " Output warnings in JSON format"
+;;
+
 let mk_color f =
   "-color", Arg.Symbol (["auto"; "always"; "never"], f),
   Printf.sprintf
@@ -927,6 +931,7 @@ module type Core_options = sig
   val _unsafe : unit -> unit
   val _warn_error : string -> unit
   val _warn_help : unit -> unit
+  val _warn_json : string -> unit
 
   val _dno_unique_ids : unit -> unit
   val _dunique_ids : unit -> unit
@@ -1218,6 +1223,7 @@ struct
     mk_w F._w;
     mk_warn_error F._warn_error;
     mk_warn_help F._warn_help;
+    mk_warn_json F._warn_json;
     mk_where F._where;
     mk__ F.anonymous;
 
@@ -1286,6 +1292,7 @@ struct
     mk_w F._w;
     mk_warn_error F._warn_error;
     mk_warn_help F._warn_help;
+    mk_warn_json F._warn_json;
     mk__ F.anonymous;
     mk_color F._color;
     mk_error_style F._error_style;
@@ -1415,6 +1422,7 @@ struct
     mk_w F._w;
     mk_warn_error F._warn_error;
     mk_warn_help F._warn_help;
+    mk_warn_json F._warn_json;
     mk_where F._where;
     mk__ F.anonymous;
 
@@ -1530,6 +1538,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_w F._w;
     mk_warn_error F._warn_error;
     mk_warn_help F._warn_help;
+    mk_warn_json F._warn_json;
     mk__ F.anonymous;
     mk_color F._color;
     mk_error_style F._error_style;
@@ -1712,6 +1721,7 @@ module Default = struct
     let _unsafe = set unsafe
     let _warn_error s = Warnings.parse_options true s
     let _warn_help = Warnings.help_warnings
+    let _warn_json s = warn_json := Some s
   end
 
   module Native = struct

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -57,6 +57,7 @@ module type Core_options = sig
   val _unsafe : unit -> unit
   val _warn_error : string -> unit
   val _warn_help : unit -> unit
+  val _warn_json : string -> unit
 
   val _dno_unique_ids : unit -> unit
   val _dunique_ids : unit -> unit

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -105,10 +105,13 @@ let main argv ppf =
     end;
   with
   | exception (Compenv.Exit_compiler n) ->
+    Location.warn_json ppf;
     n
   | exception x ->
+    Location.warn_json ppf;
     Location.report_exception ppf x;
     2
   | () ->
+    Location.warn_json ppf;
     Profile.print Format.std_formatter !Clflags.profile_columns;
     0

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -130,10 +130,13 @@ let main argv ppf =
     end;
   with
   | exception (Exit_compiler n) ->
+    Location.warn_json ppf;
     n
   | exception x ->
+    Location.warn_json ppf;
     Location.report_exception ppf x;
     2
   | () ->
+    Location.warn_json ppf;
     Profile.print Format.std_formatter !Clflags.profile_columns;
     0

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -135,6 +135,7 @@ type report = {
   kind : report_kind;
   main : msg;
   sub : msg list;
+  info : (t * Warnings.reporting_information) option;
 }
 
 type report_printer = {
@@ -285,3 +286,6 @@ val raise_errorf: ?loc:t -> ?sub:msg list ->
 
 val report_exception: formatter -> exn -> unit
 (** Reraise the exception if it is unknown. *)
+
+val warn_json: formatter -> unit
+(** Print reported warnings to the given formatter in JSON format. *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -231,6 +231,8 @@ let unbox_closures_factor =
   ref default_unbox_closures_factor      (* -unbox-closures-factor *)
 let remove_unused_arguments = ref false (* -remove-unused-arguments *)
 
+let warn_json = ref None (* -warn-json *)
+
 type inlining_arguments = {
   inline_call_cost : int option;
   inline_alloc_cost : int option;

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -210,6 +210,8 @@ val afl_instrument : bool ref
 val afl_inst_ratio : int ref
 val function_sections : bool ref
 
+val warn_json : string option ref
+
 val all_passes : string list ref
 val dumped_pass : string -> bool
 val set_dumped_pass : string -> bool -> unit


### PR DESCRIPTION
This PR is a weekend experiment adding a `-warn-json <output-file>` to output warnings in JSON format. The objective is to make it easier for other tools to interact with the compiler programmatically. Currently the warnings are not printed in human-readable format when this flag is passed.

For example, if
```ocaml
(* foo.ml *)

let f x y = y
let g = f; 12
module Q (M : sig type t end) = struct end
```
the command-line `ocamlc -warn-json - -c foo.ml` (the `-` argument to `-warn-json` means to output on `stderr`) produces
```json
[
  {
    "id": "60",
    "message": "unused module M.",
    "is_error": false,
    "loc": {
      "loc_start": {
        "pos_fname": "foo.ml",
        "pos_lnum": 5,
        "pos_bol": 30,
        "pos_cnum": 40
      },
      "loc_end": {
        "pos_fname": "foo.ml",
        "pos_lnum": 5,
        "pos_bol": 30,
        "pos_cnum": 41
      },
      "loc_ghost": false
    },
    "sub_locs": []
  },
  {
    "id": "34",
    "message": "unused type t.",
    "is_error": false,
    "loc": {
      "loc_start": {
        "pos_fname": "foo.ml",
        "pos_lnum": 5,
        "pos_bol": 30,
        "pos_cnum": 48
      },
      "loc_end": {
        "pos_fname": "foo.ml",
        "pos_lnum": 5,
        "pos_bol": 30,
        "pos_cnum": 54
      },
      "loc_ghost": false
    },
    "sub_locs": []
  },
  {
    "id": "27",
    "message": "unused variable x.",
    "is_error": false,
    "loc": {
      "loc_start": {
        "pos_fname": "foo.ml",
        "pos_lnum": 1,
        "pos_bol": 0,
        "pos_cnum": 6
      },
      "loc_end": {
        "pos_fname": "foo.ml",
        "pos_lnum": 1,
        "pos_bol": 0,
        "pos_cnum": 7
      },
      "loc_ghost": false
    },
    "sub_locs": []
  },
  {
    "id": "10",
    "message": "this expression should have type unit.",
    "is_error": false,
    "loc": {
      "loc_start": {
        "pos_fname": "foo.ml",
        "pos_lnum": 3,
        "pos_bol": 15,
        "pos_cnum": 23
      },
      "loc_end": {
        "pos_fname": "foo.ml",
        "pos_lnum": 3,
        "pos_bol": 15,
        "pos_cnum": 24
      },
      "loc_ghost": false
    },
    "sub_locs": []
  }
]
```

The PR is very rough as it is an experiment. It would be great to hear from those developing external tools that interact with the compiler: what kind of information would you like to see in the JSON output? Would you like to have a similar treatment for errors? etc.

cc @jeremiedimino, since this could be relevant for `dune`.