### PR TITLE
Make Tsubst directly retain two arguments, instead of nesting a Ttuple

### DIFF
--- a/.depend
+++ b/.depend
@@ -6284,6 +6284,8 @@ toplevel/trace.cmi : \
     typing/path.cmi \
     parsing/longident.cmi \
     typing/env.cmi
+toplevel/byte/topdirs.cmi : \
+    parsing/longident.cmi
 toplevel/byte/topeval.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
@@ -6363,11 +6365,20 @@ toplevel/byte/topeval.cmi : \
     typing/path.cmi \
     parsing/parsetree.cmi \
     typing/env.cmi
+toplevel/byte/toploop.cmi : \
+    utils/warnings.cmi \
+    typing/types.cmi \
+    typing/path.cmi \
+    parsing/parsetree.cmi \
+    typing/outcometree.cmi \
+    parsing/longident.cmi \
+    parsing/location.cmi \
+    typing/env.cmi
 toplevel/byte/topmain.cmo : \
     toplevel/byte/trace.cmi \
-    toplevel/toploop.cmi \
+    toplevel/byte/toploop.cmi \
     toplevel/byte/topeval.cmi \
-    toplevel/topdirs.cmi \
+    toplevel/byte/topdirs.cmi \
     toplevel/topcommon.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
@@ -6382,9 +6393,9 @@ toplevel/byte/topmain.cmo : \
     toplevel/byte/topmain.cmi
 toplevel/byte/topmain.cmx : \
     toplevel/byte/trace.cmx \
-    toplevel/toploop.cmx \
+    toplevel/byte/toploop.cmi \
     toplevel/byte/topeval.cmx \
-    toplevel/topdirs.cmx \
+    toplevel/byte/topdirs.cmi \
     toplevel/topcommon.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \

--- a/Changes
+++ b/Changes
@@ -75,7 +75,7 @@ Working version
   with respect to closing.
   (Xavier Leroy, report by Jacques-Henri Jourdan, review by Guillaume
    Munch-Maccagnoni, Gabriel Scherer, Jacques-Henri Jourdan)
-  
+
 - #10139: Remove confusing navigation bar from stdlib documentation.
   Removes the 'Up', 'Previous' and 'Next' links from the top of each standard
   library module's documentation.

--- a/Changes
+++ b/Changes
@@ -8,6 +8,12 @@ Working version
     'let* x = x in ...' and 'let%ext x = x in ...' respectively.
   (Stephen Dolan, review by Gabriel Scherer)
 
+### Type system:
+
+- #10174: Make Tsubst more robust by avoiding strange workarounds
+  (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer and
+   Florian Angeletti)
+
 ### Runtime system:
 
 - #9284: Add -config option to display the configuration of ocamlrun on stdout,

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -506,8 +506,8 @@ let remove_option typ =
     | Types.Tnil
     | Types.Tvariant _
     | Types.Tpackage _ -> t
-    | Types.Tlink t2
-    | Types.Tsubst (t2, _) -> iter t2.Types.desc
+    | Types.Tlink t2 -> iter t2.Types.desc
+    | Types.Tsubst _ -> assert false
   in
   Types.Private_type_expr.create (iter typ.Types.desc)
     ~level:typ.Types.level ~scope:typ.Types.scope ~id:typ.Types.id

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -507,7 +507,7 @@ let remove_option typ =
     | Types.Tvariant _
     | Types.Tpackage _ -> t
     | Types.Tlink t2
-    | Types.Tsubst t2 -> iter t2.Types.desc
+    | Types.Tsubst (t2, _) -> iter t2.Types.desc
   in
   Types.Private_type_expr.create (iter typ.Types.desc)
     ~level:typ.Types.level ~scope:typ.Types.scope ~id:typ.Types.id

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -32,7 +32,7 @@ let string_of_variance t (co,cn) =
 let rec is_arrow_type t =
   match t.Types.desc with
     Types.Tarrow _ -> true
