### PR TITLE
Changes to the run-time system to address static analysis alarms

### DIFF
--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -147,6 +147,8 @@ static void update_environment(array local_env)
       memcpy(value, pos_eq + 1, value_length);
       value[value_length] = '\0';
       setenv(name, value, 1); /* 1 means overwrite */
+      free(name);
+      free(value);
     }
   }
 }

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -76,7 +76,7 @@ DOMAIN_STATE(intnat, stat_heap_chunks)
 /* See gc_ctrl.c */
 
 DOMAIN_STATE(uintnat, eventlog_startup_timestamp)
-DOMAIN_STATE(uint32_t, eventlog_startup_pid)
+DOMAIN_STATE(long, eventlog_startup_pid)
 DOMAIN_STATE(uintnat, eventlog_paused)
 DOMAIN_STATE(uintnat, eventlog_enabled)
 DOMAIN_STATE(FILE*, eventlog_out)

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -139,12 +139,12 @@ static void setup_eventlog_file()
   eventlog_filename = caml_secure_getenv(T("OCAML_EVENTLOG_PREFIX"));
 
   if (eventlog_filename) {
-    int ret = snprintf_os(output_file, OUTPUT_FILE_LEN, T("%s.%d.eventlog"),
+    int ret = snprintf_os(output_file, OUTPUT_FILE_LEN, T("%s.%ld.eventlog"),
                          eventlog_filename, Caml_state->eventlog_startup_pid);
     if (ret > OUTPUT_FILE_LEN)
       caml_fatal_error("eventlog: specified OCAML_EVENTLOG_PREFIX is too long");
   } else {
-    snprintf_os(output_file, OUTPUT_FILE_LEN, T("caml-%d.eventlog"),
+    snprintf_os(output_file, OUTPUT_FILE_LEN, T("caml-%ld.eventlog"),
                Caml_state->eventlog_startup_pid);
   }
 

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -1523,7 +1523,7 @@ static header_t *bf_allocate (mlsize_t wosz)
       return Hp_val (block);
     }else{
       /* allocate from the next available size */
-      mlsize_t s = ffs (bf_small_map & ((-1) << wosz));
+      mlsize_t s = ffs (bf_small_map & ((~0U) << wosz));
       FREELIST_DEBUG_bf_check ();
       if (s != 0){
         block = bf_small_fl[s].free;

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -149,7 +149,7 @@ char * caml_instr_string (code_t pc)
     snprintf(buf, sizeof(buf), "%s %d, %d", nam, pc[0], pc[1]);
     break;
   case SWITCH:
-    snprintf(buf, sizeof(buf), "SWITCH sz%#lx=%ld::ntag%ld nint%ld",
+    snprintf(buf, sizeof(buf), "SWITCH sz%#lx=%ld::ntag%lu nint%lu",
             (long) pc[0], (long) pc[0], (unsigned long) pc[0] >> 16,
             (unsigned long) pc[0] & 0xffff);
     break;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -429,7 +429,7 @@ void caml_shrink_heap (char *chunk)
 
   Caml_state->stat_heap_wsz -= Wsize_bsize (Chunk_size (chunk));
   caml_gc_message (0x04, "Shrinking heap to %"
-                   ARCH_INTNAT_PRINTF_FORMAT "uk words\n",
+                   ARCH_INTNAT_PRINTF_FORMAT "dk words\n",
                    Caml_state->stat_heap_wsz / 1024);
 
 #ifdef DEBUG

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -52,7 +52,7 @@ extern uintnat caml_percent_free;                   /* major_gc.c */
 /* Page table management */
 
 #define Page(p) ((uintnat) (p) >> Page_log)
-#define Page_mask ((uintnat) -1 << Page_log)
+#define Page_mask ((~(uintnat)0) << Page_log)
 
 #ifdef ARCH_SIXTYFOUR
 


### PR DESCRIPTION
This is a collection of small patches addressing warnings reported by the [PVS-Studio](https://www.viva64.com/en/pvs-studio/) static analyser.