### PR TITLE
Manual: add warning about Caml_ba_array_val

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2163,6 +2163,11 @@ The kind of array elements is one of the following constants:
 \entree{"CAML_BA_NATIVE_INT"}{32- or 64-bit (platform-native) integers}
 \end{tableau}
 %
+\paragraph{Warning:} The expression "Caml_ba_array_val("\var{v}")"
+resolves to a derived pointer: it is not a valid OCaml value but points to
+a memory region managed by the GC. For this reason this value must not be
+stored in any memory location that could be live cross a GC.
+
 The following example shows the passing of a two-dimensional Bigarray
 to a C function and a Fortran function.
 \begin{verbatim}

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2163,8 +2163,10 @@ The kind of array elements is one of the following constants:
 \entree{"CAML_BA_NATIVE_INT"}{32- or 64-bit (platform-native) integers}
 \end{tableau}
 %
-\paragraph{Warning:} The expression "Caml_ba_array_val("\var{v}")"
-resolves to a derived pointer: it is not a valid OCaml value but points to
+\paragraph{Warning:}
+"Caml_ba_array_val("\var{v}")" must always be dereferenced immediately and not stored
+anywhere, including local variables.
+It resolves to a derived pointer: it is not a valid OCaml value but points to
 a memory region managed by the GC. For this reason this value must not be
 stored in any memory location that could be live cross a GC.
 


### PR DESCRIPTION
Follow up to https://github.com/ocaml/ocaml/issues/9360#issuecomment-731255844: add a small paragraph warning about raw uses of the `Caml_ba_array_val` macro.

Suggestions for improvements welcome.