### PR TITLE
Fix double free of toplevel bytecode

### DIFF
--- a/Changes
+++ b/Changes
@@ -387,6 +387,9 @@ Working version
 - #9753: fix build for Android
   (Github user @EduardoRFS, review by Xavier Leroy)
 
+- #9848, #9855: Fix double free of bytecode in toplevel
+  (Stephen Dolan, report by Sampsa Kiiskinen, review by Gabriel Scherer)
+
 
 OCaml 4.11
 ----------

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -8,5 +8,7 @@ val g : unit -> int = <fun>
 Exception: Not_found.
 Raised at f in file "//toplevel//", line 2, characters 11-26
 Called from g in file "//toplevel//", line 1, characters 11-15
-Called from Toploop.load_lambda in file "toplevel/toploop.ml", line 212, characters 17-27
+Called from Stdlib__fun.protect in file "fun.ml", line 33, characters 8-15
+Re-raised at Stdlib__fun.protect in file "fun.ml", line 38, characters 6-52
+Called from Toploop.load_lambda in file "toplevel/toploop.ml", line 212, characters 4-150
 

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -207,15 +207,15 @@ let load_lambda ppf lam =
   Symtable.update_global_table();
   let initial_bindings = !toplevel_value_bindings in
   let bytecode, closure = Meta.reify_bytecode code [| events |] None in
-  try
+  match
     may_trace := true;
-    let retval = closure () in
-    may_trace := false;
-    if can_free then Meta.release_bytecode bytecode;
-    Result retval
-  with x ->
-    may_trace := false;
-    if can_free then Meta.release_bytecode bytecode;
+    Fun.protect
+      ~finally:(fun () -> may_trace := false;
+                          if can_free then Meta.release_bytecode bytecode)
+      closure
+  with
+  | retval -> Result retval
+  | exception x ->
     record_backtrace ();
     toplevel_value_bindings := initial_bindings; (* PR#6211 *)
     Symtable.restore_state initial_symtable;


### PR DESCRIPTION
In toploop, it's possible for a bytecode to be freed twice, if an exception arises during the allocation `Result retval`. (This was the cause of #9848)

The fix is to use `Fun.protect` to ensure it's only freed once.

cc @dra27 