### PR TITLE
Deprecate non-prefixed letters in warning specifications

### DIFF
--- a/.depend
+++ b/.depend
@@ -5876,6 +5876,7 @@ driver/main_args.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \
     utils/misc.cmi \
+    parsing/location.cmi \
     utils/config.cmi \
     driver/compenv.cmi \
     utils/clflags.cmi \
@@ -5884,6 +5885,7 @@ driver/main_args.cmx : \
     utils/warnings.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
+    parsing/location.cmx \
     utils/config.cmx \
     driver/compenv.cmx \
     utils/clflags.cmx \

--- a/Changes
+++ b/Changes
@@ -184,6 +184,12 @@ Working version
 - #8877: Call the linker when ocamlopt is invoked with .o and .a files only.
   (Greta Yorsh, review by Leo White)
 
+- #10207: deprecate single uppercase or lowercase letter in warning
+  specifications.
+  The form `-w aBcD` was equivalent to `-w -a+b-c+d`.
+  It is now deprecated to improve the coexistence with warning mnemonics.
+  (Florian Angeletti, review by Damien Doligez and Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - #9243, simplify parser rules for array indexing operations

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
         -I driver -I toplevel
 
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
-	  -warn-error A \
+	  -warn-error +a \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -22,7 +22,7 @@ DYNLINKDIR=$(ROOTDIR)/otherlibs/dynlink
 UNIXDIR=$(ROOTDIR)/otherlibs/$(UNIXLIB)
 
 CAMLC=$(BEST_OCAMLC) -g -nostdlib -I $(ROOTDIR)/stdlib
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error +A \
           -safe-string -strict-sequence -strict-formats
 LINKFLAGS=-linkall -I $(UNIXDIR) -I $(DYNLINKDIR)
 OCAMLLEX ?= $(BEST_OCAMLLEX)

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -221,6 +221,9 @@ let set_compiler_pass ppf ~name v flag ~filter =
    because they are not understood by some versions of OCaml. *)
 let can_discard = ref []
 
+let parse_warnings error v =
+  Option.iter Location.(prerr_alert none) @@ Warnings.parse_options error v
+
 let read_one_param ppf position name v =
   let set name options s =  setter ppf (fun b -> b) name options s in
   let clear name options s = setter ppf (fun b -> not b) name options s in
@@ -277,11 +280,11 @@ let read_one_param ppf position name v =
   |  "dstartup" -> set "dstartup" [ Clflags.keep_startup_file ] v
 
   (* warn-errors *)
-  | "we" | "warn-error" -> Warnings.parse_options true v
+  | "we" | "warn-error" -> parse_warnings true v
   (* warnings *)
-  |  "w"  ->               Warnings.parse_options false v
+  |  "w"  ->               parse_warnings false v
   (* warn-errors *)
-  | "wwe" ->               Warnings.parse_options false v
+  | "wwe" ->               parse_warnings false v
   (* alerts *)
   | "alert" ->             Warnings.parse_alert_option v
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1700,7 +1700,8 @@ module Default = struct
     let _strict_sequence = set strict_sequence
     let _unboxed_types = set unboxed_types
     let _unsafe_string = set unsafe_string
-    let _w s = Warnings.parse_options false s
+    let _w s =
+      Warnings.parse_options false s |> Option.iter Location.(prerr_alert none)
 
     let anonymous = Compenv.anonymous
 
@@ -1724,7 +1725,8 @@ module Default = struct
     let _nopervasives = set nopervasives
     let _ppx s = Compenv.first_ppx := (s :: (!Compenv.first_ppx))
     let _unsafe = set unsafe
-    let _warn_error s = Warnings.parse_options true s
+    let _warn_error s =
+      Warnings.parse_options true s |> Option.iter Location.(prerr_alert none)
     let _warn_help = Warnings.help_warnings
   end
 

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -24,7 +24,7 @@ OCAMLYACCFLAGS = -v
 CAMLC = $(BOOT_OCAMLC) -strict-sequence -nostdlib \
         -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
 CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -nostdlib -I $(ROOTDIR)/stdlib
-COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -warn-error +A \
             -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS =
 OCAMLLEX ?= $(BOOT_OCAMLLEX)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -75,7 +75,7 @@ INCLUDES_NODEP=\
 DEPINCLUDES=$(INCLUDES_DEP)
 INCLUDES=$(INCLUDES_DEP) $(INCLUDES_NODEP)
 
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error +A \
   -safe-string -strict-sequence -strict-formats -bin-annot -principal
 
 LINKFLAGS=$(INCLUDES) -nostdlib

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -190,7 +190,7 @@ include_directories := $(addprefix -I , $(directories))
 
 flags := -g -nostdlib $(include_directories) \
   -strict-sequence -safe-string -strict-formats \
-  -w +a-4-9-41-42-44-45-48 -warn-error A
+  -w +a-4-9-41-42-44-45-48 -warn-error +A
 
 ocamlc = $(BEST_OCAMLC) $(flags)
 

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -30,7 +30,7 @@ OC_CFLAGS += $(SHAREDLIB_CFLAGS) $(EXTRACFLAGS)
 OC_CPPFLAGS += -I$(ROOTDIR)/runtime $(EXTRACPPFLAGS)
 
 # Compilation options
-COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g \
+COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error +A -bin-annot -g \
           -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -29,7 +29,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) -g -nostdlib -I $(ROOTDIR)/stdlib
 
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-40-41-42-44-45-48-66 \
-	  -warn-error A \
+	  -warn-error +A \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -35,7 +35,7 @@ CAMLC=$(BEST_OCAMLC) $(LIBS)
 CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
 
 MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
-COMPFLAGS=-w +33..39 -warn-error A -g -bin-annot -safe-string
+COMPFLAGS=-w +33..39 -warn-error +A -g -bin-annot -safe-string
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -179,7 +179,9 @@ let warning_attribute ?(ppwarning = true) =
   let process loc txt errflag payload =
     match string_of_payload payload with
     | Some s ->
-        begin try Warnings.parse_options errflag s
+        begin try
+          Option.iter (Location.prerr_alert loc)
+            (Warnings.parse_options errflag s)
         with Arg.Bad msg -> warn_payload loc txt msg
         end
     | None ->

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -27,10 +27,10 @@ case $1 in
     # never instrument camlinternalOO or camlinternalLazy (PR#7725)
   stdlib__Buffer.cmx) echo ' -inline 3';;
                            # make sure add_char is inlined (PR#5872)
-  stdlib__Buffer.cm[io]) echo ' -w A';;
-  camlinternalFormat.cm[io]) echo ' -w Ae';;
+  stdlib__Buffer.cm[io]) echo ' -w +A';;
+  camlinternalFormat.cm[io]) echo ' -w +A -w -fragile-match';;
   stdlib__Printf.cm[io]|stdlib__Format.cm[io]|stdlib__Scanf.cm[io])
-      echo ' -w Ae';;
+      echo ' -w +A -w -fragile-match';;
   stdlib__Scanf.cmx) echo ' -inline 9';;
   *Labels.cmi) echo ' -pp "$AWK -f ./expand_module_aliases.awk"';;
   *Labels.cm[ox]) echo ' -nolabels -no-alias-deps';;

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -22,7 +22,7 @@ TARGET_BINDIR ?= $(BINDIR)
 COMPILER=$(ROOTDIR)/ocamlc$(EXE)
 CAMLC=$(CAMLRUN) $(COMPILER)
 COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
-          -g -warn-error A -bin-annot -nostdlib -principal \
+          -g -warn-error +A -bin-annot -nostdlib -principal \
           -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/testsuite/tests/ast-invariants/test.ml
+++ b/testsuite/tests/ast-invariants/test.ml
@@ -30,7 +30,7 @@ let invariants : type a. a kind -> a -> unit = function
   | Interf -> Ast_invariants.signature
 
 let check_file kind fn =
-  Warnings.parse_options false "-a";
+  ignore (Warnings.parse_options false "-a");
   let ic = open_in fn in
   Location.input_name := fn;
   let lexbuf = Lexing.from_channel ic in

--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags += " -w a "
+   flags += " -w -a "
    modules = "globrootsprim.c"
 *)
 

--- a/testsuite/tests/lib-digest/md5.ml
+++ b/testsuite/tests/lib-digest/md5.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags += " -w a "
+   flags += " -w -a "
 *)
 
 (* Test int32 arithmetic and optimizations using the MD5 algorithm *)

