### PR TITLE
Add colors to type clash error message

### DIFF
--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -492,8 +492,8 @@ module Functor_suberror = struct
       let g = With_shorthand.definition_of_argument g in
       let e = With_shorthand.definition e in
       Format.dprintf
-        "Modules do not match:@ @[%t@]@;<1 -2>\
-         is not included in@ @[%t@]%t"
+        "Modules do not match:@ @[@{<clash>%t@}@]@;<1 -2>\
+         is not included in@ @[@{<clash>%t@}@]%t"
         g e (more ())
 
     (** Specialized to avoid introducing shorthand names
@@ -506,8 +506,8 @@ module Functor_suberror = struct
         | Types.Named(_, mty) -> dmodtype mty
       in
       Format.dprintf
-        "Modules do not match:@ @[%t@]@;<1 -2>\
-         is not included in@ @[%t@]%t"
+        "Modules do not match:@ @[@{<clash>%t@}@]@;<1 -2>\
+         is not included in@ @[@{<clash>%t@}@]%t"
         (dmodtype mty) e (more ())
 
 
@@ -657,14 +657,14 @@ let core env id x =
 
 let missing_field ppf item =
   let id, loc, kind =  Includemod.item_ident_name item in
-  Format.fprintf ppf "The %s `%a' is required but not provided%a"
+  Format.fprintf ppf "The %s `@{<clash>%a@}' is required but not provided%a"
     (Includemod.kind_of_field_desc kind) Printtyp.ident id
     (show_loc "Expected declaration") loc
 
 let module_types {Err.got=mty1; expected=mty2} =
   Format.dprintf
     "@[<hv 2>Modules do not match:@ \
-     %a@;<1 -2>is not included in@ %a@]"
+      @{<clash>%a@}@;<1 -2>is not included in@ @{<clash>%a@}@]"
     !Oprint.out_module_type (Printtyp.tree_of_modtype mty1)
     !Oprint.out_module_type (Printtyp.tree_of_modtype mty2)
 
@@ -746,8 +746,8 @@ and functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
   let main =
     Format.dprintf
       "@[<hv 2>Modules do not match:@ \
-       @[functor@ %t@ -> ...@]@;<1 -2>is not included in@ \
-       @[functor@ %t@ -> ...@]@]"
+       @[functor@ @{<clash>%t@}@ -> ...@]@;<1 -2>is not included in@ \
+       @[functor@ @{<clash>%t@}@ -> ...@]@]"
       actual expected
   in
   let msgs = dwith_context ctx main :: before in

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2056,7 +2056,7 @@ let type_path_expansion ppf = function
 let rec trace fst txt ppf = function
   | {Errortrace.got; expected} :: rem ->
       if not fst then fprintf ppf "@,";
-      fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@]%a"
+      fprintf ppf "@[Type@;<1 2>@{<clash>%a@}@ %s@;<1 2>@{<clash>%a@}@]%a"
        type_expansion got txt type_expansion expected
        (trace false txt) rem
   | _ -> ()
@@ -2357,7 +2357,7 @@ let head_error_printer mode txt_got txt_but = function
   | None -> ignore
   | Some d ->
       let d = Errortrace.map_diff (trees_of_type_expansion mode) d in
-      dprintf "%t@;<1 2>%a@ %t@;<1 2>%a"
+      dprintf "%t@;<1 2>@{<clash>%a@}@ %t@;<1 2>@{<clash>%a@}"
         txt_got type_expansion d.Errortrace.got
         txt_but type_expansion d.Errortrace.expected
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -654,7 +654,8 @@ module Color = struct
     error: style list;
     warning: style list;
     loc: style list;
-    hint:style list;
+    hint: style list;
+    clash: style list;
   }
 
   let default_styles = {
@@ -662,6 +663,7 @@ module Color = struct
     error = [Bold; FG Red];
     loc = [Bold];
     hint = [Bold; FG Blue];
+    clash = [Bold];
   }
 
   let cur_styles = ref default_styles
@@ -675,6 +677,7 @@ module Color = struct
     | Format.String_tag "warning" -> (!cur_styles).warning
     | Format.String_tag "loc" -> (!cur_styles).loc
     | Format.String_tag "hint" -> (!cur_styles).hint
+    | Format.String_tag "clash" -> (!cur_styles).clash
     | Style s -> s
     | _ -> raise Not_found
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -460,6 +460,7 @@ module Color : sig
     warning: style list;
     loc: style list;
     hint: style list;
+    clash: style list;
   }
 
   val default_styles: styles


### PR DESCRIPTION
## Problem

Currently OCaml messages lacks visual clues on type clashes which forces the user to actually read the error message to understand what was expected and what is received.

## Solution

By making the received type red and the expected type green, it highlights the important parts of the message and what should be addressed. Received is red because it is the wrong type, and expected is green because it is the right type.

Note that the arrow pointing out to the location is already red to give the same kind of visual clue.

## Example

![images with error message showing received type with color red and expected type with color green](https://user-images.githubusercontent.com/3393115/113587658-7eb92d80-9605-11eb-86f5-aaac0a854d78.png)
