### PR TITLE
Restore testing manual build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,23 @@ jobs:
     - name: Install
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh install
+    - name: Check for manual changes
+      id: manual
+      run: >-
+        tools/ci/actions/check-manual-modified.sh
+        '${{ github.event_name }}'
+        '${{ github.event.pull_request.base.ref }}'
+        '${{ github.event.pull_request.base.sha }}'
+        '${{ github.event.pull_request.head.ref }}'
+        '${{ github.event.pull_request.head.sha }}'
+        '${{ github.event.ref }}'
+        '${{ github.event.before }}'
+        '${{ github.event.ref }}'
+        '${{ github.event.after }}'
     - name: Build the manual
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual
+      if: steps.manual.outputs.changed == 'true'
     - name: Other checks
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         '${{ github.event.before }}'
         '${{ github.event.ref }}'
         '${{ github.event.after }}'
+        '${{ github.event.repository.full_name }}'
     - name: Build the manual
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Packages
       run: |
-        sudo apt-get update -y && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended
+        sudo apt-get update -y && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended hevea sass
   # Ensure that make distclean can be run from an empty tree
     - name: distclean
       run: |
@@ -66,6 +66,9 @@ jobs:
     - name: Install
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh install
+    - name: Build the manual
+      run: |
+        MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh manual
     - name: Other checks
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh other-checks

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -45,5 +45,5 @@ clean:
 	$(MAKE) -C tests  clean
 
 .PHONY: distclean
-distclean:
+distclean: clean
 	$(MAKE) -C src distclean

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -87,7 +87,9 @@ text: files latex_files
 
 
 all:
-	$(MAKE) html text info manual
+	$(MAKE) html
+	$(MAKE) text
+	$(MAKE) info
 	$(MAKE) manual
 	$(MAKE) index
 	$(MAKE) manual

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -165,3 +165,7 @@ clean:
 	                   manual.hmanual manual.hmanual.kwd manual.css
 	cd textman; rm -f manual.txt *.haux *.hind *.htoc
 	cd infoman; rm -f ocaml.info ocaml.info-*  *.haux *.hind *.info*.gz
+
+.PHONY: distclean
+distclean:
+	$(MAKE) -C html_processing distclean

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -167,5 +167,5 @@ clean:
 	cd infoman; rm -f ocaml.info ocaml.info-*  *.haux *.hind *.info*.gz
 
 .PHONY: distclean
