### PR TITLE
Build system refactoring: rules to generate lexers and parsers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,7 +652,7 @@ otherlibs/dynlink/dynlink.cmxa: otherlibs/dynlink/native/dynlink.ml
 # The lexer
 
 parsing/lexer.ml: parsing/lexer.mll
-	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
+	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
 
 partialclean::
 	rm -f parsing/lexer.ml

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ else
 OCAML_NATDYNLINKOPTS = -ccopt "$(NATDYNLINKOPTS)"
 endif
 
-CAMLLEX=$(CAMLRUN) boot/ocamllex
+BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+OCAMLLEX ?= $(BOOT_OCAMLLEX)
 CAMLDEP=$(CAMLRUN) boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
@@ -651,8 +652,8 @@ otherlibs/dynlink/dynlink.cmxa: otherlibs/dynlink/native/dynlink.ml
 
 # The lexer
 
-parsing/lexer.ml: parsing/lexer.mll
-	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
+%.ml: %.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 partialclean::
 	rm -f parsing/lexer.ml

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ else
 OCAML_NATDYNLINKOPTS = -ccopt "$(NATDYNLINKOPTS)"
 endif
 
-BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 OCAMLLEX ?= $(BOOT_OCAMLLEX)
 CAMLDEP=$(CAMLRUN) boot/ocamlc -depend
 DEPFLAGS=-slash
@@ -650,10 +649,7 @@ natruntop:
 otherlibs/dynlink/dynlink.cmxa: otherlibs/dynlink/native/dynlink.ml
 	$(MAKE) -C otherlibs/dynlink allopt
 
-# The lexer
-
-%.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
+# Cleanup the lexer
 
 partialclean::
 	rm -f parsing/lexer.ml

--- a/Makefile.common
+++ b/Makefile.common
@@ -67,7 +67,7 @@ ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif
 # By default, request ocamllex to be quiet
-OCAMLLEX_FLAGS ?= -q
+OCAMLLEXFLAGS ?= -q
 
 # Escape special characters in the argument string.
 # There are four characters that need escaping:

--- a/Makefile.common
+++ b/Makefile.common
@@ -66,8 +66,6 @@ OPTCOMPFLAGS=
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif
-# By default, request ocamllex to be quiet
-OCAMLLEXFLAGS ?= -q
 
 # Escape special characters in the argument string.
 # There are four characters that need escaping:
@@ -120,3 +118,25 @@ ifneq ($(EXE),)
 $(1): $(1)$(EXE)
 endif
 endef # PROGRAM_SYNONYM
+
+# Lexer generation
+
+BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+# The OCAMLLEX command used in the recipe below is defined in the individual
+# makefiles, because its default value is directory-specific.
+# By default, some directories use BOOT_OCAMLLEX while others use the
+# freshly compiled lexer generator.
+
+OCAMLLEXFLAGS ?= -q
+
+%.ml: %.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
+
+# Parser generation
+
+OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+
+OCAMLYACCFLAGS ?=
+
+%.ml %.mli: %.mly
+	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -94,7 +94,7 @@ OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc$(EXE) \
 OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt$(EXE) $(OCFLAGS) \
          $(RUNTIME_VARIANT)
 OCAMLDOC=$(OCAMLRUN) $(OTOPDIR)/ocamldoc/ocamldoc$(EXE)
-OCAMLLEX=$(OCAMLRUN) $(OTOPDIR)/lex/ocamllex$(EXE)
+OCAMLLEX ?= $(OCAMLRUN) $(OTOPDIR)/lex/ocamllex$(EXE)
 OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib$(EXE) \
            -ocamlc "$(OTOPDIR)/runtime/ocamlrun$(USE_RUNTIME)$(EXE) \
                     $(OTOPDIR)/ocamlc$(EXE) $(OCFLAGS) $(RUNTIME_VARIANT)" \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -78,7 +78,7 @@ depend: beforedepend
 	| sed -e 's,$(UNIXDIR)/,$$(UNIXDIR)/,' > .depend
 
 debugger_lexer.ml: debugger_lexer.mll
-	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
+	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
 clean::
 	rm -f debugger_lexer.ml
 beforedepend:: debugger_lexer.ml

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -20,8 +20,6 @@ include $(ROOTDIR)/Makefile.best_binaries
 
 DYNLINKDIR=$(ROOTDIR)/otherlibs/dynlink
 UNIXDIR=$(ROOTDIR)/otherlibs/$(UNIXLIB)
-OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
-OCAMLYACCFLAGS =
 
 CAMLC=$(BEST_OCAMLC) -g -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
@@ -78,14 +76,10 @@ depend: beforedepend
 	$(CAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mli *.ml \
 	| sed -e 's,$(UNIXDIR)/,$$(UNIXDIR)/,' > .depend
 
-%.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 clean::
 	rm -f debugger_lexer.ml
 beforedepend:: debugger_lexer.ml
 
-%.ml %.mli: %.mly
-	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 clean::
 	rm -f debugger_parser.ml debugger_parser.mli
 beforedepend:: debugger_parser.ml debugger_parser.mli

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -20,13 +20,14 @@ include $(ROOTDIR)/Makefile.best_binaries
 
 DYNLINKDIR=$(ROOTDIR)/otherlibs/dynlink
 UNIXDIR=$(ROOTDIR)/otherlibs/$(UNIXLIB)
-CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACCFLAGS =
 
 CAMLC=$(BEST_OCAMLC) -g -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
           -safe-string -strict-sequence -strict-formats
 LINKFLAGS=-linkall -I $(UNIXDIR) -I $(DYNLINKDIR)
-CAMLLEX=$(BEST_OCAMLLEX)
+OCAMLLEX ?= $(BEST_OCAMLLEX)
 CAMLDEP=$(BEST_OCAMLDEP)
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
@@ -77,14 +78,14 @@ depend: beforedepend
 	$(CAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mli *.ml \
 	| sed -e 's,$(UNIXDIR)/,$$(UNIXDIR)/,' > .depend
 
-debugger_lexer.ml: debugger_lexer.mll
-	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
+%.ml: %.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 clean::
 	rm -f debugger_lexer.ml
 beforedepend:: debugger_lexer.ml
 
-debugger_parser.ml debugger_parser.mli: debugger_parser.mly
-	$(CAMLYACC) debugger_parser.mly
+%.ml %.mli: %.mly
+	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 clean::
 	rm -f debugger_parser.ml debugger_parser.mli
 beforedepend:: debugger_parser.ml debugger_parser.mli

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -19,7 +19,8 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.common
 
-CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACCFLAGS = -v
 
 CAMLC = $(BOOT_OCAMLC) -strict-sequence -nostdlib \
         -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
@@ -27,7 +28,8 @@ CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
             -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS =
-CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+OCAMLLEX ?= $(BOOT_OCAMLLEX)
 CAMLDEP = $(BOOT_OCAMLC) -depend
 DEPFLAGS = -slash
 DEPINCLUDES =
@@ -54,16 +56,16 @@ clean::
 	rm -f $(programs) $(programs:=.exe)
 	rm -f *.cmo *.cmi *.cmx *.cmt *.cmti *.o *.obj
 
-parser.ml parser.mli: parser.mly
-	$(CAMLYACC) -v parser.mly
+%.ml %.mli: %.mly
+	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 clean::
 	rm -f parser.ml parser.mli parser.output
 
 beforedepend:: parser.ml parser.mli
 
-lexer.ml: lexer.mll
-	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
+%.ml: %.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 clean::
 	rm -f lexer.ml

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -63,7 +63,7 @@ clean::
 beforedepend:: parser.ml parser.mli
 
 lexer.ml: lexer.mll
-	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
+	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
 
 clean::
 	rm -f lexer.ml

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -19,7 +19,6 @@ ROOTDIR = ..
 
 include $(ROOTDIR)/Makefile.common
 
-OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 OCAMLYACCFLAGS = -v
 
 CAMLC = $(BOOT_OCAMLC) -strict-sequence -nostdlib \
@@ -28,7 +27,6 @@ CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
             -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS =
-BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 OCAMLLEX ?= $(BOOT_OCAMLLEX)
 CAMLDEP = $(BOOT_OCAMLC) -depend
 DEPFLAGS = -slash
@@ -56,16 +54,10 @@ clean::
 	rm -f $(programs) $(programs:=.exe)
 	rm -f *.cmo *.cmi *.cmx *.cmt *.cmti *.o *.obj
 
-%.ml %.mli: %.mly
-	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
-
 clean::
 	rm -f parser.ml parser.mli parser.output
 
 beforedepend:: parser.ml parser.mli
-
-%.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 clean::
 	rm -f lexer.ml

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -229,7 +229,7 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 	$(OCAMLOPT_CMD) -shared -o $@ $(COMPFLAGS) $<
 
 .mll.ml:
-	$(OCAMLLEX) $(OCAMLLEX_FLAGS) $<
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 .mly.ml:
 	$(OCAMLYACC) --strict -v $<
@@ -409,10 +409,10 @@ clean:
 depend:
 	$(OCAMLYACC) odoc_text_parser.mly
 	$(OCAMLYACC) odoc_parser.mly
-	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_text_lexer.mll
-	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_lexer.mll
-	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_ocamlhtml.mll
-	$(OCAMLLEX) $(OCAMLLEX_FLAGS) odoc_see_lexer.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_text_lexer.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_lexer.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_ocamlhtml.mll
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_see_lexer.mll
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mll *.mly *.ml *.mli > .depend
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) -shared generators/*.ml >> .depend
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -19,13 +19,14 @@ include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
 OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACCFLAGS = --strict -v
 
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLC = $(BEST_OCAMLC) $(STDLIBFLAGS)
 OCAMLOPT = $(BEST_OCAMLOPT) $(STDLIBFLAGS)
 OCAMLDEP = $(BEST_OCAMLDEP)
 DEPFLAGS = -slash
-OCAMLLEX = $(BEST_OCAMLLEX)
+OCAMLLEX ?= $(BEST_OCAMLLEX)
 
 # For installation
 ##############
@@ -194,27 +195,20 @@ dot: ocamldoc.dot
 ocamldoc.dot: $(EXECMOFILES)
 	$(OCAMLDOC_RUN) -dot -dot-reduce -o $@ $(INCLUDES) odoc*.ml
 
-# Parsers and lexers dependencies :
-###################################
-odoc_text_parser.ml: odoc_text_parser.mly
-odoc_text_parser.mli: odoc_text_parser.mly
+# Lexers and parsers
 
-odoc_parser.ml:	odoc_parser.mly
-odoc_parser.mli:odoc_parser.mly
+LEXERS = $(addsuffix .mll,\
+  odoc_text_lexer odoc_lexer odoc_ocamlhtml odoc_see_lexer)
 
-odoc_text_lexer.ml: odoc_text_lexer.mll
+PARSERS = $(addsuffix .mly,odoc_parser  odoc_text_parser)
 
-odoc_lexer.ml:odoc_lexer.mll
-
-odoc_ocamlhtml.ml: odoc_ocamlhtml.mll
-
-odoc_see_lexer.ml: odoc_see_lexer.mll
-
+DEPEND_PREREQS = $(LEXERS:.mll=.ml) \
+  $(PARSERS:.mly=.mli) $(PARSERS:.mly=.ml)
 
 # generic rules :
 #################
 
-.SUFFIXES: .mll .mly .ml .mli .cmo .cmi .cmx .cmxs
+.SUFFIXES: .ml .mli .cmo .cmi .cmx .cmxs
 
 .ml.cmo:
 	$(OCAMLC) $(COMPFLAGS) -c $<
@@ -228,14 +222,11 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 .ml.cmxs:
 	$(OCAMLOPT_CMD) -shared -o $@ $(COMPFLAGS) $<
 
-.mll.ml:
+%.ml: %.mll
 	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
-.mly.ml:
-	$(OCAMLYACC) --strict -v $<
-
-.mly.mli:
-	$(OCAMLYACC) --strict -v $<
+%.ml %.mli: %.mly
+	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 # Installation targets
 ######################
@@ -406,13 +397,7 @@ clean:
         generators/*.cmx[as]
 
 .PHONY: depend
-depend:
-	$(OCAMLYACC) odoc_text_parser.mly
-	$(OCAMLYACC) odoc_parser.mly
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_text_lexer.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_lexer.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_ocamlhtml.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) odoc_see_lexer.mll
+depend: $(DEPEND_PREREQS)
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) *.mll *.mly *.ml *.mli > .depend
 	$(OCAMLDEP) $(DEPFLAGS) $(DEPINCLUDES) -shared generators/*.ml >> .depend
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -18,7 +18,6 @@ ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common
 include $(ROOTDIR)/Makefile.best_binaries
 
-OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
 OCAMLYACCFLAGS = --strict -v
 
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
@@ -221,12 +220,6 @@ DEPEND_PREREQS = $(LEXERS:.mll=.ml) \
 
 .ml.cmxs:
 	$(OCAMLOPT_CMD) -shared -o $@ $(COMPFLAGS) $<
-
-%.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
-
-%.ml %.mli: %.mly
-	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 # Installation targets
 ######################

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -242,7 +242,7 @@ ocamltest.opt$(EXE): $(deps_opt) $(native_modules)
 	$(ocamlyacc) $<
 
 %.ml: %.mll
-	$(ocamllex) $(OCAMLLEX_FLAGS) $<
+	$(ocamllex) $(OCAMLLEXFLAGS) $<
 
 ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix).ml
 	echo '# 1 "$^"' > $@

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -202,9 +202,6 @@ depincludes :=
 
 OCAMLLEX ?= $(BEST_OCAMLLEX)
 
-OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
-OCAMLYACCFLAGS =
-
 .SECONDARY: $(lexers:.mll=.ml) $(parsers:.mly=.mli) $(parsers:.mly=.ml)
 
 .PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
@@ -238,12 +235,6 @@ ocamltest.opt$(EXE): $(deps_opt) $(native_modules)
 
 %.cmi: %.mli $(deps_byte)
 	$(ocamlc) -c $<
-
-%.ml %.mli: %.mly
-	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
-
-%.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix).ml
 	echo '# 1 "$^"' > $@

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -200,9 +200,10 @@ ocamldep := $(BEST_OCAMLDEP)
 depflags := -slash
 depincludes :=
 
-ocamllex := $(BEST_OCAMLLEX)
+OCAMLLEX ?= $(BEST_OCAMLLEX)
 
-ocamlyacc := $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc$(EXE)
+OCAMLYACCFLAGS =
 
 .SECONDARY: $(lexers:.mll=.ml) $(parsers:.mly=.mli) $(parsers:.mly=.ml)
 
@@ -239,10 +240,10 @@ ocamltest.opt$(EXE): $(deps_opt) $(native_modules)
 	$(ocamlc) -c $<
 
 %.ml %.mli: %.mly
-	$(ocamlyacc) $<
+	$(OCAMLYACC) $(OCAMLYACCFLAGS) $<
 
 %.ml: %.mll
-	$(ocamllex) $(OCAMLLEXFLAGS) $<
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 ocamltest_unix.ml: ocamltest_unix_$(ocamltest_unix).ml
 	echo '# 1 "$^"' > $@

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -332,7 +332,7 @@ clean::
 # Common stuff
 
 %.ml: %.mll
-	$(CAMLLEX) $(OCAMLLEX_FLAGS) $<
+	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
 
 %.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) - $<

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -71,7 +71,8 @@ endef
 CAMLC = $(BOOT_OCAMLC) -g -nostdlib -I $(ROOTDIR)/boot \
         -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
 CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -g -nostdlib -I $(ROOTDIR)/stdlib
-CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+OCAMLLEX ?= $(BOOT_OCAMLLEX)
 INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp \
                        middle_end middle_end/closure middle_end/flambda \
                        middle_end/flambda/base_types driver toplevel \
@@ -332,7 +333,7 @@ clean::
 # Common stuff
 
 %.ml: %.mll
-	$(CAMLLEX) $(OCAMLLEXFLAGS) $<
+	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 %.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) - $<

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -71,7 +71,6 @@ endef
 CAMLC = $(BOOT_OCAMLC) -g -nostdlib -I $(ROOTDIR)/boot \
         -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
 CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -g -nostdlib -I $(ROOTDIR)/stdlib
-BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 OCAMLLEX ?= $(BOOT_OCAMLLEX)
 INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp \
                        middle_end middle_end/closure middle_end/flambda \
@@ -331,9 +330,6 @@ clean::
 	rm -f -- caml-tex caml-tex.exe caml_tex.cm?
 
 # Common stuff
-
-%.ml: %.mll
-	$(OCAMLLEX) $(OCAMLLEXFLAGS) $<
 
 %.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) - $<


### PR DESCRIPTION
It may be useful to be able to use already-installed tools rather than
those from the repository to re-compile the compiler.

This PR is a first step towards making this possible. It makes sure
it is possible to specify which ocamllex and ocmalyacc to use when running
make.

To make sure the OCAMLLEX and OCAMLYACC build variables are used
consistently, the rules used to generate lexers and parsers have been moved
from directory-specific makefiles to a central place, `Makefile.common`.