### PR TITLE
warning cli: tweak single-letter warning deprecation

### DIFF
--- a/Changes
+++ b/Changes
@@ -187,7 +187,7 @@ Working version
 - #8877: Call the linker when ocamlopt is invoked with .o and .a files only.
   (Greta Yorsh, review by Leo White)
 
-- #10207: deprecate single uppercase or lowercase letter in warning
+- #10207, #10312: deprecate single uppercase or lowercase letter in warning
   specifications.
   The form `-w aBcD` was equivalent to `-w -a+b-c+d`.
   It is now deprecated to improve the coexistence with warning mnemonics.

--- a/Changes
+++ b/Changes
@@ -187,10 +187,12 @@ Working version
 - #8877: Call the linker when ocamlopt is invoked with .o and .a files only.
   (Greta Yorsh, review by Leo White)
 
-- #10207, #10312: deprecate single uppercase or lowercase letter in warning
+- #10207, #10312: deprecate consecutive letters in warning
   specifications.
   The form `-w aBcD` was equivalent to `-w -a+b-c+d`.
   It is now deprecated to improve the coexistence with warning mnemonics.
+  However, using isolated single letter is not deprecated to allow the form
+  `-w "A-32..50-45"`.
   (Florian Angeletti, review by Damien Doligez and Gabriel Scherer)
 
 ### Internal/compiler-libs changes:

--- a/testsuite/tests/warnings/deprecated_warning_specs.ml
+++ b/testsuite/tests/warnings/deprecated_warning_specs.ml
@@ -1,0 +1,38 @@
+(* TEST
+   * expect
+*)
+
+(** Deprecated sequences of unsigned letters *)
+
+[@@@warning "fragile-math"]
+[%%expect {|
+Line 3, characters 0-27:
+3 | [@@@warning "fragile-math"]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
+like 'ath', is deprecated.
+Use the equivalent signed form: -f-r-a-g-i-l-e-m-a-t-h.
+Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
+Hint: Did you make a spelling mistake when using a mnemonic name?
+|}]
+
+[@@@warning "ab-cdg+efh"]
+[%%expect {|
+Line 1, characters 0-25:
+1 | [@@@warning "ab-cdg+efh"]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
+like 'fh', is deprecated.
+Use the equivalent signed form: -a-b-c-d-g+e-f-h.
+Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
+|}]
+
+
+(** -w "a+10..." and -w "A-10..." are still supported *)
+[@@@warning "a+1..20+50"]
+[%%expect {|
+|}]
+
+[@@@warning "A-3..14-56"]
+[%%expect {|
+|}]

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -532,7 +532,7 @@ let letter_alert tokens =
     commit_chunk l on_going
   in
   match consecutive_letters with
-  | [] | [] :: _ -> None
+  | [] -> None
   | example :: _  ->
       let pos = { Lexing.dummy_pos with pos_fname = "_none_" } in
       let nowhere = { loc_start=pos; loc_end=pos; loc_ghost=true } in

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -533,7 +533,7 @@ let letter_alert tokens =
   in
   match consecutive_letters with
   | [] | [] :: _ -> None
-  | (example :: _ ) :: _  ->
+  | example :: _  ->
       let pos = { Lexing.dummy_pos with pos_fname = "_none_" } in
       let nowhere = { loc_start=pos; loc_end=pos; loc_ghost=true } in
       let spelling_hint ppf =
@@ -551,13 +551,12 @@ let letter_alert tokens =
       let message =
         Format.asprintf
           "@[<v>@[Setting a warning with a sequence of lowercase \
-           or uppercase letters, like '%c%c',@ is deprecated.@]@ \
+           or uppercase letters,@ like '%a',@ is deprecated.@]@ \
            @[Use the equivalent signed form:@ %t.@]@ \
            @[Hint: Enabling or disabling a warning by its mnemonic name \
            requires a + or - prefix.@]\
            %t@?@]"
-          (Char.lowercase_ascii example)
-          (Char.uppercase_ascii example)
+          Format.(pp_print_list ~pp_sep:(fun _ -> ignore) pp_print_char) example
           (fun ppf -> List.iter (print_token ppf) tokens)
           spelling_hint
       in

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -497,7 +497,14 @@ type token =
   | Num of int * int * modifier
 
 let letter_alert tokens =
