### PR TITLE
iff -> if and only if

### DIFF
--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -42,7 +42,7 @@ external ( || ) : bool -> bool -> bool = "%sequor"
 (** {1:preds Predicates and comparisons} *)
 
 val equal : bool -> bool -> bool
-(** [equal b0 b1] is [true] only if [b0] and [b1] are both [true]
+(** [equal b0 b1] is [true] if and only if [b0] and [b1] are both [true]
     or both [false]. *)
 
 val compare : bool -> bool -> int

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -42,7 +42,7 @@ external ( || ) : bool -> bool -> bool = "%sequor"
 (** {1:preds Predicates and comparisons} *)
 
 val equal : bool -> bool -> bool
-(** [equal b0 b1] is [true] iff [b0] and [b1] are both either [true]
+(** [equal b0 b1] is [true] if and only if [b0] and [b1] are both either [true]
     or [false]. *)
 
 val compare : bool -> bool -> int

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -42,8 +42,8 @@ external ( || ) : bool -> bool -> bool = "%sequor"
 (** {1:preds Predicates and comparisons} *)
 
 val equal : bool -> bool -> bool
-(** [equal b0 b1] is [true] if and only if [b0] and [b1] are both either [true]
-    or [false]. *)
+(** [equal b0 b1] is [true] only if [b0] and [b1] are both [true]
+    or both [false]. *)
 
 val compare : bool -> bool -> int
 (** [compare b0 b1] is a total order on boolean values. [false] is smaller

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -123,23 +123,24 @@ val epsilon : float
     floating-point number greater than [1.0]. *)
 
 val is_finite : float -> bool
-(** [is_finite x] is [true] iff [x] is finite i.e., not infinite and
+(** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
    not {!nan}.
 
    @since 4.08.0 *)
 
 val is_infinite : float -> bool
-(** [is_infinite x] is [true] iff [x] is {!infinity} or {!neg_infinity}.
+(** [is_infinite x] is [true] if and only if [x] is {!infinity} or
+    {!neg_infinity}.
 
    @since 4.08.0 *)
 
 val is_nan : float -> bool
-(** [is_nan x] is [true] iff [x] is not a number (see {!nan}).
+(** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}).
 
    @since 4.08.0 *)
 
 val is_integer : float -> bool
-(** [is_integer x] is [true] iff [x] is an integer.
+(** [is_integer x] is [true] if and only if [x] is an integer.
 
    @since 4.08.0 *)
 
@@ -320,7 +321,7 @@ external copy_sign : float -> float -> float
 
 external sign_bit : (float [@unboxed]) -> bool
   = "caml_signbit_float" "caml_signbit" [@@noalloc]
-(** [sign_bit x] is [true] iff the sign bit of [x] is set.
+(** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
     For example [sign_bit 1.] and [signbit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true].
 

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -103,7 +103,7 @@ external shift_right_logical : int -> int -> int = "%lsrint"
 (** {1:preds Predicates and comparisons} *)
 
 val equal : int -> int -> bool
-(** [equal x y] is [true] iff [x = y]. *)
+(** [equal x y] is [true] if and only if [x = y]. *)
 
 val compare : int -> int -> int
 (** [compare x y] is {!Stdlib.compare}[ x y] but more efficient. *)

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -55,14 +55,14 @@ val iter : ('a -> unit) -> 'a option -> unit
 (** {1:preds Predicates and comparisons} *)
 
 val is_none : 'a option -> bool
-(** [is_none o] is [true] iff [o] is [None]. *)
+(** [is_none o] is [true] if and only if [o] is [None]. *)
 
 val is_some : 'a option -> bool
-(** [is_some o] is [true] iff [o] is [Some o]. *)
+(** [is_some o] is [true] if and only if [o] is [Some o]. *)
 
 val equal : ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
-(** [equal eq o0 o1] is [true] iff [o0] and [o1] are both [None] or if
-    they are [Some v0] and [Some v1] and [eq v0 v1] is [true]. *)
+(** [equal eq o0 o1] is [true] if and only if [o0] and [o1] are both [None]
+    or if they are [Some v0] and [Some v1] and [eq v0 v1] is [true]. *)
 
 val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int
 (** [compare cmp o0 o1] is a total order on options using [cmp] to compare

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -68,10 +68,10 @@ val iter_error : ('e -> unit) -> ('a, 'e) result -> unit
 (** {1:preds Predicates and comparisons} *)
 
 val is_ok : ('a, 'e) result -> bool
-(** [is_ok r] is [true] iff [r] is [Ok _]. *)
+(** [is_ok r] is [true] if and only if [r] is [Ok _]. *)
 
 val is_error : ('a, 'e) result -> bool
-(** [is_error r] is [true] iff [r] is [Error _]. *)
+(** [is_error r] is [true] if and only if [r] is [Error _]. *)
 
 val equal :
   ok:('a -> 'a -> bool) -> error:('e -> 'e -> bool) -> ('a, 'e) result ->

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -119,7 +119,8 @@ val concat : string -> string list -> string
 (** {1:predicates Predicates and comparisons} *)
 
 val equal : t -> t -> bool
-(** [equal s0 s1] is [true] iff [s0] and [s1] are character-wise equal.
+(** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
+    equal.
     @since 4.03.0 (4.05.0 in StringLabels) *)
 
 val compare : t -> t -> int
@@ -128,25 +129,26 @@ val compare : t -> t -> int
 
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] iff [s] starts with [prefix].
+(** [starts_with ][~][prefix s] is [true] if and only if [s] starts with
+    [prefix].
 
     @since 4.12.0 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with suffix s] is [true] iff [s] ends with [suffix].
+(** [ends_with suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.12.0 *)
 
 val contains_from : string -> int -> char -> bool
-(** [contains_from s start c] is [true] iff [c] appears in [s] after position
-    [start].
+(** [contains_from s start c] is [true] if and only if [c] appears in [s]
+    after position [start].
 
     @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : string -> int -> char -> bool
-(** [rcontains_from s stop c] is [true] iff [c] appears in [s] before position
-    [stop+1].
+(** [rcontains_from s stop c] is [true] if and only if [c] appears in [s]
+    before position [stop+1].
 
     @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -119,7 +119,8 @@ val concat : sep:string -> string list -> string
 (** {1:predicates Predicates and comparisons} *)
 
 val equal : t -> t -> bool
-(** [equal s0 s1] is [true] iff [s0] and [s1] are character-wise equal.
+(** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
+    equal.
     @since 4.03.0 (4.05.0 in StringLabels) *)
 
 val compare : t -> t -> int
@@ -128,25 +129,26 @@ val compare : t -> t -> int
 
 val starts_with :
   prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] iff [s] starts with [prefix].
+(** [starts_with ][~][prefix s] is [true] if and only if [s] starts with
+    [prefix].
 
     @since 4.12.0 *)
 
 val ends_with :
   suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with ~suffix s] is [true] iff [s] ends with [suffix].
+(** [ends_with ~suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.12.0 *)
 
 val contains_from : string -> int -> char -> bool
-(** [contains_from s start c] is [true] iff [c] appears in [s] after position
-    [start].
+(** [contains_from s start c] is [true] if and only if [c] appears in [s]
+    after position [start].
 
     @raise Invalid_argument if [start] is not a valid position in [s]. *)
 
 val rcontains_from : string -> int -> char -> bool
-(** [rcontains_from s stop c] is [true] iff [c] appears in [s] before position
-    [stop+1].
+(** [rcontains_from s stop c] is [true] if and only if [c] appears in [s]
+    before position [stop+1].
 
     @raise Invalid_argument if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)

--- a/stdlib/templates/float.template.mli
+++ b/stdlib/templates/float.template.mli
@@ -123,23 +123,24 @@ val epsilon : float
     floating-point number greater than [1.0]. *)
 
 val is_finite : float -> bool
-(** [is_finite x] is [true] iff [x] is finite i.e., not infinite and
+(** [is_finite x] is [true] if and only if [x] is finite i.e., not infinite and
    not {!nan}.
 
    @since 4.08.0 *)
 
 val is_infinite : float -> bool
-(** [is_infinite x] is [true] iff [x] is {!infinity} or {!neg_infinity}.
+(** [is_infinite x] is [true] if and only if [x] is {!infinity} or
+    {!neg_infinity}.
 
    @since 4.08.0 *)
 
 val is_nan : float -> bool
-(** [is_nan x] is [true] iff [x] is not a number (see {!nan}).
+(** [is_nan x] is [true] if and only if [x] is not a number (see {!nan}).
 
    @since 4.08.0 *)
 
 val is_integer : float -> bool
-(** [is_integer x] is [true] iff [x] is an integer.
+(** [is_integer x] is [true] if and only if [x] is an integer.
 
    @since 4.08.0 *)
 
@@ -320,7 +321,7 @@ external copy_sign : float -> float -> float
 
 external sign_bit : (float [@unboxed]) -> bool
   = "caml_signbit_float" "caml_signbit" [@@noalloc]
-(** [sign_bit x] is [true] iff the sign bit of [x] is set.
+(** [sign_bit x] is [true] if and only if the sign bit of [x] is set.
     For example [sign_bit 1.] and [signbit 0.] are [false] while
     [sign_bit (-1.)] and [sign_bit (-0.)] are [true].
 

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -58,7 +58,7 @@ val pred : t -> t
     @raise Invalid_argument if [u] is {!min}. *)
 
 val is_valid : int -> bool
-(** [is_valid n] is [true] iff [n] is a Unicode scalar value
+(** [is_valid n] is [true] if and only if [n] is a Unicode scalar value
     (i.e. in the ranges [0x0000]...[0xD7FF] or [0xE000]...[0x10FFFF]).*)
 
 val of_int : int -> t
@@ -74,7 +74,7 @@ val to_int : t -> int
 (** [to_int u] is [u] as an integer. *)
 
 val is_char : t -> bool
-(** [is_char u] is [true] iff [u] is a latin1 OCaml character. *)
+(** [is_char u] is [true] if and only if [u] is a latin1 OCaml character. *)
 
 val of_char : char -> t
 (** [of_char c] is [c] as a Unicode character. *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -98,8 +98,8 @@ module Stdlib : sig
         There is no constraint on the relative lengths of the lists. *)
 
     val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
-    (** Returns [true] iff the given lists have the same length and content
-        with respect to the given equality function. *)
+    (** Returns [true] if and only if the given lists have the same length and
+        content with respect to the given equality function. *)
 
     val some_if_all_elements_are_some : 'a option t -> 'a t option
     (** If all elements of the given list are [Some _] then [Some xs]
@@ -121,8 +121,8 @@ module Stdlib : sig
       -> 'a list
       -> of_:'a list
       -> bool
-    (** Returns [true] iff the given list, with respect to the given equality
-        function on list members, is a prefix of the list [of_]. *)
+    (** Returns [true] if and only if the given list, with respect to the given
+        equality function on list members, is a prefix of the list [of_]. *)
 
     type 'a longest_common_prefix_result = private {
       longest_common_prefix : 'a list;


### PR DESCRIPTION
This PR replaces "iff" with "if and only if" throughout .mli files which appear in the reference manual.

iff can be confusing for a) non-mathematicians and b) schoolchildren. It's also not trivial to Google (and looks like a typo to the uninitiated). The effect of the extra verbosity on the rest of us is minimal.

No changes entry required, so far as I can see.
