### PR TITLE
Improve code-generation for inlined comparisons

### DIFF
--- a/Changes
+++ b/Changes
@@ -70,6 +70,9 @@ Working version
 - #9937: improvements in ARM64 code generation (constants, sign extensions)
   (Xavier Leroy, review by Stephen Dolan)
 
+- #??: Better code-generation for inlined comparisons
+  (Stephen Dolan, review by ??)
+
 ### Standard library:
 
 - #9533: Added String.starts_with and String.ends_with.

--- a/Changes
+++ b/Changes
@@ -70,8 +70,8 @@ Working version
 - #9937: improvements in ARM64 code generation (constants, sign extensions)
   (Xavier Leroy, review by Stephen Dolan)
 
-- #??: Better code-generation for inlined comparisons
-  (Stephen Dolan, review by ??)
+- #10228: Better code-generation for inlined comparisons
+  (Stephen Dolan, review by Alain Frisch and Xavier Leroy)
 
 ### Standard library:
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1117,7 +1117,7 @@ and transl_unbox_sized size dbg env exp =
   | Thirty_two -> transl_unbox_int dbg env Pint32 exp
   | Sixty_four -> transl_unbox_int dbg env Pint64 exp
 
-and transl_let env str kind id exp body =
+and transl_let' env str kind id exp transl_body =
   let dbg = Debuginfo.none in
   let cexp = transl env exp in
   let unboxing =
@@ -1151,20 +1151,23 @@ and transl_let env str kind id exp body =
       (* N.B. [body] must still be traversed even if [exp] will never return:
          there may be constant closures inside that need lifting out. *)
       begin match str, kind with
-      | Immutable, _ -> Clet(id, cexp, transl env body)
-      | Mutable, Pintval -> Clet_mut(id, typ_int, cexp, transl env body)
-      | Mutable, _ -> Clet_mut(id, typ_val, cexp, transl env body)
+      | Immutable, _ -> Clet(id, cexp, transl_body env)
+      | Mutable, Pintval -> Clet_mut(id, typ_int, cexp, transl_body env)
+      | Mutable, _ -> Clet_mut(id, typ_val, cexp, transl_body env)
       end
   | Boxed (boxed_number, false) ->
       let unboxed_id = V.create_local (VP.name id) in
       let v = VP.create unboxed_id in
       let cexp = unbox_number dbg boxed_number cexp in
       let body =
-        transl (add_unboxed_id (VP.var id) unboxed_id boxed_number env) body in
+        transl_body (add_unboxed_id (VP.var id) unboxed_id boxed_number env) in
       begin match str, boxed_number with
       | Immutable, _ -> Clet (v, cexp, body)
       | Mutable, bn -> Clet_mut (v, typ_of_boxed_number bn, cexp, body)
       end
+
+and transl_let env str kind id exp body =
+  transl_let' env str kind id exp (fun env -> transl env body)
 
 and make_catch ncatch body handler dbg = match body with
 | Cexit (nexit,[]) when nexit=ncatch -> handler
@@ -1202,6 +1205,9 @@ and transl_if env (approx : then_else)
         ifso_dbg arg2
         then_dbg then_
         else_dbg else_
+  | Ulet(str, kind, id, exp, cond) ->
+      transl_let' env str kind id exp (fun env ->
+        transl_if env approx dbg cond then_dbg then_ else_dbg else_)
   | Uprim (Psequand, [arg1; arg2], inner_dbg) ->
       transl_sequand env approx
         inner_dbg arg1


### PR DESCRIPTION
Non-Flambda compilers currently generate terrible code when functions involving comparisons get inlined:
```ocaml
let int_eq (a : int) (b : int) = (a = b)
let pair_eq (a0, a1) (b0, b1) =
  int_eq a0 b0 && int_eq a1 b1
let same p q =
  if pair_eq p q then "same" else "diff"
```
The amd64 assembly for "same" is:
```asm
	movq	%rax, %rdi
	movq	(%rbx), %rax
	movq	(%rdi), %rsi
	cmpq	%rax, %rsi
	sete	%al
	movzbq	%al, %rax
	leaq	1(%rax,%rax), %rax
	cmpq	$1, %rax
	je	.L106
	movq	8(%rbx), %rax
	movq	8(%rdi), %rbx
	cmpq	%rax, %rbx
	sete	%al
	movzbq	%al, %rax
	leaq	1(%rax,%rax), %rax
	cmpq	$1, %rax
	je	.L106
	movq	camlBr__1@GOTPCREL(%rip), %rax
	ret
	.align	4
.L106:
	movq	camlBr__2@GOTPCREL(%rip), %rax
	ret
```

The `cmpq/sete/movzbq/leaq/cmpq` sequence is: do the comparison, convert the result to an integer, tag the integer, compare the tagged integer with zero.

The reason this is so longwinded is that after inlining, a Clambda expression of the form `if (let x = ... in ... = ...) then ... else ...` arises. The Cmm generator doesn't know what to do with a let expression as a conditional, and gives up.

The Cmm generator already has lots of optimisations for particular forms of `if`. For instance, this is why the code generated for `&&` above is good, involving direct branching and no conversion / tagging. This patch adds another case to this optimisation, to handle `if let`, converting:
```ocaml
if (let x = E in COND) then THEN else ELSE
==>
let x = E in (if COND then THEN else ELSE)
```
(In normal OCaml, this is slightly dodgy transformation as you might shadow some other `x`. In Cmm, names are unique so it's fine)

With this transformation, the generated code is:
```asm
	movq	(%rbx), %rdi
	movq	(%rax), %rsi
	cmpq	%rdi, %rsi
	jne	.L106
	movq	8(%rbx), %rbx
	movq	8(%rax), %rax
	cmpq	%rbx, %rax
	jne	.L106
	movq	camlBr__1@GOTPCREL(%rip), %rax
	ret
	.align	4
.L106:
	movq	camlBr__2@GOTPCREL(%rip), %rax
	ret
```