### PR TITLE
typing: fix the scope of extension constructor declarations

### DIFF
--- a/Changes
+++ b/Changes
@@ -652,6 +652,13 @@ OCaml 4.12.0
 - #9999: fix -dsource printing of the pattern (`A as x | (`B as x)).
   (Gabriel Scherer, report by Anton Bachin, review by Florian Angeletti)
 
+- #9970, #10010: fix the declaration scope of extensible-datatype constructors.
+  A regression that dates back to 4.08 makes extensible-datatype constructors
+  with inline records very fragile, for example:
+    type 'a t += X of {x : 'a}
+  (Gabriel Scherer, review by Thomas Refis and Leo White,
+   report by Nicolás Ojeda Bär)
+
 OCaml 4.11.1
 ------------
 

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -187,6 +187,30 @@ let get_num : type a. a foo -> a -> a option = fun f i1 ->
 val get_num : 'a foo -> 'a -> 'a option = <fun>
 |}]
 
+(* Extensions can have inline records (regression test for #9970) *)
+type _ inline = ..
+type 'a inline += X of {x : 'a}
+;;
+[%%expect {|
+type _ inline = ..
+type 'a inline += X of { x : 'a; }
+|}]
+
+let _ = X {x = 1};;
+[%%expect {|
+- : int inline = X {x = 1}
+|}]
+
+let must_be_polymorphic = fun x -> X {x};;
+[%%expect {|
+val must_be_polymorphic : 'a -> 'a inline = <fun>
+|}]
+
+let must_be_polymorphic : 'a . 'a -> 'a inline = fun x -> X {x};;
+[%%expect {|
+val must_be_polymorphic : 'a -> 'a inline = <fun>
+|}]
+
 (* Extensions must obey constraints *)
 
 type 'a foo = .. constraint 'a = [> `Var ]


### PR DESCRIPTION
fixes #9970 (hopefully?)

I am not completely sure of what I am doing in this PR. I understand that the previous code was broken (see below), and the new code (1) looks reasonable and (2) gets the code of `transl_type_extension` closer to the code of `transl_declaration`, which I think is desirable.

(Reviewing this is for @garrigue, @trefis, @lpw25.)

Below: here is an example of what gets very wrong before this PR, and works fine after this PR. The example only describes what happens (incorrectly) before the PR. This is copied from https://github.com/ocaml/ocaml/issues/9970#issuecomment-723597231

```
# type _ t = ..;;
# type 'a t += X of {x : 'a};;
# X {x = 1};;
Error: The record field x belongs to the type 'a X
       but is mixed here with fields of type 'b X
       The type constructor X would escape its scope
# X {x = 1};;
- : int t = X {x = <poly>}
```

What happens:
- `Typedecl.transl_extension_constructor` creates a new scope for X.
  (In my debug runs, X has scope 3.)
- Then the following toplevel phrase runs at a level below the scope of X. It therefore builds type that are ill-scoped
  (In my debug runs, a Tconstr(X, ...) at level 2).
- When a phrase fails to type-check in the toplevel, the current level is not reset to its previous level.
  The following phrase thus starts with a higher level, higher than the scope of X, so there is no scope escape anymore.
  (In my debug runs, at level 5)