### PR TITLE
Provide semaphores in the threading library

### DIFF
--- a/Changes
+++ b/Changes
@@ -300,6 +300,11 @@ Working version
   (Ivan Gotovchits and Xavier Leroy, review by Sébastien Hinderer and
    David Allsopp)
 
+- #9930: new module Semaphore in the thread library, implementing
+  counting semaphores and binary semaphores
+  (Xavier Leroy, review by Daniel Bünzli and Damien Doligez,
+   additional suggestions by Stephen Dolan and Craig Ferguson)
+
 - #9958: Raise exception in case of error in Unix.setsid.
   (Nicolás Ojeda Bär, review by Stephen Dolan)
 

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -30,7 +30,7 @@ COMPILER_LIBS_INTF = Asthelper.tex Astmapper.tex Asttypes.tex \
   $(COMPILER_LIBS_PLUGIN_HOOKS)
 
 OTHERLIB_INTF = Unix.tex UnixLabels.tex Str.tex \
-  Thread.tex Mutex.tex Condition.tex Event.tex \
+  Thread.tex Mutex.tex Condition.tex Semaphore.tex Event.tex \
   Dynlink.tex Bigarray.tex
 
 INTF = $(CORE_INTF) $(STDLIB_INTF) $(COMPILER_LIBS_INTF) $(OTHERLIB_INTF)

--- a/manual/manual/library/libthreads.etex
+++ b/manual/manual/library/libthreads.etex
@@ -31,11 +31,13 @@ the "-I +threads" option (see chapter~\ref{c:camlc}).
 \item \ahref{libref/Thread.html}{Module \texttt{Thread}: lightweight threads}
 \item \ahref{libref/Mutex.html}{Module \texttt{Mutex}: locks for mutual exclusion}
 \item \ahref{libref/Condition.html}{Module \texttt{Condition}: condition variables to synchronize between threads}
+\item \ahref{libref/Semaphore.html}{Module \texttt{Semaphore}: semaphores, another thread synchronization mechanism}
 \item \ahref{libref/Event.html}{Module \texttt{Event}: first-class synchronous communication}
 \end{links}
 \else
 \input{Thread.tex}
 \input{Mutex.tex}
 \input{Condition.tex}
+\input{Semaphore.tex}
 \input{Event.tex}
 \fi

--- a/ocamldoc/Makefile.docfiles
+++ b/ocamldoc/Makefile.docfiles
@@ -23,7 +23,7 @@ STR_MLIS = $(addprefix $(SRC)/otherlibs/str/, str.mli)
 UNIX_MLIS = $(addprefix $(SRC)/otherlibs/unix/, unix.mli unixLabels.mli)
 DYNLINK_MLIS = $(addprefix $(SRC)/otherlibs/dynlink/, dynlink.mli)
 THREAD_MLIS = $(addprefix $(SRC)/otherlibs/systhreads/, \
-  thread.mli condition.mli mutex.mli event.mli threadUnix.mli)
+  thread.mli condition.mli mutex.mli event.mli semaphore.mli threadUnix.mli)
 DRIVER_MLIS = $(SRC)/driver/pparse.mli
 
 

--- a/otherlibs/systhreads/.depend
+++ b/otherlibs/systhreads/.depend
@@ -20,6 +20,15 @@ mutex.cmo : \
 mutex.cmx : \
     mutex.cmi
 mutex.cmi :
+semaphore.cmo : \
+    mutex.cmi \
+    condition.cmi \
+    semaphore.cmi
+semaphore.cmx : \
+    mutex.cmx \
+    condition.cmx \
+    semaphore.cmi
+semaphore.cmi :
 thread.cmo : \
     thread.cmi
 thread.cmx : \

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -49,12 +49,15 @@ LIBNAME=threads
 BYTECODE_C_OBJS=st_stubs.b.$(O)
 NATIVECODE_C_OBJS=st_stubs.n.$(O)
 
-THREADS_SOURCES = thread.ml mutex.ml condition.ml event.ml threadUnix.ml
+THREADS_SOURCES = thread.ml mutex.ml condition.ml event.ml threadUnix.ml \
+  semaphore.ml
 
 THREADS_BCOBJS = $(THREADS_SOURCES:.ml=.cmo)
 THREADS_NCOBJS = $(THREADS_SOURCES:.ml=.cmx)
 
