### PR TITLE
Use text-diff for configure script and not binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,7 +31,7 @@
 
 # configure is a shell-script; the linguist-generated attribute suppresses
 # changes being displayed by default in pull requests.
-/configure text eol=lf -diff linguist-generated
+/configure text eol=lf linguist-generated
 
 # 'union' merge driver just unions textual content in case of conflict
 #   http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/


### PR DESCRIPTION
Using binary diff for the configure script is wrong as the script is
text and not binary, and the patch utility doesn't always have support
for the git format of binary patches which makes it impossible to
apply patches generated with git with the patch utility.

This doesn't change the rendering as binary of the configure script in
the GitHub UI. As proof:
https://github.com/MisterDA/ocaml/compare/unbinary-configure...MisterDA:unbinary-configure-test?expand=1

imo the configure script shouldn't be in version control as it is
_generated_, but if it is removed a bit of infrastructure should be
added to generate it in the released archives so that we don't require
Autotools as a build dependency.