### PR TITLE
Try expanding aliases in Ctype.nondep_type_rec

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,7 +27,7 @@ Working version
 ### Bug fixes:
 
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
-  (Stephen Dolan, review by Gabriel Scherer)
+  (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)
 
 OCaml 4.12.0
 ------------

--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
 
 ### Bug fixes:
 
+- #10005: Try expanding aliases in Ctype.nondep_type_rec
+  (Stephen Dolan, review by Gabriel Scherer)
+
 OCaml 4.12.0
 ------------
 

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -35,3 +35,12 @@ module M :
     sig module type S = sig type t = float val foo : t X.t end end
 module N : sig module type S = sig type t = float val foo : int end end
 |}]
+
+type 'a always_int = int
+module F (X : sig type t end) = struct type s = X.t always_int end
+module M = F (struct type t = T end)
+[%%expect{|
+type 'a always_int = int
+module F : functor (X : sig type t end) -> sig type s = X.t always_int end
+module M : sig type s = int end
+|}]


### PR DESCRIPTION
Ctype.nondep_type_rec sometimes fails to expand aliases:
```ocaml
type 'a always_int = int
module F (X : sig type t end) = struct type s = X.t always_int end
module M = F (struct type t = T end)
```
Trunk currently gives `M : sig type s end`, because it cannot write `X.t always_int` without mentioning `X`. However, by expanding `X.t always_int`, it could give instead `M : sig type s = int end`, which is what you'd get if you manually expanded `X.t always_int` to `int`.

This patch always expands if nondep fails.