### PR TITLE
Actually remove directories in ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -315,9 +315,9 @@ Working version
   attributes are present.
   (Matthew Ryan, review by Nicolás Ojeda Bär)
 
-- #9797: Eliminate the routine use of external commands in ocamltest. ocamltest
-  no longer calls the mkdir, rm and ln external commands (at present, the only
-  external command ocamltest uses is diff).
+- #9797, #9849: Eliminate the routine use of external commands in ocamltest.
+  ocamltest no longer calls the mkdir, rm and ln external commands (at present,
+  the only external command ocamltest uses is diff).
   (David Allsopp, review by Nicolás Ojeda Bär, Sébastien Hinderer and
    Xavier Leroy)
 

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -94,10 +94,11 @@ module Sys = struct
 
   let rm_rf path =
     let rec erase path =
-      if Sys.is_directory path
-      then Array.iter (fun entry -> erase (Filename.concat path entry))
-                      (Sys.readdir path)
-      else erase_file path
+      if Sys.is_directory path then begin
+        Array.iter (fun entry -> erase (Filename.concat path entry))
+                   (Sys.readdir path);
+        Sys.rmdir path
+      end else erase_file path
     in
       try if Sys.file_exists path then erase path
       with Sys_error err ->


### PR DESCRIPTION
Following up https://github.com/ocaml/ocaml/pull/9797#discussion_r473927434 which noted that the more concise implementation in https://github.com/ocaml/ocaml/pull/9797#discussion_r460108288 omitted the call to `Sys.rmdir`.

This seems to work correctly on a quick `make one DIR=tests/basic` (`tests/_ocamltest/tests/basic` remains at the end, which I think is correct).