### PR TITLE
Ctype nitpicks

### DIFF
--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -553,61 +553,6 @@ end = struct
     res
 end
 
-(* Mark a type. *)
-
-let not_marked_node ty = ty.level >= lowest_level
-    (* type nodes with negative levels are "marked" *)
-
-let flip_mark_node ty = Private_type_expr.set_level ty (pivot_level - ty.level)
-
-let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
-
-let rec mark_type ty =
-  let ty = repr ty in
-  if not_marked_node ty then begin
-    flip_mark_node ty;
-    iter_type_expr mark_type ty
-  end
-
-let mark_type_params ty =
-  iter_type_expr mark_type ty
-
-let type_iterators =
-  let it_type_expr it ty =
-    let ty = repr ty in
-    if try_mark_node ty then it.it_do_type_expr it ty
-  in
-  {type_iterators with it_type_expr}
-
-
-(* Remove marks from a type. *)
-let rec unmark_type ty =
-  let ty = repr ty in
-  if ty.level < lowest_level then begin
-    (* flip back the marked level *)
-    flip_mark_node ty;
-    iter_type_expr unmark_type ty
-  end
-
-let unmark_iterators =
-  let it_type_expr _it ty = unmark_type ty in
-  {type_iterators with it_type_expr}
-
-let unmark_type_decl decl =
-  unmark_iterators.it_type_declaration unmark_iterators decl
-
-let unmark_extension_constructor ext =
-  List.iter unmark_type ext.ext_type_params;
-  iter_type_expr_cstr_args unmark_type ext.ext_args;
-  Option.iter unmark_type ext.ext_ret_type
-
-let unmark_class_signature sign =
-  unmark_type sign.csig_self;
-  Vars.iter (fun _l (_m, _v, t) -> unmark_type t) sign.csig_vars
-
-let unmark_class_type cty =
-  unmark_iterators.it_class_type unmark_iterators cty
-
 
                   (*******************************************)
                   (*  Memorization of abbreviation expansion *)
@@ -827,3 +772,58 @@ let undo_compress (changes, _old) =
             Private_type_expr.set_desc ty desc; r := !next
         | _ -> ())
         log
+
+(* Mark a type. *)
+
+let not_marked_node ty = ty.level >= lowest_level
+    (* type nodes with negative levels are "marked" *)
+
+let flip_mark_node ty = Private_type_expr.set_level ty (pivot_level - ty.level)
+
+let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
+
+let rec mark_type ty =
+  let ty = repr ty in
+  if not_marked_node ty then begin
+    flip_mark_node ty;
+    iter_type_expr mark_type ty
+  end
+
+let mark_type_params ty =
+  iter_type_expr mark_type ty
+
+let type_iterators =
+  let it_type_expr it ty =
+    let ty = repr ty in
+    if try_mark_node ty then it.it_do_type_expr it ty
+  in
+  {type_iterators with it_type_expr}
+
+
+(* Remove marks from a type. *)
+let rec unmark_type ty =
+  let ty = repr ty in
+  if ty.level < lowest_level then begin
+    (* flip back the marked level *)
+    flip_mark_node ty;
+    iter_type_expr unmark_type ty
+  end
+
+let unmark_iterators =
+  let it_type_expr _it ty = unmark_type ty in
+  {type_iterators with it_type_expr}
+
+let unmark_type_decl decl =
+  unmark_iterators.it_type_declaration unmark_iterators decl
+
+let unmark_extension_constructor ext =
+  List.iter unmark_type ext.ext_type_params;
+  iter_type_expr_cstr_args unmark_type ext.ext_args;
+  Option.iter unmark_type ext.ext_ret_type
+
+let unmark_class_signature sign =
+  unmark_type sign.csig_self;
+  Vars.iter (fun _l (_m, _v, t) -> unmark_type t) sign.csig_vars
+
+let unmark_class_type cty =
+  unmark_iterators.it_class_type unmark_iterators cty

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -779,6 +779,7 @@ let not_marked_node ty = ty.level >= lowest_level
     (* type nodes with negative levels are "marked" *)
 
 let flip_mark_node ty = Private_type_expr.set_level ty (pivot_level - ty.level)
+let logged_mark_node ty = set_level ty (pivot_level - ty.level)
 
 let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -782,6 +782,7 @@ let flip_mark_node ty = Private_type_expr.set_level ty (pivot_level - ty.level)
 let logged_mark_node ty = set_level ty (pivot_level - ty.level)
 
 let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
