### PR TITLE
Use "error checking" mutexes in the threads library

### DIFF
--- a/Changes
+++ b/Changes
@@ -259,7 +259,7 @@ Working version
   reliably raises a Sys_error exception.  Before, it could
   deadlock or succeed (and do recursive locking), depending on the OS.
   (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by
-  Guillaume Munch-Maccagnoni and David Allsopp)
+  Guillaume Munch-Maccagnoni, David Allsopp, and Stephen Dolan)
 
 - #9802: Ensure signals are handled before Unix.kill returns
   (Stephen Dolan, review by Jacques-Henri Jourdan)

--- a/Changes
+++ b/Changes
@@ -251,6 +251,16 @@ Working version
   information before the first load.
   (Daniel Bünzli, review by Xavier Leroy and Nicolás Ojeda Bär)
 
+* #9757, #9846: check proper ownership when operating over mutexes.
+  Now, unlocking a mutex held by another thread or not locked at all
+  reliably raises a Sys_error exception.  Before, it was undefined
+  behavior, but the documentation did not say so.
+  Likewise, locking a mutex already locked by the current thread
+  reliably raises a Sys_error exception.  Before, it could
+  deadlock or succeed (and do recursive locking), depending on the OS.
+  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by
+  Guillaume Munch-Maccagnoni and David Allsopp)
+
 - #9802: Ensure signals are handled before Unix.kill returns
   (Stephen Dolan, review by Jacques-Henri Jourdan)
 

--- a/otherlibs/systhreads/mutex.mli
+++ b/otherlibs/systhreads/mutex.mli
@@ -36,10 +36,12 @@ val lock : t -> unit
 (** Lock the given mutex. Only one thread can have the mutex locked
    at any time. A thread that attempts to lock a mutex already locked
    by another thread will suspend until the other thread unlocks
-   the mutex.  If the mutex is already locked by the thread calling
-   {!Mutex.lock}, a {!Sys_error} exception is raised instead of deadlocking.
+   the mutex.
+   
+   @raise Sys_error if the mutex is already locked by the thread calling
+   {!Mutex.lock}.
 
-   @since 4.12 concerning the raising of {!Sys_error} instead of deadlocking *)
+   @before 4.12 {!Sys_error} was not raised for recursive locking (platform-dependent behaviour) *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
@@ -50,8 +52,9 @@ val try_lock : t -> bool
 val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
-   by the thread that calls {!Mutex.unlock}.  If the mutex is unlocked
-   or was locked by another thread, a {!Sys_error} exception is raised.
+   by the thread that calls {!Mutex.unlock}.
+   
+   @raise Sys_error if the mutex is unlocked or was locked by another thread.
 
-   @since 4.12 concerning the raising of {!Sys_error} if the mutex is
-   not locked by the calling thread. *)
+   @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
+   or when unlocking a mutex from a different thread. *)

--- a/otherlibs/systhreads/mutex.mli
+++ b/otherlibs/systhreads/mutex.mli
@@ -36,7 +36,10 @@ val lock : t -> unit
 (** Lock the given mutex. Only one thread can have the mutex locked
    at any time. A thread that attempts to lock a mutex already locked
    by another thread will suspend until the other thread unlocks
-   the mutex. *)
+   the mutex.  If the mutex is already locked by the thread calling
+   {!Mutex.lock}, a {!Sys_error} exception is raised instead of deadlocking.
+
+   @since 4.12 concerning the raising of {!Sys_error} instead of deadlocking *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
@@ -46,4 +49,9 @@ val try_lock : t -> bool
 
 val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
-   the mutex will restart. *)
+   the mutex will restart.  The mutex must have been previously locked
+   by the thread that calls {!Mutex.unlock}.  If the mutex is unlocked
+   or was locked by another thread, a {!Sys_error} exception is raised.
+
+   @since 4.12 concerning the raising of {!Sys_error} if the mutex is
+   not locked by the calling thread. *)

