### PR TITLE
Don't redo coldstart during opt.opt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,7 @@ opt: checknative
 .PHONY: opt.opt
 opt.opt: checknative
 	$(MAKE) checkstack
-	$(MAKE) runtime
-	$(MAKE) core
+	$(MAKE) coreall
 	$(MAKE) ocaml
 	$(MAKE) opt-core
 	$(MAKE) ocamlc.opt


### PR DESCRIPTION
I thought I'd broken something when I happened to spot that `make opt.opt` was copying things from `runtime/` to `boot/`.

`world.opt` is supposed to bring up the system from cold, but `opt.opt` was always supposed to be run after `world` and so after `coldstart`. `coldstart` is not supposed to be repeated while developing. So, if `opt.opt` is allowed to assume that `coldstart` has been run, it should be building `coreall`, not `core`. `coreall` already depends on `runtime`, so that recursive call can be removed too.

With this small change, following `make world opt`, `make opt.opt` now begins (I've omitted Entering/Leaving lines):

```
make checkstack
# Runs as expected
make coreall
make -C runtime  all
make[2]: Nothing to be done for 'all'.
make ocamlc
make[2]: 'ocamlc' is up to date.
make ocamllex ocamltools library
make -C yacc  all
make[3]: Nothing to be done for 'all'.
make -C lex all
make[3]: Nothing to be done for 'all'.
make -C tools all
make[3]: Nothing to be done for 'all'.
make -C stdlib  all
make[3]: Nothing to be done for 'all'.
make ocaml
make[1]: 'ocaml' is up to date.
make opt-core
make -C runtime  allopt
make[2]: Nothing to be done for 'allopt'.
make ocamlopt
make[2]: 'ocamlopt' is up to date.
make libraryopt
make -C stdlib  allopt
make[3]: Nothing to be done for 'allopt'.
make ocamlc.opt
# And we start actually building stuff here...
```
which seems more correct.