### PR TITLE
Allowing displaying multi-line backtrace locations in the same way as errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -197,6 +197,7 @@ runtime/caml/sizeclasses.h typo.missing-header typo.white-at-eol
 # Tests which include references spanning multiple lines fail with \r\n
 # endings, so use \n endings only, even on Windows.
 testsuite/tests/backtrace/names.ml text eol=lf
+testsuite/tests/backtrace/print_location.ml text eol=lf
 testsuite/tests/basic-modules/anonymous.ml text eol=lf
 testsuite/tests/formatting/test_locations.ml text eol=lf
 testsuite/tests/functors/functors.ml text eol=lf

--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Working version
 
 ### Runtime system:
 
+- #10111: Increase the detail of location information for debugging events to
+  allow the end line number and character offset to be reported.
+  (David Allsopp, review by Nick Barnes, Enguerrand Decorne and Stephen Dolan)
+
 - #10403, #12202: introduce `caml_ext_table_add_noexc` that does not
   raise `Out_of_memory` exceptions and use it inside the blocking sections
   of `caml_read_directory`.  Also, check for overflows in ext table sizes.

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -313,48 +313,6 @@ let emit_frames a =
         else
           partially_pack_info rs d (rest <> [])
       in
-      let () =
-        let overflows_old =
-          d.dinfo_line > 0xFFFFF
-          || d.dinfo_char_start > 0xFF
-          || d.dinfo_char_end > 0x3FF
-        and overflows_new =
-          d.dinfo_line > 0x7FFFF
-          || d.dinfo_end_line - d.dinfo_line > 0x3FFFF
-          || d.dinfo_char_start > 0xFFFF
-          || char_end > 0xFFFF
-          || d.dinfo_char_end > 0x3FFFFFFF
-        and overhead_new =
-          if is_fully_packable then
-            0
-          else
-            let l = String.length defname + 1 in
-            let defname_overhead =
-              if Hashtbl.mem defnames (d.dinfo_file, defname, None) then
-                4 + l + l mod 4
-              else
-                0
-            in
-            8 + defname_overhead
-        in
-          let status =
-            match overflows_old, overflows_new with
-            | false, false -> ""
-            | false, true -> " (broken)"
-            | true, false -> " (fixed)"
-            | true, true -> " (unfixed)"
-          in
-          Printf.eprintf "<debuginfo> +%d%s %s in %s at %d, %d, %d, %d, %d\n%!"
-            overhead_new
-            status
-            defname
-            d.dinfo_file
-            d.dinfo_line
-            d.dinfo_char_start
-            d.dinfo_end_line
-            char_end
-            d.dinfo_char_end
-      in
       let loc =
         if is_fully_packable then
           None

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -90,8 +90,8 @@ static void print_location(struct caml_loc_info * li, int index)
     fprintf(stderr, "%s unknown location%s\n", info, inlined);
   } else {
     fprintf (stderr, "%s %s in file \"%s\"%s, line %d, characters %d-%d\n",
-             info, li->loc_defname, li->loc_filename, inlined, li->loc_lnum,
-             li->loc_startchr, li->loc_endchr);
+             info, li->loc_defname, li->loc_filename, inlined,
+             li->loc_start_lnum, li->loc_start_chr, li->loc_end_offset);
   }
 }
 
