### PR TITLE
Remove duplicate Iterators sections, unify elsewhere

### DIFF
--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -315,13 +315,13 @@ val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
 
 val to_seq : 'a array -> 'a Seq.t
 (** Iterate on the array, in increasing order. Modifications of the
-    array during iteration will be reflected in the iterator.
+    array during iteration will be reflected in the sequence.
     @since 4.07 *)
 
 val to_seqi : 'a array -> (int * 'a) Seq.t
 (** Iterate on the array, in increasing order, yielding indices along elements.
     Modifications of the array during iteration will be reflected in the
-    iterator.
+    sequence.
     @since 4.07 *)
 
 val of_seq : 'a Seq.t -> 'a array

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -311,7 +311,7 @@ val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
     faster on typical input. *)
 
 
-(** {1 Iterators} *)
+(** {1 Arrays and Sequences} *)
 
 val to_seq : 'a array -> 'a Seq.t
 (** Iterate on the array, in increasing order. Modifications of the

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -315,13 +315,13 @@ val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 
 val to_seq : 'a array -> 'a Seq.t
 (** Iterate on the array, in increasing order. Modifications of the
-    array during iteration will be reflected in the iterator.
+    array during iteration will be reflected in the sequence.
     @since 4.07 *)
 
 val to_seqi : 'a array -> (int * 'a) Seq.t
 (** Iterate on the array, in increasing order, yielding indices along elements.
     Modifications of the array during iteration will be reflected in the
-    iterator.
+    sequence.
     @since 4.07 *)
 
 val of_seq : 'a Seq.t -> 'a array

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -311,7 +311,7 @@ val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
     faster on typical input. *)
 
 
-(** {1 Iterators} *)
+(** {1 Arrays and Sequences} *)
 
 val to_seq : 'a array -> 'a Seq.t
 (** Iterate on the array, in increasing order. Modifications of the

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -157,7 +157,7 @@ val truncate : t -> int -> unit
   @raise Invalid_argument if [len < 0] or [len > length b].
   @since 4.05.0 *)
 
-(** {1 Iterators} *)
+(** {1 Buffers and Sequences} *)
 
 val to_seq : t -> char Seq.t
 (** Iterate on the buffer, in increasing order.

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -457,7 +457,7 @@ let s = Bytes.of_string "hello"
 
 val to_seq : t -> char Seq.t
 (** Iterate on the string, in increasing index order. Modifications of the
-    string during iteration will be reflected in the iterator.
+    string during iteration will be reflected in the sequence.
     @since 4.07 *)
 
 val to_seqi : t -> (int * char) Seq.t

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -457,7 +457,7 @@ let s = Bytes.of_string "hello"
 
 val to_seq : t -> char Seq.t
 (** Iterate on the string, in increasing index order. Modifications of the
-    string during iteration will be reflected in the iterator.
+    string during iteration will be reflected in the sequence.
     @since 4.07 *)
 
 val to_seqi : t -> (int * char) Seq.t

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -588,12 +588,12 @@ module Array : sig
 
   val to_seq : t -> float Seq.t
   (** Iterate on the floatarray, in increasing order. Modifications of the
-      floatarray during iteration will be reflected in the iterator. *)
+      floatarray during iteration will be reflected in the sequence. *)
 
   val to_seqi : t -> (int * float) Seq.t
   (** Iterate on the floatarray, in increasing order, yielding indices along
       elements. Modifications of the floatarray during iteration will be
-      reflected in the iterator. *)
+      reflected in the sequence. *)
 
   val of_seq : float Seq.t -> t
   (** Create an array from the generator. *)
@@ -810,12 +810,12 @@ module ArrayLabels : sig
 
   val to_seq : t -> float Seq.t
   (** Iterate on the floatarray, in increasing order. Modifications of the
-      floatarray during iteration will be reflected in the iterator. *)
+      floatarray during iteration will be reflected in the sequence. *)
 
   val to_seqi : t -> (int * float) Seq.t
   (** Iterate on the floatarray, in increasing order, yielding indices along
       elements. Modifications of the floatarray during iteration will be
-      reflected in the iterator. *)
+      reflected in the sequence. *)
 
   val of_seq : float Seq.t -> t
   (** Create an array from the generator. *)

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -584,7 +584,7 @@ module Array : sig
   (** Same as {!sort} or {!stable_sort}, whichever is faster
       on typical input. *)
 
