### PR TITLE
Expose module signature when typing implementation

### DIFF
--- a/.depend
+++ b/.depend
@@ -5743,6 +5743,7 @@ driver/compenv.cmx : \
 driver/compenv.cmi : \
     utils/clflags.cmi
 driver/compile.cmo : \
+    typing/typedtree.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
     utils/profile.cmi \
@@ -5756,6 +5757,7 @@ driver/compile.cmo : \
     bytecomp/bytegen.cmi \
     driver/compile.cmi
 driver/compile.cmx : \
+    typing/typedtree.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
     utils/profile.cmx \
@@ -5934,6 +5936,7 @@ driver/makedepend.cmx : \
     driver/makedepend.cmi
 driver/makedepend.cmi :
 driver/optcompile.cmo : \
+    typing/typedtree.cmi \
     lambda/translmod.cmi \
     lambda/simplif.cmi \
     utils/profile.cmi \
@@ -5949,6 +5952,7 @@ driver/optcompile.cmo : \
     asmcomp/asmgen.cmi \
     driver/optcompile.cmi
 driver/optcompile.cmx : \
+    typing/typedtree.cmx \
     lambda/translmod.cmx \
     lambda/simplif.cmx \
     utils/profile.cmx \

--- a/.depend
+++ b/.depend
@@ -1010,6 +1010,7 @@ typing/printtyp.cmi : \
     parsing/asttypes.cmi
 typing/printtyped.cmo : \
     typing/types.cmi \
+    typing/typemod.cmi \
     typing/typedtree.cmi \
     parsing/printast.cmi \
     typing/path.cmi \
@@ -1022,6 +1023,7 @@ typing/printtyped.cmo : \
     typing/printtyped.cmi
 typing/printtyped.cmx : \
     typing/types.cmx \
+    typing/typemod.cmx \
     typing/typedtree.cmx \
     parsing/printast.cmx \
     typing/path.cmx \

--- a/.depend
+++ b/.depend
@@ -1010,7 +1010,6 @@ typing/printtyp.cmi : \
     parsing/asttypes.cmi
 typing/printtyped.cmo : \
     typing/types.cmi \
-    typing/typemod.cmi \
     typing/typedtree.cmi \
     parsing/printast.cmi \
     typing/path.cmi \
@@ -1023,7 +1022,6 @@ typing/printtyped.cmo : \
     typing/printtyped.cmi
 typing/printtyped.cmx : \
     typing/types.cmx \
-    typing/typemod.cmx \
     typing/typedtree.cmx \
     parsing/printast.cmx \
     typing/path.cmx \

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -27,7 +27,7 @@ let interface ~source_file ~output_prefix =
 
 (** Bytecode compilation backend for .ml files. *)
 
-let to_bytecode i (typedtree, coercion) =
+let to_bytecode i (typedtree, coercion, _signature) =
   (typedtree, coercion)
   |> Profile.(record transl)
     (Translmod.transl_implementation i.module_name)

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -27,7 +27,7 @@ let interface ~source_file ~output_prefix =
 
 (** Bytecode compilation backend for .ml files. *)
 
-let to_bytecode i Typemod.{structure; coercion; _} =
+let to_bytecode i Typedtree.{structure; coercion; _} =
   (structure, coercion)
   |> Profile.(record transl)
     (Translmod.transl_implementation i.module_name)

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -27,8 +27,8 @@ let interface ~source_file ~output_prefix =
 
 (** Bytecode compilation backend for .ml files. *)
 
-let to_bytecode i (typedtree, coercion, _signature) =
-  (typedtree, coercion)
+let to_bytecode i Typemod.{structure; coercion; _} =
+  (structure, coercion)
   |> Profile.(record transl)
     (Translmod.transl_implementation i.module_name)
   |> Profile.(record ~accumulate:true generate)

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -25,7 +25,7 @@ val implementation:
 
 val to_bytecode :
   Compile_common.info ->
