### PR TITLE
fix / enhance dune build

### DIFF
--- a/dune
+++ b/dune
@@ -92,7 +92,7 @@
     bytegen bytelibrarian bytelink bytepackager emitcode printinstr
 
     ;; driver/
-    errors compile
+    errors compile maindriver
  ))
 
 (library
@@ -164,7 +164,7 @@
    compute_ranges
 
    ;; driver/
-   optcompile opterrors
+   optcompile opterrors optmaindriver
  )
 )
 

--- a/ocamltest/dune
+++ b/ocamltest/dune
@@ -29,8 +29,7 @@
    ../Makefile.common
    ../Makefile.best_binaries
    Makefile
-   ./ocamltest_config.ml.in
-   ./getocamloptdefaultflags)
+   ./ocamltest_config.ml.in)
  (action (run make %{targets} COMPUTE_DEPS=false)))
 
 ;; FIXME: handle UNIX_OR_WIN32 or something similar

--- a/runtime/dune
+++ b/runtime/dune
@@ -60,6 +60,7 @@
   (wrapped false)
   (modules runtime)
   (flags (-nostdlib -nopervasives))
+  (library_flags -cclib "-I runtime")
   (self_build_stubs_archive (runtime)))
 
 (rule

--- a/runtime/dune
+++ b/runtime/dune
@@ -67,5 +67,11 @@
   (action (copy libcamlrun.a %{targets})))
 
 (rule
+ (targets dllruntime_stubs.so)
+ (action
+   (progn
+     (run %{cc} %{null} -shared -o %{targets})))) ; hack
+
+(rule
   (targets runtime.ml)
   (action (write-file %{targets} "let linkme = ()")))

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -30,8 +30,26 @@
 
 (rule
  (targets sys.ml)
- (deps (:version ../VERSION) (:p sys.mlp))
+ (deps
+   (:version ../VERSION)
+   (:p sys.mlp)
+   camlheader) ; camlheader here is a hack
  (action
    (with-stdout-to %{targets}
      (bash
        "sed -e \"s|%%VERSION%%|`sed -e 1q %{version} | tr -d '\r'`|\" %{p}"))))
+
+(rule
+ (targets camlheader)
+ (deps
+   ../Makefile.config
+   ../Makefile.build_config
+   ../Makefile.config_if_required
+   ../Makefile.common
+   Makefile
+   StdlibModules)
+ (action
+   (progn
+     (bash "touch .depend") ; hack.
+     (run make %{targets} COMPUTE_DEPS=false)
+     (bash "rm .depend"))))


### PR DESCRIPTION
This PR fixes the build of the following dune executables: `main.bc`, `main.exe`, `optmain.bc` and `optmain.exe`.

## Why

This is important for me as dune is the easiest way to get merlin / ocaml-lsp to work when doing compiler development and it's also seems to be the fastest feedback loop when actually building a compiler to test / experiment.

## Review

I added a couple of comments on the commits, and each one is standalone, so feel free to review commit-to-commit.

## Problems / Solutions

A couple of this are hacks, but all of them were properly marked as hacks.

**TLDR: this patch is not ideal, but it's better than a broken workflow**
### General

`optmaindriver` and `maindriver` were missing from the respective binaries

`getocamloptdefaultflags` was removed in the past, but not from the dune file

### .bc

Dune always adds a `-dllib -lruntime_stubs`, but there is no such library to load on runtime as it's a piece of `ocamlrun` to workaround it makes an empty `dllruntime_stubs.so`.

`camlheader` is required to make `.bc` files, to get it, I'm just calling `make` and adding it as a dependency on the `library` through the `sys.ml` file, this seems to be required as dune doesn't have a way to add files as dependencies on a `(library)` stanza.

### .exe

`-I runtime` is required to find the headers when building the custom bytecode runtime, but was not present, so it failed to build with an error pointing to a missing `caml/mlvalues.h`