### PR TITLE
Simplify Windows debugger socket setup

### DIFF
--- a/Changes
+++ b/Changes
@@ -60,6 +60,10 @@ Working version
   default overhead parameter accordingly.
   (Damien Doligez, review by Josh Berdine and Xavier Leroy)
 
+- #10212: Simplify and improve the Windows-specific code that connects
+  to the debugger via a socket.
+  (Antonin Décimo, review by Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #9876: do not cache the young_limit GC variable in a processor register.

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -66,7 +66,7 @@ CAMLexport void caml_debugger_cleanup_fork(void)
 #include <netdb.h>
 #else
 #define ATOM ATOM_WS
-#include <winsock.h>
+#include <winsock2.h>
 #undef ATOM
 #include <process.h>
 #endif
@@ -103,29 +103,21 @@ static struct skiplist event_points_table = SKIPLIST_STATIC_INITIALIZER;
 static void open_connection(void)
 {
 #ifdef _WIN32
-  /* Set socket to synchronous mode so that file descriptor-oriented
-     functions (read()/write() etc.) can be used */
-
-  int oldvalue, oldvaluelen, newvalue, retcode;
-  oldvaluelen = sizeof(oldvalue);
-  retcode = getsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-                       (char *) &oldvalue, &oldvaluelen);
-  if (retcode == 0) {
-      newvalue = SO_SYNCHRONOUS_NONALERT;
-      setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-                 (char *) &newvalue, sizeof(newvalue));
-  }
-#endif
+  /* Set socket to synchronous mode (= non-overlapped) so that file
+     descriptor-oriented functions (read()/write() etc.) can be
+     used */
+  SOCKET sock = WSASocket(sock_domain, SOCK_STREAM, 0,
+                          NULL, 0,
+                          0 /* not WSA_FLAG_OVERLAPPED */);
+  if (sock != INVALID_SOCKET &&
+      connect(sock, &sock_addr.s_gen, sock_addr_len) == 0)
+    dbg_socket = _open_osfhandle(sock, 0);
+  if (dbg_socket == -1) {
+#else
   dbg_socket = socket(sock_domain, SOCK_STREAM, 0);
-#ifdef _WIN32
-  if (retcode == 0) {
-    /* Restore initial mode */
-    setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-               (char *) &oldvalue, oldvaluelen);
-  }
-#endif
   if (dbg_socket == -1 ||
-      connect(dbg_socket, &sock_addr.s_gen, sock_addr_len) == -1){
+      connect(dbg_socket, &sock_addr.s_gen, sock_addr_len) == -1) {
+#endif
     caml_fatal_error
     (
       "cannot connect to debugger at %s\n"
@@ -134,11 +126,7 @@ static void open_connection(void)
       strerror (errno)
     );
   }
-#ifdef _WIN32
-  dbg_socket = _open_osfhandle(dbg_socket, 0);
-  if (dbg_socket == -1)
-    caml_fatal_error("_open_osfhandle failed");
-#endif
+
   dbg_in = caml_open_descriptor_in(dbg_socket);
   dbg_out = caml_open_descriptor_out(dbg_socket);
   /* The code in this file does not bracket channel I/O operations with

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -116,7 +116,7 @@ static void open_connection(void)
                      (dbg_addr ? dbg_addr : "(none)"),
                      WSAGetLastError());
   dbg_socket = _open_osfhandle(sock, 0);
-  if (dbg_socket != -1)
+  if (dbg_socket == -1)
 #else
   dbg_socket = socket(sock_domain, SOCK_STREAM, 0);
   if (dbg_socket == -1 ||


### PR DESCRIPTION
Don't use `SO_OPENTYPE` in Windows debugger. It was probably deprecated
at some point, and the same feature can be achieved with `WSASocket`.

The documentation reads (about `SO_OPENTYPE`):

> Once set, affects whether subsequent sockets that are created will
> be non-overlapped. The possible values for this option are
> `SO_SYNCHRONOUS_ALERT` and `SO_SYNCHRONOUS_NONALERT`. This option should
> not be used. Instead use the `WSASocket` function and leave the
> `WSA_FLAG_OVERLAPPED` bit in the `dwFlags` parameter turned off.

<https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options>

This allows to merge Windows-specific code and to remove all the
sockopt related code. Keeping the `_open_osfhandle` error is not
necessary.