### PR TITLE
Tidy caml_main declaration

### DIFF
--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -21,8 +21,6 @@
 #include "mlvalues.h"
 #include "exec.h"
 
-CAMLextern void caml_main(char_os **argv);
-
 CAMLextern void caml_startup_code(
            code_t code, asize_t code_size,
            char *data, asize_t data_size,

--- a/runtime/main.c
+++ b/runtime/main.c
@@ -22,11 +22,10 @@
 #include "caml/mlvalues.h"
 #include "caml/sys.h"
 #include "caml/osdeps.h"
+#include "caml/callback.h"
 #ifdef _WIN32
 #include <windows.h>
 #endif
-
-CAMLextern void caml_main (char_os **);
 
 #ifdef _WIN32
 CAMLextern void caml_expand_command_line (int *, wchar_t ***);


### PR DESCRIPTION
`caml_main` is publicly declared in `callback.h` but the declaration was duplicated in `startup.h` and manually specified in `main.c`.

There's no need for the internal declaration in `startup.h` and no harm in `#include`ing `callback.h` in `main.c`

This arises from altering the code-base to ensure that `CAMLextern` is used headers only to check that export-control macros are used properly.