### PR TITLE
printtyp: cache short path data in wrap_env

### DIFF
--- a/Changes
+++ b/Changes
@@ -351,6 +351,9 @@ Working version
   (David Allsopp, review by Damien Doligez, much input and thought from
    Daniel Bünzli, Damien Doligez, Sébastien Hinderer, and Xavier Leroy)
 
+- #9889: more caching when printing types with -short-path.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Build system:
 
 - #7121, #9558: Always the autoconf-discovered ld in PACKLD. For

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1584,8 +1584,18 @@ let cltype_declaration id ppf cl =
 
 let wrap_env fenv ftree arg =
   let env = !printing_env in
+  let old_depth = !printing_depth in
+  let old_cont = !printing_cont in
+  let old_pers = !printing_pers in
+  let old_map = !printing_map in
   set_printing_env (fenv env);
   let tree = ftree arg in
+  printing_depth := old_depth;
+  printing_cont := old_cont;
+  printing_pers := old_pers;
+  printing_map := old_map;
+  printing_old := env;
+  (* set_printing_env checks that persistent modules did not change *)
   set_printing_env env;
   tree
 


### PR DESCRIPTION
This PR makes `Printtyp.wrap_env` cache the short-path data associated with the input environment .
Extracted from #8929 .