### PR TITLE
Untypeast: define untype_expression, untype_pattern

### DIFF
--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -893,4 +893,3 @@ let untype_expression ?(mapper=default_mapper) expression =
 
 let untype_pattern ?(mapper=default_mapper) pattern =
   mapper.pat mapper pattern
-

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -887,3 +887,10 @@ let untype_structure ?(mapper=default_mapper) structure =
 
 let untype_signature ?(mapper=default_mapper) signature =
   mapper.signature mapper signature
+
+let untype_expression ?(mapper=default_mapper) expression =
+  mapper.expr mapper expression
+
+let untype_pattern ?(mapper=default_mapper) pattern =
+  mapper.pat mapper pattern
+

--- a/typing/untypeast.mli
+++ b/typing/untypeast.mli
@@ -81,5 +81,7 @@ val default_mapper : mapper
 
 val untype_structure : ?mapper:mapper -> Typedtree.structure -> structure
 val untype_signature : ?mapper:mapper -> Typedtree.signature -> signature
+val untype_expression : ?mapper:mapper -> Typedtree.expression -> expression
+val untype_pattern : ?mapper:mapper -> _ Typedtree.general_pattern -> pattern
 
 val constant : Asttypes.constant -> Parsetree.constant


### PR DESCRIPTION
Just exposing some convenience functions that we've been defining in merlin for the past few years.