### PR TITLE
Doc: Marshal.to_channel may throw exception

### DIFF
--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -109,6 +109,9 @@ val to_channel : out_channel -> 'a -> extern_flags list -> unit
    when read back on a 32-bit platform.  The [Mashal.Compat_32] flag
    only matters when marshaling is performed on a 64-bit platform;
    it has no effect if marshaling is performed on a 32-bit platform.
+   
+   It raises [Failure "output_value: not a binary channel"] if channel
+   [chan] is not in binary mode.
  *)
 
 external to_bytes :

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -110,8 +110,7 @@ val to_channel : out_channel -> 'a -> extern_flags list -> unit
    only matters when marshaling is performed on a 64-bit platform;
    it has no effect if marshaling is performed on a 32-bit platform.
    
-   It raises [Failure "output_value: not a binary channel"] if channel
-   [chan] is not in binary mode.
+   @raise Failure if [chan] is not in binary mode.
  *)
 
 external to_bytes :

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -141,10 +141,11 @@ val from_channel : in_channel -> 'a
    one of the [Marshal.to_*] functions, and reconstructs and
    returns the corresponding value.
 
-   It raises [End_of_file] if the function has already reached the
-   end of file when starting to read from the channel, and raises
-   [Failure "input_value: truncated object"] if it reaches the end
-   of file later during the unmarshalling. *)
+   @raise End_of_file if the function has already reached the end
+   of file when starting to read from [chan].
+   
+   @raise Failure if it reaches the end of the file during
+   the unmarshalling. *)
 
 val from_bytes : bytes -> int -> 'a
 (** [Marshal.from_bytes buff ofs] unmarshals a structured value

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -109,7 +109,6 @@ val to_channel : out_channel -> 'a -> extern_flags list -> unit
    when read back on a 32-bit platform.  The [Mashal.Compat_32] flag
    only matters when marshaling is performed on a 64-bit platform;
    it has no effect if marshaling is performed on a 32-bit platform.
-   
    @raise Failure if [chan] is not in binary mode.
  *)
 

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -141,11 +141,10 @@ val from_channel : in_channel -> 'a
    one of the [Marshal.to_*] functions, and reconstructs and
    returns the corresponding value.
 
-   @raise End_of_file if the function has already reached the end
-   of file when starting to read from [chan].
-   
-   @raise Failure if it reaches the end of the file during
-   the unmarshalling. *)
+   @raise End_of_file if [chan] is already at the end of the file.
+
+   @raise Failure if the end of the file is reached during
+   unmarshalling itself. *)
 
 val from_bytes : bytes -> int -> 'a
 (** [Marshal.from_bytes buff ofs] unmarshals a structured value

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -143,7 +143,7 @@ val from_channel : in_channel -> 'a
    @raise End_of_file if [chan] is already at the end of the file.
 
    @raise Failure if the end of the file is reached during
-   unmarshalling itself. *)
+   unmarshalling itself or if [chan] is not in binary mode.*)
 
 val from_bytes : bytes -> int -> 'a
 (** [Marshal.from_bytes buff ofs] unmarshals a structured value


### PR DESCRIPTION
`Marshal.to_channel` throws an exception if the provided channel is not in binary mode (mostly an issue on Windows). This should be mentioned in the docs.
Here is the respective snippet of `caml_output_val` (called by `Marshal.to_channel` via `caml_output_value`):
```
void caml_output_val(struct channel *chan, value v, value flags)
{
  char header[32];
  int header_len;
  struct output_block * blk, * nextblk;

  if (! caml_channel_binary_mode(chan))
    caml_failwith("output_value: not a binary channel");
[..]
```