### PR TITLE
Limit declaration of C primitives in runtime headers

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,10 @@ Working version
    Leroy and Damien Doligez, benchmarking by Shubham Kumar and KC
    Sivaramakrishnan)
 
+- #9919: Introduce caml_record_backtraces and update Interfacing with C to
+  refer to it (previous instruction to use caml_record_backtrace primitive was
+  not possible without defining CAML_INTERNALS)
+
 - #10102: Ignore PROFINFO_WIDTH if WITH_PROFINFO is not defined (technically
   a breaking change if the configuration system was being abused before).
   (David Allsopp, review by Xavier Leroy)

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -473,7 +473,8 @@ let link_bytecode_as_c tolink outfile with_main =
 \nextern \"C\" {\
 \n#endif\
 \n#include <caml/mlvalues.h>\
-\n#include <caml/startup.h>\n";
+\n#include <caml/startup.h>\
+\n#include <caml/sys.h>\n";
        output_string outchan "static int caml_code[] = {\n";
        Symtable.init();
        clear_crc_interfaces ();
@@ -516,7 +517,7 @@ let link_bytecode_as_c tolink outfile with_main =
 \n                    caml_sections, sizeof(caml_sections),\
 \n                    /* pooling */ 0,\
 \n                    argv);\
-\n  caml_sys_exit(Val_int(0));\
+\n  caml_do_exit(0);\
 \n  return 0; /* not reached */\
 \n}\n"
        end else begin

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1740,7 +1740,8 @@ information is available, but the backtrace mechanism needs to be
 turned on programmatically.   This can be achieved from the OCaml side
 by calling "Printexc.record_backtrace true" in the initialization of
 one of the OCaml modules.  This can also be achieved from the C side
-by calling "caml_record_backtrace(Val_int(1));" in the OCaml-C glue code.
+by calling "caml_record_backtraces(1);" in the OCaml-C glue code.
+("caml_record_backtraces" is declared in "backtrace.h")
 
 \paragraph{Unloading the runtime.}
 

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -35,10 +35,8 @@ void caml_init_backtrace(void)
 }
 
 /* Start or stop the backtrace machinery */
-CAMLprim value caml_record_backtrace(value vflag)
+CAMLexport void caml_record_backtraces(int flag)
 {
-  int flag = Int_val(vflag);
-
   if (flag != Caml_state->backtrace_active) {
     Caml_state->backtrace_active = flag;
     Caml_state->backtrace_pos = 0;
@@ -49,6 +47,12 @@ CAMLprim value caml_record_backtrace(value vflag)
        Caml_state->backtrace_buffer). So we don't have to allocate it here.
     */
   }
+  return;
+}
+
+CAMLprim value caml_record_backtrace(value flag)
+{
+  caml_record_backtraces(Int_val(flag));
   return Val_unit;
 }
 

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -16,9 +16,19 @@
 #ifndef CAML_BACKTRACE_H
 #define CAML_BACKTRACE_H
 
+#include "mlvalues.h"
+
+/* [caml_record_backtraces] controls backtrace recording.
+ * This function can be called at runtime by user-code, or during
+ * initialization if backtraces were requested.
+ *
+ * It might be called before GC initialization, so it shouldn't do OCaml
+ * allocation.
+ */
+CAMLextern void caml_record_backtraces(int);
+
 #ifdef CAML_INTERNALS
 
-#include "mlvalues.h"
 #include "exec.h"
 
 /* Runtime support for backtrace generation.
@@ -52,7 +62,8 @@
  *   OCaml values of algebraic data-type [Printexc.backtrace_slot]
  */
  /* [Caml_state->backtrace_active] is non zero iff backtraces are recorded.
- * This variable must be changed with [caml_record_backtrace].
+ * This variable must be changed with [caml_record_backtrace] in OCaml or
+ * [caml_record_backtraces] in C.
  */
 #define caml_backtrace_active (Caml_state_field(backtrace_active))
 /* The [Caml_state->backtrace_buffer] and [Caml_state->backtrace_last_exn]
@@ -88,16 +99,6 @@
  * - directly resetting [Caml_state->backtrace_pos] to 0 in native
      runtimes for raise.
  */
-
-/* [caml_record_backtrace] toggle backtrace recording on and off.
- * This function can be called at runtime by user-code, or during
- * initialization if backtraces were requested.
- *
- * It might be called before GC initialization, so it shouldn't do OCaml
- * allocation.
- */
-CAMLextern value caml_record_backtrace(value vflag);
-
 
 #ifndef NATIVE_CODE
 

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -217,8 +217,6 @@
 #define page_table caml_page_table
 
 /* **** md5.c */
-#define md5_string caml_md5_string
-#define md5_chan caml_md5_chan
 #define MD5Init caml_MD5Init
 #define MD5Update caml_MD5Update
 #define MD5Final caml_MD5Final

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -287,7 +287,6 @@
 
 /* **** sys.c */
 #define sys_error caml_sys_error
-#define sys_exit caml_sys_exit
 
 /* **** terminfo.c */
 

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -28,7 +28,6 @@ void caml_final_invert_finalisable_values (void);
 void caml_final_oldify_young_roots (void);
 void caml_final_empty_young (void);
 void caml_final_update_minor_roots(void);
-value caml_final_register (value f, value v);
 void caml_final_invariant_check(void);
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -49,8 +49,6 @@ void caml_init_gc (uintnat minor_size, uintnat major_size, uintnat major_incr,
                    uintnat policy);
 
 
