### PR TITLE
Maintain more structural information in type-checking errors

### DIFF
--- a/.depend
+++ b/.depend
@@ -506,6 +506,7 @@ typing/ctype.cmo : \
     parsing/location.cmi \
     utils/local_store.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     utils/clflags.cmi \
     typing/btype.cmi \
@@ -522,6 +523,7 @@ typing/ctype.cmx : \
     parsing/location.cmx \
     utils/local_store.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     utils/clflags.cmx \
     typing/btype.cmx \
@@ -534,6 +536,7 @@ typing/ctype.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/datarepr.cmo : \
@@ -632,6 +635,20 @@ typing/envaux.cmi : \
     typing/subst.cmi \
     typing/path.cmi \
     typing/env.cmi
+typing/errortrace.cmo : \
+    typing/types.cmi \
+    typing/path.cmi \
+    parsing/asttypes.cmi \
+    typing/errortrace.cmi
+typing/errortrace.cmx : \
+    typing/types.cmx \
+    typing/path.cmx \
+    parsing/asttypes.cmi \
+    typing/errortrace.cmi
+typing/errortrace.cmi : \
+    typing/types.cmi \
+    typing/path.cmi \
+    parsing/asttypes.cmi
 typing/ident.cmo : \
     utils/misc.cmi \
     utils/local_store.cmi \
@@ -670,8 +687,10 @@ typing/includecore.cmo : \
     typing/typedtree.cmi \
     typing/type_immediacy.cmi \
     typing/printtyp.cmi \
+    typing/primitive.cmi \
     typing/path.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
@@ -683,8 +702,10 @@ typing/includecore.cmx : \
     typing/typedtree.cmx \
     typing/type_immediacy.cmx \
     typing/printtyp.cmx \
+    typing/primitive.cmx \
     typing/path.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
@@ -698,8 +719,8 @@ typing/includecore.cmi : \
     typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    typing/env.cmi \
-    typing/ctype.cmi
+    typing/errortrace.cmi \
+    typing/env.cmi
 typing/includemod.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \
@@ -1024,6 +1045,7 @@ typing/printtyp.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -1044,6 +1066,7 @@ typing/printtyp.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
@@ -1057,8 +1080,8 @@ typing/printtyp.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
-    typing/ctype.cmi \
     parsing/asttypes.cmi
 typing/printtyped.cmo : \
     typing/types.cmi \
@@ -1211,6 +1234,7 @@ typing/typeclass.cmo : \
     parsing/location.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -1238,6 +1262,7 @@ typing/typeclass.cmx : \
     parsing/location.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -1254,6 +1279,7 @@ typing/typeclass.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1278,6 +1304,7 @@ typing/typecore.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -1308,6 +1335,7 @@ typing/typecore.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -1325,8 +1353,8 @@ typing/typecore.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
-    typing/ctype.cmi \
     parsing/asttypes.cmi
 typing/typedecl.cmo : \
     utils/warnings.cmi \
@@ -1351,6 +1379,7 @@ typing/typedecl.cmo : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
@@ -1385,6 +1414,7 @@ typing/typedecl.cmx : \
     parsing/location.cmx \
     typing/includecore.cmx \
     typing/ident.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
@@ -1408,8 +1438,8 @@ typing/typedecl.cmi : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
-    typing/ctype.cmi \
     parsing/asttypes.cmi
 typing/typedecl_immediacy.cmo : \
     typing/types.cmi \
@@ -1712,6 +1742,7 @@ typing/typetexp.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -1732,6 +1763,7 @@ typing/typetexp.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    typing/errortrace.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
@@ -1747,8 +1779,8 @@ typing/typetexp.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    typing/errortrace.cmi \
     typing/env.cmi \
-    typing/ctype.cmi \
     parsing/asttypes.cmi
 typing/untypeast.cmo : \
     typing/typedtree.cmi \

--- a/Changes
+++ b/Changes
@@ -337,6 +337,13 @@ Working version
 - #8936: Per-function environment for Emit
   (Greta Yorsh, review by Vincent Laviron and Florian Angeletti)
 
+- #10170: Maintain more structural information in type-checking errors
+  A mostly-internal change that preserves more information in errors
+  during type checking; most significantly, it split the errors from
+  unification, moregen, and type equality into three different types.
+  (Antal Spector-Zabusky and Mekhrubon Tuarev, review by Leo White,
+  Florian Angeletti, and Jacques Garrigue)
+
 ### Build system:
 
 - #9191, #10091, #10182: take the LDFLAGS variable into account, except on

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -84,6 +84,7 @@ TYPING = \
   file_formats/cmi_format.cmo \
   typing/persistent_env.cmo \
   typing/env.cmo \
+  typing/errortrace.cmo \
   typing/typedtree.cmo \
   typing/printtyped.cmo \
   typing/ctype.cmo \

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -181,14 +181,7 @@ and raise_kind =
   | Raise_reraise
   | Raise_notrace
 
-let equal_boxed_integer x y =
-  match x, y with
-  | Pnativeint, Pnativeint
-  | Pint32, Pint32
-  | Pint64, Pint64 ->
-    true
-  | (Pnativeint | Pint32 | Pint64), _ ->
-    false
+let equal_boxed_integer = Primitive.equal_boxed_integer
 
 let equal_primitive =
   (* Should be implemented like [equal_value_kind] of [equal_boxed_integer],

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -156,7 +156,6 @@ Here is an example of a case that is not matched:
 Exception: Match_failure ("", 6, 23).
 |}]
 
-
 (* #9866, #9873 *)
 
 type 'a t = 'b  constraint 'a = 'b t;;
@@ -259,3 +258,41 @@ struct
   type !'a t = 'b constraint 'a = 'b s
 end
 *)
+
+type 'a t = T
+  constraint 'a = int
+  constraint 'a = float
+[%%expect{|
+Line 3, characters 13-23:
+3 |   constraint 'a = float
+                 ^^^^^^^^^^
+Error: The type constraints are not consistent.
+Type int is not compatible with type float
+|}]
+
+type ('a,'b) t = T
+  constraint 'a = int -> float
+  constraint 'b = bool -> char
+  constraint 'a = 'b
+[%%expect{|
+Line 4, characters 13-20:
+4 |   constraint 'a = 'b
+                 ^^^^^^^
+Error: The type constraints are not consistent.
+Type int -> float is not compatible with type bool -> char
+Type int is not compatible with type bool
+|}]
+
+class type ['a, 'b] a = object
+  constraint 'a = 'b
+  constraint 'a = int * int
+  constraint 'b = float * float
+end;;
+[%%expect{|
+Line 4, characters 2-31:
+4 |   constraint 'b = float * float
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The class constraints are not consistent.
+Type int * int is not compatible with type float * float
+Type int is not compatible with type float
+|}]

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -213,7 +213,7 @@ Line 1, characters 0-59:
 1 | type 'a t = <a : 'a; b : 'b> constraint <a : 'a; ..> = 'b t;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: A type variable is unbound in this type declaration.
-In method b: 'b the variable 'b is unbound
+       In method b: 'b the variable 'b is unbound
 |}]
 
 module rec M : sig type 'a t = 'b constraint 'a = 'b t end = M;;
@@ -267,7 +267,7 @@ Line 3, characters 13-23:
 3 |   constraint 'a = float
                  ^^^^^^^^^^
 Error: The type constraints are not consistent.
-Type int is not compatible with type float
+       Type int is not compatible with type float
 |}]
 
 type ('a,'b) t = T
@@ -279,8 +279,8 @@ Line 4, characters 13-20:
 4 |   constraint 'a = 'b
                  ^^^^^^^
 Error: The type constraints are not consistent.
-Type int -> float is not compatible with type bool -> char
-Type int is not compatible with type bool
+       Type int -> float is not compatible with type bool -> char
+       Type int is not compatible with type bool
 |}]
 
 class type ['a, 'b] a = object
@@ -293,6 +293,6 @@ Line 4, characters 2-31:
 4 |   constraint 'b = float * float
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The class constraints are not consistent.
-Type int * int is not compatible with type float * float
-Type int is not compatible with type float
+       Type int * int is not compatible with type float * float
+       Type int is not compatible with type float
 |}]

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -308,7 +308,8 @@ Error: Signature mismatch:
          class type c = object method m : t/2 end
        does not match
          class type c = object method m : t/1 end
-       The method m has type t/2 but is expected to have type t/1 = K.t
+       The method m has type t/2 but is expected to have type t/1
+       Type t/2 is not equal to type t/1 = K.t
        Line 12, characters 4-10:
          Definition of type t/1
        Line 9, characters 2-8:

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -308,8 +308,7 @@ Error: Signature mismatch:
          class type c = object method m : t/2 end
        does not match
          class type c = object method m : t/1 end
-       The method m has type t/2 but is expected to have type t/1
-       Type t/2 is not compatible with type t/1 = K.t
+       The method m has type t/2 but is expected to have type t/1 = K.t
        Line 12, characters 4-10:
          Definition of type t/1
        Line 9, characters 2-8:

--- a/testsuite/tests/typing-misc/pr7937.ml
+++ b/testsuite/tests/typing-misc/pr7937.ml
@@ -12,7 +12,6 @@ Line 3, characters 35-39:
                                        ^^^^
 Error: This expression has type bool but an expression was expected of type
          ([< `X of int & 'a ] as 'a) r
-       Types for tag `X are incompatible
 |}, Principal{|
 type 'a r = 'a constraint 'a = [< `X of int & 'a ]
 Line 3, characters 35-39:
@@ -20,7 +19,6 @@ Line 3, characters 35-39:
                                        ^^^^
 Error: This expression has type bool but an expression was expected of type
          ([< `X of 'b & 'a & 'c ] as 'a) r
-       Types for tag `X are incompatible
 |}]
 
 let g: 'a. 'a r -> 'a r = fun x -> { contents = 0 };;
@@ -30,7 +28,6 @@ Line 1, characters 35-51:
                                        ^^^^^^^^^^^^^^^^
 Error: This expression has type int ref
        but an expression was expected of type ([< `X of int & 'a ] as 'a) r
-       Types for tag `X are incompatible
 |}, Principal{|
 Line 1, characters 35-51:
 1 | let g: 'a. 'a r -> 'a r = fun x -> { contents = 0 };;
@@ -38,7 +35,6 @@ Line 1, characters 35-51:
 Error: This expression has type int ref
        but an expression was expected of type
          ([< `X of 'b & 'a & 'c ] as 'a) r
-       Types for tag `X are incompatible
 |}]
 
 let h: 'a. 'a r -> _ = function true | false -> ();;

--- a/testsuite/tests/typing-misc/unbound_type_variables.ml
+++ b/testsuite/tests/typing-misc/unbound_type_variables.ml
@@ -1,0 +1,61 @@
+(* TEST
+   * expect
+*)
+
+type synonym = 'a -> 'a
+
+[%%expect{|
+Line 1, characters 15-17:
+1 | type synonym = 'a -> 'a
+                   ^^
+Error: The type variable 'a is unbound in this type declaration.
+|}]
+
+type record = { contents: 'a }
+
+[%%expect{|
+Line 1, characters 26-28:
+1 | type record = { contents: 'a }
+                              ^^
+Error: The type variable 'a is unbound in this type declaration.
+|}]
+
+type wrapper = Wrapper of 'a
+
+[%%expect{|
+Line 1, characters 26-28:
+1 | type wrapper = Wrapper of 'a
+                              ^^
+Error: The type variable 'a is unbound in this type declaration.
+|}]
+
+(* This type secretly has a type variable in it *)
+type polyvariant = [> `C]
+
+[%%expect{|
+Line 1, characters 0-25:
+1 | type polyvariant = [> `C]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A type variable is unbound in this type declaration.
+In type [> `C ] as 'a the variable 'a is unbound
+|}]
+
+type 'a only_one = 'a * 'b
+
+[%%expect{|
+Line 1, characters 24-26:
+1 | type 'a only_one = 'a * 'b
+                            ^^
+Error: The type variable 'b is unbound in this type declaration.
+|}]
+
+type extensible = ..
+type extensible += Extension of 'a
+
+[%%expect{|
+type extensible = ..
+Line 2, characters 32-34:
+2 | type extensible += Extension of 'a
+                                    ^^
+Error: The type variable 'a is unbound in this type declaration.
+|}]

--- a/testsuite/tests/typing-misc/unbound_type_variables.ml
+++ b/testsuite/tests/typing-misc/unbound_type_variables.ml
@@ -37,7 +37,7 @@ Line 1, characters 0-25:
 1 | type polyvariant = [> `C]
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: A type variable is unbound in this type declaration.
-In type [> `C ] as 'a the variable 'a is unbound
+       In type [> `C ] as 'a the variable 'a is unbound
 |}]
 
 type 'a only_one = 'a * 'b

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1,0 +1,1174 @@
+(* TEST
+ * expect
+*)
+
+(********************************** Equality **********************************)
+
+module M : sig
+  type ('a, 'b) t = 'a * 'b
+end = struct
+  type ('a, 'b) t = 'a * 'a
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t = 'a * 'a
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t = 'a * 'a end
+       is not included in
+         sig type ('a, 'b) t = 'a * 'b end
+       Type declarations do not match:
+         type ('a, 'b) t = 'a * 'a
+       is not included in
+         type ('a, 'b) t = 'a * 'b
+|}];;
+
+module M : sig
+  type ('a, 'b) t = 'a * 'a
+end = struct
+  type ('a, 'b) t = 'a * 'b
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t = 'a * 'b
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t = 'a * 'b end
+       is not included in
+         sig type ('a, 'b) t = 'a * 'a end
+       Type declarations do not match:
+         type ('a, 'b) t = 'a * 'b
+       is not included in
+         type ('a, 'b) t = 'a * 'a
+|}];;
+
+module M : sig
+  type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>
+end = struct
+  type t = <m : 'a. 'a * ('a * 'foo)> as 'foo
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <m : 'a. 'a * ('a * 'foo)> as 'foo
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < m : 'a. 'a * ('a * 'b) > as 'b end
+       is not included in
+         sig type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) > end
+       Type declarations do not match:
+         type t = < m : 'a. 'a * ('a * 'b) > as 'b
+       is not included in
+         type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
+|}];;
+
+type s = private < m : int; .. >;;
+[%%expect{|
+type s = private < m : int; .. >
+|}];;
+
+module M : sig
+  type t = s
+end = struct
+  type t = <m : int>
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <m : int>
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < m : int > end
+       is not included in
+         sig type t = s end
+       Type declarations do not match:
+         type t = < m : int >
+       is not included in
+         type t = s
+|}];;
+
+module M : sig
+  type t = <m : int>
+end = struct
+  type t = s
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = s
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = s end
+       is not included in
+         sig type t = < m : int > end
+       Type declarations do not match:
+         type t = s
+       is not included in
+         type t = < m : int >
+|}];;
+
+module M : sig
+  type t =
+    | Foo of (int)*float
+end = struct
+  type t =
+    | Foo of (int*int)*float
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t =
+6 |     | Foo of (int*int)*float
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Foo of (int * int) * float end
+       is not included in
+         sig type t = Foo of int * float end
+       Type declarations do not match:
+         type t = Foo of (int * int) * float
+       is not included in
+         type t = Foo of int * float
+       Constructors do not match:
+         Foo of (int * int) * float
+       is not compatible with:
+         Foo of int * float
+       The types are not equal.
+|}];;
+
+module M : sig
+  type t = (int * float)
+end = struct
+  type t = (int * float * int)
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = (int * float * int)
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = int * float * int end
+       is not included in
+         sig type t = int * float end
+       Type declarations do not match:
+         type t = int * float * int
+       is not included in
+         type t = int * float
+|}];;
+
+module M : sig
+  type t = <n : int; m : float>
+end = struct
+  type t = <n : int; f : float>
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <n : int; f : float>
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < f : float; n : int > end
+       is not included in
+         sig type t = < m : float; n : int > end
+       Type declarations do not match:
+         type t = < f : float; n : int >
+       is not included in
+         type t = < m : float; n : int >
+|}];;
+
+module M : sig
+  type t = <n : int; m : float>
+end = struct
+  type t = <n : int>
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <n : int>
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < n : int > end
+       is not included in
+         sig type t = < m : float; n : int > end
+       Type declarations do not match:
+         type t = < n : int >
+       is not included in
+         type t = < m : float; n : int >
+|}];;
+
+module M4 : sig
+  type t = <n : int; m : float * int>
+end = struct
+  type t = <n : int; m : int>
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <n : int; m : int>
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < m : int; n : int > end
+       is not included in
+         sig type t = < m : float * int; n : int > end
+       Type declarations do not match:
+         type t = < m : int; n : int >
+       is not included in
+         type t = < m : float * int; n : int >
+|}];;
+
+module M4 : sig
+  type t =
+    | Foo of [`Foo of string | `Bar of string]
+end = struct
+  type t =
+    | Foo of [`Bar of string]
+end;;
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type t =
+6 |     | Foo of [`Bar of string]
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Foo of [ `Bar of string ] end
+       is not included in
+         sig type t = Foo of [ `Bar of string | `Foo of string ] end
+       Type declarations do not match:
+         type t = Foo of [ `Bar of string ]
+       is not included in
+         type t = Foo of [ `Bar of string | `Foo of string ]
+       Constructors do not match:
+         Foo of [ `Bar of string ]
+       is not compatible with:
+         Foo of [ `Bar of string | `Foo of string ]
+       The types are not equal.
+|}];;
+
+module M : sig
+  type t = private [`C of int]
+end = struct
+  type t = private [`C]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [`C]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [ `C ] end
+       is not included in
+         sig type t = private [ `C of int ] end
+       Type declarations do not match:
+         type t = private [ `C ]
+       is not included in
+         type t = private [ `C of int ]
+|}];;
+
+module M : sig
+  type t = private [`C]
+end = struct
+  type t = private [`C of int]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [`C of int]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [ `C of int ] end
+       is not included in
+         sig type t = private [ `C ] end
+       Type declarations do not match:
+         type t = private [ `C of int ]
+       is not included in
+         type t = private [ `C ]
+|}];;
+
+module M : sig
+  type t = [`C of [< `A] | `C of [`A]]
+end = struct
+  type t = [`C of [< `A | `B] | `C of [`A]]
+end;;
+[%%expect{|
+module M : sig type t = [ `C of [ `A ] ] end
+|}];;
+
+module M : sig
+  type t = private [> `A of int]
+end = struct
+  type t = private [`A of int]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [`A of int]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [ `A of int ] end
+       is not included in
+         sig type t = private [> `A of int ] end
+       Type declarations do not match:
+         type t = private [ `A of int ]
+       is not included in
+         type t = private [> `A of int ]
+|}];;
+
+module M : sig
+  type t = private [`A of int]
+end = struct
+  type t = private [> `A of int]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [> `A of int]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [> `A of int ] end
+       is not included in
+         sig type t = private [ `A of int ] end
+       Type declarations do not match:
+         type t = private [> `A of int ]
+       is not included in
+         type t = private [ `A of int ]
+|}];;
+
+module M : sig
+  type 'a t =  [> `A of int | `B of int] as 'a
+end = struct
+  type 'a t =  [> `A of int] as 'a
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t =  [> `A of int] as 'a
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a constraint 'a = [> `A of int ] end
+       is not included in
+         sig type 'a t = 'a constraint 'a = [> `A of int | `B of int ] end
+       Type declarations do not match:
+         type 'a t = 'a constraint 'a = [> `A of int ]
+       is not included in
+         type 'a t = 'a constraint 'a = [> `A of int | `B of int ]
+|}];;
+
+module M : sig
+  type 'a t =  [> `A of int] as 'a
+end = struct
+  type 'a t =  [> `A of int | `C of float] as 'a
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t =  [> `A of int | `C of float] as 'a
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a constraint 'a = [> `A of int | `C of float ] end
+       is not included in
+         sig type 'a t = 'a constraint 'a = [> `A of int ] end
+       Type declarations do not match:
+         type 'a t = 'a constraint 'a = [> `A of int | `C of float ]
+       is not included in
+         type 'a t = 'a constraint 'a = [> `A of int ]
+|}];;
+
+module M : sig
+  type t = [`C of [< `A | `B] | `C of [`A]]
+end = struct
+  type t = [`C of [< `A] | `C of [`A]]
+end;;
+[%%expect{|
+module M : sig type t = [ `C of [ `A ] ] end
+|}];;
+
+module M : sig
+  type t = private [< `C]
+end = struct
+  type t = private [< `C of int&float]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [< `C of int&float]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `C of int & float ] end
+       is not included in
+         sig type t = private [< `C ] end
+       Type declarations do not match:
+         type t = private [< `C of int & float ]
+       is not included in
+         type t = private [< `C ]
+|}];;
+
+(********************************** Moregen ***********************************)
+
+module type T = sig
+  type t
+end
+module Int = struct
+  type t = int
+end
+module type S = sig
+  module Choice : T
+  val r : Choice.t list ref ref
+end
+module Force (X : functor () -> S) = struct end
+module Choose () = struct
+  module Choice =
+    (val (module Int : T))
+  let r = ref (ref [])
+end
+module Ignore = Force(Choose)
+[%%expect{|
+module type T = sig type t end
+module Int : sig type t = int end
+module type S = sig module Choice : T val r : Choice.t list ref ref end
+module Force : functor (X : functor () -> S) -> sig end
+module Choose :
+  functor () -> sig module Choice : T val r : '_weak1 list ref ref end
+Line 17, characters 16-29:
+17 | module Ignore = Force(Choose)
+                     ^^^^^^^^^^^^^
+Error: Modules do not match:
+       functor () -> sig module Choice : T val r : '_weak1 list ref ref end
+     is not included in functor () -> S
+     Modules do not match:
+       sig module Choice : T val r : '_weak1 list ref ref end
+     is not included in
+       S
+     Values do not match:
+       val r : '_weak1 list ref ref
+     is not included in
+       val r : Choice.t list ref ref
+|}];;
+
+module O = struct
+  module type s
+  module M: sig
+    val f: (module s) -> unit
+  end = struct
+    module type s
+    let f (module X:s) = ()
+  end
+end;;
+[%%expect{|
+Lines 5-8, characters 8-5:
+5 | ........struct
+6 |     module type s
+7 |     let f (module X:s) = ()
+8 |   end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type s val f : (module s) -> unit end
+       is not included in
+         sig val f : (module s) -> unit end
+       Values do not match:
+         val f : (module s/1) -> unit
+       is not included in
+         val f : (module s/2) -> unit
+       Line 6, characters 4-17:
+         Definition of module type s/1
+       Line 2, characters 2-15:
+         Definition of module type s/2
+|}];;
+
+module M : sig
+  val f : (<m : 'b. ('b * <m: 'c. 'c * 'bar> as 'bar)>) -> unit
+end = struct
+  let f (x : <m : 'a. ('a * 'foo)> as 'foo) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : <m : 'a. ('a * 'foo)> as 'foo) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : (< m : 'a. 'a * 'b > as 'b) -> unit end
+       is not included in
+         sig val f : < m : 'b. 'b * < m : 'c. 'c * 'a > as 'a > -> unit end
+       Values do not match:
+         val f : (< m : 'a. 'a * 'b > as 'b) -> unit
+       is not included in
+         val f : < m : 'b. 'b * < m : 'c. 'c * 'a > as 'a > -> unit
+|}];;
+
+type s = private < m : int; .. >;;
+
+module M : sig
+  val f : s -> s
+end = struct
+  let f (x : <m : int>) = x
+end;;
+[%%expect{|
+type s = private < m : int; .. >
+Lines 5-7, characters 6-3:
+5 | ......struct
+6 |   let f (x : <m : int>) = x
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : < m : int > -> < m : int > end
+       is not included in
+         sig val f : s -> s end
+       Values do not match:
+         val f : < m : int > -> < m : int >
+       is not included in
+         val f : s -> s
+|}];;
+
+module M : sig
+  val x : 'a list ref
+end = struct
+  let x = ref []
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let x = ref []
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val x : '_weak2 list ref end
+       is not included in
+         sig val x : 'a list ref end
+       Values do not match:
+         val x : '_weak2 list ref
+       is not included in
+         val x : 'a list ref
+|}];;
+
+module M = struct let r = ref [] end;;
+type t;;
+module N : sig val r : t list ref end = M;;
+[%%expect{|
+module M : sig val r : '_weak3 list ref end
+type t
+Line 3, characters 40-41:
+3 | module N : sig val r : t list ref end = M;;
+                                            ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val r : '_weak3 list ref end
+       is not included in
+         sig val r : t list ref end
+       Values do not match:
+         val r : '_weak3 list ref
+       is not included in
+         val r : t list ref
+|}];;
+
+type (_, _) eq = Refl : ('a, 'a) eq;;
+
+module T : sig
+  type t
+  type s
+  val eq : (t, s) eq
+end = struct
+  type t = int
+  type s = int
+  let eq = Refl
+end;;
+
+module M = struct let r = ref [] end;;
+
+let foo p (e : (T.t, T.s) eq) (x : T.t) (y : T.s) =
+  match e with
+  | Refl ->
+    let z = if p then x else y in
+    let module N = struct
+      module type S = module type of struct let r = ref [z] end
+    end in
+    let module O : N.S = M in
+    ();;
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+module T : sig type t type s val eq : (t, s) eq end
+module M : sig val r : '_weak4 list ref end
+Line 22, characters 25-26:
+22 |     let module O : N.S = M in
+                              ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val r : '_weak4 list ref end
+       is not included in
+         N.S
+       Values do not match:
+         val r : '_weak4 list ref
+       is not included in
+         val r : T.s list ref
+|}];;
+
+module M: sig
+  val f : int -> float
+end = struct
+  let f (x : 'a) = x
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : 'a) = x
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         sig val f : int -> float end
+       Values do not match:
+         val f : 'a -> 'a
+       is not included in
+         val f : int -> float
+|}];;
+
+module M: sig
+  val f : (int * float * int) -> (int -> int)
+end = struct
+  let f (x : (int * int)) = x
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : (int * int)) = x
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int * int -> int * int end
+       is not included in
+         sig val f : int * float * int -> int -> int end
+       Values do not match:
+         val f : int * int -> int * int
+       is not included in
+         val f : int * float * int -> int -> int
+|}];;
+
+module M: sig
+  val f : <m : int; n : float> -> <m : int; n : float>
+end = struct
+  let f (x : <m : int; f : float>) = x
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : <m : int; f : float>) = x
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : < f : float; m : int > -> < f : float; m : int > end
+       is not included in
+         sig val f : < m : int; n : float > -> < m : int; n : float > end
+       Values do not match:
+         val f : < f : float; m : int > -> < f : float; m : int >
+       is not included in
+         val f : < m : int; n : float > -> < m : int; n : float >
+|}];;
+
+module M : sig
+  val f : [`Foo] -> unit
+end = struct
+  let f (x : [ `Foo | `Bar]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [ `Foo | `Bar]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [ `Bar | `Foo ] -> unit end
+       is not included in
+         sig val f : [ `Foo ] -> unit end
+       Values do not match:
+         val f : [ `Bar | `Foo ] -> unit
+       is not included in
+         val f : [ `Foo ] -> unit
+|}];;
+
+module M : sig
+  val f : [>`Foo] -> unit
+end = struct
+  let f (x : [< `Foo]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [< `Foo]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [< `Foo ] -> unit end
+       is not included in
+         sig val f : [> `Foo ] -> unit end
+       Values do not match:
+         val f : [< `Foo ] -> unit
+       is not included in
+         val f : [> `Foo ] -> unit
+|}];;
+
+module M : sig
+  val f : [< `Foo | `Bar] -> unit
+end = struct
+  let f (x : [< `Foo]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [< `Foo]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [< `Foo ] -> unit end
+       is not included in
+         sig val f : [< `Bar | `Foo ] -> unit end
+       Values do not match:
+         val f : [< `Foo ] -> unit
+       is not included in
+         val f : [< `Bar | `Foo ] -> unit
+|}];;
+
+module M : sig
+  val f : < m : [< `Foo]> -> unit
+end = struct
+  let f (x : < m : 'a. [< `Foo] as 'a >) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : < m : 'a. [< `Foo] as 'a >) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : < m : 'a. [< `Foo ] as 'a > -> unit end
+       is not included in
+         sig val f : < m : [< `Foo ] > -> unit end
+       Values do not match:
+         val f : < m : 'a. [< `Foo ] as 'a > -> unit
+       is not included in
+         val f : < m : [< `Foo ] > -> unit
+|}];;
+
+module M : sig
+  val f : < m : 'a. [< `Foo] as 'a > -> unit
+end = struct
+  let f (x : < m : [`Foo]>) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : < m : [`Foo]>) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : < m : [ `Foo ] > -> unit end
+       is not included in
+         sig val f : < m : 'a. [< `Foo ] as 'a > -> unit end
+       Values do not match:
+         val f : < m : [ `Foo ] > -> unit
+       is not included in
+         val f : < m : 'a. [< `Foo ] as 'a > -> unit
+|}];;
+
+module M : sig
+  val f : [< `C] -> unit
+end = struct
+  let f (x : [< `C of int&float]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [< `C of int&float]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [< `C of int & float ] -> unit end
+       is not included in
+         sig val f : [< `C ] -> unit end
+       Values do not match:
+         val f : [< `C of int & float ] -> unit
+       is not included in
+         val f : [< `C ] -> unit
+|}];;
+
+module M : sig
+  val f : [`Foo] -> unit
+end = struct
+  let f (x : [`Foo of int]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [`Foo of int]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [ `Foo of int ] -> unit end
+       is not included in
+         sig val f : [ `Foo ] -> unit end
+       Values do not match:
+         val f : [ `Foo of int ] -> unit
+       is not included in
+         val f : [ `Foo ] -> unit
+|}];;
+
+module M : sig
+  val f : [`Foo of int] -> unit
+end = struct
+  let f (x : [`Foo]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [`Foo]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [ `Foo ] -> unit end
+       is not included in
+         sig val f : [ `Foo of int ] -> unit end
+       Values do not match:
+         val f : [ `Foo ] -> unit
+       is not included in
+         val f : [ `Foo of int ] -> unit
+|}];;
+
+module M : sig
+  val f : [< `Foo | `Bar | `Baz] -> unit
+end = struct
+  let f (x : [< `Foo | `Bar | `Baz]) = ()
+end;;
+[%%expect{|
+module M : sig val f : [< `Bar | `Baz | `Foo ] -> unit end
+|}];;
+
+module M : sig
+  val f : [< `Foo | `Bar | `Baz] -> unit
+end = struct
+  let f (x : [> `Foo | `Bar]) = ()
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : [> `Foo | `Bar]) = ()
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : [> `Bar | `Foo ] -> unit end
+       is not included in
+         sig val f : [< `Bar | `Baz | `Foo ] -> unit end
+       Values do not match:
+         val f : [> `Bar | `Foo ] -> unit
+       is not included in
+         val f : [< `Bar | `Baz | `Foo ] -> unit
+|}];;
+
+(******************************* Type manifests *******************************)
+
+module M : sig
+  type t = private [< `A | `B]
+end = struct
+  type t = [`C]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = [`C]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = [ `C ] end
+       is not included in
+         sig type t = private [< `A | `B ] end
+       Type declarations do not match:
+         type t = [ `C ]
+       is not included in
+         type t = private [< `A | `B ]
+|}];;
+
+module M : sig
+  type t = private [< `A | `B]
+end = struct
+  type t = private [> `A]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [> `A]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [> `A ] end
+       is not included in
+         sig type t = private [< `A | `B ] end
+       Type declarations do not match:
+         type t = private [> `A ]
+       is not included in
+         type t = private [< `A | `B ]
+|}];;
+
+module M : sig
+  type t = private [< `A | `B > `A]
+end = struct
+  type t = [`B]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = [`B]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = [ `B ] end
+       is not included in
+         sig type t = private [< `A | `B > `A ] end
+       Type declarations do not match:
+         type t = [ `B ]
+       is not included in
+         type t = private [< `A | `B > `A ]
+|}];;
+
+module M : sig
+  type t = private [> `A of int]
+end = struct
+  type t = [`A]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = [`A]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = [ `A ] end
+       is not included in
+         sig type t = private [> `A of int ] end
+       Type declarations do not match:
+         type t = [ `A ]
+       is not included in
+         type t = private [> `A of int ]
+|}];;
+
+module M : sig
+   type t = private [< `A of int]
+end = struct
+   type t = private [< `A of & int]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |    type t = private [< `A of & int]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `A of & int ] end
+       is not included in
+         sig type t = private [< `A of int ] end
+       Type declarations do not match:
+         type t = private [< `A of & int ]
+       is not included in
+         type t = private [< `A of int ]
+|}];;
+
+
+module M : sig
+  type t = private [< `A of int]
+end = struct
+  type t = private [< `A]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [< `A]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `A ] end
+       is not included in
+         sig type t = private [< `A of int ] end
+       Type declarations do not match:
+         type t = private [< `A ]
+       is not included in
+         type t = private [< `A of int ]
+|}];;
+
+
+module M : sig
+  type t = private [< `A of int & float]
+end = struct
+  type t = private [< `A]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [< `A]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `A ] end
+       is not included in
+         sig type t = private [< `A of int & float ] end
+       Type declarations do not match:
+         type t = private [< `A ]
+       is not included in
+         type t = private [< `A of int & float ]
+|}];;
+
+module M : sig
+  type t = private [> `A of int]
+end = struct
+  type t = [`A of float]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = [`A of float]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = [ `A of float ] end
+       is not included in
+         sig type t = private [> `A of int ] end
+       Type declarations do not match:
+         type t = [ `A of float ]
+       is not included in
+         type t = private [> `A of int ]
+|}];;
+
+module M : sig
+  type t = private <a : int; ..>
+end = struct
+  type t = <b : int>
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <b : int>
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < b : int > end
+       is not included in
+         sig type t = private < a : int; .. > end
+       Type declarations do not match:
+         type t = < b : int >
+       is not included in
+         type t = private < a : int; .. >
+|}];;
+
+module M : sig
+  type t = private <a : float; ..>
+end = struct
+  type t = <a : int>
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = <a : int>
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = < a : int > end
+       is not included in
+         sig type t = private < a : float; .. > end
+       Type declarations do not match:
+         type t = < a : int >
+       is not included in
+         type t = private < a : float; .. >
+|}];;
+
+type w = private float
+type q = private (int * w)
+type u = private (int * q)
+module M : sig (* Confussing error message :( *)
+  type t = private (int * (int * int))
+end = struct
+  type t = private u
+end;;
+[%%expect{|
+type w = private float
+type q = private int * w
+type u = private int * q
+Lines 6-8, characters 6-3:
+6 | ......struct
+7 |   type t = private u
+8 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private u end
+       is not included in
+         sig type t = private int * (int * int) end
+       Type declarations do not match:
+         type t = private u
+       is not included in
+         type t = private int * (int * int)
+|}];;
+
+type w = float
+type q = (int * w)
+type u = private (int * q)
+module M : sig (* Confussing error message :( *)
+  type t = private (int * (int * int))
+end = struct
+  type t = private u
+end;;
+[%%expect{|
+type w = float
+type q = int * w
+type u = private int * q
+Lines 6-8, characters 6-3:
+6 | ......struct
+7 |   type t = private u
+8 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private u end
+       is not included in
+         sig type t = private int * (int * int) end
+       Type declarations do not match:
+         type t = private u
+       is not included in
+         type t = private int * (int * int)
+|}];;
+
+type s = private int
+
+module M : sig
+  type t = private float
+end = struct
+  type t = private s
+end;;
+[%%expect{|
+type s = private int
+Lines 5-7, characters 6-3:
+5 | ......struct
+6 |   type t = private s
+7 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private s end
+       is not included in
+         sig type t = private float end
+       Type declarations do not match:
+         type t = private s
+       is not included in
+         type t = private float
+|}];;

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -47,3 +47,4 @@ Error: The class type
        Type exp = < eval : (string, exp) Hashtbl.t -> expr >
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ] 
+       Types for tag `App are incompatible

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -16,25 +16,5 @@ Error: This type entity = < destroy_subject : id subject; entity_id : id >
        Type (id subject, id) observer = < notify : id subject -> id -> unit >
        is not compatible with type
          'a entity_container =
-           < add_entity : (< destroy_subject : < add_observer : 'a
-                                                                entity_container ->
-                                                                'f;
-                                                 .. >
-                                               as 'e;
-                             .. >
-                           as 'd) ->
-                          'f;
-             notify : 'd -> id -> unit > 
-       Type entity = < destroy_subject : id subject; entity_id : id >
-       is not compatible with type < destroy_subject : 'e; .. > as 'd 
-       Type
-         id subject =
-           < add_observer : (id subject, id) observer -> unit;
-             notify_observers : id -> unit >
-       is not compatible with type
-         < add_observer : 'a entity_container -> 'f; .. > as 'e 
-       Type (id subject, id) observer = < notify : id subject -> id -> unit >
-       is not compatible with type
-         'a entity_container =
-           < add_entity : 'd -> 'f; notify : 'd -> id -> unit > 
-       The first object type has no method add_entity
+           < add_entity : 'a -> 'c; notify : 'a -> id -> unit > 
+       Types for method add_observer are incompatible

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -976,6 +976,7 @@ Line 3, characters 13-29:
                  ^^^^^^^^^^^^^^^^
 Error: Constraints are not satisfied in this type.
        Type (float, string) t should be an instance of (int, int) t
+       Type float is not compatible with type int
 |}]
 
 (* Example of wrong expansion *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -966,6 +966,18 @@ Error: Constraints are not satisfied in this type.
        Type 'a u t should be an instance of g t
 |}];;
 
