### PR TITLE
Declare caml_expand_command_line in osdeps.h

### DIFF
--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -159,6 +159,8 @@ extern value caml_copy_string_of_utf16(const wchar_t *s);
 
 extern int caml_win32_isatty(int fd);
 
+CAMLextern void caml_expand_command_line (int *, wchar_t ***);
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/runtime/main.c
+++ b/runtime/main.c
@@ -29,8 +29,6 @@
 CAMLextern void caml_main (char_os **);
 
 #ifdef _WIN32
-CAMLextern void caml_expand_command_line (int *, wchar_t ***);
-
 int wmain(int argc, wchar_t **argv)
 #else
 int main(int argc, char **argv)


### PR DESCRIPTION
Related to #9901, this simply puts the declaration of the Win32-specific `caml_expand_command_line` in `osdeps.h` where it belongs.