### PR TITLE
Convert the Travis hygiene tests to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: main
+name: Build
 
 on: [push, pull_request]
 

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -1,0 +1,70 @@
+name: Hygiene
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  hygiene:
+    name: Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub Context
+        run: echo $GITHUB_CONTEXT
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        # Comment out the line below to enable (debugging) display of the github
+        # context variable.
+        if: failure()
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+
+      - name: Changes updated
+        run: >-
+          tools/ci/actions/check-changes-modified.sh
+          'pull_request'
+          '${{ github.event.pull_request.base.ref }}'
+          '${{ github.event.pull_request.base.sha }}'
+          '${{ github.event.pull_request.head.ref }}'
+          '${{ github.event.pull_request.head.sha }}'
+        if: >-
+          !contains(github.event.pull_request.labels.*.name, 'no-change-entry-needed')
+          && github.event_name == 'pull_request'
+
+      - name: configure correctly generated
+        run: >-
+          tools/ci/actions/check-configure.sh
+          '${{ github.event_name }}'
+          '${{ github.event.pull_request.base.ref }}'
+          '${{ github.event.pull_request.base.sha }}'
+          '${{ github.event.pull_request.head.ref }}'
+          '${{ github.event.pull_request.head.sha }}'
+          '${{ github.event.ref }}'
+          '${{ github.event.before }}'
+          '${{ github.event.ref }}'
+          '${{ github.event.after }}'
+        if: ${{ always() }}
+
+      - name: check-typo revered
+        run: >-
+          tools/ci/actions/check-typo.sh
+          '${{ github.event_name }}'
+          '${{ github.event.pull_request.base.ref }}'
+          '${{ github.event.pull_request.base.sha }}'
+          '${{ github.event.pull_request.head.ref }}'
+          '${{ github.event.pull_request.head.sha }}'
+          '${{ github.event.ref }}'
+          '${{ github.event.before }}'
+          '${{ github.event.ref }}'
+          '${{ github.event.after }}'
+        if: ${{ always() }}
+
+      - name: check-typo on whole tree
+        run: tools/check-typo
+        if: >-
+          github.event_name == 'push'
+          && (startsWith(github.event.ref, 'refs/heads/4.')
+             || github.event.ref == 'refs/heads/trunk')
+          && always()

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ script: tools/ci/travis/travis-ci.sh
 matrix:
   include:
   - env: CI_KIND=check-depend
-  - env: CI_KIND=changes
   - env: CI_KIND=manual
-  - env: CI_KIND=check-typo
 
 notifications:
   email:

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 |=====
 | Branch `trunk` | Branch `4.12` | Branch `4.11` | Branch `4.10`
 
-| image:https://github.com/ocaml/ocaml/workflows/main/badge.svg?branch=trunk["Github CI Build Status (trunk branch)",
-     link="https://github.com/ocaml/ocaml/actions?query=workflow%3Amain"]
+| image:https://github.com/ocaml/ocaml/workflows/Build/badge.svg?branch=trunk["Github CI Build Status (trunk branch)",
+     link="https://github.com/ocaml/ocaml/actions?query=workflow%3ABuild"]
   image:https://github.com/ocaml/ocaml/workflows/Hygiene/badge.svg?branch=trunk["Github CI Hygiene Status (trunk branch)",
      link="https://github.com/ocaml/ocaml/actions?query=workflow%3AHygiene"]
   image:https://ci.appveyor.com/api/projects/status/github/ocaml/ocaml?branch=trunk&svg=true["AppVeyor Build Status (trunk branch)",

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,8 @@
 
 | image:https://github.com/ocaml/ocaml/workflows/main/badge.svg?branch=trunk["Github CI Build Status (trunk branch)",
      link="https://github.com/ocaml/ocaml/actions?query=workflow%3Amain"]
+  image:https://github.com/ocaml/ocaml/workflows/Hygiene/badge.svg?branch=trunk["Github CI Hygiene Status (trunk branch)",
+     link="https://github.com/ocaml/ocaml/actions?query=workflow%3AHygiene"]
   image:https://ci.appveyor.com/api/projects/status/github/ocaml/ocaml?branch=trunk&svg=true["AppVeyor Build Status (trunk branch)",
      link="https://ci.appveyor.com/project/avsm/ocaml"]
 | image:https://github.com/ocaml/ocaml/workflows/main/badge.svg?branch=4.12["Github CI Build Status (4.12 branch)",

