### PR TITLE
Ensure atomicity in the Atomic module is respected by flambda

### DIFF
--- a/Changes
+++ b/Changes
@@ -252,8 +252,8 @@ OCaml 4.12.0
   OCaml.
   (Gabriel Scherer, review by Xavier Leroy)
 
-- ?    : Make sure that flambda respects atomicity in the Atomic module.
-  (Guillaume Munch-Maccagnoni, review by )
+- #10035: Make sure that flambda respects atomicity in the Atomic module.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
 
 - #9571: Make at_exit and Printexc.register_printer thread-safe.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)

--- a/Changes
+++ b/Changes
@@ -252,6 +252,9 @@ OCaml 4.12.0
   OCaml.
   (Gabriel Scherer, review by Xavier Leroy)
 
+- ?    : Make sure that flambda respects atomicity in the Atomic module.
+  (Guillaume Munch-Maccagnoni, review by )
+
 - #9571: Make at_exit and Printexc.register_printer thread-safe.
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer and Xavier Leroy)
 

--- a/stdlib/camlinternalAtomic.ml
+++ b/stdlib/camlinternalAtomic.ml
@@ -28,21 +28,32 @@ let make v = {v}
 let get r = r.v
 let set r v = r.v <- v
 
-let exchange r v =
+(* The following functions are set to never be inlined: Flambda is
+   allowed to move surrounding code inside the critical section,
+   including allocations. *)
+
+let[@inline never] exchange r v =
+  (* BEGIN ATOMIC *)
   let cur = r.v in
   r.v <- v;
+  (* END ATOMIC *)
   cur
 
-let compare_and_set r seen v =
+let[@inline never] compare_and_set r seen v =
+  (* BEGIN ATOMIC *)
   let cur = r.v in
-  if cur == seen then
-    (r.v <- v; true)
-  else
+  if cur == seen then (
+    r.v <- v;
+    (* END ATOMIC *)
+    true
+  ) else
     false
 
-let fetch_and_add r n =
+let[@inline never] fetch_and_add r n =
+  (* BEGIN ATOMIC *)
   let cur = r.v in
   r.v <- (cur + n);
+  (* END ATOMIC *)
   cur
 
 let incr r = ignore (fetch_and_add r 1)


### PR DESCRIPTION
This PR ensures that the Atomic module is really atomic when taking flambda into account. It might be considered as a bugfix for 4.12.

I explain in terms of `ref` but it goes the same for `Atomic.t`. The code below is a stack thread-safe for systhread:
```ocaml
    let r : unit list ref = ref []

    let rec push_this x =
      let old_val = r.contents in
      let new_val = x :: old_val in
      let success =
        if r.contents == old_val
        then (r.contents <- new_val; true)
        else false
      in
      if not success then push_this x
```
But flambda considers that it can move allocations around, and that it is equivalent to:
```ocaml
    let r : unit list ref = ref []

    let rec push_this x =
      let old_val = r.contents in
      let success =
        if r.contents == old_val
        then (let new_val = x :: old_val in r.contents <- new_val; true)
        else false
      in
      if not success then push_this x
```
This is no longer thread-safe because there can be a context-switch between the equality test and the assignation.

Code of this form is used in the standard library with the Atomic module. `Atomic.compare_and_set` is defined as follows:
```ocaml
    let compare_and_set r seen v =
      let cur = r.v in
      if cur == seen then
        (r.v <- v; true)
      else
        false
```
However, flambda considers that it can inline this function and subsequently move surrounding code between the test and the assignation.

There is no testcase in this PR, because I did not manage to trigger the issue in actual code. But it was confirmed to me that this is something flambda is allowed to do.

A short-term solution is to forbid inlining atomic functions from the Atomic module, which is the strategy taken in this PR. In the longer term it would be nice to have a way to force flambda to respect the semantics of polling locations inside specific pieces of code with an annotation (this is beyond the scope of this PR, there will be opportunities to discuss it elsewhere).

(Thank you to @lthls for his explanations, who I ping again in case he is interested in reviewing this PR.)