### PR TITLE
Refactor: Remove Ctype.enforce_constraints

### DIFF
--- a/testsuite/tests/typing-gadts/gadthead.ml
+++ b/testsuite/tests/typing-gadts/gadthead.ml
@@ -1,0 +1,30 @@
+(* TEST
+   * expect
+*)
+
+module M : sig
+  type t
+  val x : t
+  val print : t -> unit
+end = struct
+  type t = string
+  let x = "hello"
+  let print = print_endline
+end
+
+type _ g = I : int g
+[%%expect{|
+module M : sig type t val x : t val print : t -> unit end
+type _ g = I : int g
+|}]
+
+let g (x : M.t) =
+  match x with I -> M.print I
+let () = g M.x
+[%%expect{|
+Line 2, characters 15-16:
+2 |   match x with I -> M.print I
+                   ^
+Error: This pattern matches values of type 'a g
+       but a pattern was expected which matches values of type M.t
+|}]

--- a/testsuite/tests/typing-gadts/pr6980.ml
+++ b/testsuite/tests/typing-gadts/pr6980.ml
@@ -17,7 +17,7 @@ let g (Aux(Second, f)) = f it;;
 [%%expect{|
 type 'a t = 'a constraint 'a = [< `Bar | `Foo ]
 type 'a s = 'a constraint 'a = [< `Bar | `Baz | `Foo > `Bar ]
-type 'a first = First : 'b t second -> ([< `Bar | `Foo ] as 'b) t first
+type 'a first = First : 'a t second -> ([< `Bar | `Foo ] as 'a) t first
 and 'a second = Second : [< `Bar | `Baz | `Foo > `Bar ] s second
 type aux = Aux : ([< `Bar | `Foo ] as 'a) t second * ('a -> int) -> aux
 val it : [< `Bar | `Foo > `Bar ] = `Bar
@@ -26,6 +26,6 @@ Line 11, characters 27-29:
                                 ^^
 Error: This expression has type [< `Bar | `Foo > `Bar ]
        but an expression was expected of type [< `Bar | `Foo ]
-       The second variant type is bound to $Aux,
+       The second variant type is bound to $Aux_'a,
        it may not allow the tag(s) `Bar
 |}];;

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -362,7 +362,7 @@ val foo : int foo -> int = <fun>
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and int as equal.
 But the knowledge of these types is not principal.
 val foo : int foo -> int = <fun>
 |}]
@@ -404,7 +404,7 @@ val foo : string foo -> string = <fun>
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18 [not-principal]: typing this pattern requires considering M.t and N.t as equal.
+Warning 18 [not-principal]: typing this pattern requires considering M.t and string as equal.
 But the knowledge of these types is not principal.
 val foo : string foo -> string = <fun>
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -404,7 +404,7 @@ end;;
 Line 5, characters 6-9:
 5 |       Foo -> 5
           ^^^
-Error: This pattern matches values of type 'a t
+Error: This pattern matches values of type int t
        but a pattern was expected which matches values of type int
 |}];;
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -404,7 +404,7 @@ end;;
 Line 5, characters 6-9:
 5 |       Foo -> 5
           ^^^
-Error: This pattern matches values of type int t
+Error: This pattern matches values of type 'a t
        but a pattern was expected which matches values of type int
 |}];;
 

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -143,8 +143,8 @@ let () = print_endline (match PR6505b.x with `Bar s -> s);; (* fails *)
 module PR6505b :
   sig
     type 'o is_an_object = 'o constraint 'o = [>  ]
-    type ('a, 'b) abs = 'b constraint 'a = 'b is_an_object
-      constraint 'b = [>  ]
+    type ('a, 'o) abs = 'o constraint 'a = 'o is_an_object
+      constraint 'o = [>  ]
     val x : (([> `Foo of int ] as 'a) is_an_object, 'a is_an_object) abs
   end
 Line 6, characters 23-57:

--- a/testsuite/tests/typing-misc/pr7937.ml
+++ b/testsuite/tests/typing-misc/pr7937.ml
@@ -19,7 +19,7 @@ Line 3, characters 35-39:
 3 | let f: 'a. 'a r -> 'a r = fun x -> true;;
                                        ^^^^
 Error: This expression has type bool but an expression was expected of type
-         ([< `X of 'b & 'a & 'c & 'd & 'e ] as 'a) r
+         ([< `X of 'b & 'a & 'c ] as 'a) r
        Types for tag `X are incompatible
 |}]
 
@@ -37,7 +37,7 @@ Line 1, characters 35-51:
                                        ^^^^^^^^^^^^^^^^
 Error: This expression has type int ref
        but an expression was expected of type
-         ([< `X of 'b & 'a & 'c & 'd & 'e ] as 'a) r
+         ([< `X of 'b & 'a & 'c ] as 'a) r
        Types for tag `X are incompatible
 |}]
 
@@ -49,7 +49,6 @@ Line 1, characters 32-36:
 Error: This pattern matches values of type bool
        but a pattern was expected which matches values of type
          ([< `X of int & 'a ] as 'a) r
-       Types for tag `X are incompatible
 |}]
 
 
