### PR TITLE
Fix reproducibility for `-no-alias-deps`

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
 
 ### Bug fixes:
 
+- #9991: Fix reproducibility for `-no-alias-deps`
+  (Leo White, review by Gabriel Scherer and Florian Angeletti)
+
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
   (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)
 

--- a/testsuite/tests/reproducibility/cmis_on_file_system.ml
+++ b/testsuite/tests/reproducibility/cmis_on_file_system.ml
@@ -4,7 +4,7 @@
   ** ocamlc.byte
   compile_only = "true"
   module = "cmis_on_file_system.ml"
-  flags="-bin-annot"
+  flags="-bin-annot -no-alias-deps -w '-49'"
   *** script
   script= "mv cmis_on_file_system.cmt lone.cmt"
   **** ocamlc.byte
@@ -12,7 +12,7 @@
   compile_only="true"
   ***** ocamlc.byte
   compile_only = "true"
-  flags="-bin-annot"
+  flags="-bin-annot -no-alias-deps -w '-49'"
   module="cmis_on_file_system.ml"
   ****** compare-binary-files
   program="cmis_on_file_system.cmt"
@@ -24,3 +24,5 @@
     at a given point in time *)
 type t = int
 let () = ()
+
+module M = Cmis_on_file_system_companion


### PR DESCRIPTION
#9345 makes environment summaries reproducible by only adding `Env_persistent` in cases where the entry materially changes the environment. This ensures that cmt files do not depend on which unrelated cmi files are on the filesystem.

However, such unrelated cmis still affect sharing of strings in initial environment itself. Normally this sharing is not observable because if you try to look up a module for which there is no cmi then you will error. However, with `-no-alias-deps` we allow look ups of module aliases to succeed even if there is no cmi, which reveals the difference in sharing and leads to reproducibility issues.

This PR changes the behaviour in `-no-alias-deps` mode to only add persistent modules to the initial environment if doing so would materially change the environment.

It also modifies the reproducibility test in the test suite to trigger this case.