### PR TITLE
Remove CAMLprim and CAMLexport from backtrace.h

### DIFF
--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -96,7 +96,7 @@
  * It might be called before GC initialization, so it shouldn't do OCaml
  * allocation.
  */
-CAMLprim value caml_record_backtrace(value vflag);
+CAMLextern value caml_record_backtrace(value vflag);
 
 
 #ifndef NATIVE_CODE
@@ -122,7 +122,7 @@ extern void caml_stash_backtrace(value exn, value * sp, int reraise);
 CAMLextern void caml_print_exception_backtrace(void);
 
 void caml_init_backtrace(void);
-CAMLexport void caml_init_debug_info(void);
+CAMLextern void caml_init_debug_info(void);
 
 #endif /* CAML_INTERNALS */
 


### PR DESCRIPTION
These appear to have been simply copy-and-paste mistakes from C files in 640b242 (for `caml_record_backtrace`) and 304c9c9 (for `caml_init_debug_info`).

`CAMLprim` and `CAMLexport` should only be used in C files on definitions, not on declarations.