--- a/testsuite/tests/lib-unix/win-env/test_env.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env.ml
@@ -1,6 +1,6 @@
 (* TEST
 include unix
-flags += "-strict-sequence -safe-string -w A -warn-error A"
+flags += "-strict-sequence -safe-string -w +A -warn-error +A"
 modules = "stubs.c"
 * libwin32unix
 ** bytecode

--- a/testsuite/tests/output-complete-obj/github9344.ml
+++ b/testsuite/tests/output-complete-obj/github9344.ml
@@ -4,7 +4,7 @@ use_runtime = "false"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
-flags = "-w a -output-complete-exe -ccopt -I${ocamlsrcdir}/runtime"
+flags = "-w -a -output-complete-exe -ccopt -I${ocamlsrcdir}/runtime"
 program = "github9344"
 *** run
 program = "sh ${test_source_directory}/github9344.sh"

--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -5,7 +5,7 @@ files = "test.ml_stub.c"
 * libunix
 ** setup-ocamlc.byte-build-env
 *** ocamlc.byte
-flags = "-w a -output-complete-obj"
+flags = "-w -a -output-complete-obj"
 program = "test.ml.bc.${objext}"
 **** script
 script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe \
@@ -17,7 +17,7 @@ stdout = "program-output"
 stderr = "program-output"
 ** setup-ocamlopt.byte-build-env
 *** ocamlopt.byte
-flags = "-w a -output-complete-obj"
+flags = "-w -a -output-complete-obj"
 program = "test.ml.exe.${objext}"
 **** script
 script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe \

--- a/testsuite/tests/output-complete-obj/test2.ml
+++ b/testsuite/tests/output-complete-obj/test2.ml
@@ -7,7 +7,7 @@ use_runtime = "false"
 include unix
 ** setup-ocamlc.byte-build-env
 *** ocamlc.byte
-flags = "-w a -output-complete-exe puts.c -ccopt -I${ocamlsrcdir}/runtime"
+flags = "-w -a -output-complete-exe puts.c -ccopt -I${ocamlsrcdir}/runtime"
 program = "test2"
 **** run
 program = "./test2"

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w a"
+flags = "-w -a"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/runtime-errors/syserror.ml
+++ b/testsuite/tests/runtime-errors/syserror.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w a"
+flags = "-w -a"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/tool-ocaml/t000.ml
+++ b/testsuite/tests/tool-ocaml/t000.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t010-const0.ml
+++ b/testsuite/tests/tool-ocaml/t010-const0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t010-const1.ml
+++ b/testsuite/tests/tool-ocaml/t010-const1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t010-const2.ml
+++ b/testsuite/tests/tool-ocaml/t010-const2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t010-const3.ml
+++ b/testsuite/tests/tool-ocaml/t010-const3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t011-constint.ml
+++ b/testsuite/tests/tool-ocaml/t011-constint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t020.ml
+++ b/testsuite/tests/tool-ocaml/t020.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t021-pushconst1.ml
+++ b/testsuite/tests/tool-ocaml/t021-pushconst1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t021-pushconst2.ml
+++ b/testsuite/tests/tool-ocaml/t021-pushconst2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t021-pushconst3.ml
+++ b/testsuite/tests/tool-ocaml/t021-pushconst3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t022-pushconstint.ml
+++ b/testsuite/tests/tool-ocaml/t022-pushconstint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t040-makeblock1.ml
+++ b/testsuite/tests/tool-ocaml/t040-makeblock1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t040-makeblock2.ml
+++ b/testsuite/tests/tool-ocaml/t040-makeblock2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t040-makeblock3.ml
+++ b/testsuite/tests/tool-ocaml/t040-makeblock3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t041-makeblock.ml
+++ b/testsuite/tests/tool-ocaml/t041-makeblock.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t050-getglobal.ml
+++ b/testsuite/tests/tool-ocaml/t050-getglobal.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t050-pushgetglobal.ml
+++ b/testsuite/tests/tool-ocaml/t050-pushgetglobal.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t051-getglobalfield.ml
+++ b/testsuite/tests/tool-ocaml/t051-getglobalfield.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t051-pushgetglobalfield.ml
+++ b/testsuite/tests/tool-ocaml/t051-pushgetglobalfield.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t060-raise.ml
+++ b/testsuite/tests/tool-ocaml/t060-raise.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 ocaml_exit_status = "2"
 * setup-ocaml-build-env

--- a/testsuite/tests/tool-ocaml/t070-branch.ml
+++ b/testsuite/tests/tool-ocaml/t070-branch.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t070-branchif.ml
+++ b/testsuite/tests/tool-ocaml/t070-branchif.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t070-branchifnot.ml
+++ b/testsuite/tests/tool-ocaml/t070-branchifnot.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t071-boolnot.ml
+++ b/testsuite/tests/tool-ocaml/t071-boolnot.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t080-eq.ml
+++ b/testsuite/tests/tool-ocaml/t080-eq.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t080-geint.ml
+++ b/testsuite/tests/tool-ocaml/t080-geint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t080-gtint.ml
+++ b/testsuite/tests/tool-ocaml/t080-gtint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t080-leint.ml
+++ b/testsuite/tests/tool-ocaml/t080-leint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t080-ltint.ml
+++ b/testsuite/tests/tool-ocaml/t080-ltint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t080-neq.ml
+++ b/testsuite/tests/tool-ocaml/t080-neq.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc0.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc1.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc2.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc3.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc4.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc5.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc5.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc6.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc6.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t090-acc7.ml
+++ b/testsuite/tests/tool-ocaml/t090-acc7.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t091-acc.ml
+++ b/testsuite/tests/tool-ocaml/t091-acc.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc0.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc1.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc2.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc3.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc4.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc5.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc5.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc6.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc6.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t092-pushacc7.ml
+++ b/testsuite/tests/tool-ocaml/t092-pushacc7.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t093-pushacc.ml
+++ b/testsuite/tests/tool-ocaml/t093-pushacc.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t100-pushtrap.ml
+++ b/testsuite/tests/tool-ocaml/t100-pushtrap.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t101-poptrap.ml
+++ b/testsuite/tests/tool-ocaml/t101-poptrap.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-addint.ml
+++ b/testsuite/tests/tool-ocaml/t110-addint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-andint.ml
+++ b/testsuite/tests/tool-ocaml/t110-andint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-asrint-1.ml
+++ b/testsuite/tests/tool-ocaml/t110-asrint-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-asrint-2.ml
+++ b/testsuite/tests/tool-ocaml/t110-asrint-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-divint-1.ml
+++ b/testsuite/tests/tool-ocaml/t110-divint-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-divint-2.ml
+++ b/testsuite/tests/tool-ocaml/t110-divint-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-divint-3.ml
+++ b/testsuite/tests/tool-ocaml/t110-divint-3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-lslint.ml
+++ b/testsuite/tests/tool-ocaml/t110-lslint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-lsrint.ml
+++ b/testsuite/tests/tool-ocaml/t110-lsrint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-modint-1.ml
+++ b/testsuite/tests/tool-ocaml/t110-modint-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-modint-2.ml
+++ b/testsuite/tests/tool-ocaml/t110-modint-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-mulint.ml
+++ b/testsuite/tests/tool-ocaml/t110-mulint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-negint.ml
+++ b/testsuite/tests/tool-ocaml/t110-negint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-offsetint.ml
+++ b/testsuite/tests/tool-ocaml/t110-offsetint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-orint.ml
+++ b/testsuite/tests/tool-ocaml/t110-orint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-subint.ml
+++ b/testsuite/tests/tool-ocaml/t110-subint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t110-xorint.ml
+++ b/testsuite/tests/tool-ocaml/t110-xorint.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t120-getstringchar.ml
+++ b/testsuite/tests/tool-ocaml/t120-getstringchar.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t121-setstringchar.ml
+++ b/testsuite/tests/tool-ocaml/t121-setstringchar.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t130-getvectitem.ml
+++ b/testsuite/tests/tool-ocaml/t130-getvectitem.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t130-vectlength.ml
+++ b/testsuite/tests/tool-ocaml/t130-vectlength.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t131-setvectitem.ml
+++ b/testsuite/tests/tool-ocaml/t131-setvectitem.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t140-switch-1.ml
+++ b/testsuite/tests/tool-ocaml/t140-switch-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t140-switch-2.ml
+++ b/testsuite/tests/tool-ocaml/t140-switch-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t140-switch-3.ml
+++ b/testsuite/tests/tool-ocaml/t140-switch-3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t140-switch-4.ml
+++ b/testsuite/tests/tool-ocaml/t140-switch-4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t141-switch-5.ml
+++ b/testsuite/tests/tool-ocaml/t141-switch-5.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t141-switch-6.ml
+++ b/testsuite/tests/tool-ocaml/t141-switch-6.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t141-switch-7.ml
+++ b/testsuite/tests/tool-ocaml/t141-switch-7.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t142-switch-8.ml
+++ b/testsuite/tests/tool-ocaml/t142-switch-8.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t142-switch-9.ml
+++ b/testsuite/tests/tool-ocaml/t142-switch-9.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t142-switch-A.ml
+++ b/testsuite/tests/tool-ocaml/t142-switch-A.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t150-push-1.ml
+++ b/testsuite/tests/tool-ocaml/t150-push-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t150-push-2.ml
+++ b/testsuite/tests/tool-ocaml/t150-push-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t160-closure.ml
+++ b/testsuite/tests/tool-ocaml/t160-closure.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t161-apply1.ml
+++ b/testsuite/tests/tool-ocaml/t161-apply1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t162-return.ml
+++ b/testsuite/tests/tool-ocaml/t162-return.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t163.ml
+++ b/testsuite/tests/tool-ocaml/t163.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t164-apply2.ml
+++ b/testsuite/tests/tool-ocaml/t164-apply2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t164-apply3.ml
+++ b/testsuite/tests/tool-ocaml/t164-apply3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t165-apply.ml
+++ b/testsuite/tests/tool-ocaml/t165-apply.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t170-envacc2.ml
+++ b/testsuite/tests/tool-ocaml/t170-envacc2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t170-envacc3.ml
+++ b/testsuite/tests/tool-ocaml/t170-envacc3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t170-envacc4.ml
+++ b/testsuite/tests/tool-ocaml/t170-envacc4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t171-envacc.ml
+++ b/testsuite/tests/tool-ocaml/t171-envacc.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t172-pushenvacc1.ml
+++ b/testsuite/tests/tool-ocaml/t172-pushenvacc1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t172-pushenvacc2.ml
+++ b/testsuite/tests/tool-ocaml/t172-pushenvacc2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t172-pushenvacc3.ml
+++ b/testsuite/tests/tool-ocaml/t172-pushenvacc3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t172-pushenvacc4.ml
+++ b/testsuite/tests/tool-ocaml/t172-pushenvacc4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t173-pushenvacc.ml
+++ b/testsuite/tests/tool-ocaml/t173-pushenvacc.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t180-appterm1.ml
+++ b/testsuite/tests/tool-ocaml/t180-appterm1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t180-appterm2.ml
+++ b/testsuite/tests/tool-ocaml/t180-appterm2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t180-appterm3.ml
+++ b/testsuite/tests/tool-ocaml/t180-appterm3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t181-appterm.ml
+++ b/testsuite/tests/tool-ocaml/t181-appterm.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t190-makefloatblock-1.ml
+++ b/testsuite/tests/tool-ocaml/t190-makefloatblock-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t190-makefloatblock-2.ml
+++ b/testsuite/tests/tool-ocaml/t190-makefloatblock-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t190-makefloatblock-3.ml
+++ b/testsuite/tests/tool-ocaml/t190-makefloatblock-3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t191-vectlength.ml
+++ b/testsuite/tests/tool-ocaml/t191-vectlength.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t192-getfloatfield-1.ml
+++ b/testsuite/tests/tool-ocaml/t192-getfloatfield-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t192-getfloatfield-2.ml
+++ b/testsuite/tests/tool-ocaml/t192-getfloatfield-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t193-setfloatfield-1.ml
+++ b/testsuite/tests/tool-ocaml/t193-setfloatfield-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t193-setfloatfield-2.ml
+++ b/testsuite/tests/tool-ocaml/t193-setfloatfield-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t200-getfield0.ml
+++ b/testsuite/tests/tool-ocaml/t200-getfield0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t200-getfield1.ml
+++ b/testsuite/tests/tool-ocaml/t200-getfield1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t200-getfield2.ml
+++ b/testsuite/tests/tool-ocaml/t200-getfield2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t200-getfield3.ml
+++ b/testsuite/tests/tool-ocaml/t200-getfield3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t201-getfield.ml
+++ b/testsuite/tests/tool-ocaml/t201-getfield.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t210-setfield0.ml
+++ b/testsuite/tests/tool-ocaml/t210-setfield0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t210-setfield1.ml
+++ b/testsuite/tests/tool-ocaml/t210-setfield1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t210-setfield2.ml
+++ b/testsuite/tests/tool-ocaml/t210-setfield2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t210-setfield3.ml
+++ b/testsuite/tests/tool-ocaml/t210-setfield3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t211-setfield.ml
+++ b/testsuite/tests/tool-ocaml/t211-setfield.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t220-assign.ml
+++ b/testsuite/tests/tool-ocaml/t220-assign.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t230-check_signals.ml
+++ b/testsuite/tests/tool-ocaml/t230-check_signals.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t240-c_call1.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t240-c_call2.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t240-c_call3.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t240-c_call4.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t240-c_call5.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call5.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t250-closurerec-1.ml
+++ b/testsuite/tests/tool-ocaml/t250-closurerec-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t250-closurerec-2.ml
+++ b/testsuite/tests/tool-ocaml/t250-closurerec-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t251-pushoffsetclosure0.ml
+++ b/testsuite/tests/tool-ocaml/t251-pushoffsetclosure0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t251-pushoffsetclosure2.ml
+++ b/testsuite/tests/tool-ocaml/t251-pushoffsetclosure2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t251-pushoffsetclosurem2.ml
+++ b/testsuite/tests/tool-ocaml/t251-pushoffsetclosurem2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t252-pushoffsetclosure.ml
+++ b/testsuite/tests/tool-ocaml/t252-pushoffsetclosure.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t253-offsetclosure0.ml
+++ b/testsuite/tests/tool-ocaml/t253-offsetclosure0.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t253-offsetclosure2.ml
+++ b/testsuite/tests/tool-ocaml/t253-offsetclosure2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t253-offsetclosurem2.ml
+++ b/testsuite/tests/tool-ocaml/t253-offsetclosurem2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t254-offsetclosure.ml
+++ b/testsuite/tests/tool-ocaml/t254-offsetclosure.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t260-offsetref.ml
+++ b/testsuite/tests/tool-ocaml/t260-offsetref.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t270-push_retaddr.ml
+++ b/testsuite/tests/tool-ocaml/t270-push_retaddr.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t300-getmethod.ml
+++ b/testsuite/tests/tool-ocaml/t300-getmethod.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t301-object.ml
+++ b/testsuite/tests/tool-ocaml/t301-object.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t310-alloc-1.ml
+++ b/testsuite/tests/tool-ocaml/t310-alloc-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t310-alloc-2.ml
+++ b/testsuite/tests/tool-ocaml/t310-alloc-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t320-gc-1.ml
+++ b/testsuite/tests/tool-ocaml/t320-gc-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t320-gc-2.ml
+++ b/testsuite/tests/tool-ocaml/t320-gc-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t320-gc-3.ml
+++ b/testsuite/tests/tool-ocaml/t320-gc-3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t330-compact-1.ml
+++ b/testsuite/tests/tool-ocaml/t330-compact-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t330-compact-2.ml
+++ b/testsuite/tests/tool-ocaml/t330-compact-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t330-compact-3.ml
+++ b/testsuite/tests/tool-ocaml/t330-compact-3.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t330-compact-4.ml
+++ b/testsuite/tests/tool-ocaml/t330-compact-4.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t340-weak.ml
+++ b/testsuite/tests/tool-ocaml/t340-weak.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t350-heapcheck.ml
+++ b/testsuite/tests/tool-ocaml/t350-heapcheck.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t360-stacks-1.ml
+++ b/testsuite/tests/tool-ocaml/t360-stacks-1.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocaml/t360-stacks-2.ml
+++ b/testsuite/tests/tool-ocaml/t360-stacks-2.ml
@@ -1,6 +1,6 @@
 (* TEST
 include tool-ocaml-lib
-flags = "-w a"
+flags = "-w -a"
 ocaml_script_as_argument = "true"
 * setup-ocaml-build-env
 ** ocaml

--- a/testsuite/tests/tool-ocamlc-error-cleanup/test.ml
+++ b/testsuite/tests/tool-ocamlc-error-cleanup/test.ml
@@ -3,7 +3,7 @@
 compiler_output = "compiler-output.raw"
 ** ocamlc.byte
 all_modules = "test.ml"
-flags = "-warn-error A"
+flags = "-warn-error +A"
 ocamlc_byte_exit_status = "2"
 *** script
 script = "sh ${test_source_directory}/check-error-cleanup.sh"
@@ -11,6 +11,6 @@ script = "sh ${test_source_directory}/check-error-cleanup.sh"
 
 (* Regression test for MPR#7918 *)
 let f () =
-  (* -warn-error A will error with unused x below *)
+  (* -warn-error +A will error with unused x below *)
   let x = 12 in
   1

--- a/testsuite/tests/typing-fstclassmod/fstclassmod.ml
+++ b/testsuite/tests/typing-fstclassmod/fstclassmod.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w A -warn-error A"
+   flags = "-w +A -warn-error +A"
 *)
 
 (* Example of algorithm parametrized with modules *)

--- a/testsuite/tests/typing-misc-bugs/core_array_reduced_ok.ml
+++ b/testsuite/tests/typing-misc-bugs/core_array_reduced_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-misc-bugs/pr6303_bad.ml
+++ b/testsuite/tests/typing-misc-bugs/pr6303_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-misc-bugs/pr6946_bad.ml
+++ b/testsuite/tests/typing-misc-bugs/pr6946_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/gatien_baron_20131019_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/gatien_baron_20131019_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr5164_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr5164_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr51_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr51_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr5663_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr5663_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr5914_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr5914_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6240_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6240_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6293_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6293_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr6427_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6427_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr6485_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6485_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6513_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6513_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6572_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6572_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6651_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6651_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6752_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6752_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr6752_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6752_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6899_first_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6899_first_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr6899_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6899_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6899_second_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6899_second_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr6944_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6944_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6954_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6954_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6981_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6981_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6982_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6985_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6985_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr6992_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6992_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr7036_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7036_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7082_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7082_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7112_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7112_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr7112_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7112_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7152_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7152_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7182_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7182_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7305_principal.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7305_principal.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -principal -w +18+19 -warn-error A "
+flags = " -principal -w +18+19 -warn-error +A "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7321_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7321_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7414_2_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7414_2_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr7414_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7414_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-modules-bugs/pr7519_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7519_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7601_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7601_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr7601a_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7601a_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-modules-bugs/pr9695_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr9695_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a -no-alias-deps"
+flags = " -w -a -no-alias-deps"
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.ml
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.ml
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-objects-bugs/pr4435_bad.ml
+++ b/testsuite/tests/typing-objects-bugs/pr4435_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-objects-bugs/pr4766_ok.ml
+++ b/testsuite/tests/typing-objects-bugs/pr4766_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-objects-bugs/pr4824_ok.ml
+++ b/testsuite/tests/typing-objects-bugs/pr4824_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-objects-bugs/pr4824a_bad.ml
+++ b/testsuite/tests/typing-objects-bugs/pr4824a_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-objects-bugs/pr5156_ok.ml
+++ b/testsuite/tests/typing-objects-bugs/pr5156_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-objects-bugs/pr7284_bad.ml
+++ b/testsuite/tests/typing-objects-bugs/pr7284_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-objects-bugs/pr7293_ok.ml
+++ b/testsuite/tests/typing-objects-bugs/pr7293_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-objects-bugs/woodyatt_ok.ml
+++ b/testsuite/tests/typing-objects-bugs/woodyatt_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-objects-bugs/yamagata021012_ok.ml
+++ b/testsuite/tests/typing-objects-bugs/yamagata021012_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-poly-bugs/pr5322_ok.ml
+++ b/testsuite/tests/typing-poly-bugs/pr5322_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-poly-bugs/pr5673_ok.ml
+++ b/testsuite/tests/typing-poly-bugs/pr5673_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-poly-bugs/pr6922_ok.ml
+++ b/testsuite/tests/typing-poly-bugs/pr6922_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-polyvariants-bugs/pr4775_ok.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr4775_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-polyvariants-bugs/pr4933_ok.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr4933_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-polyvariants-bugs/pr5057_ok.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr5057_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-polyvariants-bugs/pr5057a_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr5057a_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-polyvariants-bugs/pr7199_ok.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7199_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-polyvariants-bugs/privrowsabate_ok.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/privrowsabate_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-private-bugs/pr5026_bad.ml
+++ b/testsuite/tests/typing-private-bugs/pr5026_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-private-bugs/pr5469_ok.ml
+++ b/testsuite/tests/typing-private-bugs/pr5469_ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t01bad.ml
+++ b/testsuite/tests/typing-recmod/t01bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t02bad.ml
+++ b/testsuite/tests/typing-recmod/t02bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t03ok.ml
+++ b/testsuite/tests/typing-recmod/t03ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t04bad.ml
+++ b/testsuite/tests/typing-recmod/t04bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t05bad.ml
+++ b/testsuite/tests/typing-recmod/t05bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t06ok.ml
+++ b/testsuite/tests/typing-recmod/t06ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t07bad.ml
+++ b/testsuite/tests/typing-recmod/t07bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t08bad.ml
+++ b/testsuite/tests/typing-recmod/t08bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t09bad.ml
+++ b/testsuite/tests/typing-recmod/t09bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t10ok.ml
+++ b/testsuite/tests/typing-recmod/t10ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t11bad.ml
+++ b/testsuite/tests/typing-recmod/t11bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t12bad.ml
+++ b/testsuite/tests/typing-recmod/t12bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t13ok.ml
+++ b/testsuite/tests/typing-recmod/t13ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t14bad.ml
+++ b/testsuite/tests/typing-recmod/t14bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t15bad.ml
+++ b/testsuite/tests/typing-recmod/t15bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-recmod/t16ok.ml
+++ b/testsuite/tests/typing-recmod/t16ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t17ok.ml
+++ b/testsuite/tests/typing-recmod/t17ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t18ok.ml
+++ b/testsuite/tests/typing-recmod/t18ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t20ok.ml
+++ b/testsuite/tests/typing-recmod/t20ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t21ok.ml
+++ b/testsuite/tests/typing-recmod/t21ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-recmod/t22ok.ml
+++ b/testsuite/tests/typing-recmod/t22ok.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a "
+flags = " -w -a "
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 *** check-ocamlc.byte-output

--- a/testsuite/tests/typing-rectypes-bugs/pr5343_bad.ml
+++ b/testsuite/tests/typing-rectypes-bugs/pr5343_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a -rectypes "
+flags = " -w -a -rectypes "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-rectypes-bugs/pr6174_bad.ml
+++ b/testsuite/tests/typing-rectypes-bugs/pr6174_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a -rectypes "
+flags = " -w -a -rectypes "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-rectypes-bugs/pr6870_bad.ml
+++ b/testsuite/tests/typing-rectypes-bugs/pr6870_bad.ml
@@ -1,5 +1,5 @@
 (* TEST
-flags = " -w a -rectypes "
+flags = " -w -a -rectypes "
 ocamlc_byte_exit_status = "2"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/coercions.ml
+++ b/testsuite/tests/typing-warnings/coercions.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/open_warnings.ml
+++ b/testsuite/tests/typing-warnings/open_warnings.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A-41-42-18"
+   flags = " -w +A-41-42-18"
    * expect
 *)
 module T1 : sig end = struct

--- a/testsuite/tests/typing-warnings/pr5892.ml
+++ b/testsuite/tests/typing-warnings/pr5892.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr7085.ml
+++ b/testsuite/tests/typing-warnings/pr7085.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr7115.ml
+++ b/testsuite/tests/typing-warnings/pr7115.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr7261.ml
+++ b/testsuite/tests/typing-warnings/pr7261.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * toplevel
 *)
 

--- a/testsuite/tests/typing-warnings/pr7297.ml
+++ b/testsuite/tests/typing-warnings/pr7297.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/pr9244.ml
+++ b/testsuite/tests/typing-warnings/pr9244.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A "
+   flags = " -w +A "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/unused_functor_parameter.ml
+++ b/testsuite/tests/typing-warnings/unused_functor_parameter.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A "
+   flags = " -w +A "
    * expect
 *)
 

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = " -w A -strict-sequence "
+   flags = " -w +A -strict-sequence "
    * expect
 *)
 

