### PR TITLE
Link all DLLs with -static-libgcc on mingw32

### DIFF
--- a/Changes
+++ b/Changes
@@ -453,6 +453,11 @@ OCaml 4.12.0
 - #10008: Improve error message for aliases to the current compilation unit.
   (Leo White, review by Gabriel Scherer)
 
+- #10046: Link all DLLs with -static-libgcc on mingw32 to prevent dependency
+  on libgcc_s_sjlj-1.dll with mingw-w64 runtime 8.0.0 (previously this was
+  only needed for dllunix.dll).
+  (David Allsopp, report by Andreas Hauptmann, review by ???)
+
 ### Internal/compiler-libs changes:
 
 - #8987: Make some locations more accurate

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -27,3 +27,7 @@ INSTALL_PROG ?= @INSTALL_PROGRAM@
 # The command to generate C dependency information
 DEP_CC=@DEP_CC@ -MM
 COMPUTE_DEPS=@compute_deps@
+
+# This is munged into utils/config.ml, not overridable by other parts of
+# the build system.
+OC_DLL_LDFLAGS=@oc_dll_ldflags@

--- a/configure
+++ b/configure
@@ -803,6 +803,7 @@ ocamlc_cppflags
 ocamlc_cflags
 nativecclibs
 bytecclibs
+oc_dll_ldflags
 oc_ldflags
 oc_cppflags
 oc_cflags
@@ -2780,6 +2781,7 @@ internal_cppflags=""
 ocamlc_cflags=""
 ocamlc_cppflags=""
 oc_ldflags=""
+oc_dll_ldflags=""
 with_sharedlibs=true
 ostype="Unix"
 iflexdir=""
@@ -2837,6 +2839,7 @@ VERSION=4.13.0+dev0-2020-10-19
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -12783,7 +12786,7 @@ fi
     if $with_sharedlibs; then :
   case $host in #(
   i686-*-*) :
-    flexdll_chain="mingw" ;; #(
+    flexdll_chain="mingw"; oc_dll_ldflags="-static-libgcc" ;; #(
   x86_64-*-*) :
     flexdll_chain="mingw64" ;; #(
   *) :
@@ -13629,6 +13632,11 @@ if test x"$enable_shared" != "xno"; then :
   *-*-mingw32) :
     mksharedlib='$(FLEXLINK)'
       mkmaindll='$(FLEXLINK) -maindll'
+      if test -n "$oc_dll_ldflags"; then :
+
+        mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
+        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
+fi
       shared_libraries_supported=$with_sharedlibs ;; #(
   *-pc-windows) :
     mksharedlib='$(FLEXLINK)'

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ internal_cppflags=""
 ocamlc_cflags=""
 ocamlc_cppflags=""
 oc_ldflags=""
+oc_dll_ldflags=""
 with_sharedlibs=true
 ostype="Unix"
 iflexdir=""
@@ -108,6 +109,7 @@ AC_SUBST([toolchain])
 AC_SUBST([oc_cflags])
 AC_SUBST([oc_cppflags])
 AC_SUBST([oc_ldflags])
+AC_SUBST([oc_dll_ldflags])
 AC_SUBST([bytecclibs])
 AC_SUBST([nativecclibs])
 AC_SUBST([ocamlc_cflags])
