### PR TITLE
Split Ppat_or case in Typecore.type_pat

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1812,27 +1812,18 @@ and type_pat_aux
         pat_type = instance expected_ty;
         pat_attributes = sp.ppat_attributes;
         pat_env = !env })
-  | Ppat_or(sp1, sp2) ->
-      let may_split, must_split =
+  | Ppat_or(sp1, sp2) when mode <> Normal ->
+      (* We are in counter-example mode, but try to avoid backtracking *)
+      let must_split =
         match get_splitting_mode mode with
-        | None -> false, false
-        | Some Backtrack_or -> true, true
-        | Some (Refine_or _) -> true, false in
+        | None -> assert false
+        | Some Backtrack_or -> true
+        | Some (Refine_or _) -> false in
       let state = save_state env in
       let split_or sp =
-        assert may_split;
         let typ pat = type_pat category pat expected_ty k in
         find_valid_alternative (fun pat -> set_state state env; typ pat) sp in
       if must_split then split_or sp else begin
-        let initial_pattern_variables = !pattern_variables in
-        let initial_module_variables = !module_variables in
-        let equation_level = !gadt_equations_level in
-        let outter_lev = get_current_level () in
-        (* introduce a new scope *)
-        begin_def ();
-        let lev = get_current_level () in
-        gadt_equations_level := Some lev;
-        let env1 = ref !env in
         let inside_or = enter_nonsplit_or mode in
         let type_pat_result env sp : (_, abort_reason) result =
           match
@@ -1842,24 +1833,8 @@ and type_pat_aux
           | exception Need_backtrack -> Error Adds_constraints
           | exception Empty_branch -> Error Empty
         in
-        let p1 = type_pat_result env1 sp1 in
-        let p1_variables = !pattern_variables in
-        let p1_module_variables = !module_variables in
-        pattern_variables := initial_pattern_variables;
-        module_variables := initial_module_variables;
-        let env2 = ref !env in
-        let p2 = type_pat_result env2 sp2 in
-        end_def ();
-        gadt_equations_level := equation_level;
-        let p2_variables = !pattern_variables in
-        (* Make sure no variable with an ambiguous type gets added to the
-           environment. *)
-        List.iter (fun { pv_type; pv_loc; _ } ->
-          check_scope_escape pv_loc !env1 outter_lev pv_type
-        ) p1_variables;
-        List.iter (fun { pv_type; pv_loc; _ } ->
-          check_scope_escape pv_loc !env2 outter_lev pv_type
-        ) p2_variables;
+        let p1 = type_pat_result (ref !env) sp1 in
+        let p2 = type_pat_result (ref !env) sp2 in
         begin match p1, p2 with
         | Error Empty, Error Empty ->
             raise Empty_branch
@@ -1876,20 +1851,54 @@ and type_pat_aux
         | Error _, Ok p ->
             rp k p
         | Ok p1, Ok p2 ->
-            let alpha_env =
-              enter_orpat_variables loc !env p1_variables p2_variables in
-            let p2 = alpha_pat alpha_env p2 in
-            pattern_variables := p1_variables;
-            module_variables := p1_module_variables;
-            let make_pat desc =
-              { pat_desc = desc;
-                pat_loc = loc; pat_extra=[];
-                pat_type = instance expected_ty;
-                pat_attributes = sp.ppat_attributes;
-                pat_env = !env } in
-            rp k (make_pat (Tpat_or(p1, p2, None)))
+            rp k { pat_desc = Tpat_or (p1, p2, None);
+                   pat_loc = loc; pat_extra = [];
+                   pat_type = instance expected_ty;
+                   pat_attributes = sp.ppat_attributes;
+                   pat_env = !env }
         end
       end
