### PR TITLE
stdlib: add List.intersperse and List.intercalate

### DIFF
--- a/Changes
+++ b/Changes
@@ -176,6 +176,10 @@ Working version
 - #10389, #10391, #10392: Add {Int,Int32,Int64,Nativeint}.{min,max}.
   (Nicolás Ojeda Bär and Alain Frisch, review by Xavier Leroy)
 
+- #9962: Add List.{intercalate,intersperse}.
+  (Craig Ferguson, review by Damien Doligez, Daniel Bünzli,
+  Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 - #10047: Add `Unix.realpath`

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -87,6 +87,21 @@ let rec flatten = function
 
 let concat = flatten
 
+let intersperse sep =
+  let rec inner acc = function
+    | ([] | [ _ ]) as l -> rev_append acc l
+    | x :: (_ :: _ as xs) -> inner (sep :: x :: acc) xs
+  in
+  inner []
+
+let intercalate sep =
+  let rec inner acc = function
+    | [] | [[]] -> rev acc
+    | [] :: (_ :: _ as ys) -> inner (rev_append sep acc) ys
+    | (x :: xs) :: ys -> inner (x :: acc) (xs :: ys)
+  in
+  inner []
+
 let rec map f = function
     [] -> []
   | a::l -> let r = f a in r :: map f l

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -120,6 +120,21 @@ val flatten : 'a list list -> 'a list
    (length of the argument + length of the longest sub-list).
  *)
 
+val intersperse : 'a -> 'a list -> 'a list
+(** [intersperse sep l] is the list formed by inserting [sep] between
+    adjacent elements of [l].
+
+    For example, [intersperse 0 \[1; 2; 3\]] is [\[1; 0; 2; 0; 3\]].
+    @since 4.13.0
+ *)
+
+val intercalate : 'a list -> 'a list list -> 'a list
+(** [intercalate sep l] is the list formed by inserting the list [sep]
+    between adjacent lists in [l] and then concatenating the result.
+    It is equivalent to [intersperse sep l |> concat].
+
+    @since 4.13.0
+  *)
 
 (** {1 Comparison} *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -120,6 +120,21 @@ val flatten : 'a list list -> 'a list
    (length of the argument + length of the longest sub-list).
  *)
 
+val intersperse : sep:'a -> 'a list -> 'a list
+(** [intersperse ~sep l] is the list formed by inserting [sep] between
+    adjacent elements of [l].
+
+    For example, [intersperse 0 \[1; 2; 3\]] is [\[1; 0; 2; 0; 3\]].
+    @since 4.13.0
+ *)
+
+val intercalate : sep:'a list -> 'a list list -> 'a list
+(** [intercalate ~sep l] is the list formed by inserting the list [sep]
+    between adjacent lists in [l] and then concatenating the result.
+    It is equivalent to [intersperse ~sep l |> concat].
+
+    @since 4.13.0
+  *)
 
 (** {1 Comparison} *)
 

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.byte.reference
@@ -6,7 +6,7 @@ Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 137, characters 16-25
 Re-raised at Dynlink.Bytecode.run in file "otherlibs/dynlink/dynlink.ml", line 139, characters 6-137
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
 Called from Test10_main in file "test10_main.ml", line 51, characters 13-69

--- a/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
+++ b/testsuite/tests/lib-dynlink-initializers/test10_main.native.reference
@@ -5,9 +5,9 @@ Called from Test10_plugin in file "test10_plugin.ml", line 10, characters 2-6
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Called from Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 85, characters 12-29
 Re-raised at Dynlink.Native.run.(fun) in file "otherlibs/dynlink/native/dynlink.ml", line 87, characters 10-149
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Dynlink_common.Make.load.(fun) in file "otherlibs/dynlink/dynlink_common.ml", line 337, characters 13-44
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 335, characters 8-240
 Re-raised at Dynlink_common.Make.load in file "otherlibs/dynlink/dynlink_common.ml", line 345, characters 8-17
 Called from Dynlink_common.Make.loadfile in file "otherlibs/dynlink/dynlink_common.ml" (inlined), line 347, characters 26-45

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -92,6 +92,19 @@ let () =
   assert (
     let f a b = a + b, string_of_int b in
     List.fold_left_map f 0 l = (45, sl));
+
+  assert (List.intersperse 0 [] = []);
+  assert (List.intersperse 0 [1] = [1]);
+  assert (List.intersperse 0 [1; 2; 3] = [1; 0; 2; 0; 3]);
+  assert (List.intersperse 0 [1; 2; 3; 4] = [1; 0; 2; 0; 3; 0; 4]);
+
+  assert (List.intercalate [10] [] = []);
+  assert (List.intercalate [10] [[1; 2]] = [1; 2]);
+  assert (List.intercalate [10] [[1; 2]; [3; 4]; [5; 6]]
+          = [1; 2; 10; 3; 4; 10; 5; 6]);
+  assert (List.intercalate [10; 20] [[1; 2]; [3; 4]; [5; 6]]
+          = [1; 2; 10; 20; 3; 4; 10; 20; 5; 6]);
+
   ()
 ;;
 

