### PR TITLE
Define ARCH_INT64_PRINT_FORMAT correctly on mingw-w64

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,6 +219,9 @@ OCaml 4.12.0
   representation for closures
   (Nathanaël Courant, review by Xavier Leroy)
 
+- #10062: set ARCH_INT64_PRINTF_FORMAT correctly for both modes of mingw-w64
+  (David Allsopp, review by Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #9551: ocamlc no longer loads DLLs at link time to check that

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -101,7 +101,7 @@
 #endif
 #endif
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !__USE_MINGW_ANSI_STDIO
   #define ARCH_INT64_TYPE long long
   #define ARCH_UINT64_TYPE unsigned long long
   #define ARCH_INT64_PRINTF_FORMAT "I64"


### PR DESCRIPTION
Addresses (hopefully) https://github.com/ocaml/ocaml/pull/9939#issuecomment-735909808