### PR TITLE
Add type_parameter record in Typedtree

### DIFF
--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1273,7 +1273,7 @@ module Analyser =
               te_type_name =
                 Odoc_env.full_type_name new_env (Name.from_path tt_tyext.tyext_path);
               te_type_parameters =
-                List.map (fun (ctyp, _) -> Odoc_env.subst_type new_env ctyp.ctyp_type)  tt_tyext.tyext_params;
+                List.map (fun p -> Odoc_env.subst_type new_env p.typa_type)  tt_tyext.tyext_params;
               te_private = tt_tyext.tyext_private;
               te_constructors = [];
               te_loc = { loc_impl = Some loc ; loc_inter = None } ;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -44,6 +44,9 @@ let rec fmt_longident_aux f x =
 
 let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x.txt;;
 
+let fmt_string_loc f (x : string loc) =
+  fprintf f "\"%s\" %a" x.txt fmt_location x.loc
+
 let fmt_ident = Ident.print
 
 let fmt_modname f = function
@@ -449,7 +452,23 @@ and binding_op i ppf x =
     fmt_location x.bop_loc;
   expression i ppf x.bop_exp
 
-and type_parameter i ppf (x, _variance) = core_type i ppf x
+and type_parameter i ppf x =
+  (match x.typa_name.txt with
+   | Some n ->
+     line i ppf "typa_name %a\n" fmt_string_loc { x.typa_name with txt = n }
+   | None ->
+     line i ppf "typa_name _\n");
+  let variance =
+    match x.typa_variance with
+    | Covariant -> "Covariant"
+    | Contravariant -> "Contravariant"
+    | NoVariance -> "NoVariance" in
+  line i ppf "typa_variance %s\n" variance;
+  let injectivity =
+    match x.typa_injectivity with
+    | Injective -> "Injective"
+    | NoInjectivity -> "NoInjectivity" in
+  line i ppf "typa_injectivity %s\n" injectivity
 
 and type_declaration i ppf x =
   line i ppf "type_declaration %a %a\n" fmt_ident x.typ_id fmt_location

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -44,9 +44,6 @@ let rec fmt_longident_aux f x =
 
 let fmt_longident f x = fprintf f "\"%a\"" fmt_longident_aux x.txt;;
 
-let fmt_string_loc f (x : string loc) =
-  fprintf f "\"%s\" %a" x.txt fmt_location x.loc
-
 let fmt_ident = Ident.print
 
 let fmt_modname f = function
@@ -453,22 +450,20 @@ and binding_op i ppf x =
   expression i ppf x.bop_exp
 
 and type_parameter i ppf x =
-  (match x.typa_name.txt with
-   | Some n ->
-     line i ppf "typa_name %a\n" fmt_string_loc { x.typa_name with txt = n }
-   | None ->
-     line i ppf "typa_name _\n");
+  line i ppf "type_parameter %s %a\n"
+    (Option.value ~default:"_" x.typa_name)
+    fmt_location x.typa_loc;
   let variance =
     match x.typa_variance with
     | Covariant -> "Covariant"
     | Contravariant -> "Contravariant"
     | NoVariance -> "NoVariance" in
-  line i ppf "typa_variance %s\n" variance;
+  line (i+1) ppf "typa_variance %s\n" variance;
   let injectivity =
     match x.typa_injectivity with
     | Injective -> "Injective"
     | NoInjectivity -> "NoInjectivity" in
-  line i ppf "typa_injectivity %s\n" injectivity
+  line (i+1) ppf "typa_injectivity %s\n" injectivity
 
 and type_declaration i ppf x =
   line i ppf "type_declaration %a %a\n" fmt_ident x.typ_id fmt_location

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -65,8 +65,7 @@ let structure sub {str_items; str_final_env; _} =
   List.iter (sub.structure_item sub) str_items;
   sub.env sub str_final_env
 
-let class_infos sub f x =
-  List.iter (fun (ct, _) -> sub.typ sub ct) x.ci_params;
+let class_infos _sub f x =
   f x.ci_expr
 
 let module_type_declaration sub {mtd_type; _} =
@@ -122,20 +121,18 @@ let type_kind sub = function
   | Ttype_record list -> List.iter (label_decl sub) list
   | Ttype_open -> ()
 
