### PR TITLE
Missing declarations in io.h [Cygwin64 pre-req 6/6]

### DIFF
--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -75,9 +75,6 @@ CAMLextern void caml_seek_out (struct channel *, file_offset);
 CAMLextern file_offset caml_pos_in (struct channel *);
 CAMLextern file_offset caml_pos_out (struct channel *);
 
-CAMLextern void caml_finalize_channel (value);
-CAMLextern int caml_do_read (int, char *, unsigned int);
-
 /* I/O on channels from C. The channel must be locked (see below) before
    calling any of the functions and macros below */
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -69,7 +69,11 @@ enum {
 CAMLextern struct channel * caml_open_descriptor_in (int);
 CAMLextern struct channel * caml_open_descriptor_out (int);
 CAMLextern void caml_close_channel (struct channel *);
-
+CAMLextern file_offset caml_channel_size (struct channel *);
+CAMLextern void caml_seek_in (struct channel *, file_offset);
+CAMLextern void caml_seek_out (struct channel *, file_offset);
+CAMLextern file_offset caml_pos_in (struct channel *);
+CAMLextern file_offset caml_pos_out (struct channel *);
 
 /* I/O on channels from C. The channel must be locked (see below) before
    calling any of the functions and macros below */

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -75,6 +75,9 @@ CAMLextern void caml_seek_out (struct channel *, file_offset);
 CAMLextern file_offset caml_pos_in (struct channel *);
 CAMLextern file_offset caml_pos_out (struct channel *);
 
+CAMLextern void caml_finalize_channel (value);
+CAMLextern int caml_do_read (int, char *, unsigned int);
+
 /* I/O on channels from C. The channel must be locked (see below) before
    calling any of the functions and macros below */
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -369,7 +369,7 @@ CAMLexport file_offset caml_pos_in(struct channel *channel)
   return channel->offset - (file_offset)(channel->max - channel->curr);
 }
 
-CAMLexport intnat caml_input_scan_line(struct channel *channel)
+intnat caml_input_scan_line(struct channel *channel)
 {
   char * p;
   int n;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -416,7 +416,7 @@ intnat caml_input_scan_line(struct channel *channel)
    objects into a heap-allocated object.  Perform locking
    and unlocking around the I/O operations. */
 
-/* FIXME CAMLexport, but not in io.h  exported for Cash ? */
+/* caml_finalize_channel is exported for Cash */
 CAMLexport void caml_finalize_channel(value vchan)
 {
   struct channel * chan = Channel(vchan);

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -266,8 +266,7 @@ CAMLexport file_offset caml_pos_out(struct channel *channel)
 
 /* Input */
 
-/* caml_do_read is exported for Cash */
-CAMLexport int caml_do_read(int fd, char *p, unsigned int n)
+int caml_do_read(int fd, char *p, unsigned int n)
 {
   int r;
   do {
@@ -416,8 +415,7 @@ intnat caml_input_scan_line(struct channel *channel)
    objects into a heap-allocated object.  Perform locking
    and unlocking around the I/O operations. */
 
-/* caml_finalize_channel is exported for Cash */
-CAMLexport void caml_finalize_channel(value vchan)
+void caml_finalize_channel(value vchan)
 {
   struct channel * chan = Channel(vchan);
   if ((chan->flags & CHANNEL_FLAG_MANAGED_BY_GC) == 0) return;


### PR DESCRIPTION
_This is part of a series of self-contained (hopefully) simple PRs removing smaller parts of #1633. The aim is to restore Cygwin64 support, preferably for 4.12. The final aim is that symbols marked `CAMLexport` in the C file should always appear _publicly_ in the headers and vice versa._

Add missing declarations in `caml/io.h` for `caml_channel_size`, `caml_pos_in`, `caml_pos_out`, `caml_seek_in` and `caml_seek_out`. Prior to OCaml 3.08.0, these 5 symbols were primitives. The primitives got renamed to `caml_ml_channel_size`, etc. but the C symbols therefore were risky to export routinely, so they remained in `compatibility.h` only. 17 years after its release, I think we can risk `caml/io.h` now breaking 3.07 and earlier in a very obscure corner case. These C functions are used in Ocsfml (which manually declares them).

`caml_finalize_channel` and `caml_do_read` are marked `CAMLexport` in `io.c` for the benefits of [Cash](http://pauillac.inria.fr/cash/). Cash 0.20 can't build on 3.10 without significant patching and doesn't build even on 3.08 without a lot of help. The dev version included on the web-page can't build because of a missing dependency. However, noting #1108, the two functions are instead formally declared in `caml/io.h`. I do wonder though if it's time (again) to consider whether keeping the code in _current_ OCaml is necessary?