### PR TITLE
stdlib: add List.split_map

### DIFF
--- a/Changes
+++ b/Changes
@@ -185,6 +185,10 @@ Working version
 - #10389, #10391, #10392: Add {Int,Int32,Int64,Nativeint}.{min,max}.
   (Nicolás Ojeda Bär and Alain Frisch, review by Xavier Leroy)
 
+- #10115: Add List.split_map.
+  (Craig Ferguson, review by Gabriel Scherer, Nicolás Ojeda Bär and Damien
+  Doligez)
+
 ### Other libraries:
 
 - #10047: Add `Unix.realpath`

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -299,6 +299,13 @@ let rec split = function
   | (x,y)::l ->
       let (rx, ry) = split l in (x::rx, y::ry)
 
+let rec split_map f = function
+    [] -> ([], [])
+  | hd::tl ->
+      let x, y = f hd in
+      let (rx, ry) = split_map f tl in
+      (x::rx, y::ry)
+
 let rec combine l1 l2 =
   match (l1, l2) with
     ([], []) -> []

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -429,10 +429,25 @@ val split : ('a * 'b) list -> 'a list * 'b list
    Not tail-recursive.
  *)
 
+val split_map : ('a -> 'b * 'c) -> 'a list -> 'b list * 'c list
+(** Split a list into a pair of lists by applying a given splitting function
+    to each element.
+
+    [split_map f \[a1; ...; an\]] is [(\[b1; ...; bn\], \[c1; ...; cn\])],
+    where [f ai = (bi, ci)].
+
+    Not tail-recursive.
+
+    @since 4.13.0
+ *)
+
 val combine : 'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
+
+   Equivalent to [map2 (fun a b -> (a, b))].
+
    @raise Invalid_argument if the two lists
    have different lengths. Not tail-recursive.
  *)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -429,10 +429,25 @@ val split : ('a * 'b) list -> 'a list * 'b list
    Not tail-recursive.
  *)
 
+val split_map : f:('a -> 'b * 'c) -> 'a list -> 'b list * 'c list
+(** Split a list into a pair of lists by applying a given splitting function
+    to each element.
+
+    [split_map ~f \[a1; ...; an\]] is [(\[b1; ...; bn\], \[c1; ...; cn\])],
+    where [f ai = (bi, ci)].
+
+    Not tail-recursive.
+
+    @since 4.13.0
+ *)
+
 val combine : 'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
+
+   Equivalent to [map2 (fun a b -> (a, b))].
+
    @raise Invalid_argument if the two lists
    have different lengths. Not tail-recursive.
  *)

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -92,6 +92,10 @@ let () =
   assert (
     let f a b = a + b, string_of_int b in
     List.fold_left_map f 0 l = (45, sl));
+
+  assert (List.split_map Fun.id [(1, -1); (2, -2); (3, -3)]
+          = ([1; 2; 3],[-1; -2; -3]));
+
   ()
 ;;
 


### PR DESCRIPTION
Adds the following functions to the standard library:

```ocaml
module List : sig
  (* ... *)

  val split_with   : ('a -> 'b * 'c) -> 'a t -> 'b t * 'c t
  val combine_with : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
end
```

These functions generalise the existing `List.split` and `List.combine` to take arbitrary functions for splitting and combining. In particular:

```ocaml
List.split    ≡  List.split_with (fun (a, b) -> (a, b))
List.combine  ≡  List.combine_with (fun a b -> (a, b))
```

These functions are useful when dealing with data in records or abstract types rather than pairs, and I'm occasionally bitten by the lack of them when refactoring the latter into the former. Providing them here avoids the need for a two-pass transformation w/ `List.map` in these cases.

These functions are quite popular in Haskell code – as [`zipWith`](https://hoogle.haskell.org/?hoogle=zipWith) and [`unzipWith`](https://hoogle.haskell.org/?hoogle=unzipWith) – but AFAICS are not provided by the big OCaml stdlib replacement libraries; make of that what you will.