### PR TITLE
Update a copyright year

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,10 +76,8 @@ the compiler may work under other operating systems with little work.
 
 == Copyright
 
-All files marked "Copyright INRIA" in this distribution are copyright 1996,
-1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,
-2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
-Institut National de Recherche en Informatique et en Automatique (INRIA)
+All files marked "Copyright INRIA" in this distribution are copyright since
+1996 Institut National de Recherche en Informatique et en Automatique (INRIA)
 and distributed under the conditions stated in file LICENSE.
 
 == Installation


### PR DESCRIPTION
Hello,

I update copyright year in README.
Because it remains as it was 1996 - 2019.

At first, I was only going to add 2020 in it.
However, if that’s the case we need to update it every year.

So, I suggest that we describe "since 1996" instead of "1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020". 

Because the copyright only needs to describe the year of publication of the work.
By this, we don't need to update it every year.

Thanks,