### PR TITLE
Consider that IPv6 is always enabled in Windows code

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,9 @@ Working version
   directory.
   (Nicolás Ojeda Bär, review by Gabriel Scherer and Xavier Leroy)
 
+- #10185: Consider that IPv6 is always enabled on Windows.
+  (Antonin Décimo, review by David Allsopp and Xavier Leroy)
+
 ### Tools:
 
 - #10139: Remove confusing navigation bar from stdlib documentation.

--- a/otherlibs/unix/socket.c
+++ b/otherlibs/unix/socket.c
@@ -27,8 +27,8 @@ int socket_domain_table[] = {
   PF_UNIX, PF_INET,
 #if defined(HAS_IPV6)
   PF_INET6
-#elif defined(PF_UNDEF)
-  PF_UNDEF
+#elif defined(PF_UNSPEC)
+  PF_UNSPEC
 #else
   0
 #endif

--- a/otherlibs/win32unix/socket.c
+++ b/otherlibs/win32unix/socket.c
@@ -20,6 +20,8 @@ int socket_domain_table[] = {
   PF_UNIX, PF_INET,
 #if defined(HAS_IPV6)
   PF_INET6
+#elif defined(PF_UNSPEC)
+  PF_UNSPEC
 #else
   0
 #endif

--- a/otherlibs/win32unix/socket.c
+++ b/otherlibs/win32unix/socket.c
@@ -17,14 +17,7 @@
 #include "unixsupport.h"
 
 int socket_domain_table[] = {
-  PF_UNIX, PF_INET,
-#if defined(HAS_IPV6)
-  PF_INET6
-#elif defined(PF_UNSPEC)
-  PF_UNSPEC
-#else
-  0
-#endif
+  PF_UNIX, PF_INET, PF_INET6
 };
 
 int socket_type_table[] = {
@@ -34,14 +27,6 @@ int socket_type_table[] = {
 CAMLprim value unix_socket(value cloexec, value domain, value type, value proto)
 {
   SOCKET s;
-
-  #ifndef HAS_IPV6
-  /* IPv6 requires WinSock2, we must raise an error on PF_INET6 */
-  if (Int_val(domain) >= sizeof(socket_domain_table)/sizeof(int)) {
-    win32_maperr(WSAEPFNOSUPPORT);
-    uerror("socket", Nothing);
-  }
-  #endif
 
   s = socket(socket_domain_table[Int_val(domain)],
                    socket_type_table[Int_val(type)],

--- a/otherlibs/win32unix/unixsupport.h
+++ b/otherlibs/win32unix/unixsupport.h
@@ -24,10 +24,8 @@
 #include <process.h>
 #include <sys/types.h>
 #include <winsock2.h>
-#ifdef HAS_IPV6
 #include <ws2tcpip.h>
 #include <wspiapi.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`HAS_IPV6` is hardcoded in the build system, support in Windows has been there for a long time, so we can unconditionally use IPv6.
