### PR TITLE
Fix subtle bug in test file weaklifetime.ml

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,6 +44,9 @@ Working version
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
   (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)
 
+- #10071: Fix bug in tests/misc/weaklifetime.ml that was reported in #10055
+  (Damien Doligez and Gabriel Scherer, report by David Allsopp)
+
 
 OCaml 4.12.0
 ------------


### PR DESCRIPTION
This fixes the bug reported by @dra27 in #10055.

The bug is in the interaction of four things:
1. the compilation of pattern-matching
2. the bytecode compiler's management of scope
3. the fact that `Gc.quick_stat` needs to allocate
4. the way `weaklifetime.ml` is written

Looking at `weaklifetime.ml`, the compilation of pattern-matching inserts a let-binding of `data.(i).objs.(j)` for the pattern-matching in `check_and_change`. This let-binding's scope is the entire pattern-matching, including the actions. The bytecode compiler will thus keep it in a root until the end of the pattern-matching (and the function).

Now look at the `Present _, true` case. It does some random-number generation, some tests, some assignments, and a call to `gccount`. It does a second call to `gccount` after erasing the pointer, in an attempt to get the number of a cycle that started after the last (strong) pointer to the value was erased. It has to do that because `Gc.quick_stat` allocates and might thus start a new cycle and return the number of the previous cycle. But this is all for nought because the secoind call to `gccount`, which happens after we erase the pointer from the data structure, is still in the scope of the `let` introduced by pattern-matching that keeps the data alive. Hence we set the data to `Absent gc2` while the cycle `gc2+1` can (in rare circumstances) still see the data alive.

Note that the native-code compiler does scope minimization and removes the root as soon as it's not needed by the program, in this case when we enter the action, and avoids the problem entirely.

To make the problem easily reproducible (even on 64-bit Unix) just apply the following patch, which simply adds lots of allocations after the call to `Gc.quick_stat`:

```diff
--- weaklifetime.ml.orig	2020-12-04 14:29:20.000000000 +0100
+++ weaklifetime.ml	2020-12-04 14:42:35.000000000 +0100
@@ -1,7 +1,10 @@
 (* TEST
 *)
 
-Random.init 12345;;
+let seed = ref Random.(self_init(); bits());;
+if Array.length Sys.argv > 1 then seed := int_of_string Sys.argv.(1);;
+Printf.printf "seed=%d\n" !seed;;
+Random.init !seed;;
 
 let size = 1000;;
 
@@ -27,7 +30,11 @@
   )
 ;;
 
-let gccount () = (Gc.quick_stat ()).Gc.major_collections;;
+let gccount n =
+  let count = (Gc.quick_stat ()).Gc.major_collections in
+  for i = 0 to n do ignore (Sys.opaque_identity (Array.make 20 20)) done;
+  count
+;;
 
 (* Check the correctness condition on the data at (i,j):
    1. if the block is present, the weak pointer must be full
@@ -39,7 +46,7 @@
    2. if the block and weak pointer are present, randomly erase the block
 *)
 let check_and_change i j =
-  let gc1 = gccount () in
+  let gc1 = gccount 0 in
   match data.(i).objs.(j), Weak.check data.(i).wp j with
   | Present x, false -> assert false
   | Absent n, true -> assert (gc1 <= n+1)
@@ -50,14 +57,14 @@
   | Present _, true ->
     if Random.int 10 = 0 then begin
       data.(i).objs.(j) <- Absent gc1;
-      let gc2 = gccount () in
+      let gc2 = gccount 200 in
       if gc1 <> gc2 then data.(i).objs.(j) <- Absent gc2;
     end
 ;;
 
 let dummy = ref [||];;
 
-while gccount () < 20 do
+while gccount 0 < 20 do
   dummy := Array.make (Random.int 300) 0;
   let i = Random.int size in
   let j = Random.int (Array.length data.(i).objs) in
```

I think the simplest fix is to get out of the scope of `match` before we erase the pointer, by doing a tail-call to an auxiliary function.

Note: the Changes entry is my best attempt at predicting the future.