--- a/otherlibs/systhreads/mutex.mli
+++ b/otherlibs/systhreads/mutex.mli
@@ -54,7 +54,6 @@ val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
    by the thread that calls {!Mutex.unlock}.
-   
    @raise Sys_error if the mutex is unlocked or was locked by another thread.
 
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex

--- a/otherlibs/systhreads/mutex.mli
+++ b/otherlibs/systhreads/mutex.mli
@@ -37,11 +37,12 @@ val lock : t -> unit
    at any time. A thread that attempts to lock a mutex already locked
    by another thread will suspend until the other thread unlocks
    the mutex.
-   
+
    @raise Sys_error if the mutex is already locked by the thread calling
    {!Mutex.lock}.
 
-   @before 4.12 {!Sys_error} was not raised for recursive locking (platform-dependent behaviour) *)
+   @before 4.12 {!Sys_error} was not raised for recursive locking
+   (platform-dependent behaviour) *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -208,6 +208,7 @@ static int st_mutex_create(st_mutex * res)
   if (m == NULL) { rc = ENOMEM; goto error2; }
   rc = pthread_mutex_init(m, &attr);
   if (rc != 0) goto error3;
+  pthread_mutexattr_destroy(&attr);
   *res = m;
   return 0;
 error3:

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -275,7 +275,7 @@ static void caml_io_mutex_lock(struct channel *chan)
     chan->mutex = mutex;
   }
   /* PR#4351: first try to acquire mutex without releasing the master lock */
