### PR TITLE
Fix for #9295.Do not print options in usage msg

### DIFF
--- a/Changes
+++ b/Changes
@@ -220,6 +220,9 @@ Working version
 
 ### Build system:
 
+- #10289: Do not print option documentation in usage messages.
+    (Pavlo Khrystenko, review by Gabriel Scherer)
+
 - #9191, #10091, #10182: take the LDFLAGS variable into account, except on
   flexlink-using systems.
   (Gabriel Scherer, review by Sébastien Hinderer and David Allsopp,

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -716,4 +716,33 @@ let process_deferred_actions env =
     !print_types ||
     match !stop_after with
     | None -> false
-    | Some p -> Clflags.Compiler_pass.is_compilation_pass p;
+    | Some p -> Clflags.Compiler_pass.is_compilation_pass p
+
+(* This function is almost the same as [Arg.parse_expand], except
+   that [Arg.parse_expand] could not be used because it does not take a
+   reference for [arg_spec].
+   We use a marker \000 for Arg.parse_and_expand_argv_dynamic
+   so we can split out error message from usage options, because
+   it always concatenates
+   error message with usage options *)
+let parse_arguments ?(current=ref 0) argv f program =
+    try
+      Arg.parse_and_expand_argv_dynamic current argv Clflags.arg_spec f "\000"
+    with
+    | Arg.Bad err_msg ->
+      let usage_msg = create_usage_msg program in
+      let err_msg = err_msg
+      |> String.split_on_char '\000'
+      |> List.hd
+      |> String.trim in
+      Printf.eprintf "%s\n%s\n" err_msg usage_msg;
+      raise (Exit_with_status 2)
+    | Arg.Help msg ->
+      let err_msg =
+        msg
+        |> String.split_on_char '\000'
+        |> String.concat "" in
+      let help_msg =
+        Printf.sprintf "Usage: %s <options> <files>\nOptions are:" program in
+      Printf.printf "%s\n%s" help_msg err_msg;
+      raise (Exit_with_status 0)

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -80,3 +80,8 @@ val process_deferred_actions :
   string * (* ocaml module extension *)
   string -> (* ocaml library extension *)
   unit
+(* [parse_arguments ?current argv anon_arg program] will parse the arguments,
+ using the arguments provided in [Clflags.arg_spec].
+*)
+val parse_arguments : ?current:(int ref)
+      -> string array ref -> Arg.anon_fun -> string -> unit

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -15,18 +15,18 @@
 
 open Clflags
 
-let usage = "Usage: ocamlc <options> <files>\nOptions are:"
 
 module Options = Main_args.Make_bytecomp_options (Main_args.Default.Main)
 
 let main argv ppf =
+  let program = "ocamlc" in
   Clflags.add_arguments __LOC__ Options.list;
   Clflags.add_arguments __LOC__
     ["-depend", Arg.Unit Makedepend.main_from_option,
      "<options> Compute dependencies (use 'ocamlc -depend -help' for details)"];
   match
     Compenv.readenv ppf Before_args;
-    Clflags.parse_arguments argv Compenv.anonymous usage;
+    Compenv.parse_arguments (ref argv) Compenv.anonymous program;
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
@@ -40,7 +40,7 @@ let main argv ppf =
     with Arg.Bad msg ->
       begin
         prerr_endline msg;
-        Clflags.print_arguments usage;
+        Clflags.print_arguments program;
         exit 2
       end
     end;

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -653,16 +653,15 @@ let run_main argv =
          "<file> Read additional NUL separated command line arguments from \n\
          \      <file>"
   ];
-  let usage =
-    Printf.sprintf "Usage: %s [options] <source files>\nOptions are:"
-                   (Filename.basename Sys.argv.(0))
-  in
-  Clflags.parse_arguments argv (add_dep_arg (fun f -> Src (f, None))) usage;
+  let program = Filename.basename Sys.argv.(0) in
+  Compenv.parse_arguments (ref argv)
+      (add_dep_arg (fun f -> Src (f, None))) program;
   process_dep_args (List.rev !dep_args_rev);
   Compenv.readenv ppf Before_link;
   if !sort_files then sort_files_by_dependencies !files
   else List.iter print_file_dependencies (List.sort compare !files);
   exit (if Error_occurred.get () then 2 else 0)
+
 
 let main () =
   run_main Sys.argv

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -33,11 +33,11 @@ module Backend = struct
 end
 let backend = (module Backend : Backend_intf.S)
 
-let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 
 module Options = Main_args.Make_optcomp_options (Main_args.Default.Optmain)
 let main argv ppf =
   native_code := true;
+  let program = "ocamlopt" in
   match
     Compenv.readenv ppf Before_args;
     Clflags.add_arguments __LOC__ (Arch.command_line_options @ Options.list);
@@ -45,7 +45,7 @@ let main argv ppf =
       ["-depend", Arg.Unit Makedepend.main_from_option,
        "<options> Compute dependencies \
         (use 'ocamlopt -depend -help' for details)"];
