### PR TITLE
Tidy up docs for compiler libs

### DIFF
--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** {1 Source code locations (ranges of positions), used in parsetree}
+(** Source code locations (ranges of positions), used in parsetree.
 
   {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.

--- a/parsing/longident.mli
+++ b/parsing/longident.mli
@@ -18,6 +18,9 @@
   {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.
 
+  To print a longident, see {!Pprintast.longident}, using
+    {!Format.asprintf} to convert to a string.
+
 *)
 
 type t =
@@ -53,8 +56,3 @@ use \"Parse.longident\" or \"Longident.unflatten\""]
    input-location support.
 
 *)
-
-
-
-(** To print a longident, see {!Pprintast.longident}, using
-    {!Format.asprintf} to convert to a string. *)


### PR DESCRIPTION
Sorry for the small size of this. I had intended to fill in some of the missing compiler-libs docstrings too, but realised I might get things wrong and do more harm than good. So this is all I want to change.