+(* Full unification trace reported for "Constraints are not satisfied in this type" *)
+type ('a,'b) t constraint 'a = 'b
+               constraint 'a = int
+  and 'a u = (float,string) t;;
+[%%expect {|
+Line 3, characters 13-29:
+3 |   and 'a u = (float,string) t;;
+                 ^^^^^^^^^^^^^^^^
+Error: Constraints are not satisfied in this type.
+       Type (float, string) t should be an instance of (int, int) t
+|}]
+
 (* Example of wrong expansion *)
 type 'a u = < m : 'a v > and 'a v = 'a list u;;
 [%%expect {|
@@ -1005,14 +1017,14 @@ type u = 'a t as 'a
 |}];;
 
 (* pass typetexp, but fails during Typedecl.check_recursion *)
-type ('a, 'b) a = 'a -> unit constraint 'a = [> `B of ('a, 'b) b as 'b]
-and  ('a, 'b) b = 'b -> unit constraint 'b = [> `A of ('a, 'b) a as 'a];;
+type ('a1, 'b1) ty1 = 'a1 -> unit constraint 'a1 = [> `V1 of ('a1, 'b1) ty2 as 'b1]
+and  ('a2, 'b2) ty2 = 'b2 -> unit constraint 'b2 = [> `V2 of ('a2, 'b2) ty1 as 'a2];;
 [%%expect {|
-Line 1, characters 0-71:
-1 | type ('a, 'b) a = 'a -> unit constraint 'a = [> `B of ('a, 'b) b as 'b]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The definition of a contains a cycle:
-       [> `B of ('a, 'b) b as 'b ] as 'a
+Line 1, characters 0-83:
+1 | type ('a1, 'b1) ty1 = 'a1 -> unit constraint 'a1 = [> `V1 of ('a1, 'b1) ty2 as 'b1]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of ty1 contains a cycle:
+       [> `V1 of ('a, 'b) ty2 as 'b ] as 'a
 |}];;
 
 (* PR#8359: expanding may change original in Ctype.unify2 *)

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -29,8 +29,5 @@ Error: This expression has type
          < m : 'left 'right. < left : 'left; right : 'right > pair >
        but an expression was expected of type
          < m : 'left 'right. < left : 'left; right : 'right > pair >
-       Type < left : 'left; right : 'right > pair = 'a * 'b
-       is not compatible with type < left : 'left0; right : 'right0 > pair
-       The method left has type 'a, but the expected method type was 'left
-       The universal variable 'left would escape its scope
+       Types for method m are incompatible
 |}]

--- a/testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference
+++ b/testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference
@@ -1,6 +1,5 @@
 File "pr3918c.ml", line 24, characters 11-12:
 24 | let f x = (x : 'a vlist :> 'b vlist)
                 ^
-Error: This expression has type 'b Pr3918b.vlist = 'a
+Error: This expression has type 'b Pr3918b.vlist
        but an expression was expected of type 'b Pr3918b.vlist
-       The type variable 'a occurs inside ('d * 'c) Pr3918a.voption as 'c

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -588,7 +588,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       let rec find = function
       | [] -> raise Not_found
       | (_name, Simple (sch, printer)) :: remainder ->
-          if Ctype.moregeneral env false sch ty
+          if Ctype.is_moregeneral env false sch ty
           then printer
           else find remainder
       | (_name, Generic (path, fn)) :: remainder ->

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -398,7 +398,7 @@ let () =
  * one for exception constructors and another for
  * non-exception constructors (normal and extensible variants). *)
 let is_exception_constructor env type_expr =
-  Ctype.equal env true [type_expr] [Predef.type_exn]
+  Ctype.is_equal env true [type_expr] [Predef.type_exn]
 
 let is_extension_constructor = function
   | Cstr_extension _ -> true

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -64,22 +64,25 @@ exception Subtype of Errortrace.Subtype.t * unification Errortrace.t
 
 exception Escape of desc Errortrace.escape
 
-(* For local use: throw the appropriate exception.  Can be passed into local functions as
-   a parameter *)
+(* For local use: throw the appropriate exception.  Can be passed into local
+   functions as a parameter *)
 type _ trace_exn =
 | Unify    : unification trace_exn
 | Moregen  : comparison  trace_exn
 | Equality : comparison  trace_exn
 
-let raise_trace_for (type variant) (tr_exn : variant trace_exn) (tr : variant Errortrace.t) : 'a =
+let raise_trace_for
+      (type variant)
+      (tr_exn : variant trace_exn)
+      (tr     : variant Errortrace.t) : 'a =
   match tr_exn with
   | Unify    -> raise (Unify    tr)
   | Equality -> raise (Equality tr)
   | Moregen  -> raise (Moregen  tr)
 
-(* Uses of this function are a bit suspicious, as we usually want to maintain trace
-   information; sometimes it makes sense, however, since we're maintaining the trace at an
-   outer exception handler. *)
+(* Uses of this function are a bit suspicious, as we usually want to maintain
+   trace information; sometimes it makes sense, however, since we're maintaining
+   the trace at an outer exception handler. *)
 let raise_unexplained_for tr_exn =
   raise_trace_for tr_exn []
 
@@ -1715,8 +1718,8 @@ let expand_head_opt env ty =
 (* Recursively expand the head of a type.
    Also expand #-types.
 
-   Error printing relies on [full_expand] returning exactly its input (i.e., a physically
-   equal type) when nothing changes. *)
+   Error printing relies on [full_expand] returning exactly its input (i.e., a
+   physically equal type) when nothing changes. *)
 let full_expand ~may_forget_scope env ty =
   let ty =
     if may_forget_scope then
@@ -2226,10 +2229,10 @@ let rec expands_to_datatype env ty =
       end
   | _ -> false
 
-(* [mcomp] tests if two types are "compatible" -- i.e., if they could ever unify.  (This
-   is distinct from [eqtype], which checks if two types *are* exactly the same.)  This is
-   used to decide whether GADT cases are unreachable.  It is broadly part of
-   unification. *)
+(* [mcomp] tests if two types are "compatible" -- i.e., if they could ever
+   unify.  (This is distinct from [eqtype], which checks if two types *are*
+   exactly the same.)  This is used to decide whether GADT cases are
+   unreachable.  It is broadly part of unification. *)
 
 (* mcomp type_pairs subst env t1 t2 does not raise an
    exception if it is possible that t1 and t2 are actually
@@ -2278,7 +2281,8 @@ let rec mcomp type_pairs env t1 t2 =
         | (Tconstr (p, _, _), _) | (_, Tconstr (p, _, _)) ->
             begin try
               let decl = Env.find_type p env in
-              if non_aliasable p decl || is_datatype decl then raise Incompatible
+              if non_aliasable p decl || is_datatype decl then
+                raise Incompatible
             with Not_found -> ()
             end
         (*
@@ -2869,8 +2873,10 @@ and unify3 env t1 t1' t2 t2' =
             List.iter (fun (_n, ty) -> reify env ty) (fl1 @ fl2);
             (* if !generate_equations then List.iter2 (mcomp !env) tl1 tl2 *)
           end
-      | (Tnil,  Tconstr _ ) -> raise (Unify Errortrace.[Obj(Abstract_row Second)])
-      | (Tconstr _,  Tnil ) -> raise (Unify Errortrace.[Obj(Abstract_row First)])
+      | (Tnil,  Tconstr _ ) ->
+          raise (Unify Errortrace.[Obj(Abstract_row Second)])
+      | (Tconstr _,  Tnil ) ->
+          raise (Unify Errortrace.[Obj(Abstract_row First)])
       | (_, _) -> raise_unexplained_for Unify
       end;
       (* XXX Commentaires + changer "create_recursion"
@@ -3629,7 +3635,8 @@ let rec eqtype rename type_pairs subst env t1 t2 =
           normalize_subst subst;
           if List.assq t1 !subst != t2 then raise_unexplained_for Equality
         with Not_found ->
-          if List.exists (fun (_, t) -> t == t2) !subst then raise_unexplained_for Equality;
+          if List.exists (fun (_, t) -> t == t2) !subst then
+            raise_unexplained_for Equality;
           subst := (t1, t2) :: !subst
         end
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
@@ -3648,10 +3655,11 @@ let rec eqtype rename type_pairs subst env t1 t2 =
           | (Tvar _, Tvar _) when rename ->
               begin try
                 normalize_subst subst;
-                if List.assq t1' !subst != t2' then raise_unexplained_for Equality
+                if List.assq t1' !subst != t2' then
+                  raise_unexplained_for Equality
               with Not_found ->
-                if List.exists (fun (_, t) -> t == t2') !subst
-                then raise_unexplained_for Equality;
+                if List.exists (fun (_, t) -> t == t2') !subst then
+                  raise_unexplained_for Equality;
                 subst := (t1', t2') :: !subst
               end
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) when l1 = l2
@@ -3669,8 +3677,10 @@ let rec eqtype rename type_pairs subst env t1 t2 =
                   t1'.level p1 fl1 t2'.level p2 fl2
               with Not_found -> raise_unexplained_for Equality
               end
-          | (Tnil,  Tconstr _ ) -> raise_for Equality (Obj (Abstract_row Second))
-          | (Tconstr _,  Tnil ) -> raise_for Equality (Obj (Abstract_row First))
+          | (Tnil,  Tconstr _ ) ->
+              raise_for Equality (Obj (Abstract_row Second))
+          | (Tconstr _,  Tnil ) ->
+              raise_for Equality (Obj (Abstract_row First))
           | (Tvariant row1, Tvariant row2) ->
               eqtype_row rename type_pairs subst env row1 row2
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
@@ -3721,7 +3731,7 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
            try
              eqtype rename type_pairs subst env t1 t2;
            with Equality trace ->
-             raise ( Equality (Errortrace.incompatible_fields n t1 t2 :: trace )))
+             raise (Equality (Errortrace.incompatible_fields n t1 t2 :: trace)))
         pairs
 
 and eqtype_kind k1 k2 =
@@ -3739,8 +3749,10 @@ and eqtype_row rename type_pairs subst env row1 row2 =
   | _ ->
   let row1 = row_repr row1 and row2 = row_repr row2 in
   let r1, r2, pairs = merge_row_fields row1.row_fields row2.row_fields in
-  if row1.row_closed <> row2.row_closed
-  then raise_for Equality (Variant (Openness (if row2.row_closed then First else Second)));
+  if row1.row_closed <> row2.row_closed then begin
+    raise_for Equality
+      (Variant (Openness (if row2.row_closed then First else Second)))
+  end;
   if not row1.row_closed then begin
     match r1, r2 with
     | _::_, _ -> raise_for Equality (Variant (No_tags (Second, r1)))
@@ -3868,15 +3880,17 @@ let rec moregen_clty trace type_pairs env cty1 cty2 =
         List.iter
           (fun (lab, _k1, t1, _k2, t2) ->
             try moregen true type_pairs env t1 t2 with Moregen trace ->
-              raise (Failure [CM_Meth_type_mismatch
-                                 (CM_Moregen, lab, env, expand_trace env trace)]))
+              raise (Failure [
+                CM_Meth_type_mismatch
+                  (CM_Moregen, lab, env, expand_trace env trace)]))
           pairs;
       Vars.iter
         (fun lab (_mut, _v, ty) ->
            let (_mut', _v', ty') = Vars.find lab sign1.csig_vars in
            try moregen true type_pairs env ty' ty with Moregen trace ->
-             raise (Failure [CM_Val_type_mismatch
-                                (CM_Moregen, lab, env, expand_trace env trace)]))
+             raise (Failure [
+               CM_Val_type_mismatch
+                 (CM_Moregen, lab, env, expand_trace env trace)]))
         sign2.csig_vars
   | _ ->
       raise (Failure [])
@@ -3933,7 +3947,8 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
         (fun (lab, k1, _t1, k2, _t2) err ->
            match moregen_kind k1 k2 with
            | () -> err
-           | exception Public_method_to_private_method -> CM_Public_method lab::err)
+           | exception Public_method_to_private_method ->
+               CM_Public_method lab :: err)
         pairs error
     in
     let error =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -19,6 +19,7 @@ open Misc
 open Asttypes
 open Types
 open Btype
+open Errortrace
 
 open Local_store
 
@@ -56,109 +57,41 @@ open Local_store
 
 (**** Errors ****)
 
-module Unification_trace = struct
+exception Unify of unification Errortrace.t
+exception Equality of non_unification Errortrace.t
+exception Moregen of non_unification Errortrace.t
+exception Subtype of Errortrace.Subtype.t * unification Errortrace.t
 
-  type position = First | Second
-  let swap_position = function
-    | First -> Second
-    | Second -> First
+exception Escape of desc Errortrace.escape
 
-  type desc = { t: type_expr; expanded: type_expr option }
-  type 'a diff = { got: 'a; expected: 'a}
+(* For local use: throw the appropriate exception.  Can be passed into local functions as
+   a parameter *)
+type _ trace_exn =
+| Unify    : unification     trace_exn
+| Moregen  : non_unification trace_exn
+| Equality : non_unification trace_exn
 
-  type 'a escape =
-    | Constructor of Path.t
-    | Univ of type_expr
-    (* The type_expr argument of [Univ] is always a [Tunivar _],
-       we keep a [type_expr] to track renaming in {!Printtyp} *)
-    | Self
-    | Module_type of Path.t
-    | Equation of 'a
+let raise_for (type variant) (tr_exn : variant trace_exn) (tr : variant Errortrace.t) : 'a =
+  match tr_exn with
+  | Unify    -> raise (Unify    tr)
+  | Equality -> raise (Equality tr)
+  | Moregen  -> raise (Moregen  tr)
 
-  type fixed_row_case =
-    | Cannot_be_closed
-    | Cannot_add_tags of string list
+(* Uses of this function are a bit suspicious, as we usually want to maintain trace
+   information; sometimes it makes sense, however, since we're maintaining the trace at an
+   outer exception handler. *)
+let raise_nil_for tr_exn =
+  raise_for tr_exn []
 
-  type variant =
-    | No_intersection
-    | No_tags of position * (Asttypes.label * row_field) list
-    | Incompatible_types_for of string
-    | Fixed_row of position * fixed_row_case * fixed_explanation
+let raise1_for tr_exn e =
+  raise_for tr_exn [e]
 
+(* Thrown from [moregen_kind] *)
+exception Public_method_to_private_method
 
-  type obj =
-    | Missing_field of position * string
-    | Abstract_row of position
-    | Self_cannot_be_closed
-
-  type 'a elt =
-    | Diff of 'a diff
-    | Variant of variant
-    | Obj of obj
-    | Escape of {context:type_expr option; kind: 'a escape}
-    | Incompatible_fields of {name:string; diff:type_expr diff }
-    | Rec_occur of type_expr * type_expr
-
-  type t = desc elt list
-  let short t = { t; expanded = None }
-  let map_diff f r =
-    (* ordering is often meaningful when dealing with type_expr *)
-    let got = f r.got in
-    let expected = f r.expected in
-    { got; expected}
-  let diff got expected = Diff (map_diff short {got;expected})
-
-  let map_elt f = function
-    | Diff x -> Diff (map_diff f x)
-    | Escape {kind=Equation x; context} -> Escape {kind=Equation(f x); context}
-    | Rec_occur (_,_)
-    | Escape {kind=(Univ _ | Self|Constructor _ | Module_type _ ); _}
-    | Variant _ | Obj _
-    | Incompatible_fields _ as x -> x
-  let map f = List.map (map_elt f)
-
-
-  (* Convert desc to type_expr * type_expr *)
-  let flatten_desc f x = match x.expanded with
-    | None -> f x.t x.t
-    | Some expanded -> f x.t expanded
-  let flatten f = map (flatten_desc f)
-
-  (* Permute the expected and actual values *)
-  let swap_diff x = { got = x.expected; expected = x.got }
-  let swap_elt = function
-    | Diff x -> Diff (swap_diff x)
-    | Incompatible_fields {name;diff} ->
-        Incompatible_fields { name; diff = swap_diff diff}
-    | Obj (Missing_field(pos,s)) -> Obj(Missing_field(swap_position pos,s))
-    | Obj (Abstract_row pos) -> Obj(Abstract_row (swap_position pos))
-    | Variant (Fixed_row(pos,k,f)) -> Variant (Fixed_row(swap_position pos,k,f))
-    | Variant (No_tags(pos,f)) -> Variant (No_tags(swap_position pos,f))
-    | x -> x
-  let swap x = List.map swap_elt x
-
-  exception Unify of t
-
-  let escape kind =  Escape { kind; context = None}
-  let scope_escape x = Unify[escape (Equation (short x))]
-  let rec_occur x y = Unify[Rec_occur(x, y)]
-  let incompatible_fields name got expected =
-    Incompatible_fields {name; diff={got; expected} }
-
-  let explain trace f =
-    let rec explain = function
-      | [] -> None
-      | [h] -> f ~prev:None h
-      | h :: (prev :: _ as rem) ->
-        match f ~prev:(Some prev) h with
-        | Some _ as m -> m
-        | None -> explain rem in
-    explain (List.rev trace)
-
-end
-module Trace = Unification_trace
-
-exception Unify = Trace.Unify
+let escape kind = {kind; context = None}
+let escape_exn kind = Escape (escape kind)
+let scope_escape_exn kind = escape_exn (Equation (short kind))
 
 exception Tags of label * label
 
@@ -175,11 +108,15 @@ let () =
       | _ -> None
     )
 
-exception Subtype of Unification_trace.t * Unification_trace.t
-
 exception Cannot_expand
 
 exception Cannot_apply
+
+exception Cannot_subst
+
+exception Cannot_unify_universal_variables of type_expr * type_expr
+
+exception Matches_failure of Env.t * unification Errortrace.t
 
 (**** Type level management ****)
 
@@ -790,8 +727,8 @@ let rec generalize_spine ty =
       List.iter generalize_spine tyl
   | _ -> ()
 
-let forward_try_expand_once = (* Forward declaration *)
-  ref (fun _env _ty -> raise Cannot_expand)
+let forward_try_expand_safe = (* Forward declaration *)
+  ref (fun _env _ty -> assert false)
 
 (*
    Lower the levels of a type (assume [level] is not
@@ -819,18 +756,18 @@ let rec check_scope_escape env level ty =
   let orig_level = ty.level in
   if try_logged_mark_node ty then begin
     if level < ty.scope then
-      raise(Trace.scope_escape ty);
+      raise(scope_escape_exn ty);
     begin match ty.desc with
     | Tconstr (p, _, _) when level < Path.scope p ->
-        begin match !forward_try_expand_once env ty with
+        begin match !forward_try_expand_safe env ty with
         | ty' ->
             check_scope_escape env level ty'
         | exception Cannot_expand ->
-            raise Trace.(Unify [escape (Constructor p)])
+            raise (escape_exn (Constructor p))
         end
     | Tpackage (p, fl) when level < Path.scope p ->
         let p' = normalize_package_path env p in
-        if Path.same p p' then raise Trace.(Unify [escape (Module_type p)]);
+        if Path.same p p' then raise (escape_exn (Module_type p));
         check_scope_escape env level
           (Btype.newty2 orig_level (Tpackage (p', fl)))
     | _ ->
@@ -841,18 +778,23 @@ let rec check_scope_escape env level ty =
 let check_scope_escape env level ty =
   let snap = snapshot () in
   try check_scope_escape env level ty; backtrack snap
-  with Unify [Trace.Escape x] ->
+  with Escape e ->
     backtrack snap;
-    raise Trace.(Unify[Escape { x with context = Some ty }])
+    raise (Escape { e with context = Some ty })
 
 let rec update_scope scope ty =
   let ty = repr ty in
   if ty.scope < scope then begin
-    if ty.level < scope then raise (Trace.scope_escape ty);
+    if ty.level < scope then raise (scope_escape_exn ty);
     set_scope ty scope;
     (* Only recurse in principal mode as this is not necessary for soundness *)
     if !Clflags.principal then iter_type_expr (update_scope scope) ty
   end
+
+let update_scope_for tr_exn scope ty =
+  try
+    update_scope scope ty
+  with Escape e -> raise1_for tr_exn (Escape e)
 
 (* Note: the level of a type constructor must be greater than its binding
     time. That way, a type constructor cannot escape the scope of its
@@ -865,15 +807,15 @@ let rec update_scope scope ty =
 let rec update_level env level expand ty =
   let ty = repr ty in
   if ty.level > level then begin
-    if level < ty.scope then raise (Trace.scope_escape ty);
+    if level < ty.scope then raise (scope_escape_exn ty);
     match ty.desc with
       Tconstr(p, _tl, _abbrev) when level < Path.scope p ->
         (* Try first to replace an abbreviation by its expansion. *)
         begin try
-          link_type ty (!forward_try_expand_once env ty);
+          link_type ty (!forward_try_expand_safe env ty);
           update_level env level expand ty
         with Cannot_expand ->
-          raise Trace.(Unify [escape(Constructor p)])
+          raise (escape_exn(Constructor p))
         end
     | Tconstr(p, (_ :: _ as tl), _) ->
         let variance =
@@ -887,7 +829,7 @@ let rec update_level env level expand ty =
         in
         begin try
           if not needs_expand then raise Cannot_expand;
-          link_type ty (!forward_try_expand_once env ty);
+          link_type ty (!forward_try_expand_safe env ty);
           update_level env level expand ty
         with Cannot_expand ->
           set_level ty level;
@@ -895,7 +837,7 @@ let rec update_level env level expand ty =
         end
     | Tpackage (p, fl) when level < Path.scope p ->
         let p' = normalize_package_path env p in
-        if Path.same p p' then raise Trace.(Unify [escape (Module_type p)]);
+        if Path.same p p' then raise (escape_exn (Module_type p));
         set_type_desc ty (Tpackage (p', fl));
         update_level env level expand ty
     | Tobject(_, ({contents=Some(p, _tl)} as nm))
@@ -913,7 +855,7 @@ let rec update_level env level expand ty =
         iter_type_expr (update_level env level expand) ty
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && (repr ty1).level > level ->
-        raise Trace.(Unify [escape Self])
+        raise (escape_exn Self)
     | _ ->
         set_level ty level;
         (* XXX what about abbreviations in Tconstr ? *)
@@ -928,7 +870,7 @@ let update_level env level ty =
     let snap = snapshot () in
     try
       update_level env level false ty
-    with Unify _ ->
+    with Escape _ ->
       backtrack snap;
       update_level env level true ty
   end
@@ -970,7 +912,7 @@ let rec lower_contravariant env var_level visited contra ty =
                   else lower_rec contra t)
               variance tyl in
           if maybe_expand then (* we expand cautiously to avoid missing cmis *)
-            match !forward_try_expand_once env ty with
+            match !forward_try_expand_safe env ty with
             | ty -> lower_rec contra ty
             | exception Cannot_expand -> not_expanded ()
           else not_expanded ()
@@ -1514,32 +1456,36 @@ let instance_label fixed lbl =
 (**** Instantiation with parameter substitution ****)
 
 let unify' = (* Forward declaration *)
-  ref (fun _env _ty1 _ty2 -> raise (Unify []))
+  ref (fun _env _ty1 _ty2 -> assert false)
+
 
 let subst env level priv abbrev ty params args body =
-  if List.length params <> List.length args then raise (Unify []);
+  if List.length params <> List.length args then raise Cannot_subst;
   let old_level = !current_level in
   current_level := level;
-  try
-    let body0 = newvar () in          (* Stub *)
-    begin match ty with
-      None      -> ()
+  let body0 = newvar () in          (* Stub *)
+  let undo_abbrev =
+    match ty with
+    | None -> fun () -> () (* No abbreviation added *)
     | Some ({desc = Tconstr (path, tl, _)} as ty) ->
         let abbrev = proper_abbrevs path tl abbrev in
-        memorize_abbrev abbrev priv path ty body0
+        memorize_abbrev abbrev priv path ty body0;
+        fun () -> forget_abbrev abbrev path
     | _ ->
         assert false
-    end;
-    abbreviations := abbrev;
-    let (params', body') = instance_parameterized_type params body in
-    abbreviations := ref Mnil;
+  in
+  abbreviations := abbrev;
+  let (params', body') = instance_parameterized_type params body in
+  abbreviations := ref Mnil;
+  try
     !unify' env body0 body';
     List.iter2 (!unify' env) params' args;
     current_level := old_level;
     body'
-  with Unify _ as exn ->
+  with Unify _ ->
     current_level := old_level;
-    raise exn
+    undo_abbrev ();
+    raise Cannot_subst
 
 (*
    Only the shape of the type matters, not whether it is generic or
@@ -1551,7 +1497,7 @@ let apply env params body args =
   try
     subst env generic_level Public (ref Mnil) None params args body
   with
-    Unify _ -> raise Cannot_apply
+    Cannot_subst -> raise Cannot_apply
 
 let () = Subst.ctype_apply_env_empty := apply Env.empty
 
@@ -1605,7 +1551,7 @@ let expand_abbrev_gen kind find_type_expansion env ty =
           if level <> generic_level then
             begin try
               update_level env level ty'
-            with Unify _ ->
+            with Escape _ ->
               (* XXX This should not happen.
                  However, levels are not correctly restored after a
                  typing error *)
@@ -1613,7 +1559,7 @@ let expand_abbrev_gen kind find_type_expansion env ty =
             end;
           begin try
             update_scope scope ty';
-          with Unify _ ->
+          with Escape _ ->
             (* XXX This should not happen.
                However, levels are not correctly restored after a
                typing error *)
@@ -1632,7 +1578,11 @@ let expand_abbrev_gen kind find_type_expansion env ty =
           | (params, body, lv) ->
             (* prerr_endline
               ("add a "^string_of_kind kind^" expansion for "^Path.name path);*)
-            let ty' = subst env level kind abbrev (Some ty) params args body in
+            let ty' =
+              try
+                subst env level kind abbrev (Some ty) params args body
+              with Cannot_subst -> raise (escape_exn Constraint)
+            in
             (* For gadts, remember type as non exportable *)
             (* The ambiguous level registered for ty' should be the highest *)
             (* if !trace_gadt_instances then begin *)
@@ -1650,7 +1600,9 @@ let expand_abbrev env ty =
 
 (* Expand once the head of a type *)
 let expand_head_once env ty =
-  try expand_abbrev env (repr ty) with Cannot_expand -> assert false
+  try
+    expand_abbrev env (repr ty)
+  with Cannot_expand | Escape _ -> assert false
 
 (* Check whether a type can be expanded *)
 let safe_abbrev env ty =
@@ -1659,14 +1611,14 @@ let safe_abbrev env ty =
     Cannot_expand ->
       Btype.backtrack snap;
       false
-  | Unify _ ->
+  | Escape _ ->
       Btype.backtrack snap;
       cleanup_abbrev ();
       false
 
 (* Expand the head of a type once.
    Raise Cannot_expand if the type cannot be expanded.
-   May raise Unify, if a recursion was hidden in the type. *)
+   May raise Escape, if a recursion was hidden in the type. *)
 let try_expand_once env ty =
   let ty = repr ty in
   match ty.desc with
@@ -1677,7 +1629,7 @@ let try_expand_once env ty =
 let try_expand_safe env ty =
   let snap = Btype.snapshot () in
   try try_expand_once env ty
-  with Unify _ ->
+  with Escape _ ->
     Btype.backtrack snap; cleanup_abbrev (); raise Cannot_expand
 
 (* Fully expand the head of a type. *)
@@ -1686,15 +1638,19 @@ let rec try_expand_head try_once env ty =
   try try_expand_head try_once env ty'
   with Cannot_expand -> ty'
 
-(* Unsafe full expansion, may raise Unify. *)
+(* Unsafe full expansion, may raise [Unify [Escape _]]. *)
 let expand_head_unif env ty =
-  try try_expand_head try_expand_once env ty with Cannot_expand -> repr ty
+  try
+    try_expand_head try_expand_once env ty
+  with
+  | Cannot_expand -> repr ty
+  | Escape e -> raise1_for Unify (Escape e)
 
 (* Safe version of expand_head, never fails *)
 let expand_head env ty =
   try try_expand_head try_expand_safe env ty with Cannot_expand -> repr ty
 
-let _ = forward_try_expand_once := try_expand_safe
+let _ = forward_try_expand_safe := try_expand_safe
 
 
 (* Expand until we find a non-abstract type declaration,
@@ -1722,8 +1678,15 @@ let rec extract_concrete_typedecl env ty =
    normally hidden to the type-checker out of the implementation module of
    the private abbreviation. *)
 
-let expand_abbrev_opt =
-  expand_abbrev_gen Private Env.find_type_expansion_opt
+let expand_abbrev_opt env ty =
+  expand_abbrev_gen Private Env.find_type_expansion_opt env ty
+
+let safe_abbrev_opt env ty =
+  let snap = Btype.snapshot () in
+  try ignore (expand_abbrev_opt env ty); true
+  with Cannot_expand | Escape _ ->
+    Btype.backtrack snap;
+    false
 
 let try_expand_once_opt env ty =
   let ty = repr ty in
@@ -1731,20 +1694,14 @@ let try_expand_once_opt env ty =
     Tconstr _ -> repr (expand_abbrev_opt env ty)
   | _ -> raise Cannot_expand
 
-let rec try_expand_head_opt env ty =
-  let ty' = try_expand_once_opt env ty in
-  begin try
-    try_expand_head_opt env ty'
-  with Cannot_expand ->
-    ty'
-  end
+let try_expand_safe_opt env ty =
+  let snap = Btype.snapshot () in
+  try try_expand_once_opt env ty
+  with Escape _ ->
+    Btype.backtrack snap; raise Cannot_expand
 
 let expand_head_opt env ty =
-  let snap = Btype.snapshot () in
-  try try_expand_head_opt env ty
-  with Cannot_expand | Unify _ -> (* expand_head shall never fail *)
-    Btype.backtrack snap;
-    repr ty
+  try try_expand_head try_expand_safe_opt env ty with Cannot_expand -> repr ty
 
 (* Recursively expand the head of a type.
    Also expand #-types.
@@ -1858,12 +1815,15 @@ let occur env ty0 ty =
     merge type_changed old
   with exn ->
     merge type_changed old;
-    match exn with
-    | Occur -> raise (Trace.rec_occur ty0 ty)
-    | _ -> raise exn
+    raise exn
+
+let occur_for tr_exn env t1 t2 =
+  try
+    occur env t1 t2
+  with Occur -> raise1_for tr_exn (Rec_occur(t1, t2))
 
 let occur_in env ty0 t =
-  try occur env ty0 t; false with Unify _ -> true
+  try occur env ty0 t; false with Occur -> true
 
 (* Check that a local constraint is well-founded *)
 (* PR#6405: not needed since we allow recursion and work on normalized types *)
@@ -1882,7 +1842,7 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
         begin try
           (* try expanding, since [p] could be hidden *)
           local_non_recursive_abbrev ~allow_rec strict visited env p
-            (try_expand_head try_expand_once_opt env ty)
+            (try_expand_head try_expand_safe_opt env ty)
         with Cannot_expand ->
           let params =
             try (Env.find_type p' env).type_params
@@ -1920,7 +1880,7 @@ let local_non_recursive_abbrev env p ty =
 (* Since we cannot duplicate universal variables, unification must
    be done at meta-level, using bindings in univar_pairs *)
 (* TODO: use find_opt *)
-let rec unify_univar t1 t2 = function
+let rec link_univar t1 t2 = function
     (cl1, cl2) :: rem ->
       let find_univ t cl =
         try
@@ -1934,11 +1894,17 @@ let rec unify_univar t1 t2 = function
       | Some({contents=None} as r1), Some({contents=None} as r2) ->
           set_univar r1 t2; set_univar r2 t1
       | None, None ->
-          unify_univar t1 t2 rem
+          link_univar t1 t2 rem
       | _ ->
-          raise (Unify [])
+          raise (Cannot_unify_universal_variables (t1, t2))
       end
-  | [] -> raise (Unify [])
+  | [] -> raise (Cannot_unify_universal_variables (t1, t2))
+
+(* The same as [link_univar], but raises [Unify] instead of
+   [Cannot_unify_universal_variables] *)
+let unify_univar t1 t2 univar_pairs =
+  try link_univar t1 t2 univar_pairs
+  with Cannot_unify_universal_variables (_, _) -> raise_nil_for Unify
 
 (* Test the occurrence of free univars in a type *)
 (* That's way too expensive. Must do some kind of caching *)
@@ -1963,7 +1929,7 @@ let occur_univar ?(inj_only=false) env ty =
       match ty.desc with
         Tunivar _ ->
           if not (TypeSet.mem ty bound) then
-            raise Trace.(Unify [escape (Univ ty)])
+            raise (escape_exn (Univ ty))
       | Tpoly (ty, tyl) ->
           let bound = List.fold_right TypeSet.add (List.map repr tyl) bound in
           occur_rec bound  ty
@@ -1994,9 +1960,9 @@ let occur_univar ?(inj_only=false) env ty =
     ~always:(fun () -> unmark_type ty)
 
 let has_free_univars env ty =
-  try occur_univar ~inj_only:false env ty; false with Unify _ -> true
+  try occur_univar ~inj_only:false env ty; false with Escape _ -> true
 let has_injective_univars env ty =
-  try occur_univar ~inj_only:true env ty; false with Unify _ -> true
+  try occur_univar ~inj_only:true env ty; false with Escape _ -> true
 
 (* Grouping univars by families according to their binders *)
 let add_univars =
@@ -2026,8 +1992,7 @@ let univars_escape env univar_pairs vl ty =
         Tpoly (t, tl) ->
           if List.exists (fun t -> TypeSet.mem (repr t) family) tl then ()
           else occur t
-      | Tunivar _ ->
-          if TypeSet.mem t family then raise Trace.(Unify [escape(Univ t)])
+      | Tunivar _ -> if TypeSet.mem t family then raise (escape_exn (Univ t))
       | Tconstr (_, [], _) -> ()
       | Tconstr (p, tl, _) ->
           begin try
@@ -2062,6 +2027,11 @@ let enter_poly env univar_pairs t1 tl1 t2 tl2 f =
   univar_pairs := (cl1,cl2) :: (cl2,cl1) :: old_univars;
   Misc.try_finally (fun () -> f t1 t2)
     ~always:(fun () -> univar_pairs := old_univars)
+
+let enter_poly_for tr_exn env univar_pairs t1 tl1 t2 tl2 f =
+  try
+    enter_poly env univar_pairs t1 tl1 t2 tl2 f
+  with Escape e -> raise1_for tr_exn (Escape e)
 
 let univar_pairs = ref []
 
@@ -2110,16 +2080,19 @@ let rec has_cached_expansion p abbrev =
 (**** Transform error trace ****)
 (* +++ Move it to some other place ? *)
 
-let expand_trace env trace =
-  let expand_desc x =
-    let open Trace in
-    match x.expanded with
+let expand_any_trace map env trace =
+  let expand_desc x = match x.Errortrace.expanded with
     | None ->
-        let expanded = full_expand ~may_forget_scope:true env x.t in
-        { t = repr x.t; expanded = Some expanded }
-    | Some _ -> x
-  in
-  Unification_trace.map expand_desc trace
+      let expanded = full_expand ~may_forget_scope:true env x.t in
+      Errortrace.{ t = repr x.t; expanded = Some expanded }
+    | Some _ -> x in
+  map expand_desc trace
+
+let expand_trace env trace =
+  expand_any_trace Errortrace.map env trace
+
+let expand_subtype_trace env trace =
+  expand_any_trace Subtype.map env trace
 
 (**** Unification ****)
 
@@ -2171,7 +2144,7 @@ let reify env t =
           let path, t = create_fresh_constr ty.level o in
           link_type ty t;
           if ty.level < fresh_constr_scope then
-            raise Trace.(Unify [escape (Constructor path)])
+            raise1_for Unify (Escape (escape (Constructor path)))
       | Tvariant r ->
           let r = row_repr r in
           if not (static_row r) then begin
@@ -2185,7 +2158,7 @@ let reify env t =
                   {r with row_fields=[]; row_fixed; row_more = t} in
                 link_type m (newty2 m.level (Tvariant row));
                 if m.level < fresh_constr_scope then
-                  raise Trace.(Unify [escape (Constructor path)])
+                  raise1_for Unify (Escape (escape (Constructor path)))
             | _ -> assert false
           end;
           iter_row iterator r
@@ -2234,10 +2207,15 @@ let rec expands_to_datatype env ty =
     Tconstr (p, _, _) ->
       begin try
         is_datatype (Env.find_type p env) ||
-        expands_to_datatype env (try_expand_once env ty)
+        expands_to_datatype env (try_expand_safe env ty)
       with Not_found | Cannot_expand -> false
       end
   | _ -> false
+
+(* [mcomp] tests if two types are "compatible" -- i.e., if they could ever unify.  (This
+   is distinct from [eqtype], which checks if two types *are* exactly the same.)  This is
+   used to decide whether GADT cases are unreachable.  It is broadly part of
+   unification. *)
 
 (* mcomp type_pairs subst env t1 t2 does not raise an
    exception if it is possible that t1 and t2 are actually
@@ -2286,7 +2264,7 @@ let rec mcomp type_pairs env t1 t2 =
         | (Tconstr (p, _, _), _) | (_, Tconstr (p, _, _)) ->
             begin try
               let decl = Env.find_type p env in
-              if non_aliasable p decl || is_datatype decl then raise (Unify [])
+              if non_aliasable p decl || is_datatype decl then raise_nil_for Unify
             with Not_found -> ()
             end
         (*
@@ -2305,17 +2283,17 @@ let rec mcomp type_pairs env t1 t2 =
         | (Tpoly (t1, []), Tpoly (t2, [])) ->
             mcomp type_pairs env t1 t2
         | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
-            enter_poly env univar_pairs t1 tl1 t2 tl2
-              (mcomp type_pairs env)
+            enter_poly_for Unify env univar_pairs
+              t1 tl1 t2 tl2 (mcomp type_pairs env)
         | (Tunivar _, Tunivar _) ->
             unify_univar t1' t2' !univar_pairs
         | (_, _) ->
-            raise (Unify [])
+            raise_nil_for Unify
       end
 
 and mcomp_list type_pairs env tl1 tl2 =
   if List.length tl1 <> List.length tl2 then
-    raise (Unify []);
+    raise_nil_for Unify;
   List.iter2 (mcomp type_pairs env) tl1 tl2
 
 and mcomp_fields type_pairs env ty1 ty2 =
@@ -2327,7 +2305,7 @@ and mcomp_fields type_pairs env ty1 ty2 =
     List.exists (fun (_, k, _) -> field_kind_repr k = Fpresent) in
   mcomp type_pairs env rest1 rest2;
   if has_present miss1  && (object_row ty2).desc = Tnil
-  || has_present miss2  && (object_row ty1).desc = Tnil then raise (Unify []);
+  || has_present miss2  && (object_row ty1).desc = Tnil then raise_nil_for Unify;
   List.iter
     (function (_n, k1, t1, k2, t2) ->
        mcomp_kind k1 k2;
@@ -2339,7 +2317,7 @@ and mcomp_kind k1 k2 =
   let k2 = field_kind_repr k2 in
   match k1, k2 with
     (Fpresent, Fabsent)
-  | (Fabsent, Fpresent) -> raise (Unify [])
+  | (Fabsent, Fpresent) -> raise_nil_for Unify
   | _                   -> ()
 
 and mcomp_row type_pairs env row1 row2 =
@@ -2351,7 +2329,7 @@ and mcomp_row type_pairs env row1 row2 =
     | Rabsent | Reither _ -> false
   in
   if row1.row_closed && List.exists cannot_erase r2
-  || row2.row_closed && List.exists cannot_erase r1 then raise (Unify []);
+  || row2.row_closed && List.exists cannot_erase r1 then raise_nil_for Unify;
   List.iter
     (fun (_,f1,f2) ->
       match row_field_repr f1, row_field_repr f2 with
@@ -2359,7 +2337,7 @@ and mcomp_row type_pairs env row1 row2 =
       | Rpresent (Some _), (Rpresent None | Reither (true, _, _, _) | Rabsent)
       | (Reither (_, _::_, _, _) | Rabsent), Rpresent None
       | (Reither (true, _, _, _) | Rabsent), Rpresent (Some _) ->
-          raise (Unify [])
+          raise_nil_for Unify
       | Rpresent(Some t1), Rpresent(Some t2) ->
           mcomp type_pairs env t1 t2
       | Rpresent(Some t1), Reither(false, tl2, _, _) ->
@@ -2382,7 +2360,7 @@ and mcomp_type_decl type_pairs env p1 p2 tl1 tl2 =
         (fun i (t1,t2) -> if i then mcomp type_pairs env t1 t2)
         inj (List.combine tl1 tl2)
     end else if non_aliasable p1 decl && non_aliasable p2 decl' then
-      raise (Unify [])
+      raise_nil_for Unify
     else
       match decl.type_kind, decl'.type_kind with
       | Type_record (lst,r), Type_record (lst',r') when r = r' ->
@@ -2396,14 +2374,14 @@ and mcomp_type_decl type_pairs env p1 p2 tl1 tl2 =
       | Type_abstract, Type_abstract -> ()
       | Type_abstract, _ when not (non_aliasable p1 decl)-> ()
       | _, Type_abstract when not (non_aliasable p2 decl') -> ()
-      | _ -> raise (Unify [])
+      | _ -> raise_nil_for Unify
   with Not_found -> ()
 
 and mcomp_type_option type_pairs env t t' =
   match t, t' with
     None, None -> ()
   | Some t, Some t' -> mcomp type_pairs env t t'
-  | _ -> raise (Unify [])
+  | _ -> raise_nil_for Unify
 
 and mcomp_variant_description type_pairs env xs ys =
   let rec iter = fun x y ->
@@ -2414,13 +2392,13 @@ and mcomp_variant_description type_pairs env xs ys =
       | Cstr_tuple l1, Cstr_tuple l2 -> mcomp_list type_pairs env l1 l2
       | Cstr_record l1, Cstr_record l2 ->
           mcomp_record_description type_pairs env l1 l2
-      | _ -> raise (Unify [])
+      | _ -> raise_nil_for Unify
       end;
      if Ident.name c1.cd_id = Ident.name c2.cd_id
       then iter xs ys
-      else raise (Unify [])
+      else raise_nil_for Unify
     | [],[] -> ()
-    | _ -> raise (Unify [])
+    | _ -> raise_nil_for Unify
   in
   iter xs ys
 
@@ -2432,9 +2410,9 @@ and mcomp_record_description type_pairs env =
         if Ident.name l1.ld_id = Ident.name l2.ld_id &&
            l1.ld_mutable = l2.ld_mutable
         then iter xs ys
-        else raise (Unify [])
+        else raise_nil_for Unify
     | [], [] -> ()
-    | _ -> raise (Unify [])
+    | _ -> raise_nil_for Unify
   in
   iter
 
@@ -2564,6 +2542,18 @@ let unify_package env unify_list lv1 p1 fl1 lv2 p2 fl2 =
 (* force unification in Reither when one side has a non-conjunctive type *)
 let rigid_variants = ref false
 
+(* Only used in unify; could become [update_level_for tr_exn] if it were used elsewhere *)
+let unify_update_level env level ty =
+  try
+    update_level env level ty
+  with Escape e -> raise1_for Unify (Escape e)
+
+(* Only used in unify; could become [occur_univar_for tr_exn] if it were used elsewhere *)
+let unify_occur_univar env ty =
+  try
+    occur_univar env ty
+  with Escape e -> raise1_for Unify (Escape e)
+
 let unify_eq t1 t2 =
   t1 == t2 ||
   match !umode with
@@ -2574,11 +2564,16 @@ let unify_eq t1 t2 =
 
 let unify1_var env t1 t2 =
   assert (is_Tvar t1);
-  occur env t1 t2;
-  match occur_univar env t2 with
+  occur_for Unify env t1 t2;
+  match unify_occur_univar env t2 with
   | () ->
-      update_level env t1.level t2;
-      update_scope t1.scope t2;
+      begin
+        try
+          update_level env t1.level t2;
+          update_scope t1.scope t2
+        with Escape e ->
+          raise1_for Unify (Escape e)
+      end;
       link_type t1 t2;
       true
   | exception Unify _ when !umode = Pattern ->
@@ -2592,8 +2587,8 @@ let record_equation t1 t2 =
 
 (* Called from unify3 *)
 let unify3_var env t1' t2 t2' =
-  occur !env t1' t2;
-  match occur_univar !env t2 with
+  occur_for Unify !env t1' t2;
+  match unify_occur_univar !env t2 with
   | () -> link_type t1' t2
   | exception Unify _ when !umode = Pattern ->
       reify env t1';
@@ -2648,8 +2643,8 @@ let rec unify (env:Env.t ref) t1 t2 =
         if unify1_var !env t2 t1 then () else unify2 env t1 t2
     | (Tunivar _, Tunivar _) ->
         unify_univar t1 t2 !univar_pairs;
-        update_level !env t1.level t2;
-        update_scope t1.scope t2;
+        unify_update_level !env t1.level t2;
+        update_scope_for Unify t1.scope t2;
         link_type t1 t2
     | (Tconstr (p1, [], a1), Tconstr (p2, [], a2))
           when Path.same p1 p2 (* && actual_mode !env = Old *)
@@ -2658,8 +2653,8 @@ let rec unify (env:Env.t ref) t1 t2 =
                when any of the types has a cached expansion. *)
             && not (has_cached_expansion p1 !a1
                  || has_cached_expansion p2 !a2) ->
-        update_level !env t1.level t2;
-        update_scope t1.scope t2;
+        unify_update_level !env t1.level t2;
+        update_scope_for Unify t1.scope t2;
         link_type t1 t2
     | (Tconstr (p1, [], _), Tconstr (p2, [], _))
       when Env.has_local_constraints !env
@@ -2667,9 +2662,9 @@ let rec unify (env:Env.t ref) t1 t2 =
         (* Do not use local constraints more than necessary *)
         begin try
           if find_expansion_scope !env p1 > find_expansion_scope !env p2 then
-            unify env t1 (try_expand_once !env t2)
+            unify env t1 (try_expand_safe !env t2)
           else
-            unify env (try_expand_once !env t1) t2
+            unify env (try_expand_safe !env t1) t2
         with Cannot_expand ->
           unify2 env t1 t2
         end
@@ -2679,21 +2674,24 @@ let rec unify (env:Env.t ref) t1 t2 =
     reset_trace_gadt_instances reset_tracing;
   with Unify trace ->
     reset_trace_gadt_instances reset_tracing;
-    raise( Unify (Trace.diff t1 t2 :: trace) )
+    raise( Unify (Errortrace.diff t1 t2 :: trace) )
 
 and unify2 env t1 t2 =
   (* Second step: expansion of abbreviations *)
   (* Expansion may change the representative of the types. *)
-  ignore (expand_head_unif !env t1);
-  ignore (expand_head_unif !env t2);
-  let t1' = expand_head_unif !env t1 in
-  let t2' = expand_head_unif !env t2 in
+  let t1', t2' =
+    ignore (expand_head_unif !env t1);
+    ignore (expand_head_unif !env t2);
+    let t1' = expand_head_unif !env t1 in
+    let t2' = expand_head_unif !env t2 in
+    t1', t2'
+  in
   let lv = min t1'.level t2'.level in
   let scope = max t1'.scope t2'.scope in
-  update_level !env lv t2;
-  update_level !env lv t1;
-  update_scope scope t2;
-  update_scope scope t1;
+  unify_update_level !env lv t2;
+  unify_update_level !env lv t1;
+  update_scope_for Unify scope t2;
+  update_scope_for Unify scope t1;
   if unify_eq t1' t2' then () else
 
   let t1 = repr t1 and t2 = repr t2 in
@@ -2710,7 +2708,7 @@ and unify2 env t1 t2 =
     unify3 env t1 t1' t2 t2'
   else
     try unify3 env t2 t2' t1 t1' with Unify trace ->
-      raise (Unify (Trace.swap trace))
+      raise (Unify (swap_unification_trace trace))
 
 and unify3 env t1 t1' t2 t2' =
   (* Third step: truly unification *)
@@ -2731,7 +2729,7 @@ and unify3 env t1 t1' t2 t2' =
   | _ ->
     begin match !umode with
     | Expression ->
-        occur !env t1' t2';
+        occur_for Unify !env t1' t2';
         if is_self_type d1 (* PR#7711: do not abbreviate self type *)
         then link_type t1' t2'
         else link_type t1' t2
@@ -2759,7 +2757,8 @@ and unify3 env t1 t1' t2 t2' =
               ~allow_recursive:!allow_recursive_equation
               (fun () -> unify_list env tl1 tl2)
           else if in_current_module p1 (* || in_pervasives p1 *)
-                  || List.exists (expands_to_datatype !env) [t1'; t1; t2] then
+               || List.exists (expands_to_datatype !env) [t1'; t1; t2]
+          then
             unify_list env tl1 tl2
           else
             let inj =
@@ -2776,7 +2775,8 @@ and unify3 env t1 t1' t2 t2' =
                     let snap = snapshot () in
                     try unify env t1 t2 with Unify _ ->
                       backtrack snap;
-                      reify env t1; reify env t2
+                      reify env t1;
+                      reify env t2
                   end)
               inj (List.combine tl1 tl2)
       | (Tconstr (path,[],_),
@@ -2841,30 +2841,30 @@ and unify3 env t1 t1' t2 t2' =
               else unify env (newty2 rem.level Tnil) rem
           | _      ->
               if f = dummy_method then
-                raise (Unify Trace.[Obj Self_cannot_be_closed])
+                raise1_for Unify (Obj Self_cannot_be_closed)
               else if d1 = Tnil then
-                raise (Unify Trace.[Obj(Missing_field (First, f))])
+                raise1_for Unify (Obj (Missing_field(First, f)))
               else
-                raise (Unify Trace.[Obj(Missing_field (Second, f))])
+                raise1_for Unify (Obj (Missing_field(Second, f)))
           end
       | (Tnil, Tnil) ->
           ()
       | (Tpoly (t1, []), Tpoly (t2, [])) ->
           unify env t1 t2
       | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
-          enter_poly !env univar_pairs t1 tl1 t2 tl2 (unify env)
+          enter_poly_for Unify !env univar_pairs t1 tl1 t2 tl2 (unify env)
       | (Tpackage (p1, fl1), Tpackage (p2, fl2)) ->
           begin try
             unify_package !env (unify_list env)
               t1.level p1 fl1 t2.level p2 fl2
           with Not_found ->
-            if !umode = Expression then raise (Unify []);
+            if !umode = Expression then raise_nil_for Unify;
             List.iter (fun (_n, ty) -> reify env ty) (fl1 @ fl2);
             (* if !generate_equations then List.iter2 (mcomp !env) tl1 tl2 *)
           end
-      | (Tnil,  Tconstr _ ) -> raise (Unify Trace.[Obj(Abstract_row Second)])
-      | (Tconstr _,  Tnil ) -> raise (Unify Trace.[Obj(Abstract_row First)])
-      | (_, _) -> raise (Unify [])
+      | (Tnil,  Tconstr _ ) -> raise (Unify Errortrace.[Obj(Abstract_row Second)])
+      | (Tconstr _,  Tnil ) -> raise (Unify Errortrace.[Obj(Abstract_row First)])
+      | (_, _) -> raise_nil_for Unify
       end;
       (* XXX Commentaires + changer "create_recursion"
          ||| Comments + change "create_recursion" *)
@@ -2884,7 +2884,7 @@ and unify3 env t1 t1' t2 t2' =
 
 and unify_list env tl1 tl2 =
   if List.length tl1 <> List.length tl2 then
-    raise (Unify []);
+    raise_nil_for Unify;
   List.iter2 (unify env) tl1 tl2
 
 (* Build a fresh row variable for unification *)
@@ -2922,12 +2922,12 @@ and unify_fields env ty1 ty2 =          (* Optimization *)
         unify_kind k1 k2;
         try
           if !trace_gadt_instances then begin
-            update_level !env va.level t1;
-            update_scope va.scope t1
+            unify_update_level !env va.level t1;
+            update_scope_for Unify va.scope t1
           end;
           unify env t1 t2
         with Unify trace ->
-          raise( Unify (Trace.incompatible_fields n t1 t2 :: trace) )
+          raise( Unify (Errortrace.incompatible_fields n t1 t2 :: trace) )
       )
       pairs
   with exn ->
@@ -2983,7 +2983,7 @@ and unify_row env row1 row2 =
       (fun (_,f1,f2) ->
         row_field_repr f1 = Rabsent || row_field_repr f2 = Rabsent)
       pairs
-  then raise Trace.( Unify [Variant No_intersection] );
+  then raise1_for Unify (Variant No_intersection);
   let name =
     if row1.row_name <> None && (row1.row_closed || empty r2) &&
       (not row2.row_closed || keep (fun f1 f2 -> f1, f2) && empty r1)
@@ -3003,28 +3003,28 @@ and unify_row env row1 row2 =
     begin match fixed_explanation row with
       | None ->
           if rest <> [] && row.row_closed then
-            let pos = if row == row1 then Trace.First else Trace.Second in
-            raise Trace.(Unify [Variant (No_tags(pos,rest))])
+            let pos = if row == row1 then First else Second in
+            raise1_for Unify (Variant (No_tags(pos,rest)))
       | Some fixed ->
-          let pos = if row == row1 then Trace.First else Trace.Second in
+          let pos = if row == row1 then First else Second in
           if closed && not row.row_closed then
-            raise Trace.(Unify [Variant(Fixed_row(pos,Cannot_be_closed,fixed))])
+            raise1_for Unify (Variant (Fixed_row(pos,Cannot_be_closed,fixed)))
           else if rest <> [] then
-            let case = Trace.Cannot_add_tags (List.map fst rest) in
-            raise Trace.(Unify [Variant(Fixed_row(pos,case,fixed))])
+            let case = Cannot_add_tags (List.map fst rest) in
+            raise1_for Unify (Variant (Fixed_row(pos,case,fixed)))
     end;
     (* The following test is not principal... should rather use Tnil *)
     let rm = row_more row in
     (*if !trace_gadt_instances && rm.desc = Tnil then () else*)
     if !trace_gadt_instances then
-      update_level !env rm.level (newgenty (Tvariant row));
+      unify_update_level !env rm.level (newgenty (Tvariant row));
     if row_fixed row then
       if more == rm then () else
       if is_Tvar rm then link_type rm more else unify env rm more
     else
       let ty = newgenty (Tvariant {row0 with row_fields = rest}) in
-      update_level !env rm.level ty;
-      update_scope rm.scope ty;
+      unify_update_level !env rm.level ty;
+      update_scope_for Unify rm.scope ty;
       link_type rm ty
   in
   let md1 = rm1.desc and md2 = rm2.desc in
@@ -3035,7 +3035,7 @@ and unify_row env row1 row2 =
       (fun (l,f1,f2) ->
         try unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2
         with Unify trace ->
-          raise Trace.( Unify( Variant (Incompatible_types_for l) :: trace ))
+          raise ( Unify( Variant (Incompatible_types_for l) :: trace ))
       )
       pairs;
     if static_row row1 then begin
@@ -3052,9 +3052,9 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
     match fixed with
     | None -> f ()
     | Some fix ->
-        let tr = Trace.[ Variant (Fixed_row (pos,Cannot_add_tags [l],fix)) ] in
+        let tr = [Variant(Fixed_row(pos,Cannot_add_tags [l],fix))] in
         raise (Unify tr) in
-  let first = Trace.First, fixed1 and second = Trace.Second, fixed2 in
+  let first = First, fixed1 and second = Second, fixed2 in
   let either_fixed = match fixed1, fixed2 with
     | None, None -> false
     | _ -> true in
@@ -3076,7 +3076,7 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
          !rigid_variants && (List.length tl1 = 1 || List.length tl2 = 1)) &&
         begin match tl1 @ tl2 with [] -> false
         | t1 :: tl ->
-            if c1 || c2 then raise (Unify []);
+            if c1 || c2 then raise_nil_for Unify;
             List.iter (unify env t1) tl;
             !e1 <> None || !e2 <> None
         end in
@@ -3095,18 +3095,19 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
       | (tu1::tlu1), _ :: _ ->
           (* Attempt to merge all the types containing univars *)
           List.iter (unify env tu1) (tlu1@tlu2)
-      | (tu::_, []) | ([], tu::_) -> occur_univar !env tu
+      | (tu::_, []) | ([], tu::_) ->
+          unify_occur_univar !env tu
       end;
       (* Is this handling of levels really principal? *)
       List.iter (fun ty ->
         let rm = repr rm2 in
-        update_level !env rm.level ty;
-        update_scope rm.scope ty;
+        unify_update_level !env rm.level ty;
+        update_scope_for Unify rm.scope ty;
       ) tl1';
       List.iter (fun ty ->
         let rm = repr rm1 in
-        update_level !env rm.level ty;
-        update_scope rm.scope ty;
+        unify_update_level !env rm.level ty;
+        update_scope_for Unify rm.scope ty;
       ) tl2';
       let e = ref None in
       let f1' = Reither(c1 || c2, tl2', m1 || m2, e)
@@ -3121,8 +3122,8 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
       if_not_fixed first (fun () ->
           set_row_field e1 f2;
           let rm = repr rm1 in
-          update_level !env rm.level t2;
-          update_scope rm.scope t2;
+          unify_update_level !env rm.level t2;
+          update_scope_for Unify rm.scope t2;
           (try List.iter (fun t1 -> unify env t1 t2) tl
            with exn -> e1 := None; raise exn)
         )
@@ -3130,8 +3131,8 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
       if_not_fixed second (fun () ->
           set_row_field e2 f1;
           let rm = repr rm2 in
-          update_level !env rm.level t1;
-          update_scope rm.scope t1;
+          unify_update_level !env rm.level t1;
+          update_scope_for Unify rm.scope t1;
           (try List.iter (unify env t1) tl
            with exn -> e2 := None; raise exn)
         )
@@ -3139,7 +3140,7 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
       if_not_fixed first (fun () -> set_row_field e1 f2)
   | Rpresent None, Reither(true, [], _, e2) ->
       if_not_fixed second (fun () -> set_row_field e2 f1)
-  | _ -> raise (Unify [])
+  | _ -> raise_nil_for Unify
 
 let unify env ty1 ty2 =
   let snap = Btype.snapshot () in
@@ -3177,14 +3178,16 @@ let unify_var env t1 t2 =
   | Tvar _, _ ->
       let reset_tracing = check_trace_gadt_instances env in
       begin try
-        occur env t1 t2;
-        update_level env t1.level t2;
-        update_scope t1.scope t2;
+        occur_for Unify env t1 t2;
+        unify_update_level env t1.level t2;
+        update_scope_for Unify t1.scope t2;
         link_type t1 t2;
         reset_trace_gadt_instances reset_tracing;
       with Unify trace ->
         reset_trace_gadt_instances reset_tracing;
-        let expanded_trace = expand_trace env @@ Trace.diff t1 t2 :: trace in
+        let expanded_trace =
+          expand_trace env @@ Errortrace.diff t1 t2 :: trace
+        in
         raise (Unify expanded_trace)
       end
   | _ ->
@@ -3229,7 +3232,7 @@ let filter_arrow env t l =
     when l = l' || !Clflags.classic && l = Nolabel && not (is_optional l') ->
       (t1, t2)
   | _ ->
-      raise (Unify [])
+      raise_nil_for Unify
 
 (* Used by [filter_method]. *)
 let rec filter_method_field env name priv ty =
@@ -3256,7 +3259,7 @@ let rec filter_method_field env name priv ty =
       end else
         filter_method_field env name priv ty2
   | _ ->
-      raise (Unify [])
+      raise_nil_for Unify
 
 (* Unify [ty] and [< name : 'a; .. >]. Return ['a]. *)
 let filter_method env name priv ty =
@@ -3265,14 +3268,14 @@ let filter_method env name priv ty =
     Tvar _ ->
       let ty1 = newvar () in
       let ty' = newobj ty1 in
-      update_level env ty.level ty';
-      update_scope ty.scope ty';
+      unify_update_level env ty.level ty';
+      update_scope_for Unify ty.scope ty';
       link_type ty ty';
       filter_method_field env name priv ty1
   | Tobject(f, _) ->
       filter_method_field env name priv f
   | _ ->
-      raise (Unify [])
+      raise_nil_for Unify
 
 let check_filter_method env name priv ty =
   ignore(filter_method env name priv ty)
@@ -3305,11 +3308,13 @@ let moregen_occur env level ty =
   begin try
     occur ty; unmark_type ty
   with Occur ->
-    unmark_type ty; raise (Unify [])
+    unmark_type ty; raise_nil_for Moregen
   end;
   (* also check for free univars *)
-  occur_univar env ty;
-  update_level env level ty
+  try
+    occur_univar env ty;
+    update_level env level ty
+  with Escape e -> raise1_for Moregen (Escape e)
 
 let may_instantiate inst_nongen t1 =
   if inst_nongen then t1.level <> generic_level - 1
@@ -3320,13 +3325,12 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
   let t1 = repr t1 in
   let t2 = repr t2 in
   if t1 == t2 then () else
-
   try
     match (t1.desc, t2.desc) with
-      (Tvar _, _) when may_instantiate inst_nongen t1 ->
+    | (Tvar _, _) when may_instantiate inst_nongen t1 ->
         moregen_occur env t1.level t2;
-        update_scope t1.scope t2;
-        occur env t1 t2;
+        update_scope_for Moregen t1.scope t2;
+        occur_for Moregen env t1 t2;
         link_type t1 t2
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
         ()
@@ -3343,7 +3347,7 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
           match (t1'.desc, t2'.desc) with
             (Tvar _, _) when may_instantiate inst_nongen t1' ->
               moregen_occur env t1'.level t2;
-              update_scope t1'.scope t2;
+              update_scope_for Moregen t1'.scope t2;
               link_type t1' t2
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) when l1 = l2
             || !Clflags.classic && not (is_optional l1 || is_optional l2) ->
@@ -3358,8 +3362,10 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
               begin try
                 unify_package env (moregen_list inst_nongen type_pairs env)
                   t1'.level p1 fl1 t2'.level p2 fl2
-              with Not_found -> raise (Unify [])
+              with Not_found -> raise_nil_for Moregen
               end
+          | (Tnil,  Tconstr _ ) -> raise1_for Moregen (Obj (Abstract_row Second))
+          | (Tconstr _,  Tnil ) -> raise1_for Moregen (Obj (Abstract_row First))
           | (Tvariant row1, Tvariant row2) ->
               moregen_row inst_nongen type_pairs env row1 row2
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
@@ -3371,35 +3377,44 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
           | (Tpoly (t1, []), Tpoly (t2, [])) ->
               moregen inst_nongen type_pairs env t1 t2
           | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
-              enter_poly env univar_pairs t1 tl1 t2 tl2
+              enter_poly_for Moregen env univar_pairs t1 tl1 t2 tl2
                 (moregen inst_nongen type_pairs env)
           | (Tunivar _, Tunivar _) ->
-              unify_univar t1' t2' !univar_pairs
+              begin try
+                link_univar t1' t2' !univar_pairs
+              with
+              | Cannot_unify_universal_variables (_, _) ->
+                raise_nil_for Moregen
+              end
           | (_, _) ->
-              raise (Unify [])
+              raise_nil_for Moregen
         end
-  with Unify trace ->  raise( Unify ( Trace.diff t1 t2 :: trace ) )
+  with Moregen trace -> raise ( Moregen ( Errortrace.diff t1 t2 :: trace ) );
+
 
 and moregen_list inst_nongen type_pairs env tl1 tl2 =
   if List.length tl1 <> List.length tl2 then
-    raise (Unify []);
+    raise_nil_for Moregen;
   List.iter2 (moregen inst_nongen type_pairs env) tl1 tl2
 
 and moregen_fields inst_nongen type_pairs env ty1 ty2 =
   let (fields1, rest1) = flatten_fields ty1
   and (fields2, rest2) = flatten_fields ty2 in
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
-  if miss1 <> [] then raise (Unify []);
+  begin
+    match miss1 with
+    | (n, _, _) :: _ -> raise1_for Moregen (Obj (Missing_field (Second, n)))
+    | [] -> ()
+  end;
   moregen inst_nongen type_pairs env rest1
     (build_fields (repr ty2).level miss2 rest2);
+
   List.iter
     (fun (n, k1, t1, k2, t2) ->
+       (* The below call should never throw [Public_method_to_private_method] *)
        moregen_kind k1 k2;
-       try moregen inst_nongen type_pairs env t1 t2 with Unify trace ->
-         let e = Trace.diff
-             (newty (Tfield(n, k1, t1, rest2)))
-             (newty (Tfield(n, k2, t2, rest2))) in
-         raise( Unify ( e :: trace ) )
+       try moregen inst_nongen type_pairs env t1 t2 with Moregen trace ->
+         raise( Moregen ( Errortrace.incompatible_fields n t1 t2 :: trace ) )
     )
     pairs
 
@@ -3410,7 +3425,8 @@ and moregen_kind k1 k2 =
   match k1, k2 with
     (Fvar r, (Fvar _ | Fpresent))  -> set_kind r k2
   | (Fpresent, Fpresent)           -> ()
-  | _                              -> raise (Unify [])
+  | (Fpresent, Fvar _)             -> raise Public_method_to_private_method
+  | (Fabsent, _) | (_, Fabsent)    -> assert false
 
 and moregen_row inst_nongen type_pairs env row1 row2 =
   let row1 = row_repr row1 and row2 = row_repr row2 in
@@ -3424,55 +3440,72 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
       filter_row_fields may_inst r1, filter_row_fields false r2
     else r1, r2
   in
-  if r1 <> [] || row1.row_closed && (not row2.row_closed || r2 <> [])
-  then raise (Unify []);
+  begin
+    match r1 with
+    | [] -> ()
+    | _ :: _ -> raise1_for Moregen (Variant (No_tags (Second, r1)))
+  end;
+  if row1.row_closed then begin
+    match row2.row_closed, r2 with
+    | false, _ -> raise1_for Moregen (Variant (Openness Second))
+    | _, _ :: _ -> raise1_for Moregen (Variant (No_tags (First, r2)))
+    | _, [] -> ()
+  end;
   begin match rm1.desc, rm2.desc with
     Tunivar _, Tunivar _ ->
-      unify_univar rm1 rm2 !univar_pairs
+      begin try
+        link_univar rm1 rm2 !univar_pairs
+      with Cannot_unify_universal_variables (_, _) -> raise_nil_for Moregen
+      end
   | Tunivar _, _ | _, Tunivar _ ->
-      raise (Unify [])
+      raise_nil_for Moregen
   | _ when static_row row1 -> ()
   | _ when may_inst ->
       let ext =
         newgenty (Tvariant {row2 with row_fields = r2; row_name = None})
       in
       moregen_occur env rm1.level ext;
-      update_scope rm1.scope ext;
+      update_scope_for Moregen rm1.scope ext;
       link_type rm1 ext
   | Tconstr _, Tconstr _ ->
       moregen inst_nongen type_pairs env rm1 rm2
-  | _ -> raise (Unify [])
+  | _ -> raise_nil_for Moregen
   end;
   List.iter
-    (fun (_l,f1,f2) ->
-      let f1 = row_field_repr f1 and f2 = row_field_repr f2 in
-      if f1 == f2 then () else
-      match f1, f2 with
-        Rpresent(Some t1), Rpresent(Some t2) ->
-          moregen inst_nongen type_pairs env t1 t2
-      | Rpresent None, Rpresent None -> ()
-      | Reither(false, tl1, _, e1), Rpresent(Some t2) when may_inst ->
-          set_row_field e1 f2;
-          List.iter (fun t1 -> moregen inst_nongen type_pairs env t1 t2) tl1
-      | Reither(c1, tl1, _, e1), Reither(c2, tl2, m2, e2) ->
-          if e1 != e2 then begin
-            if c1 && not c2 then raise(Unify []);
-            set_row_field e1 (Reither (c2, [], m2, e2));
-            if List.length tl1 = List.length tl2 then
-              List.iter2 (moregen inst_nongen type_pairs env) tl1 tl2
-            else match tl2 with
-              t2 :: _ ->
-                List.iter (fun t1 -> moregen inst_nongen type_pairs env t1 t2)
-                  tl1
-            | [] ->
-                if tl1 <> [] then raise (Unify [])
-          end
-      | Reither(true, [], _, e1), Rpresent None when may_inst ->
-          set_row_field e1 f2
-      | Reither(_, _, _, e1), Rabsent when may_inst ->
-          set_row_field e1 f2
-      | Rabsent, Rabsent -> ()
-      | _ -> raise (Unify []))
+    (fun (l,f1,f2) ->
+       try
+         let f1 = row_field_repr f1 and f2 = row_field_repr f2 in
+         if f1 == f2 then () else
+         match f1, f2 with
+         | Rpresent(Some t1), Rpresent(Some t2) ->
+             moregen inst_nongen type_pairs env t1 t2
+         | Rpresent None, Rpresent None -> ()
+         | Reither(false, tl1, _, e1), Rpresent(Some t2) when may_inst ->
+             set_row_field e1 f2;
+             List.iter (fun t1 -> moregen inst_nongen type_pairs env t1 t2) tl1
+         | Reither(c1, tl1, _, e1), Reither(c2, tl2, m2, e2) ->
+             if e1 != e2 then begin
+               if c1 && not c2 then raise_nil_for Moregen;
+               set_row_field e1 (Reither (c2, [], m2, e2));
+               if List.length tl1 = List.length tl2 then
+                 List.iter2 (moregen inst_nongen type_pairs env) tl1 tl2
+               else match tl2 with
+                 | t2 :: _ ->
+                     List.iter
+                       (fun t1 -> moregen inst_nongen type_pairs env t1 t2)
+                       tl1
+                 | [] -> if tl1 <> [] then raise_nil_for Moregen
+             end
+         | Reither(true, [], _, e1), Rpresent None when may_inst ->
+             set_row_field e1 f2
+         | Reither(_, _, _, e1), Rabsent when may_inst -> set_row_field e1 f2
+         | Rabsent, Rabsent -> ()
+         | Rpresent (Some _), Rpresent None -> raise_nil_for Moregen
+         | Rpresent None, Rpresent (Some _) -> raise_nil_for Moregen
+         | Rpresent _, Reither _ -> raise_nil_for Moregen
+         | _ -> raise_nil_for Moregen
+       with Moregen err ->
+         raise (Moregen (Variant (Incompatible_types_for l) :: err)))
     pairs
 
 (* Must empty univar_pairs first *)
@@ -3501,13 +3534,15 @@ let moregeneral env inst_nongen pat_sch subj_sch =
   current_level := generic_level;
   (* Duplicate generic variables *)
   let patt = instance pat_sch in
-  let res =
-    try moregen inst_nongen (TypePairs.create 13) env patt subj; true with
-      Unify _ -> false
-  in
-  current_level := old_level;
-  res
 
+  Misc.try_finally
+    (fun () -> moregen inst_nongen (TypePairs.create 13) env patt subj)
+    ~always:(fun () -> current_level := old_level)
+
+let is_moregeneral env inst_nongen pat_sch subj_sch =
+  match moregeneral env inst_nongen pat_sch subj_sch with
+  | () -> true
+  | exception Moregen _ -> false
 
 (* Alternative approach: "rigidify" a type scheme,
    and check validity after unification *)
@@ -3554,13 +3589,21 @@ let matches env ty ty' =
   let snap = snapshot () in
   let vars = rigidify ty in
   cleanup_abbrev ();
-  let ok =
-    try unify env ty ty'; all_distinct_vars env vars
-    with Unify _ -> false
-  in
-  backtrack snap;
-  ok
+  try
+    unify env ty ty';
+    if not (all_distinct_vars env vars) then begin
+      backtrack snap;
+      raise (Matches_failure (env, [Errortrace.diff ty ty']))
+    end;
+    backtrack snap
+  with Unify trace ->
+    backtrack snap;
+    raise (Matches_failure (env, trace))
 
+let does_match env ty ty' =
+  match matches env ty ty' with
+  | () -> true
+  | exception Matches_failure (_, _) -> false
 
                  (*********************************************)
                  (*  Equivalence between parameterized types  *)
@@ -3586,12 +3629,12 @@ let rec eqtype rename type_pairs subst env t1 t2 =
 
   try
     match (t1.desc, t2.desc) with
-      (Tvar _, Tvar _) when rename ->
+    | (Tvar _, Tvar _) when rename ->
         begin try
           normalize_subst subst;
-          if List.assq t1 !subst != t2 then raise (Unify [])
+          if List.assq t1 !subst != t2 then raise_nil_for Equality
         with Not_found ->
-          if List.exists (fun (_, t) -> t == t2) !subst then raise (Unify []);
+          if List.exists (fun (_, t) -> t == t2) !subst then raise_nil_for Equality;
           subst := (t1, t2) :: !subst
         end
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
@@ -3607,13 +3650,13 @@ let rec eqtype rename type_pairs subst env t1 t2 =
         with Not_found ->
           TypePairs.add type_pairs (t1', t2') ();
           match (t1'.desc, t2'.desc) with
-            (Tvar _, Tvar _) when rename ->
+          | (Tvar _, Tvar _) when rename ->
               begin try
                 normalize_subst subst;
-                if List.assq t1' !subst != t2' then raise (Unify [])
+                if List.assq t1' !subst != t2' then raise_nil_for Equality
               with Not_found ->
                 if List.exists (fun (_, t) -> t == t2') !subst
-                then raise (Unify []);
+                then raise_nil_for Equality;
                 subst := (t1', t2') :: !subst
               end
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) when l1 = l2
@@ -3629,8 +3672,10 @@ let rec eqtype rename type_pairs subst env t1 t2 =
               begin try
                 unify_package env (eqtype_list rename type_pairs subst env)
                   t1'.level p1 fl1 t2'.level p2 fl2
-              with Not_found -> raise (Unify [])
+              with Not_found -> raise_nil_for Equality
               end
+          | (Tnil,  Tconstr _ ) -> raise1_for Equality (Obj (Abstract_row Second))
+          | (Tconstr _,  Tnil ) -> raise1_for Equality (Obj (Abstract_row First))
           | (Tvariant row1, Tvariant row2) ->
               eqtype_row rename type_pairs subst env row1 row2
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
@@ -3642,18 +3687,21 @@ let rec eqtype rename type_pairs subst env t1 t2 =
           | (Tpoly (t1, []), Tpoly (t2, [])) ->
               eqtype rename type_pairs subst env t1 t2
           | (Tpoly (t1, tl1), Tpoly (t2, tl2)) ->
-              enter_poly env univar_pairs t1 tl1 t2 tl2
+              enter_poly_for Equality env univar_pairs t1 tl1 t2 tl2
                 (eqtype rename type_pairs subst env)
           | (Tunivar _, Tunivar _) ->
-              unify_univar t1' t2' !univar_pairs
+              begin try
+                link_univar t1' t2' !univar_pairs
+                with Cannot_unify_universal_variables (_, _) -> raise_nil_for Equality
+              end
           | (_, _) ->
-              raise (Unify [])
+              raise_nil_for Equality
         end
-  with Unify trace ->  raise ( Unify (Trace.diff t1 t2 :: trace) )
+  with Equality trace ->  raise ( Equality (Errortrace.diff t1 t2 :: trace) )
 
 and eqtype_list rename type_pairs subst env tl1 tl2 =
   if List.length tl1 <> List.length tl2 then
-    raise (Unify []);
+    raise_nil_for Equality;
   List.iter2 (eqtype rename type_pairs subst env) tl1 tl2
 
 and eqtype_fields rename type_pairs subst env ty1 ty2 =
@@ -3671,25 +3719,26 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
   | _ ->
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
   eqtype rename type_pairs subst env rest1 rest2;
-  if (miss1 <> []) || (miss2 <> []) then raise (Unify []);
-  List.iter
-    (function (n, k1, t1, k2, t2) ->
-       eqtype_kind k1 k2;
-       try eqtype rename type_pairs subst env t1 t2 with Unify trace ->
-         let e = Trace.diff
-             (newty (Tfield(n, k1, t1, rest2)))
-             (newty (Tfield(n, k2, t2, rest2))) in
-         raise ( Unify ( e :: trace ) )
-    )
-    pairs
+  match miss1, miss2 with
+  | ((n, _, _)::_, _) -> raise1_for Equality (Obj (Missing_field (Second, n)))
+  | (_, (n, _, _)::_) -> raise1_for Equality (Obj (Missing_field (First, n)))
+  | [], [] ->
+      List.iter
+        (function (n, k1, t1, k2, t2) ->
+           eqtype_kind k1 k2;
+           try
+             eqtype rename type_pairs subst env t1 t2;
+           with Equality trace ->
+             raise ( Equality (Errortrace.incompatible_fields n t1 t2 :: trace )))
+        pairs
 
 and eqtype_kind k1 k2 =
   let k1 = field_kind_repr k1 in
   let k2 = field_kind_repr k2 in
   match k1, k2 with
-    (Fvar _, Fvar _)
+  | (Fvar _, Fvar _)
   | (Fpresent, Fpresent) -> ()
-  | _                    -> raise (Unify [])
+  | _                    -> raise_nil_for Equality
 
 and eqtype_row rename type_pairs subst env row1 row2 =
   (* Try expansion, needed when called from Includecore.type_manifest *)
@@ -3699,31 +3748,53 @@ and eqtype_row rename type_pairs subst env row1 row2 =
   let row1 = row_repr row1 and row2 = row_repr row2 in
   let r1, r2, pairs = merge_row_fields row1.row_fields row2.row_fields in
   if row1.row_closed <> row2.row_closed
-  || not row1.row_closed && (r1 <> [] || r2 <> [])
-  || filter_row_fields false (r1 @ r2) <> []
-  then raise (Unify []);
+  then raise1_for Equality (Variant (Openness (if row2.row_closed then First else Second)));
+  if not row1.row_closed then begin
+    match r1, r2 with
+    | _::_, _ -> raise1_for Equality (Variant (No_tags (Second, r1)))
+    | _, _::_ -> raise1_for Equality (Variant (No_tags (First,  r2)))
+    | _, _ -> ()
+  end;
+  begin
+    match filter_row_fields false r1 with
+    | [] -> ();
+    | _ :: _ as r1 -> raise1_for Equality (Variant (No_tags (Second, r1)))
+  end;
+  begin
+    match filter_row_fields false r2 with
+    | [] -> ()
+    | _ :: _ as r2 -> raise1_for Equality (Variant (No_tags (First, r2)))
+  end;
   if not (static_row row1) then
     eqtype rename type_pairs subst env row1.row_more row2.row_more;
   List.iter
-    (fun (_,f1,f2) ->
-      match row_field_repr f1, row_field_repr f2 with
-        Rpresent(Some t1), Rpresent(Some t2) ->
-          eqtype rename type_pairs subst env t1 t2
-      | Reither(c1, [], _, _), Reither(c2, [], _, _) when c1 = c2 ->
-          ()
-      | Reither(c1, t1::tl1, _, _), Reither(c2, t2::tl2, _, _) when c1 = c2 ->
-          eqtype rename type_pairs subst env t1 t2;
-          if List.length tl1 = List.length tl2 then
-            (* if same length allow different types (meaning?) *)
-            List.iter2 (eqtype rename type_pairs subst env) tl1 tl2
-          else begin
-            (* otherwise everything must be equal *)
-            List.iter (eqtype rename type_pairs subst env t1) tl2;
-            List.iter (fun t1 -> eqtype rename type_pairs subst env t1 t2) tl1
-          end
-      | Rpresent None, Rpresent None -> ()
-      | Rabsent, Rabsent -> ()
-      | _ -> raise (Unify []))
+    (fun (l,f1,f2) ->
+       try
+         match row_field_repr f1, row_field_repr f2 with
+         | Rpresent(Some t1), Rpresent(Some t2) ->
+             eqtype rename type_pairs subst env t1 t2
+         | Reither(c1, [], _, _), Reither(c2, [], _, _) when c1 = c2 -> ()
+         | Reither(c1, t1::tl1, _, _), Reither(c2, t2::tl2, _, _)
+           when c1 = c2 ->
+             eqtype rename type_pairs subst env t1 t2;
+             if List.length tl1 = List.length tl2 then
+               (* if same length allow different types (meaning?) *)
+               List.iter2 (eqtype rename type_pairs subst env) tl1 tl2
+             else begin
+               (* otherwise everything must be equal *)
+               List.iter (eqtype rename type_pairs subst env t1) tl2;
+               List.iter
+                 (fun t1 -> eqtype rename type_pairs subst env t1 t2) tl1
+             end
+         | Rpresent None, Rpresent None -> ()
+         | Rabsent, Rabsent -> ()
+         | Rpresent (Some _), Rpresent None -> raise_nil_for Equality
+         | Rpresent None, Rpresent (Some _) -> raise_nil_for Equality
+         | Rpresent _, Reither _ -> raise_nil_for Equality
+         | Reither _, Rpresent _ -> raise_nil_for Equality
+         | _ -> raise_nil_for Equality
+       with Equality err ->
+         raise (Equality (Variant (Incompatible_types_for l):: err)))
     pairs
 
 (* Must empty univar_pairs first *)
@@ -3739,25 +3810,35 @@ let eqtype rename type_pairs subst env t1 t2 =
 
 (* Two modes: with or without renaming of variables *)
 let equal env rename tyl1 tyl2 =
-  try
-    eqtype_list rename (TypePairs.create 11) (ref []) env tyl1 tyl2; true
-  with
-    Unify _ -> false
+  eqtype_list rename (TypePairs.create 11) (ref []) env tyl1 tyl2
 
+let is_equal env rename tyl1 tyl2 =
+  match equal env rename tyl1 tyl2 with
+  | () -> true
+  | exception Equality _ -> false
+
+let rec equal_private env params1 ty1 params2 ty2 =
+  match equal env true (params1 @ [ty1]) (params2 @ [ty2]) with
+  | () -> ()
+  | exception (Equality _ as err) ->
+      match try_expand_safe_opt env (expand_head env ty1) with
+      | ty1' -> equal_private env params1 ty1' params2 ty2
+      | exception Cannot_expand -> raise err
 
                           (*************************)
                           (*  Class type matching  *)
                           (*************************)
 
-
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
-  | CM_Type_parameter_mismatch of Env.t * Unification_trace.t
+  | CM_Type_parameter_mismatch of Env.t * non_unification Errortrace.t (* Equality *)
   | CM_Class_type_mismatch of Env.t * class_type * class_type
-  | CM_Parameter_mismatch of Env.t * Unification_trace.t
-  | CM_Val_type_mismatch of string * Env.t * Unification_trace.t
-  | CM_Meth_type_mismatch of string * Env.t * Unification_trace.t
+  | CM_Parameter_mismatch of Env.t * non_unification Errortrace.t (* Moregen *)
+  | CM_Val_type_mismatch of string * Env.t * non_unification Errortrace.t (* Moregen *)
+  | CM_Val_type_mismatch_eq of string * Env.t * non_unification Errortrace.t (* Equality *)
+  | CM_Meth_type_mismatch of string * Env.t * non_unification Errortrace.t (* Moregen *)
+  | CM_Meth_type_mismatch_eq of string * Env.t * non_unification Errortrace.t (* Equality *)
   | CM_Non_mutable_value of string
   | CM_Non_concrete_value of string
   | CM_Missing_value of string
@@ -3778,7 +3859,7 @@ let rec moregen_clty trace type_pairs env cty1 cty2 =
     | _, Cty_constr (_, _, cty2) ->
         moregen_clty true type_pairs env cty1 cty2
     | Cty_arrow (l1, ty1, cty1'), Cty_arrow (l2, ty2, cty2') when l1 = l2 ->
-        begin try moregen true type_pairs env ty1 ty2 with Unify trace ->
+        begin try moregen true type_pairs env ty1 ty2 with Moregen trace ->
           raise (Failure [CM_Parameter_mismatch (env, expand_trace env trace)])
         end;
         moregen_clty false type_pairs env cty1' cty2'
@@ -3790,15 +3871,14 @@ let rec moregen_clty trace type_pairs env cty1 cty2 =
         let (pairs, _miss1, _miss2) = associate_fields fields1 fields2 in
         List.iter
           (fun (lab, _k1, t1, _k2, t2) ->
-            begin try moregen true type_pairs env t1 t2 with Unify trace ->
+            try moregen true type_pairs env t1 t2 with Moregen trace ->
               raise (Failure [CM_Meth_type_mismatch
-                                 (lab, env, expand_trace env trace)])
-           end)
-        pairs;
+                                 (lab, env, expand_trace env trace)]))
+          pairs;
       Vars.iter
         (fun lab (_mut, _v, ty) ->
            let (_mut', _v', ty') = Vars.find lab sign1.csig_vars in
-           try moregen true type_pairs env ty' ty with Unify trace ->
+           try moregen true type_pairs env ty' ty with Moregen trace ->
              raise (Failure [CM_Val_type_mismatch
                                 (lab, env, expand_trace env trace)]))
         sign2.csig_vars
@@ -3855,8 +3935,9 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
     let error =
       List.fold_right
         (fun (lab, k1, _t1, k2, _t2) err ->
-           try moregen_kind k1 k2; err with
-             Unify _ -> CM_Public_method lab::err)
+           match moregen_kind k1 k2 with
+           | () -> err
+           | exception Public_method_to_private_method -> CM_Public_method lab::err)
         pairs error
     in
     let error =
@@ -3903,48 +3984,32 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
   current_level := old_level;
   res
 
-let rec equal_clty trace type_pairs subst env cty1 cty2 =
+let equal_clsig trace type_pairs subst env sign1 sign2 =
   try
-    match cty1, cty2 with
-      Cty_constr (_, _, cty1), Cty_constr (_, _, cty2) ->
-        equal_clty true type_pairs subst env cty1 cty2
-    | Cty_constr (_, _, cty1), _ ->
-        equal_clty true type_pairs subst env cty1 cty2
-    | _, Cty_constr (_, _, cty2) ->
-        equal_clty true type_pairs subst env cty1 cty2
-    | Cty_arrow (l1, ty1, cty1'), Cty_arrow (l2, ty2, cty2') when l1 = l2 ->
-        begin try eqtype true type_pairs subst env ty1 ty2 with Unify trace ->
-          raise (Failure [CM_Parameter_mismatch (env, expand_trace env trace)])
-        end;
-        equal_clty false type_pairs subst env cty1' cty2'
-    | Cty_signature sign1, Cty_signature sign2 ->
-        let ty1 = object_fields (repr sign1.csig_self) in
-        let ty2 = object_fields (repr sign2.csig_self) in
-        let (fields1, _rest1) = flatten_fields ty1
-        and (fields2, _rest2) = flatten_fields ty2 in
-        let (pairs, _miss1, _miss2) = associate_fields fields1 fields2 in
-        List.iter
-          (fun (lab, _k1, t1, _k2, t2) ->
-             begin try eqtype true type_pairs subst env t1 t2 with
-               Unify trace ->
-                 raise (Failure [CM_Meth_type_mismatch
-                                    (lab, env, expand_trace env trace)])
-             end)
-          pairs;
-        Vars.iter
-          (fun lab (_, _, ty) ->
-             let (_, _, ty') = Vars.find lab sign1.csig_vars in
-             try eqtype true type_pairs subst env ty' ty with Unify trace ->
-               raise (Failure [CM_Val_type_mismatch
-                                  (lab, env, expand_trace env trace)]))
-          sign2.csig_vars
-    | _ ->
-        raise
-          (Failure (if trace then []
-                    else [CM_Class_type_mismatch (env, cty1, cty2)]))
+    let ty1 = object_fields (repr sign1.csig_self) in
+    let ty2 = object_fields (repr sign2.csig_self) in
+    let (fields1, _rest1) = flatten_fields ty1
+    and (fields2, _rest2) = flatten_fields ty2 in
+    let (pairs, _miss1, _miss2) = associate_fields fields1 fields2 in
+    List.iter
+      (fun (lab, _k1, t1, _k2, t2) ->
+         begin try eqtype true type_pairs subst env t1 t2 with
+           Equality trace ->
+           raise (Failure [CM_Meth_type_mismatch_eq
+                             (lab, env, expand_trace env trace)])
+         end)
+      pairs;
+    Vars.iter
+      (fun lab (_, _, ty) ->
+         let (_, _, ty') = Vars.find lab sign1.csig_vars in
+         try eqtype true type_pairs subst env ty' ty with Equality trace ->
+           raise (Failure [CM_Val_type_mismatch_eq
+                             (lab, env, expand_trace env trace)]))
+      sign2.csig_vars
   with
     Failure error when trace ->
-      raise (Failure (CM_Class_type_mismatch (env, cty1, cty2)::error))
+      raise (Failure (CM_Class_type_mismatch
+                        (env, Cty_signature sign1, Cty_signature sign2)::error))
 
 let match_class_declarations env patt_params patt_type subj_params subj_type =
   let type_pairs = TypePairs.create 53 in
@@ -4028,13 +4093,12 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
         if lp  <> ls then
           raise (Failure [CM_Parameter_arity_mismatch (lp, ls)]);
         List.iter2 (fun p s ->
-          try eqtype true type_pairs subst env p s with Unify trace ->
+          try eqtype true type_pairs subst env p s with Equality trace ->
             raise (Failure [CM_Type_parameter_mismatch
                                (env, expand_trace env trace)]))
           patt_params subj_params;
      (* old code: equal_clty false type_pairs subst env patt_type subj_type; *)
-        equal_clty false type_pairs subst env
-          (Cty_signature sign1) (Cty_signature sign2);
+        equal_clsig false type_pairs subst env sign1 sign2;
         (* Use moregeneral for class parameters, need to recheck everything to
            keeps relationships (PR#4824) *)
         let clty_params =
@@ -4130,8 +4194,10 @@ let rec build_subtype env visited loops posi level t =
         Tobject _ when posi && not (opened_object t') ->
           let cl_abbr, body = find_cltype_for_path env p in
           let ty =
-            subst env !current_level Public abbrev None
-              cl_abbr.type_params tl body in
+            try
+              subst env !current_level Public abbrev None
+                cl_abbr.type_params tl body
+            with Cannot_subst -> assert false in
           let ty = repr ty in
           let ty1, tl1 =
             match ty.desc with
@@ -4277,7 +4343,7 @@ let enlarge_type env ty =
 let subtypes = TypePairs.create 17
 
 let subtype_error env trace =
-  raise (Subtype (expand_trace env (List.rev trace), []))
+  raise (Subtype (expand_subtype_trace env (List.rev trace), []))
 
 let rec subtype_rec env trace t1 t2 cstrs =
   let t1 = repr t1 in
@@ -4294,8 +4360,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
         (trace, t1, t2, !univar_pairs)::cstrs
     | (Tarrow(l1, t1, u1, _), Tarrow(l2, t2, u2, _)) when l1 = l2
       || !Clflags.classic && not (is_optional l1 || is_optional l2) ->
-        let cstrs = subtype_rec env (Trace.diff t2 t1::trace) t2 t1 cstrs in
-        subtype_rec env (Trace.diff u1 u2::trace) u1 u2 cstrs
+        let cstrs = subtype_rec env (Subtype.diff t2 t1::trace) t2 t1 cstrs in
+        subtype_rec env (Subtype.diff u1 u2::trace) u1 u2 cstrs
     | (Ttuple tl1, Ttuple tl2) ->
         subtype_list env trace tl1 tl2 cstrs
     | (Tconstr(p1, [], _), Tconstr(p2, [], _)) when Path.same p1 p2 ->
@@ -4316,15 +4382,17 @@ let rec subtype_rec env trace t1 t2 cstrs =
                 if cn then
                   (trace, newty2 t1.level (Ttuple[t1]),
                    newty2 t2.level (Ttuple[t2]), !univar_pairs) :: cstrs
-                else subtype_rec env (Trace.diff t1 t2::trace) t1 t2 cstrs
+                else subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
               else
-                if cn then subtype_rec env (Trace.diff t2 t1::trace) t2 t1 cstrs
+                if cn
+                then subtype_rec env (Subtype.diff t2 t1::trace) t2 t1 cstrs
                 else cstrs)
             cstrs decl.type_variance (List.combine tl1 tl2)
         with Not_found ->
           (trace, t1, t2, !univar_pairs)::cstrs
         end
-    | (Tconstr(p1, _, _), _) when generic_private_abbrev env p1 ->
+    | (Tconstr(p1, _, _), _)
+      when generic_private_abbrev env p1 && safe_abbrev_opt env t1 ->
         subtype_rec env trace (expand_abbrev_opt env t1) t2 cstrs
 (*  | (_, Tconstr(p2, _, _)) when generic_private_abbrev false env p2 ->
         subtype_rec env trace t1 (expand_abbrev_opt env t2) cstrs *)
@@ -4349,7 +4417,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
         begin try
           enter_poly env univar_pairs u1 tl1 u2 tl2
             (fun t1 t2 -> subtype_rec env trace t1 t2 cstrs)
-        with Unify _ ->
+        with Escape _ ->
           (trace, t1, t2, !univar_pairs)::cstrs
         end
     | (Tpackage (p1, fl1), Tpackage (p2, fl2)) ->
@@ -4366,12 +4434,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
           else begin
             (* need to check module subtyping *)
             let snap = Btype.snapshot () in
-            try
-              List.iter (fun (_, t1, t2, _) -> unify env t1 t2) cstrs';
-              if !package_subtype env p1 fl1 p2 fl2
-              then (Btype.backtrack snap; cstrs' @ cstrs)
-              else raise (Unify [])
-            with Unify _ ->
+            match List.iter (fun (_, t1, t2, _) -> unify env t1 t2) cstrs' with
+            | () when !package_subtype env p1 fl1 p2 fl2 ->
+              Btype.backtrack snap; cstrs' @ cstrs
+            | () | exception Unify _ ->
               Btype.backtrack snap; raise Not_found
           end
         with Not_found ->
@@ -4385,7 +4451,7 @@ and subtype_list env trace tl1 tl2 cstrs =
   if List.length tl1 <> List.length tl2 then
     subtype_error env trace;
   List.fold_left2
-    (fun cstrs t1 t2 -> subtype_rec env (Trace.diff t1 t2::trace) t1 t2 cstrs)
+    (fun cstrs t1 t2 -> subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs)
     cstrs tl1 tl2
 
 and subtype_fields env trace ty1 ty2 cstrs =
@@ -4396,7 +4462,7 @@ and subtype_fields env trace ty1 ty2 cstrs =
   let cstrs =
     if rest2.desc = Tnil then cstrs else
     if miss1 = [] then
-      subtype_rec env (Trace.diff rest1 rest2::trace) rest1 rest2 cstrs
+      subtype_rec env (Subtype.diff rest1 rest2::trace) rest1 rest2 cstrs
     else
       (trace, build_fields (repr ty1).level miss1 rest1, rest2,
        !univar_pairs) :: cstrs
@@ -4409,7 +4475,7 @@ and subtype_fields env trace ty1 ty2 cstrs =
   List.fold_left
     (fun cstrs (_, _k1, t1, _k2, t2) ->
       (* These fields are always present *)
-      subtype_rec env (Trace.diff t1 t2::trace) t1 t2 cstrs)
+      subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs)
     cstrs pairs
 
 and subtype_row env trace row1 row2 cstrs =
@@ -4422,7 +4488,7 @@ and subtype_row env trace row1 row2 cstrs =
   and more2 = repr row2.row_more in
   match more1.desc, more2.desc with
     Tconstr(p1,_,_), Tconstr(p2,_,_) when Path.same p1 p2 ->
-      subtype_rec env (Trace.diff more1 more2::trace) more1 more2 cstrs
+      subtype_rec env (Subtype.diff more1 more2::trace) more1 more2 cstrs
   | (Tvar _|Tconstr _|Tnil), (Tvar _|Tconstr _|Tnil)
     when row1.row_closed && r1 = [] ->
       List.fold_left
@@ -4431,16 +4497,16 @@ and subtype_row env trace row1 row2 cstrs =
             (Rpresent None|Reither(true,_,_,_)), Rpresent None ->
               cstrs
           | Rpresent(Some t1), Rpresent(Some t2) ->
-              subtype_rec env (Trace.diff t1 t2::trace) t1 t2 cstrs
+              subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
           | Reither(false, t1::_, _, _), Rpresent(Some t2) ->
-              subtype_rec env (Trace.diff t1 t2::trace) t1 t2 cstrs
+              subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
           | Rabsent, _ -> cstrs
           | _ -> raise Exit)
         cstrs pairs
   | Tunivar _, Tunivar _
     when row1.row_closed = row2.row_closed && r1 = [] && r2 = [] ->
       let cstrs =
-        subtype_rec env (Trace.diff more1 more2::trace) more1 more2 cstrs in
+        subtype_rec env (Subtype.diff more1 more2::trace) more1 more2 cstrs in
       List.fold_left
         (fun cstrs (_,f1,f2) ->
           match row_field_repr f1, row_field_repr f2 with
@@ -4450,7 +4516,7 @@ and subtype_row env trace row1 row2 cstrs =
               cstrs
           | Rpresent(Some t1), Rpresent(Some t2)
           | Reither(false,[t1],_,_), Reither(false,[t2],_,_) ->
-              subtype_rec env (Trace.diff t1 t2::trace) t1 t2 cstrs
+              subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
           | _ -> raise Exit)
         cstrs pairs
   | _ ->
@@ -4460,14 +4526,14 @@ let subtype env ty1 ty2 =
   TypePairs.clear subtypes;
   univar_pairs := [];
   (* Build constraint set. *)
-  let cstrs = subtype_rec env [Trace.diff ty1 ty2] ty1 ty2 [] in
+  let cstrs = subtype_rec env [Subtype.diff ty1 ty2] ty1 ty2 [] in
   TypePairs.clear subtypes;
   (* Enforce constraints. *)
   function () ->
     List.iter
       (function (trace0, t1, t2, pairs) ->
          try unify_pairs (ref env) t1 t2 pairs with Unify trace ->
-           raise (Subtype (expand_trace env (List.rev trace0),
+           raise (Subtype (expand_subtype_trace env (List.rev trace0),
                            List.tl trace)))
       (List.rev cstrs)
 
@@ -4578,8 +4644,12 @@ let rec normalize_type_rec visited ty =
                 List.fold_left
                   (fun tyl ty ->
                     if List.exists
-                        (fun ty' -> equal Env.empty false [ty] [ty']) tyl
-                    then tyl else ty::tyl)
+                          (fun ty' ->
+                             match equal Env.empty false [ty] [ty'] with
+                             | () -> true
+                             | exception Equality _ -> false)
+                          tyl
+                     then tyl else ty::tyl)
                   [ty] tyl
               in
               if f != f0 || List.length tyl' < List.length tyl then
@@ -4641,8 +4711,9 @@ let clear_hash ()   =
   TypeHash.clear nondep_hash; TypeHash.clear nondep_variants
 
 let rec nondep_type_rec ?(expand_private=false) env ids ty =
-  let expand_abbrev env t =
-    if expand_private then expand_abbrev_opt env t else expand_abbrev env t
+  let try_expand env t =
+    if expand_private then try_expand_safe_opt env t
+    else try_expand_safe env t
   in
   match ty.desc with
     Tvar _ | Tunivar _ -> ty
@@ -4664,14 +4735,14 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
           with (Nondep_cannot_erase _) as exn ->
             (* If that doesn't work, try expanding abbrevs *)
             try Tlink (nondep_type_rec ~expand_private env ids
-                       (expand_abbrev env (newty2 ty.level ty.desc)))
+                       (try_expand env (newty2 ty.level ty.desc)))
               (*
                  The [Tlink] is important. The expanded type may be a
                  variable, or may not be completely copied yet
                  (recursive type), so one cannot just take its
                  description.
                *)
-            with Cannot_expand | Unify _ -> raise exn
+            with Cannot_expand -> raise exn
           end
       | Tpackage(p, fl) when Path.exists_free ids p ->
           let p' = normalize_package_path env p in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -91,9 +91,9 @@ exception Public_method_to_private_method
 
 let escape kind = {kind; context = None}
 let escape_exn kind = Escape (escape kind)
-let scope_escape_exn kind = escape_exn (Equation (short kind))
+let scope_escape_exn ty = escape_exn (Equation (short ty))
 let raise_escape_exn kind = raise (escape_exn kind)
-let raise_scope_escape_exn kind = raise (scope_escape_exn kind)
+let raise_scope_escape_exn ty = raise (scope_escape_exn ty)
 
 exception Tags of label * label
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -21,8 +21,8 @@ open Types
 module TypePairs : Hashtbl.S with type key = type_expr * type_expr
 
 exception Unify of Errortrace.unification Errortrace.t
-exception Equality of Errortrace.non_unification Errortrace.t
-exception Moregen of Errortrace.non_unification Errortrace.t
+exception Equality of Errortrace.comparison Errortrace.t
+exception Moregen of Errortrace.comparison Errortrace.t
 exception Subtype of Errortrace.Subtype.t * Errortrace.unification Errortrace.t
 exception Escape of Errortrace.desc Errortrace.escape
 
@@ -31,6 +31,8 @@ exception Cannot_expand
 exception Cannot_apply
 exception Matches_failure of Env.t * Errortrace.unification Errortrace.t
   (* Raised from [matches], hence the odd name *)
+exception Incompatible
+  (* Raised from [mcomp] *)
 
 val init_def: int -> unit
         (* Set the initial variable level *)
@@ -232,16 +234,20 @@ val does_match: Env.t -> type_expr -> type_expr -> bool
 val reify_univars : Env.t -> Types.type_expr -> Types.type_expr
         (* Replaces all the variables of a type by a univar. *)
 
+type class_match_failure_trace_type =
+  | CM_Equality
+  | CM_Moregen
+
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
-  | CM_Type_parameter_mismatch of Env.t * Errortrace.non_unification Errortrace.t
+  | CM_Type_parameter_mismatch of Env.t * Errortrace.comparison Errortrace.t
   | CM_Class_type_mismatch of Env.t * class_type * class_type
-  | CM_Parameter_mismatch of Env.t * Errortrace.non_unification Errortrace.t
-  | CM_Val_type_mismatch of string * Env.t * Errortrace.non_unification Errortrace.t
-  | CM_Val_type_mismatch_eq of string * Env.t * Errortrace.non_unification Errortrace.t
-  | CM_Meth_type_mismatch of string * Env.t * Errortrace.non_unification Errortrace.t
-  | CM_Meth_type_mismatch_eq of string * Env.t * Errortrace.non_unification Errortrace.t
+  | CM_Parameter_mismatch of Env.t * Errortrace.comparison Errortrace.t
+  | CM_Val_type_mismatch of
+      class_match_failure_trace_type * string * Env.t * Errortrace.comparison Errortrace.t
+  | CM_Meth_type_mismatch of
+      class_match_failure_trace_type * string * Env.t * Errortrace.comparison Errortrace.t
   | CM_Non_mutable_value of string
   | CM_Non_concrete_value of string
   | CM_Missing_value of string
@@ -342,4 +348,5 @@ val package_subtype :
     (Env.t -> Path.t -> (Longident.t * type_expr) list ->
       Path.t -> (Longident.t * type_expr) list -> bool) ref
 
+(* Raises [Incompatible] *)
 val mcomp : Env.t -> type_expr -> type_expr -> unit

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -245,9 +245,11 @@ type class_match_failure =
   | CM_Class_type_mismatch of Env.t * class_type * class_type
   | CM_Parameter_mismatch of Env.t * Errortrace.comparison Errortrace.t
   | CM_Val_type_mismatch of
-      class_match_failure_trace_type * string * Env.t * Errortrace.comparison Errortrace.t
+      class_match_failure_trace_type *
+      string * Env.t * Errortrace.comparison Errortrace.t
   | CM_Meth_type_mismatch of
-      class_match_failure_trace_type * string * Env.t * Errortrace.comparison Errortrace.t
+      class_match_failure_trace_type *
+      string * Env.t * Errortrace.comparison Errortrace.t
   | CM_Non_mutable_value of string
   | CM_Non_concrete_value of string
   | CM_Missing_value of string

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -1,3 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*              Antal Spector-Zabusky, Jane Street, New York              *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 open Types
 open Format
 

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -82,7 +82,8 @@ type 'variety variant =
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
-  | Fixed_row : position * fixed_row_case * fixed_explanation -> unification variant
+  | Fixed_row :
+      position * fixed_row_case * fixed_explanation -> unification variant
   (* Equality & Moregen *)
   | Openness : position (* Always [Second] for Moregen *) -> comparison variant
 
@@ -96,10 +97,11 @@ type 'variety obj =
 type ('a, 'variety) elt =
   (* Common *)
   | Diff : 'a diff -> ('a, _) elt
-  | Variant :  'variety variant -> ('a, 'variety) elt
-  | Obj :  'variety obj -> ('a, 'variety) elt
+  | Variant : 'variety variant -> ('a, 'variety) elt
+  | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
-  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt (* Could move into [obj] *)
+  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
+      (* Could move [Incompatible_fields] into [obj] *)
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) elt
 
@@ -110,8 +112,10 @@ let diff got expected = Diff (map_diff short { got; expected })
 
 let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Diff x -> Diff (map_diff f x)
-  | Escape { kind = Equation x; context} -> Escape { kind = Equation (f x); context }
-  | Escape { kind = (Univ _ | Self | Constructor _ | Module_type _ | Constraint); _ }
+  | Escape {kind = Equation x; context} ->
+      Escape { kind = Equation (f x); context }
+  | Escape {kind = (Univ _ | Self | Constructor _ | Module_type _ | Constraint);
+            _}
   | Variant _ | Obj _ | Incompatible_fields _ | Rec_occur (_, _) as x -> x
 
 let map f t = List.map (map_elt f) t
@@ -152,4 +156,3 @@ module Subtype = struct
 
   let flatten f t = map (flatten_desc f) t
 end
-

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -1,0 +1,139 @@
+open Types
+open Format
+
+type position = First | Second
+
+let swap_position = function
+  | First -> Second
+  | Second -> First
+
+let print_pos ppf = function
+  | First -> fprintf ppf "first"
+  | Second -> fprintf ppf "second"
+
+type desc = { t: type_expr; expanded: type_expr option }
+type 'a diff = { got: 'a; expected: 'a}
+
+let short t = { t; expanded = None }
+let map_diff f r =
+  (* ordering is often meaningful when dealing with type_expr *)
+  let got = f r.got in
+  let expected = f r.expected in
+  { got; expected}
+
+let flatten_desc f x = match x.expanded with
+  | None -> f x.t x.t
+  | Some expanded -> f x.t expanded
+
+let swap_diff x = { got = x.expected; expected = x.got }
+
+type 'a escape_kind =
+  | Constructor of Path.t
+  | Univ of type_expr
+  (* The type_expr argument of [Univ] is always a [Tunivar _],
+     we keep a [type_expr] to track renaming in {!Printtyp} *)
+  | Self
+  | Module_type of Path.t
+  | Equation of 'a
+  | Constraint
+
+type 'a escape =
+  { kind : 'a escape_kind;
+    context : type_expr option }
+
+let explain trace f =
+  let rec explain = function
+    | [] -> None
+    | [h] -> f ~prev:None h
+    | h :: (prev :: _ as rem) ->
+      match f ~prev:(Some prev) h with
+      | Some _ as m -> m
+      | None -> explain rem in
+  explain (List.rev trace)
+
+(* Type indices *)
+type unification     = private Unification
+type non_unification = private Non_unification
+
+type fixed_row_case =
+  | Cannot_be_closed
+  | Cannot_add_tags of string list
+
+type 'variety variant =
+  (* Common *)
+  | Incompatible_types_for : string -> _ variant
+  | No_tags : position * (Asttypes.label * row_field) list -> _ variant
+  (* Unification *)
+  | No_intersection : unification variant
+  | Fixed_row : position * fixed_row_case * fixed_explanation -> unification variant
+  (* Equality & Moregen *)
+  | Openness : position (* Always [Second] for Moregen *) -> non_unification variant
+
+type 'variety obj =
+  (* Common *)
+  | Missing_field : position * string -> _ obj
+  | Abstract_row : position -> _ obj
+  (* Unification *)
+  | Self_cannot_be_closed : unification obj
+
+type ('a, 'variety) elt =
+  (* Common *)
+  | Diff : 'a diff -> ('a, _) elt
+  | Variant :  'variety variant -> ('a, 'variety) elt
+  | Obj :  'variety obj -> ('a, 'variety) elt
+  | Escape : 'a escape -> ('a, _) elt
+  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt (* Could move into [obj] *)
+  (* Unification & Moregen; included in Equality for simplicity *)
+  | Rec_occur : type_expr * type_expr -> ('a, _) elt
+
+type 'variety t =
+  (desc, 'variety) elt list
+
+let diff got expected = Diff (map_diff short { got; expected })
+
+let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
+  | Diff x -> Diff (map_diff f x)
+  | Escape { kind = Equation x; context} -> Escape { kind = Equation (f x); context }
+  | Escape { kind = (Univ _ | Self | Constructor _ | Module_type _ | Constraint); _ }
+  | Variant _ | Obj _ | Incompatible_fields _ as x -> x
+  | Rec_occur (_, _) as x -> x
+
+let map f t = List.map (map_elt f) t
+
+(* Convert desc to type_expr * type_expr *)
+let flatten f = map (flatten_desc f)
+
+let incompatible_fields name got expected =
+  Incompatible_fields { name; diff={got; expected} }
+
+
+let swap_unification_elt = function
+  | Diff x -> Diff (swap_diff x)
+  | Incompatible_fields { name; diff } ->
+    Incompatible_fields { name; diff = swap_diff diff}
+  | Obj (Missing_field(pos,s)) -> Obj (Missing_field(swap_position pos,s))
+  | Obj (Abstract_row pos) -> Obj (Abstract_row (swap_position pos))
+  | Variant (Fixed_row(pos,k,f)) ->
+    Variant (Fixed_row(swap_position pos,k,f))
+  | Variant (No_tags(pos,f)) ->
+    Variant (No_tags(swap_position pos,f))
+  | x -> x
+
+let swap_unification_trace e = List.map swap_unification_elt e
+
+module Subtype = struct
+  type 'a elt =
+    | Diff of 'a diff
+
+  type t = desc elt list
+
+  let diff got expected = Diff (map_diff short {got;expected})
+
+  let map_elt f = function
+    | Diff x -> Diff (map_diff f x)
+
+  let map f t = List.map (map_elt f) t
+
+  let flatten f t = map (flatten_desc f) t
+end
+

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -1,0 +1,97 @@
+open Types
+
+type position = First | Second
+
+val swap_position : position -> position
+val print_pos : Format.formatter -> position -> unit
+
+type desc = { t: type_expr; expanded: type_expr option }
+type 'a diff = { got: 'a; expected: 'a}
+
+(** [map_diff f {expected;got}] is [{expected=f expected; got=f got}] *)
+val map_diff: ('a -> 'b) -> 'a diff -> 'b diff
+
+(** Scope escape related errors *)
+type 'a escape_kind =
+  | Constructor of Path.t
+  | Univ of type_expr
+  (* The type_expr argument of [Univ] is always a [Tunivar _],
+     we keep a [type_expr] to track renaming in {!Printtyp} *)
+  | Self
+  | Module_type of Path.t
+  | Equation of 'a
+  | Constraint
+
+type 'a escape =
+  { kind : 'a escape_kind;
+    context : type_expr option }
+
+val short : type_expr -> desc
+
+val explain: 'a list ->
+  (prev:'a option -> 'a -> 'b option) ->
+  'b option
+
+(* Type indices *)
+type unification     = private Unification
+type non_unification = private Non_unification
+
+type fixed_row_case =
+  | Cannot_be_closed
+  | Cannot_add_tags of string list
+
+type 'variety variant =
+  (* Common *)
+  | Incompatible_types_for : string -> _ variant
+  | No_tags : position * (Asttypes.label * row_field) list -> _ variant
+  (* Unification *)
+  | No_intersection : unification variant
+  | Fixed_row : position * fixed_row_case * fixed_explanation -> unification variant
+  (* Equality & Moregen *)
+  | Openness : position (* Always [Second] for Moregen *) -> non_unification variant
+
+type 'variety obj =
+  (* Common *)
+  | Missing_field : position * string -> _ obj
+  | Abstract_row : position -> _ obj
+  (* Unification *)
+  | Self_cannot_be_closed : unification obj
+
+type ('a, 'variety) elt =
+  (* Common *)
+  | Diff : 'a diff -> ('a, _) elt
+  | Variant :  'variety variant -> ('a, 'variety) elt
+  | Obj :  'variety obj -> ('a, 'variety) elt
+  | Escape : 'a escape -> ('a, _) elt
+  | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
+  (* Unification & Moregen; included in Equality for simplicity *)
+  | Rec_occur : type_expr * type_expr -> ('a, _) elt
+
+type 'variety t =
+  (desc, 'variety) elt list
+
+val diff : type_expr -> type_expr -> (desc, _) elt
+
+(** [flatten f trace] flattens all elements of type {!desc} in
+    [trace] to either [f x.t expanded] if [x.expanded=Some expanded]
+    or [f x.t x.t] otherwise *)
+val flatten: (type_expr -> type_expr -> 'a) -> 'variant t -> ('a, 'variant) elt list
+
+val map : ('a -> 'b) -> ('a, 'variant) elt list -> ('b, 'variant) elt list
+
+val incompatible_fields : string -> type_expr -> type_expr -> (desc, _) elt
+
+val swap_unification_trace : unification t -> unification t
+
+module Subtype : sig
+  type 'a elt =
+    | Diff of 'a diff
+
+  type t = desc elt list
+
+  val diff: type_expr -> type_expr -> desc elt
+
+  val map : (desc -> desc) -> desc elt list -> desc elt list
+
+  val flatten : (type_expr -> type_expr -> 'a) -> t -> 'a elt list
+end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -33,8 +33,8 @@ val explain: 'a list ->
   'b option
 
 (* Type indices *)
-type unification     = private Unification
-type non_unification = private Non_unification
+type unification = private Unification
+type comparison  = private Comparison
 
 type fixed_row_case =
   | Cannot_be_closed
@@ -48,7 +48,7 @@ type 'variety variant =
   | No_intersection : unification variant
   | Fixed_row : position * fixed_row_case * fixed_explanation -> unification variant
   (* Equality & Moregen *)
-  | Openness : position (* Always [Second] for Moregen *) -> non_unification variant
+  | Openness : position (* Always [Second] for Moregen *) -> comparison variant
 
 type 'variety obj =
   (* Common *)
@@ -75,13 +75,13 @@ val diff : type_expr -> type_expr -> (desc, _) elt
 (** [flatten f trace] flattens all elements of type {!desc} in
     [trace] to either [f x.t expanded] if [x.expanded=Some expanded]
     or [f x.t x.t] otherwise *)
-val flatten: (type_expr -> type_expr -> 'a) -> 'variant t -> ('a, 'variant) elt list
+val flatten: (type_expr -> type_expr -> 'a) -> 'variety t -> ('a, 'variety) elt list
 
-val map : ('a -> 'b) -> ('a, 'variant) elt list -> ('b, 'variant) elt list
+val map : ('a -> 'b) -> ('a, 'variety) elt list -> ('b, 'variety) elt list
 
 val incompatible_fields : string -> type_expr -> type_expr -> (desc, _) elt
 
-val swap_unification_trace : unification t -> unification t
+val swap_trace : 'variety t -> 'variety t
 
 module Subtype : sig
   type 'a elt =
@@ -91,7 +91,7 @@ module Subtype : sig
 
   val diff: type_expr -> type_expr -> desc elt
 
-  val map : (desc -> desc) -> desc elt list -> desc elt list
-
   val flatten : (type_expr -> type_expr -> 'a) -> t -> 'a elt list
+
+  val map : (desc -> desc) -> desc elt list -> desc elt list
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -63,7 +63,8 @@ type 'variety variant =
   | No_tags : position * (Asttypes.label * row_field) list -> _ variant
   (* Unification *)
   | No_intersection : unification variant
-  | Fixed_row : position * fixed_row_case * fixed_explanation -> unification variant
+  | Fixed_row :
+      position * fixed_row_case * fixed_explanation -> unification variant
   (* Equality & Moregen *)
   | Openness : position (* Always [Second] for Moregen *) -> comparison variant
 
@@ -77,8 +78,8 @@ type 'variety obj =
 type ('a, 'variety) elt =
   (* Common *)
   | Diff : 'a diff -> ('a, _) elt
-  | Variant :  'variety variant -> ('a, 'variety) elt
-  | Obj :  'variety obj -> ('a, 'variety) elt
+  | Variant : 'variety variant -> ('a, 'variety) elt
+  | Obj : 'variety obj -> ('a, 'variety) elt
   | Escape : 'a escape -> ('a, _) elt
   | Incompatible_fields : { name:string; diff: type_expr diff } -> ('a, _) elt
   (* Unification & Moregen; included in Equality for simplicity *)
@@ -92,7 +93,8 @@ val diff : type_expr -> type_expr -> (desc, _) elt
 (** [flatten f trace] flattens all elements of type {!desc} in
     [trace] to either [f x.t expanded] if [x.expanded=Some expanded]
     or [f x.t x.t] otherwise *)
-val flatten: (type_expr -> type_expr -> 'a) -> 'variety t -> ('a, 'variety) elt list
+val flatten :
+  (type_expr -> type_expr -> 'a) -> 'variety t -> ('a, 'variety) elt list
 
 val map : ('a -> 'b) -> ('a, 'variety) elt list -> ('b, 'variety) elt list
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -1,3 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*              Antal Spector-Zabusky, Jane Street, New York              *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 open Types
 
 type position = First | Second

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -57,7 +57,7 @@ let include_err ppf =
       fprintf ppf
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (env, trace) ->
-      Printtyp.report_unification_error ppf env trace
+      Printtyp.report_error Printtyp.equality ppf env trace
         (function ppf ->
           fprintf ppf "A type parameter has type")
         (function ppf ->
@@ -70,23 +70,35 @@ let include_err ppf =
           "is not matched by the class type"
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (env, trace) ->
-      Printtyp.report_unification_error ppf env trace
+      Printtyp.report_error Printtyp.moregen ppf env trace
         (function ppf ->
           fprintf ppf "A parameter has type")
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Val_type_mismatch (lab, env, trace) ->
-      Printtyp.report_unification_error ppf env trace
+      Printtyp.report_error Printtyp.moregen ppf env trace
         (function ppf ->
           fprintf ppf "The instance variable %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
+  | CM_Val_type_mismatch_eq (lab, env, trace) ->
+      Printtyp.report_error Printtyp.equality ppf env trace
+        (function ppf ->
+           fprintf ppf "The instance variable %s@ has type" lab)
+        (function ppf ->
+           fprintf ppf "but is expected to have type")
   | CM_Meth_type_mismatch (lab, env, trace) ->
-      Printtyp.report_unification_error ppf env trace
+      Printtyp.report_error Printtyp.moregen ppf env trace
         (function ppf ->
           fprintf ppf "The method %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
+  | CM_Meth_type_mismatch_eq (lab, env, trace) ->
+      Printtyp.report_error Printtyp.equality ppf env trace
+        (function ppf ->
+           fprintf ppf "The method %s@ has type" lab)
+        (function ppf ->
+           fprintf ppf "but is expected to have type")
   | CM_Non_mutable_value lab ->
       fprintf ppf
        "@[The non-mutable instance variable %s cannot become mutable@]" lab

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -50,8 +50,8 @@ let rec hide_params = function
 *)
 
 let printtyp_for = function
-  | CM_Equality -> Printtyp.equality
-  | CM_Moregen  -> Printtyp.moregen
+  | CM_Equality -> Printtyp.Equality
+  | CM_Moregen  -> Printtyp.Moregen
 
 let include_err ppf =
   function
@@ -61,7 +61,7 @@ let include_err ppf =
       fprintf ppf
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (env, trace) ->
-      Printtyp.report_error Printtyp.equality ppf env trace
+      Printtyp.report_error Printtyp.Equality ppf env trace
         (function ppf ->
           fprintf ppf "A type parameter has type")
         (function ppf ->
@@ -74,7 +74,7 @@ let include_err ppf =
           "is not matched by the class type"
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (env, trace) ->
-      Printtyp.report_error Printtyp.moregen ppf env trace
+      Printtyp.report_error Printtyp.Moregen ppf env trace
         (function ppf ->
           fprintf ppf "A parameter has type")
         (function ppf ->

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -49,9 +49,9 @@ let rec hide_params = function
   | cty -> cty
 *)
 
-let printtyp_for = function
-  | CM_Equality -> Printtyp.Equality
-  | CM_Moregen  -> Printtyp.Moregen
+let report_error_for = function
+  | CM_Equality -> Printtyp.report_equality_error
+  | CM_Moregen  -> Printtyp.report_moregen_error
 
 let include_err ppf =
   function
@@ -61,7 +61,7 @@ let include_err ppf =
       fprintf ppf
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (env, trace) ->
-      Printtyp.report_error Printtyp.Equality ppf env trace
+      Printtyp.report_equality_error ppf env trace
         (function ppf ->
           fprintf ppf "A type parameter has type")
         (function ppf ->
@@ -74,19 +74,19 @@ let include_err ppf =
           "is not matched by the class type"
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (env, trace) ->
-      Printtyp.report_error Printtyp.Moregen ppf env trace
+      Printtyp.report_moregen_error ppf env trace
         (function ppf ->
           fprintf ppf "A parameter has type")
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Val_type_mismatch (trace_type, lab, env, trace) ->
-      Printtyp.report_error (printtyp_for trace_type) ppf env trace
+      report_error_for trace_type ppf env trace
         (function ppf ->
           fprintf ppf "The instance variable %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Meth_type_mismatch (trace_type, lab, env, trace) ->
-      Printtyp.report_error (printtyp_for trace_type) ppf env trace
+      report_error_for trace_type  ppf env trace
         (function ppf ->
           fprintf ppf "The method %s@ has type" lab)
         (function ppf ->

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -49,6 +49,10 @@ let rec hide_params = function
   | cty -> cty
 *)
 
+let printtyp_for = function
+  | CM_Equality -> Printtyp.equality
+  | CM_Moregen  -> Printtyp.moregen
+
 let include_err ppf =
   function
   | CM_Virtual_class ->
@@ -75,30 +79,18 @@ let include_err ppf =
           fprintf ppf "A parameter has type")
         (function ppf ->
           fprintf ppf "but is expected to have type")
-  | CM_Val_type_mismatch (lab, env, trace) ->
-      Printtyp.report_error Printtyp.moregen ppf env trace
+  | CM_Val_type_mismatch (trace_type, lab, env, trace) ->
+      Printtyp.report_error (printtyp_for trace_type) ppf env trace
         (function ppf ->
           fprintf ppf "The instance variable %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
-  | CM_Val_type_mismatch_eq (lab, env, trace) ->
-      Printtyp.report_error Printtyp.equality ppf env trace
-        (function ppf ->
-           fprintf ppf "The instance variable %s@ has type" lab)
-        (function ppf ->
-           fprintf ppf "but is expected to have type")
-  | CM_Meth_type_mismatch (lab, env, trace) ->
-      Printtyp.report_error Printtyp.moregen ppf env trace
+  | CM_Meth_type_mismatch (trace_type, lab, env, trace) ->
+      Printtyp.report_error (printtyp_for trace_type) ppf env trace
         (function ppf ->
           fprintf ppf "The method %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
-  | CM_Meth_type_mismatch_eq (lab, env, trace) ->
-      Printtyp.report_error Printtyp.equality ppf env trace
-        (function ppf ->
-           fprintf ppf "The method %s@ has type" lab)
-        (function ppf ->
-           fprintf ppf "but is expected to have type")
   | CM_Non_mutable_value lab ->
       fprintf ppf
        "@[The non-mutable instance variable %s cannot become mutable@]" lab

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -20,9 +20,55 @@ open Path
 open Types
 open Typedtree
 
+type position = Errortrace.position = First | Second
+
 (* Inclusion between value descriptions *)
 
-exception Dont_match
+type primitive_mismatch =
+  | Name
+  | Arity
+  | No_alloc of position
+  | Native_name
+  | Result_repr
+  | Argument_repr of int
+
+let native_repr_args nra1 nra2 =
+  let rec loop i nra1 nra2 =
+    match nra1, nra2 with
+    | [], [] -> None
+    | [], _ :: _ -> assert false
+    | _ :: _, [] -> assert false
+    | nr1 :: nra1, nr2 :: nra2 ->
+      if not (Primitive.equal_native_repr nr1 nr2) then Some (Argument_repr i)
+      else loop (i+1) nra1 nra2
+  in
+  loop 1 nra1 nra2
+
+let primitive_descriptions pd1 pd2 =
+  let open Primitive in
+  if not (String.equal pd1.prim_name pd2.prim_name) then
+    Some Name
+  else if not (Int.equal pd1.prim_arity pd2.prim_arity) then
+    Some Arity
+  else if (not pd1.prim_alloc) && pd2.prim_alloc then
+    Some (No_alloc First)
+  else if pd1.prim_alloc && (not pd2.prim_alloc) then
+    Some (No_alloc Second)
+  else if not (String.equal pd1.prim_native_name pd2.prim_native_name) then
+    Some Native_name
+  else if not
+    (Primitive.equal_native_repr
+       pd1.prim_native_repr_res pd2.prim_native_repr_res) then
+    Some Result_repr
+  else
+    native_repr_args pd1.prim_native_repr_args pd2.prim_native_repr_args
+
+type value_mismatch =
+  | Primitive_mismatch of primitive_mismatch
+  | Not_a_primitive
+  | Type of Env.t * Errortrace.non_unification Errortrace.t
+
+exception Dont_match of value_mismatch
 
 let value_descriptions ~loc env name
     (vd1 : Types.value_description)
@@ -33,18 +79,24 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  if Ctype.moregeneral env true vd1.val_type vd2.val_type then begin
-    match (vd1.val_kind, vd2.val_kind) with
-        (Val_prim p1, Val_prim p2) ->
-          if p1 = p2 then Tcoerce_none else raise Dont_match
+  match Ctype.moregeneral env true vd1.val_type vd2.val_type with
+  | exception Ctype.Moregen trace -> raise (Dont_match (Type (env, trace)))
+  | () -> begin
+      match (vd1.val_kind, vd2.val_kind) with
+      | (Val_prim p1, Val_prim p2) -> begin
+          match primitive_descriptions p1 p2 with
+          | None -> Tcoerce_none
+          | Some err -> raise (Dont_match (Primitive_mismatch err))
+        end
       | (Val_prim p, _) ->
-          let pc = {pc_desc = p; pc_type = vd2.Types.val_type;
-                  pc_env = env; pc_loc = vd1.Types.val_loc; } in
+          let pc =
+            { pc_desc = p; pc_type = vd2.Types.val_type;
+              pc_env = env; pc_loc = vd1.Types.val_loc; }
+          in
           Tcoerce_primitive pc
-      | (_, Val_prim _) -> raise Dont_match
+      | (_, Val_prim _) -> raise (Dont_match Not_a_primitive)
       | (_, _) -> Tcoerce_none
-  end else
-    raise Dont_match
+    end
 
 (* Inclusion between "private" annotations *)
 
@@ -59,70 +111,14 @@ let private_flags decl1 decl2 =
 
 let is_absrow env ty =
   match ty.desc with
-    Tconstr(Pident _, _, _) ->
-      begin match Ctype.expand_head env ty with
-        {desc=Tobject _|Tvariant _} -> true
+  | Tconstr(Pident _, _, _) -> begin
+      match Ctype.expand_head env ty with
+      | {desc=Tobject _|Tvariant _} -> true
       | _ -> false
       end
   | _ -> false
 
-let type_manifest env ty1 params1 ty2 params2 priv2 =
-  let ty1' = Ctype.expand_head env ty1 and ty2' = Ctype.expand_head env ty2 in
-  match ty1'.desc, ty2'.desc with
-    Tvariant row1, Tvariant row2 when is_absrow env (Btype.row_more row2) ->
-      let row1 = Btype.row_repr row1 and row2 = Btype.row_repr row2 in
-      Ctype.equal env true (ty1::params1) (row2.row_more::params2) &&
-      begin match row1.row_more with
-        {desc=Tvar _|Tconstr _|Tnil} -> true
-      | _ -> false
-      end &&
-      let r1, r2, pairs =
-        Ctype.merge_row_fields row1.row_fields row2.row_fields in
-      (not row2.row_closed ||
-       row1.row_closed && Ctype.filter_row_fields false r1 = []) &&
-      List.for_all
-        (fun (_,f) -> match Btype.row_field_repr f with
-          Rabsent | Reither _ -> true | Rpresent _ -> false)
-        r2 &&
-      let to_equal = ref (List.combine params1 params2) in
-      List.for_all
-        (fun (_, f1, f2) ->
-          match Btype.row_field_repr f1, Btype.row_field_repr f2 with
-            Rpresent(Some t1),
-            (Rpresent(Some t2) | Reither(false, [t2], _, _)) ->
-              to_equal := (t1,t2) :: !to_equal; true
-          | Rpresent None, (Rpresent None | Reither(true, [], _, _)) -> true
-          | Reither(c1,tl1,_,_), Reither(c2,tl2,_,_)
-            when List.length tl1 = List.length tl2 && c1 = c2 ->
-              to_equal := List.combine tl1 tl2 @ !to_equal; true
-          | Rabsent, (Reither _ | Rabsent) -> true
-          | _ -> false)
-        pairs &&
-      let tl1, tl2 = List.split !to_equal in
-      Ctype.equal env true tl1 tl2
-  | Tobject (fi1, _), Tobject (fi2, _)
-    when is_absrow env (snd(Ctype.flatten_fields fi2)) ->
-      let (fields2,rest2) = Ctype.flatten_fields fi2 in
-      Ctype.equal env true (ty1::params1) (rest2::params2) &&
-      let (fields1,rest1) = Ctype.flatten_fields fi1 in
-      (match rest1 with {desc=Tnil|Tvar _|Tconstr _} -> true | _ -> false) &&
-      let pairs, _miss1, miss2 = Ctype.associate_fields fields1 fields2 in
-      miss2 = [] &&
-      let tl1, tl2 =
-        List.split (List.map (fun (_,_,t1,_,t2) -> t1, t2) pairs) in
-      Ctype.equal env true (params1 @ tl1) (params2 @ tl2)
-  | _ ->
-      let rec check_super ty1 =
-        Ctype.equal env true (ty1 :: params1) (ty2 :: params2) ||
-        priv2 = Private &&
-        try check_super
-              (Ctype.try_expand_once_opt env (Ctype.expand_head env ty1))
-        with Ctype.Cannot_expand -> false
-      in check_super ty1
-
 (* Inclusion between type declarations *)
-
-type position = Ctype.Unification_trace.position = First | Second
 
 let choose ord first second =
   match ord with
@@ -135,7 +131,7 @@ let choose_other ord first second =
   | Second -> choose First first second
 
 type label_mismatch =
-  | Type
+  | Type of Env.t * Errortrace.non_unification Errortrace.t
   | Mutability of position
 
 type record_mismatch =
@@ -147,7 +143,7 @@ type record_mismatch =
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
-  | Type
+  | Type of Env.t * Errortrace.non_unification Errortrace.t
   | Arity
   | Inline_record of record_mismatch
   | Kind of position
@@ -167,12 +163,25 @@ type extension_constructor_mismatch =
                             * Types.extension_constructor
                             * constructor_mismatch
 
+type private_variant_mismatch =
+  | Openness
+  | Missing of position * string
+  | Presence of string
+  | Incompatible_types_for of string
+  | Types of Env.t * Errortrace.non_unification Errortrace.t
+
+type private_object_mismatch =
+  | Missing of string
+  | Types of Env.t * Errortrace.non_unification Errortrace.t
+
 type type_mismatch =
   | Arity
   | Privacy
   | Kind
-  | Constraint
-  | Manifest
+  | Constraint of Env.t * Errortrace.non_unification Errortrace.t
+  | Manifest of Env.t * Errortrace.non_unification Errortrace.t
+  | Private_variant of type_expr * type_expr * private_variant_mismatch
+  | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance
   | Record_mismatch of record_mismatch
   | Variant_mismatch of variant_mismatch
@@ -182,7 +191,7 @@ type type_mismatch =
 let report_label_mismatch first second ppf err =
   let pr fmt = Format.fprintf ppf fmt in
   match (err : label_mismatch) with
-  | Type -> pr "The types are not equal."
+  | Type _ -> pr "The types are not equal."
   | Mutability ord ->
       pr "%s is mutable and %s is not."
         (String.capitalize_ascii  (choose ord first second))
@@ -212,7 +221,7 @@ let report_record_mismatch first second decl ppf err =
 let report_constructor_mismatch first second decl ppf err =
   let pr fmt  = Format.fprintf ppf fmt in
   match (err : constructor_mismatch) with
-  | Type -> pr "The types are not equal."
+  | Type _ -> pr "The types are not equal."
   | Arity -> pr "They have different arities."
   | Inline_record err -> report_record_mismatch first second decl ppf err
   | Kind ord ->
@@ -258,8 +267,10 @@ let report_type_mismatch0 first second decl ppf err =
   | Arity -> pr "They have different arities."
   | Privacy -> pr "A private type would be revealed."
   | Kind -> pr "Their kinds differ."
-  | Constraint -> pr "Their constraints differ."
-  | Manifest -> ()
+  | Constraint _ -> pr "Their constraints differ."
+  | Manifest _ -> ()
+  | Private_variant _ -> ()
+  | Private_object _ -> ()
   | Variance -> pr "Their variances do not agree."
   | Record_mismatch err -> report_record_mismatch first second decl ppf err
   | Variant_mismatch err -> report_variant_mismatch first second decl ppf err
@@ -277,18 +288,23 @@ let report_type_mismatch0 first second decl ppf err =
             first
 
 let report_type_mismatch first second decl ppf err =
-  if err = Manifest then () else
-  Format.fprintf ppf "@ %a" (report_type_mismatch0 first second decl) err
+  match err with
+  | Manifest _ -> ()
+  | Private_variant _ -> ()
+  | Private_object _ -> ()
+  | _ -> Format.fprintf ppf "@ %a" (report_type_mismatch0 first second decl) err
 
 let rec compare_constructor_arguments ~loc env params1 params2 arg1 arg2 =
   match arg1, arg2 with
   | Types.Cstr_tuple arg1, Types.Cstr_tuple arg2 ->
       if List.length arg1 <> List.length arg2 then
         Some (Arity : constructor_mismatch)
-      else if
+      else begin
         (* Ctype.equal must be called on all arguments at once, cf. PR#7378 *)
-        Ctype.equal env true (params1 @ arg1) (params2 @ arg2)
-      then None else Some Type
+        match Ctype.equal env true (params1 @ arg1) (params2 @ arg2) with
+        | exception Ctype.Equality trace -> Some (Type (env, trace))
+        | () -> None
+      end
   | Types.Cstr_record l1, Types.Cstr_record l2 ->
       Option.map
         (fun rec_err -> Inline_record rec_err)
@@ -298,10 +314,11 @@ let rec compare_constructor_arguments ~loc env params1 params2 arg1 arg2 =
 
 and compare_constructors ~loc env params1 params2 res1 res2 args1 args2 =
   match res1, res2 with
-  | Some r1, Some r2 ->
-      if Ctype.equal env true [r1] [r2] then
-        compare_constructor_arguments ~loc env [r1] [r2] args1 args2
-      else Some Type
+  | Some r1, Some r2 -> begin
+      match Ctype.equal env true [r1] [r2] with
+      | exception Ctype.Equality trace -> Some (Type (env, trace))
+      | () -> compare_constructor_arguments ~loc env [r1] [r2] args1 args2
+    end
   | Some _, None -> Some (Explicit_return_type First)
   | None, Some _ -> Some (Explicit_return_type Second)
   | None, None ->
@@ -332,16 +349,18 @@ and compare_variants ~loc env params1 params2 n
       end
 
 and compare_labels env params1 params2
-      (ld1 : Types.label_declaration)
-      (ld2 : Types.label_declaration) =
-      if ld1.ld_mutable <> ld2.ld_mutable
-      then
-        let ord = if ld1.ld_mutable = Asttypes.Mutable then First else Second in
-        Some (Mutability  ord)
-      else
-        if Ctype.equal env true (ld1.ld_type::params1) (ld2.ld_type::params2)
-        then None
-        else Some (Type : label_mismatch)
+      (ld1 : Types.label_declaration) (ld2 : Types.label_declaration) =
+  if ld1.ld_mutable <> ld2.ld_mutable then begin
+    let ord = if ld1.ld_mutable = Asttypes.Mutable then First else Second in
+    Some (Mutability  ord)
+  end else begin
+    let tl1 = params1 @ [ld1.ld_type] in
+    let tl2 = params2 @ [ld2.ld_type] in
+    match Ctype.equal env true tl1 tl2 with
+    | exception Ctype.Equality trace ->
+        Some (Type (env, trace) : label_mismatch)
+    | () -> None
+  end
 
 and compare_records ~loc env params1 params2 n
     (labels1 : Types.label_declaration list)
@@ -378,6 +397,125 @@ let compare_records_with_representation ~loc env params1 params2 n
       Some (Unboxed_float_representation pos)
   | err -> err
 
+let private_variant env row1 params1 row2 params2 =
+    let r1, r2, pairs =
+      Ctype.merge_row_fields row1.row_fields row2.row_fields
+    in
+    let err =
+      if row2.row_closed && not row1.row_closed then Some Openness
+      else begin
+        match row2.row_closed, Ctype.filter_row_fields false r1 with
+        | true, (s, _) :: _ ->
+            Some (Missing (Second, s) : private_variant_mismatch)
+        | _, _ -> None
+      end
+    in
+    if err <> None then err else
+    let err =
+      let missing =
+        List.find_opt
+          (fun (_,f) ->
+             match Btype.row_field_repr f with
+             | Rabsent | Reither _ -> false
+             | Rpresent _ -> true)
+          r2
+      in
+      match missing with
+      | None -> None
+      | Some (s, _) -> Some (Missing (First, s) : private_variant_mismatch)
+    in
+    if err <> None then err else
+    let rec loop tl1 tl2 pairs =
+      match pairs with
+      | [] -> begin
+          match Ctype.equal env true tl1 tl2 with
+          | exception Ctype.Equality trace ->
+              Some (Types (env, trace) : private_variant_mismatch)
+          | () -> None
+        end
+      | (s, f1, f2) :: pairs -> begin
+          match Btype.row_field_repr f1, Btype.row_field_repr f2 with
+          | Rpresent to1, Rpresent to2 -> begin
+              match to1, to2 with
+              | Some t1, Some t2 ->
+                  loop (t1 :: tl1) (t2 :: tl2) pairs
+              | None, None ->
+                  loop tl1 tl2 pairs
+              | Some _, None | None, Some _ ->
+                  Some (Incompatible_types_for s)
+            end
+          | Rpresent to1, Reither(const2, tl2, _, _) -> begin
+              match to1, const2, tl2 with
+              | Some t1, false, [t2] -> loop (t1 :: tl1) (t2 :: tl2) pairs
+              | None, true, [] -> loop tl1 tl2 pairs
+              | _, _, _ -> Some (Incompatible_types_for s)
+            end
+          | Rpresent _, Rabsent ->
+              Some (Missing (Second, s) : private_variant_mismatch)
+          | Reither(const1, ts1, _, _), Reither(const2, ts2, _, _) ->
+              if const1 = const2 && List.length ts1 = List.length ts2 then
+                loop (ts1 @ tl1) (ts2 @ tl2) pairs
+              else
+                Some (Incompatible_types_for s)
+          | Reither _, Rpresent _ ->
+              Some (Presence s)
+          | Reither _, Rabsent ->
+              Some (Missing (Second, s) : private_variant_mismatch)
+          | Rabsent, (Reither _ | Rabsent) ->
+              loop tl1 tl2 pairs
+          | Rabsent, Rpresent _ ->
+              Some (Missing (First, s) : private_variant_mismatch)
+        end
+    in
+    loop params1 params2 pairs
+
+let private_object env fields1 params1 fields2 params2 =
+  let pairs, _miss1, miss2 = Ctype.associate_fields fields1 fields2 in
+  let err =
+    match miss2 with
+    | [] -> None
+    | (f, _, _) :: _ -> Some (Missing f)
+  in
+  if err <> None then err else
+  let tl1, tl2 =
+    List.split (List.map (fun (_,_,t1,_,t2) -> t1, t2) pairs)
+  in
+  begin
+    match Ctype.equal env true (params1 @ tl1) (params2 @ tl2) with
+    | exception Ctype.Equality trace -> Some (Types (env, trace))
+    | () -> None
+  end
+
+let type_manifest env ty1 params1 ty2 params2 priv2 =
+  let ty1' = Ctype.expand_head env ty1 and ty2' = Ctype.expand_head env ty2 in
+  match ty1'.desc, ty2'.desc with
+  | Tvariant row1, Tvariant row2
+    when is_absrow env (Btype.row_more row2) -> begin
+      let row1 = Btype.row_repr row1 and row2 = Btype.row_repr row2 in
+      assert (Ctype.is_equal env true (ty1::params1) (row2.row_more::params2));
+      match private_variant env row1 params1 row2 params2 with
+      | None -> None
+      | Some err -> Some (Private_variant(ty1, ty2, err))
+    end
+  | Tobject (fi1, _), Tobject (fi2, _)
+    when is_absrow env (snd (Ctype.flatten_fields fi2)) -> begin
+      let (fields2,rest2) = Ctype.flatten_fields fi2 in
+      let (fields1,_) = Ctype.flatten_fields fi1 in
+      assert (Ctype.is_equal env true (ty1::params1) (rest2::params2));
+      match private_object env fields1 params1 fields2 params2 with
+      | None -> None
+      | Some err -> Some (Private_object(ty1, ty2, err))
+    end
+  | _ -> begin
+    match
+      match priv2 with
+      | Private -> Ctype.equal_private env params1 ty1 params2 ty2
+      | Public -> Ctype.equal env true (params1 @ [ty1]) (params2 @ [ty2])
+    with
+    | exception Ctype.Equality trace -> Some (Manifest (env, trace))
+    | () -> None
+  end
+
 let type_declarations ?(equality = false) ~loc env ~mark name
       decl1 path decl2 =
   Builtin_attributes.check_alerts_inclusion
@@ -390,20 +528,24 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   if not (private_flags decl1 decl2) then Some Privacy else
   let err = match (decl1.type_manifest, decl2.type_manifest) with
       (_, None) ->
-        if Ctype.equal env true decl1.type_params decl2.type_params
-        then None else Some Constraint
+        begin
+          match Ctype.equal env true decl1.type_params decl2.type_params with
+          | exception Ctype.Equality trace -> Some (Constraint(env, trace))
+          | () -> None
+        end
     | (Some ty1, Some ty2) ->
-        if type_manifest env ty1 decl1.type_params ty2 decl2.type_params
-            decl2.type_private
-        then None else Some Manifest
+         type_manifest env ty1 decl1.type_params ty2 decl2.type_params
+           decl2.type_private
     | (None, Some ty2) ->
         let ty1 =
           Btype.newgenty (Tconstr(path, decl2.type_params, ref Mnil))
         in
-        if Ctype.equal env true decl1.type_params decl2.type_params then
-          if Ctype.equal env false [ty1] [ty2] then None
-          else Some Manifest
-        else Some Constraint
+        match Ctype.equal env true decl1.type_params decl2.type_params with
+        | exception Ctype.Equality trace -> Some (Constraint(env, trace))
+        | () ->
+          match Ctype.equal env false [ty1] [ty2] with
+          | exception Ctype.Equality trace -> Some (Manifest(env, trace))
+          | () -> None
   in
   if err <> None then err else
   let err =
@@ -503,17 +645,21 @@ let extension_constructors ~loc env ~mark id ext1 ext2 =
   let ty2 =
     Btype.newgenty (Tconstr(ext2.ext_type_path, ext2.ext_type_params, ref Mnil))
   in
-  if not (Ctype.equal env true (ty1 :: ext1.ext_type_params)
-                               (ty2 :: ext2.ext_type_params))
-  then Some (Constructor_mismatch (id, ext1, ext2, Type))
-  else
+  let tl1 = ty1 :: ext1.ext_type_params in
+  let tl2 = ty2 :: ext2.ext_type_params in
+  match Ctype.equal env true tl1 tl2 with
+  | exception Ctype.Equality trace ->
+      Some (Constructor_mismatch (id, ext1, ext2, Type(env, trace)))
+  | () ->
     let r =
-      compare_constructors ~loc env ext1.ext_type_params ext2.ext_type_params
+      compare_constructors ~loc env
+        ext1.ext_type_params ext2.ext_type_params
         ext1.ext_ret_type ext2.ext_ret_type
         ext1.ext_args ext2.ext_args
     in
     match r with
     | Some r -> Some (Constructor_mismatch (id, ext1, ext2, r))
-    | None -> match ext1.ext_private, ext2.ext_private with
-        Private, Public -> Some Constructor_privacy
+    | None ->
+      match ext1.ext_private, ext2.ext_private with
+      | Private, Public -> Some Constructor_privacy
       | _, _ -> None

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -66,7 +66,7 @@ let primitive_descriptions pd1 pd2 =
 type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
-  | Type of Env.t * Errortrace.non_unification Errortrace.t
+  | Type of Env.t * Errortrace.comparison Errortrace.t
 
 exception Dont_match of value_mismatch
 
@@ -131,7 +131,7 @@ let choose_other ord first second =
   | Second -> choose First first second
 
 type label_mismatch =
-  | Type of Env.t * Errortrace.non_unification Errortrace.t
+  | Type of Env.t * Errortrace.comparison Errortrace.t
   | Mutability of position
 
 type record_mismatch =
@@ -143,7 +143,7 @@ type record_mismatch =
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
-  | Type of Env.t * Errortrace.non_unification Errortrace.t
+  | Type of Env.t * Errortrace.comparison Errortrace.t
   | Arity
   | Inline_record of record_mismatch
   | Kind of position
@@ -168,18 +168,18 @@ type private_variant_mismatch =
   | Missing of position * string
   | Presence of string
   | Incompatible_types_for of string
-  | Types of Env.t * Errortrace.non_unification Errortrace.t
+  | Types of Env.t * Errortrace.comparison Errortrace.t
 
 type private_object_mismatch =
   | Missing of string
-  | Types of Env.t * Errortrace.non_unification Errortrace.t
+  | Types of Env.t * Errortrace.comparison Errortrace.t
 
 type type_mismatch =
   | Arity
   | Privacy
   | Kind
-  | Constraint of Env.t * Errortrace.non_unification Errortrace.t
-  | Manifest of Env.t * Errortrace.non_unification Errortrace.t
+  | Constraint of Env.t * Errortrace.comparison Errortrace.t
+  | Manifest of Env.t * Errortrace.comparison Errortrace.t
   | Private_variant of type_expr * type_expr * private_variant_mismatch
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -18,12 +18,25 @@
 open Typedtree
 open Types
 
-exception Dont_match
+type position = Errortrace.position = First | Second
 
-type position = Ctype.Unification_trace.position = First | Second
+type primitive_mismatch =
+  | Name
+  | Arity
+  | No_alloc of position
+  | Native_name
+  | Result_repr
+  | Argument_repr of int
+
+type value_mismatch =
+  | Primitive_mismatch of primitive_mismatch
+  | Not_a_primitive
+  | Type of Env.t * Errortrace.non_unification Errortrace.t
+
+exception Dont_match of value_mismatch
 
 type label_mismatch =
-  | Type
+  | Type of Env.t * Errortrace.non_unification Errortrace.t
   | Mutability of position
 
 type record_mismatch =
@@ -33,7 +46,7 @@ type record_mismatch =
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
-  | Type
+  | Type of Env.t * Errortrace.non_unification Errortrace.t
   | Arity
   | Inline_record of record_mismatch
   | Kind of position
@@ -53,12 +66,25 @@ type extension_constructor_mismatch =
                             * extension_constructor
                             * constructor_mismatch
 
+type private_variant_mismatch =
+  | Openness
+  | Missing of position * string
+  | Presence of string
+  | Incompatible_types_for of string
+  | Types of Env.t * Errortrace.non_unification Errortrace.t
+
+type private_object_mismatch =
+  | Missing of string
+  | Types of Env.t * Errortrace.non_unification Errortrace.t
+
 type type_mismatch =
   | Arity
   | Privacy
   | Kind
-  | Constraint
-  | Manifest
+  | Constraint of Env.t * Errortrace.non_unification Errortrace.t
+  | Manifest of Env.t * Errortrace.non_unification Errortrace.t
+  | Private_variant of type_expr * type_expr * private_variant_mismatch
+  | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance
   | Record_mismatch of record_mismatch
   | Variant_mismatch of variant_mismatch

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -31,12 +31,12 @@ type primitive_mismatch =
 type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
-  | Type of Env.t * Errortrace.non_unification Errortrace.t
+  | Type of Env.t * Errortrace.comparison Errortrace.t
 
 exception Dont_match of value_mismatch
 
 type label_mismatch =
-  | Type of Env.t * Errortrace.non_unification Errortrace.t
+  | Type of Env.t * Errortrace.comparison Errortrace.t
   | Mutability of position
 
 type record_mismatch =
@@ -46,7 +46,7 @@ type record_mismatch =
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
-  | Type of Env.t * Errortrace.non_unification Errortrace.t
+  | Type of Env.t * Errortrace.comparison Errortrace.t
   | Arity
   | Inline_record of record_mismatch
   | Kind of position
@@ -71,18 +71,18 @@ type private_variant_mismatch =
   | Missing of position * string
   | Presence of string
   | Incompatible_types_for of string
-  | Types of Env.t * Errortrace.non_unification Errortrace.t
+  | Types of Env.t * Errortrace.comparison Errortrace.t
 
 type private_object_mismatch =
   | Missing of string
-  | Types of Env.t * Errortrace.non_unification Errortrace.t
+  | Types of Env.t * Errortrace.comparison Errortrace.t
 
 type type_mismatch =
   | Arity
   | Privacy
   | Kind
-  | Constraint of Env.t * Errortrace.non_unification Errortrace.t
-  | Manifest of Env.t * Errortrace.non_unification Errortrace.t
+  | Constraint of Env.t * Errortrace.comparison Errortrace.t
+  | Manifest of Env.t * Errortrace.comparison Errortrace.t
   | Private_variant of type_expr * type_expr * private_variant_mismatch
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -22,6 +22,7 @@ open Types
 type symptom =
     Missing_field of Ident.t * Location.t * string (* kind *)
   | Value_descriptions of Ident.t * value_description * value_description
+                          * Includecore.value_mismatch
   | Type_declarations of Ident.t * type_declaration
         * type_declaration * Includecore.type_mismatch
   | Extension_constructors of Ident.t * extension_constructor
@@ -158,7 +159,7 @@ let value_descriptions ~loc env ~mark subst id vd1 vd2 =
   let vd2 = Subst.value_description subst vd2 in
   try
     Ok (Includecore.value_descriptions ~loc env (Ident.name id) vd1 vd2)
-  with Includecore.Dont_match ->
+  with Includecore.Dont_match _err ->
     Error Error.(Core (Value_descriptions (sdiff vd1 vd2)))
 
 (* Inclusion between type declarations *)
@@ -982,7 +983,6 @@ module Functor_app_diff = struct
     Diffing.variadic_diff ~weight ~test ~update state args params
 
 end
-
 
 (* Hide the context and substitution parameters to the outside world *)
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -178,7 +178,9 @@ val print_coercion: Format.formatter -> module_coercion -> unit
 
 type symptom =
     Missing_field of Ident.t * Location.t * string (* kind *)
-  | Value_descriptions of Ident.t * value_description * value_description
+  | Value_descriptions of
+      Ident.t * value_description * value_description
+      * Includecore.value_mismatch
   | Type_declarations of Ident.t * type_declaration
         * type_declaration * Includecore.type_mismatch
   | Extension_constructors of Ident.t * extension_constructor

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -237,7 +237,8 @@ let enrich_typedecl env p id decl =
   | None ->
     match Env.find_type p env with
     | exception Not_found -> decl
-        (* Type which was not present in the signature, so we don't have anything to do. *)
+        (* Type which was not present in the signature, so we don't have
+           anything to do. *)
     | orig_decl ->
         if decl.type_arity <> orig_decl.type_arity then
           decl
@@ -253,9 +254,10 @@ let enrich_typedecl env p id decl =
           let env = Env.add_type ~check:false id decl env in
           match Ctype.mcomp env orig_ty new_ty with
           | exception Ctype.Incompatible -> decl
-              (* The current declaration is not compatible with the one we got from the
-                 signature. We should just fail now, but then, we could also have failed
-                 if the arities of the two decls were different, which we didn't. *)
+              (* The current declaration is not compatible with the one we got
+                 from the signature. We should just fail now, but then, we could
+                 also have failed if the arities of the two decls were
+                 different, which we didn't. *)
           | () ->
               let orig_ty =
                 Btype.newgenty(Tconstr(p, decl.type_params, ref Mnil))

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -200,6 +200,30 @@ let native_name p =
 let byte_name p =
   p.prim_name
 
+let equal_boxed_integer bi1 bi2 =
+  match bi1, bi2 with
+  | Pnativeint, Pnativeint
+  | Pint32, Pint32
+  | Pint64, Pint64 ->
+    true
+  | (Pnativeint | Pint32 | Pint64), _ ->
+    false
+
+let equal_native_repr nr1 nr2 =
+  match nr1, nr2 with
+  | Same_as_ocaml_repr, Same_as_ocaml_repr -> true
+  | Same_as_ocaml_repr,
+    (Unboxed_float | Unboxed_integer _ | Untagged_int) -> false
+  | Unboxed_float, Unboxed_float -> true
+  | Unboxed_float,
+    (Same_as_ocaml_repr | Unboxed_integer _ | Untagged_int) -> false
+  | Unboxed_integer bi1, Unboxed_integer bi2 -> equal_boxed_integer bi1 bi2
+  | Unboxed_integer _,
+    (Same_as_ocaml_repr | Unboxed_float | Untagged_int) -> false
+  | Untagged_int, Untagged_int -> true
+  | Untagged_int,
+    (Same_as_ocaml_repr | Unboxed_float | Unboxed_integer _) -> false
+
 let native_name_is_external p =
   let nat_name = native_name p in
   nat_name <> "" && nat_name.[0] <> '%'

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -63,6 +63,9 @@ val print
 val native_name: description -> string
 val byte_name: description -> string
 
+val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
+val equal_native_repr : native_repr -> native_repr -> bool
+
 (** [native_name_is_externa] returns [true] iff the [native_name] for the
     given primitive identifies that the primitive is not implemented in the
     compiler itself. *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2014,16 +2014,18 @@ let diff_printing_status { Errortrace.got=t1, t1'; expected=t2, t2'} =
   else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
   else Keep
 
-(* A configuration type that controls which trace we print.  This could be exposed, but we
-   instead expose three separate [report_{unification,equality,moregen}_error] functions.
-   This also lets us give the unification case an extra optional argument without adding
-   it to the equality and moregen cases. *)
+(* A configuration type that controls which trace we print.  This could be
+   exposed, but we instead expose three separate
+   [report_{unification,equality,moregen}_error] functions.  This also lets us
+   give the unification case an extra optional argument without adding it to the
+   equality and moregen cases. *)
 type 'variety trace_format =
   | Unification : Errortrace.unification trace_format
   | Equality    : Errortrace.comparison  trace_format
   | Moregen     : Errortrace.comparison  trace_format
 
-let incompatibility_phrase (type variety) : variety trace_format -> string = function
+let incompatibility_phrase (type variety) : variety trace_format -> string =
+  function
   | Unification -> "is not compatible with type"
   | Equality    -> "is not equal to type"
   | Moregen     -> "is not compatible with type"
@@ -2124,8 +2126,10 @@ let explanation_diff env t3 t4 : (Format.formatter -> unit) option =
       None
 
 let explain_fixed_row_case ppf = function
-  | Errortrace.Cannot_be_closed -> fprintf ppf "it cannot be closed"
-  | Errortrace.Cannot_add_tags tags -> fprintf ppf "it may not allow the tag(s) %a" print_tags tags
+  | Errortrace.Cannot_be_closed ->
+      fprintf ppf "it cannot be closed"
+  | Errortrace.Cannot_add_tags tags ->
+      fprintf ppf "it may not allow the tag(s) %a" print_tags tags
 
 let explain_fixed_row pos expl = match expl with
   | Fixed_private ->
@@ -2134,7 +2138,8 @@ let explain_fixed_row pos expl = match expl with
     dprintf "The %a variant type is bound to the universal type variable %a"
       Errortrace.print_pos pos type_expr x
   | Reified p ->
-    dprintf "The %a variant type is bound to %t" Errortrace.print_pos pos (print_path p)
+    dprintf "The %a variant type is bound to %t"
+      Errortrace.print_pos pos (print_path p)
   | Rigid -> ignore
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
@@ -2150,7 +2155,9 @@ let explain_variant (type variety) : variety Errortrace.variant -> _ = function
         Errortrace.print_pos pos
         print_tags (List.map fst fields)
     )
-  | Errortrace.Fixed_row (pos, k, (Univar _ | Reified _ | Fixed_private as e)) ->
+  | Errortrace.Fixed_row (pos,
+                          k,
+                          (Univar _ | Reified _ | Fixed_private as e)) ->
       Some (
         dprintf "@,@[%t,@ %a@]" (explain_fixed_row pos e)
           explain_fixed_row_case k
@@ -2189,8 +2196,10 @@ let explain_escape pre = function
       None
 
 let explain_object (type variety) : variety Errortrace.obj -> _ = function
-  | Errortrace.Missing_field (pos,f) ->
-      Some(dprintf "@,@[The %a object type has no method %s@]" Errortrace.print_pos pos f)
+  | Errortrace.Missing_field (pos,f) -> Some(
+      dprintf "@,@[The %a object type has no method %s@]"
+        Errortrace.print_pos pos f
+    )
   | Errortrace.Abstract_row pos -> Some(
       dprintf
         "@,@[The %a object type has an abstract row, it cannot be closed@]"
@@ -2199,7 +2208,8 @@ let explain_object (type variety) : variety Errortrace.obj -> _ = function
   | Errortrace.Self_cannot_be_closed ->
       Some (dprintf "@,Self type cannot be unified with a closed object type")
 
-let explanation (type variety) intro prev env : ('a, variety) Errortrace.elt -> _ = function
+let explanation (type variety) intro prev env
+  : ('a, variety) Errortrace.elt -> _ = function
   | Errortrace.Diff { Errortrace.got = _,s; expected = _,t } ->
     explanation_diff env s t
   | Errortrace.Escape {kind;context} ->
@@ -2258,7 +2268,8 @@ let warn_on_missing_def env ppf t =
   | _ -> ()
 
 let prepare_expansion_head empty_tr = function
-  | Errortrace.Diff d -> Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
+  | Errortrace.Diff d ->
+      Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
   | _ -> None
 
 let head_error_printer txt_got txt_but = function
@@ -2312,15 +2323,19 @@ let report_error trace_format ppf env tr
                                      type_expected_explanation)
     ~error:true
 
-let report_unification_error = report_error Unification
-let report_equality_error    = report_error Equality    ?type_expected_explanation:None
-let report_moregen_error     = report_error Moregen     ?type_expected_explanation:None
+let report_unification_error =
+  report_error Unification
+let report_equality_error =
+  report_error Equality ?type_expected_explanation:None
+let report_moregen_error =
+  report_error Moregen ?type_expected_explanation:None
 
 module Subtype = struct
-  (* There's a frustrating amount of code duplication between this module and the outside
-     code, particularly in [prepare_trace] and [filter_trace].  Unfortunately, [Subtype]
-     is *just* similar enough to have code duplication, while being *just* different
-     enough (it's only [Diff]) for the abstraction to be nonobvious.  Someday, perhaps… *)
+  (* There's a frustrating amount of code duplication between this module and
+     the outside code, particularly in [prepare_trace] and [filter_trace].
+     Unfortunately, [Subtype] is *just* similar enough to have code duplication,
+     while being *just* different enough (it's only [Diff]) for the abstraction
+     to be nonobvious.  Someday, perhaps... *)
 
   let printing_status = function
     | Errortrace.Subtype.Diff d -> diff_printing_status d
@@ -2357,17 +2372,18 @@ module Subtype = struct
     | [] -> []
     | [Errortrace.Subtype.Diff d as elt]
       when printing_status elt = Optional_refinement ->
-      if keep_last then [d] else []
-    | Errortrace.Subtype.Diff d :: rem -> d :: filter_subtype_trace keep_last rem
+        if keep_last then [d] else []
+    | Errortrace.Subtype.Diff d :: rem ->
+        d :: filter_subtype_trace keep_last rem
 
   let unification_get_diff = function
     | Errortrace.Diff diff ->
-      Some (Errortrace.map_diff trees_of_type_expansion diff)
+        Some (Errortrace.map_diff trees_of_type_expansion diff)
     | _ -> None
 
   let subtype_get_diff = function
     | Errortrace.Subtype.Diff diff ->
-      Some (Errortrace.map_diff trees_of_type_expansion diff)
+        Some (Errortrace.map_diff trees_of_type_expansion diff)
 
   let report_error ppf env tr1 txt1 tr2 =
     wrap_printing_env ~error:true env (fun () ->
@@ -2386,8 +2402,8 @@ module Subtype = struct
       if tr2 = [] then fprintf ppf "@]" else
         let mis = mismatch (dprintf "Within this type") env tr2 in
         fprintf ppf "%a%t%t@]"
-          (trace filter_unification_trace unification_get_diff false (mis = None)
-             "is not compatible with type") tr2
+          (trace filter_unification_trace unification_get_diff false
+             (mis = None) "is not compatible with type") tr2
           (explain mis)
           Conflicts.print_explanations
     )

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2254,6 +2254,10 @@ let warn_on_missing_def env ppf t =
     end
   | _ -> ()
 
+let prepare_expansion_head empty_tr = function
+  | Errortrace.Diff d -> Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
+  | _ -> None
+
 let head_error_printer txt_got txt_but = function
   | None -> ignore
   | Some d ->
@@ -2268,12 +2272,7 @@ let warn_on_missing_defs env ppf = function
       warn_on_missing_def env ppf te1;
       warn_on_missing_def env ppf te2
 
-(* ASZ lifted back? *)
 let error trace_format env tr txt1 ppf txt2 ty_expect_explanation =
-  let prepare_expansion_head empty_tr = function
-    | Errortrace.Diff d -> Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
-    | _ -> None
-  in
   reset ();
   let tr = prepare_trace (fun t t' -> t, hide_variant_name t') tr in
   let mis = mismatch txt1 env tr in

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1974,9 +1974,7 @@ let type_expansion ppf = function
   | Diff(t,t') ->
       fprintf ppf "@[<2>%a@ =@ %a@]"  !Oprint.out_type t  !Oprint.out_type t'
 
-module Trace = Ctype.Unification_trace
-
-let trees_of_trace = List.map (Trace.map_diff trees_of_type_expansion)
+let trees_of_trace = List.map (Errortrace.map_diff trees_of_type_expansion)
 
 let trees_of_type_path_expansion (tp,tp') =
   if Path.same tp tp' then Same(tree_of_path Type tp) else
@@ -1990,13 +1988,12 @@ let type_path_expansion ppf = function
         !Oprint.out_ident p'
 
 let rec trace fst txt ppf = function
-  | {Trace.got; expected} :: rem ->
+  | {Errortrace.got; expected} :: rem ->
       if not fst then fprintf ppf "@,";
       fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@] %a"
        type_expansion got txt type_expansion expected
        (trace false txt) rem
   | _ -> ()
-
 
 type printing_status =
   | Discard
@@ -2010,36 +2007,75 @@ type printing_status =
       type error.
   *)
 
-let printing_status  = function
-  | Trace.(Diff { got=t1, t1'; expected=t2, t2'}) ->
-      if  is_constr_row ~allow_ident:true t1'
-       || is_constr_row ~allow_ident:true t2'
-      then Discard
-      else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
-      else Keep
+let diff_printing_status { Errortrace.got=t1, t1'; expected=t2, t2'} =
+  if  is_constr_row ~allow_ident:true t1'
+   || is_constr_row ~allow_ident:true t2'
+  then Discard
+  else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
+  else Keep
+
+type 'variety trace_format = {
+  incompatibility_phrase : string;
+  constraint_escape_status : printing_status;
+  drop_from_trace : 'a. (Types.type_expr * 'a, 'variety) Errortrace.elt -> bool;
+  explain_contextless_escaped_field_mismatch : bool
+}
+
+(* Each of these is used 2/3 times; none are changed in [unification], two are changed in
+   [equality], and the other two in [moregen] *)
+let default_trace_format = {
+  incompatibility_phrase = "is not compatible with type";
+  constraint_escape_status = Discard;
+  drop_from_trace = (fun _ -> false);
+  explain_contextless_escaped_field_mismatch = true
+}
+
+let unification = default_trace_format
+
+let equality = {default_trace_format with
+  incompatibility_phrase = "is not equal to type";
+  drop_from_trace = (function
+    | Diff {got = ({desc = Tpoly _}, _); expected = ({desc = Tpoly _}, _)} -> true
+    | _ -> false);
+}
+
+let moregen = {default_trace_format with
+  constraint_escape_status = Keep;
+  explain_contextless_escaped_field_mismatch = false
+}
+
+let printing_status trace_format = function
+  | Errortrace.Diff d -> diff_printing_status d
+  | Errortrace.Escape {kind = Constraint} -> trace_format.constraint_escape_status
   | _ -> Keep
 
 (** Flatten the trace and remove elements that are always discarded
     during printing *)
-let prepare_trace f tr =
+let prepare_any_trace drop printing_status tr =
   let clean_trace x l = match printing_status x with
     | Keep -> x :: l
     | Optional_refinement when l = [] -> [x]
     | Optional_refinement | Discard -> l
   in
-  match Trace.flatten f tr with
-  | [] -> []
-  | elt :: rem -> (* the first element is always kept *)
-      elt :: List.fold_right clean_trace rem []
+  let rec prepare_trace_helper tr = match tr with
+    | [] -> []
+    | elt :: rem when drop elt = true -> prepare_trace_helper rem
+    | elt :: rem -> elt :: List.fold_right clean_trace rem []
+  in
+  prepare_trace_helper tr
+
+let prepare_trace trace_format f tr =
+  prepare_any_trace trace_format.drop_from_trace (printing_status trace_format) (Errortrace.flatten f tr)
 
 (** Keep elements that are not [Diff _ ] and take the decision
     for the last element, require a prepared trace *)
-let rec filter_trace keep_last = function
+let rec filter_trace trace_format keep_last = function
   | [] -> []
-  | [Trace.Diff d as elt] when printing_status elt = Optional_refinement ->
-      if keep_last then [d] else []
-  | Trace.Diff d :: rem -> d :: filter_trace keep_last rem
-  | _ :: rem -> filter_trace keep_last rem
+  | [Errortrace.Diff d as elt]
+    when printing_status trace_format elt = Optional_refinement ->
+    if keep_last then [d] else []
+  | Errortrace.Diff d :: rem -> d :: filter_trace trace_format keep_last rem
+  | _ :: rem -> filter_trace trace_format keep_last rem
 
 let type_path_list =
   Format.pp_print_list ~pp_sep:(fun ppf () -> Format.pp_print_break ppf 2 0)
@@ -2065,6 +2101,8 @@ let may_prepare_expansion compact (t, t') =
     Tvariant _ | Tobject _ when compact ->
       mark_loops t; (t, t)
   | _ -> prepare_expansion (t, t')
+
+let print_path f p = !Oprint.out_ident f (tree_of_path Type p)
 
 let print_tag ppf = fprintf ppf "`%s"
 
@@ -2102,118 +2140,120 @@ let explanation_diff env t3 t4 : (Format.formatter -> unit) option =
   | _ ->
       None
 
-let print_pos ppf = function
-  | Trace.First -> fprintf ppf "first"
-  | Trace.Second -> fprintf ppf "second"
-
 let explain_fixed_row_case ppf = function
-  | Trace.Cannot_be_closed -> Format.fprintf ppf "it cannot be closed"
-  | Trace.Cannot_add_tags tags ->
-      Format.fprintf ppf "it may not allow the tag(s) %a"
-        print_tags tags
+  | Errortrace.Cannot_be_closed -> fprintf ppf "it cannot be closed"
+  | Errortrace.Cannot_add_tags tags -> fprintf ppf "it may not allow the tag(s) %a" print_tags tags
 
 let explain_fixed_row pos expl = match expl with
-  | Types.Fixed_private ->
-      dprintf "The %a variant type is private" print_pos pos
-  | Types.Univar x ->
-      dprintf "The %a variant type is bound to the universal type variable %a"
-        print_pos pos type_expr x
-  | Types.Reified p ->
-      let p = tree_of_path Type p in
-      dprintf "The %a variant type is bound to %a" print_pos pos
-        !Oprint.out_ident p
-  | Types.Rigid -> ignore
+  | Fixed_private ->
+    dprintf "The %a variant type is private" Errortrace.print_pos pos
+  | Univar x ->
+    dprintf "The %a variant type is bound to the universal type variable %a"
+      Errortrace.print_pos pos type_expr x
+  | Reified p ->
+    dprintf "The %a variant type is bound to %a" Errortrace.print_pos pos print_path p
+  | Rigid -> ignore
 
-let explain_variant = function
-  | Trace.No_intersection ->
+let explain_variant (type variety) : variety Errortrace.variant -> _ = function
+  (* Common *)
+  | Errortrace.Incompatible_types_for s ->
+      Some(dprintf "@,Types for tag `%s are incompatible" s)
+  (* Unification *)
+  | Errortrace.No_intersection ->
       Some(dprintf "@,These two variant types have no intersection")
-  | Trace.No_tags(pos,fields) -> Some(
+  | Errortrace.No_tags(pos,fields) -> Some(
       dprintf
         "@,@[The %a variant type does not allow tag(s)@ @[<hov>%a@]@]"
-        print_pos pos
+        Errortrace.print_pos pos
         print_tags (List.map fst fields)
     )
-  | Trace.Incompatible_types_for s ->
-      Some(dprintf "@,Types for tag `%s are incompatible" s)
-  | Trace.Fixed_row (pos, k, (Univar _ | Reified _ | Fixed_private as e)) ->
+  | Errortrace.Fixed_row (pos, k, (Univar _ | Reified _ | Fixed_private as e)) ->
       Some (
         dprintf "@,@[%t,@ %a@]" (explain_fixed_row pos e)
           explain_fixed_row_case k
       )
-  | Trace.Fixed_row (_,_, Rigid) ->
+  | Errortrace.Fixed_row (_,_, Rigid) ->
       (* this case never happens *)
       None
+  (* Equality & Moregen *)
+  | Errortrace.Openness pos ->
+    Some(dprintf "@,The %a variant is open and the %a is not"
+           Errortrace.print_pos pos
+           Errortrace.print_pos (Errortrace.swap_position pos))
 
-
-let explain_escape intro prev ctx e =
-  let pre = match ctx with
-    | Some ctx ->  dprintf "@[%t@;<1 2>%a@]" intro type_expr ctx
-    | None -> match e, prev with
-      | Trace.Univ _, Some(Trace.Incompatible_fields {name; diff}) ->
-          dprintf "@,@[The method %s has type@ %a,@ \
-                   but the expected method type was@ %a@]" name
-            type_expr diff.Trace.got type_expr diff.Trace.expected
-      | _ -> ignore in
-  match e with
-  | Trace.Univ u ->  Some(
+let explain_escape pre = function
+  | Errortrace.Univ u -> Some(
       dprintf "%t@,The universal variable %a would escape its scope"
         pre type_expr u)
-  | Trace.Constructor p -> Some(
+  | Errortrace.Constructor p -> Some(
       dprintf
         "%t@,@[The type constructor@;<1 2>%a@ would escape its scope@]"
         pre path p
     )
-  | Trace.Module_type p -> Some(
+  | Errortrace.Module_type p -> Some(
       dprintf
         "%t@,@[The module type@;<1 2>%a@ would escape its scope@]"
         pre path p
     )
-  | Trace.Equation (_,t) -> Some(
+  | Errortrace.Equation (_,t) -> Some(
       dprintf "%t @,@[<hov>This instance of %a is ambiguous:@ %s@]"
         pre type_expr t
         "it would escape the scope of its equation"
     )
-  | Trace.Self ->
+  | Errortrace.Self ->
       Some (dprintf "%t@,Self type cannot escape its class" pre)
+  | Errortrace.Constraint ->
+      Some (dprintf "%t@,###########Constraint##########" pre)
 
-
-let explain_object = function
-  | Trace.Self_cannot_be_closed ->
-      Some (dprintf "@,Self type cannot be unified with a closed object type")
-  | Trace.Missing_field (pos,f) ->
-      Some(dprintf "@,@[The %a object type has no method %s@]" print_pos pos f)
-  | Trace.Abstract_row pos -> Some(
+let explain_object (type variety) : variety Errortrace.obj -> _ = function
+  | Errortrace.Missing_field (pos,f) ->
+      Some(dprintf "@,@[The %a object type has no method %s@]" Errortrace.print_pos pos f)
+  | Errortrace.Abstract_row pos -> Some(
       dprintf
         "@,@[The %a object type has an abstract row, it cannot be closed@]"
-        print_pos pos
+        Errortrace.print_pos pos
     )
+  | Errortrace.Self_cannot_be_closed ->
+      Some (dprintf "@,Self type cannot be unified with a closed object type")
 
+let explanation (type variety) trace_format intro prev env : ('a, variety) Errortrace.elt -> _ = function
+  | Errortrace.Diff { Errortrace.got = _,s; expected = _,t } ->
+    explanation_diff env s t
+  | Errortrace.Escape {kind;context} ->
+    let pre = match context, kind, prev with
+      | Some ctx, _, _ ->
+        dprintf "@[%t@;<1 2>%a@]" intro type_expr ctx
+      | None, Univ _, Some(Errortrace.Incompatible_fields {name; diff})
+        when trace_format.explain_contextless_escaped_field_mismatch ->
+        dprintf "@,@[The method %s has type@ %a,@ \
+                 but the expected method type was@ %a@]"
+          name type_expr diff.got type_expr diff.expected
+      | _ -> ignore
+    in explain_escape pre kind
+  | Errortrace.Incompatible_fields { name; _ } ->
+    Some(dprintf "@,Types for method %s are incompatible" name)
+  | Errortrace.Variant v ->
+    explain_variant v
+  | Errortrace.Obj o ->
+    explain_object o
+  | Errortrace.Rec_occur(x,y) ->
+    mark_loops y;
+    begin match x.desc with
+    | Tvar _ | Tunivar _  ->
+        Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
+               type_expr x type_expr y)
+    | _ ->
+        (* We had a delayed unification of the type variable with
+           a non-variable after the occur check. *)
+        Some ignore
+        (* There is no need to search further for an explanation, but
+           we don't want to print a message of the form:
+             {[ The type int occurs inside int list -> 'a |}
+        *)
+    end
 
-let explanation intro prev env = function
-  | Trace.Diff { Trace.got = _, s; expected = _,t } -> explanation_diff env s t
-  | Trace.Escape {kind;context} -> explain_escape intro prev context kind
-  | Trace.Incompatible_fields { name; _ } ->
-        Some(dprintf "@,Types for method %s are incompatible" name)
-  | Trace.Variant v -> explain_variant v
-  | Trace.Obj o -> explain_object o
-  | Trace.Rec_occur(x,y) ->
-      reset_and_mark_loops y;
-      begin match x.desc with
-      | Tvar _ | Tunivar _  ->
-          Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
-                 marked_type_expr x marked_type_expr y)
-      | _ ->
-          (* We had a delayed unification of the type variable with
-             a non-variable after the occur check. *)
-          Some ignore
-           (* There is no need to search further for an explanation, but
-              we don't want to print a message of the form:
-                {[ The type int occurs inside int list -> 'a |}
-           *)
-      end
-
-let mismatch intro env trace =
-  Trace.explain trace (fun ~prev h -> explanation intro prev env h)
+let mismatch trace_format intro env trace =
+  Errortrace.explain trace (fun ~prev h -> explanation trace_format intro prev env h)
 
 let explain mis ppf =
   match mis with
@@ -2233,30 +2273,32 @@ let warn_on_missing_def env ppf t =
     end
   | _ -> ()
 
-
-let prepare_expansion_head empty_tr = function
-  | Trace.Diff d ->
-      Some(Trace.map_diff (may_prepare_expansion empty_tr) d)
-  | _ -> None
-
 let head_error_printer txt_got txt_but = function
   | None -> ignore
   | Some d ->
-      let d = Trace.map_diff trees_of_type_expansion d in
+      let d = Errortrace.map_diff trees_of_type_expansion d in
       dprintf "%t@;<1 2>%a@ %t@;<1 2>%a"
-        txt_got type_expansion d.Trace.got
-        txt_but type_expansion d.Trace.expected
+        txt_got type_expansion d.Errortrace.got
+        txt_but type_expansion d.Errortrace.expected
 
 let warn_on_missing_defs env ppf = function
   | None -> ()
-  | Some {Trace.got=te1,_; expected=te2,_ } ->
+  | Some {Errortrace.got=te1,_; expected=te2,_ } ->
       warn_on_missing_def env ppf te1;
       warn_on_missing_def env ppf te2
 
-let unification_error env tr txt1 ppf txt2 ty_expect_explanation =
-  reset ();
-  let tr = prepare_trace (fun t t' -> t, hide_variant_name t') tr in
-  let mis = mismatch txt1 env tr in
+let handle_trace
+      filter_trace
+      prepare_expansion_head
+      env
+      tr
+      trace_txt
+      mis
+      txt1
+      ppf
+      txt2
+      ty_expect_explanation
+  =
   match tr with
   | [] -> assert false
   | elt :: tr ->
@@ -2264,7 +2306,7 @@ let unification_error env tr txt1 ppf txt2 ty_expect_explanation =
       print_labels := not !Clflags.classic;
       let tr = filter_trace (mis = None) tr in
       let head = prepare_expansion_head (tr=[]) elt in
-      let tr = List.map (Trace.map_diff prepare_expansion) tr in
+      let tr = List.map (Errortrace.map_diff prepare_expansion) tr in
       let head_error = head_error_printer txt1 txt2 head in
       let tr = trees_of_trace tr in
       fprintf ppf
@@ -2273,7 +2315,7 @@ let unification_error env tr txt1 ppf txt2 ty_expect_explanation =
          @]"
         head_error
         ty_expect_explanation
-        (trace false "is not compatible with type") tr
+        (trace false trace_txt) tr
         (explain mis);
       if env <> Env.empty
       then warn_on_missing_defs env ppf head;
@@ -2283,51 +2325,96 @@ let unification_error env tr txt1 ppf txt2 ty_expect_explanation =
       print_labels := true;
       raise exn
 
-let report_unification_error ppf env tr
-    ?(type_expected_explanation = fun _ -> ())
-    txt1 txt2 =
-  wrap_printing_env env (fun () -> unification_error env tr txt1 ppf txt2
-                            type_expected_explanation)
-    ~error:true
-;;
+let error trace_format env tr txt1 ppf txt2 ty_expect_explanation =
+  let prepare_expansion_head empty_tr = function
+    | Errortrace.Diff d -> Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
+    | _ -> None
+  in
+  reset ();
+  let tr = prepare_trace trace_format (fun t t' -> t, hide_variant_name t') tr in
+  let mis = mismatch trace_format txt1 env tr in
+  handle_trace (filter_trace trace_format) prepare_expansion_head
+    env tr trace_format.incompatibility_phrase mis txt1 ppf txt2 ty_expect_explanation
 
-(** [trace] requires the trace to be prepared *)
-let trace fst keep_last txt ppf tr =
-  print_labels := not !Clflags.classic;
-  try match tr with
-    | elt :: tr' ->
-        let elt = match elt with
-          | Trace.Diff diff -> [Trace.map_diff trees_of_type_expansion diff]
-          | _ -> [] in
+let report_error trace_format ppf env tr
+      ?(type_expected_explanation = fun _ -> ())
+      txt1 txt2 =
+  wrap_printing_env env (fun () -> error trace_format env tr txt1 ppf txt2
+                                     type_expected_explanation)
+    ~error:true
+
+module Subtype = struct
+  (* There's a frustrating amount of code duplication between this module and
+     [Make_trace_printer], particularly in [prepare_trace] and [filter_trace].
+     Unfortunately, [Subtype] is *just* similar enough to have code duplication, while
+     being *just* different enough (it's only [Diff]) for the abstraction to be
+     nonobvious.  Someday, perhaps… *)
+
+  let printing_status = function
+    | Errortrace.Subtype.Diff d -> diff_printing_status d
+
+  let prepare_unification_trace = prepare_trace unification
+
+  let prepare_trace f tr =
+    prepare_any_trace (fun _ -> false) printing_status (Errortrace.Subtype.flatten f tr)
+
+  let trace filter_trace map_diff fst keep_last txt ppf tr =
+    print_labels := not !Clflags.classic;
+    try match tr with
+      | elt :: tr' ->
+        let elt = map_diff elt in
         let tr =
           trees_of_trace
-          @@ List.map (Trace.map_diff prepare_expansion)
+          @@ List.map (Errortrace.map_diff prepare_expansion)
           @@ filter_trace keep_last tr' in
-      if fst then trace fst txt ppf (elt @ tr)
-      else trace fst txt ppf tr;
-      print_labels := true
-  | _ -> ()
-  with exn ->
-    print_labels := true;
-    raise exn
+        if fst then trace fst txt ppf (elt @ tr)
+        else trace fst txt ppf tr;
+        print_labels := true
+      | _ -> ()
+    with exn ->
+      print_labels := true;
+      raise exn
 
-let report_subtyping_error ppf env tr1 txt1 tr2 =
-  wrap_printing_env ~error:true env (fun () ->
-    reset ();
-    let tr1 = prepare_trace (fun t t' -> prepare_expansion (t, t')) tr1 in
-    let tr2 = prepare_trace (fun t t' -> prepare_expansion (t, t')) tr2 in
-    let keep_first = match tr2 with
-      | Trace.[Obj _ | Variant _ | Escape _ ] | [] -> true
-      | _ -> false in
-    fprintf ppf "@[<v>%a" (trace true keep_first txt1) tr1;
-    if tr2 = [] then fprintf ppf "@]" else
-    let mis = mismatch (dprintf "Within this type") env tr2 in
-    fprintf ppf "%a%t%t@]"
-      (trace false (mis = None) "is not compatible with type") tr2
-      (explain mis)
-      Conflicts.print_explanations
-  )
+  let filter_unification_trace = filter_trace unification
 
+  let rec filter_trace keep_last = function
+    | [] -> []
+    | [Errortrace.Subtype.Diff d as elt]
+      when printing_status elt = Optional_refinement ->
+      if keep_last then [d] else []
+    | Errortrace.Subtype.Diff d :: rem -> d :: filter_trace keep_last rem
+
+  let unification_map_diff elt = match elt with
+    | Errortrace.Diff diff ->
+      [Errortrace.map_diff trees_of_type_expansion diff]
+    | _ -> []
+
+  let subtype_map_diff elt = match elt with
+    | Errortrace.Subtype.Diff diff -> [Errortrace.map_diff trees_of_type_expansion diff]
+
+  let report_error ppf env tr1 txt1 tr2 =
+    wrap_printing_env ~error:true env (fun () ->
+      reset ();
+      let tr1 =
+        prepare_trace (fun t t' -> prepare_expansion (t, t')) tr1
+      in
+      let tr2 =
+        prepare_unification_trace (fun t t' -> prepare_expansion (t, t')) tr2
+      in
+      let keep_first = match tr2 with
+        | [Obj _ | Variant _ | Escape _ ] | [] -> true
+        | _ -> false in
+      fprintf ppf "@[<v>%a"
+        (trace filter_trace subtype_map_diff true keep_first txt1) tr1;
+      if tr2 = [] then fprintf ppf "@]" else
+        let mis = mismatch unification (dprintf "Within this type") env tr2 in
+        fprintf ppf "%a%t%t@]"
+          (trace filter_unification_trace unification_map_diff false (mis = None)
+             "is not compatible with type") tr2
+          (explain mis)
+          Conflicts.print_explanations
+    )
+end
 
 let report_ambiguous_type_error ppf env tp0 tpl txt1 txt2 txt3 =
   wrap_printing_env ~error:true env (fun () ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2014,7 +2014,10 @@ let diff_printing_status { Errortrace.got=t1, t1'; expected=t2, t2'} =
   else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
   else Keep
 
-(* A record that's kept abstract for ease of future extensibility *)
+(* A configuration type that controls which trace we print.  This could be exposed, but we
+   instead expose three separate [report_{unification,equality,moregen}_error] functions.
+   This also lets us give the unification case an extra optional argument without adding
+   it to the equality and moregen cases. *)
 type 'variety trace_format =
   | Unification : Errortrace.unification trace_format
   | Equality    : Errortrace.comparison  trace_format
@@ -2308,6 +2311,10 @@ let report_error trace_format ppf env tr
   wrap_printing_env env (fun () -> error trace_format env tr txt1 ppf txt2
                                      type_expected_explanation)
     ~error:true
+
+let report_unification_error = report_error Unification
+let report_equality_error    = report_error Equality    ?type_expected_explanation:None
+let report_moregen_error     = report_error Moregen     ?type_expected_explanation:None
 
 module Subtype = struct
   (* There's a frustrating amount of code duplication between this module and the outside

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2015,13 +2015,15 @@ let diff_printing_status { Errortrace.got=t1, t1'; expected=t2, t2'} =
   else Keep
 
 (* A record that's kept abstract for ease of future extensibility *)
-type 'variety trace_format = {
-  incompatibility_phrase : string
-}
+type 'variety trace_format =
+  | Unification : Errortrace.unification trace_format
+  | Equality    : Errortrace.comparison  trace_format
+  | Moregen     : Errortrace.comparison  trace_format
 
-let unification = { incompatibility_phrase = "is not compatible with type" }
-let equality    = { incompatibility_phrase = "is not equal to type" }
-let moregen     = { incompatibility_phrase = "is not compatible with type" }
+let incompatibility_phrase (type variety) : variety trace_format -> string = function
+  | Unification -> "is not compatible with type"
+  | Equality    -> "is not equal to type"
+  | Moregen     -> "is not compatible with type"
 
 let printing_status = function
   | Errortrace.Diff d -> diff_printing_status d
@@ -2291,7 +2293,7 @@ let error trace_format env tr txt1 ppf txt2 ty_expect_explanation =
          @]"
         head_error
         ty_expect_explanation
-        (trace false trace_format.incompatibility_phrase) tr
+        (trace false (incompatibility_phrase trace_format)) tr
         (explain mis);
       if env <> Env.empty
       then warn_on_missing_defs env ppf head;
@@ -2343,7 +2345,7 @@ module Subtype = struct
       print_labels := true;
       raise exn
 
-  let filter_unification_trace = filter_trace unification
+  let filter_unification_trace = filter_trace Unification
 
   let rec filter_subtype_trace keep_last = function
     | [] -> []

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -177,16 +177,22 @@ val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
 
-type 'variety trace_format =
-  | Unification : Errortrace.unification trace_format
-  | Equality    : Errortrace.comparison  trace_format
-  | Moregen     : Errortrace.comparison  trace_format
-
-val report_error :
-  'variety trace_format ->
+val report_unification_error :
   formatter -> Env.t ->
-  'variety Errortrace.t ->
+  Errortrace.unification Errortrace.t ->
   ?type_expected_explanation:(formatter -> unit) ->
+  (formatter -> unit) -> (formatter -> unit) ->
+  unit
+
+val report_equality_error :
+  formatter -> Env.t ->
+  Errortrace.comparison Errortrace.t ->
+  (formatter -> unit) -> (formatter -> unit) ->
+  unit
+
+val report_moregen_error :
+  formatter -> Env.t ->
+  Errortrace.comparison Errortrace.t ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -178,9 +178,9 @@ val report_ambiguous_type_error:
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
 
 type 'variety trace_format
-val unification : Errortrace.unification     trace_format
-val equality    : Errortrace.non_unification trace_format
-val moregen     : Errortrace.non_unification trace_format
+val unification : Errortrace.unification trace_format
+val equality    : Errortrace.comparison  trace_format
+val moregen     : Errortrace.comparison  trace_format
 
 val report_error :
   'variety trace_format ->

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -173,21 +173,32 @@ val tree_of_cltype_declaration:
 val cltype_declaration: Ident.t -> formatter -> class_type_declaration -> unit
 val type_expansion: type_expr -> Format.formatter -> type_expr -> unit
 val prepare_expansion: type_expr * type_expr -> type_expr * type_expr
-val trace:
-  bool -> bool-> string -> formatter
-  -> (type_expr * type_expr) Ctype.Unification_trace.elt list -> unit
-val report_unification_error:
-    formatter -> Env.t ->
-    Ctype.Unification_trace.t ->
-    ?type_expected_explanation:(formatter -> unit) ->
-    (formatter -> unit) -> (formatter -> unit) ->
-    unit
-val report_subtyping_error:
-    formatter -> Env.t -> Ctype.Unification_trace.t -> string
-    -> Ctype.Unification_trace.t -> unit
 val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
+
+type 'variety trace_format
+val unification : Errortrace.unification     trace_format
+val equality    : Errortrace.non_unification trace_format
+val moregen     : Errortrace.non_unification trace_format
+
+val report_error :
+  'variety trace_format ->
+  formatter -> Env.t ->
+  'variety Errortrace.t ->
+  ?type_expected_explanation:(formatter -> unit) ->
+  (formatter -> unit) -> (formatter -> unit) ->
+  unit
+
+module Subtype : sig
+  val report_error :
+    formatter ->
+    Env.t ->
+    Errortrace.Subtype.t ->
+    string ->
+    Errortrace.unification Errortrace.t ->
+    unit
+end
 
 (* for toploop *)
 val print_items: (Env.t -> signature_item -> 'a option) ->

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -177,10 +177,10 @@ val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
 
-type 'variety trace_format
-val unification : Errortrace.unification trace_format
-val equality    : Errortrace.comparison  trace_format
-val moregen     : Errortrace.comparison  trace_format
+type 'variety trace_format =
+  | Unification : Errortrace.unification trace_format
+  | Equality    : Errortrace.comparison  trace_format
+  | Moregen     : Errortrace.comparison  trace_format
 
 val report_error :
   'variety trace_format ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1889,12 +1889,12 @@ let report_error env ppf = function
       fprintf ppf "A type parameter occurs several times"
   | Unconsistent_constraint trace ->
       fprintf ppf "@[<v>The class constraints are not consistent.@ ";
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "is not compatible with type");
       fprintf ppf "@]"
   | Field_type_mismatch (k, m, trace) ->
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "The %s %s@ has type" k m)
         (function ppf ->
@@ -1932,7 +1932,7 @@ let report_error env ppf = function
         !Oprint.out_type (Printtyp.tree_of_typexp false actual)
         !Oprint.out_type (Printtyp.tree_of_typexp false expected)
   | Constructor_type_mismatch (c, trace) ->
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "The expression \"new %s\" has type" c)
         (function ppf ->
@@ -1960,7 +1960,7 @@ let report_error env ppf = function
            but is here applied to %i type argument(s)@]"
         Printtyp.longident lid expected provided
   | Parameter_mismatch trace ->
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "The type parameter")
         (function ppf ->
@@ -2015,12 +2015,12 @@ let report_error env ppf = function
         "@[The type of this class,@ %a,@ \
            contains non-collapsible conjunctive types in constraints.@ %t@]"
         (Printtyp.class_declaration id) clty
-        (fun ppf -> Printtyp.report_error Printtyp.Unification ppf env trace
+        (fun ppf -> Printtyp.report_unification_error ppf env trace
             (fun ppf -> fprintf ppf "Type")
             (fun ppf -> fprintf ppf "is not compatible with type")
         )
   | Final_self_clash trace ->
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "This object is expected to have type")
         (function ppf ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1889,12 +1889,12 @@ let report_error env ppf = function
       fprintf ppf "A type parameter occurs several times"
   | Unconsistent_constraint trace ->
       fprintf ppf "@[<v>The class constraints are not consistent.@ ";
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "is not compatible with type");
       fprintf ppf "@]"
   | Field_type_mismatch (k, m, trace) ->
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (function ppf ->
            fprintf ppf "The %s %s@ has type" k m)
         (function ppf ->
@@ -1932,7 +1932,7 @@ let report_error env ppf = function
         !Oprint.out_type (Printtyp.tree_of_typexp false actual)
         !Oprint.out_type (Printtyp.tree_of_typexp false expected)
   | Constructor_type_mismatch (c, trace) ->
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (function ppf ->
            fprintf ppf "The expression \"new %s\" has type" c)
         (function ppf ->
@@ -1960,7 +1960,7 @@ let report_error env ppf = function
            but is here applied to %i type argument(s)@]"
         Printtyp.longident lid expected provided
   | Parameter_mismatch trace ->
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (function ppf ->
            fprintf ppf "The type parameter")
         (function ppf ->
@@ -2015,12 +2015,12 @@ let report_error env ppf = function
         "@[The type of this class,@ %a,@ \
            contains non-collapsible conjunctive types in constraints.@ %t@]"
         (Printtyp.class_declaration id) clty
-        (fun ppf -> Printtyp.report_error Printtyp.unification ppf env trace
+        (fun ppf -> Printtyp.report_error Printtyp.Unification ppf env trace
             (fun ppf -> fprintf ppf "Type")
             (fun ppf -> fprintf ppf "is not compatible with type")
         )
   | Final_self_clash trace ->
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (function ppf ->
            fprintf ppf "This object is expected to have type")
         (function ppf ->

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -90,8 +90,8 @@ val type_classes :
 *)
 
 type error =
-    Unconsistent_constraint of Ctype.Unification_trace.t
-  | Field_type_mismatch of string * string * Ctype.Unification_trace.t
+  | Unconsistent_constraint of Errortrace.unification Errortrace.t
+  | Field_type_mismatch of string * string * Errortrace.unification Errortrace.t
   | Structure_expected of class_type
   | Cannot_apply of class_type
   | Apply_wrong_label of arg_label
@@ -100,10 +100,10 @@ type error =
   | Unbound_class_2 of Longident.t
   | Unbound_class_type_2 of Longident.t
   | Abbrev_type_clash of type_expr * type_expr * type_expr
-  | Constructor_type_mismatch of string * Ctype.Unification_trace.t
+  | Constructor_type_mismatch of string * Errortrace.unification Errortrace.t
   | Virtual_class of bool * bool * string list * string list
   | Parameter_arity_mismatch of Longident.t * int * int
-  | Parameter_mismatch of Ctype.Unification_trace.t
+  | Parameter_mismatch of Errortrace.unification Errortrace.t
   | Bad_parameters of Ident.t * type_expr * type_expr
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
@@ -111,8 +111,8 @@ type error =
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
-      Ident.t * Types.class_declaration * Ctype.Unification_trace.t
-  | Final_self_clash of Ctype.Unification_trace.t
+      Ident.t * Types.class_declaration * Errortrace.unification Errortrace.t
+  | Final_self_clash of Errortrace.unification Errortrace.t
   | Mutability_mismatch of string * mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5439,7 +5439,7 @@ let report_type_expected_explanation_opt expl ppf =
 let report_unification_error ~loc ?sub env trace
     ?type_expected_explanation txt1 txt2 =
   Location.error_of_printer ~loc ?sub (fun ppf () ->
-    Printtyp.report_error Printtyp.Unification ppf env trace
+    Printtyp.report_unification_error ppf env trace
       ?type_expected_explanation txt1 txt2
   ) ()
 
@@ -5459,14 +5459,12 @@ let report_error ~loc env = function
   | Pattern_type_clash (trace, pat) ->
       let diff = type_clash_of_trace trace in
       let sub = report_pattern_type_clash_hints pat diff in
-      Location.error_of_printer ~loc ~sub (fun ppf () ->
-        Printtyp.report_error Printtyp.Unification ppf env trace
-          (function ppf ->
-            fprintf ppf "This pattern matches values of type")
-          (function ppf ->
-            fprintf ppf "but a pattern was expected which matches values of \
-                         type");
-      ) ()
+      report_unification_error ~loc ~sub env trace
+        (function ppf ->
+          fprintf ppf "This pattern matches values of type")
+        (function ppf ->
+          fprintf ppf "but a pattern was expected which matches values of \
+                       type");
   | Or_pattern_type_clash (id, trace) ->
       report_unification_error ~loc env trace
         (function ppf ->
@@ -5488,15 +5486,13 @@ let report_error ~loc env = function
   | Expr_type_clash (trace, explanation, exp) ->
       let diff = type_clash_of_trace trace in
       let sub = report_expr_type_clash_hints exp diff in
-      Location.error_of_printer ~loc ~sub (fun ppf () ->
-        Printtyp.report_error Printtyp.Unification ppf env trace
-          ~type_expected_explanation:
-            (report_type_expected_explanation_opt explanation)
-          (function ppf ->
-             fprintf ppf "This expression has type")
-          (function ppf ->
-             fprintf ppf "but an expression was expected of type");
-      ) ()
+      report_unification_error ~loc ~sub env trace
+        ~type_expected_explanation:
+          (report_type_expected_explanation_opt explanation)
+        (function ppf ->
+           fprintf ppf "This expression has type")
+        (function ppf ->
+           fprintf ppf "but an expression was expected of type");
   | Apply_non_function typ ->
       begin match (repr typ).desc with
         Tarrow _ ->
@@ -5613,7 +5609,7 @@ let report_error ~loc env = function
         v
   | Coercion_failure (ty, ty', trace, b) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.report_error Printtyp.Unification ppf env trace
+        Printtyp.report_unification_error ppf env trace
           (function ppf ->
              let ty, ty' = Printtyp.prepare_expansion (ty, ty') in
              fprintf ppf "This expression cannot be coerced to type@;<1 2>%a;@ \

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -76,14 +76,14 @@ type existential_restriction =
 
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
-  | Label_mismatch of Longident.t * Ctype.Unification_trace.t
+  | Label_mismatch of Longident.t * Errortrace.unification Errortrace.t
   | Pattern_type_clash :
-      Ctype.Unification_trace.t * _ pattern_desc option -> error
-  | Or_pattern_type_clash of Ident.t * Ctype.Unification_trace.t
+      Errortrace.unification Errortrace.t * _ pattern_desc option -> error
+  | Or_pattern_type_clash of Ident.t * Errortrace.unification Errortrace.t
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
-      Ctype.Unification_trace.t * type_forcing_context option
+      Errortrace.unification Errortrace.t * type_forcing_context option
       * expression_desc option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr * bool
@@ -102,17 +102,17 @@ type error =
   | Private_constructor of constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
-  | Not_subtype of Ctype.Unification_trace.t * Ctype.Unification_trace.t
+  | Not_subtype of Errortrace.Subtype.t * Errortrace.unification Errortrace.t
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
-      type_expr * type_expr * Ctype.Unification_trace.t * bool
+      type_expr * type_expr * Errortrace.unification Errortrace.t * bool
   | Too_many_arguments of bool * type_expr * type_forcing_context option
   | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
   | Scoping_let_module of string * type_expr
   | Not_a_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * Ctype.Unification_trace.t
+  | Less_general of string * Errortrace.unification Errortrace.t
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
@@ -132,9 +132,9 @@ type error =
   | Illegal_letrec_pat
   | Illegal_letrec_expr
   | Illegal_class_expr
-  | Letop_type_clash of string * Ctype.Unification_trace.t
-  | Andop_type_clash of string * Ctype.Unification_trace.t
-  | Bindings_type_clash of Ctype.Unification_trace.t
+  | Letop_type_clash of string * Errortrace.unification Errortrace.t
+  | Andop_type_clash of string * Errortrace.unification Errortrace.t
+  | Bindings_type_clash of Errortrace.unification Errortrace.t
   | Unbound_existential of Ident.t list * type_expr
   | Missing_type_constraint
 
@@ -1303,8 +1303,8 @@ let rec has_literal_pattern p = match p.ppat_desc with
 
 let check_scope_escape loc env level ty =
   try Ctype.check_scope_escape env level ty
-  with Unify trace ->
-    raise(Error(loc, env, Pattern_type_clash(trace, None)))
+  with Escape trace ->
+    raise(Error(loc, env, Pattern_type_clash([Escape trace], None)))
 
 type pattern_checking_mode =
   | Normal
@@ -2491,7 +2491,7 @@ let check_univars env kind exp ty_expected vars =
   if not complete then
     let ty_expected = instance ty_expected in
     raise (Error (exp.exp_loc, env,
-                  Less_general(kind, [Unification_trace.diff ty ty_expected])))
+                  Less_general(kind, [Errortrace.diff ty ty_expected])))
 
 let generalize_and_check_univars env kind exp ty_expected vars =
   generalize exp.exp_type;
@@ -4932,7 +4932,7 @@ and type_cases
     let has_equation_escape err =
       match trace_of_error err with
         Some tr ->
-          List.exists Ctype.Unification_trace.
+          List.exists Errortrace.
             (function Escape {kind=Equation _} -> true | _ -> false) tr
       | None -> false
     in
@@ -5360,7 +5360,7 @@ let longident = Printtyp.longident
 
 (* Returns the first diff of the trace *)
 let type_clash_of_trace trace =
-  Ctype.Unification_trace.(explain trace (fun ~prev:_ -> function
+  Errortrace.(explain trace (fun ~prev:_ -> function
     | Diff diff -> Some diff
     | _ -> None
   ))
@@ -5392,8 +5392,7 @@ let report_literal_type_constraint expected_type const =
   | _, _ -> []
 
 let report_literal_type_constraint const = function
-  | Some Unification_trace.
-    { expected = { t = { desc = Tconstr (typ, [], _) } } } ->
+  | Some Errortrace.{ expected = { t = { desc = Tconstr (typ, [], _) } } } ->
       report_literal_type_constraint typ const
   | Some _ | None -> []
 
@@ -5440,7 +5439,7 @@ let report_type_expected_explanation_opt expl ppf =
 let report_unification_error ~loc ?sub env trace
     ?type_expected_explanation txt1 txt2 =
   Location.error_of_printer ~loc ?sub (fun ppf () ->
-    Printtyp.report_unification_error ppf env trace
+    Printtyp.report_error Printtyp.unification ppf env trace
       ?type_expected_explanation txt1 txt2
   ) ()
 
@@ -5461,7 +5460,7 @@ let report_error ~loc env = function
       let diff = type_clash_of_trace trace in
       let sub = report_pattern_type_clash_hints pat diff in
       Location.error_of_printer ~loc ~sub (fun ppf () ->
-        Printtyp.report_unification_error ppf env trace
+        Printtyp.report_error Printtyp.unification ppf env trace
           (function ppf ->
             fprintf ppf "This pattern matches values of type")
           (function ppf ->
@@ -5490,7 +5489,7 @@ let report_error ~loc env = function
       let diff = type_clash_of_trace trace in
       let sub = report_expr_type_clash_hints exp diff in
       Location.error_of_printer ~loc ~sub (fun ppf () ->
-        Printtyp.report_unification_error ppf env trace
+        Printtyp.report_error Printtyp.unification ppf env trace
           ~type_expected_explanation:
             (report_type_expected_explanation_opt explanation)
           (function ppf ->
@@ -5603,7 +5602,7 @@ let report_error ~loc env = function
       Location.errorf ~loc "The instance variable %s is not mutable" v
   | Not_subtype(tr1, tr2) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.report_subtyping_error ppf env tr1 "is not a subtype of" tr2
+        Printtyp.Subtype.report_error ppf env tr1 "is not a subtype of" tr2
       ) ()
   | Outside_class ->
       Location.errorf ~loc
@@ -5614,7 +5613,7 @@ let report_error ~loc env = function
         v
   | Coercion_failure (ty, ty', trace, b) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.report_unification_error ppf env trace
+        Printtyp.report_error Printtyp.unification ppf env trace
           (function ppf ->
              let ty, ty' = Printtyp.prepare_expansion (ty, ty') in
              fprintf ppf "This expression cannot be coerced to type@;<1 2>%a;@ \

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5439,7 +5439,7 @@ let report_type_expected_explanation_opt expl ppf =
 let report_unification_error ~loc ?sub env trace
     ?type_expected_explanation txt1 txt2 =
   Location.error_of_printer ~loc ?sub (fun ppf () ->
-    Printtyp.report_error Printtyp.unification ppf env trace
+    Printtyp.report_error Printtyp.Unification ppf env trace
       ?type_expected_explanation txt1 txt2
   ) ()
 
@@ -5460,7 +5460,7 @@ let report_error ~loc env = function
       let diff = type_clash_of_trace trace in
       let sub = report_pattern_type_clash_hints pat diff in
       Location.error_of_printer ~loc ~sub (fun ppf () ->
-        Printtyp.report_error Printtyp.unification ppf env trace
+        Printtyp.report_error Printtyp.Unification ppf env trace
           (function ppf ->
             fprintf ppf "This pattern matches values of type")
           (function ppf ->
@@ -5489,7 +5489,7 @@ let report_error ~loc env = function
       let diff = type_clash_of_trace trace in
       let sub = report_expr_type_clash_hints exp diff in
       Location.error_of_printer ~loc ~sub (fun ppf () ->
-        Printtyp.report_error Printtyp.unification ppf env trace
+        Printtyp.report_error Printtyp.Unification ppf env trace
           ~type_expected_explanation:
             (report_type_expected_explanation_opt explanation)
           (function ppf ->
@@ -5613,7 +5613,7 @@ let report_error ~loc env = function
         v
   | Coercion_failure (ty, ty', trace, b) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.report_error Printtyp.unification ppf env trace
+        Printtyp.report_error Printtyp.Unification ppf env trace
           (function ppf ->
              let ty, ty' = Printtyp.prepare_expansion (ty, ty') in
              fprintf ppf "This expression cannot be coerced to type@;<1 2>%a;@ \

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -127,14 +127,14 @@ val self_coercion : (Path.t * Location.t list ref) list ref
 
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
-  | Label_mismatch of Longident.t * Ctype.Unification_trace.t
+  | Label_mismatch of Longident.t * Errortrace.unification Errortrace.t
   | Pattern_type_clash :
-      Ctype.Unification_trace.t * _ Typedtree.pattern_desc option -> error
-  | Or_pattern_type_clash of Ident.t * Ctype.Unification_trace.t
+      Errortrace.unification Errortrace.t * _ Typedtree.pattern_desc option -> error
+  | Or_pattern_type_clash of Ident.t * Errortrace.unification Errortrace.t
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
-      Ctype.Unification_trace.t * type_forcing_context option
+      Errortrace.unification Errortrace.t * type_forcing_context option
       * Typedtree.expression_desc option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr * bool
@@ -153,17 +153,17 @@ type error =
   | Private_constructor of constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
-  | Not_subtype of Ctype.Unification_trace.t * Ctype.Unification_trace.t
+  | Not_subtype of Errortrace.Subtype.t * Errortrace.unification Errortrace.t
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
-      type_expr * type_expr * Ctype.Unification_trace.t * bool
+      type_expr * type_expr * Errortrace.unification Errortrace.t * bool
   | Too_many_arguments of bool * type_expr * type_forcing_context option
   | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
   | Scoping_let_module of string * type_expr
   | Not_a_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * Ctype.Unification_trace.t
+  | Less_general of string * Errortrace.unification Errortrace.t
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
@@ -183,9 +183,9 @@ type error =
   | Illegal_letrec_pat
   | Illegal_letrec_expr
   | Illegal_class_expr
-  | Letop_type_clash of string * Ctype.Unification_trace.t
-  | Andop_type_clash of string * Ctype.Unification_trace.t
-  | Bindings_type_clash of Ctype.Unification_trace.t
+  | Letop_type_clash of string * Errortrace.unification Errortrace.t
+  | Andop_type_clash of string * Errortrace.unification Errortrace.t
+  | Bindings_type_clash of Errortrace.unification Errortrace.t
   | Unbound_existential of Ident.t list * type_expr
   | Missing_type_constraint
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -129,7 +129,8 @@ type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Errortrace.unification Errortrace.t
   | Pattern_type_clash :
-      Errortrace.unification Errortrace.t * _ Typedtree.pattern_desc option -> error
+      Errortrace.unification Errortrace.t * _ Typedtree.pattern_desc option
+      -> error
   | Or_pattern_type_clash of Ident.t * Errortrace.unification Errortrace.t
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1675,7 +1675,7 @@ let report_error ppf = function
         err
   | Constraint_failed (env, trace) ->
       fprintf ppf "@[<v>Constraints are not satisfied in this type.@ ";
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "should be an instance of");
       fprintf ppf "@]"
@@ -1716,12 +1716,12 @@ let report_error ppf = function
       end
   | Inconsistent_constraint (env, trace) ->
       fprintf ppf "@[<v>The type constraints are not consistent.@ ";
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "is not compatible with type");
       fprintf ppf "@]"
   | Type_clash (env, trace) ->
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (function ppf ->
            fprintf ppf "This type constructor expands to type")
         (function ppf ->
@@ -1775,7 +1775,7 @@ let report_error ppf = function
            "the type" "this extension" "definition")
         err
   | Rebind_wrong_type (lid, env, trace) ->
-      Printtyp.report_error Printtyp.unification ppf env trace
+      Printtyp.report_error Printtyp.Unification ppf env trace
         (function ppf ->
            fprintf ppf "The constructor %a@ has type"
              Printtyp.longident lid)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -49,7 +49,8 @@ type error =
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
   | Extension_mismatch of Path.t * Includecore.type_mismatch
-  | Rebind_wrong_type of Longident.t * Env.t * Errortrace.unification Errortrace.t
+  | Rebind_wrong_type of
+      Longident.t * Env.t * Errortrace.unification Errortrace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1675,7 +1675,7 @@ let report_error ppf = function
         err
   | Constraint_failed (env, trace) ->
       fprintf ppf "@[<v>Constraints are not satisfied in this type.@ ";
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "should be an instance of");
       fprintf ppf "@]"
@@ -1716,12 +1716,12 @@ let report_error ppf = function
       end
   | Inconsistent_constraint (env, trace) ->
       fprintf ppf "@[<v>The type constraints are not consistent.@ ";
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "is not compatible with type");
       fprintf ppf "@]"
   | Type_clash (env, trace) ->
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "This type constructor expands to type")
         (function ppf ->
@@ -1775,7 +1775,7 @@ let report_error ppf = function
            "the type" "this extension" "definition")
         err
   | Rebind_wrong_type (lid, env, trace) ->
-      Printtyp.report_error Printtyp.Unification ppf env trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
            fprintf ppf "The constructor %a@ has type"
              Printtyp.longident lid)

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -86,7 +86,8 @@ type error =
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
   | Extension_mismatch of Path.t * Includecore.type_mismatch
-  | Rebind_wrong_type of Longident.t * Env.t * Errortrace.unification Errortrace.t
+  | Rebind_wrong_type of
+      Longident.t * Env.t * Errortrace.unification Errortrace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -71,9 +71,9 @@ type error =
   | Recursive_abbrev of string
   | Cycle_in_def of string * type_expr
   | Definition_mismatch of type_expr * Includecore.type_mismatch option
-  | Constraint_failed of type_expr * type_expr
-  | Inconsistent_constraint of Env.t * Ctype.Unification_trace.t
-  | Type_clash of Env.t * Ctype.Unification_trace.t
+  | Constraint_failed of Env.t * Errortrace.unification Errortrace.t
+  | Inconsistent_constraint of Env.t * Errortrace.unification Errortrace.t
+  | Type_clash of Env.t * Errortrace.unification Errortrace.t
   | Non_regular of {
       definition: Path.t;
       used_as: type_expr;
@@ -86,7 +86,7 @@ type error =
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
   | Extension_mismatch of Path.t * Includecore.type_mismatch
-  | Rebind_wrong_type of Longident.t * Env.t * Ctype.Unification_trace.t
+  | Rebind_wrong_type of Longident.t * Env.t * Errortrace.unification Errortrace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -219,7 +219,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
       let v2 =
         TypeMap.fold
           (fun t vt v ->
-            if Ctype.equal env false [ty] [t] then union vt v else v)
+             if Ctype.is_equal env false [ty] [t] then union vt v else v)
           !tvl2 null in
       Btype.backtrack snap;
       let (c1,n1) = get_upper v1 and (c2,n2,_,i2) = get_lower v2 in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -33,8 +33,8 @@ type error =
   | Bound_type_variable of string
   | Recursive_type
   | Unbound_row_variable of Longident.t
-  | Type_mismatch of Ctype.Unification_trace.t
-  | Alias_type_mismatch of Ctype.Unification_trace.t
+  | Type_mismatch of Errortrace.unification Errortrace.t
+  | Alias_type_mismatch of Errortrace.unification Errortrace.t
   | Present_has_conjunction of string
   | Present_has_no_type of string
   | Constructor_mismatch of type_expr * type_expr
@@ -235,7 +235,7 @@ and transl_type_aux env policy styp =
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_param env ty' cty.ctyp_type with Unify trace ->
-             let trace = Unification_trace.swap trace in
+             let trace = Errortrace.swap_unification_trace trace in
              raise (Error(sty.ptyp_loc, env, Type_mismatch trace))
         )
         (List.combine stl args) params;
@@ -285,7 +285,7 @@ and transl_type_aux env policy styp =
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_var env ty' cty.ctyp_type with Unify trace ->
-             let trace = Unification_trace.swap trace in
+             let trace = Errortrace.swap_unification_trace trace in
              raise (Error(sty.ptyp_loc, env, Type_mismatch trace))
         )
         (List.combine stl args) params;
@@ -337,7 +337,7 @@ and transl_type_aux env policy styp =
           in
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify trace ->
-            let trace = Unification_trace.swap trace in
+            let trace = Errortrace.swap_unification_trace trace in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch trace))
           end;
           ty
@@ -348,7 +348,7 @@ and transl_type_aux env policy styp =
             TyVarMap.add alias (t, styp.ptyp_loc) !used_variables;
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify trace ->
-            let trace = Unification_trace.swap trace in
+            let trace = Errortrace.swap_unification_trace trace in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch trace))
           end;
           if !Clflags.principal then begin
@@ -379,7 +379,7 @@ and transl_type_aux env policy styp =
           (* Check for tag conflicts *)
           if l <> l' then raise(Error(styp.ptyp_loc, env, Variant_tags(l, l')));
           let ty = mkfield l f and ty' = mkfield l f' in
-          if equal env false [ty] [ty'] then () else
+          if is_equal env false [ty] [ty'] then () else
           try unify env ty ty'
           with Unify _trace ->
             raise(Error(loc, env, Constructor_mismatch (ty,ty')))
@@ -526,7 +526,7 @@ and transl_fields env policy o fields =
   let add_typed_field loc l ty =
     try
       let ty' = Hashtbl.find hfields l in
-      if equal env false [ty] [ty'] then () else
+      if is_equal env false [ty] [ty'] then () else
         try unify env ty ty'
         with Unify _trace ->
           raise(Error(loc, env, Method_mismatch (l, ty, ty')))
@@ -724,13 +724,13 @@ let report_error env ppf = function
          anywhere so it's unclear how it should be handled *)
       fprintf ppf "Unbound row variable in #%a" longident lid
   | Type_mismatch trace ->
-      Printtyp.report_unification_error ppf Env.empty trace
+      Printtyp.report_error Printtyp.unification ppf Env.empty trace
         (function ppf ->
            fprintf ppf "This type")
         (function ppf ->
            fprintf ppf "should be an instance of type")
   | Alias_type_mismatch trace ->
-      Printtyp.report_unification_error ppf Env.empty trace
+      Printtyp.report_error Printtyp.unification ppf Env.empty trace
         (function ppf ->
            fprintf ppf "This alias is bound to type")
         (function ppf ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -235,7 +235,7 @@ and transl_type_aux env policy styp =
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_param env ty' cty.ctyp_type with Unify trace ->
-             let trace = Errortrace.swap_unification_trace trace in
+             let trace = Errortrace.swap_trace trace in
              raise (Error(sty.ptyp_loc, env, Type_mismatch trace))
         )
         (List.combine stl args) params;
@@ -285,7 +285,7 @@ and transl_type_aux env policy styp =
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_var env ty' cty.ctyp_type with Unify trace ->
-             let trace = Errortrace.swap_unification_trace trace in
+             let trace = Errortrace.swap_trace trace in
              raise (Error(sty.ptyp_loc, env, Type_mismatch trace))
         )
         (List.combine stl args) params;
@@ -337,7 +337,7 @@ and transl_type_aux env policy styp =
           in
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify trace ->
-            let trace = Errortrace.swap_unification_trace trace in
+            let trace = Errortrace.swap_trace trace in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch trace))
           end;
           ty
@@ -348,7 +348,7 @@ and transl_type_aux env policy styp =
             TyVarMap.add alias (t, styp.ptyp_loc) !used_variables;
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify trace ->
-            let trace = Errortrace.swap_unification_trace trace in
+            let trace = Errortrace.swap_trace trace in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch trace))
           end;
           if !Clflags.principal then begin

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -724,13 +724,13 @@ let report_error env ppf = function
          anywhere so it's unclear how it should be handled *)
       fprintf ppf "Unbound row variable in #%a" longident lid
   | Type_mismatch trace ->
-      Printtyp.report_error Printtyp.unification ppf Env.empty trace
+      Printtyp.report_error Printtyp.Unification ppf Env.empty trace
         (function ppf ->
            fprintf ppf "This type")
         (function ppf ->
            fprintf ppf "should be an instance of type")
   | Alias_type_mismatch trace ->
-      Printtyp.report_error Printtyp.unification ppf Env.empty trace
+      Printtyp.report_error Printtyp.Unification ppf Env.empty trace
         (function ppf ->
            fprintf ppf "This alias is bound to type")
         (function ppf ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -724,13 +724,13 @@ let report_error env ppf = function
          anywhere so it's unclear how it should be handled *)
       fprintf ppf "Unbound row variable in #%a" longident lid
   | Type_mismatch trace ->
-      Printtyp.report_error Printtyp.Unification ppf Env.empty trace
+      Printtyp.report_unification_error ppf Env.empty trace
         (function ppf ->
            fprintf ppf "This type")
         (function ppf ->
            fprintf ppf "should be an instance of type")
   | Alias_type_mismatch trace ->
-      Printtyp.report_error Printtyp.Unification ppf Env.empty trace
+      Printtyp.report_unification_error ppf Env.empty trace
         (function ppf ->
            fprintf ppf "This alias is bound to type")
         (function ppf ->

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -50,8 +50,8 @@ type error =
   | Bound_type_variable of string
   | Recursive_type
   | Unbound_row_variable of Longident.t
-  | Type_mismatch of Ctype.Unification_trace.t
-  | Alias_type_mismatch of Ctype.Unification_trace.t
+  | Type_mismatch of Errortrace.unification Errortrace.t
+  | Alias_type_mismatch of Errortrace.unification Errortrace.t
   | Present_has_conjunction of string
   | Present_has_no_type of string
   | Constructor_mismatch of type_expr * type_expr


### PR DESCRIPTION
### Introduction

This PR refactors the types that make up type-checking errors to maintain more structural information.  Most significantly, we split out the errors we get from unification, moregen, and type equality in `Ctype` into three distinct exceptions, and retain the sorts of information we keep during unification in the other two cases as well (no more `Unify []`).  We also maintain more information in `Includecore` about mismatches of primitives, manifests, and private objects and variants

This PR doesn't make a lot of changes to the user-visible error messages yet, only what's necessary to support the type changes, but it enables a forthcoming patch where we use this improvement to produce more informative error messages.

This PR builds heavily on work done by Mekhrubon Tuarev (@MekhrubonT) during his internship at Jane Street in 2019; most of the tricky work of figuring out where to insert these new exception calls was his, and I built on top of this.  Both of us were assisted by @lpw25.

### Motivation

In the past, the OCaml compiler used `Unify` as its major exception in most cases; it would `raise (Unify [])` from places like moregen and type equality where unification wasn't what was being called.  This both lost information and also didn't let us distinguish between (1) errors intentionally raised by moregen/type equality and (2) errors raised by calls to `Unify` as *implementation details* of moregen/type equality, which accidentally leaked out.  It also led to the use of `Unify []` as a general signifier for "this type-checking–related function had a problem of some sort", which meant it was possible for code to accidentally handle more errors than it expected to by assuming that the wrong function was raising the `Unify`.

### Eventual goals

The plan is to eventually use this patch to improve the actual text of errors during various kinds of module inclusion.  Right now, those errors are "shallow"; we would like to make them "deep".  For example, consider the following example in current OCaml:

    module M : sig
      val x : bool * int
    end = struct
      let x = false , "not an int"
    end

This produces the following error:

    Error: Signature mismatch:
           Modules do not match:
             sig val x : bool * string end
           is not included in
             sig val x : bool * int end
           Values do not match:
             val x : bool * string
           is not included in
             val x : bool * int

This error omits a key detail, though: the reason the signatures don't match is that `string` is not `int`.  And we *would* get that error if we used an ordinary type annotation:


    let y = false, "still not an int" in
    (y : bool * int)

This gives the more useful error

    Error: This expression has type bool * string
           but an expression was expected of type bool * int
           Type string is not compatible with type int 

In particular, note the last line.  The eventual goal of this patch is to add "Type string is not compatible with type int" (and similar messages) to the module error above (and similar errors).

Again, this patch doesn't make that change, it just lays the groundwork, with one exception: the following test case from `testsuite/tests/typing-poly/poly.ml`, lines 970–980.  The code is

    type ('a,'b) t constraint 'a = 'b
                   constraint 'a = int
      and 'a u = (float,string) t;;


This now produces the following error:

    Line 3, characters 13-29:
    3 |   and 'a u = (float,string) t;;
                     ^^^^^^^^^^^^^^^^
    Error: Constraints are not satisfied in this type.
           Type (float, string) t should be an instance of (int, int) t
           Type float is not compatible with type int

The last line, "Type float is not compatible with type int", was added by this patch.

### Changes

This PR makes the following changes:

* Move `Ctype.Unification_trace` (often bound locally as `Trace`) into the new module `Errortrace`, and make it a GADT differentiating between unification traces and non-unification traces (i.e., equality or moregen traces).

* Ensure that the code in `Ctype` correctly raises these the new `Moregen` and `Equality` exceptions, building a trace much like during unification.  Note that we do still raise `Moregen []` and `Equality []` sometimes, since our goal is for the improvement of error messages (rather than the necessary precondition of improving the machinery) to be a separate PR for easier comprehensibility.

* Be more intentional in handling `Unify` errors that arise during implementation.  This shows up in two ways: (1) hiding that unification was used as an implementation detail, and (2) not raising `Unify []` as a general "there was a problem" signifier.  For an example of (1), `Ctype.subst` uses unification internally to handle the case of a type with constraints.  However, previously, if that failed – a situation which can only happen in rare corner cases – a `Unify` exception would come out of substitution, which other functions might not expect.  Now, `subst` instead raises the new error `Cannot_subst`, which we handle wherever `subst` is called; a mistake will result in an unexpected `Cannot_subst` error, instead of an incorrectly-handled `Unify` error.

* Maintain more structural information in `Includecore`, specifically about mismatches of primitives, manifests, and private objects and variants.

* Add many new tests, most of which point at behavior that we changed but some of which point at behavior that we did not change.  We expect more of these changes in the forthcoming patch that takes advantage of the new exception structure.

The changes are structured into two commits: first, a commit that adds new tests; and second, a commit that makes the actual code changes and updates all the necessary tests.

### Detailed, file-by-file changes

This section documents the changes we made to every file, since we touch so many of them; it is not required reading, but hopefully helps review.  There is nothing after this section in this PR, so if you don't want to read the gory details, you can stop now.

The key files to look at are, in roughly descending order, `typing/ctype.ml`, `typing/printtyp.ml`, `typing/errortrace.ml`, and `typing/includecore.ml`, as well as, to a lesser extent, their `.mli` files.

* `.depend` *(modified)*:
  
  Inessential changes, autogenerated

* `compilerlibs/Makefile.compilerlibs` *(modified)*:
  
  Added the new `Errortrace` module

* `lambda/lambda.ml` *(modified)*:

  Moved `equal_boxed_integer` to `primitive.ml`.

* `testsuite/tests/typing-misc/constraints.ml` *(modified)*:

  New tests for `constraint` errors; these errors highlight old behavior that hasn't changed, not new behavior.  However, because we fix an indentation bug, the tests we added, as well as one other test, show up in the diff.

* `testsuite/tests/typing-misc/pr6416.ml` *(modified)*:

  Changed the error message output here, removing some arguably-redundant text that was leaking out of `subst` (see the discussion in `Ctype.ml`).

* `testsuite/tests/typing-misc/pr7937.ml` *(modified)*:

  Deleted a bunch of spurious "Types for tag \`X are incompatible" lines from errors; they were showing up even when only one side was a variant, and now they're gone instead

* `testsuite/tests/typing-misc/unbound_type_variables.ml` *(new)*:

  New tests about unbound type variables; these errors highlight old behavior that hasn't changed, not new behavior.  One error has an indentation fix.

* `testsuite/tests/typing-modules/inclusion_errors.ml` *(new)*:

   New tests that confirm our changes to moregen and type equality (in `Ctype`), and our changes to manifest checking (in `Includecore`) do not change existing behavior.  The file has three sections:
   1. First, it checks that our new `Equality` exception is handled like `Unification` was previously.
   2. Second, it similarly checks that our new `Moregen` exception is handled like `Unification` was previously.
   3. Finally, tests for the new changes in `Includecore` that provide improved handling of the situation when manifests don't match (a manifest, also known as an equation, is the `s` in `type t = s = X | Y` or `type t = s`).

* `testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference` *(modified)*:

  In making "is more general than" errors consistent with "unify" errors, this test output has one more line at the end saying "Types for tag ``App` are incompatible".  This refers to the tag *two* errors before the message, not *one* more.  Changes to improve this error could (should?) be made, but are deferred to making changes that improve unify errors more generally.

* `testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference` *(modified)*:

  Reduced a lot of noise in this error message that was due to a `Unify` error escaping when a substitution failed due to constraints (`ctype.ml:1456-1459`, in `Ctype.subst`).

* `testsuite/tests/typing-poly/poly.ml` *(modified)*:

  Add one new test that confirms that we're maintaining more of an error trace, and reword one test to have clearer names

* `testsuite/tests/typing-poly/pr9603.ml` *(modified)*:

  There is a known bug with polymorphic methods where unifying with universal variables is over-aggressively forbidden.  This error message was cut short due to `Ctype.subst` no longer revealing that it uses unification internally; the previous text was not particularly helpful, but the new error text is not particularly more helpful, just shorter.

* `testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference` *(modified)*:

  Reduce the text in the error message that occurs when we cannot find interface files.  The error message didn't make sense before ("the type variable `'a` occurs inside [an expression without `'a`]") and still doesn't make sense now ("This expression has type `'b Pr3918b.vlist` but an expression was expected of type `'b Pr3918b.vlist`" – the same thing twice).

* `toplevel/byte/topdirs.ml` *(modified)*:

  Changed `Ctype.equal` to `Ctype.is_equal`; see `typing/ctype.ml` for details.

* `toplevel/genprintval.ml` *(modified)*:

  Changed `Ctype.moregeneral` to `Ctype.is_moregeneral`; see `typing/ctype.ml` for details.

* `typing/ctype.ml` *(modified)*:

  As in `ctype.mli`, we remove `Unification_trace`, moving it to `Errortrace` and improving it, and add several new exceptions.  `Unification_trace` was also bound locally as `Trace`; we do not preserve the synonym.  We also add some local exceptions, which we use to ensure that our handlers are not overbroad, and some local functions for creating the new `Escape` exception.
   
  We make some common changes, such as:
  + Bringing in `Errortrace`.
  + Changing which exceptions we raise and catch to use the new exception types: `Trace.scope_escape` becomes `scope_escape`, `Trace.(Unify [escape ...])` becomes `escape_exn ...`, etc.
  + Relatedly, we define a new `trace_exn` type, which allows us to specify which of the three trace exceptions (`Unify`, `Moregen`, or `Equality`) we should raise at runtime.  We switch all raises of `Unify` to use the associated `raise{_nil,1}_for` functions and, when we change `moregen` and `equal` to raise their new associated exceptions, use `raise{_nil,1}_for` as well.  The real win from defining this type, however, is that when we define wrappers around utility functions to rewrap their errors from bespoke errors to trace errors, we need define only one wrapper, rather than two or three (for instance, we define `occur_for` which wraps `occur`, and then can use both `occur_for Unify` and `occur_for Moregen`).
  + Replacing `try_expand_once` with `try_expand_safe` nearly everywhere, since the latter throws fewer exceptions.
  + We change the definition of `expand_head_opt` to be more consistent with the behavior of `expand_head`.
  + Replacing various occurrences of `unify_univar` with `link_univar`, since it throws a more specific exception (see below).
   
  In `subst`, we correctly forget type abbreviations, which fixes a bug.  Before, abbreviations which were tentatively expanded during a failed substitution would stick around.  Substitution can only fail like this because of strange type constraints.  We also swallow the unification trace during these failures, as the fact that substitution failed because of unification is an implementation detail; this shortens unhelpful error messages in a few places.
   
  The local function `unify_univar` becomes `link_univar`, and raises the new `Cannot_unify_universal_variables` exception instead of a generic `Unify` exception; `unify_univar` is still provided, raising the old exception.
   
  We define `equal_private`, a variant of `equal` that on failure tries again after looking through private types.
   
  We replace `equal_clty` with `equal_clsig`, which contains the only portion of the old `equal_clty` that we actually used.

* `typing/ctype.mli` *(modified)*:

  Remove `Unification_trace`, moving it to `Errortrace` and improving it, and add several new exceptions: `Equality` and `Moregen`, which behave like `Unification`; `Escape`; and `Matches_failure`.  We also improve the `Subtype` exception.
   
  On the value side, we continue to manage exceptions: first, we replace `try_expand_once` with the safer `try_expand_safe`, which can never raise `Escape` (formerly `Unify`).  More generally, we change `moregeneral`, `matches`, and `equal` to return `unit`, *raising an exception* on failure.  The old behavior is available through `is_moregeneral` and `is_equal` (we do not provide `does_match` as it wasn't necessary).
   
  Finally, we add `equal_private`, a type equality that can look inside private types; this is used in our changes to `Includecore`.

* `typing/errortrace.ml` *(new)*:

  A new module, replacing `Ctype.Unification_trace` (sometimes bound locally as `Trace`).  See `typing/ctype.ml` for more details.
   
  In our refactoring, we discovered that unification and moregen can both throw `Rec_occur`, and unification, moregen, and equality can all three throw `Escape`.  We don't quite see how moregen and equality can throw these exceptions – we expect these type-mutation–related errors to only show up during proper unification.  But we're not absolutely convinced those code paths will never fire.  Either a patch to remove those constructors demonstrating that this is safe, or a test case proving that they're necessary, would be a good item of future work.

* `typing/errortrace.mli` *(new)*:

  A new module, replacing `Ctype.Unification_trace` (sometimes bound locally as `Trace`).  See `typing/ctype.ml` for more details.

* `typing/includeclass.ml` *(modified)*:

  Two changes: (1) switch from `Printtyp.report_unification` to `Printtyp.report_error` with the appropriate trace format; (2) Add basic printing for the new equality-error cases `CM_Val_type_mismatch_eq` and `CM_Meth_type_mismatch_eq`.

* `typing/includecore.ml` *(modified)*:

  Improve the handling of mismatches of primitives, manifests, and private objects and variants.  This involves incorporating values of appropriate `Errortrace.t` types, as well as maintaining new structural information in this file.  For example, we now maintain the reason two primitives are not the same in a `primitive_mismatch` type that records the difference.  The function `type_manifest` is also moved much later in the file and simplified by having much of its contents factored out.

* `typing/includecore.mli` *(modified)*:

  Maintain extra structural information about mismatches of primitives, manifests, and private types.

* `typing/includemod.ml` *(modified)*:

  Save the information from the new `Includecore` errors, but don't print it yet.  We pack an `Includecore.value_mismatch` value into `Value_descriptions`, but then ignore it when pattern-matching.

* `typing/includemod.mli` *(modified)*:

  Save the information from the new `Includecore` errors in the `Value_descriptions` case.

* `typing/primitive.ml` *(modified)*:

  Equality functions used in `Includecore`; `equal_boxed_integer` comes from `lambda.ml`.

* `typing/primitive.mli` *(modified)*:

  Equality functions used in `Includecore`; `equal_boxed_integer` comes from `lambda.ml`.

* `typing/printtyp.ml` *(modified)*:

  Here is where we apply the printing change.  This is actually smaller than might otherwise be expected; the changes to printing are largely around making everything *more uniform*.  That said, there is certainly churn here, including noise from replacing `Trace` (i.e., `Ctype.Unification_trace`) with `Errortrace` everywhere.
   
  One big change is that we introduce the type `trace_format`, which configures trace printing, and provide one value of this type for each kind of trace: `unification : unification trace_format`, `equality : non_unification trace_format`, and `moregen : non_unification trace_format`.  In the end, the user will call `report_error unification`, `report_error equality`, or `report_error moregen` as necessary.
   
  Various functions are generalized by taking this extra parameter, in order to configure their behavior.  Other functions are generalized to support ordinary traces or subtyping traces (e.g. `prepare_any_trace`, which can handle both kinds, vs. `prepare_trace`, which is specialized to ordinary traces).
   
  The `print_pos` function moved to `Errortrace`, to be with the definition of the type.
   
  Most of the explanation functions retained their old behavior, but there is visual churn in the diff due to changing module names and indentation (the latter hopefully minimized, but occasionally unavoidable).
   
  The new outwards-facing entry point is principally `report_error`, which is designed to support all three major traces; similarly, we have `Subtyping.report_error` for subtyping traces.  The `Subtyping` module in general now holds all subtyping-trace–related code in order to use the same names and be self-contained.  Someday, I hope that we can unify it more fully.

* `typing/printtyp.mli` *(modified)*:

  Replace `report_unification_error` and `report_subtyping_error` with `report_error` and `Subtype.report_error`, respectively; the former is parameterized by a new `trace_format` type that controls which sort of trace (unification, equality, or moregen) to use.

* `typing/typeclass.ml` *(modified)*:

  Replace `Ctype.Unification_trace.t` with `Errortrace.unification Errortrace.t`, drop reference to `Ctype.Unification_trace`, replace `Printtyp.report` with `Printtyp.report_error`.  One error message got more of a printing box placed around it.

* `typing/typeclass.mli` *(modified)*:

  Replace `Ctype.Unification_trace.t` with `Errortrace.unification Errortrace.t` everywhere.

* `typing/typecore.ml` *(modified)*:

  Upgrade to the new errors: replace `Ctype.Unification_trace` with `Errortype`, replace `Printtyp.report_unification_error` with `Printtyp.report_error`, etc.

* `typing/typecore.mli` *(modified)*:

  Upgrade to the new errors: replace `Ctype.Unification_trace` with `Errortype`.

* `typing/typedecl.ml` *(modified)*:

  Upgrade to the new errors.  The new `Env.t` in the `Constraint_failed` case enables us to lose less information.  We also generally improve printing (in addition to the use of the new `Printtyp.report_error`): we fix the indentation of one error message by changing `@.` to `@ `, improve the printing in the `Constraint_failed` case (where we now have more information), and use more formatting boxen.

* `typing/typedecl.mli` *(modified)*:

  Upgrade to the new errors: replace `Ctype.Unification_trace.t` with `Errortype.t`.  Also, in the `Constraint_failed` case, replace a pair of `type_expr`s with an `Env.t` and an `Errortrace.t`.

* `typing/typedecl_variance.ml` *(modified)*:

  Change `Ctype.equal` to `Ctype.is_equal`; see `ctype.ml` for more information.

* `typing/typetexp.ml` *(modified)*:

  Replace `Ctype.Unification_trace` with `Errortrace`, `Ctype.equal` with `Ctype.is_equal`, and `Printtyp.report_unification_error` with `Printtyp.report_error`.

* `typing/typetexp.mli` *(modified)*:

  Replace `Ctype.Unification_trace.t` with the appropriate `Errortrace.t`
