### PR TITLE
Reimplement Condition.t on Win32

### DIFF
--- a/Changes
+++ b/Changes
@@ -235,6 +235,10 @@ Working version
 - #9869: Add Unix.SO_REUSEPORT
   (Yishuai Li, review by Xavier Leroy)
 
+- #9894: New Win32 implementation of Condition.t with fairer semantics for
+  Condition.signal.
+  (David Allsopp, review by ???)
+
 ### Tools:
 
 - #9551: ocamlobjinfo is now able to display information on .cmxs shared


### PR DESCRIPTION
This is an end-of-day experiment with the comment in https://github.com/ocaml/ocaml/pull/9863#discussion_r484896736.

This toy example:

```ocaml
let cv = Condition.create ()
let m = Mutex.create ()
let run = ref true

let worker () =
  let self = Thread.self () in
  while !run do
    Mutex.lock m;
    Condition.wait cv m;
    Printf.eprintf "Worker %d awoke\n%!" (Thread.id self);
    Mutex.unlock m
  done

let () =
  for i = 1 to 1024 do
    ignore (Thread.create worker ());
  done;
  Unix.sleep 1;
  let start = Unix.gettimeofday () in
  while Unix.gettimeofday () -. start < 10.0 do
    Unix.sleepf 0.1;
    Mutex.lock m;
    Condition.signal cv;
    Printf.eprintf "Master has signalled the condition\n%!";
    Mutex.unlock m
  done;
  run := false
```

on Windows produces a constant stream of "Worker 1024 awoke" because that thread will always get its event to the head of the list. This PR makes the behaviour on Windows a little more like the behaviour on Unix - a random thread gets awoken each time.

I have tested it with a toy example for broadcast as well:

```ocaml
let cv = Condition.create ()
let m = Mutex.create ()
let run = ref true
let count = Hashtbl.create 1024

let worker () =
  let self = Thread.id @@ Thread.self () in
  while !run do
    Mutex.lock m;
    Condition.wait cv m;
    if Hashtbl.mem count self then
      Printf.eprintf "Thread %d: double-entry!\n%!" self
    else
      Hashtbl.add count self ();
    Mutex.unlock m
  done

let () =
  for i = 1 to 1024 do
    ignore (Thread.create worker ());
  done;
  Unix.sleep 1;
  let start = Unix.gettimeofday () in
  while Unix.gettimeofday () -. start < 10.0 do
    Unix.sleepf 0.1;
    Printf.eprintf "Count is %d\n%!" @@ Hashtbl.length count;
    Mutex.lock m;
    Hashtbl.clear count;
    Condition.broadcast cv;
    Printf.eprintf "Master has broadcast the condition\n%!";
    Mutex.unlock m
  done;
  run := false
```

this (hopefully correctly) checks that each thread actually gets woken up exactly once on each broadcast cycle.

Very unusually for me, this implementation deletes more code than it adds! However:

- I'm not certain (yet) that it's correct
- I've made no effort to check whether it's more performant - I expect with a condition variable with a large number of waiters it probably is, but that may be less true for a very low number of waiters (that said, Condition.wait prior to 3.12 was implemented with `WaitForMultipleObjects`)