### PR TITLE
The attack of the binding operators: introduce (let@) in the compiler codebase

### DIFF
--- a/.depend
+++ b/.depend
@@ -1385,6 +1385,7 @@ typing/typedecl_properties.cmi : \
 typing/typedecl_separability.cmo : \
     typing/types.cmi \
     typing/typedecl_properties.cmi \
+    utils/misc.cmi \
     parsing/location.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
@@ -1395,6 +1396,7 @@ typing/typedecl_separability.cmo : \
 typing/typedecl_separability.cmx : \
     typing/types.cmx \
     typing/typedecl_properties.cmx \
+    utils/misc.cmx \
     parsing/location.cmx \
     typing/env.cmx \
     typing/ctype.cmx \

--- a/Changes
+++ b/Changes
@@ -342,6 +342,10 @@ Working version
   (David Allsopp, review by Nicolás Ojeda Bär, Sébastien Hinderer and
    Xavier Leroy)
 
+- #9887: introduce `(let@)` in Misc.BindingOps:
+  `let@ x = a in b` is equivalent to `a @@ fun x -> b`.
+  (Gabriel Scherer, review by ???)
+
 ### Build system:
 
 - #7121, #9558: Always the autoconf-discovered ld in PACKLD. For

--- a/debugger/input_handling.ml
+++ b/debugger/input_handling.ml
@@ -63,21 +63,21 @@ let main_loop () =
     let old_state = !continue_main_loop in
     fun () -> continue_main_loop := old_state
   in
-    Fun.protect ~finally @@ fun () ->
-      continue_main_loop := true;
-      while !continue_main_loop do
-        try
-          let (input, _, _) =
-            select (List.map fst !active_files) [] [] (-1.)
-          in
-            List.iter
-              (function fd ->
-                 let (funct, iochan) = (List.assoc fd !active_files) in
-                   funct iochan)
-              input
-        with
-          Unix_error (EINTR, _, _) -> ()
-      done
+  let@ () = Fun.protect ~finally in
+  continue_main_loop := true;
+  while !continue_main_loop do
+    try
+      let (input, _, _) =
+        select (List.map fst !active_files) [] [] (-1.)
+      in
+        List.iter
+          (function fd ->
+             let (funct, iochan) = (List.assoc fd !active_files) in
+               funct iochan)
+          input
+    with
+      Unix_error (EINTR, _, _) -> ()
+  done
 
 (*** Managing user inputs ***)
 

--- a/debugger/primitives.ml
+++ b/debugger/primitives.ml
@@ -26,6 +26,8 @@ let cleanup e f =
 
 let nothing _ = ()
 
+let ( let@ ) f x = f x
+
 (*** Operations on lists. ***)
 
 (* Remove an element from a list *)

--- a/debugger/primitives.mli
+++ b/debugger/primitives.mli
@@ -19,6 +19,9 @@
 (*** Miscellaneous ***)
 val nothing : 'a -> unit
 
+val ( let@ ) : ('a -> 'b) -> 'a -> 'b
+(** [let@ x = a in b] is [a @@ fun x -> b]. *)
+
 (*** Types and exceptions. ***)
 exception Out_of_range
 

--- a/debugger/question.ml
+++ b/debugger/question.ml
@@ -19,30 +19,30 @@ module Lexer = Debugger_lexer
 
 (* Ask user a yes or no question. *)
 let yes_or_no message =
-  if !interactif then
+  if not !interactif then false
+  else begin
     let finally =
       let old_prompt = !current_prompt in
       fun () -> stop_user_input (); current_prompt := old_prompt
     in
-      Fun.protect ~finally @@ fun () ->
-        current_prompt := message ^ " ? (y or n) ";
-        let answer =
-          let rec ask () =
-            resume_user_input ();
-            let line =
-              string_trim (Lexer.line (Lexing.from_function read_user_input))
-            in
-              match (if String.length line > 0 then line.[0] else ' ') with
-                'y' -> true
-              | 'n' -> false
-              | _ ->
-                stop_user_input ();
-                print_string "Please answer y or n.";
-                print_newline ();
-                ask ()
-          in
-            ask ()
+    let@ () = Fun.protect ~finally in
+    current_prompt := message ^ " ? (y or n) ";
+    let answer =
+      let rec ask () =
+        resume_user_input ();
+        let line =
+          string_trim (Lexer.line (Lexing.from_function read_user_input))
         in