-let type_declaration sub {typ_cstrs; typ_kind; typ_manifest; typ_params; _} =
+let type_declaration sub {typ_cstrs; typ_kind; typ_manifest; _} =
   List.iter
     (fun (c1, c2, _) ->
       sub.typ sub c1;
       sub.typ sub c2)
     typ_cstrs;
   sub.type_kind sub typ_kind;
-  Option.iter (sub.typ sub) typ_manifest;
-  List.iter (fun (c, _) -> sub.typ sub c) typ_params
+  Option.iter (sub.typ sub) typ_manifest
 
 let type_declarations sub (_, list) = List.iter (sub.type_declaration sub) list
 
-let type_extension sub {tyext_constructors; tyext_params; _} =
-  List.iter (fun (c, _) -> sub.typ sub c) tyext_params;
+let type_extension sub {tyext_constructors; _} =
   List.iter (sub.extension_constructor sub) tyext_constructors
 
 let type_exception sub {tyexn_constructor; _} =

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -80,9 +80,8 @@ let structure sub {str_items; str_type; str_final_env} =
     str_type;
   }
 
-let class_infos sub f x =
+let class_infos _sub f x =
   {x with
-   ci_params = List.map (tuple2 (sub.typ sub) id) x.ci_params;
    ci_expr = f x.ci_expr;
   }
 
@@ -166,18 +165,16 @@ let type_declaration sub x =
   in
   let typ_kind = sub.type_kind sub x.typ_kind in
   let typ_manifest = Option.map (sub.typ sub) x.typ_manifest in
-  let typ_params = List.map (tuple2 (sub.typ sub) id) x.typ_params in
-  {x with typ_cstrs; typ_kind; typ_manifest; typ_params}
+  {x with typ_cstrs; typ_kind; typ_manifest}
 
 let type_declarations sub (rec_flag, list) =
   (rec_flag, List.map (sub.type_declaration sub) list)
 
 let type_extension sub x =
-  let tyext_params = List.map (tuple2 (sub.typ sub) id) x.tyext_params in
   let tyext_constructors =
     List.map (sub.extension_constructor sub) x.tyext_constructors
   in
-  {x with tyext_constructors; tyext_params}
+  {x with tyext_constructors}
 
 let type_exception sub x =
   let tyexn_constructor =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1394,13 +1394,13 @@ let class_infos define_class kind
   let ci_params =
     let make_param (sty, v) =
       try
-          (transl_type_param env sty, v)
+        transl_type_param sty v
       with Already_bound ->
         raise(Error(sty.ptyp_loc, env, Repeated_parameter))
     in
       List.map make_param cl.pci_params
   in
-  let params = List.map (fun (cty, _) -> cty.ctyp_type) ci_params in
+  let params = List.map (fun cty -> cty.typa_type) ci_params in
 
   (* Allow self coercions (only for class declarations) *)
   let coercion_locs = ref [] in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -191,10 +191,10 @@ let set_fixed_row env loc p decl =
 
 (* Translate one type declaration *)
 
-let make_params env params =
+let make_params params =
   let make_param (sty, v) =
     try
-      (transl_type_param env sty, v)
+      transl_type_param sty v
     with Already_bound ->
       raise(Error(sty.ptyp_loc, Repeated_parameter))
   in
@@ -278,8 +278,8 @@ let transl_declaration env sdecl (id, uid) =
   (* Bind type parameters *)
   reset_type_variables();
   Ctype.begin_def ();
