### PR TITLE
add exposed Array.unsafe_blit

### DIFF
--- a/Changes
+++ b/Changes
@@ -101,6 +101,9 @@ Working version
 
 ### Standard library:
 
+- #10286: Added Array.unsafe_blit.
+  (Andrew Hunter, review by TK.)
+
 - #9533: Added String.starts_with and String.ends_with.
   (Bernhard Schommer, review by Daniel Bünzli, Gabriel Scherer and
   Alain Frisch)

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -337,6 +337,9 @@ val of_seq : 'a Seq.t -> 'a array
 external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
 external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
 
+external unsafe_blit : 'a array -> int -> 'a array
+  -> int -> int -> unit = "caml_array_blit"
+
 module Floatarray : sig
   external create : int -> floatarray = "caml_floatarray_create"
   external length : floatarray -> int = "%floatarray_length"

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -337,6 +337,9 @@ val of_seq : 'a Seq.t -> 'a array
 external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
 external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
 
+external unsafe_blit : src:'a array -> src_pos:int -> dst:'a array
+  -> dst_pos:int -> len:int -> unit = "caml_array_blit"
+
 module Floatarray : sig
   external create : int -> floatarray = "caml_floatarray_create"
   external length : floatarray -> int = "%floatarray_length"


### PR DESCRIPTION
Expose unsafe_blit as we do unsafe_get/unsafe_set; I think this is useful for the same reason.

(In principle one could just define a local external value for `caml_array_blit` but this feels considerably nicer, in case the name changes, or similar?)

I did not add any more tests, as it appears there aren't corresponding tests for unsafe_get/unsafe_set, unless I missed them. One easily could if that'd make people more comfortable, but it seems pretty clear by inspection.