### PR TITLE
Avoid Cconst_natint where Cconst_int will do

### DIFF
--- a/.depend
+++ b/.depend
@@ -2877,6 +2877,7 @@ asmcomp/spacetime_profiling.cmo : \
     lambda/lambda.cmi \
     lambda/debuginfo.cmi \
     utils/config.cmi \
+    asmcomp/cmm_helpers.cmi \
     asmcomp/cmm.cmi \
     middle_end/backend_var.cmi \
     parsing/asttypes.cmi \
@@ -2890,6 +2891,7 @@ asmcomp/spacetime_profiling.cmx : \
     lambda/lambda.cmx \
     lambda/debuginfo.cmx \
     utils/config.cmx \
+    asmcomp/cmm_helpers.cmx \
     asmcomp/cmm.cmx \
     middle_end/backend_var.cmx \
     parsing/asttypes.cmi \

--- a/Changes
+++ b/Changes
@@ -128,6 +128,10 @@ Working version
    so that the ARM64 iOS/macOS calling conventions can be honored.
    (Xavier Leroy, review by Mark Shinwell and Github user @EduardoRFS)
 
+- #9838: Ensure that Cmm immediates are generated as Cconst_int where
+  possible, improving instruction selection.
+  (Stephen Dolan, review by Leo White and Xavier Leroy)
+
 ### Standard library:
 
 - #9781: add injectivity annotations to parameterized abstract types

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -33,7 +33,7 @@ let reverse_shape = ref ([] : Mach.spacetime_shape)
 (* CR-someday mshinwell: This code could be updated to use [placeholder_dbg] as
    in [Cmmgen]. *)
 let cconst_int i = Cmm.Cconst_int (i, Debuginfo.none)
-let cconst_natint i = Cmm.Cconst_natint (i, Debuginfo.none)
+let cconst_natint i = Cmm_helpers.natint_const_untagged Debuginfo.none i
 let cconst_symbol s = Cmm.Cconst_symbol (s, Debuginfo.none)
 
 let something_was_instrumented () =


### PR DESCRIPTION
`Cmmgen` generally prefers to use `Cconst_int` for small constants rather than `Cconst_natint`. This generates better code, as the instruction selector assumes that small immediates will be encoded as `Cconst_int`.

However, constants of boxed integer type always used `Cconst_natint`, which means they never hit the small-immediate cases in the code generator. This patch uses `Cconst_int` instead, where possible.

As an example:
```ocaml
let f x = Int64.add x 1L
```

The addition goes from this:
```asm
        movl    $1, %edi
        movq    8(%rbx), %rbx
        addq    %rdi, %rbx
```
to this:
```asm
        movq    8(%rax), %rax
        incq    %rax
```