### PR TITLE
Refactor type_descriptions in the typing env

### DIFF
--- a/Changes
+++ b/Changes
@@ -337,6 +337,10 @@ Working version
 - #8936: Per-function environment for Emit
   (Greta Yorsh, review by Vincent Laviron and Florian Angeletti)
 
+- #10307: Refactor type_description in the typing env
+  (Nicolas Chataing, review by Takafumi Saikawa, Florian Angeletti and Thomas
+   Refis)
+
 - #10170: Maintain more structural information in type-checking errors
   A mostly-internal change that preserves more information in errors
   during type checking; most significantly, it split the errors from

--- a/ocamldoc/odoc_sig.mli
+++ b/ocamldoc/odoc_sig.mli
@@ -164,7 +164,7 @@ module Analyser :
          by associating the comment found in the parsetree of each constructor/field, if any.*)
       val get_type_kind :
           Odoc_env.env -> (string * Odoc_types.info option) list ->
-            Types.type_kind -> Odoc_type.type_kind
+            Types.type_decl_kind -> Odoc_type.type_kind
 
       (** This function converts a [Types.constructor_arguments] into a
           [Odoc_type.constructor_args], by associating the comment found

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -348,7 +348,7 @@ type type_iterators =
     it_functor_param: type_iterators -> functor_parameter -> unit;
     it_module_type: type_iterators -> module_type -> unit;
     it_class_type: type_iterators -> class_type -> unit;
-    it_type_kind: type_iterators -> type_kind -> unit;
+    it_type_kind: type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: type_iterators -> type_expr -> unit;
     it_type_expr: type_iterators -> type_expr -> unit;
     it_path: Path.t -> unit; }

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -127,7 +127,7 @@ type type_iterators =
     it_functor_param: type_iterators -> functor_parameter -> unit;
     it_module_type: type_iterators -> module_type -> unit;
     it_class_type: type_iterators -> class_type -> unit;
-    it_type_kind: type_iterators -> type_kind -> unit;
+    it_type_kind: type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: type_iterators -> type_expr -> unit;
     it_type_expr: type_iterators -> type_expr -> unit;
     it_path: Path.t -> unit; }
@@ -268,7 +268,7 @@ val set_commu: commutable ref -> commutable -> unit
 (**** Forward declarations ****)
 val print_raw: (Format.formatter -> type_expr -> unit) ref
 
-val iter_type_expr_kind: (type_expr -> unit) -> (type_kind -> unit)
+val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
 
 val iter_type_expr_cstr_args: (type_expr -> unit) ->
   (constructor_arguments -> unit)

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -57,8 +57,11 @@ val initial_safe_string: t
 val initial_unsafe_string: t
 val diff: t -> t -> Ident.t list
 
-type type_descriptions =
-    constructor_description list * label_description list
+type type_descr_kind =
+  (label_description, constructor_description) type_kind
+
+  (* alias for compatibility *)
+type type_descriptions = type_descr_kind
 
 (* For short-paths *)
 type iter_cont

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -229,7 +229,7 @@ end
 type type_declaration =
   { type_params: type_expr list;
     type_arity: int;
-    type_kind: type_kind;
+    type_kind: type_decl_kind;
     type_private: private_flag;
     type_manifest: type_expr option;
     type_variance: Variance.t list;
@@ -243,10 +243,12 @@ type type_declaration =
     type_uid: Uid.t;
  }
 
-and type_kind =
+and type_decl_kind = (label_declaration, constructor_declaration) type_kind
+
+and ('lbl, 'cstr) type_kind =
     Type_abstract
-  | Type_record of label_declaration list  * record_representation
-  | Type_variant of constructor_declaration list
+  | Type_record of 'lbl list * record_representation
+  | Type_variant of 'cstr list
   | Type_open
 
 and record_representation =

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -359,7 +359,7 @@ end
 type type_declaration =
   { type_params: type_expr list;
     type_arity: int;
-    type_kind: type_kind;
+    type_kind: type_decl_kind;
     type_private: private_flag;
     type_manifest: type_expr option;
     type_variance: Variance.t list;
@@ -374,10 +374,12 @@ type type_declaration =
     type_uid: Uid.t;
   }
 
-and type_kind =
+and type_decl_kind = (label_declaration, constructor_declaration) type_kind
+
+and ('lbl, 'cstr) type_kind =
     Type_abstract
-  | Type_record of label_declaration list  * record_representation
-  | Type_variant of constructor_declaration list
+  | Type_record of 'lbl list  * record_representation
+  | Type_variant of 'cstr list
   | Type_open
 
 and record_representation =


### PR DESCRIPTION
For new datatype definitions the typer records "declarations", which are mostly direct information obtained from the program source, and "descriptions", which contains lower-level, computed information on data representation (constructor tags, record field offsets).

Before this PR, the type used to define datatype descriptions was

    type type_descriptions =
      constructor_description list * label_description list

which basically assumes that a datatype may have both constructors and labels, which is nonsensical.

The current refactoring uses a variant instead of a product here, following the existing structure of the 'type_kind' field of declarations. This avoids having to use empty lists in impossible configurations, and makes the code less surprising.