-    Clflags.parse_arguments argv Compenv.anonymous usage;
+    Compenv.parse_arguments (ref argv) Compenv.anonymous program;
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
@@ -59,7 +59,7 @@ let main argv ppf =
     with Arg.Bad msg ->
       begin
         prerr_endline msg;
-        Clflags.print_arguments usage;
+        Clflags.print_arguments program;
         exit 2
       end
     end;

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -119,9 +119,6 @@ let _ = Topcommon.add_directive "untrace_all"
 (* --- *)
 
 
-let usage = "Usage: ocaml <options> <object-files> [script-file [arguments]]\n\
-             options are:"
-
 let preload_objects = ref []
 
 (* Position of the first non expanded argument *)
@@ -209,15 +206,10 @@ let () =
 
 let main () =
   let ppf = Format.err_formatter in
+  let program = "ocaml" in
   Compenv.readenv ppf Before_args;
-  let list = ref Options.list in
-  begin
-    try
-      Arg.parse_and_expand_argv_dynamic current argv list file_argument usage;
-    with
-    | Arg.Bad msg -> Printf.eprintf "%s" msg; raise (Compenv.Exit_with_status 2)
-    | Arg.Help msg -> Printf.printf "%s" msg; raise (Compenv.Exit_with_status 0)
-  end;
+  Clflags.add_arguments __LOC__ Options.list;
+  Compenv.parse_arguments ~current argv file_argument program;
   Compenv.readenv ppf Before_link;
   Compmisc.read_clflags_from_env ();
   if not (prepare ppf) then raise (Compenv.Exit_with_status 2);

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -13,9 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let usage = "Usage: ocamlnat <options> <object-files> [script-file]\n\
-             options are:"
-
 let preload_objects = ref []
 
 (* Position of the first non expanded argument *)
@@ -99,17 +96,12 @@ let () =
   Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
 
 let main () =
+  let ppf = Format.err_formatter in
   Clflags.native_code := true;
-  let list = ref Options.list in
-  begin
-    try
-      Arg.parse_and_expand_argv_dynamic current argv list file_argument usage;
-    with
-    | Arg.Bad msg -> Format.fprintf Format.err_formatter "%s%!" msg;
-                     raise (Compenv.Exit_with_status 2)
-    | Arg.Help msg -> Format.fprintf Format.std_formatter "%s%!" msg;
-                      raise (Compenv.Exit_with_status 0)
-  end;
+  let program = "ocamlnat" in
+  Compenv.readenv ppf Before_args;
+  Clflags.add_arguments __LOC__ Options.list;
+  Compenv.parse_arguments ~current argv file_argument program;
   Compmisc.read_clflags_from_env ();
   if not (prepare Format.err_formatter) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -567,17 +567,10 @@ let add_arguments loc args =
       arg_names := String.Map.add arg_name loc !arg_names
   ) args
 
-let print_arguments usage =
-  Arg.usage !arg_spec usage
+let create_usage_msg program =
+  Printf.sprintf "Usage: %s <options> <files>\n\
+    Try '%s --help' for more information." program program
 
-(* This function is almost the same as [Arg.parse_expand], except
-   that [Arg.parse_expand] could not be used because it does not take a
-   reference for [arg_spec].*)
-let parse_arguments argv f msg =
-  try
-    let argv = ref argv in
-    let current = ref 0 in
-    Arg.parse_and_expand_argv_dynamic current argv arg_spec f msg
-  with
-  | Arg.Bad msg -> Printf.eprintf "%s" msg; exit 2
-  | Arg.Help msg -> Printf.printf "%s" msg; exit 0
+
+let print_arguments program =
+  Arg.usage !arg_spec (create_usage_msg program)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+
+
 (** Command line flags *)
 
 (** Optimization parameters represented as ints indexed by round number. *)
@@ -260,11 +262,8 @@ val arg_spec : (string * Arg.spec * string) list ref
    added. *)
 val add_arguments : string -> (string * Arg.spec * string) list -> unit
 
-(* [parse_arguments argv anon_arg usage] will parse the arguments, using
-  the arguments provided in [Clflags.arg_spec].
-*)
-val parse_arguments : string array -> Arg.anon_fun -> string -> unit
-
+(* [create_usage_msg program] creates a usage message for [program] *)
+val create_usage_msg: string -> string
 (* [print_arguments usage] print the standard usage message *)
 val print_arguments : string -> unit
 


### PR DESCRIPTION
See #9295.
affected tools
- ocamlc
- ocamlopt
- ocaml
- ocamlnat

example output 
```bash
> ./ocamlopt -blah
./ocamlopt: unknown option '-blah'.
Usage: ocamlopt <options> <files>
Try 'ocamlopt --help' for more information.
> ./ocamlopt -help
Usage: ocamlopt <options> <files>
Options are:

[..options list]
```