### PR TITLE
Run the C# tests on mingw too

### DIFF
--- a/Changes
+++ b/Changes
@@ -268,6 +268,9 @@ Working version
   to the implementation and the coercion.
   (Leandro Ostera, review by Gabriel Scherer and Thomas Refis)
 
+- #10045: Add libext variable to ocamltest
+  (David Allsopp)
+
 * #10061, #10078, #10187: remove library `ocamlopttoplevel`, remove modules
   `Opttoploop`, `Opttopstart`, which are replaced by `Toploop` and `Topstart` in
   library `ocamltoplevel`, made available in native code.

--- a/Changes
+++ b/Changes
@@ -268,8 +268,8 @@ Working version
   to the implementation and the coercion.
   (Leandro Ostera, review by Gabriel Scherer and Thomas Refis)
 
-- #10045: Add libext variable to ocamltest
-  (David Allsopp)
+- #10045: Add libext variable to ocamltest and enable C# tests on on mingw
+  (David Allsopp, review by Gabriel Scherer)
 
 * #10061, #10078, #10187: remove library `ocamlopttoplevel`, remove modules
   `Opttoploop`, `Opttopstart`, which are replaced by `Toploop` and `Topstart` in

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -52,23 +52,22 @@ endif
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)" | cygpath -w -f -)
+  CSC := csc
+  ifeq "$(HOST:i686-%=i686)" "i686"
+    CSCFLAGS := /platform:x86
+  else
+    CSCFLAGS :=
+  endif
+  CSCFLAGS += /nologo /nowarn:1668
 else
   ocamlsrcdir := $(abspath $(shell pwd)/..)
+  CSC :=
+  CSCFLAGS :=
 endif
 mkexe := $(MKEXE)
 
 ifeq "$(TOOLCHAIN)" "msvc"
 CPP := $(CPP) 2> nul
-CSC := csc
-ifeq "$(HOST)" "i686-pc-windows"
-CSCFLAGS := /platform:x86
-else
-CSCFLAGS :=
-endif
-CSCFLAGS += /nologo /nowarn:1668
-else
-CSC :=
-CSCFLAGS :=
 endif
 
 ifeq "$(WITH_OCAMLDOC)" "ocamldoc"

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -255,6 +255,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	    $(call SUBST,WITH_OCAMLDOC) \
 	    $(call SUBST,WITH_OCAMLDEBUG) \
 	    $(call SUBST,O) \
+	    $(call SUBST,A) \
 	    $(call SUBST,S) \
 	    $(call SUBST,NATIVE_COMPILER) \
 	    $(call SUBST,NATDYNLINK) \

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1088,6 +1088,7 @@ let config_variables _log env =
     Ocaml_variables.shared_library_cflags,
       Ocamltest_config.shared_library_cflags;
     Ocaml_variables.objext, Ocamltest_config.objext;
+    Ocaml_variables.libext, Ocamltest_config.libext;
     Ocaml_variables.asmext, Ocamltest_config.asmext;
     Ocaml_variables.sharedobjext, Ocamltest_config.sharedobjext;
     Ocaml_variables.ocamlc_default_flags,

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -123,6 +123,9 @@ let nativecc_libs = make ("nativecc_libs",
 let objext = make ("objext",
   "Extension of object files")
 
+let libext = make ("libext",
+  "Extension of library files")
+
 let asmext = make ("asmext",
   "Extension of assembly files")
 
@@ -260,6 +263,7 @@ let _ = List.iter register_variable
     modules;
     nativecc_libs;
     objext;
+    libext;
     asmext;
     ocamlc_byte;
     ocamlopt_byte;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -76,6 +76,7 @@ val nativecc_libs : Variables.t
 (** Libraries to link with for native code *)
 
 val objext : Variables.t
+val libext : Variables.t
 val asmext : Variables.t
 
 val ocamlc_byte : Variables.t

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -37,6 +37,8 @@ let str = %%str%%
 
 let objext = "%%O%%"
 
+let libext = "%%A%%"
+
 let asmext = "%%S%%"
 
 let system = "%%SYSTEM%%"

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -49,6 +49,9 @@ val str : bool
 val objext : string
 (** Extension of object files *)
 
+val libext : string
+(** Extension of library files *)
+
 val asmext : string
 (** Extension of assembly files *)
 

--- a/testsuite/tests/lib-dynlink-csharp/main.ml
+++ b/testsuite/tests/lib-dynlink-csharp/main.ml
@@ -34,7 +34,7 @@ program = "main_obj.${objext}"
 all_modules = "dynlink.cma entry.c main.ml"
 ****** script
 script = "${mkdll} -maindll -o main.dll main_obj.${objext} entry.${objext} \
-                   ${ocamlsrcdir}/runtime/libcamlrun.lib ${bytecc_libs}"
+                   ${ocamlsrcdir}/runtime/libcamlrun.${libext} ${bytecc_libs}"
 ******* script
 script = "${csharp_cmd}"
 ******** run
@@ -70,7 +70,7 @@ program = "main_obj.${objext}"
 all_modules = "dynlink.cmxa entry.c main.ml"
 ****** script
 script = "${mkdll} -maindll -o main.dll main_obj.${objext} entry.${objext} \
-                   ${ocamlsrcdir}/runtime/libasmrun.lib ${nativecc_libs}"
+                   ${ocamlsrcdir}/runtime/libasmrun.${libext} ${nativecc_libs}"
 ******* script
 script = "${csharp_cmd}"
 ******** run

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -138,5 +138,10 @@ goto :EOF
 goto :EOF
 
 :test
-if "%BUILD_MODE%" neq "C" "%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh test" || exit /b 1
+rem No tests run in the "C" build mode
+if "%BUILD_MODE%" equ "C" goto :EOF
+rem Add a C# compiler in PATH for the testsuite for mingw
+if "%PORT%" equ "mingw64" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+if "%PORT%" equ "mingw32" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh test" || exit /b 1
 goto :EOF


### PR DESCRIPTION
While working on the second part of #9939, I had need to run the `lib-dynlink-csharp` tests on mingw, rather than msvc. This PR enables that - all that's needed is the addition of `${libext}` in ocamltest. The motion in the AppVeyor script is to ensure that a Microsoft build environment is always available so that the mingw32 test has access to `csc`.