### PR TITLE
No longer mark Windows Unicode runtime as experimental

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,10 @@ Working version
   (Xavier Leroy, reports by Tomasz Kłoczko and R.W.M. Jones, review by Anil
    Madhavapeddy, Stephen Dolan, and Florian Angeletti)
 
+- #10318: Windows Unicode runtime functions are no longer marked as
+  experimental.
+  (Nicolás Ojeda Bär, review by David Allsopp)
+
 ### Code generation and optimizations:
 
 - #9876: do not cache the young_limit GC variable in a processor register.

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -2539,10 +2539,6 @@ use the OCaml run-time system, typically a blocking input/output operation.
 This section contains some general guidelines for writing C stubs that use
 Windows Unicode APIs.
 
-{\bf Note:} This is an experimental feature of OCaml: the set of APIs below, as
-well as their exact semantics are not final and subject to change in future
-releases.
-
 The OCaml system under Windows can be configured at build time in one of two
 modes:
 
@@ -2645,9 +2641,7 @@ of the function to bind:
 The rest of the binding is the same for both platforms:
 
 \begin{verbatim}
-/* The following define is necessary because the API is experimental */
 #define CAML_NAME_SPACE
-#define CAML_INTERNALS
 
 #include <caml/mlvalues.h>
 #include <caml/misc.h>

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -127,6 +127,16 @@ CAMLextern int win_wide_char_to_multi_byte(const wchar_t* s,
                                        char *out,
                                        int outlen);
 
+CAMLextern int caml_win32_isatty(int fd);
+
+CAMLextern void caml_expand_command_line (int *, wchar_t ***);
+
+#endif /* _WIN32 */
+
+#endif /* CAML_INTERNALS */
+
+#ifdef _WIN32
+
 /* [caml_stat_strdup_to_utf16(s)] returns a NULL-terminated copy of [s],
    re-encoded in UTF-16.  The encoding of [s] is assumed to be UTF-8 if
    [caml_windows_unicode_runtime_enabled] is non-zero **and** [s] is valid
@@ -152,12 +162,6 @@ CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
 */
 CAMLextern value caml_copy_string_of_utf16(const wchar_t *s);
 
-CAMLextern int caml_win32_isatty(int fd);
-
-CAMLextern void caml_expand_command_line (int *, wchar_t ***);
-
 #endif /* _WIN32 */
-
-#endif /* CAML_INTERNALS */
 
 #endif /* CAML_OSDEPS_H */


### PR DESCRIPTION
This PR removes the `CAML_INTERNALS` guard around the three functions
```
CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
/* [caml_stat_strdup_of_utf16(s)] returns a NULL-terminated copy of [s],
   re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
   the current Windows code page otherwise.
   The returned string is allocated with [caml_stat_alloc], so it should be free
   using [caml_stat_free].
*/
CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
/* [caml_copy_string_of_utf16(s)] returns an OCaml string containing a copy of
   [s] re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero
   or in the current code page otherwise.
*/
CAMLextern value caml_copy_string_of_utf16(const wchar_t *s);
```
which are used to interface with Windows Unicode APIs by the runtime but can also be used by those writing C bindings (introduced in 4.06!). The manual is adapted accordingly.