### PR TITLE
Revise List.sort_uniq to return a sublist of List.stable_sort

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -430,7 +430,7 @@ let sort_uniq cmp l =
     | l1, [] -> rev_append l1 accu
     | h1::t1, h2::t2 ->
         let c = cmp h1 h2 in
-        if c = 0 then rev_merge t1 t2 (h1::accu)
+        if c = 0 then rev_merge t1 t2 (h2::accu)
         else if c < 0
         then rev_merge t1 l2 (h1::accu)
         else rev_merge l1 t2 (h2::accu)
@@ -441,7 +441,7 @@ let sort_uniq cmp l =
     | l1, [] -> rev_append l1 accu
     | h1::t1, h2::t2 ->
         let c = cmp h1 h2 in
-        if c = 0 then rev_merge_rev t1 t2 (h1::accu)
+        if c = 0 then rev_merge_rev t1 t2 (h2::accu)
         else if c > 0
         then rev_merge_rev t1 l2 (h1::accu)
         else rev_merge_rev l1 t2 (h2::accu)
@@ -451,7 +451,7 @@ let sort_uniq cmp l =
     | 2, x1 :: x2 :: tl ->
         let s =
           let c = cmp x1 x2 in
-          if c = 0 then [x1] else if c < 0 then [x1; x2] else [x2; x1]
+          if c = 0 then [x2] else if c < 0 then [x1; x2] else [x2; x1]
         in
         (s, tl)
     | 3, x1 :: x2 :: x3 :: tl ->
@@ -459,23 +459,23 @@ let sort_uniq cmp l =
           let c = cmp x1 x2 in
           if c = 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x1] else if c < 0 then [x2; x3] else [x3; x2]
+            if c = 0 then [x3] else if c < 0 then [x2; x3] else [x3; x2]
           else if c < 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x1; x2]
+            if c = 0 then [x1; x3]
             else if c < 0 then [x1; x2; x3]
             else
               let c = cmp x1 x3 in
-              if c = 0 then [x1; x2]
+              if c = 0 then [x3; x2]
               else if c < 0 then [x1; x3; x2]
               else [x3; x1; x2]
           else
             let c = cmp x1 x3 in
-            if c = 0 then [x2; x1]
+            if c = 0 then [x2; x3]
             else if c < 0 then [x2; x1; x3]
             else
               let c = cmp x2 x3 in
-              if c = 0 then [x2; x1]
+              if c = 0 then [x3; x1]
               else if c < 0 then [x2; x3; x1]
               else [x3; x2; x1]
         in
@@ -491,7 +491,7 @@ let sort_uniq cmp l =
     | 2, x1 :: x2 :: tl ->
         let s =
           let c = cmp x1 x2 in
-          if c = 0 then [x1] else if c > 0 then [x1; x2] else [x2; x1]
+          if c = 0 then [x2] else if c > 0 then [x1; x2] else [x2; x1]
         in
         (s, tl)
     | 3, x1 :: x2 :: x3 :: tl ->
@@ -499,23 +499,23 @@ let sort_uniq cmp l =
           let c = cmp x1 x2 in
           if c = 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x1] else if c > 0 then [x2; x3] else [x3; x2]
+            if c = 0 then [x3] else if c > 0 then [x2; x3] else [x3; x2]
           else if c > 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x1; x2]
+            if c = 0 then [x1; x3]
             else if c > 0 then [x1; x2; x3]
             else
               let c = cmp x1 x3 in
-              if c = 0 then [x1; x2]
+              if c = 0 then [x3; x2]
               else if c > 0 then [x1; x3; x2]
               else [x3; x1; x2]
           else
             let c = cmp x1 x3 in
-            if c = 0 then [x2; x1]
+            if c = 0 then [x2; x3]
             else if c > 0 then [x2; x1; x3]
             else
               let c = cmp x2 x3 in
-              if c = 0 then [x2; x1]
+              if c = 0 then [x3; x1]
               else if c > 0 then [x2; x3; x1]
               else [x3; x2; x1]
         in

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -459,7 +459,7 @@ let sort_uniq cmp l =
           let c = cmp x1 x2 in
           if c = 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x2] else if c < 0 then [x2; x3] else [x3; x2]
