### PR TITLE
Harden descriptor_is_in_binary_mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -422,7 +422,7 @@ Working version
 - #9860: wrong range constraint for subtract immediate on zSystems / s390x
   (Xavier Leroy, review by Stephen Dolan)
 
-- #9868, #9872: bugs in {in,out}_channel_length and seek_in
+- #9868, #9872, #9892: bugs in {in,out}_channel_length and seek_in
   for files opened in text mode under Windows
   (Xavier Leroy, report by Alain Frisch, review by Nicolás Ojeda Bär
   and Alain Frisch)

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -84,7 +84,7 @@ Caml_inline int descriptor_is_in_binary_mode(int fd)
 {
 #if defined(_WIN32) || defined(__CYGWIN__)
   int oldmode = setmode(fd, O_TEXT);
-  if (oldmode == O_BINARY) setmode(fd, O_BINARY);
+  if (oldmode != -1 && oldmode != O_TEXT) setmode(fd, oldmode);
   return oldmode == O_BINARY;
 #else
   return 1;


### PR DESCRIPTION
Spotted while post-reviewing #9872 - the new `descriptor_is_in_binary_mode` contains a check which used to be in `caml_channel_binary_mode`. While it was almost certainly correct when the function was originally written in the nineties, extra modes were added in the version 7 CRT (.NET 2002). They're not compatible with the OCaml runtime, but it doesn't feel correct the _querying_ an fd should actually change its properties. This simply tweaks the check restore the mode which was returned instead.