### PR TITLE
Factorise yet another small bit of the byte/native toplevels

### DIFF
--- a/.depend
+++ b/.depend
@@ -6120,7 +6120,6 @@ toplevel/genprintval.cmi : \
     typing/outcometree.cmi \
     typing/env.cmi
 toplevel/topcommon.cmo : \
-    typing/types.cmi \
     parsing/printast.cmi \
     typing/predef.cmi \
     parsing/pprintast.cmi \
@@ -6135,6 +6134,7 @@ toplevel/topcommon.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     parsing/lexer.cmi \
+    typing/ident.cmi \
     toplevel/genprintval.cmi \
     typing/env.cmi \
     bytecomp/dll.cmi \
@@ -6145,7 +6145,6 @@ toplevel/topcommon.cmo : \
     parsing/ast_helper.cmi \
     toplevel/topcommon.cmi
 toplevel/topcommon.cmx : \
-    typing/types.cmx \
     parsing/printast.cmx \
     typing/predef.cmx \
     parsing/pprintast.cmx \
@@ -6160,6 +6159,7 @@ toplevel/topcommon.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     parsing/lexer.cmx \
+    typing/ident.cmx \
     toplevel/genprintval.cmx \
     typing/env.cmx \
     bytecomp/dll.cmx \
@@ -6177,6 +6177,7 @@ toplevel/topcommon.cmi : \
     typing/outcometree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    typing/ident.cmi \
     toplevel/genprintval.cmi \
     typing/env.cmi
 toplevel/topdirs.cmo : \
@@ -6231,9 +6232,7 @@ toplevel/topdirs.cmi : \
     parsing/longident.cmi
 toplevel/topeval.cmi : \
     toplevel/topcommon.cmi \
-    typing/path.cmi \
-    parsing/parsetree.cmi \
-    typing/env.cmi
+    parsing/parsetree.cmi
 toplevel/toploop.cmo : \
     utils/warnings.cmi \
     typing/typetexp.cmi \
@@ -6301,7 +6300,6 @@ toplevel/byte/topeval.cmo : \
     bytecomp/printinstr.cmi \
     typing/predef.cmi \
     typing/persistent_env.cmi \
-    typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     bytecomp/opcodes.cmi \
@@ -6311,7 +6309,6 @@ toplevel/byte/topeval.cmo : \
     utils/load_path.cmi \
     typing/includemod.cmi \
     typing/ident.cmi \
-    toplevel/genprintval.cmi \
     typing/env.cmi \
     bytecomp/emitcode.cmi \
     bytecomp/dll.cmi \
@@ -6338,7 +6335,6 @@ toplevel/byte/topeval.cmx : \
     bytecomp/printinstr.cmx \
     typing/predef.cmx \
     typing/persistent_env.cmx \
-    typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     bytecomp/opcodes.cmx \
@@ -6348,7 +6344,6 @@ toplevel/byte/topeval.cmx : \
     utils/load_path.cmx \
     typing/includemod.cmx \
     typing/ident.cmx \
-    toplevel/genprintval.cmx \
     typing/env.cmx \
     bytecomp/emitcode.cmx \
     bytecomp/dll.cmx \
@@ -6361,9 +6356,7 @@ toplevel/byte/topeval.cmx : \
     toplevel/byte/topeval.cmi
 toplevel/byte/topeval.cmi : \
     toplevel/topcommon.cmi \
-    typing/path.cmi \
-    parsing/parsetree.cmi \
-    typing/env.cmi
+    parsing/parsetree.cmi
 toplevel/byte/topmain.cmo : \
     toplevel/byte/trace.cmi \
     toplevel/toploop.cmi \
@@ -6444,7 +6437,6 @@ toplevel/native/topeval.cmo : \
     typing/printtyp.cmi \
     lambda/printlambda.cmi \
     typing/predef.cmi \
-    typing/path.cmi \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     utils/misc.cmi \
@@ -6454,7 +6446,6 @@ toplevel/native/topeval.cmo : \
     typing/includemod.cmi \
     middle_end/flambda/import_approx.cmi \
     typing/ident.cmi \
-    toplevel/genprintval.cmi \
     middle_end/flambda/flambda_middle_end.cmi \
     typing/env.cmi \
     utils/config.cmi \
@@ -6483,7 +6474,6 @@ toplevel/native/topeval.cmx : \
     typing/printtyp.cmx \
     lambda/printlambda.cmx \
     typing/predef.cmx \
