### PR TITLE
Distinguished lambda constructors for ref variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,10 +96,12 @@ Working version
   changes in the parser.
   (François Pottier, review by Gabriel Scherer and Xavier Leroy.)
 
+- #10090: Distinguished constructors for ref variables at lambda level
+  (Keryan Didier, review by Gabriel Scherer and Vincent Laviron)
+
 - #10113: add a `-timeout` option to ocamltest and use it in the test suite.
   (Xavier Leroy and Gabriel Scherer, review by Sébastien Hinderer
    and David Allsopp)
-
 
 ### Build system:
 

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -524,7 +524,7 @@ module Storer =
 let rec comp_expr env exp sz cont =
   if sz > !max_stack_used then max_stack_used := sz;
   match exp with
-    Lvar id ->
+    Lvar id | Lmutvar id ->
       begin try
         let pos = Ident.find_same id env.ce_stack in
         Kacc(sz - pos) :: cont

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -591,7 +591,8 @@ let rec comp_expr env exp sz cont =
       Stack.push to_compile functions_to_compile;
       comp_args env (List.map (fun n -> Lvar n) fv) sz
         (Kclosure(lbl, List.length fv) :: cont)
-  | Llet(_str, _k, id, arg, body) ->
+  | Llet(_, _k, id, arg, body)
+  | Lmutlet(_k, id, arg, body) ->
       comp_expr env arg sz
         (Kpush :: comp_expr (add_var id (sz+1) env) body (sz+1)
           (add_pop 1 cont))

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -284,6 +284,7 @@ type scoped_location = Debuginfo.Scoped_location.t
 
 type lambda =
     Lvar of Ident.t
+  | Lmutvar of Ident.t
   | Lconst of structured_constant
   | Lapply of lambda_apply
   | Lfunction of lfunction
@@ -382,7 +383,8 @@ let make_key e =
     incr count ;
     if !count > max_raw then raise Not_simple ; (* Too big ! *)
     match e with
-    | Lvar id ->
+    | Lvar id
+    | Lmutvar id ->
       begin
         try Ident.find_same id env
         with Not_found -> e
@@ -479,12 +481,13 @@ let iter_opt f = function
 
 let shallow_iter ~tail ~non_tail:f = function
     Lvar _
+  | Lmutvar _
   | Lconst _ -> ()
   | Lapply{ap_func = fn; ap_args = args} ->
       f fn; List.iter f args
   | Lfunction{body} ->
       f body
-  | Llet(_str, _k, _id, arg, body) ->
+  | Llet(_, _k, _id, arg, body) ->
       f arg; tail body
   | Lletrec(decl, body) ->
       tail body;
@@ -533,7 +536,8 @@ let iter_head_constructor f l =
   shallow_iter ~tail:f ~non_tail:f l
 
 let rec free_variables = function
-  | Lvar id -> Ident.Set.singleton id
+  | Lvar id
+  | Lmutvar id -> Ident.Set.singleton id
   | Lconst _ -> Ident.Set.empty
   | Lapply{ap_func = fn; ap_args = args} ->
       free_variables_list (free_variables fn) args
@@ -715,6 +719,12 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
                 to [l]; it is a free variable of the input term. *)
              begin try Ident.Map.find id s with Not_found -> lam end
         end
