### PR TITLE
Expand aliases if necessary during immediacy computation

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
 
 ### Bug fixes:
 
+- #??: Expand aliases if necessary during @@immediate checks
+  (Stephen Dolan, review by ??)
+
 OCaml 4.12.0
 ------------
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -380,7 +380,11 @@ val get_current_level: unit -> int
 val wrap_trace_gadt_instances: Env.t -> ('a -> 'b) -> 'a -> 'b
 val reset_reified_var_counter: unit -> unit
 
-val immediacy : Env.t -> type_expr -> Type_immediacy.t
+val approx_immediacy : Env.t -> type_expr -> Type_immediacy.t
+       (* Compute an over-approximation of the immediacy of a type *)
+val check_immediacy : Env.t -> as_:Type_immediacy.t -> type_expr ->
+  (unit, Type_immediacy.Violation.t) result
+       (* Verify that a type has a specified immediacy *)
 
 val maybe_pointer_type : Env.t -> type_expr -> bool
        (* True if type is possibly pointer, false if definitely not a pointer *)

--- a/typing/typedecl_immediacy.ml
+++ b/typing/typedecl_immediacy.ml
@@ -19,29 +19,45 @@ open Types
 type error = Bad_immediacy_attribute of Type_immediacy.Violation.t
 exception Error of Location.t * error
 
-let compute_decl env tdecl =
+type immediacy_kind =
+  | Explicit of Type_immediacy.t
+  | Of_type of Types.type_expr
+
+let compute_imm env tdecl =
   match (tdecl.type_kind, tdecl.type_manifest) with
   | (Type_variant [{cd_args = Cstr_tuple [arg]; _}], _)
     | (Type_variant [{cd_args = Cstr_record [{ld_type = arg; _}]; _}], _)
     | (Type_record ([{ld_type = arg; _}], _), _)
   when tdecl.type_unboxed.unboxed ->
     begin match Typedecl_unboxed.get_unboxed_type_representation env arg with
-    | Typedecl_unboxed.Unavailable -> Type_immediacy.Unknown
-    | Typedecl_unboxed.This argrepr -> Ctype.immediacy env argrepr
+    | Typedecl_unboxed.Unavailable -> Explicit Unknown
+    | Typedecl_unboxed.This argrepr -> Of_type argrepr
     | Typedecl_unboxed.Only_on_64_bits argrepr ->
-        match Ctype.immediacy env argrepr with
-        | Type_immediacy.Always -> Type_immediacy.Always_on_64bits
-        | Type_immediacy.Always_on_64bits | Type_immediacy.Unknown as x -> x
+       (* FIXME *)
+        match Ctype.approx_immediacy env argrepr with
+        | Type_immediacy.Always -> Explicit Always_on_64bits
+        | Type_immediacy.Always_on_64bits | Type_immediacy.Unknown as x -> Explicit x
     end
   | (Type_variant (_ :: _ as cstrs), _) ->
     if not (List.exists (fun c -> c.Types.cd_args <> Types.Cstr_tuple []) cstrs)
     then
-      Type_immediacy.Always
+      Explicit Always
     else
-      Type_immediacy.Unknown
-  | (Type_abstract, Some(typ)) -> Ctype.immediacy env typ
-  | (Type_abstract, None) -> Type_immediacy.of_attributes tdecl.type_attributes
-  | _ -> Type_immediacy.Unknown
+      Explicit Unknown
+  | (Type_abstract, Some(typ)) -> Of_type typ
+  | (Type_abstract, None) ->
+     Explicit (Type_immediacy.of_attributes tdecl.type_attributes)
+  | _ -> Explicit Unknown
+
+let compute_decl env tdecl =
+  match compute_imm env tdecl with
+  | Explicit imm -> imm
+  | Of_type ty -> Ctype.approx_immediacy env ty
+
+let check_decl env tdecl ~as_ =
+  match compute_imm env tdecl with
+  | Explicit imm -> Type_immediacy.coerce imm ~as_
+  | Of_type ty -> Ctype.check_immediacy env ~as_ ty
 
 let property : (Type_immediacy.t, unit) Typedecl_properties.property =
   let open Typedecl_properties in
@@ -50,9 +66,9 @@ let property : (Type_immediacy.t, unit) Typedecl_properties.property =
   let default _decl = Type_immediacy.Unknown in
   let compute env decl () = compute_decl env decl in
   let update_decl decl immediacy = { decl with type_immediate = immediacy } in
-  let check _env _id decl () =
+  let check env _id decl () =
     let written_by_user = Type_immediacy.of_attributes decl.type_attributes in
-    match Type_immediacy.coerce decl.type_immediate ~as_:written_by_user with
+    match check_decl env decl ~as_:written_by_user with
     | Ok () -> ()
     | Error violation ->
         raise (Error (decl.type_loc,


### PR DESCRIPTION
The following uses of `[@@immediate]` currently fail:
```
# type 'a id = 'a
  type s = int id [@@immediate];;
Error: Types marked with the immediate attribute must be non-pointer types
       like int or bool.

#  module F (X : sig type t end) = X
   module I = struct type t = int end
   type t = F(I).t [@@immediate];;
Error: Types marked with the immediate attribute must be non-pointer types
       like int or bool.

#  module type T = sig type t type s = t end
   module F (X : T with type t = int) = struct
     type t = X.s [@@immediate]
   end;;
Error: Types marked with the immediate attribute must be non-pointer types
       like int or bool.
```
In each of these three cases, the type in question is in fact equal to `int`, so I think this error is wrong.

---

The issue is the same as in #10005: sometimes, we need to expand aliases to see that a type is immediate.

The fix here is to switch immediacy checking to the algorithm proposed in the unboxed types prototype (see [RFC #10](https://github.com/ocaml/RFCs/pull/10)). The `Ctype.immediacy` function is split in two:

  - `Ctype.approx_immediacy` computes a sound over-approximation of the immediacy of a type. (This is only an approximation because it's possible that environment substitutions or type parameters or expansions may cause a type's immediacy to be refined.)

  - `Ctype.check_immediacy` verifies that a type has a given immediacy.

`Ctype.approx_immediacy` is exactly the same as the current `Ctype.immediacy`. `Ctype.check_immediacy` differs in the `Tconstr` case - if a path's `type_immediate` field doesn't match the given immediacy, then rather than triggering an error immediately the type is expanded.

In other words, for type aliases the `type_immediate` field becomes merely an upper bound on the immediacy, which is consulted first during immediacy checking as an optimisation. If this optimised check fails, then the full check is done by expanding the alias.

Note that this does not increase the amount of expansion done in programs that currently work: the extra expansion occurs only in cases where the current behaviour would fail.

---

TODO: there's a case I haven't figured out yet about `Typedecl_unboxed.Only_on_64_bits`