### PR TITLE
Refactor AppVeyor scripts to enable all ports

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -389,6 +389,29 @@ entry needed)" in one of your commit messages -- but in general all
 patches submitted should come with a Changes entry; see the guidelines
 in link:CONTRIBUTING.md[].
 
+The Windows ports take a long time to test - INRIA's precheck service is the
+best to use when all 6 Windows ports need testing for a branch, but the
+AppVeyor scripts also support the other ports. The matrix is controlled by
+the following environment variables, which should be set in appveyor.yml:
+
+- `PORT` - this must be set on each job. Either `mingw`, `msvc` or `cygwin`
+  followed by `32` or `64`.
+- `BOOTSTRAP_FLEXDLL` - must be set on each job. Either `true` or `false`.
+  At present, must be `false` for Cygwin builds. Controls whether flexlink
+  is bootstrapped as part of the test or installed from a binary archive.
+- `FORCE_CYGWIN_UPGRADE`. Default: `0`. Set to `1` to force an upgrade of
+  Cygwin packages as part of the build. Normally a full upgrade is only
+  triggered if the packages installed require it.
+- `BUILD_MODE`. Default: `world.opt`. Either `world.opt`, `steps`, or `C`.
+  Controls whether the build uses the `world.opt` target or the classic
+  `world`, `opt`, `opt.opt` targets. The `C` build is a fast test used to
+  build just enough of the tree to cover the C sources (it's used to test
+  old MSVC compilers).
+- `SDK`. Defaults to Visual Studio 2015. Specifies the exact command to run
+  to set-up the Microsoft build environment.
+- `CYGWIN_DIST`. Default: `64`. Either `64` or `32`, selects 32-bit or 64-bit
+  Cygwin as the build environment.
+
 ==== INRIA's Continuous Integration (CI)
 
 INRIA provides a Jenkins continuous integration service that OCaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
     CYG_ROOT: C:/cygwin64
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     CYG_CACHE: C:/cygwin64/var/cache/setup
-    FLEXDLL_VERSION: 0.38
+    FLEXDLL_VERSION: 0.39
     OCAMLRUNPARAM: v=0,b
   matrix:
     - PORT: mingw32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ environment:
     CYG_CACHE: C:/cygwin64/var/cache/setup
     FLEXDLL_VERSION: 0.39
     OCAMLRUNPARAM: v=0,b
+    FORCE_CYGWIN_UPGRADE: 0
   matrix:
     - PORT: mingw32
       BOOTSTRAP_FLEXDLL: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,11 +29,18 @@ environment:
     FLEXDLL_VERSION: 0.39
     OCAMLRUNPARAM: v=0,b
     FORCE_CYGWIN_UPGRADE: 0
+    BUILD_MODE: world.opt
   matrix:
     - PORT: mingw32
       BOOTSTRAP_FLEXDLL: true
     - PORT: msvc64
       BOOTSTRAP_FLEXDLL: false
+      BUILD_MODE: steps
+    - PORT: msvc32
+      BOOTSTRAP_FLEXDLL: false
+      BUILD_MODE: C
+      SDK: |-
+        "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,9 @@ environment:
     OCAMLRUNPARAM: v=0,b
   matrix:
     - PORT: mingw32
+      BOOTSTRAP_FLEXDLL: true
     - PORT: msvc64
+      BOOTSTRAP_FLEXDLL: false
 
 matrix:
   fast_finish: true

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -119,7 +119,7 @@ if "%PORT%" equ "cygwin64" (
 )
 
 set CYGWIN_INSTALL_PACKAGES=
-set CYGWIN_UPGRADE_REQUIRED=0
+set CYGWIN_UPGRADE_REQUIRED=%FORCE_CYGWIN_UPGRADE%
 
 for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
 call :UpgradeCygwin

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -206,5 +206,14 @@ case "$1" in
       exit 1
     esac
 
+    echo DLL base addresses
+    case "$PORT" in
+      *32)
+        ARG='-4';;
+      *64)
+        ARG='-8';;
+    esac
+    find "../$BUILD_PREFIX-$PORT" -type f -name \*.dll | xargs rebase -i "$ARG"
+
     ;;
 esac


### PR DESCRIPTION
While working on #10062, it was useful to be able to enable mingw64 testing on AppVeyor on my private fork. That involved a non-trivial amount of hacking in the AppVeyor script.

I don't propose changing what we regularly build, but this PR refactors the scripts enough to allow each port to be specified for building; it also splits off the partial msvc32 which is done with the Windows 7 SDK into a separate job.

A version of this PR with the full matrix of 7 jobs can be seen on [my fork's AppVeyor](https://ci.appveyor.com/project/dra27/ocaml/builds/36607758) correctly showing mingw-w64 failing (because #10062 is not yet merged) and Cygwin64 failing (because the worker used flexlink 0.37 instead of flexlink 0.39).

I also updated `HACKING.adoc` to include details of how to customise the appveyor.yml when it's needed. Future work could include always having those 7 entries but using a label (as we do `no-changes-entry`) to turn on the 4 builds we don't normally want.