### PR TITLE
9859: revert 9348, inferred function types and :>

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ OCaml 4.11.1
   weak polymorphic variables.
   (Leo White, review by Jacques Garrigue)
 
+- #9859, #9862: Remove an erroneous assertion when inferred function types
+  appear in the right hand side of an explicit :> coercion
+  (Florian Angeletti, review by Thomas Refis)
+
 OCaml 4.11.0 (19 August 2020)
 ---------------------------
 

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -90,3 +90,32 @@ Line 1, characters 45-46:
 Warning 19: commuted an argument without principality.
 val f : (x:int -> unit -> int) -> x:int -> int = <fun>
 |}];;
+
+(* 9859: inferred function types may appear in the right hand side of :> *)
+class setup = object
+  method with_ f = (f 0:unit)
+end
+class virtual fail = object (self)
+  method trigger = (self :> setup )
+end
+[%%expect {|
+class setup : object method with_ : (int -> unit) -> unit end
+class virtual fail :
+  object
+    method trigger : setup
+    method virtual with_ : (int -> unit) -> unit
+  end
+|}]
+
+module type T = sig type t  end
+let type_of (type x) (x: x) = (module struct type t = x end: T with type t = x)
+let f g = 1 + g ~x:0 ~y:0;;
+module E = (val type_of f)
+let g = ( (fun _ -> f) :> 'a -> E.t)
+[%%expect {|
+module type T = sig type t end
+val type_of : 'x -> (module T with type t = 'x) = <fun>
+val f : (x:int -> y:int -> int) -> int = <fun>
+module E : sig type t = (x:int -> y:int -> int) -> int end
+val g : 'a -> E.t = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3999,8 +3999,7 @@ let rec build_subtype env visited loops posi level t =
           (t, Unchanged)
       else
         (t, Unchanged)
-  | Tarrow(l, t1, t2, com) ->
-      assert (com = Cok);
+  | Tarrow(l, t1, t2, _) ->
       if memq_warn t visited then (t, Unchanged) else
       let visited = t :: visited in
       let (t1', c1) = build_subtype env visited loops (not posi) level t1 in


### PR DESCRIPTION
This PR reverts #9348 in the 4.11 branch and adds two related tests to the testsuite.

Since  the #9348 PR only added a new assertion, which breaks on existing user code,  I am planning to integrate this revert in the 4.11.1 release.