### PR TITLE
Add Map.of_list following Set.of_list

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,6 +86,9 @@ Working version
   build (the Dune rules still do not generate a distributable compiler).
   (David Allsopp and Mark Shinwell, review by Gabriel Scherer)
 
+- #10240: Add Map.of_list operation analogous to Set.of_list.
+  (Josh Berdine, review by ???)
+
 ### Other libraries:
 
 * #10084: Unix.open_process_args* functions now look up the program in the PATH.

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -418,9 +418,11 @@ stdlib__ListLabels.cmi : listLabels.mli \
     stdlib__Either.cmi
 stdlib__Map.cmo : map.ml \
     stdlib__Seq.cmi \
+    stdlib__List.cmi \
     stdlib__Map.cmi
 stdlib__Map.cmx : map.ml \
     stdlib__Seq.cmx \
+    stdlib__List.cmx \
     stdlib__Map.cmi
 stdlib__Map.cmi : map.mli \
     stdlib__Seq.cmi

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -459,7 +459,7 @@ let sort_uniq cmp l =
           let c = cmp x1 x2 in
           if c = 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x2] else if c < 0 then [x2; x3] else [x3; x2]
+            if c = 0 then [x1] else if c < 0 then [x2; x3] else [x3; x2]
           else if c < 0 then
             let c = cmp x2 x3 in
             if c = 0 then [x1; x2]
@@ -499,7 +499,7 @@ let sort_uniq cmp l =
           let c = cmp x1 x2 in
           if c = 0 then
             let c = cmp x2 x3 in
-            if c = 0 then [x2] else if c > 0 then [x2; x3] else [x3; x2]
+            if c = 0 then [x1] else if c > 0 then [x2; x3] else [x3; x2]
           else if c > 0 then
             let c = cmp x2 x3 in
             if c = 0 then [x1; x2]

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -335,9 +335,9 @@ module type S =
     (** [of_list l] creates a map from a list of bindings.
         This is usually more efficient than folding [add] over the list,
         except perhaps for lists with many duplicated elements.
-        If the list contains multiple bindings for keys that are equal with
-        respect to [Ord.compare], then the map contains the first such
-        binding and the rest are ignored.
+        If the list contains multiple bindings for keys that are equal
+        with respect to [Ord.compare], it is unspecified which of the
+        bindings the map contains.
         @since 4.13 *)
 
     (** {1 Maps and Sequences} *)

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -331,6 +331,15 @@ module type S =
     (** Same as {!S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
+    val of_list: (key * 'a) list -> 'a t
+    (** [of_list l] creates a map from a list of bindings.
+        This is usually more efficient than folding [add] over the list,
+        except perhaps for lists with many duplicated elements.
+        If the list contains multiple bindings for keys that are equal with
+        respect to [Ord.compare], then the map contains the first such
+        binding and the rest are ignored.
+        @since 4.13 *)
+
     (** {1 Maps and Sequences} *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -846,6 +846,15 @@ module Map : sig
       (** Same as {!S.map}, but the function receives as arguments both the
          key and the associated value for each binding of the map. *)
 
+      val of_list: (key * 'a) list -> 'a t
+      (** [of_list l] creates a map from a list of bindings.
+          This is usually more efficient than folding [add] over the list,
+          except perhaps for lists with many duplicated elements.
+          If the list contains multiple bindings for keys that are equal
+          with respect to [Ord.compare], it is unspecified which of the
+          bindings the map contains.
+          @since 4.13 *)
+
       (** {1 Maps and Sequences} *)
 
       val to_seq : 'a t -> (key * 'a) Seq.t

--- a/stdlib/templates/map.template.mli
+++ b/stdlib/templates/map.template.mli
@@ -331,6 +331,15 @@ module type S =
     (** Same as {!S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
+    val of_list: (key * 'a) list -> 'a t
+    (** [of_list l] creates a map from a list of bindings.
+        This is usually more efficient than folding [add] over the list,
+        except perhaps for lists with many duplicated elements.
+        If the list contains multiple bindings for keys that are equal
+        with respect to [Ord.compare], it is unspecified which of the
+        bindings the map contains.
+        @since 4.13 *)
+
     (** {1 Maps and Sequences} *)
 
     val to_seq : 'a t -> (key * 'a) Seq.t

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -122,4 +122,17 @@ let () =
   test (threshold + 1) (* Tail-recursive case *)
 ;;
 
+(* Sort *)
+let () =
+  let cmp_fst (x, _) (y, _) = compare x y in
+  (* [sort_uniq cmp l] is a sublist of [sort cmp l] *)
+  assert (
+    let three_equal = [(1, 1); (1, 2); (1, 3)] in
+    List.hd (List.sort_uniq cmp_fst three_equal)
+    = List.hd (List.sort cmp_fst three_equal));
+  assert (
+    let six_equal = [(1, 1); (1, 2); (1, 3); (1, 4); (1, 5); (1, 6)] in
+    List.hd (List.sort_uniq cmp_fst six_equal)
+    = List.hd (List.sort cmp_fst six_equal))
+
 let () = print_endline "OK";;

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -340,6 +340,7 @@ module type MapT =
     val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+    val of_list : (key * 'a) list -> 'a t
     val to_seq : 'a t -> (key * 'a) Seq.t
     val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
@@ -393,6 +394,7 @@ module SSMap :
     val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+    val of_list : (key * 'a) list -> 'a t
     val to_seq : 'a t -> (key * 'a) Seq.t
     val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -53,6 +53,7 @@ module Core :
             val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
             val map : ('a -> 'b) -> 'a t -> 'b t
             val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+            val of_list : (key * 'a) list -> 'a t
             val to_seq : 'a t -> (key * 'a) Seq.t
             val to_rev_seq : 'a t -> (key * 'a) Seq.t
             val to_seq_from : key -> 'a t -> (key * 'a) Seq.t


### PR DESCRIPTION
This patch adds a `Map.of_list` operation that directly follows `Set.of_list` that @alainfrisch added in https://github.com/ocaml/ocaml/commit/edb771d22b0d253e84b553259efff06efc719610, with only very minor adjustments due to nodes of map trees also having a data field.

This PR is stacked on top of https://github.com/ocaml/ocaml/pull/10238 in order to specify the behavior in case the list contains multiple elements with keys that compare equal.