### PR TITLE
in doc, add a since annotation about `let exception`

### DIFF
--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -437,7 +437,10 @@ and allow one to use this polymorphism in recursive occurrences
 (when using @"let" "rec"@). Note however that this is a normal polymorphic
 type, unifiable with any instance of itself.
 
-It is possible to define local exceptions in expressions since 4.04:
+\subsubsection{sss:expr-local-exception}{Local exceptions}
+(Introduced in 4.04)
+
+It is possible to define local exceptions in expressions:
 @ "let" exception constr-decl "in" expr @ .
 The syntactic scope of the exception constructor is the inner
 expression, but nothing prevents exception values created with this

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -437,7 +437,7 @@ and allow one to use this polymorphism in recursive occurrences
 (when using @"let" "rec"@). Note however that this is a normal polymorphic
 type, unifiable with any instance of itself.
 
-It is possible to define local exceptions in expressions:
+It is possible to define local exceptions in expressions since 4.04:
 @ "let" exception constr-decl "in" expr @ .
 The syntactic scope of the exception constructor is the inner
 expression, but nothing prevents exception values created with this


### PR DESCRIPTION
construct introduced in 4.04 as per https://ocaml.org/releases/4.04.html
(thanks to theblatte@freenode for finding the release note)