### PR TITLE
Add Hashtbl.update and {Map,Hashtbl}.find_or_add

### DIFF
--- a/Changes
+++ b/Changes
@@ -184,6 +184,9 @@ Working version
 
 ### Standard library:
 
+- #9929: add Hashtbl.update, Hashtbl.find_or_add, and Map.find_or_add.
+  (André Duarte)
+
 - #9865: add Format.pp_print_seq
   (Raphaël Proust, review by Nicolás Ojeda Bär)
 

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -230,6 +230,45 @@ module GenHashTable = struct
       (* TODO inline 3 iterations *)
       find_rec_opt key hkey (h.data.(key_index h hkey))
 
+    let update h key f =
+      let rec loop h i key (hkey: int) f = function
+        (* Key not in table *)
+        | Empty ->
+          begin match f None with
+          | Some info ->
+            h.size <- h.size + 1;
+            let container = H.create key info in
+            Cons(hkey, container, Empty)
+          | None ->
+            Empty
+          end
+        | Cons(hk, c, next) when hkey = hk ->
+          begin match H.equal c key with
+          | ETrue ->
+            begin match H.get_data c with
+            | None -> Cons(hk, c, loop h i key hkey f next)
+            (* Key found in table *)
+            | Some _ as input ->
+              begin match f input with
+              | Some info ->
+                let container = H.create key info in
+                Cons(hkey, container, next)
+              | None ->
+                h.size <- h.size - 1;
+                next
+              end
+            end
+          | EFalse | EDead ->
+            Cons(hk, c, loop h i key hkey f next)
+          end
+        | Cons(hk, c, next) ->
+          Cons(hk, c, loop h i key hkey f next)
+      in
+      let hkey = H.hash h.seed key in
+      let i = key_index h hkey in
+      h.data.(i) <- loop h i key hkey f h.data.(i);
+      if h.size > Array.length h.data lsl 1 then resize h
+
     let find_all h key =
       let hkey = H.hash h.seed key in
       let rec find_in_bucket = function

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -269,6 +269,39 @@ module GenHashTable = struct
       h.data.(i) <- loop h i key hkey f h.data.(i);
       if h.size > Array.length h.data lsl 1 then resize h
 
+    let find_or_add h key f_info =
+      let cons_front h i key hkey info =
+        let container = H.create key info in
+        let bucket = Cons(hkey, container, h.data.(i)) in
+        h.data.(i) <- bucket;
+        h.size <- h.size + 1;
+        if h.size > Array.length h.data lsl 1 then resize h;
+        info
+      in
+      let rec find_or_add_rec h i key (hkey: int) f_info = function
+        | Empty ->
+          cons_front h i key hkey (f_info())
+        | Cons(hk, c, next) when hkey = hk  ->
+          begin match H.equal c key with
+          | ETrue ->
+            begin match H.get_data c with
+            (* This case is not impossible because the gc can run between
+               H.equal and H.get_data *)
+            | None ->
+              find_or_add_rec h i key hkey f_info next
+            | Some d -> d
+            end
+          | EFalse | EDead ->
+            find_or_add_rec h i key hkey f_info next
+          end
+        | Cons(_, _, next) ->
+          find_or_add_rec h i key hkey f_info next
+      in
+      let hkey = H.hash h.seed key in
+      let i = key_index h hkey in
+      let bucket = h.data.(i) in
+      find_or_add_rec h i key hkey f_info bucket
+
     let find_all h key =
       let hkey = H.hash h.seed key in
       let rec find_in_bucket = function

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -295,6 +295,7 @@ module type S =
     val copy: 'a t -> 'a t
     val add: 'a t -> key -> 'a -> unit
     val remove: 'a t -> key -> unit
+    val update: 'a t -> key -> ('a option -> 'a option) -> unit
     val find: 'a t -> key -> 'a
     val find_opt: 'a t -> key -> 'a option
     val find_all: 'a t -> key -> 'a list
@@ -323,6 +324,7 @@ module type SeededS =
     val copy : 'a t -> 'a t
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
+    val update: 'a t -> key -> ('a option -> 'a option) -> unit
     val find : 'a t -> key -> 'a
     val find_opt: 'a t -> key -> 'a option
     val find_all : 'a t -> key -> 'a list
@@ -417,6 +419,63 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
               | Empty -> None
               | Cons{key=k3; data=d3; next=next3} ->
                   if H.equal key k3 then Some d3 else find_rec_opt key next3
