### PR TITLE
Enable debug info with "--output-complete-exe" binaries

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -243,6 +243,8 @@ FUNCTION_SECTIONS=@function_sections@
 AWK=@AWK@
 STDLIB_MANPAGES=@stdlib_manpages@
 NAKED_POINTERS=@naked_pointers@
+MKRES=@mkres@
+RESEXT=@resext@
 
 ### Native command to build ocamlrun.exe
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -502,6 +502,7 @@ let link_bytecode_as_c tolink outfile with_main =
 \nextern \"C\" {\
 \n#endif\
 \n#include <caml/mlvalues.h>\
+\n#include <caml/backtrace.h>\
 \n#include <caml/startup.h>\n";
        output_string outchan "static int caml_code[] = {\n";
        Symtable.init();
@@ -538,7 +539,6 @@ let link_bytecode_as_c tolink outfile with_main =
            debug_info_to_win32_resource debug_file_name;
            Printf.fprintf outchan "\
 \n#include <caml/osdeps.h>\
-\n#include <caml/backtrace.h>\
 \nvoid read_main_debug_info(struct debug_info *di)\
 \n{\
 \n  int size;\
@@ -550,12 +550,12 @@ let link_bytecode_as_c tolink outfile with_main =
            debug_info_to_file debug_file_name;
            Printf.fprintf outchan "\
 \n#define INCBIN_STYLE INCBIN_STYLE_SNAKE\
+\n#define INCBIN_PREFIX\
 \n#include <caml/incbin.h>\
-\n#include <caml/backtrace.h>\
 \nINCBIN(caml_debug,\"%s\");\
 \nvoid read_main_debug_info(struct debug_info *di)\
 \n{\
-\n  caml_read_main_debug_info_from_value(di, (char *)gcaml_debug_data, gcaml_debug_size);\
+\n  caml_read_main_debug_info_from_value(di, (char *)caml_debug_data, caml_debug_size);\
 \n}" debug_file_name
          end else
            output_string outchan "\

--- a/configure
+++ b/configure
@@ -746,6 +746,8 @@ build_os
 build_vendor
 build_cpu
 build
+resext
+mkres
 naked_pointers_checker
 naked_pointers
 compute_deps
@@ -2891,6 +2893,8 @@ VERSION=4.13.0+dev0-2020-10-19
 
 
  # TODO: rename this variable
+
+
 
 
 
@@ -14323,6 +14327,21 @@ if test "x$ac_cv_func_copysign" = xyes; then :
 fi
 
 fi ;;
+esac
+
+case $host in #(
+  *-*-mingw32) :
+
+    mkres="${toolpref}windres -o "
+    resext=.o
+   ;; #(
+  *-pc-windows) :
+
+    mkres="rc /nolog /fo "
+    resext=.res
+   ;; #(
+  *) :
+     ;;
 esac
 
 ## getrusage

--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,8 @@ AC_SUBST([stdlib_manpages])
 AC_SUBST([compute_deps])
 AC_SUBST([naked_pointers])
 AC_SUBST([naked_pointers_checker])
+AC_SUBST([mkres])
+AC_SUBST([resext])
 
 ## Generated files
 
@@ -1156,6 +1158,16 @@ AS_CASE([$host],
       [has_c99_float_ops=false])])
   AS_IF([$has_c99_float_ops],
     [AC_CHECK_FUNC([copysign], [AC_DEFINE([HAS_C99_FLOAT_OPS])])])])
+
+AS_CASE([$host],
+  [*-*-mingw32], [
+    mkres="${toolpref}windres -o "
+    resext=.o
+  ],
+  [*-pc-windows], [
+    mkres="rc /nolog /fo "
+    resext=.res
+  ])
 
 ## getrusage
 AC_CHECK_FUNC([getrusage], [AC_DEFINE([HAS_GETRUSAGE])])

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -32,15 +32,10 @@ type tool =
                 }
   | Internal of ignore
 
