### PR TITLE
Fix incorrection instruction selection for Ibased on ppc

### DIFF
--- a/Changes
+++ b/Changes
@@ -104,6 +104,10 @@ Working version
 - #10244: Optimise Int32.unsigned_to_int
   (Fabian Hemmer, review by Stephen Dolan and Xavier Leroy)
 
+- #10302, #10303: Fix incorrect instruction selection for string constant loads
+  on ppc.
+  (David Allsopp, review by Stephen Dolan)
+
 - #10349: Fix destroyed_at_c_call on RISC-V
   (Mark Shinwell, review by Nicolás Ojeda Bär)
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -244,7 +244,12 @@ let emit_load_store instr addressing_mode addr n arg =
         let (lo, hi) = low_high_s d in
         if hi <> 0 then
           `	addis	11, 11, {emit_int hi}\n`;
-        `	{emit_string instr}	{emit_reg arg}, {emit_int lo}(11)\n`
+        if valid_offset instr lo then
+          `	{emit_string instr}	{emit_reg arg}, {emit_int lo}(11)\n`
+        else begin
+          `	li	0, {emit_int lo}\n`;
+          `	{emit_string instr}x	{emit_reg arg}, 11, 0\n`
+        end
       end
   | Iindexed ofs ->
       if is_immediate ofs && valid_offset instr ofs then

--- a/testsuite/tests/lib-string/binary.ml
+++ b/testsuite/tests/lib-string/binary.ml
@@ -97,7 +97,6 @@ let () =
 
 let () =
   let b = "\xfe\xdc\xba\x98\x76\x54\x32\x10\x01\x00" in
-  let b = Bytes.(to_string (copy (of_string b))) in
   assert (String.get_int64_le b 0 = 0x1032547698badcfeL);
   assert (String.get_int64_be b 0 = 0xfedcba9876543210L);
   assert (String.get_int64_le b 1 = 0x011032547698badcL);


### PR DESCRIPTION
Attempt at fixing #10302. Also reverts 414bdec9ae387129b8102cc6bf3c0b6ae173eeb9 which was put onto trunk to restore CI.