### PR TITLE
Fix testsuite for spacetime

### DIFF
--- a/testsuite/tests/statmemprof/callstacks.flat-float-array.reference
+++ b/testsuite/tests/statmemprof/callstacks.flat-float-array.reference
@@ -1,74 +1,74 @@
 -----------
-Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 19, characters 30-53
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 21, characters 30-53
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 22, characters 30-76
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 24, characters 30-76
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 27, characters 12-66
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 29, characters 12-66
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 30, characters 30-60
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 32, characters 30-60
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 33, characters 30-55
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 35, characters 30-55
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 37, characters 12-62
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 39, characters 12-62
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 40, characters 22-27
-Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 42, characters 30-65
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 42, characters 22-27
+Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 44, characters 30-65
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 45, characters 30-69
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 47, characters 30-69
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 48, characters 30-73
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 50, characters 30-73
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 52, characters 30-43
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 54, characters 30-43
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.get0 in file "callstacks.ml", line 55, characters 28-33
-Called from Callstacks.getfloatfield in file "callstacks.ml", line 57, characters 30-47
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.get0 in file "callstacks.ml", line 57, characters 28-33
+Called from Callstacks.getfloatfield in file "callstacks.ml", line 59, characters 30-47
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
 Raised by primitive operation at Stdlib__marshal.from_bytes in file "marshal.ml", line 61, characters 9-35
-Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 63, characters 12-87
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 65, characters 12-87
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 66, characters 30-59
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 68, characters 30-59
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 69, characters 37-43
-Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 71, characters 30-49
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 71, characters 37-43
+Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 73, characters 30-49
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27

--- a/testsuite/tests/statmemprof/callstacks.ml
+++ b/testsuite/tests/statmemprof/callstacks.ml
@@ -2,15 +2,17 @@
    flags = "-g -w -5"
    compare_programs = "false"
 
-   * flat-float-array
-     reference = "${test_source_directory}/callstacks.flat-float-array.reference"
-   ** native
-   ** bytecode
+   * no-spacetime
 
-   * no-flat-float-array
-     reference = "${test_source_directory}/callstacks.no-flat-float-array.reference"
-   ** native
-   ** bytecode
+   ** flat-float-array
+      reference = "${test_source_directory}/callstacks.flat-float-array.reference"
+   *** native
+   *** bytecode
+
+   ** no-flat-float-array
+      reference = "${test_source_directory}/callstacks.no-flat-float-array.reference"
+   *** native
+   *** bytecode
 *)
 
 open Gc.Memprof

--- a/testsuite/tests/statmemprof/callstacks.no-flat-float-array.reference
+++ b/testsuite/tests/statmemprof/callstacks.no-flat-float-array.reference
@@ -1,70 +1,70 @@
 -----------
-Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 19, characters 30-53
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 21, characters 30-53
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 22, characters 30-76
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 24, characters 30-76
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 27, characters 12-66
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 29, characters 12-66
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 30, characters 30-60
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 32, characters 30-60
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 33, characters 30-55
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 35, characters 30-55
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 37, characters 12-62
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 39, characters 12-62
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 40, characters 22-27
-Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 42, characters 30-65
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 42, characters 22-27
+Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 44, characters 30-65
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 45, characters 30-69
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 47, characters 30-69
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 48, characters 30-73
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 50, characters 30-73
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 52, characters 30-43
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 54, characters 30-43
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
 No callstack
 -----------
 Raised by primitive operation at Stdlib__marshal.from_bytes in file "marshal.ml", line 61, characters 9-35
-Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 63, characters 12-87
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 65, characters 12-87
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 66, characters 30-59
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 68, characters 30-59
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27
 -----------
-Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 69, characters 37-43
-Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 71, characters 30-49
-Called from Callstacks.test in file "callstacks.ml", line 93, characters 2-10
+Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 71, characters 37-43
+Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 73, characters 30-49
+Called from Callstacks.test in file "callstacks.ml", line 95, characters 2-10
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 100, characters 2-27
+Called from Callstacks in file "callstacks.ml", line 102, characters 2-27

--- a/testsuite/tests/statmemprof/comballoc.byte.reference
+++ b/testsuite/tests/statmemprof/comballoc.byte.reference
@@ -1,49 +1,49 @@
 2: 0.42 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 2-19
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 2-19
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 3: 0.42 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 6-18
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 6-18
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 4: 0.42 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 13, characters 11-20
+Called from Comballoc.f in file "comballoc.ml", line 16, characters 13-17
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 2: 0.01 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 2-19
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 2-19
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 3: 0.01 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 6-18
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 6-18
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 4: 0.01 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 13, characters 11-20
+Called from Comballoc.f in file "comballoc.ml", line 16, characters 13-17
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 2: 0.83 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 2-19
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 2-19
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 3: 0.83 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 6-18
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 6-18
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 4: 0.83 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 13, characters 11-20
+Called from Comballoc.f in file "comballoc.ml", line 16, characters 13-17
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 OK

--- a/testsuite/tests/statmemprof/comballoc.ml
+++ b/testsuite/tests/statmemprof/comballoc.ml
@@ -1,10 +1,11 @@
 (* TEST
    flags = "-g"
-   * bytecode
-     reference = "${test_source_directory}/comballoc.byte.reference"
-   * native
-     reference = "${test_source_directory}/comballoc.opt.reference"
-     compare_programs = "false"
+   * no-spacetime
+   ** bytecode
+      reference = "${test_source_directory}/comballoc.byte.reference"
+   ** native
+      reference = "${test_source_directory}/comballoc.opt.reference"
+      compare_programs = "false"
 *)
 
 open Gc.Memprof

--- a/testsuite/tests/statmemprof/comballoc.opt.reference
+++ b/testsuite/tests/statmemprof/comballoc.opt.reference
@@ -1,49 +1,49 @@
 2: 0.42 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 2-19
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 2-19
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 3: 0.42 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 6-18
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 6-18
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 4: 0.42 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 13, characters 11-20
+Called from Comballoc.f in file "comballoc.ml", line 16, characters 13-17
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 2: 0.01 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 2-19
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 2-19
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 3: 0.01 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 6-18
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 6-18
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 4: 0.01 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 13, characters 11-20
+Called from Comballoc.f in file "comballoc.ml", line 16, characters 13-17
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 2: 0.83 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 2-19
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 2-19
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 3: 0.83 false
-Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 15, characters 6-18
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 16, characters 6-18
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 4: 0.83 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
-Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 13, characters 11-20
+Called from Comballoc.f in file "comballoc.ml", line 16, characters 13-17
+Called from Comballoc.test in file "comballoc.ml", line 41, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
-Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
+Called from Comballoc in file "comballoc.ml", line 71, characters 2-35
 OK


### PR DESCRIPTION
This PR is based on 4.11 because spacetime on trunk is presently a mess. There are two tests which fail if Spacetime is enabled because of different traces. Assuming the difference in trace is to be expected, the easiest thing seems to be to disable these tests under spacetime, which is what this PR does. This should be then be cherry-picked back to `trunk`.

cc @stedolan & @jhjourdan just to confirm that the difference is to be expected