### PR TITLE
Restrict 'test_locations' to not run with afl active

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -1,75 +1,75 @@
 [
-  structure_item (test_locations.ml[42,1350+0]..[44,1388+34])
+  structure_item (test_locations.ml[43,1389+0]..[45,1427+34])
     Pstr_value Rec
     [
       <def>
-        pattern (test_locations.ml[42,1350+8]..[42,1350+11])
-          Ppat_var "fib" (test_locations.ml[42,1350+8]..[42,1350+11])
-        expression (test_locations.ml[42,1350+14]..[44,1388+34])
+        pattern (test_locations.ml[43,1389+8]..[43,1389+11])
+          Ppat_var "fib" (test_locations.ml[43,1389+8]..[43,1389+11])
+        expression (test_locations.ml[43,1389+14]..[45,1427+34])
           Pexp_function
           [
             <case>
-              pattern (test_locations.ml[43,1373+4]..[43,1373+9])
+              pattern (test_locations.ml[44,1412+4]..[44,1412+9])
                 Ppat_or
-                pattern (test_locations.ml[43,1373+4]..[43,1373+5])
+                pattern (test_locations.ml[44,1412+4]..[44,1412+5])
                   Ppat_constant PConst_int (0,None)
-                pattern (test_locations.ml[43,1373+8]..[43,1373+9])
+                pattern (test_locations.ml[44,1412+8]..[44,1412+9])
                   Ppat_constant PConst_int (1,None)
-              expression (test_locations.ml[43,1373+13]..[43,1373+14])
+              expression (test_locations.ml[44,1412+13]..[44,1412+14])
                 Pexp_constant PConst_int (1,None)
             <case>
-              pattern (test_locations.ml[44,1388+4]..[44,1388+5])
-                Ppat_var "n" (test_locations.ml[44,1388+4]..[44,1388+5])
-              expression (test_locations.ml[44,1388+9]..[44,1388+34])
+              pattern (test_locations.ml[45,1427+4]..[45,1427+5])
+                Ppat_var "n" (test_locations.ml[45,1427+4]..[45,1427+5])
+              expression (test_locations.ml[45,1427+9]..[45,1427+34])
                 Pexp_apply
-                expression (test_locations.ml[44,1388+21]..[44,1388+22])
-                  Pexp_ident "+" (test_locations.ml[44,1388+21]..[44,1388+22])
+                expression (test_locations.ml[45,1427+21]..[45,1427+22])
+                  Pexp_ident "+" (test_locations.ml[45,1427+21]..[45,1427+22])
                 [
                   <arg>
                   Nolabel
-                    expression (test_locations.ml[44,1388+9]..[44,1388+20])
+                    expression (test_locations.ml[45,1427+9]..[45,1427+20])
                       Pexp_apply
-                      expression (test_locations.ml[44,1388+9]..[44,1388+12])
-                        Pexp_ident "fib" (test_locations.ml[44,1388+9]..[44,1388+12])
+                      expression (test_locations.ml[45,1427+9]..[45,1427+12])
+                        Pexp_ident "fib" (test_locations.ml[45,1427+9]..[45,1427+12])
                       [
                         <arg>
                         Nolabel
-                          expression (test_locations.ml[44,1388+13]..[44,1388+20])
+                          expression (test_locations.ml[45,1427+13]..[45,1427+20])
                             Pexp_apply
-                            expression (test_locations.ml[44,1388+16]..[44,1388+17])
-                              Pexp_ident "-" (test_locations.ml[44,1388+16]..[44,1388+17])
+                            expression (test_locations.ml[45,1427+16]..[45,1427+17])
+                              Pexp_ident "-" (test_locations.ml[45,1427+16]..[45,1427+17])
                             [
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1388+14]..[44,1388+15])
-                                  Pexp_ident "n" (test_locations.ml[44,1388+14]..[44,1388+15])
+                                expression (test_locations.ml[45,1427+14]..[45,1427+15])
+                                  Pexp_ident "n" (test_locations.ml[45,1427+14]..[45,1427+15])
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1388+18]..[44,1388+19])
+                                expression (test_locations.ml[45,1427+18]..[45,1427+19])
                                   Pexp_constant PConst_int (1,None)
                             ]
                       ]
                   <arg>
                   Nolabel
