### PR TITLE
Guard caml_fatal_uncaught_exception with CAML_INTERNALS [Cygwin64 pre-req 5/6]

### DIFF
--- a/runtime/caml/printexc.h
+++ b/runtime/caml/printexc.h
@@ -26,7 +26,9 @@ extern "C" {
 
 
 CAMLextern char * caml_format_exception (value);
+#ifdef CAML_INTERNALS
 CAMLnoreturn_start void caml_fatal_uncaught_exception (value) CAMLnoreturn_end;
+#endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
_This is part of a series of self-contained (hopefully) simple PRs removing smaller parts of #1633. The aim is to restore Cygwin64 support, preferably for 4.12. The final aim is that symbols marked `CAMLexport` in the C file should always appear _publicly_ in the headers and vice versa._

`caml_fatal_uncaught_exception` isn't marked `CAMLexport` in `printexc.c`, so guard the declaration with `CAML_INTERNALS` (a code search suggest it's not used outside the runtime).

As with the `caml_*_ops`, this is more about consistency - if something isn't marked as being exported in the C file, then guard it with `CAML_INTERNALS` in the headers (because marking as exported and being declared properly in the headers will shortly have significance again).