### PR TITLE
Always allow linking AFL-instrumented modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -269,6 +269,10 @@ OCaml 4.12.0
 - #10062: set ARCH_INT64_PRINTF_FORMAT correctly for both modes of mingw-w64
   (David Allsopp, review by Xavier Leroy)
 
+- #10107: Ensure modules compiled with -afl-instrument can still link on
+  platforms without AFL support.
+  (David Allsopp, review by ???)
+
 ### Code generation and optimizations:
 
 - #9551: ocamlc no longer loads DLLs at link time to check that

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -15,12 +15,23 @@
 /* Runtime support for afl-fuzz */
 #include "caml/config.h"
 
+/* Values used by the instrumentation logic (see cmmgen.ml) */
+static unsigned char afl_area_initial[1 << 16];
+unsigned char* caml_afl_area_ptr = afl_area_initial;
+uintnat caml_afl_prev_loc;
+
 #if !defined(HAS_SYS_SHM_H) || !defined(HAS_SHMAT)
 
 #include "caml/mlvalues.h"
 
 CAMLprim value caml_reset_afl_instrumentation(value full)
 {
+  return Val_unit;
+}
+
+CAMLexport value caml_setup_afl(value unit)
+{
+  /* AFL is not supported */
   return Val_unit;
 }
 
@@ -44,11 +55,6 @@ static int afl_initialised = 0;
 /* afl uses abnormal termination (SIGABRT) to check whether
    to count a testcase as "crashing" */
 extern int caml_abort_on_uncaught_exn;
-
-/* Values used by the instrumentation logic (see cmmgen.ml) */
-static unsigned char afl_area_initial[1 << 16];
-unsigned char* caml_afl_area_ptr = afl_area_initial;
-uintnat caml_afl_prev_loc;
 
 /* File descriptors used to synchronise with afl-fuzz */
 #define FORKSRV_FD_READ 198


### PR DESCRIPTION
#9998 added `testsuite/tests/flambda/afl_lazy.ml`. This test fails to link on platforms which don't support AFL (like Windows).

This has been wrong forever, but as the test itself was added in 4.12, I propose including this bug fix in 4.12.

More detail: AFL support is _always_ built in the runtime if the required shared memory support is available. The `--with-afl` option simply controls whether the `-afl-instrument` option is the default. So ocamlopt always requires the `caml_afl_area_ptr` and `caml_afl_prev_loc` data areas and also `caml_setup_afl` to be a valid function. The fix is therefore easy - always define the two data values and include a dummy stub for `caml_setup_afl` returning `Val_unit` (this is what `caml_setup_afl` normally does when an instrumented program is run without AFL).

More seriously: we appear to be no longer continuously testing Windows flambda anywhere?