### PR TITLE
Clean up caml_alloc_shr

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -36,12 +36,10 @@ extern "C" {
 #endif
 
 CAMLextern value caml_alloc_shr (mlsize_t wosize, tag_t);
-#ifdef WITH_PROFINFO
+
+/* Variant of [caml_alloc_shr] with explicit profinfo.
+   Equivalent to caml_alloc_shr unless WITH_PROFINFO is true */
 CAMLextern value caml_alloc_shr_with_profinfo (mlsize_t, tag_t, intnat);
-#else
-#define caml_alloc_shr_with_profinfo(size, tag, profinfo) \
-  caml_alloc_shr(size, tag)
-#endif /* WITH_PROFINFO */
 
 /* Variant of [caml_alloc_shr] where no memprof sampling is performed. */
 CAMLextern value caml_alloc_shr_no_track_noexc (mlsize_t, tag_t);

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -124,11 +124,15 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #ifdef WITH_PROFINFO
 #define PROFINFO_SHIFT (Gen_profinfo_shift(PROFINFO_WIDTH))
 #define PROFINFO_MASK (Gen_profinfo_mask(PROFINFO_WIDTH))
+/* Use NO_PROFINFO to debug problems with profinfo macros */
+#define NO_PROFINFO 0xff
 #define Hd_no_profinfo(hd) ((hd) & ~(PROFINFO_MASK << PROFINFO_SHIFT))
 #define Wosize_hd(hd) ((mlsize_t) ((Hd_no_profinfo(hd)) >> 10))
 #define Profinfo_hd(hd) (Gen_profinfo_hd(PROFINFO_WIDTH, hd))
 #else
+#define NO_PROFINFO 0
 #define Wosize_hd(hd) ((mlsize_t) ((hd) >> 10))
+#define Profinfo_hd(hd) NO_PROFINFO
 #endif /* WITH_PROFINFO */
 
 #define Hd_val(val) (((header_t *) (val)) [-1])        /* Also an l-value. */

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -464,29 +464,17 @@ CAMLexport color_t caml_allocation_color (void *hp)
 }
 
 Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
-                                      int raise_oom, uintnat profinfo)
+                                      uintnat profinfo)
 {
   header_t *hp;
   value *new_block;
 
-  if (wosize > Max_wosize) {
-    if (raise_oom)
-      caml_raise_out_of_memory ();
-    else
-      return 0;
-  }
+  if (wosize > Max_wosize) return 0;
   CAML_EV_ALLOC(wosize);
   hp = caml_fl_allocate (wosize);
   if (hp == NULL){
     new_block = expand_heap (wosize);
-    if (new_block == NULL) {
-      if (!raise_oom)
-        return 0;
-      else if (Caml_state->in_minor_collection)
-        caml_fatal_error ("out of memory");
-      else
-        caml_raise_out_of_memory ();
-    }
+    if (new_block == NULL) return 0;
     caml_fl_add_blocks ((value) new_block);
     hp = caml_fl_allocate (wosize);
   }
@@ -524,41 +512,37 @@ Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
   return Val_hp (hp);
 }
 
-#ifdef WITH_PROFINFO
-
-/* Use this to debug problems with macros... */
-#define NO_PROFINFO 0xff
+Caml_inline value check_oom(value v)
+{
+  if (v == 0) {
+    if (Caml_state->in_minor_collection)
+      caml_fatal_error ("out of memory");
+    else
+      caml_raise_out_of_memory ();
+  }
+  return v;
+}
 
 CAMLexport value caml_alloc_shr_with_profinfo (mlsize_t wosize, tag_t tag,
                                                intnat profinfo)
 {
-  return caml_alloc_shr_aux(wosize, tag, 1, 1, profinfo);
+  return check_oom(caml_alloc_shr_aux(wosize, tag, 1, profinfo));
 }
 
 CAMLexport value caml_alloc_shr_for_minor_gc (mlsize_t wosize,
-                                              tag_t tag, header_t old_header)
+                                              tag_t tag, header_t old_hd)
 {
-  return caml_alloc_shr_aux (wosize, tag, 0, 1, Profinfo_hd(old_header));
+  return check_oom(caml_alloc_shr_aux(wosize, tag, 0, Profinfo_hd(old_hd)));
 }
-
-#else
-#define NO_PROFINFO 0
-
-CAMLexport value caml_alloc_shr_for_minor_gc (mlsize_t wosize,
-                                              tag_t tag, header_t old_header)
-{
-  return caml_alloc_shr_aux (wosize, tag, 0, 1, NO_PROFINFO);
-}
-#endif /* WITH_PROFINFO */
 
 CAMLexport value caml_alloc_shr (mlsize_t wosize, tag_t tag)
 {
-  return caml_alloc_shr_aux (wosize, tag, 1, 1, NO_PROFINFO);
+  return caml_alloc_shr_with_profinfo(wosize, tag, NO_PROFINFO);
 }
 
 CAMLexport value caml_alloc_shr_no_track_noexc (mlsize_t wosize, tag_t tag)
 {
-  return caml_alloc_shr_aux (wosize, tag, 0, 0, NO_PROFINFO);
+  return caml_alloc_shr_aux(wosize, tag, 0, NO_PROFINFO);
 }
 
 /* Dependent memory is all memory blocks allocated out of the heap


### PR DESCRIPTION
I found the various implementations of caml_alloc_shr hard to read, so here's a tiny patch to clean them up a bit. The changes are:
  - The different callers of caml_alloc_shr handle errors differently. This patch does the error handling in the caller, rather than passing a flag to caml_alloc_shr to control error handling.
  - Moves the implementation of caml_alloc_shr_with_profinfo out of `#ifdef`