+
+    let rec find_slot_rec key prev curr =
+      match curr with
+      | Empty -> Empty, Empty
+      | Cons{key=k; next} ->
+        if H.equal key k then prev, curr else
+        find_slot_rec key curr next
+
+    (* Manually unrolled for first 3 slots *)
+    let find_slot key x =
+      match x with
+      | Empty -> Empty, Empty
+      | Cons{key=k1; next=next1} ->
+      if H.equal key k1 then Empty, x else
+      match next1 with
+      | Empty -> Empty, Empty
+      | Cons{key=k2; next=next2} ->
+      if H.equal key k2 then x, next1 else
+      match next2 with
+      | Empty -> Empty, Empty
+      | Cons{key=k3; next=next3} ->
+      if H.equal key k3 then next1, next2 else
+      find_slot_rec key next2 next3
+
+    let update h key f =
+      let i = key_index h key in
+      let bucket = h.data.(i) in
+      let prev, slot = find_slot key bucket in
+      match slot with
+      (* Key not in table *)
+      | Empty ->
+        begin match f None with
+        | Some data ->
+          let bucket' = Cons{key; data; next=bucket} in
+          h.data.(i) <- bucket';
+          h.size <- h.size + 1;
+          if h.size > Array.length h.data lsl 1 then resize key_index h
+        | None ->
+          ()
+        end
+      (* Key in table *)
+      | Cons slot ->
+        begin match f (Some slot.data) with
+        | Some data ->
+          slot.key <- key;
+          slot.data <- data;
+        | None ->
+          h.size <- h.size - 1;
+          begin match prev with
+          (* Key was in the head slot of its bucket *)
+          | Empty ->
+            h.data.(i) <- slot.next
+          (* Key was in the tail slot of its bucket *)
+          | Cons prev ->
+            prev.next <- slot.next
+          end
+        end
 
     let find_all h key =
       let rec find_in_bucket = function
@@ -567,6 +626,63 @@ let find_opt h key =
           | Empty -> None
           | Cons{key=k3; data=d3; next=next3} ->
               if compare key k3 = 0 then Some d3 else find_rec_opt key next3
+
+let update h key f =
+  let rec find_slot_rec key prev curr =
+    match curr with
+    | Empty -> Empty, Empty
+    | Cons{key=k; next} ->
+      if compare key k = 0 then prev, curr else find_slot_rec key curr next
+  in
+  (* Manually unrolled for first 3 slots *)
+  let find_slot key x =
+    match x with
+    | Empty -> Empty, Empty
+    | Cons{key=k1; next=next1} ->
+    if compare key k1 = 0 then Empty, x else
+    match next1 with
+    | Empty -> Empty, Empty
+    | Cons{key=k2; next=next2} ->
+    if compare key k2 = 0 then x, next1 else
+    match next2 with
+    | Empty -> Empty, Empty
+    | Cons{key=k3; next=next3} ->
+    if compare key k3 = 0 then next1, next2 else
+    find_slot_rec key next2 next3
+  in
+
+  let i = key_index h key in
+  let bucket = h.data.(i) in
+  let prev, slot = find_slot key bucket in
+  match slot with
+  (* Key not in table *)
+  | Empty ->
+    begin match f None with
+    | Some data ->
+      let bucket' = Cons{key; data; next=bucket} in
+      h.data.(i) <- bucket';
+      h.size <- h.size + 1;
+      if h.size > Array.length h.data lsl 1 then resize key_index h
+    | None ->
+      ()
+    end
+  (* Key table *)
+  | Cons slot ->
+    begin match f (Some slot.data) with
+    | Some data ->
+      slot.key <- key;
+      slot.data <- data;
+    | None ->
+      h.size <- h.size - 1;
+      (* Key was in the head slot of its bucket *)
+      begin match prev with
+      | Empty ->
+        h.data.(i) <- slot.next
+      (* Key was in the tail slot of its bucket *)
+      | Cons prev ->
+        prev.next <- slot.next
+      end
+    end
 
 let find_all h key =
   let rec find_in_bucket = function

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -117,6 +117,16 @@ val replace : ('a, 'b) t -> 'a -> 'b -> unit
    This is functionally equivalent to {!remove}[ tbl key]
    followed by {!add}[ tbl key data]. *)
 