-MLIFILES=thread.mli mutex.mli condition.mli event.mli threadUnix.mli
+MLIFILES=thread.mli mutex.mli condition.mli event.mli threadUnix.mli \
+  semaphore.mli
+
 CMIFILES=$(MLIFILES:.mli=.cmi)
 
 all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)

--- a/otherlibs/systhreads/semaphore.ml
+++ b/otherlibs/systhreads/semaphore.ml
@@ -26,8 +26,7 @@ module Counting = struct
 type t = sem
 
 let make v =
-  if v < 0 then
-    raise (Sys_error "Semaphore.Counting.init: wrong initial value");
+  if v < 0 then invalid_arg "Semaphore.Counting.init: wrong initial value";
   { mut = Mutex.create(); v; nonzero = Condition.create() }
 
 let release s =

--- a/otherlibs/systhreads/semaphore.ml
+++ b/otherlibs/systhreads/semaphore.ml
@@ -38,7 +38,7 @@ let release s =
     Mutex.unlock s.mut
   end else begin
     Mutex.unlock s.mut;
-   raise (Sys_error "Semaphore.Counting.release: overflow")
+    raise (Sys_error "Semaphore.Counting.release: overflow")
   end
 
 let acquire s =

--- a/otherlibs/systhreads/semaphore.ml
+++ b/otherlibs/systhreads/semaphore.ml
@@ -1,0 +1,67 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Xavier Leroy, Collège de France and INRIA Paris               *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Semaphores *)
+
+type t = {
+  mut: Mutex.t;                         (* protects [v] *)
+  mutable v: int;                       (* the current value *)
+  max: int option;                      (* the maximal value *)
+  nonzero: Condition.t                  (* signaled when [v > 0] *)
+}
+
+let make ?max v =
+  let m = Option.value max ~default:max_int in
+  if v < 0 || v > m then
+    raise (Sys_error "Semaphore.init: wrong initial value");
+  if m <= 0 then
+    raise (Sys_error "Semaphore.init: wrong maximal value");
+  { mut = Mutex.create(); v; max; nonzero = Condition.create() }
+
+let make_binary b =
+  { mut = Mutex.create();
+    v = if b then 1 else 0;
+    max = Some 1;
+    nonzero = Condition.create() }
+
+let post s =
+  Mutex.lock s.mut;
+  begin match s.max with
+    | None ->
+        if s.v < max_int then
+          s.v <- s.v + 1
+        else begin
+          Mutex.unlock s.mut;
+          raise (Sys_error "Semaphore.post: overflow")
+        end
+    | Some m ->
+        if s.v < m then
+          s.v <- s.v + 1
+  end;
+  Condition.signal s.nonzero;
+  Mutex.unlock s.mut
+
+let wait s =
+  Mutex.lock s.mut;
+  while s.v = 0 do Condition.wait s.nonzero s.mut done;
+  s.v <- s.v - 1;
+  Mutex.unlock s.mut
+
+let trywait s =
+  Mutex.lock s.mut;
+  let ret = if s.v = 0 then false else (s.v <- s.v - 1; true) in
+  Mutex.unlock s.mut;
+  ret
+

--- a/otherlibs/systhreads/semaphore.ml
+++ b/otherlibs/systhreads/semaphore.ml
@@ -18,48 +18,48 @@
 type t = {
   mut: Mutex.t;                         (* protects [v] *)
   mutable v: int;                       (* the current value *)
-  max: int option;                      (* the maximal value *)
+  capacity: int option;                 (* the maximal value *)
   nonzero: Condition.t                  (* signaled when [v > 0] *)
 }
 
-let make ?max v =
-  let m = Option.value max ~default:max_int in
-  if v < 0 || v > m then
+let make ?capacity v =
+  let cap = Option.value capacity ~default:max_int in
+  if v < 0 || v > cap then
     raise (Sys_error "Semaphore.init: wrong initial value");
-  if m <= 0 then
-    raise (Sys_error "Semaphore.init: wrong maximal value");
-  { mut = Mutex.create(); v; max; nonzero = Condition.create() }
+  if cap <= 0 then
+    raise (Sys_error "Semaphore.init: wrong capacity");
+  { mut = Mutex.create(); v; capacity; nonzero = Condition.create() }
 
 let make_binary b =
   { mut = Mutex.create();
     v = if b then 1 else 0;
-    max = Some 1;
+    capacity = Some 1;
     nonzero = Condition.create() }
 
