### PR TITLE
Instrumented runtime: put libraries to link with in their own build variable

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -217,7 +217,8 @@ MKMAINDLL=@mkmaindll@
 
 MKEXEDEBUGFLAG=@mkexedebugflag@
 RUNTIMED=@debug_runtime@
-RUNTIMEI=@instrumented_runtime@
+INSTRUMENTED_RUNTIME=@instrumented_runtime@
+INSTRUMENTED_RUNTIME_LIBS=@instrumented_runtime_libs@
 WITH_DEBUGGER=@with_debugger@
 WITH_CAMLTEX=@with_camltex@
 WITH_OCAMLDOC=@ocamldoc@
@@ -278,3 +279,9 @@ else # ifeq "$(UNIX_OR_WIN32)" "win32"
   # On Unix, make sure FLEXLINK is defined but empty
   FLEXLINK =
 endif # ifeq "$(UNIX_OR_WIN32)" "win32"
+
+# Deprecated variables
+
+## Variables renamed in OCaml 4.13
+
+RUNTIMEI=$(INSTRUMENTED_RUNTIME)

--- a/configure
+++ b/configure
@@ -786,6 +786,7 @@ as_has_debug_prefix_map
 cc_has_debug_prefix_map
 otherlibraries
 has_monotonic_clock
+instrumented_runtime_libs
 instrumented_runtime
 debug_runtime
 cmxs
@@ -2793,7 +2794,7 @@ profinfo=false
 profinfo_width=0
 extralibs=
 instrumented_runtime=false
-instrumented_runtime_ldlibs=""
+instrumented_runtime_libs=""
 
 # Information about the package
 
@@ -2841,6 +2842,7 @@ VERSION=4.13.0+dev0-2020-10-19
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -14519,9 +14521,9 @@ fi
 
             instrumented_runtime=true
             if test "x$ac_cv_search_clock_gettime" = "xnone required"; then :
-  instrumented_runtime_ldlibs=""
+  instrumented_runtime_libs=""
 else
-  instrumented_runtime_ldlibs=$ac_cv_search_clock_gettime
+  instrumented_runtime_libs=$ac_cv_search_clock_gettime
 
 fi
            ;; #(
@@ -16902,7 +16904,7 @@ case $host in #(
     bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib" ;; #(
   *) :
-    bytecclibs="$cclibs $DLLIBS $pthread_link $instrumented_runtime_ldlibs"
+    bytecclibs="$cclibs $DLLIBS $pthread_link"
   nativecclibs="$cclibs $DLLIBS" ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ profinfo=false
 profinfo_width=0
 extralibs=
 instrumented_runtime=false
-instrumented_runtime_ldlibs=""
+instrumented_runtime_libs=""
 
 # Information about the package
 
@@ -129,6 +129,7 @@ AC_SUBST([natdynlinkopts])
 AC_SUBST([cmxs])
 AC_SUBST([debug_runtime])
 AC_SUBST([instrumented_runtime])
+AC_SUBST([instrumented_runtime_libs])
 AC_SUBST([has_monotonic_clock])
 AC_SUBST([otherlibraries])
 AC_SUBST([cc_has_debug_prefix_map])
@@ -1237,8 +1238,8 @@ but no proper monotonic clock source was found.])
           [
             instrumented_runtime=true
             AS_IF([test "x$ac_cv_search_clock_gettime" = "xnone required"],
-              [instrumented_runtime_ldlibs=""],
-              [instrumented_runtime_ldlibs=$ac_cv_search_clock_gettime]
+              [instrumented_runtime_libs=""],
+              [instrumented_runtime_libs=$ac_cv_search_clock_gettime]
             )
           ],
         [yes,false,*],
@@ -1797,7 +1798,7 @@ AS_CASE([$host],
   [*-pc-windows],
     [bytecclibs="advapi32.lib ws2_32.lib version.lib"
     nativecclibs="advapi32.lib ws2_32.lib version.lib"],
-  [bytecclibs="$cclibs $DLLIBS $pthread_link $instrumented_runtime_ldlibs"
+  [bytecclibs="$cclibs $DLLIBS $pthread_link"
   nativecclibs="$cclibs $DLLIBS"])
 
 AS_IF([test x"$libdir" = x'${exec_prefix}/lib'],

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -256,7 +256,7 @@ ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix).ml
 
 ocamltest_config.ml: ocamltest_config.ml.in Makefile ../Makefile.config
 	sed $(call SUBST,AFL_INSTRUMENT) \
-	    $(call SUBST,RUNTIMEI) \
+	    $(call SUBST,INSTRUMENTED_RUNTIME) \
 	    $(call SUBST,ARCH) \
 	    $(call SUBST,SUPPORTS_SHARED_LIBRARIES) \
 	    $(call SUBST,unix) \

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -62,12 +62,6 @@ let dumpenv = make
   (fun log env ->
     Environments.dump log env; (Result.pass, env))
 
-let hasinstrumentedruntime = make
-  "hasinstrumentedruntime"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.has_instrumented_runtime)
-    "instrumented runtime available"
-    "instrumented runtime not available")
-
 let hasunix = make
   "hasunix"
   (Actions_helpers.pass_or_skip (Ocamltest_config.libunix <> None)
@@ -262,7 +256,6 @@ let _ =
     fail;
     cd;
     dumpenv;
-    hasinstrumentedruntime;
     hasunix;
     hassysthreads;
     hasstr;

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1153,6 +1153,12 @@ let debugger = Actions.make
      "debugger available"
      "debugger not available")
 
