### PR TITLE
Export config as library Ocamlcompconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,8 @@ _build
 /tools/eventlog_metadata
 
 /utils/config.ml
+/utils/ocamlcompconfig.ml
+/utils/ocamlcompconfig.mli
 /utils/domainstate.ml
 /utils/domainstate.mli
 

--- a/Makefile
+++ b/Makefile
@@ -891,10 +891,12 @@ partialclean::
 
 .PHONY: otherlibraries
 otherlibraries: ocamltools
+	$(MAKE) compilerlibs/ocamlcompconfig.cma
 	$(MAKE) -C otherlibs all
 
 .PHONY: otherlibrariesopt
 otherlibrariesopt:
+	$(MAKE) compilerlibs/ocamlcompconfig.cmxa
 	$(MAKE) -C otherlibs allopt
 
 partialclean::

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -341,11 +341,15 @@ utils/ocamlcompconfig.mli: utils/config.mli
 utils/ocamlcompconfig.cmo: utils/ocamlcompconfig.cmi
 utils/ocamlcompconfig.cmx: utils/ocamlcompconfig.cmi
 
-partialclean::
-	rm -f utils/ocamlcompconfig.*
-
 compilerlibs/ocamlcompconfig.cma: utils/ocamlcompconfig.cmo
 	$(CAMLC) -a -o $@ $<
 
 compilerlibs/ocamlcompconfig.cmxa: utils/ocamlcompconfig.cmx
 	$(CAMLOPT) -a -o $@ $<
+
+partialclean::
+	rm -f utils/ocamlcompconfig.*
+	rm -f compilerlibs/ocamlcompconfig.cma \
+	      compilerlibs/ocamlcompconfig.cmxa \
+	      compilerlibs/ocamlcompconfig.a \
+	      compilerlibs/ocamlcompconfig.lib

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -331,3 +331,21 @@ compilerlibs/ocamlopttoplevel.cmxa: $(OPTTOPLEVEL_CMI) $(OPTTOPLEVEL:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamlopttoplevel.cmxa \
 	  compilerlibs/ocamlopttoplevel.a compilerlibs/ocamlopttoplevel.lib
+
+utils/ocamlcompconfig.ml: utils/config.ml
+	cp $< $@
+
+utils/ocamlcompconfig.mli: utils/config.mli
+	cp $< $@
+
+utils/ocamlcompconfig.cmo: utils/ocamlcompconfig.cmi
+utils/ocamlcompconfig.cmx: utils/ocamlcompconfig.cmi
+
+partialclean::
+	rm -f utils/ocamlcompconfig.*
+
+compilerlibs/ocamlcompconfig.cma: utils/ocamlcompconfig.cmo
+	$(CAMLC) -a -o $@ $<
+
+compilerlibs/ocamlcompconfig.cmxa: utils/ocamlcompconfig.cmx
+	$(CAMLOPT) -a -o $@ $<


### PR DESCRIPTION
A draft proposal for the option of exporting the `Config` module as a library of its own, as discussed in #9842.