### PR TITLE
(html manual) replace triangles for items by discs or diamonds

### DIFF
--- a/manual/src/html_processing/scss/_common.scss
+++ b/manual/src/html_processing/scss/_common.scss
@@ -7,7 +7,7 @@ $logocolor:#ec6a0d;
 $logo_height:67px;
 
 @if $ocamlorg {
-    .container { 
+    .container {
 	margin-left:0;
 	margin-right:0;
     }
@@ -179,7 +179,7 @@ html {
 	}
     }
 }
-    
+
 @mixin nav-toc-mobile {
     position:static;
     width:auto;
@@ -225,7 +225,7 @@ html {
 	position: absolute;
 	background: transparent;
     }
-    .content, .api {    
+    .content, .api {
 	nav.toc {
 	    margin-right: 1em;
 	    float: left;
@@ -249,13 +249,18 @@ html {
     content:"●";
     color:$logocolor;
     margin-right:4px;
-    margin-left:-1em
+    margin-left:-1em;
+    font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+    font-size:13px;
+    vertical-align:1px;
 }
 
 @mixin diamond {
     content:"◆";
-    font-size:smaller;	
     color:$logocolor;
     margin-right:4px;
-    margin-left:-1em
-}   
+    margin-left:-1em;
+    font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+    font-size:14px;
+    vertical-align:1px;
+}

--- a/manual/src/html_processing/scss/_common.scss
+++ b/manual/src/html_processing/scss/_common.scss
@@ -244,3 +244,18 @@ html {
     margin-right:4px;
     margin-left:-1em
 }
+
+@mixin disc {
+    content:"●";
+    color:$logocolor;
+    margin-right:4px;
+    margin-left:-1em
+}
+
+@mixin diamond {
+    content:"◆";
+    font-size:smaller;	
+    color:$logocolor;
+    margin-right:4px;
+    margin-left:-1em
+}   

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -23,7 +23,7 @@
 	}
     }
     ul{list-style:none;}
-    ul.itemize li::before{@include caret;}
+    ul.itemize li::before{@include disc;}
 
     /* When the TOC is repeated in the main content */
     ul.ul-content {
@@ -54,7 +54,10 @@
 	}
     }
     /* only for Contents/Foreword in index.html: */
-    ul.ul-content li::before{@include caret;}
+    ul.ul-content li::before{
+	@include disc;
+	margin-left: 0;
+    }
     /* table of contents: (manual.001.html): */
     ul.toc ul.toc ul.toc{
 	font-size:smaller;
@@ -275,7 +278,7 @@ blockquote.quote{
 }
 #part-menu li.active a{
     color:#000;
-    &::before{@include caret;}
+    &::before{@include diamond}
 }
 span.c003{
     color:#564233;


### PR DESCRIPTION
this should fix https://github.com/ocaml/ocaml.org/issues/1279

filled discs are used instead of right-pointing triangles because of ambiguous semantics of the latter,
except for indicating the current chapter where diamonds are used