### PR TITLE
Tidy-up the Windows locale settings in runtime/floats.c

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.result}}
+      full-matrix: ${{ steps.matrix.outputs.full-matrix }}
       skip-testsuite: ${{ steps.skip.outputs.result }}
     steps:
       - name: Compute matrix for the "build" job
@@ -49,10 +50,12 @@ jobs:
             // # be changed, and then forcing a re-run of the workflow, rather
             // # than having labelling triggering a fresh workflow event (which
             // # is wasteful).
+            let full_matrix = false;
             if (context.payload.pull_request) {
               const { data: labels } =
                 await github.rest.issues.listLabelsOnIssue({...context.repo, issue_number: context.payload.pull_request.number});
-              if (labels.some(label => label.name === 'CI: Full matrix')) {
+              full_matrix = labels.some(label => label.name === 'CI: Full matrix');
+              if (full_matrix) {
                 console.log('Full matrix requested');
                 // # Test Cygwin as well
                 compilers.push('gcc');
@@ -64,6 +67,7 @@ jobs:
                 libdir.push('relative');
               }
             }
+            core.setOutput('full-matrix', full_matrix);
             return {os: ['windows-latest'], prefix: ['$PROGRAMFILES/Бактріан🐫'], opam: ['false'], config_arg: [''], arch: ['x86_64'], cc: compilers, libdir: libdir, include: include};
       - name: Determine if the testsuite should be skipped
         id: skip
@@ -92,7 +96,7 @@ jobs:
 
     strategy:
       matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
-      fail-fast: true
+      fail-fast: ${{ needs.config.outputs.full-matrix != 'true' }}
 
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,15 @@ jobs:
         include:
           - id: normal
             name: normal
-            dependencies: texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra hevea sass gdb lldb
+            dependencies: >-
+              texlive-latex-extra
+              texlive-fonts-recommended
+              texlive-fonts-extra
+              hevea
+              sass
+              gdb
+              lldb
+              language-pack-nl
           - id: opam
             name: opam installation
           - id: debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
             name: extra (debug)
           - id: debug-s4096
             name: extra (debug-s4096)
-      fail-fast: true
+      fail-fast: ${{ needs.config.outputs.full-matrix != 'true' }}
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v8
@@ -266,7 +266,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(needs.config.outputs.jobs) }}
-      fail-fast: true
+      fail-fast: ${{ needs.config.outputs.full-matrix != 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ Working version
 
 ### Runtime system:
 
+- #10258: Overhaul the locale code used for mingw/msvc in float<->string
+  conversions.
+  (David Allsopp, review by Antonin Décimo)
+
 - #13629: Major GC ephemeron cleanup.
   (Nick Barnes, review by Stephen Dolan and Tim McGilchrist).
 

--- a/configure
+++ b/configure
@@ -21280,15 +21280,8 @@ fi
 fi
 
 
-## newlocale() and <locale.h>
-# Note: the detection fails on msvc so we hardcode the result
-# (should be debugged later)
-case $target in #(
-  *-pc-windows) :
-    printf "%s\n" "#define HAS_LOCALE_H 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_header_compile "$LINENO" "locale.h" "ac_cv_header_locale_h" "$ac_includes_default"
+## <locale.h>
+ac_fn_c_check_header_compile "$LINENO" "locale.h" "ac_cv_header_locale_h" "$ac_includes_default"
 if test "x$ac_cv_header_locale_h" = xyes
 then :
   ac_fn_c_check_func "$LINENO" "newlocale" "ac_cv_func_newlocale"
@@ -21302,15 +21295,31 @@ if test "x$ac_cv_func_uselocale" = xyes
 then :
   printf "%s\n" "#define HAS_LOCALE_H 1" >>confdefs.h
 
+         printf "%s\n" "#define HAS_USELOCALE 1" >>confdefs.h
+
 fi
+
+fi
+
+else $as_nop
+  ac_fn_c_check_func "$LINENO" "_wsetlocale" "ac_cv_func__wsetlocale"
+if test "x$ac_cv_func__wsetlocale" = xyes
+then :
+  printf "%s\n" "#define HAS_LOCALE_H 1" >>confdefs.h
+
+       ac_fn_c_check_func "$LINENO" "_configthreadlocale" "ac_cv_func__configthreadlocale"
+if test "x$ac_cv_func__configthreadlocale" = xyes
+then :
+  printf "%s\n" "#define HAS_CONFIGTHREADLOCALE 1" >>confdefs.h
 
 fi
 
 fi
 
 fi
- ;;
-esac
+
+fi
+
 
 ac_fn_c_check_header_compile "$LINENO" "xlocale.h" "ac_cv_header_xlocale_h" "$ac_includes_default"
 if test "x$ac_cv_header_xlocale_h" = xyes
@@ -21326,6 +21335,8 @@ if test "x$ac_cv_func_uselocale" = xyes
 then :
   printf "%s\n" "#define HAS_XLOCALE_H 1" >>confdefs.h
 
+         printf "%s\n" "#define HAS_USELOCALE 1" >>confdefs.h
+
 fi
 
 fi
@@ -21336,21 +21347,52 @@ fi
 
 
 ## strtod_l
-# Note: not detected on MSVC so hardcoding the result
-# (should be debugged later)
-case $target in #(
-  *-pc-windows) :
-    printf "%s\n" "#define HAS_STRTOD_L 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_func "$LINENO" "strtod_l" "ac_cv_func_strtod_l"
+ac_fn_c_check_func "$LINENO" "strtod_l" "ac_cv_func_strtod_l"
 if test "x$ac_cv_func_strtod_l" = xyes
 then :
   printf "%s\n" "#define HAS_STRTOD_L 1" >>confdefs.h
 
