### PR TITLE
Update a comment in the top-level printer.

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -360,8 +360,11 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                     a case (PR#6669).
 
                     Unfortunately, there is a corner-case that *is*
-                    a real cycle: using -rectypes one can define
-                      let rec x = lazy x
+                    a real cycle: using unboxed types one can define
+
+                       type t = T : t Lazy.t -> t [@@unboxed]
+                       let rec x = lazy (T x)
+
                     which creates a Forward_tagged block that points to
                     itself. For this reason, we still "nest"
                     (detect head cycles) on forward tags.


### PR DESCRIPTION
The toplevel printer has a [comment](https://github.com/ocaml/ocaml/blob/fb6cfaf74c2a723b058c4c920b7eda9330fe5ba7/toplevel/genprintval.ml#L362-L367) about the need to detect cycles involving `Forward` tags:

```
Unfortunately, there is a corner-case that *is*
a real cycle: using -rectypes one can define
  let rec x = lazy x
which creates a Forward_tagged block that points to
itself. For this reason, we still "nest"
(detect head cycles) on forward tags.
```

The comment is no longer valid since recent versions of OCaml reject `let rec x = lazy x`, even with `-rectypes`.  However, it's still necessary to detect cycles involving `Forward` tags, since there's a more modern way to build them using unboxing:

```ocaml
    type t = T : t Lazy.t -> t [@@unboxed]
    let rec x = lazy (T x)
```