### PR TITLE
Fix List.nth_opt behavior in the case of a negative index

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -43,7 +43,7 @@ let nth l n =
   in nth_aux l n
 
 let nth_opt l n =
-  if n < 0 then invalid_arg "List.nth" else
+  if n < 0 then None else
   let rec nth_aux l n =
     match l with
     | [] -> None

--- a/testsuite/tests/basic/opt_variants.ml
+++ b/testsuite/tests/basic/opt_variants.ml
@@ -28,6 +28,8 @@ let () =
   assert(float_of_string_opt (String.make 1000 '9') = Some infinity);
 
   assert(List.nth_opt [] 0 = None);
+  assert(List.nth_opt [] -1 = None);
+  assert(List.nth_opt [42] -1 = None);
   assert(List.nth_opt [42] 0 = Some 42);
   assert(List.nth_opt [42] 1 = None);
 


### PR DESCRIPTION
`List.nth_opt` still throws, in the case of a negative index. This is confusing - my expectation was `nth_opt` shouldn't throw, but it can, if a negative index is passed.

Based on reading through the PR that introduced the `_opt` methods - https://github.com/ocaml/ocaml/pull/885 - it does seem like the intent was for these not to raise an exception.

I suspect this may be just a copy-paste error, given that the `invalid_arg "List.nth"` wasn't updated to `invalid_arg "List.nth_opt"`, so figured it couldn't hurt to open a PR.