### PR TITLE
Fix #10298: Incorrect propagation of type equalities in functor application

### DIFF
--- a/Changes
+++ b/Changes
@@ -287,8 +287,9 @@ Working version
 - #10283, #10284: Enforce right-to-left evaluation order for Lstaticraise
   (Vincent Laviron, report by Github user Ngoguey42, review by Gabriel Scherer)
 
-- #10298: Incorrect propagation of type equalities in functor application
-  (Jacques Garrigue, report by Didier Remy)
+- #10298, #10305: Incorrect propagation of type equalities in functor
+  application
+  (Jacques Garrigue, report and review by Didier Remy)
 
 OCaml 4.12.0 (24 February 2021)
 -------------------------------

--- a/Changes
+++ b/Changes
@@ -287,6 +287,9 @@ Working version
 - #10283, #10284: Enforce right-to-left evaluation order for Lstaticraise
   (Vincent Laviron, report by Github user Ngoguey42, review by Gabriel Scherer)
 
+- #10298: Incorrect propagation of type equalities in functor application
+  (Jacques Garrigue, report by Didier Remy)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -83,6 +83,19 @@ module IndirectPriv = I(struct end);;
 module IndirectPriv : sig type t end
 |}]
 
+(* These two behave as though a functor was defined *)
+module DirectPrivEta =
+  (functor (X : sig end) -> Priv(X))(struct end);;
+[%%expect{|
+module DirectPrivEta : sig type t end
+|}]
+
+module DirectPrivEtaUnit =
+  (functor (_ : sig end) -> Priv)(struct end)(struct end);;
+[%%expect{|
+module DirectPrivEtaUnit : sig type t end
+|}]
+
 (*** Test proposed by Jacques in
      https://github.com/ocaml/ocaml/pull/1826#discussion_r194290729 ***)
 

--- a/testsuite/tests/typing-modules/pr10298.ml
+++ b/testsuite/tests/typing-modules/pr10298.ml
@@ -1,0 +1,22 @@
+(* TEST
+   * expect
+*)
+
+module type S = sig type t end
+module Res_ko =
+  (functor (X : S) -> X)(struct type t = int end)
+[%%expect{|
+module type S = sig type t end
+module Res_ko : sig type t = int end
+|}]
+
+module Res_ok2 =
+  (functor (X : S) -> struct include X end) (struct type t = int end)
+[%%expect{|
+module Res_ok2 : sig type t = int end
+|}]
+module Res_ok3 =
+  (functor (X : S) -> struct type t = X.t end) (struct type t = int end)
+[%%expect{|
+module Res_ok3 : sig type t = int end
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2105,7 +2105,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
           in
           Named (id, param, mty), Types.Named (id, mty.mty_type), newenv, true
       in
-      let body = type_module sttn funct_body None newenv sbody in
+      let body = type_module true funct_body None newenv sbody in
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type);
         mod_env = env;


### PR DESCRIPTION
This PR sets `sttn` to `true` in the body of functors.

The `sttn` flag comes from #4933, and is an answer to the dilemma one faces when given the choice between a private abbreviation and a public one, that should subsume it, but may end up becoming abstract. Since there is only one slot to put the abbreviation, one has to choose one or the other. The public one is generally better, except if we know that it is going to be erased later through `nondep_type`.
`sttn` informs subcalls that we have no path for the argument, so that even if we strengthen the type of the functor, the types will be discarded.
In general, this is the correct behavior, however in #10298 @diremy found an exception: if the functor itself is an inline lambda-abstraction which does not use its argument, the path of the argument is not used for strengthening, so there is no reason to prevent strengthening.
This PR avoid this by re-enabling strengthening when typing the body of functors. This does not completely remove `sttn`: it is still used, but only if the functor is a module path (which is by far the most common case).

Note that this change is not always optimal. For instance, the `DirectPrivEta` and `DirectPrivEtaUnit` examples in `nondep_private_abbrev.ml` were given a better type with `sttn` left as `false`. However, this coding style is virtually inexistant, and the new behavior is coherent with defining a functor rather than applying it directly, so this seems reasonable.
As said above, there is no principal solution, so predictability is what matters most here.