+val update : ('a, 'b) t -> 'a -> ('b option -> 'b option) -> unit
+(** [Hashtbl.update tbl key f] updates the bindings of [key] depending on
+    the value it's currently bound to. Depending on the value of [y], where
+    [y] is [f (find_opt key tbl)], the binding of [key] can be added,
+    replaced, or removed. If [y] is [None], the current binding is removed
+    if it exists,restoring the previous binding, if it exists. If [y] is
+    [Some data], then [key] is bound to [data], replacing the previously
+    bound value if it existed. This function only calculates the hash of
+    [key] once. *)
+
 val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
 (** [Hashtbl.iter f tbl] applies [f] to all bindings in table [tbl].
    [f] receives the key as first argument, and the associated value
@@ -340,6 +350,9 @@ module type S =
     val copy : 'a t -> 'a t
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
+    val update : 'a t -> key -> ('a option -> 'a option) -> unit
+    (** @since 4.12.0 *)
+
     val find : 'a t -> key -> 'a
     val find_opt : 'a t -> key -> 'a option
     (** @since 4.05.0 *)
@@ -417,8 +430,12 @@ module type SeededS =
     val copy : 'a t -> 'a t
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
+    val update : 'a t -> key -> ('a option -> 'a option) -> unit
+    (** @since 4.12.0 *)
+
     val find : 'a t -> key -> 'a
-    val find_opt : 'a t -> key -> 'a option (** @since 4.05.0 *)
+    val find_opt : 'a t -> key -> 'a option
+    (** @since 4.05.0 *)
 
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key -> 'a -> unit

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -102,6 +102,14 @@ val find_all : ('a, 'b) t -> 'a -> 'b list
    The current binding is returned first, then the previous
    bindings, in reverse order of introduction in the table. *)
 
+val find_or_add : ('a, 'b) t -> 'a -> (unit -> 'b) -> 'b
+(** [Hashtbl.find_or_add tbl key data] returns the data associated with
+    [key] if it exists. Otherwise, it adds a binding from [key] to [data()]
+    in the table, and returns it. This function only calculates the hash of
+    [x] once, and only evaluates [data()] if [key] is not bound in the
+    table.
+    @since 4.12.0 *)
+
 val mem : ('a, 'b) t -> 'a -> bool
 (** [Hashtbl.mem tbl x] checks if [x] is bound in [tbl]. *)
 
@@ -125,7 +133,8 @@ val update : ('a, 'b) t -> 'a -> ('b option -> 'b option) -> unit
     if it exists,restoring the previous binding, if it exists. If [y] is
     [Some data], then [key] is bound to [data], replacing the previously
     bound value if it existed. This function only calculates the hash of
-    [key] once. *)
+    [key] once.
+    @since 4.12.0 *)
 
 val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
 (** [Hashtbl.iter f tbl] applies [f] to all bindings in table [tbl].
@@ -358,6 +367,9 @@ module type S =
     (** @since 4.05.0 *)
 
     val find_all : 'a t -> key -> 'a list
+    val find_or_add : 'a t -> key -> (unit -> 'a) -> 'a
+    (** @since 4.12.0 *)
+
     val replace : 'a t -> key -> 'a -> unit
     val mem : 'a t -> key -> bool
     val iter : (key -> 'a -> unit) -> 'a t -> unit
@@ -438,6 +450,9 @@ module type SeededS =
     (** @since 4.05.0 *)
 
     val find_all : 'a t -> key -> 'a list
+    val find_or_add : 'a t -> key -> (unit -> 'a) -> 'a
+    (** @since 4.12.0 *)
+
     val replace : 'a t -> key -> 'a -> unit
     val mem : 'a t -> key -> bool
     val iter : (key -> 'a -> unit) -> 'a t -> unit

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -320,6 +320,13 @@ module type S =
         @since 4.05
        *)
 
