### PR TITLE
Export, document, and use Unix._exit

### DIFF
--- a/Changes
+++ b/Changes
@@ -240,6 +240,11 @@ Working version
 - #9869: Add Unix.SO_REUSEPORT
   (Yishuai Li, review by Xavier Leroy)
 
+- #9906, #9914: Add Unix._exit as a way to exit the process immediately,
+  skipping any finalization action
+  (Ivan Gotovchits and Xavier Leroy, review by Sébastien Hinderer and
+   David Allsopp)
+
 ### Tools:
 
 - #9551: ocamlobjinfo is now able to display information on .cmxs shared

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -241,6 +241,26 @@ val system : string -> process_status
    The result [WEXITED 127] indicates that the shell couldn't be
    executed. *)
 
+val _exit : int -> 'a
+(** Terminate the calling process immediately, returning the given
+   status code to the operating system: usually 0 to indicate no
+   errors, and a small positive integer to indicate failure.
+   Unlike {!Stdlib.exit}, {!Unix._exit} performs no finalization
+   whatsoever: functions registered with {!Stdlib.at_exit} are not called,
+   input/output channels are not flushed, and the C run-time system
+   is not finalized either.
+
+   The typical use of {!Unix._exit} is after a {!Unix.fork} operation,
+   when the child process runs into a fatal error and must exit.  In
+   this case, it is preferable to not perform any finalization action
+   in the child process, as these actions could interfere with similar
+   actions performed by the parent process.  For example, output
+   channels should not be flushed by the child process, as the parent
+   process may flush them again later, resulting in duplicate
+   output.
+
+   @since 4.12.0 *)
+
 val getpid : unit -> int
 (** Return the pid of the process. *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -215,6 +215,26 @@ val system : string -> process_status
    etc. The result [WEXITED 127] indicates that the shell couldn't
    be executed. *)
 
+val _exit : int -> 'a
+(** Terminate the calling process immediately, returning the given
+   status code to the operating system: usually 0 to indicate no
+   errors, and a small positive integer to indicate failure.
+   Unlike {!Stdlib.exit}, {!Unix._exit} performs no finalization
+   whatsoever: functions registered with {!Stdlib.at_exit} are not called,
+   input/output channels are not flushed, and the C run-time system
+   is not finalized either.
+
+   The typical use of {!Unix._exit} is after a {!Unix.fork} operation,
+   when the child process runs into a fatal error and must exit.  In
+   this case, it is preferable to not perform any finalization action
+   in the child process, as these actions could interfere with similar
+   actions performed by the parent process.  For example, output
+   channels should not be flushed by the child process, as the parent
+   process may flush them again later, resulting in duplicate
+   output.
+
+   @since 4.12.0 *)
+
 val getpid : unit -> int
 (** Return the pid of the process. *)
 

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -241,6 +241,7 @@ let execvpe prog args env =
 
 external waitpid : wait_flag list -> int -> int * process_status
                  = "win_waitpid"
+external _exit : int -> 'a = "unix_exit"
 external getpid : unit -> int = "unix_getpid"
 
 let fork () = invalid_arg "Unix.fork not implemented"

--- a/testsuite/tests/lib-unix/common/uexit.ml
+++ b/testsuite/tests/lib-unix/common/uexit.ml
@@ -1,0 +1,11 @@
+(* TEST
+* hasunix
+include unix
+** bytecode
+** native
+*)
+
+let _ =
+  at_exit (fun () -> print_string "B\n"; flush stdout);
+  print_string "A\n"; (* don't flush *)
+  Unix._exit 0


### PR DESCRIPTION
This is a wrapper around the `_exit` system call.  It has been implemented in otherlibs/unix/exit.c for a long time but never exported.  This PR exports and documents it as `Unix._exit`.

The Unix implementation of `establish_server` is changed to use `_exit` and to have gender-neutral comments.

A test was added to check that OCaml finalization actions are not performed.
