### PR TITLE
Declare caml_*_ops in headers [Cygwin64 pre-req 1/6]

### DIFF
--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -75,6 +75,11 @@ extern struct custom_operations *
           caml_final_custom_operations(void (*fn)(value));
 
 extern void caml_init_custom_operations(void);
+
+extern struct custom_operations caml_nativeint_ops;
+extern struct custom_operations caml_int32_ops;
+extern struct custom_operations caml_int64_ops;
+extern struct custom_operations caml_ba_ops;
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -155,11 +155,6 @@ struct custom_operations * caml_final_custom_operations(final_fun fn)
   return ops;
 }
 
-extern struct custom_operations caml_int32_ops,
-                                caml_nativeint_ops,
-                                caml_int64_ops,
-                                caml_ba_ops;
-
 void caml_init_custom_operations(void)
 {
   caml_register_custom_operations(&caml_int32_ops);


### PR DESCRIPTION
_This is part of a series of self-contained (hopefully) simple PRs removing smaller parts of #1633. The aim is to restore Cygwin64 support, preferably for 4.12. The final aim is that symbols marked `CAMLexport` in the C file should always appear _publicly_ in the headers and vice versa._

This PR simply moves the declarations of `caml_int32_ops`, `caml_int64_ops`, `caml_nativeint_ops` and `caml_ba_ops` out of `custom.c` and into a `CAML_INTERNALS` section of `caml/custom.h`.

The rationale is tidying up things marked with `CAMLexport` as actually existing in headers. This PR is largely for "consistency".