-    typing/path.cmx \
     parsing/parsetree.cmi \
     typing/outcometree.cmi \
     utils/misc.cmx \
@@ -6493,7 +6483,6 @@ toplevel/native/topeval.cmx : \
     typing/includemod.cmx \
     middle_end/flambda/import_approx.cmx \
     typing/ident.cmx \
-    toplevel/genprintval.cmx \
     middle_end/flambda/flambda_middle_end.cmx \
     typing/env.cmx \
     utils/config.cmx \
@@ -6510,9 +6499,7 @@ toplevel/native/topeval.cmx : \
     toplevel/native/topeval.cmi
 toplevel/native/topeval.cmi : \
     toplevel/topcommon.cmi \
-    typing/path.cmi \
-    parsing/parsetree.cmi \
-    typing/env.cmi
+    parsing/parsetree.cmi
 toplevel/native/topmain.cmo : \
     toplevel/toploop.cmi \
     toplevel/native/topeval.cmi \

--- a/Changes
+++ b/Changes
@@ -143,7 +143,7 @@ Working version
   to the implementation and the coercion.
   (Leandro Ostera, review by Gabriel Scherer and Thomas Refis)
 
-* #10061, #10078: remove library `ocamlopttoplevel`, remove modules
+* #10061, #10078, #10187: remove library `ocamlopttoplevel`, remove modules
   `Opttoploop`, `Opttopstart`, which are replaced by `Toploop` and `Topstart` in
   library `ocamltoplevel`, made available in native code.
 

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -10,5 +10,5 @@ Raised at f in file "//toplevel//", line 2, characters 11-26
 Called from g in file "//toplevel//", line 1, characters 11-15
 Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
 Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 114, characters 4-150
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-150
 

--- a/toplevel/topcommon.mli
+++ b/toplevel/topcommon.mli
@@ -66,7 +66,28 @@ val print_out_signature :
 val print_out_phrase :
   (formatter -> Outcometree.out_phrase -> unit) ref
 
-module type PRINTER = sig
+
+exception Undefined_global of string
+
+module type EVAL_BASE = sig
+
+  (* Return the value referred to by a base ident
+     @raise [Undefined_global] if not found *)
+  val eval_ident: Ident.t -> Obj.t
+
+end
+
+
+module MakeEvalPrinter (_ : EVAL_BASE) : sig
+
+  val eval_address: Env.address -> Obj.t
+    (* Used for printers *)
+
+  val eval_module_path: Env.t -> Path.t -> Obj.t
+  val eval_value_path: Env.t -> Path.t -> Obj.t
+  val eval_extension_path: Env.t -> Path.t -> Obj.t
+  val eval_class_path: Env.t -> Path.t -> Obj.t
+    (* Return the toplevel object referred to by the given path *)
 
   module Printer: Genprintval.S with type t = Obj.t
 
@@ -97,8 +118,6 @@ module type PRINTER = sig
 
 end
 
-module MakePrinter (P : Genprintval.S with type t = Obj.t):
-  PRINTER with module Printer = P
 
 (* Interface with toplevel directives *)
 

--- a/toplevel/topeval.mli
+++ b/toplevel/topeval.mli
@@ -40,18 +40,12 @@ val execute_phrase : bool -> formatter -> Parsetree.toplevel_phrase -> bool
            [use_file] prints the types and values of the results.
            [use_silently] does not print them.
            [mod_use_file] wrap the file contents into a module. *)
-val eval_module_path: Env.t -> Path.t -> Obj.t
-val eval_value_path: Env.t -> Path.t -> Obj.t
-val eval_extension_path: Env.t -> Path.t -> Obj.t
-val eval_class_path: Env.t -> Path.t -> Obj.t
-        (* Return the toplevel object referred to by the given path *)
-
-val eval_address: Env.address -> Obj.t
-        (* Used for printers *)
 
 val may_trace : bool ref
 
-include Topcommon.PRINTER with type Printer.t = Obj.t
+module EvalBase: Topcommon.EVAL_BASE
+
+include module type of Topcommon.MakeEvalPrinter(EvalBase)
 
 (* For topmain.ml. Maybe shouldn't be there *)
 val load_file : bool -> formatter -> string -> bool


### PR DESCRIPTION
It's actually even simpler this way!

Note that one small change in the interface was required: the function
Toploop.eval_address could raise a `Symtable.Error` for undefined globals. Since
that wouldn't make sense for the native toplevel, we define a specific exception
for this purpose. Hopefully no one was relying on this at so low-level.