### PR TITLE
Fix running win-unicode test

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -977,83 +977,80 @@ let run_test_program_in_toplevel (toplevel : Ocaml_toplevels.toplevel) log env =
   (* This is a sub-optimal check - skip the test if any libraries requiring
      C stubs are loaded. It would be better at this point to build a custom
      toplevel. *)
-  let toplevel_can_run =
+  let toplevel_supports_dynamic_loading =
     Config.supports_shared_libraries || backend <> Ocaml_backends.Bytecode
   in
-  if not toplevel_can_run then
-    (Result.skip, env)
-  else
-    match cmas_need_dynamic_loading (directories env) libraries with
-      | Some (Error reason) ->
-        (Result.fail_with_reason reason, env)
-      | Some (Ok ()) ->
-        (Result.skip, env)
-      | None ->
-        let testfile = Actions_helpers.testfile env in
-        let expected_exit_status =
-          Ocaml_tools.expected_exit_status env (toplevel :> Ocaml_tools.tool) in
-        let compiler_output_variable = toplevel#output_variable in
-        let compiler = toplevel#compiler in
-        let compiler_name = compiler#name in
-        let modules_with_filetypes =
-          List.map Ocaml_filetypes.filetype (modules env) in
-        let (result, env) = compile_modules
-          compiler compiler_name compiler_output_variable
-          modules_with_filetypes log env in
-        if Result.is_pass result then begin
-          let what =
-            Printf.sprintf "Running %s in %s toplevel \
-                            (expected exit status: %d)"
-            testfile
-            (Ocaml_backends.string_of_backend backend)
-            expected_exit_status in
-          Printf.fprintf log "%s\n%!" what;
-          let toplevel_name = toplevel#name in
-          let ocaml_script_as_argument =
-            match
-              Environments.lookup_as_bool
-                Ocaml_variables.ocaml_script_as_argument env
-            with
-            | None -> false
-            | Some b -> b
-          in
-          let commandline =
-          [
-            toplevel_name;
-            Ocaml_flags.toplevel_default_flags;
-            toplevel#flags;
-            Ocaml_flags.stdlib;
-            directory_flags env;
-            Ocaml_flags.include_toplevel_directory;
-            flags env;
-            libraries;
-            binary_modules backend env;
-            if ocaml_script_as_argument then testfile else "";
-            Environments.safe_lookup Builtin_variables.arguments env
-          ] in
-          let exit_status =
-            if ocaml_script_as_argument
-            then Actions_helpers.run_cmd
-              ~environment:default_ocaml_env
-              ~stdout_variable:compiler_output_variable
-              ~stderr_variable:compiler_output_variable
-              log env commandline
-            else Actions_helpers.run_cmd
-              ~environment:default_ocaml_env
-              ~stdin_variable:Builtin_variables.test_file
-              ~stdout_variable:compiler_output_variable
-              ~stderr_variable:compiler_output_variable
-              log env commandline
-          in
-          if exit_status=expected_exit_status
-          then (Result.pass, env)
-          else begin
-            let reason =
-              (Actions_helpers.mkreason
-                what (String.concat " " commandline) exit_status) in
-            (Result.fail_with_reason reason, env)
-          end
-        end else (result, env)
+  match cmas_need_dynamic_loading (directories env) libraries with
+    | Some (Error reason) ->
+      (Result.fail_with_reason reason, env)
+    | Some (Ok ()) when not toplevel_supports_dynamic_loading ->
+      (Result.skip, env)
+    | _ ->
+      let testfile = Actions_helpers.testfile env in
+      let expected_exit_status =
+        Ocaml_tools.expected_exit_status env (toplevel :> Ocaml_tools.tool) in
+      let compiler_output_variable = toplevel#output_variable in
+      let compiler = toplevel#compiler in
+      let compiler_name = compiler#name in
+      let modules_with_filetypes =
+        List.map Ocaml_filetypes.filetype (modules env) in
+      let (result, env) = compile_modules
+        compiler compiler_name compiler_output_variable
+        modules_with_filetypes log env in
+      if Result.is_pass result then begin
+        let what =
+          Printf.sprintf "Running %s in %s toplevel \
+                          (expected exit status: %d)"
+          testfile
+          (Ocaml_backends.string_of_backend backend)
+          expected_exit_status in
+        Printf.fprintf log "%s\n%!" what;
+        let toplevel_name = toplevel#name in
+        let ocaml_script_as_argument =
+          match
+            Environments.lookup_as_bool
+              Ocaml_variables.ocaml_script_as_argument env
+          with
+          | None -> false
+          | Some b -> b
+        in
+        let commandline =
+        [
+          toplevel_name;
+          Ocaml_flags.toplevel_default_flags;
+          toplevel#flags;
+          Ocaml_flags.stdlib;
+          directory_flags env;
+          Ocaml_flags.include_toplevel_directory;
+          flags env;
+          libraries;
+          binary_modules backend env;
+          if ocaml_script_as_argument then testfile else "";
+          Environments.safe_lookup Builtin_variables.arguments env
+        ] in
+        let exit_status =
+          if ocaml_script_as_argument
+          then Actions_helpers.run_cmd
+            ~environment:default_ocaml_env
+            ~stdout_variable:compiler_output_variable
+            ~stderr_variable:compiler_output_variable
+            log env commandline
+          else Actions_helpers.run_cmd
+            ~environment:default_ocaml_env
+            ~stdin_variable:Builtin_variables.test_file
+            ~stdout_variable:compiler_output_variable
+            ~stderr_variable:compiler_output_variable
+            log env commandline
+        in
+        if exit_status=expected_exit_status
+        then (Result.pass, env)
+        else begin
+          let reason =
+            (Actions_helpers.mkreason
+              what (String.concat " " commandline) exit_status) in
+          (Result.fail_with_reason reason, env)
+        end
+      end else (result, env)
 
 let ocaml = Actions.make
   "ocaml"


### PR DESCRIPTION
If OCaml is configured without shared library support, it's not possible to run `ocaml unix.cma` and `ocamlmktop` has to be used. #2160 added a half-way house solution to this which was supposed to skip toplevel tests if the test requires a library which has C stubs. The test wasn't implemented correctly, though, and its approach disables all toplevel tests if shared libraries aren't available and never allows toplevel tests which use libraries with C stubs.

The first problem meant that the `--disable-shared` test on Travis was skipping tests it could run (minor). The second problem means we haven't been running the win-unicode test anywhere since 4.08 (it's the toplevel test which loads unix.cma).

This PR corrects this. The diff in GitHub is pretty useless, as it's mostly whitespace. The actual change is:

```
-|  let toplevel_can_run =
+|  let toplevel_supports_dynamic_loading =
 |    Config.supports_shared_libraries || backend <> Ocaml_backends.Bytecode
 |  in
-|  if not toplevel_can_run then
-|    (Result.skip, env)
-|  else
 |  match cmas_need_dynamic_loading (directories env) libraries with
 |    | Some (Error reason) ->
 |      (Result.fail_with_reason reason, env)
!|    | Some (Ok ()) when not toplevel_supports_dynamic_loading ->
 |      (Result.skip, env)
-|      | None ->
+|    | _ ->
```