-let post s =
+let release s =
   Mutex.lock s.mut;
-  begin match s.max with
+  begin match s.capacity with
     | None ->
         if s.v < max_int then
           s.v <- s.v + 1
         else begin
           Mutex.unlock s.mut;
-          raise (Sys_error "Semaphore.post: overflow")
+          raise (Sys_error "Semaphore.release: overflow")
         end
-    | Some m ->
-        if s.v < m then
+    | Some cap ->
+        if s.v < cap then
           s.v <- s.v + 1
   end;
   Condition.signal s.nonzero;
   Mutex.unlock s.mut
 
-let wait s =
+let acquire s =
   Mutex.lock s.mut;
   while s.v = 0 do Condition.wait s.nonzero s.mut done;
   s.v <- s.v - 1;
   Mutex.unlock s.mut
 
-let trywait s =
+let try_acquire s =
   Mutex.lock s.mut;
   let ret = if s.v = 0 then false else (s.v <- s.v - 1; true) in
   Mutex.unlock s.mut;

--- a/otherlibs/systhreads/semaphore.mli
+++ b/otherlibs/systhreads/semaphore.mli
@@ -1,0 +1,80 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Xavier Leroy, Collège de France and INRIA Paris               *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Semaphores
+
+  A counting semaphore is a counter that can be accessed concurrently
+  by several threads.  The typical use is to synchronize producers and
+  consumers of a resource by counting how many units of the resource
+  are available.
+
+  The two basic operations on semaphores are:
+- "post" (also called "V", "up", "signal", and "release"), which
+  increments the value of the counter;
+- "wait" (also called "P", "down", "pend", and "acquire"), which
+  waits until the counter is greater than zero and decrements it.
+
+  A variant of the counting semaphore is the binary semaphore,
+  which has only two values, 0 and 1.  "post" sets the value to 1
+  and "wait" waits until the value is 1 and sets it to 0.
+
+  @since 4.12
+*)
+
+type t
+(** The type of semaphores. *)
+
+val make : ?max: int -> int -> t
+(** [make n] returns a new counted semaphore, with initial value [n].
+    The initial value [n] must be nonnegative.
+
+    The [max] optional argument specifies the maximal value of
+    the semaphore: once the value of the semaphore reaches [max],
+    subsequent {!post} operations will not increase it
+    above [max].  If provided, [max] must be positive and
+    greater than or equal to [n].
+
+    @raise Sys_error if [n < 0] or [max <= 0] or [n > max]
+*)
+
+val make_binary : bool -> t
+(** [make_binary b] is equivalent to [{!make} ~max:1 (if b then 1 else 0)].
+    It returns a new binary semaphore, with initial value [b]
+    ([false] means [0], [true] means [1]) and maximal value [1].
+*)
+
+val post : t -> unit
+(** [post s] increments the value of semaphore [s].
+    If other threads are waiting on [s], one of them is restarted.
+    If semaphore [s] was created with a maximal value, and the current
+    value is equal to this maximal value, the value of the semaphore
+    is unchanged and [post s] has no effect.
+    If semaphore [s] was created without a maximal value, and the
+    current value is equal to [max_int], the value of the semaphore
+    is unchanged and a [Sys_error] exception is raised to signal overflow.
+
+    @raise Sys_error if the value of the semaphore would overflow [max_int]
+*)
+
+val wait : t -> unit
+(** [wait s] blocks the calling thread until the value of semaphore [s]
+    is not zero, then atomically decrements the value of [s] and returns.
+*)
+
+val trywait : t -> bool
+(** [trywait s] immediately returns [false] if the value of semaphore [s]
+    is zero.  Otherwise, the value of [s] is atomically decremented
+    and [trywait s] returns [true].
+*)

--- a/otherlibs/systhreads/semaphore.mli
+++ b/otherlibs/systhreads/semaphore.mli
@@ -21,14 +21,22 @@
   are available.
 
   The two basic operations on semaphores are:
-- "post" (also called "V", "up", "signal", and "release"), which
-  increments the value of the counter;
-- "wait" (also called "P", "down", "pend", and "acquire"), which
+- "release" (also called "V", "post", "up", and "signal"), which
+  increments the value of the counter.  This corresponds to producing
+  one more unit of the shared resource and making it available to others.
+- "acquire" (also called "P", "wait", "down", and "pend"), which
   waits until the counter is greater than zero and decrements it.