@@ -244,14 +244,16 @@ static value caml_convert_debuginfo(debuginfo dbg)
   if (li.loc_valid) {
     fname = caml_copy_string(li.loc_filename);
     dname = caml_copy_string(li.loc_defname);
-    p = caml_alloc_small(7, 0);
+    p = caml_alloc_small(9, 0);
     Field(p, 0) = Val_bool(li.loc_is_raise);
     Field(p, 1) = fname;
-    Field(p, 2) = Val_int(li.loc_lnum);
-    Field(p, 3) = Val_int(li.loc_startchr);
-    Field(p, 4) = Val_int(li.loc_endchr);
-    Field(p, 5) = Val_bool(li.loc_is_inlined);
-    Field(p, 6) = dname;
+    Field(p, 2) = Val_int(li.loc_start_lnum);
+    Field(p, 3) = Val_int(li.loc_start_chr);
+    Field(p, 4) = Val_int(li.loc_end_offset);
+    Field(p, 5) = Val_int(li.loc_end_lnum);
+    Field(p, 6) = Val_int(li.loc_end_chr);
+    Field(p, 7) = Val_bool(li.loc_is_inlined);
+    Field(p, 8) = dname;
   } else {
     p = caml_alloc_small(1, 1);
     Field(p, 0) = Val_bool(li.loc_is_raise);

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -102,25 +102,27 @@ static int cmp_ev_info(const void *a, const void *b)
   int num_b;
 
   /* Perform a full lexicographic comparison to make sure the resulting order is
-     the same under all implementations of qsort (which is not stable). */
+     the same under all implementations of qsort (which is not stable).
+     NB a->ev_end_offset == b->ev_end_offset =>
+           a->ev_end_lnum == b->ev_end_lnum && a->ev_end_chr == b->ev_end_chr */
 
   if (pc_a > pc_b) return 1;
   if (pc_a < pc_b) return -1;
 
-  num_a = ev_a->ev_lnum;
-  num_b = ev_b->ev_lnum;
+  num_a = ev_a->ev_start_lnum;
+  num_b = ev_b->ev_start_lnum;
 
   if (num_a > num_b) return 1;
   if (num_a < num_b) return -1;
 
-  num_a = ev_a->ev_startchr;
-  num_b = ev_b->ev_startchr;
+  num_a = ev_a->ev_start_chr;
+  num_b = ev_b->ev_start_chr;
 
   if (num_a > num_b) return 1;
   if (num_a < num_b) return -1;
 
-  num_a = ev_a->ev_endchr;
-  num_b = ev_b->ev_endchr;
+  num_a = ev_a->ev_end_offset;
+  num_b = ev_b->ev_end_offset;
 
   if (num_a > num_b) return 1;
   if (num_a < num_b) return -1;
@@ -133,7 +135,7 @@ static struct ev_info *process_debug_events(code_t code_start,
                                             mlsize_t *num_events)
 {
   CAMLparam1(events_heap);
-  CAMLlocal3(l, ev, ev_start);
+  CAMLlocal4(l, ev, ev_start, ev_end);
   mlsize_t i, j;
   struct ev_info *events;
 
@@ -159,6 +161,7 @@ static struct ev_info *process_debug_events(code_t code_start,
                                  + Long_val(Field(ev, EV_POS)));
 
       ev_start = Field(Field(ev, EV_LOC), LOC_START);
+      ev_end = Field(Field(ev, EV_LOC), LOC_END);
 
       {
         const char *fname = String_val(Field(ev_start, POS_FNAME));
@@ -177,13 +180,14 @@ static struct ev_info *process_debug_events(code_t code_start,
         events[j].ev_defname = "<old bytecode>";
       }
 
-      events[j].ev_lnum = Int_val(Field(ev_start, POS_LNUM));
-      events[j].ev_startchr =
-        Int_val(Field(ev_start, POS_CNUM))
-        - Int_val(Field(ev_start, POS_BOL));
-      events[j].ev_endchr =
-        Int_val(Field(Field(Field(ev, EV_LOC), LOC_END), POS_CNUM))
-        - Int_val(Field(ev_start, POS_BOL));
+      events[j].ev_start_lnum = Int_val(Field(ev_start, POS_LNUM));
+      events[j].ev_start_chr =
+        Int_val(Field(ev_start, POS_CNUM)) - Int_val(Field(ev_start, POS_BOL));
+      events[j].ev_end_lnum = Int_val(Field(ev_end, POS_LNUM));
+      events[j].ev_end_chr =
+        Int_val(Field(ev_end, POS_CNUM)) - Int_val(Field(ev_end, POS_BOL));
+      events[j].ev_end_offset =
+        Int_val(Field(ev_end, POS_CNUM)) - Int_val(Field(ev_start, POS_BOL));
 
       j++;
     }
@@ -571,9 +575,9 @@ void caml_debuginfo_location(debuginfo dbg,
   li->loc_is_inlined = 0;
   li->loc_filename = event->ev_filename;
   li->loc_defname = event->ev_defname;
-  li->loc_lnum = event->ev_lnum;
-  li->loc_startchr = event->ev_startchr;
-  li->loc_endchr = event->ev_endchr;
+  li->loc_lnum = event->ev_start_lnum;
+  li->loc_startchr = event->ev_start_chr;
+  li->loc_endchr = event->ev_end_offset;
 }
 
 debuginfo caml_debuginfo_extract(backtrace_slot slot)

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -575,9 +575,11 @@ void caml_debuginfo_location(debuginfo dbg,
   li->loc_is_inlined = 0;
   li->loc_filename = event->ev_filename;
   li->loc_defname = event->ev_defname;
-  li->loc_lnum = event->ev_start_lnum;
-  li->loc_startchr = event->ev_start_chr;
-  li->loc_endchr = event->ev_end_offset;
+  li->loc_start_lnum = event->ev_start_lnum;
+  li->loc_start_chr = event->ev_start_chr;
+  li->loc_end_lnum = event->ev_end_lnum;
+  li->loc_end_chr = event->ev_end_chr;
+  li->loc_end_offset = event->ev_end_offset;
 }
 
 debuginfo caml_debuginfo_extract(backtrace_slot slot)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -332,19 +332,22 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
     li->loc_defname = name_and_loc_info->name;
     li->loc_filename =
       (char *)name_and_loc_info + name_and_loc_info->filename_offs;
-    li->loc_lnum = (info2 >> 12) & 0x7FFFF;
-    li->loc_startchr = name_and_loc_info->start_chr;
-    li->loc_endchr = name_and_loc_info->end_offset;
+    li->loc_start_lnum = li->loc_end_lnum = (info2 >> 12) & 0x7FFFF;
+    li->loc_end_lnum += ((info2 & 0xFFF) << 6) | (info1 >> 26);
+    li->loc_start_chr = name_and_loc_info->start_chr;
+    li->loc_end_chr = name_and_loc_info->end_chr;
+    li->loc_end_offset = name_and_loc_info->end_offset;
   } else {
     struct name_info * name_info =
       (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
     li->loc_defname = name_info->name;
     li->loc_filename =
       (char *)name_info + name_info->filename_offs;
-    li->loc_lnum = info2 >> 19;
-    li->loc_startchr = (info2 >> 10) & 0x3F;
-    li->loc_endchr = (info2 >> 3) & 0x7F;
-    li->loc_endchr += (((info2 & 0x7) << 6) | (info1 >> 26));
+    li->loc_start_lnum = li->loc_end_lnum = info2 >> 19;
+    li->loc_end_lnum += (info2 >> 16) & 0x7;
+    li->loc_start_chr = (info2 >> 10) & 0x3F;
+    li->loc_end_chr = li->loc_end_offset = (info2 >> 3) & 0x7F;
+    li->loc_end_offset += (((info2 & 0x7) << 6) | (info1 >> 26));
   }
 }
 

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -37,9 +37,11 @@ struct caml_loc_info {
   int loc_is_raise;
   char * loc_filename;
   char * loc_defname;
-  int loc_lnum;
-  int loc_startchr;
-  int loc_endchr;
+  int loc_start_lnum;
+  int loc_start_chr;
+  int loc_end_lnum;
+  int loc_end_chr;
+  int loc_end_offset;
   int loc_is_inlined;
 };
 

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -110,9 +110,11 @@ struct ev_info {
   code_t ev_pc;
   char *ev_filename;
   char *ev_defname;
-  int ev_lnum;
-  int ev_startchr;
-  int ev_endchr;
+  int ev_start_lnum;
+  int ev_start_chr;  /* Relative to ev_start_lnum */
+  int ev_end_lnum;
+  int ev_end_chr;    /* Relative to ev_end_lnum */
+  int ev_end_offset; /* Relative to ev_start_lnum */
 };
 
 /* Find the event with the given pc. */

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -56,7 +56,7 @@ caml_event_trace(code_t pc)
      Caml_state->id,
      (long) (pc - caml_start_code),
      evi->ev_defname, evi->ev_filename,
-     evi->ev_lnum, evi->ev_startchr, evi->ev_endchr);
+     evi->ev_start_lnum, evi->ev_start_chr, evi->ev_end_offset);
   fflush (stdout);
 }
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -205,6 +205,8 @@ type location = {
   line_number : int;
   start_char : int;
   end_char : int;
+  end_line : int;
+  end_col : int;
 }
 
 let backtrace_slot_location = function
