### PR TITLE
Fix #8907

### DIFF
--- a/Changes
+++ b/Changes
@@ -599,7 +599,7 @@ OCaml 4.12.0
   (Jacques Garrigue, report and review by Thomas Refis)
 
 * #8907, #9878: `Typemod.normalize_signature` uses wrong environment
-  (Jacques Garrigue, report by Leo White)
+  (Jacques Garrigue, report and review by Leo White)
 
 - #9421, #9427: fix printing of (::) in ocamldoc
   (Florian Angeletti, report by Yawar Amin, review by Damien Doligez)

--- a/Changes
+++ b/Changes
@@ -598,6 +598,9 @@ OCaml 4.12.0
 - #8747, #9709: incorrect principality warning on functional updates of records
   (Jacques Garrigue, report and review by Thomas Refis)
 
+* #8907, #9878: `Typemod.normalize_signature` uses wrong environment
+  (Jacques Garrigue, report by Leo White)
+
 - #9421, #9427: fix printing of (::) in ocamldoc
   (Florian Angeletti, report by Yawar Amin, review by Damien Doligez)
 

--- a/testsuite/tests/typing-misc/normalize_type.ml
+++ b/testsuite/tests/typing-misc/normalize_type.ml
@@ -1,0 +1,20 @@
+(* TEST
+   * expect
+*)
+
+(* #8907 *)
+
+module M = struct
+  type t = int
+  let f (x : [< `Foo of t & int & string]) = ()
+end;;
+[%%expect{|
+module M : sig type t = int val f : [< `Foo of t & int & string ] -> unit end
+|}]
+
+type t = int
+let f (x : [< `Foo of t & int & string]) = () ;;
+[%%expect{|
+type t = int
+val f : [< `Foo of t & int & string ] -> unit = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4546,7 +4546,7 @@ let closed_schema env ty =
 
 (* Normalize a type before printing, saving... *)
 (* Cannot use mark_type because deep_occur uses it too *)
-let rec normalize_type_rec env visited ty =
+let rec normalize_type_rec visited ty =
   let ty = repr ty in
   if not (TypeSet.mem ty !visited) then begin
     visited := TypeSet.add ty !visited;
@@ -4567,7 +4567,8 @@ let rec normalize_type_rec env visited ty =
               let tyl' =
                 List.fold_left
                   (fun tyl ty ->
-                    if List.exists (fun ty' -> equal env false [ty] [ty']) tyl
+                    if List.exists
+                        (fun ty' -> equal Env.empty false [ty] [ty']) tyl
                     then tyl else ty::tyl)
                   [ty] tyl
               in
@@ -4605,11 +4606,11 @@ let rec normalize_type_rec env visited ty =
         set_type_desc fi fi'.desc
     | _ -> ()
     end;
-    iter_type_expr (normalize_type_rec env visited) ty
+    iter_type_expr (normalize_type_rec visited) ty
   end
 
-let normalize_type env ty =
-  normalize_type_rec env (ref TypeSet.empty) ty
+let normalize_type ty =
+  normalize_type_rec (ref TypeSet.empty) ty
 
 
                               (*************************)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -349,7 +349,7 @@ val nondep_cltype_declaration:
 (*val correct_abbrev: Env.t -> Path.t -> type_expr list -> type_expr -> unit*)
 val cyclic_abbrev: Env.t -> Ident.t -> type_expr -> bool
 val is_contractive: Env.t -> Path.t -> bool
-val normalize_type: Env.t -> type_expr -> unit
+val normalize_type: type_expr -> unit
 
 val closed_schema: Env.t -> type_expr -> bool
         (* Check whether the given type scheme contains no non-generic

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -923,7 +923,7 @@ let rec mark_loops_rec visited ty =
     | Tunivar _ -> add_named_var ty
 
 let mark_loops ty =
-  normalize_type Env.empty ty;
+  normalize_type ty;
   mark_loops_rec [] ty;;
 
 let reset_loop_marks () =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2451,17 +2451,17 @@ let type_structure = type_structure false None
 
 (* Normalize types in a signature *)
 
-let rec normalize_modtype env = function
+let rec normalize_modtype = function
     Mty_ident _
   | Mty_alias _ -> ()
-  | Mty_signature sg -> normalize_signature env sg
-  | Mty_functor(_param, body) -> normalize_modtype env body
+  | Mty_signature sg -> normalize_signature sg
+  | Mty_functor(_param, body) -> normalize_modtype body
 
-and normalize_signature env = List.iter (normalize_signature_item env)
+and normalize_signature sg = List.iter normalize_signature_item sg
 
-and normalize_signature_item env = function
-    Sig_value(_id, desc, _) -> Ctype.normalize_type env desc.val_type
-  | Sig_module(_id, _, md, _, _) -> normalize_modtype env md.md_type
+and normalize_signature_item = function
+    Sig_value(_id, desc, _) -> Ctype.normalize_type desc.val_type
+  | Sig_module(_id, _, md, _, _) -> normalize_modtype md.md_type
   | _ -> ()
 
 (* Extract the module type of a module expression *)
@@ -2668,7 +2668,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
               sourcefile sg "(inferred signature)" simple_sg
           in
           check_nongen_schemes finalenv simple_sg;
-          normalize_signature finalenv simple_sg;
+          normalize_signature simple_sg;
           Typecore.force_delayed_checks ();
           (* See comment above. Here the target signature contains all
              the value being exported. We can still capture unused


### PR DESCRIPTION
Fix #8907 by making `Ctype.normalize_type` not depend on env.

This may break code that copied the previously inferred normal form to the mli.