### PR TITLE
adds `unix_exit` to `unix.cmxs`

### DIFF
--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -82,7 +82,7 @@ else
 endif
 
 $(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB)
-	$(CAMLOPT_CMD) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
+	$(CAMLOPT_CMD) -shared -linkall -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
 
 lib$(CLIBNAME).$(A): $(COBJS)
 	$(MKLIB_CMD) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -208,6 +208,7 @@ external execvp : string -> string array -> 'a = "unix_execvp"
 external execvpe : string -> string array -> string array -> 'a = "unix_execvpe"
 
 external fork : unit -> int = "unix_fork"
+external _exit : int -> 'a = "unix_exit"
 external wait : unit -> int * process_status = "unix_wait"
 external waitpid : wait_flag list -> int -> int * process_status
    = "unix_waitpid"

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -211,6 +211,17 @@ val fork : unit -> int
 
    On Windows: not implemented, use {!create_process} or threads. *)
 
+val _exit : int -> 'a
+(** Terminates the calling process immediately and returns the given
+    status code to the operating system. The functions registered with
+    {!Stdlib.at_exit} are not called and opened output channels are
+    not flushed.
+
+    See also {!Stdlib.exit}.
+
+    @since 4.12.0
+*)
+
 val wait : unit -> int * process_status
 (** Wait until one of the children processes die, and return its pid
    and termination status.


### PR DESCRIPTION
The `unix_exit` primitive is not linked into the `unix.cmxs` file because it is not used/referenced anywhere in the unix.cmxa library. As a result it is not possible to dynamically link libraries that reference this primitive, e.g., `lwt.unix`.

This branch is fixing this problem by explicitly mentioning this primitive in the unix.ml file.

Note: the description and the title was updated, see the history for details.
