### PR TITLE
Fix the scope handling to detect ambiguous results of applications

### DIFF
--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -720,11 +720,12 @@ Line 4, characters 11-19:
                ^^^^^^^^
 Warning 18 [not-principal]: typing this pattern requires considering GADT_ordering.point and a as equal.
 But the knowledge of these types is not principal.
-Line 5, characters 13-14:
+Line 5, characters 11-19:
 5 |       and+ { x; y } = a in
-                 ^
-Error: The record field x belongs to the type GADT_ordering.point
-       but is mixed here with fields of type a = GADT_ordering.point
+               ^^^^^^^^
+Error: This pattern matches values of type GADT_ordering.point
+       but a pattern was expected which matches values of type
+         a = GADT_ordering.point
        This instance of GADT_ordering.point is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -1,0 +1,38 @@
+(* TEST
+   * expect
+*)
+
+type (_,_) eq = Refl : ('a,'a) eq;;
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+|}]
+
+(* Both should fail *)
+let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
+   let Refl = w1 in let Refl = w2 in g 3;;
+[%%expect{|
+Line 2, characters 37-40:
+2 |    let Refl = w1 in let Refl = w2 in g 3;;
+                                         ^^^
+Error: This expression has type b = int
+       but an expression was expected of type 'a
+       This instance of int is ambiguous:
+       it would escape the scope of its equation
+|}]
+let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
+   let Refl = w2 in let Refl = w1 in g 3;;
+[%%expect{|
+Line 2, characters 37-40:
+2 |    let Refl = w2 in let Refl = w1 in g 3;;
+                                         ^^^
+Error: This expression has type int but an expression was expected of type 'a
+       This instance of int is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+(* Ok *)
+let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) : b =
+   let Refl = w2 in let Refl = w1 in g 3;;
+[%%expect{|
+val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> 'b = <fun>
+|}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -362,7 +362,7 @@ val foo : int foo -> int = <fun>
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and int as equal.
 But the knowledge of these types is not principal.
 val foo : int foo -> int = <fun>
 |}]

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -381,7 +381,6 @@ val collapse_conj_params: Env.t -> type_expr list -> unit
         (* Collapse conjunctive types in class parameters *)
 
 val get_current_level: unit -> int
-val wrap_trace_gadt_instances: Env.t -> ('a -> 'b) -> 'a -> 'b
 val reset_reified_var_counter: unit -> unit
 
 val immediacy : Env.t -> type_expr -> Type_immediacy.t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2385,7 +2385,7 @@ let rec list_labels_aux env visited ls ty_fun =
       List.rev ls, is_Tvar ty
 
 let list_labels env ty =
-  wrap_trace_gadt_instances env (list_labels_aux env [] []) ty
+  list_labels_aux env [] [] ty
 
 (* Check that all univars are safe in a type. Both exp.exp_type and
    ty_expected should already be generalized. *)
@@ -2854,7 +2854,7 @@ and type_expect_
         end;
         let ty = instance funct.exp_type in
         end_def ();
-        wrap_trace_gadt_instances env (lower_args []) ty;
+        lower_args [] ty;
         funct
       in
       let funct, sargs =
@@ -4238,9 +4238,9 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
     let ls, tvar = list_labels env ty in
     not tvar && List.for_all ((=) Nolabel) ls
   in
-  match expand_head env ty_expected' with
-    {desc = Tarrow(Nolabel,ty_arg,ty_res,_); level = lv}
-    when is_inferred sarg ->
+  let lv = (repr ty_expected').level in
+  match expand_head env (correct_levels ty_expected') with
+    {desc = Tarrow(Nolabel,_,ty_res0,_)} when is_inferred sarg ->
       (* apply optional arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
       if !Clflags.principal then begin_def ();
@@ -4264,10 +4264,15 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
         (lv <> generic_level || (repr ty_fun').level <> generic_level)
       and texp = {texp with exp_type = instance texp.exp_type}
       and ty_fun = instance ty_fun' in
-      if not (simple_res || no_labels ty_res) then begin
+      if not (simple_res || no_labels ty_res0) then begin
         unify_exp env texp ty_expected;
         texp
       end else begin
+      let ty_arg, ty_res =
+        match expand_head env ty_expected' with
+          {desc = Tarrow(Nolabel,ty_arg,ty_res,_)} -> ty_arg, ty_res
+        | _ -> assert false
+      in
       unify_exp env {texp with exp_type = ty_fun} ty_expected;
       if args = [] then texp else
       (* eta-expand to avoid side effects *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -653,7 +653,7 @@ let check_well_founded env loc path to_check ty =
     | _ -> Option.iter raise arg_exn
   in
   let snap = Btype.snapshot () in
-  try Ctype.wrap_trace_gadt_instances env (check ty TypeSet.empty) ty
+  try check ty TypeSet.empty ty
   with Ctype.Unify _ ->
     (* Will be detected by check_recursion *)
     Btype.backtrack snap


### PR DESCRIPTION
Following the discovery of cases where ambiguity was not correctly detected, this extends `Ctype.update_scope` to update scopes recursively.

See `ambivalent_apply.ml` for examples.