### PR TITLE
Add Printexc.return_address_of_raw_entry

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -668,13 +668,11 @@ G(caml_system__code_end):
         .align  EIGHT_ALIGN
 G(caml_system__frametable):
         .quad   1           /* one descriptor */
-        .quad   LBL(107)    /* return address into callback */
-        .value  -1          /* negative frame size => use callback link */
+        .long   0           /* no debuginfo */
+        .value  0xffff      /* negative frame size => use callback link */
         .value  0           /* no roots here */
+        .quad   LBL(107)    /* return address into callback */
         .align  EIGHT_ALIGN
-        .quad   16
-        .quad   0
-        .string "amd64.S"
 
 #if defined(SYS_macosx)
         .literal16

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -430,9 +430,10 @@ caml_system__code_end:
         PUBLIC  caml_system__frametable
 caml_system__frametable LABEL QWORD
         QWORD   1           ; one descriptor
-        QWORD   L107        ; return address into callback
+        DWORD   0           ; no debuginfo
         WORD    -1          ; negative frame size => use callback link
         WORD    0           ; no roots here
+        QWORD   L107        ; return address into callback
         ALIGN   8
 
         PUBLIC  caml_negf_mask

--- a/runtime/arm.S
+++ b/runtime/arm.S
@@ -436,9 +436,10 @@ caml_system__code_end:
         .globl  caml_system__frametable
 caml_system__frametable:
         .word   1               /* one descriptor */
-        .word   .Lcaml_retaddr  /* return address into callback */
+        .word   0               /* no debuginfo */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */
+        .word   .Lcaml_retaddr  /* return address into callback */
         .align  2
         .type   caml_system__frametable, %object
         .size   caml_system__frametable, .-caml_system__frametable

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -516,9 +516,10 @@ G(caml_system__code_end):
 
 OBJECT(caml_system__frametable)
         .quad   1               /* one descriptor */
-        .quad   L(caml_retaddr) /* return address into callback */
+        .word   0               /* no debuginfo */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */
+        .quad   L(caml_retaddr) /* return address into callback */
         .align  3
         END_OBJECT(caml_system__frametable)
 

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -374,3 +374,10 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
   caml_stat_free(callstack);
   CAMLreturn(res);
 }
+
+CAMLprim value caml_raw_backtrace_entry_retaddr(value entry)
+{
+  backtrace_slot slot = Backtrace_slot_val(entry);
+  uintnat addr = caml_debuginfo_return_address(slot);
+  return caml_copy_nativeint((intnat)addr);
+}

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -500,6 +500,11 @@ void caml_debuginfo_location(debuginfo dbg,
   li->loc_endchr = event->ev_endchr;
 }
 
+uintnat caml_debuginfo_return_address(backtrace_slot slot)
+{
+  return 0;
+}
+
 debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
   return (debuginfo)slot;

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -155,6 +155,11 @@ intnat caml_collect_current_callstack(value** ptrace, intnat* plen,
   return trace_pos;
 }
 
+uintnat caml_debuginfo_return_address(backtrace_slot slot)
+{
+  return caml_find_frame_descr_start(slot)->retaddr;
+}
+
 debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
   /* Debuginfo pointers are stored as 32-bit relative offsets,

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -58,6 +58,9 @@ int caml_debug_info_available(void);
  * startup.h if something went wrong loading the debug information. */
 int caml_debug_info_status(void);
 
