### PR TITLE
Allow running a single test in testsuite/Makefile

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -93,9 +93,9 @@ default:
 	@echo "  parallel        launch all tests using GNU parallel"
 	@echo "  parallel-foo    launch all tests beginning with foo using \
 	GNU parallel"
-	@echo "  list FILE=f     launch the tests listed in f (one per line)"
+	@echo "  one TEST=f      launch just this single test"
 	@echo "  one DIR=p       launch the tests located in path p"
-	@echo "  just TEST=f     launch just this single test"
+	@echo "  one LIST=f      launch the tests listed in f (one per line)"
 	@echo "  promote DIR=p   promote the reference files for the tests in p"
 	@echo "  lib             build library modules"
 	@echo "  tools           build test tools"
@@ -187,27 +187,38 @@ parallel: parallel-*
 .PHONY: list
 list: lib tools
 	@if [ -z "$(FILE)" ]; \
-	  then echo "No value set for variable 'FILE'."; \
-	  exit 1; \
-	fi
-	@while IFS='' read -r LINE; do \
-	  $(MAKE) --no-print-directory exec-one DIR=$$LINE; \
-	done <$(FILE) 2>&1 | tee $(TESTLOG)
-	@$(MAKE) --no-print-directory retries
-	@$(MAKE) report
+    then echo "No value set for variable 'FILE'."; \
+    exit 1; \
+  fi
+	@$(MAKE) --no-print-directory one LIST="$(FILE)"
 
 .PHONY: one
 one: lib tools
-	@if [ -z "$(DIR)" ]; then \
-	  echo "No value set for variable 'DIR'."; \
-	  exit 1; \
-	fi
-	@if [ ! -d $(DIR) ]; then \
-	  echo "Directory '$(DIR)' does not exist."; \
-	  exit 1; \
-	fi
-	@$(MAKE) --no-print-directory exec-one DIR=$(DIR)
+	@case "$(words $(DIR) $(LIST) $(TEST))" in \
+   0) echo 'No value set for variable DIR, LIST or TEST'>&2; exit 1;; \
+   1) exit 0;; \
+   *) echo 'Please specify just one of DIR, LIST or TEST'>&2; exit 1;; \
+   esac
+	@if [ -n '$(DIR)' ] && [ ! -d '$(DIR)' ]; then \
+    echo "Directory '$(DIR)' does not exist."; exit 1; \
+  fi
+	@if [ -n '$(TEST)' ] && [ ! -e '$(TEST)' ]; then \
+    echo "Test '$(TEST)' does not exist."; exit 1; \
+  fi
+	@if [ -n '$(LIST)' ] && [ ! -e '$(LIST)' ]; then \
+    echo "File '$(LIST)' does not exist."; exit 1; \
+  fi
+	@if [ -n '$(DIR)' ] ; then \
+    $(MAKE) --no-print-directory exec-one DIR=$(DIR); fi
+	@if [ -n '$(TEST)' ] ; then \
+    TERM=dumb $(OCAMLTESTENV) $(ocamltest) $(OCAMLTESTFLAGS) $(TEST); fi
 	@$(MAKE) check-failstamp
+	@if [ -n '$(LIST)' ] ; then \
+     while IFS='' read -r LINE; do \
+       $(MAKE) --no-print-directory exec-one DIR=$$LINE ; \
+     done < $$LIST 2>&1 | tee $(TESTLOG) ; \
+     $(MAKE) --no-print-directory retries ; \
+     $(MAKE) report ; fi
 
 .PHONY: exec-one
 exec-one:
@@ -233,18 +244,6 @@ exec-ocamltest:
 	     $(ocamltest) $(OCAMLTESTFLAGS) $(DIR)/$$testfile || \
 	   echo " ... testing '$$testfile' => unexpected error"; \
 	done) || echo directory "$(DIR)" >>$(failstamp)