-                    expression (test_locations.ml[44,1388+23]..[44,1388+34])
+                    expression (test_locations.ml[45,1427+23]..[45,1427+34])
                       Pexp_apply
-                      expression (test_locations.ml[44,1388+23]..[44,1388+26])
-                        Pexp_ident "fib" (test_locations.ml[44,1388+23]..[44,1388+26])
+                      expression (test_locations.ml[45,1427+23]..[45,1427+26])
+                        Pexp_ident "fib" (test_locations.ml[45,1427+23]..[45,1427+26])
                       [
                         <arg>
                         Nolabel
-                          expression (test_locations.ml[44,1388+27]..[44,1388+34])
+                          expression (test_locations.ml[45,1427+27]..[45,1427+34])
                             Pexp_apply
-                            expression (test_locations.ml[44,1388+30]..[44,1388+31])
-                              Pexp_ident "-" (test_locations.ml[44,1388+30]..[44,1388+31])
+                            expression (test_locations.ml[45,1427+30]..[45,1427+31])
+                              Pexp_ident "-" (test_locations.ml[45,1427+30]..[45,1427+31])
                             [
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1388+28]..[44,1388+29])
-                                  Pexp_ident "n" (test_locations.ml[44,1388+28]..[44,1388+29])
+                                expression (test_locations.ml[45,1427+28]..[45,1427+29])
+                                  Pexp_ident "n" (test_locations.ml[45,1427+28]..[45,1427+29])
                               <arg>
                               Nolabel
-                                expression (test_locations.ml[44,1388+32]..[44,1388+33])
+                                expression (test_locations.ml[45,1427+32]..[45,1427+33])
                                   Pexp_constant PConst_int (2,None)
                             ]
                       ]
@@ -80,78 +80,78 @@
 
 let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
-  structure_item (test_locations.ml[42,1350+0]..test_locations.ml[44,1388+34])
+  structure_item (test_locations.ml[43,1389+0]..test_locations.ml[45,1427+34])
     Tstr_value Rec
     [
       <def>
-        pattern (test_locations.ml[42,1350+8]..test_locations.ml[42,1350+11])
+        pattern (test_locations.ml[43,1389+8]..test_locations.ml[43,1389+11])
           Tpat_var "fib"
-        expression (test_locations.ml[42,1350+14]..test_locations.ml[44,1388+34])
+        expression (test_locations.ml[43,1389+14]..test_locations.ml[45,1427+34])
           Texp_function
           Nolabel
           [
             <case>
-              pattern (test_locations.ml[43,1373+4]..test_locations.ml[43,1373+9])
+              pattern (test_locations.ml[44,1412+4]..test_locations.ml[44,1412+9])
                 Tpat_or
-                pattern (test_locations.ml[43,1373+4]..test_locations.ml[43,1373+5])
+                pattern (test_locations.ml[44,1412+4]..test_locations.ml[44,1412+5])
                   Tpat_constant Const_int 0
-                pattern (test_locations.ml[43,1373+8]..test_locations.ml[43,1373+9])
+                pattern (test_locations.ml[44,1412+8]..test_locations.ml[44,1412+9])
                   Tpat_constant Const_int 1
-              expression (test_locations.ml[43,1373+13]..test_locations.ml[43,1373+14])
+              expression (test_locations.ml[44,1412+13]..test_locations.ml[44,1412+14])
                 Texp_constant Const_int 1
             <case>
-              pattern (test_locations.ml[44,1388+4]..test_locations.ml[44,1388+5])
+              pattern (test_locations.ml[45,1427+4]..test_locations.ml[45,1427+5])
                 Tpat_var "n"
-              expression (test_locations.ml[44,1388+9]..test_locations.ml[44,1388+34])
+              expression (test_locations.ml[45,1427+9]..test_locations.ml[45,1427+34])
                 Texp_apply
-                expression (test_locations.ml[44,1388+21]..test_locations.ml[44,1388+22])
+                expression (test_locations.ml[45,1427+21]..test_locations.ml[45,1427+22])
                   Texp_ident "Stdlib!.+"
                 [
                   <arg>
                     Nolabel
-                    expression (test_locations.ml[44,1388+9]..test_locations.ml[44,1388+20])
+                    expression (test_locations.ml[45,1427+9]..test_locations.ml[45,1427+20])
                       Texp_apply
-                      expression (test_locations.ml[44,1388+9]..test_locations.ml[44,1388+12])
+                      expression (test_locations.ml[45,1427+9]..test_locations.ml[45,1427+12])
                         Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
-                          expression (test_locations.ml[44,1388+13]..test_locations.ml[44,1388+20])
+                          expression (test_locations.ml[45,1427+13]..test_locations.ml[45,1427+20])
                             Texp_apply
-                            expression (test_locations.ml[44,1388+16]..test_locations.ml[44,1388+17])
+                            expression (test_locations.ml[45,1427+16]..test_locations.ml[45,1427+17])
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1388+14]..test_locations.ml[44,1388+15])
+                                expression (test_locations.ml[45,1427+14]..test_locations.ml[45,1427+15])
                                   Texp_ident "n"
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1388+18]..test_locations.ml[44,1388+19])
+                                expression (test_locations.ml[45,1427+18]..test_locations.ml[45,1427+19])
                                   Texp_constant Const_int 1
                             ]
                       ]
                   <arg>
                     Nolabel