+let instrumented_runtime = make
+  "instrumented-runtime"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.instrumented_runtime)
+    "instrumented runtime available"
+    "instrumented runtime not available")
+
 let csharp_compiler = Actions.make
   "csharp-compiler"
   (Actions_helpers.pass_or_skip (Ocamltest_config.csc<>"")
@@ -1367,6 +1373,7 @@ let _ =
     native_compiler;
     native_dynlink;
     debugger;
+    instrumented_runtime;
     csharp_compiler;
     windows_unicode;
     afl_instrument;

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -83,6 +83,6 @@ let windows_unicode = %%WINDOWS_UNICODE%% != 0
 
 let function_sections = %%FUNCTION_SECTIONS%%
 
-let has_instrumented_runtime = %%RUNTIMEI%%
+let instrumented_runtime = %%INSTRUMENTED_RUNTIME%%
 
 let naked_pointers = %%NAKED_POINTERS%%

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -116,7 +116,7 @@ val function_sections : bool
 (** Whether the compiler was configured to generate
     each function in a separate section *)
 
-val has_instrumented_runtime : bool
+val instrumented_runtime : bool
 (** Whether the instrumented runtime is available *)
 
 val naked_pointers : bool

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -62,7 +62,7 @@ BYTECODE_STATIC_LIBRARIES += libcamlrund.$(A)
 NATIVE_STATIC_LIBRARIES += libasmrund.$(A)
 endif
 
-ifeq "$(RUNTIMEI)" "true"
+ifeq "$(INSTRUMENTED_RUNTIME)" "true"
 PROGRAMS += ocamlruni$(EXE)
 BYTECODE_STATIC_LIBRARIES += libcamlruni.$(A)
 NATIVE_STATIC_LIBRARIES += libasmruni.$(A)
@@ -284,7 +284,7 @@ libcamlrund.$(A): $(libcamlrund_OBJECTS)
 	$(call MKLIB,$@, $^)
 
 ocamlruni$(EXE): prims.$(O) libcamlruni.$(A)
-	$(MKEXE) -o $@ $^ $(LIBS)
+	$(MKEXE) -o $@ $^ $(INSTRUMENTED_RUNTIME_LIBS) $(LIBS)
 
 libcamlruni.$(A): $(libcamlruni_OBJECTS)
 	$(call MKLIB,$@, $^)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -50,7 +50,7 @@ ifeq "$(RUNTIMED)" "true"
 all: camlheaderd target_camlheaderd
 endif
 
-ifeq "$(RUNTIMEI)" "true"
+ifeq "$(INSTRUMENTED_RUNTIME)" "true"
 all: camlheaderi target_camlheaderi
 endif
 
@@ -75,7 +75,7 @@ install::
 	$(INSTALL_DATA) target_camlheaderd "$(INSTALL_LIBDIR)/camlheaderd"
 endif
 
-ifeq "$(RUNTIMEI)" "true"
+ifeq "$(INSTRUMENTED_RUNTIME)" "true"
 install::
 	$(INSTALL_DATA) target_camlheaderi "$(INSTALL_LIBDIR)/camlheaderi"
 endif

--- a/testsuite/tests/instrumented-runtime/main.ml
+++ b/testsuite/tests/instrumented-runtime/main.ml
@@ -1,5 +1,5 @@
 (* TEST
-  * hasinstrumentedruntime
+  * instrumented-runtime
   ** native
     flags = "-runtime-variant=i"
 *)


### PR DESCRIPTION
Before this PR, these libraries were part of the BYTECCLIBS build
variable so they were used not only when linking the instrumented
runtime but also while linking other bytecode programs.

This PR also renames the RUNTIMEI build variable to INSTRUMENTED_RUNTIME
and renames a few things in ocamltest. Finally, it moves the
instrumented_runtime test from builtin_actions to ocaml_actions.