### PR TITLE
Add String.subrange

### DIFF
--- a/Changes
+++ b/Changes
@@ -142,6 +142,9 @@ Working version
 
 ### Standard library:
 
+- #XXXX: add String.subrange
+ (Daniel Bünzli)
+
 - #9781: add injectivity annotations to parameterized abstract types
   (Jeremy Yallop, review by Nicolás Ojeda Bär)
 

--- a/Changes
+++ b/Changes
@@ -142,8 +142,8 @@ Working version
 
 ### Standard library:
 
-- #XXXX: add String.subrange
- (Daniel Bünzli)
+- #9893: add String.subrange
+  (Daniel Bünzli, review by Alain Frisch)
 
 - #9781: add injectivity annotations to parameterized abstract types
   (Jeremy Yallop, review by Nicolás Ojeda Bär)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -202,6 +202,17 @@ type t = string
 let compare (x: t) (y: t) = Stdlib.compare x y
 external equal : string -> string -> bool = "caml_string_equal" [@@noalloc]
 
+let subrange ?(first = 0) ?last s =
+  let first = if first < 0 then 0 else first in
+  let max = length s - 1 in
+  let last = match last with
+    | None -> max
+    | Some l when l > max -> max
+    | Some l -> l
+  in
+  if first > last then "" else
+  sub s first (last - first + 1)
+
 let split_on_char sep s =
   let r = ref [] in
   let j = ref (length s) in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -202,16 +202,16 @@ type t = string
 let compare (x: t) (y: t) = Stdlib.compare x y
 external equal : string -> string -> bool = "caml_string_equal" [@@noalloc]
 
-let subrange ?(first = 0) ?last s =
-  let first = if first < 0 then 0 else first in
-  let max = length s - 1 in
-  let last = match last with
-    | None -> max
-    | Some l when l > max -> max
-    | Some l -> l
-  in
+let subrange ?(first = 0) ?(last = max_int) s =
+  let max_idx = length s - 1 in
+  let first = max 0 first in
+  let last = min max_idx last in
   if first > last then "" else
