### PR TITLE
document some types in typecore.ml

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3889,7 +3889,8 @@ and type_function ?(in_function : (Location.t * type_expr) option)
     with Unify _ ->
       match expand_head env ty_expected with
         {desc = Tarrow _} as ty ->
-          raise(Error(loc, env, Abstract_wrong_label(arg_label, ty, explanation)))
+          raise(Error(loc, env,
+                      Abstract_wrong_label(arg_label, ty, explanation)))
       | _ ->
           raise(Error(loc_fun, env,
                       Too_many_arguments (in_function <> None,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4632,10 +4632,9 @@ and type_statement ?explanation env sexp =
     exp
   end
 
-and type_unpacks : ?in_function: Location.t * type_expr ->
-  Env.t -> (string Location.loc * Location.t * Uid.t) list ->
-  Parsetree.expression -> type_expected -> expression
-= fun ?in_function env unpacks sbody expected_ty ->
+and type_unpacks ?(in_function : (Location.t * type_expr) option)
+    env (unpacks : (string Location.loc * Location.t * Uid.t) list)
+    sbody expected_ty =
   let ty = newvar() in
   (* remember original level *)
   let extended_env, tunpacks =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -43,8 +43,6 @@ type type_expected = {
 type to_unpack = {
   tu_name: string Location.loc;
   tu_loc: Location.t;
-  (* Simply naming these fields like [loc] causes conflicts e.g. with
-      [Asttypes.loc] *)
   tu_uid: Uid.t
 }
 


### PR DESCRIPTION
This PR intends to increase the readability of `typecore.ml` by adding some type annotations.

Some other minor improvements are included:
1. `with_explanation` is pulled out of the mutually  recursive definition of `type_exp`.
2. In `type_unpacks`, some occurrences of `unpacks`  are renamed to `tunpacks` for a better coherence to its type.