### PR TITLE
Speed up GC by prefetching during marking

### DIFF
--- a/Changes
+++ b/Changes
@@ -177,6 +177,10 @@ OCaml 4.13.0
   platforms without AFL support.
   (David Allsopp, review by Xavier Leroy)
 
+- #10195: Speed up GC by prefetching during marking
+  (Stephen Dolan, review by Xavier Leroy, Guillaume Munch-Maccagnoni,
+   Jacques-Henri Jourdan and Damien Doligez)
+
 * #10098: Improve command-line parsing in ocamlrun: strictly recognise options,
   be more informative for `ocamlrun -I` and support `--` for terminating options
   parsing.

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -21,21 +21,28 @@
 #include "freelist.h"
 #include "misc.h"
 
+/* An interval of a single object to be scanned.
+   The end pointer must always be one-past-the-end of a heap block,
+   but the start pointer is not necessarily the start of the block */
+typedef struct {
+  value* start;
+  value* end;
+} mark_entry;
+
 typedef struct {
   void *block;           /* address of the malloced block this chunk lives in */
   asize_t alloc;         /* in bytes, used for compaction */
   asize_t size;          /* in bytes */
   char *next;
-  value* redarken_start;  /* first block in chunk to redarken */
-  value* redarken_end;    /* last block in chunk that needs redarkening */
+  mark_entry redarken_first;  /* first block in chunk to redarken */
+  value* redarken_end;        /* end of last block in chunk that needs redarkening */
 } heap_chunk_head;
 
-#define Chunk_size(c) (((heap_chunk_head *) (c)) [-1]).size
-#define Chunk_alloc(c) (((heap_chunk_head *) (c)) [-1]).alloc
-#define Chunk_next(c) (((heap_chunk_head *) (c)) [-1]).next
-#define Chunk_block(c) (((heap_chunk_head *) (c)) [-1]).block
-#define Chunk_redarken_start(c) (((heap_chunk_head *) (c)) [-1]).redarken_start
-#define Chunk_redarken_end(c) (((heap_chunk_head *) (c)) [-1]).redarken_end
+#define Chunk_head(c) (((heap_chunk_head *) (c)) - 1)
+#define Chunk_size(c) Chunk_head(c)->size
+#define Chunk_alloc(c) Chunk_head(c)->alloc
+#define Chunk_next(c) Chunk_head(c)->next
+#define Chunk_block(c) Chunk_head(c)->block
 
 extern int caml_gc_phase;
 extern int caml_gc_subphase;

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -35,7 +35,7 @@ typedef struct {
   asize_t size;          /* in bytes */
   char *next;
   mark_entry redarken_first;  /* first block in chunk to redarken */
-  value* redarken_end;        /* end of last block in chunk that needs redarkening */
+  value* redarken_end;        /* end of last block that needs redarkening */
 } heap_chunk_head;
 
 #define Chunk_head(c) (((heap_chunk_head *) (c)) - 1)

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -35,7 +35,7 @@ typedef struct {
   asize_t size;          /* in bytes */
   char *next;
   mark_entry redarken_first;  /* first block in chunk to redarken */
-  value* redarken_end;        /* end of last block that needs redarkening */
+  value* redarken_end;     /* one-past-end of last block for redarkening */
 } heap_chunk_head;
 
 #define Chunk_head(c) (((heap_chunk_head *) (c)) - 1)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -74,6 +74,15 @@ CAMLdeprecated_typedef(addr, char *);
   #define Noreturn
 #endif
 
+/* Manually preventing inlining */
+#if defined(__GNUC__)
+  #define CAMLnoinline __attribute__ ((noinline))
+#elif defined(_MSC_VER)
+  #define CAMLnoinline __declspec(noinline)
+#else
+  #define CAMLnoinline
+#endif
+
 /* Export control (to mark primitives and to handle Windows DLL) */
 
 #ifndef CAMLDLLIMPORT

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -76,11 +76,11 @@ CAMLdeprecated_typedef(addr, char *);
 
 /* Manually preventing inlining */
 #if defined(__GNUC__)