--- a/testsuite/tests/warnings/deprecated_module.ml
+++ b/testsuite/tests/warnings/deprecated_module.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * bytecode
 

--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * bytecode
 

--- a/testsuite/tests/warnings/deprecated_module_use.ml
+++ b/testsuite/tests/warnings/deprecated_module_use.ml
@@ -4,12 +4,12 @@ modules = "deprecated_module.mli deprecated_module.ml"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
-flags = "-w a"
+flags = "-w -a"
 module = "deprecated_module.mli"
 *** ocamlc.byte
 module = "deprecated_module.ml"
 **** ocamlc.byte
-flags = "-w A"
+flags = "-w +A"
 module = "deprecated_module_use.ml"
 ***** check-ocamlc.byte-output
 

--- a/testsuite/tests/warnings/w01.ml
+++ b/testsuite/tests/warnings/w01.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w03.ml
+++ b/testsuite/tests/warnings/w03.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w04.ml
+++ b/testsuite/tests/warnings/w04.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w04_failure.ml
+++ b/testsuite/tests/warnings/w04_failure.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w06.ml
+++ b/testsuite/tests/warnings/w06.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w32b.ml
+++ b/testsuite/tests/warnings/w32b.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w33.ml
+++ b/testsuite/tests/warnings/w33.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w45.ml
+++ b/testsuite/tests/warnings/w45.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w47_inline.ml
+++ b/testsuite/tests/warnings/w47_inline.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w50.ml
+++ b/testsuite/tests/warnings/w50.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w51.ml
+++ b/testsuite/tests/warnings/w51.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w A"
+   flags = "-w +A"
    * expect
 *)
 