-let cmp_result_of_exitcode commandline = function
-  | 0 -> Same
-  | 1 -> Different
-  | exit_code -> (Error (commandline, exit_code))
-
 let make_cmp_tool ~ignore =
   Internal ignore
 
-let make_comparison_tool ?(result_of_exitcode = cmp_result_of_exitcode)
+let make_comparison_tool ~result_of_exitcode
                          name flags =
   External
     {

--- a/ocamltest/filecompare.mli
+++ b/ocamltest/filecompare.mli
@@ -27,7 +27,7 @@ type ignore = {bytes: int; lines: int}
 val make_cmp_tool : ignore:ignore -> tool
 
 val make_comparison_tool :
-  ?result_of_exitcode:(string -> int -> result) -> string -> string -> tool
+  result_of_exitcode:(string -> int -> result) -> string -> string -> tool
 
 val default_comparison_tool : tool
 
@@ -42,8 +42,6 @@ type files = {
 val compare_files : ?tool:tool -> files -> result
 
 val check_file : ?tool:tool -> files -> result
-
-val cmp_result_of_exitcode : string -> int -> result
 
 val diff : files -> (string, string) Stdlib.result
 

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -864,17 +864,23 @@ let compare_programs backend comparison_tool log env =
     (Result.pass_with_reason reason, env)
   end else really_compare_programs backend comparison_tool log env
 
-let make_bytecode_programs_comparison_tool =
+let make_bytecode_programs_comparison_tool ~result_of_exitcode =
   let ocamlrun = Ocaml_files.ocamlrun in
   let cmpbyt = Ocaml_files.cmpbyt in
   let tool_name = ocamlrun ^ " " ^ cmpbyt in
-  Filecompare.make_comparison_tool tool_name ""
+  Filecompare.make_comparison_tool ~result_of_exitcode tool_name ""
 
 let native_programs_comparison_tool = Filecompare.default_comparison_tool
 
+let result_of_exitcode commandline = function
+  | 0 -> Filecompare.Same
+  | 1 -> Filecompare.Different
+  | 3 -> Filecompare.Same (* bad bytecode magic -- program was compiled to C exexcutable *)
+  | exit_code -> Filecompare.Error (commandline, exit_code)
+
 let compare_bytecode_programs_code log env =
   let bytecode_programs_comparison_tool =
-    make_bytecode_programs_comparison_tool in
+    make_bytecode_programs_comparison_tool ~result_of_exitcode in
   compare_programs
     Ocaml_backends.Bytecode bytecode_programs_comparison_tool log env
 

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -110,6 +110,13 @@ CAMLextern char_os * caml_cds_file;
 extern void caml_stash_backtrace(value exn, value * sp, int reraise);
 
 CAMLextern void caml_load_main_debug_info(void);
+
+struct debug_info;
+
+CAMLextern void caml_read_main_debug_info_from_value(struct debug_info *, char *, int);
+
+CAMLextern void (*caml_read_main_debug_info)(struct debug_info *);
+
 #endif
 
 

--- a/runtime/caml/incbin.h
+++ b/runtime/caml/incbin.h
@@ -1,0 +1,368 @@
+/**
+ * @file incbin.h
+ * @author Dale Weiler
+ * @brief Utility for including binary files
+ *
+ * Facilities for including binary files into the current translation unit and
+ * making use from them externally in other translation units.
+ */
+#ifndef INCBIN_HDR
+#define INCBIN_HDR
+#include <limits.h>
+#if   defined(__AVX512BW__) || \
+      defined(__AVX512CD__) || \
+      defined(__AVX512DQ__) || \
+      defined(__AVX512ER__) || \
+      defined(__AVX512PF__) || \
+      defined(__AVX512VL__) || \
+      defined(__AVX512F__)
+# define INCBIN_ALIGNMENT_INDEX 6
+#elif defined(__AVX__)      || \
+      defined(__AVX2__)
+# define INCBIN_ALIGNMENT_INDEX 5
+#elif defined(__SSE__)      || \
+      defined(__SSE2__)     || \
+      defined(__SSE3__)     || \
+      defined(__SSSE3__)    || \
+      defined(__SSE4_1__)   || \
+      defined(__SSE4_2__)   || \
+      defined(__neon__)
+# define INCBIN_ALIGNMENT_INDEX 4
+#elif ULONG_MAX != 0xffffffffu
+# define INCBIN_ALIGNMENT_INDEX 3
+# else
+# define INCBIN_ALIGNMENT_INDEX 2
+#endif
+
+/* Lookup table of (1 << n) where `n' is `INCBIN_ALIGNMENT_INDEX' */
+#define INCBIN_ALIGN_SHIFT_0 1
+#define INCBIN_ALIGN_SHIFT_1 2
+#define INCBIN_ALIGN_SHIFT_2 4
+#define INCBIN_ALIGN_SHIFT_3 8
+#define INCBIN_ALIGN_SHIFT_4 16
+#define INCBIN_ALIGN_SHIFT_5 32
+#define INCBIN_ALIGN_SHIFT_6 64
+
+/* Actual alignment value */
+#define INCBIN_ALIGNMENT \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \
+        INCBIN_ALIGNMENT_INDEX)
+
+/* Stringize */
+#define INCBIN_STR(X) \
+    #X
+#define INCBIN_STRINGIZE(X) \
+    INCBIN_STR(X)
+/* Concatenate */
+#define INCBIN_CAT(X, Y) \
+    X ## Y
+#define INCBIN_CONCATENATE(X, Y) \
+    INCBIN_CAT(X, Y)
+/* Deferred macro expansion */
+#define INCBIN_EVAL(X) \
+    X
+#define INCBIN_INVOKE(N, ...) \
+    INCBIN_EVAL(N(__VA_ARGS__))
+
+/* Green Hills uses a different directive for including binary data */
+#if defined(__ghs__)
+#  if (__ghs_asm == 2)
+#    define INCBIN_MACRO ".file"
+/* Or consider the ".myrawdata" entry in the ld file */
+#  else
+#    define INCBIN_MACRO "\tINCBIN"
+#  endif
+#else
+#  define INCBIN_MACRO ".incbin"
+#endif
+
+#ifndef _MSC_VER
+#  define INCBIN_ALIGN \
+    __attribute__((aligned(INCBIN_ALIGNMENT)))
+#else
+#  define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
+#endif
+
+#if defined(__arm__) || /* GNU C and RealView */ \
+    defined(__arm) || /* Diab */ \
+    defined(_ARM) /* ImageCraft */
+#  define INCBIN_ARM
+#endif
+
+#ifdef __GNUC__
+/* Utilize .balign where supported */
+#  define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".balign 1\n"
+#elif defined(INCBIN_ARM)
+/*
+ * On arm assemblers, the alignment value is calculated as (1 << n) where `n' is
+ * the shift count. This is the value passed to `.align'
+ */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 0\n"
+#else
+/* We assume other inline assembler's treat `.align' as `.balign' */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 1\n"
+#endif
+
+/* INCBIN_CONST is used by incbin.c generated files */
+#if defined(__cplusplus)
+#  define INCBIN_EXTERNAL extern "C"
+#  define INCBIN_CONST    extern const
+#else
+#  define INCBIN_EXTERNAL extern
+#  define INCBIN_CONST    const
+#endif
+
+/**
+ * @brief Optionally override the linker section into which data is emitted.
+ *
+ * @warning If you use this facility, you'll have to deal with platform-specific linker output
+ * section naming on your own
+ *
+ * Overriding the default linker output section, e.g for esp8266/Arduino:
+ * @code
+ * #define INCBIN_OUTPUT_SECTION ".irom.text"
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ * // Data is emitted into program memory that never gets copied to RAM
+ * @endcode
+ */
+#if !defined(INCBIN_OUTPUT_SECTION)
+#  if defined(__APPLE__)
+#    define INCBIN_OUTPUT_SECTION         ".const_data"
+#  else
+#    define INCBIN_OUTPUT_SECTION         ".rodata"
+#  endif
+#endif
+
+#if defined(__APPLE__)
+/* The directives are different for Apple branded compilers */
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_INT             ".long "
+#  define INCBIN_MANGLE          "_"
+#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_TYPE(...)
+#else
+#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  if defined(__ghs__)
+#    define INCBIN_INT           ".word "
+#  else
+#    define INCBIN_INT           ".int "
+#  endif
+#  if defined(__USER_LABEL_PREFIX__)
+#    define INCBIN_MANGLE        INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
+#  else
+#    define INCBIN_MANGLE        ""
+#  endif
+#  if defined(INCBIN_ARM)
+/* On arm assemblers, `@' is used as a line comment token */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
+#  elif defined(__MINGW32__) || defined(__MINGW64__)
+/* Mingw doesn't support this directive either */
+#    define INCBIN_TYPE(NAME)
+#  else
+/* It's safe to use `@' on other architectures */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
+#  endif
+#  define INCBIN_BYTE            ".byte "
+#endif
+
+/* List of style types used for symbol names */
+#define INCBIN_STYLE_CAMEL 0
+#define INCBIN_STYLE_SNAKE 1
+
+/**
+ * @brief Specify the prefix to use for symbol names.
+ *
+ * By default this is `g', producing symbols of the form:
+ * @code
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char gFooData[];
+ * // const unsigned char *const gFooEnd;
+ * // const unsigned int gFooSize;
+ * @endcode
+ *
+ * If however you specify a prefix before including: e.g:
+ * @code
+ * #define INCBIN_PREFIX incbin
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols instead:
+ * // const unsigned char incbinFooData[];
+ * // const unsigned char *const incbinFooEnd;
+ * // const unsigned int incbinFooSize;
+ * @endcode
+ */
+#if !defined(INCBIN_PREFIX)
+#  define INCBIN_PREFIX g
+#endif
+
+/**
+ * @brief Specify the style used for symbol names.
+ *
+ * Possible options are
+ * - INCBIN_STYLE_CAMEL "CamelCase"
+ * - INCBIN_STYLE_SNAKE "snake_case"
+ *
+ * Default option is *INCBIN_STYLE_CAMEL* producing symbols of the form:
+ * @code
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>FooData[];
+ * // const unsigned char *const <prefix>FooEnd;
+ * // const unsigned int <prefix>FooSize;
+ * @endcode
+ *
+ * If however you specify a style before including: e.g:
+ * @code
+ * #define INCBIN_STYLE INCBIN_STYLE_SNAKE
+ * #include "incbin.h"
+ * INCBIN(foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>foo_data[];
+ * // const unsigned char *const <prefix>foo_end;
+ * // const unsigned int <prefix>foo_size;
+ * @endcode
+ */
+#if !defined(INCBIN_STYLE)
+#  define INCBIN_STYLE INCBIN_STYLE_CAMEL
+#endif
+
+/* Style lookup tables */
+#define INCBIN_STYLE_0_DATA Data
+#define INCBIN_STYLE_0_END End
+#define INCBIN_STYLE_0_SIZE Size
+#define INCBIN_STYLE_1_DATA _data
+#define INCBIN_STYLE_1_END _end
+#define INCBIN_STYLE_1_SIZE _size
+
+/* Style lookup: returning identifier */
+#define INCBIN_STYLE_IDENT(TYPE) \
+    INCBIN_CONCATENATE( \
+        INCBIN_STYLE_, \
+        INCBIN_CONCATENATE( \
+            INCBIN_EVAL(INCBIN_STYLE), \
+            INCBIN_CONCATENATE(_, TYPE)))
+
+/* Style lookup: returning string literal */
+#define INCBIN_STYLE_STRING(TYPE) \
+    INCBIN_STRINGIZE( \
+        INCBIN_STYLE_IDENT(TYPE)) \
+
+/* Generate the global labels by indirectly invoking the macro with our style
+ * type and concatenating the name against them. */
+#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \
+    INCBIN_INVOKE( \
+        INCBIN_GLOBAL, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE))) \
+    INCBIN_INVOKE( \
+        INCBIN_TYPE, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE)))
+
+/**
+ * @brief Externally reference binary data included in another translation unit.
+ *
+ * Produces three external symbols that reference the binary data included in
+ * another translation unit.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name given for the binary data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const unsigned char <prefix>FooData[];
+ * // extern const unsigned char *const <prefix>FooEnd;
+ * // extern const unsigned int <prefix>FooSize;
+ * @endcode
+ */
+#define INCBIN_EXTERN(NAME) \
+    INCBIN_EXTERNAL const INCBIN_ALIGN unsigned char \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(DATA))[]; \
+    INCBIN_EXTERNAL const INCBIN_ALIGN unsigned char *const \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+        INCBIN_STYLE_IDENT(END)); \
+    INCBIN_EXTERNAL const unsigned int \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(SIZE))
+
+/**
+ * @brief Include a binary file into the current translation unit.
+ *
+ * Includes a binary file into the current translation unit, producing three symbols
+ * for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCBIN(Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>IconData[];
+ * // const unsigned char *const <prefix>IconEnd;
+ * // const unsigned int <prefix>IconSize;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#ifdef _MSC_VER
+#define INCBIN(NAME, FILENAME) \
+    INCBIN_EXTERN(NAME)
+#else
+#define INCBIN(NAME, FILENAME) \
+    __asm__(INCBIN_SECTION \
+            INCBIN_GLOBAL_LABELS(NAME, DATA) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) ":\n" \
+            INCBIN_MACRO " \"" FILENAME "\"\n" \
+            INCBIN_GLOBAL_LABELS(NAME, END) \
+            INCBIN_ALIGN_BYTE \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
+                INCBIN_BYTE "1\n" \
+            INCBIN_GLOBAL_LABELS(NAME, SIZE) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \
+                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " \
+                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) "\n" \
+            INCBIN_ALIGN_HOST \
+            ".text\n" \
+    ); \
+    INCBIN_EXTERN(NAME)
+
+#endif
+#endif

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -29,7 +29,6 @@ extern unsigned short caml_win32_revision;
 
 #include "misc.h"
 #include "memory.h"
-
 #define Io_interrupted (-1)
 
 /* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
@@ -155,6 +154,8 @@ CAMLextern value caml_copy_string_of_utf16(const wchar_t *s);
 CAMLextern int caml_win32_isatty(int fd);
 
 CAMLextern void caml_expand_command_line (int *, wchar_t ***);
+
+CAMLextern void *caml_load_win32_resource(int name, int *size);
 
 #endif /* _WIN32 */
 

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1014,3 +1014,30 @@ int caml_num_rows_fd(int fd)
 {
   return -1;
 }
