### PR TITLE
Remove interp.c from primitives generation

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -18,7 +18,7 @@
  (deps
    ; matches the line structure of files in gen_primitives.sh
    alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c intern.c
-     interp.c ints.c io.c
+     ints.c io.c
    lexing.c md5.c meta.c memprof.c obj.c parsing.c signals.c str.c sys.c
      callback.c weak.c
    finalise.c stacks.c dynlink.c backtrace_byt.c backtrace.c

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -22,7 +22,7 @@
 export LC_ALL=C
 (
   for prim in \
-      alloc array compare extern floats gc_ctrl hash intern interp ints io \
+      alloc array compare extern floats gc_ctrl hash intern ints io \
       lexing md5 meta memprof obj parsing signals str sys callback weak \
       finalise stacks dynlink backtrace_byt backtrace spacetime_byt afl \
       bigarray eventlog


### PR DESCRIPTION
_This is part of a series of self-contained (hopefully) simple PRs removing smaller parts of #1633. The aim is to restore Cygwin64 support, preferably for 4.12. The final aim is that symbols marked `CAMLexport` in the C file should always appear _publicly_ in the headers and vice versa._

Minor tweak, since it doesn't (and shouldn't ever) contain any bytecode primitives, removing it from the list of files scanned.