### PR TITLE
fix for a pattern-arity mismatch

### DIFF
--- a/Changes
+++ b/Changes
@@ -256,6 +256,9 @@ Working version
   (Xavier Leroy, report by Github user quakerquickoats, review by
    Jeremie Dimino)
 
+- #10294, #10295: fix an assert-failure in pattern-matching compilation
+  (Gabriel Scherer, report by Nicolás Ojeda Bär)
+
 - #10147, #10148: Fix building runtime with GCC on macOS.
   (David Allsopp, report by John Skaller)
 

--- a/testsuite/tests/basic-more/pr10294.ml
+++ b/testsuite/tests/basic-more/pr10294.ml
@@ -1,0 +1,45 @@
+(* TEST *)
+
+type import_error = Node of string
+type export_error = Variant of string * string
+
+exception Import of import_error
+exception Export of export_error
+(* Pattern-matching analysis and compilation considers that two
+   exceptions constructors may be equal (one may be a rebinding of
+   the other) as long as they have the same arity, as is the case
+   here.
+
+   The result of splitting on these two exception constructors is what
+   we call an "incoherent row", a pattern matrix whose rows have
+   incompatible types (one matching on [import_error], the other on
+   [export_error]).
+
+   In the case of the code below, the incoherent row is as follows:
+
+   (Node _)
+   (Variant (_, _))
+
+   Note that the two constructors [Node] and [Variant] have different
+   arities, but the same tag (0).
+
+   In bug #10924, this causes an assertion-failure in the
+   pattern-matching compiler, because a matrix-decomposition
+   computation in Default_environment ends up considering that Node
+   and Variant are equal, creating a sub-matrix with one wildcard
+   pattern in the first row, and two in the second.
+
+   This is fixed by comparing constructors by more than their tags
+   (which is insufficient for incoherent rows).
+*)
+let f = function
+  | Import (Node _) ->
+      1
+  | Export (Variant (_, _)) ->
+      2
+  | _ ->
+      3
+
+let () =
+  assert (f (Import (Node "foo")) = 1);
+  assert (f (Export (Variant ("foo", "bar"))) = 2);

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -440,9 +440,14 @@ let equal_tag t1 t2 =
       Path.same path1 path2 && b1 = b2
   | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
 
-let may_equal_constr c1 c2 = match c1.cstr_tag,c2.cstr_tag with
-| Cstr_extension _,Cstr_extension _ -> c1.cstr_arity = c2.cstr_arity
-| tag1,tag2 -> equal_tag tag1 tag2
+let may_equal_constr c1 c2 =
+  c1.cstr_arity = c2.cstr_arity
+  && (match c1.cstr_tag,c2.cstr_tag with
+     | Cstr_extension _,Cstr_extension _ ->
+         (* extension constructors may be rebindings of each other *)
+         true
+     | tag1, tag2 ->
+         equal_tag tag1 tag2)
 
 type label_description =
   { lbl_name: string;                   (* Short name *)


### PR DESCRIPTION
This is a preliminary fix for #10294. I believe that the fix is safe and correct, but we may want to change more things to solve this problem in a stronger way, and the PR is a good place to discuss it, in particular with @trefis and possibly @maranget.

(I also need to add a regression test to the testsuite, etc.)

## Explanation of what is going on

### What fails

@nojb's repro case is as follows:

```ocaml
type import_error =
  | Node of string

type export_error =
  | Variant of string * string

exception Excel_import of import_error
exception Excel_export of export_error

let f = function
  | Excel_import (Node _) ->
      None
  | Excel_export (Variant (_, _)) ->
      None
  | _ ->
      None
```

The assert failure comes from there:

```ocaml
module Default_environment = [..]

  let specialize_matrix arity matcher pss =
    let rec filter_rec = function
      [...]
              match matcher p ps with
              | exception NoMatch -> filter_rec rem
              | specialized ->
                  assert (List.length specialized = List.length ps + arity); (* THERE *)
                  specialized :: filter_rec rem
```

So the problem is that a pattern-matrix decomposition (within `Default_environment` which is an analysis used for optimization) is breaking an arity invariant: we are trying to create a matrix with several rows of different sizes.

### Why it fails

`Excel_import` and `Excel_import` are two exceptions (extension constructors), so one may secretly be an alias of the other (`exception Foo = Bar`). When decomposing matrices, the pattern-matching engine assumes that they may or may not be equal, so the decomposition of their parameters will be joined into a single sub-matrix. The logic implementing this is as follows:

```ocaml
(* matching.ml *)
  | Construct cstr, Construct cstr' ->
      (* NB: may_equal_constr considers (potential) constructor rebinding;
          Types.may_equal_constr does check that the arities are the same,
          preserving row-size coherence. *)
      yesif (Types.may_equal_constr cstr cstr')

(* typing/types.ml *)
let may_equal_constr c1 c2 = match c1.cstr_tag,c2.cstr_tag with
| Cstr_extension _,Cstr_extension _ -> c1.cstr_arity = c2.cstr_arity
| tag1,tag2 -> equal_tag tag1 tag2
```

Notice that in the case where two constructors are extension constructors, we assume that they may be compatible, but only if they have the same arity. In the present case `Excel_import` and `Excel_export` have the same arity 1, so they are considered compatible. The arity logic is crucial to avoid arity-inconsistencies during decomposition, as we had a few years ago, and it was introduced by @marangent, @trefis and myself when solving this few-years-ago bug.

So we get a submatrix to decompose which now looks like this:

```
(Node _)
(Variant (_, _))
```

This submatrix is inconsistent, the two constructors have distinct types (we know this can happen during decomposition due to this may-equal-constr or due to GADTs), but both rows have the same arity. The problem is that after the *next* decomposition step, we get the following:

```
(_)
(_ _)
```

The first row has one pattern, the second row has two patterns. This happened because `Node` and `Variant`, which are *not* extension constructors, are checked using the same `may_equal_constr` function, which checks that (as regular constructors) they have the same tag. And indeed they have the same tag, 0.

### Solutions

The following strengthening of may-equal-constr would solve this issue:
1. also in the non-extension case, check that the arities are the same
2. in the non-extension case, check the constructor names

The proposed PR implements (1): we always consider two constructor with different arities incompatible. This is obviously sound, it feels right, and it is the minimal change that guarantees that this particular source of incoherent-row-arity errors is gone. Maybe we should use a stronger criterion, but I am less sure about them.