### PR TITLE
manual/README.md enhancements

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -4,7 +4,7 @@ OCAML DOCUMENTATION
 Prerequisites
 -------------
 
-- Any prerequisites required to build OCaml from sources.
+- Any prerequisites required to build the OCaml compiler from sources.
 
 - A LaTeX installation.
 
@@ -15,16 +15,19 @@ Note that you must make sure `hevea.sty` is installed into TeX properly. Your
 package manager may not do this for you. Run `kpsewhich hevea.sty` to check.
 
 
-Building
+Building the manual
 --------
 
-0. Install the OCaml distribution. You must build the native compiler.
+0. Build the OCaml compiler (including the native one) from sources.
 
-1. Run `make` in the manual.
+You don't need to install the compiler since the manual is built using
+the one from the source tree.
+
+1. Run `make` in the manual directory.
 
 NB: If you already set `LD_LIBRARY_PATH` (OS X: `DYLD_LIBRARY_PATH`)
- in your environment don't forget to add
- `otherlibs/unix:otherlibs/str` to it in an absolute way.
+ in your environment don't forget to append the absolute paths to
+ `otherlibs/unix` and `otherlibs/str` to it.
 
 Outputs
 -------
@@ -41,10 +44,11 @@ In the manual:
 
 Source files
 ------------
-The manual is written in an extended dialect of latex and is split in many
-source files. During the build process, the sources files are converted into
-classical latex file using the tools available in `tools`. These files are
-then converted to the different output formats using either latex or hevea.
+The manual is written in an extended dialect of LaTeX and is split across many
+source files. During the build process, these source files are converted into
+classical LaTeX files using the tools available in the `manual/tools`
+directory. These files are then converted to the different output
+formats using either LaTeX or hevea.
 
 Each part of the manual corresponds to a specific directory, and each distinct
 chapters (or sometimes sections) are mapped to a distinct `.etex` file:
@@ -57,12 +61,12 @@ chapters (or sometimes sections) are mapped to a distinct `.etex` file:
   - Advanced examples with classes and modules: `advexamples.etex`
 
 - Part II, The OCaml language: `refman`
-  This part is separated in two very distinct  chapters; the
+  This part is divided in two very distinct chapters; the
   `OCaml language` chapter and the `Language extensions` chapter.
 
   - The OCaml language: `refman.etex`
     This chapter consists in a technical description of the OCaml language.
-    Each section of this chapter is mapped to a separated latex file:
+    Each section of this chapter is mapped to a separate LaTeX file:
      - `lex.etex`, `values.etex`, `names.etex`, `types.etex`, `const.etex`,
      `patterns.etex`, `expr.etex`, `typedecl.etex`, `classes.etex`,
      `modtypes.etex`, `compunit.etex`
@@ -127,13 +131,13 @@ A similar macro, `\lparagraph`, is provided for paragraphs.
 
 ### Caml environments
 
-The tool `tools/caml-tex` is used to generate the latex code for the examples
+The tool `tools/caml-tex` is used to generate the LaTeX code for the examples
 in the introduction and language extension parts of the manual. It implements
 two pseudo-environments: `caml_example` and `caml_eval`.
 
 The pseudo-environment `caml_example` evaluates its contents using an ocaml
 interpreter and then translates both the input code and the interpreter output
-to latex code, e.g.
+to LaTeX code, e.g.
 ```latex
 \begin{caml_example}{toplevel}
 let f x = x;;


### PR DESCRIPTION
This is a follow-up to a private discussion with @Octachron.

Our initial decision was that @Octachron would shoot first, but I wanted to
keep track of this discussion somehow so I thought it wouldn't hurt
to get the ball rolling.

I am not sure what is the best thing to do though. Since the README
describes where the generated files are written, the commit in this PR
could also be integrated in PR #9997 so that the file does not need to be
modified twice. As you prefer @Octachron.

I am also wondering whether the note about `LD_LIBRARY_PATH` is still
relevant? It feels to me that, if the build system for the manual is not yet
clever enough to include these directories, this is something that
could and should be changed, rather than relying on the user.