+
+/* read the debugging info from a Windows resource */
+
+CAMLexport void *caml_load_win32_resource(int name, int *size)
+{
+  HRSRC hRes;
+  HGLOBAL hResLoad;
+  LPVOID lpResLock;
+  DWORD dwSize;
+
+  *size = 0;
+
+  hRes = FindResource(NULL, MAKEINTRESOURCE(name), RT_RCDATA);
+  if (hRes == NULL) return NULL;
+
+  hResLoad = LoadResource(NULL, hRes);
+  if (hResLoad == NULL) return NULL;
+
+  lpResLock = LockResource(hResLoad);
+  if (lpResLock == NULL) return NULL;
+
+  dwSize = SizeofResource(NULL, hRes);
+  if (dwSize == 0) return NULL;
+
+  *size = dwSize;
+  return lpResLock;
+}

--- a/testsuite/tests/backtrace/output_complete_exe.ml
+++ b/testsuite/tests/backtrace/output_complete_exe.ml
@@ -1,0 +1,22 @@
+(* TEST
+
+flags = "-g -output-complete-exe -ccopt -I -ccopt ${ocamlsrcdir}/runtime"
+
+* bytecode
+*)
+
+let () =
+  Printexc.record_backtrace true
+
+let f () = if true then raise Exit
+
+let g () =
+  print_endline "in g";
+  f ();
+  print_endline "after f"
+
+let () =
+  try
+    g ()
+  with e ->
+    Printexc.print_backtrace stdout