-  Typemod.typed_impl ->
+  Typedtree.t ->
   Instruct.instruction list * Ident.Set.t
 (** [to_bytecode info typed] takes a typechecked implementation
     and returns its bytecode.

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -25,7 +25,7 @@ val implementation:
 
 val to_bytecode :
   Compile_common.info ->
-  Typedtree.structure * Typedtree.module_coercion * Types.signature ->
+  Typemod.typed_impl ->
   Instruct.instruction list * Ident.Set.t
 (** [to_bytecode info typed] takes a typechecked implementation
     and returns its bytecode.

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -25,7 +25,7 @@ val implementation:
 
 val to_bytecode :
   Compile_common.info ->
-  Typedtree.structure * Typedtree.module_coercion ->
+  Typedtree.structure * Typedtree.module_coercion * Types.signature ->
   Instruct.instruction list * Ident.Set.t
 (** [to_bytecode info typed] takes a typechecked implementation
     and returns its bytecode.

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -25,7 +25,7 @@ val implementation:
 
 val to_bytecode :
   Compile_common.info ->
-  Typedtree.t ->
+  Typedtree.implementation ->
   Instruct.instruction list * Ident.Set.t
 (** [to_bytecode info typed] takes a typechecked implementation
     and returns its bytecode.

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -74,7 +74,8 @@ val typecheck_impl : info -> Parsetree.structure -> Typedtree.implementation
     coercion against that public interface.
 *)
 
-val implementation : info -> backend:(info -> Typedtree.implementation -> unit) -> unit
+val implementation :
+  info -> backend:(info -> Typedtree.implementation -> unit) -> unit
 (** The complete compilation pipeline for implementations. *)
 
 (** {2 Build artifacts} *)

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -68,13 +68,13 @@ val interface : info -> unit
 val parse_impl : info -> Parsetree.structure
 (** [parse_impl info] parses an implementation (usually an [.ml] file). *)
 
-val typecheck_impl : info -> Parsetree.structure -> Typemod.typed_impl
+val typecheck_impl : info -> Parsetree.structure -> Typedtree.t
 (** [typecheck_impl info parsetree] typechecks an implementation and returns
     the typedtree of the associated module, its public interface, and a
     coercion against that public interface.
 *)
 
-val implementation : info -> backend:(info -> Typemod.typed_impl -> unit) -> unit
+val implementation : info -> backend:(info -> Typedtree.t -> unit) -> unit
 (** The complete compilation pipeline for implementations. *)
 
 (** {2 Build artifacts} *)

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -69,15 +69,19 @@ val parse_impl : info -> Parsetree.structure
 (** [parse_impl info] parses an implementation (usually an [.ml] file). *)
 
 val typecheck_impl :
-  info -> Parsetree.structure -> Typedtree.structure * Typedtree.module_coercion
+  info ->
+  Parsetree.structure ->
+  Typedtree.structure * Typedtree.module_coercion * Types.signature
 (** [typecheck_impl info parsetree] typechecks an implementation and returns
     the typedtree of the associated module, along with a coercion against
-    its public interface.
+    its public interface, and its public interface.
 *)
 
 val implementation :
   info ->
-  backend:(info -> Typedtree.structure * Typedtree.module_coercion -> unit) ->
+  backend:(info ->
+           Typedtree.structure * Typedtree.module_coercion * Types.signature ->
+           unit) ->
   unit
 (** The complete compilation pipeline for implementations. *)
 

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -68,13 +68,13 @@ val interface : info -> unit
 val parse_impl : info -> Parsetree.structure
 (** [parse_impl info] parses an implementation (usually an [.ml] file). *)
 
-val typecheck_impl : info -> Parsetree.structure -> Typedtree.t
+val typecheck_impl : info -> Parsetree.structure -> Typedtree.implementation
 (** [typecheck_impl info parsetree] typechecks an implementation and returns
     the typedtree of the associated module, its public interface, and a
     coercion against that public interface.
 *)
 
-val implementation : info -> backend:(info -> Typedtree.t -> unit) -> unit
+val implementation : info -> backend:(info -> Typedtree.implementation -> unit) -> unit
 (** The complete compilation pipeline for implementations. *)
 
 (** {2 Build artifacts} *)

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -68,21 +68,13 @@ val interface : info -> unit
 val parse_impl : info -> Parsetree.structure
 (** [parse_impl info] parses an implementation (usually an [.ml] file). *)
 
-val typecheck_impl :
-  info ->
-  Parsetree.structure ->
-  Typedtree.structure * Typedtree.module_coercion * Types.signature
+val typecheck_impl : info -> Parsetree.structure -> Typemod.typed_impl
 (** [typecheck_impl info parsetree] typechecks an implementation and returns
-    the typedtree of the associated module, along with a coercion against
-    its public interface, and its public interface.
+    the typedtree of the associated module, its public interface, and a
+    coercion against that public interface.
 *)
 
-val implementation :
-  info ->
-  backend:(info ->
-           Typedtree.structure * Typedtree.module_coercion * Types.signature ->
-           unit) ->
-  unit
+val implementation : info -> backend:(info -> Typemod.typed_impl -> unit) -> unit
 (** The complete compilation pipeline for implementations. *)
 
 (** {2 Build artifacts} *)

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -31,13 +31,14 @@ let (|>>) (x, y) f = (x, f y)
 
 (** Native compilation backend for .ml files. *)
 
-let flambda i backend typed =
+let flambda i backend (structure, coercion, _signature) =
   if !Clflags.classic_inlining then begin
     Clflags.default_simplify_rounds := 1;
     Clflags.use_inlining_arguments_set Clflags.classic_arguments;
     Clflags.unbox_free_vars_of_closures := false;
     Clflags.unbox_specialised_args := false
   end;
+  let typed = (structure, coercion) in
   typed
   |> Profile.(record transl)
       (Translmod.transl_implementation_flambda i.module_name)
@@ -66,8 +67,9 @@ let flambda i backend typed =
         program);
     Compilenv.save_unit_info (cmx i))
 
-let clambda i backend typed =
+let clambda i backend (structure, coercion, _signature) =
   Clflags.use_inlining_arguments_set Clflags.classic_arguments;
+  let typed = (structure, coercion) in
   typed
   |> Profile.(record transl)
     (Translmod.transl_store_implementation i.module_name)

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -31,15 +31,14 @@ let (|>>) (x, y) f = (x, f y)
 
 (** Native compilation backend for .ml files. *)
 
-let flambda i backend (structure, coercion, _signature) =
+let flambda i backend Typemod.{structure; coercion; _} =
   if !Clflags.classic_inlining then begin
     Clflags.default_simplify_rounds := 1;
     Clflags.use_inlining_arguments_set Clflags.classic_arguments;
     Clflags.unbox_free_vars_of_closures := false;
     Clflags.unbox_specialised_args := false
   end;
-  let typed = (structure, coercion) in
-  typed
+  (structure, coercion)
   |> Profile.(record transl)
       (Translmod.transl_implementation_flambda i.module_name)
   |> Profile.(record generate)
@@ -67,10 +66,9 @@ let flambda i backend (structure, coercion, _signature) =
         program);
     Compilenv.save_unit_info (cmx i))
 
