### PR TITLE
Add one new test file containing 1086 tests of the syntax error messages (plus tooling)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -111,6 +111,7 @@ testsuite/tests/misc-unsafe/almabench.ml                typo.long-line
 testsuite/tests/tool-toplevel/strings.ml                typo.utf8
 testsuite/tests/win-unicode/*.ml                        typo.utf8
 testsuite/tests/asmgen/immediates.cmm                   typo.very-long-line
+testsuite/tests/generated-parse-errors/errors.*         typo.very-long-line
 testsuite/tools/*.S                                     typo.missing-header
 testsuite/tools/*.asm                                   typo.missing-header
 testsuite/typing                                        typo.missing-header

--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ _build
 /parsing/parser.output
 /parsing/parser.automaton
 /parsing/parser.conflicts
+/parsing/parser.auto.messages
 /parsing/camlinternalMenhirLib.ml
 /parsing/camlinternalMenhirLib.mli
 

--- a/Changes
+++ b/Changes
@@ -55,8 +55,8 @@ Working version
   sentences that covers all error states of the LR automaton. Add these
   sentences to the test suite. This can be used to evaluate the quality of the
   parser's syntax error messages and (in the future) to evaluate the impact of
-  changes in the parser. (François Pottier, review by Gabriel Scherer and
-  Xavier Leroy.)
+  changes in the parser.
+  (François Pottier, review by Gabriel Scherer and Xavier Leroy.)
 
 ### Build system:
 

--- a/Changes
+++ b/Changes
@@ -50,6 +50,14 @@ Working version
   `Opttoploop`, `Opttopstart`, which are replaced by `Toploop` and `Topstart` in
   library `ocamltoplevel`, made available in native code.
 
+* #10086: add the commands `make list-parse-errors` and `make
+  generate-parse-errors` to generate a set of syntactically incorrect
+  sentences that covers all error states of the LR automaton. Add these
+  sentences to the test suite. This can be used to evaluate the quality of the
+  parser's syntax error messages and (in the future) to evaluate the impact of
+  changes in the parser. (François Pottier, review by Gabriel Scherer and
+  Xavier Leroy.)
+
 ### Build system:
 
 ### Bug fixes:

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -132,7 +132,8 @@ test-menhir: parsing/parser.mly
 partialclean-menhir::
 	rm -f \
 	  $(addprefix parsing/parser.,ml mli) \
-	  $(addprefix parsing/camlinternalMenhirLib.,ml mli)
+	  $(addprefix parsing/camlinternalMenhirLib.,ml mli) \
+	  $(addprefix parsing/parser.,automaton conflicts) \
 
 clean-menhir: partialclean-menhir
 

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -57,11 +57,27 @@ MENHIR ?= menhir
 
 unused_tokens := COMMENT DOCSTRING EOL GREATERRBRACKET
 
-## Menhir compilation flags
+## Menhir's flags.
 
-MENHIRFLAGS := --explain --dump --ocamlc "$(CAMLC) $(COMPFLAGS)" --infer \
-	--lalr --strict --table -lg 1 -la 1 \
-        $(addprefix --unused-token ,$(unused_tokens)) --fixed-exception
+# The basic flags influence the analysis of the grammar and the construction
+# of the automaton. The complete set of flags includes extra flags that
+# influence type inference and code production.
+
+MENHIRBASICFLAGS := \
+  --lalr \
+  --explain \
+  --dump \
+  --strict \
+  -lg 1 \
+  -la 1 \
+  $(addprefix --unused-token ,$(unused_tokens)) \
+
+MENHIRFLAGS := \
+  $(MENHIRBASICFLAGS) \
+  --infer \
+  --ocamlc "$(CAMLC) $(COMPFLAGS)" \
+  --fixed-exception \
+  --table \
 
 ## promote-menhir
 
@@ -158,7 +174,7 @@ include .depend.menhir
 
 interpret-menhir:
 	@ echo "Please wait, I am building the LALR automaton..."
-	@ $(MENHIR) $(MENHIRFLAGS) parsing/parser.mly \
+	@ $(MENHIR) $(MENHIRBASICFLAGS) parsing/parser.mly \
 	    --interpret \
 	    --interpret-show-cst \
 	    --trace \

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -48,7 +48,7 @@ MENHIR ?= menhir
 
 ## Unused tokens
 
-# tokens COMMENT, DOCSTRING and EOL are produced by special lexer
+# The tokens COMMENT, DOCSTRING and EOL are produced by special lexer
 # modes used by other consumers than the parser.
 
 # GREATERBRACKET ">]" was added by the parser by symmetry with "[<"

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -67,6 +67,7 @@ MENHIRBASICFLAGS := \
   --lalr \
   --explain \
   --dump \
+  --require-aliases \
   --strict \
   -lg 1 \
   -la 1 \

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -151,6 +151,7 @@ partialclean-menhir::
 	  $(addprefix parsing/parser.,ml mli) \
 	  $(addprefix parsing/camlinternalMenhirLib.,ml mli) \
 	  $(addprefix parsing/parser.,automaton conflicts) \
+	  $(addprefix parsing/parser.,auto.messages) \
 
 clean-menhir: partialclean-menhir
 
@@ -179,3 +180,34 @@ interpret-menhir:
 	    --interpret \
 	    --interpret-show-cst \
 	    --trace \
+
+## list-errors
+
+# This rule runs Menhir's reachability analysis, which produces a list of all
+# states where a syntax error can be detected (and a corresponding list of of
+# erroneous sentences). This data is stored in parsing/parser.auto.messages.
+# This analysis requires about 3 minutes and 6GB of RAM.
+
+# The analysis is performed on a copy of the grammar where every block
+# of text comprised between the markers BEGIN AVOID and END AVOID has
+# been removed. This allows us to avoid certain syntactic forms in the
+# sentences that we produce. See parser.mly for more explanations.
+
+# Because of this, we must run Menhir twice: once on a modified copy of the
+# grammar to produce the sentences, and once on the original grammar to update
+# the auto-comments (which would otherwise be incorrect).
+
+.PHONY: list-errors
+list-errors:
+	@ tmp=`mktemp -d /tmp/parser.XXXX` && \
+	  sed -e '/BEGIN AVOID/,/END AVOID/d' \
+	    parsing/parser.mly > $$tmp/parser.mly && \
+	  $(MENHIR) $(MENHIRBASICFLAGS) $$tmp/parser.mly \
+	    --list-errors -la 2 \
+	    > parsing/parser.auto.messages && \
+	  rm -rf $$tmp
+	@ cp parsing/parser.auto.messages parsing/parser.auto.messages.bak
+	@ $(MENHIR) $(MENHIRBASICFLAGS) parsing/parser.mly \
+	    --update-errors parsing/parser.auto.messages.bak \
+	    > parsing/parser.auto.messages
+	@ rm -f parsing/parser.auto.messages.bak

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -181,7 +181,7 @@ interpret-menhir:
 	    --interpret-show-cst \
 	    --trace \
 
-## list-errors
+## list-parse-errors
 
 # This rule runs Menhir's reachability analysis, which produces a list of all
 # states where a syntax error can be detected (and a corresponding list of of
@@ -197,8 +197,8 @@ interpret-menhir:
 # grammar to produce the sentences, and once on the original grammar to update
 # the auto-comments (which would otherwise be incorrect).
 
-.PHONY: list-errors
-list-errors:
+.PHONY: list-parse-errors
+list-parse-errors:
 	@ tmp=`mktemp -d /tmp/parser.XXXX` && \
 	  sed -e '/BEGIN AVOID/,/END AVOID/d' \
 	    parsing/parser.mly > $$tmp/parser.mly && \
@@ -214,7 +214,7 @@ list-errors:
 
 ## generate-parse-errors
 
-# This rule assumes that [make list-errors] has been run first.
+# This rule assumes that [make list-parse-errors] has been run first.
 
 # This rule turns the error sentences stored in parsing/parser.auto.messages
 # into one .ml file.

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -211,3 +211,91 @@ list-errors:
 	    --update-errors parsing/parser.auto.messages.bak \
 	    > parsing/parser.auto.messages
 	@ rm -f parsing/parser.auto.messages.bak
+
+## generate-parse-errors
+
+# This rule assumes that [make list-errors] has been run first.
+
+# This rule turns the error sentences stored in parsing/parser.auto.messages
+# into one .ml file.
+
+# (It would in principle be preferable to create one file per sentence, but
+# that would be much slower. We abuse the ability of the OCaml toplevel to
+# resynchronize after an error, and put all sentences into a single file.)
+
+# This requires Menhir 20201214 or newer.
+
+GPE_DIR   := tests/generated-parse-errors
+GPE_ML    := errors.ml
+GPE_REF   := errors.compilers.reference
+GPE_START := implementation use_file toplevel_phrase
+
+.PHONY: generate-parse-errors
+generate-parse-errors:
+	@ \
+	mkdir -p testsuite/$(GPE_DIR) && \
+	$(MENHIR) $(MENHIRBASICFLAGS) parsing/parser.mly \
+	    --echo-errors-concrete parsing/parser.auto.messages 2>/dev/null | \
+	(cd testsuite/$(GPE_DIR) && touch $(GPE_REF) && ( \
+	  echo "(* TEST\n   * toplevel\n*)" && \
+	  while IFS= read -r symbolic ; do \
+	    IFS= read -r concrete ; \
+	    concrete=$${concrete#### Concrete syntax: } ; \
+	    : '$$symbolic is the sentence in symbolic form' ; \
+	    : '$$concrete is the sentence in concrete form' ; \
+	    case "$$symbolic" in \
+	    *": SEMISEMI"*) \
+	      : 'If the sentence begins with SEMISEMI, ignore it. Our hack' ; \
+	      : 'does not support these sentences, and there are only 6 of' ; \
+	      : 'them anyway.' ; \
+	      continue ;; \
+	    *) \
+	      case "$$symbolic" in \
+	      *"EOF") \
+	        : 'If the sentence ends with EOF, replace it on the fly' ; \
+	        : 'with some other token (say, WHEN).' ; \
+	        echo "#0 \"$${symbolic%%EOF}WHEN\"" ; \
+	        echo "$$concrete when"   ; \
+	        echo ";;"                ;; \
+	      *) \
+	        : 'Emit a # directive containing the symbolic sentence.' ; \
+	        echo "#0 \"$$symbolic\"" ; \
+	        : 'Emit the concrete sentence.' ; \
+	        echo "$$concrete"        ; \
+	        : 'Emit a double semicolon to allow resynchronization.' ; \
+	        echo ";;"                ;; \
+	      esac \
+	    esac \
+	  done) \
+	  > $(GPE_ML) && \
+	  : 'Count how many sentences we have emitted, per start symbol.' ; \
+	  for symbol in $(GPE_START) ; do \
+	    count=$$(grep -h -e "$$symbol:" $(GPE_ML) | wc -l) && \
+	    echo "$$count sentences whose start symbol is $$symbol." ; \
+	  done \
+	)
+	@ \
+	read -p "Re-generate the expected output for this test? " -n 1 -r && \
+	echo && \
+	if [[ $$REPLY =~ ^[Yy]$$ ]] ; then \
+	  make -C testsuite promote DIR=$(GPE_DIR) >/dev/null 2>&1 && \
+	  echo "Done." ; \
+	  make classify-parse-errors ; \
+	else \
+	  echo "OK, stop." ; \
+	fi
+
+.PHONY: classify-parse-errors
+classify-parse-errors:
+	@ ( \
+	cd testsuite/$(GPE_DIR) && \
+	echo "The parser's output can be described as follows:" && \
+	c=$$(grep "^Error: Syntax error" $(GPE_REF) | wc -l) && \
+	echo "$${c} syntax errors reported." && \
+	c=$$(grep "^Error: Syntax error$$" $(GPE_REF) | wc -l) && \
+	echo "$${c} errors without an explanation." && \
+	c=$$(grep "^Error: Syntax" $(GPE_REF) | grep expected | wc -l) && \
+	echo "$${c} errors with an indication of what was expected." && \
+	c=$$(grep "might be unmatched" $(GPE_REF) | wc -l) && \
+	echo "$${c} errors with an indication of an unmatched delimiter." && \
+	true)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -15,6 +15,13 @@
 
 /* The parser definition */
 
+/* The commands [make list-errors] and [make generate-parse-errors]
+   run Menhir on a modified copy of the parser where every block of
+   text comprised between the markers [BEGIN AVOID] and -----------
+   [END AVOID] has been removed. This file should be formatted in
+   such a way that this results in a clean removal of certain
+   symbols, productions, or declarations. */
+
 %{
 
 open Asttypes

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -811,14 +811,23 @@ The precedences must be listed from low to high.
 
 /* Entry points */
 
+/* Several start symbols are marked with AVOID so that they are not used by
+   [make generate-parse-errors]. The three start symbols that we keep are
+   [implementation], [use_file], and [toplevel_phrase]. The latter two are
+   of marginal importance; only [implementation] really matters, since most
+   states in the automaton are reachable from it. */
+
 %start implementation                   /* for implementation files */
 %type <Parsetree.structure> implementation
+/* BEGIN AVOID */
 %start interface                        /* for interface files */
 %type <Parsetree.signature> interface
+/* END AVOID */
 %start toplevel_phrase                  /* for interactive use */
 %type <Parsetree.toplevel_phrase> toplevel_phrase
 %start use_file                         /* for the #use directive */
 %type <Parsetree.toplevel_phrase list> use_file
+/* BEGIN AVOID */
 %start parse_core_type
 %type <Parsetree.core_type> parse_core_type
 %start parse_expression
@@ -837,6 +846,8 @@ The precedences must be listed from low to high.
 %type <Longident.t> parse_mod_longident
 %start parse_any_longident
 %type <Longident.t> parse_any_longident
+/* END AVOID */
+
 %%
 
 /* macros */
@@ -1106,11 +1117,13 @@ implementation:
     { $1 }
 ;
 
+/* BEGIN AVOID */
 (* An .mli file. *)
 interface:
   signature EOF
     { $1 }
 ;
+/* END AVOID */
 
 (* A toplevel phrase. *)
 toplevel_phrase:
@@ -1163,6 +1176,7 @@ use_file:
       { $1 }
 ;
 
+/* BEGIN AVOID */
 parse_core_type:
   core_type EOF
     { $1 }
@@ -1207,6 +1221,8 @@ parse_any_longident:
   any_longident EOF
     { $1 }
 ;
+/* END AVOID */
+
 (* -------------------------------------------------------------------------- *)
 
 (* Functor arguments appear in module expressions and module types. *)
@@ -3586,6 +3602,7 @@ class_longident:
    mk_longident(mod_longident,LIDENT) { $1 }
 ;
 
+/* BEGIN AVOID */
 /* For compiler-libs: parse all valid longidents and a little more:
    final identifiers which are value specific are accepted even when
    the path prefix is only valid for types: (e.g. F(X).(::)) */
@@ -3595,6 +3612,7 @@ any_longident:
     ) { $1 }
   | constr_extra_nonprefix_ident { Lident $1 }
 ;
+/* END AVOID */
 
 /* Toplevel directives */
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -586,133 +586,143 @@ let mk_directive ~loc name arg =
 
 /* Tokens */
 
-%token AMPERAMPER
-%token AMPERSAND
-%token AND
-%token AS
-%token ASSERT
-%token BACKQUOTE
-%token BANG
-%token BAR
-%token BARBAR
-%token BARRBRACKET
-%token BEGIN
-%token <char> CHAR
-%token CLASS
-%token COLON
-%token COLONCOLON
-%token COLONEQUAL
-%token COLONGREATER
-%token COMMA
-%token CONSTRAINT
-%token DO
-%token DONE
-%token DOT
-%token DOTDOT
-%token DOWNTO
-%token ELSE
-%token END
-%token EOF
-%token EQUAL
-%token EXCEPTION
-%token EXTERNAL
-%token FALSE
-%token <string * char option> FLOAT
-%token FOR
-%token FUN
-%token FUNCTION
-%token FUNCTOR
-%token GREATER
-%token GREATERRBRACE
-%token GREATERRBRACKET
-%token IF
-%token IN
-%token INCLUDE
-%token <string> INFIXOP0
-%token <string> INFIXOP1
-%token <string> INFIXOP2
-%token <string> INFIXOP3
-%token <string> INFIXOP4
-%token <string> DOTOP
-%token <string> LETOP
-%token <string> ANDOP
-%token INHERIT
-%token INITIALIZER
-%token <string * char option> INT
-%token <string> LABEL
-%token LAZY
-%token LBRACE
-%token LBRACELESS
-%token LBRACKET
-%token LBRACKETBAR
-%token LBRACKETLESS
-%token LBRACKETGREATER
-%token LBRACKETPERCENT
-%token LBRACKETPERCENTPERCENT
-%token LESS
-%token LESSMINUS
-%token LET
-%token <string> LIDENT
-%token LPAREN
-%token LBRACKETAT
-%token LBRACKETATAT
-%token LBRACKETATATAT
-%token MATCH
-%token METHOD
-%token MINUS
-%token MINUSDOT
-%token MINUSGREATER
-%token MODULE
-%token MUTABLE
-%token NEW
-%token NONREC
-%token OBJECT
-%token OF
-%token OPEN
-%token <string> OPTLABEL
-%token OR
-/* %token PARSER */
-%token PERCENT
-%token PLUS
-%token PLUSDOT
-%token PLUSEQ
-%token <string> PREFIXOP
-%token PRIVATE
-%token QUESTION
-%token QUOTE
-%token RBRACE
-%token RBRACKET
-%token REC
-%token RPAREN
-%token SEMI
-%token SEMISEMI
-%token HASH
-%token <string> HASHOP
-%token SIG
-%token STAR
-%token <string * Location.t * string option> STRING
-%token
-  <string * Location.t * string * Location.t * string option> QUOTED_STRING_EXPR
-%token
-  <string * Location.t * string * Location.t * string option> QUOTED_STRING_ITEM
-%token STRUCT
-%token THEN
-%token TILDE
-%token TO
-%token TRUE
-%token TRY
-%token TYPE
-%token <string> UIDENT
-%token UNDERSCORE
-%token VAL
-%token VIRTUAL
-%token WHEN
-%token WHILE
-%token WITH
-%token <string * Location.t> COMMENT
-%token <Docstrings.docstring> DOCSTRING
+/* The alias that follows each token is used by Menhir when it needs to
+   produce a sentence (that is, a sequence of tokens) in concrete syntax. */
 
-%token EOL
+/* Some tokens represent multiple concrete strings. In most cases, an
+   arbitrary concrete string can be chosen. In a few cases, one must
+   be careful: e.g., in PREFIXOP and INFIXOP2, one must choose a concrete
+   string that will not trigger a syntax error; see how [not_expecting]
+   is used in the definition of [type_variance]. */
+
+%token AMPERAMPER             "&&"
+%token AMPERSAND              "&"
+%token AND                    "and"
+%token AS                     "as"
+%token ASSERT                 "assert"
+%token BACKQUOTE              "`"
+%token BANG                   "!"
+%token BAR                    "|"
+%token BARBAR                 "||"
+%token BARRBRACKET            "|]"
+%token BEGIN                  "begin"
+%token <char> CHAR            "'a'" (* just an example *)
+%token CLASS                  "class"
+%token COLON                  ":"
+%token COLONCOLON             "::"
+%token COLONEQUAL             ":="
+%token COLONGREATER           ":>"
+%token COMMA                  ","
+%token CONSTRAINT             "constraint"
+%token DO                     "do"
+%token DONE                   "done"
+%token DOT                    "."
+%token DOTDOT                 ".."
+%token DOWNTO                 "downto"
+%token ELSE                   "else"
+%token END                    "end"
+%token EOF                    ""
+%token EQUAL                  "="
+%token EXCEPTION              "exception"
+%token EXTERNAL               "external"
+%token FALSE                  "false"
+%token <string * char option> FLOAT "42.0" (* just an example *)
+%token FOR                    "for"
+%token FUN                    "fun"
+%token FUNCTION               "function"
+%token FUNCTOR                "functor"
+%token GREATER                ">"
+%token GREATERRBRACE          ">}"
+%token GREATERRBRACKET        ">]"
+%token IF                     "if"
+%token IN                     "in"
+%token INCLUDE                "include"
+%token <string> INFIXOP0      "!="   (* just an example *)
+%token <string> INFIXOP1      "@"    (* just an example *)
+%token <string> INFIXOP2      "+!"   (* chosen with care; see above *)
+%token <string> INFIXOP3      "land" (* just an example *)
+%token <string> INFIXOP4      "**"   (* just an example *)
+%token <string> DOTOP         ".+"
+%token <string> LETOP         "let*" (* just an example *)
+%token <string> ANDOP         "and*" (* just an example *)
+%token INHERIT                "inherit"
+%token INITIALIZER            "initializer"
+%token <string * char option> INT "42"  (* just an example *)
+%token <string> LABEL         "~label:" (* just an example *)
+%token LAZY                   "lazy"
+%token LBRACE                 "{"
+%token LBRACELESS             "{<"
+%token LBRACKET               "["
+%token LBRACKETBAR            "[|"
+%token LBRACKETLESS           "[<"
+%token LBRACKETGREATER        "[>"
+%token LBRACKETPERCENT        "[%"
+%token LBRACKETPERCENTPERCENT "[%%"
+%token LESS                   "<"
+%token LESSMINUS              "<-"
+%token LET                    "let"
+%token <string> LIDENT        "lident" (* just an example *)
+%token LPAREN                 "("
+%token LBRACKETAT             "[@"
+%token LBRACKETATAT           "[@@"
+%token LBRACKETATATAT         "[@@@"
+%token MATCH                  "match"
+%token METHOD                 "method"
+%token MINUS                  "-"
+%token MINUSDOT               "-."
+%token MINUSGREATER           "->"
+%token MODULE                 "module"
+%token MUTABLE                "mutable"
+%token NEW                    "new"
+%token NONREC                 "nonrec"
+%token OBJECT                 "object"
+%token OF                     "of"
+%token OPEN                   "open"
+%token <string> OPTLABEL      "?label:" (* just an example *)
+%token OR                     "or"
+/* %token PARSER              "parser" */
+%token PERCENT                "%"
+%token PLUS                   "+"
+%token PLUSDOT                "+."
+%token PLUSEQ                 "+="
+%token <string> PREFIXOP      "!+" (* chosen with care; see above *)
+%token PRIVATE                "private"
+%token QUESTION               "?"
+%token QUOTE                  "'"
+%token RBRACE                 "}"
+%token RBRACKET               "]"
+%token REC                    "rec"
+%token RPAREN                 ")"
+%token SEMI                   ";"
+%token SEMISEMI               ";;"
+%token HASH                   "#"
+%token <string> HASHOP        "##" (* just an example *)
+%token SIG                    "sig"
+%token STAR                   "*"
+%token <string * Location.t * string option>
+       STRING                 "\"hello\"" (* just an example *)
+%token <string * Location.t * string * Location.t * string option>
+       QUOTED_STRING_EXPR     "{%hello|world|}"  (* just an example *)
+%token <string * Location.t * string * Location.t * string option>
+       QUOTED_STRING_ITEM     "{%%hello|world|}" (* just an example *)
+%token STRUCT                 "struct"
+%token THEN                   "then"
+%token TILDE                  "~"
+%token TO                     "to"
+%token TRUE                   "true"
+%token TRY                    "try"
+%token TYPE                   "type"
+%token <string> UIDENT        "UIdent" (* just an example *)
+%token UNDERSCORE             "_"
+%token VAL                    "val"
+%token VIRTUAL                "virtual"
+%token WHEN                   "when"
+%token WHILE                  "while"
+%token WITH                   "with"
+%token <string * Location.t> COMMENT    "(* comment *)"
+%token <Docstrings.docstring> DOCSTRING "(** documentation *)"
+
+%token EOL                    "\\n"      (* not great, but EOL is unused *)
 
 /* Precedences and associativities.
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -2493,8 +2493,14 @@ let_binding_body_no_punning:
 let_binding_body:
   | let_binding_body_no_punning
       { let p,e = $1 in (p,e,false) }
+/* BEGIN AVOID */
   | val_ident %prec below_HASH
       { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, true) }
+  (* The production that allows puns is marked so that [make list-errors]
+     does not attempt to exploit it. That would be problematic because it
+     would then generate bindings such as [let x], which are rejected by the
+     auxiliary function [addlb] via a call to [syntax_error]. *)
+/* END AVOID */
 ;
 (* The formal parameter EXT can be instantiated with ext or no_ext
    so as to indicate whether an extension is allowed or disallowed. *)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -15,7 +15,7 @@
 
 /* The parser definition */
 
-/* The commands [make list-errors] and [make generate-parse-errors]
+/* The commands [make list-parse-errors] and [make generate-parse-errors]
    run Menhir on a modified copy of the parser where every block of
    text comprised between the markers [BEGIN AVOID] and -----------
    [END AVOID] has been removed. This file should be formatted in
@@ -2512,7 +2512,7 @@ let_binding_body:
 /* BEGIN AVOID */
   | val_ident %prec below_HASH
       { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, true) }