-  | Types.Tlink t2 | Types.Tsubst t2 -> is_arrow_type t2
+  | Types.Tlink t2 | Types.Tsubst (t2, _) -> is_arrow_type t2
   | Types.Ttuple _
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
@@ -44,7 +44,7 @@ let raw_string_of_type_list sep type_list =
   let rec need_parent t =
     match t.Types.desc with
       Types.Tarrow _ | Types.Ttuple _ -> true
-    | Types.Tlink t2 | Types.Tsubst t2 -> need_parent t2
+    | Types.Tlink t2 | Types.Tsubst (t2, _) -> need_parent t2
     | Types.Tconstr _ ->
         false
     | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -45,11 +45,11 @@ let raw_string_of_type_list sep type_list =
   let rec need_parent t =
     match t.Types.desc with
       Types.Tarrow _ | Types.Ttuple _ -> true
-    | Types.Tlink t2 | Types.Tsubst (t2, _) -> need_parent t2
-    | Types.Tconstr _ ->
-        false
+    | Types.Tlink t2 -> need_parent t2
+    | Types.Tconstr _
     | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
     | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _ -> false
+    | Types.Tsubst _ -> assert false
   in
   let print_one_type variance t =
     Printtyp.mark_loops t;

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -32,11 +32,12 @@ let string_of_variance t (co,cn) =
 let rec is_arrow_type t =
   match t.Types.desc with
     Types.Tarrow _ -> true
-  | Types.Tlink t2 | Types.Tsubst (t2, _) -> is_arrow_type t2
+  | Types.Tlink t2 -> is_arrow_type t2
   | Types.Ttuple _
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
   | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _ -> false
+  | Types.Tsubst _ -> assert false
 
 let raw_string_of_type_list sep type_list =
   let buf = Buffer.create 256 in

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -76,8 +76,6 @@ let parameter_list_from_arrows typ =
       Types.Tarrow (l, t1, t2, _) ->
         (l, t1) :: (iter t2)
     | Types.Tlink texp
-    | Types.Tsubst (texp, _) ->
-        iter texp
     | Types.Tpoly (texp, _) -> iter texp
     | Types.Tvar _
     | Types.Ttuple _
@@ -89,6 +87,8 @@ let parameter_list_from_arrows typ =
     | Types.Tpackage _
     | Types.Tvariant _ ->
         []
+    | Types.Tsubst _ ->
+        assert false
   in
   iter typ
 

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -76,7 +76,7 @@ let parameter_list_from_arrows typ =
       Types.Tarrow (l, t1, t2, _) ->
         (l, t1) :: (iter t2)
     | Types.Tlink texp
-    | Types.Tsubst texp ->
+    | Types.Tsubst (texp, _) ->
         iter texp
     | Types.Tpoly (texp, _) -> iter texp
     | Types.Tvar _
@@ -115,7 +115,7 @@ let dummy_parameter_list typ =
               Odoc_parameter.sn_type = t ;
               Odoc_parameter.sn_text = None }
     | Types.Tlink t2
-    | Types.Tsubst t2 ->
+    | Types.Tsubst (t2, _) ->
         (iter (label, t2))
 
     | _ ->

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -114,10 +114,10 @@ let dummy_parameter_list typ =
             { Odoc_parameter.sn_name = normal_name label ;
               Odoc_parameter.sn_type = t ;
               Odoc_parameter.sn_text = None }
-    | Types.Tlink t2
-    | Types.Tsubst (t2, _) ->
+    | Types.Tlink t2 ->
         (iter (label, t2))
