### PR TITLE
Remove caml_ensure_spacetime_dot_o_is_included

### DIFF
--- a/runtime/spacetime_byt.c
+++ b/runtime/spacetime_byt.c
@@ -19,8 +19,6 @@
 #include "caml/io.h"
 #include "caml/spacetime.h"
 
-int caml_ensure_spacetime_dot_o_is_included = 42;
-
 CAMLprim value caml_spacetime_only_works_for_native_code(value foo, ...)
 {
   caml_failwith("Spacetime profiling only works for native code");

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -330,8 +330,6 @@ extern void caml_install_invalid_parameter_handler();
 
 #endif
 
-extern int caml_ensure_spacetime_dot_o_is_included;
-
 /* Main entry point when loading code from a file */
 
 CAMLexport void caml_main(char_os **argv)
@@ -343,8 +341,6 @@ CAMLexport void caml_main(char_os **argv)
   char * req_prims;
   char_os * shared_lib_path, * shared_libs;
   char_os * exe_name, * proc_self_exe;
-
-  caml_ensure_spacetime_dot_o_is_included++;
 
   /* Initialize the domain */
   caml_init_domain();


### PR DESCRIPTION
This was looked at briefly in #973, but I've hit it checking for globals and externally visible symbols. The `caml_ensure_spacetime_dot_o_is_included` is defined in `spacetime_byt.c` and referenced in `startup_byt.c` apparently to ensure that the dummy primitives are definitely linked.

This has always been unnecessary - `spacetime_byt.c` is scanned for CAMLprim and the primitives are added to `prims.c`. `startup_byt.c` already references `prims.c` in `parse_command_line` via the `caml_names_of_builtin_cprim` global. So linking `startup_byt.o` should always pull in `prims.o` which should always pull in `spacetime.o`. The linking might have been necessary when spacetime was being finished off if `spacetime.c` hadn't at some point been added to the list of files to scan for primitives.

(this is not prerequisite to Cygwin64)