### PR TITLE
Fix native toplevel on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -203,6 +203,9 @@ OCaml 4.12.0
   segfault.
   (Nicolás Ojeda Bär, report by Xavier Leroy, review by Xavier Leroy)
 
+- #9907: Fix native toplevel on native Windows.
+  (David Allsopp, review by Florian Angeletti)
+
 - #9909: Remove caml_code_area_start and caml_code_area_end globals (no longer
   needed as the pagetable heads towards retirement).
   (David Allsopp, review by Xavier Leroy)

--- a/Makefile
+++ b/Makefile
@@ -630,16 +630,14 @@ runtop:
 	$(MAKE) ocamlc
 	$(MAKE) otherlibraries
 	$(MAKE) ocaml
-	@rlwrap --help 2>/dev/null && $(EXTRAPATH) rlwrap $(RUNTOP) ||\
-	  $(EXTRAPATH) $(RUNTOP)
+	@$(EXTRAPATH) $(RLWRAP) $(RUNTOP)
 
 .PHONY: natruntop
 natruntop:
 	$(MAKE) core
 	$(MAKE) opt
 	$(MAKE) ocamlnat
-	@rlwrap --help 2>/dev/null && $(EXTRAPATH) rlwrap $(NATRUNTOP) ||\
-	  $(EXTRAPATH) $(NATRUNTOP)
+	@$(EXTRAPATH) $(RLWRAP) $(NATRUNTOP)
 
 # Native dynlink
 

--- a/Makefile
+++ b/Makefile
@@ -637,7 +637,7 @@ natruntop:
 	$(MAKE) core
 	$(MAKE) opt
 	$(MAKE) ocamlnat
-	@$(EXTRAPATH) $(RLWRAP) $(NATRUNTOP)
+	@$(FLEXLINK_ENV) $(EXTRAPATH) $(RLWRAP) $(NATRUNTOP)
 
 # Native dynlink
 

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -31,3 +31,6 @@ COMPUTE_DEPS=@compute_deps@
 # This is munged into utils/config.ml, not overridable by other parts of
 # the build system.
 OC_DLL_LDFLAGS=@oc_dll_ldflags@
+
+# The rlwrap command (for the *runtop targets)
+RLWRAP=@rlwrap@

--- a/configure
+++ b/configure
@@ -694,6 +694,7 @@ PTHREAD_CFLAGS
 PTHREAD_LIBS
 PTHREAD_CC
 ax_pthread_config
+rlwrap
 DIRECT_LD
 INSTALL_DATA
 INSTALL_SCRIPT
@@ -14172,6 +14173,53 @@ fi
 if test -z "$ASPP"; then :
   ASPP="$default_aspp"
 fi
+
+# Utilities
+# Extract the first word of "rlwrap", so it can be a program name with args.
+set dummy rlwrap; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_rlwrap+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$rlwrap"; then
+  ac_cv_prog_rlwrap="$rlwrap" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_rlwrap="rlwrap"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+rlwrap=$ac_cv_prog_rlwrap
+if test -n "$rlwrap"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $rlwrap" >&5
+$as_echo "$rlwrap" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+case $rlwrap,$system in #(
+  rlwrap,win*|rlwrap,mingw*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: rlwrap doesn't work with native win32 - disabling" >&5
+$as_echo "$as_me: rlwrap doesn't work with native win32 - disabling" >&6;}
+     rlwrap='' ;; #(
+  *) :
+     ;;
+esac
 
 # Checks for library functions
 

--- a/configure.ac
+++ b/configure.ac
@@ -1110,6 +1110,13 @@ AS_IF([test -z "$AS"], [AS="$default_as"])
 
 AS_IF([test -z "$ASPP"], [ASPP="$default_aspp"])
 
+# Utilities
+AC_CHECK_PROG([rlwrap],[rlwrap],[rlwrap])
+AS_CASE([$rlwrap,$system],
+  [rlwrap,win*|rlwrap,mingw*],
+    [AC_MSG_NOTICE([rlwrap doesn't work with native win32 - disabling])
+     rlwrap=''])
+
 # Checks for library functions
 
 ## Check the semantics of signal handlers

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -241,7 +241,7 @@ void * caml_dlsym(void * handle, const char * name)
 
 void * caml_globalsym(const char * name)
 {
-  return flexdll_dlsym(flexdll_dlopen(NULL,0), name);
+  return flexdll_dlsym(flexdll_wdlopen(NULL,0), name);
 }
 
 char * caml_dlerror(void)


### PR DESCRIPTION
Setting `OCAML_FLEXLINK` allows `make natruntop` to work with the four native Windows ports.