### PR TITLE
Ensure that the mark stack push optimisation handles naked pointers.

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,6 +127,10 @@ Working version
   needed as the pagetable heads towards retirement).
   (David Allsopp, review by Xavier Leroy)
 
+- #9951: Ensure that the mark stack push optimisation handles naked pointers
+  (KC Sivaramakrishnan, reported by Enguerrand Decorne, review by Gabriel
+   Scherer, and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #9551: ocamlc no longer loads DLLs at link time to check that

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -241,7 +241,7 @@ Caml_inline void mark_stack_push(struct mark_stack* stk, value block,
   for (i = offset; i < end; i++) {
     v = Field(block, i);
 
-    if (Is_block(v) && !Is_black_val(v))
+    if (Is_block(v) && !Is_young(v))
       /* found something to mark */
       break;
   }


### PR DESCRIPTION
In the presence of naked pointers, only blocks that are in the heap are guaranteed to have valid headers. Hence, we guard the test to see if the header is black with a test to check that object is in the major heap. This fixes #9950. 

The check for whether we should push the object into the mark stack is now more precise. However, this is not additional work as we would have done this check elsewhere during marking. 