### PR TITLE
z Systems: subtract immediate has its own range of valid immediate values

### DIFF
--- a/Changes
+++ b/Changes
@@ -397,6 +397,9 @@ Working version
 - #9848, #9855: Fix double free of bytecode in toplevel
   (Stephen Dolan, report by Sampsa Kiiskinen, review by Gabriel Scherer)
 
+- #9860: wrong range constraint for subtract immediate on zSystems / s390x
+  (Xavier Leroy, review by Stephen Dolan)
+
 
 OCaml 4.11
 ----------

--- a/asmcomp/s390x/selection.ml
+++ b/asmcomp/s390x/selection.ml
@@ -80,6 +80,12 @@ method! select_operation op args dbg =
   match (op, args) with
   (* Z does not support immediate operands for multiply high *)
     (Cmulhi, _) -> (Iintop Imulh, args)
+  (* sub immediate is turned into add immediate opposite, 
+     hence the immediate range is special *)
+  | (Csubi, [arg; Cconst_int (n, _)]) when self#is_immediate (-n) ->
+      (Iintop_imm(Isub, n), [arg])
+  | (Csubi, _) ->
+      (Iintop Isub, args)
   (* The and, or and xor instructions have a different range of immediate
      operands than the other instructions *)
   | (Cand, _) ->


### PR DESCRIPTION
That's because sub immediate it is turned into add immediate opposite in emit.mlp.

The problem was exhibited by the merge of #9838 but it was there before.