--- a/testsuite/tests/warnings/w51_bis.ml
+++ b/testsuite/tests/warnings/w51_bis.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w52.ml
+++ b/testsuite/tests/warnings/w52.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w A"
+   flags = "-w +A"
    * expect
 *)
 

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A-60"
+flags = "-w +A-60"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w54.ml
+++ b/testsuite/tests/warnings/w54.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w55.ml
+++ b/testsuite/tests/warnings/w55.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 compile_only = "true"
 
 * setup-ocamlc.byte-build-env

--- a/testsuite/tests/warnings/w58.ml
+++ b/testsuite/tests/warnings/w58.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 files = "module_without_cmx.mli"
 
 * setup-ocamlc.byte-build-env

--- a/testsuite/tests/warnings/w59.ml
+++ b/testsuite/tests/warnings/w59.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 compile_only = "true"
 
 * setup-ocamlc.byte-build-env

--- a/testsuite/tests/warnings/w60.ml
+++ b/testsuite/tests/warnings/w60.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A-67"
+flags = "-w +A-67"
 
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte

--- a/testsuite/tests/warnings/w68.ml
+++ b/testsuite/tests/warnings/w68.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-w A"
+flags = "-w +A"
 
 * setup-ocamlopt.byte-build-env
 ** ocamlopt.byte

