### PR TITLE
Add examples to Arg, Buffer modules

### DIFF
--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -19,21 +19,21 @@
    arguments from the command line to the program. For example:
 
 {[
-        let usage_msg = "append [-verbose] <file1> [<file2>] ... -o <output>"
-        let verbose = ref false
-        let input_files = ref []
-        let output_file = ref ""
+     let usage_msg = "append [-verbose] <file1> [<file2>] ... -o <output>"
+     let verbose = ref false
+     let input_files = ref []
+     let output_file = ref ""
 
-        let anon_fun filename =
-          input_files := filename::!input_files
+     let anon_fun filename =
+       input_files := filename::!input_files
 
-        let speclist =
-          [("-verbose", Arg.Set verbose, "Output debug information");
-           ("-o", Arg.Set_string output_file, "Set output file name")]
+     let speclist =
+       [("-verbose", Arg.Set verbose, "Output debug information");
+        ("-o", Arg.Set_string output_file, "Set output file name")]
 
-        let () =
-          Arg.parse speclist anon_fun usage_msg;
-          (* Main functionality here *)
+     let () =
+       Arg.parse speclist anon_fun usage_msg;
+       (* Main functionality here *)
 ]}
 
    Syntax of command lines:

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -16,7 +16,25 @@
 (** Parsing of command line arguments.
 
    This module provides a general mechanism for extracting options and
-   arguments from the command line to the program.
+   arguments from the command line to the program. For example:
+
+{[
+        let usage_msg = "append [-verbose] <file1> [<file2>] ... -o <output>"
+        let verbose = ref false
+        let input_files = ref []
+        let output_file = ref ""
+
+        let anon_fun filename =
+          input_files := filename::!input_files
+
+        let speclist =
+          [("-verbose", Arg.Set verbose, "Output debug information");
+           ("-o", Arg.Set_string output_file, "Set output file name")]
+
+        let () =
+          Arg.parse speclist anon_fun usage_msg;
+          (* Main functionality here *)
+]}
 
    Syntax of command lines:
     A keyword is a character string starting with a [-].

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -21,10 +21,10 @@
    concatenated pairwise). For example:
 
 {[
-            let concat_strings ss =
-              let b = Buffer.create 16 in
-                List.iter (Buffer.add_string b) ss;
-                Buffer.contents b
+     let concat_strings ss =
+       let b = Buffer.create 16 in
+         List.iter (Buffer.add_string b) ss;
+         Buffer.contents b
 
 ]}
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -18,7 +18,16 @@
    This module implements buffers that automatically expand
    as necessary.  It provides accumulative concatenation of strings
    in quasi-linear time (instead of quadratic time when strings are
-   concatenated pairwise).
+   concatenated pairwise). For example:
+
+{[
+            let concat_strings ss =
+              let b = Buffer.create 16 in
+                List.iter (Buffer.add_string b) ss;
+                Buffer.contents b
+
+]}
+
 *)
 
 type t

--- a/stdlib/either.mli
+++ b/stdlib/either.mli
@@ -25,7 +25,8 @@
 
     For example:
 