+    | Lmutvar id as lam ->
+       begin match Ident.Map.find id l with
+          | id' -> Lmutvar id'
+          | exception Not_found ->
+             begin try Ident.Map.find id s with Not_found -> lam end
+        end
     | Lconst _ as l -> l
     | Lapply ap ->
         Lapply{ap with ap_func = subst s l ap.ap_func;
@@ -818,6 +828,7 @@ let duplicate lam =
 
 let shallow_map f = function
   | Lvar _
+  | Lmutvar _
   | Lconst _ as lam -> lam
   | Lapply { ap_func; ap_args; ap_loc; ap_tailcall;
              ap_inlined; ap_specialised } ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -259,7 +259,7 @@ type local_attribute =
 
 type function_kind = Curried | Tupled
 
-type let_kind = Strict | Alias | StrictOpt | Variable
+type let_kind = Strict | Alias | StrictOpt
 
 type meth_kind = Self | Public | Cached
 
@@ -289,6 +289,7 @@ type lambda =
   | Lapply of lambda_apply
   | Lfunction of lfunction
   | Llet of let_kind * value_kind * Ident.t * lambda * lambda
+  | Lmutlet of value_kind * Ident.t * lambda * lambda
   | Lletrec of (Ident.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
   | Lswitch of lambda * lambda_switch * scoped_location
@@ -407,6 +408,10 @@ let make_key e =
         let ex = tr_rec env ex in
         let y = make_key x in
         Llet (str,k,y,ex,tr_rec (Ident.add x (Lvar y) env) e)
+    | Lmutlet (k,x,ex,e) ->
+        let ex = tr_rec env ex in
+        let y = make_key x in
+        Lmutlet (k,y,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
     | Lprim (p,es,_) ->
         Lprim (p,tr_recs env es, Loc_unknown)
     | Lswitch (e,sw,loc) ->
@@ -487,7 +492,8 @@ let shallow_iter ~tail ~non_tail:f = function
       f fn; List.iter f args
   | Lfunction{body} ->
       f body
-  | Llet(_, _k, _id, arg, body) ->
+  | Llet(_, _k, _id, arg, body)
+  | Lmutlet(_k, _id, arg, body) ->
       f arg; tail body
   | Lletrec(decl, body) ->
       tail body;
@@ -544,7 +550,8 @@ let rec free_variables = function
   | Lfunction{body; params} ->
       Ident.Set.diff (free_variables body)
         (Ident.Set.of_list (List.map fst params))
-  | Llet(_str, _k, id, arg, body) ->
+  | Llet(_, _k, id, arg, body)
+  | Lmutlet(_k, id, arg, body) ->
       Ident.Set.union
         (free_variables arg)
         (Ident.Set.remove id (free_variables body))
@@ -735,6 +742,9 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Llet(str, k, id, arg, body) ->
         let id, l' = bind id l in
         Llet(str, k, id, subst s l arg, subst s l' body)
+    | Lmutlet(k, id, arg, body) ->
+        let id, l' = bind id l in
+        Lmutlet(k, id, subst s l arg, subst s l' body)
     | Lletrec(decl, body) ->
         let decl, l' = bind_many decl l in
         Lletrec(List.map (subst_decl s l') decl, subst s l' body)
@@ -844,6 +854,8 @@ let shallow_map f = function
       Lfunction { kind; params; return; body = f body; attr; loc; }
   | Llet (str, k, v, e1, e2) ->
       Llet (str, k, v, f e1, f e2)
+  | Lmutlet (k, v, e1, e2) ->
+      Lmutlet (k, v, f e1, f e2)
   | Lletrec (idel, e2) ->
       Lletrec (List.map (fun (v, e) -> (v, f e)) idel, f e2)
   | Lprim (p, el, loc) ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -730,6 +730,8 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
        begin match Ident.Map.find id l with
           | id' -> Lmutvar id'
           | exception Not_found ->
+             (* Note: a mutable [id] should not appear in [s].
+                Keeping the behavior of Lvar case for now. *)
              begin try Ident.Map.find id s with Not_found -> lam end
         end
     | Lconst _ as l -> l

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -264,6 +264,7 @@ type scoped_location = Debuginfo.Scoped_location.t
 
 type lambda =
     Lvar of Ident.t
+  | Lmutvar of Ident.t
   | Lconst of structured_constant
   | Lapply of lambda_apply
   | Lfunction of lfunction

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -234,7 +234,7 @@ type local_attribute =
 
 type function_kind = Curried | Tupled
 
-type let_kind = Strict | Alias | StrictOpt | Variable
+type let_kind = Strict | Alias | StrictOpt
 (* Meaning of kinds for let x = e in e':
     Strict: e may have side-effects; always evaluate e first
       (If e is a simple expression, e.g. a variable or constant,
@@ -243,7 +243,6 @@ type let_kind = Strict | Alias | StrictOpt | Variable
       in e'
     StrictOpt: e does not have side-effects, but depend on the store;
       we can discard e if x does not appear in e'
-    Variable: the variable x is assigned later in e'
  *)
 
 type meth_kind = Self | Public | Cached
@@ -269,6 +268,7 @@ type lambda =
   | Lapply of lambda_apply
   | Lfunction of lfunction
   | Llet of let_kind * value_kind * Ident.t * lambda * lambda
+  | Lmutlet of value_kind * Ident.t * lambda * lambda
   | Lletrec of (Ident.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
   | Lswitch of lambda * lambda_switch * scoped_location

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3549,6 +3549,7 @@ let simple_for_let ~scopes loc param pat body =
 
 let rec map_return f = function
   | Llet (str, k, id, l1, l2) -> Llet (str, k, id, l1, map_return f l2)
+  | Lmutlet (k, id, l1, l2) -> Lmutlet (k, id, l1, map_return f l2)
   | Lletrec (l1, l2) -> Lletrec (l1, map_return f l2)
   | Lifthenelse (lcond, lthen, lelse) ->
       Lifthenelse (lcond, map_return f lthen, map_return f lelse)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3576,8 +3576,8 @@ let rec map_return f = function
           Option.map (map_return f) def,
           loc )
   | (Lstaticraise _ | Lprim (Praise _, _, _)) as l -> l
-  | ( Lvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _ | Lwhile _
-    | Lfor _ | Lassign _ | Lifused _ ) as l ->
+  | ( Lvar _ | Lmutvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _
+    | Lwhile _ | Lfor _ | Lassign _ | Lifused _ ) as l ->
       f l
 
 (* The 'opt' reference indicates if the optimization is worthy.

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -524,29 +524,26 @@ let rec lam ppf = function
             fprintf ppf ")" in
       fprintf ppf "@[<2>(function%a@ %a%a%a)@]" pr_params params
         function_attribute attr return_kind return lam body
-  | Llet(str, k, id, arg, body) ->
-     let kind = function
-          Alias -> "a" | Strict -> "" | StrictOpt -> "o"
+  | Llet(_, k, id, arg, body)
+  | Lmutlet(k, id, arg, body) as l ->
+      let let_kind = begin function
+        | Llet(str,_,_,_,_) ->
+           begin match str with
+             Alias -> "a" | Strict -> "" | StrictOpt -> "o"
+           end
+        | Lmutlet _ -> "mut"
+        | _ -> assert false
+        end
       in
       let rec letbody = function
-        | Llet(str, k, id, arg, body) ->
-            fprintf ppf "@ @[<2>%a =%s%a@ %a@]"
-              Ident.print id (kind str) value_kind k lam arg;
-            letbody body
+        | Llet(_, k, id, arg, body)
+        | Lmutlet(k, id, arg, body) as l ->
+           fprintf ppf "@ @[<2>%a =%s%a@ %a@]"
+             Ident.print id (let_kind l) value_kind k lam arg;
+           letbody body
         | expr -> expr in
       fprintf ppf "@[<2>(let@ @[<hv 1>(@[<2>%a =%s%a@ %a@]"
-        Ident.print id (kind str) value_kind k lam arg;
-      let expr = letbody body in
-      fprintf ppf ")@]@ %a)@]" lam expr
-  | Lmutlet(k, id, arg, body) ->
-      let rec letbody = function
-        | Lmutlet(k, id, arg, body) ->
-            fprintf ppf "@ @[<2>%a =%a@ %a@]"
-              Ident.print id value_kind k lam arg;
-            letbody body
-        | expr -> expr in
-      fprintf ppf "@[<2>(let[mut]@ @[<hv 1>(@[<2>%a =%a@ %a@]"
-        Ident.print id value_kind k lam arg;
+        Ident.print id (let_kind l) value_kind k lam arg;
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Lletrec(id_arg_list, body) ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -495,6 +495,8 @@ let apply_specialised_attribute ppf = function
 let rec lam ppf = function
   | Lvar id ->
       Ident.print ppf id
+  | Lmutvar id ->
+      fprintf ppf "*%a" Ident.print id
   | Lconst cst ->
       struct_const ppf cst
   | Lapply ap ->
@@ -523,7 +525,7 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(function%a@ %a%a%a)@]" pr_params params
         function_attribute attr return_kind return lam body
   | Llet(str, k, id, arg, body) ->
-      let kind = function
+     let kind = function
           Alias -> "a" | Strict -> "" | StrictOpt -> "o" | Variable -> "v"
       in
       let rec letbody = function

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -526,7 +526,7 @@ let rec lam ppf = function
         function_attribute attr return_kind return lam body
   | Llet(str, k, id, arg, body) ->
      let kind = function
-          Alias -> "a" | Strict -> "" | StrictOpt -> "o" | Variable -> "v"
+          Alias -> "a" | Strict -> "" | StrictOpt -> "o"
       in
       let rec letbody = function
         | Llet(str, k, id, arg, body) ->
@@ -536,6 +536,17 @@ let rec lam ppf = function
         | expr -> expr in
       fprintf ppf "@[<2>(let@ @[<hv 1>(@[<2>%a =%s%a@ %a@]"
         Ident.print id (kind str) value_kind k lam arg;
+      let expr = letbody body in
+      fprintf ppf ")@]@ %a)@]" lam expr
+  | Lmutlet(k, id, arg, body) ->
+      let rec letbody = function
+        | Lmutlet(k, id, arg, body) ->
+            fprintf ppf "@ @[<2>%a =%a@ %a@]"
+              Ident.print id value_kind k lam arg;
+            letbody body
+        | expr -> expr in
+      fprintf ppf "@[<2>(let[mut]@ @[<hv 1>(@[<2>%a =%a@ %a@]"
+        Ident.print id value_kind k lam arg;
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Lletrec(id_arg_list, body) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -47,7 +47,7 @@ let rec eliminate_ref id = function
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
   | Lprim(Poffsetref delta, [Lvar v], loc) when Ident.same v id ->
-      Lassign(id, Lprim(Poffsetint delta, [Lvar id], loc))
+      Lassign(id, Lprim(Poffsetint delta, [Lmutvar id], loc))
   | Lprim(p, el, loc) ->
       Lprim(p, List.map (eliminate_ref id) el, loc)
   | Lswitch(e, sw, loc) ->
@@ -512,13 +512,13 @@ let simplify_lets lam =
   in
 
   let rec simplif = function
-    Lvar v | Lmutvar v as l ->
+    Lvar v as l ->
       begin try
         Hashtbl.find subst v
       with Not_found ->
         l
       end
-  | Lconst _ as l -> l
+  | Lmutvar _ | Lconst _ as l -> l
   | Lapply ({ap_func = ll; ap_args = args} as ap) ->
       let no_opt () =
         Lapply {ap with ap_func = simplif ap.ap_func;

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -663,7 +663,8 @@ let free_methods l =
     | Lsend _ -> ()
     | Lfunction{params} ->
         List.iter (fun (param, _) -> fv := Ident.Set.remove param !fv) params
-    | Llet(_str, _k, id, _arg, _body) ->
+    | Llet(_, _k, id, _arg, _body)
+    | Lmutlet(_k, id, _arg, _body) ->
         fv := Ident.Set.remove id !fv
     | Lletrec(decl, _body) ->
         List.iter (fun (id, _exp) -> fv := Ident.Set.remove id !fv) decl

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -674,7 +674,7 @@ let free_methods l =
     | Lfor(v, _e1, _e2, _dir, _e3) ->
         fv := Ident.Set.remove v !fv
     | Lassign _
-    | Lvar _ | Lconst _ | Lapply _
+    | Lvar _ | Lmutvar _ | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _
     | Lifthenelse _ | Lsequence _ | Lwhile _
     | Levent _ | Lifused _ -> ()

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -861,8 +861,9 @@ let close_var env id =
 let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   let module B = (val backend : Backend_intf.S) in
   match lam with
-  | Lvar id | Lmutvar id ->
-      close_approx_var env id
+  | Lvar id ->
+     close_approx_var env id
+  | Lmutvar id -> (Uvar id, Value_unknown)
   | Lconst cst ->
       let str ?(shared = true) cst =
         let name =

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -861,7 +861,7 @@ let close_var env id =
 let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   let module B = (val backend : Backend_intf.S) in
   match lam with
-  | Lvar id ->
+  | Lvar id | Lmutvar id ->
       close_approx_var env id
   | Lconst cst ->
       let str ?(shared = true) cst =

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -991,23 +991,24 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
        Value_unknown)
   | Llet(str, kind, id, lam, body) ->
       let (ulam, alam) = close_named env id lam in
-      begin match (str, alam) with
-        (Variable, _) ->
-          let env = {env with mutable_vars = V.Set.add id env.mutable_vars} in
-          let (ubody, abody) = close env body in
-          (Ulet(Mutable, kind, VP.create id, ulam, ubody), abody)
-      | (_, Value_const _)
-        when str = Alias || is_pure ulam ->
-          close { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
-            body
-      | (_, _) ->
-          let (ubody, abody) =
-            close
-              { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
-              body
-          in
-          (Ulet(Immutable, kind, VP.create id, ulam, ubody), abody)
+      begin match alam with
+        Value_const _
+           when str = Alias || is_pure ulam ->
+         close { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
+           body
+      | _ ->
+         let (ubody, abody) =
+           close
+             { backend; fenv = (V.Map.add id alam fenv); cenv; mutable_vars }
+             body
+         in
+         (Ulet(Immutable, kind, VP.create id, ulam, ubody), abody)
       end
+  | Lmutlet(kind, id, lam, body) ->
+     let (ulam, _) = close_named env id lam in
+     let env = {env with mutable_vars = V.Set.add id env.mutable_vars} in
+     let (ubody, abody) = close env body in
+     (Ulet(Mutable, kind, VP.create id, ulam, ubody), abody)
   | Lletrec(defs, body) ->
       if List.for_all
            (function (_id, Lfunction _) -> true | _ -> false)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -170,16 +170,21 @@ let lambda_const_int i : Lambda.structured_constant =
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
   match lam with
-  | Lvar id | Lmutvar id ->
-    begin match Env.find_var_exn env id with
-    | var -> Var var
-    | exception Not_found ->
-      match Env.find_mutable_var_exn env id with
-      | mut_var ->
-        name_expr (Read_mutable mut_var) ~name:Names.read_mutable
-      | exception Not_found ->
+  | Lvar id ->
+     begin match Env.find_var_exn env id with
+     | var -> Var var
+     | exception Not_found ->
         Misc.fatal_errorf "Closure_conversion.close: unbound identifier %a"
           Ident.print id
+     end
+  | Lmutvar id ->
+    begin match Env.find_mutable_var_exn env id with
+    | mut_var ->
+       name_expr (Read_mutable mut_var) ~name:Names.read_mutable
+    | exception Not_found ->
+       Misc.fatal_errorf
+         "Closure_conversion.close: unbound mutable identifier %a"
+         Ident.print id
     end
   | Lconst cst ->
     let cst, name = close_const t cst in

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -192,7 +192,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     in
     let body = close t (Env.add_var env id var) body in
     Flambda.create_let var defining_expr body
-  | Llet (Variable, block_kind, id, defining_expr, body) ->
+  | Lmutlet (block_kind, id, defining_expr, body) ->
     let mut_var = Mutable_variable.create_with_same_name_as_ident id in
     let var = Variable.create_with_same_name_as_ident id in
     let defining_expr =

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -170,7 +170,7 @@ let lambda_const_int i : Lambda.structured_constant =
 
 let rec close t env (lam : Lambda.lambda) : Flambda.t =
   match lam with
-  | Lvar id ->
+  | Lvar id | Lmutvar id ->
     begin match Env.find_var_exn env id with
     | var -> Var var
     | exception Not_found ->


### PR DESCRIPTION
This follows issue #9954 which makes notice of an undesired behavior of the `simplify_lets` optimisation pass on the lambda representation.

The patch consists of replacing the attribute `Variable` of the `Llet` constructor, whose role was to identify bindings related to `ref` values. Instead, we have the specialized constructors `Lmutlet` and `Lmutvar` used to distinguish such bindings and their subsequent use respectively.

This distinction prevents incorrect substitutions of mutable variables by `simplify_lets` and thus act as a fix for #9954. 