### PR TITLE
propagate distclean in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1077,6 +1077,7 @@ distclean: clean
 	rm -f tools/eventlog_metadata
 	rm -f tools/*.bak
 	rm -f testsuite/_log*
+	$(MAKE) -C manual distclean
 
 include .depend
 


### PR DESCRIPTION
I'm not sure about this one, but shouldn't the `distclean` target call `$(MAKE) -C manual distclean` as well?
It would be more consistent when the travis CI calls `distclean` and check left-overs.