### PR TITLE
Fix #9759: Typing without -principal is broken in 4.11 and trunk

### DIFF
--- a/Changes
+++ b/Changes
@@ -826,6 +826,10 @@ OCaml 4.11
 - #9695, #9702: no error when opening an alias to a missing module
   (Jacques Garrigue, report and review by Gabriel Scherer)
 
+- #9759: Typing without -principal is broken in 4.11 and trunk
+  (Jacques Garrigue, report by Thomas Refis)
+
+
 OCaml 4.10 maintenance branch
 -----------------------------
 

--- a/Changes
+++ b/Changes
@@ -826,7 +826,7 @@ OCaml 4.11
 - #9695, #9702: no error when opening an alias to a missing module
   (Jacques Garrigue, report and review by Gabriel Scherer)
 
-- #9759: Typing without -principal is broken in 4.11 and trunk
+- #9759: Spurious ambiguity without -principal in 4.11 and trunk
   (Jacques Garrigue, report by Thomas Refis)
 
 

--- a/testsuite/tests/typing-gadts/pr9759.ml
+++ b/testsuite/tests/typing-gadts/pr9759.ml
@@ -1,0 +1,31 @@
+(* TEST
+   * expect
+*)
+
+(* #9759 by Thomas Refis *)
+
+type 'a general = { indir: 'a desc; unit: unit }
+and 'a desc =
+  | C : unit general -> unit desc ;;
+[%%expect{|
+type 'a general = { indir : 'a desc; unit : unit; }
+and 'a desc = C : unit general -> unit desc
+|}]
+
+let rec foo : type k . k general -> k general = fun g ->
+  match g.indir with
+  | C g' ->
+      let new_g' = foo g' in
+      if true then
+        {g with indir = C new_g'}
+      else
+          new_g'
+  | indir ->
+     {g with indir} ;;
+[%%expect{|
+Line 9, characters 4-9:
+9 |   | indir ->
+        ^^^^^
+Warning 11: this match case is unused.
+val foo : 'k general -> 'k general = <fun>
+|}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -490,8 +490,8 @@ let rec raw_type ppf ty =
   let ty = safe_repr [] ty in
   if List.memq ty !visited then fprintf ppf "{id=%d}" ty.id else begin
     visited := ty :: !visited;
-    fprintf ppf "@[<1>{id=%d;level=%d;desc=@,%a}@]" ty.id ty.level
-      raw_type_desc ty.desc
+    fprintf ppf "@[<1>{id=%d;level=%d;scope=%d;desc=@,%a}@]" ty.id ty.level
+      ty.scope raw_type_desc ty.desc
   end
 and raw_type_list tl = raw_list raw_type tl
 and raw_type_desc ppf = function

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4724,15 +4724,10 @@ and type_cases
             end_def ();
             generalize_structure ty; ty
           end
-          else if does_contain_gadt then
-            (* Even though we've already done that, apparently we need to do it
-               again.
-               stdlib/camlinternalFormat.ml:2288 is an example of use of this
-               call to [correct_levels]... *)
+          else if contains_gadt then
+            (* allow propagation from preceding branches *)
             correct_levels ty_res
           else ty_res in
-(*        Format.printf "@[%i %i, ty_res' =@ %a@]@." lev (get_current_level())
-          Printtyp.raw_type_expr ty_res'; *)
         let guard =
           match pc_guard with
           | None -> None

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2917,7 +2917,7 @@ and type_expect_
           (fun x -> x)
       in
       with_explanation (fun () ->
-        unify_exp_types loc env ty_record (instance ty_expected));
+        unify_exp_types loc env (instance ty_record) (instance ty_expected));
 
       (* type_label_a_list returns a list of labels sorted by lbl_pos *)
       (* note: check_duplicates would better be implemented in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4724,7 +4724,7 @@ and type_cases
             end_def ();
             generalize_structure ty; ty
           end
-          else if contains_gadt then
+          else if does_contain_gadt then
             (* Even though we've already done that, apparently we need to do it
                again.
                stdlib/camlinternalFormat.ml:2288 is an example of use of this


### PR DESCRIPTION
Quick fix for #9759: `type_expect` may modify the expected type in non `-principal` mode, so use `correct_levels` before calling it in `type_cases`.

It might be better ultimately to fully review the way `ty_expected` is used, including its semantics, but this would be a much bigger change.