### PR TITLE
Add `Sys.frame_pointers`

### DIFF
--- a/Changes
+++ b/Changes
@@ -182,6 +182,9 @@ Working version
   (David Allsopp, review by Nicolás Ojeda Bär, Sébastien Hinderer and
    Xavier Leroy)
 
+- #9842: Add Sys.frame_pointers.
+  (Leo White, review by Mark Shinwell and David Allsopp)
+
 ### Other libraries:
 
 * #9206, #9419: update documentation of the threads library;

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -180,8 +180,11 @@ stdlib.cma: $(OBJS)
 stdlib.cmxa: $(OBJS:.cmo=.cmx)
 	$(CAMLOPT) -a -o $@ $^
 
-sys.ml: $(ROOTDIR)/VERSION sys.mlp
-	sed -e "s|%%VERSION%%|`sed -e 1q $< | tr -d '\r'`|" sys.mlp > $@
+VERSION = $(shell sed -e 1q $(ROOTDIR)/VERSION | tr -d '\r')
+sys.ml: sys.mlp $(ROOTDIR)/VERSION
+	sed $(call SUBST_STRING,VERSION) \
+	    $(call SUBST,WITH_FRAME_POINTERS) \
+	    $< > $@
 
 .PHONY: clean
 clean::

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -171,6 +171,12 @@ val big_endian : bool
 (** Whether the machine currently executing the Caml program is big-endian.
     @since 4.00.0 *)
 
+val frame_pointers : bool
+(** Whether the currently executing OCaml program is a native-code program
+    built with frame pointers.
+
+    @since 4.12.0 *)
+
 val max_string_length : int
 (** Maximum length of strings and byte sequences. *)
 

--- a/stdlib/sys.mlp
+++ b/stdlib/sys.mlp
@@ -45,6 +45,7 @@ let int_size = int_size ()
 let unix = unix ()
 let win32 = win32 ()
 let cygwin = cygwin ()
+let frame_pointers = %%WITH_FRAME_POINTERS%% && backend_type = Native
 let max_array_length = max_wosize ()
 let max_floatarray_length = max_array_length / (64 / word_size)
 let max_string_length = word_size / 8 * max_array_length - 1


### PR DESCRIPTION
I recently had a user ask how to know whether the current OCaml program was compiled with frame pointers. I was slightly surprised that it wasn't available in `Sys`, so this PR makes that information available in `Sys`.