### PR TITLE
Rename ocamlopttoplevel.cmxa to ocamltoplevel.cmxa

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,8 +42,9 @@ Working version
   to the implementation and the coercion.
   (Leandro Ostera, review by Gabriel Scherer and Thomas Refis)
 
-* #10061: remove modules `Opttoploop`, `Opttopstart`, which are replaced by
-  `Toploop` and `Topstart`, made available in native code.
+* #10061, #10078: remove library `ocamlopttoplevel`, remove modules
+  `Opttoploop`, `Opttopstart`, which are replaced by `Toploop` and `Topstart` in
+  library `ocamltoplevel`, made available in native code.
 
 ### Build system:
 

--- a/Makefile
+++ b/Makefile
@@ -1014,7 +1014,7 @@ endif
 ocamlnat$(EXE): compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
     compilerlibs/ocamlbytecomp.cmxa \
     otherlibs/dynlink/dynlink.cmxa \
-    compilerlibs/ocamlopttoplevel.cmxa \
+    compilerlibs/ocamltoplevel.cmxa \
     $(TOPLEVELSTART:.cmo=.cmx)
 	$(CAMLOPT_CMD) $(LINKFLAGS) -linkall -I toplevel/native -o $@ $^
 
@@ -1025,7 +1025,7 @@ $(TOPLEVELSTART:.cmo=.cmx): $(TOPLEVELSTART:.cmo=.ml) \
 partialclean::
 	rm -f ocamlnat ocamlnat.exe
 
-toplevel/opttoploop.cmx: otherlibs/dynlink/dynlink.cmxa
+toplevel/native/toploop.cmx: otherlibs/dynlink/dynlink.cmxa
 
 # The numeric opcodes
 

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -345,8 +345,8 @@ compilerlibs/ocamltoplevel.cma: $(TOPLEVEL_CMI) $(TOPLEVEL)
 partialclean::
 	rm -f compilerlibs/ocamltoplevel.cma
 
-compilerlibs/ocamlopttoplevel.cmxa: $(OPTTOPLEVEL_CMI) $(OPTTOPLEVEL:.cmo=.cmx)
+compilerlibs/ocamltoplevel.cmxa: $(OPTTOPLEVEL_CMI) $(OPTTOPLEVEL:.cmo=.cmx)
 	$(CAMLOPT) -a -o $@ -I toplevel/native $(OPTTOPLEVEL:.cmo=.cmx)
 partialclean::
-	rm -f compilerlibs/ocamlopttoplevel.cmxa \
-	  compilerlibs/ocamlopttoplevel.a compilerlibs/ocamlopttoplevel.lib
+	rm -f compilerlibs/ocamltoplevel.cmxa \
+	  compilerlibs/ocamltoplevel.a compilerlibs/ocamltoplevel.lib

--- a/toplevel/native/topdirs.ml
+++ b/toplevel/native/topdirs.ml
@@ -130,7 +130,7 @@ let match_printer_type ppf desc typename =
   let printer_type =
     match
       Env.find_type_by_name
-        (Ldot(Lident "Opttopdirs", typename)) !toplevel_env
+        (Ldot(Lident "Topdirs", typename)) !toplevel_env
     with
     | (path, _) -> path
     | exception Not_found ->

--- a/toplevel/native/toploop.ml
+++ b/toplevel/native/toploop.ml
@@ -36,7 +36,7 @@ let global_symbol id =
   let sym = Compilenv.symbol_for_global id in
   match Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol:sym with
   | None ->
-    fatal_error ("Opttoploop.global_symbol " ^ (Ident.unique_name id))
+    fatal_error ("Toploop.global_symbol " ^ (Ident.unique_name id))
   | Some obj -> obj
 
 let need_symbol sym =
@@ -50,7 +50,7 @@ let dll_run dll entry =
     | Result r ->
         match Obj.magic r with
           | Ok x -> Result x
-          | Err s -> fatal_error ("Opttoploop.dll_run " ^ s)
+          | Err s -> fatal_error ("Toploop.dll_run " ^ s)
 
 
 type directive_fun =


### PR DESCRIPTION
This follows from #10061 by renaming the library to further unify the two toplevels.

Some remaining references to `Opttop*` have also been cleaned up.

Note that no further patch to `ocamlfind` should be necessary as the included `META` file already declared `opttoplevel.cmxa` as the native archive for the toplevel — https://github.com/ocaml/ocamlfind/blob/9e406208dfe60160fbdc1ea135d1cc0e2ef8e216/site-lib-src/compiler-libs/META.in#L37
This might be an issue for linking the native toplevel with dune until it has dedicated support, but that will only affect the native toplevel, that doesn't seem to be used in the wild (as the lack of META definition points out...).