### PR TITLE
Report usage rather than definition location for let binds in ocamllex

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,10 @@ Working version
 
 ### Tools:
 
+- #10076, #10077: use the location of usage rather than definition
+  for ocamllex named regular expressions.
+  (David Allsopp, report by Léo Andrès, review by ???)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/lex/common.ml
+++ b/lex/common.ml
@@ -71,14 +71,14 @@ let copy_chars =
     "Win32" | "Cygwin" -> copy_chars_win32
   | _       -> copy_chars_unix
 
-let copy_chunk ic oc trl loc add_parens =
+let copy_chunk ic oc trl loc ?(report_loc=loc) add_parens =
   if loc.start_pos < loc.end_pos || add_parens then begin
-    fprintf oc "# %d \"%s\"\n" loc.start_line loc.loc_file;
+    fprintf oc "# %d \"%s\"\n" report_loc.start_line report_loc.loc_file;
     if add_parens then begin
-      for _i = 1 to loc.start_col - 1 do output_char oc ' ' done;
+      for _i = 1 to report_loc.start_col - 1 do output_char oc ' ' done;
       output_char oc '(';
     end else begin
-      for _i = 1 to loc.start_col do output_char oc ' ' done;
+      for _i = 1 to report_loc.start_col do output_char oc ' ' done;
     end;
     seek_in ic loc.start_pos;
     copy_chars ic oc loc.start_pos loc.end_pos;
@@ -134,14 +134,14 @@ let output_env ic oc tr env =
          in apparition order *)
       let env =
         List.sort
-          (fun ((_,p1),_) ((_,p2),_) ->
+          (fun ((_,p1,_),_) ((_,p2,_),_) ->
             Stdlib.compare p1.start_pos  p2.start_pos)
           env in
 
       List.iter
-        (fun ((_,pos),v) ->
+        (fun ((_,pos,report_loc),v) ->
           fprintf oc "%s\n" !pref ;
-          copy_chunk ic oc tr pos false ;
+          copy_chunk ic oc tr pos ~report_loc false ;
           begin match v with
           | Ident_string (o,nstart,nend) ->
               fprintf oc

--- a/lex/common.mli
+++ b/lex/common.mli
@@ -17,7 +17,8 @@ type line_tracker;;
 val open_tracker : string -> out_channel -> line_tracker
 val close_tracker : line_tracker -> unit
 val copy_chunk :
-  in_channel -> out_channel -> line_tracker -> Syntax.location -> bool -> unit
+  in_channel -> out_channel -> line_tracker -> Syntax.location ->
+  ?report_loc:Syntax.location -> bool -> unit
 val output_mem_access : out_channel -> int -> unit
 val output_memory_actions :
   string -> out_channel -> Lexgen.memory_action list -> unit

--- a/lex/lexgen.ml
+++ b/lex/lexgen.ml
@@ -23,7 +23,7 @@ exception Memory_overflow
 
 (* Deep abstract syntax for regular expressions *)
 
-type ident = string *  Syntax.location
+type ident = string * Syntax.location * Syntax.location
 
 type tag_info = {id : string ; start : bool ; action : int}
 
@@ -83,7 +83,7 @@ type ('args,'action) automata_entry =
 module Ints =
   Set.Make(struct type t = int let compare (x:t) y = compare x y end)
 
-let id_compare (id1,_) (id2,_) = String.compare id1 id2
+let id_compare (id1,_,_) (id2,_,_) = String.compare id1 id2
 
 let tag_compare t1 t2 = Stdlib.compare t1 t2
 
@@ -284,7 +284,7 @@ let rec encode_regexp char_vars act = function
   | Repetition r ->
       let r = encode_regexp char_vars act r in
       Star r
-  | Bind (r,((name,_) as x)) ->
+  | Bind (r,((name,_,_) as x)) ->
       let r = encode_regexp char_vars act r in
       if IdSet.mem x char_vars then
         Seq (Tag {id=name ; start=true ; action=act},r)
@@ -314,7 +314,7 @@ let add_pos p i = match p with
 | None -> None
 
 let mem_name name id_set =
-  IdSet.exists (fun (id_name,_) -> name = id_name) id_set
+  IdSet.exists (fun (id_name,_,_) -> name = id_name) id_set
 
 let opt_regexp all_vars char_vars optional_vars double_vars r =
 
@@ -456,7 +456,7 @@ let opt_regexp all_vars char_vars optional_vars double_vars r =
   let r,_ = alloc_exp None r in
   let m =
     IdSet.fold
-      (fun ((name,_) as x) r ->
+      (fun ((name,_,_) as x) r ->
 
         let v =
           if IdSet.mem x char_vars then
@@ -1128,7 +1128,7 @@ let extract_tags l =
     (fun (act,m,_) ->
       envs.(act) <-
          List.fold_right
-           (fun ((name,_),v) r -> match v with
+           (fun ((name,_,_),v) r -> match v with
            | Ident_char (_,t) -> make_tag_entry name true act t r
            | Ident_string (_,t1,t2) ->
                make_tag_entry name true act t1

--- a/lex/lexgen.mli
+++ b/lex/lexgen.mli
@@ -35,7 +35,7 @@ and memory_action =
 
 and tag_action = SetTag of int * int | EraseTag of int
 
-type ident = string *  Syntax.location
+type ident = string * Syntax.location * Syntax.location
 
 (* Representation of entry points *)
 type tag_base = Start | End | Mem of int

--- a/lex/syntax.ml
+++ b/lex/syntax.ml
@@ -33,7 +33,7 @@ type regular_expression =
   | Sequence of regular_expression * regular_expression
   | Alternative of regular_expression * regular_expression
   | Repetition of regular_expression
-  | Bind of regular_expression * (string * location)
+  | Bind of regular_expression * (string * location * location)
 
 type ('arg,'action) entry =
   {name:string ;

--- a/lex/syntax.mli
+++ b/lex/syntax.mli
@@ -30,7 +30,7 @@ type regular_expression =
   | Sequence of regular_expression * regular_expression
   | Alternative of regular_expression * regular_expression
   | Repetition of regular_expression
-  | Bind of regular_expression * (string * location)
+  | Bind of regular_expression * (string * location * location)
 
 type ('arg,'action) entry =
   {name:string ;


### PR DESCRIPTION
Possible solution to #10076. With this small example:

```ocaml
let t_digit   = ['0'-'9']
let t_int_part  = '0' | ['1'-'9'] ('_'? t_digit+)*
let t_fractional_int_part  = t_digit ('_'? t_digit+)*
let t_sign    = ['-''+']
let t_int     = (t_sign as int_sign)? (t_int_part as int_part)
let t_exp     = ['E''e'] t_int
let t_frac    = '.' t_fractional_int_part
let t_float   = t_sign? t_int_part ((t_frac t_exp?) | t_exp)

rule lex = parse
| t_int {(int_part, int_sign)}
| t_float as value {value, None}
```

the warning changes from:

```
File "test.mll", line 5, characters 27-35:
Warning 26: unused variable int_sign.
File "test.mll", line 5, characters 53-61:
Warning 26: unused variable int_part.
```
referring to the variables themselves to:

```
File "test.mll", line 12, characters 2-10:
Warning 26: unused variable int_sign.
File "test.mll", line 12, characters 2-10:
Warning 26: unused variable int_part.
```
referring to the actual usage of the regexp. This is less confusing in this case, since the names are used in one rule and not in another. It is more confusing in that location doesn't actually contain the name.

This would need tidying up - opening the PR for further discussion before doing so