### PR TITLE
Fix #10189: Universal variables leaking through GADT equations

### DIFF
--- a/Changes
+++ b/Changes
@@ -171,6 +171,9 @@ Working version
 - #10166: Fix illegal permutation error reporting in module aliases.
   (Matthew Ryan, review by Florian Angeletti)
 
+- #10189: Universal variables leaking through GADT equations
+  (Jacques Garrigue, report by Leo White)
+
 OCaml 4.12.0
 ------------
 

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -31,3 +31,62 @@ let g (type a b) (y : (a,b) j t option) =
 [%%expect{|
 val g : ('a, 'b) j t option -> unit = <fun>
 |}]
+
+(* more examples by @lpw25 *)
+module M = struct
+  type a
+  type i = C of <m : 'c. 'c -> 'c >
+  type j = C of <m : 'c. 'c -> a >
+end
+type _ t = A : M.i t;;
+let f (y : M.j t) = match y with _ -> .;;
+[%%expect{|
+module M :
+  sig
+    type a
+    type i = C of < m : 'c. 'c -> 'c >
+    type j = C of < m : 'c. 'c -> a >
+  end
+type _ t = A : M.i t
+val f : M.j t -> 'a = <fun>
+|}]
+
+module M = struct
+  type a
+  type i = C of <m : 'c. 'c -> 'c -> 'c >
+  type j = C of <m : 'c. 'c -> a >
+end
+type _ t = A : M.i t;;
+let f (y : M.j t) = match y with _ -> .;;
+[%%expect{|
+module M :
+  sig
+    type a
+    type i = C of < m : 'c. 'c -> 'c -> 'c >
+    type j = C of < m : 'c. 'c -> a >
+  end
+type _ t = A : M.i t
+val f : M.j t -> 'a = <fun>
+|}]
+
+module M = struct
+  type 'a a
+  type i = C of <m : 'c. 'c -> 'c -> 'c >
+  type j = C of <m : 'c. 'c -> 'c a >
+end
+type _ t = A : M.i t;;
+let f (y : M.j t) = match y with _ -> .;;
+[%%expect{|
+module M :
+  sig
+    type 'a a
+    type i = C of < m : 'c. 'c -> 'c -> 'c >
+    type j = C of < m : 'c. 'c -> 'c a >
+  end
+type _ t = A : M.i t
+Line 7, characters 33-34:
+7 | let f (y : M.j t) = match y with _ -> .;;
+                                     ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: A
+|}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -32,6 +32,61 @@ let g (type a b) (y : (a,b) j t option) =
 val g : ('a, 'b) j t option -> unit = <fun>
 |}]
 
+module M = struct
+  type 'a d = D
+  type j = <m : 'c. 'c -> 'c d >
+end ;;
+let g (y : M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M : sig type 'a d = D type j = < m : 'c. 'c -> 'c d > end
+val g : M.j t option -> unit = <fun>
+|}]
+
+module M = struct
+  type 'a d
+  type j = <m : 'c. 'c -> 'c d >
+end ;;
+let g (y : M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M : sig type 'a d type j = < m : 'c. 'c -> 'c d > end
+Line 6, characters 2-20:
+6 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : M.j t option -> unit = <fun>
+|}]
+
+module M = struct
+  type e
+  type 'a d
+  type i = <m : 'c. 'c -> 'c d >
+  type j = <m : 'c. 'c -> e >
+end ;;
+type _ t = A : M.i t
+let g (y : M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M :
+  sig
+    type e
+    type 'a d
+    type i = < m : 'c. 'c -> 'c d >
+    type j = < m : 'c. 'c -> e >
+  end
+type _ t = A : M.i t
+Line 9, characters 2-20:
+9 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : M.j t option -> unit = <fun>
+|}]
+
 (* more examples by @lpw25 *)
 module M = struct
   type a

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -1,0 +1,27 @@
+(* TEST
+   * expect
+*)
+
+type i = <m : 'c. 'c -> 'c >
+type ('a, 'b) j = <m : 'c. 'a -> 'b >
+type _ t = A : i t;;
+[%%expect{|
+type i = < m : 'c. 'c -> 'c >
+type ('a, 'b) j = < m : 'a -> 'b >
+type _ t = A : i t
+|}]
+
+let f (type a b) (y : (a, b) j t) : a -> b =
+  let A = y in fun x -> x;;
+[%%expect{|
+Line 2, characters 6-7:
+2 |   let A = y in fun x -> x;;
+          ^
+Error: This pattern matches values of type i t
+       but a pattern was expected which matches values of type (a, b) j t
+       Type i = < m : 'c. 'c -> 'c > is not compatible with type
+         (a, b) j = < m : a -> b >
+       The method m has type 'c. 'c -> 'c, but the expected method type was
+       a -> b
+       The universal variable 'c would escape its scope
+|}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -104,6 +104,30 @@ module M :
     type 'a j = < m : 'c. 'c -> 'a >
   end
 type _ t = A : M.i t
+Line 9, characters 2-20:
+9 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : 'a M.j t option -> unit = <fun>
+|}, Principal{|
+module M :
+  sig
+    type 'a d
+    type i = < m : 'c. 'c -> 'c d >
+    type 'a j = < m : 'c. 'c -> 'a >
+  end
+type _ t = A : M.i t
+File "_none_", line 1:
+Warning 18 [not-principal]: typing this pattern requires considering $0 and 'c M.d as equal.
+But the knowledge of these types is not principal.
+Line 9, characters 2-20:
+9 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
 val g : 'a M.j t option -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -25,3 +25,9 @@ Error: This pattern matches values of type i t
        a -> b
        The universal variable 'c would escape its scope
 |}]
