### PR TITLE
Ensure Mtype.nondep_sig checks use the correct environment

### DIFF
--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -100,11 +100,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type t/144 by t/161
+Error: Illegal shadowing of included type t/146 by t/163
        Line 2, characters 2-11:
-         Type t/144 came from this include
+         Type t/146 came from this include
        Line 3, characters 2-24:
-         The value ignore has no valid type if t/144 is shadowed
+         The value ignore has no valid type if t/146 is shadowed
 |}]
 
 module type Module = sig
@@ -140,11 +140,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module M/232 by M/249
+Error: Illegal shadowing of included module M/237 by M/254
        Line 2, characters 2-11:
-         Module M/232 came from this include
+         Module M/237 came from this include
        Line 3, characters 2-26:
-         The value ignore has no valid type if M/232 is shadowed
+         The value ignore has no valid type if M/237 is shadowed
 |}]
 
 
@@ -181,11 +181,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module type T/317 by T/334
+Error: Illegal shadowing of included module type T/324 by T/341
        Line 2, characters 2-11:
-         Module type T/317 came from this include
+         Module type T/324 came from this include
        Line 3, characters 2-39:
-         The module F has no valid type if T/317 is shadowed
+         The module F has no valid type if T/324 is shadowed
 |}]
 
 module type Extension = sig
@@ -198,11 +198,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type ext/352 by ext/369
+Error: Illegal shadowing of included type ext/360 by ext/377
        Line 2, characters 2-11:
-         Type ext/352 came from this include
+         Type ext/360 came from this include
        Line 3, characters 14-16:
-         The extension constructor C2 has no valid type if ext/352 is shadowed
+         The extension constructor C2 has no valid type if ext/360 is shadowed
 |}]
 
 module type Class = sig

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -19,3 +19,19 @@ Error: This functor has type
        The parameter cannot be eliminated in the result type.
        Please bind the argument to a module identifier.
 |}]
+
+module M (X : sig type 'a t constraint 'a = float end) = struct
+  module type S = sig
+    type t = float
+    val foo : t X.t
+  end
+end
+
+module N = M (struct type 'a t = int constraint 'a = float end)
+
+[%%expect{|
+module M :
+  functor (X : sig type 'a t constraint 'a = float end) ->
+    sig module type S = sig type t = float val foo : t X.t end end
+module N : sig module type S = sig type t = float val foo : int end end
+|}]

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -222,6 +222,8 @@ and nondep_sig_item env va ids = function
       Sig_class_type(id, Ctype.nondep_cltype_declaration env ids d, rs, vis)
 
 and nondep_sig env va ids sg =
+  let scope = Ctype.create_scope () in
+  let sg, env = Env.enter_signature ~scope sg env in
   List.map (nondep_sig_item env va ids) sg
 
 and nondep_modtype_decl env ids mtd =


### PR DESCRIPTION
`Mtype.nondep_sig` checks are currently done in the wrong environment, which means they sometimes return the wrong answer, at least in the presence of constraints. The issue is a bit tricky. First, you need a functor that accepts a constrained signature:
```ocaml
module M (X : sig type 'a t constraint 'a = float end) = struct
  module type S = sig
    type t = float
    val foo : t X.t
  end
end
```
Next, you instantiate this functor with an anonymous argument:
```ocaml
module N = M (struct type 'a t = int constraint 'a = float)
```
This should report the signature of `N` after substituting `'a t` away:
```ocaml
module N : sig
  module type S = sig
    type t = float
    val foo : int
  end
end
```
Instead, it currently makes `S` abstract:
```ocaml
module N : sig module type S end
```
The problem is in the `Mtype.nondep_sig` check, which checks whether, after applying the anonymous argument, it can write the signature `S` without mentioning `X`. It should be able to, as it should be able to expand `t X.t` into `int`.

However, to expand `t X.t` the typechecker first verifies that `X.t`'s constraints are satisfied, which requires that `t = float`. This doesn't currently work, because the check is done in the original environment that does not mention `t`, so it cannot see the equation `t = float` (or indeed, even see that `t` exists). The fix is to do the check after adding the contents of `S` to the environment, so that `t = float` holds.

(This issue came up during work on a prototype for the unboxed types proposal ([RFC #10](https://github.com/ocaml/rfcs/pull/10)), but turns out to affect trunk as well)