### PR TITLE
Fix Sys.file_exists and Sys.is_directory for symlinks on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,11 @@ Working version
 
 ### Bug fixes:
 
+- #9793: Fix Sys.file_exists and Sys.is_directory for symlinks and Windows and
+  harden those and Unix.stat against "zombie" files (files marked for deletion
+  but not yet removed).
+  (David Allsopp, review by ???)
+
 OCaml 4.14.0
 ----------------
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -310,7 +310,9 @@ extern double caml_log1p(double);
 
 #define access_os _waccess
 #define open_os _wopen
+#ifndef CAML_INTERNALS
 #define stat_os _wstati64
+#endif
 #define unlink_os _wunlink
 #define rename_os caml_win32_rename
 #define chdir_os _wchdir
@@ -350,7 +352,9 @@ extern double caml_log1p(double);
 
 #define access_os access
 #define open_os open
+#ifndef CAML_INTERNALS
 #define stat_os stat
+#endif
 #define unlink_os unlink
 #define rename_os rename
 #define chdir_os chdir
@@ -389,6 +393,12 @@ extern double caml_log1p(double);
 #define caml_unlink unlink_os
 #endif
 
+#ifdef CAML_INTERNALS
+/* stat cannot be used in a cross-platform way because Windows implementations
+   are unreliable. Windows-specific code will almost certainly be needed and you
+   should not trust any documentation which suggests using _wstati64! */
+#define stat_os(path, buf) @dont_use_stat_see_misc_h
+#endif
 
 /* Data structures */
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -139,6 +139,8 @@ CAMLextern void caml_expand_command_line (int *, wchar_t ***);
 
 CAMLextern clock_t caml_win32_clock(void);
 
+extern int caml_win32_get_attributes(wchar_t *p);
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/testsuite/tests/lib-sys/symlink.ml
+++ b/testsuite/tests/lib-sys/symlink.ml
@@ -1,0 +1,40 @@
+(* TEST
+* hasunix
+include unix
+** has_symlink
+*** bytecode
+*** native
+*)
+
+let test = Printf.printf "%s: %b\n%!"
+
+(* Returns false if f returns any value and true if Sys_error is raised *)
+let fails text f =
+  let outcome =
+    try f () && false
+    with Sys_error _ -> true
+  in
+    test (text ^ " raises Sys_error") outcome
+
+(* Tests for Sys.file_exists and Sys.directory_exists *)
+let () =
+  Unix.mkdir "realdir" 0o777;
+  let h = Unix.(openfile "realfile" [O_CREAT; O_RDWR] 0o666) in
+  assert (Unix.write_substring h "test" 0 4 = 4);
+  Unix.close h;
+  Unix.symlink "realdir" "linkdir";
+  Unix.symlink "realfile" "linkfile";
+  Unix.symlink ~to_dir:true "fakedir" "deadlinkdir";
+  Unix.symlink "fakefile" "deadlinkfile";
+  test "Sys.file_exists \"realdir\"" @@ Sys.file_exists "realdir";
+  test "Sys.file_exists \"realfile\"" @@ Sys.file_exists "realfile";
+  test "Sys.is_directory \"realdir\"" @@ Sys.is_directory "realdir";
+  test "Sys.is_directory \"realfile\"" @@ Sys.is_directory "realfile";
+  test "Sys.file_exists \"linkdir\"" @@ Sys.file_exists "linkdir";
+  test "Sys.file_exists \"linkfile\"" @@ Sys.file_exists "linkfile";
+  test "Sys.is_directory \"linkdir\"" @@ Sys.is_directory "linkdir";
+  test "Sys.is_directory \"linkfile\"" @@ Sys.is_directory "linkfile";
+  test "Sys.file_exists \"deadlinkdir\"" @@ Sys.file_exists "deadlinkdir";
+  test "Sys.file_exists \"deadlinkfile\"" @@ Sys.file_exists "deadlinkfile";
+  fails "Sys.is_directory \"deadlinkdir\"" (fun () -> Sys.is_directory "deadlinkdir");
+  fails "Sys.is_directory \"deadlinkfile\"" (fun () -> Sys.is_directory "deadlinkfile")

--- a/testsuite/tests/lib-sys/symlink.reference
+++ b/testsuite/tests/lib-sys/symlink.reference
@@ -1,0 +1,12 @@
+Sys.file_exists "realdir": true
+Sys.file_exists "realfile": true
+Sys.is_directory "realdir": true
+Sys.is_directory "realfile": false
+Sys.file_exists "linkdir": true
+Sys.file_exists "linkfile": true
+Sys.is_directory "linkdir": true
+Sys.is_directory "linkfile": false
+Sys.file_exists "deadlinkdir": false
+Sys.file_exists "deadlinkfile": false
+Sys.is_directory "deadlinkdir" raises Sys_error: true
+Sys.is_directory "deadlinkfile" raises Sys_error: true