+  | Ppat_or(sp1, sp2) ->
+      assert construction_not_used_in_counterexamples;
+      let initial_pattern_variables = !pattern_variables in
+      let initial_module_variables = !module_variables in
+      let equation_level = !gadt_equations_level in
+      let outter_lev = get_current_level () in
+      (* introduce a new scope *)
+      begin_def ();
+      let lev = get_current_level () in
+      gadt_equations_level := Some lev;
+      let type_pat_rec env sp =
+        type_pat category sp expected_ty ~env (fun x -> x) in
+      let env1 = ref !env in
+      let p1 = type_pat_rec env1 sp1 in
+      let p1_variables = !pattern_variables in
+      let p1_module_variables = !module_variables in
+      pattern_variables := initial_pattern_variables;
+      module_variables := initial_module_variables;
+      let env2 = ref !env in
+      let p2 = type_pat_rec env2 sp2 in
+      end_def ();
+      gadt_equations_level := equation_level;
+      let p2_variables = !pattern_variables in
+      (* Make sure no variable with an ambiguous type gets added to the
+         environment. *)
+      List.iter (fun { pv_type; pv_loc; _ } ->
+        check_scope_escape pv_loc !env1 outter_lev pv_type
+      ) p1_variables;
+      List.iter (fun { pv_type; pv_loc; _ } ->
+        check_scope_escape pv_loc !env2 outter_lev pv_type
+      ) p2_variables;
+      let alpha_env =
+        enter_orpat_variables loc !env p1_variables p2_variables in
+      let p2 = alpha_pat alpha_env p2 in
+      pattern_variables := p1_variables;
+      module_variables := p1_module_variables;
+      rp k { pat_desc = Tpat_or (p1, p2, None);
+             pat_loc = loc; pat_extra = [];
+             pat_type = instance expected_ty;
+             pat_attributes = sp.ppat_attributes;
+             pat_env = !env }
   | Ppat_lazy sp1 ->
       let nv = newgenvar () in
       unify_pat_types ~refine loc env (Predef.type_lazy_t nv)
@@ -1903,6 +1912,7 @@ and type_pat_aux
         pat_attributes = sp.ppat_attributes;
         pat_env = !env })
   | Ppat_constraint(sp, sty) ->
+      assert construction_not_used_in_counterexamples;
       (* Pretend separate = true *)
       begin_def();
       let cty, ty, force = Typetexp.transl_simple_type_delayed !env sty in
@@ -1930,12 +1940,14 @@ and type_pat_aux
              { p with pat_type = ty; pat_extra = extra::p.pat_extra }
         in k p)
   | Ppat_type lid ->
+      assert construction_not_used_in_counterexamples;
       let (path, p,ty) = build_or_pat !env loc lid in
       unify_pat_types ~refine loc env ty (instance expected_ty);
       k @@ pure category @@ { p with pat_extra =
         (Tpat_type (path, lid), loc, sp.ppat_attributes)
         :: p.pat_extra }
   | Ppat_open (lid,p) ->
+      assert construction_not_used_in_counterexamples;
       let path, new_env =
         !type_open Asttypes.Fresh !env sp.ppat_loc lid in
       let new_env = ref new_env in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1824,18 +1824,16 @@ and type_pat_aux
         let typ pat = type_pat category pat expected_ty k in
         find_valid_alternative (fun pat -> set_state state env; typ pat) sp in
       if must_split then split_or sp else begin
-        let inside_or = enter_nonsplit_or mode in
         let type_pat_result env sp : (_, abort_reason) result =
-          match
-            type_pat category ~mode:inside_or sp expected_ty ~env (fun x -> x)
-          with
+          let mode = enter_nonsplit_or mode in
+          match type_pat category ~mode sp expected_ty ~env (fun x -> x) with
           | res -> Ok res
           | exception Need_backtrack -> Error Adds_constraints
           | exception Empty_branch -> Error Empty
         in
         let p1 = type_pat_result (ref !env) sp1 in
         let p2 = type_pat_result (ref !env) sp2 in
-        begin match p1, p2 with
+        match p1, p2 with
         | Error Empty, Error Empty ->
             raise Empty_branch
         | Error Adds_constraints, Error _
@@ -1856,7 +1854,6 @@ and type_pat_aux
                    pat_type = instance expected_ty;
                    pat_attributes = sp.ppat_attributes;
                    pat_env = !env }
