### PR TITLE
Fix #10271 for named existentials

### DIFF
--- a/testsuite/tests/typing-gadts/name_existentials.ml
+++ b/testsuite/tests/typing-gadts/name_existentials.ml
@@ -110,10 +110,18 @@ let () =
 |}]
 
 (* Also allow annotations on multiary constructors *)
+
 type ('a,'b) pair = Pair of 'a * 'b
 
 let f = function Pair (x, y : int * _) -> x + y
 [%%expect{|
 type ('a, 'b) pair = Pair of 'a * 'b
 val f : (int, int) pair -> int = <fun>
+|}]
+
+(* Interaction with local open in patterns (see also #10271) *)
+
+let f String.(Dyn (type a) (w, x : a ty * a)) = ignore (x : a)
+[%%expect{|
+val f : dyn -> unit = <fun>
 |}]


### PR DESCRIPTION
The shadowing of freshly introduced types by local open in patterns (#10271) has been already fixed in #10273, but one occurrence of `Env.enter_type` was missed, namely the one for naming existentials.
Since we want the name to be usable, using `Env.add_local_type` is not an option, so we use the classical approach of adding yet another global variable, and using `Env.add_type` to re-register those types in the external environment.