### PR TITLE
Add forgotten cloexec parameter to un-implemented socketpair

### DIFF
--- a/otherlibs/unix/socketpair.c
+++ b/otherlibs/unix/socketpair.c
@@ -50,7 +50,8 @@ CAMLprim value unix_socketpair(value cloexec, value domain,
 
 #else
 
-CAMLprim value unix_socketpair(value domain, value type, value proto)
+CAMLprim value unix_socketpair(value cloexec, value domain, value type,
+                               value proto)
 { caml_invalid_argument("socketpair not implemented"); }
 
 #endif


### PR DESCRIPTION
It probably was forgotten in the commit
ab4e3beab1b343a9e002e158c963e10dcd80ee58 introducing the cloexec
parameter.