### PR TITLE
Move the examples of labeled functions to StdLabels

### DIFF
--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -23,8 +23,8 @@
 
 (** Array operations.
 
-    The labeled version of this module, {!ArrayLabels}, can be used
-    as described in the {!StdLabels} module.
+    The labeled version of this module can be used as described in the
+    {!StdLabels} module.
 *)
 
 type 'a t = 'a array

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -23,16 +23,9 @@
 
 (** Array operations.
 
-   The labeled version of this module, {!ArrayLabels}, is intended to be used
-   via {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and {!String}
-   with their labeled counterparts
-
-   For example:
-   {[
-      open StdLabels
-
-      let everything = Array.create_matrix ~dimx:42 ~dimy:42 42
-   ]} *)
+    The labeled version of this module, {!ArrayLabels}, can be used
+    as described in the {!StdLabels} module.
+*)
 
 type 'a t = 'a array
 (** An alias for the type of arrays. *)

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -23,8 +23,8 @@
 
 (** Array operations.
 
-    The labeled version of this module, {!ArrayLabels}, can be used
-    as described in the {!StdLabels} module.
+    The labeled version of this module can be used as described in the
+    {!StdLabels} module.
 *)
 
 type 'a t = 'a array

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -23,16 +23,9 @@
 
 (** Array operations.
 
-   The labeled version of this module, {!ArrayLabels}, is intended to be used
-   via {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and {!String}
-   with their labeled counterparts
-
-   For example:
-   {[
-      open StdLabels
-
-      let everything = Array.create_matrix ~dimx:42 ~dimy:42 42
-   ]} *)
+    The labeled version of this module, {!ArrayLabels}, can be used
+    as described in the {!StdLabels} module.
+*)
 
 type 'a t = 'a array
 (** An alias for the type of arrays. *)

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -47,16 +47,8 @@
 
    Bytes are represented by the OCaml type [char].
 
-   The labeled version of this module, {!BytesLabels}, is intended to be used
-   through {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and
-   {!String} with their labeled counterparts.
-
-   For example:
-   {[
-      open StdLabels
-
-      let first = Bytes.sub ~pos:0 ~len:1
-   ]}
+   The labeled version of this module, {!BytesLabels}, can be used
+   as described in the {!StdLabels} module.
 
    @since 4.02.0
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -47,8 +47,8 @@
 
    Bytes are represented by the OCaml type [char].
 
-   The labeled version of this module, {!BytesLabels}, can be used
-   as described in the {!StdLabels} module.
+   The labeled version of this module can be used as described in the
+   {!StdLabels} module.
 
    @since 4.02.0
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -47,16 +47,8 @@
 
    Bytes are represented by the OCaml type [char].
 
-   The labeled version of this module, {!BytesLabels}, is intended to be used
-   through {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and
-   {!String} with their labeled counterparts.
-
-   For example:
-   {[
-      open StdLabels
-
-      let first = Bytes.sub ~pos:0 ~len:1
-   ]}
+   The labeled version of this module, {!BytesLabels}, can be used
+   as described in the {!StdLabels} module.
 
    @since 4.02.0
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -47,8 +47,8 @@
 
    Bytes are represented by the OCaml type [char].
 
-   The labeled version of this module, {!BytesLabels}, can be used
-   as described in the {!StdLabels} module.
+   The labeled version of this module can be used as described in the
+   {!StdLabels} module.
 
    @since 4.02.0
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -33,16 +33,8 @@
    The above considerations can usually be ignored if your lists are not
    longer than about 10000 elements.
 
-   The labeled version of this module, {!ListLabels}, is intended to be used
-   through {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and
-   {!String} with their labeled counterparts.
-
-   For example:
-   {[
-      open StdLabels
-
-      let seq len = List.init ~f:(function i -> i) ~len
-   ]}
+   The labeled version of this module, {!ListLabels}, can be used
+   as described in the {!StdLabels} module.
  *)
 
 type 'a t = 'a list = [] | (::) of 'a * 'a list (**)

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -33,8 +33,8 @@
    The above considerations can usually be ignored if your lists are not
    longer than about 10000 elements.
 
-   The labeled version of this module, {!ListLabels}, can be used
-   as described in the {!StdLabels} module.
+   The labeled version of this module can be used as described in the
+   {!StdLabels} module.
  *)
 
 type 'a t = 'a list = [] | (::) of 'a * 'a list (**)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -33,16 +33,8 @@
    The above considerations can usually be ignored if your lists are not
    longer than about 10000 elements.
 
-   The labeled version of this module, {!ListLabels}, is intended to be used
-   through {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and
-   {!String} with their labeled counterparts.
-
-   For example:
-   {[
-      open StdLabels
-
-      let seq len = List.init ~f:(function i -> i) ~len
-   ]}
+   The labeled version of this module, {!ListLabels}, can be used
+   as described in the {!StdLabels} module.
  *)
 
 type 'a t = 'a list = [] | (::) of 'a * 'a list (**)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -33,8 +33,8 @@
    The above considerations can usually be ignored if your lists are not
    longer than about 10000 elements.
 
-   The labeled version of this module, {!ListLabels}, can be used
-   as described in the {!StdLabels} module.
+   The labeled version of this module can be used as described in the
+   {!StdLabels} module.
  *)
 
 type 'a t = 'a list = [] | (::) of 'a * 'a list (**)

