### PR TITLE
Eliminate caml_code_area globals

### DIFF
--- a/Changes
+++ b/Changes
@@ -118,6 +118,10 @@ Working version
   segfault.
   (Nicolás Ojeda Bär, report by Xavier Leroy, review by Xavier Leroy)
 
+- #9909: Remove caml_code_area_start and caml_code_area_end globals (no longer
+  needed as the pagetable heads towards retirement).
+  (David Allsopp, review by Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #9551: ocamlc no longer loads DLLs at link time to check that

--- a/runtime/caml/address_class.h
+++ b/runtime/caml/address_class.h
@@ -91,8 +91,6 @@
 /***********************************************************************/
 /* The rest of this file is private and may change without notice. */
 
-extern char * caml_code_area_start, * caml_code_area_end;
-
 #define Not_in_heap 0
 #define In_heap 1
 #define In_young 2

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -47,7 +47,6 @@
 #endif
 
 extern int caml_parser_trace;
-char * caml_code_area_start, * caml_code_area_end;
 extern char caml_system__code_begin, caml_system__code_end;
 
 /* Initialize the atom table and the static data and code area limits. */
@@ -57,6 +56,8 @@ struct segment { char * begin; char * end; };
 static void init_static(void)
 {
   extern struct segment caml_data_segments[], caml_code_segments[];
+
+  char * caml_code_area_start, * caml_code_area_end;
   int i;
 
   caml_init_atom_table ();


### PR DESCRIPTION
Getting Cygwin64 breathing again and, more importantly, wanting to keep it and the other 64-bit Windows ports breathing, is making me comb through our global variables and the location of C declarations. For reasons of sanity, it is desirable to have `extern` declarations in header files. For most, that'll come in another PR, but this one stands out for separate attention.

Since #9682, `caml_code_area_start` and `caml_code_area_end` are no longer used outside `startup_nat.c`. So this PR proposes their removal as globals (the declarations in `address_class.h` are not protected by `CAML_INTERNALS` but are preceded by a comment allowing their deletion!).