### PR TITLE
ocamlmklib configuration module cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,7 +251,6 @@ _build
 /tools/keywords
 /tools/ocamlmklib
 /tools/ocamlmklib.opt
-/tools/ocamlmklibconfig.ml
 /tools/ocamlcmt
 /tools/ocamlcmt.opt
 /tools/cmpbyt

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -274,7 +274,6 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
   FLEXLINK_CMD=flexlink
   FLEXDLL_CHAIN=@flexdll_chain@
   # FLEXLINK_FLAGS must be safe to insert in an OCaml string
-  #   (see ocamlmklibconfig.ml in tools/Makefile)
   FLEXLINK_FLAGS=@flexlink_flags@
   FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 else # ifeq "$(UNIX_OR_WIN32)" "win32"

--- a/tools/.depend
+++ b/tools/.depend
@@ -151,15 +151,11 @@ ocamldep.cmo : \
 ocamldep.cmx : \
     ../driver/makedepend.cmx
 ocamlmklib.cmo : \
-    ocamlmklibconfig.cmo \
     ../utils/misc.cmi \
     ../utils/config.cmi
 ocamlmklib.cmx : \
-    ocamlmklibconfig.cmx \
     ../utils/misc.cmx \
     ../utils/config.cmx
-ocamlmklibconfig.cmo :
-ocamlmklibconfig.cmx :
 ocamlmktop.cmo : \
     ../utils/config.cmi \
     ../utils/ccomp.cmi

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -139,20 +139,8 @@ installopt::
 
 # To help building mixed-mode libraries (OCaml + C)
 
-$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
+$(call byte_and_opt,ocamlmklib,config.cmo \
 	         build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo,)
-
-
-ocamlmklibconfig.ml: $(ROOTDIR)/Makefile.config Makefile
-	(echo 'let bindir = "$(BINDIR)"'; \
-         echo 'let default_rpath = "$(RPATH)"'; \
-         echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"';) \
-        > $@
-
-beforedepend:: ocamlmklibconfig.ml
-
-clean::
-	rm -f ocamlmklibconfig.ml
 
 # To make custom toplevels
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -145,11 +145,9 @@ $(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
 
 ocamlmklibconfig.ml: $(ROOTDIR)/Makefile.config Makefile
 	(echo 'let bindir = "$(BINDIR)"'; \
-         echo 'let supports_shared_libraries = $(SUPPORTS_SHARED_LIBRARIES)';\
          echo 'let default_rpath = "$(RPATH)"'; \
-         echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"'; \
-         echo 'let toolpref = "$(TOOLPREF)"';) \
-        > ocamlmklibconfig.ml
+         echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"';) \
+        > $@
 
 beforedepend:: ocamlmklibconfig.ml
 

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -42,7 +42,7 @@ and c_objs = ref []         (* .o, .a, .obj, .lib, .dll, .dylib, .so files to
                                pass to mksharedlib and ar *)
 and caml_libs = ref []      (* -cclib to pass to ocamlc, ocamlopt *)
 and caml_opts = ref []      (* -ccopt to pass to ocamlc, ocamlopt *)
-and dynlink = ref supports_shared_libraries
+and dynlink = ref Config.supports_shared_libraries
 and failsafe = ref false    (* whether to fall back on static build only *)
 and c_libs = ref []         (* libs to pass to mksharedlib and ocamlc -cclib *)
 and c_Lopts = ref []      (* options to pass to mksharedlib and ocamlc -cclib *)

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -14,7 +14,6 @@
 (**************************************************************************)
 
 open Printf
-open Ocamlmklibconfig
 
 let syslib x =
   if Config.ccomp_type = "msvc" then x ^ ".lib" else "-l" ^ x
@@ -34,7 +33,7 @@ let mklib out files opts =
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)
 let compiler_path name =
-  if Sys.os_type = "Win32" then name else Filename.concat bindir name
+  if Sys.os_type = "Win32" then name else Filename.concat Config.bindir name
 
 let bytecode_objs = ref []  (* .cmo,.cma,.ml,.mli files to pass to ocamlc *)
 and native_objs = ref []    (* .cmx,.ml,.mli files to pass to ocamlopt *)
@@ -304,7 +303,7 @@ let build_libs () =
              (String.concat " " !c_objs)
              (String.concat " " !c_opts)
              (String.concat " " !ld_opts)
-             (make_rpath mksharedlibrpath)
+             (make_rpath Config.mksharedlibrpath)
              (String.concat " " !c_libs)
              (String.concat " " flexdll_dirs)
           )
@@ -330,7 +329,7 @@ let build_libs () =
                   (Filename.basename !output_c)
                   (Filename.basename !output_c)
                   (String.concat " " (prefix_list "-ccopt " !c_opts))
-                  (make_rpath_ccopt default_rpath)
+                  (make_rpath_ccopt Config.default_rpath)
                   (String.concat " " (prefix_list "-cclib " !c_libs))
                   (String.concat " " !caml_libs));
   if !native_objs <> [] then
