### PR TITLE
make partialclean remove files from boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ coldstart:
 	cd stdlib; cp $(LIBFILES) ../boot
 	cd boot; $(LN) ../runtime/libcamlrun.$(A) .
 
+partialclean::
+	cd boot; rm -f $(LIBFILES) libcamlrun.*
+
 # Recompile the core system using the bootstrap compiler
 .PHONY: coreall
 coreall: runtime


### PR DESCRIPTION
Somehow, no target seems to clean-up the boot directory.
These two lines do that.
This is necessary after a recent change which modified the capitalization of cmis from the standard library, which has weird consequences under MacOS if you do not clean up boot first.

The `libcamlrun.*` is there because `libcamlrun.$(A)` does not work for me (MacOS Big Sur). Very mysterious.