### PR TITLE
manual: use the underscore package

### DIFF
--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -25,7 +25,7 @@ STDLIB_INTF = $(STDLIB_MODs:%=%.tex)
 
 COMPILER_LIBS_PLUGIN_HOOKS = Pparse.tex Typemod.tex
 
-COMPILER_LIBS_INTF = Asthelper.tex Astmapper.tex Asttypes.tex \
+COMPILER_LIBS_INTF = Ast_helper.tex Ast_mapper.tex Asttypes.tex \
   Lexer.tex Location.tex Longident.tex Parse.tex Pprintast.tex Printast.tex \
   $(COMPILER_LIBS_PLUGIN_HOOKS)
 
@@ -63,9 +63,6 @@ ocamldoc.out: $(DOC_ALL)
 	  -latex-module-prefix "" \
 	  -latex-module-type-prefix "" \
 	  -latex-value-prefix ""
-	mv Ast_helper.tex Asthelper.tex
-	mv Ast_mapper.tex Astmapper.tex
-	mv Ocaml_operators.tex Ocamloperators.tex
 
 %.tex: %.etex
 	$(TEXQUOTE) < $< > $*.texquote_error.tex

--- a/manual/manual/library/compilerlibs.etex
+++ b/manual/manual/library/compilerlibs.etex
@@ -45,8 +45,8 @@ type\\*"#load \"compiler-libs/ocamlcommon.cma\";;".
 % Ast_helper is excluded from the PDF and text manuals.
 % It is over 20 pages long and does not have doc-comments. It is expected
 % that Ast_helper will be only useful in the HTML manual (to look up signatures).
-% \input{Asthelper.tex}
-\input{Astmapper.tex}
+% \input{Ast_helper.tex}
+\input{Ast_mapper.tex}
 \input{Asttypes.tex}
 % \input{Lexer.tex}
 \input{Location.tex}

--- a/manual/manual/library/stdlib-blurb.etex
+++ b/manual/manual/library/stdlib-blurb.etex
@@ -217,6 +217,6 @@ be called from C \\
 \input{Uchar.tex}
 \input{Unit.tex}
 \input{Weak.tex}
-\input{Ocamloperators.tex}
+\input{Ocaml_operators.tex}
 }
 \fi

--- a/manual/manual/macros.tex
+++ b/manual/manual/macros.tex
@@ -41,11 +41,6 @@
 \setcounter{tocdepth}{1}        % Pour ne pas mettre les \subsection
                                 % dans la table des matieres
 
-% Pour avoir "_" qui marche en mode math et en mode normal
-\catcode`\_=13
-\catcode`\=8
-\def\_{\hbox{\tt\char95}}
-\def_{\ifmmode\else\_\fi}
 
 \def\ttstretch{\tt\spaceskip=5.77pt plus 1.83pt minus 1.22pt}
 % La fonte cmr10 a normalement des espaces de 5.25pt non extensibles.

--- a/manual/manual/manual.tex
+++ b/manual/manual/manual.tex
@@ -119,6 +119,11 @@
 \fi
 
 \usepackage[colorlinks,linkcolor=blue]{hyperref}
+
+% Make _ a normal character in text mode
+% it must be the last package included
+\usepackage[strings,nohyphen]{underscore}
+
 %\makeatletter \def\@wrindex#1#2{\xdef \@indexfile{\csname #1@idxfile\endcsname}\@@wrindex#2||\\}\makeatother
 \def\th{^{\hbox{\scriptsize th}}}
 


### PR DESCRIPTION
The manual makes some effort to make `_` usable in normal text while preserving its subscript meaning in math mode. Unfortunately, this is not enough to completely handle file names with underscore thus the manual's Makefiles contain some logic to rename module names that contain `_`.

This PR proposes to let the `underscore` package handle all those issues for us.