### PR TITLE
testsuite/tests/backtrace: attempt to fix Windows \r\n issue

### DIFF
--- a/testsuite/tests/backtrace/filter-locations.sh
+++ b/testsuite/tests/backtrace/filter-locations.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-sed -e "s/^.*in file/File/" -e 's/ (inlined)//' -e "s/, raise.*//" | grep ^File
+# This location filter is erasing information from the backtrace
+# to be robust to different inlining choices made by different compiler settings.
+# It checks that the expected locations occur (in the expected order).
+sed -e "s/^.*in file/File/" -e 's/ (inlined)//' | grep ^File

--- a/testsuite/tests/backtrace/inline_traversal_test.reference
+++ b/testsuite/tests/backtrace/inline_traversal_test.reference
@@ -1,4 +1,4 @@
-File inline_traversal_test.ml:14
+File inline_traversal_test.ml:14, raise
 File inline_traversal_test.ml:17
 File inline_traversal_test.ml:20
 File inline_traversal_test.ml:23


### PR DESCRIPTION
This test coming from 28dc83203 previously used `grep -o`, but
apparently `-o` is not POSIX so it was changed in 4d5978f32e to use
`sed` in a way that apparently breaks Windows line endings. Life is
hard!