### PR TITLE
warning attributes: support for "-missing-mli"

### DIFF
--- a/asmcomp/debug/compute_ranges_intf.ml
+++ b/asmcomp/debug/compute_ranges_intf.ml
@@ -13,6 +13,7 @@
 (**************************************************************************)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
+[@@@ocaml.warning "-missing-mli"]
 
 (** This file defines types that are used to specify the interface of
     [Compute_ranges].  The description of [Compute_ranges] is:

--- a/testsuite/tests/ppx-attributes/warning.ml
+++ b/testsuite/tests/ppx-attributes/warning.ml
@@ -2,6 +2,7 @@
 *)
 
 [@@@ocaml.warning "@A"]
+[@@@ocaml.warning "-missing-mli"]
 [@@@ocaml.alert "++all"]
 
 (* Fixture *)

--- a/testsuite/tests/warnings/w70.ml
+++ b/testsuite/tests/warnings/w70.ml
@@ -1,0 +1,12 @@
+(* TEST
+
+flags = "-w +a"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+compile_only = "true"
+*** check-ocamlc.byte-output
+
+*)
+
+[@@@warning "-missing-mli"]

--- a/testsuite/tests/warnings/w70bis.compilers.reference
+++ b/testsuite/tests/warnings/w70bis.compilers.reference
@@ -1,0 +1,2 @@
+File "w70bis.ml", line 1:
+Warning 70 [missing-mli]: Cannot find interface file.

--- a/testsuite/tests/warnings/w70bis.ml
+++ b/testsuite/tests/warnings/w70bis.ml
@@ -1,0 +1,9 @@
+(* TEST
+
+ flags = "-w +a"
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+compile_only = "true"
+*** check-ocamlc.byte-output
+
+*)


### PR DESCRIPTION
This PR adds support for `[@@@warning "-missing-mli"]` by extending the scope of warning attributes written in an implementation file to the end of the typing of this file.

Previously, the global warning state was restored at the end of the typing of the structure, which happens before we start looking for mli files.