### PR TITLE
Move all function declarations into headers

### DIFF
--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -13,11 +13,10 @@
 /**************************************************************************/
 
 /* Runtime support for afl-fuzz */
-#include "caml/config.h"
+#define CAML_INTERNALS
+#include "caml/mlvalues.h"
 
 #if !defined(HAS_SYS_SHM_H) || !defined(HAS_SHMAT)
-
-#include "caml/mlvalues.h"
 
 CAMLprim value caml_setup_afl (value unit)
 {
@@ -39,16 +38,11 @@ CAMLprim value caml_reset_afl_instrumentation(value unused)
 #include <stdio.h>
 #include <string.h>
 
-#define CAML_INTERNALS
 #include "caml/misc.h"
-#include "caml/mlvalues.h"
 #include "caml/osdeps.h"
+#include "caml/printexc.h"
 
 static int afl_initialised = 0;
-
-/* afl uses abnormal termination (SIGABRT) to check whether
-   to count a testcase as "crashing" */
-extern int caml_abort_on_uncaught_exn;
 
 /* Values used by the instrumentation logic (see cmmgen.ml) */
 static unsigned char afl_area_initial[1 << 16];

--- a/runtime/caml/compact.h
+++ b/runtime/caml/compact.h
@@ -31,6 +31,8 @@ void caml_compact_heap (intnat new_allocation_policy);
 void caml_compact_heap_maybe (void);
 void caml_invert_root (value v, value *p);
 
+extern uintnat caml_percent_max;
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_COMPACT_H */

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -80,6 +80,10 @@ extern struct custom_operations caml_nativeint_ops;
 extern struct custom_operations caml_int32_ops;
 extern struct custom_operations caml_int64_ops;
 extern struct custom_operations caml_ba_ops;
+
+extern uintnat caml_custom_major_ratio;
+extern uintnat caml_custom_minor_ratio;
+extern uintnat caml_custom_minor_max_bsz;
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -27,6 +27,27 @@
 #include "mlvalues.h"
 
 #ifdef CAML_INTERNALS
+/* Predefined exceptions */
+#ifdef NATIVE_CODE
+
+typedef value caml_generated_constant[1];
+
+extern caml_generated_constant
+  caml_exn_Out_of_memory,
+  caml_exn_Sys_error,
+  caml_exn_Failure,
+  caml_exn_Invalid_argument,
+  caml_exn_End_of_file,
+  caml_exn_Division_by_zero,
+  caml_exn_Not_found,
+  caml_exn_Match_failure,
+  caml_exn_Sys_blocked_io,
+  caml_exn_Stack_overflow,
+  caml_exn_Assert_failure,
+  caml_exn_Undefined_recursive_module;
+
+#else
+
 #define OUT_OF_MEMORY_EXN 0     /* "Out_of_memory" */
 #define SYS_ERROR_EXN 1         /* "Sys_error" */
 #define FAILURE_EXN 2           /* "Failure" */
@@ -39,6 +60,8 @@
 #define SYS_BLOCKED_IO 9        /* "Sys_blocked_io" */
 #define ASSERT_FAILURE_EXN 10   /* "Assert_failure" */
 #define UNDEFINED_RECURSIVE_MODULE_EXN 11 /* "Undefined_recursive_module" */
+
+#endif /* NATIVE_CODE */
 
 #ifdef POSIX_SIGNALS
 struct longjmp_buffer {

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -67,6 +67,12 @@ int caml_is_special_exception(value exn);
 
 value caml_raise_if_exception(value res);
 
+#ifdef NATIVE_CODE
+CAMLnoreturn_start
+  extern void caml_raise_exception (caml_domain_state* state, value bucket)
+CAMLnoreturn_end;
+#endif /* NATIVE_CODE */
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/freelist.h
+++ b/runtime/caml/freelist.h
@@ -24,6 +24,7 @@
 #include "mlvalues.h"
 
 extern asize_t caml_fl_cur_wsz;
+extern value caml_fl_merge;
 
 /* See [freelist.c] for usage info on these functions. */
 extern header_t *(*caml_fl_p_allocate) (mlsize_t wo_sz);

--- a/runtime/caml/freelist.h
+++ b/runtime/caml/freelist.h
@@ -62,6 +62,10 @@ Caml_inline void caml_fl_check (void)
   { (*caml_fl_p_check) (); }
 #endif
 
+#ifdef CAML_INSTR
+extern uintnat caml_instr_alloc_jump;
+#endif /*CAML_INSTR*/
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_FREELIST_H */

--- a/runtime/caml/freelist.h
+++ b/runtime/caml/freelist.h
@@ -52,6 +52,7 @@ Caml_inline void caml_make_free_blocks
   (value *p, mlsize_t size, int do_merge, int color)
   { (*caml_fl_p_make_free_blocks) (p, size, do_merge, color); }
 
+extern uintnat caml_allocation_policy;
 extern void caml_set_allocation_policy (intnat);
 extern void caml_fl_reset_and_switch_policy (intnat);
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -66,6 +66,7 @@ extern uintnat caml_percent_free;
 
 CAMLextern char *caml_heap_start;
 extern uintnat total_heap_size;
+extern uintnat caml_major_heap_increment;
 extern char *caml_gc_sweep_hp;
 
 extern int caml_major_window;

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -43,6 +43,7 @@ extern uintnat caml_allocated_words;
 extern double caml_extra_heap_resources;
 extern uintnat caml_dependent_size, caml_dependent_allocated;
 extern uintnat caml_fl_wsz_at_phase_change;
+extern uintnat caml_percent_free;
 
 #define Phase_mark 0
 #define Phase_clean 1

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -182,9 +182,9 @@ CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 #endif
 
 
-/* void caml_shrink_heap (char *);        Only used in compact.c */
-
 #ifdef CAML_INTERNALS
+
+void caml_shrink_heap (char *);
 
 extern uintnat caml_use_huge_pages;
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -170,6 +170,8 @@ extern void caml_install_invalid_parameter_handler();
 
 extern int caml_win32_random_seed (intnat data[16]);
 
+extern void caml_win32_overflow_detection (void);
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -168,6 +168,8 @@ extern void caml_win32_unregister_overflow_detection (void);
 extern void caml_install_invalid_parameter_handler();
 #endif
 
+extern int caml_win32_random_seed (intnat data[16]);
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -161,6 +161,13 @@ extern int caml_win32_isatty(int fd);
 
 CAMLextern void caml_expand_command_line (int *, wchar_t ***);
 
+extern void caml_win32_unregister_overflow_detection (void);
+
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
+/* PR 4887: avoid crash box of windows runtime on some system calls */
+extern void caml_install_invalid_parameter_handler();
+#endif
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/parsing.h
+++ b/runtime/caml/parsing.h
@@ -1,0 +1,25 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#ifndef CAML_PARSING_H
+#define CAML_PARSING_H
+
+#ifdef CAML_INTERNALS
+
+extern int caml_parser_trace;
+
+#endif /* CAML_INTERNALS */
+
+#endif /* CAML_PARSING_H */

--- a/runtime/caml/printexc.h
+++ b/runtime/caml/printexc.h
@@ -24,10 +24,16 @@
 extern "C" {
 #endif
 
-
 CAMLextern char * caml_format_exception (value);
+
 #ifdef CAML_INTERNALS
 CAMLnoreturn_start void caml_fatal_uncaught_exception (value) CAMLnoreturn_end;
+
+/* Determine if caml_fatal_uncaught_exception calls exit(2) or abort() for an
+   uncaught exception. afl uses abnormal termination (SIGABRT) to check whether
+   to count a testcase as "crashing". */
+extern int caml_abort_on_uncaught_exn;
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -96,6 +96,10 @@ CAMLextern int (*caml_sigmask_hook)(int, const sigset_t *, sigset_t *);
 
 typedef void (*signal_handler)(int signo);
 
+#ifdef NATIVE_CODE
+extern void caml_init_signals (void);
+#endif
+
 #ifdef _WIN32
 extern signal_handler caml_win32_signal(int sig, signal_handler action);
 #endif

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -93,6 +93,13 @@ CAMLextern void (*caml_leave_blocking_section_hook)(void);
 #ifdef POSIX_SIGNALS
 CAMLextern int (*caml_sigmask_hook)(int, const sigset_t *, sigset_t *);
 #endif
+
+typedef void (*signal_handler)(int signo);
+
+#ifdef _WIN32
+extern signal_handler caml_win32_signal(int sig, signal_handler action);
+#endif
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/spacetime.h
+++ b/runtime/caml/spacetime.h
@@ -195,6 +195,11 @@ extern void caml_spacetime_automatic_snapshot (void);
   profinfo = (uintnat) 0;
 #endif
 
+#ifdef CAML_INTERNALS
 
+/* [caml_spacetime_shapes] is defined in the startup file. */
+extern uint64_t* caml_spacetime_shapes;
+
+#endif /* CAML_INTERNALS */
 
 #endif /* CAML_SPACETIME_H */

--- a/runtime/caml/stacks.h
+++ b/runtime/caml/stacks.h
@@ -42,6 +42,8 @@ uintnat caml_stack_usage (void);
 
 CAMLextern uintnat (*caml_stack_usage_hook)(void);
 
+extern uintnat caml_max_stack_size;
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_STACKS_H */

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -53,6 +53,10 @@ enum caml_byte_program_mode
 
 extern enum caml_byte_program_mode caml_byte_program_mode;
 
+#ifdef _WIN32
+extern void caml_signal_thread(void * lpParam);
+#endif
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_STARTUP_H */

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -32,7 +32,6 @@
 #include "caml/memprof.h"
 #include "caml/eventlog.h"
 
-extern uintnat caml_percent_free;                   /* major_gc.c */
 extern void caml_shrink_heap (char *);              /* memory.c */
 
 /* Colors

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -32,8 +32,6 @@
 #include "caml/memprof.h"
 #include "caml/eventlog.h"
 
-extern void caml_shrink_heap (char *);              /* memory.c */
-
 /* Colors
 
    We use the GC's color bits in the following way:

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -52,10 +52,6 @@ extern caml_generated_constant
 
 /* Exception raising */
 
-CAMLnoreturn_start
-  extern void caml_raise_exception (caml_domain_state* state, value bucket)
-CAMLnoreturn_end;
-
 /* Used by the stack overflow handler -> deactivate ASAN (see
    segv_handler in signals_nat.c). */
 CAMLno_asan

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -32,24 +32,6 @@
 #include "caml/roots.h"
 #include "caml/callback.h"
 
-/* The globals holding predefined exceptions */
-
-typedef value caml_generated_constant[1];
-
-extern caml_generated_constant
-  caml_exn_Out_of_memory,
-  caml_exn_Sys_error,
-  caml_exn_Failure,
-  caml_exn_Invalid_argument,
-  caml_exn_End_of_file,
-  caml_exn_Division_by_zero,
-  caml_exn_Not_found,
-  caml_exn_Match_failure,
-  caml_exn_Sys_blocked_io,
-  caml_exn_Stack_overflow,
-  caml_exn_Assert_failure,
-  caml_exn_Undefined_recursive_module;
-
 /* Exception raising */
 
 /* Used by the stack overflow handler -> deactivate ASAN (see

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -37,6 +37,7 @@
 #include "caml/stacks.h"
 #endif
 #include "caml/startup_aux.h"
+#include "caml/parsing.h"
 
 #define Next(hp) ((header_t *)(hp) + Whsize_hp (hp))
 
@@ -711,8 +712,6 @@ CAMLprim value caml_runtime_variant (value unit)
   return caml_copy_string ("");
 #endif
 }
-
-extern int caml_parser_trace;
 
 CAMLprim value caml_runtime_parameters (value unit)
 {

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -43,7 +43,6 @@ extern uintnat caml_max_stack_size;    /* defined in stacks.c */
 #endif
 
 extern uintnat caml_major_heap_increment; /* percent or words; see major_gc.c */
-extern uintnat caml_percent_free;         /*        see major_gc.c */
 extern uintnat caml_percent_max;          /*        see compact.c */
 extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,10 +38,6 @@
 #endif
 #include "caml/startup_aux.h"
 
-#ifndef NATIVE_CODE
-extern uintnat caml_max_stack_size;    /* defined in stacks.c */
-#endif
-
 extern uintnat caml_major_heap_increment; /* percent or words; see major_gc.c */
 extern uintnat caml_percent_max;          /*        see compact.c */
 extern uintnat caml_allocation_policy;    /*        see freelist.c */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,7 +38,6 @@
 #endif
 #include "caml/startup_aux.h"
 
-extern uintnat caml_major_heap_increment; /* percent or words; see major_gc.c */
 extern uintnat caml_percent_max;          /*        see compact.c */
 extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,7 +38,6 @@
 #endif
 #include "caml/startup_aux.h"
 
-extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_max_bsz; /* see custom.c */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,10 +38,6 @@
 #endif
 #include "caml/startup_aux.h"
 
-extern uintnat caml_custom_major_ratio;   /* see custom.c */
-extern uintnat caml_custom_minor_ratio;   /* see custom.c */
-extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
-
 #define Next(hp) ((header_t *)(hp) + Whsize_hp (hp))
 
 #ifdef DEBUG

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -38,7 +38,6 @@
 #endif
 #include "caml/startup_aux.h"
 
-extern uintnat caml_percent_max;          /*        see compact.c */
 extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_ratio;   /* see custom.c */

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -31,8 +31,7 @@
 #include "caml/prims.h"
 #include "caml/stacks.h"
 #include "caml/startup_aux.h"
-
-extern code_t caml_start_code;
+#include "caml/fix_code.h"
 
 intnat caml_icount = 0;
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -66,8 +66,6 @@ uintnat caml_dependent_size, caml_dependent_allocated;
 double caml_extra_heap_resources;
 uintnat caml_fl_wsz_at_phase_change = 0;
 
-extern value caml_fl_merge;  /* Defined in freelist.c. */
-
 /* redarken_first_chunk is the first chunk needing redarkening, if NULL no
   redarkening required */
 static char *redarken_first_chunk = NULL;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -47,8 +47,6 @@ uintnat caml_use_huge_pages = 0;
    after that.
 */
 
-extern uintnat caml_percent_free;                   /* major_gc.c */
-
 /* Page table management */
 
 #define Page(p) ((uintnat) (p) >> Page_log)

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -453,10 +453,6 @@ void caml_empty_minor_heap (void)
 #endif
 }
 
-#ifdef CAML_INSTR
-extern uintnat caml_instr_alloc_jump;
-#endif /*CAML_INSTR*/
-
 /* Do a minor collection or a slice of major collection, call finalisation
    functions, etc.
    Leave enough room in the minor heap to allocate at least one object.

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -23,6 +23,7 @@
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
 #include "caml/alloc.h"
+#include "caml/parsing.h"
 
 #define ERRCODE 256
 

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -30,6 +30,8 @@
 #include "caml/memory.h"
 #include "caml/memprof.h"
 
+int caml_abort_on_uncaught_exn = 0; /* see afl.c */
+
 struct stringbuf {
   char * ptr;
   char * end;
@@ -132,8 +134,6 @@ static void default_fatal_uncaught_exception(value exn)
   if (Caml_state->backtrace_active && !DEBUGGER_IN_USE)
     caml_print_exception_backtrace();
 }
-
-int caml_abort_on_uncaught_exn = 0; /* see afl.c */
 
 void caml_fatal_uncaught_exception(value exn)
 {

--- a/runtime/signals_byt.c
+++ b/runtime/signals_byt.c
@@ -32,8 +32,6 @@
 #endif
 
 #ifdef _WIN32
-typedef void (*sighandler)(int sig);
-extern sighandler caml_win32_signal(int sig, sighandler action);
 #define signal(sig,act) caml_win32_signal(sig,act)
 #endif
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -38,15 +38,15 @@
 #include "caml/memprof.h"
 #include "caml/finalise.h"
 
+#ifdef _WIN32
+#define signal(sig,act) caml_win32_signal(sig,act)
+#endif
+
 #ifndef NSIG
 #define NSIG 64
 #endif
 
-typedef void (*signal_handler)(int signo);
-
 #ifdef _WIN32
-extern signal_handler caml_win32_signal(int sig, signal_handler action);
-#define signal(sig,act) caml_win32_signal(sig,act)
 extern void caml_win32_overflow_detection();
 #endif
 

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -184,10 +184,6 @@ static char sig_alt_stack[SIGSTKSZ];
    EXTRA_STACK bytes below the stack pointer. */
 #define EXTRA_STACK 256
 
-#ifdef RETURN_AFTER_STACK_OVERFLOW
-extern void caml_stack_overflow(caml_domain_state*);
-#endif
-
 /* Address sanitizer is confused when running the stack overflow
    handler in an alternate stack. We deactivate it for all the
    functions used by the stack overflow handler. */

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -46,10 +46,6 @@
 #define NSIG 64
 #endif
 
-#ifdef _WIN32
-extern void caml_win32_overflow_detection();
-#endif
-
 /* This routine is the common entry point for garbage collection
    and signal handling.  It can trigger a callback to OCaml code.
    With system threads, this callback can cause a context switch.

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -427,3 +427,7 @@
      sigact.sa_flags = 0
 
 #endif
+
+#ifdef RETURN_AFTER_STACK_OVERFLOW
+extern void caml_stack_overflow(caml_domain_state*);
+#endif

--- a/runtime/spacetime_nat.c
+++ b/runtime/spacetime_nat.c
@@ -84,9 +84,6 @@ typedef struct per_thread {
 static per_thread* per_threads = NULL;
 static int num_per_threads = 0;
 
-/* [caml_spacetime_shapes] is defined in the startup file. */
-extern uint64_t* caml_spacetime_shapes;
-
 uint64_t** caml_spacetime_static_shape_tables = NULL;
 shape_table* caml_spacetime_dynamic_shape_tables = NULL;
 

--- a/runtime/spacetime_snapshot.c
+++ b/runtime/spacetime_snapshot.c
@@ -329,8 +329,6 @@ CAMLprim value caml_spacetime_take_snapshot(value v_time_opt, value v_channel)
   return Val_unit;
 }
 
-extern struct custom_operations caml_int64_ops;  /* ints.c */
-
 static value
 allocate_int64_outside_heap(uint64_t i)
 {

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -29,6 +29,7 @@
 #include "caml/osdeps.h"
 #include "caml/startup_aux.h"
 #include "caml/memprof.h"
+#include "caml/parsing.h"
 
 
 #ifdef _WIN32
@@ -85,7 +86,6 @@ uintnat caml_init_major_window = Major_window_def;
 uintnat caml_init_custom_major_ratio = Custom_major_ratio_def;
 uintnat caml_init_custom_minor_ratio = Custom_minor_ratio_def;
 uintnat caml_init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
-extern int caml_parser_trace;
 uintnat caml_trace_level = 0;
 int caml_cleanup_on_exit = 0;
 

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -32,10 +32,6 @@
 #include "caml/parsing.h"
 
 
-#ifdef _WIN32
-extern void caml_win32_unregister_overflow_detection (void);
-#endif
-
 CAMLexport header_t *caml_atom_table = NULL;
 
 /* Initialize the atom table */

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -323,13 +323,6 @@ static int parse_command_line(char_os **argv)
 extern void caml_signal_thread(void * lpParam);
 #endif
 
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
-
-/* PR 4887: avoid crash box of windows runtime on some system calls */
-extern void caml_install_invalid_parameter_handler();
-
-#endif
-
 /* Main entry point when loading code from a file */
 
 CAMLexport void caml_main(char_os **argv)

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -319,10 +319,6 @@ static int parse_command_line(char_os **argv)
   return i;
 }
 
-#ifdef _WIN32
-extern void caml_signal_thread(void * lpParam);
-#endif
-
 /* Main entry point when loading code from a file */
 
 CAMLexport void caml_main(char_os **argv)

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -46,6 +46,7 @@
 #include "caml/ui.h"
 #endif
 #include "caml/parsing.h"
+#include "caml/signals.h"
 
 extern char caml_system__code_begin, caml_system__code_end;
 
@@ -94,7 +95,6 @@ struct longjmp_buffer caml_termination_jmpbuf;
 void (*caml_termination_hook)(void *) = NULL;
 
 extern value caml_start_program (caml_domain_state*);
-extern void caml_init_signals (void);
 #ifdef _WIN32
 extern void caml_win32_overflow_detection (void);
 #endif

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -48,8 +48,6 @@
 #include "caml/parsing.h"
 #include "caml/signals.h"
 
-extern char caml_system__code_begin, caml_system__code_end;
-
 /* Initialize the atom table and the static data and code area limits. */
 
 struct segment { char * begin; char * end; };
@@ -57,6 +55,7 @@ struct segment { char * begin; char * end; };
 static void init_static(void)
 {
   extern struct segment caml_data_segments[], caml_code_segments[];
+  extern char caml_system__code_begin, caml_system__code_end;
 
   char * caml_code_area_start, * caml_code_area_end;
   int i;

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -95,9 +95,6 @@ struct longjmp_buffer caml_termination_jmpbuf;
 void (*caml_termination_hook)(void *) = NULL;
 
 extern value caml_start_program (caml_domain_state*);
-#ifdef _WIN32
-extern void caml_win32_overflow_detection (void);
-#endif
 
 value caml_startup_common(char_os **argv, int pooling)
 {

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -45,8 +45,8 @@
 #ifdef HAS_UI
 #include "caml/ui.h"
 #endif
+#include "caml/parsing.h"
 
-extern int caml_parser_trace;
 extern char caml_system__code_begin, caml_system__code_end;
 
 /* Initialize the atom table and the static data and code area limits. */

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -99,13 +99,6 @@ extern void caml_init_signals (void);
 extern void caml_win32_overflow_detection (void);
 #endif
 
-#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
-
-/* PR 4887: avoid crash box of windows runtime on some system calls */
-extern void caml_install_invalid_parameter_handler();
-
-#endif
-
 value caml_startup_common(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -548,10 +548,6 @@ CAMLprim value caml_sys_time(value unit)
   return caml_copy_double(caml_sys_time_unboxed(unit));
 }
 
-#ifdef _WIN32
-extern int caml_win32_random_seed (intnat data[16]);
-#endif
-
 CAMLprim value caml_sys_random_seed (value unit)
 {
   intnat data[16];

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -289,7 +289,7 @@ char * caml_dlerror(void)
 
 typedef void (*sighandler)(int sig);
 static int ctrl_handler_installed = 0;
-static volatile sighandler ctrl_handler_action = SIG_DFL;
+static volatile signal_handler ctrl_handler_action = SIG_DFL;
 
 static BOOL WINAPI ctrl_handler(DWORD event)
 {


### PR DESCRIPTION
Resurrecting Cygwin64 (and moving from there to using `-fvisiblity` elsewhere) means a certain amount of care is needed with the declarations for functions. It's slightly less awkward to reason about all this if the declarations are actually all in headers, which is what this PR does.

All the changes in headers are inside `CAML_INTERNALS` blocks. Viewed commit-by-commit, the movements are fairly straightforward (so using gitk/tig or another visualisation tool may be superior to checking in GitHub).