### PR TITLE
Add Genlex.from_seq

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -313,6 +313,7 @@ stdlib__Gc.cmi : gc.mli \
 stdlib__Genlex.cmo : genlex.ml \
     stdlib__String.cmi \
     stdlib__Stream.cmi \
+    stdlib__Seq.cmi \
     stdlib__List.cmi \
     stdlib__Hashtbl.cmi \
     stdlib__Char.cmi \
@@ -321,13 +322,15 @@ stdlib__Genlex.cmo : genlex.ml \
 stdlib__Genlex.cmx : genlex.ml \
     stdlib__String.cmx \
     stdlib__Stream.cmx \
+    stdlib__Seq.cmx \
     stdlib__List.cmx \
     stdlib__Hashtbl.cmx \
     stdlib__Char.cmx \
     stdlib__Bytes.cmx \
     stdlib__Genlex.cmi
 stdlib__Genlex.cmi : genlex.mli \
-    stdlib__Stream.cmi
+    stdlib__Stream.cmi \
+    stdlib__Seq.cmi
 stdlib__Hashtbl.cmo : hashtbl.ml \
     stdlib__Sys.cmi \
     stdlib__String.cmi \

--- a/stdlib/genlex.mli
+++ b/stdlib/genlex.mli
@@ -71,3 +71,17 @@ val make_lexer : string list -> char Stream.t -> token Stream.t
    Blanks and newlines are skipped. Comments delimited by [(*] and [*)]
    are skipped as well, and can be nested. A {!Stream.Failure} exception
    is raised if end of stream is unexpectedly reached.*)
+
+exception End_of_input
+exception Error of string
+
+val from_seq : string list -> char Seq.t -> token Seq.t
+(** Construct the lexer function. The first argument is the list of
+   keywords. An identifier [s] is returned as [Kwd s] if [s]
+   belongs to this list, and as [Ident s] otherwise.
+   A special character [s] is returned as [Kwd s] if [s]
+   belongs to this list, and cause a lexical error (exception
+   {!Error} with the offending lexeme as its parameter) otherwise.
+   Blanks and newlines are skipped. Comments delimited by [(*] and [*)]
+   are skipped as well, and can be nested. A {!End_of_input} exception
+   is raised if end of stream is unexpectedly reached.*)


### PR DESCRIPTION
I regularly get annoyed that https://github.com/ocaml/ocaml/issues/6711 is not a reality yet.

Apparently, the majority of the pushback seems to be that "Genlex is useful independently of Stream and camlp*". While I'm not personally convinced by this idea, this patch adds a function `Genlex.from_seq`, which allow people to continue using `Genlex` with `Seq`.

The translation from `Stream`-code is very systematic (for a human). 

I hope that *then* we can finally deprecate `Stream`.