--- a/tools/ci/actions/check-changes-modified.sh
+++ b/tools/ci/actions/check-changes-modified.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 David Allsopp, OCaml Labs, Cambridge.                  *
+#*                                                                        *
+#*   Copyright 2021 David Allsopp Ltd.                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+set -e
+
+# Hygiene Checks: check that Changes has been updated in PRs
+# One of the following must be true:
+#   - A commit in the PR alters the Changes file
+#   - A commit in the PR contains a line like 'No change needed' ($REGEX below)
+#   - The no-change-entry-needed label is applied to the PR (handled in YAML)
+
+# We need all the commits in the PR to be available
+. tools/ci/actions/deepen-fetch.sh
+
+MSG='Check Changes has been updated'
+COMMIT_RANGE="$MERGE_BASE..$PR_HEAD"
+
+# Check if Changes has been updated in the PR
+if git diff "$COMMIT_RANGE" --name-only --exit-code Changes > /dev/null; then
+  # Check if any commit messages include something like No Changes entry needed
+  REGEX='[Nn]o [Cc]hange.* needed'
+  if [[ -n $(git log --grep="$REGEX" --max-count=1 "$COMMIT_RANGE") ]]; then
+    echo -e "$MSG: \e[33mSKIPPED\e[0m (owing to commit message)"
+  else
+    echo -e "$MSG: \e[31mNO\e[0m"
+    cat <<"EOF"
+------------------------------------------------------------------------
+Most contributions should come with a message in the Changes file, as
+described in our contributor documentation:
+
+  https://github.com/ocaml/ocaml/blob/trunk/CONTRIBUTING.md#changelog
+
+Some very minor changes (typo fixes for example) may not need
+a Changes entry. In this case, you may explicitly disable this test by
+adding the code word "No change entry needed" (on a single line) to
+a commit message of the PR, or using the "no-change-entry-needed" label
+on the github pull request.
+------------------------------------------------------------------------
+EOF
+    exit 1
+  fi
+else
+  echo -e "$MSG: \e[32mYES\e[0m"
+fi

--- a/tools/ci/actions/check-configure.sh
+++ b/tools/ci/actions/check-configure.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 David Allsopp, OCaml Labs, Cambridge.                  *
+#*                                                                        *
+#*   Copyright 2021 David Allsopp Ltd.                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# Hygiene Checks: ensure that configure.ac generates configure
+# This tests both branches and PRs. Any commit which updates either files which
+# affect configure (configure.ac, VERSION, aclocal.m4 and build-aux/*) and also
+# which alter this script.
+# The behaviour is slightly different for pushes vs pull requests: in a PR, all
+# commits must be correct; in a push, it must be the case that the configure is
+# correct at the tip of the branch. This allows you to push a correcting PR to
+# trunk, for example, but rejects a PR which includes bad commits (for increased
+# bisect safety).
+
+set -e
+
+if [[ $1 = 'pull_request' ]]; then
+  ALL_COMMITS_MUST_PASS=1
+else
+  ALL_COMMITS_MUST_PASS=0
+fi
+
+# We need all the commits in the PR to be available
+. tools/ci/actions/deepen-fetch.sh
+
+# Display failing commits in red for PRs and yellow for branches (error/warning)
+if ((ALL_COMMITS_MUST_PASS)); then
+  COLOR='31'
+else
+  COLOR='33'
+fi
+
+CI_SCRIPT='tools/ci/actions/check-configure.sh'
+PATHS='configure\|configure\.ac\|VERSION\|aclocal\.m4\|build-aux/.*'
+
+# $1 - commit to checkout files from
+# $2 - range of commits to diff
+# When testing a single commit, $1 and $2 will be the same; when validating the
+# tip of a branch, $1 will be HEAD and $2 will be the range of commits in the
+# branch.
+CheckTree () {
+  RET=0
+  COMMIT="$1"
+  COMMITS_TO_SEARCH="$2"
+  if git diff-tree --diff-filter=d --no-commit-id --name-only -r \
+       "$COMMITS_TO_SEARCH" | grep -qx "$PATHS\|$CI_SCRIPT"; then
+    git checkout -qB return
+    git checkout -q "$COMMIT"
+    mv configure configure.ref
+    make -s configure
+    if diff -q configure configure.ref >/dev/null ; then
+      echo -e "$COMMIT: \e[32mconfigure.ac generates configure\e[0m"
+    else
+      RET=1
+      echo -e \
+        "$COMMIT: \e[${COLOR}mconfigure.ac doesn't generate configure\e[0m"
+    fi
+    mv configure.ref configure
+    git checkout -q return
+  fi
+  return $RET
+}
+
+# $RESULT is 1 for success and 0 for error
+RESULT=1
+# We traverse the commits in commit order; if $ALL_COMMITS_MUST_PASS=0, the
+# success of the most recent commit of the branch (traversed last) will
+# override any previous failure.
+for commit in $(git rev-list "$MERGE_BASE..$PR_HEAD" --reverse); do
+  if CheckTree "$commit" "$commit"; then
+    if ((!ALL_COMMITS_MUST_PASS)); then
+      # Commit passed, so reset any previous failure
+      RESULT=1
+    fi
+  else
+    RESULT=0
+  fi
+done
+
+if ((!RESULT)); then
+  echo 'configure.ac no longer generates configure'
+  if ((ALL_COMMITS_MUST_PASS)); then
+    echo 'Please rebase the PR, editing the commits identified above and run:'
+  else
+    echo 'Please fix the branch by committing changes after running:'
+  fi
+  echo 'make -B configure'
+  exit 1
+fi