+/* Get return address for a given slot (returns 0 in bytecode) */
+uintnat caml_debuginfo_return_address(backtrace_slot slot);
+
 /* Return debuginfo associated to a slot or NULL. */
 debuginfo caml_debuginfo_extract(backtrace_slot slot);
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -447,10 +447,8 @@ extern int caml_snwprintf(wchar_t * buf,
 #endif /* CAML_INTERNALS */
 
 /* The [backtrace_slot] type represents values stored in
- * [Caml_state->backtrace_buffer].  In bytecode, it is the same as a
- * [code_t], in native code it is either a [frame_descr *] or a [debuginfo],
- * depending on the second-lowest bit.  In any case, the lowest bit must
- * be 0.
+ * [Caml_state->backtrace_buffer].  In bytecode, it is the same as a [code_t],
+ * in native code it points to a debuginfo offset within a [frame_descr *].
  * The representation doesn't matter for code outside [backtrace_{byt,nat}.c],
  * so it is just exposed as a [void *].
  */

--- a/runtime/i386.S
+++ b/runtime/i386.S
@@ -425,7 +425,7 @@ G(caml_system__code_end):
         .globl  G(caml_system__frametable)
 G(caml_system__frametable):
         .long   1               /* one descriptor */
-        .long   LBL(107)        /* return address into callback */
+        .long   0               /* no debuginfo */
 #ifndef SYS_solaris
         .word   -1              /* negative frame size => use callback link */
         .word   0               /* no roots here */
@@ -433,6 +433,7 @@ G(caml_system__frametable):
         .value  -1              /* negative frame size => use callback link */
         .value  0               /* no roots here */
 #endif
+        .long   LBL(107)        /* return address into callback */
 
         .globl  G(caml_extra_params)
 G(caml_extra_params):

--- a/runtime/i386nt.asm
+++ b/runtime/i386nt.asm
@@ -304,9 +304,10 @@ _caml_system__code_end:
         PUBLIC  _caml_system__frametable
 _caml_system__frametable LABEL DWORD
         DWORD   1               ; one descriptor
-        DWORD   L107            ; return address into callback
+        DWORD   0               ; no debuginfo
         WORD    -1              ; negative frame size => use callback link
         WORD    0               ; no roots here
+        DWORD   L107            ; return address into callback
 
         PUBLIC  _caml_extra_params
 _caml_extra_params LABEL DWORD

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -654,9 +654,10 @@ caml_system__code_end:
         .type   caml_system__frametable, @object
 caml_system__frametable:
         datag   1               /* one descriptor */
-        datag   .L105 + 4       /* return address into callback */
+        .long   0               /* no debuginfo */
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
+        datag   .L105 + 4       /* return address into callback */
 
 /* TOC entries */
 

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -415,8 +415,9 @@ caml_system__code_end:
         .type   caml_system__frametable, @object
 caml_system__frametable:
         .quad   1               /* one descriptor */
-        .quad   .Lcaml_retaddr  /* return address into callback */
+        .long   0               /* no debuginfo */
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots */
+        .quad   .Lcaml_retaddr  /* return address into callback */
         .align  3
         .size   caml_system__frametable, .-caml_system__frametable

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -78,7 +78,13 @@ static link* frametables_list_tail(link *list) {
   return tail;
 }
 
-static frame_descr * next_frame_descr(frame_descr * d) {
+static frame_descr * first_frame_descr(intnat * tbl)
+{
+  return caml_find_frame_descr_start((uint32_t*)(tbl + 1));
+}
+
+static frame_descr * next_frame_descr(frame_descr * d)
+{
   unsigned char num_allocs = 0, *p;
   CAMLassert(d->retaddr >= 4096);
   /* Skip to end of live_ofs */
@@ -88,15 +94,8 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     num_allocs = *p;
     p += num_allocs + 1;
   }
-  /* Skip debug info if present */
-  if (d->frame_size & 1) {
-    /* Align to 32 bits */
-    p = Align_to(p, uint32_t);
-    p += sizeof(uint32_t) * (d->frame_size & 2 ? num_allocs : 1);
-  }
-  /* Align to word size */
-  p = Align_to(p, void*);
-  return ((frame_descr*) p);
+  /* Skip debug info pointers */
+  return caml_find_frame_descr_start(p);
 }
 
 static void fill_hashtable(link *frametables) {
@@ -109,14 +108,14 @@ static void fill_hashtable(link *frametables) {
   iter_list(frametables,lnk) {
     tbl = (intnat*) lnk->data;
     len = *tbl;
-    d = (frame_descr *)(tbl + 1);
     for (j = 0; j < len; j++) {
+      if (j == 0) d = first_frame_descr(tbl);
+      else d = next_frame_descr(d);
       h = Hash_retaddr(d->retaddr);
       while (caml_frame_descriptors[h] != NULL) {
         h = (h+1) & caml_frame_descriptors_mask;
       }
       caml_frame_descriptors[h] = d;
-      d = next_frame_descr(d);
     }
   }
 }
@@ -212,10 +211,10 @@ void caml_unregister_frametable(intnat *table) {
   frame_descr * d;
 
   len = *table;
-  d = (frame_descr *)(table + 1);
   for (j = 0; j < len; j++) {
+    if (j == 0) d = first_frame_descr(table);
+    else d = next_frame_descr(d);
     remove_entry(d);
-    d = next_frame_descr(d);
   }
 
   iter_list(frametables,lnk) {

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -346,9 +346,10 @@ caml_system__code_end:
         .type   caml_system__frametable, @object
 caml_system__frametable:
         .quad   1               /* one descriptor */
-        .quad   .L105           /* return address into callback */
+        .long   0               /* no debuginfo */
         .short  -1              /* negative size count => use callback link */
         .short  0               /* no roots here */
+        .quad   .L105           /* return address into callback */
         .align  8
 
 /* Mark stack as non-executable */

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -97,6 +97,9 @@ type raw_backtrace = raw_backtrace_entry array
 
 let raw_backtrace_entries bt = bt
 
+external return_address_of_raw_entry:
+  raw_backtrace_entry -> nativeint = "caml_raw_backtrace_entry_retaddr"
+
 external get_raw_backtrace:
   unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
 

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -149,6 +149,12 @@ type raw_backtrace_entry = private int
 val raw_backtrace_entries : raw_backtrace -> raw_backtrace_entry array
 (** @since 4.12.0 *)
 
+val return_address_of_raw_entry : raw_backtrace_entry -> Nativeint.t
+(** On native-code targets, gets the return address associated with
+    a backtrace entry. (Always returns 0 on bytecode)
+
+    @since 4.13.0 *)
+
 val get_raw_backtrace: unit -> raw_backtrace
 (** [Printexc.get_raw_backtrace ()] returns the same exception
     backtrace that [Printexc.print_backtrace] would print, but in


### PR DESCRIPTION
This PR adds a new primitive to Printexc, allowing the concrete return address to be extracted from a backtrace. (This is in response to a feature request I've gotten: it's useful to be able to correlate results of Memprof with native profiling tools, which generally work with return addresses).

This should be trivial. A backtrace is represented as a bunch of frame descriptors, and frame descriptors hold return addresses, so the information desired is just pointer away.

Unfortunately, the current representation of backtraces collected by Memprof during Comballoc allocations makes this hard. So, this PR first refactors and simplifies the backtrace representation, then adds Printexc.return_address_of_raw_entry with the trivial implementation.

### Old representation

There are two different structures used to represent this information: `frame_descr` and `debuginfo`. A `frame_descr` contains the information used by the GC to traverse the stack, while a `debuginfo` contains detailed location information, stored out-of-line as it is rarely accessed.

The frame_descr structure consists of the following data:
  - Return address
  - Frame size
  - Locations of live values
  - List of allocation sizes (optional, for Comballoc frames)
  - Debuginfo pointer (or several, for Comballoc frames)

The elements of a backtrace are `backtrace_slot`s, which are currently a tagged union of either `frame_descr` or `debuginfo`. Mostly, backtrace slots are `frame_descrs`, but when Memtrace wants to make a backtrace for a specific one of a combined set of allocations it uses a specific `debuginfo` instead.

The problem is that when it does this, there's no way of getting back from the `debuginfo` to the corresponding `frame_descr`, so there's no way to find the return address.

### New representation

The change in this PR is to move the `debuginfo` pointer(s) to the *start* of the `frame_descr` rather than the end. There is always at least one of them, and if there are more (in the Comballoc case) then the rest are tagged with the low bit.

A `backtrace_slot` is now _the address of a debuginfo pointer_. Since each `frame_descr` begins with a debuginfo pointer, a `frame_descr` can be cast directly to a `backtrace_slot`, but when Memtrace wants to represent a specific one of a combined set of allocations it can pick an earlier debuginfo pointer.

Given such a backtrace_slot, it's now always possible to find the corresponding `frame_descr`, by walking forwards until you find a debuginfo pointer which isn't tagged. This pointer signals the start of the `frame_descr`.

---

This is tricky code. However, it's well-tested tricky code: mistakes here tend to show up by breaking the backtrace testsuite, the statmemprof testsuite, or (most commonly) just crashing on startup / first GC. There is a tiny amount of per-architecture code, as each assembly stub contains a manually constructed frametable. (This also includes a revert of #663, which added some extra information here for the now-defunct Spacetime).