### PR TITLE
Optimise Int32.unsigned_to_int on 64-bit

### DIFF
--- a/Changes
+++ b/Changes
@@ -73,6 +73,9 @@ Working version
 - #10228: Better code-generation for inlined comparisons
   (Stephen Dolan, review by Alain Frisch and Xavier Leroy)
 
+- #10244: Optimise Int32.unsigned_to_int
+  (Fabian Hemmer, review by Stephen Dolan and Xavier Leroy)
+
 ### Standard library:
 
 - #9533: Added String.starts_with and String.ends_with.

--- a/stdlib/int32.ml
+++ b/stdlib/int32.ml
@@ -63,8 +63,8 @@ let unsigned_to_int =
           None
   | 64 ->
       (* So that it compiles in 32-bit *)
-      let move = int_of_string "0x1_0000_0000" in
-      fun n -> let i = to_int n in Some (if i < 0 then i + move else i)
+      let mask = 0xFFFF lsl 16 lor 0xFFFF in
+      fun n -> Some (to_int n land mask)
   | _ ->
       assert false
 


### PR DESCRIPTION
This implements two small optimisations in `Int32.unsigned_to_int`:

1. Replace the branch with a single bitwise mask. In my opinion this also makes the implementation easier to read
2. Replace `int_of_string "0x1_0000_0000"` by bits hifts to prevent the constant `"0x1_0000_0000"` from ending up in the data section. The bit shifts are constant-propagated as expected (at least on flambda)

Obligatory micro-benchmark (on 4.11.1+flambda with `-O2`):

```ocaml
open Core_bench

let unsigned_to_int' = …

let () =
  let xs = Array.init 1000 (fun _ -> Int32.sub (Random.int32 100l) 50l) in
  Bench.bench [
    Bench.Test.create ~name:"Int32.unsigned_to_int" (fun () ->
        Array.iter (fun x -> ignore (Sys.opaque_identity (Int32.unsigned_to_int x))) xs
      );
    Bench.Test.create ~name:"unsigned_to_int'" (fun () ->
        Array.iter (fun x -> ignore (Sys.opaque_identity (unsigned_to_int' x))) xs
      );
  ]
```

```
┌───────────────────────┬──────────┬─────────┬─────────┐
│ Name                  │ Time/Run │ mWd/Run │ mGC/Run │
├───────────────────────┼──────────┼─────────┼─────────┤
│ Int32.unsigned_to_int │   3.74us │  2.00kw │ 7.63e-3 │
│ unsigned_to_int'      │   2.66us │  2.00kw │ 7.63e-3 │
└───────────────────────┴──────────┴─────────┴─────────┘
```