### PR TITLE
Generate lambda/runtimedef.ml correctly in Swedish

### DIFF
--- a/Changes
+++ b/Changes
@@ -280,6 +280,10 @@ Working version
   socklen_t detection on Windows.
   (Antonin Décimo, review by David Allsopp and Sébastien Hinderer)
 
+- #10332, #10333: Generate lambda/runtimedef.ml correctly in Swedish locale.
+  (the letter 'w' is not included in '[a-z]' in sv_SE.UTF-8)
+  (David Allsopp, report by Anders Jackson, review by Gabriel Scherer)
+
 ### Bug fixes:
 
 * #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section

--- a/Changes
+++ b/Changes
@@ -282,7 +282,8 @@ Working version
 
 - #10332, #10333: Generate lambda/runtimedef.ml correctly in Swedish locale.
   (the letter 'w' is not included in '[a-z]' in sv_SE.UTF-8)
-  (David Allsopp, report by Anders Jackson, review by Gabriel Scherer)
+  (David Allsopp, report by Anders Jackson, review by Florian Angeletti and
+   Gabriel Scherer)
 
 ### Bug fixes:
 

--- a/lambda/generate_runtimedef.sh
+++ b/lambda/generate_runtimedef.sh
@@ -15,6 +15,9 @@
 #*                                                                        *
 #**************************************************************************
 
+# #10332: the meaning of character range a-z depends on the locale, so force C
+#         locale throughout.
+export LC_ALL=C
 echo 'let builtin_exceptions = [|'
 tr -d '\r' < "$1" | sed -n -e 's|.*/\* \("[A-Za-z_]*"\) \*/$|  \1;|p'
 echo '|]'

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -135,7 +135,7 @@ warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
 	 echo "% when a new warning is documented.";\
 	 echo "%";\
 	 $(SET_LD_PATH) $(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
-	 | sed -e 's/^ *\([0-9][0-9]*\) *\[\([a-z][a-z-]*\)\]\(.*\)/\\item[\1 "\2"] \3/' \
+	 | LC_ALL=C sed -e 's/^ *\([0-9][0-9]*\) *\[\([a-z][a-z-]*\)\]\(.*\)/\\item[\1 "\2"] \3/' \
                -e 's/^ *\([0-9A-Z][0-9]*\) *\([^]].*\)/\\item[\1] \2/'\
 	) >$@
 #	sed --inplace is not portable, emulate


### PR DESCRIPTION
Given #8985, I'm surprised this hasn't come up already - the problem is very similar.

Fixes #10332.