### PR TITLE
Fix caml pooled mode and recursive startup

### DIFF
--- a/Changes
+++ b/Changes
@@ -85,6 +85,12 @@ Working version
   experimental.
   (Nicolás Ojeda Bär, review by David Allsopp)
 
+- #10304: Fix a crash when combining the instrumented runtime and the
+   pooled mode, and fixes some leaks in the normal runtime in pooled mode
+   or when calling caml_startup* several times.
+  (Guillaume Munch-Maccagnoni, review by Max Mouratov and Gabriel
+   Scherer)
+
 ### Code generation and optimizations:
 
 - #9876: do not cache the young_limit GC variable in a processor register.

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -1748,14 +1748,13 @@ In case the shared library produced with "-output-obj" is to be loaded and
 unloaded repeatedly by a single process, care must be taken to unload the
 OCaml runtime explicitly, in order to avoid various system resource leaks.
 
-Since 4.05, "caml_shutdown" function can be used to shut the runtime down
+Since 4.06, "caml_shutdown" function can be used to shut the runtime down
 gracefully, which equals the following:
 \begin{itemize}
 \item Running the functions that were registered with "Stdlib.at_exit".
 \item Triggering finalization of allocated custom blocks (see
-section~\ref{s:c-custom}). For example, "Stdlib.in_channel" and
-"Stdlib.out_channel" are represented by custom blocks that enclose file
-descriptors, which are to be released.
+section~\ref{s:c-custom}). For example, arrays created with
+"Bigarray.create" get their memory released.
 \item Unloading the dependent shared libraries that were loaded by the runtime,
 including "dynlink" plugins.
 \item Freeing the memory blocks that were allocated by the runtime with
@@ -1764,7 +1763,9 @@ from "memory.h" for managing static (that is, non-moving) blocks of heap
 memory, as all the blocks allocated with these functions are automatically
 freed by "caml_shutdown". For ensuring compatibility with legacy C stubs that
 have used "caml_stat_*" incorrectly, this behaviour is only enabled if the
-runtime is started with a specialized "caml_startup_pooled" function.
+runtime is started with a specialized "caml_startup_pooled" function, or with
+runtime parameter "c" (``cleanup on exit'', which in addition calls
+"caml_shutdown" on exit).
 \end{itemize}
 
 As a shared library may have several clients simultaneously, it is made for

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -89,8 +89,8 @@ void major_collection (void);
 void caml_finish_major_cycle (void);
 void caml_set_major_window (int);
 
-/* Forces finalisation of all heap-allocated values,
-   disregarding both local and global roots.
+/* Forces finalisation of all custom blocks, disregarding both local
+   and global roots.
 
    Warning: finalisation is performed by means of forced sweeping, which may
    result in pointers referencing nonexistent values; therefore the function

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -27,10 +27,11 @@ extern uintnat caml_init_max_stack_wsz;
 extern uintnat caml_trace_level;
 extern int caml_cleanup_on_exit;
 
-/* Common entry point to caml_startup.
+/* Common entry point to the various caml_startup functions.
    Returns 0 if the runtime is already initialized.
-   If [pooling] is 1, [caml_stat_*] functions will be backed by a pool. */
-extern int caml_startup_aux (int pooling);
+   If [pooling] is 1, [caml_stat_*] functions will be backed by a pool
+   that will be freed on caml_shutdown. */
+extern int caml_startup_common(int pooling);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -23,27 +23,13 @@
 extern void caml_init_locale(void);
 extern void caml_free_locale(void);
 
-extern void caml_init_atom_table (void);
-
-extern uintnat caml_init_percent_free;
-extern uintnat caml_init_max_percent_free;
-extern uintnat caml_init_minor_heap_wsz;
-extern uintnat caml_init_heap_chunk_sz;
-extern uintnat caml_init_heap_wsz;
 extern uintnat caml_init_max_stack_wsz;
-extern uintnat caml_init_major_window;
-extern uintnat caml_init_custom_major_ratio;
-extern uintnat caml_init_custom_minor_ratio;
-extern uintnat caml_init_custom_minor_max_bsz;
-extern uintnat caml_init_policy;
 extern uintnat caml_trace_level;
 extern int caml_cleanup_on_exit;
 
-extern void caml_parse_ocamlrunparam (void);
-
 /* Common entry point to caml_startup.
    Returns 0 if the runtime is already initialized.
-   If [pooling] is 0, [caml_stat_*] functions will not be backed by a pool. */
+   If [pooling] is 1, [caml_stat_*] functions will be backed by a pool. */
 extern int caml_startup_aux (int pooling);
 
 #endif /* CAML_INTERNALS */

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -157,6 +157,12 @@ int caml_startup_aux(int pooling)
     caml_fatal_error("caml_startup was called after the runtime "
                      "was shut down with caml_shutdown");
 
