### PR TITLE
manual: document unary extension operators

### DIFF
--- a/manual/src/refman/extensions/extensionsyntax.etex
+++ b/manual/src/refman/extensions/extensionsyntax.etex
@@ -7,16 +7,30 @@ external tools can exploit this parser leniency to extend the language
 with these new syntactic constructions by rewriting them to
 vanilla constructions.
 \subsection{ss:extension-operators}{Extension operators} \label{s:ext-ops}
-(Introduced in OCaml 4.02.2)
+(Introduced in OCaml 4.02.2, extended to unary operators in OCaml 4.12.0)
 \begin{syntax}
 infix-symbol:
           ...
-        | "#" {operator-chars} "#"  {operator-char '|' "#"}
+        | "#" {operator-char} "#" {operator-char || "#"}
+;
+prefix-symbol:
+          ...
+        | ('?'||'~'||'!') { operator-char } "#" { operator-char || "#"}
 ;
 \end{syntax}
 
-Operator names starting with a "#" character and containing more than
-one "#" character are reserved for extensions.
+There are two classes of operators available for extensions:
+infix operators with a name starting with a "#" character and containing more
+than one "#" character, and unary operators with a name (starting with a "?",
+"~", or "!" character) containing at least one "#" character.
+
+For instance:
+\begin{caml_example}{toplevel}[error]
+let infix x y = x##y;;
+let prefix x = !#x;;
+\end{caml_example}
+Note that both "##" and "!#" must be eliminated by a ppx rewriter to make
+this example valid.
 
 \subsection{ss:extension-literals}{Extension literals}
 (Introduced in OCaml 4.03)


### PR DESCRIPTION
Since OCaml 4.12.0, it is possible to use unary operators containing a "#" in the name (e.g. `!#`) as ppx-only unary operators. This PR updates the manual to document this feature.