### PR TITLE
More powerful variant of Sys.reachable_words

### DIFF
--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -1127,7 +1127,11 @@ CAMLexport void caml_serialize_block_float_8(void * data, intnat len)
 #endif
 }
 
-static intnat reachable_words_traverse(int traverse, int scan_closures, value v) {
+static intnat reachable_words_traverse(
+                                       int traverse,
+                                       int scan_closures,
+                                       value v
+                                       ) {
   struct extern_item * sp = extern_stack;
   intnat size = 0;
   uintnat h = 0;
@@ -1195,7 +1199,11 @@ CAMLprim value caml_obj_reachable_words(value v) {
   return Val_long(size);
 }
 
-CAMLprim value caml_obj_reachable_words_many(value v_scan_closures, value except_values, value values) {
+CAMLprim value caml_obj_reachable_words_many(
+                                             value v_scan_closures,
+                                             value except_values,
+                                             value values
+                                             ) {
   CAMLparam2(except_values, values);
   CAMLlocal1(sizes);
   mlsize_t n_values;
@@ -1203,8 +1211,8 @@ CAMLprim value caml_obj_reachable_words_many(value v_scan_closures, value except
   int j;
 
   /* Protect against [| Obj.repr 42. |] in flat-float array mode */
-  if (Tag_val(values) != 0) caml_invalid_argument("reachable_words_many");
-  if (Tag_val(except_values) != 0) caml_invalid_argument("reachable_words_many");
+  if (Tag_val(values) != 0 || Tag_val(except_values) != 0)
+    caml_invalid_argument("reachable_words_many");
 
   extern_init_position_table();
 
@@ -1215,7 +1223,8 @@ CAMLprim value caml_obj_reachable_words_many(value v_scan_closures, value except
   n_values = Wosize_val(values);
   sizes = caml_alloc(n_values, 0);
   for (j = 0; j < n_values; j++)
-    Field(sizes, j) = Val_long(reachable_words_traverse(1, scan_closures, Field(values, j)));
+    Field(sizes, j) =
+      Val_long(reachable_words_traverse(1, scan_closures, Field(values, j)));
 
   extern_free_stack();
   extern_free_position_table();

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -1127,101 +1127,98 @@ CAMLexport void caml_serialize_block_float_8(void * data, intnat len)
 #endif
 }
 
-static void reachable_words_full(
-                                 int scan_closures,
-                                 mlsize_t ignored,
-                                 mlsize_t n_values, value *values,
-                                 intnat *sizes
-                                 )
-{
-  value v;
-  intnat size;
-  struct extern_item * sp;
+static intnat reachable_words_traverse(int traverse, int scan_closures, value v) {
+  struct extern_item * sp = extern_stack;
+  intnat size = 0;
   uintnat h = 0;
   uintnat pos;
-  mlsize_t j;
 
-  extern_init_position_table();
-  sp = extern_stack;
-  size = 0;
-
-  for (j = 0; j < n_values; j++) {
-    v = values[j];
-    while (1) {
-      if (Is_long(v)) {
-        /* Tagged integers contribute 0 to the size, nothing to do */
-      } else if (! Is_in_heap_or_young(v)) {
-        /* Out-of-heap blocks contribute 0 to the size, nothing to do */
-        /* However, in no-naked-pointers mode, we don't distinguish
-           between major heap blocks and out-of-heap blocks,
-           and the test above is always false,
-           so we end up counting out-of-heap blocks too. */
-      } else if (extern_lookup_position(v, &pos, &h)) {
-        /* Already seen and counted, nothing to do */
-      } else {
-        header_t hd = Hd_val(v);
-        tag_t tag = Tag_hd(hd);
-        mlsize_t sz = Wosize_hd(hd);
-        /* Infix pointer: go back to containing closure */
-        if (tag == Infix_tag) {
-          v = v - Infix_offset_hd(hd);
-          continue;
-        }
-        /* Remember that we've visited this block */
-        extern_record_location(v, h);
-        if (ignored <= j && (scan_closures || tag != Closure_tag)) {
-          /* The block contributes to the total size */
-          size += 1 + sz;           /* header word included */
-          if (tag < No_scan_tag) {
-            /* i is the position of the first field to traverse recursively */
-            uintnat i =
-              tag == Closure_tag ? Start_env_closinfo(Closinfo_val(v)) : 0;
-            if (i < sz) {
-              if (i < sz - 1) {
-                /* Remember that we need to count fields i + 1 ... sz - 1 */
-                sp++;
-                if (sp >= extern_stack_limit) sp = extern_resize_stack(sp);
-                sp->v = &Field(v, i + 1);
-                sp->count = sz - i - 1;
-              }
-              /* Continue with field i */
-              v = Field(v, i);
-              continue;
+  while (1) {
+    if (Is_long(v)) {
+      /* Tagged integers contribute 0 to the size, nothing to do */
+    } else if (! Is_in_heap_or_young(v)) {
+      /* Out-of-heap blocks contribute 0 to the size, nothing to do */
+      /* However, in no-naked-pointers mode, we don't distinguish
+         between major heap blocks and out-of-heap blocks,
+         and the test above is always false,
+         so we end up counting out-of-heap blocks too. */
+    } else if (extern_lookup_position(v, &pos, &h)) {
+      /* Already seen and counted, nothing to do */
+    } else {
+      header_t hd = Hd_val(v);
+      tag_t tag = Tag_hd(hd);
+      mlsize_t sz = Wosize_hd(hd);
+      /* Infix pointer: go back to containing closure */
+      if (tag == Infix_tag) {
+        v = v - Infix_offset_hd(hd);
+        continue;
+      }
+      /* Remember that we've visited this block */
+      extern_record_location(v, h);
+      if (traverse && (scan_closures || tag != Closure_tag)) {
+        /* The block contributes to the total size */
+        size += 1 + sz;           /* header word included */
+        if (tag < No_scan_tag) {
+          /* i is the position of the first field to traverse recursively */
+          uintnat i =
+            tag == Closure_tag ? Start_env_closinfo(Closinfo_val(v)) : 0;
+          if (i < sz) {
+            if (i < sz - 1) {
+              /* Remember that we need to count fields i + 1 ... sz - 1 */
+              sp++;
+              if (sp >= extern_stack_limit) sp = extern_resize_stack(sp);
+              sp->v = &Field(v, i + 1);
+              sp->count = sz - i - 1;
             }
+            /* Continue with field i */
+            v = Field(v, i);
+            continue;
           }
         }
       }
-      /* Pop one more item to traverse, if any */
-      if (sp == extern_stack) break;
-      v = *((sp->v)++);
-      if (--(sp->count) == 0) sp--;
     }
-    sizes[j] = Val_long(size);
+    /* Pop one more item to traverse, if any */
+    if (sp == extern_stack) break;
+    v = *((sp->v)++);
+    if (--(sp->count) == 0) sp--;
   }
-  extern_free_stack();
-  extern_free_position_table();
+  return size;
 }
 
 
 CAMLprim value caml_obj_reachable_words(value v) {
-  value size;
-  reachable_words_full(1, 0, 1, &v, &size);
-  return size;
+  intnat size;
+  extern_init_position_table();
+  size = reachable_words_traverse(1, 1, v);
+  extern_free_stack();
+  extern_free_position_table();
+  return Val_long(size);
 }
 
-CAMLprim value caml_obj_reachable_words_many(value v_scan_closures, value v_ignored, value values) {
-  CAMLparam1(values);
+CAMLprim value caml_obj_reachable_words_many(value v_scan_closures, value except_values, value values) {
+  CAMLparam2(except_values, values);
   CAMLlocal1(sizes);
   mlsize_t n_values;
-  mlsize_t ignored = Long_val(v_ignored);
   int scan_closures = Bool_val(v_scan_closures);
+  int j;
 
   /* Protect against [| Obj.repr 42. |] in flat-float array mode */
   if (Tag_val(values) != 0) caml_invalid_argument("reachable_words_many");
-  n_values = Wosize_val(values);
-  if (ignored < 0 || n_values < ignored) caml_invalid_argument("reachable_words_many");
+  if (Tag_val(except_values) != 0) caml_invalid_argument("reachable_words_many");
 
+  extern_init_position_table();
+
+  n_values = Wosize_val(except_values);
+  for (j = 0; j < n_values; j++)
+    reachable_words_traverse(0, 0, Field(except_values, j));
+
+  n_values = Wosize_val(values);
   sizes = caml_alloc(n_values, 0);
-  reachable_words_full(scan_closures, ignored, n_values, &Field(values, 0), &Field(sizes, 0));
+  for (j = 0; j < n_values; j++)
+    Field(sizes, j) = Val_long(reachable_words_traverse(1, scan_closures, Field(values, j)));
+
+  extern_free_stack();
+  extern_free_position_table();
+
   CAMLreturn(sizes);
 }

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -28,7 +28,9 @@ external tag : t -> int = "caml_obj_tag" [@@noalloc]
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"
 external reachable_words : t -> int = "caml_obj_reachable_words"
-external reachable_words_many : bool -> t array -> t array -> int array = "caml_obj_reachable_words_many"
+external reachable_words_many :
+  bool -> t array -> t array -> int array =
+  "caml_obj_reachable_words_many"
 
 let reachable_words_many ?without_closures ?(except = [||]) values =
   reachable_words_many (without_closures = None) except values

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -28,10 +28,10 @@ external tag : t -> int = "caml_obj_tag" [@@noalloc]
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"
 external reachable_words : t -> int = "caml_obj_reachable_words"
-external reachable_words_many : bool -> int -> t array -> int array = "caml_obj_reachable_words_many"
+external reachable_words_many : bool -> t array -> t array -> int array = "caml_obj_reachable_words_many"
 
-let reachable_words_many ?without_closures ?(ignored = 0) values =
-  reachable_words_many (without_closures = None) ignored values
+let reachable_words_many ?without_closures ?(except = [||]) values =
+  reachable_words_many (without_closures = None) except values
 
 external field : t -> int -> t = "%obj_field"
 external set_field : t -> int -> t -> unit = "%obj_set_field"

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -28,6 +28,11 @@ external tag : t -> int = "caml_obj_tag" [@@noalloc]
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"
 external reachable_words : t -> int = "caml_obj_reachable_words"
+external reachable_words_many : bool -> int -> t array -> int array = "caml_obj_reachable_words_many"
+
+let reachable_words_many ?without_closures ?(ignored = 0) values =
+  reachable_words_many (without_closures = None) ignored values
+
 external field : t -> int -> t = "%obj_field"
 external set_field : t -> int -> t -> unit = "%obj_set_field"
 external floatarray_get : floatarray -> int -> float = "caml_floatarray_get"

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -39,7 +39,11 @@ external reachable_words : t -> int = "caml_obj_reachable_words"
      @Since 4.04
   *)
 
-val reachable_words_many : ?without_closures:unit -> ?except:t array -> t array -> int array
+val reachable_words_many :
+  ?without_closures:unit ->
+  ?except:t array ->
+  t array ->
+  int array
 (** Given an array of values [values], returns an array of integers
     [sizes] where [sizes.(i)] is the total size of all heap blocks
     accessible from [values.(i)] but not from any [values.(j)] with [j

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -49,7 +49,7 @@ val reachable_words_many : ?without_closures:unit -> ?except:t array -> t array 
 
     For instance [(reachable_words_many [|v1;v2|]).(1)] is the number
     of heap words accessible from [v2] but not from [v1] and
-    [reachable_words_many ~except:[|v1|] [|v2|]] is the number
+    [(reachable_words_many ~except:[|v1|] [|v2|]).(0)] is the number
     of heap words accessible from [v2] without crossing [v1].
 
      @Since X.YY

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -39,34 +39,21 @@ external reachable_words : t -> int = "caml_obj_reachable_words"
      @Since 4.04
   *)
 
-val reachable_words_many : ?without_closures:unit -> ?ignored:int -> t array -> int array
-  (** Given an array of values [values], returns a monotonic array of
-     integers [sizes] where [sizes.(i)] is the total size of all heap
-     blocks accessible from one of [values.(0)], ..., [values.(i)],
-     using the same definition as in [reachable_words].
+val reachable_words_many : ?without_closures:unit -> ?except:t array -> t array -> int array
+(** Given an array of values [values], returns an array of integers
+    [sizes] where [sizes.(i)] is the total size of all heap blocks
+    accessible from [values.(i)] but not from any [values.(j)] with [j
+    < i] and without crossing any of the values in [except].  If
+    [without_closures] is passed, closure blocks are ignored (their
+    size does not count and their environment is not traversed).
 
-     For instance [let a = reachable_words_many [|v1;v2|] in a.(1) -
-     a.(0)] returns the number of heap words accessible from [v2] but
-     not from [v1].
-
-     If [ignored] is provided, it must be between [0] and
-     [Array.length values]. The size computed for [i], [0 <= i <
-     ignored] will always be [0] and the traversal done for
-     calculating heap blocks reachable from [values.(i)] with [i >=
-     ignored] stops if it reaches one of [values.(i)] with [i <
-     ignored].  This allows excluding specific values (but not blocks
-     reachable from them).
-
-     For instance [let a = reachable_words_many ~ignored:1 [|v1;v2|] in
-     a.(1) - a.(0)] returns the number of heap words accessible from
-     [v2] without crossing [v1].
-
-     If [without_closures] is passed, closure blocks are ignored
-     (their size does not count and their environment is not
-     traversed).
+    For instance [(reachable_words_many [|v1;v2|]).(1)] is the number
+    of heap words accessible from [v2] but not from [v1] and
+    [reachable_words_many ~except:[|v1|] [|v2|]] is the number
+    of heap words accessible from [v2] without crossing [v1].
 
      @Since X.YY
-  *)
+*)
 
 external field : t -> int -> t = "%obj_field"
 

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -39,6 +39,35 @@ external reachable_words : t -> int = "caml_obj_reachable_words"
      @Since 4.04
   *)
 
+val reachable_words_many : ?without_closures:unit -> ?ignored:int -> t array -> int array
+  (** Given an array of values [values], returns a monotonic array of
+     integers [sizes] where [sizes.(i)] is the total size of all heap
+     blocks accessible from one of [values.(0)], ..., [values.(i)],
+     using the same definition as in [reachable_words].
+
+     For instance [let a = reachable_words_many [|v1;v2|] in a.(1) -
+     a.(0)] returns the number of heap words accessible from [v2] but
+     not from [v1].
+
+     If [ignored] is provided, it must be between [0] and
+     [Array.length values]. The size computed for [i], [0 <= i <
+     ignored] will always be [0] and the traversal done for
+     calculating heap blocks reachable from [values.(i)] with [i >=
+     ignored] stops if it reaches one of [values.(i)] with [i <
+     ignored].  This allows excluding specific values (but not blocks
+     reachable from them).
+
+     For instance [let a = reachable_words_many ~ignored:1 [|v1;v2|] in
+     a.(1) - a.(0)] returns the number of heap words accessible from
+     [v2] without crossing [v1].
+
+     If [without_closures] is passed, closure blocks are ignored
+     (their size does not count and their environment is not
+     traversed).
+
+     @Since X.YY
+  *)
+
 external field : t -> int -> t = "%obj_field"
 
 (** When using flambda:


### PR DESCRIPTION
`Sys.reachable_words` turns out to be very useful when doing some exploratory work for better understanding the memory usage of an application.  This PR adds a more powerful variant of it (currently named `Sys.reachable_words_many`), which adds the following features:

   - Ability to compute the "incremental" reachable words for an array of values.  This returns a monotonic array of integers of the same size, each integer representing the number of words reachable from the corresponding input value or any value before that one.  This makes it possible to compute, in particular, the marginal contribution of a value when adding it to a set of roots; it also makes it possible to "decompose" the reachable size of an array or record by showing for each successive cell/field its incremental contribution to the total reachable size.

  - Ability to exclude a some values (but not their descendant) from the traversal, i.e. marking them as already traversed.  This allows excluding, for instance, a big data structure which is known to be accessible (through its root) and which should not be counted.

  - Ability to exclude all closures blocks (not counting their size, and not traversing their environment).  This can be useful, for instance, to estimate the of some data structures with lazy fields, with the assumption that unforced lazy slots can refer to some values which should not be counted.

I believe these additions make the function much more useful.

Discussion on the API is welcome!  I'll write the changelog entry and tests if/when the PR is accepted in principle.

Note: the diff is better reviewed ignoring whitespace (indentation) changes.