--- a/testsuite/tests/backtrace/output_complete_exe.reference
+++ b/testsuite/tests/backtrace/output_complete_exe.reference
@@ -1,0 +1,4 @@
+in g
+Raised at Output_complete_exe.f in file "output_complete_exe.ml", line 11, characters 24-34
+Called from Output_complete_exe.g in file "output_complete_exe.ml", line 15, characters 2-6
+Called from Output_complete_exe in file "output_complete_exe.ml", line 20, characters 4-8

--- a/tools/cmpbyt.ml
+++ b/tools/cmpbyt.ml
@@ -84,4 +84,7 @@ let _ =
     eprintf "Usage: cmpbyt <file 1> <file 2>\n";
     exit 2
   end;
-  if cmpbyt Sys.argv.(1) Sys.argv.(2) then exit 0 else exit 1
+  try
+    if cmpbyt Sys.argv.(1) Sys.argv.(2) then exit 0 else exit 1
+  with Bytesections.Bad_magic_number ->
+    exit 3

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -92,6 +92,8 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST,FUNCTION_SECTIONS) \
 	    $(call SUBST,CC_HAS_DEBUG_PREFIX_MAP) \
 	    $(call SUBST,AS_HAS_DEBUG_PREFIX_MAP) \
+	    $(call SUBST,MKRES) \
+	    $(call SUBST,RESEXT) \
 	    $< > $@
 
 # Test for the substitution functions above

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -212,3 +212,7 @@ let linker_is_flexlink =
      invocations for the native Windows ports and for Cygwin, if shared library
      support is enabled. *)
   Sys.win32 || Config.supports_shared_libraries && Sys.cygwin