-          answer
-  else
-    false
+          match (if String.length line > 0 then line.[0] else ' ') with
+            'y' -> true
+          | 'n' -> false
+          | _ ->
+            stop_user_input ();
+            print_string "Please answer y or n.";
+            print_newline ();
+            ask ()
+      in
+        ask ()
+    in
+      answer
+  end

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Misc
+open Misc.BindingOps
 open Compenv
 
 type info = {
@@ -37,7 +38,7 @@ let with_info ~native ~tool_name ~source_file ~output_prefix ~dump_ext k =
   Env.set_unit_name module_name;
   let env = Compmisc.initial_env() in
   let dump_file = String.concat "." [output_prefix; dump_ext] in
-  Compmisc.with_ppf_dump ~file_prefix:dump_file @@ fun ppf_dump ->
+  let@ ppf_dump = Compmisc.with_ppf_dump ~file_prefix:dump_file in
   k {
     module_name;
     output_prefix;
@@ -56,7 +57,7 @@ let parse_intf i =
   |> print_if i.ppf_dump Clflags.dump_source Pprintast.signature
 
 let typecheck_intf info ast =
-  Profile.(record_call typing) @@ fun () ->
+  let@ () = Profile.(record_call typing) in
   let tsg =
     ast
     |> Typemod.type_interface info.env
@@ -83,7 +84,7 @@ let emit_signature info ast tsg =
     info.output_prefix info.source_file info.env sg
 
 let interface info =
-  Profile.record_call info.source_file @@ fun () ->
+  let@ () = Profile.record_call info.source_file in
   let ast = parse_intf info in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let tsg = typecheck_intf info ast in
@@ -109,7 +110,7 @@ let typecheck_impl i parsetree =
     Printtyped.implementation_with_coercion
 
 let implementation info ~backend =
-  Profile.record_call info.source_file @@ fun () ->
+  let@ () = Profile.record_call info.source_file in
   let exceptionally () =
     let sufs = if info.native then [ cmx; obj ] else [ cmo ] in
     List.iter (fun suf -> remove_file (suf info)) sufs;

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -16,6 +16,7 @@
 (** The batch compiler *)
 
 open Misc
+open Misc.BindingOps
 open Compile_common
 
 let tool_name = "ocamlopt"
@@ -24,7 +25,7 @@ let with_info =
   Compile_common.with_info ~native:true ~tool_name
 
 let interface ~source_file ~output_prefix =
-  with_info ~source_file ~output_prefix ~dump_ext:"cmi" @@ fun info ->
+  let@ info = with_info ~source_file ~output_prefix ~dump_ext:"cmi" in
   Compile_common.interface info
 
 let (|>>) (x, y) f = (x, f y)
@@ -92,5 +93,5 @@ let implementation ~backend ~source_file ~output_prefix =
     then flambda info backend typed
     else clambda info backend typed
   in
-  with_info ~source_file ~output_prefix ~dump_ext:"cmx" @@ fun info ->
+  let@ info = with_info ~source_file ~output_prefix ~dump_ext:"cmx" in
   Compile_common.implementation info ~backend

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -13,6 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Misc.BindingOps
 open Format
 
 type error =
@@ -217,7 +218,7 @@ let parse_file ~tool_name invariant_fun parse kind sourcefile =
   let inputfile = preprocess sourcefile in
   Misc.try_finally
     (fun () ->
-       Profile.record_call "parsing" @@ fun () ->
+       let@ () = Profile.record_call "parsing" in
        file_aux ~tool_name inputfile parse invariant_fun kind)
     ~always:(fun () -> remove_preprocessed inputfile)
 

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -60,7 +60,7 @@ type files = {
 }
 
 let read_text_file lines_to_drop fn =
-  Sys.with_input_file ~bin:true fn @@ fun ic ->
+  let@ ic = Sys.with_input_file ~bin:true fn in
   let drop_cr s =
     let l = String.length s in
     if l > 0 && s.[l - 1] = '\r' then String.sub s 0 (l - 1)
@@ -107,8 +107,8 @@ let really_input_up_to ic =
     Bytes.sub buf 0 bytes_read
 
 let compare_binary_files bytes_to_ignore file1 file2 =
-  Sys.with_input_file ~bin:true file1 @@ fun ic1 ->
-  Sys.with_input_file ~bin:true file2 @@ fun ic2 ->
+  let@ ic1 = Sys.with_input_file ~bin:true file1 in
+  let@ ic2 = Sys.with_input_file ~bin:true file2 in
   seek_in ic1 bytes_to_ignore;
   seek_in ic2 bytes_to_ignore;
   let rec compare () =
@@ -175,14 +175,14 @@ let diff files =
 let promote {filetype; reference_filename; output_filename} ignore_conf =
   match filetype, ignore_conf with
   | Text, {lines = skip_lines; _} ->
-      Sys.with_output_file reference_filename @@ fun reference ->
-      Sys.with_input_file output_filename @@ fun output ->
+      let@ reference = Sys.with_output_file reference_filename in
+      let@ output = Sys.with_input_file output_filename in
       for _ = 1 to skip_lines do
         try ignore (input_line output) with End_of_file -> ()
       done;
       Sys.copy_chan output reference
   | Binary, {bytes = skip_bytes; _} ->
-      Sys.with_output_file ~bin:true reference_filename @@ fun reference ->
-      Sys.with_input_file ~bin:true output_filename @@ fun output ->
+      let@ reference = Sys.with_output_file ~bin:true reference_filename in
+      let@ output = Sys.with_input_file ~bin:true output_filename in
       seek_in output skip_bytes;
       Sys.copy_chan output reference

--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -17,6 +17,8 @@
 
 module Unix = Ocamltest_unix
 
+include Misc.BindingOps
+
 let input_line_opt ic =
   try Some (input_line ic) with End_of_file -> None
 
@@ -126,7 +128,7 @@ module Sys = struct
     with_input_file filename in_channel_length = 0
 
   let string_of_file filename =
-    with_input_file ~bin:true filename @@ fun chan ->
+    let@ chan = with_input_file ~bin:true filename in
     let filesize = in_channel_length chan in
     if filesize > Sys.max_string_length then
       failwith
@@ -169,8 +171,8 @@ module Sys = struct
     in loop ()
 
   let copy_file src dest =
-    with_input_file ~bin:true src @@ fun ic ->
-    with_output_file ~bin:true dest @@ fun oc ->
+    let@ ic = with_input_file ~bin:true src in
+    let@ oc = with_output_file ~bin:true dest in
     copy_chan ic oc
 
   let force_remove file =

--- a/ocamltest/ocamltest_stdlib.mli
+++ b/ocamltest/ocamltest_stdlib.mli
@@ -19,6 +19,8 @@
 
 val input_line_opt : in_channel -> string option
 
+include module type of Misc.BindingOps
+
 module Char : sig
   include module type of Char
   val is_blank : char -> bool

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -14,6 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Misc.BindingOps
 open Types
 
 type type_definition = type_declaration
@@ -81,7 +82,8 @@ let structure : type_definition -> type_structure = fun def ->
       end
   | Type_record (labels, _) ->
       Algebraic (One (
-        demultiply_list labels @@ fun ld -> {
+        let@ ld = demultiply_list labels in
+        {
           location = ld.ld_loc;
           kind = Record_field;
           mutability = ld.ld_mutable;
@@ -90,7 +92,8 @@ let structure : type_definition -> type_structure = fun def ->
         }
       ))
   | Type_variant constructors ->
-      Algebraic (demultiply_list constructors @@ fun cd ->
+      Algebraic (
+        let@ cd = demultiply_list constructors in
         let result_type_parameter_instances =
           match cd.cd_res with
           (* cd_res is the optional return type (in a GADT);
@@ -105,7 +108,8 @@ let structure : type_definition -> type_structure = fun def ->
         in
         begin match cd.cd_args with
         | Cstr_tuple tys ->
-            demultiply_list tys @@ fun argument_type -> {
+            let@ argument_type = demultiply_list tys in
+            {
               location = cd.cd_loc;
               kind = Constructor_parameter;
               mutability = Asttypes.Immutable;
@@ -113,15 +117,15 @@ let structure : type_definition -> type_structure = fun def ->
               result_type_parameter_instances;
             }
         | Cstr_record labels ->
-            demultiply_list labels @@ fun ld ->
-              let argument_type = ld.ld_type in
-              {
-                location = ld.ld_loc;
-                kind = Constructor_field;
-                mutability = ld.ld_mutable;
-                argument_type;
-                result_type_parameter_instances;
-              }
+            let@ ld = demultiply_list labels in
+            let argument_type = ld.ld_type in
+            {
+              location = ld.ld_loc;
+              kind = Constructor_field;
+              mutability = ld.ld_mutable;
+              argument_type;
+              result_type_parameter_instances;
+            }
         end)
 
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1185,3 +1185,8 @@ module Magic_number = struct
            | Error err -> Error (Unexpected_error err)
            | Ok () -> Ok info
 end
+
+
+module BindingOps = struct
+  let ( let@ ) f x = f x
+end

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -686,3 +686,11 @@ module Magic_number : sig
 
   val all_kinds : kind list
 end
+
+
+(** binding operators *)
+module BindingOps : sig
+
+  val ( let@ ) : ('a -> 'b) -> 'a -> 'b
+  (** [let@ x = a in b] is [a @@ fun x -> b]. *)
+end


### PR DESCRIPTION
This PR introduces a `(let@)` binding operator that is the most trivial, but also arguably one of the most useful, binding operator: `let@ x = a in b` is just `a @@ fun x -> b`. (The name comes precisely from the `@@` operator.)

The operator is introduced in the compiler codebase, not in the standard library. (See, it's cute and harmless.)

I have rewritten most use-sites of `a @@ fun x -> b` to use it instead. Rationale:
- this gives an idea of the style we get when using it
- people who are allergic to fancy notations already hated the previous style, so maybe they won't complain less about the change (one can always dream)

The result looks somewhat similar to the [`use` keyword](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/resource-management-the-use-keyword) in F# to explicitly allocate lexically-scoped resources. One can keep in mind that `let@` has a dynamic effect that scopes over the body, or abstract over it to see simple-looking code that reads nicely and does the right thing.

Examples (from the PR):

```ocaml
let interface ~source_file ~output_prefix =
  let@ info = with_info ~source_file ~output_prefix ~dump_ext:"cmi" in
  Compile_common.interface info


  let@ () = Profile.record_call "parsing" in
  file_aux ~tool_name inputfile parse invariant_fun kind


let copy_file src dest =
  let@ ic = with_input_file ~bin:true src in
  let@ oc = with_output_file ~bin:true dest in
  copy_chan ic oc
```

I found this operator very useful when working with simplified forms of continuation monads, for example as part of my research work on the [Inferno](https://gitlab.inria.fr/fpottier/inferno) library. It may take some time getting used to (as for any new notation), but I believe that it will replace the `@@ fun x ->` notation as people get more used to binding operators.

Note: some people have proposed in the distant past to use exactly this definition for a "flexible monadic-bind", usually with `let!` as the notation.

Note: There are some callsites in ocamltest that use the `@@ fun` notation with non-unary currified functions: `Action.make [...] @@ fun log env ->`. The callsites have not been converted: they would require to tuplify the function, which is used (without `@@`-notation) in several other places of the codebase. In the future when designing new quantifier-like operations, it is recommended to make their continuation tuplified instead of currified to ease binding-operator usage.