### PR TITLE
Add a `-timeout` option to ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -69,6 +69,11 @@ Working version
   changes in the parser.
   (François Pottier, review by Gabriel Scherer and Xavier Leroy.)
 
+- #10113: add a `-timeout` option to ocamltest and use it in the test suite.
+  (Xavier Leroy and Gabriel Scherer, review by Sébastien Hinderer
+   and David Allsopp)
+
+
 ### Build system:
 
 - #9191, #10091: take the LDFLAGS variable into account, except on

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -107,7 +107,7 @@ let run_cmd
     ?(stdout_variable=Builtin_variables.stdout)
     ?(stderr_variable=Builtin_variables.stderr)
     ?(append=false)
-    ?(timeout=0)
+    ?timeout
     log env original_cmd
   =
   let log_redirection std filename =
@@ -150,6 +150,13 @@ let run_cmd
     Array.append
       environment
       (Environments.to_system_env env)
+  in
+  let timeout =
+    match timeout with
+    | Some timeout -> timeout
+    | None ->
+        Option.value ~default:0
+          (Environments.lookup_as_int Builtin_variables.timeout env)
   in
   let n =
     Run_command.run {
@@ -273,6 +280,9 @@ let run_hook hook_name log input_env =
     Builtin_variables.ocamltest_response response_file input_env in
   let systemenv =
     Environments.to_system_env hookenv in
+  let timeout =
+    Option.value ~default:0
+      (Environments.lookup_as_int Builtin_variables.timeout input_env) in
   let open Run_command in
   let settings = {
     progname = "sh";
@@ -282,7 +292,7 @@ let run_hook hook_name log input_env =
     stdout_filename = "";
     stderr_filename = "";
     append = false;
-    timeout = 0;
+    timeout = timeout;
     log = log;
   } in let exit_status = run settings in
   let final_value = match exit_status with

--- a/ocamltest/builtin_variables.ml
+++ b/ocamltest/builtin_variables.ml
@@ -101,7 +101,8 @@ let test_skip = Variables.make ("TEST_SKIP",
 let test_fail = Variables.make ("TEST_FAIL",
   "Exit code to let a script report failure")
 
-
+let timeout = Variables.make ("timeout",
+  "Maximal execution time for every command (in seconds)")
 
 let _ = List.iter Variables.register_variable
   [
@@ -129,4 +130,5 @@ let _ = List.iter Variables.register_variable
     test_pass;
     test_skip;
     test_fail;
+    timeout;
   ]

--- a/ocamltest/builtin_variables.mli
+++ b/ocamltest/builtin_variables.mli
@@ -65,3 +65,5 @@ val test_pass : Variables.t
 val test_skip : Variables.t
 
 val test_fail : Variables.t
+
+val timeout : Variables.t

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -62,6 +62,12 @@ let lookup_as_bool variable env =
   | Some "true" -> Some true
   | Some _ -> Some false
 
+let lookup_as_int variable env =
+  match lookup variable env with
+  | None -> None
+  | Some value ->
+      int_of_string_opt value
+
 let safe_lookup variable env = match lookup variable env with
   | None -> ""
   | Some value -> value

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -33,6 +33,11 @@ val lookup_as_bool : Variables.t -> t -> bool option
     [Some false] if it is set to another string, and
     [None] if not set. *)
 
+val lookup_as_int : Variables.t -> t -> int option
+(** returns [Some n] if the variable is set to a string
+    representation of the integer [n],
+    and [None] if it is not an integer or not set. *)
+
 val add : Variables.t -> string -> t -> t
 val add_if_undefined : Variables.t -> string -> t -> t
 val add_bindings : (Variables.t * string) list -> t -> t

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -167,6 +167,7 @@ let test_file test_filename =
   let summary = Sys.with_chdir test_build_directory_prefix
     (fun () ->
        let promote = string_of_bool Options.promote in
+       let default_timeout = string_of_int Options.default_timeout in
        let install_hook name =
          let hook_name = Filename.make_filename hookname_prefix name in
          if Sys.file_exists hook_name then begin
@@ -187,6 +188,7 @@ let test_file test_filename =
              Builtin_variables.test_build_directory_prefix,
                test_build_directory_prefix;
              Builtin_variables.promote, promote;
+             Builtin_variables.timeout, default_timeout;
            ] in
        let rootenv =
          Environments.initialize Environments.Pre log initial_environment in

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -49,6 +49,8 @@ let log_to_stderr = ref false
 
 let promote = ref false
 
+let default_timeout = ref 0
+
 let keep_test_dir_on_success = ref false
 
 let find_test_dirs = ref []
@@ -66,6 +68,11 @@ let commandline_options =
   ("-show-actions", Arg.Unit show_actions, " Show available actions.");
   ("-show-tests", Arg.Unit show_tests, " Show available tests.");
   ("-show-variables", Arg.Unit show_variables, " Show available variables.");
+  ("-timeout",
+     Arg.Int (fun t -> if t >= 0
+                       then default_timeout := t
+                       else raise (Arg.Bad "negative timeout")),
+     "<seconds> Set maximal execution time for every command (in seconds)");
   ("-find-test-dirs", Arg.String (add_to_list find_test_dirs),
    " Find directories that contain tests (recursive).");
   ("-list-tests", Arg.String (add_to_list list_tests),
@@ -84,6 +91,7 @@ let () =
 let log_to_stderr = !log_to_stderr
 let files_to_test = !files_to_test
 let promote = !promote
+let default_timeout = !default_timeout
 let find_test_dirs = !find_test_dirs
 let list_tests = !list_tests
 let keep_test_dir_on_success = !keep_test_dir_on_success

--- a/ocamltest/options.mli
+++ b/ocamltest/options.mli
@@ -21,6 +21,8 @@ val files_to_test : string list
 
 val promote : bool
 
+val default_timeout : int
+
 val usage : string
 
 val find_test_dirs : string list

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -314,7 +314,7 @@ static int run_command_parent(const command_settings *settings, pid_t child_pid)
           if ((settings->timeout > 0) && (timeout_expired))
           {
             timeout_expired = 0;
-            fprintf(stderr, "Timeout expired, killing all child processes");
+            fprintf(stderr, "Timeout expired, killing all child processes\n");
             if (kill(-child_pid, SIGKILL) == -1) myperror("kill");
           };
           break;

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -86,7 +86,10 @@ else
   OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG := -keep-test-dir-on-success
 endif
 
+TIMEOUT ?= 600 # 10 minutes
+
 OCAMLTESTFLAGS := \
+  -timeout $(TIMEOUT) \
   $(OCAMLTEST_PROMOTE_FLAG) \
   $(OCAMLTEST_KEEP_TEST_DIR_ON_SUCCESS_FLAG)
 


### PR DESCRIPTION
This PR adds a `-timeout` _N_ option to `ocamltest`, whose effect is to abort any external command that has not completed after _N_ seconds, and report the corresponding test action as "failed".

It then uses this option to enforce a timeout of 10 minutes (per external command) when running the tests in `testsuite/`.

To accelerate the discussion, the remainder of this PR is in Q&A style.

### What's the motivation?

Some of our regression tests involving threads have been known to deadlock in the past, and might still deadlock in the future, e.g. after updates to the C standard library that changes the corner-case behavior of some POSIX threads operations.  

Deadlocks are obvious when running the test suite interactively, but wreck havoc on automated CI.

### What about putting a timeout on the CI runs themselves?

That's what we do for the Inria CI (thanks @shindere), but I'm not fully satisfied.

- The log just says "Testing killed on a timeout", but doesn't clearly say which test caused the timeout.  This is especially true with `make parallel` in the test suite.  So, it is necessary to re-run the test suite manually to identify the problematic test.
- Testing stops at the first test that times out, while there may be several such tests.
- The timeout must be pretty long (typically 45 minutes) because it must be bigger than the total running time of the CI job.  So, deadlocks take longer to be noticed.

### Should the timeout be configurable within each test, by setting an ocamltest variable in the ocamltest test header?

That might be nice, even though I found no use for it.  But a global timeout is a must-have: we don't know in advance which tests may not terminate, and we don't want to add a `timeout=600` line to every test file.

### Why 10 minutes?

This timeout was chosen to be well above the execution time of any of our tests on any of our testing platforms, yet short enough that timeouts are reported relatively quickly.  5 minutes would probably be enough.  A different timeout can be selected via `make TIMEOUT=N all` in `testsuite/`.

### Is this real time or CPU time?

Real time.  CPU time would require a rather different implementation under Unix, and may not be implementable under Windows.