-  #define CAMLnoinline __attribute__ ((noinline))
+  #define Caml_noinline __attribute__ ((noinline))
 #elif defined(_MSC_VER)
-  #define CAMLnoinline __declspec(noinline)
+  #define Caml_noinline __declspec(noinline)
 #else
-  #define CAMLnoinline
+  #define Caml_noinline
 #endif
 
 /* Export control (to mark primitives and to handle Windows DLL) */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -719,6 +719,11 @@ Caml_noinline static intnat do_some_marking
         prefetch_block(v);
         pb[(pb_enqueued++) & Pb_mask] = v;
       }
+#if defined(NAKED_POINTERS_CHECKER) && defined(NATIVE_CODE)
+      else if (Is_block_and_not_young (v) && !Is_in_heap (v)){
+        is_naked_pointer_safe (v, scan);
+      }
+#endif
     }
 
     if (scan < obj_end) {
@@ -743,7 +748,7 @@ Caml_noinline static intnat do_some_marking
   CAMLassert(pb_enqueued == pb_dequeued);
   *Caml_state->mark_stack = stk;
   if (darkened_anything)
-    ephe_list_pure = 0;
+    caml_ephe_list_pure = 0;
 #ifdef CAML_INSTR
   *pslice_fields += slice_fields;
   *pslice_pointers += slice_pointers;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -346,10 +346,12 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
   heap_chunk_head* chunk = Chunk_head(heap_chunk);
   mark_entry me = chunk->redarken_first;
   header_t* end = (header_t*)chunk->redarken_end;
+  if (chunk->redarken_end <= me.start) return 1;
+
   while (1) {
     header_t* hp;
     /* Skip a prefix of fields that need no marking */
-    CAMLassert(me.start <= me.end);
+    CAMLassert(me.start <= me.end && (header_t*)me.end <= end);
     while (me.start < me.end &&
            (!Is_block(*me.start) || Is_young(*me.start))) {
       me.start++;
@@ -369,6 +371,7 @@ static int redarken_chunk(char* heap_chunk, struct mark_stack* stk) {
 
     /* Find the next block that needs to be re-marked */
     hp = (header_t*)me.end;
+    CAMLassert(hp <= end);
     while (hp < end) {
       value v = Val_hp(hp);
       if (Tag_val(v) < No_scan_tag && Is_black_val(v))

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -633,7 +633,7 @@ Caml_noinline static intnat do_some_marking
   uintnat half_young_len =
     ((uintnat)Caml_state->young_end - (uintnat)Caml_state->young_start) >> 1;
 #define Is_block_and_not_young(v) \
-  (((intnat)rotate1((uintnat)v - young_start)) > (intnat)half_young_len)
+  (((intnat)rotate1((uintnat)v - young_start)) >= (intnat)half_young_len)
 #ifdef NO_NAKED_POINTERS
   #define Is_major_block(v) Is_block_and_not_young(v)
 #else

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -625,7 +625,8 @@ Caml_noinline static intnat do_some_marking(intnat work)
      so that they can be stored in registers */
   struct mark_stack stk = *Caml_state->mark_stack;
   uintnat young_start = (uintnat)Val_hp(Caml_state->young_start);
-  uintnat half_young_len = ((uintnat)Caml_state->young_end - (uintnat)Caml_state->young_start) >> 1;
+  uintnat half_young_len =
+    ((uintnat)Caml_state->young_end - (uintnat)Caml_state->young_start) >> 1;
 #define Is_block_and_not_young(v) \
   (((intnat)rotate1((uintnat)v - young_start)) > (intnat)half_young_len)
 #ifdef NO_NAKED_POINTERS


### PR DESCRIPTION
This PR rewrites the core marking loop of the major GC, using prefetching to make better use of the processor's memory parallelism. This removes essentially all of the cache misses that occur during marking, speeding up GC.

On [a microbenchmark with about 800MB of heap](https://gist.github.com/stedolan/4369a0fa27820e27d6e56bee5e412896), the time for a `Gc.full_major` improves from about 1.8 seconds to 0.5 seconds.

Of course, most programs don't spend 100% of their time in GC, so improvements are not generally this dramatic. On the few programs it's been tested on, marking time is reduced by 1/3 - 2/3, leading to overall performance improvements of anywhere around 5-20%, depending on how much GC the program does. (More benchmarking is needed!)

I only expect to see any improvements on programs where the heap is much bigger than the cache. Programs that use less than a few tens of megabytes are unlikely to be improved much by this patch, although they shouldn't get slower.

### Algorithm

The current marking algorithm is a pure depth-first-search: marking always proceeds with the object on top of the mark stack, and new blocks are pushed to the stack as they are found. Since the objects are unlikely to be in cache, the GC spends much of its time stalling on cache misses as it waits for the header of a new object to be loaded.

The algorithm in this PR uses a small (currently 256-entry) circular buffer as a queue in front of the mark stack, known as the _prefetch buffer_. During marking, the next object to be scanned is drawn from the prefetch buffer (if it has at least `Pb_min` elements), or popped from the mark stack if the prefetch buffer is empty or close to empty. When new pointers are discovered during marking, these are prefetched and enqueued in the prefetch buffer rather than being followed immediately. Blocks are only pushed to the mark stack when the prefetch buffer overflows.

This ensures that new objects scanned have generally been prefetched at least `Pb_min` steps ago, which means they are very likely to already be in cache.

### Mark stack changes

This PR also contains a small change to the mark stack structure. It can already contain intervals, to indicate that an object is partially scanned, but those intervals are represented by a `(value, offset)` pair. This patch changes that to a `(start, end)` pair, where `start = value + offset` and `end = value + Wosize_val(value)`. This saves a cache miss in determining `Wosize_val(value)` when traversing the tail end of a long array.

### Configuration parameters

The testing and benchmarking of this patch has been done on Intel x86_64 processors with a non-default configuration:
```
./configure --disable-naked-pointers CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'
```

The patch should work with naked pointers enabled, although no optimisation work has been done in this configuration and I expect performance to be much worse. 

The `-mbranches-within-32B` option is a workaround for a bug in most recent Intel processors, the [Intel JCC Erratum](https://www.intel.co.uk/content/www/uk/en/support/articles/000055650/processors.html). Intel's microcode workaround for this bug introduces a performance issue in instruction decoding when branch instructions straddle 32-byte boundaries. Most programs are not seriously affected by this as instruction decoding is rarely the bottleneck. However, as the prefetching GC loop generally hits cache, instructions execute quickly (approx 2.9 of them per cycle) and it is possible to become performance-bound by decoding. On the `markbench.ml` microbenchmark above, removing the `-mbranches-within-32B` option had a cost of up to 20%. (The numbers for trunk use the same configuration, although it is not as strongly affected).

(We should perhaps consider enabling `-mbranches-within-32B` by default. It has a 1-2% code size penalty and a performance improvement that's usually irrelevant and occasionally dramatic. It's annoying to ask AMD users to pay the code size penalty for Intel's mistake, though).

### Remaining work

  - **Code cleanup** There's some commented out test / debug code in this patch, and not much commenting otherwise. It needs some cleanup before merging, but this version should be good for initial discussion / testing.
  - **Benchmarking** This has not yet been benchmarked on interestingly-large programs.
  - **Forward_tag optimisation** This patch does not currently implement the Forward_tag lazy short-circuiting optimisation, which is somewhat tricky to fit with the prefetching style. Very preliminary testing has suggested that this optimisation might not be very important, as most lazy values seem to be forced early (and so caught by the _minor_ GC's short-circuiting) or not forced at all. More benchmarking is needed, either to show that this optimisation doesn't matter much or to show that it can be implemented efficiently.

---

_[The design and initial implementation of this patch was in collaboration with Will Hasenplaugh, remaining bugs are my own]_