### PR TITLE
Add initial tranche of examples to reference manual

### DIFF
--- a/Changes
+++ b/Changes
@@ -119,7 +119,8 @@ Working version
 - #10247: Add initial tranche of examples to reference manual.
   Adds some eighty examples to the reference manual, principally to the
   expressions and patterns sections.
-  (John Whitington, review by ...)
+  (John Whitington, review by Xavier Leroy, Gabriel Scherer, @Fourchaux, and
+  Florian Angeletti)
 
 - #9786, #10181: improved documentation of Unix.{in,out}_channel_of_descr
   with respect to closing.

--- a/Changes
+++ b/Changes
@@ -116,6 +116,11 @@ Working version
 
 ### Manual and documentation:
 
+- #10247: Add initial tranche of examples to reference manual.
+  Adds some eighty examples to the reference manual, principally to the
+  expressions and patterns sections.
+  (John Whitington, review by ...)
+
 - #9786, #10181: improved documentation of Unix.{in,out}_channel_of_descr
   with respect to closing.
   (Xavier Leroy, report by Jacques-Henri Jourdan, review by Guillaume

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -1,8 +1,13 @@
 \documentclass[11pt]{book}
 \usepackage{ae}
+
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 % HEVEA\@def@charset{UTF-8}%
+% Unicode character declarations
+\DeclareUnicodeCharacter{207A}{{}^{+}}
+\DeclareUnicodeCharacter{2014}{---}
+
 \usepackage{fullpage}
 \usepackage{syntaxdef}
 \usepackage{multind}
@@ -19,8 +24,11 @@
 \usepackage[normalem]{ulem}% for underlining errors in code examples
 
 \input{macros.tex}
+% Listing environments
 \lstnewenvironment{camloutput}{
   \lstset{
+    inputencoding=utf8,
+    extendedchars=true,
     basicstyle=\small\ttfamily\slshape,
     showstringspaces=false,
     language=caml,
@@ -38,7 +46,10 @@
 \else
   \lstset{
     upquote=true,
-    literate={'"'}{\textquotesingle "\textquotesingle}3
+    literate=%
+    {⁺}{{${}^{+}$}}1%
+    {—}{{---}}1%
+    {'"'}{\textquotesingle "\textquotesingle}3%
     {'\\"'}{\textquotesingle \textbackslash"\textquotesingle}4,
 }
 \fi
@@ -46,6 +57,8 @@
 
 \lstnewenvironment{camlinput}{
   \lstset{
+    inputencoding=utf8,
+    extendedchars=true,
     basicstyle=\ttfamily,
     showstringspaces=false,
     language=caml,
@@ -67,7 +80,10 @@
 %not implemented in hevea: upquote and literate
   \lstset{
     upquote=true,
-    literate={'"'}{\textquotesingle "\textquotesingle}3
+    literate=%
+    {⁺}{{${}^{+}$}}1%
+    {—}{{---}}1%
+    {'"'}{\textquotesingle "\textquotesingle}3%
     {'\\"'}{\textquotesingle \textbackslash"\textquotesingle}4,
 }
 \fi

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -577,6 +577,7 @@ exception definition). For instance:
 
 \begin{caml_example}{toplevel}
 let gen () = let exception A in A
+
 let () = assert(gen () = gen ());;
 \end{caml_example}
 

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -1074,11 +1074,12 @@ evaluates to a new object containing the instance variables and
 methods of this class.
 
 \begin{caml_example}{toplevel}
-class of_list (l : int list) = object
-  val mutable l = l
+class of_list (lst : int list) = object
+  val mutable l = lst
   method next =
-    if l = [] then raise (Failure "empty list");
-    let r = List.hd l in l <- List.tl l; r
+    match l with
+    | [] -> raise (Failure "empty list");
+    | h::t -> l <- t; h
 end
 
 let a = new of_list [1; 1; 2; 3; 5; 8; 13]
@@ -1121,16 +1122,17 @@ The expression @expr '#' method-name@ invokes the method
 @method-name@ of the object denoted by @expr@.
 
 \begin{caml_example}{toplevel}
-class of_list (l : int list) = object
-  val mutable l = l
+class of_list (lst : int list) = object
+  val mutable l = lst
   method next =
-    if l = [] then raise (Failure "empty list");
-    let r = List.hd l in l <- List.tl l; r
+    match l with
+    | [] -> raise (Failure "empty list");
+    | h::t -> l <- t; h
 end
 
 let a = new of_list [1; 1; 2; 3; 5; 8; 13]
 
-let second = ignore a#next; a#next;;
+let third = ignore a#next; ignore a#next; a#next;;
 \end{caml_example}
 
 If @method-name@ is a polymorphic method, its type should be known at
@@ -1150,11 +1152,12 @@ variable @inst-var-name@, which must be mutable.  The whole expression
 @inst-var-name '<-' expr@ evaluates to @"()"@.
 
 \begin{caml_example}{toplevel}
-class of_list (l : int list) = object
-  val mutable l = l
+class of_list (lst : int list) = object
+  val mutable l = lst
   method next =
-    if l = [] then raise (Failure "empty list");
-    let r = List.hd l in l <- List.tl l; r  (* access and modify instance variable *)
+    match l with                            (* access instance variable *)
+    | [] -> raise (Failure "empty list");
+    | h::t -> l <- t; h                     (* modify instance variable *)
 end;;
 \end{caml_example}
 

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -785,10 +785,8 @@ exception value is raised again, thereby transparently ``passing
 through'' the @'try'@ construct.
 
 \begin{caml_example}{toplevel}
-let option_exception f x =
-  try Some (f x) with
-  | Assert_failure (a, b, c) -> raise (Assert_failure (a, b, c))
-  | _ -> None;;
+let find_opt p l =
+  try Some (List.find p l) with Not_found -> None;;
 \end{caml_example}
 
 \subsection{ss:expr-ops-on-data}{Operations on data structures}

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -214,14 +214,14 @@ let y = (1 + 2) * 3;;
 \begin{caml_example}{toplevel}
 let f a b =
   if a = b then
-    print_string "Equal"
-  else
-    begin
+    print_endline "Equal"
+  else begin
       print_string "Not Equal: ";
       print_int a;
       print_string " and ";
-      print_int b
-    end;;
+      print_int b;
+      print_newline ()
+  end;;
 \end{caml_example}
 
 Parenthesized expressions can contain a type constraint, as in @'('
@@ -342,7 +342,7 @@ matches the argument, the exception "Match_failure" is raised.
 (function (0, 0) -> "both zero"
         | (0, _) -> "first only zero"
         | (_, 0) -> "second only zero"
-        | _ -> "neither zero")
+        | (_, _) -> "neither zero")
 (7, 0);;
 \end{caml_example}
 
@@ -357,8 +357,8 @@ This expression is equivalent to:
 \end{center}
 
 \begin{caml_example}{toplevel}
-let p = (fun a -> fun b -> fun c -> a + b + c)
-let q = (fun a b c -> a + b + c);;
+let f = (fun a -> fun b -> fun c -> a + b + c)
+let g = (fun a b c -> a + b + c);;
 \end{caml_example}
 
 An optional type constraint @typexpr@ can be added before "->" to enforce
@@ -414,14 +414,12 @@ is a fresh variable, except that it is unspecified when @expr_0@ is evaluated.
 
 \begin{caml_example}{toplevel}
 let open_file_for_input ?binary filename =
-  (match binary with
-   | Some false -> open_in
-   | Some true -> open_in_bin
-   | None -> open_in)
-  filename
+  match binary with
+  | Some true -> open_in_bin filename
+  | Some false | None -> open_in filename
 
 let open_file_for_input' ?(binary=false) filename =
-  (if binary then open_in_bin else open_in) filename;;
+  if binary then open_in_bin filename else open_in filename;;
 \end{caml_example}
 
 After these two transformations, expressions are of the form
@@ -467,9 +465,9 @@ is resumed against the patterns following @pattern_i@.
 
 \begin{caml_example}{toplevel}
 let rec repeat f = function
-  | n when n < 0 -> raise (Invalid_argument "repeat")
   | 0 -> ()
-  | n -> f (); repeat f (n - 1);; 
+  | n when n > 0 -> f (); repeat f (n - 1)
+  | _ -> raise (Invalid_argument "repeat");;
 \end{caml_example}
 
 \subsubsection*{sss:expr-localdef}{Local definitions}
@@ -612,7 +610,7 @@ let print_pair (a, b) =
   print_string (string_of_int a);
   print_string ",";
   print_string (string_of_int b);
-  print_string ")";;
+  print_endline ")";;
 \end{caml_example}
 
 \subsubsection*{sss:expr-conditional}{Conditional}
@@ -635,7 +633,7 @@ The @"else" expr_3@ part can be omitted, in which case it defaults to
 let debug = ref false
 
 let log msg =
-  if !debug then prerr_string (msg ^ "\n");;
+  if !debug then prerr_endline msg;;
 \end{caml_example}
 
 \subsubsection*{sss:expr-case}{Case expression}\ikwd{match\@\texttt{match}}
@@ -660,7 +658,7 @@ selected.
 let rec sum l =
   match l with
   | [] -> 0
-  | h::t -> h + sum t;; 
+  | h :: t -> h + sum t;; 
 \end{caml_example}
 
 If none of the patterns match the value of @expr@, the
@@ -722,7 +720,7 @@ let chars_of_string s =
   let i = ref 0 in
   let chars = ref [] in
     while !i < String.length s do
-      chars := s.[!i]::!chars;
+      chars := s.[!i] :: !chars;
       i := !i + 1
     done;
     List.rev !chars;;
@@ -741,7 +739,7 @@ bound to the values
 let chars_of_string s =
   let l = ref [] in
     for p = 0 to String.length s - 1 do
-      l := s.[p]::!l
+      l := s.[p] :: !l
     done;
     List.rev !l;;
 \end{caml_example}
@@ -755,7 +753,7 @@ evaluates similarly, except that @name@ is successively bound to the values
 let chars_of_string s =
   let l = ref [] in
     for p = String.length s - 1 downto 0 do
-      l := s.[p]::!l
+      l := s.[p] :: !l
     done;
     !l;;
 \end{caml_example}
@@ -789,7 +787,7 @@ through'' the @'try'@ construct.
 \begin{caml_example}{toplevel}
 let option_exception f x =
   try Some (f x) with
-  | Assert_failure _ as e -> raise e
+  | Assert_failure (a, b, c) -> raise (Assert_failure (a, b, c))
   | _ -> None;;
 \end{caml_example}
 
@@ -834,7 +832,7 @@ expr_n ']'@ is equivalent to @expr_1 '::' \ldots '::' expr_n '::'
 values of @expr_1@ to @expr_n@.
 
 \begin{caml_example}{toplevel}
-0::[1; 2; 3] = 0::1::2::3::[];;
+0 :: [1; 2; 3] = 0 :: 1 :: 2 :: 3 :: [];;
 \end{caml_example}
 
 \subsubsection*{sss:expr-polyvars}{Polymorphic variants}
@@ -939,13 +937,13 @@ the value of @expr_3@. The exception "Invalid_argument" is raised if
 the access is out of bounds. The value of the whole expression is @'()'@.
 
 \begin{caml_example}{toplevel}
-let mul arr n =
+let scale arr n =
   for x = 0 to Array.length arr - 1 do
     arr.(x) <- arr.(x) * n
   done
 
 let x = [|1; 10; 100|]
-let _ = mul x 2;;
+let _ = scale x 2;;
 \end{caml_example}
 
 \subsubsection*{sss:expr-strings}{Strings}

--- a/manual/src/refman/expr.etex
+++ b/manual/src/refman/expr.etex
@@ -171,17 +171,28 @@ precedence come first. For infix and prefix symbols, we write
 \entree{"let  match  fun  function  try"}{--}
 \end{tableau}
 
+It is simple to test or refresh one's understanding:
+
+\begin{caml_example}{toplevel}
+3 + 3 mod 2, 3 + (3 mod 2), (3 + 3) mod 2;;
+\end{caml_example}
+
 \subsection{ss:expr-basic}{Basic expressions}
 
 \subsubsection*{sss:expr-constants}{Constants}
 
-An expression consisting in a constant evaluates to this constant.
+An expression consisting in a constant evaluates to this constant. For example,
+\texttt{3.14} or \texttt{[||]}.
 
 \subsubsection*{sss:expr-var}{Value paths}
 
 An expression consisting in an access path evaluates to the value bound to
 this path in the current evaluation environment. The path can
 be either a value name or an access path to a value component of a module.
+
+\begin{caml_example}{toplevel}
+Float.ArrayLabels.to_list;;
+\end{caml_example}
 
 \subsubsection*{sss:expr-parenthesized}{Parenthesized expressions}
 \ikwd{begin\@\texttt{begin}}
@@ -194,6 +205,24 @@ is good style to use @'begin' \ldots 'end'@ inside control structures:
         if \ldots then begin \ldots ; \ldots end else begin \ldots ; \ldots end
 \end{alltt}
 and @'(' \ldots ')'@ for the other grouping situations.
+
+\begin{caml_example}{toplevel}
+let x = 1 + 2 * 3
+let y = (1 + 2) * 3;;
+\end{caml_example}
+
+\begin{caml_example}{toplevel}
+let f a b =
+  if a = b then
+    print_string "Equal"
+  else
+    begin
+      print_string "Not Equal: ";
+      print_int a;
+      print_string " and ";
+      print_int b
+    end;;
+\end{caml_example}
 
 Parenthesized expressions can contain a type constraint, as in @'('
 expr ':' typexpr ')'@. This constraint forces the type of @expr@ to be
@@ -216,15 +245,35 @@ functional value $f$, which is then applied to the values of
 The order in which the expressions @expr, argument_1, \ldots,
 argument_n@ are evaluated is not specified.
 
+\begin{caml_example}{toplevel}
+List.fold_left ( + ) 0 [1; 2; 3; 4; 5];;
+\end{caml_example}
+
 Arguments and parameters are matched according to their respective
 labels. Argument order is irrelevant, except among arguments with the
 same label, or no label.
+
+\begin{caml_example}{toplevel}
+ListLabels.fold_left ~f:( @ ) ~init:[] [[1; 2; 3]; [4; 5; 6]; [7; 8; 9]];;
+\end{caml_example}
 
 If a parameter is specified as optional (label prefixed by @"?"@) in the
 type of @expr@, the corresponding argument will be automatically
 wrapped with the constructor "Some", except if the argument itself is
 also prefixed by @"?"@, in which case it is passed as is.
-%
+
+\begin{caml_example}{toplevel}
+let fullname ?title first second =
+  match title with
+  | Some t -> t ^ " " ^ first ^ " " ^ second
+  | None -> first ^ " " ^ second
+
+let name = fullname ~title:"Mrs" "Jane" "Fisher"
+
+let address ?title first second town =
+  fullname ?title first second ^ "\n" ^ town;;
+\end{caml_example}
+
 If a non-labeled argument is passed, and its corresponding parameter
 is preceded by one or several optional parameters, then these
 parameters are {\em defaulted}, {\em i.e.} the value "None" will be
@@ -235,11 +284,27 @@ optional and non-optional, will be kept, and the result of the
 function will still be a function of these missing parameters to the
 body of $f$.
 
+\begin{caml_example}{toplevel}
+let fullname ?title first second =
+  match title with
+  | Some t -> t ^ " " ^ first ^ " " ^ second
+  | None -> first ^ " " ^ second
+
+let name = fullname "Jane" "Fisher";;
+\end{caml_example}
+
 As a special case, if the function has a known arity, all the
 arguments are unlabeled, and their number matches the number of
 non-optional parameters, then labels are ignored and non-optional
 parameters are matched in their definition order. Optional arguments
 are defaulted.
+
+\begin{caml_example}{toplevel}
+let f ~a ?b c = 
+  match b with Some n -> a + n + c | None -> a + c
+
+let r = f 2 3;;
+\end{caml_example}
 
 In all cases but exact match of order and labels, without optional
 parameters, the function type should be known at the application
@@ -273,7 +338,13 @@ matches the argument, the exception "Match_failure" is raised.
 %
 \index{Matchfailure\@\verb`Match_failure`}
 
-\medskip
+\begin{caml_example}{toplevel}
+(function (0, 0) -> "both zero"
+        | (0, _) -> "first only zero"
+        | (_, 0) -> "second only zero"
+        | _ -> "neither zero")
+(7, 0);;
+\end{caml_example}
 
 The other form of function definition is introduced by the keyword "fun":
 \ikwd{fun\@\texttt{fun}}
@@ -285,6 +356,11 @@ This expression is equivalent to:
 @"fun" parameter_1 "->" \ldots "fun" parameter_n "->" expr@
 \end{center}
 
+\begin{caml_example}{toplevel}
+let p = (fun a -> fun b -> fun c -> a + b + c)
+let q = (fun a b c -> a + b + c);;
+\end{caml_example}
+
 An optional type constraint @typexpr@ can be added before "->" to enforce
 the type of the result to be compatible with the constraint @typexpr@:
 \begin{center}
@@ -295,6 +371,7 @@ is equivalent to
   @"fun" parameter_1 "->" \ldots "fun" parameter_n "->" %
   (expr ":" typexpr )@
 \end{center}
+
 Beware of the small syntactic difference between a type constraint on
 the last parameter
 \begin{center}
@@ -305,10 +382,24 @@ and one on the result
   @"fun" parameter_1 \ldots parameter_n":" typexpr "->" expr @
 \end{center}
 
+\begin{caml_example}{toplevel}
+let eq = fun (a : int) (b : int) -> a = b
+let eq2 = fun a b : bool -> a = b
+let eq3 = fun (a : int) (b : int) : bool -> a = b;;
+\end{caml_example}
+
 The parameter patterns @"~"lab@ and @"~("lab [":" typ]")"@
 are shorthands for respectively @"~"lab":"lab@ and
 @"~"lab":("lab [":" typ]")"@, and similarly for their optional
 counterparts.
+
+\begin{caml_example}{toplevel}
+let bool_map ~cmp:(cmp : int -> int -> bool) l =
+  List.map cmp l
+
+let bool_map' ~(cmp : int -> int -> bool) l =
+  List.map cmp l;;
+\end{caml_example}
 
 A function of the form @"fun" "?" lab ":(" pattern '=' expr_0 ')' '->'
 expr@ is equivalent to
@@ -320,6 +411,18 @@ expr@ is equivalent to
 \end{center}
 where @ident@
 is a fresh variable, except that it is unspecified when @expr_0@ is evaluated.
+
+\begin{caml_example}{toplevel}
+let open_file_for_input ?binary filename =
+  (match binary with
+   | Some false -> open_in
+   | Some true -> open_in_bin
+   | None -> open_in)
+  filename
+
+let open_file_for_input' ?(binary=false) filename =
+  (if binary then open_in_bin else open_in) filename;;
+\end{caml_example}
 
 After these two transformations, expressions are of the form
 \begin{center}
@@ -362,6 +465,13 @@ then @expr_i@ is evaluated and its value returned as the result of the
 matching, as usual. But if @@cond@_i@ evaluates to "false", the matching
 is resumed against the patterns following @pattern_i@.
 
+\begin{caml_example}{toplevel}
+let rec repeat f = function
+  | n when n < 0 -> raise (Invalid_argument "repeat")
+  | 0 -> ()
+  | n -> f (); repeat f (n - 1);; 
+\end{caml_example}
+
 \subsubsection*{sss:expr-localdef}{Local definitions}
 
 \ikwd{let\@\texttt{let}}
@@ -380,6 +490,17 @@ matchings fails, the exception "Match_failure" is raised.
 %
 \index{Matchfailure\@\verb`Match_failure`}
 
+\begin{caml_example}{toplevel}
+let v =
+  let x = 1 in [x; x; x]
+
+let v' =
+  let a, b = (1, 2) in a + b
+
+let v'' =
+  let a = 1 and b = 2 in a + b;;
+\end{caml_example}
+
 An alternate syntax is provided to bind variables to functional
 values: instead of writing
 \begin{center}
@@ -390,13 +511,21 @@ in a @"let"@ expression, one may instead write
 @"let" ident parameter_1 \ldots parameter_m "=" expr@
 \end{center}
 
-\medskip
+\begin{caml_example}{toplevel}
+let f = fun x -> fun y -> fun z -> x + y + z
+
+let f' = fun x y z -> x + y + z
+
+let f'' x y z = x + y + z;;
+\end{caml_example}
+
 \noindent
 Recursive definitions of names are introduced by @"let" "rec"@:
 \begin{center}
 @"let" "rec" pattern_1 "=" expr_1 "and" \ldots "and" pattern_n "=" expr_n
        "in" expr@
 \end{center}
+
 The only difference with the @"let"@ construct described above is
 that the bindings of names to values performed by the
 pattern-matching are considered already performed when the expressions
@@ -404,6 +533,15 @@ pattern-matching are considered already performed when the expressions
 to @expr_n@ can reference identifiers that are bound by one of the
 patterns @pattern_1, \ldots, pattern_n@, and expect them to have the
 same value as in @expr@, the body of the @"let" "rec"@ construct.
+
+\begin{caml_example}{toplevel}
+let rec even =
+  function 0 -> true | n -> odd (n - 1)
+and odd =
+  function 0 -> false | n -> even (n - 1)
+in
+  even 1000;;
+\end{caml_example}
 
 The recursive definition is guaranteed to behave as described above if
 the expressions @expr_1@ to @expr_n@ are function definitions
@@ -422,6 +560,28 @@ The behavior of other forms of @"let" "rec"@ definitions is
 implementation-dependent. The current implementation also supports
 a certain class of recursive definitions of non-functional values,
 as explained in section~\ref{s:letrecvalues}.
+
+It is possible to define local exceptions in expressions:
+@ "let" exception constr-decl "in" expr @ .
+
+\begin{caml_example}{toplevel}
+let map_empty_on_negative f l =
+  let exception Negative in
+  let aux x = if x < 0 then raise Negative else f x in
+    try List.map aux l with Negative -> [];;
+\end{caml_example}
+
+The syntactic scope of the exception constructor is the inner
+expression, but nothing prevents exception values created with this
+constructor from escaping this scope.  Two executions of the definition
+above result in two incompatible exception constructors (as for any
+exception definition). For instance:
+
+\begin{caml_example}{toplevel}
+let gen () = let exception A in A
+let () = assert(gen () = gen ());;
+\end{caml_example}
+
 \subsubsection{sss:expr-explicit-polytype}{Explicit polymorphic type annotations}
 (Introduced in OCaml 3.12)
 
@@ -437,21 +597,7 @@ and allow one to use this polymorphism in recursive occurrences
 (when using @"let" "rec"@). Note however that this is a normal polymorphic
 type, unifiable with any instance of itself.
 
-\subsubsection{sss:expr-local-exception}{Local exceptions}
-(Introduced in 4.04)
 
-It is possible to define local exceptions in expressions:
-@ "let" exception constr-decl "in" expr @ .
-The syntactic scope of the exception constructor is the inner
-expression, but nothing prevents exception values created with this
-constructor from escaping this scope.  Two executions of the definition
-above result in two incompatible exception constructors (as for any
-exception definition). For instance, the following assertion is
-true:
-\begin{verbatim}
-  let gen () = let exception A in A
-  let () = assert(gen () <> gen ())
-\end{verbatim}
 
 \subsection{ss:expr-control}{Control structures}
 
@@ -459,6 +605,15 @@ true:
 
 The expression @expr_1 ";" expr_2@ evaluates @expr_1@ first, then
 @expr_2@, and returns the value of @expr_2@.
+
+\begin{caml_example}{toplevel}
+let print_pair (a, b) =
+  print_string "(";
+  print_string (string_of_int a);
+  print_string ",";
+  print_string (string_of_int b);
+  print_string ")";;
+\end{caml_example}
 
 \subsubsection*{sss:expr-conditional}{Conditional}
 \ikwd{if\@\texttt{if}}
@@ -468,8 +623,20 @@ the value of @expr_2@ if @expr_1@ evaluates to the boolean @"true"@,
 and to the value of @expr_3@ if @expr_1@ evaluates to the boolean
 @"false"@.
 
+\begin{caml_example}{toplevel}
+let rec factorial x =
+  if x <= 1 then 1 else x * factorial (x - 1);;
+\end{caml_example}
+
 The @"else" expr_3@ part can be omitted, in which case it defaults to
 @"else" "()"@.
+
+\begin{caml_example}{toplevel}
+let debug = ref false
+
+let log msg =
+  if !debug then prerr_string (msg ^ "\n");;
+\end{caml_example}
 
 \subsubsection*{sss:expr-case}{Case expression}\ikwd{match\@\texttt{match}}
 
@@ -487,10 +654,27 @@ value of the whole @'match'@ expression. The evaluation of
 @expr_i@ takes place in an environment enriched by the bindings
 performed during matching. If several patterns match the value of
 @expr@, the one that occurs first in the @'match'@ expression is
-selected. If none of the patterns match the value of @expr@, the
+selected.
+
+\begin{caml_example}{toplevel}
+let rec sum l =
+  match l with
+  | [] -> 0
+  | h::t -> h + sum t;; 
+\end{caml_example}
+
+If none of the patterns match the value of @expr@, the
 exception "Match_failure" is raised.
 %
 \index{Matchfailure\@\verb`Match_failure`}
+
+\begin{caml_example}{toplevel}[warning=8, error]
+let unoption o =
+  match o with
+  | Some x -> x 
+
+let l = List.map unoption [Some 1; Some 10; None; Some 2];;
+\end{caml_example}
 
 \subsubsection*{sss:expr-boolean-operators}{Boolean operators}
 
@@ -519,6 +703,11 @@ exactly as
 The boolean operators @'&'@ and @'or'@ are deprecated synonyms for
 (respectively) @'&&'@ and @'||'@.
 
+\begin{caml_example}{toplevel}
+let xor a b =
+  (a || b) && not (a && b);;
+\end{caml_example}
+
 \subsubsection*{sss:expr-loops}{Loops}
 
 \ikwd{while\@\texttt{while}}
@@ -527,6 +716,17 @@ evaluates @expr_2@ while @expr_1@ evaluates to @'true'@. The loop
 condition @expr_1@ is evaluated and tested at the beginning of each
 iteration. The whole @'while' \ldots 'done'@ expression evaluates to
 the unit value @'()'@.
+
+\begin{caml_example}{toplevel}
+let chars_of_string s =
+  let i = ref 0 in
+  let chars = ref [] in
+    while !i < String.length s do
+      chars := s.[!i]::!chars;
+      i := !i + 1
+    done;
+    List.rev !chars;;
+\end{caml_example}
 
 \ikwd{for\@\texttt{for}}
 The expression @'for' name '=' expr_1 'to' expr_2 'do' expr_3 'done'@
@@ -537,12 +737,28 @@ bound to the values
    $n$, $n+1$, \ldots, $p-1$, $p$.
    The loop body is never evaluated if $n > p$.
 
+\begin{caml_example}{toplevel}
+let chars_of_string s =
+  let l = ref [] in
+    for p = 0 to String.length s - 1 do
+      l := s.[p]::!l
+    done;
+    List.rev !l;;
+\end{caml_example}
 
 The expression @'for' name '=' expr_1 'downto' expr_2 'do' expr_3 'done'@
 evaluates similarly, except that @name@ is successively bound to the values
    $n$, $n-1$, \ldots, $p+1$, $p$.
    The loop body is never evaluated if $n < p$.
 
+\begin{caml_example}{toplevel}
+let chars_of_string s =
+  let l = ref [] in
+    for p = String.length s - 1 downto 0 do
+      l := s.[p]::!l
+    done;
+    !l;;
+\end{caml_example}
 
 In both cases, the whole @'for'@ expression evaluates to the unit
 value @'()'@.
@@ -570,6 +786,13 @@ selected. If none of the patterns matches the value of @expr@, the
 exception value is raised again, thereby transparently ``passing
 through'' the @'try'@ construct.
 
+\begin{caml_example}{toplevel}
+let option_exception f x =
+  try Some (f x) with
+  | Assert_failure _ as e -> raise e
+  | _ -> None;;
+\end{caml_example}
+
 \subsection{ss:expr-ops-on-data}{Operations on data structures}
 
 \subsubsection*{sss:expr-products}{Products}
@@ -577,6 +800,10 @@ through'' the @'try'@ construct.
 The expression @expr_1 ',' \ldots ',' expr_n@ evaluates to the
 \var{n}-tuple of the values of expressions @expr_1@ to @expr_n@. The
 evaluation order of the subexpressions is not specified.
+
+\begin{caml_example}{toplevel}
+(1 + 2 * 3, (1 + 2) * 3, 1 + (2 * 3));;
+\end{caml_example}
 
 \subsubsection*{sss:expr-variants}{Variants}
 
@@ -591,6 +818,12 @@ The expression @constr '('expr_1, \ldots, expr_n')'@ evaluates to the
 variant value whose constructor is @constr@, and whose arguments are
 the values of @expr_1 \ldots expr_n@.
 
+\begin{caml_example}{toplevel}
+type t = Var of string | Not of t | And of t * t | Or of t * t
+
+let test = And (Var "x", Not (Or (Var "y", Var "z")));;
+\end{caml_example}
+
 For lists, some syntactic sugar is provided. The expression
 @expr_1 '::' expr_2@ stands for the constructor @'(' '::' ')' @
 applied to the arguments @'(' expr_1 ',' expr_2 ')'@, and therefore
@@ -600,10 +833,18 @@ expr_n ']'@ is equivalent to @expr_1 '::' \ldots '::' expr_n '::'
 '[]'@, and therefore evaluates to the list whose elements are the
 values of @expr_1@ to @expr_n@.
 
+\begin{caml_example}{toplevel}
+0::[1; 2; 3] = 0::1::2::3::[];;
+\end{caml_example}
+
 \subsubsection*{sss:expr-polyvars}{Polymorphic variants}
 
 The expression @"`"tag-name expr@ evaluates to the polymorphic variant
 value whose tag is @tag-name@, and whose argument is the value of @expr@.
+
+\begin{caml_example}{toplevel}
+let with_counter x = `V (x, ref 0);;
+\end{caml_example}
 
 \subsubsection*{sss:expr-records}{Records}
 
@@ -623,6 +864,14 @@ specified. Optional type constraints can be added after each field
  \ldots ';' field_n ':' typexpr_n '=' expr_n '}'@
 to force the type of @field_k@ to be compatible with @typexpr_k@.
 
+\begin{caml_example}{toplevel}
+type t = {house_no : int; street : string; town : string; postcode : string}
+
+let address x =
+  Printf.sprintf "The occupier\n%i %s\n%s\n%s"
+    x.house_no x.street x.town x.postcode;;
+\end{caml_example}
+
 The expression
 @"{" expr "with" field_1 ["=" expr_1] ";" \ldots ";" field_n ["=" expr_n] "}"@
 builds a fresh record with fields @field_1 \ldots field_n@ equal to
@@ -638,6 +887,13 @@ with
 @"{" expr "with" field_1 ':' typexpr_1 "=" expr_1 ";" %
  \ldots ";" field_n ':' typexpr_n "=" expr_n "}"@.
 
+\begin{caml_example}{toplevel}
+type t = {house_no : int; street : string; town : string; postcode : string}
+
+let uppercase_town address =
+  {address with town = String.uppercase_ascii address.town};;
+\end{caml_example}
+
 The expression @expr_1 '.' field@ evaluates @expr_1@ to a record
 value, and returns the value associated to @field@ in this record
 value.
@@ -649,6 +905,20 @@ associated to @field@ in this record by the value of
 declared @'mutable'@ in the definition of the record type. The whole
 expression @expr_1 '.' field '<-' expr_2@ evaluates to the unit value
 @'()'@.
+
+\begin{caml_example}{toplevel}
+type t = {mutable upper : int; mutable lower : int; mutable other : int}
+
+let stats = {upper = 0; lower = 0; other = 0}
+
+let collect =
+  String.iter
+    (function
+     | 'A'..'Z' -> stats.upper <- stats.upper + 1
+     | 'a'..'z' -> stats.lower <- stats.lower + 1
+     | _ -> stats.other <- stats.other + 1);;
+\end{caml_example}
+
 
 \subsubsection*{sss:expr-arrays}{Arrays}
 
@@ -668,6 +938,16 @@ the array denoted by @expr_1@, replacing element number @expr_2@ by
 the value of @expr_3@. The exception "Invalid_argument" is raised if
 the access is out of bounds. The value of the whole expression is @'()'@.
 
+\begin{caml_example}{toplevel}
+let mul arr n =
+  for x = 0 to Array.length arr - 1 do
+    arr.(x) <- arr.(x) * n
+  done
+
+let x = [|1; 10; 100|]
+let _ = mul x 2;;
+\end{caml_example}
+
 \subsubsection*{sss:expr-strings}{Strings}
 
 The expression @expr_1 '.[' expr_2 ']'@ returns the value of character
@@ -676,11 +956,15 @@ has number 0; the last character has number $n-1$, where \var{n} is the
 length of the string. The exception "Invalid_argument" is raised if the
 access is out of bounds.
 
+\begin{caml_example}{toplevel}
+let iter f s =
+  for x = 0 to String.length s - 1 do f s.[x] done;;
+\end{caml_example}
+
 The expression @expr_1 '.[' expr_2 ']' '<-' expr_3@ modifies in-place
 the string denoted by @expr_1@, replacing character number @expr_2@ by
 the value of @expr_3@. The exception "Invalid_argument" is raised if
 the access is out of bounds. The value of the whole expression is @'()'@.
-
 {\bf Note:} this possibility is offered only for backward
 compatibility with older versions of OCaml and will be removed in a
 future version. New code should use byte sequences and the "Bytes.set"
@@ -703,6 +987,10 @@ expressions). Symbols from the class @prefix-symbol@, as well as
 the keywords @"-"@ and @"-."@
 can appear in prefix position (in front of an expression).
 
+\begin{caml_example}{toplevel}
+(( * ), ( := ), ( || ));;
+\end{caml_example}
+
 Infix and prefix symbols do not have a fixed meaning: they are simply
 interpreted as applications of functions bound to the names
 corresponding to the symbols.  The expression @prefix-symbol expr@ is
@@ -715,6 +1003,10 @@ and their initial meaning. (See the description of the core
 library module "Stdlib" in chapter~\ref{c:corelib} for more
 details). Their meaning may be changed at any time using
 @"let" "(" infix-op ")" name_1 name_2 "=" \ldots@
+
+\begin{caml_example}{toplevel}
+let ( + ), ( - ), ( * ), ( / ) = Int64.(add, sub, mul, div);;
+\end{caml_example}
 
 Note: the operators @'&&'@, @'||'@, and @'~-'@ are handled specially
 and it is not advisable to change their meaning.
@@ -784,6 +1076,19 @@ When @class-path@ evaluates to a class body, @'new' class-path@
 evaluates to a new object containing the instance variables and
 methods of this class.
 
+\begin{caml_example}{toplevel}
+class of_list (l : int list) = object
+  val mutable l = l
+  method next =
+    if l = [] then raise (Failure "empty list");
+    let r = List.hd l in l <- List.tl l; r
+end
+
+let a = new of_list [1; 1; 2; 3; 5; 8; 13]
+
+let b = new of_list;;
+\end{caml_example}
+
 When @class-path@ evaluates to a class function, @'new' class-path@
 evaluates to a function expecting the same number of arguments and
 returning a new object of this class.
@@ -798,6 +1103,15 @@ class-name '=' 'object' class-body 'end'@ ---see sections
 \ref{sss:class-body} and following for the syntax of @class-body@---
 and immediately creating a single object from it by @'new' class-name@.
 
+\begin{caml_example}{toplevel}
+let o =
+  object
+    val secret = 99
+    val password = "unlock"
+    method get guess = if guess <> password then None else Some secret
+  end;;
+\end{caml_example}
+
 The typing of immediate objects is slightly different from explicitly
 defining a class in two respects. First, the inferred object type may
 contain free type variables. Second, since the class body of an
@@ -808,6 +1122,19 @@ with a closed object type.
 
 The expression @expr '#' method-name@ invokes the method
 @method-name@ of the object denoted by @expr@.
+
+\begin{caml_example}{toplevel}
+class of_list (l : int list) = object
+  val mutable l = l
+  method next =
+    if l = [] then raise (Failure "empty list");
+    let r = List.hd l in l <- List.tl l; r
+end
+
+let a = new of_list [1; 1; 2; 3; 5; 8; 13]
+
+let second = ignore a#next; a#next;;
+\end{caml_example}
 
 If @method-name@ is a polymorphic method, its type should be known at
 the invocation site.  This is true for instance if @expr@ is the name
@@ -825,6 +1152,14 @@ evaluates to the value of the given instance variable.  The expression
 variable @inst-var-name@, which must be mutable.  The whole expression
 @inst-var-name '<-' expr@ evaluates to @"()"@.
 
+\begin{caml_example}{toplevel}
+class of_list (l : int list) = object
+  val mutable l = l
+  method next =
+    if l = [] then raise (Failure "empty list");
+    let r = List.hd l in l <- List.tl l; r  (* access and modify instance variable *)
+end;;
+\end{caml_example}
 
 \subsubsection*{sss:expr-obj-duplication}{Object duplication}
 
@@ -835,6 +1170,16 @@ returns a copy of self with the given instance variables replaced by
 the values of the associated expressions. A single instance variable
 name @id@ stands for @id '=' id@. Other instance variables have the same
 value in the returned object as in self.
+
+\begin{caml_example}{toplevel}
+let o =
+  object
+    val secret = 99
+    val password = "unlock"
+    method get guess = if guess <> password then None else Some secret
+    method with_new_secret s = {< secret = s >}
+  end;;
+\end{caml_example}
 
 \subsection{ss:expr-coercions}{Coercions}
 
@@ -963,6 +1308,12 @@ location of @expr@ as arguments.  Assertion
 checking can be turned off with the "-noassert" compiler option.  In
 this case, @expr@ is not evaluated at all.
 
+\begin{caml_example}{toplevel}
+let f a b c =
+  assert (a <= b && b <= c);
+  (b -. a) /. (c -. b);; 
+\end{caml_example}
+
 As a special case, @"assert false"@ is reduced to
 @'raise' '('@"Assert_failure ..."@')'@, which gives it a polymorphic
 type.  This means that it can be used in place of any expression (for
@@ -971,6 +1322,12 @@ the @"assert false"@ ``assertions'' cannot be turned off by the
 "-noassert" option.
 %
 \index{Assertfailure\@\verb`Assert_failure`}
+
+\begin{caml_example}{toplevel}
+let min_known_nonempty = function
+  | [] -> assert false
+  | l -> List.hd (List.sort compare l);;
+\end{caml_example}
 
 \subsubsection*{sss:expr-lazy}{Lazy expressions}
 \ikwd{lazy\@\texttt{lazy}}
@@ -983,6 +1340,12 @@ be performed the first time the function "Lazy.force" is applied to the value
 of "Lazy.force" to \var{v} do not evaluate @expr@ again. Applications
 of "Lazy.force" may be implicit through pattern matching (see~\ref{sss:pat-lazy}).
 
+\begin{caml_example}{toplevel}
+let lazy_greeter = lazy (print_string "Hello, World!\n");;
+
+Lazy.force lazy_greeter;;
+\end{caml_example}
+
 \subsubsection*{sss:expr-local-modules}{Local modules}
 \ikwd{let\@\texttt{let}}
 \ikwd{module\@\texttt{module}}
@@ -992,13 +1355,14 @@ The expression
 locally binds the module expression @module-expr@ to the identifier
 @module-name@ during the evaluation of the expression @expr@.
 It then returns the value of @expr@.  For example:
-\begin{caml_example}{verbatim}
+\begin{caml_example}{toplevel}
 let remove_duplicates comparison_fun string_list =
   let module StringSet =
     Set.Make(struct type t = string
-                    let compare = comparison_fun end) in
-  StringSet.elements
-    (List.fold_right StringSet.add string_list StringSet.empty)
+                    let compare = comparison_fun end)
+  in
+    StringSet.elements
+      (List.fold_right StringSet.add string_list StringSet.empty);;
 \end{caml_example}
 
 \subsubsection*{sss:local-opens}{Local opens}
@@ -1010,11 +1374,25 @@ The expressions @"let" "open" module-path "in" expr@ and
 constructions locally open the module referred to by the module path
 @module-path@ in the respective scope of the expression @expr@.
 
+\begin{caml_example}{toplevel}
+let map_3d_matrix f m =
+  let open Array in
+    map (map (map f)) m
+
+let map_3d_matrix' f =
+  Array.(map (map (map f)));;
+\end{caml_example}
+
 When the body of a local open expression is delimited by
 @'[' ']'@,  @'[|' '|]'@,  or @'{' '}'@, the parentheses can be omitted.
 For expression, parentheses can also be omitted for @'{<' '>}'@.
 For example, @module-path'.['expr']'@ is equivalent to
 @module-path'.(['expr'])'@, and @module-path'.[|' expr '|]'@ is
 equivalent to @module-path'.([|' expr '|])'@.
+
+\begin{caml_example}{toplevel}
+let vector = Random.[|int 255; int 255; int 255; int 255|];;
+\end{caml_example}
+
 
 %% \newpage

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -16,6 +16,17 @@ no intervening blanks. Comments are treated as blank characters.
 Comments do not occur inside string or character literals. Nested
 comments are handled correctly.
 
+\begin{caml_example}{verbatim}
+(* single line comment *)
+
+(* multiple line comment, commenting out part of a program, and containing a
+nested comment:
+let f = function
+  | 'A'..'Z' -> "Uppercase"
+    (* Add other cases later... *)
+*)
+\end{caml_example}
+
 \subsubsection*{sss:lex:identifiers}{Identifiers}
 
 \begin{syntax}
@@ -80,6 +91,13 @@ representable integer values is undefined.
 For convenience and readability, underscore characters (@"_"@) are accepted
 (and ignored) within integer literals.
 
+\begin{caml_example}{toplevel}
+let house_number = 37
+let million = 1_000_000
+let copyright = 0x00A9
+let counter64bit = ref 0L;;
+\end{caml_example}
+
 \subsubsection*{sss:floating-point-literals}{Floating-point literals}
 
 \begin{syntax}
@@ -116,6 +134,12 @@ It is written in decimal and interpreted as a power of 2.
 For convenience and readability, underscore characters (@"_"@) are accepted
 (and ignored) within floating-point literals.
 
+\begin{caml_example}{toplevel}
+let pi = 3.14159265358979312
+let small_negative = -1e-5
+let hex = 0x1.fp3;;
+\end{caml_example}
+
 \subsubsection*{sss:character-literals}{Character literals}
 \label{s:characterliteral}
 
@@ -149,6 +173,11 @@ The two single quotes enclose either one character different from
 \entree{"\\o"\var{ooo}}{the character with ASCII code \var{ooo} in octal}
 \end{tableau}
 
+\begin{caml_example}{toplevel}
+let a = 'a'
+let single_quote = '\''
+let copyright = '\xA9';;
+\end{caml_example}
 \subsubsection*{sss:stringliterals}{String literals}
 
 \begin{syntax}
@@ -158,7 +187,6 @@ string-literal:
 ;
 quoted-string-id:
      { 'a'...'z' || '_' }
-;
 ;
 string-character:
           regular-string-char
@@ -178,10 +206,24 @@ encoding of the specified Unicode scalar value. The Unicode scalar
 value, an integer in the ranges 0x0000...0xD7FF or 0xE000...0x10FFFF,
 is defined using 1 to 6 hexadecimal digits; leading zeros are allowed.
 
+\begin{caml_example}{toplevel}
+let greeting = "Hello, World!\n"
+let superscript_plus = "\u{207A}";;
+\end{caml_example}
+
 To allow splitting long string literals across lines, the sequence
 "\\"\var{newline}~\var{spaces-or-tabs} (a backslash at the end of a line
 followed by any number of spaces and horizontal tabulations at the
 beginning of the next line) is ignored inside string literals.
+
+\begin{caml_example}{toplevel}
+let longstr =
+  "Call me Ishmael. Some years ago — never mind how long \
+  precisely — having little or no money in my purse, and \
+  nothing particular to interest me on shore, I thought I\
+   would sail about a little and see the watery part of t\
+  he world.";;
+\end{caml_example}
 
 Quoted string literals provide an alternative lexical syntax for
 string literals. They are useful to represent strings of arbitrary content
@@ -192,8 +234,12 @@ any character in a special way but requires that the
 sequence @'|' quoted-string-id '}'@ does not occur in the string itself.
 The identifier @quoted-string-id@ is a (possibly empty) sequence of
 lowercase letters and underscores that can be freely chosen to avoid
-such issue (e.g. "{|hello|}", "{ext|hello {|world|}|ext}", ...).
+such issue.
 
+\begin{caml_example}{toplevel}
+let greeting_with_quotation_marks = {|"Hello, World!"|}
+let nested = {ext|hello {|world|}|ext};;
+\end{caml_example}
 
 The current implementation places practically no restrictions on the
 length of string literals.
@@ -302,16 +348,16 @@ longest first token.
 
 \begin{syntax}
 linenum-directive:
-     '#' {{"0" \ldots "9"}} '"' { string-character } '"'
+        '#' {{"0" \ldots "9"}}
+      | '#' {{"0" \ldots "9"}} '"' { string-character } '"'
 \end{syntax}
 
 Preprocessors that generate OCaml source code can insert line number
 directives in their output so that error messages produced by the
 compiler contain line numbers and file names referring to the source
 file before preprocessing, instead of after preprocessing.
-A line number directive starts at the beginning of a line,
-is composed of a @"#"@ (sharp sign), followed by
-a positive integer (the source line number), followed by a
+A line number directive is composed of a @"#"@ (sharp sign), followed by
+a positive integer (the source line number), optionally followed by a
 character string (the source file name).
 Line number directives are treated as blanks during lexical
 analysis.

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -348,16 +348,16 @@ longest first token.
 
 \begin{syntax}
 linenum-directive:
-        '#' {{"0" \ldots "9"}}
-      | '#' {{"0" \ldots "9"}} '"' { string-character } '"'
+     '#' {{"0" \ldots "9"}} '"' { string-character } '"'
 \end{syntax}
 
 Preprocessors that generate OCaml source code can insert line number
 directives in their output so that error messages produced by the
 compiler contain line numbers and file names referring to the source
 file before preprocessing, instead of after preprocessing.
-A line number directive is composed of a @"#"@ (sharp sign), followed by
-a positive integer (the source line number), optionally followed by a
+A line number directive starts at the beginning of a line,
+is composed of a @"#"@ (sharp sign), followed by
+a positive integer (the source line number), followed by a
 character string (the source file name).
 Line number directives are treated as blanks during lexical
 analysis.

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -135,7 +135,7 @@ For convenience and readability, underscore characters (@"_"@) are accepted
 (and ignored) within floating-point literals.
 
 \begin{caml_example}{toplevel}
-let pi = 3.14159265358979312
+let pi = 3.141_592_653_589_793_12
 let small_negative = -1e-5
 let hex = 0x1.fp3;;
 \end{caml_example}
@@ -220,8 +220,8 @@ beginning of the next line) is ignored inside string literals.
 let longstr =
   "Call me Ishmael. Some years ago — never mind how long \
   precisely — having little or no money in my purse, and \
-  nothing particular to interest me on shore, I thought I \
-  would sail about a little and see the watery part of t\
+  nothing particular to interest me on shore, I thought I\
+  \ would sail about a little and see the watery part of t\
   he world.";;
 \end{caml_example}
 
@@ -237,7 +237,7 @@ lowercase letters and underscores that can be freely chosen to avoid
 such issue.
 
 \begin{caml_example}{toplevel}
-let greeting_with_quotation_marks = {|"Hello, World!"|}
+let quoted_greeting = {|"Hello, World!"|}
 let nested = {ext|hello {|world|}|ext};;
 \end{caml_example}
 

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -137,7 +137,7 @@ For convenience and readability, underscore characters (@"_"@) are accepted
 \begin{caml_example}{toplevel}
 let pi = 3.141_592_653_589_793_12
 let small_negative = -1e-5
-let hex = 0x1.fp3;;
+let machine_epsilon = 0x1p-52;;
 \end{caml_example}
 
 \subsubsection*{sss:character-literals}{Character literals}

--- a/manual/src/refman/lex.etex
+++ b/manual/src/refman/lex.etex
@@ -220,8 +220,8 @@ beginning of the next line) is ignored inside string literals.
 let longstr =
   "Call me Ishmael. Some years ago — never mind how long \
   precisely — having little or no money in my purse, and \
-  nothing particular to interest me on shore, I thought I\
-   would sail about a little and see the watery part of t\
+  nothing particular to interest me on shore, I thought I \
+  would sail about a little and see the watery part of t\
   he world.";;
 \end{caml_example}
 

--- a/manual/src/refman/patterns.etex
+++ b/manual/src/refman/patterns.etex
@@ -123,7 +123,7 @@ constraint forces the type of @pattern_1@ to be compatible with
 
 \begin{caml_example}{toplevel}
 let int_triple_is_ordered ((a, b, c) : int * int * int) =
-  a < b && b < c;;
+  a <= b && b <= c;;
 \end{caml_example}
 
 \subsubsection*{sss:pat-or}{``Or'' patterns}

--- a/manual/src/refman/patterns.etex
+++ b/manual/src/refman/patterns.etex
@@ -107,10 +107,8 @@ the name @value-name@ is bound to the matched value, in addition to the
 bindings performed by the matching against @pattern_1@.
 
 \begin{caml_example}{toplevel}
-let option_exception f x =
-  try Some (f x) with
-  | Assert_failure _ as e -> raise e
-  | _ -> None;;
+let sort_pair ((x, y) as p) =
+  if x <= y then p else (y, x);;
 \end{caml_example}
 
 \subsubsection*{sss:pat-parenthesized}{Parenthesized patterns}
@@ -179,7 +177,7 @@ respectively. This pattern behaves like
 let rec destutter = function
   | [] -> []
   | [a] -> [a]
-  | a::b::t -> if a = b then destutter (b::t) else a::destutter (b::t);;
+  | a :: b :: t -> if a = b then destutter (b :: t) else a :: destutter (b :: t);;
 \end{caml_example}
 
 \subsubsection*{sss:pat-polyvar}{Polymorphic variant patterns}
@@ -191,11 +189,11 @@ whose tag is equal to @tag-name@, and whose argument matches
 \begin{caml_example}{toplevel}
 let rec split = function
   | [] -> ([], [])
-  | h::t ->
+  | h :: t ->
       let ss, gs = split t in
         match h with
-        | `Sheep _ as s -> (s::ss, gs)
-        | `Goat _ as g -> (ss, g::gs);;
+        | `Sheep _ as s -> (s :: ss, gs)
+        | `Goat _ as g -> (ss, g :: gs);;
 \end{caml_example}
 
 \subsubsection*{sss:pat-polyvar-abbrev}{Polymorphic variant abbreviation patterns}

--- a/manual/src/refman/patterns.etex
+++ b/manual/src/refman/patterns.etex
@@ -59,15 +59,41 @@ A pattern that consists in a value name matches any value,
 binding the name to the value. The pattern @"_"@ also matches
 any value, but does not bind any name.
 
+\begin{caml_example}{toplevel}
+let print_int_opt = function
+  | Some x -> print_int x
+  | _ -> ();;
+\end{caml_example}
+
 Patterns are {\em linear\/}: a variable cannot be bound several times by
 a given pattern. In particular, there is no way to test for equality
-between two parts of a data structure using only a pattern (but
-@"when"@ guards can be used for this purpose).
+between two parts of a data structure using only a pattern:
+
+\begin{caml_example}{toplevel}[error]
+let pair_equal = function
+  | x, x -> true
+  | x, y -> false;;
+\end{caml_example}
+
+However, we can use a @"when"@ guard for this purpose:
+
+\begin{caml_example}{toplevel}
+let pair_equal = function
+  | x, y when x = y -> true
+  | _ -> false;;
+\end{caml_example}
 
 \subsubsection*{sss:pat-const}{Constant patterns}
 
 A pattern consisting in a constant matches the values that
 are equal to this constant.
+
+\begin{caml_example}{toplevel}
+let bool_of_string = function
+  | "true" -> true
+  | "false" -> false
+  | _ -> raise (Invalid_argument "bool_of_string");;
+\end{caml_example}
 
 %% FIXME for negative numbers, blanks are allowed between the minus
 %% sign and the first digit.
@@ -80,6 +106,13 @@ The pattern @pattern_1 "as" value-name@ matches the same values as
 the name @value-name@ is bound to the matched value, in addition to the
 bindings performed by the matching against @pattern_1@.
 
+\begin{caml_example}{toplevel}
+let option_exception f x =
+  try Some (f x) with
+  | Assert_failure _ as e -> raise e
+  | _ -> None;;
+\end{caml_example}
+
 \subsubsection*{sss:pat-parenthesized}{Parenthesized patterns}
 
 The pattern @"(" pattern_1 ")"@ matches the same values as
@@ -87,6 +120,11 @@ The pattern @"(" pattern_1 ")"@ matches the same values as
 parenthesized pattern, as in @"(" pattern_1 ":" typexpr ")"@. This
 constraint forces the type of @pattern_1@ to be compatible with
 @typexpr@.
+
+\begin{caml_example}{toplevel}
+let int_triple_is_ordered ((a, b, c) : int * int * int) =
+  a < b && b < c;;
+\end{caml_example}
 
 \subsubsection*{sss:pat-or}{``Or'' patterns}
 
@@ -101,6 +139,14 @@ in case some value~$v$ matches @pattern_1 "|" pattern_2@, the bindings
 performed are those of @pattern_1@ when $v$ matches @pattern_1@.
 Otherwise, value~$v$ matches @pattern_2@ whose bindings are performed.
 
+\begin{caml_example}{toplevel}
+type shape =
+  Square of float | Rect of (float * float) | Circle of float
+
+let is_rectangular = function
+  | Square _ | Rect _ -> true
+  | _ -> false;;
+\end{caml_example}
 
 \subsubsection*{sss:pat-variant}{Variant patterns}
 
@@ -113,6 +159,14 @@ number of arguments expected by the constructor.
 The pattern @constr '_'@ matches all variants whose constructor is
 @constr@.
 
+\begin{caml_example}{toplevel}
+type 'a tree = Lf | Br of 'a tree * 'a * 'a tree
+
+let rec total = function
+  | Br (l, x, r) -> total l + x + total r
+  | Lf -> 0;;
+\end{caml_example}
+
 The pattern @pattern_1 "::" pattern_2@ matches non-empty lists whose
 heads match @pattern_1@, and whose tails match @pattern_2@.
 
@@ -121,11 +175,28 @@ of length $n$ whose elements match @pattern_1@ \ldots @pattern_n@,
 respectively. This pattern behaves like
 @pattern_1 "::" \ldots "::" pattern_n "::" "[]"@.
 
+\begin{caml_example}{toplevel}
+let rec destutter = function
+  | [] -> []
+  | [a] -> [a]
+  | a::b::t -> if a = b then destutter (b::t) else a::destutter (b::t);;
+\end{caml_example}
+
 \subsubsection*{sss:pat-polyvar}{Polymorphic variant patterns}
 
 The pattern @"`"tag-name pattern_1@ matches all polymorphic variants
 whose tag is equal to @tag-name@, and whose argument matches
 @pattern_1@.
+
+\begin{caml_example}{toplevel}
+let rec split = function
+  | [] -> ([], [])
+  | h::t ->
+      let ss, gs = split t in
+        match h with
+        | `Sheep _ as s -> (s::ss, gs)
+        | `Goat _ as g -> (ss, g::gs);;
+\end{caml_example}
 
 \subsubsection*{sss:pat-polyvar-abbrev}{Polymorphic variant abbreviation patterns}
 
@@ -135,12 +206,25 @@ is a shorthand for the following or-pattern:
 @"(" "`"tag-name_1"(_" ":" typexpr_1")" "|" \ldots "|" "`"tag-name_n"(_"
 ":" typexpr_n"))"@. It matches all values of type @"[<" typeconstr "]"@.
 
+\begin{caml_example}{toplevel}
+type 'a any_rectangle = [`Square of 'a | `Rectangle of 'a * 'a]
+
+let to_string = function
+  | #any_rectangle -> "Rectangle"
+  | `Circle _ -> "Circle";;
+\end{caml_example}
+
 \subsubsection*{sss:pat-tuple}{Tuple patterns}
 
 The pattern @pattern_1 "," \ldots "," pattern_n@ matches $n$-tuples
 whose components match the patterns @pattern_1@ through @pattern_n@. That
 is, the pattern matches the tuple values $(v_1, \ldots, v_n)$ such that
 @pattern_i@ matches $v_i$ for \fromoneto{i}{n}.
+
+\begin{caml_example}{toplevel}
+let vector (x0, y0) (x1, y1) =
+  (x1 -. x0, y1 -. y0);;
+\end{caml_example}
 
 \subsubsection*{sss:pat-record}{Record patterns}
 
@@ -161,12 +245,29 @@ Optional type constraints can be added field by field with
 \ldots ";"field_n ":" typexpr_n "=" pattern_n "}"@ to force the type
 of @field_k@ to be compatible with @typexpr_k@.
 
+\begin{caml_example}{toplevel}
+let bytes_allocated
+    {Gc.minor_words = minor;
+     Gc.major_words = major;
+     Gc.promoted_words = prom;
+     _}
+  =
+    (Sys.word_size / 4) * int_of_float (minor +. major -. prom);;
+\end{caml_example}
 
 \subsubsection*{sss:pat-array}{Array patterns}
 
 The pattern @"[|" pattern_1 ";" \ldots ";" pattern_n "|]"@
 matches arrays of length $n$ such that the $i$-th array element
 matches the pattern @pattern_i@, for \fromoneto{i}{n}.
+
+\begin{caml_example}{toplevel}
+let matrix3_is_symmetric = function
+  | [|[|_; b; c|];
+      [|d; _; f|];
+      [|g; h; _|]|] -> b = d && c = g && f = h
+  | _ -> failwith "matrix3_is_symmetric: not a 3x3 matrix";;
+\end{caml_example}
 
 \subsubsection*{sss:pat-range}{Range patterns}
 
@@ -179,6 +280,16 @@ The pattern
 where \nth{c}{1}, \nth{c}{2}, \ldots, \nth{c}{n} are the characters
 that occur between \var{c} and \var{d} in the ASCII character set. For
 instance, the pattern "'0'"@'..'@"'9'" matches all characters that are digits.
+
+\begin{caml_example}{toplevel}
+type char_class = Uppercase | Lowercase | Digit | Other
+
+let classify_char = function
+  | 'A'..'Z' -> Uppercase
+  | 'a'..'z' -> Lowercase
+  | '0'..'9' -> Digit
+  | _ -> Other;;
+\end{caml_example}
 
 \subsubsection{sss:pat-lazy}{Lazy patterns}
 
@@ -198,6 +309,12 @@ those that imply no test such as @"lazy" value-name@ or @"lazy" "_"@.
 Matching a value with a @pattern-matching@ where some patterns
 contain @"lazy"@ sub-patterns may imply forcing parts of the value,
 even when the pattern selected in the end has no @"lazy"@ sub-pattern.
+
+\begin{caml_example}{toplevel}
+let lazy_option_map f = function
+  | lazy (Some x) -> Some (Lazy.force f x)
+  | _ -> None;;
+\end{caml_example}
 
 For more information, see the description of module "Lazy" in the
 standard library (module \stdmoduleref{Lazy}).
@@ -229,6 +346,13 @@ A pattern match must contain at least one value case. It is an error if
 all cases are exceptions, because there would be no code to handle
 the return of a value.
 
+\begin{caml_example}{toplevel}
+let range l =
+  match (List.hd l, List.hd (List.rev l)) with
+  | (f, l) -> Some (l - f)
+  | exception (Failure _) -> None;;
+\end{caml_example}
+
 \subsubsection*{sss:pat-open}{Local opens for patterns}
 \ikwd{open\@\texttt{open}}
 (Introduced in OCaml 4.04)
@@ -243,3 +367,9 @@ When the body of a local open pattern is delimited by
 For example, @module-path'.['pattern']'@ is equivalent to
 @module-path'.(['pattern'])'@, and @module-path'.[|' pattern '|]'@ is
 equivalent to @module-path'.([|' pattern '|])'@.
+
+\begin{caml_example}{toplevel}
+let bytes_allocated Gc.{minor_words; major_words; promoted_words; _} =
+    (Sys.word_size / 4)
+  * int_of_float (minor_words +. major_words -. promoted_words);;
+\end{caml_example}

--- a/manual/src/refman/patterns.etex
+++ b/manual/src/refman/patterns.etex
@@ -204,11 +204,12 @@ is a shorthand for the following or-pattern:
 ":" typexpr_n"))"@. It matches all values of type @"[<" typeconstr "]"@.
 
 \begin{caml_example}{toplevel}
-type 'a any_rectangle = [`Square of 'a | `Rectangle of 'a * 'a]
+type 'a rectangle = [`Square of 'a | `Rectangle of 'a * 'a]
+type 'a shape = [`Circle of 'a | 'a rectangle]
 
-let to_string = function
-  | #any_rectangle -> "Rectangle"
-  | `Circle _ -> "Circle";;
+let try_rectangle = function
+  | #rectangle as r -> Some r
+  | `Circle _ -> None;;
 \end{caml_example}
 
 \subsubsection*{sss:pat-tuple}{Tuple patterns}
@@ -308,9 +309,9 @@ contain @"lazy"@ sub-patterns may imply forcing parts of the value,
 even when the pattern selected in the end has no @"lazy"@ sub-pattern.
 
 \begin{caml_example}{toplevel}
-let lazy_option_map f = function
-  | lazy (Some x) -> Some (Lazy.force f x)
-  | _ -> None;;
+let force_opt = function
+  | Some (lazy n) -> n
+  | None -> 0;;
 \end{caml_example}
 
 For more information, see the description of module "Lazy" in the

--- a/manual/src/refman/patterns.etex
+++ b/manual/src/refman/patterns.etex
@@ -60,9 +60,9 @@ binding the name to the value. The pattern @"_"@ also matches
 any value, but does not bind any name.
 
 \begin{caml_example}{toplevel}
-let print_int_opt = function
-  | Some x -> print_int x
-  | _ -> ();;
+let is_empty = function
+  | [] -> true
+  | _ :: _ -> false;;
 \end{caml_example}
 
 Patterns are {\em linear\/}: a variable cannot be bound several times by
@@ -138,12 +138,11 @@ performed are those of @pattern_1@ when $v$ matches @pattern_1@.
 Otherwise, value~$v$ matches @pattern_2@ whose bindings are performed.
 
 \begin{caml_example}{toplevel}
-type shape =
-  Square of float | Rect of (float * float) | Circle of float
+type shape = Square of float | Rect of (float * float) | Circle of float
 
 let is_rectangular = function
   | Square _ | Rect _ -> true
-  | _ -> false;;
+  | Circle _ -> false;;
 \end{caml_example}
 
 \subsubsection*{sss:pat-variant}{Variant patterns}
@@ -345,10 +344,10 @@ all cases are exceptions, because there would be no code to handle
 the return of a value.
 
 \begin{caml_example}{toplevel}
-let range l =
-  match (List.hd l, List.hd (List.rev l)) with
-  | (f, l) -> Some (l - f)
-  | exception (Failure _) -> None;;
+let find_opt p l =
+  match List.find p l with
+  | exception Not_found -> None
+  | x -> Some x;;
 \end{caml_example}
 
 \subsubsection*{sss:pat-open}{Local opens for patterns}

--- a/manual/src/refman/refman.etex
+++ b/manual/src/refman/refman.etex
@@ -10,7 +10,7 @@
 This document is intended as a reference manual for the OCaml
 language. It lists the language constructs, and gives their precise
 syntax and informal semantics. It is by no means a tutorial
-introduction to the language: there is not a single example. A good
+introduction to the language. A good
 working knowledge of OCaml is assumed.
 
 No attempt has been made at mathematical rigor: words are employed

--- a/manual/src/refman/typedecl.etex
+++ b/manual/src/refman/typedecl.etex
@@ -84,6 +84,17 @@ optional type equation, then an optional type representation, and then
 a constraint clause. The identifier is the name of the type
 constructor being defined.
 
+\begin{verbatim}
+type colour =
+  | Red | Green | Blue | Yellow | Black | White
+  | RGB of {r : int; g : int; b : int}
+
+type 'a tree = Lf | Br of 'a * 'a tree * 'a;;
+
+type t = {decoration : string; substance : t'}
+and t' = Int of int | List of t list
+\end{verbatim}
+
 In the right-hand side of type definitions, references to one of the
 type constructor name being defined are considered as recursive,
 unless "type" is followed by "nonrec". The "nonrec" keyword was
@@ -241,7 +252,20 @@ Exception definitions add new constructors to the built-in variant
 type \verb"exn" of exception values. The constructors are declared as
 for a definition of a variant type.
 
+\begin{caml_example}{toplevel}
+exception E of int * string;;
+\end{caml_example}
+
 The form @'exception' constr-decl@
 generates a new exception, distinct from all other exceptions in the system.
 The form @'exception' constr-name '=' constr@
 gives an alternate name to an existing exception.
+
+\begin{caml_example}{toplevel}
+exception E of int * string
+
+exception F = E
+
+let eq =
+   E (1, "one") = F (1, "one");;
+\end{caml_example}


### PR DESCRIPTION
(This is work funded by the OCaml Software Foundation)

This PR introduces about eighty examples into the reference manual, which has not previously contained any.

First order principles. Examples should:

- be unobtrusive to readers who would previously have read this part of the manual
- increase the proportion of readers who find this part of the manual useful
- be substantive, not trivial
- be concise -- less than ten lines for whole `caml_example` box in output
- be idiomatic -- code one might actually write
- make use of the `toplevel` environment everywhere possible or useful
- meet the OCaml style guide
- encourage by their existence the addition of new examples when new features are added to the language

Second order principle. Examples should:

- be exhaustive -- exercise every variation of every construct in the language

This PR consists, mostly, of examples for the "Patterns" and "Expressions" sections of the chapter. The examples try to follow the list of first order principles above, but make only limited efforts with the second order principle.

There are other places in the manual where it is less obvious that examples would help, or where they might be obtrusive. And so, I would like to present the more obviously useful material first, in this PR.

The rendered sections containing new examples may be found here:

https://coherentpdf.com/tmp/lex.html
https://coherentpdf.com/tmp/patterns.html
https://coherentpdf.com/tmp/expr.html
https://coherentpdf.com/tmp/typedecl.html

Suggestions for making any of these examples more concise, more idiomatic, and more useful much appreciated. Coming up with sensible examples is hard, and outside input is very useful.