### PR TITLE
stdlib: rename Atomic.make into Atomic.create

### DIFF
--- a/Changes
+++ b/Changes
@@ -166,10 +166,11 @@ Working version
 - #9561: Unbox Unix.gettimeofday and Unix.time
   (Stephen Dolan, review by David Allsopp)
 
-- #9570: Provide an Atomic module with a trivial purely-sequential
+- #9570, #9921: Provide an Atomic module with a purely-sequential
   implementation, to help write code that is compatible with Multicore
   OCaml.
-  (Gabriel Scherer, review by Xavier Leroy)
+  (Gabriel Scherer, Guillaume Munch-Maccagnoni and Daniel Bünzli,
+   review by Xavier Leroy)
 
 - #9571: Make at_exit and Printexc.register_printer thread-safe.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -30,7 +30,7 @@
 type !'a t
 
 (** Create an atomic reference. *)
-val make : 'a -> 'a t
+val create : 'a -> 'a t
 
 (** Get the current value of the atomic reference. *)
 val get : 'a t -> 'a

--- a/stdlib/camlinternalAtomic.ml
+++ b/stdlib/camlinternalAtomic.ml
@@ -24,7 +24,7 @@ external ignore : 'a -> unit = "%ignore"
    signals and other asynchronous callbacks might break atomicity. *)
 type 'a t = {mutable v: 'a}
 
-let make v = {v}
+let create v = {v}
 let get r = r.v
 let set r v = r.v <- v
 

--- a/stdlib/camlinternalAtomic.mli
+++ b/stdlib/camlinternalAtomic.mli
@@ -20,7 +20,7 @@
    Stdlib__ prefix trick. *)
 
 type !'a t
-val make : 'a -> 'a t
+val create : 'a -> 'a t
 val get : 'a t -> 'a
 val set : 'a t -> 'a -> unit
 val exchange : 'a t -> 'a -> 'a

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -17,7 +17,7 @@ open Printf
 
 type t = exn = ..
 
-let printers = Atomic.make []
+let printers = Atomic.create []
 
 let locfmt = format_of_string "File \"%s\", line %d, characters %d-%d: %s"
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -543,12 +543,12 @@ let ( ^^ ) (Format (fmt1, str1)) (Format (fmt2, str2)) =
 
 external sys_exit : int -> 'a = "caml_sys_exit"
 
-let exit_function = CamlinternalAtomic.make flush_all
+let exit_function = CamlinternalAtomic.create flush_all
 
 let rec at_exit f =
   let module Atomic = CamlinternalAtomic in
   (* MPR#7253, MPR#7796: make sure "f" is executed only once *)
-  let f_yet_to_run = Atomic.make true in
+  let f_yet_to_run = Atomic.create true in
   let old_exit = Atomic.get exit_function in
   let new_exit () =
     if Atomic.compare_and_set f_yet_to_run true false then f () ;

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -1,6 +1,6 @@
 (* TEST *)
 
-let r = Atomic.make 1
+let r = Atomic.create 1
 let () = assert (Atomic.get r = 1)
 
 let () = Atomic.set r 2
@@ -27,13 +27,13 @@ let () = assert ((Atomic.incr r; Atomic.get r) = 5)
 let () = assert ((Atomic.decr r; Atomic.get r) = 4)
 
 let () =
-  let r = Atomic.make 0 in
+  let r = Atomic.create 0 in
   let cur = Atomic.get r in
   ignore (Atomic.set r (cur + 1), Atomic.set r (cur - 1));
   assert (Atomic.get r <> cur)
 
 let () =
-  let r = Atomic.make 0 in
+  let r = Atomic.create 0 in
   let cur = Atomic.get r in
   ignore (Atomic.incr r, Atomic.decr r);
   assert (Atomic.get r = cur)

--- a/testsuite/tests/lib-systhreads/eintr.ml
+++ b/testsuite/tests/lib-systhreads/eintr.ml
@@ -7,7 +7,7 @@ include systhreads
 *** native
 *)
 
-let signals_requested = Atomic.make 0
+let signals_requested = Atomic.create 0
 let signal_delay = 0.1
 let _ = Thread.create (fun () ->
   let signals_sent = ref 0 in
@@ -56,7 +56,7 @@ let poke_stdout () =
   | exception Sys_error _ -> ()
 
 let () =
-  let r = Atomic.make true in
+  let r = Atomic.create true in
   Sys.set_signal Sys.sigint (Signal_handle (fun _ ->
     poke_stdout (); Atomic.set r false));
   request_signal ();
@@ -69,7 +69,7 @@ let () =
 let () =
   let mklist () = List.init 1000 (fun i -> (i, i)) in
   let before = Sys.opaque_identity (ref (mklist ())) in
-  let during = Atomic.make (Sys.opaque_identity (mklist ())) in
+  let during = Atomic.create (Sys.opaque_identity (mklist ())) in
   let siglist = ref [] in
   Sys.set_signal Sys.sigint (Signal_handle (fun _ ->
     Gc.full_major (); poke_stdout (); Gc.compact ();


### PR DESCRIPTION
@dbuenzli remarked that `create` is consistently used in the stdlib to initialize a mutable container with an element/value (arrays are the exception, but Queue, Stack, etc. use `create`).

In https://github.com/ocaml-multicore/ocaml-multicore/issues/393, the Multicore-OCaml people support the change and agree to fix the code affected on their end. @ctk21 proposed a multicore-OCaml PR to implement the change in https://github.com/ocaml-multicore/ocaml-multicore/pull/396.

The present PR updates the upward-compatibility Atomic module of the stdlib to rename Atomic.make into Atomic.create. This module has not been release yet, so the interface-breaking change is fine if we get it before 4.12 gets release.