### PR TITLE
Use the SipHash-1-3 function for randomized hash tables

### DIFF
--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -27,6 +27,8 @@ struct custom_fixed_length {
   intnat bsize_64;
 };
 
+struct caml_hash_state; /* opaque struct, passed by reference */
+
 struct custom_operations {
   char const *identifier;
   void (*finalize)(value v);
@@ -38,6 +40,7 @@ struct custom_operations {
   uintnat (*deserialize)(void * dst);
   int (*compare_ext)(value v1, value v2);
   const struct custom_fixed_length* fixed_length;
+  void (*hash_ext)(struct caml_hash_state * st, value v);
 };
 
 #define custom_finalize_default NULL
@@ -47,6 +50,7 @@ struct custom_operations {
 #define custom_deserialize_default NULL
 #define custom_compare_ext_default NULL
 #define custom_fixed_length_default NULL
+#define custom_hash_ext_default NULL
 
 #define Custom_ops_val(v) (*((struct custom_operations **) (v)))
 

--- a/runtime/caml/hash.h
+++ b/runtime/caml/hash.h
@@ -31,6 +31,26 @@ CAMLextern uint32_t caml_hash_mix_double(uint32_t h, double d);
 CAMLextern uint32_t caml_hash_mix_float(uint32_t h, float d);
 CAMLextern uint32_t caml_hash_mix_string(uint32_t h, value s);
 
+struct caml_hash_state; /* opaque struct, passed by reference */
+
+CAMLextern void caml_hash_add_header(struct caml_hash_state * st, 
+                                     uintnat sz, uint8_t tag);
+CAMLextern void caml_hash_add_uint64(struct caml_hash_state * st, uint64_t n);
+CAMLextern void caml_hash_add_double(struct caml_hash_state * st, double d);
+CAMLextern void caml_hash_add_string(struct caml_hash_state * st,
+                                     const uint8_t * s, uintnat len);
+
+Caml_inline void caml_hash_add_intnat(struct caml_hash_state * st, intnat n)
+{
+  /* Force sign extension to 64-bits to make sure that negative numbers
+     representable in 32 bits produce the same hash
+     on 32 and 64 bit platforms. */
+ caml_hash_add_uint64(st, (int64_t) n);
+}
+
+Caml_inline void caml_hash_add_float(struct caml_hash_state * st, float f)
+{ caml_hash_add_double(st, (double) f); }
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -301,6 +301,277 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
   return Val_int(h & 0x3FFFFFFFU);
 }
 
+/* The implementation based on SipHash-1-3, https://github.com/veorq/SipHash */
+
+#define ROTL64(x,n) ((x) << n | (x) >> (64-n))
+
+struct caml_hash_state {
+  uint64_t v0, v1, v2, v3;
+};
+
+static void sip_init(struct caml_hash_state * st, uint64_t seed)
+{
+  st->v0 = 0x736f6d6570736575;
+  st->v1 = 0x646f72616e646f6d;
+  st->v2 = 0x6c7967656e657261;
+  st->v3 = 0x7465646279746573;
+  st->v2 ^= seed;
+  st->v0 ^= seed;
+}
+
+Caml_inline void sip_round(struct caml_hash_state * st)
+{
+  st->v0 += st->v1;
+  st->v1 = ROTL64(st->v1, 13);
+  st->v1 ^= st->v0;
+  st->v0 = ROTL64(st->v0, 32);
+  st->v2 += st->v3;
+  st->v3 = ROTL64(st->v3, 16);
+  st->v3 ^= st->v2;
+  st->v0 += st->v3;
+  st->v3 = ROTL64(st->v3, 21);
+  st->v3 ^= st->v0;
+  st->v2 += st->v1;
+  st->v1 = ROTL64(st->v1, 17);
+  st->v1 ^= st->v2;
+  st->v2 = ROTL64(st->v2, 32);
+}
+
+static uint64_t sip_final(struct caml_hash_state * st)
+{
+  int i;
+  st->v2 ^= 0xFF;
+  /* Three rounds at the end */
+  for (i = 0; i < 3; i++) sip_round(st);
+  /* Fold state down to 64 bits */
+  return st->v0 ^ st->v1 ^ st->v2 ^ st->v3;
+}
+
+/* Mix a 64-bit integer */
+
+CAMLexport void caml_hash_add_uint64(struct caml_hash_state * st, uint64_t x)
+{
+  st->v3 ^= x;
+  sip_round(st);
+  st->v0 ^= x;
+}
+
+/* Mix a header.  
+   [tag] is a 8-bit tag as found in heap block headers.
+   [sz] is a number of 64-bit words, even on 32-bit platforms. */
+
+CAMLexport void caml_hash_add_header(struct caml_hash_state * st,
+                                     uintnat sz, uint8_t tag)
+{
+  caml_hash_add_uint64(st, (sz << 10) | (tag << 2));
+}
+
+/* Mix a double-precision float.
+   Treats +0.0 and -0.0 identically.
+   Treats all NaNs identically.
+*/
+
+CAMLexport void caml_hash_add_double(struct caml_hash_state * st, double d)
+{
+  union {
+    double d;
+    uint64_t i;
+  } u;
+  uint64_t i;
+  /* Convert to 64-bit integer */
+  u.d = d; i = u.i;
+  /* Normalize NaNs */
+  if ((i & 0x7FF0000000000000) == 0x7FF0000000000000
+      && (i & 0x000FFFFFFFFFFFFF) != 0) {
+    i = 0x7FF0000000000001;
+  }
+  /* Normalize -0 into +0 */
+  else if (i == 0x8000000000000000) {
+    i = 0;
+  }
+  caml_hash_add_uint64(st, i);
+}
+
+/* Mix a string */
+
+CAMLexport void caml_hash_add_string(struct caml_hash_state * st,
+                                     const uint8_t * s, uintnat len)
+{
+  uintnat i;
+  uint64_t w;
+
+  /* Mix by 64-bit blocks (little-endian) */
+  for (i = 0; i + 8 <= len; i += 8) {
+#if defined(ARCH_SIXTYFOUR) && !defined(ARCH_BIG_ENDIAN)
+    w = *((uint64_t *) (s + i));
+#else
+    w = (uint64_t) s[i]
+      | ((uint64_t) s[i + 1] << 8)
+      | ((uint64_t) s[i + 2] << 16)
+      | ((uint64_t) s[i + 3] << 24)
+      | ((uint64_t) s[i + 4] << 32)
+      | ((uint64_t) s[i + 5] << 40)
+      | ((uint64_t) s[i + 6] << 48)
+      | ((uint64_t) s[i + 7] << 56);
+#endif
+    caml_hash_add_uint64(st, w);
+  }
+  /* Finish with up to 7 bytes.  Also use the low 8 bits of the length. */
+  w = (uint64_t) len << 56;
+  switch (len & 7) {
+  case 7: w |= (uint64_t) s[i + 6] << 48;  /* fallthrough */
+  case 6: w |= (uint64_t) s[i + 5] << 40;  /* fallthrough */
+  case 5: w |= (uint64_t) s[i + 4] << 32;  /* fallthrough */
+  case 4: w |= (uint64_t) s[i + 3] << 24;  /* fallthrough */
+  case 3: w |= (uint64_t) s[i + 2] << 16;  /* fallthrough */
+  case 2: w |= (uint64_t) s[i + 1] << 8;   /* fallthrough */
+  case 1: w |= (uint64_t) s[i + 0];        /* fallthrough */
+  case 0: /*skip*/;
+  }
+  caml_hash_add_uint64(st, w);
+}
+
+/* The generic hash function based on SipHash-1-3 */
+
+CAMLprim value caml_hash_sip13(value count, value limit, value seed, value obj)
+{
+  value queue[HASH_QUEUE_SIZE]; /* Queue of values to examine */
+  intnat rd;                    /* Position of first value in queue */
+  intnat wr;                    /* One past position of last value in queue */
+  intnat sz;                    /* Max number of values to put in queue */
+  intnat num;                   /* Max number of meaningful values to see */
+  struct caml_hash_state st;    /* Rolling hash */
+  value v;
+  mlsize_t i, len;
+
+  sip_init(&st, Long_val(seed));
+  sz = Long_val(limit);
+  if (sz < 0 || sz > HASH_QUEUE_SIZE) sz = HASH_QUEUE_SIZE;
+  num = Long_val(count);
+  queue[0] = obj; rd = 0; wr = 1;
+
+  while (rd < wr && num > 0) {
+    v = queue[rd++];
+  again:
+    if (Is_long(v)) {
+      caml_hash_add_intnat(&st, v);
+      num--;
+    }
+    else if (!Is_in_value_area(v)) {
+      /* v is a pointer outside the heap, probably a code pointer.
+         Shall we count it?  Let's say yes by compatibility with old code. */
+      caml_hash_add_uint64(&st, v);
+      num--;
+    }
+    else {
+      switch (Tag_val(v)) {
+      case String_tag:
+        len = caml_string_length(v);
+        caml_hash_add_header(&st, len / 8 + 1, String_tag);
+        caml_hash_add_string(&st, (const uint8_t *) String_val(v), len);
+        num--;
+        break;
+      case Double_tag:
+        caml_hash_add_header(&st, 1, Double_tag);
+        caml_hash_add_double(&st, Double_val(v));
+        num--;
+        break;
+      case Double_array_tag:
+        len = Wosize_val(v) / Double_wosize;
+        caml_hash_add_header(&st, len, Double_array_tag);
+        for (i = 0; i < len; i++) {
+          caml_hash_add_double(&st, Double_flat_field(v, i));
+          num--;
+          if (num <= 0) break;
+        }
+        break;
+      case Abstract_tag:
+        /* Block contents unknown.  Do nothing. */
+        break;
+      case Infix_tag:
+        /* Mix in the offset to distinguish different functions from
+           the same mutually-recursive definition */
+        caml_hash_add_header(&st, Infix_offset_val(v), Infix_tag);
+        v = v - Infix_offset_val(v);
+        goto again;
+      case Forward_tag:
+        /* PR#6361: we can have a loop here, so limit the number of
+           Forward_tag links being followed */
+        for (i = MAX_FORWARD_DEREFERENCE; i > 0; i--) {
+          v = Forward_val(v);
+          if (Is_long(v) || !Is_in_value_area(v) || Tag_val(v) != Forward_tag)
+            goto again;
+        }
+        /* Give up on this object and move to the next */
+        break;
+      case Object_tag:
+        caml_hash_add_header(&st, 1, Object_tag);
+        caml_hash_add_uint64(&st, Oid_val(v));
+        num--;
+        break;
+      case Custom_tag:
+        if (Custom_ops_val(v)->hash_ext != NULL) {
+          Custom_ops_val(v)->hash_ext(&st, v);
+          num--;
+        }
+        else if (Custom_ops_val(v)->hash != NULL) {
+          /* Only use low 32 bits of custom hash, for 32/64 compatibility */
+          uint32_t n = (uint32_t) Custom_ops_val(v)->hash(v);
+          caml_hash_add_header(&st, 1, Custom_tag);
+          caml_hash_add_uint64(&st, n);
+          num--;
+        }
+        /* If no hashing function provided, do nothing. */
+        break;
+      case Closure_tag: {
+        mlsize_t startenv;
+        len = Wosize_val(v);
+        startenv = Start_env_closinfo(Closinfo_val(v));
+        CAMLassert (startenv <= len);
+        caml_hash_add_header(&st, len, Closure_tag);
+        /* Mix the code pointers, closure info fields, and infix headers */
+        for (i = 0; i < startenv; i++) {
+          caml_hash_add_uint64(&st, Field(v, i));
+          num--;
+        }
+        /* Copy environment fields into queue,
+           not exceeding the total size [sz] */
+        for (/*nothing*/; i < len; i++) {
+          if (wr >= sz) break;
+          queue[wr++] = Field(v, i);
+        }
+        break;
+      }
+      default:
+        len = Wosize_val(v);
+        /* Announce the block fieds */
+        caml_hash_add_header(&st, len, Tag_val(v));
+        /* Copy fields into queue, not exceeding the total size [sz] */
+        for (i = 0; i < len; i++) {
+          if (wr >= sz) break;
+          queue[wr++] = Field(v, i);
+        }
+        break;
+      }
+    }
+  }
+  /* Final mixing of bits */
+  /* Fold result to the range [0, 2^30-1] so that it is a nonnegative
+     OCaml integer both on 32 and 64-bit platforms. */
+  return Val_int(sip_final(&st) & 0x3FFFFFFFU);
+}
+
+/* SipHash-1-3 specialized to strings */
+
+CAMLprim value caml_hash_string_sip13(value seed, value v)
+{
+  struct caml_hash_state st;
+  sip_init(&st, Long_val(seed));
+  caml_hash_add_string(&st, (const uint8_t *) String_val(v),
+                       caml_string_length(v));
+  return Val_int(sip_final(&st) & 0x3FFFFFFFU);
+}
+
 /* Hashing variant tags */
 
 CAMLexport value caml_hash_variant(char const * tag)

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -20,6 +20,7 @@
 #include "caml/alloc.h"
 #include "caml/custom.h"
 #include "caml/fail.h"
+#include "caml/hash.h"
 #include "caml/intext.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
@@ -199,6 +200,12 @@ static intnat int32_hash(value v)
   return Int32_val(v);
 }
 
