### PR TITLE
Check that stack frames are not too large

### DIFF
--- a/.depend
+++ b/.depend
@@ -2076,6 +2076,7 @@ asmcomp/asmgen.cmo : \
     asmcomp/linscan.cmi \
     asmcomp/linearize.cmi \
     file_formats/linear_format.cmi \
+    asmcomp/linear.cmi \
     lambda/lambda.cmi \
     asmcomp/interval.cmi \
     asmcomp/interf.cmi \
@@ -2117,6 +2118,7 @@ asmcomp/asmgen.cmx : \
     asmcomp/linscan.cmx \
     asmcomp/linearize.cmx \
     file_formats/linear_format.cmx \
+    asmcomp/linear.cmx \
     lambda/lambda.cmx \
     asmcomp/interval.cmx \
     asmcomp/interf.cmx \
@@ -2139,6 +2141,7 @@ asmcomp/asmgen.cmx : \
     asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : \
     lambda/lambda.cmi \
+    asmcomp/emitaux.cmi \
     asmcomp/cmm.cmi \
     middle_end/clambda.cmi \
     middle_end/backend_intf.cmi

--- a/Changes
+++ b/Changes
@@ -55,6 +55,10 @@ Working version
 - #10071: Fix bug in tests/misc/weaklifetime.ml that was reported in #10055
   (Damien Doligez and Gabriel Scherer, report by David Allsopp)
 
+- #10072, #10085: Check that sizes and offsets in stack frame descriptors
+  do not overflow the 16-bit fields where they are stored.
+  (Xavier Leroy, report by Github user pveber, review by Gabriel Scherer)
+
 
 OCaml 4.12.0
 ------------

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -44,6 +44,7 @@ val compile_phrase :
 type error =
   | Assembler_error of string
   | Mismatched_for_pack of string option
+  | Asm_generation of string * Emitaux.error
 
 exception Error of error
 val report_error: Format.formatter -> error -> unit

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -15,6 +15,11 @@
 
 (* Common functions for emitting assembly code *)
 
+type error =
+  | Stack_frame_too_large of int
+
+exception Error of error
+
 let output_channel = ref stdout
 
 let emit_string s = output_string !output_channel s
@@ -178,6 +183,12 @@ let emit_frames a =
       Label_table.add debuginfos key lbl;
       lbl
   in
+  let efa_16_checked n =
+    assert (n >= 0);
+    if n < 0x1_0000
+    then a.efa_16 n
+    else raise (Error(Stack_frame_too_large n))
+  in
   let emit_frame fd =
     assert (fd.fd_frame_size land 3 = 0);
     let flags =
@@ -191,9 +202,9 @@ let emit_frames a =
         then 3 else 2
     in
     a.efa_code_label fd.fd_lbl;
-    a.efa_16 (fd.fd_frame_size + flags);
-    a.efa_16 (List.length fd.fd_live_offset);
-    List.iter a.efa_16 fd.fd_live_offset;
+    efa_16_checked (fd.fd_frame_size + flags);
+    efa_16_checked (List.length fd.fd_live_offset);
+    List.iter efa_16_checked fd.fd_live_offset;
     begin match fd.fd_debuginfo with
     | _ when flags = 0 ->
       ()
@@ -370,3 +381,7 @@ let reset () =
 
 let binary_backend_available = ref false
 let create_asm_file = ref true
+
+let report_error ppf = function
+  | Stack_frame_too_large n ->
+      Format.fprintf ppf "stack frame too large (%d bytes)" n

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -71,7 +71,6 @@ val cfi_endproc : unit -> unit
 val cfi_adjust_cfa_offset : int -> unit
 val cfi_offset : reg:int -> offset:int -> unit
 
-
 val binary_backend_available: bool ref
     (** Is a binary backend available.  If yes, we don't need
         to generate the textual assembly file (unless the user
@@ -79,3 +78,9 @@ val binary_backend_available: bool ref
 
 val create_asm_file: bool ref
     (** Are we actually generating the textual assembly file? *)
+
+type error =
+  | Stack_frame_too_large of int
+
+exception Error of error
+val report_error: Format.formatter -> error -> unit


### PR DESCRIPTION
The frame table uses 16-bit unsigned integers to store the size of a stack frame as well as the number and offsets of roots.

In extreme cases, the sizes and offsets can overflow these 16-bit fields, as reported in #10072.

This PR adds a compile-time error if these 16-bit fields overflow.  

The code is engineered  so that the 7 `asmcomp/$ARCH/emit.mlp` files are unmodified.  The check is done in `asmcomp/emitaux.ml`, raising an `Emitaux.Error` exception, which is caught in `asmcomp/asmgen.ml`, enriched with a bit of context, and re-raised as an `Asmgen.Error` exception.

