### PR TITLE
Fix printing of bindings with polymorphic type annotations and attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -142,6 +142,10 @@ Working version
 
 ### Other libraries:
 
+- #9778: Fix printing for bindings where polymorphic type annotations and
+  attributes are present.
+  (Matthew Ryan)
+
 * #9206, #9419: update documentation of the threads library;
   deprecate Thread.kill, Thread.wait_read, Thread.wait_write,
   and the whole ThreadUnix module.

--- a/Changes
+++ b/Changes
@@ -250,7 +250,7 @@ Working version
 
 - #9778: Fix printing for bindings where polymorphic type annotations and
   attributes are present.
-  (Matthew Ryan)
+  (Matthew Ryan, review by Nicolás Ojeda Bär)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -142,10 +142,6 @@ Working version
 
 ### Other libraries:
 
-- #9778: Fix printing for bindings where polymorphic type annotations and
-  attributes are present.
-  (Matthew Ryan)
-
 * #9206, #9419: update documentation of the threads library;
   deprecate Thread.kill, Thread.wait_read, Thread.wait_write,
   and the whole ThreadUnix module.
@@ -251,6 +247,10 @@ Working version
 
 - #9688: Expose the main entrypoint in compilerlibs
   (Stephen Dolan, review by Nicolás Ojeda Bär, Greta Yorsh and David Allsopp)
+
+- #9778: Fix printing for bindings where polymorphic type annotations and
+  attributes are present.
+  (Matthew Ryan)
 
 ### Build system:
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1255,7 +1255,16 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; _} =
       Some (p, pt_tyvars, e_ct, e) else None
     | _ -> None in
   if x.pexp_attributes <> []
-  then pp f "%a@;=@;%a" (pattern ctxt) p (expression ctxt) x else
+  then
+    match p with
+    | {ppat_desc=Ppat_constraint({ppat_desc=Ppat_var _; _} as pat,
+                                 ({ptyp_desc=Ptyp_poly _; _} as typ));
+       ppat_attributes=[]; _} ->
+        pp f "%a@;: %a@;=@;%a"
+          (simple_pattern ctxt) pat (core_type ctxt) typ (expression ctxt) x
+    | _ ->
+        pp f "%a@;=@;%a" (pattern ctxt) p (expression ctxt) x
+  else
   match is_desugared_gadt p x with
   | Some (p, [], ct, e) ->
       pp f "%a@;: %a@;=@;%a"

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7372,3 +7372,11 @@ let f = function
 
 let () =
   f (fun (type t) -> x)
+
+(* #9778 *)
+
+type t = unit
+
+let rec equal : 'a. ('a -> 'a -> bool) -> 'a t -> 'a t -> bool =
+ (fun poly_a (_ : unit) (_ : unit) -> true) [@ocaml.warning "-A"]
+ [@@ocaml.warning "-39"]


### PR DESCRIPTION
This fixes a bug that bit @mobileink recently, where printing the code
generated by ppx_deriving.eq and attempting to re-parse it resulted in a
parse error. This bug manifested where a let binding has a polymorphic
type `'a. _` and an attribute on the bound expression.

To reproduce:
* create `testfile` with
```ocaml
 #load_rec "parsing/pprintast.cmo";;
 #load_rec "parsing/lexer.cmo";;
 #load_rec "parsing/parser.cmo";;

let phrase =
  {ocaml|
let rec equal :
          'a.    ('a -> 'a -> Ppx_deriving_runtime.bool) -> 'a t -> 'a t
          -> Ppx_deriving_runtime.bool =
  (let open! Ppx_deriving_runtime in
  fun poly_a (_ : unit) (_ : unit) -> true) [@ocaml.warning "-A"]
  [@@ocaml.warning "-39"]
|ocaml};;

let parse_roundtrip str =
  Pprintast.string_of_structure
    (Parser.implementation Lexer.token (Lexing.from_string str));;

let phrase_roundtrip = parse_roundtrip phrase;;

parse_roundtrip phrase_roundtrip;;
```
* start the toplevel with `TOPFLAGS="-I parsing -I utils" make runtop`
* run `#use "testfile"`

On `trunk`, this fails with an error at
`parse_roundtrip phrase_roundtrip`, where the parser chokes on the
`let (equal : 'a. ...) = ...` construction. With this change, the
printer and parser round-trip successfully.