-                    expression (test_locations.ml[44,1388+23]..test_locations.ml[44,1388+34])
+                    expression (test_locations.ml[45,1427+23]..test_locations.ml[45,1427+34])
                       Texp_apply
-                      expression (test_locations.ml[44,1388+23]..test_locations.ml[44,1388+26])
+                      expression (test_locations.ml[45,1427+23]..test_locations.ml[45,1427+26])
                         Texp_ident "fib"
                       [
                         <arg>
                           Nolabel
-                          expression (test_locations.ml[44,1388+27]..test_locations.ml[44,1388+34])
+                          expression (test_locations.ml[45,1427+27]..test_locations.ml[45,1427+34])
                             Texp_apply
-                            expression (test_locations.ml[44,1388+30]..test_locations.ml[44,1388+31])
+                            expression (test_locations.ml[45,1427+30]..test_locations.ml[45,1427+31])
                               Texp_ident "Stdlib!.-"
                             [
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1388+28]..test_locations.ml[44,1388+29])
+                                expression (test_locations.ml[45,1427+28]..test_locations.ml[45,1427+29])
                                   Texp_ident "n"
                               <arg>
                                 Nolabel
-                                expression (test_locations.ml[44,1388+32]..test_locations.ml[44,1388+33])
+                                expression (test_locations.ml[45,1427+32]..test_locations.ml[45,1427+33])
                                   Texp_constant Const_int 2
                             ]
                       ]
@@ -164,13 +164,13 @@ let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
   (letrec
     (fib
        (function n[int] : int
-         (funct-body Test_locations.fib test_locations.ml(42):1364-1422
+         (funct-body Test_locations.fib test_locations.ml(43):1403-1461
            (if (isout 1 n)
-             (before Test_locations.fib test_locations.ml(44):1397-1422
+             (before Test_locations.fib test_locations.ml(45):1436-1461
                (+
-                 (after Test_locations.fib test_locations.ml(44):1397-1408
+                 (after Test_locations.fib test_locations.ml(45):1436-1447
                    (apply fib (- n 1)))
-                 (after Test_locations.fib test_locations.ml(44):1411-1422
+                 (after Test_locations.fib test_locations.ml(45):1450-1461
                    (apply fib (- n 2)))))
-             (before Test_locations.fib test_locations.ml(43):1386-1387 1)))))
+             (before Test_locations.fib test_locations.ml(44):1425-1426 1)))))
     (pseudo <unknown location> (makeblock 0 fib))))

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.clambda.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.clambda.reference
@@ -12,13 +12,13 @@ cmm:
  "camlTest_locations__gc_roots":
  addr "camlTest_locations"
  int 0)