+static void int32_hash_ext(struct caml_hash_state * st, value v)
+{
+  caml_hash_add_header(st, 1, Custom_tag);
+  caml_hash_add_intnat(st, Int32_val(v));
+}
+
 static void int32_serialize(value v, uintnat * bsize_32,
                             uintnat * bsize_64)
 {
@@ -222,7 +229,8 @@ CAMLexport struct custom_operations caml_int32_ops = {
   int32_serialize,
   int32_deserialize,
   custom_compare_ext_default,
-  &int32_length
+  &int32_length,
+  int32_hash_ext
 };
 
 CAMLexport value caml_copy_int32(int32_t i)
@@ -391,6 +399,12 @@ static intnat int64_hash(value v)
   return hi ^ lo;
 }
 
+static void int64_hash_ext(struct caml_hash_state * st, value v)
+{
+  caml_hash_add_header(st, 1, Custom_tag);
+  caml_hash_add_uint64(st, Int64_val(v));
+}
+
 static void int64_serialize(value v, uintnat * bsize_32,
                             uintnat * bsize_64)
 {
@@ -421,7 +435,8 @@ CAMLexport struct custom_operations caml_int64_ops = {
   int64_serialize,
   int64_deserialize,
   custom_compare_ext_default,
-  &int64_length
+  &int64_length,
+  int64_hash_ext
 };
 
 CAMLexport value caml_copy_int64(int64_t i)
@@ -670,6 +685,12 @@ static intnat nativeint_hash(value v)
 #endif
 }
 
