### PR TITLE
Avoid overwriting closures while initialising recursive modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -491,7 +491,7 @@ Working version
   (Jacques Garrigue, report and review by Leo White)
 
 - #10205: Avoid overwriting closures while initialising recursive modules
-  (Stephen Dolan, review by Xavier Leroy and Hugo Heuzard)
+  (Stephen Dolan, review by Xavier Leroy, Hugo Heuzard and Vincent Laviron)
 
 - #10253, #10373: tweak error message for unknown variant constructors
   or record fields in type-directed disambiguation

--- a/Changes
+++ b/Changes
@@ -490,6 +490,9 @@ Working version
 - #10189, #10190, #10347: Universal variables leaking through GADT equations
   (Jacques Garrigue, report and review by Leo White)
 
+- #10205: Avoid overwriting closures while initialising recursive modules
+  (Stephen Dolan, review by Xavier Leroy and Hugo Heuzard)
+
 - #10253, #10373: tweak error message for unknown variant constructors
   or record fields in type-directed disambiguation
   (Florian Angeletti, report by Hongbo Zhang, review by Gabriel Scherer)

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -150,16 +150,14 @@ camlinternalLazy.cmx : \
     camlinternalLazy.cmi
 camlinternalLazy.cmi :
 camlinternalMod.cmo : \
-    stdlib__Sys.cmi \
     stdlib__Obj.cmi \
-    stdlib__Nativeint.cmi \
+    stdlib__Lazy.cmi \
     camlinternalOO.cmi \
     stdlib__Array.cmi \
     camlinternalMod.cmi
 camlinternalMod.cmx : \
-    stdlib__Sys.cmx \
     stdlib__Obj.cmx \
-    stdlib__Nativeint.cmx \
+    stdlib__Lazy.cmx \
     camlinternalOO.cmx \
     stdlib__Array.cmx \
     camlinternalMod.cmi

--- a/stdlib/camlinternalMod.ml
+++ b/stdlib/camlinternalMod.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-external make_forward : Obj.t -> Obj.t -> unit = "caml_obj_make_forward"
+external _make_forward : Obj.t -> Obj.t -> unit = "caml_obj_make_forward"
 
 type shape =
   | Function
@@ -22,94 +22,70 @@ type shape =
   | Module of shape array
   | Value of Obj.t
 
