### PR TITLE
Fix native-compiler detection in ocamltest

### DIFF
--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -274,6 +274,7 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	    $(call SUBST,WITH_OCAMLDEBUG) \
 	    $(call SUBST,O) \
 	    $(call SUBST,S) \
+	    $(call SUBST,NATIVE_COMPILER) \
 	    $(call SUBST,NATDYNLINK) \
 	    $(call SUBST_STRING,SHAREDLIB_CFLAGS) \
 	    $(call SUBST,SO) \

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -20,13 +20,12 @@ open Actions
 
 (* Extracting information from environment *)
 
-let native_support = Ocamltest_config.arch <> "none"
-
 let no_native_compilers _log env =
   (Result.skip_with_reason "native compilers disabled", env)
 
 let native_action a =
-  if native_support then a else (Actions.update a no_native_compilers)
+  if Ocamltest_config.native_compiler then a
+  else (Actions.update a no_native_compilers)
 
 let get_backend_value_from_env env bytecode_var native_var =
   Ocaml_backends.make_backend_function
@@ -1138,7 +1137,7 @@ let no_shared_libraries = Actions.make
 
 let native_compiler = Actions.make
   "native-compiler"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.arch <> "none")
+  (Actions_helpers.pass_or_skip Ocamltest_config.native_compiler
     "native compiler available"
     "native compiler not available")
 

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -56,7 +56,7 @@ let native =
     test_name = "native";
     test_run_by_default = true;
     test_actions =
-      (if Ocamltest_config.arch<>"none" then opt_actions else [skip])
+      (if Ocamltest_config.native_compiler then opt_actions else [skip])
   }
 
 let toplevel = {
@@ -114,7 +114,7 @@ let asmgen_skip_on_msvc64 =
   Actions_helpers.skip_with_reason "not ported to MSVC64 yet"
 
 let asmgen_actions =
-  if Ocamltest_config.arch="none" then [asmgen_skip_on_bytecode_only]
+  if not Ocamltest_config.native_compiler then [asmgen_skip_on_bytecode_only]
   else if msvc64 then [asmgen_skip_on_msvc64]
   else [
     setup_simple_build_env;

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -58,6 +58,8 @@ let ocamldoc = %%WITH_OCAMLDOC%%
 
 let ocamldebug = %%WITH_OCAMLDEBUG%%
 
+let native_compiler = %%NATIVE_COMPILER%%
+
 let native_dynlink = %%NATDYNLINK%%
 
 let shared_library_cflags = "%%SHAREDLIB_CFLAGS%%"

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -16,7 +16,7 @@
 (* Interface for ocamltest's configuration module *)
 
 val arch : string
-(** Architecture for the native compiler, "none" if it is disabled *)
+(** Architecture for the native compiler *)
 
 val afl_instrument : bool
 (** Whether AFL support has been enabled in the compiler *)
@@ -81,6 +81,9 @@ val ocamldoc : bool
 
 val ocamldebug : bool
 (** Whether ocamldebug has been enabled at configure time *)
+
+val native_compiler : bool
+(** Whether the native compiler has been enabled at configure time *)
 
 val native_dynlink : bool
 (** Whether support for native dynlink is available or not *)


### PR DESCRIPTION
this PR is a follow-up to commit 42efb9939cc7ae77726a6156694ade6055cac372

Before that commit, it was possible to determine whether the
native-compiler was disabled by comparing the ARCH build variable with
the "none" string. This trick was used by ocamltest to figure out
whether the native compilers were available or not, because at the time
when ocamltest had to be made aware of that, this was the only way
to do (there was no build variable to keep track explictly of whether
the native compilers were enabled or not at that time, the explicit
build variable was introduced later).

So, the commit mentionned above actually broke ocamltest, causing it to
try (and fail) to run the native compilers when they were disabled
at configure time.

The present PR fixes this by making ocamltest rely on the appropriate
build variable since it has become available meanwhile.

@xavierleroy: this should help our other-configs CI jobs.