### PR TITLE
Fix #7813 (major GC fails to start)

### DIFF
--- a/Changes
+++ b/Changes
@@ -543,6 +543,9 @@ OCaml 4.12.0
 - #7538, #9669: Check for misplaced attributes on module aliases
   (Leo White, report by Thomas Leonard, review by Florian Angeletti)
 
+- #7813, #9955: make sure the major GC cycle doesn't get stuck in Idle state
+  (Damien Doligez, report by Anders Fugmann, review by Jacques-Henri Jourdan)
+
 - #7902, #9556: Type-checker infers recursive type, even though -rectypes is
   off.
   (Jacques Garrigue, report by Francois Pottier, review by Leo White)

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -603,10 +603,21 @@ cleanup:
 
 CAMLprim value caml_gc_major_slice (value v)
 {
+  value exn = Val_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR_SLICE);
   CAMLassert (Is_long (v));
-  caml_major_collection_slice (Long_val (v));
+  if (caml_gc_phase == Phase_idle){
+    /* We need to start a new major GC cycle. Go through the pending_action
+       machinery. */
+    caml_request_major_slice ();
+    exn = caml_process_pending_actions_exn ();
+      /* Calls the major GC without passing [v] but the initial slice
+         ignores this parameter anyway. */
+  }else{
+    caml_major_collection_slice (Long_val (v));
+  }
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR_SLICE);
+  caml_raise_if_exception (exn);
   return Val_long (0);
 }
 

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -469,6 +469,7 @@ void caml_gc_dispatch (void)
     /* The minor heap is full, we must do a minor collection. */
     Caml_state->requested_minor_gc = 1;
   }else{
+    /* The minor heap is half-full, do a major GC slice. */
     Caml_state->requested_major_slice = 1;
   }
   if (caml_gc_phase == Phase_idle){


### PR DESCRIPTION
The problem in #7813 is that the major GC stays in `Phase_idle` because we do a major slice without first emptying the minor heap.

There are two commits in this fix:
1. change `caml_gc_dispatch` to make sure it always starts the major GC cycle if needed
2. make `caml_gc_major_slice` call `caml_gc_dispatch` (through `caml_do_pending_actions_exn`) if the major GC needs to start a new cycle.

fixes #7813
