### PR TITLE
Remove propagation from previous branches

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,14 @@ Working version
   (GitHub user @EduardoRFS, review by Xavier Leroy, Nicolás Ojeda Bär
    and Anil Madhavapeddy, additional testing by Michael Schmidt)
 
+### Type system:
+
+* #??: remove propagation from previous branches
+  Type information inferred from previous branches was propagated in
+  non-principal mode. Revert this for better compatibility with
+  -principal mode.
+  (Jacques Garrigue, review by ??)
+
 ### Runtime system:
 
 - #9756: garbage collector colors change

--- a/Changes
+++ b/Changes
@@ -24,11 +24,12 @@ Working version
 
 ### Type system:
 
-* #??: remove propagation from previous branches
+* #9811: remove propagation from previous branches
   Type information inferred from previous branches was propagated in
   non-principal mode. Revert this for better compatibility with
   -principal mode.
-  (Jacques Garrigue, review by ??)
+  For the time being, infringing code should result in a principality warning.
+  (Jacques Garrigue, review by Thomas Refis and Gabriel Scherer)
 
 ### Runtime system:
 

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -47,13 +47,14 @@ let f (type t) (x : t) (tag : t ty) =
   | Bool -> x
 ;;
 [%%expect{|
-Line 4, characters 12-13:
+Lines 2-4, characters 2-13:
+2 | ..match tag with
+3 |   | Int -> x > 0
 4 |   | Bool -> x
-                ^
-Error: This expression has type t = bool
-       but an expression was expected of type bool
-       This instance of bool is ambiguous:
-       it would escape the scope of its equation
+Warning 18 [not-principal]:
+  The return type of this pattern-matching is ambiguous.
+  Please add a type annotation, as the choice of `bool' is not principal.
+val f : 't -> 't ty -> bool = <fun>
 |}, Principal{|
 Line 4, characters 12-13:
 4 |   | Bool -> x
@@ -74,8 +75,6 @@ Line 4, characters 11-16:
                ^^^^^
 Error: This expression has type bool but an expression was expected of type
          t = int
-       This instance of int is ambiguous:
-       it would escape the scope of its equation
 |}, Principal{|
 Line 4, characters 11-16:
 4 |   | Int -> x > 0

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -47,7 +47,13 @@ let f (type t) (x : t) (tag : t ty) =
   | Bool -> x
 ;;
 [%%expect{|
-val f : 't -> 't ty -> bool = <fun>
+Line 4, characters 12-13:
+4 |   | Bool -> x
+                ^
+Error: This expression has type t = bool
+       but an expression was expected of type bool
+       This instance of bool is ambiguous:
+       it would escape the scope of its equation
 |}, Principal{|
 Line 4, characters 12-13:
 4 |   | Bool -> x
@@ -68,6 +74,8 @@ Line 4, characters 11-16:
                ^^^^^
 Error: This expression has type bool but an expression was expected of type
          t = int
+       This instance of int is ambiguous:
+       it would escape the scope of its equation
 |}, Principal{|
 Line 4, characters 11-16:
 4 |   | Int -> x > 0

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -361,13 +361,18 @@ module Propagation = struct
 end
 ;;
 [%%expect{|
-Line 13, characters 19-20:
+Lines 11-13, characters 12-20:
+11 | ............match x with
+12 |     | IntLit n -> (n : s )
 13 |     | BoolLit b -> b
-                        ^
-Error: This expression has type bool but an expression was expected of type
-         s = bool
-       This instance of bool is ambiguous:
-       it would escape the scope of its equation
+Warning 18 [not-principal]:
+  The return type of this pattern-matching is ambiguous.
+  Please add a type annotation, as the choice of `s' is not principal.
+module Propagation :
+  sig
+    type _ t = IntLit : int -> int t | BoolLit : bool -> bool t
+    val check : 's t -> 's
+  end
 |}, Principal{|
 Line 13, characters 19-20:
 13 |     | BoolLit b -> b

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -361,11 +361,13 @@ module Propagation = struct
 end
 ;;
 [%%expect{|
-module Propagation :
-  sig
-    type _ t = IntLit : int -> int t | BoolLit : bool -> bool t
-    val check : 's t -> 's
-  end
+Line 13, characters 19-20:
+13 |     | BoolLit b -> b
+                        ^
+Error: This expression has type bool but an expression was expected of type
+         s = bool
+       This instance of bool is ambiguous:
+       it would escape the scope of its equation
 |}, Principal{|
 Line 13, characters 19-20:
 13 |     | BoolLit b -> b

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4715,9 +4715,6 @@ and type_cases
             end_def ();
             generalize_structure ty; ty
           end
-          else if contains_gadt then
-            (* allow propagation from preceding branches *)
-            correct_levels ty_res
           else ty_res in
         let guard =
           match pc_guard with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4687,7 +4687,7 @@ and type_cases
   ) half_typed_cases;
   (* type bodies *)
   let in_function = if List.length caselist = 1 then in_function else None in
-  let cases =
+  let mk_cases interbranch_propagation =
     List.map
       (fun { typed_pat = pat; branch_env = ext_env; pat_vars = pvs; unpacks;
              untyped_case = {pc_lhs = _; pc_guard; pc_rhs};
@@ -4715,6 +4715,8 @@ and type_cases
             end_def ();
             generalize_structure ty; ty
           end
+          else if contains_gadt && interbranch_propagation then
+            correct_levels ty_res
           else ty_res in
         let guard =
           match pc_guard with
@@ -4734,6 +4736,35 @@ and type_cases
         }
       )
       half_typed_cases
+  in
+  let cases =
+    let may_backtrack = does_contain_gadt && not !Clflags.principal in
+    if may_backtrack then
+      let snap = Btype.snapshot () in
+      let has_equation_escape =
+        List.exists Ctype.Unification_trace.
+          (function Escape {kind=Equation _} -> true | _ -> false)
+      in
+      try mk_cases false
+      with Error(_,_,(
+        Label_mismatch (_,tr) | Pattern_type_clash (tr,_)
+      | Or_pattern_type_clash (_,tr) | Expr_type_clash (tr,_,_)
+      | Coercion_failure (_,_,tr,_) | Less_general (_,tr)
+      | Letop_type_clash (_,tr) | Andop_type_clash (_,tr)
+      | Bindings_type_clash tr))
+      when has_equation_escape tr ->
+        Btype.backtrack snap;
+        let cases = mk_cases true in
+        let msg =
+          Format.asprintf
+            "@[<v2>@ @[<hov>The return type of this pattern-matching \
+             is ambiguous.@ \
+             Please add a type annotation,@ as the choice of `@[%a@]'@]@]"
+            Printtyp.type_expr ty_res
+        in
+        Location.prerr_warning loc (Warnings.Not_principal msg);
+        cases
+    else mk_cases false
   in
   if !Clflags.principal || does_contain_gadt then begin
     let ty_res' = instance ty_res in


### PR DESCRIPTION
This is the one commit omitted from #9767 .
There seems to be an agreement that making the non-principal mode closer to the principal mode was a good thing.
However, since it has some impact on existing code (`camlinternalFormat.ml` required some extra type annotations in principal mode), we need to assess the impact.