### PR TITLE
Ctype nitpicks, volume 2

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1203,7 +1203,7 @@ let rec copy ?partial ?keep_names scope ty =
                 match partial with
                   Some (free_univars, false) ->
                     let more' =
-                      if more.id != more'.id then
+                      if more.id <> more'.id then
                         more' (* we've already made a copy *)
                       else
                         newvar ()

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1203,9 +1203,10 @@ let rec copy ?partial ?keep_names scope ty =
                 match partial with
                   Some (free_univars, false) ->
                     let more' =
-                      if more.id != more'.id then more' else
-                      let lv = if keep then more.level else !current_level in
-                      newty2 lv (Tvar None)
+                      if more.id != more'.id then
+                        more' (* we've already made a copy *)
+                      else
+                        newvar ()
                     in
                     let not_reither (_, f) =
                       match row_field_repr f with


### PR DESCRIPTION
First commit: `keep` is defined as `... && partial = None`, so it can't be true in that match case.
Second commit: I guess `!=` works fine on integers, but still, I found it unusual and decided to switch it to `<>`.