### PR TITLE
Tidy CAML_INTERNALS in minor_gc.h and memory.h [Cygwin64 pre-req 4/6]

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -57,11 +57,13 @@ CAMLextern void caml_free_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_modify (value *, value);
 CAMLextern void caml_initialize (value *, value);
 CAMLextern value caml_check_urgent_gc (value);
+CAMLextern color_t caml_allocation_color (void *hp);
+#ifdef CAML_INTERNALS
 CAMLextern char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */
 CAMLextern void caml_free_for_heap (char *mem);
 CAMLextern void caml_disown_for_heap (char *mem);
 CAMLextern int caml_add_to_heap (char *mem);
-CAMLextern color_t caml_allocation_color (void *hp);
+#endif /* CAML_INTERNALS */
 
 CAMLextern int caml_huge_fallback_count;
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -65,9 +65,9 @@ struct caml_custom_table CAML_TABLE_STRUCT(struct caml_custom_elt);
 
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap (void);
-CAMLextern void caml_gc_dispatch (void);
+extern void caml_gc_dispatch (void);
 CAMLextern void caml_minor_collection (void);
-CAMLextern void caml_garbage_collection (void); /* runtime/signals_nat.c */
+extern void caml_garbage_collection (void); /* runtime/signals_nat.c */
 extern void caml_oldify_one (value, value *);
 extern void caml_oldify_mopup (void);
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -67,7 +67,7 @@ extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap (void);
 CAMLextern void caml_gc_dispatch (void);
 CAMLextern void caml_minor_collection (void);
-CAMLextern void garbage_collection (void); /* runtime/signals_nat.c */
+CAMLextern void caml_garbage_collection (void); /* runtime/signals_nat.c */
 extern void caml_oldify_one (value, value *);
 extern void caml_oldify_mopup (void);
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -63,10 +63,12 @@ struct caml_custom_table CAML_TABLE_STRUCT(struct caml_custom_elt);
 /* Table of custom blocks in the minor heap that contain finalizers
    or GC speed parameters. */
 
+CAMLextern void caml_minor_collection (void);
+
+#ifdef CAML_INTERNALS
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap (void);
 extern void caml_gc_dispatch (void);
-CAMLextern void caml_minor_collection (void);
 extern void caml_garbage_collection (void); /* runtime/signals_nat.c */
 extern void caml_oldify_one (value, value *);
 extern void caml_oldify_mopup (void);
@@ -130,5 +132,7 @@ Caml_inline void add_to_custom_table (struct caml_custom_table *tbl, value v,
   elt->mem = mem;
   elt->max = max;
 }
+
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_MINOR_GC_H */

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -455,7 +455,7 @@ void caml_shrink_heap (char *chunk)
   caml_free_for_heap (chunk);
 }
 
-color_t caml_allocation_color (void *hp)
+CAMLexport color_t caml_allocation_color (void *hp)
 {
   if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean ||
       (caml_gc_phase == Phase_sweep && (char *)hp >= (char *)caml_gc_sweep_hp)){

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -462,7 +462,7 @@ extern uintnat caml_instr_alloc_jump;
    Leave enough room in the minor heap to allocate at least one object.
    Guaranteed not to call any OCaml callback.
 */
-CAMLexport void caml_gc_dispatch (void)
+void caml_gc_dispatch (void)
 {
   value *trigger = Caml_state->young_trigger; /* save old value of trigger */
 


### PR DESCRIPTION
_This is part of a series of self-contained (hopefully) simple PRs removing smaller parts of #1633. The aim is to restore Cygwin64 support, preferably for 4.12. The final aim is that symbols marked `CAMLexport` in the C file should always appear _publicly_ in the headers and vice versa._

This PR addresses questions asked at the top of #1633 and @damiendoligez's https://github.com/ocaml/ocaml/pull/1633#issuecomment-395085575 and https://github.com/ocaml/ocaml/pull/1633#issuecomment-395090293.

- `caml_allocation_color` is used in Hack and ocamlnet, so its declaration certainly remains public, the other heap functions, based on a GitHub code search are, as expected, not used. `caml_allocation_color` is therefore explicitly marked `CAMLexport` in `memory.c`
- A code search reveals no uses of `caml_gc_dispatch`, so the `CAMLexport` marking is removed and the declaration made `CAML_INTERNALS`.
- As noted, the rest of `caml/minor_gc.h` is internal, except for `caml_minor_collection` (which was added in #8993) and so is moved further up the header.