@@ -679,7 +681,7 @@ AS_CASE([$CC,$host],
   [*,*-*-mingw32],
     [AS_IF([$with_sharedlibs],
       [AS_CASE([$host],
-        [i686-*-*], [flexdll_chain="mingw"],
+        [i686-*-*], [flexdll_chain="mingw"; oc_dll_ldflags="-static-libgcc"],
         [x86_64-*-*], [flexdll_chain="mingw64"])
       flexlink="flexlink -chain $flexdll_chain -merge-manifest -stack 16777216"
       flexdir=`$flexlink -where | tr -d '\015'`
@@ -822,6 +824,9 @@ AS_IF([test x"$enable_shared" != "xno"],
     [*-*-mingw32],
       [mksharedlib='$(FLEXLINK)'
       mkmaindll='$(FLEXLINK) -maindll'
+      AS_IF([test -n "$oc_dll_ldflags"],[
+        mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
+        mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])
       shared_libraries_supported=$with_sharedlibs],
     [*-pc-windows],
       [mksharedlib='$(FLEXLINK)'

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -54,11 +54,7 @@ unixLabels.cmi: \
 
 include ../Makefile.otherlibs.common
 
-ifeq "$(SYSTEM)" "mingw"
-LDOPTS=-ldopt "-link -static-libgcc" $(addprefix -ldopt ,$(WIN32_LIBS))
-else
 LDOPTS=$(addprefix -ldopt ,$(WIN32_LIBS))
-endif
 
 clean::
 	rm -f $(UNIX_FILES) $(UNIX_CAML_FILES)

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -58,8 +58,9 @@ else
   ifeq "$(FLEXLINK_ENV)" ""
     ocamltest := MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) $(ocamltest_program)
   else
+    FLEXLINK_DLL_LDFLAGS=$(if $(OC_DLL_LDFLAGS), -link "$(OC_DLL_LDFLAGS)")
     MKDLL=$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe \
-                                     $(FLEXLINK_FLAGS)
+                                     $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
 
     ocamltest := $(FLEXLINK_ENV) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
                                  $(ocamltest_program)

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -99,8 +99,10 @@ rem needs upgrading.
 set CYGWIN_PACKAGES=cygwin make diffutils
 set CYGWIN_COMMANDS=cygcheck make diff
 if "%PORT%" equ "mingw32" (
-  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-i686-gcc-core
-  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% i686-w64-mingw32-gcc
+  rem mingw64-i686-runtime does not need explictly installing, but it's useful
+  rem to have the version reported.
+  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-i686-gcc-core mingw64-i686-runtime
+  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% i686-w64-mingw32-gcc cygcheck
 )
 
 set CYGWIN_INSTALL_PACKAGES=

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -39,6 +39,7 @@ SUBST_QUOTE2=\
 SUBST_QUOTE=$(call SUBST_QUOTE2,$1,$($1))
 
 FLEXLINK_LDFLAGS=$(if $(OC_LDFLAGS), -link "$(OC_LDFLAGS)")
+FLEXLINK_DLL_LDFLAGS=$(if $(OC_DLL_LDFLAGS), -link "$(OC_DLL_LDFLAGS)")
 
 config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	sed $(call SUBST,AFL_INSTRUMENT) \
@@ -64,6 +65,7 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST_STRING,MKDLL) \
 	    $(call SUBST_STRING,MKEXE) \
 	    $(call SUBST_STRING,FLEXLINK_LDFLAGS) \
+	    $(call SUBST_STRING,FLEXLINK_DLL_LDFLAGS) \
 	    $(call SUBST_STRING,MKMAINDLL) \
 	    $(call SUBST,MODEL) \
 	    $(call SUBST_STRING,NATIVECCLIBS) \

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -65,9 +65,9 @@ let mkdll, mkexe, mkmaindll =
           let c = flexlink.[i] in
           if c = '/' then '\\' else c in
         (String.init (String.length flexlink) f) ^ " %%FLEXLINK_FLAGS%%" in
-      flexlink,
+      flexlink ^ "%%FLEXLINK_DLL_LDFLAGS%%",
       flexlink ^ " -exe%%FLEXLINK_LDFLAGS%%",
-      flexlink ^ " -maindll"
+      flexlink ^ " -maindll%%FLEXLINK_DLL_LDFLAGS%%"
     with Not_found ->
       "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
   else


### PR DESCRIPTION
This is the second half of #9939 - this issue, like #9938, is caused by the upgrade from mingw-w64 runtime 7.0.0 to 8.0.0, but the fix is not as critical as the one in #9939, nor is it related.

As on any platform, there are occasions where GCC will pull in its compiler library libgcc to provide implementations for things missing on the target hardware. In particular, we hit this sometimes with 64-bit emulation on 32-bit platforms. For mingw32, this can add a requirement to `libgcc_s_sjlj-1.dll` which is not great.

This was previously solved with the proverbial sledgehammer in https://github.com/ocaml/ocaml/issues/6411 by always compiling with `-static-libgcc` on mingw32. However, this prevented programs compiled with OCaml which wanted to use C++ shared libraries from having proper exception support, as the shared libgcc is required for this to work (that's a legitimate case where the author of the program has to accept the need for `libgcc_s_sjlj-1.dll` - mingw32 `opam.exe` is an example). I fixed this in https://github.com/ocaml/ocaml/pull/1535 so that only the bigarray library (which was completely separate then) linked statically. This propagated through to `dllunix.dll` when bigarray was moved into the distribution. mingw32 doesn't build a shared runtime, so we don't see it there.

Winding forwards to mingw-w64 8.0.0 and now - presumably from a change in the mingw CRT itself (NB there is the mingw CRT as well as MSVCRT) - any DLL built ends up pulling in `__divdi3`, `__udivdi3` and `__umoddi3`. This becomes apparent in the build system when ocamldoc tries to run to compile the stdlib manpages and is even more apparent when huge chunks of the testsuite fail!

A solution is simply to require the user to have `libgcc_s_sjlj-1.dll` in their PATH to run mingw32 programs, but this wasn't acceptable in 2014 or 2017 and I don't think it is in 2020 either!

The obvious first fix is simply to build the systhreads and str libraries (i.e. otherlibs which also have stubs) with the same `-link -static-libgcc` option. This gets a long way, except that the problem with the 8.0.0 runtime also affects cmxs (i.e. natdynlink) and the plugins in our dynlink lists.

My solution here, therefore, is to alter `Config.mkdll` and `Config.mkmaindll` to include `-link -static-libgcc`.