### PR TITLE
Add a fast path to List.compare for physically equal lists

### DIFF
--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -563,14 +563,16 @@ let rec equal eq l1 l2 =
   | a1::l1, a2::l2 -> eq a1 a2 && equal eq l1 l2
 
 let rec compare cmp l1 l2 =
-  match l1, l2 with
-  | [], [] -> 0
-  | [], _::_ -> -1
-  | _::_, [] -> 1
-  | a1::l1, a2::l2 ->
-    let c = cmp a1 a2 in
-    if c <> 0 then c
-    else compare cmp l1 l2
+  if l1 == l2 then 0
+  else
+    match l1, l2 with
+    | [], [] -> 0
+    | [], _::_ -> -1
+    | _::_, [] -> 1
+    | a1::l1, a2::l2 ->
+      let c = cmp a1 a2 in
+      if c <> 0 then c
+      else compare cmp l1 l2
 
 (** {1 Iterators} *)
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -142,12 +142,14 @@ val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
     a lexicographic comparison of the two input lists,
     using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
 
-    - [a1 :: l1] is smaller than [a2 :: l2] (negative result)
-      if [a1] is smaller than [a2], or if they are equal (0 result)
-      and [l1] is smaller than [l2]
-    - the empty list [[]] is strictly smaller than non-empty lists
+    - If `a1 == b1` or if `cmp a1 b1 = 0`, the result of the comparison
+      is the same as `compare cmp [a2; ...; an] [b2; ...; bn]`.
+    - If `a1 != b1` and `cmp a1 b1 <> 0`, the result is the same as `cmp a1 b1`.
+    - If both list are empty, the result is `0`.
+    - If only the first list is empty, the result is strictly negative;
+      if only the second list is empty the result is strictly positive.
 
-    Note: the [cmp] function will be called even if the lists have
+    Note: the [cmp] function may be called even if the lists have
     different lengths.
 
     @since 4.12.0

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -142,9 +142,10 @@ val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
     a lexicographic comparison of the two input lists,
     using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
 
-    - If `a1 == b1` or if `cmp a1 b1 = 0`, the result of the comparison
+    - If `[a1; ...; an] == [b1; ...; bm]`, the result is `0`.
+    - If `cmp a1 b1 = 0`, the result of the comparison
       is the same as `compare cmp [a2; ...; an] [b2; ...; bn]`.
-    - If `a1 != b1` and `cmp a1 b1 <> 0`, the result is the same as `cmp a1 b1`.
+    - If `cmp a1 b1 <> 0`, the result is the same as `cmp a1 b1`.
     - If both list are empty, the result is `0`.
     - If only the first list is empty, the result is strictly negative;
       if only the second list is empty the result is strictly positive.

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -142,12 +142,14 @@ val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
     a lexicographic comparison of the two input lists,
     using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
 
-    - [a1 :: l1] is smaller than [a2 :: l2] (negative result)
-      if [a1] is smaller than [a2], or if they are equal (0 result)
-      and [l1] is smaller than [l2]
-    - the empty list [[]] is strictly smaller than non-empty lists
+    - If `a1 == b1` or if `cmp a1 b1 = 0`, the result of the comparison
+      is the same as `compare cmp [a2; ...; an] [b2; ...; bn]`.
+    - If `a1 != b1` and `cmp a1 b1 <> 0`, the result is the same as `cmp a1 b1`.
+    - If both list are empty, the result is `0`.
+    - If only the first list is empty, the result is strictly negative;
+      if only the second list is empty the result is strictly positive.
 
-    Note: the [cmp] function will be called even if the lists have
+    Note: the [cmp] function may be called even if the lists have
     different lengths.
 
     @since 4.12.0

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -142,9 +142,10 @@ val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
     a lexicographic comparison of the two input lists,
     using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
 
-    - If `a1 == b1` or if `cmp a1 b1 = 0`, the result of the comparison
+    - If `[a1; ...; an] == [b1; ...; bm]`, the result is `0`.
+    - If `cmp a1 b1 = 0`, the result of the comparison
       is the same as `compare cmp [a2; ...; an] [b2; ...; bn]`.
-    - If `a1 != b1` and `cmp a1 b1 <> 0`, the result is the same as `cmp a1 b1`.
+    - If `cmp a1 b1 <> 0`, the result is the same as `cmp a1 b1`.
     - If both list are empty, the result is `0`.
     - If only the first list is empty, the result is strictly negative;
       if only the second list is empty the result is strictly positive.


### PR DESCRIPTION
As discussed in the comments on https://github.com/ocaml/ocaml/pull/9668, it is correct with respect to the specification of `List.compare` to return `0` when the arguments are physically equal. In cases where the arguments may have some internal sharing, this can be a significant optimization.

Signed-off-by: Josh Berdine <josh@berdine.net>