@@ -61,5 +60,4 @@ Line 1, characters 32-48:
 Error: This pattern matches values of type int ref
        but a pattern was expected which matches values of type
          ([< `X of int & 'a ] as 'a) r
-       Types for tag `X are incompatible
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1743,21 +1743,6 @@ let expand_head_opt env ty =
     Btype.backtrack snap;
     repr ty
 
-(* Make sure that the type parameters of the type constructor [ty]
-   respect the type constraints *)
-let enforce_constraints env ty =
-  match ty with
-    {desc = Tconstr (path, args, _abbrev); level = level} ->
-      begin try
-        let decl = Env.find_type path env in
-        ignore
-          (subst env level Public (ref Mnil) None decl.type_params args
-             (newvar2 level))
-      with Not_found -> ()
-      end
-  | _ ->
-      assert false
-
 (* Recursively expand the head of a type.
    Also expand #-types. *)
 let full_expand ~may_forget_scope env ty =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -255,8 +255,6 @@ val extract_concrete_typedecl:
            type declaration found expanding it.
            Raise [Not_found] if none appears or not a type constructor. *)
 
-val enforce_constraints: Env.t -> type_expr -> unit
-
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -352,14 +352,13 @@ let unify_pat ?refine env pat expected_ty =
 
 (* unification of a type with a Tconstr with freshly created arguments *)
 let unify_head_only ~refine loc env ty constr =
-  let ty_res = instance constr.cstr_res in
-  let ty_res = repr ty_res in
-  match ty_res.desc with
-  | Tconstr(p,args,m) ->
-      set_type_desc ty_res (Tconstr(p,List.map (fun _ -> newvar ()) args,m));
-      enforce_constraints !env ty_res;
-      unify_pat_types ~refine loc env ty_res ty
-  | _ -> assert false
+  let path =
+    match (repr constr.cstr_res).desc with
+    | Tconstr(p, _, _) -> p
+    | _ -> assert false in
+  let decl = Env.find_type path !env in
+  let ty' = Ctype.newconstr path (Ctype.instance_list decl.type_params) in
+  unify_pat_types ~refine loc env ty' ty
 
 (* Creating new conjunctive types is not allowed when typing patterns *)
 (* make all Reither present in open variants *)

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -241,11 +241,6 @@ and transl_type_aux env policy styp =
         (List.combine stl args) params;
       let constr =
         newconstr path (List.map (fun ctyp -> ctyp.ctyp_type) args) in
-      begin try
-        Ctype.enforce_constraints env constr
-      with Unify trace ->
-        raise (Error(styp.ptyp_loc, env, Type_mismatch trace))
-      end;
       ctyp (Ttyp_constr (path, lid, args)) constr
   | Ptyp_object (fields, o) ->
       let ty, fields = transl_fields env policy o fields in


### PR DESCRIPTION
In the presence of constraints, not all type expressions are well-formed. For instance, given:
```ocaml
type 'a t = ('b * 'c) constraint 'a = 'c * 'b
```

the types `int t` and `'a t` are both ill-formed. Currently, there are two ways to ensure that type expressions are well-formed:

  1. Construct types by instantiating `decl.type_params`, which always yields well-formed types. In the case of constraints, `type_params` will not consist solely of variables. For instance, the first parameter in the type above will be `'c * 'b`, not `'a`.

  2. Construct possibly-ill-formed types by directly calling `Ctype.newconstr`, and then fix them by calling `Ctype.enforce_constraints`, which instantiates `decl.type_params` and unifies.

This patch replaces the three occurrences of (2) with (1) in separate commits, and then deletes Ctype.enforce_constraints. The occurrences are:

  1.  `Typetexp.transl_type_aux`: This uses (1) to construct a well-formed type, and then (2) to redundantly check that it is well-formed. I don't think the call to `Ctype.enforce_constraints` here can ever fail (and it never does in the testsuite). The use of (1) was introduced in https://github.com/ocaml/ocaml/commit/51fc697ee to fix #8030. I believe this made the following call to `enforce_constraints` redundant, but it was never removed.

       Removing the extra unification changes a couple of error messages on ill-typed programs in the testsuite. I think the changes are either neutral or improvements, see the commit for details.

  2. `Typedecl.check_constraints_rec` contains a nontrivial use of `enforce_constraints`. A recursive type is first checked in a dummy environment, and then re-checked in the real environment. If another member of the same recursive group introduces new constraints, these must be verified.

      This is changed from style (2) to style (1), which seems slightly simpler. There are tests in the testsuite that hit this case, which are unaffected by the change.

  3. `Typecore.type_pat_aux` contains an explicit check in style (2) that GADT patterns are matched against a type satisfying the constraints of that type. However, this check appears to be redundant with the later checks that instantiate the type in style (1).

      Removing this extra check improves an error message in the test suite: a GADT constructor `Foo : int t` is now reported as matching `int t` rather than `'a t`