### PR TITLE
Clarify docstring in Str module

### DIFF
--- a/otherlibs/str/str.mli
+++ b/otherlibs/str/str.mli
@@ -156,7 +156,8 @@ val matched_group : int -> string -> string
 (** [matched_group n s] returns the substring of [s] that was matched
    by the [n]th group [\(...\)] of the regular expression that was
    matched by the last call to a matching or searching function (see
-   {!Str.matched_string} for details).
+   {!Str.matched_string} for details). When [n] is [0], it returns the
+   substring matched by the whole regular expression.
    The user must make sure that the parameter [s] is the same string
    that was passed to the matching or searching function.
    @raise Not_found if the [n]th group


### PR DESCRIPTION
The documentation of `Str.matched_group n s` does not specify what is returned in case `n` is 0.
This is an attempt to fix that.
Note that this convention is only hinted at below in the documentation, for `Str.global_replace`, so a bit too late.