-  let tparams = make_params env sdecl.ptype_params in
-  let params = List.map (fun (cty, _) -> cty.ctyp_type) tparams in
+  let tparams = make_params sdecl.ptype_params in
+  let params = List.map (fun cty -> cty.typa_type) tparams in
   let cstrs = List.map
     (fun (sty, sty', loc) ->
       transl_simple_type env false sty,
@@ -1118,8 +1118,8 @@ let transl_type_extension extend env loc styext =
   | None -> ()
   | Some err -> raise (Error(loc, Extension_mismatch (type_path, err)))
   end;
-  let ttype_params = make_params env styext.ptyext_params in
-  let type_params = List.map (fun (cty, _) -> cty.ctyp_type) ttype_params in
+  let ttype_params = make_params styext.ptyext_params in
+  let type_params = List.map (fun cty -> cty.typa_type) ttype_params in
   List.iter2 (Ctype.unify_var env)
     (Ctype.instance_list type_decl.type_params)
     type_params;
@@ -1398,8 +1398,8 @@ let transl_with_constraint id row_path ~sig_env ~sig_decl ~outer_env sdecl =
      declaration [sdecl] in the outer environment [outer_env]. *)
   let env = outer_env in
   let loc = sdecl.ptype_loc in
-  let tparams = make_params env sdecl.ptype_params in
-  let params = List.map (fun (cty, _) -> cty.ctyp_type) tparams in
+  let tparams = make_params sdecl.ptype_params in
+  let params = List.map (fun cty -> cty.typa_type) tparams in
   let arity = List.length params in
   let constraints =
     List.map (fun (ty, ty', loc) ->
@@ -1428,10 +1428,10 @@ let transl_with_constraint id row_path ~sig_env ~sig_decl ~outer_env sdecl =
   let sig_decl = Ctype.instance_declaration sig_decl in
   let arity_ok = arity = sig_decl.type_arity in
   if arity_ok then
-    List.iter2 (fun (cty, _) tparam ->
-      try Ctype.unify_var env cty.ctyp_type tparam
+    List.iter2 (fun cty tparam ->
+      try Ctype.unify_var env cty.typa_type tparam
       with Ctype.Unify tr ->
-        raise(Error(cty.ctyp_loc, Inconsistent_constraint (env, tr)))
+        raise(Error(cty.typa_name.loc, Inconsistent_constraint (env, tr)))
     ) tparams sig_decl.type_params;
   List.iter (fun (cty, cty', loc) ->
     (* Note: constraints must also be enforced in [sig_env] because

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1431,7 +1431,7 @@ let transl_with_constraint id row_path ~sig_env ~sig_decl ~outer_env sdecl =
     List.iter2 (fun cty tparam ->
       try Ctype.unify_var env cty.typa_type tparam
       with Ctype.Unify tr ->
-        raise(Error(cty.typa_name.loc, Inconsistent_constraint (env, tr)))
+        raise(Error(cty.typa_loc, Inconsistent_constraint (env, tr)))
     ) tparams sig_decl.type_params;
   List.iter (fun (cty, cty', loc) ->
     (* Note: constraints must also be enforced in [sig_env] because

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -401,12 +401,15 @@ let update_decls env sdecls decls =
   let required = List.map variance_of_sdecl sdecls in
   Typedecl_properties.compute_property property env decls required
 
+let variance_of_typaram (p : Typedtree.type_parameter) =
+  transl_variance (p.typa_variance, p.typa_injectivity)
+
 let update_class_decls env cldecls =
   let decls, required =
     List.fold_right
       (fun (obj_id, obj_abbr, _cl_abbr, _clty, _cltydef, ci) (decls, req) ->
         (obj_id, obj_abbr) :: decls,
-        variance_of_params ci.Typedtree.ci_params :: req)
+        List.map variance_of_typaram ci.Typedtree.ci_params :: req)
       cldecls ([],[])
   in
   let decls =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -480,10 +480,18 @@ and value_description =
     val_attributes: attribute list;
     }
 
+and type_parameter =
+  {
+    typa_type: type_expr;
+    typa_name: string option loc;
+    typa_variance: variance;
+    typa_injectivity: injectivity
+  }
+
 and type_declaration =
   { typ_id: Ident.t;
     typ_name: string loc;
-    typ_params: (core_type * (variance * injectivity)) list;
+    typ_params: type_parameter list;
     typ_type: Types.type_declaration;
     typ_cstrs: (core_type * core_type * Location.t) list;
     typ_kind: type_kind;
@@ -527,7 +535,7 @@ and type_extension =
   {
     tyext_path: Path.t;
     tyext_txt: Longident.t loc;
-    tyext_params: (core_type * (variance * injectivity)) list;
+    tyext_params: type_parameter list;
     tyext_constructors: extension_constructor list;
     tyext_private: private_flag;
     tyext_loc: Location.t;
@@ -600,7 +608,7 @@ and class_type_declaration =
 
 and 'a class_infos =
   { ci_virt: virtual_flag;
-    ci_params: (core_type * (variance * injectivity)) list;
+    ci_params: type_parameter list;
     ci_id_name: string loc;
     ci_id_class: Ident.t;
     ci_id_class_type: Ident.t;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -483,9 +483,10 @@ and value_description =
 and type_parameter =
   {
     typa_type: type_expr;
-    typa_name: string option loc;
+    typa_name: string option;
     typa_variance: variance;
-    typa_injectivity: injectivity
+    typa_injectivity: injectivity;
+    typa_loc: Location.t;
   }
 
 and type_declaration =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -618,11 +618,19 @@ and value_description =
     val_attributes: attributes;
     }
 
+and type_parameter =
+  {
+    typa_type: Types.type_expr;
+    typa_name: string option loc;
+    typa_variance: variance;
+    typa_injectivity: injectivity
+  }
+
 and type_declaration =
   {
     typ_id: Ident.t;
     typ_name: string loc;
-    typ_params: (core_type * (variance * injectivity)) list;
+    typ_params: type_parameter list;
     typ_type: Types.type_declaration;
     typ_cstrs: (core_type * core_type * Location.t) list;
     typ_kind: type_kind;
@@ -666,7 +674,7 @@ and type_extension =
   {
     tyext_path: Path.t;
     tyext_txt: Longident.t loc;
-    tyext_params: (core_type * (variance * injectivity)) list;
+    tyext_params: type_parameter list;
     tyext_constructors: extension_constructor list;
     tyext_private: private_flag;
     tyext_loc: Location.t;
@@ -739,7 +747,7 @@ and class_type_declaration =
 
 and 'a class_infos =
   { ci_virt: virtual_flag;
-    ci_params: (core_type * (variance * injectivity)) list;
+    ci_params: type_parameter list;
     ci_id_name : string loc;
     ci_id_class: Ident.t;
     ci_id_class_type : Ident.t;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -621,9 +621,10 @@ and value_description =
 and type_parameter =
   {
     typa_type: Types.type_expr;
-    typa_name: string option loc;
+    typa_name: string option;
     typa_variance: variance;
-    typa_injectivity: injectivity
+    typa_injectivity: injectivity;
+    typa_loc: Location.t;
   }
 
 and type_declaration =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -128,7 +128,7 @@ let valid_tyvar_name name =
 
 let transl_type_param styp (v, i) =
   let loc = styp.ptyp_loc in
-  let typa_type, name =
+  let typa_type, typa_name =
     match styp.ptyp_desc with
       Ptyp_any ->
         new_global_var ~name:"_" (), None
@@ -146,10 +146,10 @@ let transl_type_param styp (v, i) =
         in
         ty, Some name
     | _ -> assert false in
-  { typa_type;
-    typa_name = Location.mkloc name styp.ptyp_loc;
+  { typa_type; typa_name;
     typa_variance = v;
-    typa_injectivity = i }
+    typa_injectivity = i;
+    typa_loc = styp.ptyp_loc; }
 
 let transl_type_param styp vi =
   (* Currently useless, since type parameters cannot hold attributes

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -35,7 +35,8 @@ val transl_type_scheme:
 val reset_type_variables: unit -> unit
 val type_variable: Location.t -> string -> type_expr
 val transl_type_param:
-  Env.t -> Parsetree.core_type -> Typedtree.core_type
+  Parsetree.core_type -> (Asttypes.variance * Asttypes.injectivity) ->
+  Typedtree.type_parameter
 
 type variable_context
 val narrow: unit -> variable_context

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -219,7 +219,13 @@ let module_binding sub mb =
     (map_loc sub mb.mb_name)
     (sub.module_expr sub mb.mb_expr)
 
-let type_parameter sub (ct, v) = (sub.typ sub ct, v)
+let type_parameter _sub p =
+  let name =
+    match p.typa_name.txt with
+    | Some n -> Ptyp_var n
+    | None -> Ptyp_any in
+  (Typ.mk ~loc:p.typa_name.loc name,
+   (p.typa_variance, p.typa_injectivity))
 
 let type_declaration sub decl =
   let loc = sub.location sub decl.typ_loc in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -221,10 +221,10 @@ let module_binding sub mb =
 
 let type_parameter _sub p =
   let name =
-    match p.typa_name.txt with
+    match p.typa_name with
     | Some n -> Ptyp_var n
     | None -> Ptyp_any in
-  (Typ.mk ~loc:p.typa_name.loc name,
+  (Typ.mk ~loc:p.typa_loc name,
    (p.typa_variance, p.typa_injectivity))
 
 let type_declaration sub decl =


### PR DESCRIPTION
This is a simpler version of #10004, which introduces a record to represent type parameters in Typedtree, replacing the current nested tuple. This version doesn't change the Parsetree representation, making the patch much, much smaller.