### PR TITLE
String: change order of arguments in starts_with and ends_with

### DIFF
--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -197,7 +197,7 @@ let capitalize_ascii s =
 let uncapitalize_ascii s =
   B.uncapitalize_ascii (bos s) |> bts
 
-let starts_with ~prefix s =
+let starts_with s ~prefix =
   let len_s = length s
   and len_pre = length prefix in
   let rec aux i =
@@ -206,7 +206,7 @@ let starts_with ~prefix s =
     else aux (i + 1)
   in len_s >= len_pre && aux 0
 
-let ends_with ~suffix s =
+let ends_with s ~suffix =
   let len_s = length s
   and len_suf = length suffix in
   let diff = len_s - len_suf in

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -127,13 +127,13 @@ val compare : t -> t -> int
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
 val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+  string -> prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> bool
 (** [starts_with ][~][prefix s] is [true] iff [s] starts with [prefix].
 
     @since 4.12.0 *)
 
 val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+  string -> suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> bool
 (** [ends_with suffix s] is [true] iff [s] ends with [suffix].
 
     @since 4.12.0 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -127,13 +127,13 @@ val compare : t -> t -> int
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
 val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+  string -> prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> bool
 (** [starts_with ][~][prefix s] is [true] iff [s] starts with [prefix].
 
     @since 4.12.0 *)
 
 val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+  string -> suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> bool
 (** [ends_with ~suffix s] is [true] iff [s] ends with [suffix].
 
     @since 4.12.0 *)


### PR DESCRIPTION
to match extlib.
ref https://github.com/ocaml/ocaml/pull/9533#issuecomment-751786376
This change will make life for extlib maintainer (aka me) much easier and will help prevent bugs for people used to extlib String module
