### PR TITLE
Better compaction heuristic

### DIFF
--- a/Changes
+++ b/Changes
@@ -88,6 +88,11 @@ Working version
   experimental.
   (Nicolás Ojeda Bär, review by David Allsopp)
 
+- #10194: Change compaction-triggering heuristic: use the overhead measured
+  by the previous GC cycle instead of an indirect (and noisy) computation
+  of the current overhead.
+  (Damien Doligez, review by Stephen Dolan)
+
 ### Code generation and optimizations:
 
 - #9876: do not cache the young_limit GC variable in a processor register.

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-4.13.0+dev0-2020-10-19
+4.13.0+dev1+compact-study
 
 # The version string is the first line of this file.
 # It must be in the format described in stdlib/sys.mli

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-4.13.0+dev1+compact-study
+4.13.0+dev0-2020-10-19
 
 # The version string is the first line of this file.
 # It must be in the format described in stdlib/sys.mli

--- a/runtime/caml/compact.h
+++ b/runtime/caml/compact.h
@@ -28,7 +28,7 @@
 */
 void caml_compact_heap (intnat new_allocation_policy);
 
-void caml_compact_heap_maybe (void);
+void caml_compact_heap_maybe (double previous_overhead);
 void caml_invert_root (value v, value *p);
 
 #endif /* CAML_INTERNALS */

--- a/runtime/compact.c
+++ b/runtime/compact.c
@@ -514,9 +514,8 @@ void caml_compact_heap_maybe (void)
                             ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                      (uintnat) fp);
     if (fp >= caml_percent_max)
-         caml_compact_heap (-1);
+      caml_compact_heap (-1);
     else
-         caml_gc_message (0x200, "Automatic compaction aborted.\n");
-
+      caml_gc_message (0x200, "Automatic compaction aborted.\n");
   }
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -950,6 +950,8 @@ void caml_major_collection_slice (intnat howmuch)
   }
 
   if (caml_gc_phase == Phase_idle){
+    double previous_overhead; // overhead at the end of the previous cycle
+
     CAML_EV_BEGIN(EV_MAJOR_CHECK_AND_COMPACT);
     caml_gc_message (0x200, "marked words = %"
                      ARCH_INTNAT_PRINTF_FORMAT "u words\n",
@@ -958,13 +960,15 @@ void caml_major_collection_slice (intnat howmuch)
                      ARCH_INTNAT_PRINTF_FORMAT "u words\n",
                      heap_wsz_at_cycle_start);
     if (marked_words == 0){
-      caml_gc_message (0x200, "actual overhead at start of cycle = +inf\n");
+      previous_overhead = 1000000.;
+      caml_gc_message (0x200, "overhead at start of cycle = +inf\n");
     }else{
-      caml_gc_message (0x200, "actual overhead at start of cycle = %.0f%%\n",
-                       100.0 * (heap_wsz_at_cycle_start - marked_words)
-                       / marked_words);
+      previous_overhead =
+        100.0 * (heap_wsz_at_cycle_start - marked_words) / marked_words;
+      caml_gc_message (0x200, "overhead at start of cycle = %.0f%%\n",
+                       previous_overhead);
     }
-    caml_compact_heap_maybe ();
+    caml_compact_heap_maybe (previous_overhead);
     CAML_EV_END(EV_MAJOR_CHECK_AND_COMPACT);
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -960,7 +960,7 @@ void caml_major_collection_slice (intnat howmuch)
     if (marked_words == 0){
       caml_gc_message (0x200, "actual overhead at start of cycle = +inf\n");
     }else{
-      caml_gc_message (0x200, "actual overhead at start of cycle = %.2g%%\n",
+      caml_gc_message (0x200, "actual overhead at start of cycle = %.0f%%\n",
                        100.0 * (heap_wsz_at_cycle_start - marked_words)
                        / marked_words);
     }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -382,9 +382,9 @@ static void start_cycle (void)
   CAMLassert (Caml_state->mark_stack->count == 0);
   CAMLassert (redarken_first_chunk == NULL);
   caml_gc_message (0x01, "Starting new major GC cycle\n");
+  marked_words = 0;
   caml_darken_all_roots_start ();
   caml_gc_phase = Phase_mark;
-  marked_words = 0;
   heap_wsz_at_cycle_start = Caml_state->stat_heap_wsz;
   caml_gc_subphase = Subphase_mark_roots;
   ephe_list_pure = 1;


### PR DESCRIPTION
Compaction is triggered when the current memory overhead becomes too large. This can happen in two cases:
* when fragmentation makes a lot of memory unallocatable
* when the live data has shrunk a lot
In both cases, compacting the heap is a good idea.

Currently, we trigger the compaction based on an indirect computation of the overhead. In practice, this computation is noisy and the estimate is often way off. In this case, the `compact_heap_maybe` function will force a nonincremental major GC (a necessary  first step for compaction) then get the actual overhead (easy to measure because the heap is now clean) and notice that the actual overhead is much lower than the estimate, and will give up on the compaction.

A better estimate of the overhead leads to fewer of these spurious major collections.

In this PR, our better estimate is simply a precise measurement of the overhead at the end of the previous cycle.

How much better is it? That depends on your program, of course. Here are the results from a few entries of the sandmark suite. On the left the old estimate: a plot of the actual overhead (y-axis) against the estimate (x-axis); on the right the new estimate: a plot of the current overhead (y-axis) against the previous cycle's overhead (x-axis). The closer to the diagonal, the better.

Note that this is comparing the two estimates, but the program is still using the old one.

We start with well-behaved programs:

* coq
![coqc-abstract](https://user-images.githubusercontent.com/19104/106744386-fc6db680-661f-11eb-8a76-0afd7f52e7db.jpg)
Note the outliers on the x=5000 line: they are actually at 1 million and were clipped to make the graph readable. In these cases, the estimated value is infinite.
* cubicle 
![cubicle-szymanski](https://user-images.githubusercontent.com/19104/106744734-6ede9680-6620-11eb-9dc5-0d428586726e.jpg)
In this case, compaction is never triggered. Nevertheless, the new estimate looks much better.

We also have some programs with a less-standard use of memory:
* levinson-durbin 
![levinson_durbin](https://user-images.githubusercontent.com/19104/106750311-fc71b480-6627-11eb-922e-ed441727ef71.jpg)
This is numerical computation. The allocation pattern is quite different from coq or cubicle. The old estimate is always wrong: lots of points are estimated at 0 when the actual overhead is more than 1000 and would justify a compaction, while some estimates are at 1000000 (again, clipped at 5000) while the actual overhead is low. The new estimate is not perfect but still much better than the old.
* pidigits5 
![pidigits5](https://user-images.githubusercontent.com/19104/106750481-304cda00-6628-11eb-9e4c-e7dff9ef7ac4.jpg)
This is mostly out-of-heap data (zarith) and nothing in the heap. This program has unusual behavior: it alternates between major GC and compaction, which explains the strange shape of the graph on the right. The new estimate looks better, but doesn't necessarily behave much better.
