### PR TITLE
Fix unnecessary rebuilding on Windows

### DIFF
--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -268,8 +268,8 @@ OPTTOPLEVEL=toplevel/genprintval.cmo toplevel/opttoploop.cmo \
 OPTTOPLEVEL_CMI=
 
 
-$(COMMON:.cmo=.cmx) $(BYTECOMP:.cmo=.cmx) $(OPTCOMP:.cmo=.cmx): ocamlopt
-$(OPTTOPLEVEL:.cmo=.cmx): ocamlopt
+$(COMMON:.cmo=.cmx) $(BYTECOMP:.cmo=.cmx) $(OPTCOMP:.cmo=.cmx): ocamlopt$(EXE)
+$(OPTTOPLEVEL:.cmo=.cmx): ocamlopt$(EXE)
 
 
 compilerlibs/ocamlcommon.cma: $(COMMON_CMI) $(COMMON)


### PR DESCRIPTION
This looks like a tiny change missing from #9652, since `ocamlopt` changed to `ocamlopt$(EXE)`. The .cmx files for  `ocamlcommon.cmxa` & `ocamlopttoplevel.cmxa` depend on `ocamlopt` which no longer exists on Cygwin/Windows so trigger a full rebuild all the time!