### PR TITLE
Set young_trigger correctly at new major GC phase (#9955 continued)

### DIFF
--- a/Changes
+++ b/Changes
@@ -577,7 +577,8 @@ OCaml 4.12.0
 - #7538, #9669: Check for misplaced attributes on module aliases
   (Leo White, report by Thomas Leonard, review by Florian Angeletti)
 
-- #7813, #9955: make sure the major GC cycle doesn't get stuck in Idle state
+- #7813, #9955, #10055: make sure the major GC cycle doesn't get stuck in Idle
+  state
   (Damien Doligez, report by Anders Fugmann, review by Jacques-Henri Jourdan)
 
 - #7902, #9556: Type-checker infers recursive type, even though -rectypes is

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -486,7 +486,7 @@ void caml_gc_dispatch (void)
   if (Caml_state->requested_minor_gc) {
     /* reset the pointers first because the end hooks might allocate */
     CAML_EV_BEGIN(EV_MINOR);
-    Caml_state->requested_minor_gc = 0;
+    /* Caml_state->requested_minor_gc is reset later */
     Caml_state->young_trigger = Caml_state->young_alloc_mid;
     caml_update_young_limit();
     caml_empty_minor_heap ();
@@ -494,12 +494,18 @@ void caml_gc_dispatch (void)
   }
   if (Caml_state->requested_major_slice) {
     Caml_state->requested_major_slice = 0;
-    Caml_state->young_trigger = Caml_state->young_alloc_start;
-    caml_update_young_limit();
+    /* Ensure that opportunistically starting a major GC cycle doesn't
+       prevent another major GC slice when the minor heap becomes half-full.
+     */
+    if (!Caml_state->requested_minor_gc) {
+      Caml_state->young_trigger = Caml_state->young_alloc_start;
+      caml_update_young_limit();
+    }
     CAML_EV_BEGIN(EV_MAJOR);
     caml_major_collection_slice (-1);
     CAML_EV_END(EV_MAJOR);
   }
+  Caml_state->requested_minor_gc = 0;
 }
 
 /* Called by young allocations when [Caml_state->young_ptr] reaches


### PR DESCRIPTION
After #9955, if the major gc is idle then you end up with an empty minor heap but `Caml_state->young_trigger` is set to trigger only when the minor heap empties, skipping the major slice which normally be triggered when the minor heap is half full.

Fixing this appears to fix the problem being seen with `misc/weaklifetime.ml` - but I can't convince myself why that would be the case.

I have assumed that hooks should not be setting (or clearing) `Caml_state->requested_minor_gc`. If that assumption is wrong, then a local flag should be used, rather than deferring the reset of `Caml_state->requested_minor_gc`

cc @damiendoligez 