### PR TITLE
Fix #10271 using Env.remove_last_open

### DIFF
--- a/testsuite/tests/typing-gadts/pr10271.ml
+++ b/testsuite/tests/typing-gadts/pr10271.ml
@@ -1,0 +1,38 @@
+(* TEST
+   * expect
+*)
+
+module M = struct
+  type _ rr = Soa : int rr
+  type b = B : 'a rr * 'a -> b
+end
+
+let test =
+  let M.(B (k, v)) = M.(B (Soa, 0)) in
+  match k, v with
+  | M.Soa, soa -> (soa : int)
+[%%expect{|
+module M : sig type _ rr = Soa : int rr type b = B : 'a rr * 'a -> b end
+val test : int = 0
+|}]
+
+let test =
+  let open M in
+  let B (k, v) = B (Soa, 0) in
+  match k, v with
+  | Soa, soa -> (soa : int)
+[%%expect{|
+val test : int = 0
+|}]
+
+type _ ty = Int : int ty
+type dyn = Dyn : 'a ty * 'a -> dyn
+[%%expect{|
+type _ ty = Int : int ty
+type dyn = Dyn : 'a ty * 'a -> dyn
+|}]
+
+let f String.(Dyn (type a) (w, x : a ty * a)) = ignore (x : a)
+[%%expect{|
+val f : dyn -> unit = <fun>
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -177,6 +177,9 @@ module TycompTbl =
           bindings for each name, as in comp_labels and
           comp_constrs. *)
 
+      root: Path.t;
+      (** Only used to check removal of open *)
+
       using: (string -> ('a * 'a) option -> unit) option;
       (** A callback to be applied when a component is used from this
           "open".  This is used to detect unused "opens".  The
@@ -191,7 +194,7 @@ module TycompTbl =
     let add id x tbl =
       {tbl with current = Ident.add id x tbl.current}
 
-    let add_open slot wrap components next =
+    let add_open slot wrap root components next =
       let using =
         match slot with
         | None -> None
@@ -199,8 +202,16 @@ module TycompTbl =
       in
       {
         current = Ident.empty;
-        opened = Some {using; components; next};
+        opened = Some {using; components; root; next};
       }
+
+    let remove_last_open rt tbl =
+      match tbl.opened with
+      | Some {root; next; _} when Path.same rt root ->
+          { next with current =
+            Ident.fold_all Ident.add tbl.current next.current }
+      | _ ->
+          assert false
 
     let rec find_same id tbl =
       try Ident.find_same id tbl.current
@@ -226,7 +237,7 @@ module TycompTbl =
         (Ident.find_all name tbl.current) @
       match tbl.opened with
       | None -> []
-      | Some {using; next; components} ->
+      | Some {using; next; components; root = _} ->
           let rest = find_all ~mark name next in
           let using = if mark then using else None in
           match NameMap.find name components with
@@ -240,7 +251,7 @@ module TycompTbl =
     let rec fold_name f tbl acc =
       let acc = Ident.fold_name (fun _id d -> f d) tbl.current acc in
       match tbl.opened with
-      | Some {using = _; next; components} ->
+      | Some {using = _; next; components; root = _} ->
           acc
           |> NameMap.fold
             (fun _name -> List.fold_right f)
@@ -327,6 +338,14 @@ module IdTbl =
         current = Ident.empty;
         layer = Open {using; root; components; next};
       }
+
+    let remove_last_open rt tbl =
+      match tbl.layer with
+      | Open {root; next; _} when Path.same rt root ->
+          { next with current =
+            Ident.fold_all Ident.add tbl.current next.current }
+      | _ ->
+          assert false
 
     let map f next =
       {
@@ -1312,7 +1331,7 @@ let make_copy_of_types env0 =
     IdTbl.map f env0.values
   in
   (fun env ->
-     if env.values != env0.values then fatal_error "Env.make_copy_of_types";
+     (*if env.values != env0.values then fatal_error "Env.make_copy_of_types";*)
      {env with values; summary = Env_copy_types env.summary}
   )
 
@@ -2106,7 +2125,7 @@ let enter_unbound_module name reason env =
 
 let add_components slot root env0 comps =
   let add_l w comps env0 =
-    TycompTbl.add_open slot w comps env0
+    TycompTbl.add_open slot w root comps env0
   in
   let add w comps env0 = IdTbl.add_open slot w root comps env0 in
   let constrs =
@@ -2153,6 +2172,55 @@ let open_signature slot root env0 : (_,_) result =
   | Ok (Structure_comps comps) ->
     Ok (add_components slot root env0 comps)
 
+let remove_last_open root env0 =
+  let rec filter_summary summary =
+    match summary with
+    | Env_empty -> summary
+    | Env_value (s, id, vd) ->
+        Env_value (filter_summary s, id, vd)
+    | Env_type (s, id, td) ->
+        Env_type (filter_summary s, id, td)
+    | Env_extension (s, id, ec) ->
+        Env_extension (filter_summary s, id, ec)
+    | Env_module (s, id, mp, md) ->
+        Env_module (filter_summary s, id, mp, md)
+    | Env_modtype (s, id, md) ->
+        Env_modtype (filter_summary s, id, md)
+    | Env_class (s, id, cd) ->
+        Env_class (filter_summary s, id, cd)
+    | Env_cltype (s, id, ctd) ->
+        Env_cltype (filter_summary s, id, ctd)
+    | Env_open (s, p) ->
+        if Path.same p root then s else raise Exit
+    | Env_functor_arg (s, id) ->
+        Env_functor_arg (filter_summary s, id)
+    | Env_constraints (s, cstrs) ->
+        Env_constraints (filter_summary s, cstrs)
+    | Env_copy_types s ->
+        Env_copy_types (filter_summary s)
+    | Env_persistent (s, id) ->
+        Env_persistent (filter_summary s, id)
+    | Env_value_unbound (s, n, r) ->
+        Env_value_unbound (filter_summary s, n, r)
+    | Env_module_unbound (s, n, r) ->
+        Env_module_unbound (filter_summary s, n, r)
+  in
+  match filter_summary env0.summary with
+  | summary ->
+      let rem_l tbl = TycompTbl.remove_last_open root tbl
+      and rem tbl = IdTbl.remove_last_open root tbl in
+      Some { env0 with
+             summary;
+             constrs = rem_l env0.constrs;
+             labels = rem_l env0.labels;
+             values = rem env0.values;
+             types = rem env0.types;
+             modtypes = rem env0.modtypes;
+             classes = rem env0.classes;
+             cltypes = rem env0.cltypes;
+             modules = rem env0.modules; }
+  | exception Exit ->
+      None
 
 (* Open a signature from a file *)
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2187,9 +2187,9 @@ let open_signature slot root env0 : (_,_) result =
 let remove_last_open root env0 =
   let rec filter_summary summary =
     match summary with
-      Env_open (s, p) ->
+      Env_empty -> raise Exit
+    | Env_open (s, p) ->
         if Path.same p root then s else raise Exit
-    | Env_empty
     | Env_value _
     | Env_type _
     | Env_extension _

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -316,6 +316,8 @@ val open_signature:
 
 val open_pers_signature: string -> t -> (t, [`Not_found]) result
 
+val remove_last_open: Path.t -> t -> t option
+
 (* Insertion by name *)
 
 val enter_value:

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -56,7 +56,6 @@ val empty: t
 val initial_safe_string: t
 val initial_unsafe_string: t
 val diff: t -> t -> Ident.t list
-val copy_local: from:t -> t -> t
 
 type type_descriptions =
     constructor_description list * label_description list


### PR DESCRIPTION
Define a new function `Env.remove_last_open` to handle local open in pattern matching.

This should subsume both #10273 and #10299
However, the code is interacting with the structure of `Env.t` in a non trivial way, and requires to remove consistence check in `Env.make_copy_of_types`, so I'm not really comfortable with going this route.