### PR TITLE
Fix a few more errno errors in win32unix

### DIFF
--- a/Changes
+++ b/Changes
@@ -160,6 +160,10 @@ Working version
 - #10306: Map WSA error code to Unix errno for sockopt and getsockname
   functions (Antonin Décimo, review by David Allsopp)
 
+- #10309: Properly return EBADF on error in Unix.descr_of_{in,out}_channel on
+  Win32.
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
 ### Tools:
 
 - #10139: Remove confusing navigation bar from stdlib documentation.

--- a/Changes
+++ b/Changes
@@ -161,6 +161,7 @@ Working version
   functions (Antonin Décimo, review by David Allsopp)
 
 - #10309: Properly return EBADF on error in Unix.descr_of_{in,out}_channel on
+  Win32 and map Windows error correctly in Unix.truncate and Unix.ftruncate on
   Win32.
   (David Allsopp, review by Nicolás Ojeda Bär)
 

--- a/otherlibs/win32unix/channels.c
+++ b/otherlibs/win32unix/channels.c
@@ -22,6 +22,7 @@
 #include "unixsupport.h"
 #include <fcntl.h>
 #include <io.h>
+#include <errno.h>
 
 /* Check that the given file descriptor has "stream semantics" and
    can therefore be used as part of buffered I/O.  Things that
@@ -119,7 +120,7 @@ CAMLprim value win_filedescr_of_channel(value vchan)
   HANDLE h;
 
   chan = Channel(vchan);
-  if (chan->fd == -1) uerror("descr_of_channel", Nothing);
+  if (chan->fd == -1) unix_error(EBADF, "descr_of_channel", Nothing);
   h = (HANDLE) _get_osfhandle(chan->fd);
   if (chan->flags & CHANNEL_FLAG_FROM_SOCKET)
     fd = win_alloc_socket((SOCKET) h);

--- a/otherlibs/win32unix/truncate.c
+++ b/otherlibs/win32unix/truncate.c
@@ -32,6 +32,7 @@ static int win_truncate_handle(HANDLE fh, __int64 len)
   fp.QuadPart = len;
   if (SetFilePointerEx(fh, fp, NULL, FILE_BEGIN) == 0 ||
       SetEndOfFile(fh) == 0) {
+    win32_maperr(GetLastError());
     return -1;
   }
   return 0;
@@ -45,7 +46,8 @@ static int win_ftruncate(HANDLE fh, __int64 len)
   /* Duplicate the handle, so we are free to modify its file position. */
   if (DuplicateHandle(currproc, fh, currproc, &dupfh, 0, FALSE,
                       DUPLICATE_SAME_ACCESS) == 0) {
-     return -1;
+    win32_maperr(GetLastError());
+    return -1;
   }
   ret = win_truncate_handle(dupfh, len);
   CloseHandle(dupfh);
@@ -59,6 +61,7 @@ static int win_truncate(WCHAR * path, __int64 len)
   fh = CreateFile(path, GENERIC_WRITE, 0, NULL,
                   OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   if (fh == INVALID_HANDLE_VALUE) {
+    win32_maperr(GetLastError());
     return -1;
   }
   ret = win_truncate_handle(fh, len);

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -149,9 +149,7 @@ static struct error_entry win_error_table[] = {
   { WSAEINTR, 0, EINTR },
   { WSAEINVAL, 0, EINVAL },
   { WSAEMFILE, 0, EMFILE },
-#ifdef WSANAMETOOLONG
-  { WSANAMETOOLONG, 0, ENAMETOOLONG },
-#endif
+  { WSAENAMETOOLONG, 0, ENAMETOOLONG },
 #ifdef WSAENFILE
   { WSAENFILE, 0, ENFILE },
 #endif

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -150,9 +150,6 @@ static struct error_entry win_error_table[] = {
   { WSAEINVAL, 0, EINVAL },
   { WSAEMFILE, 0, EMFILE },
   { WSAENAMETOOLONG, 0, ENAMETOOLONG },
-#ifdef WSAENFILE
-  { WSAENFILE, 0, ENFILE },
-#endif
   { WSAENOTEMPTY, 0, ENOTEMPTY },
   { 0, -1, 0 }
 };


### PR DESCRIPTION
Following on from #10306:
- `win_filedescr_of_channel` (introduced in https://github.com/ocaml/ocaml/commit/f3fab9a2598efa16ac6e28570f19c806bc6874a5 to fix #4098) needed to set `errno` to `EBADF` (cf. `caml_channel_descriptor` in the runtime)
- `Unix.truncate` and `Unix.ftruncate` added in #2023 didn't set `errno`
- While looking at it: all systems are Winsock 2.0 now (cf. #10185), so we can assume that `WSAENAMETOOLONG` is available (I also checked...). It turns out the name was mistyped as well, so `ENAMETOOLONG` would never have been returned.
- Conversely no system has ever defined `WSAENFILE` (and I checked that too!)