-
-.PHONY:
-just: lib tools
-	@if [ -z "$(TEST)" ]; then \
-	  echo "No value set for variable 'TEST'."; \
-	  exit 1; \
-	fi
-	@if [ ! -e $(TEST) ]; then \
-	  echo "Test '$(TEST)' does not exist."; \
-	  exit 1; \
-	fi
-	@TERM=dumb $(OCAMLTESTENV) $(ocamltest) $(OCAMLTESTFLAGS) $(TEST)
 
 .PHONY: clean-one
 clean-one:

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -95,6 +95,7 @@ default:
 	GNU parallel"
 	@echo "  list FILE=f     launch the tests listed in f (one per line)"
 	@echo "  one DIR=p       launch the tests located in path p"
+	@echo "  just TEST=f     launch just this single test"
 	@echo "  promote DIR=p   promote the reference files for the tests in p"
 	@echo "  lib             build library modules"
 	@echo "  tools           build test tools"
@@ -232,6 +233,18 @@ exec-ocamltest:
 	     $(ocamltest) $(OCAMLTESTFLAGS) $(DIR)/$$testfile || \
 	   echo " ... testing '$$testfile' => unexpected error"; \
 	done) || echo directory "$(DIR)" >>$(failstamp)
+
+.PHONY:
+just: lib tools
+	@if [ -z "$(TEST)" ]; then \
+	  echo "No value set for variable 'TEST'."; \
+	  exit 1; \
+	fi
+	@if [ ! -e $(TEST) ]; then \
+	  echo "Test '$(TEST)' does not exist."; \
+	  exit 1; \
+	fi
+	@TERM=dumb $(OCAMLTESTENV) $(ocamltest) $(OCAMLTESTFLAGS) $(TEST)
 
 .PHONY: clean-one
 clean-one:

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -116,7 +116,7 @@ all:
 new-without-report: lib tools
 	@rm -f $(failstamp)
 	@(IFS=$$(printf "\r\n"); \
-	$(ocamltest) -find-test-dirs tests | while read dir; do \
+	$(ocamltest) -find-test-dirs tests | while IFS='' read -r dir; do \
 	  echo Running tests from \'$$dir\' ... ; \
 	  $(MAKE) exec-ocamltest DIR=$$dir \
 	    OCAMLTESTENV=""; \
@@ -190,7 +190,7 @@ list: lib tools
 	  then echo "No value set for variable 'FILE'."; \
 	  exit 1; \
 	fi
-	@while read LINE; do \
+	@while IFS='' read -r LINE; do \
 	  $(MAKE) --no-print-directory exec-one DIR=$$LINE; \
 	done <$(FILE) 2>&1 | tee $(TESTLOG)
 	@$(MAKE) --no-print-directory retries
@@ -228,7 +228,7 @@ exec-ocamltest:
 	@if [ -z "$(DIR)" ]; then exit 1; fi
 	@if [ ! -d "$(DIR)" ]; then exit 1; fi
 	@(IFS=$$(printf "\r\n"); \
-	$(ocamltest) -list-tests $(DIR) | while read testfile; do \
+	$(ocamltest) -list-tests $(DIR) | while IFS='' read -r testfile; do \
 	   TERM=dumb $(OCAMLTESTENV) \
 	     $(ocamltest) $(OCAMLTESTFLAGS) $(DIR)/$$testfile || \
 	   echo " ... testing '$$testfile' => unexpected error"; \
@@ -298,7 +298,7 @@ report:
 
 .PHONY: retry-list
 retry-list:
-	@while read LINE; do \
+	@while IFS='' read -r LINE; do \
 	  if [ -n "$$LINE" ] ; then \
 	    echo re-ran $$LINE>> $(TESTLOG); \
 	    $(MAKE) --no-print-directory clean-one DIR=$$LINE; \


### PR DESCRIPTION
This PR adds a `just` target to `testsuite/Makefile` which is like the `one` target but for a single test.

Story:
- Some tests are just slow; many tests are slow on Windows
- When we had `ocamltests`, I'd occasionally hack those in anger, thinking "there should be a better way of doing this" and use `make one DIR=`
- That better way was sort of `../ocamltest/ocamltest tests/path/to/test.ml`
- But that doesn't work if you bootstrapped FLEXLINK, etc.
- So this PR allows calling ocamltest with the environment set-up properly 🙂 