### PR TITLE
Renew table of Win32-incompatible functions in Unix

### DIFF
--- a/manual/manual/library/libunix.etex
+++ b/manual/manual/library/libunix.etex
@@ -84,11 +84,11 @@ is implemented}
 \entree{"times"}{partially implemented, will not report timings for child
 processes}
 \entree{"getitimer", "setitimer"}{not implemented}
-\entree{"getuid", "geteuid", "getgid", "getegid"}{always returns 1}
+\entree{"getuid", "geteuid", "getgid", "getegid"}{always return 1}
 \entree{"setuid", "setgid", "setgroups", "initgroups"}{not implemented}
 \entree{"getgroups"}{always returns "[|1|]" (since 2.00)}
-\entree{"getpwnam", "getpwuid"}{always raises "Not_found"}
-\entree{"getgrnam", "getgrgid"}{always raises "Not_found"}
+\entree{"getpwnam", "getpwuid"}{always raise "Not_found"}
+\entree{"getgrnam", "getgrgid"}{always raise "Not_found"}
 \entree{type "socket_domain"}{"PF_INET" is fully supported;
 "PF_INET6" is fully supported (since 4.01.0); "PF_UNIX" is not supported }
 \entree{"establish_server"}{not implemented; use threads}

--- a/manual/manual/library/libunix.etex
+++ b/manual/manual/library/libunix.etex
@@ -31,13 +31,13 @@ For interactive use of the "unix" library, do:
 or (if dynamic linking of C libraries is supported on your platform),
 start "ocaml" and type "#load \"unix.cma\";;".
 
+\begin{latexonly}
 \begin{windows}
 A fairly complete emulation of the Unix system calls is provided in
 the Windows version of OCaml. The end of this chapter gives
 more information on the functions that are not supported under Windows.
 \end{windows}
 
-\begin{latexonly}
 \begin{linklist}
 \stddocitem{Unix}{Unix system calls}
 \end{linklist}
@@ -57,6 +57,7 @@ the Unix module.  The native Win32 ports implement a subset of them.
 Below is a list of the functions that are not implemented, or only
 partially implemented, by the Win32 ports. Functions not mentioned are
 fully implemented and behave as described previously in this chapter.
+\end{windows}
 
 \begin{tableau}{|l|p{8cm}|}{Functions}{Comment}
 \entree{"fork"}{not implemented, use "create_process" or threads}
@@ -64,32 +65,33 @@ fully implemented and behave as described previously in this chapter.
 \entree{"waitpid"}{can only wait for a given PID, not any child process}
 \entree{"getppid"}{not implemented (meaningless under Windows)}
 \entree{"nice"}{not implemented}
-\entree{"truncate", "ftruncate"}{not implemented}
+\entree{"truncate", "ftruncate"}{implemented (since 4.10.0)}
 \entree{"link"}{implemented (since 3.02)}
-\entree{"symlink", "readlink"}{implemented (since 4.03.0)}
-\entree{"access"}{execute permission "X_OK" cannot be tested,
-  it just tests for read permission instead}
 \entree{"fchmod"}{not implemented}
 \entree{"chown", "fchown"}{not implemented (make no sense on a DOS
 file system)}
 \entree{"umask"}{not implemented}
+\entree{"access"}{execute permission "X_OK" cannot be tested,
+  it just tests for read permission instead}
+\entree{"chroot"}{not implemented}
 \entree{"mkfifo"}{not implemented}
+\entree{"symlink", "readlink"}{implemented (since 4.03.0)}
 \entree{"kill"}{partially implemented (since 4.00.0): only the "sigkill" signal
 is implemented}