-CAMLextern value caml_gc_stat(value v);
-
 #ifdef DEBUG
 void caml_heap_check (void);
 #endif

--- a/runtime/caml/md5.h
+++ b/runtime/caml/md5.h
@@ -23,8 +23,6 @@
 #include "mlvalues.h"
 #include "io.h"
 
-CAMLextern value caml_md5_string (value str, value ofs, value len);
-CAMLextern value caml_md5_chan (value vchan, value len);
 CAMLextern void caml_md5_block(unsigned char digest[16],
                                void * data, uintnat len);
 

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -38,7 +38,7 @@ CAMLextern double caml_sys_time_unboxed(value);
 CAMLextern void caml_sys_init (char_os * exe_name, char_os ** argv);
 
 CAMLnoreturn_start
-CAMLextern value caml_sys_exit (value)
+CAMLextern void caml_do_exit (int)
 CAMLnoreturn_end;
 
 extern char_os * caml_exe_name;

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -41,8 +41,6 @@ CAMLnoreturn_start
 CAMLextern value caml_sys_exit (value)
 CAMLnoreturn_end;
 
-CAMLextern value caml_sys_get_argv(value unit);
-
 extern char_os * caml_exe_name;
 
 #ifdef __cplusplus

--- a/runtime/main.c
+++ b/runtime/main.c
@@ -39,6 +39,6 @@ int main(int argc, char **argv)
 #endif
 
   caml_main(argv);
-  caml_sys_exit(Val_int(0));
+  caml_do_exit(0);
   return 0; /* not reached */
 }

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -111,8 +111,7 @@ void caml_parse_ocamlrunparam(void)
     while (*opt != '\0'){
       switch (*opt++){
       case 'a': scanmult (opt, &caml_init_policy); break;
-      case 'b': scanmult (opt, &p); caml_record_backtrace(Val_int (p));
-        break;
+      case 'b': scanmult (opt, &p); caml_record_backtraces(p); break;
       case 'c': scanmult (opt, &p); caml_cleanup_on_exit = (p != 0); break;
       case 'h': scanmult (opt, &caml_init_heap_wsz); break;
       case 'H': scanmult (opt, &caml_use_huge_pages); break;

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -321,7 +321,7 @@ static int parse_command_line(char_os **argv)
         exit(0);
         break;
       case 'b':
-        caml_record_backtrace(Val_true);
+        caml_record_backtraces(1);
         break;
       case 'I':
         if (argv[i + 1] != NULL) {

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -113,10 +113,8 @@ static void caml_sys_check_path(value name)
   }
 }
 
-CAMLprim value caml_sys_exit(value retcode_v)
+CAMLexport void caml_do_exit(int retcode)
 {
-  int retcode = Int_val(retcode_v);
-
   if ((caml_verb_gc & 0x400) != 0) {
     /* cf caml_gc_counters */
     double minwords = Caml_state->stat_minor_words
@@ -169,6 +167,11 @@ CAMLprim value caml_sys_exit(value retcode_v)
   }
 #endif
   exit(retcode);
+}
+
+CAMLprim value caml_sys_exit(value retcode)
+{
+  caml_do_exit(Int_val(retcode));
 }
 
 #ifndef O_BINARY

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -450,7 +450,7 @@ void caml_signal_thread(void * lpParam)
     char iobuf[2];
     /* This shall always return a single character */
     ret = ReadFile(h, iobuf, 1, &numread, NULL);
-    if (!ret || numread != 1) caml_sys_exit(Val_int(2));
+    if (!ret || numread != 1) caml_do_exit(2);
     switch (iobuf[0]) {
     case 'C':
       caml_record_signal(SIGINT);


### PR DESCRIPTION
Another piece of tidying (very nearly at the stage that `CAMLexport` and `CAMLprim` match up with headers in a predictable fashion!).

It turns out that there are very few cases where C primitives actually need to be called directly from C, and so declared in headers. This PR contains two tidying commits:

- Makes `Raw_spacetime_lib` directly call `caml_input_value_to_outside_heap` rather than declaring the single-line C stub `caml_spacetime_unmarshal_trie` which simply calls that C primitive.
- Removes declarations for primitives (all inside `CAML_INTERNALS`) which are not actually referenced anywhere (I did a GitHub code search on these as well)

and two refactoring commits:

- Rather than C code calling `caml_sys_exit` having encoded the exit status, the actual functionality of `caml_sys_exit` is moved to `caml_do_exit` which takes an `int` (I resisted the temptation to call the function `caml_start_exit` - it could also be called `caml_exit`?).
- Slightly buggily, the manual outlines calling the primitive `caml_record_backtrace` from C but doesn't actually explain how to declare it (it's internal in `backtrace.h`). As it happens, from C you're pretty much only ever going to want to turn backtraces *on* so I added `caml_record_backtraces` which is declared publicly in `backtrace.h` and then is used elsewhere in the runtime (since the runtime also only ever turns them on).

At the end of this process, we have exactly four primitives which actually have to be exported for use from C:
- `caml_ml_open_descriptor_in` and `caml_ml_open_descriptor_out` (the Unix library needs them)
- `caml_get_public_method` (that's used in C as well as in the Object system's runtime)
- `caml_set_oo_id` (which is used in `intern.c`)

It might be a nice piece of future work to generate `caml/primitives.h` in the same way as `prims.c`, but it's a non-trivial and not strictly necessary at the moment...