### PR TITLE
Harden special character support in --prefix and friends - take 2

### DIFF
--- a/Changes
+++ b/Changes
@@ -311,6 +311,9 @@ Working version
 - #9804: Build C stubs of libraries in otherlibs/ with debug info.
   (Stephen Dolan, review by Sébastien Hinderer and David Allsopp)
 
+- #9813: Harden the build system against prefixes with special characters.
+  (David Allsopp, review by ???)
+
 ### Bug fixes:
 
 - #7902, #9556: Type-checker infers recursive type, even though -rectypes is

--- a/configure
+++ b/configure
@@ -19216,3 +19216,48 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
+
+# Check for a $ not followed by [${(] - that will be expanded as a make
+# single-character variable, and is probably not what the user meant.
+unguarded_dollar="`echo "$prefix" | sed -ne 's/\$[${(]//g;/\\$/p'`"
+# Check for actual make variables - this is an advanced use-case
+mk_vars="`echo "$prefix" | sed -ne 's/\\$\\$//g;/\$\({[^}]*}\|([^)]*)\)/p'`"
+# Check for $$ not prefixed by \ - this is a seriously advanced use-case
+unescaped_dollardollar="`echo "$prefix" | sed -ne '/\(^\|[^\\]\)\\$\\$/p'`"
+# Check for " characters - an odd number is an error, the rest should be escaped
+double_quotes="`echo "$prefix" | sed -e 's/\\\\\"//g;s/[^\"]*//g'`"
+odd_quotes="`echo "$double_quotes" | sed -e 's/""//g'`"
+
+if test -n "$unguarded_dollar"; then :
+
+  as_fn_error $? "prefix contains a \$ not followed by \$, { or ( - this is probably not what you meant. A literal \$ must be written \\\$\$. If you really did mean to refer to a make variable, use \${.} or \$(.) notation." "$LINENO" 5
+
+fi
+
+if test -n "$mk_vars"; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: prefix contains make variables (\${..} or \$(..)) - we assume you know what you're doing" >&5
+$as_echo "$as_me: WARNING: prefix contains make variables (\${..} or \$(..)) - we assume you know what you're doing" >&2;}
+
+fi
+
+if test -n "$unescaped_dollardollar"; then :
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: prefix contains \$\$ without a preceding backslash - unless you really know what you're doing, you probably mean \\\$\$ which will pass literal \$ in prefix through the build system" >&5
+$as_echo "$as_me: WARNING: prefix contains \$\$ without a preceding backslash - unless you really know what you're doing, you probably mean \\\$\$ which will pass literal \$ in prefix through the build system" >&2;}
+fi
+
+if test -n "$double_quotes"; then :
+
+  if test -n "$odd_quotes"; then :
+
+    as_fn_error $? "prefix contains an odd number of \" characters which will cause errors during make install. You need to escape at least one of them as \\\"." "$LINENO" 5
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: prefix contains unescaped \" characters - this is is probably not what you meant. A literal \" must be preceded by a literal \\ (i.e. '\\\"')." >&5
+$as_echo "$as_me: WARNING: prefix contains unescaped \" characters - this is is probably not what you meant. A literal \" must be preceded by a literal \\ (i.e. '\\\"')." >&2;}
+
+fi
+
+fi

--- a/configure
+++ b/configure
@@ -2771,7 +2771,12 @@ $as_echo "$as_me: Configuring OCaml version 4.12.0+dev0-2020-04-22" >&6;}
 # Configuration variables
 
 ## Command-line arguments passed to configure
-CONFIGURE_ARGS="$*"
+CONFIGURE_ARGS=''
+for arg in "$@" ; do
+  CONFIGURE_ARGS="$CONFIGURE_ARGS${CONFIGURE_ARGS:+ }'$arg'"
+done
+# Escape CONFIGURE_ARGS for including in a Makefile
+CONFIGURE_ARGS=$(echo "$CONFIGURE_ARGS" | sed -e 's/\$/$$/g;s/#/\\#/g')
 
 # Command-line tools section of the Unix manual
 programs_man_section=1

