### PR TITLE
Fix mergeable section flags.

### DIFF
--- a/Changes
+++ b/Changes
@@ -182,6 +182,10 @@ Working version
   that is rejected by the assembler.
   (Xavier Leroy, review by Stephen Dolan)
 
+- #9969, #9981: Added mergeable flag to ELF sections containing mergeable
+  constants.  Fixes compatibility with the integrated assembler in clang 11.0.0.
+  (Jacob Young, review by Nicolás Ojeda Bär)
+
 ### Standard library:
 
 - #9865: add Format.pp_print_seq

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -956,7 +956,7 @@ let begin_assembly() =
     | S_macosx -> D.section ["__TEXT";"__literal16"] None ["16byte_literals"]
     | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
     | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst8"] (Some "a") ["@progbits"]
+    | _ -> D.section [".rodata.cst16"] (Some "aM") ["@progbits";"16"]
     end;
     D.align 16;
     _label (emit_symbol "caml_negf_mask");
@@ -982,8 +982,9 @@ let end_assembly() =
     | S_macosx -> D.section ["__TEXT";"__literal8"] None ["8byte_literals"]
     | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
     | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst8"] (Some "a") ["@progbits"]
+    | _ -> D.section [".rodata.cst8"] (Some "aM") ["@progbits";"8"]
     end;
+    D.align 8;
     List.iter (fun (cst,lbl) -> emit_float_constant cst lbl) !float_constants
   end;
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -679,7 +679,7 @@ G(caml_system__frametable):
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)
         .section .rdata,"dr"
 #else
-        .section    .rodata.cst8,"a",@progbits
+        .section    .rodata.cst16,"aM",@progbits,16
 #endif
         .globl  G(caml_negf_mask)
         .align  SIXTEEN_ALIGN


### PR DESCRIPTION
Set the correct flags and entsize on the mergeable ELF sections to avoid an assembler error.  In particular, the `cst8` &rightarrow; `cst16` changes seem particularly important to avoid the 16 byte constants from being split and merged incorrectly.  If merging is not actually wanted, then they should be placed in the normal `.rodata` section instead.