+static void nativeint_hash_ext(struct caml_hash_state * st, value v)
+{
+  caml_hash_add_header(st, 1, Custom_tag);
+  caml_hash_add_intnat(st, Nativeint_val(v));
+}
+
 static void nativeint_serialize(value v, uintnat * bsize_32,
                                 uintnat * bsize_64)
 {
@@ -710,6 +731,7 @@ static uintnat nativeint_deserialize(void * dst)
 }
 
 static const struct custom_fixed_length nativeint_length = { 4, 8 };
+
 CAMLexport struct custom_operations caml_nativeint_ops = {
   "_n",
   custom_finalize_default,
@@ -718,7 +740,8 @@ CAMLexport struct custom_operations caml_nativeint_ops = {
   nativeint_serialize,
   nativeint_deserialize,
   custom_compare_ext_default,
-  &nativeint_length
+  &nativeint_length,
+  nativeint_hash_ext
 };
 
 CAMLexport value caml_copy_nativeint(intnat i)

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 538, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 549, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", lin
 Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 538, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 549, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.force_lazy_block.(fun) in file "camlinternalLazy.ml", line 35, characters 56-63
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27

--- a/testsuite/tests/lib-hashtbl/hfun.ml
+++ b/testsuite/tests/lib-hashtbl/hfun.ml
@@ -1,45 +1,59 @@
 (* TEST
 *)
 
-(* Testing the hash function Hashtbl.hash *)
+(* Testing the hash function Hashtbl.hash and Hashtbl.seeded_hash *)
 (* What is tested:
      - reproducibility on various platforms, esp. 32/64 bit issues
      - equal values hash equally, esp NaNs. *)
 
 open Printf
 
-let _ =
+module Test(H: sig val hash: 'a -> int end) = struct
+
+let test () =
   printf "-- Strings:\n";
-  printf "\"\"\t\t%08x\n" (Hashtbl.hash "");
-  printf "\"Hello world\"\t%08x\n" (Hashtbl.hash "Hello world");
+  printf "\"\"\t\t%08x\n" (H.hash "");
+  printf "\"Hello world\"\t%08x\n" (H.hash "Hello world");
 
   printf "-- Integers:\n";
-  printf "0\t\t%08x\n" (Hashtbl.hash 0);
-  printf "-1\t\t%08x\n" (Hashtbl.hash (-1));
-  printf "42\t\t%08x\n" (Hashtbl.hash 42);
-  printf "2^30-1\t\t%08x\n" (Hashtbl.hash 0x3FFF_FFFF);
-  printf "-2^30\t\t%08x\n" (Hashtbl.hash (-0x4000_0000));
+  printf "0\t\t%08x\n" (H.hash 0);
+  printf "-1\t\t%08x\n" (H.hash (-1));
+  printf "42\t\t%08x\n" (H.hash 42);
+  printf "2^30-1\t\t%08x\n" (H.hash 0x3FFF_FFFF);
+  printf "-2^30\t\t%08x\n" (H.hash (-0x4000_0000));
 
   printf "-- Floats:\n";
-  printf "+0.0\t\t%08x\n" (Hashtbl.hash 0.0);
-  printf "-0.0\t\t%08x\n" (Hashtbl.hash (-. 0.0));
-  printf "+infty\t\t%08x\n" (Hashtbl.hash infinity);
-  printf "-infty\t\t%08x\n" (Hashtbl.hash neg_infinity);
-  printf "NaN\t\t%08x\n" (Hashtbl.hash nan);
+  printf "+0.0\t\t%08x\n" (H.hash 0.0);
+  printf "-0.0\t\t%08x\n" (H.hash (-. 0.0));
+  printf "+infty\t\t%08x\n" (H.hash infinity);
+  printf "-infty\t\t%08x\n" (H.hash neg_infinity);
+  printf "NaN\t\t%08x\n" (H.hash nan);
   printf "NaN#2\t\t%08x\n"
-         (Hashtbl.hash (Int64.float_of_bits 0xFF_F0_00_12_34_56_78_9AL));
-  printf "NaN#3\t\t%08x\n" (Hashtbl.hash (0.0 /. 0.0));
+         (H.hash (Int64.float_of_bits 0xFF_F0_00_12_34_56_78_9AL));
+  printf "NaN#3\t\t%08x\n" (H.hash (0.0 /. 0.0));
 
   printf "-- Native integers:\n";
-  printf "0\t\t%08x\n" (Hashtbl.hash 0n);
-  printf "-1\t\t%08x\n" (Hashtbl.hash (-1n));
-  printf "42\t\t%08x\n" (Hashtbl.hash 42n);
-  printf "2^30-1\t\t%08x\n" (Hashtbl.hash 0x3FFF_FFFFn);
-  printf "-2^30\t\t%08x\n" (Hashtbl.hash (-0x4000_0000n));
+  printf "0\t\t%08x\n" (H.hash 0n);
+  printf "-1\t\t%08x\n" (H.hash (-1n));
+  printf "42\t\t%08x\n" (H.hash 42n);
+  printf "2^30-1\t\t%08x\n" (H.hash 0x3FFF_FFFFn);
+  printf "-2^30\t\t%08x\n" (H.hash (-0x4000_0000n));
 
   printf "-- Lists:\n";
-  printf "[0..10]\t\t%08x\n" (Hashtbl.hash [0;1;2;3;4;5;6;7;8;9;10]);
-  printf "[0..12]\t\t%08x\n" (Hashtbl.hash [0;1;2;3;4;5;6;7;8;9;10;11;12]);
-  printf "[10..0]\t\t%08x\n" (Hashtbl.hash [10;9;8;7;6;5;4;3;2;1;0]);
+  printf "[0..10]\t\t%08x\n" (H.hash [0;1;2;3;4;5;6;7;8;9;10]);
+  printf "[0..12]\t\t%08x\n" (H.hash [0;1;2;3;4;5;6;7;8;9;10;11;12]);
+  printf "[10..0]\t\t%08x\n" (H.hash [10;9;8;7;6;5;4;3;2;1;0]);
 
   ()
+end
+
+module TestHash = Test(struct let hash = Hashtbl.hash end)
+module TestSeededHash = Test(struct let hash x = Hashtbl.seeded_hash 42 x end)
+
+let _ =
+  printf "==== Hashtbl.hash ====\n";
+  TestHash.test();
+  printf "==== Hashtbl.seeded_hash 42 ====\n";
+  TestSeededHash.test()
+
+

--- a/testsuite/tests/lib-hashtbl/hfun.reference
+++ b/testsuite/tests/lib-hashtbl/hfun.reference
@@ -1,3 +1,4 @@
+==== Hashtbl.hash ====
 -- Strings:
 ""		00000000
 "Hello world"	364b8272
@@ -25,3 +26,31 @@ NaN#3		3228858d
 [0..10]		0ade0fc9
 [0..12]		0ade0fc9
 [10..0]		0cd6259d
+==== Hashtbl.seeded_hash 42 ====
+-- Strings:
+""		088ba82e
+"Hello world"	249faf7b
+-- Integers:
+0		1304cba0
+-1		2b472d08
+42		0845c1a5
+2^30-1		3da6106d
+-2^30		1c2d673a
+-- Floats:
++0.0		3ebfa7ae
+-0.0		3ebfa7ae
++infty		389ef5ba
+-infty		08bd4a4d
+NaN		3cec5e58
+NaN#2		3cec5e58
+NaN#3		3cec5e58
+-- Native integers:
+0		0eb70957
+-1		373c073d
+42		2eba9f31
+2^30-1		02153cf1
+-2^30		06dc39cd
+-- Lists:
+[0..10]		35088377
+[0..12]		35088377
+[10..0]		31cc91c9

--- a/testsuite/tests/lib-hashtbl/sip13.ml
+++ b/testsuite/tests/lib-hashtbl/sip13.ml
@@ -1,0 +1,154 @@
+(* TEST
+*)
+
+(* Testing our SIP-based hash function against the reference SIP-1-3. *)
+
+open Printf
+
+external sip13 : int -> string -> int = "caml_hash_string_sip13"
+
+(* Test vectors are strings ["\000\001\002..."] of length 0 to 63. *)
+
+let test (len, seed, expected) =
+  let s = String.init len (fun i -> Char.chr i) in
+  let h = sip13 seed s in
+  if Int64.(logand expected 0x3FFFFFFFL <> of_int h) then
+    printf "Error: len %d, seed %d, expected %Lx, got %x\n"
+           len seed expected h
+
+(* 64-bit hashes obtained with the SIP-1-3 reference implementation
+   from https://github.com/veorq/SipHash *)
+
+let test_vectors = [
+0, 0, 0xd1fba762150c532cL;
+1, 0, 0x68a914128e01e473L;
+2, 0, 0x10bac45c41e3669L;
+3, 0, 0x4d4c9a4a8ef6e0adL;
+4, 0, 0x7cc43f98813e4dbdL;
+5, 0, 0x5abe2169dff36275L;
+6, 0, 0xe3c25f87624f1cdbL;
+7, 0, 0x2f098ab0c751325aL;
+8, 0, 0xead411e67ebe2eeaL;
+9, 0, 0x75927f9d95124362L;
+10, 0, 0xaf9f77a65ab51a1dL;
+11, 0, 0xfe64ce8b6617fcffL;
+12, 0, 0xa6baf4fb0f9fe1c2L;
+13, 0, 0xa0cf3211850f8e0dL;
+14, 0, 0x7f86049379fbfe67L;
+15, 0, 0xf30eb725bb91c9eaL;
+16, 0, 0x8972188433a5c5b7L;
+17, 0, 0x4883c49a2c009c1dL;
+18, 0, 0xadc2c0b63044067dL;
+19, 0, 0x91f4a3329f87d19L;
+20, 0, 0x639e355ae68c0100L;
+21, 0, 0xb17bef2cb5213239L;
+22, 0, 0xf8aeb1066236ccfeL;
+23, 0, 0x37332b1389daa4ffL;
+24, 0, 0x31185a47af932f3aL;
+25, 0, 0xebf352e82ae23e2fL;
+26, 0, 0xed36ff242fe478b2L;
+27, 0, 0x2454d97d299299dfL;
+28, 0, 0x8cd57fe8130d0ac7L;
+29, 0, 0xbe98eb2faf0a0e85L;
+30, 0, 0xd427c34ee09470c6L;
+31, 0, 0x169739443111d49bL;
+32, 0, 0x31ef8061c910629bL;
+33, 0, 0x7fb71d24dfa4c9f6L;
+34, 0, 0x92771f49e836d389L;
+35, 0, 0x3c393cf6f0853bc3L;
+36, 0, 0xac77921fcc642bd3L;
+37, 0, 0x422a9751192ff266L;
+38, 0, 0xc680ae8a8c584ddfL;
+39, 0, 0x6c76b6d34bb6d26bL;
+40, 0, 0x95bc321ab41d8206L;
+41, 0, 0x908a3a97a6d37669L;
+42, 0, 0xfcaf3c64874dd0b4L;
+43, 0, 0xf689479b32b84a44L;
+44, 0, 0xd857641079efd1fdL;
+45, 0, 0x8b581578722633f7L;
+46, 0, 0x83cb09d35ea7bcd4L;
+47, 0, 0x8485f7f5ae725a0dL;
+48, 0, 0xfe1f2445ba50237fL;
+49, 0, 0x23cece041d7866b0L;
+50, 0, 0x416687480b336c09L;
+51, 0, 0xf15960da7e7f3892L;
+52, 0, 0xded6177b9826835aL;
+53, 0, 0xf80dae51668be6beL;
+54, 0, 0x17ecc6ee6647df18L;
+55, 0, 0x5220d642b4a52110L;
+56, 0, 0xa4f0cf4ba4adc016L;
+57, 0, 0xe5125bb26d1f2976L;
+58, 0, 0x851b0e75f580d256L;
+59, 0, 0x12605250a37e39acL;
+60, 0, 0xd95a713568daebf1L;
+61, 0, 0xcdcf4a42ec0dd605L;
+62, 0, 0xa5c708712b617164L;
+63, 0, 0x385d3e39e5f37359L;
+0, 1, 0xc44a0ebf4e962581L;
+1, 1, 0xc7f8837cdc05230bL;
+2, 1, 0xbfeff0bc8a414c08L;
+3, 1, 0xd8c82d87fa4286e4L;
+4, 1, 0x5d51da6e88a607e0L;
+5, 1, 0x904197b89cffef85L;
+6, 1, 0x5495a918e3423106L;
+7, 1, 0x9ce896d47e204af6L;
+8, 1, 0x51738227823e2309L;
+9, 1, 0xa9d59ba0fefc9497L;
+10, 1, 0xc56750690b3345efL;
+11, 1, 0xdccd724817e07d34L;
+12, 1, 0x292cdaf7e383c05aL;
+13, 1, 0xf1274d8b4ae1246eL;
+14, 1, 0x768cb93004a0efa8L;
+15, 1, 0x535280d545ebc696L;
+16, 1, 0xde2f7768ba893d84L;
+17, 1, 0xa5f1ec80df8761a5L;
+18, 1, 0x1427ef7862a19171L;
+19, 1, 0x655a0dc22d8b90a6L;
+20, 1, 0xd0c112e9e4038c40L;
+21, 1, 0x24d633ab5ba1b7e9L;
+22, 1, 0x99b06c142bcf8b5fL;
+23, 1, 0x18feebfcbb0326b3L;
+24, 1, 0xf5e408152c880545L;
+25, 1, 0x6015f851bac89dc1L;
+26, 1, 0xac33279dc38a017eL;
+27, 1, 0x9bc7412bb2eb7394L;
+28, 1, 0x5ffa8eddba0091e6L;
+29, 1, 0xdffde98f2c745b79L;
+30, 1, 0x78db18c79a12f099L;
+31, 1, 0x446a5b127a38bf2eL;
+32, 1, 0xded378bdce3e8ed5L;
+33, 1, 0xfcca56c93ac0918cL;
+34, 1, 0x5b39d7994e4f784cL;
+35, 1, 0x1a0a1f9156633641L;
+36, 1, 0x5d8abd3827b86fcbL;
+37, 1, 0xf13609be742294abL;
+38, 1, 0x577add0b75d2c331L;
+39, 1, 0xbfde1b9768516babL;
+40, 1, 0x5f4ed25d19cdcd56L;
+41, 1, 0xf1b601b270258d7L;
+42, 1, 0xb026423c6c066fbcL;
+43, 1, 0xc1876b1f6b36efb7L;
+44, 1, 0x570442373a1298bdL;
+45, 1, 0x1d320e1f7e5bbe92L;
+46, 1, 0x527dc0ab084853dfL;
+47, 1, 0x6ef49aecf842b256L;
+48, 1, 0x196e65e9df13f340L;
+49, 1, 0x3163970e2c2a3cecL;
+50, 1, 0xc5e84ae1e8e70d1cL;
+51, 1, 0x12c3d0a742f81cb5L;
+52, 1, 0xec779699cfb6dc88L;
+53, 1, 0x1390ce0e757826d4L;
+54, 1, 0xcffe7f1d95d46cdbL;
+55, 1, 0x81739547885752ffL;
+56, 1, 0x399b320e8f24805fL;
+57, 1, 0xc01aee30b0649549L;
+58, 1, 0xfd6325afbed1d417L;
+59, 1, 0xbdc54acabc306afdL;
+60, 1, 0x19a4b0f98334c46L;
+61, 1, 0xba1a669aaa372afdL;
+62, 1, 0x828e134835b63734L;
+63, 1, 0xa35bf11b84b78be0L
+]
+
+let _ =
+  List.iter test test_vectors


### PR DESCRIPTION
[SipHash-1-3](https://en.wikipedia.org/wiki/SipHash) is a seeded hash function that, unlike MurmurHash 3, has no known seed-independent collisions.
    
This PR updates the Hashtbl implementation to use SipHash-1-3 as the hash function for randomized hash tables, making them truly resistant to hash flooding attacks.
    
Non-randomized hash tables still use MurmurHash 3, as it is faster than SipHash-1-3, especially on 32-bit platforms, yet good enough, statistically speaking, for a classic hash table.  Plus, this gives a modicum of backward compatibility with programs that marshal (non-randomized) hash tables to persistent storage.

If accepted, this will close PR #24, six years later.  Why did it take so long?  First, at the time, only SipHash-2-4 was considered, with more rounds and stronger cryptographic properties but slower running times.  It took a while before the SipHash-1-3 reduced-round version was confirmed as good enough.  Second, it took me all of 6 years to realize that we can keep using MurmurHash 3 for non-randomized hash tables, resulting in an excellent deal: more security for randomized hash tables, no slowdown for classic hash tables.
