### PR TITLE
Replaced add/sub $8, %rsp with push/pop on amd64

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -450,12 +450,16 @@ let emit_float_test cmp i lbl =
 
 (* Deallocate the stack frame before a return or tail call *)
 
-let output_epilogue ~tailcall f =
+let output_epilogue ?scratch f =
   if !frame_required then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
     if n <> 0
     then begin
-      if not tailcall && n = 8 then (I.pop rbx) else (I.add (int n) rsp);
+      (match scratch with
+      | Some reg when not !fastcode_flag && n = 8 ->
+        I.pop reg
+      | _ ->
+        I.add (int n) rsp);
       cfi_adjust_cfa_offset (-n);
     end;
     if fp then I.pop rbp;
@@ -533,7 +537,10 @@ let emit_instr fallthrough i =
       let n = frame_size() - 8 - (if fp then 8 else 0) in
       if n <> 0
       then begin
-        if n = 8 then (I.push rax) else (I.sub (int n) rsp);
+        if n = 8 && not !fastcode_flag then
+          (I.push rax)
+        else
+          (I.sub (int n) rsp);
         cfi_adjust_cfa_offset n;
       end;
     end
@@ -583,7 +590,7 @@ let emit_instr fallthrough i =
       emit_call func;
       record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Itailcall_ind { label_after; }) ->
-      output_epilogue ~tailcall:true begin fun () ->
+      output_epilogue begin fun () ->
         I.jmp (arg i 0);
         if Config.spacetime then begin
           record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
@@ -594,7 +601,7 @@ let emit_instr fallthrough i =
         if func = !function_name then
           I.jmp (label !tailrec_entry_point)
         else begin
-          output_epilogue ~tailcall:true begin fun () ->
+          output_epilogue begin fun () ->
             add_used_symbol func;
             emit_jump func
           end
@@ -800,7 +807,7 @@ let emit_instr fallthrough i =
   | Lreloadretaddr ->
       ()
   | Lreturn ->
-      output_epilogue ~tailcall:false begin fun () ->
+      output_epilogue ~scratch:rbx begin fun () ->
         I.ret ()
       end
   | Llabel lbl ->

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -450,12 +450,12 @@ let emit_float_test cmp i lbl =
 
 (* Deallocate the stack frame before a return or tail call *)
 
-let output_epilogue f =
+let output_epilogue ~tailcall f =
   if !frame_required then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
     if n <> 0
     then begin
-      I.add (int n) rsp;
+      if not tailcall && n = 8 then (I.pop rbx) else (I.add (int n) rsp);
       cfi_adjust_cfa_offset (-n);
     end;
     if fp then I.pop rbp;
@@ -533,7 +533,7 @@ let emit_instr fallthrough i =
       let n = frame_size() - 8 - (if fp then 8 else 0) in
       if n <> 0
       then begin
-        I.sub (int n) rsp;
+        if n = 8 then (I.push rax) else (I.sub (int n) rsp);
         cfi_adjust_cfa_offset n;
       end;
     end
@@ -583,7 +583,7 @@ let emit_instr fallthrough i =
       emit_call func;
       record_frame i.live (Dbg_other i.dbg) ~label:label_after
   | Lop(Itailcall_ind { label_after; }) ->
-      output_epilogue begin fun () ->
+      output_epilogue ~tailcall:true begin fun () ->
         I.jmp (arg i 0);
         if Config.spacetime then begin
           record_frame Reg.Set.empty (Dbg_other i.dbg) ~label:label_after
@@ -594,7 +594,7 @@ let emit_instr fallthrough i =
         if func = !function_name then
           I.jmp (label !tailrec_entry_point)
         else begin
-          output_epilogue begin fun () ->
+          output_epilogue ~tailcall:true begin fun () ->
             add_used_symbol func;
             emit_jump func
           end
@@ -800,7 +800,7 @@ let emit_instr fallthrough i =
   | Lreloadretaddr ->
       ()
   | Lreturn ->
-      output_epilogue begin fun () ->
+      output_epilogue ~tailcall:false begin fun () ->
         I.ret ()
       end
   | Llabel lbl ->

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -48,6 +48,7 @@ let ah  = Reg8H AH
 let cl  = Reg8L RCX
 let ax  = Reg16 RAX
 let rax = Reg64 RAX
+let rbx = Reg64 RBX
 let r10 = Reg64 R10
 let r11 = Reg64 R11
 let r13 = Reg64 R13

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -37,6 +37,7 @@ val ah: arg
 val cl: arg
 val ax: arg
 val rax: arg
+val rbx: arg
 val r10: arg
 val r11: arg
 val r13: arg


### PR DESCRIPTION
When compiling without frame pointers, functions which do not use
any locals or functions with exactly one spill slot need to adjust
the stack pointer by 8 bytes to reserve space or maintain the
required 16 byte alignment. This is presently achieved using add or
sub. Encoding add $8, %rsp and sub $8, %rsp requires at least 4 bytes
each. In contrast, push %rax and pop %rbx can be encoded in 1 byte.

This patch replaces sub $8, %rsp with push %rax in the prologue for
all functions. The adjustment in the epilogue, add $8, %rsp, is
replaced with pop %rbx for regular returns (a register cannot be
trivially chosen for tail calls since the ones storing arguments
for them are live across, so these paths fall back to add).

Code size is reduced by 0.4% on both the ocamlopt.opt and coqchk
binaries. Performance seems to be unaffected on coqchk.