+   printf "%s\n" "#define STRTOD_L strtod_l" >>confdefs.h
+
+else $as_nop
+  ac_fn_c_check_func "$LINENO" "_create_locale" "ac_cv_func__create_locale"
+if test "x$ac_cv_func__create_locale" = xyes
+then :
+  ac_fn_c_check_func "$LINENO" "_strtod_l" "ac_cv_func__strtod_l"
+if test "x$ac_cv_func__strtod_l" = xyes
+then :
+  printf "%s\n" "#define HAS_STRTOD_L 1" >>confdefs.h
+
+       printf "%s\n" "#define STRTOD_L _strtod_l" >>confdefs.h
+
 fi
- ;;
-esac
+
+fi
+
+fi
+
+
+## vsnprintf_l
+ac_fn_c_check_func "$LINENO" "vsnprintf_l" "ac_cv_func_vsnprintf_l"
+if test "x$ac_cv_func_vsnprintf_l" = xyes
+then :
+  printf "%s\n" "#define HAS_VSNPRINTF_L 1" >>confdefs.h
+
+else $as_nop
+  ac_fn_c_check_func "$LINENO" "_create_locale" "ac_cv_func__create_locale"
+if test "x$ac_cv_func__create_locale" = xyes
+then :
+  ac_fn_c_check_func "$LINENO" "_vsnprintf_l" "ac_cv_func__vsnprintf_l"
+if test "x$ac_cv_func__vsnprintf_l" = xyes
+then :
+  printf "%s\n" "#define HAS_VSNPRINTF_L 1" >>confdefs.h
+
+fi
+
+fi
+
+fi
+
 
 ## shared library support
 if $supports_shared_libraries

--- a/configure.ac
+++ b/configure.ac
@@ -2485,27 +2485,40 @@ AC_CHECK_FUNC([putenv], [AC_DEFINE([HAS_PUTENV], [1])])
 AC_CHECK_FUNC([setenv],
   [AC_CHECK_FUNC([unsetenv], [AC_DEFINE([HAS_SETENV_UNSETENV], [1])])])
 