-[List.partition_map: ('a -> ('b, 'c) either) -> 'a list -> 'b list * 'c list]
+{[List.partition_map:
+    ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list]}
 
     If you are looking for a parametrized type where
     one alternative means success and the other means failure,

--- a/stdlib/genlex.mli
+++ b/stdlib/genlex.mli
@@ -23,20 +23,20 @@
 
 
    Example: a lexer suitable for a desk calculator is obtained by
-   {[     let lexer = make_lexer ["+"; "-"; "*"; "/"; "let"; "="; "("; ")"]]}
+{[     let lexer = make_lexer ["+"; "-"; "*"; "/"; "let"; "="; "("; ")"]]}
 
    The associated parser would be a function from [token stream]
    to, for instance, [int], and would have rules such as:
 
    {[
-           let rec parse_expr = parser
-             | [< n1 = parse_atom; n2 = parse_remainder n1 >] -> n2
-           and parse_atom = parser
-             | [< 'Int n >] -> n
-             | [< 'Kwd "("; n = parse_expr; 'Kwd ")" >] -> n
-           and parse_remainder n1 = parser
-             | [< 'Kwd "+"; n2 = parse_expr >] -> n1 + n2
-             | [< >] -> n1
+     let rec parse_expr = parser
+       | [< n1 = parse_atom; n2 = parse_remainder n1 >] -> n2
+     and parse_atom = parser
+       | [< 'Int n >] -> n
+       | [< 'Kwd "("; n = parse_expr; 'Kwd ")" >] -> n
+     and parse_remainder n1 = parser
+       | [< 'Kwd "+"; n2 = parse_expr >] -> n1 + n2
+       | [< >] -> n1
    ]}
 
    One should notice that the use of the [parser] keyword and associated

--- a/stdlib/genlex.mli
+++ b/stdlib/genlex.mli
@@ -23,7 +23,7 @@
 
 
    Example: a lexer suitable for a desk calculator is obtained by
-   {[     let lexer = make_lexer ["+";"-";"*";"/";"let";"="; "("; ")"]  ]}
+   {[     let lexer = make_lexer ["+"; "-"; "*"; "/"; "let"; "="; "("; ")"]]}
 
    The associated parser would be a function from [token stream]
    to, for instance, [int], and would have rules such as:
@@ -35,7 +35,7 @@
              | [< 'Int n >] -> n
              | [< 'Kwd "("; n = parse_expr; 'Kwd ")" >] -> n
            and parse_remainder n1 = parser
-             | [< 'Kwd "+"; n2 = parse_expr >] -> n1+n2
+             | [< 'Kwd "+"; n2 = parse_expr >] -> n1 + n2
              | [< >] -> n1
    ]}
 

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -26,9 +26,9 @@
 
    For example:
    {[
-      open MoreLabels
+     open MoreLabels
 
-      Hashtbl.iter ~f:(fun ~key ~data -> g key data) table
+     Hashtbl.iter ~f:(fun ~key ~data -> g key data) table
    ]}
 *)
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -31,9 +31,9 @@
 
     Literals for native integers are suffixed by n:
     {[
-      let zero: nativeint = 0n
-      let one: nativeint = 1n
-      let m_one: nativeint = -1n
+     let zero: nativeint = 0n
+     let one: nativeint = 1n
+     let m_one: nativeint = -1n
     ]}
 *)
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -15,10 +15,10 @@
 
 (** Functional iterators.
 
-    The type ['a t] is a {b delayed list}, i.e. a list where some evaluation
-    is needed to access the next element. This makes it possible to build
-    infinite sequences, to build sequences as we traverse them, and to transform
-    them in a lazy fashion rather than upfront.
+    The type ['a Seq.t] is a {b delayed list}, i.e. a list where some
+    evaluation is needed to access the next element. This makes it possible
+    to build infinite sequences, to build sequences as we traverse them, and
+    to transform them in a lazy fashion rather than upfront.
 
     @since 4.07
 *)

--- a/stdlib/templates/moreLabels.template.mli
+++ b/stdlib/templates/moreLabels.template.mli
@@ -26,9 +26,9 @@
 
    For example:
    {[
-      open MoreLabels
+     open MoreLabels
 
-      Hashtbl.iter ~f:(fun ~key ~data -> g key data) table
+     Hashtbl.iter ~f:(fun ~key ~data -> g key data) table
    ]}
 *)
 


### PR DESCRIPTION
Examples are not widespread in the stdlib reference, because they would clutter the pages. However, they are used in some modules where appropriate.

This PR adds examples to two other appropriate places - the Arg and Buffer modules.

These are appropriate places because several moving parts are typically required to use these modules -- it is not simply a case of finding one function in a module, reading its documentation, and using it.

(This PR also contains some small formatting fixes, and one little substantive fix to the new Either module's documentation).