+\entree{"sigprocmask", "sigpending", "sigsuspend"}{not implemented (no inter-process signals on Windows}
 \entree{"pause"}{not implemented (no inter-process signals in Windows)}
 \entree{"alarm"}{not implemented}
 \entree{"times"}{partially implemented, will not report timings for child
 processes}
 \entree{"getitimer", "setitimer"}{not implemented}
-\entree{"getuid", "geteuid", "getgid", "getegid"}{always return 1}
+\entree{"getuid", "geteuid", "getgid", "getegid"}{always returns 1}
+\entree{"setuid", "setgid", "setgroups", "initgroups"}{not implemented}
 \entree{"getgroups"}{always returns "[|1|]" (since 2.00)}
-\entree{"setuid", "setgid", "setgroups"}{not implemented}
-\entree{"getpwnam", "getpwuid"}{always raise "Not_found"}
-\entree{"getgrnam", "getgrgid"}{always raise "Not_found"}
+\entree{"getpwnam", "getpwuid"}{always raises "Not_found"}
+\entree{"getgrnam", "getgrgid"}{always raises "Not_found"}
 \entree{type "socket_domain"}{"PF_INET" is fully supported;
 "PF_INET6" is fully supported (since 4.01.0); "PF_UNIX" is not supported }
 \entree{"establish_server"}{not implemented; use threads}
 \entree{terminal functions ("tc*")}{not implemented}
+\entree{"setsid"}{not implemented}
 \end{tableau}
-
-\end{windows}

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -24,7 +24,7 @@
 (* NOTE:
    When a new function is added which is not implemented on Windows (or
    partially implemented), or the Windows-status of an existing function is
-   changed, remember to update the sumamry table in
+   changed, remember to update the summary table in
    manual/manual/library/libunix.etex
 *)
 

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -17,9 +17,16 @@
    If this file is unixLabels.mli, run tools/sync_stdlib_docs after editing it
    to generate unix.mli.
 
-   If this file is unix.mli, do not edit it directly -- edit
-   unixLabels.mli instead.
- *)
+   If this file is unix.mli, do not edit it directly -- edit unixLabels.mli
+   instead.
+*)
+
+(* NOTE:
+   When a new function is added which is not implemented on Windows (or
+   partially implemented), or the Windows-status of an existing functions is
+   changed, remember to update the sumamry table in
+   manual/manual/library/libunix.etex
+*)
 
 (** Interface to the Unix system.
 

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -23,7 +23,7 @@
 
 (* NOTE:
    When a new function is added which is not implemented on Windows (or
-   partially implemented), or the Windows-status of an existing functions is
+   partially implemented), or the Windows-status of an existing function is
    changed, remember to update the sumamry table in
    manual/manual/library/libunix.etex
 *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -24,7 +24,7 @@
 (* NOTE:
    When a new function is added which is not implemented on Windows (or
    partially implemented), or the Windows-status of an existing function is
-   changed, remember to update the sumamry table in
+   changed, remember to update the summary table in
    manual/manual/library/libunix.etex
 *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -17,9 +17,16 @@
    If this file is unixLabels.mli, run tools/sync_stdlib_docs after editing it
    to generate unix.mli.
 
-   If this file is unix.mli, do not edit it directly -- edit
-   unixLabels.mli instead.
- *)
+   If this file is unix.mli, do not edit it directly -- edit unixLabels.mli
+   instead.
+*)
+
+(* NOTE:
+   When a new function is added which is not implemented on Windows (or
+   partially implemented), or the Windows-status of an existing functions is
+   changed, remember to update the sumamry table in
+   manual/manual/library/libunix.etex
+*)
 
 (** Interface to the Unix system.
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -23,7 +23,7 @@
 
 (* NOTE:
    When a new function is added which is not implemented on Windows (or
-   partially implemented), or the Windows-status of an existing functions is
+   partially implemented), or the Windows-status of an existing function is
    changed, remember to update the sumamry table in
    manual/manual/library/libunix.etex
 *)


### PR DESCRIPTION
As part of some work I'm doing for the OCaml Software Foundation, I've been asked to do a pass over the Reference Manual. I have two or three larger proposals for the manual, but I'll consult properly on those before spending time on them.

Meanwhile I have a number of (I hope uncontroversial) changes, of which this is the first.

The table of windows-incompatible functions in the main page of the Unix documentation is out of date. This PR:

- reorders the entries in the table to match the order of the Unix documentation itself for easier maintenance
- adds the missing functions to it
- adds a note in UnixLabels.mli / Unix.mli reminding programmers to update the table
- changes some of the \begin{windows} and \begin{latexonly} positions and orders to get the right result for HTML and PDF versions of the manual (the current HTML page had two paragraphs about Windows which, taken together, were rather confusing. In the PDF version of the manual, these two paragraphs appear in two different places, and make sense. After this PR, only the latter paragraph appears in the HTML version.)
