### PR TITLE
Restore full Cygwin64 on Jenkins

### DIFF
--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -149,8 +149,6 @@ case "${OCAML_ARCH}" in
   cygwin64)
     cleanup=true
     check_make_alldepend=true
-    dorebase=false
-    confoptions="$confoptions --disable-shared "
   ;;
   mingw)
     build='--build=i686-pc-cygwin'

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -128,7 +128,6 @@ ${OCAML_CONFIGURE_OPTIONS}"
 make_native=true
 cleanup=false
 check_make_alldepend=false
-dorebase=false
 jobs=''
 bootstrap=false
 
@@ -245,13 +244,6 @@ fi
 
 if $make_native && $check_make_alldepend; then
   $make --warn-undefined-variables alldepend
-fi
-
-if $dorebase; then
-    # temporary solution to the cygwin fork problem
-    # see https://github.com/alainfrisch/flexdll/issues/50
-    rebase -b 0x7cd20000 otherlibs/unix/dllunix.so
-    rebase -b 0x7cdc0000 otherlibs/systhreads/dllthreads.so
 fi
 
 $make --warn-undefined-variables install


### PR DESCRIPTION
#9927 restores shared library and natdynlink support for Cygwin64. We no longer need to run Cygwin64 with `--disable-shared` - indeed, it's better not to (in order to catch errors in any new runtime functions which should be being exported).

This can't be merged yet, since it requires:
- [x] alainfrisch/flexdll#89 to be merged and a new release cut
- [x] New release of flexlink - [0.39 released](https://github.com/alainfrisch/flexdll/releases/tag/0.39)
- [x] Cygwin64's flexdll package to be updated to this new release - [0.39 available as a test release](https://cygwin.com/packages/summary/flexdll.html)
- [x] Inria Cygwin64 worker Cygwin64 installation to be updated with that new package