### PR TITLE
Wrong skip criterion in tests/output-complete-obj/test.ml

### DIFF
--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -2,28 +2,27 @@
 
 readonly_files = "test.ml_stub.c"
 
-* libunix
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
 flags = "-w -a -output-complete-obj"
 program = "test.ml.bc.${objext}"
-**** script
+*** script
 script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe \
                    test.ml.bc.${objext} ${nativecc_libs} test.ml_stub.c"
 output = "${compiler_output}"
-***** run
+**** run
 program = "./test.ml_bc_stub.exe"
 stdout = "program-output"
 stderr = "program-output"
-** setup-ocamlopt.byte-build-env
-*** ocamlopt.byte
+* setup-ocamlopt.byte-build-env
+** ocamlopt.byte
 flags = "-w -a -output-complete-obj"
 program = "test.ml.exe.${objext}"
-**** script
+*** script
 script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe \
                    test.ml.exe.${objext} ${bytecc_libs} test.ml_stub.c"
 output = "${compiler_output}"
-***** run
+**** run
 program = "./test.ml_stub.exe"
 stdout = "program-output"
 stderr = "program-output"

--- a/testsuite/tests/output-complete-obj/test.ml_stub.c
+++ b/testsuite/tests/output-complete-obj/test.ml_stub.c
@@ -3,7 +3,11 @@
 #include <caml/callback.h>
 #include <caml/memory.h>
 
+#ifdef _WIN32
+int wmain(int argc, wchar_t ** argv){
+#else
 int main(int argc, char ** argv){
+#endif
 
   caml_startup(argv);
   return 0;


### PR DESCRIPTION
I didn't check the history, but I think this test was using `libunix` to disable this test on Windows - we have a test for that called `not-windows`! Changing to `not-windows` means that the test gets correctly run on the `MIN_BUILD=1` Travis as well, since the test doesn't depend on Unix at all.

All that said, this test should be updated to run correctly on Windows, which is why it's draft for now.