### PR TITLE
Float.Array.blit: fix case when both arrays coincide

### DIFF
--- a/Changes
+++ b/Changes
@@ -327,6 +327,9 @@ OCaml 4.12.0
   (David Allsopp, review by Nicolás Ojeda Bär, Sébastien Hinderer and
    Xavier Leroy)
 
+- #10070: Fix Float.Array.blit when source and destination arrays coincide.
+  (Nicolás Ojeda Bär, review by Alain Frisch and Xavier Leroy)
+
 ### Other libraries:
 
 - #8796: On Windows, make Unix.utimes use FILE_FLAG_BACKUP_SEMANTICS flag

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -392,6 +392,15 @@ CAMLprim value caml_make_array(value init)
 
 /* Blitting */
 
+CAMLprim value caml_floatarray_blit(value a1, value ofs1, value a2, value ofs2,
+                                    value n)
+{
+  memmove((double *)a2 + Long_val(ofs2),
+          (double *)a1 + Long_val(ofs1),
+          Long_val(n) * sizeof(double));
+  return Val_unit;
+}
+
 CAMLprim value caml_array_blit(value a1, value ofs1, value a2, value ofs2,
                                value n)
 {

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -161,10 +161,8 @@ module Array = struct
   let unsafe_fill a ofs len v =
     for i = ofs to ofs + len - 1 do unsafe_set a i v done
 
-  let unsafe_blit src sofs dst dofs len =
-    for i = 0 to len - 1 do
-      unsafe_set dst (dofs + i) (unsafe_get src (sofs + i))
-    done
+  external unsafe_blit: t -> int -> t -> int -> int -> unit =
+    "caml_floatarray_blit" [@@noalloc]
 
   let check a ofs len msg =
     if ofs < 0 || len < 0 || ofs + len < 0 || ofs + len > length a then

--- a/testsuite/tests/lib-floatarray/floatarray.ml
+++ b/testsuite/tests/lib-floatarray/floatarray.ml
@@ -211,6 +211,15 @@ module Test (A : S) : sig end = struct
   check_inval (A.blit a 0 a (-1)) 0;
   check_inval (A.blit a 0 a 100) 1;
   check_inval (A.blit a 0 a 101) 0;
+  let test_blit_overlap a ofs1 ofs2 len =
+    let a = A.of_list a in
+    let b = A.copy a in
+    A.blit a ofs1 a ofs2 len;
+    for i = 0 to len - 1 do
+      assert (A.get b (ofs1 + i) = A.get a (ofs2 + i))
+    done
+  in
+  test_blit_overlap [1.; 2.; 3.; 4.] 1 2 2;
 
   (* [to_list] [of_list] *)
   let a = A.init 1000 Float.of_int in


### PR DESCRIPTION
In spite of what the docstring says, `Float.Array.blit` does not correctly handle the case when `src` and `dst` are the same array.