--- a/testsuite/tests/win-unicode/mltest.ml
+++ b/testsuite/tests/win-unicode/mltest.ml
@@ -1,6 +1,6 @@
 (* TEST
 include unix
-flags += "-strict-sequence -safe-string -w A -warn-error A"
+flags += "-strict-sequence -safe-string -w +A -warn-error +A"
 * windows-unicode
 ** toplevel
 *)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -76,7 +76,7 @@ INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp \
                        middle_end middle_end/closure middle_end/flambda \
                        middle_end/flambda/base_types driver toplevel \
                        file_formats lambda)
-COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
+COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error +A \
  -principal -safe-string -strict-formats -bin-annot $(INCLUDES)
 LINKFLAGS = $(INCLUDES)
 VPATH := $(filter-out -I,$(INCLUDES))

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -15,7 +15,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@warning "a-40-6"]
+[@@@warning "+a-4-6-40..42-44-48"]
 open StdLabels
 open Str
 
@@ -119,7 +119,7 @@ module Toplevel = struct
     let buffer = Buffer.create 100 in
     let rec read_toplevel_stdout () =
       match Unix.select[stdout_out][][] 0. with
-      | [a], _, _ ->
+      | [_a], _, _ ->
           let n = Unix.read stdout_out b 0 size in
           Buffer.add_subbytes buffer b 0 n;
           if n = size then read_toplevel_stdout ()

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -494,7 +494,7 @@ let print_version_num () =
 
 let main () =
   try
