### PR TITLE
Fix a minor off-by-one bug in Memprof sampling

### DIFF
--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1030,7 +1030,9 @@ CAMLprim value caml_memprof_start(value lv, value szv, value tracker_param)
   if (l > 0) {
     one_log1m_lambda = l == 1 ? 0 : 1/caml_log1p(-l);
     rand_pos = RAND_BLOCK_SIZE;
-    next_rand_geom = rand_geom();
+    /* next_rand_geom can be zero if the next word is to be sampled,
+       but rand_geom always returns a value >= 1. Subtract 1 to correct. */
+    next_rand_geom = rand_geom() - 1;
   }
 
   caml_memprof_renew_minor_sample();

--- a/testsuite/tests/statmemprof/alloc_counts.ml
+++ b/testsuite/tests/statmemprof/alloc_counts.ml
@@ -1,0 +1,53 @@
+(* TEST *)
+module MP = Gc.Memprof
+
+let allocs_by_memprof f =
+  let minor = ref 0 in
+  let major = ref 0 in
+  let alloc_minor (info : MP.allocation) =
+    minor := !minor + info.n_samples;
+    None in
+  let alloc_major (info : MP.allocation) =
+    major := !major + info.n_samples;
+    None in
+  MP.start ~sampling_rate:1. ({MP.null_tracker with alloc_minor; alloc_major});
+  match Sys.opaque_identity f () with
+  | _ -> MP.stop (); (!minor, !major)
+  | exception e -> MP.stop (); raise e
+
+let allocs_by_counters f =
+  let minor1, prom1, major1 = Gc.counters () in
+  let minor2, prom2, major2 = Gc.counters () in
+  ignore (Sys.opaque_identity f ());
+  let minor3, prom3, major3 = Gc.counters () in
+  let minor =
+    minor3 -. minor2      (* allocations *)
+    -. (minor2 -. minor1) (* Gc.counters overhead *)
+  in
+  let prom =
+    prom3 -. prom2 -. (prom2 -. prom1) in
+  let major =
+    major3 -. major2 -. (major2 -. major1) in
+  int_of_float minor,
+  int_of_float (major -. prom)
+
+let compare name f =
+  let mp_minor, mp_major = allocs_by_memprof f in
+  let ct_minor, ct_major = allocs_by_counters f in
+  if mp_minor <> ct_minor || mp_major <> ct_major then
+    Printf.printf "%20s: minor: %d / %d; major: %d / %d\n"
+      name ct_minor mp_minor ct_major mp_major
+
+let many f =
+  fun () ->
+  for i = 1 to 10 do
+    ignore (Sys.opaque_identity f ())
+  done
+
+let () =
+  compare "ref" (many (fun () -> ref (ref (ref 42))));
+  compare "short array" (many (fun () -> Array.make 10 'a'));
+  compare "long array" (many (fun () -> Array.make 1000 'a'));
+  compare "curried closure" (many (fun () -> fun a b -> a + b));
+  compare "marshalling" (many (fun () ->
+    Marshal.from_string (Marshal.to_string (ref (ref (ref 42))) []) 0))


### PR DESCRIPTION
A minor off-by-one bug in `caml_memprof_start` means that the first word allocated via `rand_binom` (major allocations and minor allocations from C) can never be sampled by Memprof.

(This came up when using Memprof to sample all allocations by using sample_rate = 1. I can't imagine any other situation where it would have a noticeable effect.)