-  if (st_mutex_trylock(mutex) == PREVIOUSLY_UNLOCKED) {
+  if (st_mutex_trylock(mutex) == MUTEX_PREVIOUSLY_UNLOCKED) {
     st_tls_set(last_channel_locked_key, (void *) chan);
     return;
   }
@@ -811,7 +811,7 @@ CAMLprim value caml_mutex_lock(value wrapper)     /* ML */
   st_retcode retcode;
 
   /* PR#4351: first try to acquire mutex without releasing the master lock */
-  if (st_mutex_trylock(mut) == PREVIOUSLY_UNLOCKED) return Val_unit;
+  if (st_mutex_trylock(mut) == MUTEX_PREVIOUSLY_UNLOCKED) return Val_unit;
   /* If unsuccessful, block on mutex */
   Begin_root(wrapper)           /* prevent the deallocation of mutex */
     caml_enter_blocking_section();
@@ -837,7 +837,7 @@ CAMLprim value caml_mutex_try_lock(value wrapper)           /* ML */
   st_mutex mut = Mutex_val(wrapper);
   st_retcode retcode;
   retcode = st_mutex_trylock(mut);
-  if (retcode == ALREADY_LOCKED) return Val_false;
+  if (retcode == MUTEX_ALREADY_LOCKED) return Val_false;
   st_check_error(retcode, "Mutex.try_lock");
   return Val_true;
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -144,6 +144,18 @@ extern struct longjmp_buffer caml_termination_jmpbuf;
 extern void (*caml_termination_hook)(void);
 #endif
 
+#ifdef _WIN32
+/* Integer identifier for the currently-executing thread.
+   This is a tagged integer, so it is never 0. */
+
+static intnat st_current_thread_id(void)
+{
+  caml_thread_t th = st_tls_get(thread_descriptor_key);
+  return Ident(th->descr);
+}
+
+#endif
+
 /* Hook for scanning the stacks of the other threads */
 
 static void (*prev_scan_roots_hook) (scanning_action);

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -238,7 +238,7 @@ Caml_inline DWORD st_mutex_trylock(st_mutex m)
 Caml_inline DWORD st_mutex_unlock(st_mutex m)
 {
   LONG self, prev;
-  /* If the calling thead holds the lock, m->owner is stable and equal
+  /* If the calling thread holds the lock, m->owner is stable and equal
      to GetCurrentThreadId().
      Otherwise, the value of m->owner can be 0 (if the mutex is unlocked)
      or some other thread ID (if the mutex is held by another thread),

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -163,6 +163,9 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 struct st_mutex_ {
   CRITICAL_SECTION crit;
   volatile LONG owner;    /* 0 if unlocked */
+  /* The "owner" field is not always protected by "crit"; it is also
+     accessed without holding "crit", using the Interlocked API for
+     atomic accesses */
 };
 
 typedef struct st_mutex_ * st_mutex;

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -255,10 +255,10 @@ Caml_inline DWORD st_mutex_unlock(st_mutex m)
 {
   st_tid self, prev;
   /* If the calling thread holds the lock, m->owner is stable and equal
-     to GetCurrentThreadId().
+     to st_current_thread_id().
      Otherwise, the value of m->owner can be 0 (if the mutex is unlocked)
      or some other thread ID (if the mutex is held by another thread),
-     but is never equal to GetCurrentThreadId(). */
+     but is never equal to st_current_thread_id(). */
   self = st_current_thread_id();
   prev = Tid_Atomic_Compare_Exchange(&m->owner, 0, self);
   if (prev != self) {

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -95,6 +95,15 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
 {
   struct channel * channel;
 
+  for (channel = caml_all_opened_channels; 
+       channel != NULL;
+       channel = channel->next) {
+    if (channel->fd == fd) {
+      int newfd = dup(fd);
+      if (newfd != -1) fd = newfd;
+      break;
+    }
+  }
   channel = (struct channel *) caml_stat_alloc(sizeof(struct channel));
   channel->fd = fd;
   caml_enter_blocking_section_no_pending();

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -95,15 +95,6 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
 {
   struct channel * channel;
 
-  for (channel = caml_all_opened_channels; 
-       channel != NULL;
-       channel = channel->next) {
-    if (channel->fd == fd) {
-      int newfd = dup(fd);
-      if (newfd != -1) fd = newfd;
-      break;
-    }
-  }
   channel = (struct channel *) caml_stat_alloc(sizeof(struct channel));
   channel->fd = fd;
   caml_enter_blocking_section_no_pending();

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -59,31 +59,7 @@ let mutex_unlock_other_thread () =
     mutex_unlock_must_fail m in
   Thread.join (Thread.create f ())
 
-let async_callbacks () =
-  let m = Mutex.create () in
-  let on = ref true in
-  let create_finalised () =
-    let r = ref 0 in
-    Gc.finalise (fun _ ->
-      if !on then begin
-        Mutex.lock m ;
-        log "finalised" ;
-        Mutex.unlock m
-      end) r;
-    r in
-  begin try
-    Mutex.lock m ;
-    let x = create_finalised () in
-    Gc.full_major ();
-    Mutex.unlock m ;
-    ignore (Sys.opaque_identity x)
-  with
-    Sys_error _ -> on := false; log "Deadlock avoided"
-  end
-
 let _ =
-  log "---- Asynchronous callbacks";
-  async_callbacks();
   log "---- Self deadlock";
   mutex_deadlock();
   log "---- Unlock twice";

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -1,0 +1,95 @@
+(* TEST
+
+* hassysthreads
+include systhreads
+** bytecode
+** native
+
+*)
+
+let log s =
+  Printf.printf "%s\n%!" s
+
+let mutex_lock_must_fail m =
+  try
+    Mutex.lock m; log "Should have failed!"
+  with Sys_error _ ->
+    log "Error reported"
+
+let mutex_unlock_must_fail m =
+  try
+    Mutex.unlock m; log "Should have failed!"
+  with Sys_error _ ->
+    log "Error reported"
+
+let mutex_deadlock () =
+  let m = Mutex.create() in
+  log "Acquiring mutex";
+  Mutex.lock m;
+  log "Acquiring mutex again";
+  mutex_lock_must_fail m;
+  log "Releasing mutex";
+  Mutex.unlock m;
+  let f () =
+    log "Acquiring mutex from another thread";
+    Mutex.lock m;
+    log "Success";
+    Mutex.unlock m in
+  Thread.join (Thread.create f ())
+
+let mutex_unlock_twice () =
+  let m = Mutex.create() in
+  log "Acquiring mutex";
+  Mutex.lock m;
+  log "Releasing mutex";
+  Mutex.unlock m;
+  log "Releasing mutex again";
+  mutex_unlock_must_fail m;
+  log "Releasing mutex one more time";
+  mutex_unlock_must_fail m
+
+let mutex_unlock_other_thread () =
+  let m = Mutex.create() in
+  log "Acquiring mutex";
+  Mutex.lock m;
+  let f () =
+    log "Releasing mutex from another thread";
+    mutex_unlock_must_fail m;
+    log "Releasing mutex from another thread (again)";
+    mutex_unlock_must_fail m in
+  Thread.join (Thread.create f ())
+
+let async_callbacks () =
+  let m = Mutex.create () in
+  let on = ref true in
+  let create_finalised () =
+    let r = ref 0 in
+    Gc.finalise (fun _ ->
+      if !on then begin
+        Mutex.lock m ;
+        Mutex.unlock m
+      end) r;
+    r in
+  begin try
+    while true do
+      Mutex.lock m ;
+      let x = create_finalised () in
+      Mutex.unlock m ;
+      ignore (Sys.opaque_identity x)
+    done
+  with
+    Sys_error _ -> on := false; log "Deadlock avoided"
+  end;
+  (* Try to run all finalizers before m is deallocated *)
+  Gc.full_major();
+  ignore (Sys.opaque_identity m)
+
+let _ =
+  log "---- Self deadlock";
+  mutex_deadlock();
+  log "---- Unlock twice";
+  mutex_unlock_twice();
+  log "---- Unlock in other thread";
+  mutex_unlock_other_thread();
+  log "---- Asynchronous callbacks";
+  async_callbacks()

--- a/testsuite/tests/lib-threads/mutex_errors.reference
+++ b/testsuite/tests/lib-threads/mutex_errors.reference
@@ -1,5 +1,3 @@
----- Asynchronous callbacks
-Deadlock avoided
 ---- Self deadlock
 Acquiring mutex
 Acquiring mutex again

--- a/testsuite/tests/lib-threads/mutex_errors.reference
+++ b/testsuite/tests/lib-threads/mutex_errors.reference
@@ -1,3 +1,5 @@
+---- Asynchronous callbacks
+Deadlock avoided
 ---- Self deadlock
 Acquiring mutex
 Acquiring mutex again
@@ -18,5 +20,3 @@ Releasing mutex from another thread
 Error reported
 Releasing mutex from another thread (again)
 Error reported
----- Asynchronous callbacks
-Deadlock avoided

--- a/testsuite/tests/lib-threads/mutex_errors.reference
+++ b/testsuite/tests/lib-threads/mutex_errors.reference
@@ -1,0 +1,22 @@
+---- Self deadlock
+Acquiring mutex
+Acquiring mutex again
+Error reported
+Releasing mutex
+Acquiring mutex from another thread
+Success
+---- Unlock twice
+Acquiring mutex
+Releasing mutex
+Releasing mutex again
+Error reported
+Releasing mutex one more time
+Error reported
+---- Unlock in other thread
+Acquiring mutex
+Releasing mutex from another thread
+Error reported
+Releasing mutex from another thread (again)
+Error reported
+---- Asynchronous callbacks
+Deadlock avoided


### PR DESCRIPTION
This is an alternate implementation of #9757.  The purpose is the same:
- Make sure that `Mutex.lock` raises `Sys_error` if the mutex is already locked by the calling thread.
- Make sure that `Mutex.unlock` raises `Sys_error` if the mutex is unlocked or locked by another thread.

The main difference with #9757 is the Win32 implementation, which I hope is correct, and some more testing.