-## newlocale() and <locale.h>
-# Note: the detection fails on msvc so we hardcode the result
-# (should be debugged later)
-AS_CASE([$target],
-  [*-pc-windows], [AC_DEFINE([HAS_LOCALE_H], [1])],
-  [AC_CHECK_HEADER([locale.h],
-    [AC_CHECK_FUNC([newlocale],
-      [AC_CHECK_FUNC([freelocale],
-        [AC_CHECK_FUNC([uselocale], [AC_DEFINE([HAS_LOCALE_H], [1])])])])])])
+## <locale.h>
+AC_CHECK_HEADER([locale.h],
+  [AC_CHECK_FUNC([newlocale],
+    [AC_CHECK_FUNC([freelocale],
+      [AC_CHECK_FUNC([uselocale],
+        [AC_DEFINE([HAS_LOCALE_H], [1])
+         AC_DEFINE([HAS_USELOCALE], [1])])])],
+    [AC_CHECK_FUNC([_wsetlocale],
+      [AC_DEFINE([HAS_LOCALE_H], [1])
+       AC_CHECK_FUNC([_configthreadlocale],
+         [AC_DEFINE([HAS_CONFIGTHREADLOCALE], [1])])])])])
 
 AC_CHECK_HEADER([xlocale.h],
   [AC_CHECK_FUNC([newlocale],
     [AC_CHECK_FUNC([freelocale],
-      [AC_CHECK_FUNC([uselocale], [AC_DEFINE([HAS_XLOCALE_H], [1])])])])])
+      [AC_CHECK_FUNC([uselocale],
+        [AC_DEFINE([HAS_XLOCALE_H], [1])
+         AC_DEFINE([HAS_USELOCALE], [1])])])])])
 
 ## strtod_l