--- a/configure
+++ b/configure
@@ -19219,13 +19219,18 @@ fi
 
 # Check for a $ not followed by [${(] - that will be expanded as a make
 # single-character variable, and is probably not what the user meant.
-unguarded_dollar="`echo "$prefix" | sed -ne 's/\$[${(]//g;/\\$/p'`"
+unguarded_dollar="`echo "$prefix" | \
+  sed -ne 's/\$[${(]//g;/\\$/p'`"
 # Check for actual make variables - this is an advanced use-case
-mk_vars="`echo "$prefix" | sed -ne 's/\\$\\$//g;/\$\({[^}]*}\|([^)]*)\)/p'`"
-# Check for $$ not prefixed by \ - this is a seriously advanced use-case
-unescaped_dollardollar="`echo "$prefix" | sed -ne '/\(^\|[^\\]\)\\$\\$/p'`"
+make_variables="`echo "$prefix" | \
+  sed -ne 's/\\$\\$//g;/\$\({[^}]*}\|([^)]*)\)/p'`"
+# Check for $$ not prefixed by odd number of \ - this is a seriously advanced
+# use-case
+unescaped_dollardollar="`echo "$prefix" | \
+  sed -ne '/\(^\|[^\\]\)\(\\\\\\\\\)*\\$\\$/p'`"
 # Check for " characters - an odd number is an error, the rest should be escaped
-double_quotes="`echo "$prefix" | sed -e 's/\\\\\"//g;s/[^\"]*//g'`"
+double_quotes="`echo "$prefix" | \
+  sed -e 's/\(^\|[^\\]\)\\\\\(\\\\\\\\\)*\"//g;s/[^\"]*//g'`"
 odd_quotes="`echo "$double_quotes" | sed -e 's/""//g'`"
 
 if test -n "$unguarded_dollar"; then :
@@ -19234,7 +19239,7 @@ if test -n "$unguarded_dollar"; then :
 
 fi
 
-if test -n "$mk_vars"; then :
+if test -n "$make_variables"; then :
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: prefix contains make variables (\${..} or \$(..)) - we assume you know what you're doing" >&5
 $as_echo "$as_me: WARNING: prefix contains make variables (\${..} or \$(..)) - we assume you know what you're doing" >&2;}
@@ -19251,12 +19256,13 @@ if test -n "$double_quotes"; then :
 
   if test -n "$odd_quotes"; then :
 
-    as_fn_error $? "prefix contains an odd number of \" characters which will cause errors during make install. You need to escape at least one of them as \\\"." "$LINENO" 5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: prefix appears to contain an odd number of \" characters which will cause errors during \`make install\`. You may need to escape at least one of them as \\\"." >&5
+$as_echo "$as_me: prefix appears to contain an odd number of \" characters which will cause errors during \`make install\`. You may need to escape at least one of them as \\\"." >&6;}
 
 else
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: prefix contains unescaped \" characters - this is is probably not what you meant. A literal \" must be preceded by a literal \\ (i.e. '\\\"')." >&5
-$as_echo "$as_me: WARNING: prefix contains unescaped \" characters - this is is probably not what you meant. A literal \" must be preceded by a literal \\ (i.e. '\\\"')." >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: prefix appears to contain unescaped \" characters - this is probably not what you meant. A literal \" must be preceded by a literal \ (i.e. '\\\"')." >&5
+$as_echo "$as_me: prefix appears to contain unescaped \" characters - this is probably not what you meant. A literal \" must be preceded by a literal \ (i.e. '\\\"')." >&6;}
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1929,3 +1929,45 @@ AS_IF([test x"$enable_stdlib_manpages" != "xno"],
   [stdlib_manpages=true],[stdlib_manpages=false])
 
 AC_OUTPUT