+    val find_or_add: key -> (unit -> 'a) -> 'a t -> 'a t * 'a
+    (** [find_or_add key data m] returns a tuple with [m] and the current
+        value of [key] in [m], if it exists. If it does not exist, it returns
+        a tuple with a map containing the same bindings as [m] plus a binding
+        of [key] to [data()], and [data()].
+        @since 4.12.0 *)
+
     val map: ('a -> 'b) -> 'a t -> 'b t
     (** [map f m] returns a map with same domain as [m], where the
        associated value [a] of all bindings of [m] has been

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -119,6 +119,14 @@ module Hashtbl : sig
      The current binding is returned first, then the previous
      bindings, in reverse order of introduction in the table. *)
 
+  val find_or_add : ('a, 'b) t -> key:'a -> data:(unit -> 'b) -> 'b
+  (** [Hashtbl.find_or_add tbl ~key ~data] returns the data associated with
+      [key] if it exists. Otherwise, it adds a binding from [key] to [data()]
+      in the table, and returns it. This function only calculates the hash of
+      [x] once, and only evaluates [data()] if [key] is not bound in the
+      table.
+      @since 4.12.0 *)
+
   val mem : ('a, 'b) t -> 'a -> bool
   (** [Hashtbl.mem tbl x] checks if [x] is bound in [tbl]. *)
 
@@ -142,7 +150,8 @@ module Hashtbl : sig
       if it exists,restoring the previous binding, if it exists. If [y] is
       [Some data], then [key] is bound to [data], replacing the previously
       bound value if it existed. This function only calculates the hash of
-      [key] once. *)
+      [key] once.
+      @since 4.12.0 *)
 
   val iter : f:(key:'a -> data:'b -> unit) -> ('a, 'b) t -> unit
   (** [Hashtbl.iter ~f tbl] applies [f] to all bindings in table [tbl].
@@ -375,6 +384,9 @@ module Hashtbl : sig
       (** @since 4.05.0 *)
 
       val find_all : 'a t -> key -> 'a list
+      val find_or_add : 'a t -> key -> (unit -> 'a) -> 'a
+      (** @since 4.12.0 *)
+
       val replace : 'a t -> key:key -> data:'a -> unit
       val mem : 'a t -> key -> bool
       val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
@@ -457,6 +469,9 @@ module Hashtbl : sig
       (** @since 4.05.0 *)
 
       val find_all : 'a t -> key -> 'a list
+      val find_or_add : 'a t -> key -> (unit -> 'a) -> 'a
+      (** @since 4.12.0 *)
+
       val replace : 'a t -> key:key -> data:'a -> unit
       val mem : 'a t -> key -> bool
       val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
@@ -851,6 +866,13 @@ module Map : sig
          exists.
           @since 4.05
          *)
+
+      val find_or_add: key:key -> data:(unit -> 'a) -> 'a t -> 'a t * 'a
+      (** [find_or_add ~key ~data m] returns a tuple with [m] and the current
+          value of [key] in [m], if it exists. If it does not exist, it returns
+          a tuple with a map containing the same bindings as [m] plus a binding
+          of [key] to [data()], and [data()].
+          @since 4.12.0 *)
 
       val map: f:('a -> 'b) -> 'a t -> 'b t
       (** [map ~f m] returns a map with same domain as [m], where the

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -134,6 +134,16 @@ module Hashtbl : sig
      This is functionally equivalent to {!remove}[ tbl key]
      followed by {!add}[ tbl key data]. *)
 
+  val update : ('a, 'b) t -> key:'a -> f:('b option -> 'b option) -> unit
+  (** [Hashtbl.update tbl ~key ~f] updates the bindings of [key] depending on
+      the value it's currently bound to. Depending on the value of [y], where
+      [y] is [f (find_opt key tbl)], the binding of [key] can be added,
+      replaced, or removed. If [y] is [None], the current binding is removed
+      if it exists,restoring the previous binding, if it exists. If [y] is
+      [Some data], then [key] is bound to [data], replacing the previously
+      bound value if it existed. This function only calculates the hash of
+      [key] once. *)
+
   val iter : f:(key:'a -> data:'b -> unit) -> ('a, 'b) t -> unit
   (** [Hashtbl.iter ~f tbl] applies [f] to all bindings in table [tbl].
      [f] receives the key as first argument, and the associated value
@@ -357,6 +367,9 @@ module Hashtbl : sig
       val copy : 'a t -> 'a t
       val add : 'a t -> key:key -> data:'a -> unit
       val remove : 'a t -> key -> unit
+      val update : 'a t -> key -> ('a option -> 'a option) -> unit
+      (** @since 4.12.0 *)
+
       val find : 'a t -> key -> 'a
       val find_opt : 'a t -> key -> 'a option
       (** @since 4.05.0 *)
@@ -436,8 +449,12 @@ module Hashtbl : sig
       val copy : 'a t -> 'a t
       val add : 'a t -> key:key -> data:'a -> unit
       val remove : 'a t -> key -> unit
+      val update : 'a t -> key -> ('a option -> 'a option) -> unit
+      (** @since 4.12.0 *)
+
       val find : 'a t -> key -> 'a
-      val find_opt : 'a t -> key -> 'a option (** @since 4.05.0 *)
+      val find_opt : 'a t -> key -> 'a option
+      (** @since 4.05.0 *)
 
       val find_all : 'a t -> key -> 'a list
       val replace : 'a t -> key:key -> data:'a -> unit

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -102,6 +102,14 @@ val find_all : ('a, 'b) t -> 'a -> 'b list
    The current binding is returned first, then the previous
    bindings, in reverse order of introduction in the table. *)
 
+val find_or_add : ('a, 'b) t -> key:'a -> data:(unit -> 'b) -> 'b
+(** [Hashtbl.find_or_add tbl ~key ~data] returns the data associated with
+    [key] if it exists. Otherwise, it adds a binding from [key] to [data()]
+    in the table, and returns it. This function only calculates the hash of
+    [x] once, and only evaluates [data()] if [key] is not bound in the
+    table.
+    @since 4.12.0 *)
+
 val mem : ('a, 'b) t -> 'a -> bool
 (** [Hashtbl.mem tbl x] checks if [x] is bound in [tbl]. *)
 
