### PR TITLE
Fix type mismatch between definition and declaration

### DIFF
--- a/Changes
+++ b/Changes
@@ -358,6 +358,7 @@ Working version
   caml_spacetime_my_profinfo (bytecode version) were declared and
   defined with different types.  This is undefined behavior and
   cancause link-time errors with link-time optimization (LTO).
+  (Xavier Leroy, report by Richard Jones, review by Nicolás Ojeda Bär)
 
 
 OCaml 4.11

--- a/Changes
+++ b/Changes
@@ -354,6 +354,12 @@ Working version
   (Jacques Garrigue, report by Thomas Refis,
    review by Thomas Refis and Gabriel Scherer)
 
+- #9825, #9830: the C global variable caml_fl_merge and the C function
+  caml_spacetime_my_profinfo (bytecode version) were declared and
+  defined with different types.  This is undefined behavior and
+  cancause link-time errors with link-time optimization (LTO).
+
+
 OCaml 4.11
 ----------
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -57,7 +57,7 @@ uintnat caml_dependent_size, caml_dependent_allocated;
 double caml_extra_heap_resources;
 uintnat caml_fl_wsz_at_phase_change = 0;
 
-extern char *caml_fl_merge;  /* Defined in freelist.c. */
+extern value caml_fl_merge;  /* Defined in freelist.c. */
 
 static char *markhp, *chunk, *limit;
 static double p_backlog = 0.0; /* backlog for the gc speedup parameter */
@@ -586,7 +586,7 @@ static void sweep_slice (intnat work)
         break;
       case Caml_blue:
         /* Only the blocks of the free-list are blue.  See [freelist.c]. */
-        caml_fl_merge = Bp_hp (hp);
+        caml_fl_merge = (value) Bp_hp (hp);
         break;
       default:          /* gray or black */
         CAMLassert (Color_hd (hd) == Caml_black);

--- a/runtime/spacetime_byt.c
+++ b/runtime/spacetime_byt.c
@@ -12,8 +12,12 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include "caml/fail.h"
 #include "caml/mlvalues.h"
+#include "caml/io.h"
+#include "caml/spacetime.h"
 
 int caml_ensure_spacetime_dot_o_is_included = 42;
 
@@ -22,7 +26,8 @@ CAMLprim value caml_spacetime_only_works_for_native_code(value foo, ...)
   caml_failwith("Spacetime profiling only works for native code");
 }
 
-uintnat caml_spacetime_my_profinfo (void)
+uintnat caml_spacetime_my_profinfo (spacetime_unwind_info_cache * cached,
+                                    uintnat wosize)
 {
   return 0;
 }


### PR DESCRIPTION
The global variable `caml_fl_merge` and the function `caml_spacetime_my_profinfo` (bytecode version) are defined with one type, but declared `extern` and used with an incompatible type elsewhere.

Closes: #9825
