### PR TITLE
Remove Strings.{starts,ends}_with from 4.12 due to API issue

### DIFF
--- a/Changes
+++ b/Changes
@@ -256,10 +256,6 @@ OCaml 4.12.0
    and more generally all other data that is not a well-formed OCaml value
    (Xavier Leroy, review by Damien Doligez and Gabriel Scherer)
 
-- #9533: Added String.starts_with and String.ends_with.
-  (Bernhard Schommer, review by Daniel Bünzli, Gabriel Scherer and
-  Alain Frisch)
-
 - #9663: Extend Printexc API for raw backtrace entries.
   (Stephen Dolan, review by Nicolás Ojeda Bär and Gabriel Scherer)
 

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -100,7 +100,9 @@ module Unix : SYSDEPS = struct
     && (String.length n < 2 || String.sub n 0 2 <> "./")
     && (String.length n < 3 || String.sub n 0 3 <> "../")
   let check_suffix name suff =
-    String.ends_with ~suffix:suff name
+    String.length name >= String.length suff &&
+    String.sub name (String.length name - String.length suff)
+                    (String.length suff) = suff
 
   let chop_suffix_opt ~suffix filename =
     let len_s = String.length suffix and len_f = String.length filename in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -197,25 +197,6 @@ let capitalize_ascii s =
 let uncapitalize_ascii s =
   B.uncapitalize_ascii (bos s) |> bts
 
-let starts_with ~prefix s =
-  let len_s = length s
-  and len_pre = length prefix in
-  let rec aux i =
-    if i = len_pre then true
-    else if unsafe_get s i <> unsafe_get prefix i then false
-    else aux (i + 1)
-  in len_s >= len_pre && aux 0
-
-let ends_with ~suffix s =
-  let len_s = length s
-  and len_suf = length suffix in
-  let diff = len_s - len_suf in
-  let rec aux i =
-    if i = len_suf then true
-    else if unsafe_get s (diff + i) <> unsafe_get suffix i then false
-    else aux (i + 1)
-  in diff >= 0 && aux 0
-
 let split_on_char sep s =
   let r = ref [] in
   let j = ref (length s) in

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -126,18 +126,6 @@ val compare : t -> t -> int
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
-val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] iff [s] starts with [prefix].
-
-    @since 4.12.0 *)
-
-val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with suffix s] is [true] iff [s] ends with [suffix].
-
-    @since 4.12.0 *)
-
 val contains_from : string -> int -> char -> bool
 (** [contains_from s start c] is [true] iff [c] appears in [s] after position
     [start].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -126,18 +126,6 @@ val compare : t -> t -> int
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
-val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] iff [s] starts with [prefix].
-
-    @since 4.12.0 *)
-
-val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with ~suffix s] is [true] iff [s] ends with [suffix].
-
-    @since 4.12.0 *)
-
 val contains_from : string -> int -> char -> bool
 (** [contains_from s start c] is [true] iff [c] appears in [s] after position
     [start].

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -52,16 +52,4 @@ let ()  =
     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
     try ignore (String.concat "" !l); assert false
     with Invalid_argument _ -> ();
-    assert(String.starts_with ~prefix:"foob" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "");
-    assert(not (String.starts_with ~prefix:"foobar" "bar"));
-    assert(not (String.starts_with ~prefix:"foo" ""));
-    assert(not (String.starts_with ~prefix:"fool" "foobar"));
-    assert(String.ends_with ~suffix:"baz" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "");
-    assert(not (String.ends_with ~suffix:"foobar" "bar"));
-    assert(not (String.ends_with ~suffix:"foo" ""));
-    assert(not (String.ends_with ~suffix:"obaz" "foobar"));
   end


### PR DESCRIPTION
This PR against 4.12 (not trunk) implements implements a proposal emerging from the discussion in #10105, that seems *reasonably* consensual.

(The text below is from the commit message of the PR, it explains the decision for people who have not followed #10105.)

```ocaml
String.starts_with : prefix:string -> string -> bool
String.ends_with : suffix:string -> string -> bool
```

The problem with the API is that there is no strong
consensus (among API designers or among potential users) of the
ordering of the arguments for these functions. In theory the labels
should solve that problem for us; but in practice currently there is
no warning by default if labels are not given. This makes the
functions as-is dangerous to use, in particular mixed with other
libraries like Extlib that define them without the labels.

We are currently discussing enabling the warning by
default (requiring labeling, even for full applications) in
trunk (future 4.13), which would solve this problem. In the meantime,
it feels safer to not include the functions in 4.12.