--- a/tools/ci/actions/check-typo.sh
+++ b/tools/ci/actions/check-typo.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 David Allsopp, OCaml Labs, Cambridge.                  *
+#*                                                                        *
+#*   Copyright 2021 David Allsopp Ltd.                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# Hygiene Checks: ensure that check-typo passes for all files
+# This tests both branches and PRs. It is capable of requiring that every commit
+# in a PR satisfies check-typo, but at present it only requires that the HEAD
+# of the branch satisfies it.
+
+set -e
+
+# Set to 1 to require all commits individually to pass check-typo
+CHECK_ALL_COMMITS=0
+
+# We need all the commits in the PR to be available
+. tools/ci/actions/deepen-fetch.sh
+
+# Test to see if any part of the directory name has been marked prune
+not_pruned () {
+  DIR=$(dirname "$1")
+  if [[ $DIR = '.' ]] ; then
+    return 0
+  else
+    case ",$(git check-attr typo.prune "$DIR" | sed -e 's/.*: //')," in
+      ,set,)
+      return 1
+      ;;
+      *)
+
+      not_pruned "$DIR"
+      return $?
+    esac
+  fi
+}
+
+# $1 - commit to checkout files from
+# $2 - range of commits to diff
+CheckTypoTree () {
+  COMMIT="$1"
+  COMMITS_TO_SEARCH="$2"
+  export OCAML_CT_HEAD="$COMMIT"
+  export OCAML_CT_LS_FILES="git diff-tree --no-commit-id --name-only -r \
+$COMMITS_TO_SEARCH --"
+  export OCAML_CT_CAT='git cat-file --textconv'
+  export OCAML_CT_PREFIX="$COMMIT:"
+  GIT_INDEX_FILE=tmp-index git read-tree --reset -i "$COMMIT"
+  git diff-tree --diff-filter=d --no-commit-id --name-only -r \
+    "$COMMITS_TO_SEARCH" | (while IFS= read -r path
+  do
+    if not_pruned "$path" ; then
+      echo "Checking $COMMIT: $path"
+      if ! tools/check-typo "./$path" ; then
+        touch failed
+      fi
+    else
+      echo "NOT checking $COMMIT: $path (typo.prune)"
+    fi
+  done)
+  rm -f tmp-index
+}
+
+# tmp-index is used to ensure that correct version of .gitattributes is used by
+# check-typo
+export OCAML_CT_GIT_INDEX='tmp-index'
+export OCAML_CT_CA_FLAG='--cached'
+rm -f failed
+
+COMMIT_RANGE="$MERGE_BASE..$PR_HEAD"
+if ((CHECK_ALL_COMMITS)); then
+  # Check each commit in turn
+  for commit in $(git rev-list "$COMMIT_RANGE" --reverse); do
+    CheckTypoTree "$commit" "$commit"
+  done
+else
+  # Use the range of commits just to get the list of files to check; only HEAD
+  # is scanned.
+  CheckTypoTree "$FETCH_HEAD" "$COMMIT_RANGE"
+fi
+
+if [[ -e failed ]]; then
+  exit 1
+fi