@@ -344,7 +343,7 @@ let build_libs () =
                   (String.concat " " !native_objs)
                   (Filename.basename !output_c)
                   (String.concat " " (prefix_list "-ccopt " !c_opts))
-                  (make_rpath_ccopt default_rpath)
+                  (make_rpath_ccopt Config.default_rpath)
                   (String.concat " " (prefix_list "-cclib " !c_libs))
                   (String.concat " " !caml_libs))
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -61,6 +61,7 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST_STRING,FLEXLINK_FLAGS) \
 	    $(call SUBST_QUOTE,FLEXDLL_DIR) \
 	    $(call SUBST,HOST) \
+	    $(call SUBST_STRING,BINDIR) \
 	    $(call SUBST_STRING,LIBDIR) \
 	    $(call SUBST_STRING,MKDLL) \
 	    $(call SUBST_STRING,MKEXE) \
@@ -76,6 +77,8 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST_STRING,PACKLD) \
 	    $(call SUBST,PROFINFO_WIDTH) \
 	    $(call SUBST_STRING,RANLIBCMD) \
+	    $(call SUBST_STRING,RPATH) \
+	    $(call SUBST_STRING,MKSHAREDLIBRPATH) \
 	    $(call SUBST,FORCE_SAFE_STRING) \
 	    $(call SUBST,DEFAULT_SAFE_STRING) \
 	    $(call SUBST,WINDOWS_UNICODE) \

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -23,6 +23,9 @@
 val version: string
 (** The current version number of the system *)
 
+val bindir: string
+(** The directory containing the binary programs *)
+
 val standard_library: string
 (** The directory containing the standard libraries *)
 
@@ -81,6 +84,14 @@ val mkmaindll: string
 
 val ranlib: string
 (** Command to randomize a library, or "" if not needed *)
+
+val default_rpath: string
+(** Option to add a directory to be searched for libraries at runtime
+    (used by ocamlmklib) *)
+
+val mksharedlibrpath: string
+(** Option to add a directory to be searched for shared libraries at runtime
+    (used by ocamlmklib) *)
 
 val ar: string
 (** Name of the ar command, or "" if not needed  (MSVC) *)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -17,6 +17,8 @@
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
 
+let bindir = "%%BINDIR%%"
+
 let standard_library_default = "%%LIBDIR%%"
 
 let standard_library =
@@ -53,6 +55,8 @@ let native_c_compiler =
 let native_c_libraries = "%%NATIVECCLIBS%%"
 let native_pack_linker = "%%PACKLD%%"
 let ranlib = "%%RANLIBCMD%%"
+let default_rpath = "%%RPATH%%"
+let mksharedlibrpath = "%%MKSHAREDLIBRPATH%%"
 let ar = "%%ARCMD%%"
 let mkdll, mkexe, mkmaindll =
   (* @@DRA Cygwin - but only if shared libraries are enabled, which we


### PR DESCRIPTION
This PR removes two definitions from the ocamlmklib configuration module:

 1. toolpref, which is not used

 2. supports_shared_libraries, which can be taken from the general configuration module

There is also a Makefile cosmetic improvement.