### PR TITLE
Wrong registers used for C-- mutable let in soft FP mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -370,7 +370,7 @@ OCaml 4.11
 - #9280: Micro-optimise allocations on amd64 to save a register.
   (Stephen Dolan, review by Xavier Leroy)
 
-- #9316, #9443, #9463: Use typing information from Clambda
+- #9316, #9443, #9463, #9782: Use typing information from Clambda
   for mutable Cmm variables.
   (Stephen Dolan, review by Vincent Laviron, Guillaume Bury, Xavier Leroy,
   and Gabriel Scherer; temporary bug report by Richard Jones)

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -889,7 +889,7 @@ method private bind_let (env:environment) v r1 =
   end
 
 method private bind_let_mut (env:environment) v k r1 =
-  let rv = Reg.createv k in
+  let rv = self#regs_for k in
   name_regs v rv;
   self#insert_moves env r1 rv;
   env_add ~mut:Mutable v rv env


### PR DESCRIPTION
Software emulation of floating-point arithmetic, as in the ARM EABI port, use pairs of pseudoregisters of type Int to represent values of type Float.

This is achieved by the `regs_for` method of class `selector_generic`, which defaults to `Reg.createv` but is overriden for ARM EABI so as to perform the transformation Float -> Int,Int on the fly.

The method `bind_let_mut` uses `Reg.createv` to associate pseudoregisters to bound variables.  This is incorrect in a soft FP
context, as a bound variable of type Float will get a Float register nonetheless.  `self#regs_for` must be used instead.  This is what this commit does.