### PR TITLE
Typos (documentation)

### DIFF
--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -964,7 +964,7 @@ commands:
 $ ocamlc -o gcd gcd.ml
 $ ./gcd 6 9
 3
-$ ./fib 7 11
+$ ./gcd 7 11
 1
 \end{verbatim}
 

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -261,7 +261,7 @@ UnixLabels.write : file_descr -> buf:bytes -> pos:int -> len:int -> unit
 When there are several objects of same nature and role, they are all
 left unlabeled.
 \begin{alltt}
-"ListLabels.iter2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> unit"
+"ListLabels.iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit"
 \end{alltt}
 
 When there is no preferable object, all arguments are labeled.


### PR DESCRIPTION
https://caml.inria.fr/pub/docs/manual-ocaml-4.11/index.html

Some snippets are without signature. 
e.g. §3.11 - §3.17 - §6.1 - §6.2