--- a/stdlib/stdLabels.mli
+++ b/stdlib/stdLabels.mli
@@ -15,12 +15,21 @@
 
 (** Standard labeled libraries.
 
-   This meta-module provides labelized version of the {!Array},
-   {!Bytes}, {!List} and {!String} modules.
+   This meta-module provides versions of the {!Array}, {!Bytes},
+   {!List} and {!String} modules where function arguments are
+   systematically labeled.  It is intended to be opened at the top of
+   source files, as shown below.
 
-   They only differ by their labels. Detailed interfaces can be found
-   in [arrayLabels.mli], [bytesLabels.mli], [listLabels.mli]
-   and [stringLabels.mli].
+   {[
+     open StdLabels
+
+     let to_upper = String.map ~f:Char.uppercase_ascii
+     let seq len = List.init ~f:(function i -> i) ~len
+     let everything = Array.create_matrix ~dimx:42 ~dimy:42 42
+   ]}
+
+   Detailed interfaces documenting the function argument labels can be found
+   at {!ArrayLabels}, {!BytesLabels}, {!ListLabels} and {!StringLabels}.
 *)
 
 module Array = ArrayLabels

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -73,17 +73,9 @@ v}
     default until OCaml 4.05. Starting with 4.06, the compatibility
     mode is opt-in; we intend to remove the option in the future.
 
-
-  The labeled version of this module, {!StringLabels}, is intended to be used
-  through {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and
-  {!String} with their labeled counterparts
-
-  For example:
-  {[
-     open StdLabels
-
-     let to_upper = String.map ~f:Char.uppercase_ascii
-  ]} *)
+    The labeled version of this module, {!StringLabels}, can be used
+    as described in the {!StdLabels} module.
+*)
 
 (** {1:strings Strings} *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -73,8 +73,8 @@ v}
     default until OCaml 4.05. Starting with 4.06, the compatibility
     mode is opt-in; we intend to remove the option in the future.
 
-    The labeled version of this module, {!StringLabels}, can be used
-    as described in the {!StdLabels} module.
+    The labeled version of this module can be used as described in the
+    {!StdLabels} module.
 *)
 
 (** {1:strings Strings} *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -73,17 +73,9 @@ v}
     default until OCaml 4.05. Starting with 4.06, the compatibility
     mode is opt-in; we intend to remove the option in the future.
 
-
-  The labeled version of this module, {!StringLabels}, is intended to be used
-  through {!StdLabels} which replaces {!Array}, {!Bytes}, {!List} and
-  {!String} with their labeled counterparts
-
-  For example:
-  {[
-     open StdLabels
-
-     let to_upper = String.map ~f:Char.uppercase_ascii
-  ]} *)
+    The labeled version of this module, {!StringLabels}, can be used
+    as described in the {!StdLabels} module.
+*)
 
 (** {1:strings Strings} *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -73,8 +73,8 @@ v}
     default until OCaml 4.05. Starting with 4.06, the compatibility
     mode is opt-in; we intend to remove the option in the future.
 
-    The labeled version of this module, {!StringLabels}, can be used
-    as described in the {!StdLabels} module.
+    The labeled version of this module can be used as described in the
+    {!StdLabels} module.
 *)
 
 (** {1:strings Strings} *)


### PR DESCRIPTION
In the old days, the interfaces of the labeled modules (ArrayLabels, BytesLabels, ListLabels, StringLabels) started with short examples of labelings.

Now, the interfaces of the non-labeled modules (Array, Bytes, List, String) are automatically generated from the interfaces of the labeled modules.  As a side effect, the interfaces of Array, Bytes, List and String also start with short examples of labelings, which is somewhat strange.  (See the discussion starting at https://github.com/ocaml/ocaml/pull/9891#issuecomment-694292754 )

This commit reorganizes the documentation as follows:
- The documentation of the StdLabels module is expanded, and includes the examples of labeled functions previously scattered in  ArrayLabels, BytesLabels, ListLabels, StringLabels.
- Array, Bytes, List, String and their labeled counterparts briefly mention the labeled modules and point to StdLabels, but no longer contain examples.