@@ -215,6 +217,8 @@ let backtrace_slot_location = function
       line_number = l.start_lnum;
       start_char  = l.start_char;
       end_char    = l.end_offset;
+      end_line    = l.end_lnum;
+      end_col     = l.end_char;
     }
 
 let backtrace_slot_defname = function

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -261,16 +261,17 @@ val backtrace_slots_of_raw_entry :
     @since 4.12
 *)
 
-
 type location = {
   filename : string;
   line_number : int;
   start_char : int;
   end_char : int;
+  end_line : int; (** @since 5.2 *)
+  end_col : int; (** @since 5.2 *)
 }
 (** The type of location information found in backtraces. [start_char]
-    and [end_char] are positions relative to the beginning of the
-    line.
+    and [end_char] are positions relative to the beginning of [line_number].
+    [end_col] is relative to the beginning of [end_line].
 
     @since 4.02
 *)

--- a/testsuite/tests/backtrace/print_location.ml
+++ b/testsuite/tests/backtrace/print_location.ml
@@ -1,0 +1,12 @@
+(* TEST
+ flags = "-g";
+ ocamlrunparam += ",b=1";
+ ocamlopt_flags = "-inline 0";
+ exit_status = "2";
+*)
+
+let f () = raise
+  Exit [@@inline never]
+
+let () =
+  f ()

