### PR TITLE
Fix -fdebug-prefix-map when using flexlink

### DIFF
--- a/Changes
+++ b/Changes
@@ -481,6 +481,10 @@ Working version
   (Xavier Leroy, report by Alain Frisch, review by Nicolás Ojeda Bär
   and Alain Frisch)
 
+- #9925: Correct passing -fdebug-prefix-map to flexlink on Cygwin by prefixing
+  it with -link.
+  (David Allsopp, review by ???)
+
 
 OCaml 4.11.1
 ------------

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -573,7 +573,13 @@ let build_custom_runtime prim_name exec_name =
     else "-lcamlrun" ^ !Clflags.runtime_variant in
   let debug_prefix_map =
     if Config.c_has_debug_prefix_map && not !Clflags.keep_camlprimc_file then
-      [Printf.sprintf "-fdebug-prefix-map=%s=camlprim.c" prim_name]
+      let flag =
+        [Printf.sprintf "-fdebug-prefix-map=%s=camlprim.c" prim_name]
+      in
+        if Ccomp.linker_is_flexlink then
+          "-link" :: flag
+        else
+          flag
     else
       [] in
   let exitcode =

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -208,23 +208,7 @@ let call_linker mode output_name files extra =
   )
 
 let linker_is_flexlink =
-  let command =
-    String.trim @@ Option.value !Clflags.c_compiler ~default:Config.mkexe in
-  if String.length command < 2 then false else
-    (* Get the first "word" of command *)
-    let full_path =
-      (* This is not comprehensive, but should be good enough for Windows *)
-      if command.[0] = '"' then
-        match String.index_from command 1 '"' with
-        | idx -> String.sub command 1 (idx - 1)
-        | exception Not_found -> String.sub command 1 (String.length command - 1)
-      else
-        match String.index_from command 1 ' ' with
-        | idx -> String.sub command 0 idx
-        | exception Not_found -> command
-    in
-    let prog =
-      let prog = Filename.basename full_path in
-      Option.value ~default:prog @@ Filename.chop_suffix_opt prog ~suffix:".exe"
-    in
-      String.lowercase_ascii prog = "flexlink"
+  (* Config.mkexe, Config.mkdll and Config.mkmaindll are all flexlink
+     invocations for the native Windows ports and for Cygwin, if shared library
+     support is enabled. *)
+  Sys.win32 || Config.supports_shared_libraries && Sys.cygwin

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -206,3 +206,25 @@ let call_linker mode output_name files extra =
     in
     command cmd
   )
+
+let linker_is_flexlink =
+  let command =
+    String.trim @@ Option.value !Clflags.c_compiler ~default:Config.mkexe in
+  if String.length command < 2 then false else
+    (* Get the first "word" of command *)
+    let full_path =
+      (* This is not comprehensive, but should be good enough for Windows *)
+      if command.[0] = '"' then
+        match String.index_from command 1 '"' with
+        | idx -> String.sub command 1 (idx - 1)
+        | exception Not_found -> String.sub command 1 (String.length command - 1)
+      else
+        match String.index_from command 1 ' ' with
+        | idx -> String.sub command 0 idx
+        | exception Not_found -> command
+    in
+    let prog =
+      let prog = Filename.basename full_path in
+      Option.value ~default:prog @@ Filename.chop_suffix_opt prog ~suffix:".exe"
+    in
+      String.lowercase_ascii prog = "flexlink"

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -37,3 +37,5 @@ type link_mode =
   | Partial
 
 val call_linker: link_mode -> string -> string list -> string -> int
+
+val linker_is_flexlink : bool


### PR DESCRIPTION
On Cygwin, the `-fdebug-prefix-map` option is available. However, this gets passed to `flexlink` when configured with `--enable-shared`. This at present works with Cygwin's flexdll package because downstream patched flexlink. I'm not totally convinced that flexlink should blindly pass all `-f` options on because of the MSVC implications, so I think this is better fixed correctly at the OCaml end.

This PR introduces a check in `Ccomp` to determine if `Config.mkexe` is in fact `flexlink`. If so, it prepends `-link` to cause `flexlink` to correctly pass the flag on.