### PR TITLE
Fix build on macOS with GCC

### DIFF
--- a/Changes
+++ b/Changes
@@ -128,6 +128,9 @@ Working version
   (Xavier Leroy, report by Github user quakerquickoats, review by
    Jeremie Dimino)
 
+- #10147, #10148: Fix building runtime with GCC on macOS.
+  (David Allsopp, report by John Skaller)
+
 OCaml 4.12.0
 ------------
 

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -96,6 +96,7 @@ static int64_t time_counter(void)
 
 #elif defined(HAS_MACH_ABSOLUTE_TIME)
   static mach_timebase_info_data_t time_base = {0};
+  uint64_t now;
 
   if (time_base.denom == 0) {
     if (mach_timebase_info (&time_base) != KERN_SUCCESS)
@@ -105,7 +106,7 @@ static int64_t time_counter(void)
       return 0;
   }
 
-  uint64_t now = mach_absolute_time ();
+  now = mach_absolute_time ();
   return (int64_t)((now * time_base.numer) / time_base.denom);
 
 #elif defined(HAS_POSIX_MONOTONIC_CLOCK)


### PR DESCRIPTION
Fixes #10147

There would appear to be a bug in Clang's implementation of `-Wdeclaration-after-statement`.

I don't think this affects releases, so trunk-only seems reasonable?

There is the separate question of whether we should be testing macOS+GCC as well as macOS+clang