-  sub s first (last - first + 1)
+  if first = 0 && last = max_idx then s else
+  let len = (last - first + 1) in
+  let b = B.create len in
+  unsafe_blit s first b 0 len;
+  bts b
 
 let split_on_char sep s =
   let r = ref [] in

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -16,11 +16,12 @@
 (** Strings.
 
     A string [s] of length [n] is an indexable, immutable, sequence of
-    [n] bytes. For historical reasons these bytes are refered to as
+    [n] bytes. For historical reasons these bytes are referred to as
     characters.
 
     The semantics of string functions is defined in terms of
-    indices and positions which are visualised and described by:
+    indices and positions. These are depicted and described
+    as follows.
 
 {v
 positions  0   1   2   3   4    n-1    n
@@ -34,10 +35,10 @@ v}
        acccessed using the constant time string indexing operator
        [s.[i]].}
     {- A {e position} [i] of [s] is an integer in the range
-       \[[0];[n]\]. It can represent the point at the beginning of
-       the string, the point between two indices, or the point at the end
-       of the string. The [i]th byte index is between position [i] and
-       [i+1].}}
+       \[[0];[n]\]. It represents either the point at the beginning of
+       the string, or the point between two indices, or the point at
+       the end of the string. The [i]th byte index is between position
+       [i] and [i+1].}}
 
     Two integers [start] and [len] are said to define a {e valid
     substring} of [s] if [len >= 0] and [start], [start+len] are

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -15,26 +15,26 @@
 
 (** Strings.
 
-    A string [s] of length [l] is an indexable, immutable, sequence of
-    [l] bytes. For historical reasons these bytes are refered to as
+    A string [s] of length [n] is an indexable, immutable, sequence of
+    [n] bytes. For historical reasons these bytes are refered to as
     characters.
 
     The semantics of string functions is defined in terms of
     indices and positions which are visualised and described by:
 
 {v
-positions  0   1   2   3   4    l-1    l
+positions  0   1   2   3   4    n-1    n
            +---+---+---+---+     +-----+
-  indices  | 0 | 1 | 2 | 3 | ... | l-1 |
+  indices  | 0 | 1 | 2 | 3 | ... | n-1 |
            +---+---+---+---+     +-----+
 v}
     {ul
-    {- An {e index} [i] of [s] is an integer in the range \[[0];[l-1]\].
+    {- An {e index} [i] of [s] is an integer in the range \[[0];[n-1]\].
        It represents the [i]th byte (character) of [s] which can be
        acccessed using the constant time string indexing operator
        [s.[i]].}
     {- A {e position} [i] of [s] is an integer in the range
-       \[[0];[l]\]. It can represent the point at the beginning of
+       \[[0];[n]\]. It can represent the point at the beginning of
        the string, the point between two indices, or the point at the end
        of the string. The [i]th byte index is between position [i] and
        [i+1].}}
@@ -70,16 +70,16 @@ type t = string
 (** The type for strings. *)
 
 val make : int -> char -> string
-(** [make l c] is a string of length [l] with each index holding the
+(** [make n c] is a string of length [n] with each index holding the
     character [c].
 
-    @raise Invalid_argument if [l < 0] or [l > ]{!Sys.max_string_length}. *)
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> string
-(** [init l f] is a string of length [l] with index
+(** [init n f] is a string of length [n] with index
     [i] holding the character [f i] (called in increasing index order).
 
-    @raise Invalid_argument if [l < 0] or [l > ]{!Sys.max_string_length}.
+    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
     @since 4.02.0 *)
 
 external length : string -> int = "%string_length"

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -150,6 +150,16 @@ val sub : string -> int -> int -> string
     @raise Invalid_argument if [start] and [len] do not designate a valid
     substring of [s]. *)
 
+val subrange : ?first:int -> ?last:int -> string -> string
+(** [subrange ~first ~last s] are the consecutive bytes of [s] whose
+    indices exist in the range \[[first];[last]\]. [first] defaults to [0]
+    and [last] to [length s - 1].
+
+    Both [first] and [last] can be any integer. If [first > last] the
+    range is empty and the empty string is returned.
+
+    @since 4.12.0 *)
+
 val split_on_char : char -> string -> string list
 (** [split_on_char sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -152,11 +152,12 @@ val sub : string -> int -> int -> string
 
 val subrange : ?first:int -> ?last:int -> string -> string
 (** [subrange ~first ~last s] are the consecutive bytes of [s] whose
-    indices exist in the range \[[first];[last]\]. [first] defaults to [0]
+    indices are in the range \[[first];[last]\]. [first] defaults to [0]
     and [last] to [length s - 1].
 
     Both [first] and [last] can be any integer. If [first > last] the
-    range is empty and the empty string is returned.
+    range is empty and the empty string is returned. As such, and
+    in contrast to {!sub}, this function never raises.
 
     @since 4.12.0 *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -70,12 +70,12 @@ type t = string
 (** The type for strings. *)
 
 val make : int -> char -> string
-(** [String.make n c] returns a fresh string of length [n],
+(** [make n c] returns a fresh string of length [n],
    filled with the character [c].
    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> string
-(** [String.init n f] returns a string of length [n], with character
+(** [init n f] returns a string of length [n], with character
     [i] initialized to the result of [f i] (called in increasing
     index order).
 
@@ -86,8 +86,8 @@ external length : string -> int = "%string_length"
 (** Return the length (number of characters) of the given string. *)
 
 external get : string -> int -> char = "%string_safe_get"
-(** [String.get s n] returns the character at index [n] in string [s].
-   You can also write [s.[n]] instead of [String.get s n].
+(** [get s n] returns the character at index [n] in string [s].
+   You can also write [s.[n]] instead of [get s n].
     @raise Invalid_argument if [n] not a valid index in [s]. *)
 
 (** {1:concat Concatenating}
@@ -96,7 +96,7 @@ external get : string -> int -> char = "%string_safe_get"
     string. *)
 
 val concat : string -> string list -> string
-(** [String.concat sep sl] concatenates the list of strings [sl],
+(** [concat sep sl] concatenates the list of strings [sl],
     inserting the separator string [sep] between each.
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
@@ -114,26 +114,26 @@ val compare : t -> t -> int
     {!Set.Make} and {!Map.Make}. *)
 
 val starts_with : prefix:t -> t -> bool
-(** [String.starts_with prefix s] tests if [s] starts with [prefix]
+(** [starts_with prefix s] tests if [s] starts with [prefix]
     @since 4.12.0 *)
 
 val ends_with : suffix:t -> t -> bool
-(** [String.ends_with suffix s] tests if [s] ends with [suffix]
+(** [ends_with suffix s] tests if [s] ends with [suffix]
     @since 4.12.0 *)
 
 val contains : string -> char -> bool
-(** [String.contains s c] tests if character [c]
+(** [contains s c] tests if character [c]
    appears in the string [s]. *)
 
 val contains_from : string -> int -> char -> bool
-(** [String.contains_from s start c] tests if character [c]
+(** [contains_from s start c] tests if character [c]
    appears in [s] after position [start].
-   [String.contains s c] is equivalent to
-   [String.contains_from s 0 c].
+   [contains s c] is equivalent to
+   [contains_from s 0 c].
    @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : string -> int -> char -> bool
-(** [String.rcontains_from s stop c] tests if character [c]
+(** [rcontains_from s stop c] tests if character [c]
    appears in [s] before position [stop+1].
    @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
    position in [s]. *)
@@ -141,22 +141,22 @@ val rcontains_from : string -> int -> char -> bool
 (** {1:extract Extracting substrings} *)
 
 val sub : string -> int -> int -> string
-(** [String.sub s start len] returns a fresh string of length [len],
+(** [sub s start len] returns a fresh string of length [len],
    containing the substring of [s] that starts at position [start] and
    has length [len].
    @raise Invalid_argument if [start] and [len] do not
    designate a valid substring of [s]. *)
 
 val split_on_char: char -> string -> string list
-(** [String.split_on_char sep s] returns the list of all (possibly empty)
+(** [split_on_char sep s] returns the list of all (possibly empty)
     substrings of [s] that are delimited by the [sep] character.
 
     The function's output is specified by the following invariants:
 
     - The list is not empty.
     - Concatenating its elements using [sep] as a separator returns a
-      string equal to the input ([String.concat (String.make 1 sep)
-      (String.split_on_char sep s) = s]).
+      string equal to the input ([concat (make 1 sep)
+      (split_on_char sep s) = s]).
     - No string in the result contains the [sep] character.
 
     @since 4.04.0 *)
@@ -164,12 +164,12 @@ val split_on_char: char -> string -> string list
 (** {1:traversing Traversing} *)
 
 val iter : (char -> unit) -> string -> unit
-(** [String.iter f s] applies function [f] in turn to all
+(** [iter f s] applies function [f] in turn to all
    the characters of [s].  It is equivalent to
-   [f s.[0]; f s.[1]; ...; f s.[String.length s - 1]; ()]. *)
+   [f s.[0]; f s.[1]; ...; f s.[length s - 1]; ()]. *)
 
 val iteri : (int -> char -> unit) -> string -> unit
-(** Same as {!String.iter}, but the
+(** Same as {!iter}, but the
    function is applied to the index of the element as first argument
    (counting from 0), and the character itself as second argument.
     @since 4.00.0 *)
@@ -177,60 +177,60 @@ val iteri : (int -> char -> unit) -> string -> unit
 (** {1:searching Searching} *)
 
 val index : string -> char -> int
-(** [String.index s c] returns the index of the first
+(** [index s c] returns the index of the first
    occurrence of character [c] in string [s].
    @raise Not_found if [c] does not occur in [s]. *)
 
 val index_opt: string -> char -> int option
-(** [String.index_opt s c] returns the index of the first
+(** [index_opt s c] returns the index of the first
     occurrence of character [c] in string [s], or
     [None] if [c] does not occur in [s].
     @since 4.05 *)
 
 val rindex : string -> char -> int
-(** [String.rindex s c] returns the index of the last
+(** [rindex s c] returns the index of the last
    occurrence of character [c] in string [s].
    @raise Not_found if [c] does not occur in [s]. *)
 
 val rindex_opt: string -> char -> int option
-(** [String.rindex_opt s c] returns the index of the last occurrence
+(** [rindex_opt s c] returns the index of the last occurrence
     of character [c] in string [s], or [None] if [c] does not occur in
     [s].
     @since 4.05 *)
 
 val index_from : string -> int -> char -> int
-(** [String.index_from s i c] returns the index of the
+(** [index_from s i c] returns the index of the
    first occurrence of character [c] in string [s] after position [i].
-   [String.index s c] is equivalent to [String.index_from s 0 c].
+   [index s c] is equivalent to [index_from s 0 c].
    @raise Invalid_argument if [i] is not a valid position in [s].
    @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
-(** [String.index_from_opt s i c] returns the index of the
+(** [index_from_opt s i c] returns the index of the
     first occurrence of character [c] in string [s] after position [i]
     or [None] if [c] does not occur in [s] after position [i].
 
-    [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
+    [index_opt s c] is equivalent to [index_from_opt s 0 c].
     @raise Invalid_argument if [i] is not a valid position in [s].
 
     @since 4.05
 *)
 
 val rindex_from : string -> int -> char -> int
-(** [String.rindex_from s i c] returns the index of the
+(** [rindex_from s i c] returns the index of the
    last occurrence of character [c] in string [s] before position [i+1].
-   [String.rindex s c] is equivalent to
-   [String.rindex_from s (String.length s - 1) c].
+   [rindex s c] is equivalent to
+   [rindex_from s (length s - 1) c].
    @raise Invalid_argument if [i+1] is not a valid position in [s].
    @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
-(** [String.rindex_from_opt s i c] returns the index of the
+(** [rindex_from_opt s i c] returns the index of the
    last occurrence of character [c] in string [s] before position [i+1]
    or [None] if [c] does not occur in [s] before position [i+1].
 
-   [String.rindex_opt s c] is equivalent to
-   [String.rindex_from_opt s (String.length s - 1) c].
+   [rindex_opt s c] is equivalent to
+   [rindex_from_opt s (length s - 1) c].
    @raise Invalid_argument if [i+1] is not a valid position in [s].
 
    @since 4.05 *)
@@ -238,13 +238,13 @@ val rindex_from_opt: string -> int -> char -> int option
 (** {1:transforming Transforming} *)
 
 val map : (char -> char) -> string -> string
-(** [String.map f s] applies function [f] in turn to all the
+(** [map f s] applies function [f] in turn to all the
     characters of [s] (in increasing index order) and stores the
     results in a new string that is returned.
     @since 4.00.0 *)
 
 val mapi : (int -> char -> char) -> string -> string
-(** [String.mapi f s] calls [f] with each character of [s] and its
+(** [mapi f s] calls [f] with each character of [s] and its
     index (in increasing index order) and stores the results in a new
     string that is returned.
     @since 4.02.0 *)
@@ -312,7 +312,7 @@ val of_seq : char Seq.t -> t
 
 external create : int -> bytes = "caml_create_string"
   [@@ocaml.deprecated "Use Bytes.create instead."]
-(** [String.create n] returns a fresh byte sequence of length [n].
+(** [create n] returns a fresh byte sequence of length [n].
    The sequence is uninitialized and contains arbitrary bytes.
    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
 
@@ -320,9 +320,9 @@ external create : int -> bytes = "caml_create_string"
 
 external set : bytes -> int -> char -> unit = "%string_safe_set"
   [@@ocaml.deprecated "Use Bytes.set instead."]
-(** [String.set s n c] modifies byte sequence [s] in place,
+(** [set s n c] modifies byte sequence [s] in place,
    replacing the byte at index [n] with [c].
-   You can also write [s.[n] <- c] instead of [String.set s n c].
+   You can also write [s.[n] <- c] instead of [set s n c].
    @raise Invalid_argument if [n] is not a valid index in [s].
 
     @deprecated This is a deprecated alias of {!Bytes.set}.[ ] *)
@@ -338,7 +338,7 @@ val copy : string -> string [@@ocaml.deprecated]
 
 val fill : bytes -> int -> int -> char -> unit
   [@@ocaml.deprecated "Use Bytes.fill instead."]
-(** [String.fill s start len c] modifies byte sequence [s] in place,
+(** [fill s start len c] modifies byte sequence [s] in place,
    replacing [len] bytes with [c], starting at [start].
    @raise Invalid_argument if [start] and [len] do not
    designate a valid range of [s].

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -70,242 +70,233 @@ type t = string
 (** The type for strings. *)
 
 val make : int -> char -> string
-(** [make n c] returns a fresh string of length [n],
-   filled with the character [c].
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}. *)
+(** [make l c] is a string of length [l] with each index holding the
+    character [c].
+
+    @raise Invalid_argument if [l < 0] or [l > ]{!Sys.max_string_length}. *)
 
 val init : int -> (int -> char) -> string
-(** [init n f] returns a string of length [n], with character
-    [i] initialized to the result of [f i] (called in increasing
-    index order).
+(** [init l f] is a string of length [l] with index
+    [i] holding the character [f i] (called in increasing index order).
 
-    @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
+    @raise Invalid_argument if [l < 0] or [l > ]{!Sys.max_string_length}.
     @since 4.02.0 *)
 
 external length : string -> int = "%string_length"
-(** Return the length (number of characters) of the given string. *)
+(** [length s] is the length (number of bytes/characters) of [s]. *)
 
 external get : string -> int -> char = "%string_safe_get"
-(** [get s n] returns the character at index [n] in string [s].
-   You can also write [s.[n]] instead of [get s n].
-    @raise Invalid_argument if [n] not a valid index in [s]. *)
+(** [get s i] is the character at index [i] in [s]. This is the same
+    as writing [s.[i]].
+
+    @raise Invalid_argument if [i] not an index of [s]. *)
 
 (** {1:concat Concatenating}
 
-    {b Note.} The {!( ^ )} operator is a binary operator to concat two
-    string. *)
+    {b Note.} The {!Stdlib.( ^ )} binary operator concatenates two
+    strings. *)
 
 val concat : string -> string list -> string
-(** [concat sep sl] concatenates the list of strings [sl],
-    inserting the separator string [sep] between each.
+(** [concat sep ss] concatenates the list of strings [ss], inserting
+    the separator string [sep] between each.
+
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
 (** {1:predicates Predicates and comparisons} *)
 
 val equal : t -> t -> bool
-(** The equal function for strings.
+(** [equal s0 s1] is [true] iff [s0] and [s1] are character-wise equal.
     @since 4.03.0 *)
 
 val compare : t -> t -> int
-(** The comparison function for strings, with the same specification as
-    {!Stdlib.compare}.  Along with the type [t], this function [compare]
-    allows the module [String] to be passed as argument to the functors
-    {!Set.Make} and {!Map.Make}. *)
+(** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
+    behaves like {!Stdlib.compare} on strings but is more efficient. *)
 
 val starts_with : prefix:t -> t -> bool
-(** [starts_with prefix s] tests if [s] starts with [prefix]
+(** [starts_with prefix s] is [true] iff [s] starts with [prefix].
+
     @since 4.12.0 *)
 
 val ends_with : suffix:t -> t -> bool
-(** [ends_with suffix s] tests if [s] ends with [suffix]
+(** [ends_with suffix s] is [true] iff [s] ends with [suffix].
+
     @since 4.12.0 *)
 
-val contains : string -> char -> bool
-(** [contains s c] tests if character [c]
-   appears in the string [s]. *)
-
 val contains_from : string -> int -> char -> bool
-(** [contains_from s start c] tests if character [c]
-   appears in [s] after position [start].
-   [contains s c] is equivalent to
-   [contains_from s 0 c].
-   @raise Invalid_argument if [start] is not a valid position in [s]. *)
+(** [contains_from s start c] is [true] iff [c] appears in [s] after position
+    [start].
+
+    @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : string -> int -> char -> bool
-(** [rcontains_from s stop c] tests if character [c]
-   appears in [s] before position [stop+1].
-   @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
-   position in [s]. *)
+(** [rcontains_from s stop c] is [true] iff [c] appears in [s] before position
+    [stop+1].
+
+    @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
+    position in [s]. *)
+
+val contains : string -> char -> bool
+(** [contains s c] is {!String.contains_from}[ s 0 c]. *)
 
 (** {1:extract Extracting substrings} *)
 
 val sub : string -> int -> int -> string
-(** [sub s start len] returns a fresh string of length [len],
-   containing the substring of [s] that starts at position [start] and
-   has length [len].
-   @raise Invalid_argument if [start] and [len] do not
-   designate a valid substring of [s]. *)
+(** [sub s start len] is a string of length [len], containing the
+    substring of [s] that starts at position [start] and has length
+    [len].
 
-val split_on_char: char -> string -> string list
-(** [split_on_char sep s] returns the list of all (possibly empty)
-    substrings of [s] that are delimited by the [sep] character.
+    @raise Invalid_argument if [start] and [len] do not designate a valid
+    substring of [s]. *)
 
-    The function's output is specified by the following invariants:
+val split_on_char : char -> string -> string list
+(** [split_on_char sep s] is the list of all (possibly empty)
+    substrings of [s] that are delimited by the character [sep].
 
-    - The list is not empty.
-    - Concatenating its elements using [sep] as a separator returns a
+    The function's result is specified by the following invariants:
+    {ul
+    {- The list is not empty.}
+    {- Concatenating its elements using [sep] as a separator returns a
       string equal to the input ([concat (make 1 sep)
-      (split_on_char sep s) = s]).
-    - No string in the result contains the [sep] character.
+      (split_on_char sep s) = s]).}
+    {- No string in the result contains the [sep] character.}}
 
     @since 4.04.0 *)
-
-(** {1:traversing Traversing} *)
-
-val iter : (char -> unit) -> string -> unit
-(** [iter f s] applies function [f] in turn to all
-   the characters of [s].  It is equivalent to
-   [f s.[0]; f s.[1]; ...; f s.[length s - 1]; ()]. *)
-
-val iteri : (int -> char -> unit) -> string -> unit
-(** Same as {!iter}, but the
-   function is applied to the index of the element as first argument
-   (counting from 0), and the character itself as second argument.
-    @since 4.00.0 *)
-
-(** {1:searching Searching} *)
-
-val index : string -> char -> int
-(** [index s c] returns the index of the first
-   occurrence of character [c] in string [s].
-   @raise Not_found if [c] does not occur in [s]. *)
-
-val index_opt: string -> char -> int option
-(** [index_opt s c] returns the index of the first
-    occurrence of character [c] in string [s], or
-    [None] if [c] does not occur in [s].
-    @since 4.05 *)
-
-val rindex : string -> char -> int
-(** [rindex s c] returns the index of the last
-   occurrence of character [c] in string [s].
-   @raise Not_found if [c] does not occur in [s]. *)
-
-val rindex_opt: string -> char -> int option
-(** [rindex_opt s c] returns the index of the last occurrence
-    of character [c] in string [s], or [None] if [c] does not occur in
-    [s].
-    @since 4.05 *)
-
-val index_from : string -> int -> char -> int
-(** [index_from s i c] returns the index of the
-   first occurrence of character [c] in string [s] after position [i].
-   [index s c] is equivalent to [index_from s 0 c].
-   @raise Invalid_argument if [i] is not a valid position in [s].
-   @raise Not_found if [c] does not occur in [s] after position [i]. *)
-
-val index_from_opt: string -> int -> char -> int option
-(** [index_from_opt s i c] returns the index of the
-    first occurrence of character [c] in string [s] after position [i]
-    or [None] if [c] does not occur in [s] after position [i].
-
-    [index_opt s c] is equivalent to [index_from_opt s 0 c].
-    @raise Invalid_argument if [i] is not a valid position in [s].
-
-    @since 4.05
-*)
-
-val rindex_from : string -> int -> char -> int
-(** [rindex_from s i c] returns the index of the
-   last occurrence of character [c] in string [s] before position [i+1].
-   [rindex s c] is equivalent to
-   [rindex_from s (length s - 1) c].
-   @raise Invalid_argument if [i+1] is not a valid position in [s].
-   @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
-
-val rindex_from_opt: string -> int -> char -> int option
-(** [rindex_from_opt s i c] returns the index of the
-   last occurrence of character [c] in string [s] before position [i+1]
-   or [None] if [c] does not occur in [s] before position [i+1].
-
-   [rindex_opt s c] is equivalent to
-   [rindex_from_opt s (length s - 1) c].
-   @raise Invalid_argument if [i+1] is not a valid position in [s].
-
-   @since 4.05 *)
 
 (** {1:transforming Transforming} *)
 
 val map : (char -> char) -> string -> string
-(** [map f s] applies function [f] in turn to all the
-    characters of [s] (in increasing index order) and stores the
-    results in a new string that is returned.
+(** [map f s] is the string resulting from applying [f] to all the
+    characters of [s] in increasing order.
+
     @since 4.00.0 *)
 
 val mapi : (int -> char -> char) -> string -> string
-(** [mapi f s] calls [f] with each character of [s] and its
-    index (in increasing index order) and stores the results in a new
-    string that is returned.
+(** [mapi f s] is like {!map} but the index of the character is also
+    passed to [f].
+
     @since 4.02.0 *)
 
 val trim : string -> string
-(** Return a copy of the argument, without leading and trailing
-   whitespace.  The characters regarded as whitespace are: [' '],
-   ['\012'], ['\n'], ['\r'], and ['\t'].  If there is neither leading nor
-   trailing whitespace character in the argument, return the original
-   string itself, not a copy.
-   @since 4.00.0 *)
+(** [trim s] is [s] without leading and trailing whitespace. Whitespace
+    characters are: [' '], ['\x0C'] (form feed), ['\n'], ['\r'], and ['\t'].
+
+    @since 4.00.0 *)
 
 val escaped : string -> string
-(** Return a copy of the argument, with special characters
-    represented by escape sequences, following the lexical
-    conventions of OCaml.
-    All characters outside the ASCII printable range (32..126) are
-    escaped, as well as backslash and double-quote.
+(** [escaped s] is [s] with special characters represented by escape
+    sequences, following the lexical conventions of OCaml.
 
-    If there is no special character in the argument that needs
-    escaping, return the original string itself, not a copy.
-    @raise Invalid_argument if the result is longer than
-    {!Sys.max_string_length} bytes.
+    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    escaped, as well as backslash (0x2F) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
     i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless
-    [escape s] fails). *)
+    [escape s] fails).
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes. *)
 
 val uppercase_ascii : string -> string
-(** Return a copy of the argument, with all lowercase letters
-   translated to uppercase, using the US-ASCII character set.
-   @since 4.03.0 *)
+(** [uppercase_ascii s] is [s] with all lowercase letters
+    translated to uppercase, using the US-ASCII character set.
+
+    @since 4.03.0 *)
 
 val lowercase_ascii : string -> string
-(** Return a copy of the argument, with all uppercase letters
-   translated to lowercase, using the US-ASCII character set.
-   @since 4.03.0 *)
+(** [lowercase_ascii s] is [s] with all uppercase letters translated
+    to lowercase, using the US-ASCII character set.
+
+    @since 4.03.0 *)
 
 val capitalize_ascii : string -> string
-(** Return a copy of the argument, with the first character set to uppercase,
-   using the US-ASCII character set.
-   @since 4.03.0 *)
+(** [capitalize_ascii s] is [s] with the first character set to
+    uppercase, using the US-ASCII character set.
+
+    @since 4.03.0 *)
 
 val uncapitalize_ascii : string -> string
-(** Return a copy of the argument, with the first character set to lowercase,
-   using the US-ASCII character set.
+(** [uncapitalize_ascii s] is [s] with the first character set to lowercase,
+    using the US-ASCII character set.
+
     @since 4.03.0 *)
+
+(** {1:traversing Traversing} *)
+
+val iter : (char -> unit) -> string -> unit
+(** [iter f s] applies function [f] in turn to all the characters of [s].
+    It is equivalent to [f s.[0]; f s.[1]; ...; f s.[length s - 1]; ()]. *)
+
+val iteri : (int -> char -> unit) -> string -> unit
+(** [iteri] is like {!iter}, but the function is also given the
+    corresponding character index.
+
+    @since 4.00.0 *)
+
+(** {1:searching Searching} *)
+
+val index_from : string -> int -> char -> int
+(** [index_from s i c] is the index of the first occurrence of [c] in
+    [s] after position [i].
+
+    @raise Not_found if [c] does not occur in [s] after position [i].
+    @raise Invalid_argument if [i] is not a valid position in [s]. *)
+
+
+val index_from_opt : string -> int -> char -> int option
+(** [index_from_opt s i c] is the index of the first occurrence of [c]
+    in [s] after position [i] (if any).
+
+    @raise Invalid_argument if [i] is not a valid position in [s].
+    @since 4.05 *)
+
+val rindex_from : string -> int -> char -> int
+(** [rindex_from s i c] is the index of the last occurrence of [c] in
+    [s] before position [i+1].
+
+    @raise Not_found if [c] does not occur in [s] before position [i+1].
+    @raise Invalid_argument if [i+1] is not a valid position in [s]. *)
+
+val rindex_from_opt : string -> int -> char -> int option
+(** [rindex_from_opt s i c] is the index of the last occurrence of [c]
+    in [s] before position [i+1] (if any).
+
+    @raise Invalid_argument if [i+1] is not a valid position in [s].
+    @since 4.05 *)
+
+val index : string -> char -> int
+(** [index s c] is {!String.index_from}[ s 0 c]. *)
+
+val index_opt : string -> char -> int option
+(** [index_opt s c] is {!String.index_from_opt}[ s 0 c].
+
+    @since 4.05 *)
+
+val rindex : string -> char -> int
+(** [rindex s c] is {!String.rindex_from}[ s (length s - 1) c]. *)
+
+val rindex_opt : string -> char -> int option
+(** [rindex_opt s c] is {!String.rindex_from_opt}[ s (length s - 1) c].
+
+    @since 4.05 *)
 
 (** {1:converting Converting} *)
 
 val to_seq : t -> char Seq.t
-(** Iterate on the string, in increasing index order. Modifications of the
-    string during iteration will be reflected in the iterator.
+(** [to_seq s] is a sequence made of the string's characters in
+    increasing order. Modifications of the string during iteration
+    will be reflected in the iterator.
+
     @since 4.07 *)
 
 val to_seqi : t -> (int * char) Seq.t
-(** Iterate on the string, in increasing order, yielding indices along chars
+(** [to_seqi s] is like {!to_seq} but also tuples the corresponding index.
+
     @since 4.07 *)
 
 val of_seq : char Seq.t -> t
-(** Create a string from the generator
+(** [of_seq s] is a string made of the sequence's characters.
+
     @since 4.07 *)
 
 (** {1:deprecated Deprecated functions} *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -46,31 +46,7 @@
   opt-in; we intend to remove the option in the future.
 *)
 
-external length : string -> int = "%string_length"
-(** Return the length (number of characters) of the given string. *)
-
-external get : string -> int -> char = "%string_safe_get"
-(** [String.get s n] returns the character at index [n] in string [s].
-   You can also write [s.[n]] instead of [String.get s n].
-   @raise Invalid_argument if [n] not a valid index in [s]. *)
-
-
-external set : bytes -> int -> char -> unit = "%string_safe_set"
-  [@@ocaml.deprecated "Use Bytes.set instead."]
-(** [String.set s n c] modifies byte sequence [s] in place,
-   replacing the byte at index [n] with [c].
-   You can also write [s.[n] <- c] instead of [String.set s n c].
-   @raise Invalid_argument if [n] is not a valid index in [s].
-
-   @deprecated This is a deprecated alias of {!Bytes.set}.[ ] *)
-
-external create : int -> bytes = "caml_create_string"
-  [@@ocaml.deprecated "Use Bytes.create instead."]
-(** [String.create n] returns a fresh byte sequence of length [n].
-   The sequence is uninitialized and contains arbitrary bytes.
-   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
-
-   @deprecated This is a deprecated alias of {!Bytes.create}.[ ] *)
+(** {1:strings Strings} *)
 
 val make : int -> char -> string
 (** [String.make n c] returns a fresh string of length [n],
@@ -83,14 +59,16 @@ val init : int -> (int -> char) -> string
     index order).
 
     @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
-    @since 4.02.0
-*)
+    @since 4.02.0 *)
 
-val copy : string -> string [@@ocaml.deprecated]
-(** Return a copy of the given string.
+external length : string -> int = "%string_length"
+(** Return the length (number of characters) of the given string. *)
 
-    @deprecated Because strings are immutable, it doesn't make much
-    sense to make identical copies of them. *)
+external get : string -> int -> char = "%string_safe_get"
+(** [String.get s n] returns the character at index [n] in string [s].
+   You can also write [s.[n]] instead of [String.get s n].
+   @raise Invalid_argument if [n] not a valid index in [s]. *)
+
 
 val sub : string -> int -> int -> string
 (** [String.sub s start len] returns a fresh string of length [len],
@@ -98,15 +76,6 @@ val sub : string -> int -> int -> string
    has length [len].
    @raise Invalid_argument if [start] and [len] do not
    designate a valid substring of [s]. *)
-
-val fill : bytes -> int -> int -> char -> unit
-  [@@ocaml.deprecated "Use Bytes.fill instead."]
-(** [String.fill s start len c] modifies byte sequence [s] in place,
-   replacing [len] bytes with [c], starting at [start].
-   @raise Invalid_argument if [start] and [len] do not
-   designate a valid range of [s].
-
-   @deprecated This is a deprecated alias of {!Bytes.fill}.[ ] *)
 
 val blit : string -> int -> bytes -> int -> int -> unit
 (** Same as {!Bytes.blit_string}. *)
@@ -241,32 +210,6 @@ val rcontains_from : string -> int -> char -> bool
    @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
    position in [s]. *)
 
-val uppercase : string -> string
-  [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
-(** Return a copy of the argument, with all lowercase letters
-   translated to uppercase, including accented letters of the ISO
-   Latin-1 (8859-1) character set.
-   @deprecated Functions operating on Latin-1 character set are deprecated. *)
-
-val lowercase : string -> string
-  [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
-(** Return a copy of the argument, with all uppercase letters
-   translated to lowercase, including accented letters of the ISO
-   Latin-1 (8859-1) character set.
-   @deprecated Functions operating on Latin-1 character set are deprecated. *)
-
-val capitalize : string -> string
-  [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
-(** Return a copy of the argument, with the first character set to uppercase,
-   using the ISO Latin-1 (8859-1) character set..
-   @deprecated Functions operating on Latin-1 character set are deprecated. *)
-
-val uncapitalize : string -> string
-  [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
-(** Return a copy of the argument, with the first character set to lowercase,
-   using the ISO Latin-1 (8859-1) character set..
-   @deprecated Functions operating on Latin-1 character set are deprecated. *)
-
 val uppercase_ascii : string -> string
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, using the US-ASCII character set.
@@ -337,6 +280,66 @@ val to_seqi : t -> (int * char) Seq.t
 val of_seq : char Seq.t -> t
 (** Create a string from the generator
     @since 4.07 *)
+
+(** {1:deprecated Deprecated functions} *)
+
+external create : int -> bytes = "caml_create_string"
+  [@@ocaml.deprecated "Use Bytes.create instead."]
+(** [String.create n] returns a fresh byte sequence of length [n].
+   The sequence is uninitialized and contains arbitrary bytes.
+   @raise Invalid_argument if [n < 0] or [n > ]{!Sys.max_string_length}.
+
+   @deprecated This is a deprecated alias of {!Bytes.create}.[ ] *)
+
+external set : bytes -> int -> char -> unit = "%string_safe_set"
+  [@@ocaml.deprecated "Use Bytes.set instead."]
+(** [String.set s n c] modifies byte sequence [s] in place,
+   replacing the byte at index [n] with [c].
+   You can also write [s.[n] <- c] instead of [String.set s n c].
+   @raise Invalid_argument if [n] is not a valid index in [s].
+
+    @deprecated This is a deprecated alias of {!Bytes.set}.[ ] *)
+
+val copy : string -> string [@@ocaml.deprecated]
+(** Return a copy of the given string.
+
+    @deprecated Because strings are immutable, it doesn't make much
+    sense to make identical copies of them. *)
+
+val fill : bytes -> int -> int -> char -> unit
+  [@@ocaml.deprecated "Use Bytes.fill instead."]
+(** [String.fill s start len c] modifies byte sequence [s] in place,
+   replacing [len] bytes with [c], starting at [start].
+   @raise Invalid_argument if [start] and [len] do not
+   designate a valid range of [s].
+
+   @deprecated This is a deprecated alias of {!Bytes.fill}.[ ] *)
+
+val uppercase : string -> string
+  [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
+(** Return a copy of the argument, with all lowercase letters
+   translated to uppercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val lowercase : string -> string
+  [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
+(** Return a copy of the argument, with all uppercase letters
+   translated to lowercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val capitalize : string -> string
+  [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val uncapitalize : string -> string
+  [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 (**/**)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -13,38 +13,56 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** String operations.
+(** Strings.
 
-  A string is an immutable data structure that contains a
-  fixed-length sequence of (single-byte) characters. Each character
-  can be accessed in constant time through its index.
+    A string [s] of length [l] is an indexable, immutable, sequence of
+    [l] bytes. For historical reasons these bytes are refered to as
+    characters.
 
-  Given a string [s] of length [l], we can access each of the [l]
-  characters of [s] via its index in the sequence. Indexes start at
-  [0], and we will call an index valid in [s] if it falls within the
-  range [[0...l-1]] (inclusive). A position is the point between two
-  characters or at the beginning or end of the string.  We call a
-  position valid in [s] if it falls within the range [[0...l]]
-  (inclusive). Note that the character at index [n] is between
-  positions [n] and [n+1].
+    The semantics of string functions is defined in terms of
+    indices and positions which are visualised and described by:
 
-  Two parameters [start] and [len] are said to designate a valid
-  substring of [s] if [len >= 0] and [start] and [start+len] are
-  valid positions in [s].
+{v
+positions  0   1   2   3   4    l-1    l
+           +---+---+---+---+     +-----+
+  indices  | 0 | 1 | 2 | 3 | ... | l-1 |
+           +---+---+---+---+     +-----+
+v}
+    {ul
+    {- An {e index} [i] of [s] is an integer in the range \[[0];[l-1]\].
+       It represents the [i]th byte (character) of [s] which can be
+       acccessed using the constant time string indexing operator
+       [s.[i]].}
+    {- A {e position} [i] of [s] is an integer in the range
+       \[[0];[l]\]. It can represent the point at the beginning of
+       the string, the point between two indices, or the point at the end
+       of the string. The [i]th byte index is between position [i] and
+       [i+1].}}
 
-  Note: OCaml strings used to be modifiable in place, for instance via
-  the {!String.set} and {!String.blit} functions described below. This
-  usage is only possible when the compiler is put in "unsafe-string"
-  mode by giving the [-unsafe-string] command-line option. This
-  compatibility mode makes the types [string] and [bytes] (see module
-  {!Bytes}) interchangeable so that functions expecting byte sequences
-  can also accept strings as arguments and modify them.
+    Two integers [start] and [len] are said to define a {e valid
+    substring} of [s] if [len >= 0] and [start], [start+len] are
+    positions of [s].
 
-  The distinction between [bytes] and [string] was introduced in OCaml
-  4.02, and the "unsafe-string" compatibility mode was the default
-  until OCaml 4.05. Starting with 4.06, the compatibility mode is
-  opt-in; we intend to remove the option in the future.
-*)
+    {b Unicode text.} Strings being arbitrary sequences of bytes, they
+    can hold any kind of textual encoding. However the recommended
+    encoding for storing Unicode text in OCaml strings is UTF-8. This
+    is the encoding used by Unicode escapes in string literals. For
+    example the string ["\u{1F42B}"] is the UTF-8 encoding of the
+    Unicode character U+1F42B.
+
+    {b Past mutability.} OCaml strings used to be modifiable in place,
+    for instance via the {!String.set} and {!String.blit}
+    functions. This use is nowadays only possible when the compiler is
+    put in "unsafe-string" mode by giving the [-unsafe-string]
+    command-line option. This compatibility mode makes the types
+    [string] and [bytes] (see {!Bytes.t}) interchangeable so that
+    functions expecting byte sequences can also accept strings as
+    arguments and modify them.
+
+    The distinction between [bytes] and [string] was introduced in
+    OCaml 4.02, and the "unsafe-string" compatibility mode was the
+    default until OCaml 4.05. Starting with 4.06, the compatibility
+    mode is opt-in; we intend to remove the option in the future. *)
 
 (** {1:strings Strings} *)
 

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -42,6 +42,26 @@ let () =
 
 (* GPR#805/815/833 *)
 
+let test_subrange () =
+  assert(String.subrange ~first:1 ~last:2 "abcd" = "bc");
+  assert(String.subrange ~first:2 ~last:1 "abcd" = "");
+  assert(String.subrange ~first:1 "abcd" = "bcd");
+  assert(String.subrange ~last:2 "abcd" = "abc");
+  assert(String.subrange ~first:(-1) "abcd" = "abcd");
+  assert(String.subrange ~last:100 "abcd" = "abcd");
+  assert(String.subrange ~first:(-1) ~last:100 "abcd" = "abcd");
+  assert(String.subrange ~first:98 "abcd" = "");
+  assert(String.subrange ~first:98 ~last:100 "abcd" = "");
+  assert(String.subrange ~first:100 ~last:98 "abcd" = "");
+  assert(String.subrange ~first:(-1) ~last:(-2) "abcd" = "");
+  assert(String.subrange ~last:(-2) "abcd" = "")
+
+
+let () =
+  test_subrange ();
+  ()
+
+
 let ()  =
   if Sys.word_size = 32 then begin
     let big = String.make Sys.max_string_length 'x' in

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -40,7 +40,21 @@ let () =
   done
 ;;
 
-(* GPR#805/815/833 *)
+let test_starts_with () =
+  assert(String.starts_with ~prefix:"foob" "foobarbaz");
+  assert(String.starts_with ~prefix:"" "foobarbaz");
+  assert(String.starts_with ~prefix:"" "");
+  assert(not (String.starts_with ~prefix:"foobar" "bar"));
+  assert(not (String.starts_with ~prefix:"foo" ""));
+  assert(not (String.starts_with ~prefix:"fool" "foobar"))
+
+let test_ends_with () =
+  assert(String.ends_with ~suffix:"baz" "foobarbaz");
+  assert(String.ends_with ~suffix:"" "foobarbaz");
+  assert(String.ends_with ~suffix:"" "");
+  assert(not (String.ends_with ~suffix:"foobar" "bar"));
+  assert(not (String.ends_with ~suffix:"foo" ""));
+  assert(not (String.ends_with ~suffix:"obaz" "foobar"))
 
 let test_subrange () =
   assert(String.subrange ~first:1 ~last:2 "abcd" = "bc");
@@ -56,11 +70,12 @@ let test_subrange () =
   assert(String.subrange ~first:(-1) ~last:(-2) "abcd" = "");
   assert(String.subrange ~last:(-2) "abcd" = "")
 
-
 let () =
-  test_subrange ();
-  ()
+  test_starts_with ();
+  test_ends_with ();
+  test_subrange ()
 
+(* GPR#805/815/833 *)
 
 let ()  =
   if Sys.word_size = 32 then begin
@@ -72,16 +87,4 @@ let ()  =
     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
     try ignore (String.concat "" !l); assert false
     with Invalid_argument _ -> ();
-    assert(String.starts_with ~prefix:"foob" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "");
-    assert(not (String.starts_with ~prefix:"foobar" "bar"));
-    assert(not (String.starts_with ~prefix:"foo" ""));
-    assert(not (String.starts_with ~prefix:"fool" "foobar"));
-    assert(String.ends_with ~suffix:"baz" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "");
-    assert(not (String.ends_with ~suffix:"foobar" "bar"));
-    assert(not (String.ends_with ~suffix:"foo" ""));
-    assert(not (String.ends_with ~suffix:"obaz" "foobar"));
   end


### PR DESCRIPTION
This PR (built on top of #9891, the meat is in 1586137f0e2e038ee6048ca1641cbfed446e0f6c) proposes to add `String.subrange` to the  `Stdlib`.

`String.subrange` is a different take on `String.sub`. `String.sub` is not very ergonomic when used for example in conjunction with `String.index*` functions: it requires index arithmetic – converting indices to magnitudes – which increases the possibilities of off-by-one errors and needlessly clutters the actual intent of the code.

In contrast `String.subrange` extracts subtrings by specifying an integer range `r` of indices to extract: the function simply return the bytes of the string that exist (or intersect) the range `r` or the empty string if there are no such bytes.

The fact that the arguments of `String.subrange` are in the same "space" as the values returned by `String.index*` functions makes it much easier to use – one should note how this function makes it easy to split strings on indices without fear and pain. 

Besides, while I have become wary with the time of optional arguments I think in this case they lead to clearer code, in particular the default for `last` is useful and avoids clutter. 

Regarding the label names [first] and [last] are used rather than say [start] and [stop] since they carry (at least in my brain) more the meaning that the specified indices are included in the range.




