### PR TITLE
Changed label name for string functions to sub.

### DIFF
--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -100,7 +100,7 @@ module Unix : SYSDEPS = struct
     && (String.length n < 2 || String.sub n 0 2 <> "./")
     && (String.length n < 3 || String.sub n 0 3 <> "../")
   let check_suffix name suff =
-    String.ends_with ~suffix:suff name
+    String.ends_with ~substr:suff name
 
   let chop_suffix_opt ~suffix filename =
     let len_s = String.length suffix and len_f = String.length filename in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -232,21 +232,21 @@ let to_seqi s = bos s |> B.to_seqi
 
 let of_seq g = B.of_seq g |> bts
 
-let starts_with ~prefix s =
+let starts_with ~substr s =
   let len_s = length s
-  and len_pre = length prefix in
+  and len_pre = length substr in
   let rec aux i =
     if i = len_pre then true
-    else if unsafe_get s i <> unsafe_get prefix i then false
+    else if unsafe_get s i <> unsafe_get substr i then false
     else aux (i + 1)
   in len_s >= len_pre && aux 0
 
-let ends_with ~suffix s =
+let ends_with ~substr s =
   let len_s = length s
-  and len_suf = length suffix in
+  and len_suf = length substr in
   let diff = len_s - len_suf in
   let rec aux i =
     if i = len_suf then true
-    else if unsafe_get s (diff + i) <> unsafe_get suffix i then false
+    else if unsafe_get s (diff + i) <> unsafe_get substr i then false
     else aux (i + 1)
   in diff >= 0 && aux 0

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -300,12 +300,12 @@ val equal: t -> t -> bool
 (** The equal function for strings.
     @since 4.03.0 *)
 
-val starts_with : prefix:t -> t -> bool
-(** [String.starts_with prefix s] tests if [s] starts with [prefix]
+val starts_with : substr:t -> t -> bool
+(** [String.starts_with ~substr:prefix s] tests if [s] starts with [prefix]
     @since 4.12.0 *)
 
-val ends_with : suffix:t -> t -> bool
-(** [String.ends_with suffix s] tests if [s] ends with [suffix]
+val ends_with : substr:t -> t -> bool
+(** [String.ends_with ~substr:suffix s] tests if [s] ends with [suffix]
     @since 4.12.0 *)
 
 val split_on_char: char -> string -> string list

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -267,12 +267,12 @@ val equal: t -> t -> bool
 (** The equal function for strings.
     @since 4.05.0 *)
 
-val starts_with : prefix:t -> t -> bool
-(** [String.starts_with prefix s] tests if [s] starts with [prefix]
+val starts_with : substr:t -> t -> bool
+(** [String.starts_with ~substr:prefix s] tests if [s] starts with [prefix]
     @since 4.12.0 *)
 
-val ends_with : suffix:t -> t -> bool
-(** [String.ends_with suffix s] tests if [s] ends with [suffix]
+val ends_with : substr:t -> t -> bool
+(** [String.ends_with ~substr:suffix s] tests if [s] ends with [suffix]
     @since 4.12.0 *)
 
 val split_on_char: sep:char -> string -> string list

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -52,16 +52,16 @@ let ()  =
     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
     try ignore (String.concat "" !l); assert false
     with Invalid_argument _ -> ();
-    assert(String.starts_with ~prefix:"foob" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "");
-    assert(not (String.starts_with ~prefix:"foobar" "bar"));
-    assert(not (String.starts_with ~prefix:"foo" ""));
-    assert(not (String.starts_with ~prefix:"fool" "foobar"));
-    assert(String.ends_with ~suffix:"baz" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "");
-    assert(not (String.ends_with ~suffix:"foobar" "bar"));
-    assert(not (String.ends_with ~suffix:"foo" ""));
-    assert(not (String.ends_with ~suffix:"obaz" "foobar"));
+    assert(String.starts_with ~substr:"foob" "foobarbaz");
+    assert(String.starts_with ~substr:"" "foobarbaz");
+    assert(String.starts_with ~substr:"" "");
+    assert(not (String.starts_with ~substr:"foobar" "bar"));
+    assert(not (String.starts_with ~substr:"foo" ""));
+    assert(not (String.starts_with ~substr:"fool" "foobar"));
+    assert(String.ends_with ~substr:"baz" "foobarbaz");
+    assert(String.ends_with ~substr:"" "foobarbaz");
+    assert(String.ends_with ~substr:"" "");
+    assert(not (String.ends_with ~substr:"foobar" "bar"));
+    assert(not (String.ends_with ~substr:"foo" ""));
+    assert(not (String.ends_with ~substr:"obaz" "foobar"));
   end


### PR DESCRIPTION
As mentioned by @dbuenzli in https://github.com/ocaml/ocaml/pull/9533#issuecomment-667654162 using `sub` as label might be a better idea since it is uniform across all functions and would allow higher order usage of the function. Since the functions in questions are not yet officially released so we still can change them. I don't think this needs a changelog entry for this.