### PR TITLE
Treat set-but-empty OCAMLPARAM the same as unset

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -458,7 +458,7 @@ let read_one_param ppf position name v =
 let read_OCAMLPARAM ppf position =
   try
     let s = Sys.getenv "OCAMLPARAM" in
-    if String.length s <> 0 then
+    if s <> "" then
       let (before, after) =
         try
           parse_args s

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -458,17 +458,18 @@ let read_one_param ppf position name v =
 let read_OCAMLPARAM ppf position =
   try
     let s = Sys.getenv "OCAMLPARAM" in
-    let (before, after) =
-      try
-        parse_args s
-      with SyntaxError s ->
-        print_error ppf s;
-        [],[]
-    in
-    List.iter (fun (name, v) -> read_one_param ppf position name v)
-      (match position with
-         Before_args -> before
-       | Before_compile _ | Before_link -> after)
+    if String.length s <> 0 then
+      let (before, after) =
+        try
+          parse_args s
+        with SyntaxError s ->
+          print_error ppf s;
+          [],[]
+      in
+      List.iter (fun (name, v) -> read_one_param ppf position name v)
+        (match position with
+           Before_args -> before
+         | Before_compile _ | Before_link -> after)
   with Not_found -> ()
 
 (* OCAMLPARAM passed as file *)


### PR DESCRIPTION
In case the OCAMLPARAM environment variable is set to the empty
string, the current behavior is to attempt to parse it, which fails to
find the `_` character separating the "before" and "after"
settings. This patch changes this to treat OCAMLPARAM set to the empty
string the same as being unset, which is to do nothing.