@@ -125,7 +133,8 @@ val update : ('a, 'b) t -> key:'a -> f:('b option -> 'b option) -> unit
     if it exists,restoring the previous binding, if it exists. If [y] is
     [Some data], then [key] is bound to [data], replacing the previously
     bound value if it existed. This function only calculates the hash of
-    [key] once. *)
+    [key] once.
+    @since 4.12.0 *)
 
 val iter : f:(key:'a -> data:'b -> unit) -> ('a, 'b) t -> unit
 (** [Hashtbl.iter ~f tbl] applies [f] to all bindings in table [tbl].
@@ -358,6 +367,9 @@ module type S =
     (** @since 4.05.0 *)
 
     val find_all : 'a t -> key -> 'a list
+    val find_or_add : 'a t -> key -> (unit -> 'a) -> 'a
+    (** @since 4.12.0 *)
+
     val replace : 'a t -> key:key -> data:'a -> unit
     val mem : 'a t -> key -> bool
     val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit
@@ -438,6 +450,9 @@ module type SeededS =
     (** @since 4.05.0 *)
 
     val find_all : 'a t -> key -> 'a list
+    val find_or_add : 'a t -> key -> (unit -> 'a) -> 'a
+    (** @since 4.12.0 *)
+
     val replace : 'a t -> key:key -> data:'a -> unit
     val mem : 'a t -> key -> bool
     val iter : f:(key:key -> data:'a -> unit) -> 'a t -> unit

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -117,6 +117,16 @@ val replace : ('a, 'b) t -> key:'a -> data:'b -> unit
    This is functionally equivalent to {!remove}[ tbl key]
    followed by {!add}[ tbl key data]. *)
 
+val update : ('a, 'b) t -> key:'a -> f:('b option -> 'b option) -> unit
+(** [Hashtbl.update tbl ~key ~f] updates the bindings of [key] depending on
+    the value it's currently bound to. Depending on the value of [y], where
+    [y] is [f (find_opt key tbl)], the binding of [key] can be added,
+    replaced, or removed. If [y] is [None], the current binding is removed
+    if it exists,restoring the previous binding, if it exists. If [y] is
+    [Some data], then [key] is bound to [data], replacing the previously
+    bound value if it existed. This function only calculates the hash of
+    [key] once. *)
+
 val iter : f:(key:'a -> data:'b -> unit) -> ('a, 'b) t -> unit
 (** [Hashtbl.iter ~f tbl] applies [f] to all bindings in table [tbl].
    [f] receives the key as first argument, and the associated value
@@ -340,6 +350,9 @@ module type S =
     val copy : 'a t -> 'a t
     val add : 'a t -> key:key -> data:'a -> unit
     val remove : 'a t -> key -> unit
+    val update : 'a t -> key -> ('a option -> 'a option) -> unit
+    (** @since 4.12.0 *)
+
     val find : 'a t -> key -> 'a
     val find_opt : 'a t -> key -> 'a option
     (** @since 4.05.0 *)
@@ -417,8 +430,12 @@ module type SeededS =
     val copy : 'a t -> 'a t
     val add : 'a t -> key:key -> data:'a -> unit
     val remove : 'a t -> key -> unit
+    val update : 'a t -> key -> ('a option -> 'a option) -> unit
+    (** @since 4.12.0 *)
+
     val find : 'a t -> key -> 'a
-    val find_opt : 'a t -> key -> 'a option (** @since 4.05.0 *)
+    val find_opt : 'a t -> key -> 'a option
+    (** @since 4.05.0 *)
 
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key:key -> data:'a -> unit

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -320,6 +320,13 @@ module type S =
         @since 4.05
        *)
 