-  (** {2 Iterators} *)
+  (** {2 Float arrays and Sequences} *)
 
   val to_seq : t -> float Seq.t
   (** Iterate on the floatarray, in increasing order. Modifications of the
@@ -806,7 +806,7 @@ module ArrayLabels : sig
   (** Same as {!sort} or {!stable_sort}, whichever is faster
       on typical input. *)
 
-  (** {2 Iterators} *)
+  (** {2 Float arrays and Sequences} *)
 
   val to_seq : t -> float Seq.t
   (** Iterate on the floatarray, in increasing order. Modifications of the

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -238,7 +238,7 @@ val stats : ('a, 'b) t -> statistics
    buckets by size.
    @since 4.00.0 *)
 
-(** {1 Iterators} *)
+(** {1 Hash tables and Sequences} *)
 
 val to_seq : ('a,'b) t -> ('a * 'b) Seq.t
 (** Iterate on the whole table.  The order in which the bindings

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -494,6 +494,6 @@ val to_seq : 'a list -> 'a Seq.t
  *)
 
 val of_seq : 'a Seq.t -> 'a list
-(** Create a list from the iterator.
+(** Create a list from a sequence.
     @since 4.07
  *)

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -486,7 +486,7 @@ val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
     Not tail-recursive (sum of the lengths of the arguments).
  *)
 
-(** {1 Iterators} *)
+(** {1 Lists and Sequences} *)
 
 val to_seq : 'a list -> 'a Seq.t
 (** Iterate on the list.

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -494,6 +494,6 @@ val to_seq : 'a list -> 'a Seq.t
  *)
 
 val of_seq : 'a Seq.t -> 'a list
-(** Create a list from the iterator.
+(** Create a list from a sequence.
     @since 4.07
  *)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -486,7 +486,7 @@ val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
     Not tail-recursive (sum of the lengths of the arguments).
  *)
 
-(** {1 Iterators} *)
+(** {1 Lists and Sequences} *)
 
 val to_seq : 'a list -> 'a Seq.t
 (** Iterate on the list.

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -331,7 +331,7 @@ module type S =
     (** Same as {!S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
-    (** {1 Iterators} *)
+    (** {1 Maps and Sequences} *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order of keys

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -255,7 +255,7 @@ module Hashtbl : sig
      buckets by size.
      @since 4.00.0 *)
 
-  (** {1 Iterators} *)
+  (** {1 Hash tables and Sequences} *)
 
   val to_seq : ('a,'b) t -> ('a * 'b) Seq.t
   (** Iterate on the whole table.  The order in which the bindings
@@ -846,7 +846,7 @@ module Map : sig
       (** Same as {!S.map}, but the function receives as arguments both the
          key and the associated value for each binding of the map. *)
 
-      (** {1 Iterators} *)
+      (** {1 Maps and Sequences} *)
 
       val to_seq : 'a t -> (key * 'a) Seq.t
       (** Iterate on the whole map, in ascending order of keys

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -100,9 +100,9 @@ val to_seq : 'a t -> 'a Seq.t
     @since 4.07 *)
 
 val add_seq : 'a t -> 'a Seq.t -> unit
-(** Add the elements from the generator to the end of the queue
+(** Add the elements from a sequence to the end of the queue.
     @since 4.07 *)
 
 val of_seq : 'a Seq.t -> 'a t
-(** Create a queue from the generator
+(** Create a queue from a sequence.
     @since 4.07 *)

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Functional iterators.
+(** Sequences (functional iterators).
 
     The type ['a t] is a {b delayed list}, i.e. a list where some evaluation
     is needed to access the next element. This makes it possible to build

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -72,7 +72,7 @@ val fold : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
     and [xn] the bottom element. The stack is unchanged.
     @since 4.03 *)
 
-(** {1 Iterators} *)
+(** {1 Stacks and Sequences} *)
 
 val to_seq : 'a t -> 'a Seq.t
 (** Iterate on the stack, top to bottom.

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -80,9 +80,9 @@ val to_seq : 'a t -> 'a Seq.t
     @since 4.07 *)
 
 val add_seq : 'a t -> 'a Seq.t -> unit
-(** Add the elements from the iterator on the top of the stack.
+(** Add the elements from the sequence on the top of the stack.
     @since 4.07 *)
 
 val of_seq : 'a Seq.t -> 'a t
-(** Create a stack from the iterator
+(** Create a stack from the sequence.
     @since 4.07 *)

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -297,7 +297,7 @@ val rindex_opt : string -> char -> int option
 
     @since 4.05 *)
 
-(** {1:converting Converting} *)
+(** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t
 (** [to_seq s] is a sequence made of the string's characters in

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -302,7 +302,7 @@ val rindex_opt : string -> char -> int option
 val to_seq : t -> char Seq.t
 (** [to_seq s] is a sequence made of the string's characters in
     increasing order. In ["unsafe-string"] mode, modifications of the string
-    during iteration will be reflected in the iterator.
+    during iteration will be reflected in the sequence.
 
     @since 4.07 *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -297,7 +297,7 @@ val rindex_opt : string -> char -> int option
 
     @since 4.05 *)
 
-(** {1:converting Converting} *)
+(** {1 Strings and Sequences} *)
 
 val to_seq : t -> char Seq.t
 (** [to_seq s] is a sequence made of the string's characters in

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -302,7 +302,7 @@ val rindex_opt : string -> char -> int option
 val to_seq : t -> char Seq.t
 (** [to_seq s] is a sequence made of the string's characters in
     increasing order. In ["unsafe-string"] mode, modifications of the string
-    during iteration will be reflected in the iterator.
+    during iteration will be reflected in the sequence.
 
     @since 4.07 *)
 

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -204,12 +204,12 @@ val fast_sort : cmp:(float -> float -> int) -> t -> unit
 
 val to_seq : t -> float Seq.t
 (** Iterate on the floatarray, in increasing order. Modifications of the
-    floatarray during iteration will be reflected in the iterator. *)
+    floatarray during iteration will be reflected in the sequence. *)
 
 val to_seqi : t -> (int * float) Seq.t
 (** Iterate on the floatarray, in increasing order, yielding indices along
     elements. Modifications of the floatarray during iteration will be
-    reflected in the iterator. *)
+    reflected in the sequence. *)
 
 val of_seq : float Seq.t -> t
 (** Create an array from the generator. *)

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -200,7 +200,7 @@ val fast_sort : cmp:(float -> float -> int) -> t -> unit
 (** Same as {!sort} or {!stable_sort}, whichever is faster
     on typical input. *)
 
-(** {2 Iterators} *)
+(** {2 Float arrays and Sequences} *)
 
 val to_seq : t -> float Seq.t
 (** Iterate on the floatarray, in increasing order. Modifications of the

--- a/stdlib/templates/hashtbl.template.mli
+++ b/stdlib/templates/hashtbl.template.mli
@@ -238,7 +238,7 @@ val stats : ('a, 'b) t -> statistics
    buckets by size.
    @since 4.00.0 *)
 
-(** {1 Iterators} *)
+(** {1 Hash tables and Sequences} *)
 
 val to_seq : ('a,'b) t -> ('a * 'b) Seq.t
 (** Iterate on the whole table.  The order in which the bindings

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -331,7 +331,7 @@ module type S =
     (** Same as {!S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
-    (** {1 Iterators} *)
+    (** {1 Maps and Sequences} *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t
     (** Iterate on the whole map, in ascending order of keys


### PR DESCRIPTION
This is a tentative solution to https://github.com/ocaml/ocaml/issues/9126

In this PR, sections using the word "Iterators" to talk about sequences (functional iterators) are renamed. This avoids the duplication of HTML link names described in the original issue.

`seq.mli` itself is altered slightly to acknowledge the word Sequence explicitly. The type is called `Seq.t`, so we can't just pretend they are only called "Iterators" or "Functional iterators". Either we call them Sequences, or use both names. I think we should just call them Sequences, and say we "iterate" on them. If others agree, I can add another commit changing some more uses of 'iterator' to 'sequence' in docstrings.

Where e.g `to_seq` is already in a section with other convertors (not to do with sequences) under the section title "Convertors" I have left it as it is. But where "Convertors" only contains sequence convertors, I have changed it.
