### PR TITLE
Reference manual spelling fixes

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2300,7 +2300,7 @@ CAMLprim value foo_byte(value a, value b)
 }
 \end{verbatim}
 
-For convenicence, when all arguments and the result are annotated with
+For convenience, when all arguments and the result are annotated with
 "[\@unboxed]", it is possible to put the attribute only once on the
 declaration itself. So we can also write instead:
 

--- a/manual/manual/tutorials/advexamples.etex
+++ b/manual/manual/tutorials/advexamples.etex
@@ -446,7 +446,7 @@ class ['a, 'b] small_hashtbl : ['a, 'b] hash_table =
   object
     val mutable table = []
     method find key = List.assoc key table
-    method add key valeur = table <- (key, valeur) :: table
+    method add key value = table <- (key, value) :: table
   end;;
 \end{caml_example}
 A better implementation, and one that scales up better, is to use a

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -755,7 +755,7 @@ There is a "printf" function in the \stdmoduleref{Printf} module
 output more concisely.
 It follows the behavior of the "printf" function from the C standard library.
 The "printf" function takes a format string that describes the desired output
-as a text interspered with specifiers (for instance "%d", "%f").
+as a text interspersed with specifiers (for instance "%d", "%f").
 Next, the specifiers are substituted by the following arguments in their order
 of apparition in the format string:
 \begin{caml_example}{toplevel}

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -525,10 +525,10 @@ module Memprof :
        over their lifetime in the minor and major heap.
 
        Sampling is temporarily disabled when calling a callback
-       for the current thread. So they do not need to be reentrant if
+       for the current thread. So they do not need to be re-entrant if
        the program is single-threaded. However, if threads are used,
        it is possible that a context switch occurs during a callback,
-       in this case the callback functions must be reentrant.
+       in this case the callback functions must be re-entrant.
 
        Note that the callback can be postponed slightly after the
        actual event. The callstack passed to the callback is always

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -40,7 +40,7 @@ v}
     {ul
     {- An {e index} [i] of [s] is an integer in the range \[[0];[n-1]\].
        It represents the [i]th byte (character) of [s] which can be
-       acccessed using the constant time string indexing operator
+       accessed using the constant time string indexing operator
        [s.[i]].}
     {- A {e position} [i] of [s] is an integer in the range
        \[[0];[n]\]. It represents either the point at the beginning of

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -40,7 +40,7 @@ v}
     {ul
     {- An {e index} [i] of [s] is an integer in the range \[[0];[n-1]\].
        It represents the [i]th byte (character) of [s] which can be
-       acccessed using the constant time string indexing operator
+       accessed using the constant time string indexing operator
        [s.[i]].}
     {- A {e position} [i] of [s] is an integer in the range
        \[[0];[n]\]. It represents either the point at the beginning of


### PR DESCRIPTION
(This is the result of running aspell over .etex files in manual/ and *.mli files in stdlib)