### PR TITLE
Resurrect Cygwin64

### DIFF
--- a/Changes
+++ b/Changes
@@ -485,6 +485,9 @@ Working version
   it with -link.
   (David Allsopp, review by Xavier Leroy)
 
+- #9927: Restore Cygwin64 support.
+  (David Allsopp, review by Xavier Leroy)
+
 
 OCaml 4.11.1
 ------------

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -466,7 +466,8 @@ let link_bytecode_as_c tolink outfile with_main =
     (fun () ->
        (* The bytecode *)
        output_string outchan "\
-#define CAML_INTERNALS\
+#define CAML_INTERNALS\n\
+#define CAMLDLLIMPORT\
 \n\
 \n#ifdef __cplusplus\
 \nextern \"C\" {\

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -35,7 +35,9 @@
 #endif
 #include "caml/sys.h"
 #include "caml/memprof.h"
-#include "threads.h"
+
+/* threads.h is *not* included since it contains the _external_ declarations for
+   the caml_c_thread_register and caml_c_thread_unregister functions. */
 
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
 #include "caml/spacetime.h"

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -130,6 +130,8 @@ ifneq "$(CCOMPTYPE)" "msvc"
 OC_CFLAGS += -g
 endif
 
+OC_CPPFLAGS += -DCAMLDLLIMPORT=
+
 OC_NATIVE_CPPFLAGS = -DNATIVE_CODE -DTARGET_$(ARCH)
 
 ifeq "$(UNIX_OR_WIN32)" "unix"

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -74,13 +74,20 @@ CAMLdeprecated_typedef(addr, char *);
   #define Noreturn
 #endif
 
-
-
 /* Export control (to mark primitives and to handle Windows DLL) */
+
+#ifndef CAMLDLLIMPORT
+  #if defined(SUPPORT_DYNAMIC_LINKING) && defined(ARCH_SIXTYFOUR) \
+      && defined(__CYGWIN__)
+    #define CAMLDLLIMPORT __declspec(dllimport)
+  #else
+    #define CAMLDLLIMPORT
+  #endif
+#endif
 
 #define CAMLexport
 #define CAMLprim
-#define CAMLextern extern
+#define CAMLextern CAMLDLLIMPORT extern
 
 /* Weak function definitions that can be overridden by external libs */
 /* Conservatively restricted to ELF and MacOSX platforms */

--- a/testsuite/tests/lib-dynlink-bytecode/stub2.c
+++ b/testsuite/tests/lib-dynlink-bytecode/stub2.c
@@ -18,7 +18,7 @@
 #include "caml/alloc.h"
 #include <stdio.h>
 
-extern value stub1(void);
+CAMLextern value stub1(void);
 
 value stub2(void) {
   printf("This is stub2, calling stub1:\n"); fflush(stdout);


### PR DESCRIPTION
Cygwin64 has been building with shared-library/natdynlink support for a couple of years. This PR restores support for this.

The problem is that Cygwin64 requires DLLs to load in a memory range which is more than +/-2GiB from the executable, which prevents FlexDLL from performing the required relocations for dynamic loading. Previous work tried to fix this in flexlink by using branch islands, but this is quite heavy and doesn't work for data symbols. It's also incredibly hairy to do for ARM64, which is where this alternate approach has sprung from.

The method for this fix (related to #1633), is a partial return to using `__declspec` macros by using `__declspec(dllimport)` for _all_ symbols for Cygwin64. At present, the change is limited to Cygwin64 - there are presently nasty hacks in flexlink with base addresses in the mingw64 and msvc64 ports which can be removed, but I don't propose changing those ports this close to a version freeze.

The change is made in 3 commits which are best viewed separately - indeed the first two are best viewed using a better visualiser than GitHub (patdiff is excellent for this). The first commit removes `CAMLexport` which is no longer required (and hasn't been for some time). The second eliminates the use `CAMLextern` in the tree (but leaves `CAMLextern` defined in the public facing headers). Replacing `CAMLextern` is the new `CAMLAPI` macro intended for use in the tree only.

Why? The problem with `CAMLextern` is that it's just looked like an alias for `extern` and has been haphazardly used as such. There are two kinds of export necessary now - making a symbol accessible to the rest of the runtime (i.e. a normal C `extern` declaration) or making the symbol accessible to dynamically loaded code (an actual export). The many micro PRs previously merged have gone through and rationalised the use of the old `CAMLextern` to be the latter, so this switch just marks those `CAMLextern` declarations as actually part of the public API. The idea now is that `extern` should be written `extern` and `CAMLAPI` should be added to things which actually need to be visible to stub libraries.

Other PRs have also attempted to limit the use of C primitives from C code. A side-effect of this is that `CAMLprim` at the moment does not need to include `CAMLAPI`. That might get revisited, especially when #1633 re-rises as enabling the use of `-fvisibility`.