### PR TITLE
Fix Includemod.Illegal_permutation.find for module aliases

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,6 +137,9 @@ Working version
 - #10147, #10148: Fix building runtime with GCC on macOS.
   (David Allsopp, report by John Skaller)
 
+- #10166: Fix illegal permutation error reporting in module aliases.
+  (Matthew Ryan)
+
 OCaml 4.12.0
 ------------
 

--- a/Changes
+++ b/Changes
@@ -138,7 +138,7 @@ Working version
   (David Allsopp, report by John Skaller)
 
 - #10166: Fix illegal permutation error reporting in module aliases.
-  (Matthew Ryan)
+  (Matthew Ryan, review by Florian Angeletti)
 
 OCaml 4.12.0
 ------------

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -679,11 +679,13 @@ module Illegal_permutation = struct
   (* Find module type at position [path] and convert the [coerce_pos] path to
      a [pos] path *)
   let rec find env ctx path mt = match mt, path with
-    | (Mty_ident p | Mty_alias p), _ ->
+    | Mty_ident p, _ ->
         begin match (Env.find_modtype p env).mtd_type with
         | None -> raise Not_found
         | Some mt -> find env ctx path mt
         end
+    | Mty_alias p, _ ->
+        find env ctx path (Env.find_module p env).md_type
     | Mty_signature s , [] -> List.rev ctx, s
     | Mty_signature s, Item k :: q ->
         begin match runtime_item k s with

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -684,8 +684,7 @@ module Illegal_permutation = struct
         | None -> raise Not_found
         | Some mt -> find env ctx path mt
         end
-    | Mty_alias p, _ ->
-        find env ctx path (Env.find_module p env).md_type
+    | Mty_alias p, _ -> assert false
     | Mty_signature s , [] -> List.rev ctx, s
     | Mty_signature s, Item k :: q ->
         begin match runtime_item k s with

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -684,7 +684,7 @@ module Illegal_permutation = struct
         | None -> raise Not_found
         | Some mt -> find env ctx path mt
         end
-    | Mty_alias p, _ -> assert false
+    | Mty_alias _, _ -> assert false
     | Mty_signature s , [] -> List.rev ctx, s
     | Mty_signature s, Item k :: q ->
         begin match runtime_item k s with


### PR DESCRIPTION
This PR fixes the behaviour of `Includemod.Illegal_permutation.find` for modules of type `Mty_alias`. As written, it was looking up module aliases as module types.