-let clambda i backend (structure, coercion, _signature) =
+let clambda i backend Typemod.{structure; coercion; _} =
   Clflags.use_inlining_arguments_set Clflags.classic_arguments;
-  let typed = (structure, coercion) in
-  typed
+  (structure, coercion)
   |> Profile.(record transl)
     (Translmod.transl_store_implementation i.module_name)
   |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.program

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -31,7 +31,7 @@ let (|>>) (x, y) f = (x, f y)
 
 (** Native compilation backend for .ml files. *)
 
-let flambda i backend Typemod.{structure; coercion; _} =
+let flambda i backend Typedtree.{structure; coercion; _} =
   if !Clflags.classic_inlining then begin
     Clflags.default_simplify_rounds := 1;
     Clflags.use_inlining_arguments_set Clflags.classic_arguments;
@@ -66,7 +66,7 @@ let flambda i backend Typemod.{structure; coercion; _} =
         program);
     Compilenv.save_unit_info (cmx i))
 
-let clambda i backend Typemod.{structure; coercion; _} =
+let clambda i backend Typedtree.{structure; coercion; _} =
   Clflags.use_inlining_arguments_set Clflags.classic_arguments;
   (structure, coercion)
   |> Profile.(record transl)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -25,13 +25,17 @@ val implementation:
 (** {2 Internal functions} **)
 
 val clambda :