+            if c = 0 then [x1] else if c < 0 then [x2; x3] else [x3; x2]
           else if c < 0 then
             let c = cmp x2 x3 in
             if c = 0 then [x1; x2]
@@ -499,7 +499,7 @@ let sort_uniq cmp l =
           let c = cmp x1 x2 in
           if c = 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x2] else if c > 0 then [x2; x3] else [x3; x2]
+            if c = 0 then [x1] else if c > 0 then [x2; x3] else [x3; x2]
           else if c > 0 then
             let c = cmp x2 x3 in
             if c = 0 then [x1; x2]

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -124,15 +124,29 @@ let () =
 
 (* Sort *)
 let () =
+  let remove_nonlast_dups cmp = function
+    | [] -> []
+    | x :: xs ->
+        let rec loop pred = function
+          | curr :: rest ->
+              if cmp pred curr = 0 then loop curr rest
+              else pred :: loop curr rest
+          | [] -> [pred]
+        in
+        loop x xs
+  in
+  let check_sort_uniq_keeps_last_dup cmp l =
+    let s = remove_nonlast_dups cmp (List.stable_sort cmp l) in
+    let u = List.sort_uniq cmp l in
+    assert (compare s u = 0)
+  in
   let cmp_fst (x, _) (y, _) = compare x y in
-  (* [sort_uniq cmp l] is a sublist of [sort cmp l] *)
-  assert (
-    let three_equal = [(1, 1); (1, 2); (1, 3)] in
-    List.hd (List.sort_uniq cmp_fst three_equal)
-    = List.hd (List.sort cmp_fst three_equal));
-  assert (
-    let six_equal = [(1, 1); (1, 2); (1, 3); (1, 4); (1, 5); (1, 6)] in
-    List.hd (List.sort_uniq cmp_fst six_equal)
-    = List.hd (List.sort cmp_fst six_equal))
+  List.iter (check_sort_uniq_keeps_last_dup cmp_fst)
+    [ [(2, 0); (2, 1)]
+    ; [(2, 0); (2, 0); (2, 1)]
+    ; [(1, 0); (1, 1); (2, 0)]
+    ; [(0, 0); (0, 0); (0, 0); (0, 1)]
+    ; [(0, 0); (0, 0); (2, 0); (2, 1)]
+    ; [(0, 0); (0, 0); (3, 0); (3, 1); (0, 0)] ]
 
 let () = print_endline "OK";;

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -122,4 +122,17 @@ let () =
   test (threshold + 1) (* Tail-recursive case *)
 ;;
 
+(* Sort *)
+let () =
+  let cmp_fst (x, _) (y, _) = compare x y in
+  (* [sort_uniq cmp l] is a sublist of [sort cmp l] *)
+  assert (
+    let three_equal = [(1, 1); (1, 2); (1, 3)] in
+    List.hd (List.sort_uniq cmp_fst three_equal)
+    = List.hd (List.sort cmp_fst three_equal));
+  assert (
+    let six_equal = [(1, 1); (1, 2); (1, 3); (1, 4); (1, 5); (1, 6)] in
+    List.hd (List.sort_uniq cmp_fst six_equal)
+    = List.hd (List.sort cmp_fst six_equal))
+
 let () = print_endline "OK";;

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -124,6 +124,7 @@ let () =
 
 (* Sort *)
 let () =
+  (* check that List.sort_uniq keeps the last duplicate element, see PR#10238 *)
   let remove_nonlast_dups cmp = function
     | [] -> []
     | x :: xs ->


### PR DESCRIPTION
This patch changes the behavior of `List.sort_uniq` (and hence `Set.of_list`) in some cases where the list contains multiple elements which are equal with respect to the given comparison function. It seems less surprising if `sort_uniq cmp l` is a sublist of `stable_sort cmp l`, which is to say that the first element in the input list is retained in the output, and subsequent elements that compare equal to it are dropped.

I don't know if there is a motivation for the existing behavior. @alainfrisch, do you recall?

Signed-off-by: Josh Berdine <josh@berdine.net>