### PR TITLE
doc: typo: Update unified-options.etex, typo "supported.Note" missing space

### DIFF
--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -599,7 +599,7 @@ use it once before publishing source code.
 \item["-rectypes"]
 Allow arbitrary recursive types during type-checking.  By default,
 only recursive types where the recursion goes through an object type
-are supported.\notop{Note that once you have created an interface using this
+are supported. \notop{Note that once you have created an interface using this
 flag, you must use it again for all dependencies.}
 
 \notop{%


### PR DESCRIPTION
There is a missing space in "supported.Note" displayed for help of `-rectypes` on http://caml.inria.fr/pub/docs/manual-ocaml/comp.html
I'm not sure if this .etex file is hand-written or generated from another file, but a search on the GitHub project didn't give me anything else.
Thanks!
![Capture d’écran_2021-02-18_23-38-59](https://user-images.githubusercontent.com/11994719/108431213-e0366000-7242-11eb-836b-4df3d431b4e4.png)
