### PR TITLE
replace backtracking trail by a normal ref

### DIFF
--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -84,7 +84,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let trail = s_ref (ref Unchanged)
+let trail = s_table ref Unchanged
 
 let log_change ch =
   let r' = ref Unchanged in


### PR DESCRIPTION
The trail used for backtracking in `Btype` uses currently a weak table.
At the last developer meeting it was suggested to avoid this structure for forward compatibility.
Since the goal of this weak table was only to minimize the cost when there is no active snapshot, and since the type checker is now creating a lot of snapshots meaning that this situation is becoming exceptional, it seems simpler to revert to using a normal reference here.