### PR TITLE
String.{starts,ends}_with: use the label `sub` instead of `prefix` and `suffix`

### DIFF
--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -100,7 +100,7 @@ module Unix : SYSDEPS = struct
     && (String.length n < 2 || String.sub n 0 2 <> "./")
     && (String.length n < 3 || String.sub n 0 3 <> "../")
   let check_suffix name suff =
-    String.ends_with ~suffix:suff name
+    String.ends_with ~sub:suff name
 
   let chop_suffix_opt ~suffix filename =
     let len_s = String.length suffix and len_f = String.length filename in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -197,22 +197,22 @@ let capitalize_ascii s =
 let uncapitalize_ascii s =
   B.uncapitalize_ascii (bos s) |> bts
 
-let starts_with ~prefix s =
+let starts_with ~sub s =
   let len_s = length s
-  and len_pre = length prefix in
+  and len_pre = length sub in
   let rec aux i =
     if i = len_pre then true
-    else if unsafe_get s i <> unsafe_get prefix i then false
+    else if unsafe_get s i <> unsafe_get sub i then false
     else aux (i + 1)
   in len_s >= len_pre && aux 0
 
-let ends_with ~suffix s =
+let ends_with ~sub s =
   let len_s = length s
-  and len_suf = length suffix in
+  and len_suf = length sub in
   let diff = len_s - len_suf in
   let rec aux i =
     if i = len_suf then true
-    else if unsafe_get s (diff + i) <> unsafe_get suffix i then false
+    else if unsafe_get s (diff + i) <> unsafe_get sub i then false
     else aux (i + 1)
   in diff >= 0 && aux 0
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -128,15 +128,15 @@ val compare : t -> t -> int
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
 val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] if and only if [s] starts with
-    [prefix].
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+(** [starts_with ][~][sub s] is [true] if and only if [s] starts with
+    [sub].
 
     @since 4.12.0 *)
 
 val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with suffix s] is [true] if and only if [s] ends with [suffix].
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+(** [ends_with ][~][sub s] is [true] if and only if [s] ends with [sub].
 
     @since 4.12.0 *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -128,15 +128,15 @@ val compare : t -> t -> int
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
 val starts_with :
-  prefix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [starts_with ][~][prefix s] is [true] if and only if [s] starts with
-    [prefix].
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+(** [starts_with ][~][sub s] is [true] if and only if [s] starts with
+    [sub].
 
     @since 4.12.0 *)
 
 val ends_with :
-  suffix (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
-(** [ends_with ~suffix s] is [true] if and only if [s] ends with [suffix].
+  sub (* comment thwarts tools/sync_stdlib_docs *) :string -> string -> bool
+(** [ends_with ][~][suffix s] is [true] if and only if [s] ends with [suffix].
 
     @since 4.12.0 *)
 

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -52,16 +52,16 @@ let ()  =
     while !sz <= 0 do push big l; sz += Sys.max_string_length done;
     try ignore (String.concat "" !l); assert false
     with Invalid_argument _ -> ();
-    assert(String.starts_with ~prefix:"foob" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "foobarbaz");
-    assert(String.starts_with ~prefix:"" "");
-    assert(not (String.starts_with ~prefix:"foobar" "bar"));
-    assert(not (String.starts_with ~prefix:"foo" ""));
-    assert(not (String.starts_with ~prefix:"fool" "foobar"));
-    assert(String.ends_with ~suffix:"baz" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "foobarbaz");
-    assert(String.ends_with ~suffix:"" "");
-    assert(not (String.ends_with ~suffix:"foobar" "bar"));
-    assert(not (String.ends_with ~suffix:"foo" ""));
-    assert(not (String.ends_with ~suffix:"obaz" "foobar"));
+    assert(String.starts_with ~sub:"foob" "foobarbaz");
+    assert(String.starts_with ~sub:"" "foobarbaz");
+    assert(String.starts_with ~sub:"" "");
+    assert(not (String.starts_with ~sub:"foobar" "bar"));
+    assert(not (String.starts_with ~sub:"foo" ""));
+    assert(not (String.starts_with ~sub:"fool" "foobar"));
+    assert(String.ends_with ~sub:"baz" "foobarbaz");
+    assert(String.ends_with ~sub:"" "foobarbaz");
+    assert(String.ends_with ~sub:"" "");
+    assert(not (String.ends_with ~sub:"foobar" "bar"));
+    assert(not (String.ends_with ~sub:"foo" ""));
+    assert(not (String.ends_with ~sub:"obaz" "foobar"));
   end


### PR DESCRIPTION
This is a continuation of #9533 and #10105, a [change proposal](https://github.com/ocaml/ocaml/pull/9533#issuecomment-667937456) for `String.{starts,ends}_with` that had support from both @bschommer and @dbuenzli: use the `~sub` label for both functions instead of `~prefix` for one and `~suffix` for the other.

I also changed `ocamlmklib` to use the standard library functions instead of a local reimplementation. It's interesting to see the impact of the change (the callsites do feel more verbose).

I must say that I find this change less convincing than #10127. To me the function calls do read slightly more nicely with the current label names than with the new `~sub` labels.