-# Note: not detected on MSVC so hardcoding the result
-# (should be debugged later)
-AS_CASE([$target],
-  [*-pc-windows], [AC_DEFINE([HAS_STRTOD_L], [1])],
-  [AC_CHECK_FUNC([strtod_l], [AC_DEFINE([HAS_STRTOD_L], [1])])])
+AC_CHECK_FUNC([strtod_l],
+  [AC_DEFINE([HAS_STRTOD_L], [1])
+   AC_DEFINE([STRTOD_L], [strtod_l])],
+  [AC_CHECK_FUNC([_create_locale],
+    [AC_CHECK_FUNC([_strtod_l],
+      [AC_DEFINE([HAS_STRTOD_L], [1])
+       AC_DEFINE([STRTOD_L], [_strtod_l])])])])
+
+## vsnprintf_l
+AC_CHECK_FUNC([vsnprintf_l],
+  [AC_DEFINE([HAS_VSNPRINTF_L], [1])],
+  [AC_CHECK_FUNC([_create_locale],
+    [AC_CHECK_FUNC([_vsnprintf_l],
+      [AC_DEFINE([HAS_VSNPRINTF_L], [1])])])])
 
 ## shared library support
 AS_IF([$supports_shared_libraries],

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -241,13 +241,22 @@ let run
       else (Test_result.fail_with_reason reason, env)
     end
 
-let run_program =
+let run_program
+    (log : out_channel)
+    (env : Environments.t)
+  =
+  let can_skip =
+    let run_can_skip =
+    Environments.lookup_as_bool Builtin_variables.run_can_skip env in
+    run_can_skip = Some true in
   run
     ~log_message:"Running program"
     ~redirect_output:true
-    ~can_skip:false
+    ~can_skip
     ~prog:Builtin_variables.program
     ~args:(Some Builtin_variables.arguments)
+    log
+    env
 
 let run_script log env =
   let response_file = Filename.temp_file "ocamltest-" ".response" in

--- a/ocamltest/builtin_variables.ml
+++ b/ocamltest/builtin_variables.ml
@@ -117,6 +117,9 @@ let test_fail = Variables.make ("TEST_FAIL",
 let timeout = Variables.make ("timeout",
   "Maximal execution time for every command (in seconds)")
 
+let run_can_skip = Variables.make ("run_can_skip",
+  "Set to \"true\" to allow the run action to return skip status")
+
 let _ = List.iter Variables.register_variable
   [
     arguments;
@@ -149,4 +152,5 @@ let _ = List.iter Variables.register_variable
     test_skip;
     test_fail;
     timeout;
+    run_can_skip;
   ]

--- a/ocamltest/builtin_variables.mli
+++ b/ocamltest/builtin_variables.mli
@@ -77,3 +77,5 @@ val test_skip : Variables.t
 val test_fail : Variables.t
 
 val timeout : Variables.t
+
+val run_can_skip : Variables.t

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -251,9 +251,25 @@
 /* Define HAS_XLOCALE_H if you have the include file <xlocale.h> and the
    uselocale() function. */
 
+#undef HAS_USELOCALE
+
+/* Define HAS_USELOCALE if you have the uselocale function */
+
+#undef HAS_CONFIGTHREADLOCALE
+
+/* Define HAS_CONFIGTHREADLOCALE if you have the _configthreadlocale function */
+
 #undef HAS_STRTOD_L
 
-/* Define HAS_STRTOD_L if you have strtod_l */
+/* Define HAS_STRTOD_L if you have strtod_l/_strtod_l */
+
+#undef STRTOD_L
+
+/* Define STRTOD_L with the name of the strtod_l function */
+
+#undef HAS_VSNPRINTF_L
+
+/* Define HAS_VSNPRINTF_L if you have the vsnprintf_l/_vsnprintf_l function */
 
 #undef HAS_MMAP
 

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -17,11 +17,13 @@
 
 /* The interface of this file is in "caml/mlvalues.h" and "caml/alloc.h" */
 
+#ifndef _WIN32
 /* Needed for uselocale */
 #define _XOPEN_SOURCE 700
 
 /* Needed for strtod_l */
 #define _GNU_SOURCE
+#endif /* !_WIN32 */
 
 #include <math.h>
 #include <stdio.h>
@@ -39,9 +41,7 @@
 #include "caml/reverse.h"
 #include "caml/fiber.h"
 
-#if defined(HAS_LOCALE) || defined(__MINGW32__)
-
-#if defined(HAS_LOCALE_H) || defined(__MINGW32__)
+#if defined(HAS_LOCALE_H)
 #include <locale.h>
 #endif
 
@@ -49,19 +49,14 @@
 #include <xlocale.h>
 #endif
 
-#if defined(_MSC_VER)
-#ifndef locale_t
+#ifdef _WIN32
+/* Make the Microsoft CRT locale.h look like the POSIX version. */
 #define locale_t _locale_t
-#endif
-#ifndef freelocale
+#define newlocale(category_mask, locale, base) \
+  _create_locale(category_mask, locale)
 #define freelocale _free_locale
+#define LC_NUMERIC_MASK LC_NUMERIC
 #endif
-#ifndef strtod_l
-#define strtod_l _strtod_l
-#endif
-#endif
-
-#endif /* defined(HAS_LOCALE) */
 
 #ifdef _MSC_VER
 #include <float.h>
@@ -109,46 +104,50 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
  standard "C" locale by default, but it is possible that
  third-party code loaded into process does.
 */
-#ifdef HAS_LOCALE
-locale_t caml_locale = (locale_t)0;
+
+#if defined(_WIN32)
+#define With_C_locale(stmt) \
+  char* saved_locale = setlocale(LC_NUMERIC, NULL); \
+  setlocale(LC_NUMERIC, "C"); \
+  stmt; \
+  setlocale(LC_NUMERIC, saved_locale)
+#elif defined(HAS_USELOCALE)
+#define With_C_locale(stmt) \
+  locale_t saved_locale = uselocale(caml_locale); \
+  stmt; \
+  uselocale(saved_locale)
+#else
+#define With_C_locale(stmt) stmt
 #endif
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
-/* there is no analogue to uselocale in MSVC so just set locale for thread */
-#define USE_LOCALE setlocale(LC_NUMERIC,"C")
-#define RESTORE_LOCALE do {} while(0)
-#elif defined(HAS_LOCALE)
-#define USE_LOCALE locale_t saved_locale = uselocale(caml_locale)
-#define RESTORE_LOCALE uselocale(saved_locale)
-#else
-#define USE_LOCALE do {} while(0)
-#define RESTORE_LOCALE do {} while(0)
-#endif
+#if defined(HAS_USELOCALE) || defined(HAS_VSNPRINTF_L) || defined(HAS_STRTOD_L)
+locale_t caml_locale = (locale_t)0;
 
 void caml_init_locale(void)
 {
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(HAS_CONFIGTHREADLOCALE) \
+    && (!defined(HAS_VSNPRINTF_L) || !defined(HAS_STRTOD_L))
   _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
 #endif
-#ifdef HAS_LOCALE
   if ((locale_t)0 == caml_locale)
   {
-#if defined(_MSC_VER)
-    caml_locale = _create_locale(LC_NUMERIC, "C");
-#else
-    caml_locale = newlocale(LC_NUMERIC_MASK,"C",(locale_t)0);
-#endif
+    caml_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
   }
-#endif
 }
 
 void caml_free_locale(void)
 {
-#ifdef HAS_LOCALE
-  if ((locale_t)0 != caml_locale) freelocale(caml_locale);
+  if ((locale_t)0 != caml_locale)
+    freelocale(caml_locale);
   caml_locale = (locale_t)0;
-#endif
 }
+
+#else
+
+void caml_init_locale(void) {}
+void caml_free_locale(void) {}
+
+#endif
 
 CAMLexport value caml_copy_double(double d)
 {
@@ -172,6 +171,84 @@ CAMLexport void caml_Store_double_array_field(value val, mlsize_t i, double dbl)
 }
 #endif /* ! FLAT_FLOAT_ARRAY */
 
+#ifdef HAS_VSNPRINTF_L
+static value caml_alloc_sprintf_l(locale_t loc, const char * format, ...)
+{
+  va_list args;
+  char buf[128];
+  int n;
+  value res;
+
+#ifndef _WIN32
+  /* BSD-compatible implementation */
+  va_start(args, format);
+  /* "vsnprintf_l(dest, sz, loc, format, args)" writes at most "sz" characters
+     into "dest", including the terminating '\0'.
+     It returns the number of characters of the formatted string,
+     excluding the terminating '\0'. */
+  n = vsnprintf_l(buf, sizeof(buf), loc, format, args);
+  va_end(args);
+  if (n < sizeof(buf)) {
+    /* All output characters were written to buf, including the
+       terminating '\0'.  Allocate a Caml string with length "n" as
+       computed by vsnprintf_l, and copy the output of vsnprintf_l into it. */
+    res = caml_alloc_initialized_string(n, buf);
+  } else {
+    /* PR#7568: if the format is in the Caml heap, the following
+       caml_alloc_string could move or free the format.  To prevent
+       this, take a copy of the format outside the Caml heap. */
+    char * saved_format = caml_stat_strdup(format);
+    /* Allocate a Caml string with length "n" as computed by vsnprintf_l. */
+    res = caml_alloc_string(n);
+    /* Re-do the formatting, outputting directly in the Caml string.
+       Note that caml_alloc_string left room for a '\0' at position n,
+       so the size passed to vsnprintf_l is n+1. */
+    va_start(args, format);
+    vsnprintf_l((char *)String_val(res), n + 1, loc, saved_format, args);
+    va_end(args);
+    caml_stat_free(saved_format);
+  }
+  return res;
+#else
+  /* Implementation specific to the Microsoft UCRT/CRT library */
+  va_start(args, format);
+  /* "_vsnprintf_l(dest, sz, format, loc, args)" writes at most "sz" characters
+     into "dest".  Let "len" be the number of characters of the formatted
+     string.
+     If "len" < "sz", a null terminator was appended, and "len" is returned.
+     If "len" == "sz", no null termination, and "len" is returned.
+     If "len" > "sz", a negative value is returned. */
+  n = _vsnprintf_l(buf, sizeof(buf), format, loc, args);
+  va_end(args);
+  if (n >= 0 && n <= sizeof(buf)) {
+    /* All output characters were written to buf.
+       "n" is the actual length of the output.
+       Allocate a Caml string of length "n" and copy the characters into it. */
+    res = caml_alloc_string(n);
+    memcpy((char *)String_val(res), buf, n);
+  } else {
+    /* PR#7568: if the format is in the Caml heap, the following
+       caml_alloc_string could move or free the format.  To prevent
+       this, take a copy of the format outside the Caml heap. */
+    char * saved_format = caml_stat_strdup(format);
+    /* Determine actual length of output, excluding final '\0' */
+    va_start(args, format);
+    n = _vscprintf_l(format, loc, args);
+    va_end(args);
+    res = caml_alloc_string(n);
+    /* Re-do the formatting, outputting directly in the Caml string.
+       Note that caml_alloc_string left room for a '\0' at position n,
+       so the size passed to _vsnprintf_l is n+1. */
+    va_start(args, format);
+    _vsnprintf_l((char *)String_val(res), n + 1, saved_format, loc, args);
+    va_end(args);
+    caml_stat_free(saved_format);
+  }
+  return res;
+#endif /* !_WIN32 */
+}
+#endif /* HAS_VSNPRINTF_L */
+
 CAMLprim value caml_format_float(value fmt, value arg)
 {
   value res;
@@ -180,9 +257,11 @@ CAMLprim value caml_format_float(value fmt, value arg)
 #ifdef HAS_BROKEN_PRINTF
   if (isfinite(d)) {
 #endif
-    USE_LOCALE;
-    res = caml_alloc_sprintf(String_val(fmt), d);
-    RESTORE_LOCALE;
+#if defined(HAS_VSNPRINTF_L)
+    res = caml_alloc_sprintf_l(caml_locale, String_val(fmt), d);
+#else
+    With_C_locale(res = caml_alloc_sprintf(String_val(fmt), d));
+#endif
 #ifdef HAS_BROKEN_PRINTF
   } else {
     if (isnan(d)) {
@@ -403,12 +482,10 @@ CAMLprim value caml_float_of_string(value vs)
     if (sign < 0) d = -d;
   } else {
     /* Convert using strtod */
-#if defined(HAS_STRTOD_L) && defined(HAS_LOCALE)
-    d = strtod_l((const char *) buf, &end, caml_locale);
+#ifdef HAS_STRTOD_L
+    d = STRTOD_L((const char *) buf, &end, caml_locale);
 #else
-    USE_LOCALE;
-    d = strtod((const char *) buf, &end);
-    RESTORE_LOCALE;
+    With_C_locale(d = strtod((const char *) buf, &end));
 #endif /* HAS_STRTOD_L */
     if (end != dst) goto error;
   }

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -224,8 +224,7 @@ static value caml_alloc_sprintf_l(locale_t loc, const char * format, ...)
     /* All output characters were written to buf.
        "n" is the actual length of the output.
        Allocate a Caml string of length "n" and copy the characters into it. */
-    res = caml_alloc_string(n);
-    memcpy((char *)String_val(res), buf, n);
+    res = caml_alloc_initialized_string(n, buf);
   } else {
     /* PR#7568: if the format is in the Caml heap, the following
        caml_alloc_string could move or free the format.  To prevent

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -444,8 +444,7 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
     /* All output characters were written to buf.
        "n" is the actual length of the output.
        Allocate a Caml string of length "n" and copy the characters into it. */
-    res = caml_alloc_string(n);
-    memcpy((char *)String_val(res), buf, n);
+    res = caml_alloc_initialized_string(n, buf);
   } else {
     /* PR#7568: if the format is in the Caml heap, the following
        caml_alloc_string could move or free the format.  To prevent

--- a/testsuite/tests/locale/stubs.c
+++ b/testsuite/tests/locale/stubs.c
@@ -1,8 +1,18 @@
 #include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
 #include <locale.h>
 
 value ml_setlocale(value v_locale)
 {
-  setlocale(LC_ALL,String_val(v_locale));
-  return Val_unit;
+  CAMLparam1(v_locale);
+  CAMLlocal2(str, ret);
+  char *res = setlocale(LC_ALL,String_val(v_locale));
+  if (res) {
+    str = caml_copy_string(res);
+    ret = caml_alloc_some(str);
+  } else {
+    ret = Val_none;
+  }
+  CAMLreturn(ret);
 }

--- a/testsuite/tests/locale/test.ml
+++ b/testsuite/tests/locale/test.ml
@@ -1,5 +1,6 @@
 (* TEST
  modules = "stubs.c";
+ run_can_skip = "true";
 *)
 
 external setlocale : string -> string option = "ml_setlocale"
@@ -11,7 +12,10 @@ let show f =
 let pr fmt = Printf.ksprintf print_endline fmt
 
 let setlocale locale_aliases =
-  ignore @@ List.find (fun loc -> setlocale loc <> None) locale_aliases
+  match List.find_opt (fun loc -> setlocale loc <> None) locale_aliases with
+  | Some _ -> ()
+  | None ->
+      exit (int_of_string (Sys.getenv "TEST_SKIP"))
 
 let () =
   let s = "12345.6789" in

--- a/testsuite/tests/locale/test.ml
+++ b/testsuite/tests/locale/test.ml
@@ -2,13 +2,16 @@
  modules = "stubs.c";
 *)
 
-external setlocale : string -> unit = "ml_setlocale"
+external setlocale : string -> string option = "ml_setlocale"
 
 let show f =
   try
     string_of_float @@ f ()
   with exn -> Printf.sprintf "exn %s" (Printexc.to_string exn)
 let pr fmt = Printf.ksprintf print_endline fmt
+
+let setlocale locale_aliases =
+  ignore @@ List.find (fun loc -> setlocale loc <> None) locale_aliases
 
 let () =
   let s = "12345.6789" in
@@ -20,12 +23,12 @@ let () =
       (show @@ fun () -> float_of_string @@ string_of_float f);
   in
   pr "locale from environment";
-  setlocale "";
+  setlocale [""];
   test ();
   pr "locale nl_NL";
-  setlocale "nl_NL";
+  setlocale ["nl_NL"; "nl_NL.utf8"; "Dutch_Netherlands.1252"];
   test ();
   pr "locale POSIX";
-  setlocale "C";
+  setlocale ["C"];
   test ();
   ()


### PR DESCRIPTION
While trying to close down some other PRs, I hit problems with the mingw-w64 locale mangling in runtime/floats.c

This PR attempts to bring a little more order to it (and deals with a couple of TODO items in `configure.ac`, @shindere!).

## Before this PR

- Unix systems which have `newlocale`, `freelocale` and `uselocale` (via either `locale.h` or `xlocale.h`) use that in `caml_format_float` to ensure that `caml_alloc_sprintf` uses C locale when doing `float`→`string`
- Unix systems which have `strtod_l` use that when doing `string`→`float` and otherwise fall back to `uselocale` combined with `strtod`
- MSVC contained a "hack" to use `_strtod_l`
- MSVC and mingw-w64 use `setlocale` to change the locale but make no attempt to restore it, unlike the Unix version (mitigated slightly by calling `_configthreadlocale` on the startup thread)

In summary: the native Windows ports clobber the C locale setting on the first call to `caml_format_float` or `caml_float_of_string`, only on the running thread if you're lucky.

## With this PR

- `setlocale` is just as capable of restoring the locale as `uselocale`, so we do that if it's being used!
- `_configthreadlocale` is checked in `configure` and called if found (can affect mingw-w64)
- `locale.h` is correctly detected for mingw-w64 and MSVC (in particular, it's ignored with very old headers)
- The MSCRT has supported the BSD/macOS `vsnprintf_l` as `_vsnprintf_l` since locale support was introduced - so we use that on BSD, macOS and Windows and completely avoid `uselocale`

In summary: the native Windows ports now behave the same way as the Unix ports, unless you happen to be running with mingw-w64 with an ancient `msvcrt.dll` (you opted into that by using mingw-w64, though!).

## Niggles

The duplication between the parallel uses of `vsnprintf`/`_vsnprintf` in `runtime/str.c` and `vsnprintf_l`/`_vsnprintf_l` in `runtime/floats.c` is irritating. I debated putting `caml_alloc_sprintf_l` in `runtime/str.c` but this involves putting the locale set-up code in more than one C file (at the moment, only `runtime/floats.c` needs it). I also debated using a template for the function (they differ only by the use of `vsnprintf`/`vsnprintf_l`) but defining those using `#define` will render the code entirely unreadable.

Another option might be to _always_ use `vsnprintf_l` on systems which have it, which would eliminate the code duplication, since that would result in macros for just `vsnprintf_l` and `_vscprintf_l` rather than the entire function. I'm happy to do that, but wondering what opinions are?

`_configthreadlocale` is a strange case. Technically, the existing implementation is wrong w.r.t. systhreads - it should be called during `caml_thread_startup` as well. I haven't fixed that for two inter-connected reasons:

- Virtually all versions of MSVC have `_vscprintf_l` and `_strtod_l`, so it is never required
- No version of msvcrt.dll actually exports it (curiously, the version in Windows Vista+ has the other locale functions, but not the thread locale support!). mingw-w64 provides a dummy function to allow linking, but it always returns -1. In other words, with this PR MSVC would never need that fix, and in the default configuration of mingw-w64 it doesn't work anyway.

I've left the existing call to it in - with the corrected autoconf guard - but I expect it to be removed relatively soon as part of a general overhaul of the Windows code to move everything forwards to Windows NT 6 (i.e. matching Windows 10). I'd like to do it in that order (i.e. fix what's here first) simply because I'm still working on just how parity we can achieve between mingw-w64 and a VS2015+ w.r.t. C99 and a well-behaved (U)CRT.