### PR TITLE
Remove last vestiges of MAX_TESTSUITE_RETRIES

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -235,7 +235,6 @@ FORCE_SAFE_STRING=@force_safe_string@
 DEFAULT_SAFE_STRING=@default_safe_string@
 WINDOWS_UNICODE=@windows_unicode@
 AFL_INSTRUMENT=@afl@
-MAX_TESTSUITE_DIR_RETRIES=@max_testsuite_dir_retries@
 FLAT_FLOAT_ARRAY=@flat_float_array@
 FUNCTION_SECTIONS=@function_sections@
 AWK=@AWK@

--- a/configure
+++ b/configure
@@ -758,7 +758,6 @@ afl
 function_sections
 flat_float_array
 windows_unicode
-max_testsuite_dir_retries
 flambda_invariants
 flambda
 frame_pointers
@@ -2887,7 +2886,6 @@ VERSION=4.13.0+dev0-2020-10-19
 
 
  # TODO: rename this variable
-
 
 
 
@@ -16859,7 +16857,6 @@ fi
 
 case $host in #(
   *-*-mingw32|*-pc-windows) :
-    max_testsuite_dir_retries=1
     case $WINDOWS_UNICODE_MODE in #(
   ansi) :
     windows_unicode=0 ;; #(
@@ -16869,8 +16866,7 @@ case $host in #(
     as_fn_error $? "unexpected windows unicode mode" "$LINENO" 5 ;;
 esac ;; #(
   *) :
-    max_testsuite_dir_retries=0
-  windows_unicode=0 ;;
+    windows_unicode=0 ;;
 esac
 
 # Define flexlink chain and flags correctly for the different Windows ports

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,6 @@ AC_SUBST([profinfo_width])
 AC_SUBST([frame_pointers])
 AC_SUBST([flambda])
 AC_SUBST([flambda_invariants])
-AC_SUBST([max_testsuite_dir_retries])
 AC_SUBST([windows_unicode])
 AC_SUBST([flat_float_array])
 AC_SUBST([function_sections])
