### PR TITLE
Fix realpath test

### DIFF
--- a/testsuite/tests/lib-unix/realpath/test.ml
+++ b/testsuite/tests/lib-unix/realpath/test.ml
@@ -7,8 +7,8 @@ include unix
 
 let main () =
   (* On Windows this tests that we strip \\?\ *)
-  let cwd = String.lowercase_ascii (Sys.getcwd ()) in
-  assert (cwd = String.lowercase_ascii (Unix.realpath (Sys.getcwd ())));
+  let cwd = Sys.getcwd () in
+  assert (String.lowercase_ascii cwd = String.lowercase_ascii (Unix.realpath cwd));
   Unix.mkdir "test_dir" 0o755;
   close_out (open_out "test_dir/test_file");
   let p0 = Unix.realpath "test_dir/.//test_file" in

--- a/testsuite/tests/lib-unix/realpath/test.ml
+++ b/testsuite/tests/lib-unix/realpath/test.ml
@@ -8,7 +8,7 @@ include unix
 let main () =
   (* On Windows this tests that we strip \\?\ *)
   let cwd = String.lowercase_ascii (Sys.getcwd ()) in
-  assert (cwd = String.lowercase_ascii (Unix.realpath cwd));
+  assert (cwd = String.lowercase_ascii (Unix.realpath (Sys.getcwd ())));
   Unix.mkdir "test_dir" 0o755;
   close_out (open_out "test_dir/test_file");
   let p0 = Unix.realpath "test_dir/.//test_file" in


### PR DESCRIPTION
I get an error on the realpath test if the path to my sources contains uppercase letters. I assume that it is unintended.

Cc @dra27 @dbuenzli who worked on this test.