### PR TITLE
Document -stop-after and -save-ir-after compiler options.

### DIFF
--- a/Changes
+++ b/Changes
@@ -123,6 +123,9 @@ Working version
   (François Bobot, Nicolás Ojeda Bär, review by Daniel Bünzli and Damien
   Doligez)
 
+- #10233: Document `-save-ir-after scheduling` and update `-stop-after` options.
+  (Greta Yorsh, review by Gabriel Scherer and Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #9960: extend ocamlc/ocamlopt's -o option to work when compiling C files

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -562,7 +562,14 @@ is saved in the file
 Stop compilation after the given compilation pass. The currently
 supported passes are:
 .BR parsing ,
-.BR typing .
+.BR typing ,
+.BR scheduling ,
+.BR emit .
+.TP
+.BI \-save\-ir\-after \ pass
+Save intermediate representation after the given compilation pass. The currently
+supported passes are:
+.BR scheduling .
 .TP
 .B \-safe\-string
 Enforce the separation between types

--- a/manual/src/cmds/native.etex
+++ b/manual/src/cmds/native.etex
@@ -86,10 +86,12 @@ libraries. They are linked with the program.
 The output of the linking phase is a regular Unix or Windows
 executable file. It does not need "ocamlrun" to run.
 
-%  The following two paragraphs are a duplicate from the description of the batch compiler.
+The compiler is able to emit some information on its internal stages:
 
-The compiler is able to emit some information on its internal stages.
-It can output ".cmt" files for the implementation of the compilation unit
+\begin{itemize}
+\item
+%  The following two paragraphs are a duplicate from the description of the batch compiler.
+".cmt" files for the implementation of the compilation unit
 and ".cmti" for signatures if the option "-bin-annot" is passed to it (see the
 description of "-bin-annot" below).
 Each such file contains a typed abstract syntax tree (AST), that is produced
@@ -98,6 +100,18 @@ about the location and the specific type of each term in the source file.
 The AST is partial if type checking was unsuccessful.
 
 These ".cmt" and ".cmti" files are typically useful for code inspection tools.
+
+\item
+".cmir-linear" files for the implementation of the compilation unit
+if the option "-save-ir-after scheduling" is passed to it.
+Each such file contains a low-level intermediate representation,
+produced by the instruction scheduling pass.
+
+An external tool can perform low-level optimisations,
+such as code layout, by transforming a ".cmir-linear" file.
+To continue compilation, the compiler can be invoked with (a possibly modified)
+".cmir-linear" file as an argument, instead of the corresponding source file.
+\end{itemize}
 
 \section{s:native-options}{Options}
 

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -615,7 +615,29 @@ code such as C stubs.
 \notop{
 \item["-stop-after" \var{pass}]
 Stop compilation after the given compilation pass. The currently
-supported passes are: "parsing", "typing".
+supported passes are:
+"parsing", "typing"\nat{, "scheduling", "emit"}.
+}%notop
+
+\nat{
+\item["-save-ir-after" \var{pass}]
+Save intermediate representation after the given compilation pass
+to a file.
+The currently supported passes are: "scheduling".
+
+This experimental feature enables external tools to inspect and manipulate
+compiler's intermediate representation of the program
+using "compiler-libs" library (see
+\ifouthtml chapter~\ref{c:parsinglib} and
+\ahref{compilerlibref/Compiler\_libs.html}{ \texttt{Compiler_libs} }
+\else section~\ref{Compiler-underscorelibs}\fi
+).
+For example, "-save-ir-after scheduling" saves a low-level intermediate representation
+of each compilation unit implementation to a separate ".cmir-linear" file.
+An external tool can perform low-level optimisations,
+such as code layout, by transforming this file.
+To continue compilation, the compiler can be invoked with (a possibly modified)
+".cmir-linear" file as input instead of the corresponding source file.
 }%notop
 
 \nat{%

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -638,7 +638,7 @@ An external tool can perform low-level optimisations,
 such as code layout, by transforming this file.
 To continue compilation, the compiler can be invoked with (a possibly modified)
 ".cmir-linear" file as input instead of the corresponding source file.
-}%notop
+}%nat
 
 \nat{%
 \item["-S"]

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -623,7 +623,8 @@ supported passes are:
 \item["-save-ir-after" \var{pass}]
 Save intermediate representation after the given compilation pass
 to a file.
-The currently supported passes are: "scheduling".
+The currently supported passes and the corresponding file extensions are:
+"scheduling" (".cmir-linear").
 
 This experimental feature enables external tools to inspect and manipulate
 compiler's intermediate representation of the program

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -633,12 +633,6 @@ using "compiler-libs" library (see
 \ahref{compilerlibref/Compiler\_libs.html}{ \texttt{Compiler_libs} }
 \else section~\ref{Compiler-underscorelibs}\fi
 ).
-For example, "-save-ir-after scheduling" saves a low-level intermediate representation
-of each compilation unit implementation to a separate ".cmir-linear" file.
-An external tool can perform low-level optimisations,
-such as code layout, by transforming this file.
-To continue compilation, the compiler can be invoked with (a possibly modified)
-".cmir-linear" file as input instead of the corresponding source file.
 }%nat
 
 \nat{%


### PR DESCRIPTION
Update the manual and man pages, as discussed in https://github.com/ocaml/ocaml/pull/9003#issuecomment-780564216.

Should I submit this PR against 4.12 instead of trunk?
Is the description of "-save-ir-after" too detailed?
I am also not sure how to reference compiler-libs properly in this context, as the manual only mentions the frontend part of it. 
