### PR TITLE
Remove Ctype.cyclic_abbrev

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4502,23 +4502,6 @@ let rec arity ty =
     Tarrow(_, _t1, t2, _) -> 1 + arity t2
   | _ -> 0
 
-(* Check whether an abbreviation expands to itself. *)
-let cyclic_abbrev env id ty =
-  let rec check_cycle seen ty =
-    let ty = repr ty in
-    match ty.desc with
-      Tconstr (p, _tl, _abbrev) ->
-        p = Path.Pident id || List.memq ty seen ||
-        begin try
-          check_cycle (ty :: seen) (expand_abbrev_opt env ty)
-        with
-          Cannot_expand -> false
-        | Unify _ -> true
-        end
-    | _ ->
-        false
-  in check_cycle [] ty
-
 (* Check for non-generalizable type variables *)
 exception Non_closed0
 let visited = ref TypeSet.empty

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -351,7 +351,6 @@ val nondep_cltype_declaration:
   Env.t -> Ident.t list -> class_type_declaration -> class_type_declaration
         (* Same for class type declarations. *)
 (*val correct_abbrev: Env.t -> Path.t -> type_expr list -> type_expr -> unit*)
-val cyclic_abbrev: Env.t -> Ident.t -> type_expr -> bool
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -433,12 +433,6 @@ let transl_declaration env sdecl (id, uid) =
       in
       set_fixed_row env sdecl.ptype_loc p decl
     end;
-  (* Check for cyclic abbreviations *)
-    begin match decl.type_manifest with None -> ()
-      | Some ty ->
-        if Ctype.cyclic_abbrev env id ty then
-          raise(Error(sdecl.ptype_loc, Recursive_abbrev sdecl.ptype_name.txt));
-    end;
     {
       typ_id = id;
       typ_name = sdecl.ptype_name;


### PR DESCRIPTION
While looking at the implementation of `[@@unboxed]`, I got lost down a rabbit-hole of type expansion. I got very confused by `Ctype.cyclic_abbrev` in particular: it's used to detect and reject aliases like `type t = t`, but since it runs in the `temp_env` it can't detect cycles such as `type t = u and u = t`.

Those are detected by a better check later in `Typedecl.check_well_founded`, which seems to subsume `Ctype.cyclic_abbrev`. I can't find anything that `Ctype.cyclic_abbrev` will catch that won't be caught by `check_well_founded`, so this patch deletes the former. (I've verified that various cyclic abbrevs are still rejected, and the testsuite still passes)