### PR TITLE
MetaOCaml: reserved `>.` token

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -335,6 +335,8 @@ let identchar_latin1 =
 
 let symbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
+let symbolcharnodot =
+  ['!' '$' '%' '&' '*' '+' '-'     '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
 let dotsymbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '/' ':' '=' '>' '?' '@' '^' '|']
 let symbolchar_or_hash =
@@ -555,8 +557,12 @@ rule token = parse
             { PREFIXOP op }
   | ['~' '?'] symbolchar_or_hash + as op
             { PREFIXOP op }
-  | ['=' '<' '>' '|' '&' '$'] symbolchar * as op
-            { INFIXOP0 op }
+  (* NNN The following is needed for the case >.>.
+     NNN So it will parse as two closing brackets rather that INFIXOP0 *)
+  | ['=' '<' '|' '&' '$'] symbolchar * as op(* NNN: ">." is not INFIXOP0 *)
+             { INFIXOP0 op }
+  | ['>'] symbolcharnodot symbolchar * as op    (* NNN exclude ">." case *)
+            { INFIXOP0 op }                     (* NNN *)
   | ['@' '^'] symbolchar * as op
             { INFIXOP1 op }
   | ['+' '-'] symbolchar * as op


### PR DESCRIPTION
Submitted on behalf of Oleg, cc @yallop .

This PR is part of a series of patches sent to me by Oleg that proposes to reduce the difference between OCaml and MetaOCaml at the syntactic level.

This first PR modifies OCaml lexer to make sure that all OCaml program are syntactically valid in MetaOCaml.
In particular, it removes ">." from the set of infix operators:
```ocaml
let (>.) _ _ = ()
let () = 1 >. 2
```
emits a syntax error after this PR.
Similarly, the tokenisation of `>.>.` is modified to `>.` `>.`.

