### PR TITLE
In interactive mode, don't use the cache of included directories

### DIFF
--- a/Changes
+++ b/Changes
@@ -122,6 +122,12 @@ Working version
   do not overflow the 16-bit fields where they are stored.
   (Xavier Leroy, report by Github user pveber, review by Gabriel Scherer)
 
+- #10087, #10138: In the toplevel REPL, don't use the cache
+  of included directories, so that files created or deleted while
+  the REPL is running are correctly handled.
+  (Xavier Leroy, report by Github user quakerquickoats, review by
+   Jeremie Dimino)
+
 OCaml 4.12.0
 ------------
 

--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -109,14 +109,14 @@ let is_basename fn = Filename.basename fn = fn
 
 let find fn =
   assert (not Config.merlin || Local_store.is_bound ());
-  if is_basename fn then
+  if is_basename fn && not !Sys.interactive then
     SMap.find fn !files
   else
     Misc.find_in_path (get_paths ()) fn
 
 let find_uncap fn =
   assert (not Config.merlin || Local_store.is_bound ());
-  if is_basename fn then
+  if is_basename fn && not !Sys.interactive then
     SMap.find (String.uncapitalize_ascii fn) !files_uncap
   else
     Misc.find_in_path_uncap (get_paths ()) fn


### PR DESCRIPTION
This is a trivial fix for #10087.

In interactive mode, don't use the cache of included directories.  Instead, look up in all directories at every `find` and `find_uncap` requests.  This is slower but works better when files are being added and removed during an `ocaml` session.
