### PR TITLE
Expand module types of forbidden paths in destructive substitutions

### DIFF
--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -685,18 +685,15 @@ module rec Bad : A = Bad;;
 [%%expect{|
 module type Alias = sig module N : sig end module M = N end
 module F : functor (X : sig end) -> sig type t end
-Line 1:
-Error: Module type declarations do not match:
-         module type A = sig module M = F(List) end
-       does not match
-         module type A = sig module M = F(List) end
-       At position module type A = <here>
-       Modules do not match:
-         sig module M = F(List) end
-       is not included in
-         sig module M = F(List) end
-       At position module type A = sig module M : <here> end
-       Module F(List) cannot be aliased
+module type A = sig module M : sig type t = F(List).t end end
+module rec Bad : A
+|}];;
+
+module F (X : sig end) : Alias with module N := X = struct
+  module M = X
+end;;
+[%%expect{|
+module F : functor (X : sig end) -> sig module M : sig end end
 |}];;
 
 (* Shinwell 2014-04-23 *)

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -110,18 +110,13 @@ module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
   module Id2 = Id
 end;;
 [%%expect{|
-Lines 2-5, characters 57-3:
-2 | .........................................................struct
-3 |   module Id = T'.T.Id
-4 |   module Id2 = Id
-5 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig module Id : sig end module Id2 = Id end
-       is not included in
-         sig module Id2 = T'.Term0.Id end
-       In module Id2:
-       Module T'.Term0.Id cannot be aliased
+module Make2 :
+  functor
+    (T' : sig
+            module Term0 : sig module Id : sig end end
+            module T : sig module Id : sig end end
+          end)
+    -> sig module Id2 : sig end end
 |}]
 
 module Make3 (T' : S) = struct

--- a/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
+++ b/testsuite/tests/typing-sigsubst/sig_local_aliases.ml
@@ -42,6 +42,15 @@ end;;
 module type Accepted2 = sig val foo : F(M).t -> int end
 |}]
 
+module type Accepted3 = sig
+  module M := F(M)
+
+  module N = M
+end;;
+[%%expect{|
+module type Accepted3 = sig module N : sig type t = M.t end end
+|}]
+
 module type Reject1 = sig
   module M := Funct(M)
 end;;

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -70,6 +70,12 @@ type scoping =
   | Make_local
   | Rescope of int
 
+val add_module_alias:
+  Path.t -> Path.t -> (string list -> scoping -> module_type) -> t -> t
+(** Add a module alias substitution.
+    [Mty_alias _] nodes are expanded to the module type returned by the
+    function, where the argument is the path below the substituted module. *)
+
 val modtype: scoping -> t -> module_type -> module_type
 val signature: scoping -> t -> signature -> signature
 val signature_item: scoping -> t -> signature_item -> signature_item

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -489,7 +489,7 @@ type module_type =
     Mty_ident of Path.t
   | Mty_signature of signature
   | Mty_functor of functor_parameter * module_type
-  | Mty_alias of Path.t
+  | Mty_alias of Path.t (* Invariant: Path does not contain Papply. *)
 
 and functor_parameter =
   | Unit


### PR DESCRIPTION
This PR modifies the handling of disallowed paths (functor arguments and functor applications) in `Mty_alias`, expanding to the module type of the path.

This is most noticeable with destructive substitutions, for example
```ocaml
module F (M : sig type t end) : sig type t end = struct type t end
module A = struct type t = int end
module type S = sig
  module M : sig type t end
  module N = M
end
module type S_subst = S with module M := F(A)
```
Previously, the module `N` in `S_subst` would have type `Mty_alias F(A)`. This causes some problems because `Mty_alias` does double-duty as a module type alias in the type system *and* a signal to the code generator that the path it carries should be used in place of that module. There is currently [a hack](https://github.com/ocaml/ocaml/blob/e55dcd372ac8a22b717caf2048d2aa5b05b83f0f/typing/includemod.ml#L280) preventing such signatures from ever being instantiated, to avoid generating code using these invalid paths.

Instead of creating invalid, uninstantiable signatures, this PR expands the alias of the substituted type. This creates a valid module type, which can be safely used in all of the usual ways, and ensures that invalid paths never appear in `Mty_alias`.

This is also consistent with what we currently do with aliases: replacing the `M := F(A)` with `M = F(A)` above refines the type of `M` to `module type of F(A)`.

This is a precursor to an (in progress) change to allow and track aliases to functor applications. This will remove some pain points from modular explicits (#9187), and allow extended aliases `module M = F(A)` in signatures. However, since this will impact the typing of functor applications (`= F(M)` instead of `: ...`) -- and thus affect the signatures of many programs -- I am planning to place it behind a feature flag. This PR is thus an attempt to get the behaviour correct when that flag is disabled.