### PR TITLE
Don't allow un-bounded make parallelism on AppVeyor

### DIFF
--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -72,3 +72,8 @@ depend: $(ALL_FILES) $(UNIX_CAML_FILES) unix.ml
 	  unix.ml > .depend
 
 include .depend
+
+# This empty target is here for AppVeyor to allow dependencies to be built
+# without doing anything else.
+.PHONY: setup-depend
+setup-depend:

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -413,3 +413,8 @@ DEP_FILES := $(addsuffix .$(D), $(DEP_FILES))
 ifeq "$(COMPUTE_DEPS)" "true"
 include $(addprefix $(DEPDIR)/, $(DEP_FILES))
 endif
+
+# This empty target is here for AppVeyor to allow dependencies to be built
+# without doing anything else.
+.PHONY: setup-depend
+setup-depend:

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -21,7 +21,7 @@ BUILD_PID=0
 CACHE_DIRECTORY=/cygdrive/c/projects/cache
 
 if [[ -z $APPVEYOR_PULL_REQUEST_HEAD_COMMIT ]] ; then
-  MAKE="make -j"
+  MAKE="make -j$NUMBER_OF_PROCESSORS"
 else
   MAKE=make
 fi
@@ -181,6 +181,8 @@ case "$1" in
               -e 's/\d027\[m/\d027[0m/g' \
               -e 's/\d027\[01\([m;]\)/\d027[1\1/g'
     else
+      run "C deps: runtime" make -j64 -C runtime setup-depend
+      run "C deps: win32unix" make -j64 -C otherlibs/win32unix setup-depend
       run "$MAKE world" $MAKE world
       run "$MAKE bootstrap" $MAKE bootstrap
       run "$MAKE opt" $MAKE opt


### PR DESCRIPTION
At present, for **branch** builds, the msvc64 run builds with `make -j` in order not to clog up the AppVeyor pipeline too much.

Working on the mingw64-runtime 8.0.0, I have found that with newer Cygwins this is causing fork problems, even on Cygwin64. This PR makes two little changes:

- `-j$NUMBER_OF_PROCESSORS` provides a more logical upper-bound on make
- The second part specifically generates the dependencies in `otherlibs/win32unix` and `runtime` with a much higher `-j` parameter. This is ~a little~very hacky, but it does shave more than a minute off the AppVeyor build.