### PR TITLE
Restore the --enable-spacetime option (for error)

### DIFF
--- a/configure
+++ b/configure
@@ -890,6 +890,7 @@ enable_ocamltest
 enable_frame_pointers
 enable_naked_pointers
 enable_naked_pointers_checker
+enable_spacetime
 enable_cfi
 enable_installing_source_artifacts
 enable_installing_bytecode_programs
@@ -3178,6 +3179,12 @@ fi
 # Check whether --enable-naked-pointers-checker was given.
 if test "${enable_naked_pointers_checker+set}" = set; then :
   enableval=$enable_naked_pointers_checker;
+fi
+
+
+# Check whether --enable-spacetime was given.
+if test "${enable_spacetime+set}" = set; then :
+  enableval=$enable_spacetime; as_fn_error $? "spacetime profiling was deleted in OCaml 4.12." "$LINENO" 5
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,10 @@ AC_ARG_ENABLE([naked-pointers-checker],
   [AS_HELP_STRING([--enable-naked-pointers-checker],
     [enable the naked pointers checker])])
 
+AC_ARG_ENABLE([spacetime], [],
+  [AC_MSG_ERROR([spacetime profiling was deleted in OCaml 4.12.])],
+  [])
+
 AC_ARG_ENABLE([cfi],
   [AS_HELP_STRING([--disable-cfi],
     [disable the CFI directives in assembly files])])


### PR DESCRIPTION
I'm afraid I missed this in #9948 - `--enable-spacetime` should be an _error_, not ignored (cf. equivalent option in #2289 with `--enable-vmthreads`).

The other removed options do not matter since they have no effect without `--enable-spacetime`.

(spotted while working out multicore's rebase to 4.12)