### PR TITLE
Put Unix.SO_REUSEPORT at the end of data variant

### DIFF
--- a/Changes
+++ b/Changes
@@ -374,8 +374,8 @@ OCaml 4.12.0
 - #9802: Ensure signals are handled before Unix.kill returns
   (Stephen Dolan, review by Jacques-Henri Jourdan)
 
-- #9869: Add Unix.SO_REUSEPORT
-  (Yishuai Li, review by Xavier Leroy)
+- #9869, #10073: Add Unix.SO_REUSEPORT
+  (Yishuai Li, review by Xavier Leroy, amended by David Allsopp)
 
 - #9906, #9914: Add Unix._exit as a way to exit the process immediately,
   skipping any finalization action

--- a/otherlibs/unix/sockopt.c
+++ b/otherlibs/unix/sockopt.c
@@ -112,13 +112,13 @@ static struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_DEBUG },
   { SOL_SOCKET, SO_BROADCAST },
   { SOL_SOCKET, SO_REUSEADDR },
-  { SOL_SOCKET, SO_REUSEPORT },
   { SOL_SOCKET, SO_KEEPALIVE },
   { SOL_SOCKET, SO_DONTROUTE },
   { SOL_SOCKET, SO_OOBINLINE },
   { SOL_SOCKET, SO_ACCEPTCONN },
   { IPPROTO_TCP, TCP_NODELAY },
-  { IPPROTO_IPV6, IPV6_V6ONLY}
+  { IPPROTO_IPV6, IPV6_V6ONLY},
+  { SOL_SOCKET, SO_REUSEPORT }
 };
 
 static struct socket_option sockopt_int[] = {

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -598,13 +598,13 @@ type socket_bool_option =
     SO_DEBUG
   | SO_BROADCAST
   | SO_REUSEADDR
-  | SO_REUSEPORT
   | SO_KEEPALIVE
   | SO_DONTROUTE
   | SO_OOBINLINE
   | SO_ACCEPTCONN
   | TCP_NODELAY
   | IPV6_ONLY
+  | SO_REUSEPORT
 
 type socket_int_option =
     SO_SNDBUF

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1497,13 +1497,13 @@ type socket_bool_option =
     SO_DEBUG       (** Record debugging information *)
   | SO_BROADCAST   (** Permit sending of broadcast messages *)
   | SO_REUSEADDR   (** Allow reuse of local addresses for bind *)
-  | SO_REUSEPORT   (** Allow reuse of address and port bindings *)
   | SO_KEEPALIVE   (** Keep connection active *)
   | SO_DONTROUTE   (** Bypass the standard routing algorithms *)
   | SO_OOBINLINE   (** Leave out-of-band data in line *)
   | SO_ACCEPTCONN  (** Report whether socket listening is enabled *)
   | TCP_NODELAY    (** Control the Nagle algorithm for TCP sockets *)
   | IPV6_ONLY      (** Forbid binding an IPv6 socket to an IPv4 address *)
+  | SO_REUSEPORT   (** Allow reuse of address and port bindings *)
 (** The socket options that can be consulted with {!getsockopt}
    and modified with {!setsockopt}.  These options have a boolean
    ([true]/[false]) value. *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1497,13 +1497,13 @@ type socket_bool_option = Unix.socket_bool_option =
     SO_DEBUG       (** Record debugging information *)
   | SO_BROADCAST   (** Permit sending of broadcast messages *)
   | SO_REUSEADDR   (** Allow reuse of local addresses for bind *)
-  | SO_REUSEPORT   (** Allow reuse of address and port bindings *)
   | SO_KEEPALIVE   (** Keep connection active *)
   | SO_DONTROUTE   (** Bypass the standard routing algorithms *)
   | SO_OOBINLINE   (** Leave out-of-band data in line *)
   | SO_ACCEPTCONN  (** Report whether socket listening is enabled *)
   | TCP_NODELAY    (** Control the Nagle algorithm for TCP sockets *)
   | IPV6_ONLY      (** Forbid binding an IPv6 socket to an IPv4 address *)
+  | SO_REUSEPORT   (** Allow reuse of address and port bindings *)
 (** The socket options that can be consulted with {!getsockopt}
    and modified with {!setsockopt}.  These options have a boolean
    ([true]/[false]) value. *)

--- a/otherlibs/win32unix/sockopt.c
+++ b/otherlibs/win32unix/sockopt.c
@@ -50,13 +50,13 @@ static struct socket_option sockopt_bool[] = {
   { SOL_SOCKET, SO_DEBUG },
   { SOL_SOCKET, SO_BROADCAST },
   { SOL_SOCKET, SO_REUSEADDR },
-  { SOL_SOCKET, SO_REUSEPORT },
   { SOL_SOCKET, SO_KEEPALIVE },
   { SOL_SOCKET, SO_DONTROUTE },
   { SOL_SOCKET, SO_OOBINLINE },
   { SOL_SOCKET, SO_ACCEPTCONN },
   { IPPROTO_TCP, TCP_NODELAY },
-  { IPPROTO_IPV6, IPV6_V6ONLY}
+  { IPPROTO_IPV6, IPV6_V6ONLY},
+  { SOL_SOCKET, SO_REUSEPORT }
 };
 
 static struct socket_option sockopt_int[] = {

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -730,13 +730,13 @@ type socket_bool_option =
     SO_DEBUG
   | SO_BROADCAST
   | SO_REUSEADDR
-  | SO_REUSEPORT
   | SO_KEEPALIVE
   | SO_DONTROUTE
   | SO_OOBINLINE
   | SO_ACCEPTCONN
   | TCP_NODELAY
   | IPV6_ONLY
+  | SO_REUSEPORT
 
 type socket_int_option =
     SO_SNDBUF


### PR DESCRIPTION
In https://github.com/ocaml/ocaml/pull/9869#discussion_r488173526 I noted that the new `SO_REUSEPORT` should ideally have gone at the end of the variant for vague C compatibility reasons.

However, there's another possibly stronger reason and, given that we're still at alpha, I propose we do actually change it. Here's an error message from Lwt, prior to https://github.com/ocsigen/lwt/pull/804 being merged:

```
File "src/unix/lwt_unix.cppo.mli", lines 1020-1030, characters 0-13:
Error: This variant or record definition does not match that of type
         Unix.socket_bool_option
       Constructors number 4 have different names, SO_REUSEPORT and SO_KEEPALIVE.
```
which looks much more serious and less obvious than, with this PR:
```
File "src/unix/lwt_unix.cppo.mli", lines 1020-1030, characters 0-13:
Error: This variant or record definition does not match that of type
         Unix.socket_bool_option
       The constructor SO_REUSEPORT is only present in the original definition.
```

(cc @kit-ty-kate)