### PR TITLE
use UTF-8 encoding for ocamldoc

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -54,6 +54,7 @@ html: htmlman/libref/style.css htmlman/compilerlibref/style.css etex-files
 htmlman/libref/style.css: style.css $(STDLIB_MLIS) $(DOC_STDLIB_TEXT)
 	mkdir -p htmlman/libref
 	$(OCAMLDOC) -colorize-code -sort -html \
+	  -charset "UTF-8" \
 	  -d htmlman/libref \
 	  $(DOC_STDLIB_INCLUDES) \
           $(DOC_STDLIB_TEXT:%=-text %) \
@@ -71,6 +72,7 @@ htmlman/compilerlibref/style.css: library/compiler_libs.txt style.css \
   $(COMPILERLIBS_MLIS)
 	mkdir -p htmlman/compilerlibref
 	$(OCAMLDOC) -colorize-code -sort -html \
+	  -charset "UTF-8" \
 	  -d htmlman/compilerlibref \
 	  -I $(SRC)/stdlib \
 	  $(DOC_COMPILERLIBS_INCLUDES) \


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/pull/1789#issuecomment-695785998
Currently ocamldoc default encoding is isolatin, however it seems that some files in `libref` already use UTF8 encoding, so I assume it would be better to generate HTML files with "charset=UTF-8".