-    Warnings.parse_options false "a";
+    Option.iter Location.(prerr_alert none) @@ Warnings.parse_options false "a";
     Arg.parse_expand [
        "-f", Arg.String (fun s -> dumpfile := s),
              "<file>     Use <file> as dump file (default ocamlprof.dump)";

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -318,7 +318,7 @@ let _ = add_directive "remove_printer"
     }
 
 let parse_warnings ppf iserr s =
-  try Warnings.parse_options iserr s
+  try Option.iter Location.(prerr_alert none) @@ Warnings.parse_options iserr s
   with Arg.Bad err -> fprintf ppf "%s.@." err
 
 (* Typing information *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2773,7 +2773,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       Typecore.reset_delayed_checks ();
       Env.reset_required_globals ();
       if !Clflags.print_types then (* #7656 *)
-        Warnings.parse_options false "-32-34-37-38-60";
+        ignore @@ Warnings.parse_options false "-32-34-37-38-60";
       let (str, sg, names, finalenv) =
         type_structure initial_env ast in
       let simple_sg = Signature_names.simplify finalenv names sg in

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -99,7 +99,7 @@ type t =
 
 type alert = {kind:string; message:string; def:loc; use:loc}
 
-val parse_options : bool -> string -> unit;;
+val parse_options : bool -> string -> alert option;;
 
 val parse_alert_option: string -> unit
   (** Disable/enable alerts based on the parameter to the -alert


### PR DESCRIPTION
This PR adds a new alert, `ocaml_deprecated_cli`, when using non-prefixed letter in a warning specification.
For instance, calling ocamlopt with
```bash
$ ocamlopt -w fragile-math test.ml
```
raises the following alert:
>```
>File "_none_", line 1:
>Alert ocaml_deprecated_cli: Setting a warning with a single lowercase or uppercase letter is deprecated.
>Prefix each letter with either '+' or '-': -a-e-f-g-h-i-l-r-t.
>```

This PR aims to make the coexistence of letter and named warning more harmonious. In particular, catching spelling mistake in warning name is already an useful feature. In the longer term, removing non-prefixed letter warning would make it possible to decouple the parsing of warnings from the list of known warnings at version `v`.

Using a specific deprecation alert seemed a good option, since this a deprecation of the cli interface which is quite distinct from a deprecation in the standard library.

Looking at the change in the testsuite, most of them correspond to switching `-w a` or `-w A` to `-w -a` and `-w +A` respectively.
It might make sense to make an exception for this specific case, but regularity has its charm.

cc @gasche , @damiendoligez 