-        end
       end
   | Ppat_or(sp1, sp2) ->
       assert construction_not_used_in_counterexamples;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1813,91 +1813,90 @@ and type_pat_aux
         pat_attributes = sp.ppat_attributes;
         pat_env = !env })
   | Ppat_or(sp1, sp2) ->
-    begin match mode with
-    | Counter_example {splitting_mode; _} ->
-      (* We are in counter-example mode, but try to avoid backtracking *)
-      let must_split =
-        match splitting_mode with
-        | Backtrack_or -> true
-        | Refine_or _ -> false in
-      let state = save_state env in
-      let split_or sp =
-        let typ pat = type_pat category pat expected_ty k in
-        find_valid_alternative (fun pat -> set_state state env; typ pat) sp in
-      if must_split then split_or sp else begin
-        let type_pat_result env sp : (_, abort_reason) result =
-          let mode = enter_nonsplit_or mode in
-          match type_pat category ~mode sp expected_ty ~env (fun x -> x) with
-          | res -> Ok res
-          | exception Need_backtrack -> Error Adds_constraints
-          | exception Empty_branch -> Error Empty
-        in
-        let p1 = type_pat_result (ref !env) sp1 in
-        let p2 = type_pat_result (ref !env) sp2 in
-        match p1, p2 with
-        | Error Empty, Error Empty ->
-            raise Empty_branch
-        | Error Adds_constraints, Error _
-        | Error _, Error Adds_constraints ->
-            let inside_nonsplit_or =
-              match get_splitting_mode mode with
-              | None | Some Backtrack_or -> false
-              | Some (Refine_or {inside_nonsplit_or}) -> inside_nonsplit_or in
-            if inside_nonsplit_or
-            then raise Need_backtrack
-            else split_or sp
-        | Ok p, Error _
-        | Error _, Ok p ->
-            rp k p
-        | Ok p1, Ok p2 ->
-            rp k { pat_desc = Tpat_or (p1, p2, None);
-                   pat_loc = loc; pat_extra = [];
-                   pat_type = instance expected_ty;
-                   pat_attributes = sp.ppat_attributes;
-                   pat_env = !env }
+      begin match mode with
+      | Normal ->
+          let initial_pattern_variables = !pattern_variables in
+          let initial_module_variables = !module_variables in
+          let equation_level = !gadt_equations_level in
+          let outter_lev = get_current_level () in
+          (* introduce a new scope *)
+          begin_def ();
+          let lev = get_current_level () in
+          gadt_equations_level := Some lev;
+          let type_pat_rec env sp =
+            type_pat category sp expected_ty ~env (fun x -> x) in
+          let env1 = ref !env in
+          let p1 = type_pat_rec env1 sp1 in
+          let p1_variables = !pattern_variables in
+          let p1_module_variables = !module_variables in
+          pattern_variables := initial_pattern_variables;
+          module_variables := initial_module_variables;
+          let env2 = ref !env in
+          let p2 = type_pat_rec env2 sp2 in
+          end_def ();
+          gadt_equations_level := equation_level;
+          let p2_variables = !pattern_variables in
+          (* Make sure no variable with an ambiguous type gets added to the
+             environment. *)
+          List.iter (fun { pv_type; pv_loc; _ } ->
+            check_scope_escape pv_loc !env1 outter_lev pv_type
+          ) p1_variables;
+          List.iter (fun { pv_type; pv_loc; _ } ->
+            check_scope_escape pv_loc !env2 outter_lev pv_type
+          ) p2_variables;
+          let alpha_env =
+            enter_orpat_variables loc !env p1_variables p2_variables in
+          let p2 = alpha_pat alpha_env p2 in
+          pattern_variables := p1_variables;
+          module_variables := p1_module_variables;
+          rp k { pat_desc = Tpat_or (p1, p2, None);
+                 pat_loc = loc; pat_extra = [];
+                 pat_type = instance expected_ty;
+                 pat_attributes = sp.ppat_attributes;
+                 pat_env = !env }
+      | Counter_example {splitting_mode; _} ->
+          (* We are in counter-example mode, but try to avoid backtracking *)
+          let must_split =
+            match splitting_mode with
+            | Backtrack_or -> true
+            | Refine_or _ -> false in
+          let state = save_state env in
+          let split_or sp =
+            let typ pat = type_pat category pat expected_ty k in
+            find_valid_alternative (fun pat -> set_state state env; typ pat) sp
+          in
+          if must_split then split_or sp else
+          let type_pat_result env sp : (_, abort_reason) result =
+            let mode = enter_nonsplit_or mode in
+            match type_pat category ~mode sp expected_ty ~env (fun x -> x) with
+            | res -> Ok res
+            | exception Need_backtrack -> Error Adds_constraints
+            | exception Empty_branch -> Error Empty
+          in
+          let p1 = type_pat_result (ref !env) sp1 in
+          let p2 = type_pat_result (ref !env) sp2 in
+          match p1, p2 with
+          | Error Empty, Error Empty ->
+              raise Empty_branch
+          | Error Adds_constraints, Error _
+          | Error _, Error Adds_constraints ->
+              let inside_nonsplit_or =
+                match splitting_mode with
+                | Backtrack_or -> false
+                | Refine_or {inside_nonsplit_or} -> inside_nonsplit_or in
+              if inside_nonsplit_or
+              then raise Need_backtrack
+              else split_or sp
+          | Ok p, Error _
+          | Error _, Ok p ->
+              rp k p
+          | Ok p1, Ok p2 ->
+              rp k { pat_desc = Tpat_or (p1, p2, None);
+                     pat_loc = loc; pat_extra = [];
+                     pat_type = instance expected_ty;
+                     pat_attributes = sp.ppat_attributes;
+                     pat_env = !env }
       end
