### PR TITLE
Remove final instances CAMLextern in C files

### DIFF
--- a/otherlibs/unix/mmap.c
+++ b/otherlibs/unix/mmap.c
@@ -39,8 +39,7 @@
 #endif
 
 /* Defined in [mmap_ba.c] */
-CAMLextern value
-caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim);
+extern value caml_unix_mapped_alloc(int, int, void *, intnat *);
 
 #if defined(HAS_MMAP)
 

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -24,7 +24,7 @@
 /* Allocation of bigarrays for memory-mapped files.
    This is the OS-independent part of [mmap.c]. */
 
-CAMLextern void caml_ba_unmap_file(void * addr, uintnat len);
+extern void caml_ba_unmap_file(void *, uintnat);
 
 static void caml_ba_mapped_finalize(value v)
 {

--- a/otherlibs/win32unix/mmap.c
+++ b/otherlibs/win32unix/mmap.c
@@ -30,8 +30,7 @@
   do { win32_maperr(GetLastError()); uerror(func, arg); } while(0)
 
 /* Defined in [mmap_ba.c] */
-CAMLextern value
-caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim);
+extern value caml_unix_mapped_alloc(int, int, void *, intnat *);
 
 #ifndef INVALID_SET_FILE_POINTER
 #define INVALID_SET_FILE_POINTER (-1)


### PR DESCRIPTION
The last bit of "clearing the wood to see the trees" - this completes the elimination of `CAMLextern` in C files, meaning that import control only has to be worried about in header files. Apart from `caml_main`, the only place this happened is a few co-dependent functions in the mmap functions in the Unix library, which are clearly "internal".