### PR TITLE
Unix.setsid: guard against errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -275,6 +275,9 @@ Working version
   (Ivan Gotovchits and Xavier Leroy, review by Sébastien Hinderer and
    David Allsopp)
 
+- #9958: Raise exception in case of error in Unix.setsid.
+  (Nicolás Ojeda Bär, review by Stephen Dolan)
+
 ### Tools:
 
 - #9551: ocamlobjinfo is now able to display information on .cmxs shared

--- a/otherlibs/unix/setsid.c
+++ b/otherlibs/unix/setsid.c
@@ -23,7 +23,9 @@
 CAMLprim value unix_setsid(value unit)
 {
 #ifdef HAS_SETSID
-  return Val_int(setsid());
+  pid_t pid = setsid();
+  if (pid == (pid_t)(-1)) uerror("setsid", Nothing);
+  return Val_long(pid);
 #else
   caml_invalid_argument("setsid not implemented");
   return Val_unit;


### PR DESCRIPTION
What it says on the tin.