### PR TITLE
Seq.delay : (unit -> 'a t) -> 'a t

### DIFF
--- a/Changes
+++ b/Changes
@@ -137,6 +137,9 @@ Working version
 
 ### Standard library:
 
+- #10177: Seq.(delay : (unit -> 'a t) -> 'a t)
+  (Gabriel Scherer, review by Jeremy Yallop and François Pottier)
+
 - #14381: Add String.find_{first,last}_index, String.find_{first,last},
   String.[r]find_all.
   (Daniel Bünzli, review by Nicolás Ojeda Bär, Ali Caglayan and

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -29,6 +29,8 @@ let cons x next () = Cons (x, next)
 
 let singleton x () = Cons (x, empty)
 
+let delay delayed_seq () = delayed_seq () ()
+
 let rec append seq1 seq2 () =
   match seq1() with
   | Nil -> seq2()

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -434,6 +434,32 @@ val iterate : ('a -> 'a) -> 'a -> 'a t
 
     @since 4.14 *)
 
+val delay : (unit -> 'a t) -> 'a t
+(** [delay (fun () -> seq)] has the same elements as [seq], but the expression
+    [seq] is only evaluated when the first element is requested.
+
+   For example,
+   {[
+   let rec of_tree t =
+     match t with
+     | Leaf v -> Seq.return v
+     | Node(l, r) -> Seq.append (of_tree l) (of_tree r)
+   ]}
+   does not behave as expected, as it traverses its input tree strictly
+   even if the output sequence is not forced.
+
+   This function could instead be written as follows:
+   {[
+   let rec of_tree t =
+     Seq.delay @@ fun () ->
+     match t with
+     | Leaf v -> Seq.return v
+     | Node(l, r) -> Seq.append (of_tree l) (of_tree r)
+   ]}
+
+   @since 5.5
+*)
+
 (** {1 Transforming sequences} *)
 
 (** The functions in this section are lazy: that is, they return sequences

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -320,4 +320,14 @@ let () =
   assert (!!(Seq.(take 3 (map head matrix))) = [(0, 0); (0, 1); (0, 2)]);
   ()
 
+(* delay *)
+let () =
+  let do_not_force_too_much =
+    Seq.cons
+      (Seq.return ())
+      (Seq.delay @@ fun () -> Seq.return (assert false)) in
+  match Seq.concat do_not_force_too_much () with
+  | Seq.Nil -> assert false
+  | Seq.Cons ((), seq) -> ignore seq
+
 let () = print_endline "OK";;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1316,17 +1316,18 @@ and exhaust_single_row ext p ps n =
      best way to make a non-fragile distinction between "all As" and
      "at least one B".
   *)
-  List.to_seq [Some p; None] |> Seq.flat_map
-    (function
-      | Some p ->
-          let sub_witnesses = exhaust ext [ps] (n - 1) in
-          Seq.map (fun row -> p :: row) sub_witnesses
-      | None ->
-          (* note: calling [exhaust] recursively of p would
-             result in an infinite loop in the case n=1 *)
-          let p_witnesses = specialize_and_exhaust ext [[p]] 1 in
-          Seq.map (fun p_row -> p_row @ omegas (n - 1)) p_witnesses
-    )
+  let sub_witnesses =
+    exhaust ext [ps] (n - 1)
+    |> Seq.map (fun row -> p :: row)
+  in
+  let p_witnesses () =
+    let omega_row = omegas (n - 1) in
+    (* note: calling [exhaust] recursively of p would
+       result in an infinite loop in the case n=1 *)
+    specialize_and_exhaust ext [[p]] 1
+    |> Seq.map (fun p_row -> p_row @ omega_row)
+  in
+  Seq.append sub_witnesses (Seq.delay p_witnesses)
 
 and specialize_and_exhaust ext pss n =
   let pss = simplify_first_col pss in


### PR DESCRIPTION
Quoting the new docstring:

```ocaml
    [delay (fun () -> seq)] has the same elements as [seq], but the expression
    [seq] is only evaluated when the first element is requested.

   For example,
   {[
   let rec of_tree t =
     match t with
     | Leaf v -> Seq.return v
     | Node(l, r) -> Seq.append (of_tree l) (of_tree r)
   ]}
   does not behave as expected, as it traverses its input tree strictly
   even if the output sequence is not forced.
   This function could instead be written as follows:
   {[
   let rec of_tree t =
     Seq.delay @@ fun () ->
     match t with
     | Leaf v -> Seq.return v
     | Node(l, r) -> Seq.append (of_tree l) (of_tree r)
   ]}
```

**Edit**: a previous iteration of this PR also proposed `flatten`=>`concat` functions, now moved to a separate PR #10352.