-
+    | Types.Tsubst _ ->
+        assert false
     | _ ->
         Odoc_parameter.Simple_name
           { Odoc_parameter.sn_name = normal_name label ;

--- a/testsuite/tests/typing-misc/filter_params.ml
+++ b/testsuite/tests/typing-misc/filter_params.ml
@@ -1,0 +1,8 @@
+(* TEST
+   * expect
+*)
+
+type ('a, 'b) t constraint 'a = 'b
+[%%expect{|
+type ('b, 'a) t constraint 'a = 'b
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -473,8 +473,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 find row.row_fields
           | Tobject (_, _) ->
               Oval_stuff "<obj>"
-          | Tsubst (ty, _) ->
-              tree_of_val (depth - 1) obj ty
+          | Tsubst _ ->
+              assert false
           | Tfield(_, _, _, _) | Tnil | Tlink _ ->
               fatal_error "Printval.outval_of_value"
           | Tpoly (ty, _) ->

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -473,7 +473,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 find row.row_fields
           | Tobject (_, _) ->
               Oval_stuff "<obj>"
-          | Tsubst ty ->
+          | Tsubst (ty, _) ->
               tree_of_val (depth - 1) obj ty
           | Tfield(_, _, _, _) | Tnil | Tlink _ ->
               fatal_error "Printval.outval_of_value"

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -473,9 +473,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 find row.row_fields
           | Tobject (_, _) ->
               Oval_stuff "<obj>"
-          | Tsubst _ ->
-              assert false
-          | Tfield(_, _, _, _) | Tnil | Tlink _ ->
+          | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ ->
               fatal_error "Printval.outval_of_value"
           | Tpoly (ty, _) ->
               tree_of_val (depth - 1) obj ty

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -300,7 +300,7 @@ let rec fold_row f init row =
 let iter_row f row =
   fold_row (fun () v -> f v) () row
 
-let fold_type_expr f init ty =
+let rec fold_type_expr f init ty =
   match ty.desc with
     Tvar _              -> init
   | Tarrow (_, ty1, ty2, _) ->
@@ -320,7 +320,7 @@ let fold_type_expr f init ty =
     let result = f init ty1 in
     f result ty2
   | Tnil                -> init
-  | Tlink ty            -> f init ty
+  | Tlink ty            -> fold_type_expr f init ty
   | Tsubst _            -> assert false
   | Tunivar _           -> init
   | Tpoly (ty, tyl)     ->

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -321,7 +321,7 @@ let fold_type_expr f init ty =
     f result ty2
   | Tnil                -> init
   | Tlink ty            -> f init ty
-  | Tsubst ty           -> f init ty
+  | Tsubst (ty, _)      -> f init ty
   | Tunivar _           -> init
   | Tpoly (ty, tyl)     ->
     let result = f init ty in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -321,8 +321,7 @@ let fold_type_expr f init ty =
     f result ty2
   | Tnil                -> init
   | Tlink ty            -> f init ty
-  | Tsubst (ty, None)   -> f init ty
-  | Tsubst (ty, Some ty') -> f (f init ty) ty'
+  | Tsubst _            -> assert false
   | Tunivar _           -> init
   | Tpoly (ty, tyl)     ->
     let result = f init ty in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -321,7 +321,8 @@ let fold_type_expr f init ty =
     f result ty2
   | Tnil                -> init
   | Tlink ty            -> f init ty
-  | Tsubst (ty, _)      -> f init ty
+  | Tsubst (ty, None)   -> f init ty
+  | Tsubst (ty, Some ty') -> f (f init ty) ty'
   | Tunivar _           -> init
   | Tpoly (ty, tyl)     ->
     let result = f init ty in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -487,15 +487,6 @@ let rec copy_kind = function
 let copy_commu c =
   if commu_repr c = Cok then Cok else Clink (ref Cunknown)
 
-(* Since univars may be used as row variables, we need to do some
-   encoding during substitution *)
-let rec norm_univar ty =
-  match ty.desc with
-    Tunivar _ | Tsubst _ -> ty
-  | Tlink ty           -> norm_univar ty
-  | Ttuple (ty :: _)   -> norm_univar ty
-  | _                  -> assert false
-
 let rec copy_type_desc ?(keep_names=false) f = function
     Tvar _ as ty        -> if keep_names then ty else Tvar None
   | Tarrow (p, ty1, ty2, c)-> Tarrow (p, f ty1, f ty2, copy_commu c)
@@ -512,7 +503,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
-      let tyl = List.map (fun x -> norm_univar (f x)) tyl in
+      let tyl = List.map f tyl in
       Tpoly (f ty, tyl)
   | Tpackage (p, n, l)  -> Tpackage (p, n, List.map f l)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1477,6 +1477,7 @@ let rec copy_sep cleanup_scope fixed free bound visited ty =
   end
 
 let instance_poly' cleanup_scope ~keep_names fixed univars sch =
+  (* In order to compute univars below, [sch] schould not contain [Tsubst] *)
   let univars = List.map repr univars in
   let copy_var ty =
     match ty.desc with
@@ -1498,7 +1499,6 @@ let instance_poly ?(keep_names=false) fixed univars sch =
 
 let instance_label fixed lbl =
   For_copy.with_scope (fun scope ->
-    let ty_res = copy scope lbl.lbl_res in
     let vars, ty_arg =
       match repr lbl.lbl_arg with
         {desc = Tpoly (ty, tl)} ->
@@ -1506,6 +1506,8 @@ let instance_label fixed lbl =
       | _ ->
           [], copy scope lbl.lbl_arg
     in
+    (* call [copy] after [instance_poly] to avoid introducing [Tsubst] *)
+    let ty_res = copy scope lbl.lbl_res in
     (vars, ty_arg, ty_res)
   )
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1449,8 +1449,10 @@ let rec copy_sep cleanup_scope fixed free bound visited ty =
       match ty.desc with
         Tarrow _ | Ttuple _ | Tvariant _ | Tconstr _ | Tobject _ | Tpackage _ ->
           (ty,(t,bound)) :: visited
-      | Tvar _ | Tfield _ | Tnil | Tpoly _ | Tunivar _ | Tlink _ | Tsubst _ ->
+      | Tvar _ | Tfield _ | Tnil | Tpoly _ | Tunivar _ ->
           visited
+      | Tlink _ | Tsubst _ ->
+          assert false
     in
     let copy_rec = copy_sep cleanup_scope fixed free bound visited in
     Private_type_expr.set_desc t

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -917,8 +917,7 @@ let rec mark_loops_rec visited ty =
     | Tfield(_, _, _, ty2) ->
         mark_loops_rec visited ty2
     | Tnil -> ()
-    | Tsubst (ty, None) -> mark_loops_rec visited ty
-    | Tsubst (_, Some _) -> ()
+    | Tsubst _ -> ()  (* we do not print arguments *)
     | Tlink _ -> fatal_error "Printtyp.mark_loops_rec (2)"
     | Tpoly (ty, tyl) ->
         List.iter (fun t -> add_alias t) tyl;
@@ -1025,10 +1024,7 @@ let rec tree_of_typexp sch ty =
         tree_of_typobject sch fi !nm
     | Tnil | Tfield _ ->
         tree_of_typobject sch ty None
-    | Tsubst (ty, None) ->
-        tree_of_typexp sch ty
-          (* See filter_params below *)
-    | Tsubst (_, Some _) ->
+    | Tsubst _ ->
         Otyp_stuff "<Tsubst>"
           (* This case should not happen *)
     | Tlink _ ->
@@ -1173,7 +1169,8 @@ let filter_params tyl =
         else ty :: tyl)
       (* Two parameters might be identical due to a constraint but we need to
          print them differently in order to make the output syntactically valid.
-         We use Tsubst because it does not appear in a valid type. *)
+         We use [Ttuple [ty]] because it is printed as [ty]. *)
+      (* Replacing fold_left by fold_right does not work! *)
       [] tyl
   in List.rev params
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -917,7 +917,7 @@ let rec mark_loops_rec visited ty =
     | Tfield(_, _, _, ty2) ->
         mark_loops_rec visited ty2
     | Tnil -> ()
-    | Tsubst (ty, _) -> mark_loops_rec visited ty
+    | Tsubst _ -> ()
     | Tlink _ -> fatal_error "Printtyp.mark_loops_rec (2)"
     | Tpoly (ty, tyl) ->
         List.iter (fun t -> add_alias t) tyl;
@@ -1024,8 +1024,8 @@ let rec tree_of_typexp sch ty =
         tree_of_typobject sch fi !nm
     | Tnil | Tfield _ ->
         tree_of_typobject sch ty None
-    | Tsubst (ty, _) ->
-        tree_of_typexp sch ty
+    | Tsubst _ ->
+        Otyp_stuff "<Tsubst>"
     | Tlink _ ->
         fatal_error "Printtyp.tree_of_typexp"
     | Tpoly (ty, []) ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -518,7 +518,9 @@ and raw_type_desc ppf = function
         raw_type t1 raw_type t2
   | Tnil -> fprintf ppf "Tnil"
   | Tlink t -> fprintf ppf "@[<1>Tlink@,%a@]" raw_type t
-  | Tsubst (t, _) -> fprintf ppf "@[<1>Tsubst@,%a@]" raw_type t
+  | Tsubst (t, None) -> fprintf ppf "@[<1>Tsubst@,(%a,None)@]" raw_type t
+  | Tsubst (t, Some t') ->
+      fprintf ppf "@[<1>Tsubst@,(%a,@ Some%a)@]" raw_type t raw_type t'
   | Tunivar name -> fprintf ppf "Tunivar %a" print_name name
   | Tpoly (t, tl) ->
       fprintf ppf "@[<hov1>Tpoly(@,%a,@,%a)@]"

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1025,8 +1025,8 @@ let rec tree_of_typexp sch ty =
     | Tnil | Tfield _ ->
         tree_of_typobject sch ty None
     | Tsubst _ ->
+        (* This case should only happen when debugging the compiler *)
         Otyp_stuff "<Tsubst>"
-          (* This case should not happen *)
     | Tlink _ ->
         fatal_error "Printtyp.tree_of_typexp"
     | Tpoly (ty, []) ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -518,7 +518,7 @@ and raw_type_desc ppf = function
         raw_type t1 raw_type t2
   | Tnil -> fprintf ppf "Tnil"
   | Tlink t -> fprintf ppf "@[<1>Tlink@,%a@]" raw_type t
-  | Tsubst t -> fprintf ppf "@[<1>Tsubst@,%a@]" raw_type t
+  | Tsubst (t, _) -> fprintf ppf "@[<1>Tsubst@,%a@]" raw_type t
   | Tunivar name -> fprintf ppf "Tunivar %a" print_name name
   | Tpoly (t, tl) ->
       fprintf ppf "@[<hov1>Tpoly(@,%a,@,%a)@]"
@@ -915,7 +915,7 @@ let rec mark_loops_rec visited ty =
     | Tfield(_, _, _, ty2) ->
         mark_loops_rec visited ty2
     | Tnil -> ()
-    | Tsubst ty -> mark_loops_rec visited ty
+    | Tsubst (ty, _) -> mark_loops_rec visited ty
     | Tlink _ -> fatal_error "Printtyp.mark_loops_rec (2)"
     | Tpoly (ty, tyl) ->
         List.iter (fun t -> add_alias t) tyl;
@@ -1022,7 +1022,7 @@ let rec tree_of_typexp sch ty =
         tree_of_typobject sch fi !nm
     | Tnil | Tfield _ ->
         tree_of_typobject sch ty None
-    | Tsubst ty ->
+    | Tsubst (ty, _) ->
         tree_of_typexp sch ty
     | Tlink _ ->
         fatal_error "Printtyp.tree_of_typexp"
@@ -1162,7 +1162,7 @@ let filter_params tyl =
     List.fold_left
       (fun tyl ty ->
         let ty = repr ty in
-        if List.memq ty tyl then Btype.newgenty (Tsubst ty) :: tyl
+        if List.memq ty tyl then Btype.newgenty (Tsubst (ty, None)) :: tyl
         else ty :: tyl)
       [] tyl
   in List.rev params

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1169,7 +1169,7 @@ let filter_params tyl =
     List.fold_left
       (fun tyl ty ->
         let ty = repr ty in
-        if List.memq ty tyl then Btype.newgenty (Tsubst (ty, None)) :: tyl
+        if List.memq ty tyl then Btype.newgenty (Ttuple [ty]) :: tyl
         else ty :: tyl)
       (* Two parameters might be identical due to a constraint but we need to
          print them differently in order to make the output syntactically valid.

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -94,8 +94,8 @@ let compute_variance env visited vari ty =
     | Tfield (_, _, ty1, ty2) ->
         compute_same ty1;
         compute_same ty2
-    | Tsubst (ty, _) ->
-        compute_same ty
+    | Tsubst _ ->
+        assert false
     | Tvariant row ->
         let row = Btype.row_repr row in
         List.iter

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -94,7 +94,7 @@ let compute_variance env visited vari ty =
     | Tfield (_, _, ty1, ty2) ->
         compute_same ty1;
         compute_same ty2
-    | Tsubst ty ->
+    | Tsubst (ty, _) ->
         compute_same ty
     | Tvariant row ->
         let row = Btype.row_repr row in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -34,7 +34,7 @@ and type_desc =
   | Tfield of string * field_kind * type_expr * type_expr
   | Tnil
   | Tlink of type_expr
-  | Tsubst of type_expr         (* for copying *)
+  | Tsubst of type_expr * type_expr option    (* for copying *)
   | Tvariant of row_desc
   | Tunivar of string option
   | Tpoly of type_expr * type_expr list

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -34,7 +34,7 @@ and type_desc =
   | Tfield of string * field_kind * type_expr * type_expr
   | Tnil
   | Tlink of type_expr
-  | Tsubst of type_expr * type_expr option    (* for copying *)
+  | Tsubst of type_expr * type_expr option
   | Tvariant of row_desc
   | Tunivar of string option
   | Tpoly of type_expr * type_expr list

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -108,7 +108,7 @@ and type_desc =
   | Tlink of type_expr
   (** Indirection used by unification engine. *)
 
-  | Tsubst of type_expr         (* for copying *)
+  | Tsubst of type_expr * type_expr option    (* for copying *)
   (** [Tsubst] is used temporarily to store information in low-level
       functions manipulating representation of types, such as
       instantiation or copy.

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -108,10 +108,13 @@ and type_desc =
   | Tlink of type_expr
   (** Indirection used by unification engine. *)
 
-  | Tsubst of type_expr * type_expr option    (* for copying *)
+  | Tsubst of type_expr * type_expr option
   (** [Tsubst] is used temporarily to store information in low-level
       functions manipulating representation of types, such as
       instantiation or copy.
+      The first argument contains a copy of the original node.
+      The second is available only when the first is the row variable of
+      a polymorphic variant.  It then contains a copy of the whole variant.
       This constructor should not appear outside of these cases. *)
 
   | Tvariant of row_desc


### PR DESCRIPTION
The constructor `Tsubst` of `type_desc` has only one `type_expr` as its argument while it needs two during a copy.
The two values are currently packed as a `Ttuple` and wrapped in an extra `type_expr` before they are fed to `Tsubst`.
This style looks quite ad-hoc, and moreover it turned out to be an obstacle in our (@garrigue and me) attempt to make
`type_expr` an abstract type.

This PR adds to `Tsubst` another argument of type `type_expr option` to eliminate that hackish use of `Ttuple`.