### PR TITLE
Add Unix.setenv and Unix.unsetenv

### DIFF
--- a/Changes
+++ b/Changes
@@ -200,6 +200,9 @@ Working version
 - #9802: Ensure signals are handled before Unix.kill returns
   (Stephen Dolan, review by Jacques-Henri Jourdan)
 
+- #9810: Add Unix.setenv and Unix.unsetenv.
+  (David Allsopp, review by ???)
+
 ### Tools:
 
 - #9551: ocamlobjinfo is now able to display information on .cmxs shared

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -34,10 +34,10 @@ COBJS=accept.o access.o addrofstr.o alarm.o bind.o channels.o chdir.o \
   mkdir.o mkfifo.o mmap.o mmap_ba.o \
   nice.o open.o opendir.o pipe.o putenv.o read.o \
   readdir.o readlink.o rename.o rewinddir.o rmdir.o select.o sendrecv.o \
-  setgid.o setgroups.o setsid.o setuid.o shutdown.o signals.o \
+  setenv.o setgid.o setgroups.o setsid.o setuid.o shutdown.o signals.o \
   sleep.o socket.o socketaddr.o \
   socketpair.o sockopt.o spawn.o stat.o strofaddr.o symlink.o termios.o \
-  time.o times.o truncate.o umask.o unixsupport.o unlink.o \
+  time.o times.o truncate.o umask.o unixsupport.o unlink.o unsetenv.o \
   utimes.o wait.o write.o
 
 CAMLOBJS=unix.cmo unixLabels.cmo

--- a/otherlibs/unix/setenv.c
+++ b/otherlibs/unix/setenv.c
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                 David Allsopp, OCaml Labs, Cambridge.                  */
+/*                                                                        */
+/*   Copyright 2020 David Allsopp Ltd.                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/osdeps.h>
+
+#include "unixsupport.h"
+
+#ifdef HAS_SETENV_UNSETENV
+
+CAMLprim value unix_setenv(value overwrite, value name, value val)
+{
+  int ret;
+
+  if (!(caml_string_is_c_safe(name) && caml_string_is_c_safe(val)))
+    unix_error(EINVAL, "setenv", name);
+
+  ret = setenv(String_val(name),
+               String_val(val),
+               (Is_long(overwrite) || Val_bool(Some_val(overwrite))));
+
+  if (ret == -1) {
+    uerror("setenv", name);
+  }
+
+  return Val_unit;
+}
+
+#else
+
+CAMLprim value unix_setenv(value overwrite, value name, value val)
+{ caml_invalid_argument("setenv not implemented"); }
+
+#endif

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -192,6 +192,8 @@ external unsafe_environment : unit -> string array = "unix_environment_unsafe"
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "unix_putenv"
+external setenv: ?overwrite:bool -> string -> string -> unit = "unix_setenv"
+external unsetenv: string -> unit = "unix_unsetenv"
 
 type process_status =
     WEXITED of int

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -161,6 +161,19 @@ val putenv : string -> string -> unit
    [name] is the name of the environment variable,
    and [value] its new associated value. *)
 
+val setenv : ?overwrite:bool -> string -> string -> unit
+(** [Unix.setenv ?overwrite name value] sets the value associated to a variable
+   in the process environment. If [~overwrite] is [false] (the default is
+   [true]) and [name] is already present in the process environment, then the
+   value is not updated.
+
+   @since 4.12.0 *)
+
+val unsetenv : string -> unit
+(** [Unix.unsetenv name] ensures [name] is no longer defined in the environment.
+   [name] does not have to be bound in the environment.
+
+   @since 4.12.0 *)
 
 (** {1 Process handling} *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -146,6 +146,19 @@ val putenv : string -> string -> unit
    [name] is the name of the environment variable,
    and [value] its new associated value. *)
 
+val setenv : ?overwrite:bool -> string -> string -> unit
+(** [Unix.setenv ?overwrite name value] sets the value associated to a variable
+   in the process environment. If [~overwrite] is [false] (the default is
+   [true]) and [name] is already present in the process environment, then the
+   value is not updated.
+
+   @since 4.12.0 *)
+
+val unsetenv : string -> unit
+(** [Unix.unsetenv name] ensures [name] is no longer defined in the environment.
+    [name] does not have to be bound in the environment.
+
+   @since 4.12.0 *)
 
 (** {1 Process handling} *)
 

--- a/otherlibs/unix/unsetenv.c
+++ b/otherlibs/unix/unsetenv.c
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                 David Allsopp, OCaml Labs, Cambridge.                  */
+/*                                                                        */
+/*   Copyright 2020 David Allsopp Ltd.                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/osdeps.h>
+
+#include "unixsupport.h"
+
+#if defined(_WIN32) || defined(HAS_SETENV_UNSETENV)
+
+CAMLprim value unix_unsetenv(value name)
+{
+  char_os * s = NULL;
+  int ret;
+
+  if (!(caml_string_is_c_safe(name)))
+    unix_error(EINVAL, "unsetenv", name);
+
+#ifdef _WIN32
+  /* unix.ml formats and validates name */
+  s = caml_stat_strdup_to_os(String_val(name));
+  ret = putenv_os(s);
+  if (ret == -1) {
+    caml_stat_free(s);
+  }
+#else
+  ret = unsetenv(String_val(name));
+#endif
+
+  if (ret == -1) {
+    if (s) caml_stat_free(s);
+    uerror("unsetenv", name);
+  }
+
+  return Val_unit;
+}
+
+#else
+
+CAMLprim value unix_unsetenv(value name)
+{ caml_invalid_argument("unsetenv not implemented"); }
+
+#endif


### PR DESCRIPTION
As part of something on ocamltest, I thought I was going to need `Unix.unsetenv` and added it. It turns out I didn't need it there, but it's useful. It also rang a bell that it was discussed in #9594, so here are `setenv` and `unsetenv` for discussion, as I happened to have written them.

I haven't at this stage reimplemented `putenv` in terms of `setenv`. Given their strange potted history, I'd be more for keeping both `putenv` and `setenv` (and possibly marking `putenv` as deprecated, given how rubbish it is?).

The Windows CRT doesn't expose `setenv` or have `unsetenv`, but I provide what I believe are correct implementations of the POSIX spec in terms of `putenv`.