+    val find_or_add: key:key -> data:(unit -> 'a) -> 'a t -> 'a t * 'a
+    (** [find_or_add ~key ~data m] returns a tuple with [m] and the current
+        value of [key] in [m], if it exists. If it does not exist, it returns
+        a tuple with a map containing the same bindings as [m] plus a binding
+        of [key] to [data()], and [data()].
+        @since 4.12.0 *)
+
     val map: f:('a -> 'b) -> 'a t -> 'b t
     (** [map ~f m] returns a map with same domain as [m], where the
        associated value [a] of all bindings of [m] has been

--- a/testsuite/tests/backtrace/backtrace2.reference
+++ b/testsuite/tests/backtrace/backtrace2.reference
@@ -35,7 +35,7 @@ Uncaught exception Invalid_argument("index out of bounds")
 Raised by primitive operation at Backtrace2.run in file "backtrace2.ml", line 62, characters 14-22
 test_Not_found
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 539, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 628, characters 13-28
 Called from Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 9-42
 Re-raised at Backtrace2.test_Not_found in file "backtrace2.ml", line 43, characters 61-70
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
@@ -50,7 +50,7 @@ Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", lin
 Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
 Called from Backtrace2.run in file "backtrace2.ml", line 62, characters 11-23
 Uncaught exception Not_found
-Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 539, characters 13-28
+Raised at Stdlib__hashtbl.find in file "hashtbl.ml", line 628, characters 13-28
 Called from Backtrace2.test_lazy.exception_raised_internally in file "backtrace2.ml", line 50, characters 8-41
 Re-raised at CamlinternalLazy.force_lazy_block.(fun) in file "camlinternalLazy.ml", line 35, characters 56-63
 Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -77,6 +77,21 @@ module Test(H: Hashtbl.S) (M: Map.S with type key = H.key) = struct
       (if incl_mh !m h && incl_hm h !m then "passed" else "FAILED");
     check_to_seq_of_seq h;
     check_to_seq h;
+    (* Update some of the data *)
+    let f i d v =
+      match i mod 3 with
+      | 0 -> v
+      | 1 -> None
+      | 2 -> Some d
+      | _ -> assert false
+    in
+    Array.iteri
+      (fun i (k, d) -> H.update h k (f i d); m := M.update k (f i d) !m)
+      data;
+    printf "Update: %s\n"
+      (if incl_mh !m h && incl_hm h !m then "passed" else "FAILED");
+    check_to_seq_of_seq h;
+    check_to_seq h;
     ()
 
 end
@@ -131,6 +146,7 @@ module HofM (M: Map.S) : Hashtbl.S with type key = M.key =
     let copy = Hashtbl.copy
     let add = Hashtbl.add
     let remove = Hashtbl.remove
+    let update = Hashtbl.update
     let find = Hashtbl.find
     let find_opt = Hashtbl.find_opt
     let find_all = Hashtbl.find_all

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -92,6 +92,16 @@ module Test(H: Hashtbl.S) (M: Map.S with type key = H.key) = struct
       (if incl_mh !m h && incl_hm h !m then "passed" else "FAILED");
     check_to_seq_of_seq h;
     check_to_seq h;
+    (* Test find_or_add *)
+    Array.iter (fun (k, d) ->
+      let d_h = H.find_or_add h k (fun () -> d) in
+      let m', d_m = M.find_or_add k (fun () -> d) !m in m := m';
+      assert (d_h = d_m)
+    ) data;
+    printf "Find_or_add: %s\n"
+      (if incl_mh !m h && incl_hm h !m then "passed" else "FAILED");
+    check_to_seq_of_seq h;
+    check_to_seq h;
     ()
 
 end
@@ -150,6 +160,7 @@ module HofM (M: Map.S) : Hashtbl.S with type key = M.key =
     let find = Hashtbl.find
     let find_opt = Hashtbl.find_opt
     let find_all = Hashtbl.find_all
+    let find_or_add = Hashtbl.find_or_add
     let replace = Hashtbl.replace
     let mem = Hashtbl.mem
     let iter = Hashtbl.iter

--- a/testsuite/tests/lib-hashtbl/htbl.reference
+++ b/testsuite/tests/lib-hashtbl/htbl.reference
@@ -2,46 +2,57 @@
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Random integers, narrow range
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Strings, generic interface
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Strings, functorial interface
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Pairs of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Lists of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Weak K1 -- Strings, functorial interface
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Weak K1 -- Pairs of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Weak K2 -- Pairs of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Weak K1 -- Lists of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 -- Weak Kn -- Arrays of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
+Update: passed
 1000 elements
 100,2
 200,4

--- a/testsuite/tests/lib-hashtbl/htbl.reference
+++ b/testsuite/tests/lib-hashtbl/htbl.reference
@@ -3,56 +3,67 @@ Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Random integers, narrow range
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Strings, generic interface
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Strings, functorial interface
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Pairs of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Lists of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Weak K1 -- Strings, functorial interface
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Weak K1 -- Pairs of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Weak K2 -- Pairs of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Weak K1 -- Lists of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 -- Weak Kn -- Arrays of strings
 Insertion: passed
 Insertion: passed
 Removal: passed
 Update: passed
+Find_or_add: passed
 1000 elements
 100,2
 200,4

--- a/testsuite/tests/lib-set/testmap.ml
+++ b/testsuite/tests/lib-set/testmap.ml
@@ -29,6 +29,15 @@ let test x v s1 s2 =
     (let s = M.add x v s1 in
      fun i -> img i s = (if i = x then Some v else img i s1));
 
+  check "find_or_add" (
+    let s, d = M.find_or_add x (fun () -> v) s1 in
+    fun i ->
+      match img x s1 with
+      (* If x was already in s1, physical equality must hold *)
+      | Some existing -> s == s1 && d = existing
+      | None -> img i s = (if i = x then Some v else img i s1)
+   );
+
   check "singleton"
     (let s = M.singleton x v in
      fun i -> img i s = (if i = x then Some v else None));

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -338,6 +338,7 @@ module type MapT =
     val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
     val find_last : (key -> bool) -> 'a t -> key * 'a
     val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val find_or_add : key -> (unit -> 'a) -> 'a t -> 'a t * 'a
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t
@@ -391,6 +392,7 @@ module SSMap :
     val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
     val find_last : (key -> bool) -> 'a t -> key * 'a
     val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val find_or_add : key -> (unit -> 'a) -> 'a t -> 'a t * 'a
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
     val to_seq : 'a t -> (key * 'a) Seq.t

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -51,6 +51,7 @@ module Core :
             val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
             val find_last : (key -> bool) -> 'a t -> key * 'a
             val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
+            val find_or_add : key -> (unit -> 'a) -> 'a t -> 'a t * 'a
             val map : ('a -> 'b) -> 'a t -> 'b t
             val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
             val to_seq : 'a t -> (key * 'a) Seq.t


### PR DESCRIPTION
This PR adds important functions to the `Hashtbl` and `Map` modules. The first commit adds the function `Hashtbl.update`, an analogous to `Map.update` but for hash tables. The second commit adds functions {`Hashtbl`,`Map`}`.find_or_add`. 

The main rationale for these additions is performance and expressiveness. `Map.update` is a more flexible interface than `add`/`remove`, but most important is perhaps the matter of performance. For instance  

`if Map.mem k m then Map.add k a m else Map.add k b m`

and 

`Map.update k (function Some _ -> Some a | None -> Some b) m`

are equivalent, however the former does two passes through the tree, while the latter only does one, saving log(`Map.cardinal m`) comparisons. In `Hashtbl`, this would rather save one call to the hashing function, which for complex data structures can be quite expensive. There's currently no way to avoid this for examples such as the above with the functions available in stdlib. 

Similarly, `find_or_add` lets you avoid traversing the tree twice (in the case of `Map`) or calling the hashing function twice (in the case of `Hashtbl`). `Hashtbl.find_or_add tbl k f` is equivalent to `match Hashtbl.find_opt tbl k with Some v -> v | None -> let v = f() in Hashtbl.add tbl k v; v`. Again, without `find_or_add` there's currently no way to do this efficiently, with the functions available in stdlib. 

Hash tables are used often in performance-sensitive code, so having these tools available is rather important in my view. 