### PR TITLE
docs: clarification for Unix.open_process_args_in

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -876,10 +876,11 @@ val open_process_full :
 
 val open_process_args_in : string -> string array -> in_channel
 (** High-level pipe and process management. The first argument specifies the
-   command to run, and the second argument specifies the argument array passed
-   to the command.  This function runs the command in parallel with the program.
-   The standard output of the command is redirected to a pipe, which can be read
-   via the returned input channel.
+   path to the command to run, and the second argument specifies the argument
+   array passed to the command. The first array position must match the command.
+   This function is not run through a shell. This function runs the command
+   in parallel with the program. The standard output of the command is
+   redirected to a pipe, which can be read via the returned input channel.
 
     @since 4.08.0 *)
 


### PR DESCRIPTION
I tripped myself up on this [as can be seen here](https://discuss.ocaml.org/t/is-unix-open-process-args-in-broken/6865/3). Hoping this small change will help others in the future.

I used the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style, I hope that's okay.