### PR TITLE
Fix #10189 + occur_univars for counter examples

### DIFF
--- a/Changes
+++ b/Changes
@@ -695,6 +695,9 @@ OCaml 4.12.0
   (Gabriel Scherer, review by Thomas Refis and Florian Angeletti,
    report by Daniil Baturin)
 
+- #10189: Universal variables leaking through GADT equations
+  (Jacques Garrigue, report by Leo White)
+
 OCaml 4.11 maintenance branch
 -----------------------------
 

--- a/testsuite/tests/typing-gadts/pr10189.ml
+++ b/testsuite/tests/typing-gadts/pr10189.ml
@@ -1,0 +1,132 @@
+(* TEST
+   * expect
+*)
+
+type i = <m : 'c. 'c -> 'c >
+type ('a, 'b) j = <m : 'c. 'a -> 'b >
+type _ t = A : i t;;
+[%%expect{|
+type i = < m : 'c. 'c -> 'c >
+type ('a, 'b) j = < m : 'a -> 'b >
+type _ t = A : i t
+|}]
+
+let f (type a b) (y : (a, b) j t) : a -> b =
+  let A = y in fun x -> x;;
+[%%expect{|
+Line 2, characters 6-7:
+2 |   let A = y in fun x -> x;;
+          ^
+Error: This pattern matches values of type i t
+       but a pattern was expected which matches values of type (a, b) j t
+       Type i = < m : 'c. 'c -> 'c > is not compatible with type
+         (a, b) j = < m : a -> b >
+       The method m has type 'c. 'c -> 'c, but the expected method type was
+       a -> b
+       The universal variable 'c would escape its scope
+|}]
+
+let g (type a b) (y : (a,b) j t option) =
+  let None = y in () ;;
+[%%expect{|
+val g : ('a, 'b) j t option -> unit = <fun>
+|}]
+
+module M = struct
+  type 'a d = D
+  type j = <m : 'c. 'c -> 'c d >
+end ;;
+let g (y : M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M : sig type 'a d = D type j = < m : 'c. 'c -> 'c d > end
+val g : M.j t option -> unit = <fun>
+|}]
+
+module M = struct
+  type 'a d
+  type j = <m : 'c. 'c -> 'c d >
+end ;;
+let g (y : M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M : sig type 'a d type j = < m : 'c. 'c -> 'c d > end
+Line 6, characters 2-20:
+6 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : M.j t option -> unit = <fun>
+|}]
+
+module M = struct
+  type e
+  type 'a d
+  type i = <m : 'c. 'c -> 'c d >
+  type j = <m : 'c. 'c -> e >
+end ;;
+type _ t = A : M.i t
+let g (y : M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M :
+  sig
+    type e
+    type 'a d
+    type i = < m : 'c. 'c -> 'c d >
+    type j = < m : 'c. 'c -> e >
+  end
+type _ t = A : M.i t
+Line 9, characters 2-20:
+9 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : M.j t option -> unit = <fun>
+|}]
+
+module M = struct
+  type 'a d
+  type i = <m : 'c. 'c -> 'c d >
+  type 'a j = <m : 'c. 'c -> 'a >
+end ;;
+type _ t = A : M.i t
+(* Should warn *)
+let g (y : 'a M.j t option) =
+  let None = y in () ;;
+[%%expect{|
+module M :
+  sig
+    type 'a d
+    type i = < m : 'c. 'c -> 'c d >
+    type 'a j = < m : 'c. 'c -> 'a >
+  end
+type _ t = A : M.i t
+Line 9, characters 2-20:
+9 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : 'a M.j t option -> unit = <fun>
+|}, Principal{|
+module M :
+  sig
+    type 'a d
+    type i = < m : 'c. 'c -> 'c d >
+    type 'a j = < m : 'c. 'c -> 'a >
+  end
+type _ t = A : M.i t
+File "_none_", line 1:
+Warning 18 [not-principal]: typing this pattern requires considering $0 and 'c M.d as equal.
+But the knowledge of these types is not principal.
+Line 9, characters 2-20:
+9 |   let None = y in () ;;
+      ^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some A
+val g : 'a M.j t option -> unit = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2635,10 +2635,6 @@ let rec unify (env:Env.t ref) t1 t2 =
           unify2 env t1 t2
         else
           unify1_var !env t2 t1
-    | (Tvar _, _) ->
-        unify1_var !env t1 t2
-    | (_, Tvar _) ->
-        unify1_var !env t2 t1
     | (Tunivar _, Tunivar _) ->
         unify_univar t1 t2 !univar_pairs;
         update_level !env t1.level t2;


### PR DESCRIPTION
This is a stripped-down version of #10190 .
It fixes both #10189 and a soundness bug discovered when fixing it.
The soundness bug involves:
* polymorphic methods (for univars)
* GADTs (for counter-examples)
* non-injective (i.e. phantom) types

It may be worth merging it somewhere on the 4.12 branch.