### PR TITLE
stdlib: add Option.value_lazy 

### DIFF
--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -22,6 +22,7 @@ let value_or_else o f = match o with Some v -> v | None -> f ()
 let get = function Some v -> v | None -> invalid_arg "option is None"
 let bind o f = match o with None -> None | Some v -> f v
 let join = function Some o -> o | None -> None
+let either o1 o2 = match o1 with | Some _ -> o1 | None -> o2
 let either_or o f = match o with Some _ -> o | None -> f ()
 let map f o = match o with None -> None | Some v -> Some (f v)
 let fold ~none ~some = function Some v -> some v | None -> none

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -18,6 +18,7 @@ type 'a t = 'a option = None | Some of 'a
 let none = None
 let some v = Some v
 let value o ~default = match o with Some v -> v | None -> default
+let value_or_else o f = match o with Some v -> v | None -> f ()
 let get = function Some v -> v | None -> invalid_arg "option is None"
 let bind o f = match o with None -> None | Some v -> f v
 let join = function Some o -> o | None -> None

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -22,6 +22,7 @@ let value_or_else o f = match o with Some v -> v | None -> f ()
 let get = function Some v -> v | None -> invalid_arg "option is None"
 let bind o f = match o with None -> None | Some v -> f v
 let join = function Some o -> o | None -> None
+let either_or o f = match o with Some _ -> o | None -> f ()
 let map f o = match o with None -> None | Some v -> Some (f v)
 let fold ~none ~some = function Some v -> some v | None -> none
 let iter f = function Some v -> f v | None -> ()

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -45,6 +45,9 @@ val bind : 'a option -> ('a -> 'b option) -> 'b option
 val join : 'a option option -> 'a option
 (** [join oo] is [Some v] if [oo] is [Some (Some v)] and [None] otherwise. *)
 
+val either_or : 'a option -> (unit -> 'a option) -> 'a option
+(** [either_or o f] returns [o] if it is [Some _] and [f ()] otherwise. *)
+
 val map : ('a -> 'b) -> 'a option -> 'b option
 (** [map f o] is [None] if [o] is [None] and [Some (f v)] is [o] is [Some v]. *)
 

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -33,6 +33,9 @@ val some : 'a -> 'a option
 val value : 'a option -> default:'a -> 'a
 (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
 
+val value_or_else : 'a option -> (unit -> 'a) -> 'a
+(** [value_or_else o f] is [v] if [o] is [Some v] and [f ()] otherwise. *)
+
 val get : 'a option -> 'a
 (** [get o] is [v] if [o] is [Some v] and @raise Invalid_argument otherwise. *)
 

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -45,6 +45,9 @@ val bind : 'a option -> ('a -> 'b option) -> 'b option
 val join : 'a option option -> 'a option
 (** [join oo] is [Some v] if [oo] is [Some (Some v)] and [None] otherwise. *)
 
+val either : 'a option -> 'a option -> 'a option
+(** [either o1 o2] returns [o1] if it is [Some _] and [o2] otherwise. *)
+
 val either_or : 'a option -> (unit -> 'a option) -> 'a option
 (** [either_or o f] returns [o] if it is [Some _] and [f ()] otherwise. *)
 


### PR DESCRIPTION
Makes following addition to the stdlib: 

```
val value_lazy : 'a option -> default:'a Lazy.t -> 'a
(** [value_lazy o ~default] is [v] if [o] is [Some v] and [Lazy.force default] otherwise. *)
```

Helps to avoid boilerplate-y `function | Some v -> v | None -> (* compute default *)`

It is quite common that one wants to avoid evaluating the default value before unwrapping an option and seeing it is `None`, e.g., computing the default is expensive or contains a side-effect. 

Same thing in the Rust stdlib: https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or_else