### PR TITLE
Declare primitives used by unix in io.h

### DIFF
--- a/otherlibs/unix/channels.c
+++ b/otherlibs/unix/channels.c
@@ -64,10 +64,6 @@ static int unix_check_stream_semantics(int fd)
   }
 }
 
-/* From runtime/io.c.  To be declared in <caml/io.h> ? */
-extern value caml_ml_open_descriptor_in(value fd);
-extern value caml_ml_open_descriptor_out(value fd);
-
 CAMLprim value unix_inchannel_of_filedescr(value fd)
 {
   int err;

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -128,6 +128,10 @@ CAMLextern struct channel * caml_all_opened_channels;
 #define Val_file_offset(fofs) caml_copy_int64(fofs)
 #define File_offset_val(v) ((file_offset) Int64_val(v))
 
+/* Primitives required by the Unix library */
+CAMLextern value caml_ml_open_descriptor_in(value fd);
+CAMLextern value caml_ml_open_descriptor_out(value fd);
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_IO_H */


### PR DESCRIPTION
There's a comment that these should really be declared in io.h - it makes sense to now!

(this one is prerequisite to fixing Cygwin64)