--- a/tools/ci/actions/deepen-fetch.sh
+++ b/tools/ci/actions/deepen-fetch.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 David Allsopp, OCaml Labs, Cambridge.                  *
+#*                                                                        *
+#*   Copyright 2021 David Allsopp Ltd.                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# The aim of this script is to ensure that all the commits for a PR or branch
+# push are fetched. Particularly for long-lived PRs, the relevant commits for
+# the merge-base (i.e. the commit on trunk) will not be present by default.
+# For force pushes, the same can be true for branches (e.g. a rebase)
+# After running this script, 5 variables are available:
+#   - FETCH_HEAD - the merge commit for a PR or the tip of the branch of a push
+#   - UPSTREAM_BRANCH - the branch a PR is against or the full ref of the push
+#   - UPSTREAM_SHA - the tip of UPSTREAM_BRANCH (prior to push, if applicable)
+#   - PR_BRANCH - the PR's branch name; equal to $UPSTREAM_BRANCH for a push
+#   - PR_HEAD - the tip of PR_BRANCH (so, for a push, the new tip after pushing)
+
+# GitHub Actions doesn't support the ternary operator, so the dance is done here
+# Each script has:
+#   $1 - event type ('pull_request' or 'push')
+#   $2 - upstream branch name
+#   $3 - upstream branch SHA
+#   $4 - PR branch name
+#   $5 - PR SHA
+#   $6 - full ref being pushed
+#   $7 - upstream SHA prior to push
+#   $8 - repeats $6
+#   $9 - upstream SHA after the push
+if [[ $1 = 'pull_request' ]]; then
+  shift 1
+else
+  shift 5
+fi
+
+FETCH_HEAD=$(git rev-parse FETCH_HEAD)
+UPSTREAM_BRANCH="$1"
+UPSTREAM_HEAD="$2"
+PR_BRANCH="$3"
+PR_HEAD="$4"
+
+# Ensure that enough has been fetched to have all the commits between the
+# the two branches.
+
+NEW=0
+# Special case: new tags and new branches will have UPSTREAM_HEAD=0\{40}
+if [[ -z ${UPSTREAM_HEAD//0/} ]]; then
+  echo "$UPSTREAM_BRANCH is new: only testing HEAD"
+  UPSTREAM_HEAD="$PR_HEAD~1"
+  NEW=1
+elif ! git log -1 "$UPSTREAM_HEAD" &> /dev/null ; then
+  echo "$UPSTREAM_BRANCH has been force-pushed"
+  git fetch origin "$UPSTREAM_HEAD" &> /dev/null
+fi
+
+if ! git merge-base "$UPSTREAM_HEAD" "$PR_HEAD" &> /dev/null; then
+  echo "Determining merge-base of $UPSTREAM_HEAD..$PR_HEAD for $PR_BRANCH"
+
+  DEEPEN=50
+  MSG='Deepening'
+
+  while ! git merge-base "$UPSTREAM_HEAD" "$PR_HEAD" &> /dev/null
+  do
+    echo " - $MSG by $DEEPEN commits"
+    git fetch origin --deepen=$DEEPEN "$PR_BRANCH" &> /dev/null
+    MSG='Further deepening'
+    ((DEEPEN*=2))
+  done
+fi
+
+MERGE_BASE=$(git merge-base "$UPSTREAM_HEAD" "$PR_HEAD")
+
+if [[ $UPSTREAM_BRANCH != $PR_BRANCH ]]; then
+  echo "$PR_BRANCH branched from $UPSTREAM_BRANCH at: $MERGE_BASE"
+elif ((!NEW)); then
+  echo "$UPSTREAM_BRANCH branched at: $MERGE_BASE"
+fi


### PR DESCRIPTION
This convert the changes and check-typo Travis tests to GitHub Actions. The remaining two can be done in a separate PR as they're less fiddly.

These scripts are largely drawn from `tools/ci/travis/travis-ci.sh` - I haven't removed the code from there yet as the file can be deleted in one go once all the tests are migrated. There are two quite nice new features: firstly, the no-change-entry-needed label will always work (no API limits), and it automatically updates when added. The other is that the Hygiene checks are a single item, separate from the builds (@xavierleroy!). It's also possible in GHA to have all the steps run even if previous ones failed, so if you forget Changes, don't regenerate `configure` and put spaces at the end of all your lines, you get one red cross for Hygiene and, on looking at the log, can see that all three tests failed (as opposed to adding `Changes` and only then discovering the next problem).

The checks:
- For PRs, `configure` must be consistently generated in all commits. This wasn't properly enforced before, but should be for bisect safety. For branches, only the tip is checked, as before.
- `check-typo`, as before, has an option to enforce check-typo on all commits but doesn't do it - the full file list is checked at `HEAD` only.
- Unlike Travis, there's more information available for GitHub actions, and the checks on a branch push are only done to changed commits.
- I've tested it with tags and new branches!
- `check-typo` runs on pushes to `trunk` and `4.*`, which creates intentional noise if a PR is merged afterwards.