### PR TITLE
Fix st_current_thread_id in win32 systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -451,7 +451,7 @@ OCaml 4.12.0
   information before the first load.
   (Daniel Bünzli, review by Xavier Leroy and Nicolás Ojeda Bär)
 
-* #9757, #9846: check proper ownership when operating over mutexes.
+* #9757, #9846, #10161: check proper ownership when operating over mutexes.
   Now, unlocking a mutex held by another thread or not locked at all
   reliably raises a Sys_error exception.  Before, it was undefined
   behavior, but the documentation did not say so.

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -106,6 +106,12 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
   pthread_setspecific(k, v);
 }
 
+/* Windows-specific hook. */
+Caml_inline void st_thread_set_id(intnat id)
+{
+  return;
+}
+
 /* The master lock.  This is a mutex that is held most of the time,
    so we implement it in a slightly convoluted way to avoid
    all risks of busy-waiting.  Also, we count the number of waiting


### PR DESCRIPTION
In #10148, the [msvc64 AppVeyor job failed](https://ci.appveyor.com/project/avsm/ocaml/builds/37259511/job/w9kncxe5fhsb2glg?fullLog=true#L9939). The failure was the `lib-threads/sieve.ml` test. The message was rather concerning:

```
Thread 39 killed on uncaught exception Sys_error("Mutex.unlock: Mutex is not locked by calling thread")
```

I reproduced this locally. The error is both intermittent and infrequent occurring every 429-48325 runs during 326000 runs of the bytecode version of this test on my system (my home heating this weekend has been sponsored by OCaml).

I think (and more on the thinking later) the issue is the `st_current_thread_id` function introduced for Win32 systhreads as part of the error-checking mutexes in #9846. This function is used in four places: `st_mutex_lock`, `st_mutex_trylock`, `st_mutex_unlock` and `st_condvar_wait`. Although `st_mutex_trylock` and `st_mutex_unlock` are only used when the runtime lock is held, `st_mutex_lock` and `st_condvar_wait` are called after the runtime lock has been released. Accessing the OCaml heap is therefore invalid in these functions and I think that what's being seen is the wrong value being written to the `owner` field of the `st_mutex`. In particular, on several runs the value for the thread ID looked suspiciously like a pointer.

My proposed fix is to add a hook during thread creation/registration which receives the OCaml thread descriptor _when the runtime lock is held_ and allow the OS-specific function to do what it likes with that. The POSIX version does nothing - the Win32 version uses another TLS slot to store the value in a way which can be accessed from these two functions.

(Recall from #9846 that the reason for using the OCaml thread ID is that we don't know if Windows will reuse thread IDs, but we do know that OCaml won't, at least until the thread ID counter wraps)

More on the thinking. I have verified that this error occurs on all 4 native Win32 ports - Cygwin64 has done 21000 so far and Cygwin32 17000 without triggering it. One of our x64 Linux servers has done 96000 runs without triggering it. Taking the longest number of runs required to see 5 instances of the failure, @stedolan's law dictates that this test needs to pass 350000 times with this fix to be confident that this was in fact the bug seen - my machine is presently doing that.