### PR TITLE
Make sure the process can terminate when the last thread calls Thread.exit

### DIFF
--- a/Changes
+++ b/Changes
@@ -303,6 +303,11 @@ Working version
 - #9958: Raise exception in case of error in Unix.setsid.
   (Nicolás Ojeda Bär, review by Stephen Dolan)
 
+- #9971, #9973: Make sure the process can terminate when the last thread
+  calls Thread.exit.
+  (Xavier Leroy, report by Jacques-Henri Jourdan, review by David Allsopp
+  and Jacques-Henri Jourdan).
+
 ### Tools:
 
 - #9551: ocamlobjinfo is now able to display information on .cmxs shared

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -504,6 +504,9 @@ static void caml_thread_stop(void)
   caml_threadstatus_terminate(Terminated(curr_thread->descr));
   /* Remove th from the doubly-linked list of threads and free its info block */
   caml_thread_remove_info(curr_thread);
+  /* If no other OCaml thread remains, ask the tick thread to stop
+     so that it does not prevent the whole process from exiting (#9971) */
+  if (all_threads == NULL) caml_thread_cleanup(Val_unit);
   /* OS-specific cleanups */
   st_thread_cleanup();
   /* Release the runtime system */
@@ -637,6 +640,9 @@ CAMLexport int caml_c_thread_unregister(void)
   st_tls_set(thread_descriptor_key, NULL);
   /* Remove thread info block from list of threads, and free it */
   caml_thread_remove_info(th);
+  /* If no other OCaml thread remains, ask the tick thread to stop
+     so that it does not prevent the whole process from exiting (#9971) */
+  if (all_threads == NULL) caml_thread_cleanup(Val_unit);
   /* Release the runtime */
   st_masterlock_release(&caml_master_lock);
   return 1;

--- a/testsuite/tests/lib-threads/pr9971.ml
+++ b/testsuite/tests/lib-threads/pr9971.ml
@@ -1,0 +1,15 @@
+(* TEST
+
+* hassysthreads
+include systhreads
+** bytecode
+** native
+
+*)
+
+let t =
+  let t = Thread.create (fun _ -> ())() in
+  Thread.join t
+
+let () =
+  Thread.exit ()


### PR DESCRIPTION
To this end, the tick thread must be stopped, otherwise it prevents the whole process from exiting.

Fixes: #9971
