### PR TITLE
Map WSA error code to Unix errno for sockopt and getsockname functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -135,6 +135,9 @@ Working version
 - #10185: Consider that IPv6 is always enabled on Windows.
   (Antonin Décimo, review by David Allsopp and Xavier Leroy)
 
+- #10306: Map WSA error code to Unix errno for sockopt and getsockname
+  functions (Antonin Décimo, review by David Allsopp)
+
 ### Tools:
 
 - #10139: Remove confusing navigation bar from stdlib documentation.

--- a/otherlibs/win32unix/getsockname.c
+++ b/otherlibs/win32unix/getsockname.c
@@ -25,6 +25,9 @@ CAMLprim value unix_getsockname(value sock)
 
   addr_len = sizeof(addr);
   retcode = getsockname(Socket_val(sock), &addr.s_gen, &addr_len);
-  if (retcode == -1) uerror("getsockname", Nothing);
+  if (retcode == -1) {
+    win32_maperr(WSAGetLastError());
+    uerror("getsockname", Nothing);
+  }
   return alloc_sockaddr(&addr, addr_len, -1);
 }

--- a/otherlibs/win32unix/sockopt.c
+++ b/otherlibs/win32unix/sockopt.c
@@ -133,8 +133,10 @@ unix_getsockopt_aux(char * name,
   }
 
   if (getsockopt(Socket_val(socket), level, option,
-                 (void *) &optval, &optsize) == -1)
+                 (void *) &optval, &optsize) == -1) {
+    win32_maperr(WSAGetLastError());
     uerror(name, Nothing);
+  }
 
   switch (ty) {
   case TYPE_BOOL:
@@ -199,8 +201,10 @@ unix_setsockopt_aux(char * name,
   }
 
   if (setsockopt(Socket_val(socket), level, option,
-                 (void *) &optval, optsize) == -1)
+                 (void *) &optval, optsize) == -1) {
+    win32_maperr(WSAGetLastError());
     uerror(name, Nothing);
+  }
 
   return Val_unit;
 }


### PR DESCRIPTION
I noticed that the mapping to errno was missing. I suppose it's not intentional.
I think this helps by reporting accurate error messages. If errno was non-zero, I think a previous error message may have been reported instead of the error returned by the function.