-  Compile_common.info -> (module Backend_intf.S) -> Typedtree.t-> unit
+  Compile_common.info ->
+  (module Backend_intf.S) ->
+  Typedtree.implementation -> unit
 (** [clambda info typed] applies the regular compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)
 
 val flambda :
-  Compile_common.info -> (module Backend_intf.S) -> Typedtree.t -> unit
+  Compile_common.info ->
+  (module Backend_intf.S) ->
+  Typedtree.implementation -> unit
 (** [flambda info backend typed] applies the Flambda compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -25,13 +25,13 @@ val implementation:
 (** {2 Internal functions} **)
 
 val clambda :
-  Compile_common.info -> (module Backend_intf.S) -> Typemod.typed_impl-> unit
+  Compile_common.info -> (module Backend_intf.S) -> Typedtree.t-> unit
 (** [clambda info typed] applies the regular compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)
 
 val flambda :
-  Compile_common.info -> (module Backend_intf.S) -> Typemod.typed_impl -> unit
+  Compile_common.info -> (module Backend_intf.S) -> Typedtree.t -> unit
 (** [flambda info backend typed] applies the Flambda compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -27,7 +27,7 @@ val implementation:
 val clambda :
   Compile_common.info ->
   (module Backend_intf.S) ->
-  Typedtree.structure * Typedtree.module_coercion -> unit
+  Typedtree.structure * Typedtree.module_coercion * Types.signature -> unit
 (** [clambda info typed] applies the regular compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)
@@ -35,7 +35,7 @@ val clambda :
 val flambda :
   Compile_common.info ->
   (module Backend_intf.S) ->
-  Typedtree.structure * Typedtree.module_coercion -> unit
+  Typedtree.structure * Typedtree.module_coercion * Types.signature -> unit
 (** [flambda info backend typed] applies the Flambda compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -25,17 +25,13 @@ val implementation:
 (** {2 Internal functions} **)
 
 val clambda :
-  Compile_common.info ->
-  (module Backend_intf.S) ->
-  Typedtree.structure * Typedtree.module_coercion * Types.signature -> unit
+  Compile_common.info -> (module Backend_intf.S) -> Typemod.typed_impl-> unit
 (** [clambda info typed] applies the regular compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)
 
 val flambda :
-  Compile_common.info ->
-  (module Backend_intf.S) ->
-  Typedtree.structure * Typedtree.module_coercion * Types.signature -> unit
+  Compile_common.info -> (module Backend_intf.S) -> Typemod.typed_impl -> unit
 (** [flambda info backend typed] applies the Flambda compilation pipeline to the
     given typechecked implementation and outputs the resulting files.
 *)

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -151,7 +151,7 @@ let process_file sourcefile =
          match parsetree_typedtree_opt with
            None ->
              None
-         | Some (parsetree, (structure, coercion, _signature)) ->
+         | Some (parsetree, Typemod.{structure; coercion; _}) ->
              let typedtree = (structure, coercion) in
              let file_module = Ast_analyser.analyse_typed_tree file
                  input_file parsetree typedtree

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -151,7 +151,7 @@ let process_file sourcefile =
          match parsetree_typedtree_opt with
            None ->
              None
-         | Some (parsetree, Typemod.{structure; coercion; _}) ->
+         | Some (parsetree, Typedtree.{structure; coercion; _}) ->
              let typedtree = (structure, coercion) in
              let file_module = Ast_analyser.analyse_typed_tree file
                  input_file parsetree typedtree

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -151,7 +151,8 @@ let process_file sourcefile =
          match parsetree_typedtree_opt with
            None ->
              None
-         | Some (parsetree, typedtree) ->
+         | Some (parsetree, (structure, coercion, _signature)) ->
+             let typedtree = (structure, coercion) in
              let file_module = Ast_analyser.analyse_typed_tree file
                  input_file parsetree typedtree
              in

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -942,4 +942,4 @@ let interface ppf x = list 0 signature_item ppf x.sig_items;;
 
 let implementation ppf x = list 0 structure_item ppf x.str_items;;
 
-let implementation_with_coercion ppf (x, _) = implementation ppf x
+let implementation_with_coercion ppf (x, _, _) = implementation ppf x

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -942,4 +942,4 @@ let interface ppf x = list 0 signature_item ppf x.sig_items;;
 
 let implementation ppf x = list 0 structure_item ppf x.str_items;;
 
-let implementation_with_coercion ppf Typemod.{structure; _} = implementation ppf structure 
+let implementation_with_coercion ppf Typedtree.{structure; _} = implementation ppf structure 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -942,4 +942,5 @@ let interface ppf x = list 0 signature_item ppf x.sig_items;;
 
 let implementation ppf x = list 0 structure_item ppf x.str_items;;
 
-let implementation_with_coercion ppf Typedtree.{structure; _} = implementation ppf structure 
+let implementation_with_coercion ppf Typedtree.{structure; _} =
+  implementation ppf structure

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -942,4 +942,4 @@ let interface ppf x = list 0 signature_item ppf x.sig_items;;
 
 let implementation ppf x = list 0 structure_item ppf x.str_items;;
 
-let implementation_with_coercion ppf (x, _, _) = implementation ppf x
+let implementation_with_coercion ppf Typemod.{structure; _} = implementation ppf structure 

--- a/typing/printtyped.mli
+++ b/typing/printtyped.mli
@@ -19,4 +19,4 @@ open Format;;
 val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure -> unit;;
 
-val implementation_with_coercion : formatter -> Typedtree.t -> unit;;
+val implementation_with_coercion : formatter -> Typedtree.implementation -> unit;;

--- a/typing/printtyped.mli
+++ b/typing/printtyped.mli
@@ -20,4 +20,4 @@ val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure -> unit;;
 
 val implementation_with_coercion :
-    formatter -> (structure * module_coercion) -> unit;;
+    formatter -> (structure * module_coercion * Types.signature) -> unit;;

--- a/typing/printtyped.mli
+++ b/typing/printtyped.mli
@@ -19,4 +19,4 @@ open Format;;
 val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure -> unit;;
 
-val implementation_with_coercion : formatter -> Typemod.typed_impl -> unit;;
+val implementation_with_coercion : formatter -> Typedtree.t -> unit;;

--- a/typing/printtyped.mli
+++ b/typing/printtyped.mli
@@ -19,4 +19,5 @@ open Format;;
 val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure -> unit;;
 
-val implementation_with_coercion : formatter -> Typedtree.implementation -> unit;;
+val implementation_with_coercion :
+  formatter -> Typedtree.implementation -> unit;;

--- a/typing/printtyped.mli
+++ b/typing/printtyped.mli
@@ -20,4 +20,4 @@ val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure -> unit;;
 
 val implementation_with_coercion :
-    formatter -> (structure * module_coercion * Types.signature) -> unit;;
+    formatter -> Typemod.typed_impl -> unit;;

--- a/typing/printtyped.mli
+++ b/typing/printtyped.mli
@@ -19,5 +19,4 @@ open Format;;
 val interface : formatter -> signature -> unit;;
 val implementation : formatter -> structure -> unit;;
 
-val implementation_with_coercion :
-    formatter -> Typemod.typed_impl -> unit;;
+val implementation_with_coercion : formatter -> Typemod.typed_impl -> unit;;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -613,6 +613,13 @@ and 'a class_infos =
     ci_attributes: attribute list;
    }
 
+type t = {
+  structure: structure;
+  coercion: module_coercion;
+  signature: Types.signature
+}
+
+
 (* Auxiliary functions over the a.s.t. *)
 
 let as_computation_pattern (p : pattern) : computation general_pattern =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -613,7 +613,7 @@ and 'a class_infos =
     ci_attributes: attribute list;
    }
 
-type t = {
+type implementation = {
   structure: structure;
   coercion: module_coercion;
   signature: Types.signature

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -752,7 +752,7 @@ and 'a class_infos =
     ci_attributes: attributes;
    }
 
-type t = {
+type implementation = {
   structure: structure;
   coercion: module_coercion;
   signature: Types.signature

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -752,6 +752,12 @@ and 'a class_infos =
     ci_attributes: attributes;
    }
 
+type t = {
+  structure: structure;
+  coercion: module_coercion;
+  signature: Types.signature
+}
+
 (* Auxiliary functions over the a.s.t. *)
 
 (** [as_computation_pattern p] is a computation pattern with description

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -757,7 +757,14 @@ type implementation = {
   coercion: module_coercion;
   signature: Types.signature
 }
+(** A typechecked implementation including its module structure, its exported
+    signature, and a coercion of the module against that signature.
+  
+    If an .mli file is present, the signature will come from that file and be
+    the exported signature of the module.
 
+    If there isn't one, the signature will be inferred from the module structure.
+*)
 (* Auxiliary functions over the a.s.t. *)
 
 (** [as_computation_pattern p] is a computation pattern with description

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -759,12 +759,14 @@ type implementation = {
 }
 (** A typechecked implementation including its module structure, its exported
     signature, and a coercion of the module against that signature.
-  
+
     If an .mli file is present, the signature will come from that file and be
     the exported signature of the module.
 
-    If there isn't one, the signature will be inferred from the module structure.
+    If there isn't one, the signature will be inferred from the module
+    structure.
 *)
+
 (* Auxiliary functions over the a.s.t. *)
 
 (** [as_computation_pattern p] is a computation pattern with description

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2637,7 +2637,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
               (Printtyp.printed_signature sourcefile) simple_sg
           );
         gen_annot outputprefix sourcefile (Cmt_format.Implementation str);
-        (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)
+        (str, Tcoerce_none, simple_sg)   (* result is ignored by Compile.implementation *)
       end else begin
         let sourceintf =
           Filename.remove_extension sourcefile ^ !Config.interface_suffix in
@@ -2661,7 +2661,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
           Cmt_format.save_cmt (outputprefix ^ ".cmt") modulename
             annots (Some sourcefile) initial_env None;
           gen_annot outputprefix sourcefile annots;
-          (str, coercion)
+          (str, coercion, dclsig)
         end else begin
           let coercion =
             Includemod.compunit initial_env ~mark:Mark_positive
@@ -2685,7 +2685,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
               annots (Some sourcefile) initial_env (Some cmi);
             gen_annot outputprefix sourcefile annots
           end;
-          (str, coercion)
+          (str, coercion, simple_sg)
         end
       end
     )

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -106,6 +106,12 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
+type typed_impl = {
+  structure: Typedtree.structure;
+  coercion: Typedtree.module_coercion;
+  signature: Types.signature
+}
+
 open Typedtree
 
 let rec path_concat head p =
@@ -2637,7 +2643,10 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
               (Printtyp.printed_signature sourcefile) simple_sg
           );
         gen_annot outputprefix sourcefile (Cmt_format.Implementation str);
-        (str, Tcoerce_none, simple_sg)   (* result is ignored by Compile.implementation *)
+        { structure = str;
+          coercion = Tcoerce_none;
+          signature = simple_sg
+        } (* result is ignored by Compile.implementation *)
       end else begin
         let sourceintf =
           Filename.remove_extension sourcefile ^ !Config.interface_suffix in
@@ -2661,7 +2670,10 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
           Cmt_format.save_cmt (outputprefix ^ ".cmt") modulename
             annots (Some sourcefile) initial_env None;
           gen_annot outputprefix sourcefile annots;
-          (str, coercion, dclsig)
+          { structure = str;
+            coercion;
+            signature = dclsig
+          }
         end else begin
           let coercion =
             Includemod.compunit initial_env ~mark:Mark_positive
@@ -2685,7 +2697,10 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
               annots (Some sourcefile) initial_env (Some cmi);
             gen_annot outputprefix sourcefile annots
           end;
-          (str, coercion, simple_sg)
+          { structure = str;
+            coercion;
+            signature = simple_sg
+          }
         end
       end
     )

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -106,12 +106,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-type typed_impl = {
-  structure: Typedtree.structure;
-  coercion: Typedtree.module_coercion;
-  signature: Types.signature
-}
-
 open Typedtree
 
 let rec path_concat head p =

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -29,6 +29,12 @@ module Signature_names : sig
   val simplify: Env.t -> t -> signature -> signature
 end
 
+type typed_impl = {
+  structure: Typedtree.structure;
+  coercion: Typedtree.module_coercion;
+  signature: Types.signature
+}
+
 val type_module:
         Env.t -> Parsetree.module_expr -> Typedtree.module_expr
 val type_structure:
@@ -38,8 +44,7 @@ val type_toplevel_phrase:
   Env.t -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Env.t
 val type_implementation:
-  string -> string -> string -> Env.t -> Parsetree.structure ->
-  Typedtree.structure * Typedtree.module_coercion * Types.signature
+  string -> string -> string -> Env.t -> Parsetree.structure -> typed_impl
 val type_interface:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val transl_signature:

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -29,12 +29,6 @@ module Signature_names : sig
   val simplify: Env.t -> t -> signature -> signature
 end
 
-type typed_impl = {
-  structure: Typedtree.structure;
-  coercion: Typedtree.module_coercion;
-  signature: Types.signature
-}
-
 val type_module:
         Env.t -> Parsetree.module_expr -> Typedtree.module_expr
 val type_structure:
@@ -44,7 +38,7 @@ val type_toplevel_phrase:
   Env.t -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Env.t
 val type_implementation:
-  string -> string -> string -> Env.t -> Parsetree.structure -> typed_impl
+  string -> string -> string -> Env.t -> Parsetree.structure -> Typedtree.t
 val type_interface:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val transl_signature:

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -38,7 +38,8 @@ val type_toplevel_phrase:
   Env.t -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Env.t
 val type_implementation:
-  string -> string -> string -> Env.t -> Parsetree.structure -> Typedtree.t
+  string -> string -> string -> Env.t ->
+  Parsetree.structure -> Typedtree.implementation
 val type_interface:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val transl_signature:

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -39,7 +39,7 @@ val type_toplevel_phrase:
   Typedtree.structure * Types.signature * Signature_names.t * Env.t
 val type_implementation:
   string -> string -> string -> Env.t -> Parsetree.structure ->
-  Typedtree.structure * Typedtree.module_coercion
+  Typedtree.structure * Typedtree.module_coercion * Types.signature
 val type_interface:
         Env.t -> Parsetree.signature -> Typedtree.signature
 val transl_signature:

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -605,7 +605,7 @@ let functor_parameter sub : functor_parameter -> Parsetree.functor_parameter =
   | Unit -> Unit
   | Named (_, name, mtype) -> Named (name, sub.module_type sub mtype)
 
-let module_type sub mty =
+let module_type (sub : mapper) mty =
   let loc = sub.location sub mty.mty_loc in
   let attrs = sub.attributes sub mty.mty_attributes in
   let desc = match mty.mty_desc with
@@ -633,7 +633,7 @@ let with_constraint sub (_path, lid, cstr) =
   | Twith_modsubst (_path, lid2) ->
       Pwith_modsubst (map_loc sub lid, map_loc sub lid2)
 
-let module_expr sub mexpr =
+let module_expr (sub : mapper) mexpr =
   let loc = sub.location sub mexpr.mod_loc in
   let attrs = sub.attributes sub mexpr.mod_attributes in
   match mexpr.mod_desc with
@@ -882,10 +882,10 @@ let default_mapper =
     object_field = object_field ;
   }
 
-let untype_structure ?(mapper=default_mapper) structure =
+let untype_structure ?(mapper : mapper = default_mapper) structure =
   mapper.structure mapper structure
 
-let untype_signature ?(mapper=default_mapper) signature =
+let untype_signature ?(mapper : mapper = default_mapper) signature =
   mapper.signature mapper signature
 
 let untype_expression ?(mapper=default_mapper) expression =


### PR DESCRIPTION
While working on a new backend for OCaml to generate Erlang sources, I
found the need to read the .cmi file back into a `Types.signature`
value.

@Drup spotted that I was reading the file and pointed out this value was
already being read during the type checking process.

A quick check at the `Typedtree.module_coercion` showed us that it would
be difficul to extract the same information that is readily available in
the signature value.

This change will expose the signature value directly, so other backends
relying on this signature information do not need to do the extra work
of reading it again.