### PR TITLE
Compile tools/make_opcodes with -custom

### DIFF
--- a/Changes
+++ b/Changes
@@ -237,6 +237,10 @@ Working version
   socklen_t detection on Windows.
   (Antonin Décimo, review by David Allsopp and Sébastien Hinderer)
 
+- #10293: Build tools/make_optcodes with -custom so that it is always executable
+  during any kind of bootstrap operation.
+  (David Allsopp, report by Tom Kelly, review by ???)
+
 ### Bug fixes:
 
 * #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section

--- a/Makefile
+++ b/Makefile
@@ -1040,7 +1040,7 @@ toplevel/native/topeval.cmx: otherlibs/dynlink/dynlink.cmxa
 make_opcodes := tools/make_opcodes$(EXE)
 
 bytecomp/opcodes.ml: runtime/caml/instruct.h $(make_opcodes)
-	runtime/ocamlrun$(EXE) $(make_opcodes) -opcodes < $< > $@
+	$(make_opcodes) -opcodes < $< > $@
 
 bytecomp/opcodes.mli: bytecomp/opcodes.ml
 	$(CAMLC) -i $< > $@

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -231,10 +231,10 @@ make_opcodes := make_opcodes$(EXE)
 $(eval $(call PROGRAM_SYNONYM,make_opcodes))
 
 $(make_opcodes): make_opcodes.ml
-	$(CAMLC) $< -o $@
+	$(CAMLC) -custom $< -o $@
 
 opnames.ml: $(ROOTDIR)/runtime/caml/instruct.h $(make_opcodes)
-	$(ROOTDIR)/runtime/ocamlrun$(EXE) $(make_opcodes) -opnames < $< > $@
+	./$(make_opcodes) -opnames < $< > $@
 
 clean::
 	rm -f opnames.ml make_opcodes make_opcodes.exe make_opcodes.ml

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -230,8 +230,11 @@ make_opcodes := make_opcodes$(EXE)
 
 $(eval $(call PROGRAM_SYNONYM,make_opcodes))
 
+.INTERMEDIATE: $(make_opcodes).tmp
 $(make_opcodes): make_opcodes.ml
-	$(CAMLC) -custom $< -o $@
+	$(CAMLC) -without-runtime $< -o $@.tmp
+	cat $(ROOTDIR)/boot/ocamlrun$(EXE) $(make_opcodes).tmp > $@
+	chmod +x $@
 
 opnames.ml: $(ROOTDIR)/runtime/caml/instruct.h $(make_opcodes)
 	./$(make_opcodes) -opnames < $< > $@


### PR DESCRIPTION
Prior to #803, `bytecomp/opcodes.ml*` and `tools/opnames.ml` were generated by awk and sed scripts. They're now generated infinitely less hideously, but more bootstrappingly complicatedly, with an ocamllex script.

@ctk21 hit a problem with multicore trying to _change_ bytecode opcodes (the aim is in fact to remove opcodes which are no longer required, but which were not originally added at the end of the opcode list). Presently, the build system assumes that `tools/make_opcodes` executes with `runtime/ocamlrun` but this is incorrect during a **change** to the opcodes. After `make core` has been run and changes applied, `tools/make_opcodes` should be executed with `boot/ocamlrun`, not `runtime/ocamlrun`. That change is easy enough to make, but the bootstrap cycle is more complicated - the correct runtime gets cleaned during the bootstrap.

This PR is the simplest path for fixing this - we store the runtime used to build `tools/make_opcodes` with `tools/make_opcodes` by using `-custom`! I don't think there's any downside to this, beyond slightly more space being used during the build - we don't install the file, so none of the usual problems with `-custom` apply. I don't think we were ever planning on completely removing `-custom`, but if we did then it would be perfectly reasonable to switch to `-output-complete-exe`, I haven't done that here because `-custom` is technically quicker (it's a copy vs calling the linker).

Note that #1659 would not have been affected by this because an _added_ opcode means that `tools/make_opcodes` was executable at all times with `runtime/ocamlrun`. However, the issue would be seen if the exec magic number were bumped at the same time (it wasn't in that PR, although arguably it ought to have been).