### PR TITLE
Printtyp: explicit syntactic groups for printing

### DIFF
--- a/testsuite/tests/typing-modules/anonymous.ml
+++ b/testsuite/tests/typing-modules/anonymous.ml
@@ -29,7 +29,7 @@ end
 ;;
 [%%expect{|
 module type S =
-  sig module rec A : sig type t = B/2.t end and B : sig type t end end
+  sig module rec A : sig type t = B.t end and B : sig type t end end
 |}]
 
 let f (module _ : S) = ()

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1741,13 +1741,15 @@ and tree_of_signature sg =
 
 and tree_of_signature_rec env' sg =
   let structured = group_recursive_items (group_syntactic_items sg) in
-  let collect_trees_of_rec_group (env,trees) group =
-    let env', group_trees = trees_of_recursive_sigitem_group env group in
+  let collect_trees_of_rec_group group =
+    let env = !printing_env in
+    let env', group_trees =
+      trees_of_recursive_sigitem_group !printing_env group
+    in
     set_printing_env env';
-    env', (env, group_trees) :: trees in
-  let _, rev_trees =
-    List.fold_left collect_trees_of_rec_group (env',[]) structured in
-  List.rev rev_trees
+    (env, group_trees) in
+  set_printing_env env';
+  List.map collect_trees_of_rec_group structured
 
 and trees_of_recursive_sigitem_group env group =
   let display x =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1742,9 +1742,9 @@ and tree_of_signature sg =
 and tree_of_signature_rec env' sg =
   let structured = group_recursive_items (group_syntactic_items sg) in
   let collect_trees_of_rec_group (env,trees) group =
-    let env', more_trees = trees_of_recursive_sigitem_group env group in
+    let env', group_trees = trees_of_recursive_sigitem_group env group in
     set_printing_env env';
-    env', (env, more_trees) :: trees in
+    env', (env, group_trees) :: trees in
   let _, rev_trees =
     List.fold_left collect_trees_of_rec_group (env',[]) structured in
   List.rev rev_trees


### PR DESCRIPTION
This PR is extracted from #8929 : this restricted PR only refactorizes the printing of signature items to use an explicit notion of syntactic recursive groups in `typing/printtyp.ml`. Contrarily to #8929, this PR does not alter the handling of state, and thus does not fix the related bugs (except a small corner case bug, that was not straightforward to not fix along the refactorization).

The identification of syntactic groups is necessary when printing signature due to the presence of ghost signature items added by the typechecker. For instance,
```ocaml
type t = private [< `A]
and u = int
and v = private < .. >
```
is translated to
```ocaml
type t#row
type v#row
type t = private [< `A]
and u = int
and v = private < .. >
```
Similarly, the declaration classes and class types are augmented with ghost class type and type declarations in the typedtree:
```ocaml
class c = object end
```
is represented in the typedtree as
```ocaml
class c = ...
class type c = ...
type c = ...
type #c = ...
```

Before this PR, the printer in `typing/printtyp` was implicitly tracking the start and end of recursive definitions, and skipping ghost items on the fly. This PR materializes all those notions with an explicit `syntatic_rec_item_group` type and two kind of ghost items: ghost row type declaration (prefixed to a recursive type declaration) and ghost class type declaration (suffixed to the root class or class type declaration).