--- a/testsuite/tests/lib-sys/zombie.ml
+++ b/testsuite/tests/lib-sys/zombie.ml
@@ -1,0 +1,18 @@
+(* TEST
+* libwin32unix
+include unix
+** bytecode
+** native
+*)
+
+let test = Printf.printf "%s: %b\n%!"
+
+(* Tests for O_SHARE_DELETE and Sys.file_exists and Sys.directory_exists *)
+let () =
+  let h = Unix.(openfile "file" [O_CREAT; O_RDWR; O_SHARE_DELETE] 0o666) in
+  assert (Unix.write_substring h "test" 0 4 = 4);
+  test "Sys.file_exists \"file\"" @@ Sys.file_exists "file";
+  Sys.remove "file";
+  test "Sys.file_exists \"file\"" @@ Sys.file_exists "file";
+  Unix.close h;
+  test "Sys.file_exists \"file\"" @@ Sys.file_exists "file"

--- a/testsuite/tests/lib-sys/zombie.reference
+++ b/testsuite/tests/lib-sys/zombie.reference
@@ -1,0 +1,3 @@
+Sys.file_exists "file": true
+Sys.file_exists "file": true
+Sys.file_exists "file": false

--- a/testsuite/tests/lib-unix/win-stat/zombie.ml
+++ b/testsuite/tests/lib-unix/win-stat/zombie.ml
@@ -1,0 +1,22 @@
+(* TEST
+* has_symlink
+** libwin32unix
+include unix
+*** bytecode
+*** native
+*)
+
+let test = Printf.printf "%s: %b\n%!"
+
+(* Tests for O_SHARE_DELETE and Unix.stat *)
+let () =
+  let h = Unix.(openfile "file" [O_CREAT; O_RDWR; O_SHARE_DELETE] 0o666) in
+  assert (Unix.write_substring h "test" 0 4 = 4);
+  test "Unix.stat \"file\"" (Unix.((stat "file").st_size = 4));
+  test "Unix.fstat h" (Unix.((fstat h).st_size = 4));
+  Sys.remove "file";
+  test "Unix.stat \"file\"" (Unix.((stat "file").st_size = 4));
+  test "Unix.fstat h" (Unix.((fstat h).st_size = 4));
+  Unix.close h;
+  test "Unix.stat \"file\"" (try let _ = Unix.((stat "file").st_size) in false with Unix.Unix_error(Unix.ENOENT, _, _) -> true);
+  test "Unix.fstat h" (try let _ = Unix.((fstat h).st_size) in false with Unix.Unix_error(Unix.EBADF, _, _) -> true)

--- a/testsuite/tests/lib-unix/win-stat/zombie.reference
+++ b/testsuite/tests/lib-unix/win-stat/zombie.reference
@@ -1,0 +1,6 @@
+Unix.stat "file": true
+Unix.fstat h: true
+Unix.stat "file": true
+Unix.fstat h: true
+Unix.stat "file": true
+Unix.fstat h: true


### PR DESCRIPTION
While poking around in `runtime/sys.c` for #9787, I spotted serious problems with `caml_sys_file_exists` and `caml_sys_is_directory` - they use `stat`, which is a symlink catastrophe on Windows.

This PR makes the use of `stat_os` in the codebase an error if `CAML_INTERNALS` is defined (I'm not sure why the `_os` functions aren't guarded with `CAML_INTERNALS`, @nojb?). The function is so unreliable on Windows that it should simply never be used - the idea with the error is to sound an alarm bell that a Windows-specific piece of code will be needed.

My solution is to define a function which reads the attributes of the file entry. This - like `stat` on Unix - is done without actually opening the file. I decided to check how our friends over in Redmond do it in `FileSystem.FileExists` (it's much easier than in 2015, since .NET is open source now!) which alerted me to the matter of zombie files. These are files which have been deleted but which are still open in programs (this is real - both ocamltest and dune have had visible issues with this). Clearly `Sys.file_exists` should return `true` if you can still "see" a file with the name given - the fact you can't actually open it is a security/permissions issue. Fortunately, when this happens `GetLastError` returns one of three known errors and so in this specific case we then use the much slower `FindFirstFile` which - in what can only be described as Windows weirdness - does return the file attributes, returning a reliable answer for `Sys.file_exists` (I don't actually know if you can concoct zombie directories - you can't in directly in OCaml).

This made me realise that my implementation of `stat` in win32unix which is based on `GetFileInformationByHandle` would therefore fail for these zombie files (Microsoft's broken implementations of stat are all based on `FindFirstFile`). So this PR also fixes `Unix.stat` to return meaningful enough information for files marked for deletion.

Then I realised that the Unix implementation of `caml_sys_file_exists` is based on `stat` but `GetFileAttributes` is an `lstat` like function. This means that on Windows `Sys.file_exists` would return `true` for symlinks which point to files/directories which don't exist. It took a while to convince myself, but I believe that we definitely want `stat`-like not `lstat`-like behaviour for symbolic links. The solution for this is to to follow the symlink by opening the file and using `GetFileInformationByHandle`. Technically speaking, there is more work to do for symbolic links to zombie files - this, however, is quite tricky, very niche, and related to other work, so I leave that for another day.

I have added tests for all of these cases.