-(function{test_locations.ml:42,14-72} camlTest_locations__fib_81 (n: val)
+(function{test_locations.ml:43,14-72} camlTest_locations__fib_81 (n: val)
  (if (<a 3 n)
    (+
      (+
-       (app{test_locations.ml:44,9-20} "camlTest_locations__fib_81" (+ n -2)
+       (app{test_locations.ml:45,9-20} "camlTest_locations__fib_81" (+ n -2)
          val)
-       (app{test_locations.ml:44,23-34} "camlTest_locations__fib_81" 
+       (app{test_locations.ml:45,23-34} "camlTest_locations__fib_81" 
          (+ n -4) val))
      -1)
    3))

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.flambda.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlopt.flambda.reference
@@ -13,15 +13,15 @@ cmm:
  global "camlTest_locations__gc_roots"
  "camlTest_locations__gc_roots":
  int 0)
-(function{test_locations.ml:42,14-72} camlTest_locations__fib_5 (n: val)
+(function{test_locations.ml:43,14-72} camlTest_locations__fib_5 (n: val)
  (if (<a 3 n)
    (let
      Paddint_arg
-       (app{test_locations.ml:44,23-34} "camlTest_locations__fib_5" (+ n -4)
+       (app{test_locations.ml:45,23-34} "camlTest_locations__fib_5" (+ n -4)
          val)
      (+
        (+
-         (app{test_locations.ml:44,9-20} "camlTest_locations__fib_5" 
+         (app{test_locations.ml:45,9-20} "camlTest_locations__fib_5" 
            (+ n -2) val)
          Paddint_arg)
        -1))

--- a/testsuite/tests/formatting/test_locations.ml
+++ b/testsuite/tests/formatting/test_locations.ml
@@ -1,41 +1,42 @@
 (* TEST
 compile_only="true"
 * arch64
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
+** no-afl-instrument
+*** setup-ocamlc.byte-build-env
+**** ocamlc.byte
 flags="-g -dno-unique-ids -dno-locations -dsource -dparsetree -dtypedtree -dlambda"
-**** check-ocamlc.byte-output
+***** check-ocamlc.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dno-locations.ocamlc.reference"
 
-** setup-ocamlopt.byte-build-env
-*** ocamlopt.byte
+*** setup-ocamlopt.byte-build-env
+**** ocamlopt.byte
 flags="-g -dno-unique-ids -dno-locations -dcmm"
-**** no-flambda
-***** check-ocamlopt.byte-output
+***** no-flambda
+****** check-ocamlopt.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dno-locations.ocamlopt.clambda.reference"
-**** flambda
-***** check-ocamlc.byte-output
+***** flambda
+****** check-ocamlc.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dno-locations.ocamlopt.flambda.reference"
 
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
+*** setup-ocamlc.byte-build-env
+**** ocamlc.byte
 flags="-g -dno-unique-ids -dlocations -dsource -dparsetree -dtypedtree -dlambda"
-**** check-ocamlc.byte-output
+***** check-ocamlc.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dlocations.ocamlc.reference"
 
-** setup-ocamlopt.byte-build-env
-*** ocamlopt.byte
+*** setup-ocamlopt.byte-build-env
+**** ocamlopt.byte
 flags="-g -dno-unique-ids -dlocations -dcmm"
-**** no-flambda
-***** check-ocamlopt.byte-output
+***** no-flambda
+****** check-ocamlopt.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dlocations.ocamlopt.clambda.reference"
-**** flambda
-***** check-ocamlc.byte-output
+***** flambda
+****** check-ocamlc.byte-output
 compiler_reference =
   "${test_source_directory}/test_locations.dlocations.ocamlopt.flambda.reference"
 *)


### PR DESCRIPTION
The AFL code generator alters the generated output and the
expect tests fail.  This test is already restricted to 64-bit
only architectures for similar reasons (the output locations
change).

Also updates the expected outputs to account for the extra line
in the test case now.

Fixes #9822