### PR TITLE
add String.get_opt and Bytes.get_opt functions with doc and tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -156,6 +156,9 @@ Working version
 
 ### Standard library:
 
+- #9944: - add String.get_opt and Bytes.get_opt functions
+  (Léo Andrès, review by XXXX)
+
 - #9865: add Format.pp_print_seq
   (Raphaël Proust, review by Nicolás Ojeda Bär)
 

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -61,6 +61,12 @@ let copy s =
 let to_string b = unsafe_to_string (copy b)
 let of_string s = copy (unsafe_of_string s)
 
+(* duplicated in string.ml *)
+let get_opt b i =
+  if i < 0 then invalid_arg "Bytes.get_opt"
+  else if i >= length b then None
+  else Some (unsafe_get b i)
+
 let sub s ofs len =
   if ofs < 0 || len < 0 || ofs > length s - len
   then invalid_arg "String.sub / Bytes.sub"

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -69,6 +69,12 @@ external get : bytes -> int -> char = "%bytes_safe_get"
 (** [get s n] returns the byte at index [n] in argument [s].
     @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
+val get_opt : bytes -> int -> char option
+(** [get_opt s i] is [None] if [i] is not a valid index in [s]. Otherwise
+    it is [Some c] where [c] is the byte at index [i] in [s].
+    @raise Invalid_argument if [i < 0].
+    @since 4.12.0
+*)
 
 external set : bytes -> int -> char -> unit = "%bytes_safe_set"
 (** [set s n c] modifies [s] in place, replacing the byte at index [n]

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -69,6 +69,12 @@ external get : bytes -> int -> char = "%bytes_safe_get"
 (** [get s n] returns the byte at index [n] in argument [s].
     @raise Invalid_argument if [n] is not a valid index in [s]. *)
 
+val get_opt : bytes -> int -> char option
+(** [get_opt s i] is [None] if [i] is not a valid index in [s]. Otherwise
+    it is [Some c] where [c] is the byte at index [i] in [s].
+    @raise Invalid_argument if [i < 0].
+    @since 4.12.0
+*)
 
 external set : bytes -> int -> char -> unit = "%bytes_safe_set"
 (** [set s n c] modifies [s] in place, replacing the byte at index [n]

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -50,6 +50,12 @@ let fill =
 let blit =
   B.blit_string
 
+(* duplicated in bytes.ml *)
+let get_opt s i =
+  if i < 0 then invalid_arg "String.get_opt"
+  else if i >= length s then None
+  else Some (unsafe_get s i)
+
 let ensure_ge (x:int) y = if x >= y then x else invalid_arg "String.concat"
 
 let rec sum_lengths acc seplen = function

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -112,6 +112,13 @@ external get : string -> int -> char = "%string_safe_get"
 
     @raise Invalid_argument if [i] not an index of [s]. *)
 
+val get_opt : string -> int -> char option
+(** [get_opt s i] is [None] if [i] is not an index of [s]. Otherwise
+    it is [Some c] where [c] is the character at index [i] in [s].
+    @raise Invalid_argument if [i < 0].
+    @since 4.12.0
+*)
+
 (** {1:concat Concatenating}
 
     {b Note.} The {!Stdlib.( ^ )} binary operator concatenates two

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -112,6 +112,13 @@ external get : string -> int -> char = "%string_safe_get"
 
     @raise Invalid_argument if [i] not an index of [s]. *)
 
+val get_opt : string -> int -> char option
+(** [get_opt s i] is [None] if [i] is not an index of [s]. Otherwise
+    it is [Some c] where [c] is the character at index [i] in [s].
+    @raise Invalid_argument if [i < 0].
+    @since 4.12.0
+*)
+
 (** {1:concat Concatenating}
 
     {b Note.} The {!Stdlib.( ^ )} binary operator concatenates two

--- a/testsuite/tests/lib-bytes/test_bytes.ml
+++ b/testsuite/tests/lib-bytes/test_bytes.ml
@@ -15,6 +15,11 @@ let check b offset s =
   loop 0
 
 let () =
+  assert (None = Bytes.get_opt (Bytes.of_string "") 0);
+  assert (Some 'y' = Bytes.get_opt (Bytes.of_string "xyz") 1)
+;;
+
+let () =
   let abcde = Bytes.of_string "abcde" in
   let open Bytes in
   begin

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -34,6 +34,11 @@ let check_split sep s =
 ;;
 
 let () =
+  assert (None = String.get_opt "" 0);
+  assert (Some 'y' = String.get_opt "xyz" 1)
+;;
+
+let () =
   let s = " abc def " in
   for i = 0 to String.length s do
     check_split ' ' (String.sub s 0 i)


### PR DESCRIPTION
Hi,

I added `String.get_opt` and `Bytes.get_opt` functions.

They are the same as their `get` counterpart, except that they wrap their result in an option.