### PR TITLE
Build otherlibs with debug info in C stubs

### DIFF
--- a/Changes
+++ b/Changes
@@ -292,6 +292,9 @@ Working version
   to avoid C dependency recomputation.
   (Gabriel Scherer, review by David Allsopp)
 
+- #9804: Build C stubs of libraries in otherlibs/ with debug info.
+  (Stephen Dolan, review by Sébastien Hinderer and David Allsopp)
+
 ### Bug fixes:
 
 - #7902, #9556: Type-checker infers recursive type, even though -rectypes is

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -24,6 +24,10 @@ CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLC := $(BEST_OCAMLC) -nostdlib -I $(ROOTDIR)/stdlib
 CAMLOPT := $(BEST_OCAMLOPT) -nostdlib -I $(ROOTDIR)/stdlib
 
+ifneq "$(CCOMPTYPE)" "msvc"
+OC_CFLAGS += -g
+endif
+
 OC_CFLAGS += $(SHAREDLIB_CFLAGS) $(EXTRACFLAGS)
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime $(EXTRACPPFLAGS)
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -18,6 +18,10 @@ ROOTDIR=../..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
+ifneq "$(CCOMPTYPE)" "msvc"
+OC_CFLAGS += -g
+endif
+
 OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime


### PR DESCRIPTION
The Unix library and other otherlibs/ denizens don't get `-g` on their C stubs, which makes debugging annoying, so this patch adds it. (I copy-pasted the Makefile gunk from `runtime/`)