### PR TITLE
Improve error message for aliases to the current compilation unit

### DIFF
--- a/Changes
+++ b/Changes
@@ -427,6 +427,9 @@ OCaml 4.12.0
 - #9783: Widen warning 16 to more cases.
   (Leo White, review by Florian Angeletti)
 
+- #10008: Improve error message for aliases to the current compilation unit.
+  (Leo White, review by Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #8987: Make some locations more accurate


### PR DESCRIPTION
Due to the namespacing games played by dune (and jenga), I think it is relatively common to get an error message like:
```
Error: The module Bar is an alias for module Foo__Bar, which is missing
```
when compiling the module `bar.ml` in the package `foo`, which contains an illegal reference to itself.

With this PR that message becomes:
```
Error: The module Bar is an alias for module Foo__Bar, which is the current compilation unit
```
which I think is slightly less likely to cause confusion.