### PR TITLE
CI test no-naked-pointers mode

### DIFF
--- a/.github/workflows/nnp.yml
+++ b/.github/workflows/nnp.yml
@@ -1,0 +1,18 @@
+name: main
+
+on: [push, pull_request]
+
+jobs:
+  no-naked-pointers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: configure tree
+      run: ./configure --disable-naked-pointers --disable-stdlib-manpages
+    - name: Build
+      run: |
+        make -j world.opt
+    - name: Run the testsuite
+      run: |
+        make -C testsuite USE_RUNTIME=d all


### PR DESCRIPTION
#9619 and #9681 suggest we should have some testing for `--disable-naked-pointers` in CI. Travis already builds 5 compilers in parallel, so I propose we take advantage of free silicon in Azure for this test. You can see a failing example (just after #9619 was merged) [here](https://github.com/dra27/ocaml/runs/869457535?check_suite_focus=true#step:5:3197)

The error in #9619 wasn't strictly about breaking no-naked-pointers, but canaries are always useful.

cc @sadiqj