### PR TITLE
Overload array expressions/patterns to also work for floatarray

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -373,8 +373,8 @@ and transl_exp0 ~scopes e =
       in
       Lprim(access, [transl_exp ~scopes arg; transl_exp ~scopes newval],
             of_location ~scopes e.exp_loc)
-  | Texp_array expr_list ->
-      let kind = array_kind e in
+  | Texp_array (kind, expr_list) ->
+      let kind = array_expression_kind kind e in
       let ll = transl_list ~scopes expr_list in
       begin try
         (* For native code the decision as to which compilation strategy to

--- a/testsuite/tests/typing-extensions/floatarray.ml
+++ b/testsuite/tests/typing-extensions/floatarray.ml
@@ -1,0 +1,85 @@
+(* TEST
+   * expect
+*)
+
+let x = [|1.;2.|]
+;;
+[%%expect {|
+val x : float array = [|1.; 2.|]
+|}]
+
+let x : floatarray = [|1.; 2.|]
+;;
+[%%expect {|
+val x : floatarray = [|1.; 2.|]
+|}]
+
+let x = ([|1.; 2.|] : floatarray)
+;;
+[%%expect {|
+val x : floatarray = [|1.; 2.|]
+|}]
+
+let f (a : floatarray) = match a with [|x|] -> x | _ -> assert false
+;;
+[%%expect {|
+val f : floatarray -> float = <fun>
+|}]
+
+let _ = f [|1.|]
+;;
+[%%expect {|
+- : float = 1.
+|}]
+
+(* Does not work without the annotation *)
+
+let f a = match a with [|_|] -> Float.Array.length a | _ -> assert false
+;;
+[%%expect {|
+Line 1, characters 51-52:
+1 | let f a = match a with [|_|] -> Float.Array.length a | _ -> assert false
+                                                       ^
+Error: This expression has type 'a array
+       but an expression was expected of type Float.Array.t = floatarray
+|}]
+
+type s = floatarray
+type t = s
+let x : t = [||]
+;;
+[%%expect {|
+type s = floatarray
+type t = s
+val x : t = [||]
+|}]
+
+let f a =
+  let _ = Float.Array.length a in
+  match a with
+  | [||] -> ()
+  | _ -> ()
+;;
+[%%expect{|
+val f : Float.Array.t -> unit = <fun>
+|}, Principal{|
+Line 4, characters 4-8:
+4 |   | [||] -> ()
+        ^^^^
+Warning 18 [not-principal]: this type-based field disambiguation is not principal.
+val f : Float.Array.t -> unit = <fun>
+|}]
+
+[@@@warning "+a"]
+;;
+
+let _ = ([||] : floatarray)
+
+[%%expect{|
+Line 4, characters 9-13:
+4 | let _ = ([||] : floatarray)
+             ^^^^
+Warning 42 [disambiguated-name]: this use of ([||]) relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
+- : floatarray = [||]
+|}]

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -46,7 +46,7 @@ module Simple : sig
     | `Variant of label * pattern option * row_desc ref
     | `Record of
         (Longident.t loc * label_description * pattern) list * closed_flag
-    | `Array of pattern list
+    | `Array of array_kind * pattern list
     | `Lazy of pattern
   ]
   type pattern = view pattern_data
@@ -89,7 +89,7 @@ module Head : sig
           type_row : unit -> row_desc; }
           (* the row of the type may evolve if [close_variant] is called,
              hence the (unit -> ...) delay *)
-    | Array of int
+    | Array of array_kind * int
     | Lazy
 
   type t = desc pattern_data

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -88,7 +88,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
           fprintf ppf "@[{%a%t}@]"
             pretty_lvals filtered_lvs elision_mark
       end
-  | Tpat_array vs ->
+  | Tpat_array (_, vs) ->
       fprintf ppf "@[[| %a |]@]" (pretty_vals " ;") vs
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -115,6 +115,12 @@ let fmt_private_flag f x =
   | Private -> fprintf f "Private";
 ;;
 
+let fmt_array_kind f x =
+  match x with
+  | Floatarray -> fprintf f "Floatarray"
+  | Genarray -> fprintf f "Genarray"
+;;
+
 let line i f s (*...*) =
   fprintf f "%s" (String.make (2*i) ' ');
   fprintf f s (*...*)
@@ -254,8 +260,8 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   | Tpat_record (l, _c) ->
       line i ppf "Tpat_record\n";
       list i longident_x_pattern ppf l;
-  | Tpat_array (l) ->
-      line i ppf "Tpat_array\n";
+  | Tpat_array (k, l) ->
+      line i ppf "Tpat_array %a\n" fmt_array_kind k;
       list i pattern ppf l;
   | Tpat_lazy p ->
       line i ppf "Tpat_lazy\n";
@@ -365,8 +371,8 @@ and expression i ppf x =
       expression i ppf e1;
       longident i ppf li;
       expression i ppf e2;
-  | Texp_array (l) ->
-      line i ppf "Texp_array\n";
+  | Texp_array (k, l) ->
+      line i ppf "Texp_array %a\n" fmt_array_kind k;
       list i expression ppf l;
   | Texp_ifthenelse (e1, e2, eo) ->
       line i ppf "Texp_ifthenelse\n";

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -584,8 +584,8 @@ let rec expression : Typedtree.expression -> term_judg =
         join [expression e; list arg args] << app_mode
     | Texp_tuple exprs ->
       list expression exprs << Guard
-    | Texp_array exprs ->
-      let array_mode = match Typeopt.array_kind exp with
+    | Texp_array (kind, exprs) ->
+      let array_mode = match Typeopt.array_expression_kind kind exp with
         | Lambda.Pfloatarray ->
             (* (flat) float arrays unbox their elements *)
             Dereference

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -167,7 +167,7 @@ let pat
   | Tpat_construct (_, _, l) -> List.iter (sub.pat sub) l
   | Tpat_variant (_, po, _) -> Option.iter (sub.pat sub) po
   | Tpat_record (l, _) -> List.iter (fun (_, _, i) -> sub.pat sub i) l
-  | Tpat_array l -> List.iter (sub.pat sub) l
+  | Tpat_array (_, l) -> List.iter (sub.pat sub) l
   | Tpat_alias (p, _, _) -> sub.pat sub p
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)
@@ -217,7 +217,7 @@ let expr sub {exp_extra; exp_desc; exp_env; _} =
   | Texp_setfield (exp1, _, _, exp2) ->
       sub.expr sub exp1;
       sub.expr sub exp2
-  | Texp_array list -> List.iter (sub.expr sub) list
+  | Texp_array (_, list) -> List.iter (sub.expr sub) list
   | Texp_ifthenelse (exp1, exp2, expo) ->
       sub.expr sub exp1;
       sub.expr sub exp2;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -217,7 +217,7 @@ let pat
         Tpat_variant (l, Option.map (sub.pat sub) po, rd)
     | Tpat_record (l, closed) ->
         Tpat_record (List.map (tuple3 id id (sub.pat sub)) l, closed)
-    | Tpat_array l -> Tpat_array (List.map (sub.pat sub) l)
+    | Tpat_array (k, l) -> Tpat_array (k, List.map (sub.pat sub) l)
     | Tpat_alias (p, id, s) -> Tpat_alias (sub.pat sub p, id, s)
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->
@@ -292,8 +292,8 @@ let expr sub x =
           ld,
           sub.expr sub exp2
         )
-    | Texp_array list ->
-        Texp_array (List.map (sub.expr sub) list)
+    | Texp_array (k, list) ->
+        Texp_array (k, List.map (sub.expr sub) list)
     | Texp_ifthenelse (exp1, exp2, expo) ->
         Texp_ifthenelse (
           sub.expr sub exp1,

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -70,7 +70,7 @@ and 'k pattern_desc =
       (Longident.t loc * label_description * value general_pattern) list *
         closed_flag ->
       value pattern_desc
-  | Tpat_array : value general_pattern list -> value pattern_desc
+  | Tpat_array : array_kind * value general_pattern list -> value pattern_desc
   | Tpat_lazy : value general_pattern -> value pattern_desc
   (* computation patterns *)
   | Tpat_value : tpat_value_argument -> computation pattern_desc
@@ -118,7 +118,7 @@ and expression_desc =
   | Texp_field of expression * Longident.t loc * label_description
   | Texp_setfield of
       expression * Longident.t loc * label_description * expression
-  | Texp_array of expression list
+  | Texp_array of array_kind * expression list
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * expression
   | Texp_while of expression * expression
@@ -665,7 +665,7 @@ let shallow_iter_pattern_desc
   | Tpat_variant(_, pat, _) -> Option.iter f.f pat
   | Tpat_record (lbl_pat_list, _) ->
       List.iter (fun (_, _, pat) -> f.f pat) lbl_pat_list
-  | Tpat_array patl -> List.iter f.f patl
+  | Tpat_array (_, patl) -> List.iter f.f patl
   | Tpat_lazy p -> f.f p
   | Tpat_any
   | Tpat_var _
@@ -687,8 +687,8 @@ let shallow_map_pattern_desc
       Tpat_record (List.map (fun (lid, l,p) -> lid, l, f.f p) lpats, closed)
   | Tpat_construct (lid, c,pats) ->
       Tpat_construct (lid, c, List.map f.f pats)
-  | Tpat_array pats ->
-      Tpat_array (List.map f.f pats)
+  | Tpat_array (kind, pats) ->
+      Tpat_array (kind, List.map f.f pats)
   | Tpat_lazy p1 -> Tpat_lazy (f.f p1)
   | Tpat_variant (x1, Some p1, x2) ->
       Tpat_variant (x1, Some (f.f p1), x2)

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -18,6 +18,8 @@
 open Asttypes
 open Types
 
+type array_kind = Floatarray | Genarray
+
 (* Value expressions for the core language *)
 
 type partial = Partial | Total

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -114,7 +114,7 @@ and 'k pattern_desc =
 
             Invariant: n > 0
          *)
-  | Tpat_array : value general_pattern list -> value pattern_desc
+  | Tpat_array : array_kind * value general_pattern list -> value pattern_desc
         (** [| P1; ...; Pn |] *)
   | Tpat_lazy : value general_pattern -> value pattern_desc
         (** lazy P *)
@@ -246,7 +246,7 @@ and expression_desc =
   | Texp_field of expression * Longident.t loc * Types.label_description
   | Texp_setfield of
       expression * Longident.t loc * Types.label_description * expression
-  | Texp_array of expression list
+  | Texp_array of array_kind * expression list
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * expression
   | Texp_while of expression * expression

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -23,6 +23,8 @@
 
 open Asttypes
 
+type array_kind = Floatarray | Genarray
+
 (* Value expressions for the core language *)
 
 type partial = Partial | Total

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -115,9 +115,19 @@ let array_type_kind env ty =
       (* This can happen with e.g. Obj.field *)
       Pgenarray
 
-let array_kind exp = array_type_kind exp.exp_env exp.exp_type
+let array_expression_kind kind exp =
+  match kind with
+  | Floatarray ->
+      Pfloatarray
+  | Genarray ->
+      array_type_kind exp.exp_env exp.exp_type
 
-let array_pattern_kind pat = array_type_kind pat.pat_env pat.pat_type
+let array_pattern_kind kind pat =
+  match kind with
+  | Floatarray ->
+      Pfloatarray
+  | Genarray ->
+      array_type_kind pat.pat_env pat.pat_type
 
 let bigarray_decode_type env ty tbl dfl =
   match scrape env ty with

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -24,8 +24,8 @@ val maybe_pointer_type : Env.t -> Types.type_expr
 val maybe_pointer : Typedtree.expression -> Lambda.immediate_or_pointer
 
 val array_type_kind : Env.t -> Types.type_expr -> Lambda.array_kind
-val array_kind : Typedtree.expression -> Lambda.array_kind
-val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
+val array_expression_kind : Typedtree.array_kind -> Typedtree.expression -> Lambda.array_kind
+val array_pattern_kind : Typedtree.array_kind -> Typedtree.pattern -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -345,7 +345,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | Tpat_record (list, closed) ->
         Ppat_record (List.map (fun (lid, _, pat) ->
             map_loc sub lid, sub.pat sub pat) list, closed)
-    | Tpat_array list -> Ppat_array (List.map (sub.pat sub) list)
+    | Tpat_array (_, list) -> Ppat_array (List.map (sub.pat sub) list)
     | Tpat_lazy p -> Ppat_lazy (sub.pat sub p)
 
     | Tpat_exception p -> Ppat_exception (sub.pat sub p)
@@ -447,7 +447,7 @@ let expression sub exp =
     | Texp_setfield (exp1, lid, _label, exp2) ->
         Pexp_setfield (sub.expr sub exp1, map_loc sub lid,
           sub.expr sub exp2)
-    | Texp_array list ->
+    | Texp_array (_, list) ->
         Pexp_array (List.map (sub.expr sub) list)
     | Texp_ifthenelse (exp1, exp2, expo) ->
         Pexp_ifthenelse (sub.expr sub exp1,

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -911,3 +911,9 @@ let help_warnings () =
   done;
   exit 0
 ;;
+
+let without_warning n f =
+  let active = !current.active.(n) in
+  !current.active.(n) <- false;
+  Fun.protect ~finally:(fun () -> !current.active.(n) <- active) f
+;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -139,3 +139,5 @@ val restore: state -> unit
 val mk_lazy: (unit -> 'a) -> 'a Lazy.t
     (** Like [Lazy.of_fun], but the function is applied with
         the warning/alert settings at the time [mk_lazy] is called. *)
+
+val without_warning: int -> (unit -> 'a) -> 'a


### PR DESCRIPTION
This PR proposes to overload array expressions `[| e1; e2; ...; eN |]` and the corresponding patterns so that they can be used for both `float array` and `floatarray`. The overloading is decided based on the "expected type" (coming from the context of the expression or pattern), which means that in certain situation an explicit annotation `(... : floatarray)` may be needed to force the disambiguation.

A few examples are included to see the effect.

Opinions/suggestions welcome!