### PR TITLE
Don't display configure diffs in Pull Requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,9 +29,9 @@
 
 /boot/menhir/parser.ml* -diff
 
-# configure is declared as binary so that it doesn't get included in diffs.
-# This also means it will have the correct Unix line-endings, even on Windows.
-/configure binary
+# configure is a shell-script; the linguist-generated attribute suppresses
+# changes being displayed by default in pull requests.
+/configure text eol=lf -diff linguist-generated
 
 # 'union' merge driver just unions textual content in case of conflict
 #   http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/

--- a/configure
+++ b/configure
@@ -2811,7 +2811,7 @@ instrumented_runtime_ldlibs=""
 ## Source directory
 
 
-## Directory containing auxiliary scripts used dugring build
+## Directory containing auxiliary scripts used during build
 ac_aux_dir=
 for ac_dir in build-aux "$srcdir"/build-aux; do
   if test -f "$ac_dir/install-sh"; then

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ instrumented_runtime_ldlibs=""
 ## Source directory
 AC_CONFIG_SRCDIR([runtime/interp.c])
 
-## Directory containing auxiliary scripts used dugring build
+## Directory containing auxiliary scripts used during build
 AC_CONFIG_AUX_DIR([build-aux])
 
 ## Output variables


### PR DESCRIPTION
This is a tweak of `.gitattributes` for our lovely autoconf files. See https://github.com/github/linguist#generated-code for the magic flag (we could use this to flag a few other directories and actually make the repo report as C & OCaml only!).

In order to demonstrate the change, I've fixed a typo in `configure.ac`