+
+let g (type a b) (y : (a,b) j t option) =
+  let None = y in () ;;
+[%%expect{|
+val g : ('a, 'b) j t option -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -87,6 +87,26 @@ Some A
 val g : M.j t option -> unit = <fun>
 |}]
 
+module M = struct
+  type 'a d
+  type i = <m : 'c. 'c -> 'c d >
+  type 'a j = <m : 'c. 'c -> 'a >
+end ;;
+type _ t = A : M.i t
+(* Should warn *)
+let g (y : 'a M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M :
+  sig
+    type 'a d
+    type i = < m : 'c. 'c -> 'c d >
+    type 'a j = < m : 'c. 'c -> 'a >
+  end
+type _ t = A : M.i t
+val g : 'a M.j t option -> unit = <fun>
+|}]
+
 (* more examples by @lpw25 *)
 module M = struct
   type a

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2441,8 +2441,8 @@ let find_expansion_scope env path =
 let add_gadt_equation env source destination =
   (* Format.eprintf "@[add_gadt_equation %s %a@]@."
     (Path.name source) !Btype.print_raw destination; *)
+  occur_univar !env destination;
   if local_non_recursive_abbrev !env source destination then begin
-    occur_univar !env destination;
     let destination = duplicate_type destination in
     let expansion_scope =
       max (Path.scope source) (get_gadt_equations_level ())

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2589,10 +2589,10 @@ let unify3_var env t1' t2 t2' =
     occur_univar !env t2;
     link_type t1' t2;
   with Unify _ when !umode = Pattern ->
+    reify env t1';
+    reify env t2';
     if can_generate_equations () then begin
       occur_univar ~inj_only:true !env t2';
-      reify env t1';
-      reify env t2';
       record_equation t1' t2';
     end
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2446,7 +2446,9 @@ let find_expansion_scope env path =
 let add_gadt_equation env source destination =
   (* Format.eprintf "@[add_gadt_equation %s %a@]@."
     (Path.name source) !Btype.print_raw destination; *)
-  occur_univar !env destination;
+  let univar_leaks =
+    try occur_univar !env destination; false with Unify _ -> true in
+  if univar_leaks then occur_univar ~must_occur:true !env destination else
   if local_non_recursive_abbrev !env source destination then begin
     let destination = duplicate_type destination in
     let expansion_scope =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3068,8 +3068,7 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
       (* PR#6744 *)
       let split_univars =
         List.partition
-          (fun ty ->
-            try occur_univar !env ty; true with Unify _ -> false) in
+          (fun ty -> try occur_univar !env ty; true with Unify _ -> false) in
       let (tl1',tlu1) = split_univars tl1'
       and (tl2',tlu2) = split_univars tl2' in
       begin match tlu1, tlu2 with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2442,6 +2442,7 @@ let add_gadt_equation env source destination =
   (* Format.eprintf "@[add_gadt_equation %s %a@]@."
     (Path.name source) !Btype.print_raw destination; *)
   if local_non_recursive_abbrev !env source destination then begin
+    occur_univar !env destination;
     let destination = duplicate_type destination in
     let expansion_scope =
       max (Path.scope source) (get_gadt_equations_level ())


### PR DESCRIPTION
Fix #10189 by checking for leaking univars before adding an equation to the environment.