### PR TITLE
Spacetime seems a bit broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
   - env: >-
       CI_KIND=build
       XARCH=x64
+      CONFIG_ARG=--enable-spacetime
     addons:
       apt:
         packages:

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -26,7 +26,7 @@
 # versions: we assume that ocamlc, ocamlopt, etc. have been run first.
 
 # Set this to empty to force use of the bytecode compilers at all times
-ENABLE_BEST=yes
+ENABLE_BEST=
 
 check_not_stale = \
   $(if $(shell test $(ROOTDIR)/$1 -nt $(ROOTDIR)/$2 && echo stale), \

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -25,6 +25,9 @@
 # native binary, if available. Note that they never use the boot/
 # versions: we assume that ocamlc, ocamlopt, etc. have been run first.
 
+# Set this to empty to force use of the bytecode compilers at all times
+ENABLE_BEST=yes
+
 check_not_stale = \
   $(if $(shell test $(ROOTDIR)/$1 -nt $(ROOTDIR)/$2 && echo stale), \
     $(info Warning: we are not using the native binary $2 \
@@ -34,7 +37,7 @@ or rebuilding it (or `touch`-ing it) if you want it used.), \
     ok)
 
 choose_best = $(strip $(if \
-   $(and $(wildcard $(ROOTDIR)/$1.opt$(EXE)),$(strip \
+   $(and $(ENABLE_BEST),$(wildcard $(ROOTDIR)/$1.opt$(EXE)),$(strip \
       $(call check_not_stale,$1$(EXE),$1.opt$(EXE)))), \
     $(ROOTDIR)/$1.opt$(EXE), \
     $(CAMLRUN) $(ROOTDIR)/$1$(EXE)))
@@ -50,7 +53,7 @@ BEST_OCAMLLEX := $(call choose_best,lex/ocamllex)
 # bootrap-compiler and host-compiler object files, as ocamldep only
 # produces text output.
 BEST_OCAMLDEP := $(strip $(if \
-   $(and $(wildcard $(ROOTDIR)/ocamlc.opt$(EXE)),$(strip \
+   $(and $(ENABLE_BEST),$(wildcard $(ROOTDIR)/ocamlc.opt$(EXE)),$(strip \
       $(call check_not_stale,boot/ocamlc,ocamlc.opt$(EXE)))), \
     $(ROOTDIR)/ocamlc.opt$(EXE) -depend, \
     $(BOOT_OCAMLC) -depend))

--- a/runtime/spacetime_nat.c
+++ b/runtime/spacetime_nat.c
@@ -131,7 +131,7 @@ static void reinitialise_free_node_block(void)
 
 enum {
   FEATURE_CALL_COUNTS = 1,
-} features;
+};
 
 static uint16_t version_number = 0;
 static uint32_t magic_number_base = 0xace00ace;
@@ -355,8 +355,8 @@ CAMLprim value caml_spacetime_save_event (value v_time_opt,
 }
 
 
-void save_trie (struct channel *chan, double time_override,
-                int use_time_override)
+static void save_trie (struct channel *chan, double time_override,
+                       int use_time_override)
 {
   value v_time, v_frames, v_shapes;
   /* CR-someday mshinwell: The commented-out changes here are for multicore,


### PR DESCRIPTION
I had cause to enable spacetime while checking something - the `trunk` build seems to be a disaster at the moment. This is a draft-issue-PR to track it. It duplicates one commit from #9913 simply because Travis fails to build otherwise.

The commit adding `ENABLE_BEST` should be merged in some form regardless - there are other situations where it's useful to be able to turn off the otherwise very useful enhancement to use the .opt compilers.

Anyway, at present spacetime on trunk seems to be stack overflowing the .opt compilers a lot, and the testsuite has a relatively large number of failures.