+let try_logged_mark_node ty = not_marked_node ty && (logged_mark_node ty; true)
 
 let rec mark_type ty =
   let ty = repr ty in

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -171,6 +171,9 @@ val not_marked_node: type_expr -> bool
         (* Return true if a type node is not yet marked *)
 val flip_mark_node: type_expr -> unit
         (* Mark a type node. No [repr]'ing *)
+val logged_mark_node: type_expr -> unit
+        (* Mark a type node, logging the marking so it can be backtracked.
+           No [repr]'ing *)
 val try_mark_node: type_expr -> bool
         (* Mark a type node if it is not yet marked.
            Return false if it was already marked *)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -167,20 +167,33 @@ end
 
 val lowest_level: int
         (* Marked type: ty.level < lowest_level *)
+
 val not_marked_node: type_expr -> bool
         (* Return true if a type node is not yet marked *)
-val flip_mark_node: type_expr -> unit
-        (* Mark a type node. No [repr]'ing *)
+
 val logged_mark_node: type_expr -> unit
         (* Mark a type node, logging the marking so it can be backtracked.
            No [repr]'ing *)
+val try_logged_mark_node: type_expr -> bool
+        (* Mark a type node if it is not yet marked, logging the marking so it
+           can be backtracked.
+           Return false if it was already marked *)
+
+val flip_mark_node: type_expr -> unit
+        (* Mark a type node. No [repr]'ing.
+           The marking is not logged and will have to be manually undone using
+           one of the various [unmark]'ing functions below. *)
 val try_mark_node: type_expr -> bool
         (* Mark a type node if it is not yet marked.
+           The marking is not logged and will have to be manually undone using
+           one of the various [unmark]'ing functions below.
+
            Return false if it was already marked *)
 val mark_type: type_expr -> unit
         (* Mark a type recursively *)
 val mark_type_params: type_expr -> unit
         (* Mark the sons of a type node recursively *)
+
 val unmark_type: type_expr -> unit
 val unmark_type_decl: type_declaration -> unit
 val unmark_extension_constructor: extension_constructor -> unit

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -727,7 +727,6 @@ let duplicate_class_type ty =
 *)
 let rec generalize ty =
   let ty = repr ty in
-  (* generalize the type iff ty.level <= !current_level *)
   if (ty.level > !current_level) && (ty.level <> generic_level) then begin
     set_level ty generic_level;
     (* recur into abbrev for the speed *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -745,11 +745,11 @@ let generalize ty =
 
 (* Generalize the structure and lower the variables *)
 
-let rec generalize_structure var_level ty =
+let rec generalize_structure ty =
   let ty = repr ty in
   if ty.level <> generic_level then begin
-    if is_Tvar ty && ty.level > var_level then
-      set_level ty var_level
+    if is_Tvar ty && ty.level > !current_level then
+      set_level ty !current_level
     else if
       ty.level > !current_level &&
       match ty.desc with
@@ -758,13 +758,13 @@ let rec generalize_structure var_level ty =
       | _ -> true
     then begin
       set_level ty generic_level;
-      iter_type_expr (generalize_structure var_level) ty
+      iter_type_expr generalize_structure ty
     end
   end
 
 let generalize_structure ty =
   simple_abbrevs := Mnil;
-  generalize_structure !current_level ty
+  generalize_structure ty
 
 (* Generalize the spine of a function, if the level >= !current_level *)
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -182,7 +182,8 @@ val lower_contravariant: Env.t -> type_expr -> unit
         (* Lower level of type variables inside contravariant branches;
            to be used before generalize for expansive expressions *)
 val generalize_structure: type_expr -> unit
-        (* Same, but variables are only lowered to !current_level *)
+        (* Generalize the structure of a type, lowering variables
+           to !current_level *)
 val generalize_spine: type_expr -> unit
         (* Special function to generalize a method during inference *)
 val correct_levels: type_expr -> type_expr


### PR DESCRIPTION
The first commit (around `generalize_structure`) is just some trivial clean up that could/should have happened years ago when the surrounding code and interface changed.

The second commit removes a comment that was introduced in #9994 which is incorrect, and for which I already left a note in the PR. That comment was also, in my opinion, not really useful: it doesn't bring extra information, everything it says is obvious from the code, and it doesn't explain the motivations behind the code (not that it would be necessary in this particular case).

The next two commits are also follow ups to #9994, but I thought I'd just propose the changes instead of leaving more comments on that PR. The basic idea is that before that PR the code in `check_scope_escape` was using the exact same marking-through-levels code as the rest of `Ctype`, but the PR broke that regularity for no good reason. I think what happened is that the pattern was abstracted in that PR, and since that particular use of it didn't quite fit the template, then it got its own ad-hoc code.
So I extended a bit the template, and I think the result is neat. 