### PR TITLE
Fix #show with -short-paths

### DIFF
--- a/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
+++ b/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
@@ -10,19 +10,19 @@ type t = T of t;;
 type t = T of t
 |}]
 #show t;;
-(* this output is CORRECT, it does not use nonrec *)
+(* this output is INCORRECT, it should not use nonrec *)
 [%%expect{|
-type t = T of t
+type nonrec t = T of t
 |}];;
 
-type nonrec t = Foo of t;;
+type nonrec s = Foo of t;;
 [%%expect{|
-type nonrec t = Foo of t
+type nonrec s = Foo of t
 |}];;
-#show t;;
-(* this output in INCORRECT, it should use nonrec *)
+#show s;;
+(* this output is CORRECT, it uses nonrec *)
 [%%expect{|
-type t = Foo of t
+type nonrec s = Foo of t
 |}];;
 
 

--- a/testsuite/tests/tool-toplevel/show.ml
+++ b/testsuite/tests/tool-toplevel/show.ml
@@ -40,7 +40,7 @@ type 'a option = None | Some of 'a
 
 #show option;;
 [%%expect {|
-type 'a option = None | Some of 'a
+type nonrec 'a option = None | Some of 'a
 |}];;
 
 #show Open_binary;;
@@ -59,7 +59,7 @@ type Stdlib.open_flag =
 
 #show open_flag;;
 [%%expect {|
-type open_flag =
+type nonrec open_flag =
     Open_rdonly
   | Open_wronly
   | Open_append
@@ -90,7 +90,7 @@ type extensible += B of int
 
 #show extensible;;
 [%%expect {|
-type extensible = ..
+type nonrec extensible = ..
 |}];;
 
 type 'a t = ..;;

--- a/testsuite/tests/tool-toplevel/show_short_paths.ml
+++ b/testsuite/tests/tool-toplevel/show_short_paths.ml
@@ -1,0 +1,19 @@
+(* TEST
+   flags = " -short-paths "
+   * expect
+*)
+
+(* This is currently just a regression test for the bug
+   reported here: https://github.com/ocaml/ocaml/issues/9828 *)
+
+#show list;;
+[%%expect {|
+type 'a list = [] | (::) of 'a * 'a list
+|}];;
+
+type 'a t;;
+#show t;;
+[%%expect {|
+type 'a t
+type 'a t
+|}];;

--- a/testsuite/tests/tool-toplevel/show_short_paths.ml
+++ b/testsuite/tests/tool-toplevel/show_short_paths.ml
@@ -8,12 +8,12 @@
 
 #show list;;
 [%%expect {|
-type 'a list = [] | (::) of 'a * 'a list
+type nonrec 'a list = [] | (::) of 'a * 'a list
 |}];;
 
 type 'a t;;
 #show t;;
 [%%expect {|
 type 'a t
-type 'a t
+type nonrec 'a t
 |}];;

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -556,7 +556,7 @@ let () =
   reg_show_prim "show_type"
     (fun env loc id lid ->
        let _path, desc = Env.lookup_type ~loc lid env in
-       [ Sig_type (id, desc, Trec_first, Exported) ]
+       [ Sig_type (id, desc, Trec_not, Exported) ]
     )
     "Print the signature of the corresponding type constructor."
 


### PR DESCRIPTION
Fixes #9828.

This should be cherry-picked to 4.11 (cc @Octachron).
