### PR TITLE
Make type_expr private

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,10 @@ Working version
 - #9650, #9651: keep refactoring the pattern-matching compiler
   (Gabriel Scherer, review by Thomas Refis and Florian Angeletti)
 
+- #9994: Make Types.type_expr a private type, and abstract marking mechanism
+  (Jacques Garrigue and Takafumi Saikawa,
+   review by Gabriel Scherer and Leo White)
+
 - #10007: Driver.compile_common: when typing a .ml file, return the
   compilation unit signature (inferred or from the .cmi) in addition
   to the implementation and the coercion.

--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -175,11 +175,11 @@ let subst_type env t =
       | Types.Tconstr (p, l, a) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
-          t.Types.desc <- Types.Tconstr (new_p, l, a)
+	  Btype.set_type_desc t (Types.Tconstr (new_p, l, a))
       | Types.Tpackage (p, n, l) ->
           let new_p =
             Odoc_name.to_path (full_module_type_name env (Odoc_name.from_path p)) in
-          t.Types.desc <- Types.Tpackage (new_p, n, l)
+	  Btype.set_type_desc t (Types.Tpackage (new_p, n, l))
       | Types.Tobject (_, ({contents=Some(p,tyl)} as r)) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
@@ -187,8 +187,8 @@ let subst_type env t =
       | Types.Tvariant ({Types.row_name=Some(p, tyl)} as row) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
-          t.Types.desc <-
-            Types.Tvariant {row with Types.row_name=Some(new_p, tyl)}
+	  Btype.set_type_desc t
+            (Types.Tvariant {row with Types.row_name=Some(new_p, tyl)})
       | _ ->
           ()
     end

--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -175,11 +175,11 @@ let subst_type env t =
       | Types.Tconstr (p, l, a) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
-	  Btype.set_type_desc t (Types.Tconstr (new_p, l, a))
+          Btype.set_type_desc t (Types.Tconstr (new_p, l, a))
       | Types.Tpackage (p, n, l) ->
           let new_p =
             Odoc_name.to_path (full_module_type_name env (Odoc_name.from_path p)) in
-	  Btype.set_type_desc t (Types.Tpackage (new_p, n, l))
+          Btype.set_type_desc t (Types.Tpackage (new_p, n, l))
       | Types.Tobject (_, ({contents=Some(p,tyl)} as r)) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
@@ -187,7 +187,7 @@ let subst_type env t =
       | Types.Tvariant ({Types.row_name=Some(p, tyl)} as row) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
-	  Btype.set_type_desc t
+          Btype.set_type_desc t
             (Types.Tvariant {row with Types.row_name=Some(new_p, tyl)})
       | _ ->
           ()

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -509,4 +509,5 @@ let remove_option typ =
     | Types.Tlink t2
     | Types.Tsubst t2 -> iter t2.Types.desc
   in
-  { typ with Types.desc = iter typ.Types.desc }
+  Types.Internal.lock
+    { (Types.Internal.unlock typ) with Types.Internal.desc = iter typ.Types.desc }

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -509,5 +509,5 @@ let remove_option typ =
     | Types.Tlink t2
     | Types.Tsubst t2 -> iter t2.Types.desc
   in
-  Types.Internal.lock
-    { (Types.Internal.unlock typ) with Types.Internal.desc = iter typ.Types.desc }
+  Types.Private_type_expr.create (iter typ.Types.desc)
+    ~level:typ.Types.level ~scope:typ.Types.scope ~id:typ.Types.id

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -86,12 +86,14 @@ let simpl_class_type t =
     | Types.Cty_signature cs ->
         (* we delete vals and methods in order to not print them when
            displaying the type *)
-      let tnil =
-        { Types.desc = Types.Tnil ; Types.level = 0
-        ; Types.scope = Btype.lowest_level ; Types.id = 0 }
+      let tself =
+	let open Types.Internal in
+	lock { (unlock cs.Types.csig_self) with
+	       desc = Types.Tobject
+		 (lock { desc = Types.Tnil ; level = 0 ;
+			 scope = Btype.lowest_level ; id = 0 }, ref None) }
       in
