### PR TITLE
Fix the no-naked-pointers GitHub run on release tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: configure tree
-      run: ./configure --disable-naked-pointers --disable-stdlib-manpages
+      run: ./configure --disable-naked-pointers --disable-stdlib-manpages --disable-dependency-generation --enable-ocamltest
     - name: Build
       run: |
         make -j world.opt


### PR DESCRIPTION
The GitHub Actions runs for the 4.12 release tags have been failing, although unnoticed until it caused unnecessary stress for our release manager, @Octachron with today's!

The no-naked-pointers workflow predates the others - it's a very specific check which when multicore's merged will disappear. This PR reduces the time spent on that job with `--disable-dependency-generation` (present in the other jobs apart from the full-flambda job, where dependency generation is meant to be tested) and, more importantly, adds `--enable-ocamltest` so the future release tags will pass CI.

Running through CI just to make sure, and will then push to trunk and 4.12.