### PR TITLE
Display a clear error on empty character literals ''

### DIFF
--- a/Changes
+++ b/Changes
@@ -83,6 +83,10 @@ Working version
   the source code than the point explicitly shown in the error message.
   (François Pottier, review by Gabriel Scherer and Frédéric Bour.)
 
+- #10196, #10197: better error message on empty character literals ''.
+  (Gabriel Scherer, review by David Allsopp and Florian Angeletti
+   and Daniel Bünzli, report by Robin Björklin)
+
 ### Internal/compiler-libs changes:
 
 - #9650, #9651: keep refactoring the pattern-matching compiler

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -31,6 +31,7 @@ type error =
   | Unterminated_comment of Location.t
   | Unterminated_string
   | Unterminated_string_in_comment of Location.t * Location.t
+  | Empty_character_literal
   | Keyword_as_label of string
   | Invalid_literal of string
   | Invalid_directive of string * string option


### PR DESCRIPTION
Before:
```
# '';;
Error: Syntax error
```

After:
```
# '';;
Error: The empty character literal '' is invalid. We expect a character
       between single quotes (possibly a space ' ') or a single quote for
       type variables 'a.
```
Before, this input would get correctly lexed into QUOTE QUOTE and then
fail in the parser with a generic "Syntax error" message. (Even if we
had better error messages in the parser, here the parser-level error
would not be very illuminating as ' is never the start of a valid
expression or structure item).

Fixes #10196.