### PR TITLE
Add span user events in the instrumented runtime

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -79,4 +79,6 @@ DOMAIN_STATE(uint32_t, eventlog_startup_pid)
 DOMAIN_STATE(uintnat, eventlog_paused)
 DOMAIN_STATE(uintnat, eventlog_enabled)
 DOMAIN_STATE(FILE*, eventlog_out)
+DOMAIN_STATE(FILE*, ctf_metadata_file)
+DOMAIN_STATE(uint32_t, ctf_user_event_id)
 /* See eventlog.c */

--- a/runtime/caml/eventlog.h
+++ b/runtime/caml/eventlog.h
@@ -80,6 +80,11 @@ typedef enum {
     EV_C_REQUEST_MINOR_REALLOC_CUSTOM_TABLE
 } ev_gc_counter;
 
+typedef enum {
+    EV_USER_BEGIN,
+    EV_USER_END
+} ev_user_type;
+
 #ifdef CAML_INSTR
 
 #define CAML_EVENTLOG_DO(f) if (Caml_state->eventlog_enabled &&\

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -121,6 +121,11 @@ let create_alarm f =
 
 let delete_alarm a = a := false
 
+type event = int
+external new_event : string -> event = "caml_eventlog_new_event"
+external emit_begin_event : event -> unit = "caml_eventlog_emit_begin_event"
+external emit_end_event : event -> unit = "caml_eventlog_emit_end_event"
+
 module Memprof =
   struct
     type allocation =

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -439,6 +439,13 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
    was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
    traces before the first event.) *)
 
+type event
+
+external new_event : string -> event = "caml_eventlog_new_event"
+
+external emit_begin_event : event -> unit = "caml_eventlog_emit_begin_event"
+
+external emit_end_event : event -> unit = "caml_eventlog_emit_end_event"
 
 (** [Memprof] is a sampling engine for allocated memory words. Every
    allocated word has a probability of being sampled equal to a


### PR DESCRIPTION
Main goal of the PR: provide an API for users to instantiate new user span events through the instrumented runtime and to emit the beginning and ending of these events through OCaml code such that the user events and GC events are visualizable in the same user interface (currently the chrome://tracing Catapult format).

List of changes to enable this:

- The CTF metadata stream needs to be dynamically extendible for arbitrary user events. To do so, the previously plaintext metadata stream has been converted to a packet-based stream and appropriate event descriptions are appended to it on invocations of `Gc.new_event`.
- Addition of a few functions in the GC module implemented in `eventlog.c` that serve as the external API for this change.
- Emission of user events upon invocation of `Gc.caml_eventlog_emit_begin_event` and `Gc.caml_eventlog_emit_end_event`.
- A few changes to the metadata format found [here](https://github.com/ocaml/ocaml/blob/trunk/tools/eventlog_metadata.in) in order to make the new metadata stream compatible with babeltrace2 for visualization of the events.
- A Python helper script to convert the CTF output of running the instrumented runtime to the catapult format, which can be found [here](https://github.com/gshag/ctf-to-catapult).