### PR TITLE
Update HACKING.adoc

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -17,7 +17,11 @@ git checkout -b my-modification
 ----
 Usually, this branch wants to be based on `trunk`. If your changes must be on a
 specific release, use its release branch (*not* the release tag) instead. For
-example, to make a fix for 4.11.1, base your branch on 4.11 (not on 4.11.1).
+example, to make a fix for 4.11.1, base your branch on 4.11 (not on 4.11.1). The
+`configure` step for the compiler recognises a development build from the `+dev`
+in the version number, and release tarballs and the tagged Git commits do not
+have this which causes some important development things to be disabled
+(ocamltest and converting C compiler warnings to errors).
 
 2. Consult link:INSTALL.adoc[] for build instructions. Here is the gist of it:
 +

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -17,10 +17,10 @@ git checkout -b my-modification
 ----
 Usually, this branch wants to be based on `trunk`. If your changes must be on a
 specific release, use its release branch (*not* the release tag) instead. For
-example, to make a fix for 4.11.1, base your branch on 4.11 (not on 4.11.1). The
-`configure` step for the compiler recognises a development build from the `+dev`
-in the version number, and release tarballs and the tagged Git commits do not
-have this which causes some important development things to be disabled
+example, to make a fix for 4.11.1, base your branch on *4.11* (not on *4.11.1*).
+The `configure` step for the compiler recognises a development build from the
+`+dev` in the version number, and release tarballs and the tagged Git commits do
+not have this which causes some important development things to be disabled
 (ocamltest and converting C compiler warnings to errors).
 
 2. Consult link:INSTALL.adoc[] for build instructions. Here is the gist of it:
@@ -29,6 +29,9 @@ have this which causes some important development things to be disabled
 ./configure
 make
 ----
+If you are on a release build and need development options, you can add
+`--enable-ocamltest` (to allow running the testsuite) and `--enable-warn-error`
+(so you don't get caught by CI later!).
 
 3. Try the newly built compiler binaries `ocamlc`, `ocamlopt` or their
 `.opt` version. To try the toplevel, use:

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -19,7 +19,7 @@ Usually, this branch wants to be based on `trunk`. If your changes must be on a
 specific release, use its release branch (*not* the release tag) instead. For
 example, to make a fix for 4.11.1, base your branch on *4.11* (not on *4.11.1*).
 The `configure` step for the compiler recognises a development build from the
-`+dev` in the version number, and release tarballs and the tagged Git commits do
+`+dev` in the version number (see file `VERSION`), and release tarballs and the tagged Git commits do
 not have this which causes some important development things to be disabled
 (ocamltest and converting C compiler warnings to errors).
 
@@ -170,7 +170,7 @@ has excellent documentation.
   Makefile.tools::        used by manual/ and testsuite/ Makefiles
   README.adoc::           general information on the compiler distribution
   README.win32.adoc::     general information on the Windows ports of OCaml
-  VERSION::               version string
+  VERSION::               version string. Run `make configure` after changing.
   asmcomp/::              native-code compiler and linker
   boot/::                 bootstrap compiler
   build-aux/:             autotools support scripts

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -15,6 +15,9 @@ official distribution, please see link:CONTRIBUTING.md[].
 ----
 git checkout -b my-modification
 ----
+Usually, this branch wants to be based on `trunk`. If your changes must be on a
+specific release, use its release branch (*not* the release tag) instead. For
+example, to make a fix for 4.11.1, base your branch on 4.11 (not on 4.11.1).
 
 2. Consult link:INSTALL.adoc[] for build instructions. Here is the gist of it:
 +


### PR DESCRIPTION
#9250 turned off `ocamltest` specifically for the release tags (these are the only commits in the repository which do not include `+dev` in `VERSION`). #9935 improved the error message if, having checked out a release tag (or built from a release tarball), the testsuite was then run.

Given that this has stung a non-unitary number of people, this PR goes one step further and builds ocamltest, if necessary (regardless of whether `--disable-ocamltest` was given).

Additionally, given that building release tags also disabled C warnings being converted into errors (which wastes CI cycles later on), I've updated `HACKING.adoc` to include information on where to base topic branches.