+  This corresponds to consuming one unit of the shared resource.
 
   A variant of the counting semaphore is the binary semaphore,
-  which has only two values, 0 and 1.  "post" sets the value to 1
-  and "wait" waits until the value is 1 and sets it to 0.
+  which has only two values, 0 and 1.  "release" sets the value to 1
+  and "acquire" waits until the value is 1 and sets it to 0.  A binary
+  semaphore can be used instead of a mutex (see module {!Mutex})
+  when the mutex discipline (of unlocking the mutex from the
+  thread that locked it) is too restrictive.  The "acquire" operation
+  corresponds to locking the mutex, and the "release" operation
+  to unlocking it, but "release" can be performed in a thread different
+  than the one that performed the "acquire".
 
   @since 4.12
 *)
@@ -36,31 +44,31 @@
 type t
 (** The type of semaphores. *)
 
-val make : ?max: int -> int -> t
+val make : ?capacity: int -> int -> t
 (** [make n] returns a new counted semaphore, with initial value [n].
     The initial value [n] must be nonnegative.
 
-    The [max] optional argument specifies the maximal value of
-    the semaphore: once the value of the semaphore reaches [max],
-    subsequent {!post} operations will not increase it
-    above [max].  If provided, [max] must be positive and
+    The [capacity] optional argument specifies the maximal value of
+    the semaphore: once the value of the semaphore reaches [capacity],
+    subsequent {!release} operations will not increase it
+    above [capacity].  If provided, [capacity] must be positive and
     greater than or equal to [n].
 
-    @raise Sys_error if [n < 0] or [max <= 0] or [n > max]
+    @raise Sys_error if [n < 0] or [capacity <= 0] or [n > capacity]
 *)
 
 val make_binary : bool -> t
-(** [make_binary b] is equivalent to [{!make} ~max:1 (if b then 1 else 0)].
+(** [make_binary b] is equivalent to [{!make} ~capacity:1 (if b then 1 else 0)].
     It returns a new binary semaphore, with initial value [b]
     ([false] means [0], [true] means [1]) and maximal value [1].
 *)
 
-val post : t -> unit
-(** [post s] increments the value of semaphore [s].
+val release : t -> unit
+(** [release s] increments the value of semaphore [s].
     If other threads are waiting on [s], one of them is restarted.
     If semaphore [s] was created with a maximal value, and the current
     value is equal to this maximal value, the value of the semaphore
-    is unchanged and [post s] has no effect.
+    is unchanged and [release s] has no effect.
     If semaphore [s] was created without a maximal value, and the
     current value is equal to [max_int], the value of the semaphore
     is unchanged and a [Sys_error] exception is raised to signal overflow.
@@ -68,13 +76,13 @@ val post : t -> unit
     @raise Sys_error if the value of the semaphore would overflow [max_int]
 *)
 
-val wait : t -> unit
-(** [wait s] blocks the calling thread until the value of semaphore [s]
+val acquire : t -> unit
+(** [acquire s] blocks the calling thread until the value of semaphore [s]
     is not zero, then atomically decrements the value of [s] and returns.
 *)
 
-val trywait : t -> bool
-(** [trywait s] immediately returns [false] if the value of semaphore [s]
+val try_acquire : t -> bool
+(** [try_acquire s] immediately returns [false] if the value of semaphore [s]
     is zero.  Otherwise, the value of [s] is atomically decremented
-    and [trywait s] returns [true].
+    and [try_acquire s] returns [true].
 *)

--- a/otherlibs/systhreads/semaphore.mli
+++ b/otherlibs/systhreads/semaphore.mli
@@ -50,7 +50,7 @@ val make : int -> t
 (** [make n] returns a new counting semaphore, with initial value [n].
     The initial value [n] must be nonnegative.
 
-    @raise Sys_error if [n < 0]
+    @raise Invalid_argument if [n < 0]
 *)
 
 val release : t -> unit


### PR DESCRIPTION
This PR proposes to add a new thread-related module Semaphore, implementing [Dijkstra's semaphores](https://en.wikipedia.org/wiki/Semaphore_(programming)).

Semaphores would be useful for code that currently and incorrectly uses mutexes as binary semaphores, see discussion at #9757 , #9846, and especially https://github.com/ocaml/ocaml/pull/9846#issuecomment-691672306 .