-  let deprecated = function Letter (c,None) -> Some c | _ -> None in
+  let deprecated = function
+    | Letter (('a' | 'A'), _) ->
+        (* do not warn on 'a' and 'A' to enable the "a+x+y..." and "A-x-y..."
+           idiom *)
+        None
+    | Letter (c,None) -> Some c
+    | _ -> None
+  in
   let print_char ppf c =
     let lowercase = Char.lowercase_ascii c = c in
     Format.fprintf ppf "%c%c"

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -516,8 +516,8 @@ let letter_alert tokens =
     | Letter(l,None) -> print_warning_char ppf l
   in
   let consecutive_letters =
-    (* we are tracking consecutive unsigned letter in warning strings:
-       for instance in '-w "not-principa"'. *)
+    (* we are tracking sequences of 2 or more consecutive unsigned letters
+       in warning strings, for instance in '-w "not-principa"'. *)
     let commit_chunk l = function
       | [] | [ _ ] -> l
       | _ :: _ :: _ as chunk -> List.rev chunk :: l

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -497,15 +497,14 @@ type token =
   | Num of int * int * modifier
 
 let letter_alert tokens =
-  let deprecated = function
-    | Letter (('a' | 'A'), _) ->
-        (* do not warn on 'a' and 'A' to enable the "a+x+y..." and "A-x-y..."
-           idiom *)
-        None
-    | Letter (c,None) -> Some c
-    | _ -> None
+  let consecutive_letters (l,current) = function
+    | Letter (x, None) -> (l, x::current)
+    | _ ->
+        match current with
+        | [] | [ _ ] -> (l,current)
+        | _ :: _ :: _ -> (List.rev current :: l, [])
   in
-  let print_char ppf c =
+  let print_warning_char ppf c =
     let lowercase = Char.lowercase_ascii c = c in
     Format.fprintf ppf "%c%c"
       (if lowercase then '-' else '+') c
@@ -521,15 +520,25 @@ let letter_alert tokens =
         else
           Format.fprintf ppf "%a%d..%d" print_modifier m a b
     | Letter(l,Some m) -> Format.fprintf ppf "%a%c" print_modifier m l
-    | Letter(l,None) -> print_char ppf l
+    | Letter(l,None) -> print_warning_char ppf l
   in
-  match List.find_map deprecated tokens with
-  | None -> None
-  | Some example ->
+  let consecutive_letters =
+    let l, on_going = List.fold_left consecutive_letters ([],[]) tokens in
+    match on_going with
+    | [] | [_] -> l
+    | _ :: _ :: _ -> List.rev on_going :: l
+  in
+  match consecutive_letters with
+  | [] | [] :: _ -> None
+  | (example :: _ ) :: _  ->
       let pos = { Lexing.dummy_pos with pos_fname = "_none_" } in
       let nowhere = { loc_start=pos; loc_end=pos; loc_ghost=true } in
       let spelling_hint ppf =
-        if List.length (List.filter_map deprecated tokens) >= 5 then
+        let max_seq_len =
+          List.fold_left (fun l x -> max l (List.length x))
+            0 consecutive_letters
+        in
+        if max_seq_len >= 5 then
           Format.fprintf ppf
             "@ @[Hint: Did you make a spelling mistake \
              when using a mnemonic name?@]"
@@ -538,8 +547,8 @@ let letter_alert tokens =
       in
       let message =
         Format.asprintf
-          "@[<v>@[Setting a warning with single lowercase \
-           or uppercase letters, like '%c' or '%c',@ is deprecated.@]@ \
+          "@[<v>@[Setting a warning with a sequence of lowercase \
+           or uppercase letters, like '%c%c',@ is deprecated.@]@ \
            @[Use the equivalent signed form:@ %t.@]@ \
            @[Hint: Enabling or disabling a warning by its mnemonic name \
            requires a + or - prefix.@]\


### PR DESCRIPTION
As suggested by @lpw25 , this PR tweaks the deprecation alert for single letter warnings (e.g `-w Ae`) to restore the support for the `-w a+1+999` idiom (at the non-existent cost of mnemonic names `aa`, `aaa`, ...) .
This is done by setting the non-prefixed `a` and `A` single letter warnings as non-deprecated contrarily to other single letter warning set.