+
+# Check for a $ not followed by [${(] - that will be expanded as a make
+# single-character variable, and is probably not what the user meant.
+unguarded_dollar="`echo "$prefix" | sed -ne 's/\$[[${(]]//g;/\\$/p'`"
+# Check for actual make variables - this is an advanced use-case
+mk_vars="`echo "$prefix" | sed -ne 's/\\$\\$//g;/\$\({[[^}]]*}\|([[^)]]*)\)/p'`"
+# Check for $$ not prefixed by \ - this is a seriously advanced use-case
+unescaped_dollardollar="`echo "$prefix" | sed -ne '/\(^\|[[^\\]]\)\\$\\$/p'`"
+# Check for " characters - an odd number is an error, the rest should be escaped
+double_quotes="`echo "$prefix" | sed -e 's/\\\\\"//g;s/[[^\"]]*//g'`"
+odd_quotes="`echo "$double_quotes" | sed -e 's/""//g'`"
+
+AS_IF([test -n "$unguarded_dollar"],[
+  AC_MSG_ERROR(m4_normalize([prefix contains a \$ not followed by \$, { or ( -
+                             this is probably not what you meant. A literal \$
+                             must be written \\\$\$. If you really did mean to
+                             refer to a make variable, use \${.} or \$(.)
+                             notation.]))
+])
+
+AS_IF([test -n "$mk_vars"],[
+  AC_MSG_WARN(m4_normalize([prefix contains make variables (\${..} or \$(..)) -
+                            we assume you know what you're doing]))
+])
+
+AS_IF([test -n "$unescaped_dollardollar"],[
+  AC_MSG_WARN(m4_normalize([prefix contains \$\$ without a preceding backslash -
+                            unless you really know what you're doing, you
+                            probably mean \\\$\$ which will pass literal \$ in
+                            prefix through the build system]))])
+
+AS_IF([test -n "$double_quotes"],[
+  AS_IF([test -n "$odd_quotes"],[
+    AC_MSG_ERROR(m4_normalize([prefix contains an odd number of " characters
+                               which will cause errors during make install. You
+                               need to escape at least one of them as \\".]))
+  ],[
+    AC_MSG_WARN(m4_normalize([prefix contains unescaped " characters - this is
+                              is probably not what you meant. A literal " must
+                              be preceded by a literal \\ (i.e. '\\"').]))
+  ])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1932,13 +1932,18 @@ AC_OUTPUT
 
 # Check for a $ not followed by [${(] - that will be expanded as a make
 # single-character variable, and is probably not what the user meant.
-unguarded_dollar="`echo "$prefix" | sed -ne 's/\$[[${(]]//g;/\\$/p'`"
+unguarded_dollar="`echo "$prefix" | \
+  sed -ne 's/\$[[${(]]//g;/\\$/p'`"
 # Check for actual make variables - this is an advanced use-case
-mk_vars="`echo "$prefix" | sed -ne 's/\\$\\$//g;/\$\({[[^}]]*}\|([[^)]]*)\)/p'`"
-# Check for $$ not prefixed by \ - this is a seriously advanced use-case
-unescaped_dollardollar="`echo "$prefix" | sed -ne '/\(^\|[[^\\]]\)\\$\\$/p'`"
+make_variables="`echo "$prefix" | \
+  sed -ne 's/\\$\\$//g;/\$\({[[^}]]*}\|([[^)]]*)\)/p'`"
+# Check for $$ not prefixed by odd number of \ - this is a seriously advanced
+# use-case
+unescaped_dollardollar="`echo "$prefix" | \
+  sed -ne '/\(^\|[[^\\]]\)\(\\\\\\\\\)*\\$\\$/p'`"
 # Check for " characters - an odd number is an error, the rest should be escaped
-double_quotes="`echo "$prefix" | sed -e 's/\\\\\"//g;s/[[^\"]]*//g'`"
+double_quotes="`echo "$prefix" | \
+  sed -e 's/\(^\|[[^\\]]\)\\\\\(\\\\\\\\\)*\"//g;s/[[^\"]]*//g'`"
 odd_quotes="`echo "$double_quotes" | sed -e 's/""//g'`"
 
 AS_IF([test -n "$unguarded_dollar"],[
@@ -1949,7 +1954,7 @@ AS_IF([test -n "$unguarded_dollar"],[
                              notation.]))
 ])
 
-AS_IF([test -n "$mk_vars"],[
+AS_IF([test -n "$make_variables"],[
   AC_MSG_WARN(m4_normalize([prefix contains make variables (\${..} or \$(..)) -
                             we assume you know what you're doing]))
 ])
@@ -1962,12 +1967,14 @@ AS_IF([test -n "$unescaped_dollardollar"],[
 
 AS_IF([test -n "$double_quotes"],[
   AS_IF([test -n "$odd_quotes"],[
-    AC_MSG_ERROR(m4_normalize([prefix contains an odd number of " characters
-                               which will cause errors during make install. You
-                               need to escape at least one of them as \\".]))
+    AC_MSG_NOTICE(m4_normalize([prefix appears to contain an odd number of "
+                              characters which will cause errors during
+                              `make install`. You may need to escape at least
+                              one of them as \\".]))
   ],[
-    AC_MSG_WARN(m4_normalize([prefix contains unescaped " characters - this is
-                              is probably not what you meant. A literal " must
-                              be preceded by a literal \\ (i.e. '\\"').]))
+    AC_MSG_NOTICE(m4_normalize([prefix appears to contain unescaped " characters
+                                - this is probably not what you meant. A literal
+                                " must be preceded by a literal \\
+                                (i.e. '\\"').]))
   ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,12 @@ AC_MSG_NOTICE([Configuring OCaml version AC_PACKAGE_VERSION])
 # Configuration variables
 
 ## Command-line arguments passed to configure
-CONFIGURE_ARGS="$*"
+CONFIGURE_ARGS=''
+for arg in "$@" ; do
+  CONFIGURE_ARGS="$CONFIGURE_ARGS${CONFIGURE_ARGS:+ }'$arg'"
+done
+# Escape CONFIGURE_ARGS for including in a Makefile
+CONFIGURE_ARGS=$(echo "$CONFIGURE_ARGS" | sed -e 's/\$/$$/g;s/#/\\#/g')
 
 # Command-line tools section of the Unix manual
 programs_man_section=1

--- a/man/Makefile
+++ b/man/Makefile
@@ -20,11 +20,12 @@ DESTDIR ?=
 INSTALL_DIR=$(DESTDIR)$(MANDIR)/man$(PROGRAMS_MAN_SECTION)
 
 install:
-	for i in *.m; do cp \
-	  $$i $(INSTALL_DIR)/`basename $$i .m`.$(PROGRAMS_MAN_SECTION); done
+	$(foreach command,$(wildcard *.m),\
+	cp '$(command)' \
+	    "$(INSTALL_DIR)/$(basename $(command)).$(PROGRAMS_MAN_SECTION)";)
 	echo '.so man$(PROGRAMS_MAN_SECTION)/ocamlc.$(PROGRAMS_MAN_SECTION)' \
-	     > $(INSTALL_DIR)/ocamlc.opt.$(PROGRAMS_MAN_SECTION)
+	     > "$(INSTALL_DIR)/ocamlc.opt.$(PROGRAMS_MAN_SECTION)"
 	echo '.so man$(PROGRAMS_MAN_SECTION)/ocamlopt.$(PROGRAMS_MAN_SECTION)' \
-	     > $(INSTALL_DIR)/ocamlopt.opt.$(PROGRAMS_MAN_SECTION)
+	     > "$(INSTALL_DIR)/ocamlopt.opt.$(PROGRAMS_MAN_SECTION)"
 	echo '.so man$(PROGRAMS_MAN_SECTION)/ocamlcp.$(PROGRAMS_MAN_SECTION)' \
-	     > $(INSTALL_DIR)/ocamloptp.$(PROGRAMS_MAN_SECTION)
+	     > "$(INSTALL_DIR)/ocamloptp.$(PROGRAMS_MAN_SECTION)"

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -118,11 +118,13 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 # than \UXXXXXXXX). The \u is then translated to \x in order to accommodate
 # pre-Visual Studio 2013 compilers where \x is a non-standard alias for \u.
 OCAML_STDLIB_DIR = $(shell echo $(LIBDIR)| iconv -t JAVA | sed -e 's/\\u/\\x/g')
-STDLIB_CPP_FLAG = -DOCAML_STDLIB_DIR='L"$(OCAML_STDLIB_DIR)"'
+STDLIB_CPP_FLAG = -DOCAML_STDLIB_DIR='L"$(OCAML_STDLIB_DIR_ESCAPED)"'
 else # Unix
 OCAML_STDLIB_DIR = $(LIBDIR)
-STDLIB_CPP_FLAG = -DOCAML_STDLIB_DIR='"$(OCAML_STDLIB_DIR)"'
+STDLIB_CPP_FLAG = \
+  -DOCAML_STDLIB_DIR='"$(OCAML_STDLIB_DIR_ESCAPED)"'
 endif
+OCAML_STDLIB_DIR_ESCAPED=$(subst ",\",$(subst \,\\,$(OCAML_STDLIB_DIR)))
 
 OC_CPPFLAGS += $(IFLEXDIR)
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -213,8 +213,8 @@ distclean: clean
 # Generated non-object files
 
 ld.conf: $(ROOTDIR)/Makefile.config
-	echo "$(STUBLIBDIR)" > $@
-	echo "$(LIBDIR)" >> $@
+	echo '$(STUBLIBDIR)' > $@
+	echo '$(LIBDIR)' >> $@
 
 # If primitives contain duplicated lines (e.g. because the code is defined
 # like

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -143,13 +143,12 @@ $(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
 	         build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo,)
 
 
-ocamlmklibconfig.ml: $(ROOTDIR)/Makefile.config Makefile
-	(echo 'let bindir = "$(BINDIR)"'; \
-         echo 'let supports_shared_libraries = $(SUPPORTS_SHARED_LIBRARIES)';\
-         echo 'let default_rpath = "$(RPATH)"'; \
-         echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"'; \
-         echo 'let toolpref = "$(TOOLPREF)"';) \
-        > ocamlmklibconfig.ml
+ocamlmklibconfig.ml: ocamlmklibconfig.ml.in $(ROOTDIR)/Makefile.config Makefile
+	sed $(call SUBST_STRING,BINDIR) \
+	    $(call SUBST,SUPPORTS_SHARED_LIBRARIES) \
+	    $(call SUBST_STRING,RPATH) \
+	    $(call SUBST_STRING,MKSHAREDLIBRPATH) \
+	    $(call SUBST_STRING,TOOLPREF) $< > $@
 
 beforedepend:: ocamlmklibconfig.ml
 

--- a/tools/ocamlmklibconfig.ml.in
+++ b/tools/ocamlmklibconfig.ml.in
@@ -1,0 +1,5 @@
+let bindir = "%%BINDIR%%"
+let supports_shared_libraries = %%SUPPORTS_SHARED_LIBRARIES%%
+let default_rpath = "%%RPATH%%"
+let mksharedlibrpath = "%%MKSHAREDLIBRPATH%"
+let toolpref = "%%TOOLPREF%"


### PR DESCRIPTION
This splits off the parts of #9707 which are definitely bug fixes. Taking the very useful discussions in that PR, I have instead added a commit which attempts to warn the casual user of prefixes which may have problems. The following checks on prefix are made:
- A "naked" `$` is not permitted - `$` must either be followed by another `$` (so a literal dollar) or one of the two full variable forms in `make` must be used (so `$()` or `${}`).
- A warning is displayed if `make` variables appear in `$prefix`, because it's advanced (I guess this could be info, rather than a warning?!)
- A warning is displayed if `$$` is not preceded by `\`, since it may result in unintended variable expansion during `make install`
- It is an error for `$prefix` to contain an odd number of unescaped `"` characters (all the `install` commands will error)
- A warning is displayed for `"` characters which aren't preceded by `\`, since the intention is probably to have a filename with a literal `"` in it.

I haven't put any checks on other variables, on the basis that setting `prefix` is something many users do and setting `libdir`, `bindir`, etc. is quite advanced.

And, as in #9707, Travis tests with a very strange path indeed, just like AppVeyor.

cc @shindere