### PR TITLE
Fix #10271: open inside patterns hides fresh rigid types

### DIFF
--- a/testsuite/tests/typing-gadts/pr10271.ml
+++ b/testsuite/tests/typing-gadts/pr10271.ml
@@ -1,0 +1,26 @@
+(* TEST
+   * expect
+*)
+
+module M = struct
+  type _ rr = Soa : int rr
+  type b = B : 'a rr * 'a -> b
+end
+
+let test =
+  let M.(B (k, v)) = M.(B (Soa, 0)) in
+  match k, v with
+  | M.Soa, soa -> (soa : int)
+[%%expect{|
+module M : sig type _ rr = Soa : int rr type b = B : 'a rr * 'a -> b end
+val test : int = 0
+|}]
+
+let test =
+  let open M in
+  let B (k, v) = B (Soa, 0) in
+  match k, v with
+  | Soa, soa -> (soa : int)
+[%%expect{|
+val test : int = 0
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1311,13 +1311,12 @@ let instance_constructor ?in_pattern cstr =
     | None -> ()
     | Some (env, fresh_constr_scope) ->
         let process existential =
-          let decl = new_local_type () in
           let name = existential_name cstr existential in
-          let (id, new_env) =
-            Env.enter_type (get_new_abstract_name name) decl !env
-              ~scope:fresh_constr_scope in
+          let id = Ident.create_scoped name ~scope:fresh_constr_scope in
+          let path = Path.Pident id in
+          let new_env = Env.add_local_type path (new_local_type ()) !env in
           env := new_env;
-          let to_unify = newty (Tconstr (Path.Pident id,[],ref Mnil)) in
+          let to_unify = newconstr path [] in
           let tv = copy scope existential in
           assert (is_Tvar tv);
           link_type tv to_unify
@@ -2135,12 +2134,11 @@ let reify env t =
   let fresh_constr_scope = get_gadt_equations_level () in
   let create_fresh_constr lev name =
     let name = match name with Some s -> "$'"^s | _ -> "$" in
-    let decl = new_local_type () in
-    let (id, new_env) =
-      Env.enter_type (get_new_abstract_name name) decl !env
-        ~scope:fresh_constr_scope in
+    let name = get_new_abstract_name name in
+    let id = Ident.create_scoped name ~scope:fresh_constr_scope in
     let path = Path.Pident id in
-    let t = newty2 lev (Tconstr (path,[],ref Mnil))  in
+    let new_env = Env.add_local_type path (new_local_type ()) !env in
+    let t = newty2 lev (Tconstr (path, [], ref Mnil))  in
     env := new_env;
     path, t
   in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1314,8 +1314,7 @@ let instance_constructor ?in_pattern cstr =
           let name = existential_name cstr existential in
           let id = Ident.create_scoped name ~scope:fresh_constr_scope in
           let path = Path.Pident id in
-          let new_env = Env.add_local_type path (new_local_type ()) !env in
-          env := new_env;
+          env := Env.add_local_type path (new_local_type ()) !env;
           let to_unify = newconstr path [] in
           let tv = copy scope existential in
           assert (is_Tvar tv);
@@ -2137,10 +2136,8 @@ let reify env t =
     let name = get_new_abstract_name name in
     let id = Ident.create_scoped name ~scope:fresh_constr_scope in
     let path = Path.Pident id in
-    let new_env = Env.add_local_type path (new_local_type ()) !env in
-    let t = newty2 lev (Tconstr (path, [], ref Mnil))  in
-    env := new_env;
-    path, t
+    env := Env.add_local_type path (new_local_type ()) !env;
+    path, newty2 lev (Tconstr (path, [], ref Mnil))
   in
   let visited = ref TypeSet.empty in
   let rec iterator ty =


### PR DESCRIPTION
Fixes #10271 by using `Env.add_local_type` in `Ctype.instance_constructor` and `Ctype.reify`.

(An alternative approach would be to have `Ctype.is_instantiable` return `true` for unknown type, but this doesn't seem very clean.)