### PR TITLE
Define __USE_MINGW_ANSI_STDIO=0 for mingw-w64

### DIFF
--- a/Changes
+++ b/Changes
@@ -556,6 +556,10 @@ OCaml 4.12.0
 - #9824, #9837: Honour the CFLAGS and CPPFLAGS variables.
   (Sébastien Hinderer, review by David Allsopp)
 
+- #9938, #9939: Define __USE_MINGW_ANSI_STDIO=0 for the mingw-w64 ports to
+  prevent their C99-compliant snprintf conflicting with ours.
+  (David Allsopp, report by Michael Soegtrop, review by ???)
+
 - #9895, #9523: Avoid conflict with C++20 by not installing VERSION to the OCaml
   Standard Library directory.
   (Bernhard Schommer, review by David Allsopp)

--- a/configure
+++ b/configure
@@ -12656,7 +12656,7 @@ case $host in #(
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
         common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
-        internal_cppflags='-DUNICODE -D_UNICODE'
+        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -578,7 +578,7 @@ AS_CASE([$host],
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
         common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
-        internal_cppflags='-DUNICODE -D_UNICODE'
+        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
         internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
         internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
       [AC_MSG_ERROR([Unsupported C compiler for a Mingw build])])],

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -61,6 +61,19 @@
 #include <stdint.h>
 #endif
 
+/* Disable the mingw-w64 *printf shims */
+#if defined(CAML_INTERNALS) && defined(__MINGW32__)
+  /* Headers may have already included <_mingw.h>, so #undef if necessary. */
+  #ifdef __USE_MINGW_ANSI_STDIO
+    #undef __USE_MINGW_ANSI_STDIO
+  #endif
+  /* <stdio.h> must either be #include'd before this header or
+     __USE_MINGW_ANSI_STDIO needs to be 0 when <stdio.h> is processed. The final
+     effect will be the same - stdio.h will define snprintf and misc.h will make
+     snprintf a macro (referring to caml_snprintf). */
+  #define __USE_MINGW_ANSI_STDIO 0
+#endif
+
 #if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1800)
 #define ARCH_SIZET_PRINTF_FORMAT "I"
 #else


### PR DESCRIPTION
The latest mingw-w64 `_mingw.h` header now automatically sets `__USE_MINGW_ANSI_STDIO=1` for C99 and later. mingw-w64 always defines `snprintf` but the inline definition when `__USE_MINGW_ANSI_STDIO=0` temporarily `#undef`'s any `snprintf` macro so works in harmony with ours. The other case does not do this so we get declaration errors.

The alternative is to disable `caml_snprintf` the `__MINGW32__` but this has the immediate knock-on effect of having to use `ll` instead of `I64` and might have other implications in terms of libraries linked. Either way, for now, this fix looks like the path of least resistance.

I'll formally cherry-pick this for 4.11.2 and informally push the fix to older branches as well, just so that the patches are stored somewhere (opam-repository will want them).

Fixes #9938 