-distclean:
+distclean: clean
 	$(MAKE) -C html_processing distclean

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -161,7 +161,7 @@ clean:
 	$(MAKE) -C tutorials clean
 	$(MAKE) -C html_processing clean
 	-rm -f texstuff/*
-	cd htmlman; rm -rf libref compilerlibref index.html \
-	manual*.html *.haux *.hind *.svg
-	cd textman; rm -f manual.txt *.haux *.hind
-	cd infoman; rm -f ocaml.info ocaml.info-*  *.haux *.hind
+	cd htmlman; rm -rf libref compilerlibref *.htoc *.html *.haux *.hind *.svg \
+	                   manual.hmanual manual.hmanual.kwd manual.css
+	cd textman; rm -f manual.txt *.haux *.hind *.htoc
+	cd infoman; rm -f ocaml.info ocaml.info-*  *.haux *.hind *.info*.gz

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -77,6 +77,9 @@ img: $(WEBDIRAPI)/search_icon.svg $(WEBDIRAPI)/favicon.ico $(WEBDIRCOMP)/search_
 clean:
 	rm -rf $(WEBDIR) src/.merlin _build
 
+.PHONY: distclean
+distclean:: clean
+
 distclean::
 	rm -rf .sass-cache
 

--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -20,58 +20,59 @@ all: css js img
 	$(DUNE) exec --root=. src/process_api.exe overwrite $(DBG)
 	$(DUNE) exec --root=. src/process_api.exe compiler overwrite $(DBG)
 
-$(WEBDIR):
-	mkdir -p $(WEBDIRMAN)
-	mkdir -p $(WEBDIRCOMP)
+$(WEBDIR)/%:
+	mkdir -p $@
 
-$(WEBDIRMAN)/manual.css: scss/_common.scss scss/manual.scss $(WEBDIR)
+$(WEBDIRMAN)/manual.css: scss/_common.scss scss/manual.scss | $(WEBDIRMAN)
 	sass scss/manual.scss > $(WEBDIRMAN)/manual.css
 
-$(WEBDIRAPI)/style.css: scss/_common.scss scss/style.scss $(WEBDIR)
+$(WEBDIRAPI)/style.css: scss/_common.scss scss/style.scss | $(WEBDIRAPI)
 	sass scss/style.scss > $(WEBDIRAPI)/style.css
 	cp $(WEBDIRAPI)/style.css $(WEBDIRCOMP)/style.css
 
 css: $(WEBDIRMAN)/manual.css $(WEBDIRAPI)/style.css
 
-# Just copy the JS files
+# Just copy the JS files:
+#
 JS_FILES0 := scroll.js navigation.js
 JS_FILES1 := $(JS_FILES0) search.js
 JS_FILES := $(addprefix $(WEBDIRAPI)/, $(JS_FILES1)) $(addprefix $(WEBDIRCOMP)/, $(JS_FILES1)) $(addprefix $(WEBDIRMAN)/, $(JS_FILES0))
 
 # There must be a more clever way
-$(WEBDIRAPI)/%.js: js/%.js
+$(WEBDIRAPI)/%.js: js/%.js | $(WEBDIRAPI)
 	cp $< $@
 
-$(WEBDIRMAN)/%.js: js/%.js
+$(WEBDIRMAN)/%.js: js/%.js | $(WEBDIRMAN)
 	cp $< $@
 
-$(WEBDIRCOMP)/%.js: js/%.js
+$(WEBDIRCOMP)/%.js: js/%.js | $(WEBDIRCOMP)
 	cp $< $@
 
-js: $(WEBDIR) $(JS_FILES)
+js: $(JS_FILES)
 
 # download images for local use
 SEARCH := search_icon.svg
-$(WEBDIRAPI)/search_icon.svg: $(WEBDIR)
+$(WEBDIRAPI)/search_icon.svg: | $(WEBDIRAPI)
 	curl "https://ocaml.org/img/search.svg" > $(WEBDIRAPI)/$(SEARCH)
-	cp $(WEBDIRAPI)/$(SEARCH) $(WEBDIRCOMP)/$(SEARCH)
+
+$(WEBDIRCOMP)/%: $(WEBDIRAPI)/% | $(WEBDIRCOMP)
+	cp $< $@
+
+$(WEBDIRMAIN)/%: $(WEBDIRAPI/% | $(WEBDIRAPI)
+	cp $< $@
 
 LOGO := colour-logo.svg
-$(WEBDIRAPI)/colour-logo.svg: $(WEBDIR)
+$(WEBDIRAPI)/colour-logo.svg: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
 	curl "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/SVG/colour-logo.svg" > $(WEBDIRAPI)/$(LOGO)
-	cp $(WEBDIRAPI)/$(LOGO) $(WEBDIRMAN)/$(LOGO)
-	cp $(WEBDIRAPI)/$(LOGO) $(WEBDIRCOMP)/$(LOGO)
 
 ICON := favicon.ico
-$(WEBDIRAPI)/favicon.ico: $(WEBDIR)
+$(WEBDIRAPI)/favicon.ico: | $(WEBDIRAPI) $(WEBDIRMAN) $(WEBDIRCOMP)
 	curl "https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/Favicon/32x32.ico" > $(WEBDIRAPI)/$(ICON)
-	cp $(WEBDIRAPI)/$(ICON) $(WEBDIRMAN)/$(ICON)
-	cp $(WEBDIRAPI)/$(ICON) $(WEBDIRCOMP)/$(ICON)
 
 IMG_FILES0 := colour-logo.svg
 IMG_FILES := $(addprefix $(WEBDIRAPI)/, $(IMG_FILES0)) $(addprefix $(WEBDIRCOMP)/, $(IMG_FILES0)) $(addprefix $(WEBDIRMAN)/, $(IMG_FILES0)) 
 
-img: $(WEBDIR) $(WEBDIRAPI)/search_icon.svg $(WEBDIRAPI)/favicon.ico $(WEBDIRCOMP)/search_icon.svg $(WEBDIRCOMP)/favicon.ico $(IMG_FILES)
+img: $(WEBDIRAPI)/search_icon.svg $(WEBDIRAPI)/favicon.ico $(WEBDIRCOMP)/search_icon.svg $(WEBDIRCOMP)/favicon.ico $(IMG_FILES)
 
 clean:
 	rm -rf $(WEBDIR) src/.merlin _build

--- a/tools/ci/actions/check-manual-modified.sh
+++ b/tools/ci/actions/check-manual-modified.sh
@@ -17,8 +17,8 @@ set -e
 
 # Test whether the manual/ has been touched by this PR.
 
-if [[ $1 = 'push' ]]; then
-  # Always build the manual for pushes
+if [[ $1 = 'push' && ${10} = 'ocaml/ocaml' ]]; then
+  # Always build the manual for pushes to ocaml/ocaml
   result=true
 else
   # We need all the commits in the PR to be available

--- a/tools/ci/actions/check-manual-modified.sh
+++ b/tools/ci/actions/check-manual-modified.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                 David Allsopp, OCaml Labs, Cambridge.                  *
+#*                                                                        *
+#*   Copyright 2021 David Allsopp Ltd.                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+set -e
+
+# Test whether the manual/ has been touched by this PR.
+
+if [[ $1 = 'push' ]]; then
+  # Always build the manual for pushes
+  result=true
+else
+  # We need all the commits in the PR to be available
+  . tools/ci/actions/deepen-fetch.sh
+  if git diff "$MERGE_BASE..$PR_HEAD" --name-only --exit-code \
+       -- manual/* > /dev/null; then
+    result=false
+  else
+    result=true
+  fi
+fi
+
+echo "::set-output name=changed::$result"

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -111,6 +111,7 @@ Checks () {
   # check that the 'clean' target also works
   $MAKE clean
   $MAKE -C manual clean
+  $MAKE -C manual distclean
   # check that the `distclean` target definitely cleans the tree
   $MAKE distclean
   # Check the working tree is clean

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -136,7 +136,6 @@ EOF
 
 BuildManual () {
   $MAKE -C manual/src/html_processing duniverse
-  $MAKE -C manual manual
   $MAKE -C manual web
 }
 

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -136,6 +136,7 @@ EOF
 
 BuildManual () {
   $MAKE -C manual/src/html_processing duniverse
+  $MAKE -C manual manual
   $MAKE -C manual web
 }
 

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -133,6 +133,12 @@ EOF
 
 }
 
+BuildManual () {
+  $MAKE -C manual/src/html_processing duniverse
+  $MAKE -C manual manual
+  $MAKE -C manual web
+}
+
 # ReportBuildStatus accepts an exit code as a parameter (defaults to 1) and also
 # instructs GitHub Actions to set build-status to 'failed' on non-zero exit or
 # 'success' otherwise.
@@ -168,6 +174,7 @@ build) Build;;
 test) Test;;
 api-docs) API_Docs;;
 install) Install;;
+manual) BuildManual;;
 other-checks) Checks;;
 basic-compiler) BasicCompiler;;
 *) echo "Unknown CI instruction: $1"


### PR DESCRIPTION
As noted in https://github.com/ocaml/ocaml/pull/10333#issuecomment-817668908

Plugging this into GitHub actions revealed various clean targets which weren't working (properly) and also various parts of the build system which didn't work in parallel (building with `-j1` is very slow - at least it was faster to fix the `Makefile`s which weren't parallel rather than working out how to build the API docs in parallel and then just assemble the manual serially)

