### PR TITLE
Fix support of the LDFLAGS build variable

### DIFF
--- a/Changes
+++ b/Changes
@@ -136,7 +136,7 @@ Working version
 
 ### Build system:
 
-- #9191, #10091: take the LDFLAGS variable into account, except on
+- #9191, #10091, #10182: take the LDFLAGS variable into account, except on
   flexlink-using systems.
   (Gabriel Scherer, review by Sébastien Hinderer and David Allsopp,
    report by Ralph Seichter)

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -76,6 +76,8 @@ AS_HAS_DEBUG_PREFIX_MAP=@as_has_debug_prefix_map@
 # our own symbols):
 OC_LDFLAGS=@oc_ldflags@
 
+LDFLAGS?=@LDFLAGS@
+
 ### How to invoke the C preprocessor through the C compiler
 CPP=@CPP@
 


### PR DESCRIPTION
This is a continuation of the work started in #9191 and #10091.

With the current implementation, it is only possible to give a value to
`LDFLAGS` when runing make. Something like

```
./configure LDFLAGS=-L/foo/bar
```

is not possible (because the value given to LDFLAGS at configure time
is not stored in the build system as it should be, like for other such
variables).

Also, make rightly reports `LDFLAGS` to be undefined.

The present PR fixes this.