### PR TITLE
Fix a typo in the OCaml Manual

### DIFF
--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -429,7 +429,7 @@ Polymorphic type annotations in @"let"@-definitions behave in a way
 similar to polymorphic methods:
 
 \begin{center}
-@"let" pattern_1 ":" typ_1 \ldots typ_n "." typeexpr "=" expr  @
+@"let" pattern_1 ":" typ_1 \ldots typ_n "." typexpr "=" expr  @
 \end{center}
 
 These annotations explicitly require the defined value to be polymorphic,


### PR DESCRIPTION
Fix a typo in Chapter 7.4 of OCaml Documentation and user’s manual https://caml.inria.fr/pub/docs/manual-ocaml/expr.html
* `typeexpr` to `typexpr`