-let overwrite o n =
-  assert (Obj.size o >= Obj.size n);
-  for i = 0 to Obj.size n - 1 do
-    Obj.set_field o i (Obj.field n i)
+let rec init_mod_field modu i loc shape =
+  let init =
+    match shape with
+    | Function ->
+       let rec fn (x : 'a) =
+         let fn' : 'a -> 'b = Obj.obj modu.(i) in
+         if fn == fn' then
+           raise (Undefined_recursive_module loc)
+         else
+           fn' x in
+       Obj.repr fn
+    | Lazy ->
+       let rec l =
+         lazy (
+           let l' = Obj.obj modu.(i) in
+           if l == l' then
+             raise (Undefined_recursive_module loc)
+           else
+             Lazy.force l') in
+       Obj.repr l
+    | Class ->
+       Obj.repr (CamlinternalOO.dummy_class loc)
+    | Module comps ->
+       Obj.repr (init_mod_block loc comps)
+    | Value v -> v
+  in
+  modu.(i) <- init
+
+and init_mod_block loc comps =
+  let length = Array.length comps in
+  let modu = Array.make length (Obj.repr 0) in
+  for i = 0 to length - 1 do
+    init_mod_field modu i loc comps.(i)
+  done;
+  modu
+
+let init_mod loc shape =
+  match shape with
+  | Module comps ->
+     Obj.repr (init_mod_block loc comps)
+  | _ -> failwith "CamlinternalMod.init_mod: not a module"
+
+let rec update_mod_field modu i shape n =
+  match shape with
+  | Function | Lazy ->
+     Obj.set_field modu i n
+  | Value _ ->
+     () (* the value is already there *)
+  | Class ->
+     assert (Obj.tag n = 0 && Obj.size n = 4);
+     for j = 0 to 3 do
+       Obj.set_field (Obj.field modu i) j (Obj.field n j)
+     done
+  | Module comps ->
+     update_mod_block comps (Obj.field modu i) n
+
+and update_mod_block comps o n =
+  assert (Obj.tag n = 0 && Obj.size n >= Array.length comps);
+  for i = 0 to Array.length comps - 1 do
+    update_mod_field o i comps.(i) (Obj.field n i)
   done
 
-let overwrite_closure o n =
-  (* We need to use the [raw_field] functions at least on the code
-     pointer, which is not a valid value in -no-naked-pointers
-     mode. *)
-  assert (Obj.tag n = Obj.closure_tag);
-  assert (Obj.size o >= Obj.size n);
-  let n_start_env = Obj.Closure.((info n).start_env) in
-  let o_start_env = Obj.Closure.((info o).start_env) in
-  (* if the environment of n starts before the one of o,
-     clear the raw fields in between. *)
-  for i = n_start_env to o_start_env - 1 do
-    Obj.set_raw_field o i Nativeint.one
-  done;
-  (* if the environment of o starts before the one of n,
-     clear the environment fields in between. *)
-  for i = o_start_env to n_start_env - 1 do
-    Obj.set_field o i (Obj.repr ())
-  done;
-  for i = 0 to n_start_env - 1 do
-    (* code pointers, closure info fields, infix headers *)
-    Obj.set_raw_field o i (Obj.raw_field n i)
-  done;
-  for i = n_start_env to Obj.size n - 1 do
-    (* environment fields *)
-    Obj.set_field o i (Obj.field n i)
-  done;
-  for i = Obj.size n to Obj.size o - 1 do
-    (* clear the leftover space *)
-    Obj.set_field o i (Obj.repr ())
-  done;
-  ()
-
-let rec init_mod loc shape =
+let update_mod shape o n =
   match shape with
-  | Function ->
-      (* Two code pointer words (curried and full application), arity
-         and eight environment entries makes 11 words. *)
-      let closure = Obj.new_block Obj.closure_tag 11 in
-      let template =
-        Obj.repr (fun _ -> raise (Undefined_recursive_module loc))
-      in
-      overwrite_closure closure template;
-      closure
-  | Lazy ->
-      Obj.repr (lazy (raise (Undefined_recursive_module loc)))
-  | Class ->
-      Obj.repr (CamlinternalOO.dummy_class loc)
   | Module comps ->
-      Obj.repr (Array.map (init_mod loc) comps)
-  | Value v ->
-      v
-
-let rec update_mod shape o n =
-  match shape with
-  | Function ->
-      (* In bytecode, the RESTART instruction checks the size of closures.
-         Hence, the optimized case [overwrite o n] is valid only if [o] and
-         [n] have the same size.  (See PR#4008.)
-         In native code, the size of closures does not matter, so overwriting
-         is possible so long as the size of [n] is no greater than that of [o].
-      *)
-      if Obj.tag n = Obj.closure_tag
-      && (Obj.size n = Obj.size o
-          || (Sys.backend_type = Sys.Native
-              && Obj.size n <= Obj.size o))
-      then begin overwrite_closure o n end
-      else overwrite_closure o (Obj.repr (fun x -> (Obj.obj n : _ -> _) x))
-  | Lazy ->
-      if Obj.tag n = Obj.lazy_tag then
-        Obj.set_field o 0 (Obj.field n 0)
-      else if Obj.tag n = Obj.forward_tag then begin (* PR#4316 *)
-        make_forward o (Obj.field n 0)
-      end else begin
-        (* forwarding pointer was shortcut by GC *)
-        make_forward o n
-      end
-  | Class ->
-      assert (Obj.tag n = 0 && Obj.size n = 4);
-      overwrite o n
-  | Module comps ->
-      assert (Obj.tag n = 0 && Obj.size n >= Array.length comps);
-      for i = 0 to Array.length comps - 1 do
-        update_mod comps.(i) (Obj.field o i) (Obj.field n i)
-      done
-  | Value _ -> () (* the value is already there *)
+     update_mod_block comps o n
+  | _ -> failwith "CamlinternalMod.update_mod: not a module"

--- a/testsuite/tests/basic-modules/recursive_module_init.ml
+++ b/testsuite/tests/basic-modules/recursive_module_init.ml
@@ -1,0 +1,68 @@
+(* TEST *)
+
+let check ~stub txt f =
+  let run mode f =
+    match f mode with
+    | n -> string_of_int n
+    | exception Undefined_recursive_module _ -> "__" in
+  Printf.printf "%5s[%s]: nonrec => %s, self => %s, mod => %s\n%!"
+    txt
+    (if f == stub then "stub" else "real")
+    (run `Nonrec f)
+    (run `Self f)
+    (run `Mod f)
+
+module rec M : sig
+  val f1 : [`Nonrec|`Self|`Mod] -> int
+  val f2 : [`Nonrec|`Self|`Mod] -> int
+  val f3 : [`Nonrec|`Self|`Mod] -> int
+  val f4 : unit -> [`Nonrec|`Self|`Mod] -> int
+  val f5 : unit -> [`Nonrec|`Self|`Mod] -> int
+end = struct
+  let rec f1 mode =
+    match mode with
+    | `Nonrec -> 42
+    | `Self -> f1 `Nonrec
+    | `Mod -> M.f1 `Nonrec
+  let f2 = f1
+  let f3 = M.f1
+  let f4 () = f1
+  let f5 () = M.f1
+
+  let () =
+    check ~stub:f3 "f1" f1;
+    check ~stub:f3 "f2" f2;
+    check ~stub:f3 "f3" f3;
+    check ~stub:f3 "f4" (f4 ());
+    check ~stub:f3 "f5" (f5 ())
+end
+
+let () =
+  check ~stub:M.f3 "M.f1" M.f1;
+  check ~stub:M.f3 "M.f2" M.f2;
+  check ~stub:M.f3 "M.f3" M.f3;
+  check ~stub:M.f3 "M.f4" (M.f4 ());
+  check ~stub:M.f3 "M.f5" (M.f5 ())
+
+
+module rec Foo : sig
+  class cls : object
+    method go : unit
+  end
+  module M : sig
+    val foo : unit -> cls
+    val bar : cls Lazy.t
+  end
+end = struct
+  class cls = object
+    method go = print_endline "go"
+  end
+  module M = struct
+    let foo () = new Foo.cls
+    let bar = lazy (foo ())
+  end
+end
+
+let () =
+  List.iter (fun x -> x#go)
+    [new Foo.cls; Foo.M.foo(); Lazy.force Foo.M.bar]

--- a/testsuite/tests/basic-modules/recursive_module_init.reference
+++ b/testsuite/tests/basic-modules/recursive_module_init.reference
@@ -1,0 +1,13 @@
+   f1[real]: nonrec => 42, self => 42, mod => __
+   f2[real]: nonrec => 42, self => 42, mod => __
+   f3[stub]: nonrec => __, self => __, mod => __
+   f4[real]: nonrec => 42, self => 42, mod => __
+   f5[stub]: nonrec => __, self => __, mod => __
+ M.f1[real]: nonrec => 42, self => 42, mod => 42
+ M.f2[real]: nonrec => 42, self => 42, mod => 42
+ M.f3[stub]: nonrec => 42, self => 42, mod => 42
+ M.f4[real]: nonrec => 42, self => 42, mod => 42
+ M.f5[real]: nonrec => 42, self => 42, mod => 42
+go
+go
+go


### PR DESCRIPTION
This patch switches to a different mechanism for initialising recursive modules (which should avoid the bug in #10203) as well as adding some more testing of this mechanism. The new `recursive_module_init` test has been verified to give the same result before and after this patch.

The new mechanism never overwrites a closure. Instead, it overwrites the relevant slot in the module block. The stub closure created during initialisation always checks the relevant slot, so it doesn't need to be mutated. In most cases, I'd expect the stub closure to be garbage-collected soon after initialisation, so I expect this to have equivalent performance to the current system.

(The only cases where the stub will continue to be used after initialisation are those where a reference to a function is created during initialisation via the recursive module name, but outside of any lambdas. See `M.f3` in the test case. I don't think this will happen much in real code, and if it does pose a problem it can be worked around by eta-expanding)