### PR TITLE
Simplify Typedecl_separability unboxed types handling

### DIFF
--- a/.depend
+++ b/.depend
@@ -1417,7 +1417,6 @@ typing/typedecl_separability.cmo : \
     typing/ctype.cmi \
     utils/config.cmi \
     typing/btype.cmi \
-    parsing/asttypes.cmi \
     typing/typedecl_separability.cmi
 typing/typedecl_separability.cmx : \
     typing/types.cmx \
@@ -1427,7 +1426,6 @@ typing/typedecl_separability.cmx : \
     typing/ctype.cmx \
     utils/config.cmx \
     typing/btype.cmx \
-    parsing/asttypes.cmi \
     typing/typedecl_separability.cmi
 typing/typedecl_separability.cmi : \
     typing/types.cmi \


### PR DESCRIPTION
Simplify the handling of unboxed types in Typedecl_separability by removing some unused fields and data structures, and the code to compute them.