### PR TITLE
Add (developer) ability to disable the use of the .opt compilers in the build

### DIFF
--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -25,6 +25,9 @@
 # native binary, if available. Note that they never use the boot/
 # versions: we assume that ocamlc, ocamlopt, etc. have been run first.
 
+# Set this to empty to force use of the bytecode compilers at all times
+USE_BEST_BINARIES ?= true
+
 check_not_stale = \
   $(if $(shell test $(ROOTDIR)/$1 -nt $(ROOTDIR)/$2 && echo stale), \
     $(info Warning: we are not using the native binary $2 \
@@ -34,7 +37,7 @@ or rebuilding it (or `touch`-ing it) if you want it used.), \
     ok)
 
 choose_best = $(strip $(if \
-   $(and $(wildcard $(ROOTDIR)/$1.opt$(EXE)),$(strip \
+   $(and $(USE_BEST_BINARIES),$(wildcard $(ROOTDIR)/$1.opt$(EXE)),$(strip \
       $(call check_not_stale,$1$(EXE),$1.opt$(EXE)))), \
     $(ROOTDIR)/$1.opt$(EXE), \
     $(CAMLRUN) $(ROOTDIR)/$1$(EXE)))
@@ -50,7 +53,7 @@ BEST_OCAMLLEX := $(call choose_best,lex/ocamllex)
 # bootrap-compiler and host-compiler object files, as ocamldep only
 # produces text output.
 BEST_OCAMLDEP := $(strip $(if \
-   $(and $(wildcard $(ROOTDIR)/ocamlc.opt$(EXE)),$(strip \
+   $(and $(USE_BEST_BINARIES),$(wildcard $(ROOTDIR)/ocamlc.opt$(EXE)),$(strip \
       $(call check_not_stale,boot/ocamlc,ocamlc.opt$(EXE)))), \
     $(ROOTDIR)/ocamlc.opt$(EXE) -depend, \
     $(BOOT_OCAMLC) -depend))


### PR DESCRIPTION
#8840 causes the build to switch to using `ocamlc.opt` and `ocamlopt.opt` as soon as they have been built, mercilessly shaving many seconds off builds.

99.9% of the time this is great, but if there's something wrong (as in #9916), it can be useful to turn this off and it's not instantly obvious how to do this in `Makefile.best_binaries`.

This PR adds a variable `ENABLE_BEST` which in this very advanced case can be added to the command line and disables the use of the .opt compilers (e.g. `make ENABLE_BEST= world.opt`).

I expect I'll use it one more time between now and either my or `make`'s eventual demise, and I'd prefer not to figure it out again...