--- a/testsuite/tests/statmemprof/callstacks.flat-float-array.reference
+++ b/testsuite/tests/statmemprof/callstacks.flat-float-array.reference
@@ -1,74 +1,74 @@
 -----------
 Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 18, characters 30-53
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 21, characters 30-76
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 26, characters 12-66
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 29, characters 30-60
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 32, characters 30-55
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 36, characters 12-62
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 39, characters 22-27
 Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 41, characters 30-65
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 44, characters 30-69
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 47, characters 30-73
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 51, characters 30-43
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.get0 in file "callstacks.ml", line 54, characters 28-33
 Called from Callstacks.getfloatfield in file "callstacks.ml", line 56, characters 30-47
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 61, characters 9-35
 Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 62, characters 12-87
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 65, characters 30-59
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
 -----------
 Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 68, characters 37-43
 Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 70, characters 30-49
 Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Callstacks in file "callstacks.ml", line 99, characters 2-27

--- a/testsuite/tests/statmemprof/comballoc.byte.reference
+++ b/testsuite/tests/statmemprof/comballoc.byte.reference
@@ -1,49 +1,49 @@
 2: 0.42 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 2-19
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 3: 0.42 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 6-18
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 4: 0.42 true
 Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 11, characters 11-20
 Called from Comballoc.f in file "comballoc.ml", line 14, characters 13-17
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 2: 0.01 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 2-19
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 3: 0.01 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 6-18
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 4: 0.01 true
 Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 11, characters 11-20
 Called from Comballoc.f in file "comballoc.ml", line 14, characters 13-17
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 2: 0.83 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 2-19
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 3: 0.83 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 6-18
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 4: 0.83 true
 Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 11, characters 11-20
 Called from Comballoc.f in file "comballoc.ml", line 14, characters 13-17
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 OK

--- a/testsuite/tests/statmemprof/comballoc.opt.reference
+++ b/testsuite/tests/statmemprof/comballoc.opt.reference
@@ -1,49 +1,49 @@
 2: 0.42 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 2-19
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 3: 0.42 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 6-18
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 4: 0.42 true
 Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 11, characters 11-20
 Called from Comballoc.f in file "comballoc.ml", line 14, characters 13-17
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 2: 0.01 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 2-19
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 3: 0.01 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 6-18
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 4: 0.01 true
 Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 11, characters 11-20
 Called from Comballoc.f in file "comballoc.ml", line 14, characters 13-17
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 2: 0.83 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 2-19
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 3: 0.83 false
 Raised by primitive operation at Comballoc.f in file "comballoc.ml", line 14, characters 6-18
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 4: 0.83 true
 Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 11, characters 11-20
 Called from Comballoc.f in file "comballoc.ml", line 14, characters 13-17
 Called from Comballoc.test in file "comballoc.ml", line 39, characters 25-48
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 125, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 69, characters 2-35
 OK

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -152,7 +152,7 @@
               (function f param (apply f (field 0 param) (field 1 param)))
             map =
               (function f l
-                (apply (field 18 (global Stdlib__List!)) (apply uncurry f) l)))
+                (apply (field 20 (global Stdlib__List!)) (apply uncurry f) l)))
            (makeblock 0
              (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
              (apply map
@@ -190,7 +190,7 @@
                     (apply f (field 0 param) (field 1 param)))
                 map =
                   (function f l
-                    (apply (field 18 (global Stdlib__List!))
+                    (apply (field 20 (global Stdlib__List!))
                       (apply uncurry f) l)))
                (makeblock 0
                  (makeblock 0 (apply map eta_gen_cmp vec)


### PR DESCRIPTION
Adds a new function – `List.intersperse : 'a -> 'a list -> 'a list` – to the standard library. This transforms a list `l` by adding a separating element between each adjacent pair of elements in `l`. For example:

```ocaml
# List.intersperse 0 [1; 2; 3] ;;
- : int list = [1; 0; 2; 0; 3]

# List.intersperse 0 [] ;;
- : int list = []
```

I re-define this function reasonably often, and it's slightly annoying to do so due to the asymmetry of the empty list case. Example use-cases I've had in the past:

- adding comma / tab separators to a list representing `.csv` / `.tsv` fields;
- adding yield points to a list of computations;
- adding "spacing" elements to a DSL term (for file separators, break hints, etc.).

Notes:

- Other standard libraries that include this function: [Jane Street base](https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/List/index.html#val-intersperse), [Haskell base](https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-List.html#v:intersperse) and [Elm core](https://package.elm-lang.org/packages/elm/core/latest/List#intersperse).

- If `intersperse` is deemed useful, I think there's a strong argument for (at least) `Seq.intersperse` as well. I'm happy to add that to this PR.