+  /* Second and subsequent calls are ignored,
+     since the runtime has already started */
+  startup_count++;
+  if (startup_count > 1)
+    return 0;
+
   /* Determine options */
 #ifdef DEBUG
   caml_verb_gc = 0x3F;
@@ -168,12 +174,6 @@ int caml_startup_aux(int pooling)
 #ifdef DEBUG
   caml_gc_message(-1, "### OCaml runtime: debug mode ###\n");
 #endif
-
-  /* Second and subsequent calls are ignored,
-     since the runtime has already started */
-  startup_count++;
-  if (startup_count > 1)
-    return 0;
 
   if (pooling)
     caml_stat_create_pool();

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -150,7 +150,7 @@ static int startup_count = 0;
 /* Has the runtime been shut down already? */
 static int shutdown_happened = 0;
 
-int caml_startup_aux(int pooling)
+int caml_startup_common(int pooling)
 {
   if (shutdown_happened == 1)
     caml_fatal_error("caml_startup was called after the runtime "

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -459,7 +459,7 @@ CAMLexport void caml_main(char_os **argv)
   char_os * shared_lib_path, * shared_libs;
   char_os * exe_name, * proc_self_exe;
 
-  if (!caml_startup_aux(0)) {
+  if (!caml_startup_common(0)) {
     /* startup was already done once */
     return;
   }
@@ -582,7 +582,7 @@ CAMLexport value caml_startup_code_exn(
   char_os * cds_file;
   char_os * exe_name;
 
-  if (!caml_startup_aux(pooling)) {
+  if (!caml_startup_common(pooling)) {
     /* startup was already done once */
     return Val_unit;
   }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -519,7 +519,6 @@ CAMLexport void caml_main(char_os **argv)
   caml_read_section_descriptors(fd, &trail);
   /* Initialize the abstract machine */
   caml_init_stack (caml_init_max_stack_wsz);
-  caml_init_atom_table();
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */
@@ -596,7 +595,6 @@ CAMLexport value caml_startup_code_exn(
   if (exe_name == NULL) exe_name = caml_search_exe_in_path(argv[0]);
   /* Initialize the abstract machine */
   caml_init_stack (caml_init_max_stack_wsz);
-  caml_init_atom_table();
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -43,7 +43,7 @@
 extern int caml_parser_trace;
 extern char caml_system__code_begin, caml_system__code_end;
 
-/* Initialize the atom table and the static data and code area limits. */
+/* Initialize the static data and code area limits. */
 
 struct segment { char * begin; char * end; };
 
@@ -53,8 +53,6 @@ static void init_static(void)
 
   char * caml_code_area_start, * caml_code_area_end;
   int i;
-
-  caml_init_atom_table ();
 
   for (i = 0; caml_data_segments[i].begin != 0; i++) {
     /* PR#5509: we must include the zero word at end of data segment,

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -98,12 +98,12 @@ extern void caml_install_invalid_parameter_handler();
 
 #endif
 
-value caml_startup_common(char_os **argv, int pooling)
+static value startup(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;
   char tos;
 
-  if (!caml_startup_aux(pooling)) {
+  if (!caml_startup_common(pooling)) {
     /* startup was already done once */
     return Val_unit;
   }
@@ -133,7 +133,7 @@ value caml_startup_common(char_os **argv, int pooling)
 
 value caml_startup_exn(char_os **argv)
 {
-  return caml_startup_common(argv, /* pooling */ 0);
+  return startup(argv, /* pooling */ 0);
 }
 
 void caml_startup(char_os **argv)
@@ -150,7 +150,7 @@ void caml_main(char_os **argv)
 
 value caml_startup_pooled_exn(char_os **argv)
 {
-  return caml_startup_common(argv, /* pooling */ 1);
+  return startup(argv, /* pooling */ 1);
 }
 
 void caml_startup_pooled(char_os **argv)


### PR DESCRIPTION
Terminology:
- pooled mode: the option that ensures that all memory allocated with `caml_stat_alloc*` is freed upon shutdown.
- recursive startup: the ability to call `caml_startup*` several times (not technically recursively but whatever) described in the manual.

This PR fixes a crash in the instrumented runtime in pooled mode, and fixes some leaks in the normal runtime in pooled mode or when calling `caml_startup*` several times. It also factors some duplicated startup code and adds some comments to avoid similar issues in the future.

This affects all OCaml versions starting from 4.10.