+
+let compile_resource ~output input =
+  command (Printf.sprintf "%s %s %s") Config.mkres
+    (Filename.quote output) (Filename.quote input)

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -39,3 +39,5 @@ type link_mode =
 val call_linker: link_mode -> string -> string list -> string -> int
 
 val linker_is_flexlink : bool
+
+val compile_resource: output:string -> string -> int

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -205,6 +205,10 @@ val host : string
 val target : string
 (** Whether the compiler is a cross-compiler *)
 
+val mkres : string
+
+val res_ext : string
+
 val flambda : bool
 (** Whether the compiler was configured for flambda *)
 

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -141,6 +141,9 @@ let ext_dll = "%%EXT_DLL%%"
 let host = "%%HOST%%"
 let target = "%%TARGET%%"
 
+let mkres = "%%MKRES%%"
+let res_ext = "%%RESEXT%%"
+
 let default_executable_name =
   match Sys.os_type with
     "Unix" -> "a.out"


### PR DESCRIPTION
Fixes #9369

This PR is a proof of concept implementing a suggestion of @dra27 made in https://github.com/ocaml/ocaml/issues/9344#issuecomment-760144435

The idea is that the compiler will generate an `.o` file with the debug info and then call the linker to link it together with the generated `.c` file.

In this PR I extended our `Binutils` module to generate simple object files, and tweaked the runtime system to load the debug info by reading it directly from memory in the case of `--output-complete-exe`.

So far only the ELF support is implemented, but I wanted to sound off the general approach before extending the code to the other binary formats and cleaning up the code.

I added a small test showing that a bytecode binary built with `--output-complete-exe` can now print backtraces, but the CI still fails because `ocamltest` does not know that it should not try to compare bytecode binaries produced with this option.

cc @jeremiedimino