-  (* The production that allows puns is marked so that [make list-errors]
+  (* The production that allows puns is marked so that [make list-parse-errors]
      does not attempt to exploit it. That would be problematic because it
      would then generate bindings such as [let x], which are rejected by the
      auxiliary function [addlb] via a call to [syntax_error]. *)

--- a/testsuite/tests/generated-parse-errors/errors.compilers.reference
+++ b/testsuite/tests/generated-parse-errors/errors.compilers.reference
@@ -1,0 +1,2787 @@
+File "use_file: HASH LIDENT TRUE WITH", line 1, characters 14-18:
+Error: Syntax error
+File "use_file: QUOTED_STRING_ITEM RBRACKET", line 1, characters 17-18:
+Error: Syntax error
+File "use_file: UIDENT LBRACKETATAT AND RBRACKET AND", line 1, characters 17-20:
+Error: Syntax error
+File "use_file: UIDENT WITH", line 1, characters 7-11:
+Error: Syntax error
+File "use_file: WITH", line 1, characters 0-4:
+Error: Syntax error
+File "toplevel_phrase: HASH UIDENT UIDENT DOT WITH", line 1, characters 18-22:
+Error: Syntax error
+File "toplevel_phrase: HASH UIDENT UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error
+File "toplevel_phrase: HASH UIDENT VAL", line 1, characters 9-12:
+Error: Syntax error
+File "toplevel_phrase: HASH UIDENT WITH", line 1, characters 9-13:
+Error: Syntax error
+File "toplevel_phrase: HASH WITH", line 1, characters 2-6:
+Error: Syntax error
+File "toplevel_phrase: QUOTED_STRING_ITEM RBRACKET", line 1, characters 17-18:
+Error: Syntax error
+File "toplevel_phrase: UIDENT LBRACKETATAT AND RBRACKET VAL", line 1, characters 17-20:
+Error: Syntax error
+File "toplevel_phrase: UIDENT WITH", line 1, characters 7-11:
+Error: Syntax error
+File "toplevel_phrase: WITH", line 1, characters 0-4:
+Error: Syntax error
+File "implementation: ASSERT LBRACKETAT AND RBRACKET ASSERT", line 1, characters 16-22:
+Error: Syntax error
+File "implementation: ASSERT PERCENT AND ASSERT", line 1, characters 13-19:
+Error: Syntax error
+File "implementation: ASSERT UIDENT UIDENT", line 1, characters 14-20:
+Error: Syntax error
+File "implementation: ASSERT WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: BACKQUOTE UIDENT UIDENT UIDENT", line 1, characters 16-22:
+Error: Syntax error
+File "implementation: BACKQUOTE UIDENT WHILE", line 1, characters 9-14:
+Error: Syntax error
+File "implementation: BACKQUOTE WITH", line 1, characters 2-6:
+Error: Syntax error
+File "implementation: BANG WITH", line 1, characters 2-6:
+Error: Syntax error
+File "implementation: BEGIN LBRACKETAT AND RBRACKET AND", line 1, characters 15-18:
+Error: Syntax error
+File "implementation: BEGIN PERCENT AND VIRTUAL", line 1, characters 12-19:
+Error: Syntax error
+File "implementation: BEGIN UIDENT WITH", line 1, characters 13-17:
+Error: Syntax error: 'end' expected
+File "implementation: BEGIN UIDENT WITH", line 1, characters 0-5:
+  This 'begin' might be unmatched
+File "implementation: BEGIN WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: CLASS LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: CLASS LBRACKET UNDERSCORE WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: CLASS LBRACKET WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: CLASS LBRACKETAT AND RBRACKET LBRACELESS", line 1, characters 15-17:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LBRACKET UNDERSCORE WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LBRACKET WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 35-40:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN BANG UIDENT IN QUOTED_STRING_EXPR WITH", line 1, characters 52-56:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN BANG UIDENT IN WITH", line 1, characters 36-40:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN BANG UIDENT WITH", line 1, characters 33-37:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN BANG WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN LBRACKETAT AND RBRACKET WHILE", line 1, characters 33-38:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN UIDENT IN QUOTED_STRING_EXPR WITH", line 1, characters 50-54:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN UIDENT IN WITH", line 1, characters 34-38:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN UIDENT WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET OPEN WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LET WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LIDENT COLON UNDERSCORE MINUSGREATER WITH", line 1, characters 29-33:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LIDENT COLON UNDERSCORE WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LIDENT COLON WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON LIDENT WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT LBRACKETAT AND RBRACKET WHILE", line 1, characters 42-47:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT LBRACKETAT AND RBRACKET WHILE", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT UNDERSCORE EQUAL LIDENT INITIALIZER", line 1, characters 44-55:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT UNDERSCORE EQUAL LIDENT INITIALIZER", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT END WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON OBJECT INHERIT LBRACKETAT AND RBRACKET WHILE", line 1, characters 39-44:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT INHERIT LBRACKETAT AND RBRACKET WHILE", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT INHERIT QUOTED_STRING_EXPR WITH", line 1, characters 46-50:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT INHERIT QUOTED_STRING_EXPR WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT INHERIT WITH", line 1, characters 30-34:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT INHERIT WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT LBRACKETAT AND RBRACKET WHILE", line 1, characters 31-36:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT LBRACKETAT AND RBRACKET WHILE", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT LBRACKETATATAT AND RBRACKET WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT LBRACKETATATAT AND RBRACKET WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT LPAREN UNDERSCORE RPAREN WITH", line 1, characters 28-32:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT LPAREN UNDERSCORE RPAREN WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT LPAREN UNDERSCORE WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT LPAREN UNDERSCORE WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT LPAREN WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT LPAREN WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LBRACKETAT AND RBRACKET WHILE", line 1, characters 38-43:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LBRACKETAT AND RBRACKET WHILE", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT COLON UNDERSCORE INITIALIZER", line 1, characters 40-51:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT COLON UNDERSCORE INITIALIZER", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT COLON WITH", line 1, characters 38-42:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT COLON WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT WITH", line 1, characters 36-40:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD PRIVATE WITH", line 1, characters 37-41:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD PRIVATE WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD VIRTUAL PRIVATE WITH", line 1, characters 45-49:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD VIRTUAL PRIVATE WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD VIRTUAL WITH", line 1, characters 37-41:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD VIRTUAL WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT METHOD WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT METHOD WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT QUOTED_STRING_ITEM WITH", line 1, characters 39-43:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT QUOTED_STRING_ITEM WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL LBRACKETAT AND RBRACKET WHILE", line 1, characters 35-40:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL LBRACKETAT AND RBRACKET WHILE", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT COLON UNDERSCORE WITH", line 1, characters 37-41:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT COLON UNDERSCORE WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT COLON WITH", line 1, characters 35-39:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT COLON WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL MUTABLE WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL MUTABLE WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL VIRTUAL MUTABLE WITH", line 1, characters 42-46:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL VIRTUAL MUTABLE WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL VIRTUAL WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL VIRTUAL WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT VAL WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT VAL WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OBJECT WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: CLASS LIDENT COLON OBJECT WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: CLASS LIDENT COLON OPTLABEL UNDERSCORE MINUSGREATER WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON OPTLABEL UNDERSCORE WITH", line 1, characters 25-29:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON OPTLABEL WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR EQUAL QUOTED_STRING_EXPR WITH", line 1, characters 49-53:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR EQUAL WITH", line 1, characters 33-37:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR VAL", line 1, characters 31-34:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON UIDENT DOT LIDENT WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON UNDERSCORE MINUSGREATER WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON UNDERSCORE WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: CLASS LIDENT COLON WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 41-45:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 44-49:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET METHOD", line 1, characters 61-67:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT WITH", line 1, characters 42-46:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND VIRTUAL LBRACELESS", line 1, characters 43-45:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND WITH", line 1, characters 35-39:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 41-47:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: CLASS LIDENT EQUAL WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: CLASS LIDENT UNDERSCORE WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: CLASS LIDENT WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: CLASS PERCENT AND LBRACELESS", line 1, characters 12-14:
+Error: Syntax error
+File "implementation: CLASS TYPE LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: CLASS TYPE LBRACKETAT AND RBRACKET LBRACELESS", line 1, characters 20-22:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL LBRACKET WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 46-50:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET LBRACELESS", line 1, characters 49-51:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 75-81:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL QUOTED_STRING_EXPR WITH", line 1, characters 65-69:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL WITH", line 1, characters 49-53:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT WITH", line 1, characters 47-51:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND VIRTUAL LBRACELESS", line 1, characters 48-50:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND WITH", line 1, characters 40-44:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 46-52:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR WITH", line 1, characters 36-40:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT EQUAL WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: CLASS TYPE LIDENT WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: CLASS TYPE PERCENT AND LBRACELESS", line 1, characters 17-19:
+Error: Syntax error
+File "implementation: CLASS TYPE VIRTUAL LBRACELESS", line 1, characters 19-21:
+Error: Syntax error
+File "implementation: CLASS TYPE WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: CLASS VIRTUAL LBRACELESS", line 1, characters 14-16:
+Error: Syntax error
+File "implementation: CLASS WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: EXCEPTION LBRACKET WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: EXCEPTION LBRACKETAT AND RBRACKET EXTERNAL", line 1, characters 19-27:
+Error: Syntax error
+File "implementation: EXCEPTION LPAREN COLONCOLON WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: EXCEPTION LPAREN WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: EXCEPTION PERCENT AND EXTERNAL", line 1, characters 16-24:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT COLON UNDERSCORE MINUSGREATER UNDERSCORE WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT COLON UNDERSCORE MINUSGREATER WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT COLON UNDERSCORE STAR LIDENT VAL", line 1, characters 30-33:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT COLON UNDERSCORE WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT COLON WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL LPAREN WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL UIDENT BAR", line 1, characters 26-27:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL UIDENT DOT LPAREN WITH", line 1, characters 30-34:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL UIDENT DOT WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL UIDENT LBRACKETAT AND RBRACKET WHILE", line 1, characters 35-40:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL UIDENT WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT EQUAL WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT LBRACKETAT AND RBRACKET CHAR", line 1, characters 26-29:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON LIDENT SEMI LBRACKETAT AND RBRACKET WHILE", line 1, characters 49-54:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON UNDERSCORE GREATER", line 1, characters 33-34:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON UNDERSCORE LBRACKETAT AND RBRACKET WHILE", line 1, characters 42-47:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON UNDERSCORE SEMI WITH", line 1, characters 35-39:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE LIDENT WITH", line 1, characters 29-33:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE MUTABLE LETOP", line 1, characters 30-34:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LBRACE WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF LIDENT BAR", line 1, characters 27-28:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF UNDERSCORE STAR UNDERSCORE WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF UNDERSCORE STAR WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF UNDERSCORE WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT OF WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: EXCEPTION UIDENT WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: EXCEPTION WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: EXTERNAL LBRACKETAT AND RBRACKET WHILE", line 1, characters 18-23:
+Error: Syntax error
+File "implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH", line 1, characters 30-34:
+Error: Syntax error
+File "implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: EXTERNAL LIDENT COLON WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: EXTERNAL LIDENT WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: EXTERNAL LPAREN MODULE WITH", line 1, characters 18-22:
+Error: Syntax error: module-expr expected.
+File "implementation: EXTERNAL LPAREN WITH", line 1, characters 11-15:
+Error: Syntax error: operator expected.
+File "implementation: EXTERNAL PERCENT AND LBRACKET", line 1, characters 15-16:
+Error: Syntax error
+File "implementation: EXTERNAL WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: FOR LBRACKETAT AND RBRACKET ASSERT", line 1, characters 13-19:
+Error: Syntax error
+File "implementation: FOR PERCENT AND ASSERT", line 1, characters 10-16:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE EQUAL UIDENT TO UIDENT DO UIDENT WITH", line 1, characters 35-39:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE EQUAL UIDENT TO UIDENT DO WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE EQUAL UIDENT TO UIDENT WITH", line 1, characters 25-29:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE EQUAL UIDENT TO WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE EQUAL UIDENT WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE EQUAL WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: FOR UNDERSCORE WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: FOR WITH", line 1, characters 4-8:
+Error: Syntax error
+File "implementation: FUN LABEL WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: FUN LBRACKETAT AND RBRACKET ASSERT", line 1, characters 13-19:
+Error: Syntax error
+File "implementation: FUN LPAREN TYPE LIDENT DOT", line 1, characters 18-19:
+Error: Syntax error: operator expected.
+File "implementation: FUN LPAREN TYPE LIDENT RPAREN WITH", line 1, characters 20-24:
+Error: Syntax error: operator expected.
+File "implementation: FUN LPAREN TYPE LIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: operator expected.
+File "implementation: FUN LPAREN TYPE WITH", line 1, characters 11-15:
+Error: Syntax error: operator expected.
+File "implementation: FUN LPAREN WITH", line 1, characters 6-10:
+Error: Syntax error: operator expected.
+File "implementation: FUN OPTLABEL LPAREN UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: FUN OPTLABEL LPAREN UNDERSCORE COLON WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: FUN OPTLABEL LPAREN UNDERSCORE EQUAL CHAR WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: FUN OPTLABEL LPAREN UNDERSCORE WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: FUN OPTLABEL LPAREN WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: FUN OPTLABEL WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: FUN PERCENT AND ASSERT", line 1, characters 10-16:
+Error: Syntax error
+File "implementation: FUN QUESTION LPAREN LIDENT EQUAL UIDENT WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: FUN QUESTION LPAREN LIDENT EQUAL WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: FUN QUESTION LPAREN WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: FUN QUESTION WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: FUN TILDE LPAREN LIDENT COLON UNDERSCORE WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: FUN TILDE LPAREN LIDENT COLON WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: FUN TILDE LPAREN LIDENT EQUAL", line 1, characters 15-16:
+Error: Syntax error
+File "implementation: FUN TILDE LPAREN LIDENT WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: FUN TILDE LPAREN WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: FUN TILDE WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: FUN UNDERSCORE COLON UNDERSCORE MINUSGREATER WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: FUN UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: FUN UNDERSCORE COLON WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: FUN UNDERSCORE LPAREN TYPE LIDENT DOT", line 1, characters 20-21:
+Error: Syntax error: operator expected.
+File "implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH", line 1, characters 22-26:
+Error: Syntax error: operator expected.
+File "implementation: FUN UNDERSCORE LPAREN TYPE WITH", line 1, characters 13-17:
+Error: Syntax error: operator expected.
+File "implementation: FUN UNDERSCORE LPAREN WITH", line 1, characters 8-12:
+Error: Syntax error: operator expected.
+File "implementation: FUN UNDERSCORE MINUSGREATER WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: FUN UNDERSCORE UNDERSCORE WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: FUN UNDERSCORE WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: FUN WITH", line 1, characters 4-8:
+Error: Syntax error
+File "implementation: FUNCTION BAR WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: FUNCTION EXCEPTION LBRACKETAT AND RBRACKET ASSERT", line 1, characters 28-34:
+Error: Syntax error
+File "implementation: FUNCTION EXCEPTION PERCENT AND ASSERT", line 1, characters 25-31:
+Error: Syntax error
+File "implementation: FUNCTION EXCEPTION WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: FUNCTION LBRACKETAT AND RBRACKET ASSERT", line 1, characters 18-24:
+Error: Syntax error
+File "implementation: FUNCTION PERCENT AND ASSERT", line 1, characters 15-21:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE AS WITH", line 1, characters 14-18:
+Error: Syntax error: identifier expected.
+File "implementation: FUNCTION UNDERSCORE BAR UNDERSCORE WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE BAR WITH", line 1, characters 13-17:
+Error: Syntax error: pattern expected.
+File "implementation: FUNCTION UNDERSCORE COLONCOLON UNDERSCORE WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE COLONCOLON WITH", line 1, characters 14-18:
+Error: Syntax error: pattern expected.
+File "implementation: FUNCTION UNDERSCORE COMMA CHAR COMMA UNDERSCORE WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE COMMA CHAR COMMA WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE COMMA UNDERSCORE WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE COMMA WITH", line 1, characters 13-17:
+Error: Syntax error: pattern expected.
+File "implementation: FUNCTION UNDERSCORE MINUSGREATER CHAR BAR WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE MINUSGREATER DOT WHILE", line 1, characters 16-21:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE MINUSGREATER WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE WHEN UIDENT MINUSGREATER WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE WHEN UIDENT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE WHEN WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: FUNCTION UNDERSCORE WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: FUNCTION WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: IF LBRACKETAT AND RBRACKET AND", line 1, characters 12-15:
+Error: Syntax error
+File "implementation: IF PERCENT AND VIRTUAL", line 1, characters 9-16:
+Error: Syntax error
+File "implementation: IF UIDENT THEN OBJECT END WHILE", line 1, characters 26-31:
+Error: Syntax error
+File "implementation: IF UIDENT THEN UIDENT ELSE OBJECT END WHILE", line 1, characters 38-43:
+Error: Syntax error
+File "implementation: IF UIDENT THEN UIDENT ELSE WITH", line 1, characters 27-31:
+Error: Syntax error
+File "implementation: IF UIDENT THEN WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: IF UIDENT WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: IF WITH", line 1, characters 3-7:
+Error: Syntax error
+File "implementation: INCLUDE LBRACKETAT AND RBRACKET FUNCTION", line 1, characters 17-25:
+Error: Syntax error
+File "implementation: INCLUDE PERCENT AND FUNCTION", line 1, characters 14-22:
+Error: Syntax error
+File "implementation: INCLUDE UIDENT WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: INCLUDE WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: LAZY LBRACKETAT AND RBRACKET ASSERT", line 1, characters 14-20:
+Error: Syntax error
+File "implementation: LAZY PERCENT AND ASSERT", line 1, characters 11-17:
+Error: Syntax error
+File "implementation: LAZY UIDENT UIDENT", line 1, characters 12-18:
+Error: Syntax error
+File "implementation: LAZY WITH", line 1, characters 5-9:
+Error: Syntax error
+File "implementation: LBRACE LIDENT COLONGREATER LIDENT RPAREN", line 1, characters 19-20:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE LIDENT COLONGREATER LIDENT RPAREN", line 1, characters 0-1:
+  This '{' might be unmatched
+File "implementation: LBRACE LIDENT EQUAL CHAR GREATERRBRACE", line 1, characters 15-17:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE LIDENT EQUAL CHAR GREATERRBRACE", line 1, characters 0-1:
+  This '{' might be unmatched
+File "implementation: LBRACE LIDENT SEMI WITH", line 1, characters 11-15:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE LIDENT SEMI WITH", line 1, characters 0-1:
+  This '{' might be unmatched
+File "implementation: LBRACE LIDENT WHILE", line 1, characters 9-14:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE LIDENT WHILE", line 1, characters 0-1:
+  This '{' might be unmatched
+File "implementation: LBRACE TRUE DOT LBRACE UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE TRUE DOT LBRACE UIDENT WITH", line 1, characters 9-10:
+  This '{' might be unmatched
+File "implementation: LBRACE TRUE DOT LBRACE WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT LBRACKET UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: ']' expected
+File "implementation: LBRACE TRUE DOT LBRACKET UIDENT WITH", line 1, characters 9-10:
+  This '[' might be unmatched
+File "implementation: LBRACE TRUE DOT LBRACKET WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT LPAREN UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: ')' expected
+File "implementation: LBRACE TRUE DOT LPAREN UIDENT WITH", line 1, characters 9-10:
+  This '(' might be unmatched
+File "implementation: LBRACE TRUE DOT LPAREN WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACE UIDENT RPAREN", line 1, characters 28-29:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACE UIDENT RPAREN", line 1, characters 19-20:
+  This '{' might be unmatched
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACE WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 28-29:
+Error: Syntax error: ']' expected
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 19-20:
+  This '[' might be unmatched
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACKET WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 28-29:
+Error: Syntax error: ')' expected
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 19-20:
+  This '(' might be unmatched
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP LPAREN WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT UIDENT DOTOP WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LBRACE TRUE DOT WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: LBRACE TRUE WHILE", line 1, characters 7-12:
+Error: Syntax error
+File "implementation: LBRACE UIDENT DOT LIDENT WHILE", line 1, characters 18-23:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE UIDENT DOT LIDENT WHILE", line 1, characters 0-1:
+  This '{' might be unmatched
+File "implementation: LBRACE UIDENT DOT WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LBRACE UIDENT DOTOP LBRACE UIDENT SEMI RPAREN", line 1, characters 23-24:
+Error: Syntax error
+File "implementation: LBRACE UIDENT DOTOP LBRACE WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LBRACE UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 21-22:
+Error: Syntax error: ']' expected
+File "implementation: LBRACE UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 12-13:
+  This '[' might be unmatched
+File "implementation: LBRACE UIDENT DOTOP LBRACKET WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LBRACE UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 21-22:
+Error: Syntax error: ')' expected
+File "implementation: LBRACE UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 12-13:
+  This '(' might be unmatched
+File "implementation: LBRACE UIDENT DOTOP LPAREN WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LBRACE UIDENT DOTOP WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: LBRACE UIDENT WHILE", line 1, characters 9-14:
+Error: Syntax error
+File "implementation: LBRACE UIDENT WITH LIDENT WITH", line 1, characters 21-25:
+Error: Syntax error: '}' expected
+File "implementation: LBRACE UIDENT WITH LIDENT WITH", line 1, characters 0-1:
+  This '{' might be unmatched
+File "implementation: LBRACE UIDENT WITH WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LBRACE WITH", line 1, characters 2-6:
+Error: Syntax error
+File "implementation: LBRACELESS LIDENT EQUAL UIDENT RBRACE", line 1, characters 19-20:
+Error: Syntax error: '>}' expected
+File "implementation: LBRACELESS LIDENT EQUAL UIDENT RBRACE", line 1, characters 0-2:
+  This '{<' might be unmatched
+File "implementation: LBRACELESS LIDENT EQUAL UIDENT WITH", line 1, characters 19-23:
+Error: Syntax error: '>}' expected
+File "implementation: LBRACELESS LIDENT EQUAL UIDENT WITH", line 1, characters 0-2:
+  This '{<' might be unmatched
+File "implementation: LBRACELESS LIDENT EQUAL WITH", line 1, characters 12-16:
+Error: Syntax error: '>}' expected
+File "implementation: LBRACELESS LIDENT EQUAL WITH", line 1, characters 0-2:
+  This '{<' might be unmatched
+File "implementation: LBRACELESS LIDENT SEMI WITH", line 1, characters 12-16:
+Error: Syntax error: '>}' expected
+File "implementation: LBRACELESS LIDENT SEMI WITH", line 1, characters 0-2:
+  This '{<' might be unmatched
+File "implementation: LBRACELESS LIDENT WITH", line 1, characters 10-14:
+Error: Syntax error: '>}' expected
+File "implementation: LBRACELESS LIDENT WITH", line 1, characters 0-2:
+  This '{<' might be unmatched
+File "implementation: LBRACELESS WITH", line 1, characters 3-7:
+Error: Syntax error
+File "implementation: LBRACKET UIDENT RPAREN", line 1, characters 9-10:
+Error: Syntax error: ']' expected
+File "implementation: LBRACKET UIDENT RPAREN", line 1, characters 0-1:
+  This '[' might be unmatched
+File "implementation: LBRACKET WITH", line 1, characters 2-6:
+Error: Syntax error
+File "implementation: LBRACKETATATAT UNDERSCORE", line 1, characters 5-6:
+Error: Syntax error
+File "implementation: LBRACKETATATAT WITH UIDENT WHEN", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LBRACKETATATAT WITH VIRTUAL", line 1, characters 10-17:
+Error: Syntax error
+File "implementation: LBRACKETBAR UIDENT RPAREN", line 1, characters 10-11:
+Error: Syntax error: '|]' expected
+File "implementation: LBRACKETBAR UIDENT RPAREN", line 1, characters 0-2:
+  This '[|' might be unmatched
+File "implementation: LBRACKETBAR UIDENT SEMI WITH", line 1, characters 12-16:
+Error: Syntax error: '|]' expected
+File "implementation: LBRACKETBAR UIDENT SEMI WITH", line 1, characters 0-2:
+  This '[|' might be unmatched
+File "implementation: LBRACKETBAR UIDENT WITH", line 1, characters 10-14:
+Error: Syntax error: '|]' expected
+File "implementation: LBRACKETBAR UIDENT WITH", line 1, characters 0-2:
+  This '[|' might be unmatched
+File "implementation: LBRACKETBAR WITH", line 1, characters 3-7:
+Error: Syntax error
+File "implementation: LBRACKETPERCENT UNDERSCORE", line 1, characters 3-4:
+Error: Syntax error
+File "implementation: LBRACKETPERCENT WITH UIDENT WHEN", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LBRACKETPERCENT WITH VIRTUAL", line 1, characters 8-15:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT UNDERSCORE", line 1, characters 4-5:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LBRACKETAT AND RBRACKET WHILE", line 1, characters 26-31:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 52-56:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 55-60:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT COLON QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 81-87:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT COLON QUOTED_STRING_EXPR RPAREN", line 1, characters 71-72:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT COLON WITH", line 1, characters 55-59:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT WITH", line 1, characters 53-57:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND VIRTUAL LBRACELESS", line 1, characters 54-56:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND WITH", line 1, characters 46-50:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 52-58:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR RPAREN", line 1, characters 42-43:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS PERCENT AND LBRACELESS", line 1, characters 23-25:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS VIRTUAL LBRACELESS", line 1, characters 25-27:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION LBRACKETAT AND RBRACKET WHILE", line 1, characters 30-35:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION PERCENT AND EXTERNAL", line 1, characters 27-35:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION UIDENT WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE LBRACKETAT AND RBRACKET WHILE", line 1, characters 28-33:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE PERCENT AND FUNCTION", line 1, characters 25-33:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE UIDENT RPAREN", line 1, characters 26-27:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 27-32:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE PERCENT AND LBRACKET", line 1, characters 24-25:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 46-51:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE COLON UIDENT LBRACKETATAT AND RBRACKET METHOD", line 1, characters 58-64:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE COLON UIDENT RPAREN", line 1, characters 48-49:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE COLON WITH", line 1, characters 41-45:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE WITH", line 1, characters 39-43:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND WITH", line 1, characters 37-41:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT LBRACKETATAT AND RBRACKET METHOD", line 1, characters 43-49:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT RPAREN", line 1, characters 33-34:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE TYPE UIDENT LET", line 1, characters 30-33:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UIDENT COLONEQUAL UIDENT WITH", line 1, characters 35-39:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UIDENT COLONEQUAL WITH", line 1, characters 28-32:
+Error: Syntax error: module path expected.
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UIDENT WITH", line 1, characters 25-29:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE COLON UIDENT RPAREN", line 1, characters 29-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE COLON WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE EQUAL UIDENT WITH", line 1, characters 29-33:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE EQUAL WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE LPAREN RPAREN WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 27-32:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG PERCENT AND LBRACKET", line 1, characters 24-25:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG UIDENT WITH", line 1, characters 25-29:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN LBRACKETAT AND RBRACKET WHILE", line 1, characters 25-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN PERCENT AND LBRACKET", line 1, characters 22-23:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN UIDENT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON QUOTED_STRING_ITEM WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON SEMISEMI WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LBRACKETAT AND RBRACKET WHILE", line 1, characters 25-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 41-46:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT COLONEQUAL UNDERSCORE LBRACKETATAT AND RBRACKET METHOD", line 1, characters 54-60:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT COLONEQUAL UNDERSCORE LET", line 1, characters 44-47:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT COLONEQUAL WITH", line 1, characters 42-46:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT WITH", line 1, characters 39-43:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND UNDERSCORE LETOP", line 1, characters 34-38:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND WITH", line 1, characters 32-36:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 38-44:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL UNDERSCORE LET", line 1, characters 28-31:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT PLUSEQ PRIVATE BANG", line 1, characters 34-35:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT PLUSEQ UIDENT LET", line 1, characters 33-36:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT PLUSEQ WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE NONREC LIDENT LET", line 1, characters 30-33:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE PERCENT AND BACKQUOTE", line 1, characters 22-23:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE UIDENT DOT LIDENT WITH", line 1, characters 32-36:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE UNDERSCORE LETOP", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH COLON WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE", line 1, characters 11-12:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH UIDENT WHEN", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH VIRTUAL", line 1, characters 9-16:
+Error: Syntax error
+File "implementation: LBRACKETPERCENTPERCENT WITH WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: LET CHAR EQUAL CHAR AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 27-32:
+Error: Syntax error
+File "implementation: LET CHAR EQUAL CHAR AND UNDERSCORE EQUAL CHAR WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LET CHAR EQUAL CHAR AND WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LET CHAR EQUAL CHAR IN WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: LET CHAR EQUAL CHAR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 24-30:
+Error: Syntax error
+File "implementation: LET EXCEPTION LBRACKETAT AND RBRACKET EXTERNAL", line 1, characters 23-31:
+Error: Syntax error
+File "implementation: LET EXCEPTION PERCENT AND EXTERNAL", line 1, characters 20-28:
+Error: Syntax error
+File "implementation: LET EXCEPTION UIDENT IN WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: LET EXCEPTION UIDENT LBRACKETAT AND RBRACKET WHILE", line 1, characters 30-35:
+Error: Syntax error
+File "implementation: LET EXCEPTION UIDENT OF UNDERSCORE EXTERNAL", line 1, characters 26-34:
+Error: Syntax error
+File "implementation: LET EXCEPTION UIDENT WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: LET EXCEPTION WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LET LBRACKETAT AND RBRACKET ASSERT", line 1, characters 13-19:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE LIDENT QUOTE WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE UIDENT WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: LET LIDENT COLON QUOTE WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH", line 1, characters 29-33:
+Error: Syntax error
+File "implementation: LET LIDENT COLON TYPE LIDENT DOT WITH", line 1, characters 27-31:
+Error: Syntax error
+File "implementation: LET LIDENT COLON TYPE LIDENT RPAREN", line 1, characters 25-26:
+Error: Syntax error
+File "implementation: LET LIDENT COLON TYPE WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LET LIDENT COLON WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LET LIDENT COLONGREATER UNDERSCORE SEMI", line 1, characters 16-17:
+Error: Syntax error
+File "implementation: LET LIDENT WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LET MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: LET MODULE PERCENT AND LBRACKET", line 1, characters 17-18:
+Error: Syntax error
+File "implementation: LET MODULE UNDERSCORE EQUAL UIDENT IN WITH", line 1, characters 25-29:
+Error: Syntax error
+File "implementation: LET MODULE UNDERSCORE EQUAL UIDENT VAL", line 1, characters 22-25:
+Error: Syntax error
+File "implementation: LET MODULE UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LET MODULE WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LET OPEN BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: LET OPEN BANG PERCENT AND WHILE", line 1, characters 17-22:
+Error: Syntax error
+File "implementation: LET OPEN BANG UIDENT IN WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: LET OPEN BANG UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: LET OPEN BANG WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LET OPEN LBRACKETAT AND RBRACKET FUNCTION", line 1, characters 18-26:
+Error: Syntax error
+File "implementation: LET OPEN PERCENT AND FUNCTION", line 1, characters 15-23:
+Error: Syntax error
+File "implementation: LET OPEN UIDENT IN WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: LET OPEN UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LET OPEN WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: LET PERCENT AND ASSERT", line 1, characters 10-16:
+Error: Syntax error
+File "implementation: LET REC ASSERT", line 1, characters 8-14:
+Error: Syntax error
+File "implementation: LET UIDENT UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: LET UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: LET UNDERSCORE COLON WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: LET UNDERSCORE EQUAL CHAR WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: LET UNDERSCORE EQUAL WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: LET UNDERSCORE WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: LET WITH", line 1, characters 4-8:
+Error: Syntax error
+File "implementation: LETOP BACKQUOTE UIDENT WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LETOP HASH WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: LETOP LAZY LBRACKETAT AND RBRACKET ASSERT", line 1, characters 19-25:
+Error: Syntax error
+File "implementation: LETOP LAZY PERCENT AND WHILE", line 1, characters 16-21:
+Error: Syntax error
+File "implementation: LETOP LAZY WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: LETOP LBRACE LIDENT COLON UNDERSCORE WITH", line 1, characters 18-22:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT COLON UNDERSCORE WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT COLON WITH", line 1, characters 16-20:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT COLON WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT EQUAL UNDERSCORE WITH", line 1, characters 18-22:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT EQUAL UNDERSCORE WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT EQUAL WITH", line 1, characters 16-20:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT EQUAL WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT SEMI UNDERSCORE SEMI WITH", line 1, characters 20-24:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT SEMI UNDERSCORE SEMI WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT SEMI UNDERSCORE WITH", line 1, characters 18-22:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT SEMI UNDERSCORE WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT SEMI WITH", line 1, characters 16-20:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT SEMI WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE LIDENT WITH", line 1, characters 14-18:
+Error: Syntax error: '}' expected
+File "implementation: LETOP LBRACE LIDENT WITH", line 1, characters 5-6:
+  This '{' might be unmatched
+File "implementation: LETOP LBRACE WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: LETOP LBRACKET UNDERSCORE BARRBRACKET", line 1, characters 9-11:
+Error: Syntax error: ']' expected
+File "implementation: LETOP LBRACKET UNDERSCORE BARRBRACKET", line 1, characters 5-6:
+  This '[' might be unmatched
+File "implementation: LETOP LBRACKET WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: LETOP LBRACKETBAR UNDERSCORE RBRACKET", line 1, characters 10-11:
+Error: Syntax error: '|]' expected
+File "implementation: LETOP LBRACKETBAR UNDERSCORE RBRACKET", line 1, characters 5-7:
+  This '[|' might be unmatched
+File "implementation: LETOP LBRACKETBAR UNDERSCORE SEMI WITH", line 1, characters 12-16:
+Error: Syntax error: '|]' expected
+File "implementation: LETOP LBRACKETBAR UNDERSCORE SEMI WITH", line 1, characters 5-7:
+  This '[|' might be unmatched
+File "implementation: LETOP LBRACKETBAR UNDERSCORE WITH", line 1, characters 10-14:
+Error: Syntax error: '|]' expected
+File "implementation: LETOP LBRACKETBAR UNDERSCORE WITH", line 1, characters 5-7:
+  This '[|' might be unmatched
+File "implementation: LETOP LBRACKETBAR WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: LETOP LIDENT ANDOP WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: LETOP LIDENT EQUAL WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LETOP LIDENT IN WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: LETOP LIDENT LPAREN TYPE LIDENT DOT", line 1, characters 26-27:
+Error: Syntax error: operator expected.
+File "implementation: LETOP LIDENT LPAREN TYPE LIDENT RPAREN WITH", line 1, characters 28-32:
+Error: Syntax error: operator expected.
+File "implementation: LETOP LIDENT LPAREN TYPE WITH", line 1, characters 19-23:
+Error: Syntax error: operator expected.
+File "implementation: LETOP LIDENT LPAREN WITH", line 1, characters 14-18:
+Error: Syntax error: operator expected.
+File "implementation: LETOP LIDENT UNDERSCORE COLONGREATER LIDENT EQUAL WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: LETOP LIDENT UNDERSCORE COLONGREATER LIDENT SEMI", line 1, characters 24-25:
+Error: Syntax error
+File "implementation: LETOP LIDENT UNDERSCORE WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LETOP LIDENT WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: LETOP LPAREN MINUS WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LETOP LPAREN MINUS WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: LETOP LPAREN MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 23-28:
+Error: Syntax error: module-expr expected.
+File "implementation: LETOP LPAREN MODULE PERCENT AND WHILE", line 1, characters 20-25:
+Error: Syntax error: module-expr expected.
+File "implementation: LETOP LPAREN MODULE UNDERSCORE COLON UIDENT VAL", line 1, characters 25-28:
+Error: Syntax error: ')' expected
+File "implementation: LETOP LPAREN MODULE UNDERSCORE COLON UIDENT VAL", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: LETOP LPAREN MODULE UNDERSCORE COLON WITH", line 1, characters 18-22:
+Error: Syntax error: module-expr expected.
+File "implementation: LETOP LPAREN MODULE UNDERSCORE WITH", line 1, characters 16-20:
+Error: Syntax error: module-expr expected.
+File "implementation: LETOP LPAREN MODULE WITH", line 1, characters 14-18:
+Error: Syntax error: module-expr expected.
+File "implementation: LETOP LPAREN PLUS WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LETOP LPAREN PLUS WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: LETOP LPAREN UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error: ')' expected
+File "implementation: LETOP LPAREN UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: LETOP LPAREN UNDERSCORE COLON WITH", line 1, characters 11-15:
+Error: Syntax error: type expected.
+File "implementation: LETOP LPAREN UNDERSCORE WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LETOP LPAREN UNDERSCORE WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: LETOP LPAREN WITH", line 1, characters 7-11:
+Error: Syntax error: operator expected.
+File "implementation: LETOP MINUS WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: LETOP PLUS WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: LETOP STRING DOTDOT WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LETOP STRING WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LETOP UIDENT DOT LBRACKET WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: LETOP UIDENT DOT LPAREN UNDERSCORE WITH", line 1, characters 18-22:
+Error: Syntax error: ')' expected
+File "implementation: LETOP UIDENT DOT LPAREN UNDERSCORE WITH", line 1, characters 14-15:
+  This '(' might be unmatched
+File "implementation: LETOP UIDENT DOT LPAREN WITH", line 1, characters 16-20:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UIDENT DOT WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: LETOP UIDENT LIDENT WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: LETOP UIDENT TILDE", line 1, characters 12-13:
+Error: Syntax error
+File "implementation: LETOP UIDENT WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE AS WITH", line 1, characters 10-14:
+Error: Syntax error: identifier expected.
+File "implementation: LETOP UNDERSCORE BAR UNDERSCORE WITH", line 1, characters 11-15:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UNDERSCORE BAR WITH", line 1, characters 9-13:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UNDERSCORE COLON UNDERSCORE EQUAL WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE COLON WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE COLONCOLON UNDERSCORE WITH", line 1, characters 12-16:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UNDERSCORE COLONCOLON WITH", line 1, characters 10-14:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UNDERSCORE COMMA CHAR COMMA UNDERSCORE WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE COMMA CHAR COMMA WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE COMMA UNDERSCORE WITH", line 1, characters 11-15:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UNDERSCORE COMMA WITH", line 1, characters 9-13:
+Error: Syntax error: pattern expected.
+File "implementation: LETOP UNDERSCORE EQUAL CHAR WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE EQUAL WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: LETOP UNDERSCORE WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: LETOP WITH", line 1, characters 5-9:
+Error: Syntax error
+File "implementation: LIDENT LESSMINUS OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: LIDENT LESSMINUS WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: LIDENT WHILE", line 1, characters 7-12:
+Error: Syntax error
+File "implementation: LPAREN BANG WITH", line 1, characters 4-8:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN BANG WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN COLONCOLON WITH", line 1, characters 5-9:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LBRACE RBRACE WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN DOTOP LBRACE RBRACE WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN DOTOP LBRACE SEMI DOTDOT WITH", line 1, characters 12-16:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LBRACE WITH", line 1, characters 7-11:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LBRACKET RBRACKET WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN DOTOP LBRACKET RBRACKET WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN DOTOP LBRACKET SEMI DOTDOT WITH", line 1, characters 12-16:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LBRACKET WITH", line 1, characters 7-11:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LPAREN RPAREN WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN DOTOP LPAREN RPAREN WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN DOTOP LPAREN SEMI DOTDOT WITH", line 1, characters 12-16:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LPAREN SEMI WITH", line 1, characters 9-13:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP LPAREN WITH", line 1, characters 7-11:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN DOTOP WITH", line 1, characters 5-9:
+Error: Syntax error: operator expected.
+File "implementation: LPAREN LETOP WITH", line 1, characters 7-11:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN LETOP WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN MINUS WITH", line 1, characters 4-8:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN MINUS WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN MINUSDOT WITH", line 1, characters 5-9:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN MINUSDOT WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN MODULE LBRACKETAT AND RBRACKET FUNCTION", line 1, characters 18-26:
+Error: Syntax error: module-expr expected.
+File "implementation: LPAREN MODULE PERCENT AND WHILE", line 1, characters 15-20:
+Error: Syntax error: module-expr expected.
+File "implementation: LPAREN MODULE UIDENT COLON UIDENT VAL", line 1, characters 25-28:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN MODULE UIDENT COLON UIDENT VAL", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN MODULE UIDENT COLON WITH", line 1, characters 18-22:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN MODULE UIDENT COLON WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN MODULE UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error: module-expr expected.
+File "implementation: LPAREN MODULE WITH", line 1, characters 9-13:
+Error: Syntax error: module-expr expected.
+File "implementation: LPAREN PLUS WITH", line 1, characters 4-8:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN PLUS WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN PLUSDOT WITH", line 1, characters 5-9:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN PLUSDOT WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN PREFIXOP WITH", line 1, characters 5-9:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN PREFIXOP WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN STAR WITH", line 1, characters 4-8:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN STAR WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER UNDERSCORE WITH", line 1, characters 18-22:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER UNDERSCORE WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH", line 1, characters 16-20:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN UIDENT COLON UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN UIDENT COLON UNDERSCORE WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN UIDENT COLON WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: LPAREN UIDENT COLONGREATER LIDENT SEMI", line 1, characters 19-20:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN UIDENT COLONGREATER LIDENT SEMI", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN UIDENT COLONGREATER UNDERSCORE WITH", line 1, characters 14-18:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN UIDENT COLONGREATER UNDERSCORE WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN UIDENT COLONGREATER WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: LPAREN UIDENT WITH", line 1, characters 9-13:
+Error: Syntax error: ')' expected
+File "implementation: LPAREN UIDENT WITH", line 1, characters 0-1:
+  This '(' might be unmatched
+File "implementation: LPAREN WITH", line 1, characters 2-6:
+Error: Syntax error: operator expected.
+File "implementation: MATCH LBRACKETAT AND RBRACKET AND", line 1, characters 15-18:
+Error: Syntax error
+File "implementation: MATCH PERCENT AND VIRTUAL", line 1, characters 12-19:
+Error: Syntax error
+File "implementation: MATCH UIDENT VAL", line 1, characters 13-16:
+Error: Syntax error
+File "implementation: MATCH UIDENT WITH UNDERSCORE MINUSGREATER DOT WHILE", line 1, characters 25-30:
+Error: Syntax error
+File "implementation: MATCH UIDENT WITH WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: MATCH WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: MINUSDOT WITH", line 1, characters 3-7:
+Error: Syntax error
+File "implementation: MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 16-21:
+Error: Syntax error
+File "implementation: MODULE PERCENT AND LBRACKET", line 1, characters 13-14:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 44-49:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND UNDERSCORE EQUAL QUOTED_STRING_EXPR IN", line 1, characters 55-57:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND UNDERSCORE EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 65-71:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND UNDERSCORE WITH", line 1, characters 37-41:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND WITH", line 1, characters 35-39:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR IN", line 1, characters 31-33:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD", line 1, characters 41-47:
+Error: Syntax error
+File "implementation: MODULE REC UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: MODULE REC WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: MODULE TYPE LBRACKETAT AND RBRACKET WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: MODULE TYPE PERCENT AND WHILE", line 1, characters 18-23:
+Error: Syntax error
+File "implementation: MODULE TYPE UIDENT EQUAL UIDENT RPAREN", line 1, characters 28-29:
+Error: Syntax error
+File "implementation: MODULE TYPE UIDENT EQUAL WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: MODULE TYPE UIDENT WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: MODULE TYPE WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON FUNCTOR LBRACKETAT AND RBRACKET WHILE", line 1, characters 28-33:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON FUNCTOR LPAREN RPAREN MINUSGREATER QUOTED_STRING_EXPR WHILE", line 1, characters 42-47:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON FUNCTOR LPAREN RPAREN MINUSGREATER WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON FUNCTOR LPAREN RPAREN WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON FUNCTOR WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON LPAREN UIDENT VAL", line 1, characters 20-23:
+Error: Syntax error: ')' expected
+File "implementation: MODULE UNDERSCORE COLON LPAREN UIDENT VAL", line 1, characters 11-12:
+  This '(' might be unmatched
+File "implementation: MODULE UNDERSCORE COLON LPAREN WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON MODULE TYPE OF LBRACKETAT AND RBRACKET FUNCTION", line 1, characters 35-43:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON MODULE TYPE OF UIDENT IN", line 1, characters 33-35:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON MODULE TYPE OF WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON MODULE TYPE WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON MODULE WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON SIG LBRACKETAT AND RBRACKET WHILE", line 1, characters 24-29:
+Error: Syntax error: 'end' expected
+File "implementation: MODULE UNDERSCORE COLON SIG LBRACKETAT AND RBRACKET WHILE", line 1, characters 11-14:
+  This 'sig' might be unmatched
+File "implementation: MODULE UNDERSCORE COLON SIG SEMISEMI RBRACKET", line 1, characters 18-19:
+Error: Syntax error: 'end' expected
+File "implementation: MODULE UNDERSCORE COLON SIG SEMISEMI RBRACKET", line 1, characters 11-14:
+  This 'sig' might be unmatched
+File "implementation: MODULE UNDERSCORE COLON SIG WITH", line 1, characters 15-19:
+Error: Syntax error: 'end' expected
+File "implementation: MODULE UNDERSCORE COLON SIG WITH", line 1, characters 11-14:
+  This 'sig' might be unmatched
+File "implementation: MODULE UNDERSCORE COLON UIDENT DOT UIDENT WHILE", line 1, characters 27-32:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT DOT WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT EQUAL UIDENT WITH", line 1, characters 27-31:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT EQUAL WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT LPAREN UIDENT RPAREN WITH", line 1, characters 29-33:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT MINUSGREATER QUOTED_STRING_EXPR WHILE", line 1, characters 37-42:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT MINUSGREATER WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT VAL", line 1, characters 18-21:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WHILE", line 1, characters 18-23:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT WHILE", line 1, characters 47-52:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT COLONEQUAL WITH", line 1, characters 40-44:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE", line 1, characters 46-51:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT EQUAL WITH", line 1, characters 39-43:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT WITH", line 1, characters 37-41:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE WITH", line 1, characters 30-34:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT COLONEQUAL UNDERSCORE SEMI", line 1, characters 40-41:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT COLONEQUAL WITH", line 1, characters 38-42:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH", line 1, characters 45-49:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE AND WITH", line 1, characters 43-47:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE SEMI", line 1, characters 39-40:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL WITH", line 1, characters 37-41:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT WITH", line 1, characters 35-39:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE UNDERSCORE LETOP", line 1, characters 30-34:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON UIDENT WITH WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE COLON WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE EQUAL QUOTED_STRING_EXPR IN", line 1, characters 27-29:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE EQUAL UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE EQUAL WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE LPAREN RPAREN WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE LPAREN UNDERSCORE COLON UIDENT VAL", line 1, characters 22-25:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE LPAREN UNDERSCORE COLON WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE LPAREN UNDERSCORE WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE LPAREN WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: MODULE UNDERSCORE WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: MODULE WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: NEW LBRACKETAT AND RBRACKET WHILE", line 1, characters 13-18:
+Error: Syntax error
+File "implementation: NEW PERCENT AND LBRACKET", line 1, characters 10-11:
+Error: Syntax error
+File "implementation: NEW UIDENT DOT WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: NEW UIDENT WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: NEW WITH", line 1, characters 4-8:
+Error: Syntax error
+File "implementation: OBJECT CONSTRAINT HASH WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT HASH WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT GREATER", line 1, characters 29-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT GREATER", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF AMPERSAND WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF AMPERSAND WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND UNDERSCORE WITH", line 1, characters 38-42:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND WITH", line 1, characters 36-40:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF WITH", line 1, characters 32-36:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BAR UNDERSCORE GREATER", line 1, characters 24-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BAR UNDERSCORE GREATER", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET BAR WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET BAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE BAR UNDERSCORE GREATER", line 1, characters 26-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE BAR UNDERSCORE GREATER", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE BAR WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE BAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE RBRACKET", line 1, characters 22-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE RBRACKET", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKET WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKET WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETAT AND RBRACKET GREATER", line 1, characters 27-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETAT AND RBRACKET GREATER", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETGREATER BAR ASSERT", line 1, characters 23-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETGREATER BAR ASSERT", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETGREATER UNDERSCORE GREATER", line 1, characters 23-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETGREATER UNDERSCORE GREATER", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETGREATER WITH", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETGREATER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS BACKQUOTE UIDENT LBRACKETAT AND RBRACKET WHILE", line 1, characters 39-44:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS BACKQUOTE UIDENT LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS BAR ASSERT", line 1, characters 23-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS BAR ASSERT", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE BAR WITH", line 1, characters 25-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE BAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE GREATER WITH", line 1, characters 25-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE GREATER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS WITH", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LBRACKETLESS WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS DOTDOT WITH", line 1, characters 23-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS DOTDOT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT DOT UNDERSCORE WITH", line 1, characters 42-46:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT DOT UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT DOT WITH", line 1, characters 40-44:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT DOT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH", line 1, characters 47-51:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE LBRACKETAT AND RBRACKET FUNCTOR", line 1, characters 40-47:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE LBRACKETAT AND RBRACKET FUNCTOR", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE RBRACE", line 1, characters 31-32:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE RBRACE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE SEMI LBRACKETAT AND RBRACKET CONSTRAINT", line 1, characters 42-52:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE SEMI LBRACKETAT AND RBRACKET CONSTRAINT", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE SEMI WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE SEMI WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE WITH", line 1, characters 31-35:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS LIDENT WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS UNDERSCORE SEMI WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS UNDERSCORE SEMI WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS UNDERSCORE WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LESS WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LESS WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LIDENT COLON UNDERSCORE MINUSGREATER WITH", line 1, characters 32-36:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LIDENT COLON UNDERSCORE MINUSGREATER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LIDENT COLON UNDERSCORE WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LIDENT COLON UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LIDENT COLON WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LIDENT COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LIDENT WHILE", line 1, characters 25-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LIDENT WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 36-41:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE PERCENT AND FUNCTION", line 1, characters 33-41:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE PERCENT AND FUNCTION", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE UIDENT VAL", line 1, characters 34-37:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE UIDENT VAL", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN MODULE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT COMMA UNDERSCORE WITH", line 1, characters 35-39:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT COMMA UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT COMMA WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT COMMA WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT RPAREN HASH WITH", line 1, characters 35-39:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT RPAREN HASH WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT RPAREN WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT RPAREN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA UNDERSCORE WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT LPAREN WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT LPAREN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT OPTLABEL UNDERSCORE MINUSGREATER WITH", line 1, characters 31-35:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT OPTLABEL UNDERSCORE MINUSGREATER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT OPTLABEL UNDERSCORE WITH", line 1, characters 28-32:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT OPTLABEL UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT OPTLABEL WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT OPTLABEL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT QUESTION LIDENT WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT QUESTION LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT QUESTION WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT QUESTION WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT QUOTE WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT QUOTE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE AMPERSAND", line 1, characters 20-21:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE AMPERSAND", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE AS QUOTE WITH", line 1, characters 25-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE AS QUOTE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE AS WITH", line 1, characters 23-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE AS WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE EQUAL UNDERSCORE WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE EQUAL UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE EQUAL WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE HASH WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE HASH WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE MINUSGREATER WITH", line 1, characters 23-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE MINUSGREATER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR LIDENT STAR UNDERSCORE WHILE", line 1, characters 33-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR LIDENT STAR UNDERSCORE WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR LIDENT STAR WITH", line 1, characters 31-35:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR LIDENT STAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR UNDERSCORE WHILE", line 1, characters 24-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR UNDERSCORE WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE STAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE WHILE", line 1, characters 20-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT UNDERSCORE WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT CONSTRAINT WITH", line 1, characters 18-22:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT CONSTRAINT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT END WHILE", line 1, characters 11-16:
+Error: Syntax error
+File "implementation: OBJECT INHERIT BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 26-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT BANG QUOTED_STRING_EXPR AS LIDENT WITH", line 1, characters 43-47:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT BANG QUOTED_STRING_EXPR AS LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT BANG QUOTED_STRING_EXPR WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT BANG QUOTED_STRING_EXPR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT BANG WITH", line 1, characters 17-21:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT BANG WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT FUN LBRACKETAT AND RBRACKET WHILE", line 1, characters 28-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT FUN LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT FUN UNDERSCORE MINUSGREATER QUOTED_STRING_EXPR WITH", line 1, characters 40-44:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT FUN UNDERSCORE MINUSGREATER QUOTED_STRING_EXPR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT FUN UNDERSCORE MINUSGREATER WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT FUN UNDERSCORE MINUSGREATER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT FUN UNDERSCORE WITH", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT FUN UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT FUN WITH", line 1, characters 19-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT FUN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE COMMA UNDERSCORE WITH", line 1, characters 23-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE COMMA UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE COMMA WITH", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE COMMA WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE RBRACKET WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE WITH", line 1, characters 19-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LBRACKET UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LBRACKET WITH", line 1, characters 17-21:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LBRACKET WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LBRACKETAT AND RBRACKET FOR", line 1, characters 24-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LBRACKETAT AND RBRACKET FOR", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR IN QUOTED_STRING_EXPR WITH", line 1, characters 48-52:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR IN QUOTED_STRING_EXPR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR IN WITH", line 1, characters 32-36:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR IN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR LBRACKETATAT AND RBRACKET VAL", line 1, characters 39-42:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR LBRACKETATAT AND RBRACKET VAL", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET LBRACKETAT AND RBRACKET WHILE", line 1, characters 28-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 35-40:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN BANG UIDENT IN QUOTED_STRING_EXPR WITH", line 1, characters 52-56:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN BANG UIDENT IN QUOTED_STRING_EXPR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN BANG UIDENT IN WITH", line 1, characters 36-40:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN BANG UIDENT IN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN BANG UIDENT WITH", line 1, characters 33-37:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN BANG UIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN BANG WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN BANG WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN LBRACKETAT AND RBRACKET WHILE", line 1, characters 33-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN UIDENT IN QUOTED_STRING_EXPR WITH", line 1, characters 50-54:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN UIDENT IN QUOTED_STRING_EXPR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN UIDENT IN WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN UIDENT IN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN UIDENT WITH", line 1, characters 31-35:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN UIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET OPEN WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET OPEN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET REC ASSERT", line 1, characters 23-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET REC ASSERT", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET UNDERSCORE EQUAL CHAR WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET UNDERSCORE EQUAL CHAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LET WITH", line 1, characters 19-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LET WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LIDENT UIDENT WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LIDENT UIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LIDENT WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR COLON QUOTED_STRING_EXPR VAL", line 1, characters 51-54:
+Error: Syntax error: ')' expected
+File "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR COLON QUOTED_STRING_EXPR VAL", line 1, characters 15-16:
+  This '(' might be unmatched
+File "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR COLON WITH", line 1, characters 35-39:
+Error: Syntax error: ')' expected
+File "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR COLON WITH", line 1, characters 15-16:
+  This '(' might be unmatched
+File "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR WITH", line 1, characters 33-37:
+Error: Syntax error: ')' expected
+File "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR WITH", line 1, characters 15-16:
+  This '(' might be unmatched
+File "implementation: OBJECT INHERIT LPAREN WITH", line 1, characters 17-21:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT LPAREN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT OBJECT LBRACKETAT AND RBRACKET WHILE", line 1, characters 31-36:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT OBJECT LBRACKETAT AND RBRACKET WHILE", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT OBJECT LPAREN CHAR RPAREN WITH", line 1, characters 30-34:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT OBJECT LPAREN CHAR RPAREN WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT OBJECT WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT OBJECT WITH", line 1, characters 15-21:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT QUOTED_STRING_EXPR AS LIDENT WITH", line 1, characters 41-45:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT QUOTED_STRING_EXPR AS LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT QUOTED_STRING_EXPR AS WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT QUOTED_STRING_EXPR AS WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT QUOTED_STRING_EXPR WITH", line 1, characters 31-35:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT QUOTED_STRING_EXPR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INHERIT WITH", line 1, characters 15-19:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INHERIT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INITIALIZER LBRACKETAT AND RBRACKET AND", line 1, characters 28-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INITIALIZER LBRACKETAT AND RBRACKET AND", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INITIALIZER UIDENT WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INITIALIZER UIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT INITIALIZER WITH", line 1, characters 19-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT INITIALIZER WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LBRACKETAT AND RBRACKET CLASS", line 1, characters 16-21:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LBRACKETAT AND RBRACKET CLASS", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LBRACKETATATAT AND RBRACKET WITH", line 1, characters 18-22:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LBRACKETATATAT AND RBRACKET WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LPAREN UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 15-19:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LPAREN UNDERSCORE COLON UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LPAREN UNDERSCORE COLON WITH", line 1, characters 13-17:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LPAREN UNDERSCORE COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LPAREN UNDERSCORE RPAREN COMMENT", line 1, characters 0-2:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LPAREN UNDERSCORE RPAREN COMMENT", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LPAREN UNDERSCORE WITH", line 1, characters 11-15:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LPAREN UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT LPAREN WITH", line 1, characters 9-13:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT LPAREN WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 25-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH", line 1, characters 43-47:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH", line 1, characters 41-45:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT WITH", line 1, characters 39-43:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT RPAREN", line 1, characters 37-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT RPAREN", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE WITH", line 1, characters 30-34:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON TYPE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON UNDERSCORE EQUAL WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON UNDERSCORE EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON UNDERSCORE VAL", line 1, characters 27-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON UNDERSCORE VAL", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT COLON WITH", line 1, characters 25-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG LIDENT WITH", line 1, characters 23-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG PRIVATE LETOP", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG PRIVATE LETOP", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD BANG WITH", line 1, characters 16-20:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD BANG WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LBRACKETAT AND RBRACKET WHILE", line 1, characters 23-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH", line 1, characters 36-40:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT DOT WITH", line 1, characters 34-38:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT DOT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH", line 1, characters 41-45:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH", line 1, characters 41-45:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH", line 1, characters 39-43:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT WITH", line 1, characters 37-41:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT RPAREN", line 1, characters 35-36:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT RPAREN", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON TYPE WITH", line 1, characters 28-32:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON TYPE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE EQUAL WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE VAL", line 1, characters 25-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE VAL", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE WITH", line 1, characters 25-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT COLON WITH", line 1, characters 23-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT EQUAL CHAR WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT EQUAL CHAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD LIDENT WITH", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD PRIVATE WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD PRIVATE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD VIRTUAL LIDENT COLON WITH", line 1, characters 31-35:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD VIRTUAL LIDENT COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD VIRTUAL LIDENT WITH", line 1, characters 29-33:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD VIRTUAL LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD VIRTUAL PRIVATE WITH", line 1, characters 30-34:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD VIRTUAL PRIVATE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD VIRTUAL WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD VIRTUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT METHOD WITH", line 1, characters 14-18:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT METHOD WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT PERCENT AND COLON", line 1, characters 13-14:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT PERCENT AND COLON", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT QUOTED_STRING_ITEM WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT QUOTED_STRING_ITEM WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 22-27:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG LIDENT COLONGREATER LIDENT EQUAL WITH", line 1, characters 32-36:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG LIDENT COLONGREATER LIDENT EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG LIDENT COLONGREATER LIDENT SEMI", line 1, characters 30-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG LIDENT COLONGREATER LIDENT SEMI", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG LIDENT EQUAL WITH", line 1, characters 22-26:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG LIDENT EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG LIDENT WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG MUTABLE LETOP", line 1, characters 21-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG MUTABLE LETOP", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL BANG WITH", line 1, characters 13-17:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL BANG WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL LBRACKETAT AND RBRACKET WHILE", line 1, characters 20-25:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL LBRACKETAT AND RBRACKET WHILE", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL LIDENT COLONGREATER LIDENT EQUAL WITH", line 1, characters 30-34:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL LIDENT COLONGREATER LIDENT EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL LIDENT COLONGREATER LIDENT SEMI", line 1, characters 28-29:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL LIDENT COLONGREATER LIDENT SEMI", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL LIDENT EQUAL CHAR WITH", line 1, characters 24-28:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL LIDENT EQUAL CHAR WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL LIDENT EQUAL WITH", line 1, characters 20-24:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL LIDENT EQUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL LIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL MUTABLE WITH", line 1, characters 19-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL MUTABLE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL VIRTUAL LIDENT COLON UNDERSCORE WITH", line 1, characters 30-34:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL VIRTUAL LIDENT COLON UNDERSCORE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL VIRTUAL LIDENT COLON WITH", line 1, characters 28-32:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL VIRTUAL LIDENT COLON WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL VIRTUAL LIDENT WITH", line 1, characters 26-30:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL VIRTUAL LIDENT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL VIRTUAL MUTABLE WITH", line 1, characters 27-31:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL VIRTUAL MUTABLE WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL VIRTUAL WITH", line 1, characters 19-23:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL VIRTUAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT VAL WITH", line 1, characters 11-15:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT VAL WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OBJECT WITH", line 1, characters 7-11:
+Error: Syntax error: 'end' expected
+File "implementation: OBJECT WITH", line 1, characters 0-6:
+  This 'object' might be unmatched
+File "implementation: OPEN BANG LBRACKETAT AND RBRACKET FUNCTION", line 1, characters 16-24:
+Error: Syntax error
+File "implementation: OPEN BANG PERCENT AND WHILE", line 1, characters 13-18:
+Error: Syntax error
+File "implementation: OPEN BANG UIDENT WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: OPEN BANG WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: OPEN FUNCTOR LBRACKETAT AND RBRACKET WHILE", line 1, characters 22-27:
+Error: Syntax error
+File "implementation: OPEN FUNCTOR LPAREN RPAREN MINUSGREATER QUOTED_STRING_EXPR WHILE", line 1, characters 36-41:
+Error: Syntax error
+File "implementation: OPEN FUNCTOR LPAREN RPAREN MINUSGREATER WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: OPEN FUNCTOR LPAREN RPAREN WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: OPEN FUNCTOR WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: OPEN LBRACKETAT AND RBRACKET FUNCTION", line 1, characters 14-22:
+Error: Syntax error
+File "implementation: OPEN LBRACKETAT AND RBRACKET WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: OPEN LPAREN UIDENT COLON UIDENT VAL", line 1, characters 23-26:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN UIDENT COLON UIDENT VAL", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN UIDENT COLON WITH", line 1, characters 16-20:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN UIDENT COLON WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN UIDENT WITH", line 1, characters 14-18:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN UIDENT WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL LBRACKETAT AND RBRACKET VIRTUAL", line 1, characters 20-27:
+Error: Syntax error
+File "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT VAL", line 1, characters 37-40:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT VAL", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH", line 1, characters 30-34:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT VAL", line 1, characters 27-30:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT VAL", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL UIDENT COLON WITH", line 1, characters 20-24:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT COLON WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL UIDENT COLONGREATER UIDENT VAL", line 1, characters 28-31:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT COLONGREATER UIDENT VAL", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL UIDENT COLONGREATER WITH", line 1, characters 21-25:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT COLONGREATER WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: ')' expected
+File "implementation: OPEN LPAREN VAL UIDENT WITH", line 1, characters 5-6:
+  This '(' might be unmatched
+File "implementation: OPEN LPAREN VAL WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: OPEN LPAREN WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: OPEN PERCENT AND FUNCTION", line 1, characters 11-19:
+Error: Syntax error
+File "implementation: OPEN PERCENT UNDERSCORE", line 1, characters 7-8:
+Error: Syntax error
+File "implementation: OPEN STRUCT LBRACKETAT AND RBRACKET AND", line 1, characters 21-24:
+Error: Syntax error: 'end' expected
+File "implementation: OPEN STRUCT LBRACKETAT AND RBRACKET AND", line 1, characters 5-11:
+  This 'struct' might be unmatched
+File "implementation: OPEN STRUCT UIDENT RBRACKET", line 1, characters 19-20:
+Error: Syntax error: 'end' expected
+File "implementation: OPEN STRUCT UIDENT RBRACKET", line 1, characters 5-11:
+  This 'struct' might be unmatched
+File "implementation: OPEN STRUCT WITH", line 1, characters 12-16:
+Error: Syntax error: 'end' expected
+File "implementation: OPEN STRUCT WITH", line 1, characters 5-11:
+  This 'struct' might be unmatched
+File "implementation: OPEN UIDENT DOT WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: OPEN UIDENT LPAREN WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: OPEN UIDENT WHILE", line 1, characters 12-17:
+Error: Syntax error
+File "implementation: OPEN UIDENT WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: OPEN WITH", line 1, characters 5-9:
+Error: Syntax error
+File "implementation: PLUSDOT LET CHAR EQUAL CHAR VAL", line 1, characters 17-20:
+Error: Syntax error
+File "implementation: PLUSDOT WITH", line 1, characters 3-7:
+Error: Syntax error
+File "implementation: PREFIXOP WITH", line 1, characters 3-7:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM HASH", line 1, characters 17-18:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM LBRACKETATAT AND RBRACKET WITH", line 1, characters 27-31:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM LBRACKETATAT UNDERSCORE", line 1, characters 21-22:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM LBRACKETATAT WITH UIDENT WHEN", line 1, characters 34-38:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM LBRACKETATAT WITH VIRTUAL", line 1, characters 26-33:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM LET CHAR EQUAL CHAR IN", line 1, characters 31-33:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM LET WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: QUOTED_STRING_ITEM WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: STRING TRUE WHILE", line 1, characters 13-18:
+Error: Syntax error
+File "implementation: STRING UIDENT AS", line 1, characters 15-17:
+Error: Syntax error
+File "implementation: STRING WHILE", line 1, characters 8-13:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACE UIDENT RBRACE LESSMINUS OBJECT END WHILE", line 1, characters 32-37:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACE UIDENT RBRACE LESSMINUS WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACE UIDENT RBRACE WHILE", line 1, characters 18-23:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACE UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error: '}' expected
+File "implementation: TRUE DOT LBRACE UIDENT WITH", line 1, characters 7-8:
+  This '{' might be unmatched
+File "implementation: TRUE DOT LBRACE WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACKET UIDENT RBRACKET LESSMINUS OBJECT END WHILE", line 1, characters 32-37:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACKET UIDENT RBRACKET LESSMINUS WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACKET UIDENT RBRACKET WHILE", line 1, characters 18-23:
+Error: Syntax error
+File "implementation: TRUE DOT LBRACKET UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error: ']' expected
+File "implementation: TRUE DOT LBRACKET UIDENT WITH", line 1, characters 7-8:
+  This '[' might be unmatched
+File "implementation: TRUE DOT LBRACKET WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: TRUE DOT LIDENT LESSMINUS OBJECT END WHILE", line 1, characters 28-33:
+Error: Syntax error
+File "implementation: TRUE DOT LIDENT LESSMINUS WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: TRUE DOT LIDENT WHILE", line 1, characters 14-19:
+Error: Syntax error
+File "implementation: TRUE DOT LPAREN UIDENT RPAREN LESSMINUS OBJECT END WHILE", line 1, characters 32-37:
+Error: Syntax error
+File "implementation: TRUE DOT LPAREN UIDENT RPAREN LESSMINUS WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: TRUE DOT LPAREN UIDENT RPAREN WHILE", line 1, characters 18-23:
+Error: Syntax error
+File "implementation: TRUE DOT LPAREN UIDENT WITH", line 1, characters 16-20:
+Error: Syntax error: ')' expected
+File "implementation: TRUE DOT LPAREN UIDENT WITH", line 1, characters 7-8:
+  This '(' might be unmatched
+File "implementation: TRUE DOT LPAREN WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS OBJECT END WHILE", line 1, characters 42-47:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RBRACE WHILE", line 1, characters 28-33:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RPAREN", line 1, characters 26-27:
+Error: Syntax error: '}' expected
+File "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RPAREN", line 1, characters 17-18:
+  This '{' might be unmatched
+File "implementation: TRUE DOT UIDENT DOTOP LBRACE WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS OBJECT END WHILE", line 1, characters 42-47:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RBRACKET WHILE", line 1, characters 28-33:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 26-27:
+Error: Syntax error: ']' expected
+File "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 17-18:
+  This '[' might be unmatched
+File "implementation: TRUE DOT UIDENT DOTOP LBRACKET WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 26-27:
+Error: Syntax error: ')' expected
+File "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 17-18:
+  This '(' might be unmatched
+File "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS OBJECT END WHILE", line 1, characters 42-47:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RPAREN WHILE", line 1, characters 28-33:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP LPAREN WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT DOTOP WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: TRUE DOT UIDENT WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: TRUE DOT WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TRY LBRACKETAT AND RBRACKET AND", line 1, characters 13-16:
+Error: Syntax error
+File "implementation: TRY PERCENT AND VIRTUAL", line 1, characters 10-17:
+Error: Syntax error
+File "implementation: TRY UIDENT VAL", line 1, characters 11-14:
+Error: Syntax error
+File "implementation: TRY UIDENT WITH UNDERSCORE MINUSGREATER DOT WHILE", line 1, characters 23-28:
+Error: Syntax error
+File "implementation: TRY UIDENT WITH WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TRY WITH", line 1, characters 4-8:
+Error: Syntax error
+File "implementation: TYPE BANG WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TYPE LBRACKETAT AND RBRACKET BACKQUOTE", line 1, characters 14-15:
+Error: Syntax error
+File "implementation: TYPE LIDENT AND LBRACKETAT AND RBRACKET WHILE", line 1, characters 25-30:
+Error: Syntax error
+File "implementation: TYPE LIDENT AND LIDENT EQUAL DOTDOT AMPERSAND", line 1, characters 28-29:
+Error: Syntax error
+File "implementation: TYPE LIDENT AND LIDENT LBRACKETATAT AND RBRACKET METHOD", line 1, characters 33-39:
+Error: Syntax error
+File "implementation: TYPE LIDENT AND LIDENT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: TYPE LIDENT AND UNDERSCORE LETOP", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: TYPE LIDENT AND WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL UNDERSCORE SEMI", line 1, characters 29-30:
+Error: Syntax error
+File "implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH", line 1, characters 27-31:
+Error: Syntax error
+File "implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH", line 1, characters 25-29:
+Error: Syntax error
+File "implementation: TYPE LIDENT CONSTRAINT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL BAR UIDENT OF LIDENT IN", line 1, characters 33-35:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL BAR UIDENT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL BAR WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND", line 1, characters 17-18:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL LBRACE WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL LBRACKET WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL LPAREN WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL PRIVATE LBRACE WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL PRIVATE UNDERSCORE WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL PRIVATE WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL TRUE WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UIDENT BAR WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UIDENT LBRACKETAT AND RBRACKET WHILE", line 1, characters 30-35:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UIDENT OF LIDENT IN", line 1, characters 31-33:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UIDENT WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH", line 1, characters 20-24:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE LBRACE WITH", line 1, characters 28-32:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH", line 1, characters 18-22:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL UNDERSCORE WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: TYPE LIDENT EQUAL WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: TYPE LIDENT LBRACKETATAT WITH RBRACKET METHOD", line 1, characters 23-29:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ BAR UIDENT EQUAL TRUE WITH", line 1, characters 31-35:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ BAR UIDENT EQUAL WITH", line 1, characters 26-30:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ BAR UIDENT WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ BAR WITH", line 1, characters 17-21:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ PRIVATE BANG", line 1, characters 23-24:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ UIDENT EQUAL TRUE WITH", line 1, characters 29-33:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ UIDENT EQUAL WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ UIDENT OF LIDENT CONSTRAINT", line 1, characters 32-42:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ UIDENT WITH", line 1, characters 22-26:
+Error: Syntax error
+File "implementation: TYPE LIDENT PLUSEQ WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: TYPE LIDENT WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: TYPE LPAREN UNDERSCORE COMMA WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: TYPE LPAREN UNDERSCORE WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: TYPE LPAREN WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TYPE MINUS WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TYPE NONREC LIDENT EQUAL DOTDOT AMPERSAND", line 1, characters 24-25:
+Error: Syntax error
+File "implementation: TYPE NONREC LIDENT WITH", line 1, characters 19-23:
+Error: Syntax error
+File "implementation: TYPE NONREC UNDERSCORE LETOP", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: TYPE NONREC WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: TYPE PERCENT AND WHILE", line 1, characters 11-16:
+Error: Syntax error
+File "implementation: TYPE PLUS WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TYPE PREFIXOP WITH", line 1, characters 8-12:
+Error: Syntax error
+File "implementation: TYPE QUOTE WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TYPE UIDENT DOT LIDENT WITH", line 1, characters 21-25:
+Error: Syntax error
+File "implementation: TYPE UIDENT DOT WITH", line 1, characters 14-18:
+Error: Syntax error
+File "implementation: TYPE UIDENT LPAREN UIDENT DOT WITH", line 1, characters 23-27:
+Error: Syntax error: module path expected.
+File "implementation: TYPE UIDENT LPAREN UIDENT WITH", line 1, characters 21-25:
+Error: Syntax error: module path expected.
+File "implementation: TYPE UIDENT LPAREN WITH", line 1, characters 14-18:
+Error: Syntax error: module path expected.
+File "implementation: TYPE UIDENT WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: TYPE UNDERSCORE LETOP", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: TYPE WITH", line 1, characters 5-9:
+Error: Syntax error
+File "implementation: UIDENT AMPERAMPER OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT AMPERAMPER WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT AMPERSAND OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT AMPERSAND WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT AS", line 1, characters 7-9:
+Error: Syntax error
+File "implementation: UIDENT BARBAR OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT BARBAR WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT COLONCOLON OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT COLONCOLON WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT COLONEQUAL OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT COLONEQUAL WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT COMMA CHAR COMMA OBJECT END WHILE", line 1, characters 26-31:
+Error: Syntax error
+File "implementation: UIDENT COMMA CHAR COMMA WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: UIDENT COMMA OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT COMMA WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT DOT LBRACE WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: UIDENT DOT LBRACELESS WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: UIDENT DOT LBRACKET UIDENT RPAREN", line 1, characters 18-19:
+Error: Syntax error: ']' expected
+File "implementation: UIDENT DOT LBRACKET UIDENT RPAREN", line 1, characters 9-10:
+  This '[' might be unmatched
+File "implementation: UIDENT DOT LBRACKET WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN", line 1, characters 19-20:
+Error: Syntax error: '|]' expected
+File "implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN", line 1, characters 9-11:
+  This '[|' might be unmatched
+File "implementation: UIDENT DOT LBRACKETBAR WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: UIDENT DOT LPAREN COLONCOLON WITH", line 1, characters 14-18:
+Error: Syntax error: operator expected.
+File "implementation: UIDENT DOT LPAREN MODULE LBRACKETAT AND RBRACKET WHILE", line 1, characters 27-32:
+Error: Syntax error: module-expr expected.
+File "implementation: UIDENT DOT LPAREN MODULE PERCENT AND FUNCTION", line 1, characters 24-32:
+Error: Syntax error: module-expr expected.
+File "implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT VAL", line 1, characters 34-37:
+Error: Syntax error: ')' expected
+File "implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT VAL", line 1, characters 9-10:
+  This '(' might be unmatched
+File "implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH", line 1, characters 27-31:
+Error: Syntax error: ')' expected
+File "implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH", line 1, characters 9-10:
+  This '(' might be unmatched
+File "implementation: UIDENT DOT LPAREN MODULE UIDENT WITH", line 1, characters 25-29:
+Error: Syntax error: module-expr expected.
+File "implementation: UIDENT DOT LPAREN MODULE WITH", line 1, characters 18-22:
+Error: Syntax error: module-expr expected.
+File "implementation: UIDENT DOT LPAREN UIDENT WITH", line 1, characters 18-22:
+Error: Syntax error: ')' expected
+File "implementation: UIDENT DOT LPAREN UIDENT WITH", line 1, characters 9-10:
+  This '(' might be unmatched
+File "implementation: UIDENT DOT LPAREN WITH", line 1, characters 11-15:
+Error: Syntax error: operator expected.
+File "implementation: UIDENT DOT WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS OBJECT END WHILE", line 1, characters 35-40:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACE UIDENT RBRACE WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACE UIDENT SEMI RPAREN", line 1, characters 21-22:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACE UIDENT WITH", line 1, characters 19-23:
+Error: Syntax error: '}' expected
+File "implementation: UIDENT DOTOP LBRACE UIDENT WITH", line 1, characters 10-11:
+  This '{' might be unmatched
+File "implementation: UIDENT DOTOP LBRACE WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS OBJECT END WHILE", line 1, characters 35-40:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACKET UIDENT RBRACKET WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 19-20:
+Error: Syntax error: ']' expected
+File "implementation: UIDENT DOTOP LBRACKET UIDENT RPAREN", line 1, characters 10-11:
+  This '[' might be unmatched
+File "implementation: UIDENT DOTOP LBRACKET WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 19-20:
+Error: Syntax error: ')' expected
+File "implementation: UIDENT DOTOP LPAREN UIDENT RBRACKET", line 1, characters 10-11:
+  This '(' might be unmatched
+File "implementation: UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS OBJECT END WHILE", line 1, characters 35-40:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS WITH", line 1, characters 24-28:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LPAREN UIDENT RPAREN WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT DOTOP LPAREN WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: UIDENT DOTOP WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT EQUAL OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT EQUAL WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT GREATER OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT GREATER WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT HASH WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT HASHOP TRUE WHILE", line 1, characters 15-20:
+Error: Syntax error
+File "implementation: UIDENT HASHOP WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP0 OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP0 WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP1 OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP1 WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP2 OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP2 WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP3 OBJECT END WHILE", line 1, characters 23-28:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP3 WITH", line 1, characters 12-16:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP4 OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT INFIXOP4 WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT LABEL TRUE WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT LABEL WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: UIDENT LBRACKETAT UNDERSCORE", line 1, characters 10-11:
+Error: Syntax error
+File "implementation: UIDENT LBRACKETAT WITH UIDENT WHEN", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: UIDENT LBRACKETAT WITH VIRTUAL", line 1, characters 15-22:
+Error: Syntax error
+File "implementation: UIDENT LBRACKETATAT AND RBRACKET AND", line 1, characters 17-20:
+Error: Syntax error
+File "implementation: UIDENT LESS OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT LESS WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT MINUS OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT MINUS WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT MINUSDOT OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT MINUSDOT WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT OPTLABEL TRUE WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT OPTLABEL WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: UIDENT OR OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT OR WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT PERCENT OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT PERCENT WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT PLUS OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT PLUS WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT PLUSDOT OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT PLUSDOT WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT PLUSEQ OBJECT END WHILE", line 1, characters 21-26:
+Error: Syntax error
+File "implementation: UIDENT PLUSEQ WITH", line 1, characters 10-14:
+Error: Syntax error
+File "implementation: UIDENT QUESTION WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT RBRACKET", line 1, characters 7-8:
+Error: Syntax error
+File "implementation: UIDENT SEMI PERCENT UNDERSCORE", line 1, characters 11-12:
+Error: Syntax error
+File "implementation: UIDENT SEMI PERCENT WITH VIRTUAL", line 1, characters 16-23:
+Error: Syntax error
+File "implementation: UIDENT SEMI WHEN", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT STAR OBJECT END WHILE", line 1, characters 20-25:
+Error: Syntax error
+File "implementation: UIDENT STAR WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT TILDE WITH", line 1, characters 9-13:
+Error: Syntax error
+File "implementation: UIDENT UIDENT UIDENT", line 1, characters 14-20:
+Error: Syntax error
+File "implementation: UIDENT WHILE", line 1, characters 7-12:
+Error: Syntax error
+File "implementation: UIDENT WITH", line 1, characters 7-11:
+Error: Syntax error
+File "implementation: VAL LBRACKETAT AND RBRACKET WHILE", line 1, characters 13-18:
+Error: Syntax error
+File "implementation: VAL LIDENT COLON UNDERSCORE WITH", line 1, characters 15-19:
+Error: Syntax error
+File "implementation: VAL LIDENT COLON WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: VAL LIDENT WITH", line 1, characters 11-15:
+Error: Syntax error
+File "implementation: VAL PERCENT AND LBRACKET", line 1, characters 10-11:
+Error: Syntax error
+File "implementation: VAL WITH", line 1, characters 4-8:
+Error: Syntax error
+File "implementation: WHILE LBRACKETAT WITH RBRACKET AND", line 1, characters 16-19:
+Error: Syntax error
+File "implementation: WHILE PERCENT WITH VIRTUAL", line 1, characters 13-20:
+Error: Syntax error
+File "implementation: WHILE UIDENT DO UIDENT WITH", line 1, characters 23-27:
+Error: Syntax error
+File "implementation: WHILE UIDENT DO WITH", line 1, characters 16-20:
+Error: Syntax error
+File "implementation: WHILE UIDENT WITH", line 1, characters 13-17:
+Error: Syntax error
+File "implementation: WHILE WITH", line 1, characters 6-10:
+Error: Syntax error
+File "implementation: WITH", line 1, characters 0-4:
+Error: Syntax error
+

--- a/testsuite/tests/generated-parse-errors/errors.ml
+++ b/testsuite/tests/generated-parse-errors/errors.ml
@@ -1,0 +1,3261 @@
+(* TEST
+   * toplevel
+*)
+#0 "use_file: HASH LIDENT TRUE WITH"
+# lident true with
+;;
+#0 "use_file: QUOTED_STRING_ITEM RBRACKET"
+{%%hello|world|} ]
+;;
+#0 "use_file: UIDENT LBRACKETATAT AND RBRACKET AND"
+UIdent [@@ and ] and
+;;
+#0 "use_file: UIDENT WITH"
+UIdent with
+;;
+#0 "use_file: WITH"
+with
+;;
+#0 "toplevel_phrase: HASH UIDENT UIDENT DOT WITH"
+# UIdent UIdent . with
+;;
+#0 "toplevel_phrase: HASH UIDENT UIDENT WITH"
+# UIdent UIdent with
+;;
+#0 "toplevel_phrase: HASH UIDENT VAL"
+# UIdent val
+;;
+#0 "toplevel_phrase: HASH UIDENT WITH"
+# UIdent with
+;;
+#0 "toplevel_phrase: HASH WITH"
+# with
+;;
+#0 "toplevel_phrase: QUOTED_STRING_ITEM RBRACKET"
+{%%hello|world|} ]
+;;
+#0 "toplevel_phrase: UIDENT LBRACKETATAT AND RBRACKET VAL"
+UIdent [@@ and ] val
+;;
+#0 "toplevel_phrase: UIDENT WITH"
+UIdent with
+;;
+#0 "toplevel_phrase: WITH"
+with
+;;
+#0 "implementation: ASSERT LBRACKETAT AND RBRACKET ASSERT"
+assert [@ and ] assert
+;;
+#0 "implementation: ASSERT PERCENT AND ASSERT"
+assert % and assert
+;;
+#0 "implementation: ASSERT UIDENT UIDENT"
+assert UIdent UIdent
+;;
+#0 "implementation: ASSERT WITH"
+assert with
+;;
+#0 "implementation: BACKQUOTE UIDENT UIDENT UIDENT"
+` UIdent UIdent UIdent
+;;
+#0 "implementation: BACKQUOTE UIDENT WHILE"
+` UIdent while
+;;
+#0 "implementation: BACKQUOTE WITH"
+` with
+;;
+#0 "implementation: BANG WITH"
+! with
+;;
+#0 "implementation: BEGIN LBRACKETAT AND RBRACKET AND"
+begin [@ and ] and
+;;
+#0 "implementation: BEGIN PERCENT AND VIRTUAL"
+begin % and virtual
+;;
+#0 "implementation: BEGIN UIDENT WITH"
+begin UIdent with
+;;
+#0 "implementation: BEGIN WITH"
+begin with
+;;
+#0 "implementation: CLASS LBRACKET UNDERSCORE RBRACKET WITH"
+class [ _ ] with
+;;
+#0 "implementation: CLASS LBRACKET UNDERSCORE WITH"
+class [ _ with
+;;
+#0 "implementation: CLASS LBRACKET WITH"
+class [ with
+;;
+#0 "implementation: CLASS LBRACKETAT AND RBRACKET LBRACELESS"
+class [@ and ] {<
+;;
+#0 "implementation: CLASS LIDENT COLON LBRACKET UNDERSCORE RBRACKET WITH"
+class lident : [ _ ] with
+;;
+#0 "implementation: CLASS LIDENT COLON LBRACKET UNDERSCORE WITH"
+class lident : [ _ with
+;;
+#0 "implementation: CLASS LIDENT COLON LBRACKET WITH"
+class lident : [ with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN BANG LBRACKETAT AND RBRACKET WHILE"
+class lident : let open ! [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN BANG UIDENT IN QUOTED_STRING_EXPR WITH"
+class lident : let open ! UIdent in {%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN BANG UIDENT IN WITH"
+class lident : let open ! UIdent in with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN BANG UIDENT WITH"
+class lident : let open ! UIdent with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN BANG WITH"
+class lident : let open ! with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN LBRACKETAT AND RBRACKET WHILE"
+class lident : let open [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN UIDENT IN QUOTED_STRING_EXPR WITH"
+class lident : let open UIdent in {%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN UIDENT IN WITH"
+class lident : let open UIdent in with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN UIDENT WITH"
+class lident : let open UIdent with
+;;
+#0 "implementation: CLASS LIDENT COLON LET OPEN WITH"
+class lident : let open with
+;;
+#0 "implementation: CLASS LIDENT COLON LET WITH"
+class lident : let with
+;;
+#0 "implementation: CLASS LIDENT COLON LIDENT COLON UNDERSCORE MINUSGREATER WITH"
+class lident : lident : _ -> with
+;;
+#0 "implementation: CLASS LIDENT COLON LIDENT COLON UNDERSCORE WITH"
+class lident : lident : _ with
+;;
+#0 "implementation: CLASS LIDENT COLON LIDENT COLON WITH"
+class lident : lident : with
+;;
+#0 "implementation: CLASS LIDENT COLON LIDENT WITH"
+class lident : lident with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT LBRACKETAT AND RBRACKET WHILE"
+class lident : object constraint [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT UNDERSCORE EQUAL LIDENT INITIALIZER"
+class lident : object constraint _ = lident initializer
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT CONSTRAINT WITH"
+class lident : object constraint with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT END WITH"
+class lident : object end with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT INHERIT LBRACKETAT AND RBRACKET WHILE"
+class lident : object inherit [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT INHERIT QUOTED_STRING_EXPR WITH"
+class lident : object inherit {%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT INHERIT WITH"
+class lident : object inherit with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT LBRACKETAT AND RBRACKET WHILE"
+class lident : object [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT LBRACKETATATAT AND RBRACKET WITH"
+class lident : object [@@@ and ] with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT LPAREN UNDERSCORE RPAREN WITH"
+class lident : object ( _ ) with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT LPAREN UNDERSCORE WITH"
+class lident : object ( _ with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT LPAREN WITH"
+class lident : object ( with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD LBRACKETAT AND RBRACKET WHILE"
+class lident : object method [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT COLON UNDERSCORE INITIALIZER"
+class lident : object method lident : _ initializer
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT COLON WITH"
+class lident : object method lident : with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD LIDENT WITH"
+class lident : object method lident with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD PRIVATE WITH"
+class lident : object method private with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD VIRTUAL PRIVATE WITH"
+class lident : object method virtual private with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD VIRTUAL WITH"
+class lident : object method virtual with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT METHOD WITH"
+class lident : object method with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT QUOTED_STRING_ITEM WITH"
+class lident : object {%%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL LBRACKETAT AND RBRACKET WHILE"
+class lident : object val [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT COLON UNDERSCORE WITH"
+class lident : object val lident : _ with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT COLON WITH"
+class lident : object val lident : with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL LIDENT WITH"
+class lident : object val lident with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL MUTABLE WITH"
+class lident : object val mutable with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL VIRTUAL MUTABLE WITH"
+class lident : object val virtual mutable with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL VIRTUAL WITH"
+class lident : object val virtual with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT VAL WITH"
+class lident : object val with
+;;
+#0 "implementation: CLASS LIDENT COLON OBJECT WITH"
+class lident : object with
+;;
+#0 "implementation: CLASS LIDENT COLON OPTLABEL UNDERSCORE MINUSGREATER WITH"
+class lident : ?label: _ -> with
+;;
+#0 "implementation: CLASS LIDENT COLON OPTLABEL UNDERSCORE WITH"
+class lident : ?label: _ with
+;;
+#0 "implementation: CLASS LIDENT COLON OPTLABEL WITH"
+class lident : ?label: with
+;;
+#0 "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR EQUAL QUOTED_STRING_EXPR WITH"
+class lident : {%hello|world|} = {%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR EQUAL WITH"
+class lident : {%hello|world|} = with
+;;
+#0 "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR VAL"
+class lident : {%hello|world|} val
+;;
+#0 "implementation: CLASS LIDENT COLON QUOTED_STRING_EXPR WITH"
+class lident : {%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT COLON UIDENT DOT LIDENT WITH"
+class lident : UIdent . lident with
+;;
+#0 "implementation: CLASS LIDENT COLON UNDERSCORE MINUSGREATER WITH"
+class lident : _ -> with
+;;
+#0 "implementation: CLASS LIDENT COLON UNDERSCORE WITH"
+class lident : _ with
+;;
+#0 "implementation: CLASS LIDENT COLON WITH"
+class lident : with
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKET UNDERSCORE RBRACKET WITH"
+class lident = {%hello|world|} and [ _ ] with
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET WHILE"
+class lident = {%hello|world|} and [@ and ] while
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL LIDENT LBRACKETATAT AND RBRACKET METHOD"
+class lident = {%hello|world|} and lident = lident [@@ and ] method
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT WITH"
+class lident = {%hello|world|} and lident with
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND VIRTUAL LBRACELESS"
+class lident = {%hello|world|} and virtual {<
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR AND WITH"
+class lident = {%hello|world|} and with
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+class lident = {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: CLASS LIDENT EQUAL QUOTED_STRING_EXPR WITH"
+class lident = {%hello|world|} with
+;;
+#0 "implementation: CLASS LIDENT EQUAL WITH"
+class lident = with
+;;
+#0 "implementation: CLASS LIDENT UNDERSCORE WITH"
+class lident _ with
+;;
+#0 "implementation: CLASS LIDENT WITH"
+class lident with
+;;
+#0 "implementation: CLASS PERCENT AND LBRACELESS"
+class % and {<
+;;
+#0 "implementation: CLASS TYPE LBRACKET UNDERSCORE RBRACKET WITH"
+class type [ _ ] with
+;;
+#0 "implementation: CLASS TYPE LBRACKETAT AND RBRACKET LBRACELESS"
+class type [@ and ] {<
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL LBRACKET WITH"
+class type lident = [ with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKET UNDERSCORE RBRACKET WITH"
+class type lident = {%hello|world|} and [ _ ] with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET LBRACELESS"
+class type lident = {%hello|world|} and [@ and ] {<
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+class type lident = {%hello|world|} and lident = {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL QUOTED_STRING_EXPR WITH"
+class type lident = {%hello|world|} and lident = {%hello|world|} with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT EQUAL WITH"
+class type lident = {%hello|world|} and lident = with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND LIDENT WITH"
+class type lident = {%hello|world|} and lident with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND VIRTUAL LBRACELESS"
+class type lident = {%hello|world|} and virtual {<
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR AND WITH"
+class type lident = {%hello|world|} and with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+class type lident = {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL QUOTED_STRING_EXPR WITH"
+class type lident = {%hello|world|} with
+;;
+#0 "implementation: CLASS TYPE LIDENT EQUAL WITH"
+class type lident = with
+;;
+#0 "implementation: CLASS TYPE LIDENT WITH"
+class type lident with
+;;
+#0 "implementation: CLASS TYPE PERCENT AND LBRACELESS"
+class type % and {<
+;;
+#0 "implementation: CLASS TYPE VIRTUAL LBRACELESS"
+class type virtual {<
+;;
+#0 "implementation: CLASS TYPE WITH"
+class type with
+;;
+#0 "implementation: CLASS VIRTUAL LBRACELESS"
+class virtual {<
+;;
+#0 "implementation: CLASS WITH"
+class with
+;;
+#0 "implementation: EXCEPTION LBRACKET WITH"
+exception [ with
+;;
+#0 "implementation: EXCEPTION LBRACKETAT AND RBRACKET EXTERNAL"
+exception [@ and ] external
+;;
+#0 "implementation: EXCEPTION LPAREN COLONCOLON WITH"
+exception ( :: with
+;;
+#0 "implementation: EXCEPTION LPAREN WITH"
+exception ( with
+;;
+#0 "implementation: EXCEPTION PERCENT AND EXTERNAL"
+exception % and external
+;;
+#0 "implementation: EXCEPTION UIDENT COLON UNDERSCORE MINUSGREATER UNDERSCORE WITH"
+exception UIdent : _ -> _ with
+;;
+#0 "implementation: EXCEPTION UIDENT COLON UNDERSCORE MINUSGREATER WITH"
+exception UIdent : _ -> with
+;;
+#0 "implementation: EXCEPTION UIDENT COLON UNDERSCORE STAR LIDENT VAL"
+exception UIdent : _ * lident val
+;;
+#0 "implementation: EXCEPTION UIDENT COLON UNDERSCORE WITH"
+exception UIdent : _ with
+;;
+#0 "implementation: EXCEPTION UIDENT COLON WITH"
+exception UIdent : with
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL LPAREN WITH"
+exception UIdent = ( with
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL UIDENT BAR"
+exception UIdent = UIdent |
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL UIDENT DOT LPAREN WITH"
+exception UIdent = UIdent . ( with
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL UIDENT DOT WITH"
+exception UIdent = UIdent . with
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL UIDENT LBRACKETAT AND RBRACKET WHILE"
+exception UIdent = UIdent [@ and ] while
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL UIDENT WITH"
+exception UIdent = UIdent with
+;;
+#0 "implementation: EXCEPTION UIDENT EQUAL WITH"
+exception UIdent = with
+;;
+#0 "implementation: EXCEPTION UIDENT LBRACKETAT AND RBRACKET CHAR"
+exception UIdent [@ and ] 'a'
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON LIDENT SEMI LBRACKETAT AND RBRACKET WHILE"
+exception UIdent of { lident : lident ; [@ and ] while
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON UNDERSCORE GREATER"
+exception UIdent of { lident : _ >
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON UNDERSCORE LBRACKETAT AND RBRACKET WHILE"
+exception UIdent of { lident : _ [@ and ] while
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON UNDERSCORE SEMI WITH"
+exception UIdent of { lident : _ ; with
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE LIDENT COLON WITH"
+exception UIdent of { lident : with
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE LIDENT WITH"
+exception UIdent of { lident with
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE MUTABLE LETOP"
+exception UIdent of { mutable let*
+;;
+#0 "implementation: EXCEPTION UIDENT OF LBRACE WITH"
+exception UIdent of { with
+;;
+#0 "implementation: EXCEPTION UIDENT OF LIDENT BAR"
+exception UIdent of lident |
+;;
+#0 "implementation: EXCEPTION UIDENT OF UNDERSCORE STAR UNDERSCORE WITH"
+exception UIdent of _ * _ with
+;;
+#0 "implementation: EXCEPTION UIDENT OF UNDERSCORE STAR WITH"
+exception UIdent of _ * with
+;;
+#0 "implementation: EXCEPTION UIDENT OF UNDERSCORE WITH"
+exception UIdent of _ with
+;;
+#0 "implementation: EXCEPTION UIDENT OF WITH"
+exception UIdent of with
+;;
+#0 "implementation: EXCEPTION UIDENT WITH"
+exception UIdent with
+;;
+#0 "implementation: EXCEPTION WITH"
+exception with
+;;
+#0 "implementation: EXTERNAL LBRACKETAT AND RBRACKET WHILE"
+external [@ and ] while
+;;
+#0 "implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL STRING WITH"
+external lident : _ = "hello" with
+;;
+#0 "implementation: EXTERNAL LIDENT COLON UNDERSCORE EQUAL WITH"
+external lident : _ = with
+;;
+#0 "implementation: EXTERNAL LIDENT COLON UNDERSCORE WITH"
+external lident : _ with
+;;
+#0 "implementation: EXTERNAL LIDENT COLON WITH"
+external lident : with
+;;
+#0 "implementation: EXTERNAL LIDENT WITH"
+external lident with
+;;
+#0 "implementation: EXTERNAL LPAREN MODULE WITH"
+external ( module with
+;;
+#0 "implementation: EXTERNAL LPAREN WITH"
+external ( with
+;;
+#0 "implementation: EXTERNAL PERCENT AND LBRACKET"
+external % and [
+;;
+#0 "implementation: EXTERNAL WITH"
+external with
+;;
+#0 "implementation: FOR LBRACKETAT AND RBRACKET ASSERT"
+for [@ and ] assert
+;;
+#0 "implementation: FOR PERCENT AND ASSERT"
+for % and assert
+;;
+#0 "implementation: FOR UNDERSCORE EQUAL UIDENT TO UIDENT DO UIDENT WITH"
+for _ = UIdent to UIdent do UIdent with
+;;
+#0 "implementation: FOR UNDERSCORE EQUAL UIDENT TO UIDENT DO WITH"
+for _ = UIdent to UIdent do with
+;;
+#0 "implementation: FOR UNDERSCORE EQUAL UIDENT TO UIDENT WITH"
+for _ = UIdent to UIdent with
+;;
+#0 "implementation: FOR UNDERSCORE EQUAL UIDENT TO WITH"
+for _ = UIdent to with
+;;
+#0 "implementation: FOR UNDERSCORE EQUAL UIDENT WITH"
+for _ = UIdent with
+;;
+#0 "implementation: FOR UNDERSCORE EQUAL WITH"
+for _ = with
+;;
+#0 "implementation: FOR UNDERSCORE WITH"
+for _ with
+;;
+#0 "implementation: FOR WITH"
+for with
+;;
+#0 "implementation: FUN LABEL WITH"
+fun ~label: with
+;;
+#0 "implementation: FUN LBRACKETAT AND RBRACKET ASSERT"
+fun [@ and ] assert
+;;
+#0 "implementation: FUN LPAREN TYPE LIDENT DOT"
+fun ( type lident .
+;;
+#0 "implementation: FUN LPAREN TYPE LIDENT RPAREN WITH"
+fun ( type lident ) with
+;;
+#0 "implementation: FUN LPAREN TYPE LIDENT WITH"
+fun ( type lident with
+;;
+#0 "implementation: FUN LPAREN TYPE WITH"
+fun ( type with
+;;
+#0 "implementation: FUN LPAREN WITH"
+fun ( with
+;;
+#0 "implementation: FUN OPTLABEL LPAREN UNDERSCORE COLON UNDERSCORE WITH"
+fun ?label: ( _ : _ with
+;;
+#0 "implementation: FUN OPTLABEL LPAREN UNDERSCORE COLON WITH"
+fun ?label: ( _ : with
+;;
+#0 "implementation: FUN OPTLABEL LPAREN UNDERSCORE EQUAL CHAR WITH"
+fun ?label: ( _ = 'a' with
+;;
+#0 "implementation: FUN OPTLABEL LPAREN UNDERSCORE WITH"
+fun ?label: ( _ with
+;;
+#0 "implementation: FUN OPTLABEL LPAREN WITH"
+fun ?label: ( with
+;;
+#0 "implementation: FUN OPTLABEL WITH"
+fun ?label: with
+;;
+#0 "implementation: FUN PERCENT AND ASSERT"
+fun % and assert
+;;
+#0 "implementation: FUN QUESTION LPAREN LIDENT EQUAL UIDENT WITH"
+fun ? ( lident = UIdent with
+;;
+#0 "implementation: FUN QUESTION LPAREN LIDENT EQUAL WITH"
+fun ? ( lident = with
+;;
+#0 "implementation: FUN QUESTION LPAREN WITH"
+fun ? ( with
+;;
+#0 "implementation: FUN QUESTION WITH"
+fun ? with
+;;
+#0 "implementation: FUN TILDE LPAREN LIDENT COLON UNDERSCORE WITH"
+fun ~ ( lident : _ with
+;;
+#0 "implementation: FUN TILDE LPAREN LIDENT COLON WITH"
+fun ~ ( lident : with
+;;
+#0 "implementation: FUN TILDE LPAREN LIDENT EQUAL"
+fun ~ ( lident =
+;;
+#0 "implementation: FUN TILDE LPAREN LIDENT WITH"
+fun ~ ( lident with
+;;
+#0 "implementation: FUN TILDE LPAREN WITH"
+fun ~ ( with
+;;
+#0 "implementation: FUN TILDE WITH"
+fun ~ with
+;;
+#0 "implementation: FUN UNDERSCORE COLON UNDERSCORE MINUSGREATER WITH"
+fun _ : _ -> with
+;;
+#0 "implementation: FUN UNDERSCORE COLON UNDERSCORE WITH"
+fun _ : _ with
+;;
+#0 "implementation: FUN UNDERSCORE COLON WITH"
+fun _ : with
+;;
+#0 "implementation: FUN UNDERSCORE LPAREN TYPE LIDENT DOT"
+fun _ ( type lident .
+;;
+#0 "implementation: FUN UNDERSCORE LPAREN TYPE LIDENT RPAREN WITH"
+fun _ ( type lident ) with
+;;
+#0 "implementation: FUN UNDERSCORE LPAREN TYPE WITH"
+fun _ ( type with
+;;
+#0 "implementation: FUN UNDERSCORE LPAREN WITH"
+fun _ ( with
+;;
+#0 "implementation: FUN UNDERSCORE MINUSGREATER WITH"
+fun _ -> with
+;;
+#0 "implementation: FUN UNDERSCORE UNDERSCORE WITH"
+fun _ _ with
+;;
+#0 "implementation: FUN UNDERSCORE WITH"
+fun _ with
+;;
+#0 "implementation: FUN WITH"
+fun with
+;;
+#0 "implementation: FUNCTION BAR WITH"
+function | with
+;;
+#0 "implementation: FUNCTION EXCEPTION LBRACKETAT AND RBRACKET ASSERT"
+function exception [@ and ] assert
+;;
+#0 "implementation: FUNCTION EXCEPTION PERCENT AND ASSERT"
+function exception % and assert
+;;
+#0 "implementation: FUNCTION EXCEPTION WITH"
+function exception with
+;;
+#0 "implementation: FUNCTION LBRACKETAT AND RBRACKET ASSERT"
+function [@ and ] assert
+;;
+#0 "implementation: FUNCTION PERCENT AND ASSERT"
+function % and assert
+;;
+#0 "implementation: FUNCTION UNDERSCORE AS WITH"
+function _ as with
+;;
+#0 "implementation: FUNCTION UNDERSCORE BAR UNDERSCORE WITH"
+function _ | _ with
+;;
+#0 "implementation: FUNCTION UNDERSCORE BAR WITH"
+function _ | with
+;;
+#0 "implementation: FUNCTION UNDERSCORE COLONCOLON UNDERSCORE WITH"
+function _ :: _ with
+;;
+#0 "implementation: FUNCTION UNDERSCORE COLONCOLON WITH"
+function _ :: with
+;;
+#0 "implementation: FUNCTION UNDERSCORE COMMA CHAR COMMA UNDERSCORE WITH"
+function _ , 'a' , _ with
+;;
+#0 "implementation: FUNCTION UNDERSCORE COMMA CHAR COMMA WITH"
+function _ , 'a' , with
+;;
+#0 "implementation: FUNCTION UNDERSCORE COMMA UNDERSCORE WITH"
+function _ , _ with
+;;
+#0 "implementation: FUNCTION UNDERSCORE COMMA WITH"
+function _ , with
+;;
+#0 "implementation: FUNCTION UNDERSCORE MINUSGREATER CHAR BAR WITH"
+function _ -> 'a' | with
+;;
+#0 "implementation: FUNCTION UNDERSCORE MINUSGREATER DOT WHILE"
+function _ -> . while
+;;
+#0 "implementation: FUNCTION UNDERSCORE MINUSGREATER WITH"
+function _ -> with
+;;
+#0 "implementation: FUNCTION UNDERSCORE WHEN UIDENT MINUSGREATER WITH"
+function _ when UIdent -> with
+;;
+#0 "implementation: FUNCTION UNDERSCORE WHEN UIDENT WITH"
+function _ when UIdent with
+;;
+#0 "implementation: FUNCTION UNDERSCORE WHEN WITH"
+function _ when with
+;;
+#0 "implementation: FUNCTION UNDERSCORE WITH"
+function _ with
+;;
+#0 "implementation: FUNCTION WITH"
+function with
+;;
+#0 "implementation: IF LBRACKETAT AND RBRACKET AND"
+if [@ and ] and
+;;
+#0 "implementation: IF PERCENT AND VIRTUAL"
+if % and virtual
+;;
+#0 "implementation: IF UIDENT THEN OBJECT END WHILE"
+if UIdent then object end while
+;;
+#0 "implementation: IF UIDENT THEN UIDENT ELSE OBJECT END WHILE"
+if UIdent then UIdent else object end while
+;;
+#0 "implementation: IF UIDENT THEN UIDENT ELSE WITH"
+if UIdent then UIdent else with
+;;
+#0 "implementation: IF UIDENT THEN WITH"
+if UIdent then with
+;;
+#0 "implementation: IF UIDENT WITH"
+if UIdent with
+;;
+#0 "implementation: IF WITH"
+if with
+;;
+#0 "implementation: INCLUDE LBRACKETAT AND RBRACKET FUNCTION"
+include [@ and ] function
+;;
+#0 "implementation: INCLUDE PERCENT AND FUNCTION"
+include % and function
+;;
+#0 "implementation: INCLUDE UIDENT WITH"
+include UIdent with
+;;
+#0 "implementation: INCLUDE WITH"
+include with
+;;
+#0 "implementation: LAZY LBRACKETAT AND RBRACKET ASSERT"
+lazy [@ and ] assert
+;;
+#0 "implementation: LAZY PERCENT AND ASSERT"
+lazy % and assert
+;;
+#0 "implementation: LAZY UIDENT UIDENT"
+lazy UIdent UIdent
+;;
+#0 "implementation: LAZY WITH"
+lazy with
+;;
+#0 "implementation: LBRACE LIDENT COLONGREATER LIDENT RPAREN"
+{ lident :> lident )
+;;
+#0 "implementation: LBRACE LIDENT EQUAL CHAR GREATERRBRACE"
+{ lident = 'a' >}
+;;
+#0 "implementation: LBRACE LIDENT SEMI WITH"
+{ lident ; with
+;;
+#0 "implementation: LBRACE LIDENT WHILE"
+{ lident while
+;;
+#0 "implementation: LBRACE TRUE DOT LBRACE UIDENT WITH"
+{ true . { UIdent with
+;;
+#0 "implementation: LBRACE TRUE DOT LBRACE WITH"
+{ true . { with
+;;
+#0 "implementation: LBRACE TRUE DOT LBRACKET UIDENT WITH"
+{ true . [ UIdent with
+;;
+#0 "implementation: LBRACE TRUE DOT LBRACKET WITH"
+{ true . [ with
+;;
+#0 "implementation: LBRACE TRUE DOT LPAREN UIDENT WITH"
+{ true . ( UIdent with
+;;
+#0 "implementation: LBRACE TRUE DOT LPAREN WITH"
+{ true . ( with
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACE UIDENT RPAREN"
+{ true . UIdent .+ { UIdent )
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACE WITH"
+{ true . UIdent .+ { with
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACKET UIDENT RPAREN"
+{ true . UIdent .+ [ UIdent )
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP LBRACKET WITH"
+{ true . UIdent .+ [ with
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP LPAREN UIDENT RBRACKET"
+{ true . UIdent .+ ( UIdent ]
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP LPAREN WITH"
+{ true . UIdent .+ ( with
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT DOTOP WITH"
+{ true . UIdent .+ with
+;;
+#0 "implementation: LBRACE TRUE DOT UIDENT WITH"
+{ true . UIdent with
+;;
+#0 "implementation: LBRACE TRUE DOT WITH"
+{ true . with
+;;
+#0 "implementation: LBRACE TRUE WHILE"
+{ true while
+;;
+#0 "implementation: LBRACE UIDENT DOT LIDENT WHILE"
+{ UIdent . lident while
+;;
+#0 "implementation: LBRACE UIDENT DOT WITH"
+{ UIdent . with
+;;
+#0 "implementation: LBRACE UIDENT DOTOP LBRACE UIDENT SEMI RPAREN"
+{ UIdent .+ { UIdent ; )
+;;
+#0 "implementation: LBRACE UIDENT DOTOP LBRACE WITH"
+{ UIdent .+ { with
+;;
+#0 "implementation: LBRACE UIDENT DOTOP LBRACKET UIDENT RPAREN"
+{ UIdent .+ [ UIdent )
+;;
+#0 "implementation: LBRACE UIDENT DOTOP LBRACKET WITH"
+{ UIdent .+ [ with
+;;
+#0 "implementation: LBRACE UIDENT DOTOP LPAREN UIDENT RBRACKET"
+{ UIdent .+ ( UIdent ]
+;;
+#0 "implementation: LBRACE UIDENT DOTOP LPAREN WITH"
+{ UIdent .+ ( with
+;;
+#0 "implementation: LBRACE UIDENT DOTOP WITH"
+{ UIdent .+ with
+;;
+#0 "implementation: LBRACE UIDENT WHILE"
+{ UIdent while
+;;
+#0 "implementation: LBRACE UIDENT WITH LIDENT WITH"
+{ UIdent with lident with
+;;
+#0 "implementation: LBRACE UIDENT WITH WITH"
+{ UIdent with with
+;;
+#0 "implementation: LBRACE WITH"
+{ with
+;;
+#0 "implementation: LBRACELESS LIDENT EQUAL UIDENT RBRACE"
+{< lident = UIdent }
+;;
+#0 "implementation: LBRACELESS LIDENT EQUAL UIDENT WITH"
+{< lident = UIdent with
+;;
+#0 "implementation: LBRACELESS LIDENT EQUAL WITH"
+{< lident = with
+;;
+#0 "implementation: LBRACELESS LIDENT SEMI WITH"
+{< lident ; with
+;;
+#0 "implementation: LBRACELESS LIDENT WITH"
+{< lident with
+;;
+#0 "implementation: LBRACELESS WITH"
+{< with
+;;
+#0 "implementation: LBRACKET UIDENT RPAREN"
+[ UIdent )
+;;
+#0 "implementation: LBRACKET WITH"
+[ with
+;;
+#0 "implementation: LBRACKETATATAT UNDERSCORE"
+[@@@ _
+;;
+#0 "implementation: LBRACKETATATAT WITH UIDENT WHEN"
+[@@@ with UIdent  when
+;;
+#0 "implementation: LBRACKETATATAT WITH VIRTUAL"
+[@@@ with virtual
+;;
+#0 "implementation: LBRACKETBAR UIDENT RPAREN"
+[| UIdent )
+;;
+#0 "implementation: LBRACKETBAR UIDENT SEMI WITH"
+[| UIdent ; with
+;;
+#0 "implementation: LBRACKETBAR UIDENT WITH"
+[| UIdent with
+;;
+#0 "implementation: LBRACKETBAR WITH"
+[| with
+;;
+#0 "implementation: LBRACKETPERCENT UNDERSCORE"
+[% _
+;;
+#0 "implementation: LBRACKETPERCENT WITH UIDENT WHEN"
+[% with UIdent  when
+;;
+#0 "implementation: LBRACKETPERCENT WITH VIRTUAL"
+[% with virtual
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT UNDERSCORE"
+[%% _
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LBRACKET UNDERSCORE RBRACKET WITH"
+[%% with : class [ _ ] with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LBRACKETAT AND RBRACKET WHILE"
+[%% with : class [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LBRACKET UNDERSCORE RBRACKET WITH"
+[%% with : class lident : {%hello|world|} and [ _ ] with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET WHILE"
+[%% with : class lident : {%hello|world|} and [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT COLON QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+[%% with : class lident : {%hello|world|} and lident : {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT COLON QUOTED_STRING_EXPR RPAREN"
+[%% with : class lident : {%hello|world|} and lident : {%hello|world|} )
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT COLON WITH"
+[%% with : class lident : {%hello|world|} and lident : with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND LIDENT WITH"
+[%% with : class lident : {%hello|world|} and lident with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND VIRTUAL LBRACELESS"
+[%% with : class lident : {%hello|world|} and virtual {<
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR AND WITH"
+[%% with : class lident : {%hello|world|} and with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+[%% with : class lident : {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON QUOTED_STRING_EXPR RPAREN"
+[%% with : class lident : {%hello|world|} )
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT COLON WITH"
+[%% with : class lident : with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS LIDENT WITH"
+[%% with : class lident with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS PERCENT AND LBRACELESS"
+[%% with : class % and {<
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS VIRTUAL LBRACELESS"
+[%% with : class virtual {<
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON CLASS WITH"
+[%% with : class with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION LBRACKETAT AND RBRACKET WHILE"
+[%% with : exception [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION PERCENT AND EXTERNAL"
+[%% with : exception % and external
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION UIDENT WITH"
+[%% with : exception UIdent with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON EXCEPTION WITH"
+[%% with : exception with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE LBRACKETAT AND RBRACKET WHILE"
+[%% with : include [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE PERCENT AND FUNCTION"
+[%% with : include % and function
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE UIDENT RPAREN"
+[%% with : include UIdent )
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON INCLUDE WITH"
+[%% with : include with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE LBRACKETAT AND RBRACKET WHILE"
+[%% with : module [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE PERCENT AND LBRACKET"
+[%% with : module % and [
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND LBRACKETAT AND RBRACKET WHILE"
+[%% with : module rec _ : UIdent and [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE COLON UIDENT LBRACKETATAT AND RBRACKET METHOD"
+[%% with : module rec _ : UIdent and _ : UIdent [@@ and ] method
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE COLON UIDENT RPAREN"
+[%% with : module rec _ : UIdent and _ : UIdent )
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE COLON WITH"
+[%% with : module rec _ : UIdent and _ : with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND UNDERSCORE WITH"
+[%% with : module rec _ : UIdent and _ with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT AND WITH"
+[%% with : module rec _ : UIdent and with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT LBRACKETATAT AND RBRACKET METHOD"
+[%% with : module rec _ : UIdent [@@ and ] method
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON UIDENT RPAREN"
+[%% with : module rec _ : UIdent )
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE COLON WITH"
+[%% with : module rec _ : with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC UNDERSCORE WITH"
+[%% with : module rec _ with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE REC WITH"
+[%% with : module rec with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE TYPE UIDENT LET"
+[%% with : module type UIdent let
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UIDENT COLONEQUAL UIDENT WITH"
+[%% with : module UIdent := UIdent with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UIDENT COLONEQUAL WITH"
+[%% with : module UIdent := with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UIDENT WITH"
+[%% with : module UIdent with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE COLON UIDENT RPAREN"
+[%% with : module _ : UIdent )
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE COLON WITH"
+[%% with : module _ : with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE EQUAL UIDENT WITH"
+[%% with : module _ = UIdent with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE EQUAL WITH"
+[%% with : module _ = with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE LPAREN RPAREN WITH"
+[%% with : module _ ( ) with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE UNDERSCORE WITH"
+[%% with : module _ with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON MODULE WITH"
+[%% with : module with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG LBRACKETAT AND RBRACKET WHILE"
+[%% with : open ! [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG PERCENT AND LBRACKET"
+[%% with : open ! % and [
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG UIDENT WITH"
+[%% with : open ! UIdent with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN BANG WITH"
+[%% with : open ! with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN LBRACKETAT AND RBRACKET WHILE"
+[%% with : open [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN PERCENT AND LBRACKET"
+[%% with : open % and [
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN UIDENT WITH"
+[%% with : open UIdent with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON OPEN WITH"
+[%% with : open with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON QUOTED_STRING_ITEM WITH"
+[%% with : {%%hello|world|} with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON SEMISEMI WITH"
+[%% with : ;; with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LBRACKETAT AND RBRACKET WHILE"
+[%% with : type [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LBRACKETAT AND RBRACKET WHILE"
+[%% with : type lident := | and [@ and ] while
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT COLONEQUAL UNDERSCORE LBRACKETATAT AND RBRACKET METHOD"
+[%% with : type lident := | and lident := _ [@@ and ] method
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT COLONEQUAL UNDERSCORE LET"
+[%% with : type lident := | and lident := _ let
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT COLONEQUAL WITH"
+[%% with : type lident := | and lident := with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND LIDENT WITH"
+[%% with : type lident := | and lident with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND UNDERSCORE LETOP"
+[%% with : type lident := | and _ let*
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR AND WITH"
+[%% with : type lident := | and with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL BAR LBRACKETATAT AND RBRACKET METHOD"
+[%% with : type lident := | [@@ and ] method
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL UNDERSCORE LET"
+[%% with : type lident := _ let
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT COLONEQUAL WITH"
+[%% with : type lident := with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT PLUSEQ PRIVATE BANG"
+[%% with : type lident += private !
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT PLUSEQ UIDENT LET"
+[%% with : type lident += UIdent let
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT PLUSEQ WITH"
+[%% with : type lident += with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE LIDENT WITH"
+[%% with : type lident with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE NONREC LIDENT LET"
+[%% with : type nonrec lident let
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE PERCENT AND BACKQUOTE"
+[%% with : type % and `
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE UIDENT DOT LIDENT WITH"
+[%% with : type UIdent . lident with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE UNDERSCORE LETOP"
+[%% with : type _ let*
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON TYPE WITH"
+[%% with : type with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON UNDERSCORE WITH"
+[%% with : _ with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH COLON WITH"
+[%% with : with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH DOT UNDERSCORE"
+[%% with . _
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WHEN WITH"
+[%% with ? _ when with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH QUESTION UNDERSCORE WITH"
+[%% with ? _ with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH QUESTION WITH"
+[%% with ? with
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH UIDENT WHEN"
+[%% with UIdent  when
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH VIRTUAL"
+[%% with virtual
+;;
+#0 "implementation: LBRACKETPERCENTPERCENT WITH WITH"
+[%% with with
+;;
+#0 "implementation: LET CHAR EQUAL CHAR AND LBRACKETAT AND RBRACKET WHILE"
+let 'a' = 'a' and [@ and ] while
+;;
+#0 "implementation: LET CHAR EQUAL CHAR AND UNDERSCORE EQUAL CHAR WITH"
+let 'a' = 'a' and _ = 'a' with
+;;
+#0 "implementation: LET CHAR EQUAL CHAR AND WITH"
+let 'a' = 'a' and with
+;;
+#0 "implementation: LET CHAR EQUAL CHAR IN WITH"
+let 'a' = 'a' in with
+;;
+#0 "implementation: LET CHAR EQUAL CHAR LBRACKETATAT AND RBRACKET METHOD"
+let 'a' = 'a' [@@ and ] method
+;;
+#0 "implementation: LET EXCEPTION LBRACKETAT AND RBRACKET EXTERNAL"
+let exception [@ and ] external
+;;
+#0 "implementation: LET EXCEPTION PERCENT AND EXTERNAL"
+let exception % and external
+;;
+#0 "implementation: LET EXCEPTION UIDENT IN WITH"
+let exception UIdent in with
+;;
+#0 "implementation: LET EXCEPTION UIDENT LBRACKETAT AND RBRACKET WHILE"
+let exception UIdent [@ and ] while
+;;
+#0 "implementation: LET EXCEPTION UIDENT OF UNDERSCORE EXTERNAL"
+let exception UIdent of _ external
+;;
+#0 "implementation: LET EXCEPTION UIDENT WITH"
+let exception UIdent with
+;;
+#0 "implementation: LET EXCEPTION WITH"
+let exception with
+;;
+#0 "implementation: LET LBRACKETAT AND RBRACKET ASSERT"
+let [@ and ] assert
+;;
+#0 "implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE EQUAL WITH"
+let lident : ' lident . _ = with
+;;
+#0 "implementation: LET LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH"
+let lident : ' lident . _ with
+;;
+#0 "implementation: LET LIDENT COLON QUOTE LIDENT DOT WITH"
+let lident : ' lident . with
+;;
+#0 "implementation: LET LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH"
+let lident : ' lident ' lident with
+;;
+#0 "implementation: LET LIDENT COLON QUOTE LIDENT QUOTE WITH"
+let lident : ' lident ' with
+;;
+#0 "implementation: LET LIDENT COLON QUOTE UIDENT WITH"
+let lident : ' UIdent with
+;;
+#0 "implementation: LET LIDENT COLON QUOTE WITH"
+let lident : ' with
+;;
+#0 "implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH"
+let lident : type lident . _ = with
+;;
+#0 "implementation: LET LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH"
+let lident : type lident . _ with
+;;
+#0 "implementation: LET LIDENT COLON TYPE LIDENT DOT WITH"
+let lident : type lident . with
+;;
+#0 "implementation: LET LIDENT COLON TYPE LIDENT RPAREN"
+let lident : type lident )
+;;
+#0 "implementation: LET LIDENT COLON TYPE WITH"
+let lident : type with
+;;
+#0 "implementation: LET LIDENT COLON WITH"
+let lident : with
+;;
+#0 "implementation: LET LIDENT COLONGREATER UNDERSCORE EQUAL WITH"
+let lident :> _ = with
+;;
+#0 "implementation: LET LIDENT COLONGREATER UNDERSCORE SEMI"
+let lident :> _ ;
+;;
+#0 "implementation: LET LIDENT WITH"
+let lident with
+;;
+#0 "implementation: LET MODULE LBRACKETAT AND RBRACKET WHILE"
+let module [@ and ] while
+;;
+#0 "implementation: LET MODULE PERCENT AND LBRACKET"
+let module % and [
+;;
+#0 "implementation: LET MODULE UNDERSCORE EQUAL UIDENT IN WITH"
+let module _ = UIdent in with
+;;
+#0 "implementation: LET MODULE UNDERSCORE EQUAL UIDENT VAL"
+let module _ = UIdent val
+;;
+#0 "implementation: LET MODULE UNDERSCORE WITH"
+let module _ with
+;;
+#0 "implementation: LET MODULE WITH"
+let module with
+;;
+#0 "implementation: LET OPEN BANG LBRACKETAT AND RBRACKET WHILE"
+let open ! [@ and ] while
+;;
+#0 "implementation: LET OPEN BANG PERCENT AND WHILE"
+let open ! % and while
+;;
+#0 "implementation: LET OPEN BANG UIDENT IN WITH"
+let open ! UIdent in with
+;;
+#0 "implementation: LET OPEN BANG UIDENT WITH"
+let open ! UIdent with
+;;
+#0 "implementation: LET OPEN BANG WITH"
+let open ! with
+;;
+#0 "implementation: LET OPEN LBRACKETAT AND RBRACKET FUNCTION"
+let open [@ and ] function
+;;
+#0 "implementation: LET OPEN PERCENT AND FUNCTION"
+let open % and function
+;;
+#0 "implementation: LET OPEN UIDENT IN WITH"
+let open UIdent in with
+;;
+#0 "implementation: LET OPEN UIDENT WITH"
+let open UIdent with
+;;
+#0 "implementation: LET OPEN WITH"
+let open with
+;;
+#0 "implementation: LET PERCENT AND ASSERT"
+let % and assert
+;;
+#0 "implementation: LET REC ASSERT"
+let rec assert
+;;
+#0 "implementation: LET UIDENT UNDERSCORE WITH"
+let UIdent _ with
+;;
+#0 "implementation: LET UNDERSCORE COLON UNDERSCORE EQUAL WITH"
+let _ : _ = with
+;;
+#0 "implementation: LET UNDERSCORE COLON UNDERSCORE WITH"
+let _ : _ with
+;;
+#0 "implementation: LET UNDERSCORE COLON WITH"
+let _ : with
+;;
+#0 "implementation: LET UNDERSCORE EQUAL CHAR WITH"
+let _ = 'a' with
+;;
+#0 "implementation: LET UNDERSCORE EQUAL WITH"
+let _ = with
+;;
+#0 "implementation: LET UNDERSCORE WITH"
+let _ with
+;;
+#0 "implementation: LET WITH"
+let with
+;;
+#0 "implementation: LETOP BACKQUOTE UIDENT WITH"
+let* ` UIdent with
+;;
+#0 "implementation: LETOP HASH WITH"
+let* # with
+;;
+#0 "implementation: LETOP LAZY LBRACKETAT AND RBRACKET ASSERT"
+let* lazy [@ and ] assert
+;;
+#0 "implementation: LETOP LAZY PERCENT AND WHILE"
+let* lazy % and while
+;;
+#0 "implementation: LETOP LAZY WITH"
+let* lazy with
+;;
+#0 "implementation: LETOP LBRACE LIDENT COLON UNDERSCORE WITH"
+let* { lident : _ with
+;;
+#0 "implementation: LETOP LBRACE LIDENT COLON WITH"
+let* { lident : with
+;;
+#0 "implementation: LETOP LBRACE LIDENT EQUAL UNDERSCORE WITH"
+let* { lident = _ with
+;;
+#0 "implementation: LETOP LBRACE LIDENT EQUAL WITH"
+let* { lident = with
+;;
+#0 "implementation: LETOP LBRACE LIDENT SEMI UNDERSCORE SEMI WITH"
+let* { lident ; _ ; with
+;;
+#0 "implementation: LETOP LBRACE LIDENT SEMI UNDERSCORE WITH"
+let* { lident ; _ with
+;;
+#0 "implementation: LETOP LBRACE LIDENT SEMI WITH"
+let* { lident ; with
+;;
+#0 "implementation: LETOP LBRACE LIDENT WITH"
+let* { lident with
+;;
+#0 "implementation: LETOP LBRACE WITH"
+let* { with
+;;
+#0 "implementation: LETOP LBRACKET UNDERSCORE BARRBRACKET"
+let* [ _ |]
+;;
+#0 "implementation: LETOP LBRACKET WITH"
+let* [ with
+;;
+#0 "implementation: LETOP LBRACKETBAR UNDERSCORE RBRACKET"
+let* [| _ ]
+;;
+#0 "implementation: LETOP LBRACKETBAR UNDERSCORE SEMI WITH"
+let* [| _ ; with
+;;
+#0 "implementation: LETOP LBRACKETBAR UNDERSCORE WITH"
+let* [| _ with
+;;
+#0 "implementation: LETOP LBRACKETBAR WITH"
+let* [| with
+;;
+#0 "implementation: LETOP LIDENT ANDOP WITH"
+let* lident and* with
+;;
+#0 "implementation: LETOP LIDENT EQUAL WITH"
+let* lident = with
+;;
+#0 "implementation: LETOP LIDENT IN WITH"
+let* lident in with
+;;
+#0 "implementation: LETOP LIDENT LPAREN TYPE LIDENT DOT"
+let* lident ( type lident .
+;;
+#0 "implementation: LETOP LIDENT LPAREN TYPE LIDENT RPAREN WITH"
+let* lident ( type lident ) with
+;;
+#0 "implementation: LETOP LIDENT LPAREN TYPE WITH"
+let* lident ( type with
+;;
+#0 "implementation: LETOP LIDENT LPAREN WITH"
+let* lident ( with
+;;
+#0 "implementation: LETOP LIDENT UNDERSCORE COLONGREATER LIDENT EQUAL WITH"
+let* lident _ :> lident = with
+;;
+#0 "implementation: LETOP LIDENT UNDERSCORE COLONGREATER LIDENT SEMI"
+let* lident _ :> lident ;
+;;
+#0 "implementation: LETOP LIDENT UNDERSCORE WITH"
+let* lident _ with
+;;
+#0 "implementation: LETOP LIDENT WITH"
+let* lident with
+;;
+#0 "implementation: LETOP LPAREN MINUS WITH"
+let* ( - with
+;;
+#0 "implementation: LETOP LPAREN MODULE LBRACKETAT AND RBRACKET WHILE"
+let* ( module [@ and ] while
+;;
+#0 "implementation: LETOP LPAREN MODULE PERCENT AND WHILE"
+let* ( module % and while
+;;
+#0 "implementation: LETOP LPAREN MODULE UNDERSCORE COLON UIDENT VAL"
+let* ( module _ : UIdent val
+;;
+#0 "implementation: LETOP LPAREN MODULE UNDERSCORE COLON WITH"
+let* ( module _ : with
+;;
+#0 "implementation: LETOP LPAREN MODULE UNDERSCORE WITH"
+let* ( module _ with
+;;
+#0 "implementation: LETOP LPAREN MODULE WITH"
+let* ( module with
+;;
+#0 "implementation: LETOP LPAREN PLUS WITH"
+let* ( + with
+;;
+#0 "implementation: LETOP LPAREN UNDERSCORE COLON UNDERSCORE WITH"
+let* ( _ : _ with
+;;
+#0 "implementation: LETOP LPAREN UNDERSCORE COLON WITH"
+let* ( _ : with
+;;
+#0 "implementation: LETOP LPAREN UNDERSCORE WITH"
+let* ( _ with
+;;
+#0 "implementation: LETOP LPAREN WITH"
+let* ( with
+;;
+#0 "implementation: LETOP MINUS WITH"
+let* - with
+;;
+#0 "implementation: LETOP PLUS WITH"
+let* + with
+;;
+#0 "implementation: LETOP STRING DOTDOT WITH"
+let* "hello" .. with
+;;
+#0 "implementation: LETOP STRING WITH"
+let* "hello" with
+;;
+#0 "implementation: LETOP UIDENT DOT LBRACKET WITH"
+let* UIdent . [ with
+;;
+#0 "implementation: LETOP UIDENT DOT LPAREN UNDERSCORE WITH"
+let* UIdent . ( _ with
+;;
+#0 "implementation: LETOP UIDENT DOT LPAREN WITH"
+let* UIdent . ( with
+;;
+#0 "implementation: LETOP UIDENT DOT WITH"
+let* UIdent . with
+;;
+#0 "implementation: LETOP UIDENT LIDENT WITH"
+let* UIdent lident with
+;;
+#0 "implementation: LETOP UIDENT TILDE"
+let* UIdent ~
+;;
+#0 "implementation: LETOP UIDENT WITH"
+let* UIdent with
+;;
+#0 "implementation: LETOP UNDERSCORE AS WITH"
+let* _ as with
+;;
+#0 "implementation: LETOP UNDERSCORE BAR UNDERSCORE WITH"
+let* _ | _ with
+;;
+#0 "implementation: LETOP UNDERSCORE BAR WITH"
+let* _ | with
+;;
+#0 "implementation: LETOP UNDERSCORE COLON UNDERSCORE EQUAL WITH"
+let* _ : _ = with
+;;
+#0 "implementation: LETOP UNDERSCORE COLON UNDERSCORE WITH"
+let* _ : _ with
+;;
+#0 "implementation: LETOP UNDERSCORE COLON WITH"
+let* _ : with
+;;
+#0 "implementation: LETOP UNDERSCORE COLONCOLON UNDERSCORE WITH"
+let* _ :: _ with
+;;
+#0 "implementation: LETOP UNDERSCORE COLONCOLON WITH"
+let* _ :: with
+;;
+#0 "implementation: LETOP UNDERSCORE COMMA CHAR COMMA UNDERSCORE WITH"
+let* _ , 'a' , _ with
+;;
+#0 "implementation: LETOP UNDERSCORE COMMA CHAR COMMA WITH"
+let* _ , 'a' , with
+;;
+#0 "implementation: LETOP UNDERSCORE COMMA UNDERSCORE WITH"
+let* _ , _ with
+;;
+#0 "implementation: LETOP UNDERSCORE COMMA WITH"
+let* _ , with
+;;
+#0 "implementation: LETOP UNDERSCORE EQUAL CHAR WITH"
+let* _ = 'a' with
+;;
+#0 "implementation: LETOP UNDERSCORE EQUAL WITH"
+let* _ = with
+;;
+#0 "implementation: LETOP UNDERSCORE WITH"
+let* _ with
+;;
+#0 "implementation: LETOP WITH"
+let* with
+;;
+#0 "implementation: LIDENT LESSMINUS OBJECT END WHILE"
+lident <- object end while
+;;
+#0 "implementation: LIDENT LESSMINUS WITH"
+lident <- with
+;;
+#0 "implementation: LIDENT WHILE"
+lident while
+;;
+#0 "implementation: LPAREN BANG WITH"
+( ! with
+;;
+#0 "implementation: LPAREN COLONCOLON WITH"
+( :: with
+;;
+#0 "implementation: LPAREN DOTOP LBRACE RBRACE WITH"
+( .+ { } with
+;;
+#0 "implementation: LPAREN DOTOP LBRACE SEMI DOTDOT WITH"
+( .+ { ; .. with
+;;
+#0 "implementation: LPAREN DOTOP LBRACE WITH"
+( .+ { with
+;;
+#0 "implementation: LPAREN DOTOP LBRACKET RBRACKET WITH"
+( .+ [ ] with
+;;
+#0 "implementation: LPAREN DOTOP LBRACKET SEMI DOTDOT WITH"
+( .+ [ ; .. with
+;;
+#0 "implementation: LPAREN DOTOP LBRACKET WITH"
+( .+ [ with
+;;
+#0 "implementation: LPAREN DOTOP LPAREN RPAREN WITH"
+( .+ ( ) with
+;;
+#0 "implementation: LPAREN DOTOP LPAREN SEMI DOTDOT WITH"
+( .+ ( ; .. with
+;;
+#0 "implementation: LPAREN DOTOP LPAREN SEMI WITH"
+( .+ ( ; with
+;;
+#0 "implementation: LPAREN DOTOP LPAREN WITH"
+( .+ ( with
+;;
+#0 "implementation: LPAREN DOTOP WITH"
+( .+ with
+;;
+#0 "implementation: LPAREN LETOP WITH"
+( let* with
+;;
+#0 "implementation: LPAREN MINUS WITH"
+( - with
+;;
+#0 "implementation: LPAREN MINUSDOT WITH"
+( -. with
+;;
+#0 "implementation: LPAREN MODULE LBRACKETAT AND RBRACKET FUNCTION"
+( module [@ and ] function
+;;
+#0 "implementation: LPAREN MODULE PERCENT AND WHILE"
+( module % and while
+;;
+#0 "implementation: LPAREN MODULE UIDENT COLON UIDENT VAL"
+( module UIdent : UIdent val
+;;
+#0 "implementation: LPAREN MODULE UIDENT COLON WITH"
+( module UIdent : with
+;;
+#0 "implementation: LPAREN MODULE UIDENT WITH"
+( module UIdent with
+;;
+#0 "implementation: LPAREN MODULE WITH"
+( module with
+;;
+#0 "implementation: LPAREN PLUS WITH"
+( + with
+;;
+#0 "implementation: LPAREN PLUSDOT WITH"
+( +. with
+;;
+#0 "implementation: LPAREN PREFIXOP WITH"
+( !+ with
+;;
+#0 "implementation: LPAREN STAR WITH"
+( * with
+;;
+#0 "implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER UNDERSCORE WITH"
+( UIdent : _ :> _ with
+;;
+#0 "implementation: LPAREN UIDENT COLON UNDERSCORE COLONGREATER WITH"
+( UIdent : _ :> with
+;;
+#0 "implementation: LPAREN UIDENT COLON UNDERSCORE WITH"
+( UIdent : _ with
+;;
+#0 "implementation: LPAREN UIDENT COLON WITH"
+( UIdent : with
+;;
+#0 "implementation: LPAREN UIDENT COLONGREATER LIDENT SEMI"
+( UIdent :> lident ;
+;;
+#0 "implementation: LPAREN UIDENT COLONGREATER UNDERSCORE WITH"
+( UIdent :> _ with
+;;
+#0 "implementation: LPAREN UIDENT COLONGREATER WITH"
+( UIdent :> with
+;;
+#0 "implementation: LPAREN UIDENT WITH"
+( UIdent with
+;;
+#0 "implementation: LPAREN WITH"
+( with
+;;
+#0 "implementation: MATCH LBRACKETAT AND RBRACKET AND"
+match [@ and ] and
+;;
+#0 "implementation: MATCH PERCENT AND VIRTUAL"
+match % and virtual
+;;
+#0 "implementation: MATCH UIDENT VAL"
+match UIdent val
+;;
+#0 "implementation: MATCH UIDENT WITH UNDERSCORE MINUSGREATER DOT WHILE"
+match UIdent with _ -> . while
+;;
+#0 "implementation: MATCH UIDENT WITH WITH"
+match UIdent with with
+;;
+#0 "implementation: MATCH WITH"
+match with
+;;
+#0 "implementation: MINUSDOT WITH"
+-. with
+;;
+#0 "implementation: MODULE LBRACKETAT AND RBRACKET WHILE"
+module [@ and ] while
+;;
+#0 "implementation: MODULE PERCENT AND LBRACKET"
+module % and [
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND LBRACKETAT AND RBRACKET WHILE"
+module rec _ = {%hello|world|} and [@ and ] while
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND UNDERSCORE EQUAL QUOTED_STRING_EXPR IN"
+module rec _ = {%hello|world|} and _ = {%hello|world|} in
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND UNDERSCORE EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+module rec _ = {%hello|world|} and _ = {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND UNDERSCORE WITH"
+module rec _ = {%hello|world|} and _ with
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR AND WITH"
+module rec _ = {%hello|world|} and with
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR IN"
+module rec _ = {%hello|world|} in
+;;
+#0 "implementation: MODULE REC UNDERSCORE EQUAL QUOTED_STRING_EXPR LBRACKETATAT AND RBRACKET METHOD"
+module rec _ = {%hello|world|} [@@ and ] method
+;;
+#0 "implementation: MODULE REC UNDERSCORE WITH"
+module rec _ with
+;;
+#0 "implementation: MODULE REC WITH"
+module rec with
+;;
+#0 "implementation: MODULE TYPE LBRACKETAT AND RBRACKET WHILE"
+module type [@ and ] while
+;;
+#0 "implementation: MODULE TYPE PERCENT AND WHILE"
+module type % and while
+;;
+#0 "implementation: MODULE TYPE UIDENT EQUAL UIDENT RPAREN"
+module type UIdent = UIdent )
+;;
+#0 "implementation: MODULE TYPE UIDENT EQUAL WITH"
+module type UIdent = with
+;;
+#0 "implementation: MODULE TYPE UIDENT WITH"
+module type UIdent with
+;;
+#0 "implementation: MODULE TYPE WITH"
+module type with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON FUNCTOR LBRACKETAT AND RBRACKET WHILE"
+module _ : functor [@ and ] while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON FUNCTOR LPAREN RPAREN MINUSGREATER QUOTED_STRING_EXPR WHILE"
+module _ : functor ( ) -> {%hello|world|} while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON FUNCTOR LPAREN RPAREN MINUSGREATER WITH"
+module _ : functor ( ) -> with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON FUNCTOR LPAREN RPAREN WITH"
+module _ : functor ( ) with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON FUNCTOR WITH"
+module _ : functor with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON LPAREN UIDENT VAL"
+module _ : ( UIdent val
+;;
+#0 "implementation: MODULE UNDERSCORE COLON LPAREN WITH"
+module _ : ( with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON MODULE TYPE OF LBRACKETAT AND RBRACKET FUNCTION"
+module _ : module type of [@ and ] function
+;;
+#0 "implementation: MODULE UNDERSCORE COLON MODULE TYPE OF UIDENT IN"
+module _ : module type of UIdent in
+;;
+#0 "implementation: MODULE UNDERSCORE COLON MODULE TYPE OF WITH"
+module _ : module type of with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON MODULE TYPE WITH"
+module _ : module type with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON MODULE WITH"
+module _ : module with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON SIG LBRACKETAT AND RBRACKET WHILE"
+module _ : sig [@ and ] while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON SIG SEMISEMI RBRACKET"
+module _ : sig ;; ]
+;;
+#0 "implementation: MODULE UNDERSCORE COLON SIG WITH"
+module _ : sig with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT DOT UIDENT WHILE"
+module _ : UIdent . UIdent while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT DOT WITH"
+module _ : UIdent . with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT EQUAL UIDENT WITH"
+module _ : UIdent = UIdent with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT EQUAL WITH"
+module _ : UIdent = with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT LPAREN UIDENT RPAREN WITH"
+module _ : UIdent ( UIdent ) with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT MINUSGREATER QUOTED_STRING_EXPR WHILE"
+module _ : UIdent -> {%hello|world|} while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT MINUSGREATER WITH"
+module _ : UIdent -> with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT VAL"
+module _ : UIdent val
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WHILE"
+module _ : UIdent while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT COLONEQUAL UIDENT WHILE"
+module _ : UIdent with module UIdent := UIdent while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT COLONEQUAL WITH"
+module _ : UIdent with module UIdent := with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT EQUAL UIDENT WHILE"
+module _ : UIdent with module UIdent = UIdent while
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT EQUAL WITH"
+module _ : UIdent with module UIdent = with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE UIDENT WITH"
+module _ : UIdent with module UIdent with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH MODULE WITH"
+module _ : UIdent with module with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT COLONEQUAL UNDERSCORE SEMI"
+module _ : UIdent with type lident := _ ;
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT COLONEQUAL WITH"
+module _ : UIdent with type lident := with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL PRIVATE WITH"
+module _ : UIdent with type lident = private with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE AND WITH"
+module _ : UIdent with type lident = _ and with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL UNDERSCORE SEMI"
+module _ : UIdent with type lident = _ ;
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT EQUAL WITH"
+module _ : UIdent with type lident = with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE LIDENT WITH"
+module _ : UIdent with type lident with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE UNDERSCORE LETOP"
+module _ : UIdent with type _ let*
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH TYPE WITH"
+module _ : UIdent with type with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON UIDENT WITH WITH"
+module _ : UIdent with with
+;;
+#0 "implementation: MODULE UNDERSCORE COLON WITH"
+module _ : with
+;;
+#0 "implementation: MODULE UNDERSCORE EQUAL QUOTED_STRING_EXPR IN"
+module _ = {%hello|world|} in
+;;
+#0 "implementation: MODULE UNDERSCORE EQUAL UIDENT WITH"
+module _ = UIdent with
+;;
+#0 "implementation: MODULE UNDERSCORE EQUAL WITH"
+module _ = with
+;;
+#0 "implementation: MODULE UNDERSCORE LPAREN RPAREN WITH"
+module _ ( ) with
+;;
+#0 "implementation: MODULE UNDERSCORE LPAREN UNDERSCORE COLON UIDENT VAL"
+module _ ( _ : UIdent val
+;;
+#0 "implementation: MODULE UNDERSCORE LPAREN UNDERSCORE COLON WITH"
+module _ ( _ : with
+;;
+#0 "implementation: MODULE UNDERSCORE LPAREN UNDERSCORE WITH"
+module _ ( _ with
+;;
+#0 "implementation: MODULE UNDERSCORE LPAREN WITH"
+module _ ( with
+;;
+#0 "implementation: MODULE UNDERSCORE WITH"
+module _ with
+;;
+#0 "implementation: MODULE WITH"
+module with
+;;
+#0 "implementation: NEW LBRACKETAT AND RBRACKET WHILE"
+new [@ and ] while
+;;
+#0 "implementation: NEW PERCENT AND LBRACKET"
+new % and [
+;;
+#0 "implementation: NEW UIDENT DOT WITH"
+new UIdent . with
+;;
+#0 "implementation: NEW UIDENT WITH"
+new UIdent with
+;;
+#0 "implementation: NEW WITH"
+new with
+;;
+#0 "implementation: OBJECT CONSTRAINT HASH WITH"
+object constraint # with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT GREATER"
+object constraint [ ` UIdent >
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF AMPERSAND WITH"
+object constraint [ ` UIdent of & with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND UNDERSCORE WITH"
+object constraint [ ` UIdent of _ & _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE AMPERSAND WITH"
+object constraint [ ` UIdent of _ & with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF UNDERSCORE WITH"
+object constraint [ ` UIdent of _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT OF WITH"
+object constraint [ ` UIdent of with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BACKQUOTE UIDENT WITH"
+object constraint [ ` UIdent with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BAR UNDERSCORE GREATER"
+object constraint [ | _ >
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET BAR WITH"
+object constraint [ | with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE BAR UNDERSCORE GREATER"
+object constraint [ _ | _ >
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE BAR WITH"
+object constraint [ _ | with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE RBRACKET"
+object constraint [ _ ]
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET UNDERSCORE WITH"
+object constraint [ _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKET WITH"
+object constraint [ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETAT AND RBRACKET GREATER"
+object constraint [@ and ] >
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETGREATER BAR ASSERT"
+object constraint [> | assert
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETGREATER UNDERSCORE GREATER"
+object constraint [> _ >
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETGREATER WITH"
+object constraint [> with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETLESS BACKQUOTE UIDENT LBRACKETAT AND RBRACKET WHILE"
+object constraint [< ` UIdent [@ and ] while
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETLESS BAR ASSERT"
+object constraint [< | assert
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE BAR WITH"
+object constraint [< _ | with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE GREATER BACKQUOTE LIDENT WITH"
+object constraint [< _ > ` lident with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETLESS UNDERSCORE GREATER WITH"
+object constraint [< _ > with
+;;
+#0 "implementation: OBJECT CONSTRAINT LBRACKETLESS WITH"
+object constraint [< with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS DOTDOT WITH"
+object constraint < .. with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT DOT UNDERSCORE WITH"
+object constraint < lident : ' UIdent . _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT DOT WITH"
+object constraint < lident : ' UIdent . with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON QUOTE UIDENT QUOTE LIDENT WITH"
+object constraint < lident : ' UIdent ' lident with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE LBRACKETAT AND RBRACKET FUNCTOR"
+object constraint < lident : _ [@ and ] functor
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE RBRACE"
+object constraint < lident : _ }
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE SEMI LBRACKETAT AND RBRACKET CONSTRAINT"
+object constraint < lident : _ ; [@ and ] constraint
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE SEMI WITH"
+object constraint < lident : _ ; with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON UNDERSCORE WITH"
+object constraint < lident : _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT COLON WITH"
+object constraint < lident : with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS LIDENT WITH"
+object constraint < lident with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS UNDERSCORE SEMI WITH"
+object constraint < _ ; with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS UNDERSCORE WITH"
+object constraint < _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LESS WITH"
+object constraint < with
+;;
+#0 "implementation: OBJECT CONSTRAINT LIDENT COLON UNDERSCORE MINUSGREATER WITH"
+object constraint lident : _ -> with
+;;
+#0 "implementation: OBJECT CONSTRAINT LIDENT COLON UNDERSCORE WITH"
+object constraint lident : _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LIDENT COLON WITH"
+object constraint lident : with
+;;
+#0 "implementation: OBJECT CONSTRAINT LIDENT WHILE"
+object constraint lident while
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN MODULE LBRACKETAT AND RBRACKET WHILE"
+object constraint ( module [@ and ] while
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN MODULE PERCENT AND FUNCTION"
+object constraint ( module % and function
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN MODULE UIDENT VAL"
+object constraint ( module UIdent val
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN MODULE WITH"
+object constraint ( module with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT COMMA UNDERSCORE WITH"
+object constraint ( _ , lident , _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT COMMA WITH"
+object constraint ( _ , lident , with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT RPAREN HASH WITH"
+object constraint ( _ , lident ) # with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA LIDENT RPAREN WITH"
+object constraint ( _ , lident ) with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA UNDERSCORE WITH"
+object constraint ( _ , _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE COMMA WITH"
+object constraint ( _ , with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN UNDERSCORE WITH"
+object constraint ( _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT LPAREN WITH"
+object constraint ( with
+;;
+#0 "implementation: OBJECT CONSTRAINT OPTLABEL UNDERSCORE MINUSGREATER WITH"
+object constraint ?label: _ -> with
+;;
+#0 "implementation: OBJECT CONSTRAINT OPTLABEL UNDERSCORE WITH"
+object constraint ?label: _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT OPTLABEL WITH"
+object constraint ?label: with
+;;
+#0 "implementation: OBJECT CONSTRAINT QUESTION LIDENT WITH"
+object constraint ? lident with
+;;
+#0 "implementation: OBJECT CONSTRAINT QUESTION WITH"
+object constraint ? with
+;;
+#0 "implementation: OBJECT CONSTRAINT QUOTE WITH"
+object constraint ' with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE AMPERSAND"
+object constraint _ &
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE AS QUOTE WITH"
+object constraint _ as ' with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE AS WITH"
+object constraint _ as with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE EQUAL UNDERSCORE WITH"
+object constraint _ = _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE EQUAL WITH"
+object constraint _ = with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE HASH WITH"
+object constraint _ # with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE MINUSGREATER WITH"
+object constraint _ -> with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE STAR LIDENT STAR UNDERSCORE WHILE"
+object constraint _ * lident * _ while
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE STAR LIDENT STAR WITH"
+object constraint _ * lident * with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE STAR UNDERSCORE WHILE"
+object constraint _ * _ while
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE STAR WITH"
+object constraint _ * with
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE WHILE"
+object constraint _ while
+;;
+#0 "implementation: OBJECT CONSTRAINT UNDERSCORE WITH"
+object constraint _ with
+;;
+#0 "implementation: OBJECT CONSTRAINT WITH"
+object constraint with
+;;
+#0 "implementation: OBJECT END WHILE"
+object end while
+;;
+#0 "implementation: OBJECT INHERIT BANG LBRACKETAT AND RBRACKET WHILE"
+object inherit ! [@ and ] while
+;;
+#0 "implementation: OBJECT INHERIT BANG QUOTED_STRING_EXPR AS LIDENT WITH"
+object inherit ! {%hello|world|} as lident with
+;;
+#0 "implementation: OBJECT INHERIT BANG QUOTED_STRING_EXPR WITH"
+object inherit ! {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT BANG WITH"
+object inherit ! with
+;;
+#0 "implementation: OBJECT INHERIT FUN LBRACKETAT AND RBRACKET WHILE"
+object inherit fun [@ and ] while
+;;
+#0 "implementation: OBJECT INHERIT FUN UNDERSCORE MINUSGREATER QUOTED_STRING_EXPR WITH"
+object inherit fun _ -> {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT FUN UNDERSCORE MINUSGREATER WITH"
+object inherit fun _ -> with
+;;
+#0 "implementation: OBJECT INHERIT FUN UNDERSCORE WITH"
+object inherit fun _ with
+;;
+#0 "implementation: OBJECT INHERIT FUN WITH"
+object inherit fun with
+;;
+#0 "implementation: OBJECT INHERIT LBRACKET UNDERSCORE COMMA UNDERSCORE WITH"
+object inherit [ _ , _ with
+;;
+#0 "implementation: OBJECT INHERIT LBRACKET UNDERSCORE COMMA WITH"
+object inherit [ _ , with
+;;
+#0 "implementation: OBJECT INHERIT LBRACKET UNDERSCORE RBRACKET WITH"
+object inherit [ _ ] with
+;;
+#0 "implementation: OBJECT INHERIT LBRACKET UNDERSCORE WITH"
+object inherit [ _ with
+;;
+#0 "implementation: OBJECT INHERIT LBRACKET WITH"
+object inherit [ with
+;;
+#0 "implementation: OBJECT INHERIT LBRACKETAT AND RBRACKET FOR"
+object inherit [@ and ] for
+;;
+#0 "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR IN QUOTED_STRING_EXPR WITH"
+object inherit let 'a' = 'a' in {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR IN WITH"
+object inherit let 'a' = 'a' in with
+;;
+#0 "implementation: OBJECT INHERIT LET CHAR EQUAL CHAR LBRACKETATAT AND RBRACKET VAL"
+object inherit let 'a' = 'a' [@@ and ] val
+;;
+#0 "implementation: OBJECT INHERIT LET LBRACKETAT AND RBRACKET WHILE"
+object inherit let [@ and ] while
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN BANG LBRACKETAT AND RBRACKET WHILE"
+object inherit let open ! [@ and ] while
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN BANG UIDENT IN QUOTED_STRING_EXPR WITH"
+object inherit let open ! UIdent in {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN BANG UIDENT IN WITH"
+object inherit let open ! UIdent in with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN BANG UIDENT WITH"
+object inherit let open ! UIdent with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN BANG WITH"
+object inherit let open ! with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN LBRACKETAT AND RBRACKET WHILE"
+object inherit let open [@ and ] while
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN UIDENT IN QUOTED_STRING_EXPR WITH"
+object inherit let open UIdent in {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN UIDENT IN WITH"
+object inherit let open UIdent in with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN UIDENT WITH"
+object inherit let open UIdent with
+;;
+#0 "implementation: OBJECT INHERIT LET OPEN WITH"
+object inherit let open with
+;;
+#0 "implementation: OBJECT INHERIT LET REC ASSERT"
+object inherit let rec assert
+;;
+#0 "implementation: OBJECT INHERIT LET UNDERSCORE EQUAL CHAR WITH"
+object inherit let _ = 'a' with
+;;
+#0 "implementation: OBJECT INHERIT LET WITH"
+object inherit let with
+;;
+#0 "implementation: OBJECT INHERIT LIDENT UIDENT WITH"
+object inherit lident UIdent with
+;;
+#0 "implementation: OBJECT INHERIT LIDENT WITH"
+object inherit lident with
+;;
+#0 "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR COLON QUOTED_STRING_EXPR VAL"
+object inherit ( {%hello|world|} : {%hello|world|} val
+;;
+#0 "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR COLON WITH"
+object inherit ( {%hello|world|} : with
+;;
+#0 "implementation: OBJECT INHERIT LPAREN QUOTED_STRING_EXPR WITH"
+object inherit ( {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT LPAREN WITH"
+object inherit ( with
+;;
+#0 "implementation: OBJECT INHERIT OBJECT LBRACKETAT AND RBRACKET WHILE"
+object inherit object [@ and ] while
+;;
+#0 "implementation: OBJECT INHERIT OBJECT LPAREN CHAR RPAREN WITH"
+object inherit object ( 'a' ) with
+;;
+#0 "implementation: OBJECT INHERIT OBJECT WITH"
+object inherit object with
+;;
+#0 "implementation: OBJECT INHERIT QUOTED_STRING_EXPR AS LIDENT WITH"
+object inherit {%hello|world|} as lident with
+;;
+#0 "implementation: OBJECT INHERIT QUOTED_STRING_EXPR AS WITH"
+object inherit {%hello|world|} as with
+;;
+#0 "implementation: OBJECT INHERIT QUOTED_STRING_EXPR WITH"
+object inherit {%hello|world|} with
+;;
+#0 "implementation: OBJECT INHERIT WITH"
+object inherit with
+;;
+#0 "implementation: OBJECT INITIALIZER LBRACKETAT AND RBRACKET AND"
+object initializer [@ and ] and
+;;
+#0 "implementation: OBJECT INITIALIZER UIDENT WITH"
+object initializer UIdent with
+;;
+#0 "implementation: OBJECT INITIALIZER WITH"
+object initializer with
+;;
+#0 "implementation: OBJECT LBRACKETAT AND RBRACKET CLASS"
+object [@ and ] class
+;;
+#0 "implementation: OBJECT LBRACKETATATAT AND RBRACKET WITH"
+object [@@@ and ] with
+;;
+#0 "implementation: OBJECT LPAREN UNDERSCORE COLON UNDERSCORE WITH"
+object ( _ : _ with
+;;
+#0 "implementation: OBJECT LPAREN UNDERSCORE COLON WITH"
+object ( _ : with
+;;
+#0 "implementation: OBJECT LPAREN UNDERSCORE RPAREN COMMENT"
+object ( _ ) (* comment *)
+;;
+#0 "implementation: OBJECT LPAREN UNDERSCORE WITH"
+object ( _ with
+;;
+#0 "implementation: OBJECT LPAREN WITH"
+object ( with
+;;
+#0 "implementation: OBJECT METHOD BANG LBRACKETAT AND RBRACKET WHILE"
+object method ! [@ and ] while
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH"
+object method ! lident : type lident . _ = with
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH"
+object method ! lident : type lident . _ with
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT DOT WITH"
+object method ! lident : type lident . with
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON TYPE LIDENT RPAREN"
+object method ! lident : type lident )
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON TYPE WITH"
+object method ! lident : type with
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON UNDERSCORE EQUAL WITH"
+object method ! lident : _ = with
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON UNDERSCORE VAL"
+object method ! lident : _ val
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT COLON WITH"
+object method ! lident : with
+;;
+#0 "implementation: OBJECT METHOD BANG LIDENT WITH"
+object method ! lident with
+;;
+#0 "implementation: OBJECT METHOD BANG PRIVATE LETOP"
+object method ! private let*
+;;
+#0 "implementation: OBJECT METHOD BANG WITH"
+object method ! with
+;;
+#0 "implementation: OBJECT METHOD LBRACKETAT AND RBRACKET WHILE"
+object method [@ and ] while
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT DOT UNDERSCORE WITH"
+object method lident : ' lident . _ with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT DOT WITH"
+object method lident : ' lident . with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON QUOTE LIDENT QUOTE LIDENT WITH"
+object method lident : ' lident ' lident with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE EQUAL WITH"
+object method lident : type lident . _ = with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT UNDERSCORE WITH"
+object method lident : type lident . _ with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT DOT WITH"
+object method lident : type lident . with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON TYPE LIDENT RPAREN"
+object method lident : type lident )
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON TYPE WITH"
+object method lident : type with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE EQUAL WITH"
+object method lident : _ = with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE VAL"
+object method lident : _ val
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON UNDERSCORE WITH"
+object method lident : _ with
+;;
+#0 "implementation: OBJECT METHOD LIDENT COLON WITH"
+object method lident : with
+;;
+#0 "implementation: OBJECT METHOD LIDENT EQUAL CHAR WITH"
+object method lident = 'a' with
+;;
+#0 "implementation: OBJECT METHOD LIDENT WITH"
+object method lident with
+;;
+#0 "implementation: OBJECT METHOD PRIVATE WITH"
+object method private with
+;;
+#0 "implementation: OBJECT METHOD VIRTUAL LIDENT COLON WITH"
+object method virtual lident : with
+;;
+#0 "implementation: OBJECT METHOD VIRTUAL LIDENT WITH"
+object method virtual lident with
+;;
+#0 "implementation: OBJECT METHOD VIRTUAL PRIVATE WITH"
+object method virtual private with
+;;
+#0 "implementation: OBJECT METHOD VIRTUAL WITH"
+object method virtual with
+;;
+#0 "implementation: OBJECT METHOD WITH"
+object method with
+;;
+#0 "implementation: OBJECT PERCENT AND COLON"
+object % and :
+;;
+#0 "implementation: OBJECT QUOTED_STRING_ITEM WITH"
+object {%%hello|world|} with
+;;
+#0 "implementation: OBJECT VAL BANG LBRACKETAT AND RBRACKET WHILE"
+object val ! [@ and ] while
+;;
+#0 "implementation: OBJECT VAL BANG LIDENT COLONGREATER LIDENT EQUAL WITH"
+object val ! lident :> lident = with
+;;
+#0 "implementation: OBJECT VAL BANG LIDENT COLONGREATER LIDENT SEMI"
+object val ! lident :> lident ;
+;;
+#0 "implementation: OBJECT VAL BANG LIDENT EQUAL WITH"
+object val ! lident = with
+;;
+#0 "implementation: OBJECT VAL BANG LIDENT WITH"
+object val ! lident with
+;;
+#0 "implementation: OBJECT VAL BANG MUTABLE LETOP"
+object val ! mutable let*
+;;
+#0 "implementation: OBJECT VAL BANG WITH"
+object val ! with
+;;
+#0 "implementation: OBJECT VAL LBRACKETAT AND RBRACKET WHILE"
+object val [@ and ] while
+;;
+#0 "implementation: OBJECT VAL LIDENT COLONGREATER LIDENT EQUAL WITH"
+object val lident :> lident = with
+;;
+#0 "implementation: OBJECT VAL LIDENT COLONGREATER LIDENT SEMI"
+object val lident :> lident ;
+;;
+#0 "implementation: OBJECT VAL LIDENT EQUAL CHAR WITH"
+object val lident = 'a' with
+;;
+#0 "implementation: OBJECT VAL LIDENT EQUAL WITH"
+object val lident = with
+;;
+#0 "implementation: OBJECT VAL LIDENT WITH"
+object val lident with
+;;
+#0 "implementation: OBJECT VAL MUTABLE WITH"
+object val mutable with
+;;
+#0 "implementation: OBJECT VAL VIRTUAL LIDENT COLON UNDERSCORE WITH"
+object val virtual lident : _ with
+;;
+#0 "implementation: OBJECT VAL VIRTUAL LIDENT COLON WITH"
+object val virtual lident : with
+;;
+#0 "implementation: OBJECT VAL VIRTUAL LIDENT WITH"
+object val virtual lident with
+;;
+#0 "implementation: OBJECT VAL VIRTUAL MUTABLE WITH"
+object val virtual mutable with
+;;
+#0 "implementation: OBJECT VAL VIRTUAL WITH"
+object val virtual with
+;;
+#0 "implementation: OBJECT VAL WITH"
+object val with
+;;
+#0 "implementation: OBJECT WITH"
+object with
+;;
+#0 "implementation: OPEN BANG LBRACKETAT AND RBRACKET FUNCTION"
+open ! [@ and ] function
+;;
+#0 "implementation: OPEN BANG PERCENT AND WHILE"
+open ! % and while
+;;
+#0 "implementation: OPEN BANG UIDENT WITH"
+open ! UIdent with
+;;
+#0 "implementation: OPEN BANG WITH"
+open ! with
+;;
+#0 "implementation: OPEN FUNCTOR LBRACKETAT AND RBRACKET WHILE"
+open functor [@ and ] while
+;;
+#0 "implementation: OPEN FUNCTOR LPAREN RPAREN MINUSGREATER QUOTED_STRING_EXPR WHILE"
+open functor ( ) -> {%hello|world|} while
+;;
+#0 "implementation: OPEN FUNCTOR LPAREN RPAREN MINUSGREATER WITH"
+open functor ( ) -> with
+;;
+#0 "implementation: OPEN FUNCTOR LPAREN RPAREN WITH"
+open functor ( ) with
+;;
+#0 "implementation: OPEN FUNCTOR WITH"
+open functor with
+;;
+#0 "implementation: OPEN LBRACKETAT AND RBRACKET FUNCTION"
+open [@ and ] function
+;;
+#0 "implementation: OPEN LBRACKETAT AND RBRACKET WITH"
+open [@ and ] with
+;;
+#0 "implementation: OPEN LPAREN UIDENT COLON UIDENT VAL"
+open ( UIdent : UIdent val
+;;
+#0 "implementation: OPEN LPAREN UIDENT COLON WITH"
+open ( UIdent : with
+;;
+#0 "implementation: OPEN LPAREN UIDENT WITH"
+open ( UIdent with
+;;
+#0 "implementation: OPEN LPAREN VAL LBRACKETAT AND RBRACKET VIRTUAL"
+open ( val [@ and ] virtual
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT COLONGREATER UIDENT VAL"
+open ( val UIdent : UIdent :> UIdent val
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT COLONGREATER WITH"
+open ( val UIdent : UIdent :> with
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT COLON UIDENT VAL"
+open ( val UIdent : UIdent val
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT COLON WITH"
+open ( val UIdent : with
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT COLONGREATER UIDENT VAL"
+open ( val UIdent :> UIdent val
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT COLONGREATER WITH"
+open ( val UIdent :> with
+;;
+#0 "implementation: OPEN LPAREN VAL UIDENT WITH"
+open ( val UIdent with
+;;
+#0 "implementation: OPEN LPAREN VAL WITH"
+open ( val with
+;;
+#0 "implementation: OPEN LPAREN WITH"
+open ( with
+;;
+#0 "implementation: OPEN PERCENT AND FUNCTION"
+open % and function
+;;
+#0 "implementation: OPEN PERCENT UNDERSCORE"
+open % _
+;;
+#0 "implementation: OPEN STRUCT LBRACKETAT AND RBRACKET AND"
+open struct [@ and ] and
+;;
+#0 "implementation: OPEN STRUCT UIDENT RBRACKET"
+open struct UIdent ]
+;;
+#0 "implementation: OPEN STRUCT WITH"
+open struct with
+;;
+#0 "implementation: OPEN UIDENT DOT WITH"
+open UIdent . with
+;;
+#0 "implementation: OPEN UIDENT LPAREN WITH"
+open UIdent ( with
+;;
+#0 "implementation: OPEN UIDENT WHILE"
+open UIdent while
+;;
+#0 "implementation: OPEN UIDENT WITH"
+open UIdent with
+;;
+#0 "implementation: OPEN WITH"
+open with
+;;
+#0 "implementation: PLUSDOT LET CHAR EQUAL CHAR VAL"
++. let 'a' = 'a' val
+;;
+#0 "implementation: PLUSDOT WITH"
++. with
+;;
+#0 "implementation: PREFIXOP WITH"
+!+ with
+;;
+#0 "implementation: QUOTED_STRING_ITEM HASH"
+{%%hello|world|} #
+;;
+#0 "implementation: QUOTED_STRING_ITEM LBRACKETATAT AND RBRACKET WITH"
+{%%hello|world|} [@@ and ] with
+;;
+#0 "implementation: QUOTED_STRING_ITEM LBRACKETATAT UNDERSCORE"
+{%%hello|world|} [@@ _
+;;
+#0 "implementation: QUOTED_STRING_ITEM LBRACKETATAT WITH UIDENT WHEN"
+{%%hello|world|} [@@ with UIdent  when
+;;
+#0 "implementation: QUOTED_STRING_ITEM LBRACKETATAT WITH VIRTUAL"
+{%%hello|world|} [@@ with virtual
+;;
+#0 "implementation: QUOTED_STRING_ITEM LET CHAR EQUAL CHAR IN"
+{%%hello|world|} let 'a' = 'a' in
+;;
+#0 "implementation: QUOTED_STRING_ITEM LET WITH"
+{%%hello|world|} let with
+;;
+#0 "implementation: QUOTED_STRING_ITEM WITH"
+{%%hello|world|} with
+;;
+#0 "implementation: STRING TRUE WHILE"
+"hello" true while
+;;
+#0 "implementation: STRING UIDENT AS"
+"hello" UIdent as
+;;
+#0 "implementation: STRING WHILE"
+"hello" while
+;;
+#0 "implementation: TRUE DOT LBRACE UIDENT RBRACE LESSMINUS OBJECT END WHILE"
+true . { UIdent } <- object end while
+;;
+#0 "implementation: TRUE DOT LBRACE UIDENT RBRACE LESSMINUS WITH"
+true . { UIdent } <- with
+;;
+#0 "implementation: TRUE DOT LBRACE UIDENT RBRACE WHILE"
+true . { UIdent } while
+;;
+#0 "implementation: TRUE DOT LBRACE UIDENT WITH"
+true . { UIdent with
+;;
+#0 "implementation: TRUE DOT LBRACE WITH"
+true . { with
+;;
+#0 "implementation: TRUE DOT LBRACKET UIDENT RBRACKET LESSMINUS OBJECT END WHILE"
+true . [ UIdent ] <- object end while
+;;
+#0 "implementation: TRUE DOT LBRACKET UIDENT RBRACKET LESSMINUS WITH"
+true . [ UIdent ] <- with
+;;
+#0 "implementation: TRUE DOT LBRACKET UIDENT RBRACKET WHILE"
+true . [ UIdent ] while
+;;
+#0 "implementation: TRUE DOT LBRACKET UIDENT WITH"
+true . [ UIdent with
+;;
+#0 "implementation: TRUE DOT LBRACKET WITH"
+true . [ with
+;;
+#0 "implementation: TRUE DOT LIDENT LESSMINUS OBJECT END WHILE"
+true . lident <- object end while
+;;
+#0 "implementation: TRUE DOT LIDENT LESSMINUS WITH"
+true . lident <- with
+;;
+#0 "implementation: TRUE DOT LIDENT WHILE"
+true . lident while
+;;
+#0 "implementation: TRUE DOT LPAREN UIDENT RPAREN LESSMINUS OBJECT END WHILE"
+true . ( UIdent ) <- object end while
+;;
+#0 "implementation: TRUE DOT LPAREN UIDENT RPAREN LESSMINUS WITH"
+true . ( UIdent ) <- with
+;;
+#0 "implementation: TRUE DOT LPAREN UIDENT RPAREN WHILE"
+true . ( UIdent ) while
+;;
+#0 "implementation: TRUE DOT LPAREN UIDENT WITH"
+true . ( UIdent with
+;;
+#0 "implementation: TRUE DOT LPAREN WITH"
+true . ( with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS OBJECT END WHILE"
+true . UIdent .+ { UIdent } <- object end while
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS WITH"
+true . UIdent .+ { UIdent } <- with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RBRACE WHILE"
+true . UIdent .+ { UIdent } while
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACE UIDENT RPAREN"
+true . UIdent .+ { UIdent )
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACE WITH"
+true . UIdent .+ { with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS OBJECT END WHILE"
+true . UIdent .+ [ UIdent ] <- object end while
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS WITH"
+true . UIdent .+ [ UIdent ] <- with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RBRACKET WHILE"
+true . UIdent .+ [ UIdent ] while
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACKET UIDENT RPAREN"
+true . UIdent .+ [ UIdent )
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LBRACKET WITH"
+true . UIdent .+ [ with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RBRACKET"
+true . UIdent .+ ( UIdent ]
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS OBJECT END WHILE"
+true . UIdent .+ ( UIdent ) <- object end while
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS WITH"
+true . UIdent .+ ( UIdent ) <- with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LPAREN UIDENT RPAREN WHILE"
+true . UIdent .+ ( UIdent ) while
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP LPAREN WITH"
+true . UIdent .+ ( with
+;;
+#0 "implementation: TRUE DOT UIDENT DOTOP WITH"
+true . UIdent .+ with
+;;
+#0 "implementation: TRUE DOT UIDENT WITH"
+true . UIdent with
+;;
+#0 "implementation: TRUE DOT WITH"
+true . with
+;;
+#0 "implementation: TRY LBRACKETAT AND RBRACKET AND"
+try [@ and ] and
+;;
+#0 "implementation: TRY PERCENT AND VIRTUAL"
+try % and virtual
+;;
+#0 "implementation: TRY UIDENT VAL"
+try UIdent val
+;;
+#0 "implementation: TRY UIDENT WITH UNDERSCORE MINUSGREATER DOT WHILE"
+try UIdent with _ -> . while
+;;
+#0 "implementation: TRY UIDENT WITH WITH"
+try UIdent with with
+;;
+#0 "implementation: TRY WITH"
+try with
+;;
+#0 "implementation: TYPE BANG WITH"
+type ! with
+;;
+#0 "implementation: TYPE LBRACKETAT AND RBRACKET BACKQUOTE"
+type [@ and ] `
+;;
+#0 "implementation: TYPE LIDENT AND LBRACKETAT AND RBRACKET WHILE"
+type lident and [@ and ] while
+;;
+#0 "implementation: TYPE LIDENT AND LIDENT EQUAL DOTDOT AMPERSAND"
+type lident and lident = .. &
+;;
+#0 "implementation: TYPE LIDENT AND LIDENT LBRACKETATAT AND RBRACKET METHOD"
+type lident and lident [@@ and ] method
+;;
+#0 "implementation: TYPE LIDENT AND LIDENT WITH"
+type lident and lident with
+;;
+#0 "implementation: TYPE LIDENT AND UNDERSCORE LETOP"
+type lident and _ let*
+;;
+#0 "implementation: TYPE LIDENT AND WITH"
+type lident and with
+;;
+#0 "implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL UNDERSCORE SEMI"
+type lident constraint _ = _ ;
+;;
+#0 "implementation: TYPE LIDENT CONSTRAINT UNDERSCORE EQUAL WITH"
+type lident constraint _ = with
+;;
+#0 "implementation: TYPE LIDENT CONSTRAINT UNDERSCORE WITH"
+type lident constraint _ with
+;;
+#0 "implementation: TYPE LIDENT CONSTRAINT WITH"
+type lident constraint with
+;;
+#0 "implementation: TYPE LIDENT EQUAL BAR UIDENT OF LIDENT IN"
+type lident = | UIdent of lident in
+;;
+#0 "implementation: TYPE LIDENT EQUAL BAR UIDENT WITH"
+type lident = | UIdent with
+;;
+#0 "implementation: TYPE LIDENT EQUAL BAR WITH"
+type lident = | with
+;;
+#0 "implementation: TYPE LIDENT EQUAL DOTDOT AMPERSAND"
+type lident = .. &
+;;
+#0 "implementation: TYPE LIDENT EQUAL LBRACE WITH"
+type lident = { with
+;;
+#0 "implementation: TYPE LIDENT EQUAL LBRACKET WITH"
+type lident = [ with
+;;
+#0 "implementation: TYPE LIDENT EQUAL LPAREN WITH"
+type lident = ( with
+;;
+#0 "implementation: TYPE LIDENT EQUAL PRIVATE LBRACE WITH"
+type lident = private { with
+;;
+#0 "implementation: TYPE LIDENT EQUAL PRIVATE UNDERSCORE WITH"
+type lident = private _ with
+;;
+#0 "implementation: TYPE LIDENT EQUAL PRIVATE WITH"
+type lident = private with
+;;
+#0 "implementation: TYPE LIDENT EQUAL TRUE WITH"
+type lident = true with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UIDENT BAR WITH"
+type lident = UIdent | with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UIDENT LBRACKETAT AND RBRACKET WHILE"
+type lident = UIdent [@ and ] while
+;;
+#0 "implementation: TYPE LIDENT EQUAL UIDENT OF LIDENT IN"
+type lident = UIdent of lident in
+;;
+#0 "implementation: TYPE LIDENT EQUAL UIDENT WITH"
+type lident = UIdent with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL LBRACE WITH"
+type lident = _ = { with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE LBRACE WITH"
+type lident = _ = private { with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL PRIVATE WITH"
+type lident = _ = private with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UNDERSCORE EQUAL WITH"
+type lident = _ = with
+;;
+#0 "implementation: TYPE LIDENT EQUAL UNDERSCORE WITH"
+type lident = _ with
+;;
+#0 "implementation: TYPE LIDENT EQUAL WITH"
+type lident = with
+;;
+#0 "implementation: TYPE LIDENT LBRACKETATAT WITH RBRACKET METHOD"
+type lident [@@ with ] method
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ BAR UIDENT EQUAL TRUE WITH"
+type lident += | UIdent = true with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ BAR UIDENT EQUAL WITH"
+type lident += | UIdent = with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ BAR UIDENT WITH"
+type lident += | UIdent with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ BAR WITH"
+type lident += | with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ PRIVATE BANG"
+type lident += private !
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ UIDENT EQUAL TRUE WITH"
+type lident += UIdent = true with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ UIDENT EQUAL WITH"
+type lident += UIdent = with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ UIDENT OF LIDENT CONSTRAINT"
+type lident += UIdent of lident constraint
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ UIDENT WITH"
+type lident += UIdent with
+;;
+#0 "implementation: TYPE LIDENT PLUSEQ WITH"
+type lident += with
+;;
+#0 "implementation: TYPE LIDENT WITH"
+type lident with
+;;
+#0 "implementation: TYPE LPAREN UNDERSCORE COMMA WITH"
+type ( _ , with
+;;
+#0 "implementation: TYPE LPAREN UNDERSCORE WITH"
+type ( _ with
+;;
+#0 "implementation: TYPE LPAREN WITH"
+type ( with
+;;
+#0 "implementation: TYPE MINUS WITH"
+type - with
+;;
+#0 "implementation: TYPE NONREC LIDENT EQUAL DOTDOT AMPERSAND"
+type nonrec lident = .. &
+;;
+#0 "implementation: TYPE NONREC LIDENT WITH"
+type nonrec lident with
+;;
+#0 "implementation: TYPE NONREC UNDERSCORE LETOP"
+type nonrec _ let*
+;;
+#0 "implementation: TYPE NONREC WITH"
+type nonrec with
+;;
+#0 "implementation: TYPE PERCENT AND WHILE"
+type % and while
+;;
+#0 "implementation: TYPE PLUS WITH"
+type + with
+;;
+#0 "implementation: TYPE PREFIXOP WITH"
+type !+ with
+;;
+#0 "implementation: TYPE QUOTE WITH"
+type ' with
+;;
+#0 "implementation: TYPE UIDENT DOT LIDENT WITH"
+type UIdent . lident with
+;;
+#0 "implementation: TYPE UIDENT DOT WITH"
+type UIdent . with
+;;
+#0 "implementation: TYPE UIDENT LPAREN UIDENT DOT WITH"
+type UIdent ( UIdent . with
+;;
+#0 "implementation: TYPE UIDENT LPAREN UIDENT WITH"
+type UIdent ( UIdent with
+;;
+#0 "implementation: TYPE UIDENT LPAREN WITH"
+type UIdent ( with
+;;
+#0 "implementation: TYPE UIDENT WITH"
+type UIdent with
+;;
+#0 "implementation: TYPE UNDERSCORE LETOP"
+type _ let*
+;;
+#0 "implementation: TYPE WITH"
+type with
+;;
+#0 "implementation: UIDENT AMPERAMPER OBJECT END WHILE"
+UIdent && object end while
+;;
+#0 "implementation: UIDENT AMPERAMPER WITH"
+UIdent && with
+;;
+#0 "implementation: UIDENT AMPERSAND OBJECT END WHILE"
+UIdent & object end while
+;;
+#0 "implementation: UIDENT AMPERSAND WITH"
+UIdent & with
+;;
+#0 "implementation: UIDENT AS"
+UIdent as
+;;
+#0 "implementation: UIDENT BARBAR OBJECT END WHILE"
+UIdent || object end while
+;;
+#0 "implementation: UIDENT BARBAR WITH"
+UIdent || with
+;;
+#0 "implementation: UIDENT COLONCOLON OBJECT END WHILE"
+UIdent :: object end while
+;;
+#0 "implementation: UIDENT COLONCOLON WITH"
+UIdent :: with
+;;
+#0 "implementation: UIDENT COLONEQUAL OBJECT END WHILE"
+UIdent := object end while
+;;
+#0 "implementation: UIDENT COLONEQUAL WITH"
+UIdent := with
+;;
+#0 "implementation: UIDENT COMMA CHAR COMMA OBJECT END WHILE"
+UIdent , 'a' , object end while
+;;
+#0 "implementation: UIDENT COMMA CHAR COMMA WITH"
+UIdent , 'a' , with
+;;
+#0 "implementation: UIDENT COMMA OBJECT END WHILE"
+UIdent , object end while
+;;
+#0 "implementation: UIDENT COMMA WITH"
+UIdent , with
+;;
+#0 "implementation: UIDENT DOT LBRACE WITH"
+UIdent . { with
+;;
+#0 "implementation: UIDENT DOT LBRACELESS WITH"
+UIdent . {< with
+;;
+#0 "implementation: UIDENT DOT LBRACKET UIDENT RPAREN"
+UIdent . [ UIdent )
+;;
+#0 "implementation: UIDENT DOT LBRACKET WITH"
+UIdent . [ with
+;;
+#0 "implementation: UIDENT DOT LBRACKETBAR UIDENT RPAREN"
+UIdent . [| UIdent )
+;;
+#0 "implementation: UIDENT DOT LBRACKETBAR WITH"
+UIdent . [| with
+;;
+#0 "implementation: UIDENT DOT LPAREN COLONCOLON WITH"
+UIdent . ( :: with
+;;
+#0 "implementation: UIDENT DOT LPAREN MODULE LBRACKETAT AND RBRACKET WHILE"
+UIdent . ( module [@ and ] while
+;;
+#0 "implementation: UIDENT DOT LPAREN MODULE PERCENT AND FUNCTION"
+UIdent . ( module % and function
+;;
+#0 "implementation: UIDENT DOT LPAREN MODULE UIDENT COLON UIDENT VAL"
+UIdent . ( module UIdent : UIdent val
+;;
+#0 "implementation: UIDENT DOT LPAREN MODULE UIDENT COLON WITH"
+UIdent . ( module UIdent : with
+;;
+#0 "implementation: UIDENT DOT LPAREN MODULE UIDENT WITH"
+UIdent . ( module UIdent with
+;;
+#0 "implementation: UIDENT DOT LPAREN MODULE WITH"
+UIdent . ( module with
+;;
+#0 "implementation: UIDENT DOT LPAREN UIDENT WITH"
+UIdent . ( UIdent with
+;;
+#0 "implementation: UIDENT DOT LPAREN WITH"
+UIdent . ( with
+;;
+#0 "implementation: UIDENT DOT WITH"
+UIdent . with
+;;
+#0 "implementation: UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS OBJECT END WHILE"
+UIdent .+ { UIdent } <- object end while
+;;
+#0 "implementation: UIDENT DOTOP LBRACE UIDENT RBRACE LESSMINUS WITH"
+UIdent .+ { UIdent } <- with
+;;
+#0 "implementation: UIDENT DOTOP LBRACE UIDENT RBRACE WHILE"
+UIdent .+ { UIdent } while
+;;
+#0 "implementation: UIDENT DOTOP LBRACE UIDENT SEMI RPAREN"
+UIdent .+ { UIdent ; )
+;;
+#0 "implementation: UIDENT DOTOP LBRACE UIDENT WITH"
+UIdent .+ { UIdent with
+;;
+#0 "implementation: UIDENT DOTOP LBRACE WITH"
+UIdent .+ { with
+;;
+#0 "implementation: UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS OBJECT END WHILE"
+UIdent .+ [ UIdent ] <- object end while
+;;
+#0 "implementation: UIDENT DOTOP LBRACKET UIDENT RBRACKET LESSMINUS WITH"
+UIdent .+ [ UIdent ] <- with
+;;
+#0 "implementation: UIDENT DOTOP LBRACKET UIDENT RBRACKET WHILE"
+UIdent .+ [ UIdent ] while
+;;
+#0 "implementation: UIDENT DOTOP LBRACKET UIDENT RPAREN"
+UIdent .+ [ UIdent )
+;;
+#0 "implementation: UIDENT DOTOP LBRACKET WITH"
+UIdent .+ [ with
+;;
+#0 "implementation: UIDENT DOTOP LPAREN UIDENT RBRACKET"
+UIdent .+ ( UIdent ]
+;;
+#0 "implementation: UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS OBJECT END WHILE"
+UIdent .+ ( UIdent ) <- object end while
+;;
+#0 "implementation: UIDENT DOTOP LPAREN UIDENT RPAREN LESSMINUS WITH"
+UIdent .+ ( UIdent ) <- with
+;;
+#0 "implementation: UIDENT DOTOP LPAREN UIDENT RPAREN WHILE"
+UIdent .+ ( UIdent ) while
+;;
+#0 "implementation: UIDENT DOTOP LPAREN WITH"
+UIdent .+ ( with
+;;
+#0 "implementation: UIDENT DOTOP WITH"
+UIdent .+ with
+;;
+#0 "implementation: UIDENT EQUAL OBJECT END WHILE"
+UIdent = object end while
+;;
+#0 "implementation: UIDENT EQUAL WITH"
+UIdent = with
+;;
+#0 "implementation: UIDENT GREATER OBJECT END WHILE"
+UIdent > object end while
+;;
+#0 "implementation: UIDENT GREATER WITH"
+UIdent > with
+;;
+#0 "implementation: UIDENT HASH WITH"
+UIdent # with
+;;
+#0 "implementation: UIDENT HASHOP TRUE WHILE"
+UIdent ## true while
+;;
+#0 "implementation: UIDENT HASHOP WITH"
+UIdent ## with
+;;
+#0 "implementation: UIDENT INFIXOP0 OBJECT END WHILE"
+UIdent != object end while
+;;
+#0 "implementation: UIDENT INFIXOP0 WITH"
+UIdent != with
+;;
+#0 "implementation: UIDENT INFIXOP1 OBJECT END WHILE"
+UIdent @ object end while
+;;
+#0 "implementation: UIDENT INFIXOP1 WITH"
+UIdent @ with
+;;
+#0 "implementation: UIDENT INFIXOP2 OBJECT END WHILE"
+UIdent +! object end while
+;;
+#0 "implementation: UIDENT INFIXOP2 WITH"
+UIdent +! with
+;;
+#0 "implementation: UIDENT INFIXOP3 OBJECT END WHILE"
+UIdent land object end while
+;;
+#0 "implementation: UIDENT INFIXOP3 WITH"
+UIdent land with
+;;
+#0 "implementation: UIDENT INFIXOP4 OBJECT END WHILE"
+UIdent ** object end while
+;;
+#0 "implementation: UIDENT INFIXOP4 WITH"
+UIdent ** with
+;;
+#0 "implementation: UIDENT LABEL TRUE WHILE"
+UIdent ~label: true while
+;;
+#0 "implementation: UIDENT LABEL WITH"
+UIdent ~label: with
+;;
+#0 "implementation: UIDENT LBRACKETAT UNDERSCORE"
+UIdent [@ _
+;;
+#0 "implementation: UIDENT LBRACKETAT WITH UIDENT WHEN"
+UIdent [@ with UIdent  when
+;;
+#0 "implementation: UIDENT LBRACKETAT WITH VIRTUAL"
+UIdent [@ with virtual
+;;
+#0 "implementation: UIDENT LBRACKETATAT AND RBRACKET AND"
+UIdent [@@ and ] and
+;;
+#0 "implementation: UIDENT LESS OBJECT END WHILE"
+UIdent < object end while
+;;
+#0 "implementation: UIDENT LESS WITH"
+UIdent < with
+;;
+#0 "implementation: UIDENT MINUS OBJECT END WHILE"
+UIdent - object end while
+;;
+#0 "implementation: UIDENT MINUS WITH"
+UIdent - with
+;;
+#0 "implementation: UIDENT MINUSDOT OBJECT END WHILE"
+UIdent -. object end while
+;;
+#0 "implementation: UIDENT MINUSDOT WITH"
+UIdent -. with
+;;
+#0 "implementation: UIDENT OPTLABEL TRUE WHILE"
+UIdent ?label: true while
+;;
+#0 "implementation: UIDENT OPTLABEL WITH"
+UIdent ?label: with
+;;
+#0 "implementation: UIDENT OR OBJECT END WHILE"
+UIdent or object end while
+;;
+#0 "implementation: UIDENT OR WITH"
+UIdent or with
+;;
+#0 "implementation: UIDENT PERCENT OBJECT END WHILE"
+UIdent % object end while
+;;
+#0 "implementation: UIDENT PERCENT WITH"
+UIdent % with
+;;
+#0 "implementation: UIDENT PLUS OBJECT END WHILE"
+UIdent + object end while
+;;
+#0 "implementation: UIDENT PLUS WITH"
+UIdent + with
+;;
+#0 "implementation: UIDENT PLUSDOT OBJECT END WHILE"
+UIdent +. object end while
+;;
+#0 "implementation: UIDENT PLUSDOT WITH"
+UIdent +. with
+;;
+#0 "implementation: UIDENT PLUSEQ OBJECT END WHILE"
+UIdent += object end while
+;;
+#0 "implementation: UIDENT PLUSEQ WITH"
+UIdent += with
+;;
+#0 "implementation: UIDENT QUESTION WITH"
+UIdent ? with
+;;
+#0 "implementation: UIDENT RBRACKET"
+UIdent ]
+;;
+#0 "implementation: UIDENT SEMI PERCENT UNDERSCORE"
+UIdent ; % _
+;;
+#0 "implementation: UIDENT SEMI PERCENT WITH VIRTUAL"
+UIdent ; % with virtual
+;;
+#0 "implementation: UIDENT SEMI WHEN"
+UIdent ; when
+;;
+#0 "implementation: UIDENT STAR OBJECT END WHILE"
+UIdent * object end while
+;;
+#0 "implementation: UIDENT STAR WITH"
+UIdent * with
+;;
+#0 "implementation: UIDENT TILDE WITH"
+UIdent ~ with
+;;
+#0 "implementation: UIDENT UIDENT UIDENT"
+UIdent UIdent UIdent
+;;
+#0 "implementation: UIDENT WHILE"
+UIdent while
+;;
+#0 "implementation: UIDENT WITH"
+UIdent with
+;;
+#0 "implementation: VAL LBRACKETAT AND RBRACKET WHILE"
+val [@ and ] while
+;;
+#0 "implementation: VAL LIDENT COLON UNDERSCORE WITH"
+val lident : _ with
+;;
+#0 "implementation: VAL LIDENT COLON WITH"
+val lident : with
+;;
+#0 "implementation: VAL LIDENT WITH"
+val lident with
+;;
+#0 "implementation: VAL PERCENT AND LBRACKET"
+val % and [
+;;
+#0 "implementation: VAL WITH"
+val with
+;;
+#0 "implementation: WHILE LBRACKETAT WITH RBRACKET AND"
+while [@ with ] and
+;;
+#0 "implementation: WHILE PERCENT WITH VIRTUAL"
+while % with virtual
+;;
+#0 "implementation: WHILE UIDENT DO UIDENT WITH"
+while UIdent do UIdent with
+;;
+#0 "implementation: WHILE UIDENT DO WITH"
+while UIdent do with
+;;
+#0 "implementation: WHILE UIDENT WITH"
+while UIdent with
+;;
+#0 "implementation: WHILE WITH"
+while with
+;;
+#0 "implementation: WITH"
+with
+;;


### PR DESCRIPTION
This pull request proposes the following changes:

* Update `parser.mly` so that every token carries an alias (an example of its concrete syntax).
* Pass the flag `--require-aliases` to Menhir so that Menhir enforces this property in the future.
* Update `Makefile.menhir` with new commands, `make list-errors` and `make generate-parse-errors`.
* Adopt the convention in `parser.mly` that the parts of the grammar comprised between `BEGIN AVOID` and `END AVOID` are ignored by `make generate-parse-errors`. This is required, e.g., to avoid exercising certain productions whose semantic actions cause an error.
* Use `make generate-parse-errors` to generate one new test file that contains 1086 sentences that cause a syntax error. Executing this new test is very fast. This gives us an overview of the syntax error messages that the parser can produce, and should help us avoid regressions if/when we change the error reporting mechanisms in the future.

This requires Menhir 20201214, which is in the proces of being released (waiting for opam).