### PR TITLE
Don't clobber GetLastError in Win32 systhreads caml_leave_blocking_section_hook

### DIFF
--- a/Changes
+++ b/Changes
@@ -210,6 +210,10 @@ Working version
 
 ### Bug fixes:
 
+* #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section
+  when the systhreads library is loaded.
+  (David Allsopp, report by Anton Bachin, review by Xavier Leroy)
+
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
   (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)
 

--- a/testsuite/tests/lib-threads/pr8857.ml
+++ b/testsuite/tests/lib-threads/pr8857.ml
@@ -1,0 +1,12 @@
+(* TEST
+
+* hassysthreads
+include systhreads
+** bytecode
+** native
+
+*)
+
+let _ =
+  try Unix.utimes "does-not-exist" 0.0 0.0
+  with Unix.(Unix_error(ENOENT, _, _)) -> ()


### PR DESCRIPTION
There are a few choices on how to do this:

- It's a shame to have `#ifdef _WIN32` in `st_stubs.c`, but it seems less convoluted than introducing additional hooks
- It's the hook which causes the problem so, unlike #5982, this is fixed in `st_stubs.c` rather than `runtime/signals.c`
- It's a breaking change, since quite a few functions now return different (though correct) exceptions, and this has been worked around (cf. https://github.com/ocsigen/lwt/issues/683, for example)

Fixes #8857