--- a/testsuite/tests/backtrace/print_location.reference
+++ b/testsuite/tests/backtrace/print_location.reference
@@ -1,0 +1,3 @@
+Fatal error: exception Stdlib.Exit
+Raised at Print_location.f in file "print_location.ml", line 8, characters 11-23
+Called from Print_location in file "print_location.ml", line 12, characters 2-6


### PR DESCRIPTION
This PR paves the way for changing how backtrace locations are printed to be the same as #8541, so with locations spanning multiple lines reporting the line and column of the end location, rather than simply the number of characters offset from the start line. The current format is fine for machines, but a nuisance for the occasions when humans have to look at the output!

As it happens, though, my primary motivation for this is a series of (smaller) PRs which eliminate the special handling needed for CRLF-checkouts of the compiler's codebase. I've quietly maintained the .gitattributes entries for these for a few years (we all have our foibles) with the intention of one day sorting it out properly. That one day arrived in September, because there are recent changes to our codebase which mean that it's not just some testsuite files which need forcing to use LF-endings but some of the compiler's sources too, it's just taken me a few months to get to tidy up the code.

There are three parts:
 1. Extending `struct ev_info` to record the extra fields in bytecode (simple change)
 2. Altering the encoding of `debuginfo` to record the extra data in native code (less simple - more below)
 3. Threading this through to Printexc and adding two new fields to `Printexc.location`

Actually displaying this information will be in a future PR.

At present, the 64-bit words for debug info allow 20 bits for the line number, 8 bits for the first character location and 10 bits for the end character location. In our tree, that at present leads to just over 1000 locations which overflow the representation (not that they're necessarily ever displayed). Now I steal 1 bit from the line number (so we technically can no longer display locations from lines 524288-1048575 in a file) which is used to indicate two possible formats for the 64-bit word. The first adds no further overhead by using 12 bits for the line number, 6 bits for the character offset of the start, 3 bits to encode the _offset_ to the end-line (so 0 when the location is on the same line), 7 bits to encode the character offset of the end (relative to the end-line) and - in order to keep the information we had before - 9 bits to store the end character offset as before. This encoding captures 92% of the locations in a build of the compiler tree. When that overflows, the representation instead stores an extra 64bits in the name_info struct containing the defname (thus adding 8 bytes overhead), allowing 16bits each for the start and end character offset (the other int is used for the original end character offset relative to the start). I haven't shared `defname` strings as when I checked the tree there were only 50 locations where the strings were being duplicated, so the overhead (at least for the compiler sources) is small (indeed, the extra 4 byte offset in the other locations would dwarf the saving on the strings).

With these two representations, no locations in the compiler's tree are now unrepresentable.

Having stored that information, it clearly makes sense to be able to access it in `Printexc` - in this version I've simply added two fields to the end of the `Printexc.location`. The alternative would be an additional type with a different retrieval function.