### PR TITLE
Always define WINDOWS_UNICODE internally

### DIFF
--- a/configure
+++ b/configure
@@ -12660,9 +12660,7 @@ case $host in #(
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
         common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
-        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
-        internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-        internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE' ;; #(
   *) :
     as_fn_error $? "Unsupported C compiler for a Mingw build" "$LINENO" 5 ;;
 esac ;; #(
@@ -12700,9 +12698,7 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
   msvc-*) :
     common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
-      internal_cppflags='-DUNICODE -D_UNICODE'
-      internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-      internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+      internal_cppflags='-DUNICODE -D_UNICODE' ;; #(
   xlc-*) :
     common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
       internal_cflags="$cc_warnings" ;; #(
@@ -12710,6 +12706,9 @@ $as_echo "$as_me: WARNING: Consider using GCC version 4.2 or above." >&2;};
     common_cflags="-O" ;;
 esac ;;
 esac
+
+internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
 

--- a/configure.ac
+++ b/configure.ac
@@ -581,9 +581,7 @@ AS_CASE([$host],
 -fexcess-precision=standard"
         # TODO: see whether the code can be fixed to avoid -Wno-unused
         common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
-        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
-        internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-        internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+        internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'],
       [AC_MSG_ERROR([Unsupported C compiler for a Mingw build])])],
   [AS_CASE([$ocaml_cv_cc_vendor],
     [clang-*],
@@ -618,13 +616,14 @@ AS_CASE([$host],
     [msvc-*],
       [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
       common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
-      internal_cppflags='-DUNICODE -D_UNICODE'
-      internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-      internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+      internal_cppflags='-DUNICODE -D_UNICODE'],
     [xlc-*],
       [common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
       internal_cflags="$cc_warnings"],
     [common_cflags="-O"])])
+
+internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
+internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"
 
 internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
 


### PR DESCRIPTION
Rather than just defining `WINDOWS_UNICODE` for the Windows builds, define it for all builds (it's just always `0` on Unix). Split off from #9284.