-    | Normal ->
-      assert construction_not_used_in_counterexamples;
-      let initial_pattern_variables = !pattern_variables in
-      let initial_module_variables = !module_variables in
-      let equation_level = !gadt_equations_level in
-      let outter_lev = get_current_level () in
-      (* introduce a new scope *)
-      begin_def ();
-      let lev = get_current_level () in
-      gadt_equations_level := Some lev;
-      let type_pat_rec env sp =
-        type_pat category sp expected_ty ~env (fun x -> x) in
-      let env1 = ref !env in
-      let p1 = type_pat_rec env1 sp1 in
-      let p1_variables = !pattern_variables in
-      let p1_module_variables = !module_variables in
-      pattern_variables := initial_pattern_variables;
-      module_variables := initial_module_variables;
-      let env2 = ref !env in
-      let p2 = type_pat_rec env2 sp2 in
-      end_def ();
-      gadt_equations_level := equation_level;
-      let p2_variables = !pattern_variables in
-      (* Make sure no variable with an ambiguous type gets added to the
-         environment. *)
-      List.iter (fun { pv_type; pv_loc; _ } ->
-        check_scope_escape pv_loc !env1 outter_lev pv_type
-      ) p1_variables;
-      List.iter (fun { pv_type; pv_loc; _ } ->
-        check_scope_escape pv_loc !env2 outter_lev pv_type
-      ) p2_variables;
-      let alpha_env =
-        enter_orpat_variables loc !env p1_variables p2_variables in
-      let p2 = alpha_pat alpha_env p2 in
-      pattern_variables := p1_variables;
-      module_variables := p1_module_variables;
-      rp k { pat_desc = Tpat_or (p1, p2, None);
-             pat_loc = loc; pat_extra = [];
-             pat_type = instance expected_ty;
-             pat_attributes = sp.ppat_attributes;
-             pat_env = !env }
-    end
   | Ppat_lazy sp1 ->
       let nv = newgenvar () in
       unify_pat_types ~refine loc env (Predef.type_lazy_t nv)


### PR DESCRIPTION
The `Ppat_or` case of `Typecore.type_pat` handles two very different situations:
* In `Normal` mode, it must type an or-pattern, which may contain variables and is allowed to contain GADT constructors generating equations (which must be ignored, and not leak fresh types)
* In `Counter_example` mode, it attempts to type both patterns to see if any of them contains no GADT constructors. If this is the case it selects that case and continues, otherwise it explores all the branches through backtracking

Since there are much more differences than overlap between these two situations, it seems better to completely separate the cases, and clarify the respective invariants.