### PR TITLE
Remove unimplemented functions in caml/alloc.h [Cygwin64 pre-req 3/6]

### DIFF
--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -51,10 +51,8 @@ CAMLextern value caml_alloc_sprintf(const char * format, ...)
 ;
 CAMLextern value caml_alloc_some(value);
 
-CAMLextern value caml_alloc_with_profinfo (mlsize_t, tag_t, intnat);
 CAMLextern value caml_alloc_small_with_my_or_given_profinfo (
   mlsize_t, tag_t, uintnat);
-CAMLextern value caml_alloc_small_with_profinfo (mlsize_t, tag_t, intnat);
 
 typedef void (*final_fun)(value);
 CAMLextern value caml_alloc_final (mlsize_t wosize,


### PR DESCRIPTION
_This is part of a series of self-contained (hopefully) simple PRs removing smaller parts of #1633. The aim is to restore Cygwin64 support, preferably for 4.12. The final aim is that symbols marked `CAMLexport` in the C file should always appear _publicly_ in the headers and vice versa._

These two functions were declared in #585, but they don't exist (I think `caml_alloc_small_with_profinfo` became a macro, and there's no sign of `caml_alloc_with_profinfo`).