### PR TITLE
[RFC] Deprecate Weak.get_*_copy and Ephemeron.K*.get_*_copy

### DIFF
--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -71,6 +71,8 @@ CAMLextern int caml_ephemeron_get_key_copy(value eph, mlsize_t offset,
 
     The value [eph] must be an ephemeron and [offset] a valid key
     offset.
+
+    Deprecated in favor of [caml_ephemeron_get_key]
 */
 
 CAMLextern void caml_ephemeron_blit_key(value eph1, mlsize_t off1,
@@ -116,6 +118,8 @@ CAMLextern int caml_ephemeron_get_data_copy(value eph, value *data);
 
     The value [eph] must be an ephemeron and [offset] a valid key
     offset.
+
+    Deprecated in favor of [caml_ephemeron_get_data]
 */
 
 CAMLextern void caml_ephemeron_blit_data(value eph1, value eph2);

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -112,6 +112,7 @@ module K1 : sig
       empty, [Some x] (where [x] is the key) if it is full. *)
 
   val get_key_copy: ('k,'d) t -> 'k option
+  [@@ocaml.deprecated "Use Ephemeron.K1.get_key instead."]
   (** [Ephemeron.K1.get_key_copy eph] returns [None] if the key of [eph] is
       empty, [Some x] (where [x] is a (shallow) copy of the key) if
       it is full. This function has the same GC friendliness as {!Weak.get_copy}
@@ -149,6 +150,7 @@ module K1 : sig
       empty, [Some x] (where [x] is the data) if it is full. *)
 
   val get_data_copy: ('k,'d) t -> 'd option
+  [@@ocaml.deprecated "Use Ephemeron.K1.get_data instead."]
   (** [Ephemeron.K1.get_data_copy eph] returns [None] if the data of [eph] is
       empty, [Some x] (where [x] is a (shallow) copy of the data) if
       it is full. This function has the same GC friendliness as {!Weak.get_copy}
@@ -199,6 +201,7 @@ module K2 : sig
   (** Same as {!Ephemeron.K1.get_key} *)
 
   val get_key1_copy: ('k1,'k2,'d) t -> 'k1 option
+  [@@ocaml.deprecated "Use Ephemeron.K2.get_key1 instead."]
   (** Same as {!Ephemeron.K1.get_key_copy} *)
 
   val set_key1: ('k1,'k2,'d) t -> 'k1 -> unit
@@ -214,6 +217,7 @@ module K2 : sig
   (** Same as {!Ephemeron.K1.get_key} *)
 
   val get_key2_copy: ('k1,'k2,'d) t -> 'k2 option
+  [@@ocaml.deprecated "Use Ephemeron.K2.get_key2 instead."]
   (** Same as {!Ephemeron.K1.get_key_copy} *)
 
   val set_key2: ('k1,'k2,'d) t -> 'k2 -> unit
@@ -238,6 +242,7 @@ module K2 : sig
   (** Same as {!Ephemeron.K1.get_data} *)
 
   val get_data_copy: ('k1,'k2,'d) t -> 'd option
+  [@@ocaml.deprecated "Use Ephemeron.K2.get_data instead."]
   (** Same as {!Ephemeron.K1.get_data_copy} *)
 
   val set_data: ('k1,'k2,'d) t -> 'd -> unit
@@ -278,6 +283,7 @@ module Kn : sig
   (** Same as {!Ephemeron.K1.get_key} *)
 
   val get_key_copy: ('k,'d) t -> int -> 'k option
+  [@@ocaml.deprecated "Use Ephemeron.Kn.get_key instead."]
   (** Same as {!Ephemeron.K1.get_key_copy} *)
 
   val set_key: ('k,'d) t -> int -> 'k -> unit
@@ -296,6 +302,7 @@ module Kn : sig
   (** Same as {!Ephemeron.K1.get_data} *)
 
   val get_data_copy: ('k,'d) t -> 'd option
+  [@@ocaml.deprecated "Use Ephemeron.Kn.get_data instead."]
   (** Same as {!Ephemeron.K1.get_data_copy} *)
 
   val set_data: ('k,'d) t -> 'd -> unit

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -278,7 +278,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     let rec loop i =
       if i >= sz then ifnotfound h index
       else if h = hashes.(i) then begin
-        match get_copy bucket i with
+        match get bucket i with
         | Some v when H.equal v d
            -> begin match get bucket i with
               | Some v -> v
@@ -305,7 +305,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     let rec loop i =
       if i >= sz then None
       else if h = hashes.(i) then begin
-        match get_copy bucket i with
+        match get bucket i with
         | Some v when H.equal v d
            -> begin match get bucket i with
               | Some _ as v -> v
@@ -326,7 +326,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     let rec loop i =
       if i >= sz then ifnotfound
       else if h = hashes.(i) then begin
-        match get_copy bucket i with
+        match get bucket i with
         | Some v when H.equal v d -> iffound bucket i
         | _ -> loop (i + 1)
       end else loop (i + 1)
@@ -349,7 +349,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     let rec loop i accu =
       if i >= sz then accu
       else if h = hashes.(i) then begin
-        match get_copy bucket i with
+        match get bucket i with
         | Some v when H.equal v d
            -> begin match get bucket i with
               | Some v -> loop (i + 1) (v :: accu)

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -62,6 +62,7 @@ val get : 'a t -> int -> 'a option
    0 to {!Weak.length}[ a - 1].*)
 
 val get_copy : 'a t -> int -> 'a option
+[@@ocaml.deprecated "Use Weak.get instead."]
 (** [Weak.get_copy ar n] returns None if the [n]th cell of [ar] is
    empty, [Some x] (where [x] is a (shallow) copy of the value) if
    it is full.
@@ -107,9 +108,6 @@ val blit : 'a t -> int -> 'a t -> int -> int -> unit
     module; the [equal] relation and [hash] function are taken from that
     module.  We will say that [v] is an instance of [x] if [equal x v]
     is [true].
-
-    The [equal] relation must be able to work on a shallow copy of
-    the values and give the same result as with the values themselves.
     *)
 
 module type S = sig

--- a/testsuite/tests/lib-bigarray/weak_bigarray.compilers.reference
+++ b/testsuite/tests/lib-bigarray/weak_bigarray.compilers.reference
@@ -1,0 +1,5 @@
+File "weak_bigarray.ml", line 18, characters 10-23:
+18 |     match Weak.get_copy w 0 with
+               ^^^^^^^^^^^^^
+Alert deprecated: Stdlib.Weak.get_copy
+Use Weak.get instead.

--- a/testsuite/tests/misc/ephe_infix.compilers.reference
+++ b/testsuite/tests/misc/ephe_infix.compilers.reference
@@ -1,0 +1,5 @@
+File "ephe_infix.ml", line 11, characters 8-21:
+11 |   match Weak.get_copy w 0 with Some h -> ignore (h ()) | _ -> ()
+             ^^^^^^^^^^^^^
+Alert deprecated: Stdlib.Weak.get_copy
+Use Weak.get instead.

--- a/testsuite/tests/misc/ephetest.compilers.reference
+++ b/testsuite/tests/misc/ephetest.compilers.reference
@@ -1,0 +1,10 @@
+File "ephetest.ml", line 13, characters 8-24:
+13 |   match K1.get_data_copy eph with
+             ^^^^^^^^^^^^^^^^
+Alert deprecated: Stdlib.Ephemeron.K1.get_data_copy
+Use Ephemeron.K1.get_data instead.
+File "ephetest.ml", line 21, characters 8-23:
+21 |   match K1.get_key_copy eph with
+             ^^^^^^^^^^^^^^^
+Alert deprecated: Stdlib.Ephemeron.K1.get_key_copy
+Use Ephemeron.K1.get_key instead.


### PR DESCRIPTION
       * They are similar to a hidden Obj.copy
       * They can't copy everything
       * They are perhaps not needed in the weak hashset (the only place used in
         the stdlib) since the original hash is kept limiting the use of the
         equality function.

The drawbacks is if you have a full hash collision, between a value that is unreachable
and a value that is often accessed, the unreachable value will possibly stay
alive if it append to be before the other value in the bucket.

This MR is at that time mainly to allow people that use hashconsing to see if they have regression.