### PR TITLE
Ensure all structured constants are registered

### DIFF
--- a/Changes
+++ b/Changes
@@ -493,6 +493,10 @@ Working version
 - #9927: Restore Cygwin64 support.
   (David Allsopp, review by Xavier Leroy)
 
+- #9940: Fix unboxing of allocated constants from other compilation units
+  (Vincent Laviron, report by Stephen Dolan, review by Xavier Leroy and
+  Stephen Dolan)
+
 
 OCaml 4.11.1
 ------------

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -178,7 +178,10 @@ let rec expr_size env = function
 let transl_constant dbg = function
   | Uconst_int n ->
       int_const dbg n
-  | Uconst_ref (label, _) ->
+  | Uconst_ref (label, def_opt) ->
+      Option.iter
+        (fun def -> Cmmgen_state.add_structured_constant label def)
+        def_opt;
       Cconst_symbol (label, dbg)
 
 let emit_constant cst cont =

--- a/asmcomp/cmmgen_state.ml
+++ b/asmcomp/cmmgen_state.ml
@@ -76,6 +76,9 @@ let set_structured_constants l =
     )
     l
 
+let add_structured_constant sym cst =
+  Hashtbl.add state.structured_constants sym cst
+
 let get_structured_constant s =
   Hashtbl.find_opt state.structured_constants s
 

--- a/asmcomp/cmmgen_state.ml
+++ b/asmcomp/cmmgen_state.ml
@@ -77,7 +77,7 @@ let set_structured_constants l =
     l
 
 let add_structured_constant sym cst =
-  Hashtbl.add state.structured_constants sym cst
+  Hashtbl.replace state.structured_constants sym cst
 
 let get_structured_constant s =
   Hashtbl.find_opt state.structured_constants s

--- a/asmcomp/cmmgen_state.mli
+++ b/asmcomp/cmmgen_state.mli
@@ -41,5 +41,7 @@ val no_more_functions : unit -> bool
 
 val set_structured_constants : Clambda.preallocated_constant list -> unit
 
+val add_structured_constant : string -> Clambda.ustructured_constant -> unit
+
 (* Also looks up using Compilenv.structured_constant_of_symbol *)
 val structured_constant_of_sym : string -> Clambda.ustructured_constant option


### PR DESCRIPTION
Alternative to #9310.
This is a very quick patch, I think it results in the same constants being potentially added several times to the hash table. It might be better to check that either there is no previous definition or it is the same as the one being added, but the overall idea behind the patch doesn't change that much.