### PR TITLE
Fix GHA hygiene workflow

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -73,19 +73,20 @@ jobs:
         run: tools/ci/actions/check-labelled-interfaces.sh
         if: always()
 
-        # If this step fails, it leaves behind the file compiler-failed-to-build
-        # the presence of which can be felt by the last two steps, allowing them
-        # to skip, rather than go beserk with a faulty compiler.
+        # This step records the build success in the variable build-status,
+        # allowing the last two steps to skip, rather than go beserk with a
+        # faulty compiler.
       - name: Build a minimal compiler for alldepend
+        id: compiler
         run: tools/ci/actions/runner.sh basic-compiler
         if: always()
 
       - name: Check that dependency info is up-to-date
         run: tools/ci/actions/check-alldepend.sh
-        if: hashFiles('compiler-failed-to-build') == '' && always()
+        if: steps.compiler.outputs.build-status == 'success' && always()
 
       - name: Check global structure of the reference manual
         run: |
           # Required configuration info is left-over from the previous step
           make -C manual/tests check-stdlib check-case-collision
-        if: hashFiles('compiler-failed-to-build') == '' && always()
+        if: steps.compiler.outputs.build-status == 'success' && always()

--- a/tools/ci/actions/deepen-fetch.sh
+++ b/tools/ci/actions/deepen-fetch.sh
@@ -41,7 +41,10 @@ else
   shift 5
 fi
 
-FETCH_HEAD=$(git rev-parse FETCH_HEAD)
+# Record FETCH_HEAD (if it hasn't been by a previous step)
+git branch fetch_head FETCH_HEAD &> /dev/null || true
+
+FETCH_HEAD=$(git rev-parse fetch_head)
 UPSTREAM_BRANCH="$1"
 UPSTREAM_HEAD="$2"
 PR_BRANCH="$3"


### PR DESCRIPTION
I noticed when rebasing some older PRs that the `check-typo` job was failing _on the push_. Closer inspection showed that while it was using the correct range of commits to determine which files to check, for a force push it was using the _old_ branch ref not the new one, which was causing failures. The first commit here fixes that (and the commit message includes the somewhat dull technical detail).

While I'm here, I've also switched the rather hacky (and potentially unstable) use of a cookie file to signal the failure of the "Minimal compiler" step to use `::set-output` and record the success properly in a step output variable. It doesn't particularly shorten anything, but it does make it slightly less unclear.