### PR TITLE
Always display a test report after make -C testsuite one

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -116,7 +116,6 @@ default:
 
 .PHONY: all
 all:
-	@rm -f $(TESTLOG)
 	@$(MAKE) --no-print-directory new-without-report
 	@$(MAKE) --no-print-directory report
 
@@ -128,7 +127,7 @@ new-without-report: lib tools
 	  echo Running tests from \'$$dir\' ... ; \
 	  $(MAKE) exec-ocamltest DIR=$$dir \
 	    OCAMLTESTENV=""; \
-	done || echo outer loop >> $(failstamp)) 2>&1 | tee -a $(TESTLOG)
+	done || echo outer loop >> $(failstamp)) 2>&1 | tee $(TESTLOG)
 	@$(MAKE) check-failstamp
 
 .PHONY: check-failstamp

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -214,15 +214,19 @@ one: lib tools
     echo "File '$(LIST)' does not exist."; exit 1; \
   fi
 	@if [ -n '$(DIR)' ] ; then \
-    $(MAKE) --no-print-directory exec-one DIR=$(DIR); fi
+    $(MAKE) --no-print-directory exec-one DIR=$(DIR) \
+      2>&1 | tee $(TESTLOG).one ; \
+   fi
 	@if [ -n '$(TEST)' ] ; then \
-    TERM=dumb $(OCAMLTESTENV) $(ocamltest) $(OCAMLTESTFLAGS) $(TEST); fi
-	@$(MAKE) check-failstamp
+    TERM=dumb $(OCAMLTESTENV) $(ocamltest) $(OCAMLTESTFLAGS) $(TEST) \
+     2>&1 | tee $(TESTLOG).one; fi
 	@if [ -n '$(LIST)' ] ; then \
      while IFS='' read -r LINE; do \
        $(MAKE) --no-print-directory exec-one DIR=$$LINE ; \
-     done < $$LIST 2>&1 | tee $(TESTLOG) ; \
-     $(MAKE) report ; fi
+     done < $$LIST 2>&1 | tee $(TESTLOG).one ; \
+   fi
+	@$(MAKE) check-failstamp
+	@$(MAKE) TESTLOG=$(TESTLOG).one report
 
 .PHONY: exec-one
 exec-one:


### PR DESCRIPTION
The primary motivation for this is to be able to run a single test and have a failing exit status if that test fails (for bisecting or for hammering a test until it fails) - these little PRs today spring from investigating another failure!

I've done it by fixing an inconsistency: `make -C testsuite one LIST=foo` (formerly `make -C testsuite list`) displayed a report, but the `DIR=dir` and `TEST=test` modes did not. Previously, I have lazily created a temporary directory in `testsuite/tests/` and copied the test I was hammering/bisecting there. This is daft.

This PR makes all three "modes" of the `one` target end in a report. This may seem like overkill for a single test, but in fact even one test can create a lot of output, and spotting `failed` can be tricky:

```
DRA@Thor ~/ocaml-7/testsuite
$ make one TEST=tests/lib-dynlink-bytecode/main.ml
 ... testing 'main.ml' with 1 (shared-libraries) => passed
 ... testing 'main.ml' with 1.1 (setup-ocamlc.byte-build-env) => passed
 ... testing 'main.ml' with 1.1.1 (ocamlc.byte) => passed
 ... testing 'main.ml' with 1.1.1.1 (ocamlmklib) => passed
 ... testing 'main.ml' with 1.1.1.1.1 (ocamlmklib) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1 (ocamlmklib) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1 (ocamlmklib) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.1 (ocamlc.byte) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.1.1 (run) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.1.1.1 (check-program-output) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.2 (ocamlc.byte) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.2.1 (run) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.2.1.1 (check-program-output) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.3 (ocamlc.byte) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.3.1 (run) => passed
 ... testing 'main.ml' with 1.1.1.1.1.1.1.3.1.1 (check-program-output) => passed
make[1]: Entering directory '/cygdrive/c/Scratch/ocaml-7/testsuite'
make[1]: Leaving directory '/cygdrive/c/Scratch/ocaml-7/testsuite'
make[1]: Entering directory '/cygdrive/c/Scratch/ocaml-7/testsuite'


Summary:
   16 tests passed
    0 tests skipped
    0 tests failed
    0 tests not started (parent test skipped or failed)
    0 unexpected errors
   16 tests considered
make[1]: Leaving directory '/cygdrive/c/Scratch/ocaml-7/testsuite'
```

At the moment the log is written to a different file (`testsuite/_log.one`) which is a slight change for the `make list` behaviour. When working on something which has broken lots of things (or where reference files need investigating) I find the `_log` from `make all` to be quite precious as I can run `make report` to see the results again. I'm open to other suggestions!

(cc @shindere)