### PR TITLE
Remove $(LIBFILES) from boot/ in coldstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ coldstart:
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 	$(MAKE) -C stdlib $(BOOT_FLEXLINK_CMD) \
 	  CAMLC='$$(BOOT_OCAMLC) -use-prims ../runtime/primitives' all
+	cd boot; rm -f $(LIBFILES)
 	cd stdlib; cp $(LIBFILES) ../boot
 	cd boot; $(LN) ../runtime/libcamlrun.$(A) .
 


### PR DESCRIPTION
The change of case for the files for the stdlib in #10169 causes an issue in `boot/` if you work on a branch based before that PR was merged and subsequently change to one based after it. The build will fail and you will issue `make coldstart` but alas, on macOS/Windows and any other case-preserving file systems, the file system will fight you and the build is still broken.

The fix - tested on both Windows and macOS - is to `rm -f $(LIBFILES)` in `boot/` just prior to the `cp`. The files are always copied from `stdlib/` in `coldstart`, what this change does it to ensure that the filename is also updated.

Fixes #10267 (without breaking the bootstrap).