### PR TITLE
Fix detection of ocamlc.opt in ocamltest

### DIFF
--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -37,7 +37,7 @@ let bytecode =
     check_ocamlc_byte_output;
     run;
     check_program_output;
-  ] @ (if Ocamltest_config.arch<>"none" then opt_actions else [])
+  ] @ (if Ocamltest_config.native_compiler then opt_actions else [])
 }
 
 let native =


### PR DESCRIPTION
This completes the fix of my break which @shindere made in #10074 - there was one further case above in `ocaml_tests.ml`!