### PR TITLE
support LDFLAGS in configure and Makefile.config.in except for flexlink

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,11 @@ Working version
 
 ### Build system:
 
+- #9191, #10091: take the LDFLAGS variable into account, except on
+  flexlink-using systems.
+  (Gabriel Scherer, review by Sébastien Hinderer and David Allsopp,
+   report by Ralph Seichter)
+
 ### Bug fixes:
 
 - #10005: Try expanding aliases in Ctype.nondep_type_rec

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -33,7 +33,7 @@ The `configure` script accepts options that can be discovered by running:
 
         ./configure --help
 +
-Some options or variables like (LDFLAGS) may not be taken into account
+Some options or variables like LDLIBS may not be taken into account
 by the OCaml build system at the moment. Please report an issue if you
 discover such a variable or option and this causes troubles to you.
 +

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -248,9 +248,10 @@ ifeq "$(TOOLCHAIN)" "msvc"
           || mt -nologo -outputresource:$(1) -manifest $(1).manifest \
           && rm -f $(1).manifest
   MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) \
-    /link /subsystem:console $(OC_LDFLAGS) && ($(MERGEMANIFESTEXE))
+    /link /subsystem:console $(OC_LDFLAGS) $(LDFLAGS) && ($(MERGEMANIFESTEXE))
 else
-  MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_LDFLAGS) $(OUTPUTEXE)$(1) $(2)
+  MKEXE_BOOT=$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_LDFLAGS) $(LDFLAGS) \
+    $(OUTPUTEXE)$(1) $(2)
 endif # ifeq "$(TOOLCHAIN)" "msvc"
 
 # The following variables were defined only in the Windows-specific makefiles.

--- a/configure
+++ b/configure
@@ -2765,11 +2765,13 @@ programs_man_section=1
 libraries_man_section=3
 
 # Command to build executalbes
-# In general this command is supposed to use the CFLAGs-related variables
-# ($OC_CFLAGS and $CFLAGS), but at the moment they are not taken into
-# account on Windows, because flexlink, which is used to build
-# executables on this platform, can not handle them.
-mkexe="\$(CC) \$(OC_CFLAGS) \$(CFLAGS) \$(OC_LDFLAGS)"
+# In general this command is supposed to use the CFLAGs- and LDFLAGS-
+# related variables (OC_CFLAGS and OC_LDFLAGS for ocaml-specific
+# flags, CFLAGS and LDFLAGS for generic flags chosen by the user), but
+# at the moment they are not taken into account on Windows, because
+# flexlink, which is used to build executables on this platform, can
+# not handle them.
+mkexe="\$(CC) \$(OC_CFLAGS) \$(CFLAGS) \$(OC_LDFLAGS) \$(LDFLAGS)"
 
 # Flags for building executable files with debugging symbols
 mkexedebugflag="-g"
@@ -13624,8 +13626,9 @@ natdynlinkopts=""
 if test x"$enable_shared" != "xno"; then :
   case $host in #(
   *-apple-darwin*) :
-    mksharedlib="$CC -shared -flat_namespace -undefined suppress \
-                   -Wl,-no_compact_unwind"
+    mksharedlib="$CC -shared \
+                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
+                   \$(LDFLAGS)"
       shared_libraries_supported=true ;; #(
   *-*-mingw32) :
     mksharedlib='$(FLEXLINK)'
@@ -13647,7 +13650,7 @@ fi
   powerpc-ibm-aix*) :
     case $CC in #(
   xlc*) :
-    mksharedlib="$CC -qmkshrobj -G"
+    mksharedlib="$CC -qmkshrobj -G \$(LDFLAGS)"
                 shared_libraries_supported=true ;; #(
   *) :
      ;;
@@ -13657,9 +13660,9 @@ esac ;; #(
     sharedlib_cflags="-fPIC"
        case $CC,$host in #(
   gcc*,powerpc-*-linux*) :
-    mksharedlib="$CC -shared -mbss-plt" ;; #(
+    mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)" ;; #(
   *) :
-    mksharedlib="$CC -shared" ;;
+    mksharedlib="$CC -shared \$(LDFLAGS)" ;;
 esac
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"

--- a/configure.ac
+++ b/configure.ac
@@ -37,11 +37,13 @@ programs_man_section=1
 libraries_man_section=3
 
 # Command to build executalbes
-# In general this command is supposed to use the CFLAGs-related variables
-# ($OC_CFLAGS and $CFLAGS), but at the moment they are not taken into
-# account on Windows, because flexlink, which is used to build
-# executables on this platform, can not handle them.
-mkexe="\$(CC) \$(OC_CFLAGS) \$(CFLAGS) \$(OC_LDFLAGS)"
+# In general this command is supposed to use the CFLAGs- and LDFLAGS-
+# related variables (OC_CFLAGS and OC_LDFLAGS for ocaml-specific
+# flags, CFLAGS and LDFLAGS for generic flags chosen by the user), but
+# at the moment they are not taken into account on Windows, because
+# flexlink, which is used to build executables on this platform, can
+# not handle them.
+mkexe="\$(CC) \$(OC_CFLAGS) \$(CFLAGS) \$(OC_LDFLAGS) \$(LDFLAGS)"
 
 # Flags for building executable files with debugging symbols
 mkexedebugflag="-g"
@@ -817,8 +819,9 @@ natdynlinkopts=""
 AS_IF([test x"$enable_shared" != "xno"],
   [AS_CASE([$host],
     [*-apple-darwin*],
-      [mksharedlib="$CC -shared -flat_namespace -undefined suppress \
-                   -Wl,-no_compact_unwind"
+      [mksharedlib="$CC -shared \
+                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
+                   \$(LDFLAGS)"
       shared_libraries_supported=true],
     [*-*-mingw32],
       [mksharedlib='$(FLEXLINK)'
@@ -838,14 +841,15 @@ AS_IF([test x"$enable_shared" != "xno"],
     [powerpc-ibm-aix*],
       [AS_CASE([$CC],
                [xlc*],
-               [mksharedlib="$CC -qmkshrobj -G"
+               [mksharedlib="$CC -qmkshrobj -G \$(LDFLAGS)"
                 shared_libraries_supported=true])],
     [[*-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*]],
       [sharedlib_cflags="-fPIC"
        AS_CASE([$CC,$host],
-           [gcc*,powerpc-*-linux*], [mksharedlib="$CC -shared -mbss-plt"],
-           [mksharedlib="$CC -shared"])
+           [gcc*,powerpc-*-linux*],
+           [mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)"],
+           [mksharedlib="$CC -shared \$(LDFLAGS)"])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"


### PR DESCRIPTION
OC_LDFLAGS is for options specific to linking OCaml programs, LDFLAGS
are user-chosen flags that should be included in any call to the
system linker.

This is intended to fix #9191.

The logic followed in this PR is similar to the treatment of CFLAGS in
the build system, which comes from #9837.

Passing LDFLAGS to flexlink is not supported. It is a pain to do
correctly, and we haven't got requests from Windows users yet, only
from users of unix variants.

(cc our configuration overlords, @shindere and @dra27)