### PR TITLE
Clearer error in testsuite when ocamltest missing

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -52,14 +52,18 @@ else # Windows
   endif
 endif
 
-ifeq "$(FLEXLINK_ENV)" ""
-  ocamltest := MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) $(ocamltest_program)
+ifeq "$(ocamltest_program)" ""
+  ocamltest = $(error ocamltest not found in $(ocamltest_directory))
 else
-  MKDLL=$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe \
-                                   $(FLEXLINK_FLAGS)
+  ifeq "$(FLEXLINK_ENV)" ""
+    ocamltest := MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) $(ocamltest_program)
+  else
+    MKDLL=$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe \
+                                     $(FLEXLINK_FLAGS)
 
-  ocamltest := $(FLEXLINK_ENV) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
-                               $(ocamltest_program)
+    ocamltest := $(FLEXLINK_ENV) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
+                                 $(ocamltest_program)
+  endif
 endif
 
 # PROMOTE is only meant to be used internally in recursive calls;


### PR DESCRIPTION
Since #9250 in 4.11, it's possible to build OCaml without `ocamltest` (this was added for various reasons). If you either build a release tag or explicitly configure with `--disable-test`, the message if you try to run the testsuite is a little off:

```
dra27@summer:~/ocaml-6$ make -C testsuite all
make: Entering directory '/home/dra27/ocaml-6/testsuite'
/bin/sh: 2: -find-test-dirs: not found


Summary:
    0 tests passed
    0 tests skipped
    0 tests failed
    0 tests not started (parent test skipped or failed)
    0 unexpected errors
    0 tests considered
```
This tiny PR (most of the diff is whitespace change) displays a slightly less awful error message:
```
dra27@summer:~/ocaml-6$ make -C testsuite all
make: Entering directory '/home/dra27/ocaml-6/testsuite'
Makefile:121: *** ocamltest not found in ../ocamltest. Stop.
Makefile:115: recipe for target 'all' failed
make: *** [all] Error 2
make: Leaving directory '/home/dra27/ocaml-6/testsuite'
```