### PR TITLE
fix -dsource printing of the pattern (A as x | (B as x))

### DIFF
--- a/Changes
+++ b/Changes
@@ -629,6 +629,8 @@ OCaml 4.12.0
   (Vincent Laviron, report by Stephen Dolan, review by Xavier Leroy and
   Stephen Dolan)
 
+- #9999: fix -dsource printing of the pattern (`A as x | (`B as x)).
+  (Gabriel Scherer, report by Anton Bachin, review by Florian Angeletti)
 
 OCaml 4.11.1
 ------------

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -416,7 +416,7 @@ and pattern_or ctxt f x =
   | [] -> assert false
   | [x] -> pattern1 ctxt f x
   | orpats ->
-      pp f "@[<hov0>%a@]" (list ~sep:"@,|" (pattern1 ctxt)) orpats
+      pp f "@[<hov0>%a@]" (list ~sep:"@ | " (pattern1 ctxt)) orpats
 
 and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
   let rec pattern_list_helper f = function

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -78,7 +78,7 @@
     ]
 ]
 
-let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
+let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
   structure_item (test_locations.ml[17,534+0]..test_locations.ml[19,572+34])
     Tstr_value Rec

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -78,7 +78,7 @@
     ]
 ]
 
-let rec fib = function | 0|1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
+let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
   structure_item 
     Tstr_value Rec

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7389,3 +7389,28 @@ let rec equal : 'a. ('a -> 'a -> bool) -> 'a t -> 'a t -> bool =
 type u = [ `A ] ;;
 type v = [ u | `B ] ;;
 let f = fun (x : [ | u ]) -> x ;;
+
+(* Issue #9999 *)
+let test = function
+  | `A | `B as x -> ignore x
+
+let test = function
+  | `A as x | (`B as x) -> ignore x
+
+let test = function
+  | `A as x | (`B as x) as z -> ignore (z, x)
+
+let test = function
+  | (`A as x) | (`B as x) as z -> ignore (z, x)
+
+let test = function
+  | (`A | `B) | `C -> ()
+
+let test = function
+  | `A | (`B | `C) -> ()
+
+let test = function
+  | `A | `B | `C -> ()
+
+let test = function
+  | (`A | `B) as x | `C -> ()


### PR DESCRIPTION
fixes #9999