### PR TITLE
Always set SYSTEM, ARCH and MODEL

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,8 +32,9 @@ Working version
   (Leandro Ostera, review by Gabriel Scherer and Thomas Refis)
 
 ### Build system:
-- #10044: Always report the detected SYSTEM, even for bytecode-only builds
-  (fixes a "configuration regression" from 4.08 for the Windows builds)
+- #10044: Always report the detected ARCH, MODEL and SYSTEM, even for bytecode-
+  only builds (fixes a "configuration regression" from 4.08 for the Windows
+  builds)
   (David Allsopp, review by ??)
 
 ### Bug fixes:

--- a/Changes
+++ b/Changes
@@ -32,6 +32,9 @@ Working version
   (Leandro Ostera, review by Gabriel Scherer and Thomas Refis)
 
 ### Build system:
+- #10044: Always report the detected SYSTEM, even for bytecode-only builds
+  (fixes a "configuration regression" from 4.08 for the Windows builds)
+  (David Allsopp, review by ??)
 
 ### Bug fixes:
 

--- a/Makefile
+++ b/Makefile
@@ -915,11 +915,14 @@ partialclean::
 # Check that the native-code compiler is supported
 .PHONY: checknative
 checknative:
+ifneq "$(NATIVE_COMPILER)" "true"
+	$(error The source tree was configured with --disable-native-compiler!)
+else
 ifeq "$(ARCH)" "none"
-checknative:
 	$(error The native-code compiler is not supported on this platform)
 else
 	@
+endif
 endif
 
 # Check that the stack limit is reasonable (Unix-only)

--- a/configure
+++ b/configure
@@ -13910,7 +13910,7 @@ fi; system=elf ;; #(
 esac
 
 if test x"$enable_native_compiler" = "xno"; then :
-  arch=none; model=default; native_compiler=false
+  native_compiler=false
   { $as_echo "$as_me:${as_lineno-$LINENO}: the native compiler is disabled" >&5
 $as_echo "$as_me: the native compiler is disabled" >&6;}
 else

--- a/configure
+++ b/configure
@@ -13910,7 +13910,7 @@ fi; system=elf ;; #(
 esac
 
 if test x"$enable_native_compiler" = "xno"; then :
-  arch=none; model=default; system=unknown; native_compiler=false
+  arch=none; model=default; native_compiler=false
   { $as_echo "$as_me:${as_lineno-$LINENO}: the native compiler is disabled" >&5
 $as_echo "$as_me: the native compiler is disabled" >&6;}
 else

--- a/configure.ac
+++ b/configure.ac
@@ -989,7 +989,7 @@ AS_CASE([$host],
 )
 
 AS_IF([test x"$enable_native_compiler" = "xno"],
-  [arch=none; model=default; native_compiler=false
+  [native_compiler=false
   AC_MSG_NOTICE([the native compiler is disabled])],
   [native_compiler=true])
 

--- a/configure.ac
+++ b/configure.ac
@@ -989,7 +989,7 @@ AS_CASE([$host],
 )
 
 AS_IF([test x"$enable_native_compiler" = "xno"],
-  [arch=none; model=default; system=unknown; native_compiler=false
+  [arch=none; model=default; native_compiler=false
   AC_MSG_NOTICE([the native compiler is disabled])],
   [native_compiler=true])
 


### PR DESCRIPTION
While looking at something else, I encountered a subtle compilation fault in win32unix:

https://github.com/ocaml/ocaml/blob/a93a564301a5e36f965f96debe1a11d809827356/otherlibs/win32unix/Makefile#L57

Before 4.08 and autoconf, `config/Makefile.mingw` _always_ set `SYSTEM`:

https://github.com/ocaml/ocaml/blob/aad3b341fe594388d5761a7001927f92b4e8498d/config/Makefile.mingw#L77

so this worked. However, when we switched to autoconf, the build system adopted the usual `ARCH=none`, `MODEL=default`, `SYSTEM=unknown` **if you configure without the native compiler**.

This PR tentatively stops resetting `ARCH`, `MODEL`, and `SYSTEM`. The only place I could quickly see where these are used instead of the newer `NATIVE_COMPILER=true` variable in `Makefile.config` was the `checknative` target.

This has been wrong for a while, so there's no rush for 4.12