@@ -1793,15 +1792,13 @@ AS_IF([test x"$mandir" = x'${datarootdir}/man'],
 
 AS_CASE([$host],
   [*-*-mingw32|*-pc-windows],
-    [max_testsuite_dir_retries=1
-    AS_CASE([$WINDOWS_UNICODE_MODE],
+    [AS_CASE([$WINDOWS_UNICODE_MODE],
       [ansi],
         [windows_unicode=0],
       [compatible|""],
         [windows_unicode=1],
       [AC_MSG_ERROR([unexpected windows unicode mode])])],
-  [max_testsuite_dir_retries=0
-  windows_unicode=0])
+  [windows_unicode=0])
 
 # Define flexlink chain and flags correctly for the different Windows ports
 AS_CASE([$host],

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -141,7 +141,6 @@ all-%: lib tools
 	@for dir in tests/$**; do \
 	  $(MAKE) --no-print-directory exec-one DIR=$$dir; \
 	done 2>&1 | tee $(TESTLOG)
-	@$(MAKE) --no-print-directory retries
 	@$(MAKE) report
 
 # The targets below use GNU parallel to parallelize tests
@@ -182,7 +181,6 @@ parallel-%: lib tools
 	 | parallel --gnu --no-notice --keep-order \
 	     "$(MAKE) --no-print-directory exec-one DIR={} 2>&1" \
 	 | tee $(TESTLOG)
-	@$(MAKE) --no-print-directory retries
 	@$(MAKE) report
 
 .PHONY: parallel
@@ -221,7 +219,6 @@ one: lib tools
      while IFS='' read -r LINE; do \
        $(MAKE) --no-print-directory exec-one DIR=$$LINE ; \
      done < $$LIST 2>&1 | tee $(TESTLOG) ; \
-     $(MAKE) --no-print-directory retries ; \
      $(MAKE) report ; fi
 
 .PHONY: exec-one
@@ -298,23 +295,3 @@ clean:
 report:
 	@if [ ! -f $(TESTLOG) ]; then echo "No $(TESTLOG) file."; exit 1; fi
 	@$(AWK) -f ./summarize.awk < $(TESTLOG)
-
-.PHONY: retry-list
-retry-list:
-	@while IFS='' read -r LINE; do \
-	  if [ -n "$$LINE" ] ; then \
-	    echo re-ran $$LINE>> $(TESTLOG); \
-	    $(MAKE) --no-print-directory clean-one DIR=$$LINE; \
-	    $(MAKE) --no-print-directory exec-one DIR=$$LINE 2>&1 \
-	      | tee -a $(TESTLOG) ; \
-	  fi \
-	done <_retries;
-	@$(MAKE) --no-print-directory retries
-
-.PHONY: retries
-retries:
-	@$(AWK) -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
-	     -f ./summarize.awk < $(TESTLOG) > _retries
-	@test `cat _retries | wc -l` -eq 0 || \
-	  $(MAKE) --no-print-directory retry-list
-	@rm -f _retries

--- a/testsuite/summarize.awk
+++ b/testsuite/summarize.awk
@@ -144,88 +144,74 @@ END {
         printf ("\n#### Some fatal error occurred during testing.\n\n");
         exit (3);
     }else{
-        if (!retries){
-            for (key in SKIPPED){
-                if (!SKIPPED[key]){
-                    ++ empty;
-                    blanks[emptyidx++] = key;
-                    delete SKIPPED[key];
-                }
+        for (key in SKIPPED){
+            if (!SKIPPED[key]){
+                ++ empty;
+                blanks[emptyidx++] = key;
+                delete SKIPPED[key];
             }
-            for (key in RESULTS){
-                r = RESULTS[key];
-                if (r == "p"){
-                    ++ passed;
-                }else if (r == "f"){
-                    ++ failed;
-                    fail[failidx++] = key;
-                }else if (r == "e"){
-                    ++ unexped;
-                    unexp[unexpidx++] = key;
-                }else if (r == "s"){
-                    ++ skipped;
-                    curdir = DIRS[key];
-                    if (curdir in SKIPPED){
-                        if (SKIPPED[curdir]){
-                            SKIPPED[curdir] = 0;
-                            skips[skipidx++] = curdir;
-                        }
-                    }else{
-                        skips[skipidx++] = key;
+        }
+        for (key in RESULTS){
+            r = RESULTS[key];
+            if (r == "p"){
+                ++ passed;
+            }else if (r == "f"){
+                ++ failed;
+                fail[failidx++] = key;
+            }else if (r == "e"){
+                ++ unexped;
+                unexp[unexpidx++] = key;
+            }else if (r == "s"){
+                ++ skipped;
+                curdir = DIRS[key];
+                if (curdir in SKIPPED){
+                    if (SKIPPED[curdir]){
+                        SKIPPED[curdir] = 0;
+                        skips[skipidx++] = curdir;
                     }
-                }else if (r == "n"){
-                    ++ ignored;
+                }else{
+                    skips[skipidx++] = key;
                 }
+            }else if (r == "n"){
+                ++ ignored;
             }
-            printf("\n");
-            if (skipped != 0){
-                printf("\nList of skipped tests:\n");
-                for (i=0; i < skipidx; i++) printf("    %s\n", skips[i]);
-            }
-            if (empty != 0){
-                printf("\nList of directories returning no results:\n");
-                for (i=0; i < empty; i++) printf("    %s\n", blanks[i]);
-            }
-            if (failed != 0){
-                printf("\nList of failed tests:\n");
-                for (i=0; i < failed; i++) printf("    %s\n", fail[i]);
-            }
-            if (unexped != 0){
-                printf("\nList of unexpected errors:\n");
-                for (i=0; i < unexped; i++) printf("    %s\n", unexp[i]);
-            }
-            printf("\n");
-            printf("Summary:\n");
-            printf("  %3d tests passed\n", passed);
-            printf("  %3d tests skipped\n", skipped);
-            printf("  %3d tests failed\n", failed);
-            printf("  %3d tests not started (parent test skipped or failed)\n",
-                   ignored);
-            printf("  %3d unexpected errors\n", unexped);
-            printf("  %3d tests considered", nresults);
-            if (nresults != passed + skipped + ignored + failed + unexped){
-                printf (" (totals don't add up??)");
-            }
-            printf ("\n");
-            if (reran != 0){
-                printf("  %3d test dir re-runs\n", reran);
-            }
-            if (failed || unexped){
-                printf("#### Something failed. Exiting with error status.\n\n");
-                exit 4;
-            }
-        }else{
-            for (key in RESULTS){
-                if (RESULTS[key] == "f" || RESULTS[key] == "e"){
-                    key = DIRS[key];
-                    if (!(key in RERUNS)){
-                        RERUNS[key] = 1;
-                        if (RERAN[key] < max_retries){
-                            printf("%s\n", key);
-                        }
-                    }
-                }
-            }
+        }
+        printf("\n");
+        if (skipped != 0){
+            printf("\nList of skipped tests:\n");
+            for (i=0; i < skipidx; i++) printf("    %s\n", skips[i]);
+        }
+        if (empty != 0){
+            printf("\nList of directories returning no results:\n");
+            for (i=0; i < empty; i++) printf("    %s\n", blanks[i]);
+        }
+        if (failed != 0){
+            printf("\nList of failed tests:\n");
+            for (i=0; i < failed; i++) printf("    %s\n", fail[i]);
+        }
+        if (unexped != 0){
+            printf("\nList of unexpected errors:\n");
+            for (i=0; i < unexped; i++) printf("    %s\n", unexp[i]);
+        }
+        printf("\n");
+        printf("Summary:\n");
+        printf("  %3d tests passed\n", passed);
+        printf("  %3d tests skipped\n", skipped);
+        printf("  %3d tests failed\n", failed);
+        printf("  %3d tests not started (parent test skipped or failed)\n",
+               ignored);
+        printf("  %3d unexpected errors\n", unexped);
+        printf("  %3d tests considered", nresults);
+        if (nresults != passed + skipped + ignored + failed + unexped){
+            printf (" (totals don't add up??)");
+        }
+        printf ("\n");
+        if (reran != 0){
+            printf("  %3d test dir re-runs\n", reran);
+        }
+        if (failed || unexped){
+            printf("#### Something failed. Exiting with error status.\n\n");
+            exit 4;
         }
     }
 }


### PR DESCRIPTION
In #401, I added a facility to allow failing test directories to be re-run. Especially on Windows, it was common to see failures in the threads tests which just created unnecessary noise in CI. Wind forwards nearly 5 years and 9 releases of OCaml later and the testsuite - not to mention the runtime - receive ~~much~~even more attention than they did then. These tests just don't fail like they used to 🙂

The `MAX_TESTSUITE_RETRIES` "feature" was largely disabled (possibly by accident) in a817e340c9c39fcd02ef4eac6b18b42e4f1b93d3 in #8675, which has created an inconsistency - if you do `make all` it is _not_ honoured but if you do `make parallel` it is. GNU parallel is manually installed on the Jenkins Windows workers which is why the sporadic failure of `weaklifetime.ml` has been seen more on AppVeyor than Jenkins. I checked through recent logs on the mingw32 Jenkins worker, and many of the passing logs in fact had a failing `weaklifetime.ml` on the first attempt.

I propose removing the feature entirely - in this case it's actually masking a real problem, not a transient failure. The feature was for the old `Makefile`-based system, which was mildly hard to customise. If we need this feature again, I think we would do much better to add it as a parameter _in each individual test_ which we believe fails sporadically, rather than over the entire testsuite. `ocamltest` would then interpret this parameter and retry the test automatically, as appropriate.

cc @shindere 