### PR TITLE
2 testsuite tweaks

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -221,6 +221,8 @@ let is_test s =
 let ignored s =
   s = "" || s.[0] = '_' || s.[0] = '.'
 
+let sort_strings = List.sort String.compare
+
 let find_test_dirs dir =
   let res = ref [] in
   let rec loop dir =
@@ -236,7 +238,7 @@ let find_test_dirs dir =
     if !contains_tests then res := dir :: !res
   in
   loop dir;
-  List.rev !res
+  sort_strings !res
 
 let list_tests dir =
   let res = ref [] in
@@ -250,7 +252,7 @@ let list_tests dir =
         end
       ) (Sys.readdir dir)
   end;
-  List.rev !res
+  sort_strings !res
 
 let () =
   init_tests_to_skip()

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -16,8 +16,6 @@
 .NOTPARALLEL:
 
 BASEDIR := $(shell pwd)
-NO_PRINT=`$(MAKE) empty --no-print-directory >/dev/null 2>&1 \
-	  && echo --no-print-directory`
 
 FIND=find
 TOPDIR := ..
@@ -110,8 +108,8 @@ default:
 .PHONY: all
 all:
 	@rm -f $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) new-without-report
-	@$(MAKE) $(NO_PRINT) report
+	@$(MAKE) --no-print-directory new-without-report
+	@$(MAKE) --no-print-directory report
 
 .PHONY: new-without-report
 new-without-report: lib tools
@@ -136,9 +134,9 @@ check-failstamp:
 .PHONY: all-%
 all-%: lib tools
 	@for dir in tests/$**; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
+	  $(MAKE) --no-print-directory exec-one DIR=$$dir; \
 	done 2>&1 | tee $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) retries
+	@$(MAKE) --no-print-directory retries
 	@$(MAKE) report
 
 # The targets below use GNU parallel to parallelize tests
@@ -177,9 +175,9 @@ parallel-%: lib tools
 	     exit 1)
 	@for dir in tests/$**; do echo $$dir; done \
 	 | parallel --gnu --no-notice --keep-order \
-	     "$(MAKE) $(NO_PRINT) exec-one DIR={} 2>&1" \
+	     "$(MAKE) --no-print-directory exec-one DIR={} 2>&1" \
 	 | tee $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) retries
+	@$(MAKE) --no-print-directory retries
 	@$(MAKE) report
 
 .PHONY: parallel
@@ -192,9 +190,9 @@ list: lib tools
 	  exit 1; \
 	fi
 	@while read LINE; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE; \
+	  $(MAKE) --no-print-directory exec-one DIR=$$LINE; \
 	done <$(FILE) 2>&1 | tee $(TESTLOG)
-	@$(MAKE) $(NO_PRINT) retries
+	@$(MAKE) --no-print-directory retries
 	@$(MAKE) report
 
 .PHONY: one
@@ -207,7 +205,7 @@ one: lib tools
 	  echo "Directory '$(DIR)' does not exist."; \
 	  exit 1; \
 	fi
-	@$(MAKE) $(NO_PRINT) exec-one DIR=$(DIR)
+	@$(MAKE) --no-print-directory exec-one DIR=$(DIR)
 	@$(MAKE) check-failstamp
 
 .PHONY: exec-one
@@ -290,18 +288,17 @@ retry-list:
 	@while read LINE; do \
 	  if [ -n "$$LINE" ] ; then \
 	    echo re-ran $$LINE>> $(TESTLOG); \
-	    $(MAKE) $(NO_PRINT) clean-one DIR=$$LINE; \
-	    $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE 2>&1 | tee -a $(TESTLOG) ; \
+	    $(MAKE) --no-print-directory clean-one DIR=$$LINE; \
+	    $(MAKE) --no-print-directory exec-one DIR=$$LINE 2>&1 \
+	      | tee -a $(TESTLOG) ; \
 	  fi \
 	done <_retries;
-	@$(MAKE) $(NO_PRINT) retries
+	@$(MAKE) --no-print-directory retries
 
 .PHONY: retries
 retries:
 	@$(AWK) -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
 	     -f ./summarize.awk < $(TESTLOG) > _retries
-	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
+	@test `cat _retries | wc -l` -eq 0 || \
+	  $(MAKE) --no-print-directory retry-list
 	@rm -f _retries
-
-.PHONY: empty
-empty:


### PR DESCRIPTION
Two things found in my foray into allowing parallel runs of the testsuite on Windows:

55e57e57d added detection for GNU make's `--no-print-directory` option (machinery in `$(NO_PRINT)` in `testsuite/Makefile`). This made sense in 2010 as GNU make was not compulsory for the system. Today it is mandatory and very much used (including in `testsuite/Makefile`). `--no-print-directory` was added in GNU make 3.64 which pre-dates Linux 1.0, so I think we can assume its presence.

Before https://github.com/ocaml/ocaml/pull/8975, test directories were run in alphabetical order (well, unless you had a strange LC_COLLATE, I expect) and tests were run reliably in the order listed in `ocamltests` files. Prior to ocamltest completely, I think everything was done in alphabetical order, as the scanning was done with `ls`. Occasionally one uses grep; occasionally one expects to spot the results of "norm4.ml" to appear after "norm3.ml" and not need a command. I was surprised that `ocamltest -find-test-dirs` and `ocamltest -list-tests` seemed to go to extraordinary trouble to return strictly the order that `Sys.readdir` came up with, so I've changed it to sort them instead.