### PR TITLE
AppVeyor refactoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,7 +64,6 @@ tools/mantis2gh_stripped.csv typo.missing-header
 # tools/ci/appveyor/appveyor_build.cmd only has missing-header because
 # dra27 too lazy to update check-typo to interpret Cmd-style comments!
 /tools/ci/appveyor/appveyor_build.cmd       typo.very-long-line typo.missing-header typo.non-ascii
-/tools/ci/appveyor/appveyor_build.sh        typo.non-ascii
 /tools/ci/inria/bootstrap/remove-sinh-primitive.patch typo.prune
 /release-info/howto.md                    typo.missing-header typo.long-line
 /release-info/templates/*.md              typo.missing-header typo.very-long-line=may

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -20,6 +20,10 @@
 @rem Do not call setlocal!
 @echo off
 
+chcp 65001 > nul
+set BUILD_PREFIX=🐫реализация
+set OCAMLROOT=%PROGRAMFILES%\Бактріан🐫
+
 if "%1" neq "install" goto %1
 setlocal enabledelayedexpansion
 echo AppVeyor Environment
@@ -68,9 +72,14 @@ if %CYGWIN_UPGRADE_REQUIRED% equ 1 (
 goto :EOF
 
 :install
-chcp 65001 > nul
-rem This must be kept in sync with appveyor_build.sh
-set BUILD_PREFIX=🐫реализация
+
+if defined SDK set SDK=call %SDK%
+if not defined SDK (
+  if "%PORT%" equ "msvc64" set SDK=call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+  if "%PORT%" equ "msvc32" set SDK=call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
+)
+%SDK%
+
 git worktree add "..\%BUILD_PREFIX%-%PORT%" -b appveyor-build-%PORT%
 
 cd "..\%BUILD_PREFIX%-%PORT%"
@@ -125,21 +134,6 @@ call :UpgradeCygwin
 goto :EOF
 
 :build
-rem Testing %SDK% is tricky, since it can contain double-quotes. The "trick",
-rem is to make SDK_TEST the second character of %SDK%. If %SDK% is un-set then
-rem SDK_TEST will be the literal string %SDK:~1,1%, obviously. However, that
-rem means %SDK_TEST:~1,1% only expands to the empty string if SDK was itself
-rem un-set. <sigh>
-set SDK_TEST=%SDK:~1,1%
-if "%SDK_TEST:~1,1%" neq "" (
-  if "%PORT%" equ "msvc64" set SDK=call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
-  if "%PORT%" equ "msvc32" set SDK=call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
-) else (
-  set SDK=call %SDK%
-)
-
-%SDK%
-
 "%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh" || exit /b 1
 goto :EOF
 

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -89,23 +89,24 @@ function set_configuration {
 }
 
 APPVEYOR_BUILD_FOLDER=$(echo "$APPVEYOR_BUILD_FOLDER" | cygpath -f -)
+FLEXDLLROOT="$(echo "$OCAMLROOT" | cygpath -f -)/bin/flexdll"
 OCAMLROOT=$(echo "$OCAMLROOT" | cygpath -f - -m)
 
 if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
   case "$PORT" in
     cygwin*) ;;
-    *) export PATH="$(echo "$OCAMLROOT" | cygpath -f -)/bin/flexdll:$PATH";;
+    *) export PATH="$FLEXDLLROOT:$PATH";;
   esac
 fi
 
 case "$1" in
   install)
     if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
-      mkdir -p "$OCAMLROOT/bin/flexdll"
+      mkdir -p "$FLEXDLLROOT"
       cd "$APPVEYOR_BUILD_FOLDER/../flexdll"
       # The objects are always built from the sources
       for f in flexdll.h flexlink.exe default*.manifest ; do
-        cp "$f" "$OCAMLROOT/bin/flexdll/"
+        cp "$f" "$FLEXDLLROOT/"
       done
     fi
     case "$PORT" in
@@ -162,8 +163,8 @@ case "$1" in
       tar -xzf "$APPVEYOR_BUILD_FOLDER/flexdll.tar.gz"
       cd "flexdll-$FLEXDLL_VERSION"
       $MAKE MSVC_DETECT=0 CHAINS=${PORT%32} support
-      cp -f *.obj "$OCAMLROOT/bin/flexdll/" || \
-      cp -f *.o "$OCAMLROOT/bin/flexdll/"
+      cp -f *.obj "$FLEXDLLROOT/" 2>/dev/null || \
+      cp -f *.o "$FLEXDLLROOT/"
       cd ..
     fi
 

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -183,7 +183,8 @@ case "$1" in
           "../$BUILD_PREFIX-$PORT/build.log" |
             sed -e 's/\d027\[K//g' \
                 -e 's/\d027\[m/\d027[0m/g' \
-                -e 's/\d027\[01\([m;]\)/\d027[1\1/g';;
+                -e 's/\d027\[01\([m;]\)/\d027[1\1/g'
+        rm -f build.log;;
     steps)
       run "C deps: runtime" make -j64 -C runtime setup-depend
       run "C deps: win32unix" make -j64 -C otherlibs/win32unix setup-depend

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -210,7 +210,8 @@ case "$1" in
       *64)
         ARG='-8';;
     esac
-    find "../$BUILD_PREFIX-$PORT" -type f -name \*.dll | xargs rebase -i "$ARG"
+    find "../$BUILD_PREFIX-$PORT" -type f \( -name \*.dll -o -name \*.so \) | \
+      xargs rebase -i "$ARG"
 
     ;;
 esac

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -89,12 +89,7 @@ function set_configuration {
 }
 
 APPVEYOR_BUILD_FOLDER=$(echo "$APPVEYOR_BUILD_FOLDER" | cygpath -f -)
-# These directory names are specified here, because getting UTF-8 correctly
-# through appveyor.yml -> Command Script -> Bash is quite painful...
-OCAMLROOT=$(echo "$PROGRAMFILES/Бактріан🐫" | cygpath -f - -m)
-
-# This must be kept in sync with appveyor_build.cmd
-BUILD_PREFIX=🐫реализация
+OCAMLROOT=$(echo "$OCAMLROOT" | cygpath -f - -m)
 
 if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
   case "$PORT" in

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -99,7 +99,7 @@ BUILD_PREFIX=🐫реализация
 if [[ $BOOTSTRAP_FLEXDLL = 'false' ]] ; then
   case "$PORT" in
     cygwin*) ;;
-    *) PATH=$(echo "$OCAMLROOT" | cygpath -f -)/bin/flexdll:$PATH;;
+    *) export PATH="$(echo "$OCAMLROOT" | cygpath -f -)/bin/flexdll:$PATH";;
   esac
 fi
 


### PR DESCRIPTION
This PR is a preliminary part of an overhaul of the FlexDLL bootstrap, but as that's complex enough I've extracted out the bits which are just fixes:

- Factorise the setting of the `BUILD_PREFIX` and `OCAMLROOT` into the cmd script only
- `build.log` (created as part of translating VT100 sequences for AppVeyor) wasn't deleted
- A couple of script defects (DLL base display address wrong on Cygwin and a missing `export` annotation)
- Location of FlexDLL now specified once in `$FLEXDLLROOT`