### PR TITLE
manual: simplified rendering for toplevel code examples

### DIFF
--- a/Changes
+++ b/Changes
@@ -531,6 +531,9 @@ OCaml 4.12.0
    version, and a quick-search functionality for the API.
    (San Vũ Ngọc, review by David Allsopp and Florian Angeletti)
 
+- #10142, #10154: improved rendering and latex code for toplevel code examples.
+  (Florian Angeletti, report by John Whitington, review by Gabriel Scherer)
+
 ### Compiler user-interface and warnings:
 
 - #1931: rely on levels to enforce principality in patterns

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -155,8 +155,6 @@
 %Styles for caml-example and friends
 \newstyle{div.caml-output}{color:maroon;}
 % Styles for toplevel mode only
-\newstyle{div.caml-example.toplevel div.caml-input::before}
-         {content:"\#"; color:black;}
 \newstyle{div.caml-example.toplevel div.caml-input}{color:\#006000;}
 
 %%% Code examples
@@ -164,25 +162,14 @@
 \newcommand{\output@color}{\maroon}
 \newcommand{\machine}{\tt}
 \newenvironment{machineenv}{\begin{alltt}}{\end{alltt}}
-\newcommand{\firstline}{\ }
-\newcommand{\examplespace}{\ }
-\newcommand{\nextline}{\examplespace\ }
-\newcommand{\@zyva}{\firstline\renewcommand{\?}{\nextline}}
-\let\?=\@zyva
-\renewcommand{\:}{\renewcommand{\?}{\@zyva}}
 \newcommand{\var}[1]{\textit{#1}}
 
 %% Caml-example environment
 \newcommand{\camlexample}[1]{
-  \ifthenelse{\equal{#1}{toplevel}}
-    {\renewcommand{\examplespace}{\ }}
-    {\renewcommand{\examplespace}{}}
-  \fi
   \@open{div}{class="caml-example #1"}
 }
 \newcommand{\endcamlexample}{
   \@close{div}
-  \renewcommand{\examplespace}{\ }
 }
 
 \newenvironment{caml}{\@open{div}{class=ocaml}}{\@close{div}}

--- a/manual/manual/macros.tex
+++ b/manual/manual/macros.tex
@@ -232,13 +232,7 @@
 
 
 % Caml-example related command
-\newenvironment{camlexample}[1]{
-  \ifnum\pdfstrcmp{#1}{toplevel}=0
-    \renewcommand{\hash}{\#}
-  \else
-    \renewcommand{\hash}{}
-  \fi
-}{}
+\newenvironment{camlexample}[1]{}{}
 \newenvironment{caml}{}{}
 \newcommand{\ocamlkeyword}{\bfseries}
 \newcommand{\ocamlhighlight}{\bfseries\uline}
@@ -248,8 +242,5 @@
 \definecolor{gray}{gray}{0.5}
 \newcommand{\ocamlcomment}{\color{gray}\normalfont\small}
 \newcommand{\ocamlstring}{\color{gray}\bfseries}
-
-\newcommand{\?}{\normalsize\tt\hash{} }
-\renewcommand{\:}{\small\ttfamily\slshape}
 
 \makeatother

--- a/manual/manual/manual.inf
+++ b/manual/manual/manual.inf
@@ -5,7 +5,6 @@
 \newenvironment{machineenv}{\begin{alltt}}{\end{alltt}}
 \newenvironment{camlunder}{\@style{U}}{}
 \newcommand{\?}{\black\#\blue }
-\renewcommand{\:}{\maroon}
 
 \newcommand{\ocamlkeyword}{\bfseries}
 \newcommand{\ocamlhighlight}{\bfseries\underline}

--- a/manual/manual/manual.tex
+++ b/manual/manual/manual.tex
@@ -19,7 +19,6 @@
 \usepackage[normalem]{ulem}% for underlining errors in code examples
 
 \input{macros.tex}
-\newcommand{\hash}{\#}
 \lstnewenvironment{camloutput}{
   \lstset{
     basicstyle=\small\ttfamily\slshape,
@@ -105,7 +104,7 @@
 \fi
 }{}
 
-
+\newcommand{\?}{\color{black}\normalsize\tt\#{}}
 
 % Add meta tag to the generated head tag
 \ifouthtml

--- a/testsuite/tests/tool-caml-tex/ellipses.reference
+++ b/testsuite/tests/tool-caml-tex/ellipses.reference
@@ -1,48 +1,48 @@
 \begin{camlexample}{verbatim}
 \begin{caml}
 \begin{camlinput}
-$\?$let start = 0
-$\?$$\ldots$
-$\?$let mid = succ hidden
-$\?$$\ldots$
+let start = 0
+$\ldots$
+let mid = succ hidden
+$\ldots$
 
-$\?$module E = struct end
-$\?$$\ldots$
+module E = struct end
+$\ldots$
 
-$\?$let expr = $\ldots$
+let expr = $\ldots$
 
-$\?$let pat = match start with
-$\?$  | $\ldots$ | 1 -> succ expr
-$\?$  | _ -> succ expr
+let pat = match start with
+  | $\ldots$ | 1 -> succ expr
+  | _ -> succ expr
 
-$\?$let case = match start with
-$\?$  | 0 -> succ pat
-$\?$  | $\ldots$
+let case = match start with
+  | 0 -> succ pat
+  | $\ldots$
 
 
-$\?$let annot: $\ldots$ = succ case
+let annot: $\ldots$ = succ case
 
-$\?$let subexpr = succ annot + ($\ldots$ * 2) - 2
+let subexpr = succ annot + ($\ldots$ * 2) - 2
 
-$\?$$\ldots$
+$\ldots$
 
-$\?$class c2 = object
-$\?$  $\ldots$
-$\?$  val y = 1
-$\?$  $\ldots$
-$\?$  method n = 3
-$\?$  $\ldots$
-$\?$end
+class c2 = object
+  $\ldots$
+  val y = 1
+  $\ldots$
+  method n = 3
+  $\ldots$
+end
 
-$\?$type t = $\ldots$ | B $\ldots$ | F
-$\?$type arrow = int -> ($\ldots$)
-$\?$type record = { a:int; $\ldots$ c:int;
-$\?$                $\ldots$
-$\?$                g:int }
-$\?$type polyvar = [`A|$\ldots$ |`C
-$\?$               |$\ldots$
-$\?$               | `G ]
-$\?$type exn += $\ldots$ | B $\ldots$ | F
+type t = $\ldots$ | B $\ldots$ | F
+type arrow = int -> ($\ldots$)
+type record = { a:int; $\ldots$ c:int;
+                $\ldots$
+                g:int }
+type polyvar = [`A|$\ldots$ |`C
+               |$\ldots$
+               | `G ]
+type exn += $\ldots$ | B $\ldots$ | F
 \end{camlinput}
 \end{caml}
 \end{camlexample}

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -1,25 +1,25 @@
 \begin{camlexample}{toplevel}
 \begin{caml}
 \begin{camlinput}
-$\?$[@@@warning "+A"];;
+$\?$ [@@@warning "+A"];;
 \end{camlinput}
 \end{caml}
 \begin{caml}
 \begin{camlinput}
-$\?$1 + <<2.>> ;;
+$\?$ 1 + <<2.>> ;;
 \end{camlinput}
 \begin{camlerror}
-$\:$Error: This expression has type float but an expression was expected of type
-$\:$         int
+Error: This expression has type float but an expression was expected of type
+         int
 \end{camlerror}
 \end{caml}
 \begin{caml}
 \begin{camlinput}
-$\?$let f <<x>> = () ;;
+$\?$ let f <<x>> = () ;;
 \end{camlinput}
 \begin{camlwarn}
-$\:$Warning 27 [unused-var-strict]: unused variable x.
-$\:$val f : 'a -> unit = <fun>
+Warning 27 [unused-var-strict]: unused variable x.
+val f : 'a -> unit = <fun>
 \end{camlwarn}
 \end{caml}
 \end{camlexample}
@@ -27,13 +27,13 @@ $\:$val f : 'a -> unit = <fun>
 \begin{camlexample}{toplevel}
 \begin{caml}
 \begin{camlinput}
-$\?$Format.printf "Hello@.";
-$\?$print_endline "world";;
+$\?$ Format.printf "Hello@.";
+  print_endline "world";;
 \end{camlinput}
 \begin{camloutput}
-$\:$Hello
-$\:$world
-$\:$- : unit = ()
+Hello
+world
+- : unit = ()
 \end{camloutput}
 \end{caml}
 \end{camlexample}


### PR DESCRIPTION
Toplevel code examples in the manual are now directly generated as

```latex
$\?$ let f x =
   x * x
- : val f: int -> int = <fun>
```

with the prompt macro `\?` uniformly defined as a black colored `#`.

rather than

```latex
$\?$let f x =
$\?$  x * x
$\:$- : val f: int -> int = <fun>
```

with each backend defining its own interpretation of `\:` and `\?`.

Similarly, non-toplevel examples are now emitted as

```
let f x =
  x * x
- : val f: int -> int = <fun>
```
with neither `\:` nor `\?` present.

This simplification is enough to achieve the uniform rendering of toplevel examples requested in #10142 .

Closes #10142