### PR TITLE
Fix an assertion in gc_ctrl.c that's wrong in 32-bit builds

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -155,7 +155,8 @@ static value heap_stats (int returnstats)
           ++ fragments;
           CAMLassert (prev_hp == NULL
                       || Color_hp (prev_hp) != Caml_blue
-                      || cur_hp == (header_t *) caml_gc_sweep_hp);
+                      || cur_hp == (header_t *) caml_gc_sweep_hp
+                      || Wosize_hp (prev_hp) == Max_wosize);
         }else{
           if (caml_gc_phase == Phase_sweep
               && cur_hp >= (header_t *) caml_gc_sweep_hp){


### PR DESCRIPTION
On 32-bit runtimes, the following sequence of events is possible, and seems to have been happening during CI:

  - ~20 megabytes of memory is allocated and then becomes garbage
  - The garbage is swept, leaving ~20 MB of contiguous free space (more than Max_wosize, on 32-bit)
  - The free space is split into Max_wosize-sized chunks, plus a smaller tail
  - Allocations continue, taking memory from the end of the smaller tail (where best-fit prefers to allocate from)
  - All but one word of the smaller tail is allocated, leaving a 1-word white fragment at its beginning

We now have a Max_wosize-sized free block (coloured Caml_blue), followed by a 1-word fragment (coloured Caml_white). The fragment can't be merged into the free block, because this would take its size over Max_wosize.

There's no problem with this, and I don't think anything goes wrong in the GC. However, the assertions in `heap_stats` didn't consider this case, so incorrectly fail when it occurs.