### PR TITLE
Switch the default allocation policy to best-fit.

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,7 +41,7 @@ Working version
 
 - #10188: Switch the default allocation policy to best-fit and adjust the
   default overhead parameter accordingly.
-  (Damien Doligez, review by xxx)
+  (Damien Doligez, review by Josh Berdine and Xavier Leroy)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -39,6 +39,10 @@ Working version
 - #10136: Minor clean-ups in runtime/io.c and runtime/caml/io.h
   (Xavier Leroy, review by David Allsopp and Guillaume Munch-Maccagnoni)
 
+- #10188: Switch the default allocation policy to best-fit and adjust the
+  default overhead parameter accordingly.
+  (Damien Doligez, review by xxx)
+
 ### Code generation and optimizations:
 
 - #9876: do not cache the young_limit GC variable in a processor register.

--- a/man/ocamlrun.m
+++ b/man/ocamlrun.m
@@ -151,8 +151,7 @@ The initial size of the major heap (in words).
 .BR a \ (allocation_policy)
 The policy used for allocating in the OCaml heap.  Possible values
 are 0 for the next-fit policy, 1 for the first-fit
-policy, and 2 for the best-fit policy. Best-fit is still experimental,
-but probably the best of the three. The default is 0.
+policy, and 2 for the best-fit policy. The default is 2.
 See the Gc module documentation for details.
 .TP
 .BR s \ (minor_heap_size)

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -140,8 +140,7 @@ The following environment variables are also consulted:
   \item[a] ("allocation_policy")
     The policy used for allocating in the OCaml heap. Possible values
     are "0" for the next-fit policy, "1" for the first-fit
-    policy, and "2" for the best-fit policy. Best-fit is still experimental,
-    but probably the best of the three. The default is "0" (next-fit).
+    policy, and "2" for the best-fit policy. The default is "2" (best-fit).
     See the Gc module documentation for details.
   \item[s] ("minor_heap_size")  Size of the minor heap. (in words)
   \item[i] ("major_heap_increment")  Default size increment for the

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -240,7 +240,7 @@ typedef uint64_t uintnat;
 /* Default speed setting for the major GC.  The heap will grow until
    the dead objects and the free list represent this percentage of the
    total size of live objects. */
-#define Percent_free_def 80
+#define Percent_free_def 100
 
 /* Default setting for the compacter: 500%
    (i.e. trigger the compacter when 5/6 of the heap is free or garbage)

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -240,7 +240,7 @@ typedef uint64_t uintnat;
 /* Default speed setting for the major GC.  The heap will grow until
    the dead objects and the free list represent this percentage of the
    total size of live objects. */
-#define Percent_free_def 100
+#define Percent_free_def 120
 
 /* Default setting for the compacter: 500%
    (i.e. trigger the compacter when 5/6 of the heap is free or garbage)

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -1754,7 +1754,7 @@ enum {
   policy_best_fit = 2,
 };
 
-uintnat caml_allocation_policy = policy_next_fit;
+uintnat caml_allocation_policy = policy_best_fit;
 
 /********************* exported functions *****************************/
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -108,7 +108,7 @@ type control =
        percentage of the memory used for live data.
        The GC will work more (use more CPU time and collect
        blocks more eagerly) if [space_overhead] is smaller.
-       Default: 80. *)
+       Default: 100. *)
 
     mutable verbose : int;
     [@ocaml.deprecated_mutable "Use {(Gc.get()) with Gc.verbose = ...}"]
@@ -164,30 +164,23 @@ type control =
           memory than both next-fit and first-fit.
           (since OCaml 4.10)
 
-        The current default is next-fit, as the best-fit policy is new
-        and not yet widely tested. We expect best-fit to become the
-        default in the future.
+        The default is best-fit.
 
         On one example that was known to be bad for next-fit and first-fit,
         next-fit takes 28s using 855Mio of memory,
         first-fit takes 47s using 566Mio of memory,
         best-fit takes 27s using 545Mio of memory.
 
-        Note: When changing to a low-fragmentation policy, you may
-        need to augment the [space_overhead] setting, for example
-        using [100] instead of the default [80] which is tuned for
-        next-fit. Indeed, the difference in fragmentation behavior
-        means that different policies will have different proportion
-        of "wasted space" for a given program. Less fragmentation
-        means a smaller heap so, for the same amount of wasted space,
-        a higher proportion of wasted space. This makes the GC work
-        harder, unless you relax it by increasing [space_overhead].
+        Note: If you change to next-fit, you may need to reduce
+        the [space_overhead] setting, for example using [80] instead
+        of the default [100] which is tuned for best-fit. Otherwise,
+        your program will need more memory.
 
         Note: changing the allocation policy at run-time forces
         a heap compaction, which is a lengthy operation unless the
         heap is small (e.g. at the start of the program).
 
-        Default: 0.
+        Default: 2.
 
         @since 3.11.0 *)
 


### PR DESCRIPTION
Switching to best-fit avoids most compactions and makes the worst-case behavior **much** better than next-fit in terms of time and memory.

The code is now sufficiently well-tested (at Jane Street and by Coq, see https://github.com/coq/coq/pull/13040) so we can make the change with confidence.

