### PR TITLE
Fix bug with generalized local opens

### DIFF
--- a/Changes
+++ b/Changes
@@ -669,6 +669,9 @@ OCaml 4.12.0
   (Gabriel Scherer, review by Thomas Refis and Leo White,
    report by Nicolás Ojeda Bär)
 
+- #10048: Fix bug with generalized local opens.
+  (Leo White, review by Thomas Refis)
+
 OCaml 4.11.1
 ------------
 

--- a/testsuite/tests/generalized-open/pr10048.ml
+++ b/testsuite/tests/generalized-open/pr10048.ml
@@ -13,11 +13,5 @@ let foo (x : Ext(List).t) =
 [%%expect {|
 module Ext :
   functor (X : sig type 'a t end) -> sig type t = T : 'a X.t -> t end
-Lines 8-9, characters 4-23:
-8 | ....let open Ext(Array) in
-9 |     T (Array.of_list l)..
-Error: This expression has type t but an expression was expected of type
-         Ext(Array).t
-       The type constructor t would escape its scope
-       t is abstract because no corresponding cmi file was found in path.
+val foo : Ext(List).t -> Ext(Array).t = <fun>
 |}]

--- a/testsuite/tests/generalized-open/pr10048.ml
+++ b/testsuite/tests/generalized-open/pr10048.ml
@@ -1,0 +1,23 @@
+(* TEST
+   * expect
+*)
+module Ext (X : sig type 'a t end) = struct
+  type t = T : 'a X.t -> t
+end;;
+
+let foo (x : Ext(List).t) =
+  match x with
+  | T l ->
+    let open Ext(Array) in
+    T (Array.of_list l);;
+[%%expect {|
+module Ext :
+  functor (X : sig type 'a t end) -> sig type t = T : 'a X.t -> t end
+Lines 8-9, characters 4-23:
+8 | ....let open Ext(Array) in
+9 |     T (Array.of_list l)..
+Error: This expression has type t but an expression was expected of type
+         Ext(Array).t
+       The type constructor t would escape its scope
+       t is abstract because no corresponding cmi file was found in path.
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3612,9 +3612,13 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_open (od, e) ->
+      let tv = newvar () in
       let (od, _, newenv) = !type_open_decl env od in
       let exp = type_expect newenv e ty_expected_explained in
-      rue {
+      (* Force the return type to be well-formed in the original
+         environment. *)
+      unify_var newenv tv exp.exp_type;
+      re {
         exp_desc = Texp_open (od, exp);
         exp_type = exp.exp_type;
         exp_loc = loc;


### PR DESCRIPTION
Since local opens were generalized to allow arbitrary module expressions they are now able to bring fresh types into the environment. This means that they must take care not to include such types in their return type. The current handling is slightly wrong which leads to unnecessary errors like:

```ocaml
module Ext (X : sig type 'a t end) = struct
  type t = T : 'a X.t -> t
end;;

let foo (x : Ext(List).t) =
  match x with
  | T l ->
    let open Ext(Array) in
    T (Array.of_list l);;
[%%expect {|
module Ext :
  functor (X : sig type 'a t end) -> sig type t = T : 'a X.t -> t end
Lines 8-9, characters 4-23:
8 | ....let open Ext(Array) in
9 |     T (Array.of_list l)..
Error: This expression has type t but an expression was expected of type
         Ext(Array).t
       The type constructor t would escape its scope
       t is abstract because no corresponding cmi file was found in path.
|}]
```
This PR fixes this problem by being a bit more careful. The code is now the same as the equivalent code for local module definitions.