-        Types.Cty_signature { Types.csig_self = { cs.Types.csig_self with
-                                                  Types.desc = Types.Tobject (tnil, ref None) };
+        Types.Cty_signature { Types.csig_self = tself;
                               csig_vars = Types.Vars.empty ;
                               csig_concr = Types.Concr.empty ;
                               csig_inher = []

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -87,11 +87,11 @@ let simpl_class_type t =
         (* we delete vals and methods in order to not print them when
            displaying the type *)
       let tself =
-	let open Types.Internal in
-	lock { (unlock cs.Types.csig_self) with
-	       desc = Types.Tobject
-		 (lock { desc = Types.Tnil ; level = 0 ;
-			 scope = Btype.lowest_level ; id = 0 }, ref None) }
+        let open Types.Internal in
+        lock { (unlock cs.Types.csig_self) with
+               desc = Types.Tobject
+                 (lock { desc = Types.Tnil ; level = 0 ;
+                         scope = Btype.lowest_level ; id = 0 }, ref None) }
       in
         Types.Cty_signature { Types.csig_self = tself;
                               csig_vars = Types.Vars.empty ;

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -87,11 +87,12 @@ let simpl_class_type t =
         (* we delete vals and methods in order to not print them when
            displaying the type *)
       let tself =
-        let open Types.Internal in
-        lock { (unlock cs.Types.csig_self) with
-               desc = Types.Tobject
-                 (lock { desc = Types.Tnil ; level = 0 ;
-                         scope = Btype.lowest_level ; id = 0 }, ref None) }
+        let t = cs.Types.csig_self in
+        let t' = Types.Private_type_expr.create Types.Tnil
+            ~level:0 ~scope:Btype.lowest_level ~id:0 in
+        let desc = Types.Tobject (t', ref None) in
+        Types.Private_type_expr.create desc
+          ~level:t.Types.level ~scope:t.Types.scope ~id:t.Types.id
       in
         Types.Cty_signature { Types.csig_self = tself;
                               csig_vars = Types.Vars.empty ;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -746,12 +746,12 @@ let link_type ty ty' =
   match desc, ty'.desc with
     Tvar name, Tvar name' ->
       begin match name, name' with
-      | Some _, None ->  log_type ty'; Private_type_expr.set_desc ty' (Tvar name)
-      | None, Some _ ->  ()
+      | Some _, None -> log_type ty'; Private_type_expr.set_desc ty' (Tvar name)
+      | None, Some _ -> ()
       | Some _, Some _ ->
           if ty.level < ty'.level then
             (log_type ty'; Private_type_expr.set_desc ty' (Tvar name))
-      | None, None   ->  ()
+      | None, None   -> ()
       end
   | _ -> ()
   (* ; assert (check_memorized_abbrevs ()) *)

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -78,7 +78,6 @@ type change =
   | Ckind of field_kind option ref * field_kind option
   | Ccommu of commutable ref * commutable
   | Cuniv of type_expr option ref * type_expr option
-(*  | Ctypeset of TypeSet.t ref * TypeSet.t *)
 
 type changes =
     Change of change * changes ref

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -109,7 +109,7 @@ let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
      repr_link true t d' t'
  | t' ->
      if compress then begin
-       log_change (Ccompress (t, t.desc, d)); (Internal.unlock t).desc <- d
+       log_change (Ccompress (t, t.desc, d)); Unsafe_access.set_desc t d
      end;
      t'
 
@@ -268,7 +268,7 @@ let set_row_name decl path =
         Tvariant row when static_row row ->
           let row = {(row_repr row) with
                      row_name = Some (path, decl.type_params)} in
-          (Internal.unlock ty).desc <- Tvariant row
+          Unsafe_access.set_desc ty (Tvariant row)
       | _ -> ()
 
 
@@ -553,7 +553,7 @@ end = struct
 
   (* Restore type descriptions. *)
   let cleanup { saved_desc; saved_kinds; _ } =
-    List.iter (fun (ty, desc) -> (Internal.unlock ty).desc <- desc) saved_desc;
+    List.iter (fun (ty, desc) -> Unsafe_access.set_desc ty desc) saved_desc;
     List.iter (fun r -> r := None) saved_kinds
 
   let with_scope f =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -564,7 +564,7 @@ end = struct
 end
 
 (* Mark a type. *)
-let mirror_level level = pivot_level - level  
+let mirror_level level = pivot_level - level
 
 let rec mark_type ty =
   let ty = repr ty in
@@ -590,7 +590,7 @@ let type_iterators =
   in
   {type_iterators with it_type_expr}
 
-   
+
 (* Remove marks from a type. *)
 let rec unmark_type ty =
   let ty = repr ty in
@@ -753,7 +753,7 @@ let link_type ty ty' =
       | None, Some _ ->  ()
       | Some _, Some _ ->
           if ty.level < ty'.level then
-	    (log_type ty'; (Internal.unlock ty').desc <- Tvar name)
+            (log_type ty'; (Internal.unlock ty').desc <- Tvar name)
       | None, None   ->  ()
       end
   | _ -> ()

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -564,12 +564,11 @@ end = struct
 end
 
 (* Mark a type. *)
-let mirror_level level = pivot_level - level
 
 let not_marked_node ty = ty.level >= lowest_level
     (* type nodes with negative levels are "marked" *)
 
-let flip_mark_node ty = (Internal.unlock ty).level <- mirror_level ty.level
+let flip_mark_node ty = (Internal.unlock ty).level <- pivot_level - ty.level
 
 let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -17,7 +17,6 @@
 
 open Asttypes
 open Types
-open Internal
 
 open Local_store
 
@@ -46,7 +45,8 @@ let pivot_level = 2 * lowest_level - 1
 let new_id = s_ref (-1)
 
 let newty2 level desc  =
-  incr new_id; { desc; level; scope = lowest_level; id = !new_id }
+  incr new_id;
+  Internal.lock Internal.{ desc; level; scope = lowest_level; id = !new_id }
 let newgenty desc      = newty2 generic_level desc
 let newgenvar ?name () = newgenty (Tvar name)
 (*
@@ -109,7 +109,7 @@ let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
      repr_link true t d' t'
  | t' ->
      if compress then begin
-       log_change (Ccompress (t, t.desc, d)); (unlock t).desc <- d
+       log_change (Ccompress (t, t.desc, d)); (Internal.unlock t).desc <- d
      end;
      t'
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -574,7 +574,11 @@ let rec mark_type ty =
     iter_type_expr mark_type ty
   end
 
-let mark_type_node ?(guard = fun _ -> true) ?(after = fun _ -> ()) ty =
+let mark_type_node_only ty =
+  if ty.level >= lowest_level then
+    (Internal.unlock ty).level <- mirror_level ty.level
+
+let mark_type_node ?(guard = fun _ -> true) ~after ty =
   let ty = repr ty in
   if ty.level >= lowest_level && guard ty then begin
     (Internal.unlock ty).level <- mirror_level ty.level;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -574,17 +574,11 @@ let rec mark_type ty =
     iter_type_expr mark_type ty
   end
 
-let mark_type_node ty =
+let mark_type_node ?(guard = fun _ -> true) ?(after = fun _ -> ()) ty =
   let ty = repr ty in
-  if ty.level >= lowest_level then begin
+  if ty.level >= lowest_level && guard ty then begin
     (Internal.unlock ty).level <- mirror_level ty.level;
-  end
-
-let mark_type_node_with ty f =
-  let ty = repr ty in
-  if ty.level >= lowest_level then begin
-    (Internal.unlock ty).level <- mirror_level ty.level;
-    f ty
+    after ty
   end
 
 let mark_type_params ty =
@@ -592,11 +586,7 @@ let mark_type_params ty =
 
 let type_iterators =
   let it_type_expr it ty =
-    let ty = repr ty in
-    if ty.level >= lowest_level then begin
-      mark_type_node ty;
-      it.it_do_type_expr it ty;
-    end
+    mark_type_node ty ~after:(it.it_do_type_expr it)
   in
   {type_iterators with it_type_expr}
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -17,6 +17,7 @@
 
 open Asttypes
 open Types
+open Internal
 
 open Local_store
 
@@ -100,7 +101,7 @@ let rec field_kind_repr =
     Fvar {contents = Some kind} -> field_kind_repr kind
   | kind                        -> kind
 
-let rec repr_link compress t d =
+let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
  function
    {desc = Tlink t' as d'} ->
      repr_link true t d' t'
@@ -108,11 +109,11 @@ let rec repr_link compress t d =
      repr_link true t d' t'
  | t' ->
      if compress then begin
-       log_change (Ccompress (t, t.desc, d)); t.desc <- d
+       log_change (Ccompress (t, t.desc, d)); (unlock t).desc <- d
      end;
      t'
 
-let repr t =
+let repr (t : type_expr) =
   match t.desc with
    Tlink t' as d ->
      repr_link false t d t'

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -109,7 +109,7 @@ let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
      repr_link true t d' t'
  | t' ->
      if compress then begin
-       log_change (Ccompress (t, t.desc, d)); Unsafe_access.set_desc t d
+       log_change (Ccompress (t, t.desc, d)); Private_type_expr.set_desc t d
      end;
      t'
 
@@ -268,7 +268,7 @@ let set_row_name decl path =
         Tvariant row when static_row row ->
           let row = {(row_repr row) with
                      row_name = Some (path, decl.type_params)} in
-          Unsafe_access.set_desc ty (Tvariant row)
+          Private_type_expr.set_desc ty (Tvariant row)
       | _ -> ()
 
 
@@ -553,7 +553,7 @@ end = struct
 
   (* Restore type descriptions. *)
   let cleanup { saved_desc; saved_kinds; _ } =
-    List.iter (fun (ty, desc) -> Unsafe_access.set_desc ty desc) saved_desc;
+    List.iter (fun (ty, desc) -> Private_type_expr.set_desc ty desc) saved_desc;
     List.iter (fun r -> r := None) saved_kinds
 
   let with_scope f =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -574,23 +574,17 @@ let rec mark_type ty =
     iter_type_expr mark_type ty
   end
 
-let mark_type_node_only ty =
-  if ty.level >= lowest_level then
-    (Internal.unlock ty).level <- mirror_level ty.level
-
-let mark_type_node ?(guard = fun _ -> true) ~after ty =
-  let ty = repr ty in
-  if ty.level >= lowest_level && guard ty then begin
-    (Internal.unlock ty).level <- mirror_level ty.level;
-    after ty
-  end
+let mark_type_node ty =
+  ty.level >= lowest_level &&
+  ((Internal.unlock ty).level <- mirror_level ty.level; true)
 
 let mark_type_params ty =
   iter_type_expr mark_type ty
 
 let type_iterators =
   let it_type_expr it ty =
-    mark_type_node ty ~after:(it.it_do_type_expr it)
+    let ty = repr ty in
+    if mark_type_node ty then it.it_do_type_expr it ty
   in
   {type_iterators with it_type_expr}
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -595,7 +595,7 @@ let rec unmark_type ty =
   let ty = repr ty in
   if ty.level < lowest_level then begin
     (* flip back the marked level *)
-    (Internal.unlock ty).level <- pivot_level - ty.level;
+    (Internal.unlock ty).level <- mirror_level ty.level;
     iter_type_expr unmark_type ty
   end
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -564,24 +564,26 @@ end = struct
 end
 
 (* Mark a type. *)
+let mirror_level level = pivot_level - level  
+
 let rec mark_type ty =
   let ty = repr ty in
   if ty.level >= lowest_level then begin
     (* type nodes with negative levels are "marked" *)
-    (Internal.unlock ty).level <- pivot_level - ty.level;
+    (Internal.unlock ty).level <- mirror_level ty.level;
     iter_type_expr mark_type ty
   end
 
 let mark_type_node ty =
   let ty = repr ty in
   if ty.level >= lowest_level then begin
-    (Internal.unlock ty).level <- pivot_level - ty.level;
+    (Internal.unlock ty).level <- mirror_level ty.level;
   end
 
 let mark_type_node_with ty f =
   let ty = repr ty in
   if ty.level >= lowest_level then begin
-    (Internal.unlock ty).level <- pivot_level - ty.level;
+    (Internal.unlock ty).level <- mirror_level ty.level;
     f ty
   end
 
@@ -598,7 +600,7 @@ let type_iterators =
   in
   {type_iterators with it_type_expr}
 
-
+   
 (* Remove marks from a type. *)
 let rec unmark_type ty =
   let ty = repr ty in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -732,7 +732,6 @@ let undo_change = function
   | Ckind  (r, v) -> r := v
   | Ccommu (r, v) -> r := v
   | Cuniv  (r, v) -> r := v
-(*  | Ctypeset (r, v) -> r := v *)
 
 type snapshot = changes ref * int
 let last_snapshot = s_ref 0
@@ -787,10 +786,6 @@ let set_kind rk k =
   log_change (Ckind (rk, !rk)); rk := Some k
 let set_commu rc c =
   log_change (Ccommu (rc, !rc)); rc := c
-(*
-let set_typeset rs s =
-  log_change (Ctypeset (rs, !rs)); rs := s
-*)
 
 let snapshot () =
   let old = !last_snapshot in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -46,7 +46,7 @@ let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id;
-  Internal.lock Internal.{ desc; level; scope = lowest_level; id = !new_id }
+  Private_type_expr.create desc ~level ~scope:lowest_level ~id:!new_id
 let newgenty desc      = newty2 generic_level desc
 let newgenvar ?name () = newgenty (Tvar name)
 (*

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -171,14 +171,14 @@ val pivot_level: int
 val mirror_level: int -> int
         (* Type marking: ty.level <- pivot_level - ty.level *)
         (* mirror_level is used for unmarking; it must be involutive,
-	   invert order *)
+           invert order *)
 val mark_type: type_expr -> unit
         (* Mark a type *)
 val mark_type_node:
         ?guard:(type_expr -> bool) -> ?after:(type_expr -> unit) ->
         type_expr -> unit
         (* If the node is not already marked and [guard] returns true
-	   (the default), then mark it and run [after]. *)
+           (the default), then mark it and run [after]. *)
 val mark_type_params: type_expr -> unit
         (* Mark the sons of a type node *)
 val unmark_type: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -133,7 +133,7 @@ type type_iterators =
     it_path: Path.t -> unit; }
 val type_iterators: type_iterators
         (* Iteration on arbitrary type information.
-           [it_type_expr] calls [mark_type_node] to avoid loops. *)
+           [it_type_expr] calls [mark_node] to avoid loops. *)
 val unmark_iterators: type_iterators
         (* Unmark any structure containing types. See [unmark_type] below. *)
 
@@ -172,13 +172,17 @@ val mirror_level: int -> int
         (* Type marking: ty.level <- pivot_level - ty.level *)
         (* mirror_level is used for unmarking; it must be involutive,
            invert order *)
+val not_marked_node: type_expr -> bool
+        (* Return true if a type node is not yet marked *)
+val flip_mark_node: type_expr -> unit
+        (* Mark a type node. No [repr]'ing *)
+val try_mark_node: type_expr -> bool
+        (* Mark a type node if it is not yet marked.
+           Return false if it was already marked *)
 val mark_type: type_expr -> unit
-        (* Mark a type *)
-val mark_type_node: type_expr -> bool
-        (* Just mark a node if its level was highe than lowest_level,
-           and return whether this was done. No [repr]'ing. *)
+        (* Mark a type recursively *)
 val mark_type_params: type_expr -> unit
-        (* Mark the sons of a type node *)
+        (* Mark the sons of a type node recursively *)
 val unmark_type: type_expr -> unit
 val unmark_type_decl: type_declaration -> unit
 val unmark_extension_constructor: extension_constructor -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -175,10 +175,12 @@ val mirror_level: int -> int
 val mark_type: type_expr -> unit
         (* Mark a type *)
 val mark_type_node:
-        ?guard:(type_expr -> bool) -> ?after:(type_expr -> unit) ->
+        ?guard:(type_expr -> bool) -> after:(type_expr -> unit) ->
         type_expr -> unit
         (* If the node is not already marked and [guard] returns true
            (the default), then mark it and run [after]. *)
+val mark_type_node_only: type_expr -> unit
+        (* A much simpler variant of [mark_type_node], even without [repr]'ing  *)
 val mark_type_params: type_expr -> unit
         (* Mark the sons of a type node *)
 val unmark_type: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -167,8 +167,6 @@ end
 
 val lowest_level: int
         (* Marked type: ty.level < lowest_level *)
-val pivot_level: int
-        (* Type marking: ty.level <- pivot_level - ty.level *)
 val not_marked_node: type_expr -> bool
         (* Return true if a type node is not yet marked *)
 val flip_mark_node: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -170,14 +170,15 @@ val lowest_level: int
 val pivot_level: int
 val mirror_level: int -> int
         (* Type marking: ty.level <- pivot_level - ty.level *)
-        (* mirror_level is used for unmarking; it must be involutive, invert order *)
+        (* mirror_level is used for unmarking; it must be involutive,
+	   invert order *)
 val mark_type: type_expr -> unit
         (* Mark a type *)
-val mark_type_node: type_expr -> unit
-        (* Mark a type node (but not its sons) *)
-val mark_type_node_with: type_expr -> (type_expr -> unit) -> unit
-        (* Mark a type node (but not its sons),
-	   then process the type if it was not already marked *)
+val mark_type_node:
+        ?guard:(type_expr -> bool) -> ?after:(type_expr -> unit) ->
+        type_expr -> unit
+        (* If the node is not already marked and [guard] returns true
+	   (the default), then mark it and run [after]. *)
 val mark_type_params: type_expr -> unit
         (* Mark the sons of a type node *)
 val unmark_type: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -174,13 +174,9 @@ val mirror_level: int -> int
            invert order *)
 val mark_type: type_expr -> unit
         (* Mark a type *)
-val mark_type_node:
-        ?guard:(type_expr -> bool) -> after:(type_expr -> unit) ->
-        type_expr -> unit
-        (* If the node is not already marked and [guard] returns true
-           (the default), then mark it and run [after]. *)
-val mark_type_node_only: type_expr -> unit
-        (* A much simpler variant of [mark_type_node], even without [repr]'ing  *)
+val mark_type_node: type_expr -> bool
+        (* Just mark a node if its level was highe than lowest_level,
+           and return whether this was done. No [repr]'ing. *)
 val mark_type_params: type_expr -> unit
         (* Mark the sons of a type node *)
 val unmark_type: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -168,10 +168,7 @@ end
 val lowest_level: int
         (* Marked type: ty.level < lowest_level *)
 val pivot_level: int
-val mirror_level: int -> int
         (* Type marking: ty.level <- pivot_level - ty.level *)
-        (* mirror_level is used for unmarking; it must be involutive,
-           invert order *)
 val not_marked_node: type_expr -> bool
         (* Return true if a type node is not yet marked *)
 val flip_mark_node: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -168,7 +168,9 @@ end
 val lowest_level: int
         (* Marked type: ty.level < lowest_level *)
 val pivot_level: int
+val mirror_level: int -> int
         (* Type marking: ty.level <- pivot_level - ty.level *)
+        (* mirror_level is used for unmarking; it must be involutive, invert order *)
 val mark_type: type_expr -> unit
         (* Mark a type *)
 val mark_type_node: type_expr -> unit

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -100,6 +100,9 @@ val has_constr_row: type_expr -> bool
 val is_row_name: string -> bool
 val is_constr_row: allow_ident:bool -> type_expr -> bool
 
+(* Set the polymorphic variant row_name field *)
+val set_row_name : type_declaration -> Path.t -> unit
+
 (**** Utilities for type traversal ****)
 
 val iter_type_expr: (type_expr -> unit) -> type_expr -> unit
@@ -170,6 +173,9 @@ val mark_type: type_expr -> unit
         (* Mark a type *)
 val mark_type_node: type_expr -> unit
         (* Mark a type node (but not its sons) *)
+val mark_type_node_with: type_expr -> (type_expr -> unit) -> unit
+        (* Mark a type node (but not its sons),
+	   then process the type if it was not already marked *)
 val mark_type_params: type_expr -> unit
         (* Mark the sons of a type node *)
 val unmark_type: type_expr -> unit
@@ -241,7 +247,7 @@ val set_row_field: row_field option ref -> row_field -> unit
 val set_univar: type_expr option ref -> type_expr -> unit
 val set_kind: field_kind option ref -> field_kind -> unit
 val set_commu: commutable ref -> commutable -> unit
-val set_typeset: TypeSet.t ref -> TypeSet.t -> unit
+(* val set_typeset: TypeSet.t ref -> TypeSet.t -> unit *)
         (* Set references, logging the old value *)
 
 (**** Forward declarations ****)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -247,7 +247,6 @@ val set_row_field: row_field option ref -> row_field -> unit
 val set_univar: type_expr option ref -> type_expr -> unit
 val set_kind: field_kind option ref -> field_kind -> unit
 val set_commu: commutable ref -> commutable -> unit
-(* val set_typeset: TypeSet.t ref -> TypeSet.t -> unit *)
         (* Set references, logging the old value *)
 
 (**** Forward declarations ****)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -568,7 +568,7 @@ let really_closed = ref None
    and only returns a [variable list].
  *)
 let rec free_vars_rec real ty =
-  mark_type_node_with ty
+  mark_type_node ty ~after:
     begin fun ty -> match ty.desc, !really_closed with
       Tvar _, _ ->
         free_variables := (ty, real) :: !free_variables
@@ -2109,7 +2109,7 @@ let expand_trace env trace =
 (* Return whether [t0] occurs in [ty]. Objects are also traversed. *)
 let deep_occur t0 ty =
   let rec occur_rec ty =
-    mark_type_node_with ty
+    mark_type_node ty ~after:
       begin fun ty ->
 	if ty == t0 then raise Occur;
 	iter_type_expr occur_rec ty
@@ -2427,7 +2427,7 @@ let mcomp env t1 t2 =
 let find_lowest_level ty =
   let lowest = ref (mirror_level generic_level) in
   let rec find ty =
-    mark_type_node_with ty
+    mark_type_node ty ~after:
       begin fun ty ->
 	if ty.level > !lowest then lowest := ty.level;
 	iter_type_expr find ty
@@ -3488,7 +3488,7 @@ let moregeneral env inst_nongen pat_sch subj_sch =
 (* Simpler, no? *)
 
 let rec rigidify_rec vars ty =
-  mark_type_node_with ty
+  mark_type_node ty ~after:
     begin fun ty -> match ty.desc with
     | Tvar _ ->
         if not (List.memq ty !vars) then vars := ty :: !vars

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2105,11 +2105,10 @@ let expand_trace env trace =
 let deep_occur t0 ty =
   let rec occur_rec ty =
     let ty = repr ty in
-    if try_mark_node ty then
-      begin
-        if ty == t0 then raise Occur;
-        iter_type_expr occur_rec ty
-      end
+    if ty.level >= t0.level && try_mark_node ty then begin
+      if ty == t0 then raise Occur;
+      iter_type_expr occur_rec ty
+    end
   in
   try
     occur_rec ty; unmark_type ty; false

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1234,7 +1234,8 @@ let rec copy ?partial ?keep_names scope ty =
                 | _ -> (more', row)
               in
               (* Register new type first for recursion *)
-              Private_type_expr.set_desc more (Tsubst(newgenty(Ttuple[more';t])));
+              Private_type_expr.set_desc
+                more (Tsubst(newgenty(Ttuple[more';t])));
               (* Return a new copy *)
               Tvariant (copy_row copy true row keep more')
           end
@@ -1936,7 +1937,7 @@ let occur_univar env ty =
   let visited = ref TypeMap.empty in
   let rec occur_rec bound ty =
     let ty = repr ty in
-    if not_marked_node ty then 
+    if not_marked_node ty then
       if TypeSet.is_empty bound then
         (flip_mark_node ty; occur_desc bound ty)
       else try

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -682,7 +682,7 @@ let closed_class params sign =
     (fun (lab, _, ty) -> if lab = dummy_method then mark_type ty)
     fields;
   try
-    mark_type_node (repr sign.csig_self);
+    mark_type_node_only (repr sign.csig_self);
     List.iter
       (fun (lab, kind, ty) ->
         if field_kind_repr kind = Fpresent then

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2421,15 +2421,15 @@ let mcomp env t1 t2 =
 (* Real unification *)
 
 let find_lowest_level ty =
-  let lowest = ref (mirror_level generic_level) in
+  let lowest = ref generic_level in
   let rec find ty =
     let ty = repr ty in
-    if try_mark_node ty then
-      begin
-        if ty.level > !lowest then lowest := ty.level;
-        iter_type_expr find ty
-      end
-  in find ty; unmark_type ty; mirror_level !lowest
+    if not_marked_node ty then begin
+      if ty.level < !lowest then lowest := ty.level;
+      flip_mark_node ty;
+      iter_type_expr find ty
+    end
+  in find ty; unmark_type ty; !lowest
 
 let find_expansion_scope env path =
   (Env.find_type path env).type_expansion_scope

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -816,7 +816,7 @@ let rec normalize_package_path env p =
 let rec check_scope_escape env level ty =
   let mark ty =
     (* Mark visited types with [ty.level < lowest_level]. *)
-    set_level ty (pivot_level - ty.level)
+    set_level ty (lowest_level - 1)
   in
   let ty = repr ty in
   (* If the type hasn't been marked, check it. Otherwise, we have already

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -568,10 +568,8 @@ let really_closed = ref None
    and only returns a [variable list].
  *)
 let rec free_vars_rec real ty =
-  let ty = repr ty in
-  if ty.level >= lowest_level then begin
-    ty.level <- pivot_level - ty.level;
-    begin match ty.desc, !really_closed with
+  mark_type_node_with ty
+    begin fun ty -> match ty.desc, !really_closed with
       Tvar _, _ ->
         free_variables := (ty, real) :: !free_variables
     | Tconstr (path, tl, _), Some env ->
@@ -596,8 +594,7 @@ let rec free_vars_rec real ty =
         if not (static_row row) then free_vars_rec false row.row_more
     | _    ->
         iter_type_expr (free_vars_rec true) ty
-    end;
-  end
+    end
 
 let free_vars ?env ty =
   free_variables := [];
@@ -730,8 +727,10 @@ let duplicate_class_type ty =
 *)
 let rec generalize ty =
   let ty = repr ty in
+  (* generalize the type iff ty.level <= !current_level *)
   if (ty.level > !current_level) && (ty.level <> generic_level) then begin
     set_level ty generic_level;
+    (* recur into abbrev for the speed *)
     begin match ty.desc with
       Tconstr (_, _, abbrev) ->
         iter_abbrev generalize !abbrev
@@ -1157,8 +1156,8 @@ let rec copy ?partial ?keep_names scope ty =
     For_copy.save_desc scope ty desc;
     let t = newvar() in          (* Stub *)
     set_scope t ty.scope;
-    ty.desc <- Tsubst t;
-    t.desc <-
+    (Internal.unlock ty).desc <- Tsubst t;
+    (Internal.unlock t).desc <-
       begin match desc with
       | Tconstr (p, tl, _) ->
           let abbrevs = proper_abbrevs p tl !abbreviations in
@@ -1188,7 +1187,8 @@ let rec copy ?partial ?keep_names scope ty =
           begin match more.desc with
             Tsubst {desc = Ttuple [_;ty2]} ->
               (* This variant type has been already copied *)
-              ty.desc <- Tsubst ty2; (* avoid Tlink in the new type *)
+              (Internal.unlock ty).desc <- Tsubst ty2;
+	      (* avoid Tlink in the new type *)
               Tlink ty2
           | _ ->
               (* If the row variable is not generic, we must keep it *)
@@ -1196,6 +1196,8 @@ let rec copy ?partial ?keep_names scope ty =
               let more' =
                 match more.desc with
                   Tsubst ty -> ty
+		  (* TODO: is this case possible?
+		     possibly an interaction with (copy more) below? *)
                 | Tconstr _ | Tnil ->
                     For_copy.save_desc scope more more.desc;
                     copy more
@@ -1235,7 +1237,7 @@ let rec copy ?partial ?keep_names scope ty =
                 | _ -> (more', row)
               in
               (* Register new type first for recursion *)
-              more.desc <- Tsubst(newgenty(Ttuple[more';t]));
+              (Internal.unlock more).desc <- Tsubst(newgenty(Ttuple[more';t]));
               (* Return a new copy *)
               Tvariant (copy_row copy true row keep more')
           end
@@ -1435,7 +1437,7 @@ let rec copy_sep cleanup_scope fixed free bound visited ty =
     if ty.level <> generic_level then ty else
     let t = newvar () in
     delayed_copy :=
-      lazy (t.desc <- Tlink (copy cleanup_scope ty))
+      lazy ((Internal.unlock t).desc <- Tlink (copy cleanup_scope ty))
       :: !delayed_copy;
     t
   else try
@@ -1453,7 +1455,7 @@ let rec copy_sep cleanup_scope fixed free bound visited ty =
           visited
     in
     let copy_rec = copy_sep cleanup_scope fixed free bound visited in
-    t.desc <-
+    (Internal.unlock t).desc <-
       begin match ty.desc with
       | Tvariant row0 ->
           let row = row_repr row0 in
@@ -1910,6 +1912,7 @@ let local_non_recursive_abbrev env p ty =
 
 (* Since we cannot duplicate universal variables, unification must
    be done at meta-level, using bindings in univar_pairs *)
+(* TODO: use find_opt *)
 let rec unify_univar t1 t2 = function
     (cl1, cl2) :: rem ->
       let find_univ t cl =
@@ -1938,7 +1941,8 @@ let occur_univar env ty =
     let ty = repr ty in
     if ty.level >= lowest_level &&
       if TypeSet.is_empty bound then
-        (ty.level <- pivot_level - ty.level; true)
+        ((Internal.unlock ty).level <- pivot_level - ty.level; true)
+        (* TODO: (mark_type_node ty; true)? *)
       else try
         let bound' = TypeMap.find ty !visited in
         if TypeSet.exists (fun x -> not (TypeSet.mem x bound)) bound' then

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1183,7 +1183,7 @@ let rec copy ?partial ?keep_names scope ty =
             Tsubst {desc = Ttuple [_;ty2]} ->
               (* This variant type has been already copied *)
               (Internal.unlock ty).desc <- Tsubst ty2;
-	      (* avoid Tlink in the new type *)
+              (* avoid Tlink in the new type *)
               Tlink ty2
           | _ ->
               (* If the row variable is not generic, we must keep it *)
@@ -1191,8 +1191,8 @@ let rec copy ?partial ?keep_names scope ty =
               let more' =
                 match more.desc with
                   Tsubst ty -> ty
-		  (* TODO: is this case possible?
-		     possibly an interaction with (copy more) below? *)
+                  (* TODO: is this case possible?
+                     possibly an interaction with (copy more) below? *)
                 | Tconstr _ | Tnil ->
                     For_copy.save_desc scope more more.desc;
                     copy more
@@ -1940,7 +1940,7 @@ let occur_univar env ty =
       if ty.level < pivot_level then () else
       let bound' = TypeMap.find ty !visited in
       if TypeSet.exists (fun x -> not (TypeSet.mem x bound)) bound' then begin
-	visited := TypeMap.add ty (TypeSet.inter bound bound') !visited;
+        visited := TypeMap.add ty (TypeSet.inter bound bound') !visited;
         occur_desc bound ty
       end
     with Not_found ->
@@ -2104,8 +2104,8 @@ let deep_occur t0 ty =
   let rec occur_rec ty =
     mark_type_node ty ~after:
       begin fun ty ->
-	if ty == t0 then raise Occur;
-	iter_type_expr occur_rec ty
+        if ty == t0 then raise Occur;
+        iter_type_expr occur_rec ty
       end
   in
   try
@@ -2422,8 +2422,8 @@ let find_lowest_level ty =
   let rec find ty =
     mark_type_node ty ~after:
       begin fun ty ->
-	if ty.level > !lowest then lowest := ty.level;
-	iter_type_expr find ty
+        if ty.level > !lowest then lowest := ty.level;
+        iter_type_expr find ty
       end
   in find ty; unmark_type ty; mirror_level !lowest
 
@@ -3264,9 +3264,9 @@ let moregen_occur env level ty =
   let rec occur ty =
     mark_type_node ty ~guard:
       begin fun ty ->
-	ty.level > level &&
-	if is_Tvar ty && ty.level >= generic_level - 1 then raise Occur
-	else true
+        ty.level > level &&
+        if is_Tvar ty && ty.level >= generic_level - 1 then raise Occur
+        else true
       end
       ~after:(iter_type_expr occur)
   in
@@ -4110,7 +4110,7 @@ let rec build_subtype env visited loops posi level t =
              as this occurrence might break the occur check.
              XXX not clear whether this correct anyway... *)
           if List.exists (deep_occur ty) tl1 then raise Not_found;
-	  set_type_desc ty (Tvar None);
+          set_type_desc ty (Tvar None);
           let t'' = newvar () in
           let loops = (ty, t'') :: loops in
           (* May discard [visited] as level is going down *)
@@ -4119,7 +4119,7 @@ let rec build_subtype env visited loops posi level t =
           assert (is_Tvar t'');
           let nm =
             if c > Equiv || deep_occur ty ty1' then None else Some(p,tl1) in
-	  set_type_desc t'' (Tobject (ty1', ref nm));
+          set_type_desc t'' (Tobject (ty1', ref nm));
           (try unify_var env ty t with Unify _ -> assert false);
           (t'', Changed)
       | _ -> raise Not_found

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -180,8 +180,8 @@ let extension_descr ~current_unit path_ext ext =
       cstr_uid = ext.ext_uid;
     }
 
-let none = Internal.lock
- {desc = Ttuple []; level = -1; scope = Btype.generic_level; id = -1}
+let none = Private_type_expr.create (Ttuple [])
+    ~level:(-1) ~scope:Btype.generic_level ~id:(-1)
                                         (* Clearly ill-formed type *)
 let dummy_label =
   { lbl_name = ""; lbl_res = none; lbl_arg = none; lbl_mut = Immutable;

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -25,7 +25,7 @@ let free_vars ?(param=false) ty =
   let ret = ref TypeSet.empty in
   let rec loop ty =
     let ty = repr ty in
-    if mark_type_node ty then
+    if try_mark_node ty then
       match ty.desc with
       | Tvar _ ->
           ret := TypeSet.add ty !ret

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -24,7 +24,7 @@ open Btype
 let free_vars ?(param=false) ty =
   let ret = ref TypeSet.empty in
   let rec loop ty =
-    mark_type_node_with ty
+    mark_type_node ty ~after:
       begin fun ty -> match ty.desc with
       | Tvar _ ->
           ret := TypeSet.add ty !ret

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -24,8 +24,9 @@ open Btype
 let free_vars ?(param=false) ty =
   let ret = ref TypeSet.empty in
   let rec loop ty =
-    mark_type_node ty ~after:
-      begin fun ty -> match ty.desc with
+    let ty = repr ty in
+    if mark_type_node ty then
+      match ty.desc with
       | Tvar _ ->
           ret := TypeSet.add ty !ret
       | Tvariant row ->
@@ -39,7 +40,6 @@ let free_vars ?(param=false) ty =
       (* XXX: What about Tobject ? *)
       | _ ->
           iter_type_expr loop ty
-      end
   in
   loop ty;
   unmark_type ty;

--- a/typing/datarepr.mli
+++ b/typing/datarepr.mli
@@ -43,7 +43,3 @@ val constructor_existentials :
     - the types of the constructor's arguments
     - the existential variables introduced by the constructor
  *)
-
-
-(* Set the polymorphic variant row_name field *)
-val set_row_name : type_declaration -> Path.t -> unit

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1551,7 +1551,7 @@ let rec components_of_module_maker
               may_subst Subst.type_declaration freshening_sub decl
             in
             let final_decl = Subst.type_declaration prefixing_sub fresh_decl in
-            Datarepr.set_row_name final_decl
+            Btype.set_row_name final_decl
               (Subst.type_path prefixing_sub (Path.Pident id));
             let constructors =
               List.map snd

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1182,7 +1182,7 @@ let rec tree_of_type_decl id decl =
       let vars = free_variables ty in
       List.iter
         (function {desc = Tvar (Some "_")} as ty ->
-            if List.memq ty vars then ty.desc <- Tvar None
+            if List.memq ty vars then set_type_desc ty (Tvar None)
           | _ -> ())
         params
   | None -> ()

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -131,7 +131,8 @@ let reset_for_saving () = new_id := -1
 
 let newpersty desc =
   decr new_id;
-  Private_type_expr.create desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_id
+  Private_type_expr.create
+    desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_id
 
 (* ensure that all occurrences of 'Tvar None' are physically shared *)
 let tvar_none = Tvar None

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -131,7 +131,8 @@ let reset_for_saving () = new_id := -1
 
 let newpersty desc =
   decr new_id;
-  { desc; level = generic_level; scope = Btype.lowest_level; id = !new_id }
+  Internal.lock
+    { desc; level = generic_level; scope = Btype.lowest_level; id = !new_id }
 
 (* ensure that all occurrences of 'Tvar None' are physically shared *)
 let tvar_none = Tvar None
@@ -154,7 +155,9 @@ let rec typexp copy_scope s ty =
           else newty2 ty.level desc
         in
         For_copy.save_desc copy_scope ty desc;
-        ty.desc <- Tsubst ty';
+        (Internal.unlock ty).desc <- Tsubst ty';
+	(* TODO: move this line to btype.ml
+	   there is a similar problem also in ctype.ml *)
         ty'
       else ty
   | Tsubst ty ->
@@ -175,9 +178,10 @@ let rec typexp copy_scope s ty =
       not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm in
     (* Make a stub *)
     let ty' = if s.for_saving then newpersty (Tvar None) else newgenvar () in
-    ty'.scope <- ty.scope;
-    ty.desc <- Tsubst ty';
-    ty'.desc <-
+    (Internal.unlock ty').scope <- ty.scope;
+    (* TODO: figure out why not use set_scope *)
+    (Internal.unlock ty).desc <- Tsubst ty';
+    (Internal.unlock ty').desc <-
       begin if has_fixed_row then
         match tm.desc with (* PR#7348 *)
           Tconstr (Pdot(m,i), tl, _abbrev) ->
@@ -214,7 +218,8 @@ let rec typexp copy_scope s ty =
           begin match more.desc with
             Tsubst {desc = Ttuple [_;ty2]} ->
               (* This variant type has been already copied *)
-              ty.desc <- Tsubst ty2; (* avoid Tlink in the new type *)
+              (Internal.unlock ty).desc <- Tsubst ty2;
+	      (* avoid Tlink in the new type *)
               Tlink ty2
           | _ ->
               let dup =
@@ -232,7 +237,8 @@ let rec typexp copy_scope s ty =
                 | _ -> assert false
               in
               (* Register new type first for recursion *)
-              more.desc <- Tsubst(newgenty(Ttuple[more';ty']));
+              (Internal.unlock more).desc <- Tsubst(newgenty(Ttuple[more';ty']));
+	      (* TODO: check if more' can be eliminated *)
               (* Return a new copy *)
               let row =
                 copy_row (typexp copy_scope s) true row (not dup) more' in

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -156,8 +156,8 @@ let rec typexp copy_scope s ty =
         in
         For_copy.save_desc copy_scope ty desc;
         (Internal.unlock ty).desc <- Tsubst ty';
-	(* TODO: move this line to btype.ml
-	   there is a similar problem also in ctype.ml *)
+        (* TODO: move this line to btype.ml
+           there is a similar problem also in ctype.ml *)
         ty'
       else ty
   | Tsubst ty ->
@@ -219,7 +219,7 @@ let rec typexp copy_scope s ty =
             Tsubst {desc = Ttuple [_;ty2]} ->
               (* This variant type has been already copied *)
               (Internal.unlock ty).desc <- Tsubst ty2;
-	      (* avoid Tlink in the new type *)
+              (* avoid Tlink in the new type *)
               Tlink ty2
           | _ ->
               let dup =
@@ -237,8 +237,9 @@ let rec typexp copy_scope s ty =
                 | _ -> assert false
               in
               (* Register new type first for recursion *)
-              (Internal.unlock more).desc <- Tsubst(newgenty(Ttuple[more';ty']));
-	      (* TODO: check if more' can be eliminated *)
+              (Internal.unlock more).desc <-
+                Tsubst(newgenty(Ttuple[more';ty']));
+              (* TODO: check if more' can be eliminated *)
               (* Return a new copy *)
               let row =
                 copy_row (typexp copy_scope s) true row (not dup) more' in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2414,9 +2414,10 @@ let check_partial_application statement exp =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   let rec check ty =
-    mark_type_node ty
-      ~guard:(fun ty -> if ty.level <= level then raise Exit else true)
-      ~after:(iter_type_expr check)
+    let ty = repr ty in
+    if ty.level < lowest_level then () else
+    if ty.level <= level then raise Exit else
+    if mark_type_node ty then iter_type_expr check ty
   in
   try check ty; unmark_type ty; true
   with Exit -> unmark_type ty; false
@@ -2439,8 +2440,9 @@ let create_package_type loc env (p, l) =
 
 let contains_variant_either ty =
   let rec loop ty =
-    mark_type_node ty ~after:
-      begin fun ty -> match ty.desc with
+    let ty = repr ty in
+    if mark_type_node ty then
+      begin match ty.desc with
         Tvariant row ->
           let row = row_repr row in
           if not (is_fixed row) then

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2415,9 +2415,9 @@ let check_partial_application statement exp =
 let generalizable level ty =
   let rec check ty =
     let ty = repr ty in
-    if ty.level < lowest_level then () else
-    if ty.level <= level then raise Exit else
-    if mark_type_node ty then iter_type_expr check ty
+    if not_marked_node ty then
+      if ty.level <= level then raise Exit else
+      (flip_mark_node ty; iter_type_expr check ty)
   in
   try check ty; unmark_type ty; true
   with Exit -> unmark_type ty; false
@@ -2441,7 +2441,7 @@ let create_package_type loc env (p, l) =
 let contains_variant_either ty =
   let rec loop ty =
     let ty = repr ty in
-    if mark_type_node ty then
+    if try_mark_node ty then
       begin match ty.desc with
         Tvariant row ->
           let row = row_repr row in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1049,7 +1049,7 @@ let unify_head_only ~refine loc env ty constr =
   let ty_res = repr ty_res in
   match ty_res.desc with
   | Tconstr(p,args,m) ->
-      ty_res.desc <- Tconstr(p,List.map (fun _ -> newvar ()) args,m);
+      set_type_desc ty_res (Tconstr(p,List.map (fun _ -> newvar ()) args,m));
       enforce_constraints !env ty_res;
       unify_pat_types ~refine loc env ty_res ty
   | _ -> assert false

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -177,7 +177,8 @@ let set_fixed_row env loc p decl =
     match tm.desc with
       Tvariant row ->
         let row = Btype.row_repr row in
-        tm.desc <- Tvariant {row with row_fixed = Some Fixed_private};
+	Btype.set_type_desc tm
+	  (Tvariant {row with row_fixed = Some Fixed_private});
         if Btype.static_row row then Btype.newgenty Tnil
         else row.row_more
     | Tobject (ty, _) ->
@@ -187,7 +188,7 @@ let set_fixed_row env loc p decl =
   in
   if not (Btype.is_Tvar rv) then
     raise (Error (loc, Bad_fixed_type "has no row variable"));
-  rv.desc <- Tconstr (p, decl.type_params, ref Mnil)
+  Btype.set_type_desc rv (Tconstr (p, decl.type_params, ref Mnil))
 
 (* Translate one type declaration *)
 
@@ -987,9 +988,10 @@ let transl_extension_constructor ~scope env type_path type_params
             Ctype.free_variables (Btype.newgenty (Ttuple args))
           in
             List.iter
-              (function {desc = Tvar (Some "_")} as ty ->
-                          if List.memq ty vars then ty.desc <- Tvar None
-                        | _ -> ())
+              (function {desc = Tvar (Some "_")} as ty
+		  when List.memq ty vars ->
+		    Btype.set_type_desc ty (Tvar None)
+		| _ -> ())
               typext_params
         end;
         (* Ensure that constructor's type matches the type being extended *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -177,8 +177,8 @@ let set_fixed_row env loc p decl =
     match tm.desc with
       Tvariant row ->
         let row = Btype.row_repr row in
-	Btype.set_type_desc tm
-	  (Tvariant {row with row_fixed = Some Fixed_private});
+        Btype.set_type_desc tm
+          (Tvariant {row with row_fixed = Some Fixed_private});
         if Btype.static_row row then Btype.newgenty Tnil
         else row.row_more
     | Tobject (ty, _) ->
@@ -989,9 +989,9 @@ let transl_extension_constructor ~scope env type_path type_params
           in
             List.iter
               (function {desc = Tvar (Some "_")} as ty
-		  when List.memq ty vars ->
-		    Btype.set_type_desc ty (Tvar None)
-		| _ -> ())
+                  when List.memq ty vars ->
+                    Btype.set_type_desc ty (Tvar None)
+                | _ -> ())
               typext_params
         end;
         (* Ensure that constructor's type matches the type being extended *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -79,7 +79,7 @@ module TypeOps = struct
   let equal t1 t2 = t1 == t2
 end
 
-module Unsafe_access = struct
+module Private_type_expr = struct
   let create desc ~level ~scope ~id = {desc; level; scope; id}
   let set_desc ty d = ty.desc <- d
   let set_level ty lv = ty.level <- lv

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -19,6 +19,7 @@ open Asttypes
 
 (* Type expressions for the core language *)
 
+
 type type_expr =
   { mutable desc: type_desc;
     mutable level: int;
@@ -79,6 +80,15 @@ module TypeOps = struct
   let equal t1 t2 = t1 == t2
 end
 
+module Internal = struct
+  type type_expr_internal = type_expr =
+      { mutable desc: type_desc;
+	mutable level: int;
+	mutable scope: int;
+	id: int }
+  let lock x = x
+  let unlock x = x
+end
 (* *)
 
 module Uid = struct

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -82,9 +82,9 @@ end
 module Internal = struct
   type type_expr_internal = type_expr =
       { mutable desc: type_desc;
-	mutable level: int;
-	mutable scope: int;
-	id: int }
+        mutable level: int;
+        mutable scope: int;
+        id: int }
   let lock x = x
   let unlock x = x
 end

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -19,7 +19,6 @@ open Asttypes
 
 (* Type expressions for the core language *)
 
-
 type type_expr =
   { mutable desc: type_desc;
     mutable level: int;

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -79,14 +79,11 @@ module TypeOps = struct
   let equal t1 t2 = t1 == t2
 end
 
-module Internal = struct
-  type type_expr_internal = type_expr =
-      { mutable desc: type_desc;
-        mutable level: int;
-        mutable scope: int;
-        id: int }
-  let lock x = x
-  let unlock x = x
+module Unsafe_access = struct
+  let create desc ~level ~scope ~id = {desc; level; scope; id}
+  let set_desc ty d = ty.desc <- d
+  let set_level ty lv = ty.level <- lv
+  let set_scope ty sc = ty.scope <- sc
 end
 (* *)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -55,7 +55,7 @@ open Asttypes
 
     Note on mutability: TBD.
  *)
-type type_expr =
+type type_expr = private
   { mutable desc: type_desc;
     mutable level: int;
     mutable scope: int;
@@ -232,6 +232,16 @@ and commutable =
     Cok
   | Cunknown
   | Clink of commutable ref
+
+module Internal : sig
+  type type_expr_internal =
+      { mutable desc: type_desc;
+	mutable level: int;
+	mutable scope: int;
+	id: int }
+  val lock : type_expr_internal -> type_expr
+  val unlock : type_expr -> type_expr_internal
+end
 
 module TypeOps : sig
   type t = type_expr

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -233,14 +233,11 @@ and commutable =
   | Cunknown
   | Clink of commutable ref
 
-module Internal : sig
-  type type_expr_internal =
-      { mutable desc: type_desc;
-        mutable level: int;
-        mutable scope: int;
-        id: int }
-  val lock : type_expr_internal -> type_expr
-  val unlock : type_expr -> type_expr_internal
+module Unsafe_access : sig
+  val create : type_desc -> level: int -> scope: int -> id: int -> type_expr
+  val set_desc : type_expr -> type_desc -> unit
+  val set_level : type_expr -> int -> unit
+  val set_scope : type_expr -> int -> unit
 end
 
 module TypeOps : sig

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -236,9 +236,9 @@ and commutable =
 module Internal : sig
   type type_expr_internal =
       { mutable desc: type_desc;
-	mutable level: int;
-	mutable scope: int;
-	id: int }
+        mutable level: int;
+        mutable scope: int;
+        id: int }
   val lock : type_expr_internal -> type_expr
   val unlock : type_expr -> type_expr_internal
 end

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -233,7 +233,7 @@ and commutable =
   | Cunknown
   | Clink of commutable ref
 
-module Unsafe_access : sig
+module Private_type_expr : sig
   val create : type_desc -> level: int -> scope: int -> id: int -> type_expr
   val set_desc : type_expr -> type_desc -> unit
   val set_level : type_expr -> int -> unit

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -492,7 +492,7 @@ and transl_type_aux env policy styp =
             if deep_occur v ty then begin
               match v.desc with
                 Tvar name when v.level = Btype.generic_level ->
-		  Btype.set_type_desc v (Tunivar name);
+                  Btype.set_type_desc v (Tunivar name);
                   v :: tyl
               | _ ->
                 raise (Error (styp.ptyp_loc, env, Cannot_quantify (name, v)))
@@ -599,9 +599,9 @@ let rec make_fixed_univars ty =
         let more = Btype.row_more row in
         if Btype.is_Tunivar more then
           Btype.set_type_desc ty
-	    (Tvariant
+            (Tvariant
                {row with row_fixed=Some(Univar more);
-		row_fields = List.map
+                row_fields = List.map
                  (fun (s,f as p) -> match Btype.row_field_repr f with
                    Reither (c, tl, _m, r) -> s, Reither (c, tl, true, r)
                  | _ -> p)

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -593,7 +593,7 @@ and transl_fields env policy o fields =
 (* Make the rows "fixed" in this type, to make universal check easier *)
 let rec make_fixed_univars ty =
   let ty = repr ty in
-  if Btype.mark_type_node ty then
+  if Btype.try_mark_node ty then
     begin match ty.desc with
     | Tvariant row ->
         let row = Btype.row_repr row in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -492,7 +492,7 @@ and transl_type_aux env policy styp =
             if deep_occur v ty then begin
               match v.desc with
                 Tvar name when v.level = Btype.generic_level ->
-                  v.desc <- Tunivar name;
+		  Btype.set_type_desc v (Tunivar name);
                   v :: tyl
               | _ ->
                 raise (Error (styp.ptyp_loc, env, Cannot_quantify (name, v)))
@@ -600,13 +600,14 @@ let rec make_fixed_univars ty =
         let row = Btype.row_repr row in
         let more = Btype.row_more row in
         if Btype.is_Tunivar more then
-          ty.desc <- Tvariant
+          Btype.set_type_desc ty
+	    (Tvariant
               {row with row_fixed=Some(Univar more);
                row_fields = List.map
                  (fun (s,f as p) -> match Btype.row_field_repr f with
                    Reither (c, tl, _m, r) -> s, Reither (c, tl, true, r)
                  | _ -> p)
-                 row.row_fields};
+                 row.row_fields});
         Btype.iter_row make_fixed_univars row
     | _ ->
         Btype.iter_type_expr make_fixed_univars ty
@@ -670,7 +671,7 @@ let transl_simple_type_univars env styp =
         let v = repr v in
         match v.desc with
           Tvar name when v.level = Btype.generic_level ->
-            v.desc <- Tunivar name; v :: acc
+            Btype.set_type_desc v (Tunivar name); v :: acc
         | _ -> acc)
       [] !pre_univars
   in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -592,8 +592,9 @@ and transl_fields env policy o fields =
 
 (* Make the rows "fixed" in this type, to make universal check easier *)
 let rec make_fixed_univars ty =
-  Btype.mark_type_node ty ~after:
-    begin fun ty ->  match ty.desc with
+  let ty = repr ty in
+  if Btype.mark_type_node ty then
+    begin match ty.desc with
     | Tvariant row ->
         let row = Btype.row_repr row in
         let more = Btype.row_more row in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -592,18 +592,16 @@ and transl_fields env policy o fields =
 
 (* Make the rows "fixed" in this type, to make universal check easier *)
 let rec make_fixed_univars ty =
-  let ty = repr ty in
-  if ty.level >= Btype.lowest_level then begin
-    Btype.mark_type_node ty;
-    match ty.desc with
+  Btype.mark_type_node ty ~after:
+    begin fun ty ->  match ty.desc with
     | Tvariant row ->
         let row = Btype.row_repr row in
         let more = Btype.row_more row in
         if Btype.is_Tunivar more then
           Btype.set_type_desc ty
 	    (Tvariant
-              {row with row_fixed=Some(Univar more);
-               row_fields = List.map
+               {row with row_fixed=Some(Univar more);
+		row_fields = List.map
                  (fun (s,f as p) -> match Btype.row_field_repr f with
                    Reither (c, tl, _m, r) -> s, Reither (c, tl, true, r)
                  | _ -> p)
@@ -611,7 +609,7 @@ let rec make_fixed_univars ty =
         Btype.iter_row make_fixed_univars row
     | _ ->
         Btype.iter_type_expr make_fixed_univars ty
-  end
+    end
 
 let make_fixed_univars ty =
   make_fixed_univars ty;


### PR DESCRIPTION
This PR makes `Types.type_expr` a private record, so that one cannot directly create or modify it.
The public definition is in submodule `Internal`, with conversion (identity) functions.

To make this definition easier to use, `Btype.mark_type_node` is extended with two new optional arguments, `guard` and `after`, which are called with the `repr`ed type, respectively before marking it (returning whether to mark it or not) and after marking it.

We have plans for further abstraction, but this seems a good first step.

@t6s co-authored this PR.
