### PR TITLE
Report status of the naked pointers checker in the process exit code

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,10 @@ Working version
 - #10136: Minor clean-ups in runtime/io.c and runtime/caml/io.h
   (Xavier Leroy, review by David Allsopp and Guillaume Munch-Maccagnoni)
 
+- #10171: Tweak the naked pointers checker so that processes which trigger the
+  alarm always exit with non-zero status (i.e. exit(0) becomes exit(70)).
+  (David Allsopp, review by Xavier Leroy)
+
 - #10188, #10213: Switch the default allocation policy to best-fit and adjust
   the default overhead parameter accordingly.
   (Damien Doligez, review by Josh Berdine and Xavier Leroy)

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -98,6 +98,10 @@ void caml_set_major_window (int);
 */
 void caml_finalise_heap (void);
 
+#ifdef NAKED_POINTERS_CHECKER
+extern int caml_naked_pointers_detected;
+#endif
+
 #endif /* CAML_INTERNALiS */
 
 #endif /* CAML_MAJOR_GC_H */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -127,6 +127,10 @@ double caml_gc_clock = 0.0;
 static unsigned long major_gc_counter = 0;
 #endif
 
+#ifdef NAKED_POINTERS_CHECKER
+int caml_naked_pointers_detected = 0;
+#endif
+
 void (*caml_major_gc_hook)(void) = NULL;
 
 /* This function prunes the mark stack if it's about to overflow. It does so
@@ -1163,6 +1167,7 @@ static void is_naked_pointer_safe (value v, value *p)
   if (Is_black_hd(h) && Wosize_hd(h) < (INT64_LITERAL(1) << 40))
     return;
 
+  caml_naked_pointers_detected = 1;
   if (!Is_black_hd(h)) {
     fprintf (stderr, "Out-of-heap pointer at %p of value %p has "
                      "non-black head (tag=%d)\n", p, (void*)v, t);
@@ -1175,6 +1180,7 @@ static void is_naked_pointer_safe (value v, value *p)
   return;
 
  on_segfault:
+  caml_naked_pointers_detected = 1;
   fprintf (stderr, "Out-of-heap pointer at %p of value %p. "
            "Cannot read head.\n", p, (void*)v);
 }

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -49,6 +49,7 @@
 #include "caml/debugger.h"
 #include "caml/fail.h"
 #include "caml/gc_ctrl.h"
+#include "caml/major_gc.h"
 #include "caml/io.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
@@ -159,6 +160,13 @@ CAMLprim value caml_sys_exit(value retcode_v)
     caml_shutdown();
 #ifdef _WIN32
   caml_restore_win32_terminal();
+#endif
+#ifdef NAKED_POINTERS_CHECKER
+  if (retcode == 0 && caml_naked_pointers_detected) {
+    fprintf (stderr, "\nOut-of-heap pointers were detected by the runtime.\n"
+                     "The process would otherwise have terminated normally.\n");
+    retcode = 70; /* EX_SOFTWARE; see sysexits.h */
+  }
 #endif
   exit(retcode);
 }


### PR DESCRIPTION
This is a proposal to tweak the `--enable-naked-pointers-checker` to allow it to be used in CI more easily.

With this PR, if any messages were displayed by the runtime, then `caml_sys_exit(0)` results in `exit(1)`. The idea is that the process is not permitted to shutdown "normally" if it tripped the test at any point.

Using the smoke test at https://github.com/dra27/naked:

```
dra27@summer:~/naked$ dune exec naked || echo "Exited with code $?"
The answer is 42
Out-of-heap pointer at 0x557f0610d518 of value 0x557f07d0cc00 has non-black head (tag=33)
Out-of-heap pointer at 0x557f0610d518 of value 0x557f07d0cc00 has non-black head (tag=33)
Out-of-heap pointer at 0x557f0610d518 of value 0x557f07d0cc00 has non-black head (tag=33)

Out-of-heap pointers were detected by the runtime.
The process would otherwise have terminated normally.
Exited with code 1
```

cc @avsm, @kit-ty-kate 