### PR TITLE
Stdlib: Add take, drop, split_at, take_while and drop_while to the List module

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -261,6 +261,38 @@ let filter_map f =
   in
   aux []
 
+let take n l =
+  let rec aux i acc = function
+    | x::l when i < n -> aux (i + 1) (x::acc) l
+    | _rest -> rev acc
+  in
+  aux 0 [] l
+
+let drop n l =
+  let rec aux i = function
+    | _x::l when i < n -> aux (i + 1) l
+    | rest -> rest
+  in
+  aux 0 l
+
+let split_at n l =
+  let rec aux i acc = function
+    | x::l when i < n -> aux (i + 1) (x::acc) l
+    | rest -> (rev acc, rest)
+  in
+  aux 0 [] l
+
+let take_while p l =
+  let rec aux acc = function
+    | x::l when p x -> aux (x::acc) l
+    | _rest -> rev acc
+  in
+  aux [] l
+
+let rec drop_while p = function
+  | x::l when p x -> drop_while p l
+  | rest -> rest
+
 let concat_map f l =
   let rec aux f acc = function
     | [] -> rev acc

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -349,6 +349,39 @@ val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
    @since 4.11.0
 *)
 
+
+(** {1 List manipulation} *)
+
+
+val take : int -> 'a list -> 'a list
+(** [take n l] returns the prefix of [l] of length [n],
+    or [l] itself if [n > length l].
+    Negative values of [n] are treated as if [n = 0].
+*)
+
+val drop : int -> 'a list -> 'a list
+(** [drop n l] returns the suffix of [l] after [n] elements,
+    or [[]] if [n > length l].
+    Negative values of [n] are treated as if [n = 0].
+*)
+
+val split_at : int -> 'a list -> 'a list * 'a list
+(** [split_at i l] returns a pair of lists [(l1, l2)], where
+    [l1] is the prefix of [l] before the index [i], and
+    [l2] is the suffix of [l] on and after the index [i].
+    This function is morally equivalent to [(take i l, drop i l)].
+*)
+
+val take_while : ('a -> bool) -> 'a list -> 'a list
+(** [take_while p l] returns the prefix of [l] until the predicate [p]
+     is not satisfied anymore.
+*)
+
+val drop_while : ('a -> bool) -> 'a list -> 'a list
+(** [drop_while p l] return the suffix of [l] until the predicate [p]
+    is not satisfied anymore.
+*)
+
 val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -349,6 +349,39 @@ val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
    @since 4.11.0
 *)
 
+
+(** {1 List manipulation} *)
+
+
+val take : int -> 'a list -> 'a list
+(** [take n l] returns the prefix of [l] of length [n],
+    or [l] itself if [n > length l].
+    Negative values of [n] are treated as if [n = 0].
+*)
+
+val drop : int -> 'a list -> 'a list
+(** [drop n l] returns the suffix of [l] after [n] elements,
+    or [[]] if [n > length l].
+    Negative values of [n] are treated as if [n = 0].
+*)
+
+val split_at : int -> 'a list -> 'a list * 'a list
+(** [split_at i l] returns a pair of lists [(l1, l2)], where
+    [l1] is the prefix of [l] before the index [i], and
+    [l2] is the suffix of [l] on and after the index [i].
+    This function is morally equivalent to [(take i l, drop i l)].
+*)
+
+val take_while : ('a -> bool) -> 'a list -> 'a list
+(** [take_while p l] returns the prefix of [l] until the predicate [p]
+     is not satisfied anymore.
+*)
+
+val drop_while : ('a -> bool) -> 'a list -> 'a list
+(** [drop_while p l] return the suffix of [l] until the predicate [p]
+    is not satisfied anymore.
+*)
+
 val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition ~f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -62,6 +62,36 @@ let () =
 
   assert (List.filteri (fun i _ -> i < 2) (List.rev l) = [9; 8]);
 
+  let hello = ['H';'e';'l';'l';'o'] in
+  let world = ['W';'o';'r';'l';'d';'!'] in
+  let hello_world = hello @ [' '] @ world in
+  assert (List.take 5 hello_world = hello);
+  assert (List.take 3 [1; 2; 3; 4; 5] = [1; 2; 3]);
+  assert (List.take 3 [1; 2] = [1; 2]);
+  assert (List.take 3 [] = []);
+  assert (List.take (-1) [1; 2] = []);
+  assert (List.take 0 [1; 2] = []);
+  assert (List.drop 6 hello_world = world);
+  assert (List.drop 3 [1; 2; 3; 4; 5] = [4; 5]);
+  assert (List.drop 3 [1; 2] = []);
+  assert (List.drop 3 [] = []);
+  assert (List.drop (-1) [1; 2] = [1; 2]);
+  assert (List.drop 0 [1; 2] = [1; 2]);
+  assert (List.split_at 6 hello_world = (hello @ [' '], world));
+  assert (List.split_at 3 [1; 2; 3; 4; 5] = ([1; 2; 3], [4; 5]));
+  assert (List.split_at 1 [1; 2; 3] = ([1], [2; 3]));
+  assert (List.split_at 3 [1; 2; 3] = ([1; 2; 3], []));
+  assert (List.split_at 4 [1; 2; 3] = ([1; 2; 3], []));
+  assert (List.split_at 0 [1; 2; 3] = ([], [1; 2; 3]));
+  assert (List.split_at (-1) [1; 2; 3] = ([], [1; 2; 3]));
+  assert (List.take_while (fun x -> x < 3) [1; 2; 3; 4; 1; 2; 3; 4]
+          = [1; 2]);
+  assert (List.take_while (fun x -> x < 9) [1; 2; 3] = [1; 2; 3]);
+  assert (List.take_while (fun x -> x < 0) [1; 2; 3] = []);
+  assert (List.drop_while (fun x -> x < 3) [1; 2; 3; 4; 5; 1; 2; 3]
+          = [3; 4; 5; 1; 2; 3]);
+  assert (List.drop_while (fun x -> x < 9) [1; 2; 3] = []);
+  assert (List.drop_while (fun x -> x < 0) [1; 2; 3] = [1; 2; 3]);
   assert (List.partition is_even [1; 2; 3; 4; 5]
           = ([2; 4], [1; 3; 5]));
   assert (List.partition_map string_of_even_or_int [1; 2; 3; 4; 5]


### PR DESCRIPTION
I recently had the need for a `List.take` function and no such function was available in the standard library.
This isn't the first time I needed such functions and I feel like many other people had the need for some of those at some point.
I hope this PR is helpful for those people.

Credit for the function names, and more importantly the test cases, goes to Haskell's `Data.List` documentation: https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-List.html#g:11