### PR TITLE
Only use PROFINFO_WIDTH if WITH_PROFINFO defined

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,10 @@ Working version
   (Stephen Dolan, review by Leo White, Gabriel Scherer and Jacques-Henri
    Jourdan)
 
+- #10102: Ignore PROFINFO_WIDTH if WITH_PROFINFO is not defined (technically
+  a breaking change if the configuration system was being abused before).
+  (David Allsopp, review by Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #9937: improvements in ARM64 code generation (constants, sign extensions)

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -149,7 +149,11 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 
 #define Num_tags (1 << 8)
 #ifdef ARCH_SIXTYFOUR
+#ifdef WITH_PROFINFO
 #define Max_wosize (((intnat)1 << (54-PROFINFO_WIDTH)) - 1)
+#else
+#define Max_wosize (((intnat)1 << 54) - 1)
+#endif
 #else
 #define Max_wosize ((1 << 22) - 1)
 #endif /* ARCH_SIXTYFOUR */


### PR DESCRIPTION
Small configuration hardening split off from #9284.