### PR TITLE
Add missing `lower_contravariant` call (fixes #9856)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,12 @@
+OCaml 4.11.1
+------------
+
+### Bug fixes:
+
+- #9856, #9857: Prevent polymorphic type annotations from generalizing
+  weak polymorphic variables.
+  (Leo White, review by Jacques Garrigue)
+
 OCaml 4.11.0 (19 August 2020)
 ---------------------------
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1852,3 +1852,23 @@ Error: This expression has type < x : 'b. 'b s list >
        'a list
        The universal variable 'b would escape its scope
 |}]
+
+(* #9856 *)
+let f x =
+  let ref : type a . a option ref = ref None in
+  ref := Some x;
+  Option.get !ref
+[%%expect{|
+val f : 'a -> 'b = <fun>
+|}]
+
+type pr = { foo : 'a. 'a option ref }
+let x = { foo = ref None }
+[%%expect{|
+type pr = { foo : 'a. 'a option ref; }
+Line 2, characters 16-24:
+2 | let x = { foo = ref None }
+                    ^^^^^^^^
+Error: This field value has type 'b option ref which is less general than
+         'a. 'a option ref
+|}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1859,7 +1859,11 @@ let f x =
   ref := Some x;
   Option.get !ref
 [%%expect{|
-val f : 'a -> 'b = <fun>
+Line 2, characters 6-44:
+2 |   let ref : type a . a option ref = ref None in
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This definition has type 'a option ref which is less general than
+         'a0. 'a0 option ref
 |}]
 
 type pr = { foo : 'a. 'a option ref }

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4978,7 +4978,9 @@ and type_let
             so we do it anyway. *)
          generalize exp.exp_type
        | Some vars ->
-         generalize_and_check_univars env "definition" exp pat.pat_type vars)
+           if maybe_expansive exp then
+             lower_contravariant env exp.exp_type;
+           generalize_and_check_univars env "definition" exp pat.pat_type vars)
     pat_list exp_list;
   let l = List.combine pat_list exp_list in
   let l =


### PR DESCRIPTION
#1132 accidentally removed a call to `lower_contravariant`, presumably because of the `lower_contravariant` call a few lines up which looks equivalent but isn't. This adds it back.

This is a minimal PR for fixing the bug on the 4.11 branch. We should also add a regression test etc. for the patch to trunk.