### PR TITLE
Normalize type_expr nodes on access

### DIFF
--- a/.depend
+++ b/.depend
@@ -538,6 +538,7 @@ typing/ctype.cmi : \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    typing/btype.cmi \
     parsing/asttypes.cmi
 typing/datarepr.cmo : \
     typing/types.cmi \
@@ -1722,6 +1723,7 @@ typing/types.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/local_store.cmi \
     utils/identifiable.cmi \
     typing/ident.cmi \
     utils/config.cmi \
@@ -1735,6 +1737,7 @@ typing/types.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/local_store.cmx \
     utils/identifiable.cmx \
     typing/ident.cmx \
     utils/config.cmx \
@@ -6399,6 +6402,7 @@ toplevel/byte/topeval.cmi : \
     toplevel/topcommon.cmi \
     parsing/parsetree.cmi
 toplevel/byte/topmain.cmo : \
+    typing/types.cmi \
     toplevel/byte/trace.cmi \
     toplevel/toploop.cmi \
     toplevel/byte/topeval.cmi \
@@ -6416,6 +6420,7 @@ toplevel/byte/topmain.cmo : \
     utils/clflags.cmi \
     toplevel/byte/topmain.cmi
 toplevel/byte/topmain.cmx : \
+    typing/types.cmx \
     toplevel/byte/trace.cmx \
     toplevel/toploop.cmx \
     toplevel/byte/topeval.cmx \

--- a/Changes
+++ b/Changes
@@ -451,7 +451,8 @@ OCaml 4.13.0
   One should now use accessors such as get_desc and get_level to access fields
   of type_expr, rather than calling manually Btype.repr (which is now hidden
   in Types.Transient_expr).
-  (Jacques Garrigue and Takafumi Saikawa)
+  (Jacques Garrigue and Takafumi Saikawa,
+   review by Florian Angeletti and Gabriel Radanne)
 
 - #10358: Use a hash table for the load path.
   (Leo White, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -447,6 +447,12 @@ OCaml 4.13.0
 - #10327: Add a subdirectories variable and a copy action to ocamltest
   (Sébastien Hinderer, review by David Allsopp)
 
+* #10337: Normalize type_expr nodes on access
+  One should now use accessors such as get_desc and get_level to access fields
+  of type_expr, rather than calling manually Btype.repr (which is now hidden
+  in Types.Transient_expr).
+  (Jacques Garrigue and Takafumi Saikawa)
+
 - #10358: Use a hash table for the load path.
   (Leo White, review by Gabriel Scherer)
 

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -72,7 +72,6 @@ command_line.cmo : \
     debugger_lexer.cmi \
     debugger_config.cmi \
     debugcom.cmi \
-    ../typing/ctype.cmi \
     checkpoints.cmi \
     breakpoints.cmi \
     command_line.cmi
@@ -110,7 +109,6 @@ command_line.cmx : \
     debugger_lexer.cmx \
     debugger_config.cmx \
     debugcom.cmx \
-    ../typing/ctype.cmx \
     checkpoints.cmx \
     breakpoints.cmx \
     command_line.cmi

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -623,7 +623,7 @@ let instr_break ppf lexbuf =
         in
         begin try
           let (v, ty) = Eval.expression !selected_event env expr in
-          match (Ctype.repr ty).desc with
+          match get_desc ty with
           | Tarrow _ ->
               add_breakpoint_after_pc (Remote_value.closure_code v)
           | _ ->

--- a/debugger/eval.ml
+++ b/debugger/eval.ml
@@ -112,7 +112,7 @@ let rec expression event env = function
       end
   | E_item(arg, n) ->
       let (v, ty) = expression event env arg in
-      begin match (Ctype.repr(Ctype.expand_head_opt env ty)).desc with
+      begin match get_desc (Ctype.expand_head_opt env ty) with
         Ttuple ty_list ->
           if n < 1 || n > List.length ty_list
           then raise(Error(Tuple_index(ty, List.length ty_list, n)))
@@ -142,7 +142,7 @@ let rec expression event env = function
       end
   | E_field(arg, lbl) ->
       let (v, ty) = expression event env arg in
-      begin match (Ctype.repr(Ctype.expand_head_opt env ty)).desc with
+      begin match get_desc (Ctype.expand_head_opt env ty) with
         Tconstr(path, _, _) ->
           let tydesc = Env.find_type path env in
           begin match tydesc.type_kind with

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -242,10 +242,10 @@ let init_shape id modl =
       [] -> []
     | Sig_value(subid, {val_kind=Val_reg; val_type=ty; val_loc=loc},_) :: rem ->
         let init_v =
-          match Ctype.expand_head env ty with
-            {desc = Tarrow(_,_,_,_)} ->
+          match get_desc (Ctype.expand_head env ty) with
+            Tarrow(_,_,_,_) ->
               const_int 0 (* camlinternalMod.Function *)
-          | {desc = Tconstr(p, _, _)} when Path.same p Predef.path_lazy_t ->
+          | Tconstr(p, _, _) when Path.same p Predef.path_lazy_t ->
               const_int 1 (* camlinternalMod.Lazy *)
           | _ ->
               let not_a_function =

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -258,7 +258,7 @@ module Analyser =
 
         | Typedtree.Tpat_construct (_, cons_desc, _, _) when
             (* we give a name to the parameter only if it is unit *)
-            (match cons_desc.cstr_res.desc with
+            (match get_desc cons_desc.cstr_res with
               Tconstr (p, _, _) ->
                 Path.same p Predef.path_unit
             | _ ->
@@ -585,7 +585,7 @@ module Analyser =
               with Not_found -> raise (Failure (Odoc_messages.method_type_not_found current_class_name label))
             in
             let real_type =
-              match met_type.Types.desc with
+              match get_desc met_type with
               Tarrow (_, _, t, _) ->
                 t
             |  _ ->
@@ -627,7 +627,7 @@ module Analyser =
             with Not_found -> raise (Failure (Odoc_messages.method_not_found_in_typedtree complete_name))
           in
           let real_type =
-            match exp.exp_type.desc with
+            match get_desc exp.exp_type with
               Tarrow (_, _, t,_) ->
                 t
             |  _ ->

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -492,22 +492,27 @@ let is_optional = Btype.is_optional
 let label_name = Btype.label_name
 
 let remove_option typ =
-  let rec iter t =
+  let open Types in
+  let rec trim t =
     match t with
-    | Types.Tconstr(path, [ty], _) when Path.same path Predef.path_option -> ty.Types.desc
-    | Types.Tconstr _
-    | Types.Tvar _
-    | Types.Tunivar _
-    | Types.Tpoly _
-    | Types.Tarrow _
-    | Types.Ttuple _
-    | Types.Tobject _
-    | Types.Tfield _
-    | Types.Tnil
-    | Types.Tvariant _
-    | Types.Tpackage _ -> t
-    | Types.Tlink t2 -> iter t2.Types.desc
-    | Types.Tsubst _ -> assert false
+    | Tconstr(path, [ty], _)
+      when Path.same path Predef.path_option -> get_desc ty
+    | Tconstr _
+    | Tvar _
+    | Tunivar _
+    | Tpoly _
+    | Tarrow _
+    | Ttuple _
+    | Tobject _
+    | Tfield _
+    | Tnil
+    | Tvariant _
+    | Tpackage _ -> t
+    | Tlink t2 -> trim (get_desc t2)
+    | Tsubst _ -> assert false
   in
-  Types.Private_type_expr.create (iter typ.Types.desc)
-    ~level:typ.Types.level ~scope:typ.Types.scope ~id:typ.Types.id
+  Transient_expr.type_expr
+    (Transient_expr.create (trim (get_desc typ))
+       ~level:(get_level typ)
+       ~scope:(get_scope typ)
+       ~id:(get_id typ))

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -81,27 +81,31 @@ let string_of_module_type ?code ?(complete=false) t =
    from the signatures. Used when we don't want to print a too long class type.*)
 let simpl_class_type t =
   let rec iter t =
+    let open Types in
     match t with
-      Types.Cty_constr _ -> t
-    | Types.Cty_signature cs ->
+      Cty_constr _ -> t
+    | Cty_signature cs ->
         (* we delete vals and methods in order to not print them when
            displaying the type *)
       let tself =
-        let t = cs.Types.csig_self in
-        let t' = Types.Private_type_expr.create Types.Tnil
+        let t = cs.csig_self in
+        let t' = Transient_expr.create Tnil
             ~level:0 ~scope:Btype.lowest_level ~id:0 in
-        let desc = Types.Tobject (t', ref None) in
-        Types.Private_type_expr.create desc
-          ~level:t.Types.level ~scope:t.Types.scope ~id:t.Types.id
+        let desc =
+          Tobject (Transient_expr.type_expr t', ref None) in
+        Transient_expr.create desc
+          ~level:(get_level t)
+          ~scope:(get_scope t)
+          ~id:(get_id t)
       in
-        Types.Cty_signature { Types.csig_self = tself;
-                              csig_vars = Types.Vars.empty ;
-                              csig_concr = Types.Concr.empty ;
+        Cty_signature { csig_self = Transient_expr.type_expr tself;
+                              csig_vars = Vars.empty ;
+                              csig_concr = Concr.empty ;
                               csig_inher = []
                              }
-    | Types.Cty_arrow (l, texp, ct) ->
+    | Cty_arrow (l, texp, ct) ->
         let new_ct = iter ct in
-        Types.Cty_arrow (l, texp, new_ct)
+        Cty_arrow (l, texp, new_ct)
   in
   iter t
 

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -341,7 +341,7 @@ module Analyser =
 
 
     let manifest_structure env name_comment_list type_expr =
-      match type_expr.desc with
+      match get_desc type_expr with
       | Tobject (fields, _) ->
         let f (field_name, _, type_expr) =
           let comment_opt =

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -30,7 +30,7 @@ let string_of_variance t (co,cn) =
   else
     ""
 let rec is_arrow_type t =
-  match t.Types.desc with
+  match Types.get_desc t with
     Types.Tarrow _ -> true
   | Types.Tlink t2 -> is_arrow_type t2
   | Types.Ttuple _
@@ -43,7 +43,7 @@ let raw_string_of_type_list sep type_list =
   let buf = Buffer.create 256 in
   let fmt = Format.formatter_of_buffer buf in
   let rec need_parent t =
-    match t.Types.desc with
+    match Types.get_desc t with
       Types.Tarrow _ | Types.Ttuple _ -> true
     | Types.Tlink t2 -> need_parent t2
     | Types.Tconstr _

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -72,7 +72,7 @@ let update_value_parameters_text v =
    [parameter_list_from_arrows t = [ a ; b ]] if t = a -> b -> c.*)
 let parameter_list_from_arrows typ =
   let rec iter t =
-    match t.Types.desc with
+    match Types.get_desc t with
       Types.Tarrow (l, t1, t2, _) ->
         (l, t1) :: (iter t2)
     | Types.Tlink texp
@@ -102,7 +102,7 @@ let dummy_parameter_list typ =
   Printtyp.mark_loops typ;
   let liste_param = parameter_list_from_arrows typ in
   let rec iter (label, t) =
-    match t.Types.desc with
+    match Types.get_desc t with
     | Types.Ttuple l ->
         let open Asttypes in
         if label = Nolabel then
@@ -129,7 +129,7 @@ let dummy_parameter_list typ =
 (** Return true if the value is a function, i.e. has a functional type.*)
 let is_function v =
   let rec f t =
-    match t.Types.desc with
+    match Types.get_desc t with
       Types.Tarrow _ ->
         true
     | Types.Tlink t ->

--- a/testsuite/tests/typing-gadts/omega07.ml
+++ b/testsuite/tests/typing-gadts/omega07.ml
@@ -904,9 +904,9 @@ val suc :
   (('a, 'b, (suc, int -> int, 'c) rcons) rcons, int) lam = <fun>
 val _1 : ((zero, int, (suc, int -> int, '_weak1) rcons) rcons, int) lam =
   App (Shift (Var Suc), Var Zero)
-val _2 : ((zero, int, (suc, int -> int, '_weak2) rcons) rcons, int) lam =
+val _2 : ((zero, int, (suc, int -> int, '_weak1) rcons) rcons, int) lam =
   App (Shift (Var Suc), App (Shift (Var Suc), Var Zero))
-val _3 : ((zero, int, (suc, int -> int, '_weak3) rcons) rcons, int) lam =
+val _3 : ((zero, int, (suc, int -> int, '_weak1) rcons) rcons, int) lam =
   App (Shift (Var Suc),
    App (Shift (Var Suc), App (Shift (Var Suc), Var Zero)))
 val add :
@@ -921,7 +921,7 @@ val double :
    App (App (Shift (Shift (Shift (Var Add))), Var <poly>), Var <poly>))
 val ex3 :
   ((zero, int,
-    (suc, int -> int, (add, int -> int -> int, '_weak4) rcons) rcons)
+    (suc, int -> int, (add, int -> int -> int, '_weak2) rcons) rcons)
    rcons, int)
   lam =
   App

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -635,6 +635,15 @@ let f (type a) (x : a t) y =
     in M.z
 ;; (* fails because of aliasing... *)
 [%%expect{|
+Lines 2-4, characters 2-10:
+2 | ..match x with Int ->
+3 |     let module M = struct type b = a let z = (y : b) end
+4 |     in M.z
+Warning 18 [not-principal]:
+  The return type of this pattern-matching is ambiguous.
+  Please add a type annotation, as the choice of `a' is not principal.
+val f : 'a t -> 'a -> 'a = <fun>
+|}, Principal{|
 Line 3, characters 46-47:
 3 |     let module M = struct type b = a let z = (y : b) end
                                                   ^

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -7,8 +7,7 @@ type 'a t = [`A of 'a t t] as 'a;; (* fails *)
 Line 1, characters 0-32:
 1 | type 'a t = [`A of 'a t t] as 'a;; (* fails *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The definition of t contains a cycle:
-       'a t t as 'a
+Error: The type abbreviation t is cyclic
 |}, Principal{|
 Line 1, characters 0-32:
 1 | type 'a t = [`A of 'a t t] as 'a;; (* fails *)

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -589,20 +589,6 @@ Error: This expression has type
        but an expression was expected of type
          #comparable as 'a = < cmp : 'a -> int; .. >
        Type int_comparable = < cmp : int_comparable -> int; x : int >
-       is not compatible with type
-         int_comparable3 =
-           < cmp : int_comparable -> int; setx : int -> unit; x : int >
-       The first object type has no method setx
-|}, Principal{|
-Line 1, characters 25-27:
-1 | (new sorted_list ())#add c3;;
-                             ^^
-Error: This expression has type
-         int_comparable3 =
-           < cmp : int_comparable -> int; setx : int -> unit; x : int >
-       but an expression was expected of type
-         #comparable as 'a = < cmp : 'a -> int; .. >
-       Type int_comparable = < cmp : int_comparable -> int; x : int >
        is not compatible with type 'a = < cmp : 'a -> int; .. >
        The first object type has no method setx
 |}];;   (* Error; strange message with -principal *)

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -645,8 +645,8 @@ val f :
 - : (< p : 'b. < m : 'b; n : 'a; .. > as 'b > as 'a) ->
     (< m : 'c; n : 'a; .. > as 'c)
 = <fun>
-- : (< m : 'a. 'a * (< p : 'b. 'b * 'd * 'c > as 'e) as 'd > as 'c) ->
-    ('g * 'e as 'f)
+- : (< m : 'a. 'a * < p : 'b. 'b * 'd * 'c > as 'd > as 'c) ->
+    ('f * < p : 'b. 'b * 'e * 'c > as 'e)
 = <fun>
 - : < m : 'a. < p : 'a; .. > as 'b > -> 'b = <fun>
 |}, Principal{|
@@ -662,7 +662,11 @@ val f :
     (< m : 'c; n : < p : 'e. < m : 'e; n : 'd; .. > as 'e > as 'd; .. > as 'c)
 = <fun>
 - : (< m : 'a. 'a * < p : 'b. 'b * 'd * 'c > as 'd > as 'c) ->
-    ('f * (< p : 'b. 'b * 'e * < m : 'a. 'a * 'g > > as 'g) as 'e)
+    ('f *
+     < p : 'b.
+             'b * 'e *
+             (< m : 'a. 'a * < p : 'b0. 'b0 * 'h * 'g > as 'h > as 'g) >
+     as 'e)
 = <fun>
 - : < m : 'a. < p : 'a; .. > as 'b > -> 'b = <fun>
 |}];;

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -645,8 +645,8 @@ val f :
 - : (< p : 'b. < m : 'b; n : 'a; .. > as 'b > as 'a) ->
     (< m : 'c; n : 'a; .. > as 'c)
 = <fun>
-- : (< m : 'a. 'a * < p : 'b. 'b * 'd * 'c > as 'd > as 'c) ->
-    ('f * < p : 'b. 'b * 'e * 'c > as 'e)
+- : (< m : 'a. 'a * (< p : 'b. 'b * 'd * 'c > as 'e) as 'd > as 'c) ->
+    ('g * 'e as 'f)
 = <fun>
 - : < m : 'a. < p : 'a; .. > as 'b > -> 'b = <fun>
 |}, Principal{|
@@ -662,11 +662,7 @@ val f :
     (< m : 'c; n : < p : 'e. < m : 'e; n : 'd; .. > as 'e > as 'd; .. > as 'c)
 = <fun>
 - : (< m : 'a. 'a * < p : 'b. 'b * 'd * 'c > as 'd > as 'c) ->
-    ('f *
-     < p : 'b.
-             'b * 'e *
-             (< m : 'a. 'a * < p : 'b0. 'b0 * 'h * 'g > as 'h > as 'g) >
-     as 'e)
+    ('f * (< p : 'b. 'b * 'e * < m : 'a. 'a * 'g > > as 'g) as 'e)
 = <fun>
 - : < m : 'a. < p : 'a; .. > as 'b > -> 'b = <fun>
 |}];;

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -39,8 +39,9 @@ let dir_trace ppf lid =
           if Obj.is_block clos
           && (Obj.tag clos = Obj.closure_tag || Obj.tag clos = Obj.infix_tag)
           && (match
-                Ctype.(repr (expand_head !Topcommon.toplevel_env desc.val_type))
-              with {desc=Tarrow _} -> true | _ -> false)
+                Types.get_desc
+                  (Ctype.expand_head !Topcommon.toplevel_env desc.val_type)
+              with Tarrow _ -> true | _ -> false)
           then begin
           match is_traced clos with
           | Some opath ->

--- a/toplevel/byte/trace.ml
+++ b/toplevel/byte/trace.ml
@@ -66,7 +66,7 @@ let print_label ppf l =
 (* If a function returns a functional value, wrap it into a trace code *)
 
 let rec instrument_result env name ppf clos_typ =
-  match (Ctype.repr(Ctype.expand_head env clos_typ)).desc with
+  match get_desc (Ctype.expand_head env clos_typ) with
   | Tarrow(l, t1, t2, _) ->
       let starred_name =
         match name with
@@ -109,7 +109,7 @@ exception Dummy
 let _ = Dummy
 
 let instrument_closure env name ppf clos_typ =
-  match (Ctype.repr(Ctype.expand_head env clos_typ)).desc with
+  match get_desc (Ctype.expand_head env clos_typ) with
   | Tarrow(l, t1, t2, _) ->
       let trace_res = instrument_result env name ppf t2 in
       (fun actual_code closure arg ->

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -203,7 +203,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           Oide_ident name
       | Pdot(p, _s) ->
           if
-            match (find (Lident (Out_name.print name)) env).desc with
+            match get_desc (find (Lident (Out_name.print name)) env) with
             | Tconstr(ty_path', _, _) -> Path.same ty_path ty_path'
             | _ -> false
             | exception Not_found -> false
@@ -215,12 +215,12 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
     let tree_of_constr =
       tree_of_qualified
         (fun lid env ->
-           (Env.find_constructor_by_name lid env).cstr_res)
+          (Env.find_constructor_by_name lid env).cstr_res)
 
     and tree_of_label =
       tree_of_qualified
         (fun lid env ->
-           (Env.find_label_by_name lid env).lbl_res)
+          (Env.find_label_by_name lid env).lbl_res)
 
     (* An abstract type *)
 
@@ -260,7 +260,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
         try
           find_printer depth env ty obj
         with Not_found ->
-          match (Ctype.repr ty).desc with
+          match get_desc ty with
           | Tvar _ | Tunivar _ ->
               Oval_stuff "<poly>"
           | Tarrow _ ->
@@ -397,7 +397,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                     let type_params =
                       match cd_res with
                         Some t ->
-                          begin match (Ctype.repr t).desc with
+                          begin match get_desc t with
                             Tconstr (_,params,_) ->
                               params
                           | _ -> assert false end
@@ -559,7 +559,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
         if not (EVP.same_value slot (EVP.eval_address addr))
         then raise Not_found;
         let type_params =
-          match (Ctype.repr cstr.cstr_res).desc with
+          match get_desc cstr.cstr_res with
             Tconstr (_,params,_) ->
              params
           | _ -> assert false
@@ -592,7 +592,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
           then printer
           else find remainder
       | (_name, Generic (path, fn)) :: remainder ->
-          begin match (Ctype.expand_head env ty).desc with
+          begin match get_desc (Ctype.expand_head env ty) with
           | Tconstr (p, args, _) when Path.same p path ->
               begin try apply_generic_printer path (fn depth) args
               with exn -> (fun _obj -> out_exn path exn) end

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -175,7 +175,7 @@ exception Bad_printing_function
 
 let filter_arrow ty =
   let ty = Ctype.expand_head !toplevel_env ty in
-  match ty.desc with
+  match get_desc ty with
   | Tarrow (lbl, l, r, _) when not (Btype.is_optional lbl) -> Some (l, r)
   | _ -> None
 
@@ -189,9 +189,10 @@ let rec extract_last_arrow desc =
 let extract_target_type ty = fst (extract_last_arrow ty)
 let extract_target_parameters ty =
   let ty = extract_target_type ty |> Ctype.expand_head !toplevel_env in
-  match ty.desc with
+  match get_desc ty with
   | Tconstr (path, (_ :: _ as args), _)
-      when Ctype.all_distinct_vars !toplevel_env args -> Some (path, args)
+      when Ctype.all_distinct_vars !toplevel_env args ->
+        Some (path, args)
   | _ -> None
 
 type 'a printer_type_new = Format.formatter -> 'a -> unit
@@ -454,8 +455,8 @@ let () =
        if is_exception_constructor env desc.cstr_res then
          raise Not_found;
        let path =
-         match Ctype.repr desc.cstr_res with
-         | {desc=Tconstr(path, _, _)} -> path
+         match get_desc desc.cstr_res with
+         | Tconstr(path, _, _) -> path
          | _ -> raise Not_found
        in
        let type_decl = Env.find_type path env in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -22,9 +22,49 @@ open Local_store
 
 (**** Sets, maps and hashtables of types ****)
 
-module TypeSet = Set.Make(TypeOps)
-module TypeMap = Map.Make (TypeOps)
-module TypeHash = Hashtbl.Make(TypeOps)
+let wrap_repr f ty = f (Transient_expr.repr ty)
+let wrap_type_expr f tty = f (Transient_expr.type_expr tty)
+
+module TTypeSet = Set.Make(TransientTypeOps)
+module TypeSet = struct
+  include TTypeSet
+  let add = wrap_repr add
+  let mem = wrap_repr mem
+  let singleton = wrap_repr singleton
+  let exists p = TTypeSet.exists (wrap_type_expr p)
+  let elements set = List.map Transient_expr.type_expr (TTypeSet.elements set)
+end
+module TTypeMap = Map.Make(TransientTypeOps)
+module TypeMap = struct
+  include TTypeMap
+  let add ty = wrap_repr add ty
+  let find ty = wrap_repr find ty
+  let singleton ty = wrap_repr singleton ty
+  let fold f = TTypeMap.fold (wrap_type_expr f)
+end
+module TTypeHash = Hashtbl.Make(TransientTypeOps)
+module TypeHash = struct
+  include TTypeHash
+  let add hash = wrap_repr (add hash)
+  let find hash = wrap_repr (find hash)
+  let iter f = TTypeHash.iter (wrap_type_expr f)
+end
+module TTypePairs =
+  Hashtbl.Make (struct
+    type t = transient_expr * transient_expr
+    let equal (t1, t1') (t2, t2') = (t1 == t2) && (t1' == t2')
+    let hash (t, t') = t.id + 93 * t'.id
+ end)
+module TypePairs = struct
+  include TTypePairs
+  open Transient_expr
+  let wrap_repr f (t1, t2) = f (repr t1, repr t2)
+  let wrap_type_expr f (tt1, tt2) = f (type_expr tt1, type_expr tt2)
+  let add hash = wrap_repr (add hash)
+  let find hash = wrap_repr (find hash)
+  let mem hash = wrap_repr (mem hash)
+  let iter f = TTypePairs.iter (wrap_type_expr f)
+end
 
 (**** Forward declarations ****)
 
@@ -42,13 +82,10 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = s_ref (-1)
-
-let newty2 level desc  =
-  incr new_id;
-  Private_type_expr.create desc ~level ~scope:lowest_level ~id:!new_id
 let newgenty desc      = newty2 generic_level desc
 let newgenvar ?name () = newgenty (Tvar name)
+let newgenstub ~scope  = newty3 ~level:generic_level ~scope (Tvar None)
+
 (*
 let newmarkedvar level =
   incr new_id; { desc = Tvar; level = pivot_level - level; id = !new_id }
@@ -59,64 +96,13 @@ let newmarkedgenvar () =
 
 (**** Check some types ****)
 
-let is_Tvar = function {desc=Tvar _} -> true | _ -> false
-let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
-let is_Tconstr = function {desc=Tconstr _} -> true | _ -> false
+let is_Tvar ty = match get_desc ty with Tvar _ -> true | _ -> false
+let is_Tunivar ty = match get_desc ty with Tunivar _ -> true | _ -> false
+let is_Tconstr ty = match get_desc ty with Tconstr _ -> true | _ -> false
 
 let dummy_method = "*dummy method*"
 
-(**** Definitions for backtracking ****)
-
-type change =
-    Ctype of type_expr * type_desc
-  | Ccompress of type_expr * type_desc * type_desc
-  | Clevel of type_expr * int
-  | Cscope of type_expr * int
-  | Cname of
-      (Path.t * type_expr list) option ref * (Path.t * type_expr list) option
-  | Crow of row_field option ref * row_field option
-  | Ckind of field_kind option ref * field_kind option
-  | Ccommu of commutable ref * commutable
-  | Cuniv of type_expr option ref * type_expr option
-
-type changes =
-    Change of change * changes ref
-  | Unchanged
-  | Invalid
-
-let trail = s_table ref Unchanged
-
-let log_change ch =
-  let r' = ref Unchanged in
-  !trail := Change (ch, r');
-  trail := r'
-
 (**** Representative of a type ****)
-
-let rec field_kind_repr =
-  function
-    Fvar {contents = Some kind} -> field_kind_repr kind
-  | kind                        -> kind
-
-let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
- function
-   {desc = Tlink t' as d'} ->
-     repr_link true t d' t'
- | {desc = Tfield (_, k, _, t') as d'} when field_kind_repr k = Fabsent ->
-     repr_link true t d' t'
- | t' ->
-     if compress then begin
-       log_change (Ccompress (t, t.desc, d)); Private_type_expr.set_desc t d
-     end;
-     t'
-
-let repr (t : type_expr) =
-  match t.desc with
-   Tlink t' as d ->
-     repr_link false t d t'
- | Tfield (_, k, _, t') as d when field_kind_repr k = Fabsent ->
-     repr_link false t d t'
- | _ -> t
 
 let rec commu_repr = function
     Clink r when !r <> Cunknown -> commu_repr !r
@@ -139,7 +125,7 @@ let rec rev_concat l ll =
   | l'::ll -> rev_concat (l'@l) ll
 
 let rec row_repr_aux ll row =
-  match (repr row.row_more).desc with
+  match get_desc row.row_more with
   | Tvariant row' ->
       let f = row.row_fields in
       row_repr_aux (if f = [] then ll else f::ll) row'
@@ -154,15 +140,15 @@ let rec row_field tag row =
     | (tag',f) :: fields ->
         if tag = tag' then row_field_repr f else find fields
     | [] ->
-        match repr row.row_more with
-        | {desc=Tvariant row'} -> row_field tag row'
+        match get_desc row.row_more with
+        | Tvariant row' -> row_field tag row'
         | _ -> Rabsent
   in find row.row_fields
 
 let rec row_more row =
-  match repr row.row_more with
-  | {desc=Tvariant row'} -> row_more row'
-  | ty -> ty
+  match get_desc row.row_more with
+  | Tvariant row' -> row_more row'
+  | _ -> row.row_more
 
 let merge_fixed_explanation fixed1 fixed2 =
   match fixed1, fixed2 with
@@ -178,10 +164,9 @@ let fixed_explanation row =
   match row.row_fixed with
   | Some _ as x -> x
   | None ->
-      let more = repr row.row_more in
-      match more.desc with
+      match get_desc row.row_more with
       | Tvar _ | Tnil -> None
-      | Tunivar _ -> Some (Univar more)
+      | Tunivar _ -> Some (Univar row.row_more)
       | Tconstr (p,_,_) -> Some (Reified p)
       | _ -> assert false
 
@@ -210,28 +195,26 @@ let hash_variant s =
   if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
 
 let proxy ty =
-  let ty0 = repr ty in
-  match ty0.desc with
+  match get_desc ty with
   | Tvariant row when not (static_row row) ->
       row_more row
   | Tobject (ty, _) ->
       let rec proxy_obj ty =
-        match ty.desc with
-          Tfield (_, _, _, ty) | Tlink ty -> proxy_obj ty
+        match get_desc ty with
+          Tfield (_, _, _, ty) -> proxy_obj ty
         | Tvar _ | Tunivar _ | Tconstr _ -> ty
-        | Tnil -> ty0
+        | Tnil -> ty
         | _ -> assert false
       in proxy_obj ty
-  | _ -> ty0
+  | _ -> ty
 
 (**** Utilities for fixed row private types ****)
 
 let row_of_type t =
-  match (repr t).desc with
+  match get_desc t with
     Tobject(t,_) ->
       let rec get_row t =
-        let t = repr t in
-        match t.desc with
+        match get_desc t with
           Tfield(_,_,_,t) -> get_row t
         | _ -> t
       in get_row t
@@ -248,7 +231,7 @@ let is_row_name s =
   if l < 4 then false else String.sub s (l-4) 4 = "#row"
 
 let is_constr_row ~allow_ident t =
-  match t.desc with
+  match get_desc t with
     Tconstr (Path.Pident id, _, _) when allow_ident ->
       is_row_name (Ident.name id)
   | Tconstr (Path.Pdot (_, s), _, _) -> is_row_name s
@@ -260,12 +243,11 @@ let set_row_name decl path =
   match decl.type_manifest with
     None -> ()
   | Some ty ->
-      let ty = repr ty in
-      match ty.desc with
+      match get_desc ty with
         Tvariant row when static_row row ->
           let row = {(row_repr row) with
                      row_name = Some (path, decl.type_params)} in
-          Private_type_expr.set_desc ty (Tvariant row)
+          set_type_desc ty (Tvariant row)
       | _ -> ()
 
 
@@ -284,7 +266,7 @@ let rec fold_row f init row =
       init
       row.row_fields
   in
-  match (repr row.row_more).desc with
+  match get_desc row.row_more with
     Tvariant row -> fold_row f result row
   | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil ->
     begin match
@@ -298,27 +280,26 @@ let rec fold_row f init row =
 let iter_row f row =
   fold_row (fun () v -> f v) () row
 
-let rec fold_type_expr f init ty =
-  match ty.desc with
+let fold_type_expr f init ty =
+  match get_desc ty with
     Tvar _              -> init
   | Tarrow (_, ty1, ty2, _) ->
-    let result = f init ty1 in
-    f result ty2
+      let result = f init ty1 in
+      f result ty2
   | Ttuple l            -> List.fold_left f init l
   | Tconstr (_, l, _)   -> List.fold_left f init l
-  | Tobject(ty, {contents = Some (_, p)})
-    ->
-    let result = f init ty in
-    List.fold_left f result p
+  | Tobject(ty, {contents = Some (_, p)}) ->
+      let result = f init ty in
+      List.fold_left f result p
   | Tobject (ty, _)     -> f init ty
   | Tvariant row        ->
-    let result = fold_row f init row in
-    f result (row_more row)
+      let result = fold_row f init row in
+      f result (row_more row)
   | Tfield (_, _, ty1, ty2) ->
-    let result = f init ty1 in
-    f result ty2
+      let result = f init ty1 in
+      f result ty2
   | Tnil                -> init
-  | Tlink ty            -> fold_type_expr f init ty
+  | Tlink _
   | Tsubst _            -> assert false
   | Tunivar _           -> init
   | Tpoly (ty, tyl)     ->
@@ -440,7 +421,7 @@ let type_iterators =
     iter_type_expr_kind (it.it_type_expr it) kind
   and it_do_type_expr it ty =
     iter_type_expr (it.it_type_expr it) ty;
-    match ty.desc with
+    match get_desc ty with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
     | Tpackage (p, _) ->
@@ -498,7 +479,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
   | Tfield (p, k, ty1, ty2) -> (* the kind is kept shared *)
       Tfield (p, field_kind_repr k, f ty1, f ty2)
   | Tnil                -> Tnil
-  | Tlink ty            -> copy_type_desc f ty.desc
+  | Tlink ty            -> copy_type_desc f (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
@@ -511,14 +492,14 @@ let rec copy_type_desc ?(keep_names=false) f = function
 module For_copy : sig
   type copy_scope
 
-  val save_desc: copy_scope -> type_expr -> type_desc -> unit
+  val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
   val dup_kind: copy_scope -> field_kind option ref -> unit
 
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
-    mutable saved_desc : (type_expr * type_desc) list;
+    mutable saved_desc : (transient_expr * type_desc) list;
     (* Save association of generic nodes with their description. *)
 
     mutable saved_kinds: field_kind option ref list;
@@ -528,8 +509,10 @@ end = struct
     (* new kind variables *)
   }
 
-  let save_desc copy_scope ty desc =
-    copy_scope.saved_desc <- (ty, desc) :: copy_scope.saved_desc
+  let redirect_desc copy_scope ty desc =
+    let ty = Transient_expr.repr ty in
+    copy_scope.saved_desc <- (ty, ty.desc) :: copy_scope.saved_desc;
+    Transient_expr.set_desc ty desc
 
   let dup_kind copy_scope r =
     assert (Option.is_none !r);
@@ -542,7 +525,7 @@ end = struct
 
   (* Restore type descriptions. *)
   let cleanup { saved_desc; saved_kinds; _ } =
-    List.iter (fun (ty, desc) -> Private_type_expr.set_desc ty desc) saved_desc;
+    List.iter (fun (ty, desc) -> Transient_expr.set_desc ty desc) saved_desc;
     List.iter (fun r -> r := None) saved_kinds
 
   let with_scope f =
@@ -551,7 +534,6 @@ end = struct
     cleanup scope;
     res
 end
-
 
                   (*******************************************)
                   (*  Memorization of abbreviation expansion *)
@@ -625,6 +607,11 @@ let check_memorized_abbrevs () =
   List.for_all (fun mem -> check_abbrev_rec !mem) !memo
 *)
 
+(* Re-export backtrack *)
+
+let snapshot = snapshot
+let backtrack = backtrack ~cleanup_abbrev
+
                   (**********************************)
                   (*  Utilities for labels          *)
                   (**********************************)
@@ -651,136 +638,23 @@ let rec extract_label_aux hd l = function
 
 let extract_label l ls = extract_label_aux [] l ls
 
-
                   (**********************************)
-                  (*  Utilities for backtracking    *)
+                  (*  Utilities for level-marking   *)
                   (**********************************)
 
-let undo_change = function
-    Ctype  (ty, desc) -> Private_type_expr.set_desc ty desc
-  | Ccompress  (ty, desc, _) -> Private_type_expr.set_desc ty desc
-  | Clevel (ty, level) -> Private_type_expr.set_level ty level
-  | Cscope (ty, scope) -> Private_type_expr.set_scope ty scope
-  | Cname  (r, v) -> r := v
-  | Crow   (r, v) -> r := v
-  | Ckind  (r, v) -> r := v
-  | Ccommu (r, v) -> r := v
-  | Cuniv  (r, v) -> r := v
-
-type snapshot = changes ref * int
-let last_snapshot = s_ref 0
-
-let log_type ty =
-  if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))
-let link_type ty ty' =
-  log_type ty;
-  let desc = ty.desc in
-  Private_type_expr.set_desc ty (Tlink ty');
-  (* Name is a user-supplied name for this unification variable (obtained
-   * through a type annotation for instance). *)
-  match desc, ty'.desc with
-    Tvar name, Tvar name' ->
-      begin match name, name' with
-      | Some _, None -> log_type ty'; Private_type_expr.set_desc ty' (Tvar name)
-      | None, Some _ -> ()
-      | Some _, Some _ ->
-          if ty.level < ty'.level then
-            (log_type ty'; Private_type_expr.set_desc ty' (Tvar name))
-      | None, None   -> ()
-      end
-  | _ -> ()
-  (* ; assert (check_memorized_abbrevs ()) *)
-  (*  ; check_expans [] ty' *)
-(* TODO: consider eliminating set_type_desc, replacing it with link types *)
-let set_type_desc ty td =
-  if td != ty.desc then begin
-    log_type ty;
-    Private_type_expr.set_desc ty td
-  end
-(* TODO: separate set_level into two specific functions: *)
-(*  set_lower_level and set_generic_level *)
- let set_level ty level =
-  if level <> ty.level then begin
-    if ty.id <= !last_snapshot then log_change (Clevel (ty, ty.level));
-    Private_type_expr.set_level ty level
-  end
-(* TODO: introduce a guard and rename it to set_higher_scope? *)
-let set_scope ty scope =
-  if scope <> ty.scope then begin
-    if ty.id <= !last_snapshot then log_change (Cscope (ty, ty.scope));
-    Private_type_expr.set_scope ty scope
-  end
-let set_univar rty ty =
-  log_change (Cuniv (rty, !rty)); rty := Some ty
-let set_name nm v =
-  log_change (Cname (nm, !nm)); nm := v
-let set_row_field e v =
-  log_change (Crow (e, !e)); e := Some v
-let set_kind rk k =
-  log_change (Ckind (rk, !rk)); rk := Some k
-let set_commu rc c =
-  log_change (Ccommu (rc, !rc)); rc := c
-
-let snapshot () =
-  let old = !last_snapshot in
-  last_snapshot := !new_id;
-  (!trail, old)
-
-let rec rev_log accu = function
-    Unchanged -> accu
-  | Invalid -> assert false
-  | Change (ch, next) ->
-      let d = !next in
-      next := Invalid;
-      rev_log (ch::accu) d
-
-let backtrack (changes, old) =
-  match !changes with
-    Unchanged -> last_snapshot := old
-  | Invalid -> failwith "Btype.backtrack"
-  | Change _ as change ->
-      cleanup_abbrev ();
-      let backlog = rev_log [] change in
-      List.iter undo_change backlog;
-      changes := Unchanged;
-      last_snapshot := old;
-      trail := changes
-
-let rec rev_compress_log log r =
-  match !r with
-    Unchanged | Invalid ->
-      log
-  | Change (Ccompress _, next) ->
-      rev_compress_log (r::log) next
-  | Change (_, next) ->
-      rev_compress_log log next
-
-let undo_compress (changes, _old) =
-  match !changes with
-    Unchanged
-  | Invalid -> ()
-  | Change _ ->
-      let log = rev_compress_log [] changes in
-      List.iter
-        (fun r -> match !r with
-          Change (Ccompress (ty, desc, d), next) when ty.desc == d ->
-            Private_type_expr.set_desc ty desc; r := !next
-        | _ -> ())
-        log
-
-(* Mark a type. *)
-
-let not_marked_node ty = ty.level >= lowest_level
+let not_marked_node ty = get_level ty >= lowest_level
     (* type nodes with negative levels are "marked" *)
 
-let flip_mark_node ty = Private_type_expr.set_level ty (pivot_level - ty.level)
-let logged_mark_node ty = set_level ty (pivot_level - ty.level)
+let flip_mark_node ty =
+  let ty = Transient_expr.repr ty in
+  Transient_expr.set_level ty (pivot_level - ty.level)
+let logged_mark_node ty =
+  set_level ty (pivot_level - get_level ty)
 
 let try_mark_node ty = not_marked_node ty && (flip_mark_node ty; true)
 let try_logged_mark_node ty = not_marked_node ty && (logged_mark_node ty; true)
 
 let rec mark_type ty =
-  let ty = repr ty in
   if not_marked_node ty then begin
     flip_mark_node ty;
     iter_type_expr mark_type ty
@@ -791,7 +665,6 @@ let mark_type_params ty =
 
 let type_iterators =
   let it_type_expr it ty =
-    let ty = repr ty in
     if try_mark_node ty then it.it_do_type_expr it ty
   in
   {type_iterators with it_type_expr}
@@ -799,8 +672,7 @@ let type_iterators =
 
 (* Remove marks from a type. *)
 let rec unmark_type ty =
-  let ty = repr ty in
-  if ty.level < lowest_level then begin
+  if get_level ty < lowest_level then begin
     (* flip back the marked level *)
     flip_mark_node ty;
     iter_type_expr unmark_type ty

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -25,45 +25,46 @@ open Local_store
 let wrap_repr f ty = f (Transient_expr.repr ty)
 let wrap_type_expr f tty = f (Transient_expr.type_expr tty)
 
-module TTypeSet = Set.Make(TransientTypeOps)
+module TransientTypeSet = Set.Make(TransientTypeOps)
 module TypeSet = struct
-  include TTypeSet
+  include TransientTypeSet
   let add = wrap_repr add
   let mem = wrap_repr mem
   let singleton = wrap_repr singleton
-  let exists p = TTypeSet.exists (wrap_type_expr p)
-  let elements set = List.map Transient_expr.type_expr (TTypeSet.elements set)
+  let exists p = TransientTypeSet.exists (wrap_type_expr p)
+  let elements set =
+    List.map Transient_expr.type_expr (TransientTypeSet.elements set)
 end
-module TTypeMap = Map.Make(TransientTypeOps)
+module TransientTypeMap = Map.Make(TransientTypeOps)
 module TypeMap = struct
-  include TTypeMap
+  include TransientTypeMap
   let add ty = wrap_repr add ty
   let find ty = wrap_repr find ty
   let singleton ty = wrap_repr singleton ty
-  let fold f = TTypeMap.fold (wrap_type_expr f)
+  let fold f = TransientTypeMap.fold (wrap_type_expr f)
 end
-module TTypeHash = Hashtbl.Make(TransientTypeOps)
+module TransientTypeHash = Hashtbl.Make(TransientTypeOps)
 module TypeHash = struct
-  include TTypeHash
+  include TransientTypeHash
   let add hash = wrap_repr (add hash)
   let find hash = wrap_repr (find hash)
-  let iter f = TTypeHash.iter (wrap_type_expr f)
+  let iter f = TransientTypeHash.iter (wrap_type_expr f)
 end
-module TTypePairs =
+module TransientTypePairs =
   Hashtbl.Make (struct
     type t = transient_expr * transient_expr
     let equal (t1, t1') (t2, t2') = (t1 == t2) && (t1' == t2')
     let hash (t, t') = t.id + 93 * t'.id
  end)
 module TypePairs = struct
-  include TTypePairs
+  include TransientTypePairs
   open Transient_expr
   let wrap_repr f (t1, t2) = f (repr t1, repr t2)
   let wrap_type_expr f (tt1, tt2) = f (type_expr tt1, type_expr tt2)
   let add hash = wrap_repr (add hash)
   let find hash = wrap_repr (find hash)
   let mem hash = wrap_repr (mem hash)
-  let iter f = TTypePairs.iter (wrap_type_expr f)
+  let iter f = TransientTypePairs.iter (wrap_type_expr f)
 end
 
 (**** Forward declarations ****)

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -83,7 +83,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let newgenty desc      = newty2 generic_level desc
+let newgenty desc      = newty2 ~level:generic_level desc
 let newgenvar ?name () = newgenty (Tvar name)
 let newgenstub ~scope  = newty3 ~level:generic_level ~scope (Tvar None)
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -20,20 +20,53 @@ open Types
 
 (**** Sets, maps and hashtables of types ****)
 
-module TypeSet  : Set.S with type elt = type_expr
-module TypeMap  : Map.S with type key = type_expr
-module TypeHash : Hashtbl.S with type key = type_expr
+module TTypeSet  : Set.S with type elt = transient_expr
+module TypeSet   : sig
+  include Set.S with type elt = transient_expr and type t = TTypeSet.t
+  val add: type_expr -> t -> t
+  val mem: type_expr -> t -> bool
+  val singleton: type_expr -> t
+  val exists: (type_expr -> bool) -> t -> bool
+  val elements: t -> type_expr list
+end
+module TTypeMap   : Map.S with type key = transient_expr
+module TypeMap    : sig
+  include Map.S with type key = transient_expr
+                     and type 'a t = 'a TTypeMap.t
+  val add: type_expr -> 'a -> 'a t -> 'a t
+  val find: type_expr -> 'a t -> 'a
+  val singleton: type_expr -> 'a -> 'a t
+  val fold: (type_expr -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+end
+module TTypeHash : Hashtbl.S with type key = transient_expr
+module TypeHash  : sig
+  include Hashtbl.S with type key = transient_expr
+                     and type 'a t = 'a TTypeHash.t
+  val add: 'a t -> type_expr -> 'a -> unit
+  val find: 'a t -> type_expr -> 'a
+  val iter: (type_expr -> 'a -> unit) -> 'a t -> unit
+end
+module TTypePairs : Hashtbl.S with type key = transient_expr * transient_expr
+module TypePairs : sig
+  include Hashtbl.S with type key = transient_expr * transient_expr
+                     and type 'a t = 'a TTypePairs.t
+  val add: 'a t -> type_expr * type_expr -> 'a -> unit
+  val find: 'a t -> type_expr * type_expr -> 'a
+  val mem: 'a t -> type_expr * type_expr -> bool
+  val iter: (type_expr * type_expr -> 'a -> unit) -> 'a t -> unit
+end
 
 (**** Levels ****)
 
 val generic_level: int
 
-val newty2: int -> type_desc -> type_expr
-        (* Create a type *)
 val newgenty: type_desc -> type_expr
         (* Create a generic type *)
 val newgenvar: ?name:string -> unit -> type_expr
         (* Return a fresh generic variable *)
+val newgenstub: scope:int -> type_expr
+        (* Return a fresh generic node, to be instantiated
+           by [Transient_expr.set_stub_desc] *)
 
 (* Use Tsubst instead
 val newmarkedvar: int -> type_expr
@@ -48,13 +81,6 @@ val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
 val dummy_method: label
-
-val repr: type_expr -> type_expr
-        (* Return the canonical representative of a type. *)
-
-val field_kind_repr: field_kind -> field_kind
-        (* Return the canonical representative of an object field
-           kind. *)
 
 val commu_repr: commutable -> commutable
         (* Return the canonical representative of a commutation lock *)
@@ -113,6 +139,13 @@ val iter_row: (type_expr -> unit) -> row_desc -> unit
 val fold_row: ('a -> type_expr -> 'a) -> 'a -> row_desc -> 'a
 val iter_abbrev: (type_expr -> unit) -> abbrev_memo -> unit
         (* Iteration on types in an abbreviation list *)
+val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
+
+val iter_type_expr_cstr_args: (type_expr -> unit) ->
+  (constructor_arguments -> unit)
+val map_type_expr_cstr_args: (type_expr -> type_expr) ->
+  (constructor_arguments -> constructor_arguments)
+
 
 type type_iterators =
   { it_signature: type_iterators -> signature -> unit;
@@ -154,8 +187,8 @@ module For_copy : sig
            While it is possible to circumvent that discipline in various
            ways, you should NOT do that. *)
 
-  val save_desc: copy_scope -> type_expr -> type_desc -> unit
-        (* Save a type description *)
+  val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
+        (* Temporarily change a type description *)
 
   val dup_kind: copy_scope -> field_kind option ref -> unit
         (* Save a None field_kind, and make it point to a fresh Fvar *)
@@ -217,6 +250,14 @@ val forget_abbrev:
         abbrev_memo ref -> Path.t -> unit
         (* Remove an abbreviation from the cache *)
 
+(**** Backtracking ****)
+
+val snapshot: unit -> snapshot
+val backtrack: snapshot -> unit
+        (* Backtrack to a given snapshot. Only possible if you have
+           not already backtracked to a previous snapshot.
+           Calls [cleanup_abbrev] internally *)
+
 (**** Utilities for labels ****)
 
 val is_optional : arg_label -> bool
@@ -233,44 +274,5 @@ val extract_label :
    whether (label, value) was at the head of the list,
    list without the extracted (label, value) *)
 
-(**** Utilities for backtracking ****)
-
-type snapshot
-        (* A snapshot for backtracking *)
-val snapshot: unit -> snapshot
-        (* Make a snapshot for later backtracking. Costs nothing *)
-val backtrack: snapshot -> unit
-        (* Backtrack to a given snapshot. Only possible if you have
-           not already backtracked to a previous snapshot.
-           Calls [cleanup_abbrev] internally *)
-val undo_compress: snapshot -> unit
-        (* Backtrack only path compression. Only meaningful if you have
-           not already backtracked to a previous snapshot.
-           Does not call [cleanup_abbrev] *)
-
-(* Functions to use when modifying a type (only Ctype?) *)
-val link_type: type_expr -> type_expr -> unit
-        (* Set the desc field of [t1] to [Tlink t2], logging the old
-           value if there is an active snapshot *)
-val set_type_desc: type_expr -> type_desc -> unit
-        (* Set directly the desc field, without sharing *)
-val set_level: type_expr -> int -> unit
-val set_scope: type_expr -> int -> unit
-val set_name:
-    (Path.t * type_expr list) option ref ->
-    (Path.t * type_expr list) option -> unit
-val set_row_field: row_field option ref -> row_field -> unit
-val set_univar: type_expr option ref -> type_expr -> unit
-val set_kind: field_kind option ref -> field_kind -> unit
-val set_commu: commutable ref -> commutable -> unit
-        (* Set references, logging the old value *)
-
 (**** Forward declarations ****)
 val print_raw: (Format.formatter -> type_expr -> unit) ref
-
-val iter_type_expr_kind: (type_expr -> unit) -> (type_decl_kind -> unit)
-
-val iter_type_expr_cstr_args: (type_expr -> unit) ->
-  (constructor_arguments -> unit)
-val map_type_expr_cstr_args: (type_expr -> type_expr) ->
-  (constructor_arguments -> constructor_arguments)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -20,36 +20,31 @@ open Types
 
 (**** Sets, maps and hashtables of types ****)
 
-module TTypeSet  : Set.S with type elt = transient_expr
-module TypeSet   : sig
-  include Set.S with type elt = transient_expr and type t = TTypeSet.t
+module TypeSet : sig
+  include Set.S with type elt = transient_expr
   val add: type_expr -> t -> t
   val mem: type_expr -> t -> bool
   val singleton: type_expr -> t
   val exists: (type_expr -> bool) -> t -> bool
   val elements: t -> type_expr list
 end
-module TTypeMap   : Map.S with type key = transient_expr
-module TypeMap    : sig
+module TransientTypeMap : Map.S with type key = transient_expr
+module TypeMap : sig
   include Map.S with type key = transient_expr
-                     and type 'a t = 'a TTypeMap.t
+                     and type 'a t = 'a TransientTypeMap.t
   val add: type_expr -> 'a -> 'a t -> 'a t
   val find: type_expr -> 'a t -> 'a
   val singleton: type_expr -> 'a -> 'a t
   val fold: (type_expr -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
 end
-module TTypeHash : Hashtbl.S with type key = transient_expr
-module TypeHash  : sig
+module TypeHash : sig
   include Hashtbl.S with type key = transient_expr
-                     and type 'a t = 'a TTypeHash.t
   val add: 'a t -> type_expr -> 'a -> unit
   val find: 'a t -> type_expr -> 'a
   val iter: (type_expr -> 'a -> unit) -> 'a t -> unit
 end
-module TTypePairs : Hashtbl.S with type key = transient_expr * transient_expr
 module TypePairs : sig
   include Hashtbl.S with type key = transient_expr * transient_expr
-                     and type 'a t = 'a TTypePairs.t
   val add: 'a t -> type_expr * type_expr -> 'a -> unit
   val find: 'a t -> type_expr * type_expr -> 'a
   val mem: 'a t -> type_expr * type_expr -> bool

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1167,7 +1167,7 @@ let rec copy ?partial ?keep_names scope ty =
                 match partial with
                   Some (free_univars, false) ->
                     let more' =
-                      if eq_type more more' then
+                      if not (eq_type more more') then
                         more' (* we've already made a copy *)
                       else
                         newvar ()

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -244,11 +244,6 @@ let newconstr path tyl = newty (Tconstr (path, tyl, ref Mnil))
 
 let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 
-(**** Representative of a type ****)
-
-(* Re-export repr *)
-(* let repr = repr *)
-
 (**** unification mode ****)
 
 type unification_mode =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2744,8 +2744,7 @@ and unify2 env t1 t2 =
 
   let t1, t2 =
     if !Clflags.principal
-    && (find_lowest_level  t1' < lv ||
-        find_lowest_level  t2' < lv) then
+    && (find_lowest_level t1' < lv || find_lowest_level t2' < lv) then
       (* Expand abbreviations hiding a lower level *)
       (* Should also do it for parameterized types, after unification... *)
       (match get_desc t1 with Tconstr (_, [], _) -> t1' | _ -> t1),

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1096,7 +1096,7 @@ let rec copy ?partial ?keep_names scope ty =
   let copy = copy ?partial ?keep_names scope in
   match get_desc ty with
     Tsubst (ty, _) -> ty
-  | _ ->
+  | desc ->
     let level = get_level ty in
     if level <> generic_level && partial = None then ty else
     (* We only forget types that are non generic and do not contain
@@ -1111,7 +1111,6 @@ let rec copy ?partial ?keep_names scope ty =
           else generic_level
     in
     if forget <> generic_level then newty2 ~level:forget (Tvar None) else
-    let desc = get_desc ty in
     let t = newstub ~scope:(get_scope ty) in
     For_copy.redirect_desc scope ty (Tsubst (t, None));
     let desc' =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -231,12 +231,12 @@ let proper_abbrevs path tl abbrev =
 
 (* Re-export generic type creators *)
 
-let newty2             = Btype.newty2
-let newty desc         = newty2 !current_level desc
+let newty desc              = newty2 !current_level desc
 
 let newvar ?name ()         = newty2 !current_level (Tvar name)
 let newvar2 ?name level     = newty2 level (Tvar name)
 let new_global_var ?name () = newty2 !global_level (Tvar name)
+let newstub ~scope          = newty3 ~level:!current_level ~scope (Tvar None)
 
 let newobj fields      = newty (Tobject (fields, ref None))
 
@@ -247,17 +247,7 @@ let none = newty (Ttuple [])                (* Clearly ill-formed type *)
 (**** Representative of a type ****)
 
 (* Re-export repr *)
-let repr = repr
-
-(**** Type maps ****)
-
-module TypePairs =
-  Hashtbl.Make (struct
-    type t = type_expr * type_expr
-    let equal (t1, t1') (t2, t2') = (t1 == t2) && (t1' == t2')
-    let hash (t, t') = t.id + 93 * t'.id
- end)
-
+(* let repr = repr *)
 
 (**** unification mode ****)
 
@@ -317,14 +307,13 @@ let is_datatype decl=
 (**** Object field manipulation. ****)
 
 let object_fields ty =
-  match (repr ty).desc with
+  match get_desc ty with
     Tobject (fields, _) -> fields
   | _                   -> assert false
 
 let flatten_fields ty =
   let rec flatten l ty =
-    let ty = repr ty in
-    match ty.desc with
+    match get_desc ty with
       Tfield(s, k, ty1, ty2) ->
         flatten ((s, k, ty1)::l) ty2
     | _ ->
@@ -354,8 +343,8 @@ let associate_fields fields1 fields2 =
   associate [] [] [] (fields1, fields2)
 
 let rec has_dummy_method ty =
-  match repr ty with
-    {desc = Tfield (m, _, _, ty2)} ->
+  match get_desc ty with
+    Tfield (m, _, _, ty2) ->
       m = dummy_method || has_dummy_method ty2
   | _ -> false
 
@@ -367,19 +356,18 @@ let is_self_type = function
 
 (* +++ The abbreviation should eventually be expanded *)
 let rec object_row ty =
-  let ty = repr ty in
-  match ty.desc with
+  match get_desc ty with
     Tobject (t, _)     -> object_row t
   | Tfield(_, _, _, t) -> object_row t
   | _ -> ty
 
 let opened_object ty =
-  match (object_row ty).desc with
+  match get_desc (object_row ty) with
   | Tvar _  | Tunivar _ | Tconstr _ -> true
   | _                               -> false
 
 let concrete_object ty =
-  match (object_row ty).desc with
+  match get_desc (object_row ty) with
   | Tvar _             -> false
   | _                  -> true
 
@@ -387,16 +375,15 @@ let concrete_object ty =
 
 let close_object ty =
   let rec close ty =
-    let ty = repr ty in
-    match ty.desc with
+    match get_desc ty with
       Tvar _ ->
-        link_type ty (newty2 ty.level Tnil); true
+        link_type ty (newty2 (get_level ty) Tnil); true
     | Tfield(lab, _, _, _) when lab = dummy_method ->
         false
     | Tfield(_, _, _, ty') -> close ty'
     | _                    -> assert false
   in
-  match (repr ty).desc with
+  match get_desc ty with
     Tobject (ty, _)   -> close ty
   | _                 -> assert false
 
@@ -404,13 +391,12 @@ let close_object ty =
 
 let row_variable ty =
   let rec find ty =
-    let ty = repr ty in
-    match ty.desc with
+    match get_desc ty with
       Tfield (_, _, _, ty) -> find ty
     | Tvar _               -> ty
     | _                    -> assert false
   in
-  match (repr ty).desc with
+  match get_desc ty with
     Tobject (fi, _) -> find fi
   | _               -> assert false
 
@@ -418,14 +404,14 @@ let row_variable ty =
 (* +++ Bientot obsolete *)
 
 let set_object_name id rv params ty =
-  match (repr ty).desc with
+  match get_desc ty with
     Tobject (_fi, nm) ->
       set_name nm (Some (Path.Pident id, rv::params))
   | _ ->
       assert false
 
 let remove_object_name ty =
-  match (repr ty).desc with
+  match get_desc ty with
     Tobject (_, nm)   -> set_name nm None
   | Tconstr (_, _, _) -> ()
   | _                 -> fatal_error "Ctype.remove_object_name"
@@ -433,7 +419,7 @@ let remove_object_name ty =
 (**** Hiding of private methods ****)
 
 let hide_private_methods ty =
-  match (repr ty).desc with
+  match get_desc ty with
     Tobject (fi, nm) ->
       nm := None;
       let (fl, _) = flatten_fields fi in
@@ -459,7 +445,7 @@ let rec signature_of_class_type =
   | Cty_arrow (_, _, cty)   -> signature_of_class_type cty
 
 let self_type cty =
-  repr (signature_of_class_type cty).csig_self
+  (signature_of_class_type cty).csig_self
 
 let rec class_type_arity =
   function
@@ -530,15 +516,14 @@ let really_closed = ref None
    and only returns a [variable list].
  *)
 let rec free_vars_rec real ty =
-  let ty = repr ty in
   if try_mark_node ty then
-    match ty.desc, !really_closed with
+    match get_desc ty, !really_closed with
       Tvar _, _ ->
         free_variables := (ty, real) :: !free_variables
     | Tconstr (path, tl, _), Some env ->
         begin try
           let (_, body, _) = Env.find_type_expansion path env in
-          if (repr body).level <> generic_level then
+          if get_level body <> generic_level then
             free_variables := (ty, real) :: !free_variables
         with Not_found -> ()
         end;
@@ -636,7 +621,7 @@ type closed_class_failure =
 exception CCFailure of closed_class_failure
 
 let closed_class params sign =
-  let ty = object_fields (repr sign.csig_self) in
+  let ty = object_fields sign.csig_self in
   let (fields, rest) = flatten_fields ty in
   List.iter mark_type params;
   mark_type rest;
@@ -644,19 +629,19 @@ let closed_class params sign =
     (fun (lab, _, ty) -> if lab = dummy_method then mark_type ty)
     fields;
   try
-    ignore (try_mark_node (repr sign.csig_self));
+    ignore (try_mark_node sign.csig_self);
     List.iter
       (fun (lab, kind, ty) ->
         if field_kind_repr kind = Fpresent then
         try closed_type ty with Non_closed (ty0, real) ->
           raise (CCFailure (CC_Method (ty0, real, lab, ty))))
       fields;
-    mark_type_params (repr sign.csig_self);
+    mark_type_params sign.csig_self;
     List.iter unmark_type params;
     unmark_class_signature sign;
     None
   with CCFailure reason ->
-    mark_type_params (repr sign.csig_self);
+    mark_type_params sign.csig_self;
     List.iter unmark_type params;
     unmark_class_signature sign;
     Some reason
@@ -688,11 +673,11 @@ let duplicate_class_type ty =
    preserved. Does it worth duplicating this code ?
 *)
 let rec generalize ty =
-  let ty = repr ty in
-  if (ty.level > !current_level) && (ty.level <> generic_level) then begin
+  let level = get_level ty in
+  if (level > !current_level) && (level <> generic_level) then begin
     set_level ty generic_level;
     (* recur into abbrev for the speed *)
-    begin match ty.desc with
+    begin match get_desc ty with
       Tconstr (_, _, abbrev) ->
         iter_abbrev generalize !abbrev
     | _ -> ()
@@ -707,13 +692,13 @@ let generalize ty =
 (* Generalize the structure and lower the variables *)
 
 let rec generalize_structure ty =
-  let ty = repr ty in
-  if ty.level <> generic_level then begin
-    if is_Tvar ty && ty.level > !current_level then
+  let level = get_level ty in
+  if level <> generic_level then begin
+    if is_Tvar ty && level > !current_level then
       set_level ty !current_level
     else if
-      ty.level > !current_level &&
-      match ty.desc with
+      level > !current_level &&
+      match get_desc ty with
         Tconstr (p, _, abbrev) ->
           not (is_object_type p) && (abbrev := Mnil; true)
       | _ -> true
@@ -730,9 +715,9 @@ let generalize_structure ty =
 (* Generalize the spine of a function, if the level >= !current_level *)
 
 let rec generalize_spine ty =
-  let ty = repr ty in
-  if ty.level < !current_level || ty.level = generic_level then () else
-  match ty.desc with
+  let level = get_level ty in
+  if level < !current_level || level = generic_level then () else
+  match get_desc ty with
     Tarrow (_, ty1, ty2, _) ->
       set_level ty generic_level;
       generalize_spine ty1;
@@ -777,12 +762,11 @@ let rec normalize_package_path env p =
       | _ -> p
 
 let rec check_scope_escape env level ty =
-  let ty = repr ty in
-  let orig_level = ty.level in
+  let orig_level = get_level ty in
   if try_logged_mark_node ty then begin
-    if level < ty.scope then
+    if level < get_scope ty then
       raise_scope_escape_exn ty;
-    begin match ty.desc with
+    begin match get_desc ty with
     | Tconstr (p, _, _) when level < Path.scope p ->
         begin match !forward_try_expand_safe env ty with
         | ty' ->
@@ -794,9 +778,9 @@ let rec check_scope_escape env level ty =
         let p' = normalize_package_path env p in
         if Path.same p p' then raise_escape_exn (Module_type p);
         check_scope_escape env level
-          (Btype.newty2 orig_level (Tpackage (p', fl)))
+          (newty2 orig_level (Tpackage (p', fl)))
     | _ ->
-      iter_type_expr (check_scope_escape env level) ty
+        iter_type_expr (check_scope_escape env level) ty
     end;
   end
 
@@ -808,9 +792,8 @@ let check_scope_escape env level ty =
     raise (Escape { e with context = Some ty })
 
 let rec update_scope scope ty =
-  let ty = repr ty in
-  if ty.scope < scope then begin
-    if ty.level < scope then raise_scope_escape_exn ty;
+  if get_scope ty < scope then begin
+    if get_level ty < scope then raise_scope_escape_exn ty;
     set_scope ty scope;
     (* Only recurse in principal mode as this is not necessary for soundness *)
     if !Clflags.principal then iter_type_expr (update_scope scope) ty
@@ -830,15 +813,15 @@ let update_scope_for tr_exn scope ty =
 *)
 
 let rec update_level env level expand ty =
-  let ty = repr ty in
-  if ty.level > level then begin
-    if level < ty.scope then raise_scope_escape_exn ty;
-    match ty.desc with
+  if get_level ty > level then begin
+    if level < get_scope ty then raise_scope_escape_exn ty;
+    match get_desc ty with
       Tconstr(p, _tl, _abbrev) when level < Path.scope p ->
         (* Try first to replace an abbreviation by its expansion. *)
         begin try
-          link_type ty (!forward_try_expand_safe env ty);
-          update_level env level expand ty
+          let ty' = !forward_try_expand_safe env ty in
+          link_type ty ty';
+          update_level env level expand ty'
         with Cannot_expand ->
           raise_escape_exn (Constructor p)
         end
@@ -849,13 +832,14 @@ let rec update_level env level expand ty =
         let needs_expand =
           expand ||
           List.exists2
-            (fun var ty -> var = Variance.null && (repr ty).level > level)
+            (fun var ty -> var = Variance.null && get_level ty > level)
             variance tl
         in
         begin try
           if not needs_expand then raise Cannot_expand;
-          link_type ty (!forward_try_expand_safe env ty);
-          update_level env level expand ty
+          let ty' = !forward_try_expand_safe env ty in
+          link_type ty ty';
+          update_level env level expand ty'
         with Cannot_expand ->
           set_level ty level;
           iter_type_expr (update_level env level expand) ty
@@ -865,7 +849,7 @@ let rec update_level env level expand ty =
         if Path.same p p' then raise_escape_exn (Module_type p);
         set_type_desc ty (Tpackage (p', fl));
         update_level env level expand ty
-    | Tobject(_, ({contents=Some(p, _tl)} as nm))
+    | Tobject (_, ({contents=Some(p, _tl)} as nm))
       when level < Path.scope p ->
         set_name nm None;
         update_level env level expand ty
@@ -878,8 +862,8 @@ let rec update_level env level expand ty =
         end;
         set_level ty level;
         iter_type_expr (update_level env level expand) ty
-    | Tfield(lab, _, ty1, _)
-      when lab = dummy_method && (repr ty1).level > level ->
+    | Tfield (lab, _, ty1, _)
+      when lab = dummy_method && get_level ty1 > level ->
         raise_escape_exn Self
     | _ ->
         set_level ty level;
@@ -890,8 +874,7 @@ let rec update_level env level expand ty =
 (* First try without expanding, then expand everything,
    to avoid combinatorial blow-up *)
 let update_level env level ty =
-  let ty = repr ty in
-  if ty.level > level then begin
+  if get_level ty > level then begin
     let snap = snapshot () in
     try
       update_level env level false ty
@@ -908,17 +891,16 @@ let update_level_for tr_exn env level ty =
 (* Lower level of type variables inside contravariant branches *)
 
 let rec lower_contravariant env var_level visited contra ty =
-  let ty = repr ty in
   let must_visit =
-    ty.level > var_level &&
-    match Hashtbl.find visited ty.id with
+    get_level ty > var_level &&
+    match Hashtbl.find visited (get_id ty) with
     | done_contra -> contra && not done_contra
     | exception Not_found -> true
   in
   if must_visit then begin
-    Hashtbl.add visited ty.id contra;
+    Hashtbl.add visited (get_id ty) contra;
     let lower_rec = lower_contravariant env var_level visited in
-    match ty.desc with
+    match get_desc ty with
       Tvar _ -> if contra then set_level ty var_level
     | Tconstr (_, [], _) -> ()
     | Tconstr (path, tyl, _abbrev) ->
@@ -983,36 +965,34 @@ let correct_levels ty =
 
 (* Only generalize the type ty0 in ty *)
 let limited_generalize ty0 ty =
-  let ty0 = repr ty0 in
-
   let graph = Hashtbl.create 17 in
   let idx = ref lowest_level in
   let roots = ref [] in
 
   let rec inverse pty ty =
-    let ty = repr ty in
-    if (ty.level > !current_level) || (ty.level = generic_level) then begin
+    let level = get_level ty in
+    if (level > !current_level) || (level = generic_level) then begin
       decr idx;
       Hashtbl.add graph !idx (ty, ref pty);
-      if (ty.level = generic_level) || (ty == ty0) then
+      if (level = generic_level) || eq_type ty ty0 then
         roots := ty :: !roots;
       set_level ty !idx;
       iter_type_expr (inverse [ty]) ty
-    end else if ty.level < lowest_level then begin
-      let (_, parents) = Hashtbl.find graph ty.level in
+    end else if level < lowest_level then begin
+      let (_, parents) = Hashtbl.find graph level in
       parents := pty @ !parents
     end
 
   and generalize_parents ty =
-    let idx = ty.level in
+    let idx = get_level ty in
     if idx <> generic_level then begin
       set_level ty generic_level;
       List.iter generalize_parents !(snd (Hashtbl.find graph idx));
       (* Special case for rows: must generalize the row variable *)
-      match ty.desc with
+      match get_desc ty with
         Tvariant row ->
           let more = row_more row in
-          let lv = more.level in
+          let lv = get_level more in
           if (lv < lowest_level || lv > !current_level)
           && lv <> generic_level then set_level more generic_level
       | _ -> ()
@@ -1020,12 +1000,12 @@ let limited_generalize ty0 ty =
   in
 
   inverse [] ty;
-  if ty0.level < lowest_level then
+  if get_level ty0 < lowest_level then
     iter_type_expr (inverse []) ty0;
   List.iter generalize_parents !roots;
   Hashtbl.iter
     (fun _ (ty, _) ->
-       if ty.level <> generic_level then set_level ty !current_level)
+       if get_level ty <> generic_level then set_level ty !current_level)
     graph
 
 
@@ -1037,7 +1017,6 @@ type inv_type_expr =
       mutable inv_parents : inv_type_expr list }
 
 let rec inv_type hash pty ty =
-  let ty = repr ty in
   try
     let inv = TypeHash.find hash ty in
     inv.inv_parents <- pty @ inv.inv_parents
@@ -1051,8 +1030,8 @@ let compute_univars ty =
   inv_type inverted [] ty;
   let node_univars = TypeHash.create 17 in
   let rec add_univar univ inv =
-    match inv.inv_type.desc with
-      Tpoly (_ty, tl) when List.memq univ (List.map repr tl) -> ()
+    match get_desc inv.inv_type with
+      Tpoly (_ty, tl) when List.memq (get_id univ) (List.map get_id tl) -> ()
     | _ ->
         try
           let univs = TypeHash.find node_univars inv.inv_type in
@@ -1072,9 +1051,8 @@ let compute_univars ty =
 
 let fully_generic ty =
   let rec aux ty =
-    let ty = repr ty in
     if not_marked_node ty then
-      if ty.level = generic_level then
+      if get_level ty = generic_level then
         (flip_mark_node ty; iter_type_expr aux ty)
       else raise Exit
   in
@@ -1116,34 +1094,32 @@ let abbreviations = ref (ref Mnil)
    before we call type_pat *)
 let rec copy ?partial ?keep_names scope ty =
   let copy = copy ?partial ?keep_names scope in
-  let ty = repr ty in
-  match ty.desc with
+  match get_desc ty with
     Tsubst (ty, _) -> ty
   | _ ->
-    if ty.level <> generic_level && partial = None then ty else
+    let level = get_level ty in
+    if level <> generic_level && partial = None then ty else
     (* We only forget types that are non generic and do not contain
        free univars *)
     let forget =
-      if ty.level = generic_level then generic_level else
+      if level = generic_level then generic_level else
       match partial with
         None -> assert false
       | Some (free_univars, keep) ->
           if TypeSet.is_empty (free_univars ty) then
-            if keep then ty.level else !current_level
+            if keep then level else !current_level
           else generic_level
     in
     if forget <> generic_level then newty2 forget (Tvar None) else
-    let desc = ty.desc in
-    For_copy.save_desc scope ty desc;
-    let t = newvar() in          (* Stub *)
-    set_scope t ty.scope;
-    Private_type_expr.set_desc ty (Tsubst (t, None));
-    Private_type_expr.set_desc t
-      begin match desc with
+    let desc = get_desc ty in
+    let t = newstub ~scope:(get_scope ty) in
+    For_copy.redirect_desc scope ty (Tsubst (t, None));
+    let desc' =
+      match desc with
       | Tconstr (p, tl, _) ->
           let abbrevs = proper_abbrevs p tl !abbreviations in
           begin match find_repr p !abbrevs with
-            Some ty when repr ty != t ->
+            Some ty when not (eq_type ty t) ->
               Tlink ty
           | _ ->
           (*
@@ -1162,34 +1138,33 @@ let rec copy ?partial ?keep_names scope ty =
           end
       | Tvariant row0 ->
           let row = row_repr row0 in
-          let more = repr row.row_more in
+          let more = row.row_more in
+          let mored = get_desc more in
           (* We must substitute in a subtle way *)
           (* Tsubst takes a tuple containing the row var and the variant *)
-          begin match more.desc with
+          begin match mored with
             Tsubst (_, Some ty2) ->
               (* This variant type has been already copied *)
-              Private_type_expr.set_desc ty (Tsubst (ty2, None));
-              (* avoid Tlink in the new type *)
+              (* Change the stub to avoid Tlink in the new type *)
+              For_copy.redirect_desc scope ty (Tsubst (ty2, None));
               Tlink ty2
           | _ ->
               (* If the row variable is not generic, we must keep it *)
-              let keep = more.level <> generic_level && partial = None in
+              let keep = get_level more <> generic_level && partial = None in
               let more' =
-                match more.desc with
+                match mored with
                   Tsubst (ty, None) -> ty
                   (* TODO: is this case possible?
                      possibly an interaction with (copy more) below? *)
                 | Tconstr _ | Tnil ->
-                    For_copy.save_desc scope more more.desc;
                     copy more
                 | Tvar _ | Tunivar _ ->
-                    For_copy.save_desc scope more more.desc;
-                    if keep then more else newty more.desc
+                    if keep then more else newty mored
                 |  _ -> assert false
               in
               let row =
-                match repr more' with (* PR#6163 *)
-                  {desc=Tconstr (x,_,_)} when not (is_fixed row) ->
+                match get_desc more' with (* PR#6163 *)
+                  Tconstr (x,_,_) when not (is_fixed row) ->
                     {row with row_fixed = Some (Reified x)}
                 | _ -> row
               in
@@ -1198,7 +1173,7 @@ let rec copy ?partial ?keep_names scope ty =
                 match partial with
                   Some (free_univars, false) ->
                     let more' =
-                      if more.id <> more'.id then
+                      if eq_type more more' then
                         more' (* we've already made a copy *)
                       else
                         newvar ()
@@ -1219,8 +1194,8 @@ let rec copy ?partial ?keep_names scope ty =
                 | _ -> (more', row)
               in
               (* Register new type first for recursion *)
-              Private_type_expr.set_desc
-                more (Tsubst (more', Some t));
+              For_copy.redirect_desc scope more
+                (Tsubst(more', Some t));
               (* Return a new copy *)
               Tvariant (copy_row copy true row keep more')
           end
@@ -1235,7 +1210,8 @@ let rec copy ?partial ?keep_names scope ty =
       | Tobject (ty1, _) when partial <> None ->
           Tobject (copy ty1, ref None)
       | _ -> copy_type_desc ?keep_names copy desc
-      end;
+    in
+    Transient_expr.set_stub_desc t desc';
     t
 
 (**** Variants of instantiations ****)
@@ -1296,8 +1272,9 @@ let new_local_type ?(loc = Location.none) ?manifest_and_scope () =
     type_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
   }
 
-let existential_name cstr ty = match repr ty with
-  | {desc = Tvar (Some name)} -> "$" ^ cstr.cstr_name ^ "_'" ^ name
+let existential_name cstr ty =
+  match get_desc ty with
+  | Tvar (Some name) -> "$" ^ cstr.cstr_name ^ "_'" ^ name
   | _ -> "$" ^ cstr.cstr_name
 
 let instance_constructor ?in_pattern cstr =
@@ -1408,74 +1385,75 @@ let rec diff_list l1 l2 =
   | a :: l1 -> a :: diff_list l1 l2
 
 let conflicts free bound =
-  let bound = List.map repr bound in
-  TypeSet.exists (fun t -> List.memq (repr t) bound) free
+  let bound = List.map get_id bound in
+  TypeSet.exists (fun t -> List.memq (get_id t) bound) free
 
 let delayed_copy = ref []
     (* copying to do later *)
 
 (* Copy without sharing until there are no free univars left *)
 (* all free univars must be included in [visited]            *)
-let rec copy_sep cleanup_scope fixed free bound visited ty =
-  let ty = repr ty in
+let rec copy_sep cleanup_scope fixed free bound
+    (visited : (int * (type_expr * type_expr list)) list)
+    (ty : type_expr) : type_expr =
   let univars = free ty in
   if TypeSet.is_empty univars then
-    if ty.level <> generic_level then ty else
-    let t = newvar () in
+    if get_level ty <> generic_level then ty else
+    let t = newstub ~scope:(get_scope ty) in
     delayed_copy :=
-      lazy (Private_type_expr.set_desc t (Tlink (copy cleanup_scope ty)))
+      lazy (Transient_expr.set_stub_desc t (Tlink (copy cleanup_scope ty)))
       :: !delayed_copy;
     t
   else try
-    let t, bound_t = List.assq ty visited in
+    let t, bound_t = List.assq (get_id ty) visited in
     let dl = if is_Tunivar ty then [] else diff_list bound bound_t in
     if dl <> [] && conflicts univars dl then raise Not_found;
     t
   with Not_found -> begin
-    let t = newvar() in          (* Stub *)
+    let t = newstub ~scope:(get_scope ty) in
+    let desc = get_desc ty in
     let visited =
-      match ty.desc with
+      match desc with
         Tarrow _ | Ttuple _ | Tvariant _ | Tconstr _ | Tobject _ | Tpackage _ ->
-          (ty,(t,bound)) :: visited
+          (get_id ty, (t, bound)) :: visited
       | Tvar _ | Tfield _ | Tnil | Tpoly _ | Tunivar _ ->
           visited
       | Tlink _ | Tsubst _ ->
           assert false
     in
     let copy_rec = copy_sep cleanup_scope fixed free bound visited in
-    Private_type_expr.set_desc t
-      begin match ty.desc with
+    let desc' =
+      match desc with
       | Tvariant row0 ->
           let row = row_repr row0 in
-          let more = repr row.row_more in
+          let more = row.row_more in
           (* We shall really check the level on the row variable *)
-          let keep = is_Tvar more && more.level <> generic_level in
+          let keep = is_Tvar more && get_level more <> generic_level in
           let more' = copy_rec more in
           let fixed' = fixed && (is_Tvar more || is_Tunivar more) in
           let row = copy_row copy_rec fixed' row keep more' in
           Tvariant row
       | Tpoly (t1, tl) ->
-          let tl = List.map repr tl in
-          let tl' = List.map (fun t -> newty t.desc) tl in
+          let tl' = List.map (fun t -> newty (get_desc t)) tl in
           let bound = tl @ bound in
           let visited =
-            List.map2 (fun ty t -> ty,(t,bound)) tl tl' @ visited in
+            List.map2 (fun ty t -> get_id ty, (t, bound)) tl tl' @ visited in
           Tpoly (copy_sep cleanup_scope fixed free bound visited t1, tl')
-      | _ -> copy_type_desc copy_rec ty.desc
-      end;
+      | _ -> copy_type_desc copy_rec desc
+    in
+    Transient_expr.set_stub_desc t desc';
     t
   end
 
 let instance_poly' cleanup_scope ~keep_names fixed univars sch =
   (* In order to compute univars below, [sch] should not contain [Tsubst] *)
-  let univars = List.map repr univars in
   let copy_var ty =
-    match ty.desc with
+    match get_desc ty with
       Tunivar name -> if keep_names then newty (Tvar name) else newvar ()
     | _ -> assert false
   in
   let vars = List.map copy_var univars in
-  let pairs = List.map2 (fun u v -> u, (v, [])) univars vars in
+  let pairs = List.map2 (fun u v -> get_id u, (v, [])) univars vars in
   delayed_copy := [];
   let ty = copy_sep cleanup_scope fixed (compute_univars sch) [] pairs sch in
   List.iter Lazy.force !delayed_copy;
@@ -1490,8 +1468,8 @@ let instance_poly ?(keep_names=false) fixed univars sch =
 let instance_label fixed lbl =
   For_copy.with_scope (fun scope ->
     let vars, ty_arg =
-      match repr lbl.lbl_arg with
-        {desc = Tpoly (ty, tl)} ->
+      match get_desc lbl.lbl_arg with
+        Tpoly (ty, tl) ->
           instance_poly' scope ~keep_names:false fixed tl ty
       | _ ->
           [], copy scope lbl.lbl_arg
@@ -1507,20 +1485,21 @@ let instance_label fixed lbl =
 let unify_var' = (* Forward declaration *)
   ref (fun _env _ty1 _ty2 -> assert false)
 
-let subst env level priv abbrev ty params args body =
+let subst env level priv abbrev oty params args body =
   if List.length params <> List.length args then raise Cannot_subst;
   let old_level = !current_level in
   current_level := level;
   let body0 = newvar () in          (* Stub *)
   let undo_abbrev =
-    match ty with
+    match oty with
     | None -> fun () -> () (* No abbreviation added *)
-    | Some ({desc = Tconstr (path, tl, _)} as ty) ->
-        let abbrev = proper_abbrevs path tl abbrev in
-        memorize_abbrev abbrev priv path ty body0;
-        fun () -> forget_abbrev abbrev path
-    | _ ->
-        assert false
+    | Some ty ->
+        match get_desc ty with
+          Tconstr (path, tl, _) ->
+            let abbrev = proper_abbrevs path tl abbrev in
+            memorize_abbrev abbrev priv path ty body0;
+            fun () -> forget_abbrev abbrev path
+        | _ -> assert false
   in
   abbreviations := abbrev;
   let (params', body') = instance_parameterized_type params body in
@@ -1589,8 +1568,10 @@ let check_abbrev_env env =
 *)
 let expand_abbrev_gen kind find_type_expansion env ty =
   check_abbrev_env env;
-  match ty with
-    {desc = Tconstr (path, args, abbrev); level = level; scope} ->
+  match get_desc ty with
+    Tconstr (path, args, abbrev) ->
+      let level = get_level ty in
+      let scope = get_scope ty in
       let lookup_abbrev = proper_abbrevs path args abbrev in
       begin match find_expans kind path !lookup_abbrev with
         Some ty' ->
@@ -1613,8 +1594,6 @@ let expand_abbrev_gen kind find_type_expansion env ty =
                typing error *)
             ()
           end;
-          let ty' = repr ty' in
-          (* assert (ty != ty'); *) (* PR#7324 *)
           ty'
       | None ->
           match find_type_expansion path env with
@@ -1634,7 +1613,7 @@ let expand_abbrev_gen kind find_type_expansion env ty =
             (* For gadts, remember type as non exportable *)
             (* The ambiguous level registered for ty' should be the highest *)
             (* if !trace_gadt_instances then begin *)
-            let scope = Int.max lv ty.scope in
+            let scope = Int.max lv (get_scope ty) in
             update_scope scope ty;
             update_scope scope ty';
             ty'
@@ -1649,7 +1628,7 @@ let expand_abbrev env ty =
 (* Expand once the head of a type *)
 let expand_head_once env ty =
   try
-    expand_abbrev env (repr ty)
+    expand_abbrev env ty
   with Cannot_expand | Escape _ -> assert false
 
 (* Check whether a type can be expanded *)
@@ -1668,9 +1647,8 @@ let safe_abbrev env ty =
    Raise Cannot_expand if the type cannot be expanded.
    May raise Escape, if a recursion was hidden in the type. *)
 let try_expand_once env ty =
-  let ty = repr ty in
-  match ty.desc with
-    Tconstr _ -> repr (expand_abbrev env ty)
+  match get_desc ty with
+    Tconstr _ -> expand_abbrev env ty
   | _ -> raise Cannot_expand
 
 (* This one only raises Cannot_expand *)
@@ -1681,7 +1659,8 @@ let try_expand_safe env ty =
     Btype.backtrack snap; cleanup_abbrev (); raise Cannot_expand
 
 (* Fully expand the head of a type. *)
-let rec try_expand_head try_once env ty =
+let rec try_expand_head
+    (try_once : Env.t -> type_expr -> type_expr) env ty =
   let ty' = try_once env ty in
   try try_expand_head try_once env ty'
   with Cannot_expand -> ty'
@@ -1691,12 +1670,13 @@ let expand_head_unif env ty =
   try
     try_expand_head try_expand_once env ty
   with
-  | Cannot_expand -> repr ty
+  | Cannot_expand -> ty
   | Escape e -> raise_for Unify (Escape e)
 
 (* Safe version of expand_head, never fails *)
 let expand_head env ty =
-  try try_expand_head try_expand_safe env ty with Cannot_expand -> repr ty
+  try try_expand_head try_expand_safe env ty
+  with Cannot_expand -> ty
 
 let _ = forward_try_expand_safe := try_expand_safe
 
@@ -1712,9 +1692,8 @@ type typedecl_extraction_result =
   | May_have_typedecl
 
 let rec extract_concrete_typedecl env ty =
-  let ty = repr ty in
-  match ty.desc with
-  | Tconstr (p, _, _) ->
+  match get_desc ty with
+    Tconstr (p, _, _) ->
       let decl = Env.find_type p env in
       if decl.type_kind <> Type_abstract then Typedecl(p, p, decl)
       else begin
@@ -1750,9 +1729,8 @@ let safe_abbrev_opt env ty =
     false
 
 let try_expand_once_opt env ty =
-  let ty = repr ty in
-  match ty.desc with
-    Tconstr _ -> repr (expand_abbrev_opt env ty)
+  match get_desc ty with
+    Tconstr _ -> expand_abbrev_opt env ty
   | _ -> raise Cannot_expand
 
 let try_expand_safe_opt env ty =
@@ -1762,7 +1740,7 @@ let try_expand_safe_opt env ty =
     Btype.backtrack snap; raise Cannot_expand
 
 let expand_head_opt env ty =
-  try try_expand_head try_expand_safe_opt env ty with Cannot_expand -> repr ty
+  try try_expand_head try_expand_safe_opt env ty with Cannot_expand -> ty
 
 (* Recursively expand the head of a type.
    Also expand #-types.
@@ -1772,25 +1750,23 @@ let expand_head_opt env ty =
 let full_expand ~may_forget_scope env ty =
   let ty =
     if may_forget_scope then
-      let ty = repr ty in
       try expand_head_unif env ty with Unify_trace _ ->
         (* #10277: forget scopes when printing trace *)
         begin_def ();
-        init_def ty.level;
+        init_def (get_level ty);
         let ty =
           (* The same as [expand_head], except in the failing case we return the
              *original* type, not [correct_levels ty].*)
           try try_expand_head try_expand_safe env (correct_levels ty) with
-          | Cannot_expand -> repr ty
+          | Cannot_expand -> ty
         in
         end_def ();
         ty
     else expand_head env ty
   in
-  let ty = repr ty in
-  match ty.desc with
-    Tobject (fi, {contents = Some (_, v::_)}) when is_Tvar (repr v) ->
-      newty2 ty.level (Tobject (fi, ref None))
+  match get_desc ty with
+    Tobject (fi, {contents = Some (_, v::_)}) when is_Tvar v ->
+      newty2 (get_level ty) (Tobject (fi, ref None))
   | _ ->
       ty
 
@@ -1802,7 +1778,7 @@ let full_expand ~may_forget_scope env ty =
 let generic_abbrev env path =
   try
     let (_, body, _) = Env.find_type_expansion path env in
-    (repr body).level = generic_level
+    get_level body = generic_level
   with
     Not_found ->
       false
@@ -1813,7 +1789,7 @@ let generic_private_abbrev env path =
       {type_kind = Type_abstract;
        type_private = Private;
        type_manifest = Some body} ->
-         (repr body).level = generic_level
+         get_level body = generic_level
     | _ -> false
   with Not_found -> false
 
@@ -1831,12 +1807,9 @@ let is_contractive env p =
 
 exception Occur
 
-let rec occur_rec env allow_recursive visited ty0 = function
-  | {desc=Tlink ty} ->
-      occur_rec env allow_recursive visited ty0 ty
-  | ty ->
-  if ty == ty0  then raise Occur;
-  match ty.desc with
+let rec occur_rec env allow_recursive visited ty0 ty =
+  if eq_type ty ty0 then raise Occur;
+  match get_desc ty with
     Tconstr(p, _tl, _abbrev) ->
       if allow_recursive && is_contractive env p then () else
       begin try
@@ -1893,13 +1866,12 @@ let occur_in env ty0 t =
 
 let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
   (*Format.eprintf "@[Check %s =@ %a@]@." (Path.name p) !Btype.print_raw ty;*)
-  let ty = repr ty in
-  if not (List.memq ty visited) then begin
-    match ty.desc with
+  if not (List.memq (get_id ty) visited) then begin
+    match get_desc ty with
       Tconstr(p', args, _abbrev) ->
         if Path.same p p' then raise Occur;
         if allow_rec && not strict && is_contractive env p' then () else
-        let visited = ty :: visited in
+        let visited = get_id ty :: visited in
         begin try
           (* try expanding, since [p] could be hidden *)
           local_non_recursive_abbrev ~allow_rec strict visited env p
@@ -1911,7 +1883,7 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
           in
           List.iter2
             (fun tv ty ->
-              let strict = strict || not (is_Tvar (repr tv)) in
+              let strict = strict || not (is_Tvar tv) in
               local_non_recursive_abbrev ~allow_rec strict visited env p ty)
             params args
         end
@@ -1919,7 +1891,7 @@ let rec local_non_recursive_abbrev ~allow_rec strict visited env p ty =
         ()
     | _ ->
         if strict || not allow_rec then (* PR#7374 *)
-          let visited = ty :: visited in
+          let visited = get_id ty :: visited in
           iter_type_expr
             (local_non_recursive_abbrev ~allow_rec true visited env p) ty
   end
@@ -1945,12 +1917,12 @@ let rec unify_univar t1 t2 = function
     (cl1, cl2) :: rem ->
       let find_univ t cl =
         try
-          let (_, r) = List.find (fun (t',_) -> t == repr t') cl in
+          let (_, r) = List.find (fun (t',_) -> eq_type t t') cl in
           Some r
         with Not_found -> None
       in
       begin match find_univ t1 cl1, find_univ t2 cl2 with
-        Some {contents=Some t'2}, Some _ when t2 == repr t'2 ->
+        Some {contents=Some t'2}, Some _ when eq_type t2 t'2 ->
           ()
       | Some({contents=None} as r1), Some({contents=None} as r2) ->
           set_univar r1 t2; set_univar r2 t1
@@ -1973,7 +1945,6 @@ let unify_univar_for tr_exn t1 t2 univar_pairs =
 let occur_univar ?(inj_only=false) env ty =
   let visited = ref TypeMap.empty in
   let rec occur_rec bound ty =
-    let ty = repr ty in
     if not_marked_node ty then
       if TypeSet.is_empty bound then
         (flip_mark_node ty; occur_desc bound ty)
@@ -1987,12 +1958,12 @@ let occur_univar ?(inj_only=false) env ty =
         visited := TypeMap.add ty bound !visited;
         occur_desc bound ty
   and occur_desc bound ty =
-      match ty.desc with
+      match get_desc ty with
         Tunivar _ ->
           if not (TypeSet.mem ty bound) then
             raise_escape_exn (Univ ty)
       | Tpoly (ty, tyl) ->
-          let bound = List.fold_right TypeSet.add (List.map repr tyl) bound in
+          let bound = List.fold_right TypeSet.add tyl bound in
           occur_rec bound  ty
       | Tconstr (_, [], _) -> ()
       | Tconstr (p, tl, _) ->
@@ -2032,13 +2003,13 @@ let occur_univar_for tr_exn env ty =
 
 (* Grouping univars by families according to their binders *)
 let add_univars =
-  List.fold_left (fun s (t,_) -> TypeSet.add (repr t) s)
+  List.fold_left (fun s (t,_) -> TypeSet.add t s)
 
 let get_univar_family univar_pairs univars =
   if univars = [] then TypeSet.empty else
   let insert s = function
       cl1, (_::_ as cl2) ->
-        if List.exists (fun (t1,_) -> TypeSet.mem (repr t1) s) cl1 then
+        if List.exists (fun (t1,_) -> TypeSet.mem t1 s) cl1 then
           add_univars s cl2
         else s
     | _ -> s
@@ -2051,12 +2022,11 @@ let univars_escape env univar_pairs vl ty =
   let family = get_univar_family univar_pairs vl in
   let visited = ref TypeSet.empty in
   let rec occur t =
-    let t = repr t in
     if TypeSet.mem t !visited then () else begin
       visited := TypeSet.add t !visited;
-      match t.desc with
+      match get_desc t with
         Tpoly (t, tl) ->
-          if List.exists (fun t -> TypeSet.mem (repr t) family) tl then ()
+          if List.exists (fun t -> TypeSet.mem t family) tl then ()
           else occur t
       | Tunivar _ -> if TypeSet.mem t family then raise_escape_exn (Univ t)
       | Tconstr (_, [], _) -> ()
@@ -2083,7 +2053,6 @@ let enter_poly env univar_pairs t1 tl1 t2 tl2 f =
     List.fold_left (fun s (cl,_) -> add_univars s cl)
       TypeSet.empty old_univars
   in
-  let tl1 = List.map repr tl1 and tl2 = List.map repr tl2 in
   if List.exists (fun t -> TypeSet.mem t known_univars) tl1 then
      univars_escape env old_univars tl1 (newty(Tpoly(t2,tl2)));
   if List.exists (fun t -> TypeSet.mem t known_univars) tl2 then
@@ -2105,12 +2074,10 @@ let univar_pairs = ref []
 
 let polyfy env ty vars =
   let subst_univar scope ty =
-    let ty = repr ty in
-    match ty.desc with
-    | Tvar name when ty.level = generic_level ->
-        For_copy.save_desc scope ty ty.desc;
+    match get_desc ty with
+    | Tvar name when get_level ty = generic_level ->
         let t = newty (Tunivar name) in
-        Private_type_expr.set_desc ty (Tsubst (t, None));
+        For_copy.redirect_desc scope ty (Tsubst (t, None));
         Some t
     | _ -> None
   in
@@ -2120,7 +2087,7 @@ let polyfy env ty vars =
   For_copy.with_scope (fun scope ->
     let vars' = List.filter_map (subst_univar scope) vars in
     let ty = copy scope ty in
-    let ty = newty2 ty.level (Tpoly(repr ty, vars')) in
+    let ty = newty2 (get_level ty) (Tpoly(ty, vars')) in
     let complete = List.length vars = List.length vars' in
     ty, complete
   )
@@ -2149,7 +2116,7 @@ let rec has_cached_expansion p abbrev =
    but still might be nice. *)
 
 let expand_type env ty =
-  { ty       = repr ty;
+  { ty       = ty;
     expanded = full_expand ~may_forget_scope:true env ty }
 
 let expand_any_trace map env trace =
@@ -2190,9 +2157,8 @@ let unexpanded_diff ~got ~expected =
 (* Return whether [t0] occurs in [ty]. Objects are also traversed. *)
 let deep_occur t0 ty =
   let rec occur_rec ty =
-    let ty = repr ty in
-    if ty.level >= t0.level && try_mark_node ty then begin
-      if ty == t0 then raise Occur;
+    if get_level ty >= get_level t0 && try_mark_node ty then begin
+      if eq_type ty t0 then raise Occur;
       iter_type_expr occur_rec ty
     end
   in
@@ -2227,28 +2193,29 @@ let reify env t =
   in
   let visited = ref TypeSet.empty in
   let rec iterator ty =
-    let ty = repr ty in
     if TypeSet.mem ty !visited then () else begin
       visited := TypeSet.add ty !visited;
-      match ty.desc with
+      match get_desc ty with
         Tvar o ->
-          let path, t = create_fresh_constr ty.level o in
+          let level = get_level ty in
+          let path, t = create_fresh_constr level o in
           link_type ty t;
-          if ty.level < fresh_constr_scope then
+          if level < fresh_constr_scope then
             raise_for Unify (Escape (escape (Constructor path)))
       | Tvariant r ->
           let r = row_repr r in
           if not (static_row r) then begin
             if is_fixed r then iterator (row_more r) else
             let m = r.row_more in
-            match m.desc with
+            match get_desc m with
               Tvar o ->
-                let path, t = create_fresh_constr m.level o in
+                let level = get_level m in
+                let path, t = create_fresh_constr level o in
                 let row =
                   let row_fixed = Some (Reified path) in
                   {r with row_fields=[]; row_fixed; row_more = t} in
-                link_type m (newty2 m.level (Tvariant row));
-                if m.level < fresh_constr_scope then
+                link_type m (newty2 level (Tvariant row));
+                if level < fresh_constr_scope then
                   raise_for Unify (Escape (escape (Constructor path)))
             | _ -> assert false
           end;
@@ -2293,8 +2260,7 @@ let compatible_paths p1 p2 =
 
 (* Check for datatypes carefully; see PR#6348 *)
 let rec expands_to_datatype env ty =
-  let ty = repr ty in
-  match ty.desc with
+  match get_desc ty with
     Tconstr (p, _, _) ->
       begin try
         is_datatype (Env.find_type p env) ||
@@ -2317,11 +2283,8 @@ let rec expands_to_datatype env ty =
  *)
 
 let rec mcomp type_pairs env t1 t2 =
-  if t1 == t2 then () else
-  let t1 = repr t1 in
-  let t2 = repr t2 in
-  if t1 == t2 then () else
-  match (t1.desc, t2.desc) with
+  if eq_type t1 t2 then () else
+  match (get_desc t1, get_desc t2) with
   | (Tvar _, _)
   | (_, Tvar _)  ->
       ()
@@ -2331,12 +2294,11 @@ let rec mcomp type_pairs env t1 t2 =
       let t1' = expand_head_opt env t1 in
       let t2' = expand_head_opt env t2 in
       (* Expansion may have changed the representative of the types... *)
-      let t1' = repr t1' and t2' = repr t2' in
-      if t1' == t2' then () else
+      if eq_type t1' t2' then () else
       begin try TypePairs.find type_pairs (t1', t2')
       with Not_found ->
         TypePairs.add type_pairs (t1', t2') ();
-        match (t1'.desc, t2'.desc) with
+        match (get_desc t1', get_desc t2') with
         | (Tvar _, _)
         | (_, Tvar _)  ->
             ()
@@ -2399,8 +2361,9 @@ and mcomp_fields type_pairs env ty1 ty2 =
   let has_present =
     List.exists (fun (_, k, _) -> field_kind_repr k = Fpresent) in
   mcomp type_pairs env rest1 rest2;
-  if has_present miss1  && (object_row ty2).desc = Tnil
-  || has_present miss2  && (object_row ty1).desc = Tnil then raise Incompatible;
+  if has_present miss1  && get_desc (object_row ty2) = Tnil
+  || has_present miss2  && get_desc (object_row ty1) = Tnil
+  then raise Incompatible;
   List.iter
     (function (_n, k1, t1, k2, t2) ->
        mcomp_kind k1 k2;
@@ -2524,9 +2487,9 @@ let mcomp_for tr_exn env t1 t2 =
 let find_lowest_level ty =
   let lowest = ref generic_level in
   let rec find ty =
-    let ty = repr ty in
     if not_marked_node ty then begin
-      if ty.level < !lowest then lowest := ty.level;
+      let level = get_level ty in
+      if level < !lowest then lowest := level;
       flip_mark_node ty;
       iter_type_expr find ty
     end
@@ -2554,7 +2517,7 @@ let add_gadt_equation env source destination =
 let unify_eq_set = TypePairs.create 11
 
 let order_type_pair t1 t2 =
-  if t1.id <= t2.id then (t1, t2) else (t2, t1)
+  if get_id t1 <= get_id t2 then (t1, t2) else (t2, t1)
 
 let add_type_equality t1 t2 =
   TypePairs.add unify_eq_set (order_type_pair t1 t2) ()
@@ -2643,7 +2606,7 @@ let unify_package env unify_list lv1 p1 fl1 lv2 p2 fl2 =
 let rigid_variants = ref false
 
 let unify_eq t1 t2 =
-  t1 == t2 ||
+  eq_type t1 t2 ||
   match !umode with
   | Expression -> false
   | Pattern ->
@@ -2657,8 +2620,8 @@ let unify1_var env t1 t2 =
   | () ->
       begin
         try
-          update_level env t1.level t2;
-          update_scope t1.scope t2
+          update_level env (get_level t1) t2;
+          update_scope (get_scope t1) t2;
         with Escape e ->
           raise_for Unify (Escape e)
       end;
@@ -2671,7 +2634,8 @@ let unify1_var env t1 t2 =
 let record_equation t1 t2 =
   match !equations_generation with
   | Forbidden -> assert false
-  | Allowed { equated_types } -> TypePairs.add equated_types (t1, t2) ()
+  | Allowed { equated_types } ->
+      TypePairs.add equated_types (t1, t2) ()
 
 (* Called from unify3 *)
 let unify3_var env t1' t2 t2' =
@@ -2712,15 +2676,12 @@ let unify3_var env t1' t2 t2' =
 
 let rec unify (env:Env.t ref) t1 t2 =
   (* First step: special cases (optimizations) *)
-  if t1 == t2 then () else
-  let t1 = repr t1 in
-  let t2 = repr t2 in
   if unify_eq t1 t2 then () else
   let reset_tracing = check_trace_gadt_instances !env in
 
   try
     type_changed := true;
-    begin match (t1.desc, t2.desc) with
+    begin match (get_desc t1, get_desc t2) with
       (Tvar _, Tconstr _) when deep_occur t1 t2 ->
         unify2 env t1 t2
     | (Tconstr _, Tvar _) when deep_occur t2 t1 ->
@@ -2731,8 +2692,8 @@ let rec unify (env:Env.t ref) t1 t2 =
         if unify1_var !env t2 t1 then () else unify2 env t1 t2
     | (Tunivar _, Tunivar _) ->
         unify_univar_for Unify t1 t2 !univar_pairs;
-        update_level_for Unify !env t1.level t2;
-        update_scope_for Unify t1.scope t2;
+        update_level_for Unify !env (get_level t1) t2;
+        update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2
     | (Tconstr (p1, [], a1), Tconstr (p2, [], a2))
           when Path.same p1 p2 (* && actual_mode !env = Old *)
@@ -2741,8 +2702,8 @@ let rec unify (env:Env.t ref) t1 t2 =
                when any of the types has a cached expansion. *)
             && not (has_cached_expansion p1 !a1
                  || has_cached_expansion p2 !a2) ->
-        update_level_for Unify !env t1.level t2;
-        update_scope_for Unify t1.scope t2;
+        update_level_for Unify !env (get_level t1) t2;
+        update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2
     | (Tconstr (p1, [], _), Tconstr (p2, [], _))
       when Env.has_local_constraints !env
@@ -2771,22 +2732,22 @@ and unify2 env t1 t2 =
   ignore (expand_head_unif !env t2);
   let t1' = expand_head_unif !env t1 in
   let t2' = expand_head_unif !env t2 in
-  let lv = Int.min t1'.level t2'.level in
-  let scope = Int.max t1'.scope t2'.scope in
+  let lv = Int.min (get_level t1') (get_level t2') in
+  let scope = Int.max (get_scope t1') (get_scope t2') in
   update_level_for Unify !env lv t2;
   update_level_for Unify !env lv t1;
   update_scope_for Unify scope t2;
   update_scope_for Unify scope t1;
   if unify_eq t1' t2' then () else
 
-  let t1 = repr t1 and t2 = repr t2 in
   let t1, t2 =
     if !Clflags.principal
-    && (find_lowest_level t1' < lv || find_lowest_level t2' < lv) then
+    && (find_lowest_level  t1' < lv ||
+        find_lowest_level  t2' < lv) then
       (* Expand abbreviations hiding a lower level *)
       (* Should also do it for parameterized types, after unification... *)
-      (match t1.desc with Tconstr (_, [], _) -> t1' | _ -> t1),
-      (match t2.desc with Tconstr (_, [], _) -> t2' | _ -> t2)
+      (match get_desc t1 with Tconstr (_, [], _) -> t1' | _ -> t1),
+      (match get_desc t2 with Tconstr (_, [], _) -> t2' | _ -> t2)
     else (t1, t2)
   in
   if unify_eq t1 t1' || not (unify_eq t2 t2') then
@@ -2798,8 +2759,10 @@ and unify2 env t1 t2 =
 and unify3 env t1 t1' t2 t2' =
   (* Third step: truly unification *)
   (* Assumes either [t1 == t1'] or [t2 != t2'] *)
-  let d1 = t1'.desc and d2 = t2'.desc in
-  let create_recursion = (t2 != t2') && (deep_occur t1' t2) in
+  let tt1' = Transient_expr.repr t1' in
+  let d1 = tt1'.desc and d2 = get_desc t2' in
+  let create_recursion =
+    (not (eq_type t2 t2')) && (deep_occur t1'  t2) in
 
   begin match (d1, d2) with (* handle vars and univars specially *)
     (Tunivar _, Tunivar _) ->
@@ -2896,9 +2859,9 @@ and unify3 env t1 t1' t2 t2' =
           unify_fields env fi1 fi2;
           (* Type [t2'] may have been instantiated by [unify_fields] *)
           (* XXX One should do some kind of unification... *)
-          begin match (repr t2').desc with
+          begin match get_desc t2' with
             Tobject (_, {contents = Some (_, va::_)}) when
-              (match (repr va).desc with
+              (match get_desc va with
                 Tvar _|Tunivar _|Tnil -> true | _ -> false) -> ()
           | Tobject (_, nm2) -> set_name nm2 !nm1
           | _ -> ()
@@ -2923,7 +2886,7 @@ and unify3 env t1 t1' t2 t2' =
             Fvar r when f <> dummy_method ->
               set_kind r Fabsent;
               if d2 = Tnil then unify env rem t2'
-              else unify env (newty2 rem.level Tnil) rem
+              else unify env (newgenty Tnil) rem
           | _      ->
               if f = dummy_method then
                 raise_for Unify (Obj Self_cannot_be_closed)
@@ -2941,7 +2904,7 @@ and unify3 env t1 t1' t2 t2' =
       | (Tpackage (p1, fl1), Tpackage (p2, fl2)) ->
           begin try
             unify_package !env (unify_list env)
-              t1.level p1 fl1 t2.level p2 fl2
+              (get_level t1) p1 fl1 (get_level t2) p2 fl2
           with Not_found ->
             if !umode = Expression then raise_unexplained_for Unify;
             List.iter (fun (_n, ty) -> reify env ty) (fl1 @ fl2);
@@ -2956,16 +2919,16 @@ and unify3 env t1 t1' t2 t2' =
       (* XXX Commentaires + changer "create_recursion"
          ||| Comments + change "create_recursion" *)
       if create_recursion then
-        match t2.desc with
+        match get_desc t2 with
           Tconstr (p, tl, abbrev) ->
             forget_abbrev abbrev p;
             let t2'' = expand_head_unif !env t2 in
             if not (closed_parameterized_type tl t2'') then
-              link_type (repr t2) (repr t2')
+              link_type t2 t2'
         | _ ->
             () (* t2 has already been expanded by update_level *)
     with Unify_trace trace ->
-      Private_type_expr.set_desc t1' d1;
+      Transient_expr.set_desc tt1' d1;
       raise_trace_for Unify trace
   end
 
@@ -2977,14 +2940,14 @@ and unify_list env tl1 tl2 =
 (* Build a fresh row variable for unification *)
 and make_rowvar level use1 rest1 use2 rest2  =
   let set_name ty name =
-    match ty.desc with
+    match get_desc ty with
       Tvar None -> set_type_desc ty (Tvar name)
     | _ -> ()
   in
   let name =
-    match rest1.desc, rest2.desc with
+    match get_desc rest1, get_desc rest2 with
       Tvar (Some _ as name1), Tvar (Some _ as name2) ->
-        if rest1.level <= rest2.level then name1 else name2
+        if get_level rest1 <= get_level rest2 then name1 else name2
     | Tvar (Some _ as name), _ ->
         if use2 then set_name rest2 name; name
     | _, Tvar (Some _ as name) ->
@@ -2992,15 +2955,16 @@ and make_rowvar level use1 rest1 use2 rest2  =
     | _ -> None
   in
   if use1 then rest1 else
-  if use2 then rest2 else newvar2 ?name level
+  if use2 then rest2 else Types.newty2 level (Tvar name)
 
 and unify_fields env ty1 ty2 =          (* Optimization *)
   let (fields1, rest1) = flatten_fields ty1
   and (fields2, rest2) = flatten_fields ty2 in
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
-  let l1 = (repr ty1).level and l2 = (repr ty2).level in
+  let l1 = get_level ty1 and l2 = get_level ty2 in
   let va = make_rowvar (Int.min l1 l2) (miss2=[]) rest1 (miss1=[]) rest2 in
-  let d1 = rest1.desc and d2 = rest2.desc in
+  let tr1 = Transient_expr.repr rest1 and tr2 = Transient_expr.repr rest2 in
+  let d1 = tr1.desc and d2 = tr2.desc in
   try
     unify env (build_fields l1 miss1 va) rest2;
     unify env rest1 (build_fields l2 miss2 va);
@@ -3009,8 +2973,8 @@ and unify_fields env ty1 ty2 =          (* Optimization *)
         unify_kind k1 k2;
         try
           if !trace_gadt_instances then begin
-            update_level_for Unify !env va.level t1;
-            update_scope_for Unify va.scope t1
+            update_level_for Unify !env (get_level va) t1;
+            update_scope_for Unify (get_scope va) t1
           end;
           unify env t1 t2
         with Unify_trace trace ->
@@ -3019,8 +2983,8 @@ and unify_fields env ty1 ty2 =          (* Optimization *)
       )
       pairs
   with exn ->
-    set_type_desc rest1 d1;
-    set_type_desc rest2 d2;
+    Transient_expr.set_desc tr1 d1;
+    Transient_expr.set_desc tr2 d2;
     raise exn
 
 and unify_kind k1 k2 =
@@ -3049,10 +3013,10 @@ and unify_row env row1 row2 =
   end;
   let fixed1 = fixed_explanation row1 and fixed2 = fixed_explanation row2 in
   let more = match fixed1, fixed2 with
-    | Some _, Some _ -> if rm2.level < rm1.level then rm2 else rm1
+    | Some _, Some _ -> if get_level rm2 < get_level rm1 then rm2 else rm1
     | Some _, None -> rm1
     | None, Some _ -> rm2
-    | None, None -> newty2 (Int.min rm1.level rm2.level) (Tvar None)
+    | None, None -> newty2 (Int.min (get_level rm1) (get_level rm2)) (Tvar None)
   in
   let fixed = merge_fixed_explanation fixed1 fixed2
   and closed = row1.row_closed || row2.row_closed in
@@ -3105,17 +3069,18 @@ and unify_row env row1 row2 =
     let rm = row_more row in
     (*if !trace_gadt_instances && rm.desc = Tnil then () else*)
     if !trace_gadt_instances then
-      update_level_for Unify !env rm.level (newgenty (Tvariant row));
+      update_level_for Unify !env (get_level rm) (newgenty (Tvariant row));
     if row_fixed row then
-      if more == rm then () else
+      if eq_type more rm then () else
       if is_Tvar rm then link_type rm more else unify env rm more
     else
       let ty = newgenty (Tvariant {row0 with row_fields = rest}) in
-      update_level_for Unify !env rm.level ty;
-      update_scope_for Unify rm.scope ty;
+      update_level_for Unify !env (get_level rm) ty;
+      update_scope_for Unify (get_scope rm) ty;
       link_type rm ty
   in
-  let md1 = rm1.desc and md2 = rm2.desc in
+  let tm1 = Transient_expr.repr rm1 and tm2 = Transient_expr.repr rm2 in
+  let md1 = tm1.desc and md2 = tm2.desc in
   begin try
     set_more row2 r1;
     set_more row1 r2;
@@ -3128,10 +3093,12 @@ and unify_row env row1 row2 =
       pairs;
     if static_row row1 then begin
       let rm = row_more row1 in
-      if is_Tvar rm then link_type rm (newty2 rm.level Tnil)
+      if is_Tvar rm then link_type rm (newty2 (get_level rm) Tnil)
     end
   with exn ->
-    set_type_desc rm1 md1; set_type_desc rm2 md2; raise exn
+    Transient_expr.set_desc tm1 md1;
+    Transient_expr.set_desc tm2 md2;
+    raise exn
   end
 
 and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
@@ -3169,11 +3136,8 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
             !e1 <> None || !e2 <> None
         end in
       if redo then unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 else
-      let tl1 = List.map repr tl1 and tl2 = List.map repr tl2 in
-      let rec remq tl = function [] -> []
-        | ty :: tl' ->
-            if List.memq ty tl then remq tl tl' else ty :: remq tl tl'
-      in
+      let remq tl =
+        List.filter (fun ty -> not (List.exists (eq_type ty) tl)) in
       let tl1' = remq tl2 tl1 and tl2' = remq tl1 tl2 in
       (* PR#6744 *)
       let (tlu1,tl1') = List.partition (has_free_univars !env) tl1'
@@ -3187,16 +3151,14 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
           occur_univar_for Unify !env tu
       end;
       (* Is this handling of levels really principal? *)
-      List.iter (fun ty ->
-        let rm = repr rm2 in
-        update_level_for Unify !env rm.level ty;
-        update_scope_for Unify rm.scope ty;
-      ) tl1';
-      List.iter (fun ty ->
-        let rm = repr rm1 in
-        update_level_for Unify !env rm.level ty;
-        update_scope_for Unify rm.scope ty;
-      ) tl2';
+      let update_levels rm =
+        List.iter
+          (fun ty ->
+            update_level_for Unify !env (get_level rm) ty;
+            update_scope_for Unify (get_scope rm) ty)
+      in
+      update_levels rm2 tl1';
+      update_levels rm1 tl2';
       let e = ref None in
       let f1' = Reither(c1 || c2, tl2', m1 || m2, e)
       and f2' = Reither(c1 || c2, tl1', m1 || m2, e) in
@@ -3209,18 +3171,16 @@ and unify_row_field env fixed1 fixed2 rm1 rm2 l f1 f2 =
   | Reither(false, tl, _, e1), Rpresent(Some t2) ->
       if_not_fixed first (fun () ->
           set_row_field e1 f2;
-          let rm = repr rm1 in
-          update_level_for Unify !env rm.level t2;
-          update_scope_for Unify rm.scope t2;
+          update_level_for Unify !env (get_level rm1) t2;
+          update_scope_for Unify (get_scope rm1) t2;
           (try List.iter (fun t1 -> unify env t1 t2) tl
            with exn -> e1 := None; raise exn)
         )
   | Rpresent(Some t1), Reither(false, tl, _, e2) ->
       if_not_fixed second (fun () ->
           set_row_field e2 f1;
-          let rm = repr rm2 in
-          update_level_for Unify !env rm.level t1;
-          update_scope_for Unify rm.scope t1;
+          update_level_for Unify !env (get_level rm2) t1;
+          update_scope_for Unify (get_scope rm2) t1;
           (try List.iter (unify env t1) tl
            with exn -> e2 := None; raise exn)
         )
@@ -3258,17 +3218,16 @@ let unify_gadt ~equations_level:lev ~allow_recursive (env:Env.t ref) ty1 ty2 =
     raise e
 
 let unify_var env t1 t2 =
-  let t1 = repr t1 and t2 = repr t2 in
-  if t1 == t2 then () else
-  match t1.desc, t2.desc with
+  if eq_type t1 t2 then () else
+  match get_desc t1, get_desc t2 with
     Tvar _, Tconstr _ when deep_occur t1 t2 ->
       unify (ref env) t1 t2
   | Tvar _, _ ->
       let reset_tracing = check_trace_gadt_instances env in
       begin try
         occur_for Unify env t1 t2;
-        update_level_for Unify env t1.level t2;
-        update_scope_for Unify t1.scope t2;
+        update_level_for Unify env (get_level t1) t2;
+        update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2;
         reset_trace_gadt_instances reset_tracing;
       with Unify_trace trace ->
@@ -3326,16 +3285,16 @@ let filter_arrow env t l =
   let t =
     try expand_head_trace env t
     with Unify_trace trace ->
-      let t', _, _ = function_type t.level in
+      let t', _, _ = function_type (get_level t) in
       raise (Filter_arrow_failed
                (Unification_error
                   (expand_to_unification_error
                      env
                      (Diff { got = t'; expected = t } :: trace))))
   in
-  match t.desc with
+  match get_desc t with
   | Tvar _ ->
-      let t', t1, t2 = function_type t.level in
+      let t', t1, t2 = function_type (get_level t) in
       link_type t t';
       (t1, t2)
   | Tarrow(l', t1, t2, _) ->
@@ -3370,16 +3329,16 @@ let rec filter_method_field env name priv ty =
   let ty =
     try expand_head_trace env ty
     with Unify_trace trace ->
-      let ty', _ = method_type ty.level in
+      let ty', _ = method_type (get_level ty) in
       raise (Filter_method_failed
                (Unification_error
                   (expand_to_unification_error
                      env
                      (Diff { got = ty; expected = ty' } :: trace))))
   in
-  match ty.desc with
+  match get_desc ty with
   | Tvar _ ->
-      let ty', ty1 = method_type ty.level in
+      let ty', ty1 = method_type (get_level ty) in
       link_type ty ty';
       ty1
   | Tfield(n, kind, ty1, ty2) ->
@@ -3406,16 +3365,17 @@ let filter_method env name priv ty =
   let ty =
     try expand_head_trace env ty
     with Unify_trace trace ->
-      let ty', _ = object_type ~level:ty.level ~scope:ty.scope in
+      let ty', _ = object_type ~level:(get_level ty) ~scope:(get_scope ty) in
       raise (Filter_method_failed
                (Unification_error
                   (expand_to_unification_error
                      env
                      (Diff { got = ty; expected = ty' } :: trace))))
   in
-  match ty.desc with
+  match get_desc ty with
   | Tvar _ ->
-      let ty', ty_meth = object_type ~level:ty.level ~scope:ty.scope in
+      let ty', ty_meth =
+        object_type ~level:(get_level ty) ~scope:(get_scope ty) in
       link_type ty ty';
       ty_meth
   | Tobject(f, _) ->
@@ -3446,9 +3406,9 @@ let filter_self_method env lab priv meths ty =
 *)
 let moregen_occur env level ty =
   let rec occur ty =
-    let ty = repr ty in
-    if ty.level <= level then () else
-    if is_Tvar ty && ty.level >= generic_level - 1 then raise Occur else
+    let lv = get_level ty in
+    if lv <= level then () else
+    if is_Tvar ty && lv >= generic_level - 1 then raise Occur else
     if try_mark_node ty then iter_type_expr occur ty
   in
   begin try
@@ -3461,19 +3421,18 @@ let moregen_occur env level ty =
   update_level_for Moregen env level ty
 
 let may_instantiate inst_nongen t1 =
-  if inst_nongen then t1.level <> generic_level - 1
-                 else t1.level =  generic_level
+  let level = get_level t1 in
+  if inst_nongen then level <> generic_level - 1
+                 else level =  generic_level
 
 let rec moregen inst_nongen type_pairs env t1 t2 =
-  if t1 == t2 then () else
-  let t1 = repr t1 in
-  let t2 = repr t2 in
-  if t1 == t2 then () else
+  if eq_type t1 t2 then () else
+
   try
-    match (t1.desc, t2.desc) with
-    | (Tvar _, _) when may_instantiate inst_nongen t1 ->
-        moregen_occur env t1.level t2;
-        update_scope_for Moregen t1.scope t2;
+    match (get_desc t1, get_desc t2) with
+      (Tvar _, _) when may_instantiate inst_nongen t1 ->
+        moregen_occur env (get_level t1) t2;
+        update_scope_for Moregen (get_scope t1) t2;
         occur_for Moregen env t1 t2;
         link_type t1 t2
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
@@ -3482,16 +3441,15 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
         let t1' = expand_head env t1 in
         let t2' = expand_head env t2 in
         (* Expansion may have changed the representative of the types... *)
-        let t1' = repr t1' and t2' = repr t2' in
-        if t1' == t2' then () else
+        if eq_type t1' t2' then () else
         begin try
           TypePairs.find type_pairs (t1', t2')
         with Not_found ->
           TypePairs.add type_pairs (t1', t2') ();
-          match (t1'.desc, t2'.desc) with
+          match (get_desc t1', get_desc t2') with
             (Tvar _, _) when may_instantiate inst_nongen t1' ->
-              moregen_occur env t1'.level t2;
-              update_scope_for Moregen t1'.scope t2;
+              moregen_occur env (get_level t1') t2;
+              update_scope_for Moregen (get_scope t1') t2;
               link_type t1' t2
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) when l1 = l2
             || !Clflags.classic && not (is_optional l1 || is_optional l2) ->
@@ -3505,7 +3463,7 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
           | (Tpackage (p1, fl1), Tpackage (p2, fl2)) ->
               begin try
                 unify_package env (moregen_list inst_nongen type_pairs env)
-                  t1'.level p1 fl1 t2'.level p2 fl2
+                  (get_level t1') p1 fl1 (get_level t2') p2 fl2
               with Not_found -> raise_unexplained_for Moregen
               end
           | (Tnil,  Tconstr _ ) -> raise_for Moregen (Obj (Abstract_row Second))
@@ -3515,7 +3473,8 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
               moregen_fields inst_nongen type_pairs env fi1 fi2
           | (Tfield _, Tfield _) ->           (* Actually unused *)
-              moregen_fields inst_nongen type_pairs env t1' t2'
+              moregen_fields inst_nongen type_pairs env
+                t1' t2'
           | (Tnil, Tnil) ->
               ()
           | (Tpoly (t1, []), Tpoly (t2, [])) ->
@@ -3547,8 +3506,7 @@ and moregen_fields inst_nongen type_pairs env ty1 ty2 =
     | [] -> ()
   end;
   moregen inst_nongen type_pairs env rest1
-    (build_fields (repr ty2).level miss2 rest2);
-
+    (build_fields (get_level ty2) miss2 rest2);
   List.iter
     (fun (name, k1, t1, k2, t2) ->
        (* The below call should never throw [Public_method_to_private_method] *)
@@ -3571,10 +3529,10 @@ and moregen_kind k1 k2 =
 
 and moregen_row inst_nongen type_pairs env row1 row2 =
   let row1 = row_repr row1 and row2 = row_repr row2 in
-  let rm1 = repr row1.row_more and rm2 = repr row2.row_more in
-  if rm1 == rm2 then () else
+  let rm1 = row1.row_more and rm2 = row2.row_more in
+  if eq_type rm1 rm2 then () else
   let may_inst =
-    is_Tvar rm1 && may_instantiate inst_nongen rm1 || rm1.desc = Tnil in
+    is_Tvar rm1 && may_instantiate inst_nongen rm1 || get_desc rm1 = Tnil in
   let r1, r2, pairs = merge_row_fields row1.row_fields row2.row_fields in
   let r1, r2 =
     if row2.row_closed then
@@ -3590,8 +3548,8 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
     | _, _ :: _ -> raise_for Moregen (Variant (No_tags (First, r2)))
     | _, [] -> ()
   end;
-  let md1 = rm1.desc (* This lets us undo a following [link_type] *) in
-  begin match rm1.desc, rm2.desc with
+  let md1 = get_desc rm1 (* This lets us undo a following [link_type] *) in
+  begin match md1, get_desc rm2 with
     Tunivar _, Tunivar _ ->
       unify_univar_for Moregen rm1 rm2 !univar_pairs
   | Tunivar _, _ | _, Tunivar _ ->
@@ -3601,8 +3559,8 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
       let ext =
         newgenty (Tvariant {row2 with row_fields = r2; row_name = None})
       in
-      moregen_occur env rm1.level ext;
-      update_scope_for Moregen rm1.scope ext;
+      moregen_occur env (get_level rm1) ext;
+      update_scope_for Moregen (get_scope rm1) ext;
       (* This [link_type] has to be undone if the rest of the function fails *)
       link_type rm1 ext
   | Tconstr _, Tconstr _ ->
@@ -3736,40 +3694,40 @@ let is_moregeneral env inst_nongen pat_sch subj_sch =
 (* Simpler, no? *)
 
 let rec rigidify_rec vars ty =
-  let ty = repr ty in
   if try_mark_node ty then
-    begin match ty.desc with
+    begin match get_desc ty with
     | Tvar _ ->
-        if not (List.memq ty !vars) then vars := ty :: !vars
+        if not (TypeSet.mem ty !vars) then vars := TypeSet.add ty !vars
     | Tvariant row ->
         let row = row_repr row in
-        let more = repr row.row_more in
+        let more = row.row_more in
         if is_Tvar more && not (row_fixed row) then begin
-          let more' = newty2 more.level more.desc in
+          let more' = newty2 (get_level more) (get_desc more) in
           let row' =
             {row with row_fixed=Some Rigid; row_fields=[]; row_more=more'}
-          in link_type more (newty2 ty.level (Tvariant row'))
+          in link_type more (newty2 (get_level ty) (Tvariant row'))
         end;
         iter_row (rigidify_rec vars) row;
         (* only consider the row variable if the variant is not static *)
-        if not (static_row row) then rigidify_rec vars (row_more row)
+        if not (static_row row) then
+          rigidify_rec vars (row_more row)
     | _ ->
         iter_type_expr (rigidify_rec vars) ty
     end
 
 let rigidify ty =
-  let vars = ref [] in
+  let vars = ref TypeSet.empty in
   rigidify_rec vars ty;
   unmark_type ty;
-  !vars
+  TypeSet.elements !vars
 
 let all_distinct_vars env vars =
-  let tyl = ref [] in
+  let tys = ref TypeSet.empty in
   List.for_all
     (fun ty ->
       let ty = expand_head env ty in
-      if List.memq ty !tyl then false else
-      (tyl := ty :: !tyl; is_Tvar ty))
+      if TypeSet.mem ty !tys then false else
+      (tys := TypeSet.add ty !tys; is_Tvar ty))
     vars
 
 let matches ~expand_error_trace env ty ty' =
@@ -3807,52 +3765,41 @@ let expand_head_rigid env ty =
   let ty' = expand_head env ty in
   rigid_variants := old; ty'
 
-let normalize_subst subst =
+let eqtype_subst type_pairs subst t1 t2 =
   if List.exists
-      (function {desc=Tlink _}, _ | _, {desc=Tlink _} -> true | _ -> false)
+      (fun (t,t') ->
+        let found1 = eq_type t1 t in
+        let found2 = eq_type t2 t' in
+        if found1 && found2 then true else
+        if found1 || found2 then raise_unexplained_for Equality else false)
       !subst
-  then subst := List.map (fun (t1,t2) -> repr t1, repr t2) !subst
+  then ()
+  else begin
+    subst := (t1, t2) :: !subst;
+    TypePairs.add type_pairs (t1, t2) ()
+  end
 
 let rec eqtype rename type_pairs subst env t1 t2 =
-  if t1 == t2 then () else
-  let t1 = repr t1 in
-  let t2 = repr t2 in
-  if t1 == t2 then () else
+  if eq_type t1 t2 then () else
 
   try
-    match (t1.desc, t2.desc) with
-    | (Tvar _, Tvar _) when rename ->
-        begin try
-          normalize_subst subst;
-          if List.assq t1 !subst != t2 then raise_unexplained_for Equality
-        with Not_found ->
-          if List.exists (fun (_, t) -> t == t2) !subst then
-            raise_unexplained_for Equality;
-          subst := (t1, t2) :: !subst
-        end
+    match (get_desc t1, get_desc t2) with
+      (Tvar _, Tvar _) when rename ->
+        eqtype_subst type_pairs subst t1 t2
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
         ()
     | _ ->
         let t1' = expand_head_rigid env t1 in
         let t2' = expand_head_rigid env t2 in
         (* Expansion may have changed the representative of the types... *)
-        let t1' = repr t1' and t2' = repr t2' in
-        if t1' == t2' then () else
+        if eq_type t1' t2' then () else
         begin try
           TypePairs.find type_pairs (t1', t2')
         with Not_found ->
           TypePairs.add type_pairs (t1', t2') ();
-          match (t1'.desc, t2'.desc) with
-          | (Tvar _, Tvar _) when rename ->
-              begin try
-                normalize_subst subst;
-                if List.assq t1' !subst != t2' then
-                  raise_unexplained_for Equality
-              with Not_found ->
-                if List.exists (fun (_, t) -> t == t2') !subst then
-                  raise_unexplained_for Equality;
-                subst := (t1', t2') :: !subst
-              end
+          match (get_desc t1', get_desc t2') with
+            (Tvar _, Tvar _) when rename ->
+              eqtype_subst type_pairs subst t1' t2'
           | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _)) when l1 = l2
             || !Clflags.classic && not (is_optional l1 || is_optional l2) ->
               eqtype rename type_pairs subst env t1 t2;
@@ -3865,7 +3812,7 @@ let rec eqtype rename type_pairs subst env t1 t2 =
           | (Tpackage (p1, fl1), Tpackage (p2, fl2)) ->
               begin try
                 unify_package env (eqtype_list rename type_pairs subst env)
-                  t1'.level p1 fl1 t2'.level p2 fl2
+                  (get_level t1') p1 fl1 (get_level t2') p2 fl2
               with Not_found -> raise_unexplained_for Equality
               end
           | (Tnil,  Tconstr _ ) ->
@@ -3877,7 +3824,8 @@ let rec eqtype rename type_pairs subst env t1 t2 =
           | (Tobject (fi1, _nm1), Tobject (fi2, _nm2)) ->
               eqtype_fields rename type_pairs subst env fi1 fi2
           | (Tfield _, Tfield _) ->       (* Actually unused *)
-              eqtype_fields rename type_pairs subst env t1' t2'
+              eqtype_fields rename type_pairs subst env
+                t1' t2'
           | (Tnil, Tnil) ->
               ()
           | (Tpoly (t1, []), Tpoly (t2, [])) ->
@@ -3903,13 +3851,12 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
   let (fields2, rest2) = flatten_fields ty2 in
   (* First check if same row => already equal *)
   let same_row =
-    rest1 == rest2 || TypePairs.mem type_pairs (rest1,rest2) ||
-    (rename && List.mem (rest1, rest2) !subst)
+    eq_type rest1 rest2 || TypePairs.mem type_pairs (rest1,rest2)
   in
   if same_row then () else
   (* Try expansion, needed when called from Includecore.type_manifest *)
-  match expand_head_rigid env rest2 with
-    {desc=Tobject(ty2,_)} -> eqtype_fields rename type_pairs subst env ty1 ty2
+  match get_desc (expand_head_rigid env rest2) with
+    Tobject(ty2,_) -> eqtype_fields rename type_pairs subst env ty1 ty2
   | _ ->
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
   eqtype rename type_pairs subst env rest1 rest2;
@@ -3939,8 +3886,8 @@ and eqtype_kind k1 k2 =
 
 and eqtype_row rename type_pairs subst env row1 row2 =
   (* Try expansion, needed when called from Includecore.type_manifest *)
-  match expand_head_rigid env (row_more row2) with
-    {desc=Tvariant row2} -> eqtype_row rename type_pairs subst env row1 row2
+  match get_desc (expand_head_rigid env (row_more row2)) with
+    Tvariant row2 -> eqtype_row rename type_pairs subst env row1 row2
   | _ ->
   let row1 = row_repr row1 and row2 = row_repr row2 in
   let r1, r2, pairs = merge_row_fields row1.row_fields row2.row_fields in
@@ -4036,7 +3983,6 @@ let equal env rename tyl1 tyl2 =
   let subst = ref [] in
   try eqtype_list rename (TypePairs.create 11) subst env tyl1 tyl2
   with Equality_trace trace ->
-    normalize_subst subst;
     raise (Equality (expand_to_equality_error env trace !subst))
 
 let is_equal env rename tyl1 tyl2 =
@@ -4091,8 +4037,8 @@ let rec moregen_clty trace type_pairs env cty1 cty2 =
         end;
         moregen_clty false type_pairs env cty1' cty2'
     | Cty_signature sign1, Cty_signature sign2 ->
-        let ty1 = object_fields (repr sign1.csig_self) in
-        let ty2 = object_fields (repr sign2.csig_self) in
+        let ty1 = object_fields sign1.csig_self in
+        let ty2 = object_fields sign2.csig_self in
         let (fields1, _rest1) = flatten_fields ty1
         and (fields2, _rest2) = flatten_fields ty2 in
         let (pairs, _miss1, _miss2) = associate_fields fields1 fields2 in
@@ -4137,8 +4083,8 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
   let res =
     let sign1 = signature_of_class_type patt in
     let sign2 = signature_of_class_type subj in
-    let t1 = repr sign1.csig_self in
-    let t2 = repr sign2.csig_self in
+    let t1 = sign1.csig_self in
+    let t2 = sign2.csig_self in
     TypePairs.add type_pairs (t1, t2) ();
     let (fields1, rest1) = flatten_fields (object_fields t1)
     and (fields2, rest2) = flatten_fields (object_fields t2) in
@@ -4232,8 +4178,8 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
 
 let equal_clsig trace type_pairs subst env sign1 sign2 =
   try
-    let ty1 = object_fields (repr sign1.csig_self) in
-    let ty2 = object_fields (repr sign2.csig_self) in
+    let ty1 = object_fields sign1.csig_self in
+    let ty2 = object_fields sign2.csig_self in
     let (fields1, _rest1) = flatten_fields ty1
     and (fields2, _rest2) = flatten_fields ty2 in
     let (pairs, _miss1, _miss2) = associate_fields fields1 fields2 in
@@ -4241,7 +4187,6 @@ let equal_clsig trace type_pairs subst env sign1 sign2 =
       (fun (lab, _k1, t1, _k2, t2) ->
          begin try eqtype true type_pairs subst env t1 t2 with
            Equality_trace trace ->
-             normalize_subst subst;
              raise (Failure
                       [CM_Meth_type_mismatch
                          (lab,
@@ -4255,7 +4200,6 @@ let equal_clsig trace type_pairs subst env sign1 sign2 =
          let (_, _, ty') = Vars.find lab sign1.csig_vars in
          try eqtype true type_pairs subst env ty' ty
          with Equality_trace trace ->
-           normalize_subst subst;
            raise (Failure
                     [CM_Val_type_mismatch
                        (lab,
@@ -4273,8 +4217,8 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
   let subst = ref [] in
   let sign1 = signature_of_class_type patt_type in
   let sign2 = signature_of_class_type subj_type in
-  let t1 = repr sign1.csig_self in
-  let t2 = repr sign2.csig_self in
+  let t1 = sign1.csig_self in
+  let t2 = sign2.csig_self in
   TypePairs.add type_pairs (t1, t2) ();
   let (fields1, rest1) = flatten_fields (object_fields t1)
   and (fields2, rest2) = flatten_fields (object_fields t2) in
@@ -4351,7 +4295,6 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
           raise (Failure [CM_Parameter_arity_mismatch (lp, ls)]);
         List.iter2 (fun p s ->
           try eqtype true type_pairs subst env p s with Equality_trace trace ->
-            normalize_subst subst;
             raise (Failure
                      [CM_Type_parameter_mismatch
                         (env, expand_to_equality_error env trace !subst)]))
@@ -4411,7 +4354,7 @@ let find_cltype_for_path env p =
   let cl_abbr = Env.find_hash_type p env in
   match cl_abbr.type_manifest with
     Some ty ->
-      begin match (repr ty).desc with
+      begin match get_desc ty with
         Tobject(_,{contents=Some(p',_)}) when Path.same p p' -> cl_abbr, ty
       | _ -> raise Not_found
       end
@@ -4420,13 +4363,13 @@ let find_cltype_for_path env p =
 let has_constr_row' env t =
   has_constr_row (expand_abbrev env t)
 
-let rec build_subtype env visited loops posi level t =
-  let t = repr t in
-  match t.desc with
+let rec build_subtype env (visited : transient_expr list)
+    (loops : (int * type_expr) list) posi level t =
+  match get_desc t with
     Tvar _ ->
       if posi then
         try
-          let t' = List.assq t loops in
+          let t' = List.assq (get_id t) loops in
           warn := true;
           (t', Equiv)
         with Not_found ->
@@ -4434,16 +4377,18 @@ let rec build_subtype env visited loops posi level t =
       else
         (t, Unchanged)
   | Tarrow(l, t1, t2, _) ->
-      if memq_warn t visited then (t, Unchanged) else
-      let visited = t :: visited in
+      let tt = Transient_expr.repr t in
+      if memq_warn tt visited then (t, Unchanged) else
+      let visited = tt :: visited in
       let (t1', c1) = build_subtype env visited loops (not posi) level t1 in
       let (t2', c2) = build_subtype env visited loops posi level t2 in
       let c = max_change c1 c2 in
       if c > Unchanged then (newty (Tarrow(l, t1', t2', Cok)), c)
       else (t, Unchanged)
   | Ttuple tlist ->
-      if memq_warn t visited then (t, Unchanged) else
-      let visited = t :: visited in
+      let tt = Transient_expr.repr t in
+      if memq_warn tt visited then (t, Unchanged) else
+      let visited = tt :: visited in
       let tlist' =
         List.map (build_subtype env visited loops posi level) tlist
       in
@@ -4453,9 +4398,9 @@ let rec build_subtype env visited loops posi level t =
   | Tconstr(p, tl, abbrev)
     when level > 0 && generic_abbrev env p && safe_abbrev env t
     && not (has_constr_row' env t) ->
-      let t' = repr (expand_abbrev env t) in
+      let t' = expand_abbrev env t in
       let level' = pred_expand level in
-      begin try match t'.desc with
+      begin try match get_desc t' with
         Tobject _ when posi && not (opened_object t') ->
           let cl_abbr, body = find_cltype_for_path env p in
           let ty =
@@ -4463,9 +4408,8 @@ let rec build_subtype env visited loops posi level t =
               subst env !current_level Public abbrev None
                 cl_abbr.type_params tl body
             with Cannot_subst -> assert false in
-          let ty = repr ty in
           let ty1, tl1 =
-            match ty.desc with
+            match get_desc ty with
               Tobject(ty1,{contents=Some(p',tl1)}) when Path.same p p' ->
                 ty1, tl1
             | _ -> raise Not_found
@@ -4476,27 +4420,30 @@ let rec build_subtype env visited loops posi level t =
           if List.exists (deep_occur ty) tl1 then raise Not_found;
           set_type_desc ty (Tvar None);
           let t'' = newvar () in
-          let loops = (ty, t'') :: loops in
+          let loops = (get_id ty, t'') :: loops in
           (* May discard [visited] as level is going down *)
           let (ty1', c) =
-            build_subtype env [t'] loops posi (pred_enlarge level') ty1 in
+            build_subtype env [Transient_expr.repr t']
+              loops posi (pred_enlarge level') ty1 in
           assert (is_Tvar t'');
           let nm =
             if c > Equiv || deep_occur ty ty1' then None else Some(p,tl1) in
           set_type_desc t'' (Tobject (ty1', ref nm));
           (try unify_var env ty t with Unify _ -> assert false);
-          (t'', Changed)
+          ( t'', Changed)
       | _ -> raise Not_found
       with Not_found ->
-        let (t'',c) = build_subtype env visited loops posi level' t' in
+        let (t'',c) =
+          build_subtype env visited loops posi level' t' in
         if c > Unchanged then (t'',c)
         else (t, Unchanged)
       end
   | Tconstr(p, tl, _abbrev) ->
       (* Must check recursion on constructors, since we do not always
          expand them *)
-      if memq_warn t visited then (t, Unchanged) else
-      let visited = t :: visited in
+      let tt = Transient_expr.repr t in
+      if memq_warn tt visited then (t, Unchanged) else
+      let visited = tt :: visited in
       begin try
         let decl = Env.find_type p env in
         if level = 0 && generic_abbrev env p && safe_abbrev env t
@@ -4522,10 +4469,11 @@ let rec build_subtype env visited loops posi level t =
       end
   | Tvariant row ->
       let row = row_repr row in
-      if memq_warn t visited || not (static_row row) then (t, Unchanged) else
+      let tt = Transient_expr.repr t in
+      if memq_warn tt visited || not (static_row row) then (t, Unchanged) else
       let level' = pred_enlarge level in
       let visited =
-        t :: if level' < level then [] else filter_visited visited in
+        tt :: if level' < level then [] else filter_visited visited in
       let fields = filter_row_fields false row.row_fields in
       let fields =
         List.map
@@ -4553,10 +4501,11 @@ let rec build_subtype env visited loops posi level t =
       in
       (newty (Tvariant row), Changed)
   | Tobject (t1, _) ->
-      if memq_warn t visited || opened_object t1 then (t, Unchanged) else
+      let tt = Transient_expr.repr t in
+      if memq_warn tt visited || opened_object t1 then (t, Unchanged) else
       let level' = pred_enlarge level in
       let visited =
-        t :: if level' < level then [] else filter_visited visited in
+        tt :: if level' < level then [] else filter_visited visited in
       let (t1', c) = build_subtype env visited loops posi level' t1 in
       if c > Unchanged then (newty (Tobject (t1', ref None)), c)
       else (t, Unchanged)
@@ -4613,16 +4562,14 @@ let subtype_error ~env ~trace ~unification_trace =
                     ~unification_trace))
 
 let rec subtype_rec env trace t1 t2 cstrs =
-  let t1 = repr t1 in
-  let t2 = repr t2 in
-  if t1 == t2 then cstrs else
+  if eq_type t1 t2 then cstrs else
 
   begin try
     TypePairs.find subtypes (t1, t2);
     cstrs
   with Not_found ->
     TypePairs.add subtypes (t1, t2) ();
-    match (t1.desc, t2.desc) with
+    match (get_desc t1, get_desc t2) with
       (Tvar _, _) | (_, Tvar _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
     | (Tarrow(l1, t1, u1, _), Tarrow(l2, t2, u2, _)) when l1 = l2
@@ -4657,8 +4604,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
               let (co, cn) = Variance.get_upper v in
               if co then
                 if cn then
-                  (trace, newty2 t1.level (Ttuple[t1]),
-                   newty2 t2.level (Ttuple[t2]), !univar_pairs) :: cstrs
+                  (trace, newty2 (get_level t1) (Ttuple[t1]),
+                   newty2 (get_level t2) (Ttuple[t2]), !univar_pairs) :: cstrs
                 else
                   subtype_rec
                     env
@@ -4709,8 +4656,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
         end
     | (Tpackage (p1, fl1), Tpackage (p2, fl2)) ->
         begin try
-          let ntl1 = complete_type_list env fl2 t1.level (Mty_ident p1) fl1
-          and ntl2 = complete_type_list env fl1 t2.level (Mty_ident p2) fl2
+          let ntl1 =
+            complete_type_list env fl2 (get_level t1) (Mty_ident p1) fl1
+          and ntl2 =
+            complete_type_list env fl1 (get_level t2) (Mty_ident p2) fl2
               ~allow_absent:true in
           let cstrs' =
             List.map
@@ -4752,7 +4701,7 @@ and subtype_fields env trace ty1 ty2 cstrs =
   let (fields2, rest2) = flatten_fields ty2 in
   let (pairs, miss1, miss2) = associate_fields fields1 fields2 in
   let cstrs =
-    if rest2.desc = Tnil then cstrs else
+    if get_desc rest2 = Tnil then cstrs else
     if miss1 = [] then
       subtype_rec
         env
@@ -4760,12 +4709,12 @@ and subtype_fields env trace ty1 ty2 cstrs =
         rest1 rest2
         cstrs
     else
-      (trace, build_fields (repr ty1).level miss1 rest1, rest2,
+      (trace, build_fields (get_level ty1) miss1 rest1, rest2,
        !univar_pairs) :: cstrs
   in
   let cstrs =
     if miss2 = [] then cstrs else
-    (trace, rest1, build_fields (repr ty2).level miss2 (newvar ()),
+    (trace, rest1, build_fields (get_level ty2) miss2 (newvar ()),
      !univar_pairs) :: cstrs
   in
   List.fold_left
@@ -4784,9 +4733,9 @@ and subtype_row env trace row1 row2 cstrs =
     merge_row_fields row1.row_fields row2.row_fields in
   let r1 = if row2.row_closed then filter_row_fields false r1 else r1 in
   let r2 = if row1.row_closed then filter_row_fields false r2 else r2 in
-  let more1 = repr row1.row_more
-  and more2 = repr row2.row_more in
-  match more1.desc, more2.desc with
+  let more1 = row1.row_more
+  and more2 = row2.row_more in
+  match get_desc more1, get_desc more2 with
     Tconstr(p1,_,_), Tconstr(p2,_,_) when Path.same p1 p2 ->
       subtype_rec
         env
@@ -4865,37 +4814,37 @@ let subtype env ty1 ty2 =
 
 (* Utility for printing. The resulting type is not used in computation. *)
 let rec unalias_object ty =
-  let ty = repr ty in
-  match ty.desc with
+  let level = get_level ty in
+  match get_desc ty with
     Tfield (s, k, t1, t2) ->
-      newty2 ty.level (Tfield (s, k, t1, unalias_object t2))
-  | Tvar _ | Tnil ->
-      newty2 ty.level ty.desc
+      newty2 level (Tfield (s, k, t1, unalias_object t2))
+  | Tvar _ | Tnil as desc ->
+      newty2 level desc
   | Tunivar _ ->
       ty
   | Tconstr _ ->
-      newvar2 ty.level
+      newvar2 level
   | _ ->
       assert false
 
 let unalias ty =
-  let ty = repr ty in
-  match ty.desc with
+  let level = get_level ty in
+  match get_desc ty with
     Tvar _ | Tunivar _ ->
       ty
   | Tvariant row ->
       let row = row_repr row in
       let more = row.row_more in
-      newty2 ty.level
-        (Tvariant {row with row_more = newty2 more.level more.desc})
+      newty2 level
+        (Tvariant {row with row_more = newty2 (get_level more) (get_desc more)})
   | Tobject (ty, nm) ->
-      newty2 ty.level (Tobject (unalias_object ty, nm))
-  | _ ->
-      newty2 ty.level ty.desc
+      newty2 level (Tobject (unalias_object ty, nm))
+  | desc ->
+      newty2 level desc
 
 (* Return the arity (as for curried functions) of the given type. *)
 let rec arity ty =
-  match (repr ty).desc with
+  match get_desc ty with
     Tarrow(_, _t1, t2, _) -> 1 + arity t2
   | _ -> 0
 
@@ -4904,18 +4853,18 @@ exception Non_closed0
 let visited = ref TypeSet.empty
 
 let rec closed_schema_rec env ty =
-  let ty = repr ty in
   if TypeSet.mem ty !visited then () else begin
     visited := TypeSet.add ty !visited;
-    match ty.desc with
-      Tvar _ when ty.level <> generic_level ->
+    match get_desc ty with
+      Tvar _ when get_level ty <> generic_level ->
         raise Non_closed0
     | Tconstr _ ->
         let old = !visited in
         begin try iter_type_expr (closed_schema_rec env) ty
         with Non_closed0 -> try
           visited := old;
-          closed_schema_rec env (try_expand_head try_expand_safe env ty)
+          closed_schema_rec env
+            (try_expand_head try_expand_safe env ty)
         with Cannot_expand ->
           raise Non_closed0
         end
@@ -4945,17 +4894,16 @@ let closed_schema env ty =
 (* Normalize a type before printing, saving... *)
 (* Cannot use mark_type because deep_occur uses it too *)
 let rec normalize_type_rec visited ty =
-  let ty = repr ty in
   if not (TypeSet.mem ty !visited) then begin
     visited := TypeSet.add ty !visited;
     let tm = row_of_type ty in
     begin if not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm then
-      match tm.desc with (* PR#7348 *)
+      match get_desc tm with (* PR#7348 *)
         Tconstr (Path.Pdot(m,i), tl, _abbrev) ->
           let i' = String.sub i 0 (String.length i - 4) in
           set_type_desc ty (Tconstr(Path.Pdot(m,i'), tl, ref Mnil))
       | _ -> assert false
-    else match ty.desc with
+    else match get_desc ty with
     | Tvariant row ->
       let row = row_repr row in
       let fields = List.map
@@ -4988,22 +4936,20 @@ let rec normalize_type_rec visited ty =
             if deep_occur ty (newgenty (Ttuple l)) then
               (* The abbreviation may be hiding something, so remove it *)
               set_name nm None
-            else let v' = repr v in
-            begin match v'.desc with
-            | Tvar _ | Tunivar _ ->
-                if v' != v then set_name nm (Some (n, v' :: l))
-            | Tnil ->
-                set_type_desc ty (Tconstr (n, l, ref Mnil))
-            | _ -> set_name nm None
+            else
+            begin match get_desc v with
+            | Tvar _ | Tunivar _ -> ()
+            | Tnil -> set_type_desc ty (Tconstr (n, l, ref Mnil))
+            | _    -> set_name nm None
             end
         | _ ->
             fatal_error "Ctype.normalize_type_rec"
         end;
-        let fi = repr fi in
-        if fi.level < lowest_level then () else
+        let level = get_level fi in
+        if level < lowest_level then () else
         let fields, row = flatten_fields fi in
-        let fi' = build_fields fi.level fields row in
-        set_type_desc fi fi'.desc
+        let fi' = build_fields level fields row in
+        set_type_desc fi (get_desc fi')
     | _ -> ()
     end;
     iter_type_expr (normalize_type_rec visited) ty
@@ -5035,16 +4981,15 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
     if expand_private then try_expand_safe_opt env t
     else try_expand_safe env t
   in
-  match ty.desc with
+  match get_desc ty with
     Tvar _ | Tunivar _ -> ty
-  | Tlink ty -> nondep_type_rec env ids ty
   | _ -> try TypeHash.find nondep_hash ty
   with Not_found ->
-    let ty' = newgenvar () in        (* Stub *)
+    let ty' = newgenstub ~scope:(get_scope ty) in
     TypeHash.add nondep_hash ty ty';
-    set_type_desc ty'
-      begin match ty.desc with
-      | Tconstr(p, tl, _abbrev) ->
+    let desc =
+      match get_desc ty with
+      | Tconstr(p, tl, _abbrev) as desc ->
           begin try
             (* First, try keeping the same type constructor p *)
             match Path.find_free_opt ids p with
@@ -5055,7 +5000,7 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
           with (Nondep_cannot_erase _) as exn ->
             (* If that doesn't work, try expanding abbrevs *)
             try Tlink (nondep_type_rec ~expand_private env ids
-                       (try_expand env (newty2 ty.level ty.desc)))
+                         (try_expand env (newty2 (get_level ty) desc)))
               (*
                  The [Tlink] is important. The expanded type may be a
                  variable, or may not be completely copied yet
@@ -5081,7 +5026,7 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
                           else Some (p, List.map (nondep_type_rec env ids) tl)))
       | Tvariant row ->
           let row = row_repr row in
-          let more = repr row.row_more in
+          let more = row.row_more in
           (* We must keep sharing according to the row variable *)
           begin try
             let ty2 = TypeHash.find nondep_variants more in
@@ -5103,8 +5048,9 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
                 Tvariant {row with row_name = None}
             | _ -> Tvariant row
           end
-      | _ -> copy_type_desc (nondep_type_rec env ids) ty.desc
-      end;
+      | desc -> copy_type_desc (nondep_type_rec env ids) desc
+    in
+    Transient_expr.set_stub_desc ty' desc;
     ty'
 
 let nondep_type env id ty =
@@ -5173,7 +5119,7 @@ let nondep_extension_constructor env ids ext =
             newgenty (Tconstr(ext.ext_type_path, ext.ext_type_params, ref Mnil))
           in
           let ty' = nondep_type_rec env ids ty in
-            match (repr ty').desc with
+            match get_desc ty' with
                 Tconstr(p, tl, _) -> p, tl
               | _ -> raise (Nondep_cannot_erase id)
         end
@@ -5260,10 +5206,10 @@ let nondep_cltype_declaration env ids decl =
 
 (* collapse conjunctive types in class parameters *)
 let rec collapse_conj env visited ty =
-  let ty = repr ty in
-  if List.memq ty visited then () else
-  let visited = ty :: visited in
-  match ty.desc with
+  let id = get_id ty in
+  if List.memq id visited then () else
+  let visited = id :: visited in
+  match get_desc ty with
     Tvariant row ->
       let row = row_repr row in
       List.iter
@@ -5285,7 +5231,7 @@ let collapse_conj_params env params =
 let same_constr env t1 t2 =
   let t1 = expand_head env t1 in
   let t2 = expand_head env t2 in
-  match t1.desc, t2.desc with
+  match get_desc t1, get_desc t2 with
   | Tconstr (p1, _, _), Tconstr (p2, _, _) -> Path.same p1 p2
   | _ -> false
 
@@ -5301,7 +5247,7 @@ let is_immediate = function
       !Clflags.native_code && Sys.word_size = 64
 
 let immediacy env typ =
-   match (repr typ).desc with
+   match get_desc typ with
   | Tconstr(p, _args, _abbrev) ->
     begin try
       let type_decl = Env.find_type p env in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -18,8 +18,6 @@
 open Asttypes
 open Types
 
-module TypePairs : Hashtbl.S with type key = type_expr * type_expr
-
 exception Unify    of Errortrace.unification_error
 exception Equality of Errortrace.equality_error
 exception Moregen  of Errortrace.moregen_error
@@ -67,9 +65,6 @@ val newobj: type_expr -> type_expr
 val newconstr: Path.t -> type_expr list -> type_expr
 val none: type_expr
         (* A dummy type expression *)
-
-val repr: type_expr -> type_expr
-        (* Return the canonical representative of a type. *)
 
 val object_fields: type_expr -> type_expr
 val flatten_fields:
@@ -225,7 +220,7 @@ val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
         equations_level:int -> allow_recursive:bool ->
-        Env.t ref -> type_expr -> type_expr -> unit TypePairs.t
+        Env.t ref -> type_expr -> type_expr -> unit Btype.TypePairs.t
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible.
            Returns the pairs of types that have been equated.  *)

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -24,16 +24,15 @@ open Btype
 let free_vars ?(param=false) ty =
   let ret = ref TypeSet.empty in
   let rec loop ty =
-    let ty = repr ty in
     if try_mark_node ty then
-      match ty.desc with
+      match get_desc ty with
       | Tvar _ ->
           ret := TypeSet.add ty !ret
       | Tvariant row ->
           let row = row_repr row in
           iter_row loop row;
           if not (static_row row) then begin
-            match row.row_more.desc with
+            match get_desc row.row_more with
             | Tvar _ when param -> ret := TypeSet.add ty !ret
             | _ -> loop row.row_more
           end
@@ -177,9 +176,10 @@ let extension_descr ~current_unit path_ext ext =
       cstr_uid = ext.ext_uid;
     }
 
-let none = Private_type_expr.create (Ttuple [])
-    ~level:(-1) ~scope:Btype.generic_level ~id:(-1)
-                                        (* Clearly ill-formed type *)
+let none =
+  create_expr (Ttuple []) ~level:(-1) ~scope:Btype.generic_level ~id:(-1)
+    (* Clearly ill-formed type *)
+
 let dummy_label =
   { lbl_name = ""; lbl_res = none; lbl_arg = none; lbl_mut = Immutable;
     lbl_pos = (-1); lbl_all = [||]; lbl_repres = Record_regular;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -21,7 +21,6 @@ open Asttypes
 open Longident
 open Path
 open Types
-open Btype
 
 open Local_store
 
@@ -1340,10 +1339,10 @@ let make_copy_of_types env0 =
   let memo = Hashtbl.create 16 in
   let copy t =
     try
-      Hashtbl.find memo t.id
+      Hashtbl.find memo (get_id t)
     with Not_found ->
       let t2 = Subst.type_expr Subst.identity t in
-      Hashtbl.add memo t.id t2;
+      Hashtbl.add memo (get_id t) t2;
       t2
   in
   let f = function
@@ -2419,8 +2418,8 @@ let mark_label_used usage ld =
 
 let mark_constructor_description_used usage env cstr =
   let ty_path =
-    match repr cstr.cstr_res with
-    | {desc=Tconstr(path, _, _)} -> path
+    match get_desc cstr.cstr_res with
+    | Tconstr(path, _, _) -> path
     | _ -> assert false
   in
   mark_type_path_used env ty_path;
@@ -2430,8 +2429,8 @@ let mark_constructor_description_used usage env cstr =
 
 let mark_label_description_used usage env lbl =
   let ty_path =
-    match repr lbl.lbl_res with
-    | {desc=Tconstr(path, _, _)} -> path
+    match get_desc lbl.lbl_res with
+    | Tconstr(path, _, _) -> path
     | _ -> assert false
   in
   mark_type_path_used env ty_path;

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -518,9 +518,9 @@ let scrape_for_type_of ~remove_aliases env mty =
 let lower_nongen nglev mty =
   let open Btype in
   let it_type_expr it ty =
-    let ty = repr ty in
-    match ty with
-      {desc=Tvar _; level} ->
+    match get_desc ty with
+      Tvar _ ->
+        let level = get_level ty in
         if level < generic_level && level > nglev then set_level ty nglev
     | _ ->
         type_iterators.it_type_expr it ty

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -339,12 +339,12 @@ exception Empty (* Empty pattern *)
 
 (* May need a clean copy, cf. PR#4745 *)
 let clean_copy ty =
-  if ty.level = Btype.generic_level then ty
+  if get_level ty = Btype.generic_level then ty
   else Subst.type_expr Subst.identity ty
 
 let get_constructor_type_path ty tenv =
-  let ty = Ctype.repr (Ctype.expand_head tenv (clean_copy ty)) in
-  match ty.desc with
+  let ty = Ctype.expand_head tenv (clean_copy ty) in
+  match get_desc ty with
   | Tconstr (path,_,_) -> path
   | _ -> assert false
 
@@ -724,7 +724,7 @@ let close_variant env row =
         match Btype.row_field_repr f with
         | Reither(_, _, false, e) ->
             (* m=false means that this tag is not explicitly matched *)
-            Btype.set_row_field e Rabsent;
+            set_row_field e Rabsent;
             None
         | Rabsent | Reither (_, _, true, _) | Rpresent _ -> nm)
       row.row_name row.row_fields in
@@ -732,7 +732,8 @@ let close_variant env row =
     (* this unification cannot fail *)
     Ctype.unify env row.row_more
       (Btype.newgenty
-         (Tvariant {row with row_fields = []; row_more = Btype.newgenvar();
+         (Tvariant {row with row_fields = [];
+                    row_more = Btype.newgenvar();
                     row_closed = true; row_name = nm}))
   end
 
@@ -822,7 +823,7 @@ let pat_of_constrs ex_pat cstrs =
 
 let pats_of_type ?(always=false) env ty =
   let ty' = Ctype.expand_head env ty in
-  match ty'.desc with
+  match get_desc ty' with
   | Tconstr (path, _, _) ->
       begin match Env.find_type_descrs path env with
       | exception Not_found -> [omega]
@@ -844,7 +845,7 @@ let pats_of_type ?(always=false) env ty =
   | _ -> [omega]
 
 let rec get_variant_constructors env ty =
-  match (Ctype.repr ty).desc with
+  match get_desc ty with
   | Tconstr (path,_,_) -> begin
       try match Env.find_type path env, Env.find_type_descrs path env with
       | _, Type_variant (cstrs,_) -> cstrs

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -194,9 +194,9 @@ end = struct
             | Some a -> true, [a]
           in
           let type_row () =
-            match Ctype.expand_head q.pat_env q.pat_type with
-              | {desc = Tvariant type_row} -> Btype.row_repr type_row
-              | _ -> assert false
+            match get_desc (Ctype.expand_head q.pat_env q.pat_type) with
+            | Tvariant type_row -> Btype.row_repr type_row
+            | _ -> assert false
           in
           Variant {tag; has_arg; cstr_row; type_row}, pats
       | `Array args ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -876,7 +876,7 @@ end = struct
        of the union-find class. *)
     let t = substitute t in
     try List.assq t !names with Not_found ->
-      try TTypeMap.find t !weak_var_map with Not_found ->
+      try TransientTypeMap.find t !weak_var_map with Not_found ->
       let name =
         match t.desc with
           Tvar (Some name) | Tunivar (Some name) ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1271,7 +1271,7 @@ let filter_params tyl =
     List.fold_left
       (fun tyl ty ->
         if List.exists (eq_type ty) tyl
-        then newty2 generic_level (Ttuple [ty]) :: tyl
+        then newty2 ~level:generic_level (Ttuple [ty]) :: tyl
         else ty :: tyl)
       (* Two parameters might be identical due to a constraint but we need to
          print them differently in order to make the output syntactically valid.
@@ -2075,7 +2075,7 @@ let type_path_list =
 let hide_variant_name t =
   match get_desc t with
   | Tvariant row when (row_repr row).row_name <> None ->
-      newty2 (get_level t)
+      newty2 ~level:(get_level t)
         (Tvariant {(row_repr row) with row_name = None;
                    row_more = newvar2 (get_level (row_more row))})
   | _ -> t

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -484,10 +484,11 @@ let rec safe_commu_repr v = function
       if List.memq r v then "Clink loop" else
       safe_commu_repr (r::v) !r
 
-let rec safe_repr v = function
+let rec safe_repr v t =
+  match Transient_expr.coerce t with
     {desc = Tlink t} when not (List.memq t v) ->
       safe_repr (t::v) t
-  | t -> t
+  | t' -> t'
 
 let rec list_of_memo = function
     Mnil -> []
@@ -631,34 +632,30 @@ let printing_map = ref Path.Map.empty
    the {!printing_map} one level further (see also {!Env.run_iter_cont})
 *)
 
-let same_type t t' = repr t == repr t'
-
 let rec index l x =
   match l with
     [] -> raise Not_found
-  | a :: l -> if x == a then 0 else 1 + index l x
+  | a :: l -> if eq_type x a then 0 else 1 + index l x
 
 let rec uniq = function
     [] -> true
-  | a :: l -> not (List.memq a l) && uniq l
+  | a :: l -> not (List.memq (a : int) l) && uniq l
 
 let rec normalize_type_path ?(cache=false) env p =
   try
     let (params, ty, _) = Env.find_type_expansion p env in
-    let params = List.map repr params in
-    match repr ty with
-      {desc = Tconstr (p1, tyl, _)} ->
-        let tyl = List.map repr tyl in
+    match get_desc ty with
+      Tconstr (p1, tyl, _) ->
         if List.length params = List.length tyl
-        && List.for_all2 (==) params tyl
+        && List.for_all2 eq_type params tyl
         then normalize_type_path ~cache env p1
         else if cache || List.length params <= List.length tyl
-             || not (uniq tyl) then (p, Id)
+             || not (uniq (List.map get_id tyl)) then (p, Id)
         else
           let l1 = List.map (index params) tyl in
           let (p2, s2) = normalize_type_path ~cache env p1 in
           (p2, compose l1 s2)
-    | ty ->
+    | _ ->
         (p, Nth (index params ty))
   with
     Not_found ->
@@ -788,24 +785,24 @@ type type_or_scheme = Type | Type_scheme
 
 let is_non_gen mode ty =
   match mode with
-  | Type_scheme -> is_Tvar ty && ty.level <> generic_level
+  | Type_scheme -> is_Tvar ty && get_level ty <> generic_level
   | Type        -> false
 
 module Names : sig
   val reset_names : unit -> unit
 
-  val add_named_var : type_expr -> unit
+  val add_named_var : transient_expr -> unit
   val add_subst : (type_expr * type_expr) list -> unit
 
-  val has_name : type_expr -> bool
+  val has_name : transient_expr -> bool
 
   val new_name : unit -> string
   val new_weak_name : type_expr -> unit -> string
 
-  val name_of_type : (unit -> string) -> type_expr -> string
-  val check_name_of_type : type_expr -> unit
+  val name_of_type : (unit -> string) -> transient_expr -> string
+  val check_name_of_type : transient_expr -> unit
 
-  val remove_names : type_expr list -> unit
+  val remove_names : transient_expr list -> unit
 
   val with_local_names : (unit -> 'a) -> 'a
 
@@ -817,8 +814,8 @@ end = struct
      which maps from types to types.  The lookup process is
      "type -> apply substitution -> find name".  The substitution is presumed to
      be acyclic. *)
-  let names = ref ([] : (type_expr * string) list)
-  let name_subst = ref ([] : (type_expr * type_expr) list)
+  let names = ref ([] : (transient_expr * string) list)
+  let name_subst = ref ([] : (transient_expr * transient_expr) list)
   let name_counter = ref 0
   let named_vars = ref ([] : string list)
 
@@ -842,7 +839,10 @@ end = struct
     | exception Not_found -> ty
 
   let add_subst subst =
-    name_subst := subst @ !name_subst
+    name_subst :=
+      List.map (fun (t1,t2) -> Transient_expr.repr t1, Transient_expr.repr t2)
+        subst
+      @ !name_subst
 
   let has_name ty =
     List.mem_assq (substitute ty) !names
@@ -876,7 +876,7 @@ end = struct
        of the union-find class. *)
     let t = substitute t in
     try List.assq t !names with Not_found ->
-      try TypeMap.find t !weak_var_map with Not_found ->
+      try TTypeMap.find t !weak_var_map with Not_found ->
       let name =
         match t.desc with
           Tvar (Some name) | Tunivar (Some name) ->
@@ -904,7 +904,7 @@ end = struct
   let check_name_of_type t = ignore(name_of_type new_name t)
 
   let remove_names tyl =
-    let tyl = List.map (fun ty -> substitute (repr ty)) tyl in
+    let tyl = List.map substitute tyl in
     names := List.filter (fun (ty,_) -> not (List.memq ty tyl)) !names
 
   let with_local_names f =
@@ -920,7 +920,7 @@ end = struct
 
   let refresh_weak () =
     let refresh t name (m,s) =
-      if is_non_gen Type_scheme (repr t) then
+      if is_non_gen Type_scheme t then
         begin
           TypeMap.add t name m,
           String.Set.add name s
@@ -932,23 +932,25 @@ end = struct
     weak_var_map := m
 end
 
-let visited_objects = ref ([] : type_expr list)
-let aliased = ref ([] : type_expr list)
-let delayed = ref ([] : type_expr list)
+let visited_objects = ref ([] : transient_expr list)
+let aliased = ref ([] : transient_expr list)
+let delayed = ref ([] : transient_expr list)
 
 let add_delayed t =
   if not (List.memq t !delayed) then delayed := t :: !delayed
 
+let proxy ty = Transient_expr.repr (proxy ty)
+
 let is_aliased ty = List.memq (proxy ty) !aliased
-let add_alias ty =
-  let px = proxy ty in
-  if not (is_aliased px) then begin
+let add_alias_proxy px =
+  if not (List.memq px !aliased) then begin
     aliased := px :: !aliased;
     Names.add_named_var px
   end
+let add_alias ty = add_alias_proxy (proxy ty)
 
 let aliasable ty =
-  match ty.desc with
+  match get_desc ty with
     Tvar _ | Tunivar _ | Tpoly _ -> false
   | Tconstr (p, _, _) ->
       not (is_nth (snd (best_type_path p)))
@@ -965,12 +967,12 @@ let namable_row row =
     row.row_fields
 
 let rec mark_loops_rec visited ty =
-  let ty = repr ty in
   let px = proxy ty in
-  if List.memq px visited && aliasable ty then add_alias px else
+  if List.memq px visited && aliasable ty then add_alias_proxy px else
     let visited = px :: visited in
-    match ty.desc with
-    | Tvar _ -> Names.add_named_var ty
+    let tty = Transient_expr.repr ty in
+    match tty.desc with
+    | Tvar _ -> Names.add_named_var tty
     | Tarrow(_, ty1, ty2, _) ->
         mark_loops_rec visited ty1; mark_loops_rec visited ty2
     | Ttuple tyl -> List.iter (mark_loops_rec visited) tyl
@@ -980,7 +982,7 @@ let rec mark_loops_rec visited ty =
     | Tpackage (_, fl) ->
         List.iter (fun (_n, ty) -> mark_loops_rec visited ty) fl
     | Tvariant row ->
-        if List.memq px !visited_objects then add_alias px else
+        if List.memq px !visited_objects then add_alias_proxy px else
          begin
           let row = row_repr row in
           if not (static_row row) then
@@ -992,7 +994,7 @@ let rec mark_loops_rec visited ty =
               iter_row (mark_loops_rec visited) row
          end
     | Tobject (fi, nm) ->
-        if List.memq px !visited_objects then add_alias px else
+        if List.memq px !visited_objects then add_alias_proxy px else
          begin
           if opened_object ty then
             visited_objects := px :: !visited_objects;
@@ -1018,7 +1020,7 @@ let rec mark_loops_rec visited ty =
     | Tpoly (ty, tyl) ->
         List.iter (fun t -> add_alias t) tyl;
         mark_loops_rec visited ty
-    | Tunivar _ -> Names.add_named_var ty
+    | Tunivar _ -> Names.add_named_var tty
 
 let mark_loops ty =
   normalize_type ty;
@@ -1044,7 +1046,6 @@ let reset_and_mark_loops_list tyl =
 let print_labels = ref true
 
 let rec tree_of_typexp mode ty =
-  let ty = repr ty in
   let px = proxy ty in
   if Names.has_name px && not (List.memq px !delayed) then
    let mark = is_non_gen mode ty in
@@ -1055,22 +1056,21 @@ let rec tree_of_typexp mode ty =
    Otyp_var (mark, name) else
 
   let pr_typ () =
-    match ty.desc with
+    let tty = Transient_expr.repr ty in
+    match tty.desc with
     | Tvar _ ->
-        (*let lev =
-          if is_non_gen mode ty then "/" ^ Int.to_string ty.level else "" in*)
         let non_gen = is_non_gen mode ty in
         let name_gen =
           if non_gen then Names.new_weak_name ty else Names.new_name
         in
-        Otyp_var (non_gen, Names.name_of_type name_gen ty)
+        Otyp_var (non_gen, Names.name_of_type name_gen tty)
     | Tarrow(l, ty1, ty2, _) ->
         let lab =
           if !print_labels || is_optional l then string_of_label l else ""
         in
         let t1 =
           if is_optional l then
-            match (repr ty1).desc with
+            match get_desc ty1 with
             | Tconstr(path, [ty], _)
               when Path.same path Predef.path_option ->
                 tree_of_typexp mode ty
@@ -1110,13 +1110,14 @@ let rec tree_of_typexp mode ty =
             if row.row_closed && all_present then
               out_variant
             else
-              let non_gen = is_non_gen mode px in
+              let non_gen = is_non_gen mode (Transient_expr.type_expr px) in
               let tags =
                 if all_present then None else Some (List.map fst present) in
               Otyp_variant (non_gen, Ovar_typ out_variant, row.row_closed, tags)
         | _ ->
             let non_gen =
-              not (row.row_closed && all_present) && is_non_gen mode px in
+              not (row.row_closed && all_present) &&
+              is_non_gen mode (Transient_expr.type_expr px) in
             let fields = List.map (tree_of_row_field mode) fields in
             let tags =
               if all_present then None else Some (List.map fst present) in
@@ -1137,8 +1138,8 @@ let rec tree_of_typexp mode ty =
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
           prerr_string "; " in *)
-        let tyl = List.map repr tyl in
         if tyl = [] then tree_of_typexp mode ty else begin
+          let tyl = List.map Transient_expr.repr tyl in
           let old_delayed = !delayed in
           (* Make the names delayed, so that the real type is
              printed once when used as proxy *)
@@ -1150,7 +1151,7 @@ let rec tree_of_typexp mode ty =
           delayed := old_delayed; tr
         end
     | Tunivar _ ->
-        Otyp_var (false, Names.name_of_type Names.new_name ty)
+        Otyp_var (false, Names.name_of_type Names.new_name tty)
     | Tpackage (p, fl) ->
         let fl =
           List.map
@@ -1161,7 +1162,7 @@ let rec tree_of_typexp mode ty =
         Otyp_module (tree_of_path Module_type p, fl)
   in
   if List.memq px !delayed then delayed := List.filter ((!=) px) !delayed;
-  if is_aliased px && aliasable ty then begin
+  if is_aliased (Transient_expr.type_expr px) && aliasable ty then begin
     Names.check_name_of_type px;
     Otyp_alias (pr_typ (), Names.name_of_type Names.new_name px) end
   else pr_typ ()
@@ -1198,7 +1199,7 @@ and tree_of_typobject mode fi nm =
       let (fields, rest) = pr_fields fi in
       Otyp_object (fields, rest)
   | Some (p, ty :: tyl) ->
-      let non_gen = is_non_gen mode (repr ty) in
+      let non_gen = is_non_gen mode ty in
       let args = tree_of_typlist mode tyl in
       let (p', s) = best_type_path p in
       assert (s = Id);
@@ -1210,7 +1211,7 @@ and tree_of_typobject mode fi nm =
 and tree_of_typfields mode rest = function
   | [] ->
       let rest =
-        match rest.desc with
+        match get_desc rest with
         | Tvar _ | Tunivar _ -> Some (is_non_gen mode rest)
         | Tconstr _ -> Some false
         | Tnil -> None
@@ -1269,8 +1270,8 @@ let filter_params tyl =
   let params =
     List.fold_left
       (fun tyl ty ->
-        let ty = repr ty in
-        if List.memq ty tyl then Btype.newgenty (Ttuple [ty]) :: tyl
+        if List.exists (eq_type ty) tyl
+        then newty2 generic_level (Ttuple [ty]) :: tyl
         else ty :: tyl)
       (* Two parameters might be identical due to a constraint but we need to
          print them differently in order to make the output syntactically valid.
@@ -1293,9 +1294,9 @@ let rec tree_of_type_decl id decl =
   | Some ty ->
       let vars = free_variables ty in
       List.iter
-        (function {desc = Tvar (Some "_")} as ty ->
-            if List.memq ty vars then set_type_desc ty (Tvar None)
-          | _ -> ())
+        (fun ty ->
+          if get_desc ty = Tvar (Some "_") && List.exists (eq_type ty) vars
+          then set_type_desc ty (Tvar None))
         params
   | None -> ()
   end;
@@ -1309,13 +1310,14 @@ let rec tree_of_type_decl id decl =
     | Some ty ->
         let ty =
           (* Special hack to hide variant name *)
-          match repr ty with {desc=Tvariant row} ->
-            let row = row_repr row in
-            begin match row.row_name with
-              Some (Pident id', _) when Ident.same id id' ->
-                newgenty (Tvariant {row with row_name = None})
-            | _ -> ty
-            end
+          match get_desc ty with
+            Tvariant row ->
+              let row = row_repr row in
+              begin match row.row_name with
+                Some (Pident id', _) when Ident.same id id' ->
+                  newgenty (Tvariant {row with row_name = None})
+              | _ -> ty
+              end
           | _ -> ty
         in
         mark_loops ty;
@@ -1355,7 +1357,7 @@ let rec tree_of_type_decl id decl =
     let vari =
       List.map2
         (fun ty v ->
-          let is_var = is_Tvar (repr ty) in
+          let is_var = is_Tvar ty in
           if abstr || not is_var then
             let inj =
               decl.type_kind = Type_abstract && Variance.mem Inj v &&
@@ -1536,9 +1538,9 @@ let value_description id ppf decl =
 (* Print a class type *)
 
 let method_type (_, kind, ty) =
-  match field_kind_repr kind, repr ty with
-    Fpresent, {desc=Tpoly(ty, tyl)} -> (ty, tyl)
-  | _       , ty                    -> (ty, [])
+  match field_kind_repr kind, get_desc ty with
+    Fpresent, Tpoly(ty, tyl) -> (ty, tyl)
+  | _       , _              -> (ty, [])
 
 let tree_of_metho mode concrete csil (lab, kind, ty) =
   if lab <> dummy_method then begin
@@ -1547,7 +1549,7 @@ let tree_of_metho mode concrete csil (lab, kind, ty) =
     let virt = not (Concr.mem lab concrete) in
     let (ty, tyl) = method_type (lab, kind, ty) in
     let tty = tree_of_typexp mode ty in
-    Names.remove_names tyl;
+    Names.remove_names (List.map Transient_expr.repr tyl);
     Ocsg_method (lab, priv, virt, tty) :: csil
   end
   else csil
@@ -1561,10 +1563,9 @@ let rec prepare_class_type params = function
       then prepare_class_type params cty
       else List.iter mark_loops tyl
   | Cty_signature sign ->
-      let sty = repr sign.csig_self in
       (* Self may have a name *)
-      let px = proxy sty in
-      if List.memq px !visited_objects then add_alias sty
+      let px = proxy sign.csig_self in
+      if List.memq px !visited_objects then add_alias sign.csig_self
       else visited_objects := px :: !visited_objects;
       let (fields, _) =
         Ctype.flatten_fields (Ctype.object_fields sign.csig_self)
@@ -1587,7 +1588,7 @@ let rec tree_of_class_type mode params =
         let namespace = Namespace.best_class_namespace p' in
         Octy_constr (tree_of_path namespace p', tree_of_typlist Type_scheme tyl)
   | Cty_signature sign ->
-      let sty = repr sign.csig_self in
+      let sty = sign.csig_self in
       let self_ty =
         if is_aliased sty then
           Some (Otyp_var (false, Names.name_of_type Names.new_name (proxy sty)))
@@ -1624,7 +1625,7 @@ let rec tree_of_class_type mode params =
       in
       let tr =
        if is_optional l then
-         match (repr ty).desc with
+         match get_desc ty with
          | Tconstr(path, [ty], _) when Path.same path Predef.path_option ->
              tree_of_typexp mode ty
          | _ -> Otyp_stuff "<hidden>"
@@ -1640,8 +1641,8 @@ let tree_of_class_param param variance =
   (match tree_of_typexp Type_scheme param with
     Otyp_var (_, s) -> s
   | _ -> "?"),
-  if is_Tvar (repr param) then Asttypes.(NoVariance, NoInjectivity)
-                          else variance
+  if is_Tvar param then Asttypes.(NoVariance, NoInjectivity)
+  else variance
 
 let class_variance =
   let open Variance in let open Asttypes in
@@ -1673,7 +1674,7 @@ let class_declaration id ppf cl =
   !Oprint.out_sig_item ppf (tree_of_class_declaration id cl Trec_first)
 
 let tree_of_cltype_declaration id cl rs =
-  let params = List.map repr cl.clty_params in
+  let params = cl.clty_params in
 
   reset_except_context ();
   List.iter add_alias params;
@@ -1955,9 +1956,8 @@ let incompatibility_phrase (type variety) : variety trace_format -> string =
 (* Print a unification error *)
 
 let same_path t t' =
-  let t = repr t and t' = repr t' in
-  t == t' ||
-  match t.desc, t'.desc with
+  eq_type t t' ||
+  match get_desc t, get_desc t' with
     Tconstr(p,tl,_), Tconstr(p',tl',_) ->
       let (p1, s1) = best_type_path p and (p2, s2)  = best_type_path p' in
       begin match s1, s2 with
@@ -1965,7 +1965,7 @@ let same_path t t' =
       | (Id | Map _), (Id | Map _) when Path.same p1 p2 ->
           let tl = apply_subst s1 tl and tl' = apply_subst s2 tl' in
           List.length tl = List.length tl' &&
-          List.for_all2 same_type tl tl'
+          List.for_all2 eq_type tl tl'
       | _ -> false
       end
   | _ ->
@@ -2073,11 +2073,11 @@ let type_path_list =
 
 (* Hide variant name and var, to force printing the expanded type *)
 let hide_variant_name t =
-  match repr t with
-  | {desc = Tvariant row} as t when (row_repr row).row_name <> None ->
-      newty2 t.level
+  match get_desc t with
+  | Tvariant row when (row_repr row).row_name <> None ->
+      newty2 (get_level t)
         (Tvariant {(row_repr row) with row_name = None;
-                   row_more = newvar2 (row_more row).level})
+                   row_more = newvar2 (get_level (row_more row))})
   | _ -> t
 
 let prepare_expansion Errortrace.{ty; expanded} =
@@ -2087,7 +2087,7 @@ let prepare_expansion Errortrace.{ty; expanded} =
   Errortrace.{ty; expanded}
 
 let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
-  match (repr expanded).desc with
+  match get_desc expanded with
     Tvariant _ | Tobject _ when compact ->
       mark_loops ty; Errortrace.{ty; expanded = ty}
   | _ -> prepare_expansion ty_exp
@@ -2101,7 +2101,7 @@ let print_tags =
   Format.pp_print_list ~pp_sep:comma print_tag
 
 let is_unit env ty =
-  match (Ctype.expand_head env ty).desc with
+  match get_desc (Ctype.expand_head env ty) with
   | Tconstr (p, _, _) -> Path.same p Predef.path_unit
   | _ -> false
 
@@ -2115,7 +2115,7 @@ let unifiable env ty1 ty2 =
   res
 
 let explanation_diff env t3 t4 : (Format.formatter -> unit) option =
-  match t3.desc, t4.desc with
+  match get_desc t3, get_desc t4 with
   | Tarrow (_, ty1, ty2, _), _
     when is_unit env ty1 && unifiable env ty2 t4 ->
       Some (fun ppf ->
@@ -2245,7 +2245,7 @@ let explanation (type variety) intro prev env
     explain_object o
   | Errortrace.Rec_occur(x,y) ->
     reset_and_mark_loops y;
-    begin match x.desc with
+    begin match get_desc x with
     | Tvar _ | Tunivar _  ->
         Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
                type_expr x type_expr y)
@@ -2268,7 +2268,7 @@ let explain mis ppf =
   | Some explain -> explain ppf
 
 let warn_on_missing_def env ppf t =
-  match t.desc with
+  match get_desc t with
   | Tconstr (p,_,_) ->
     begin
       try

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -140,7 +140,7 @@ let reset_for_saving () = new_id := -1
 
 let newpersty desc =
   decr new_id;
-  Private_type_expr.create
+  create_expr
     desc ~level:generic_level ~scope:Btype.lowest_level ~id:!new_id
 
 (* ensure that all occurrences of 'Tvar None' are physically shared *)
@@ -155,24 +155,21 @@ let ctype_apply_env_empty = ref (fun _ -> assert false)
 
 (* Similar to [Ctype.nondep_type_rec]. *)
 let rec typexp copy_scope s ty =
-  let ty = repr ty in
-  match ty.desc with
-    Tvar _ | Tunivar _ as desc ->
-      if s.for_saving || ty.id < 0 then
+  let desc = get_desc ty in
+  match desc with
+    Tvar _ | Tunivar _ ->
+      if s.for_saving || get_id ty < 0 then
         let ty' =
           if s.for_saving then newpersty (norm desc)
-          else newty2 ty.level desc
+          else newty2 (get_level ty) desc
         in
-        For_copy.save_desc copy_scope ty desc;
-        Private_type_expr.set_desc ty (Tsubst (ty', None));
-        (* TODO: move this line to btype.ml
-           there is a similar problem also in ctype.ml *)
+        For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
         ty'
       else ty
   | Tsubst (ty, _) ->
       ty
   | Tfield (m, k, _t1, _t2) when not s.for_saving && m = dummy_method
-      && field_kind_repr k <> Fabsent && (repr ty).level < generic_level ->
+      && field_kind_repr k <> Fabsent && get_level ty < generic_level ->
       (* do not copy the type of self when it is not generalized *)
       ty
 (* cannot do it, since it would omit substitution
@@ -180,18 +177,18 @@ let rec typexp copy_scope s ty =
       ty
 *)
   | _ ->
-    let desc = ty.desc in
-    For_copy.save_desc copy_scope ty desc;
     let tm = row_of_type ty in
     let has_fixed_row =
       not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm in
     (* Make a stub *)
-    let ty' = if s.for_saving then newpersty (Tvar None) else newgenvar () in
-    Private_type_expr.set_scope ty' ty.scope;
-    Private_type_expr.set_desc ty (Tsubst (ty', None));
-    Private_type_expr.set_desc ty'
-      begin if has_fixed_row then
-        match tm.desc with (* PR#7348 *)
+    let ty' =
+      if s.for_saving then newpersty (Tvar None)
+      else newgenstub ~scope:(get_scope ty)
+    in
+    For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
+    let desc =
+      if has_fixed_row then
+        match get_desc tm with (* PR#7348 *)
           Tconstr (Pdot(m,i), tl, _abbrev) ->
             let i' = String.sub i 0 (String.length i - 4) in
             Tconstr(type_path s (Pdot(m,i')), tl, ref Mnil)
@@ -221,32 +218,33 @@ let rec typexp copy_scope s ty =
           Tobject (t1', ref name')
       | Tvariant row ->
           let row = row_repr row in
-          let more = repr row.row_more in
+          let more = row.row_more in
+          let mored = get_desc more in
           (* We must substitute in a subtle way *)
           (* Tsubst takes a tuple containing the row var and the variant *)
-          begin match more.desc with
+          begin match mored with
             Tsubst (_, Some ty2) ->
               (* This variant type has been already copied *)
-              Private_type_expr.set_desc ty (Tsubst (ty2, None));
-              (* avoid Tlink in the new type *)
+              (* Change the stub to avoid Tlink in the new type *)
+              For_copy.redirect_desc copy_scope ty (Tsubst (ty2, None));
               Tlink ty2
           | _ ->
               let dup =
-                s.for_saving || more.level = generic_level || static_row row ||
-                match more.desc with Tconstr _ -> true | _ -> false in
+                s.for_saving || get_level more = generic_level ||
+                static_row row || is_Tconstr more in
               (* Various cases for the row variable *)
               let more' =
-                match more.desc with
+                match mored with
                   Tsubst (ty, None) -> ty
                 | Tconstr _ | Tnil -> typexp copy_scope s more
                 | Tunivar _ | Tvar _ ->
-                    For_copy.save_desc copy_scope more more.desc;
-                    if s.for_saving then newpersty (norm more.desc) else
-                    if dup && is_Tvar more then newgenty more.desc else more
+                    if s.for_saving then newpersty (norm mored)
+                    else if dup && is_Tvar more then newgenty mored
+                    else more
                 | _ -> assert false
               in
               (* Register new type first for recursion *)
-              Private_type_expr.set_desc more
+              For_copy.redirect_desc copy_scope more
                 (Tsubst (more', Some ty'));
               (* TODO: check if more' can be eliminated *)
               (* Return a new copy *)
@@ -264,7 +262,8 @@ let rec typexp copy_scope s ty =
       | Tfield(_label, kind, _t1, t2) when field_kind_repr kind = Fabsent ->
           Tlink (typexp copy_scope s t2)
       | _ -> copy_type_desc (typexp copy_scope s) desc
-      end;
+    in
+    Transient_expr.set_stub_desc ty' desc;
     ty'
 
 (*

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -161,7 +161,7 @@ let rec typexp copy_scope s ty =
       if s.for_saving || get_id ty < 0 then
         let ty' =
           if s.for_saving then newpersty (norm desc)
-          else newty2 (get_level ty) desc
+          else newty2 ~level:(get_level ty) desc
         in
         For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
         ty'

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -309,8 +309,8 @@ let option_some env texp =
     (type_option texp.exp_type) texp.exp_loc texp.exp_env
 
 let extract_option_type env ty =
-  match expand_head env ty with {desc = Tconstr(path, [ty], _)}
-    when Path.same path Predef.path_option -> ty
+  match get_desc (expand_head env ty) with
+    Tconstr(path, [ty], _) when Path.same path Predef.path_option -> ty
   | _ -> assert false
 
 type record_extraction_result =
@@ -345,7 +345,7 @@ let extract_label_names env ty =
   | Not_a_record_type | Maybe_a_record_type -> assert false
 
 let is_principal ty =
-  (repr ty).level = generic_level || not !Clflags.principal
+  not !Clflags.principal || get_level ty = generic_level
 
 (* Typing of patterns *)
 
@@ -397,7 +397,7 @@ let unify_pat ?refine env pat expected_ty =
 (* unification of a type with a Tconstr with freshly created arguments *)
 let unify_head_only ~refine loc env ty constr =
   let path =
-    match (repr constr.cstr_res).desc with
+    match get_desc constr.cstr_res with
     | Tconstr(p, _, _) -> p
     | _ -> assert false in
   let decl = Env.find_type path !env in
@@ -408,8 +408,8 @@ let unify_head_only ~refine loc env ty constr =
 (* make all Reither present in open variants *)
 let finalize_variant pat tag opat r =
   let row =
-    match expand_head pat.pat_env pat.pat_type with
-      {desc = Tvariant row} -> r := row; row_repr row
+    match get_desc (expand_head pat.pat_env pat.pat_type) with
+      Tvariant row -> r := row; row_repr row
     | _ -> assert false
   in
   begin match row_field tag row with
@@ -591,7 +591,7 @@ and build_as_type_aux env p =
         unify_pat env {p with pat_type = ty} ty_res;
         let refinable =
           lbl.lbl_mut = Immutable && List.mem_assoc lbl.lbl_pos ppl &&
-          match (repr lbl.lbl_arg).desc with Tpoly _ -> false | _ -> true in
+          match get_desc lbl.lbl_arg with Tpoly _ -> false | _ -> true in
         if refinable then begin
           let arg = List.assoc lbl.lbl_pos ppl in
           unify_pat env {arg with pat_type = build_as_type env arg} ty_arg
@@ -621,7 +621,7 @@ let solve_Ppat_poly_constraint ~refine env loc sty expected_ty =
   let cty, ty, force = Typetexp.transl_simple_type_delayed !env sty in
   unify_pat_types ~refine loc env ty (instance expected_ty);
   pattern_force := force :: !pattern_force;
-  match ty.desc with
+  match get_desc ty with
   | Tpoly (body, tyl) ->
       begin_def ();
       init_def generic_level;
@@ -670,8 +670,8 @@ let solve_constructor_annotation env name_list sty ty_args ty_ex =
         [ty2]
     | _ ->
         unify_pat_types cty.ctyp_loc env ty1 (newty (Ttuple ty_args));
-        match repr (expand_head !env ty2) with
-          {desc = Ttuple tyl} -> tyl
+        match get_desc (expand_head !env ty2) with
+          Ttuple tyl -> tyl
         | _ -> assert false
   in
   if ids <> [] then ignore begin
@@ -679,9 +679,8 @@ let solve_constructor_annotation env name_list sty ty_args ty_ex =
     let rem =
       List.fold_left
         (fun rem tv ->
-          match repr tv with
-            {desc = Tconstr(Path.Pident id, [], _)}
-            when List.mem id rem ->
+          match get_desc tv with
+            Tconstr(Path.Pident id, [], _) when List.mem id rem ->
               list_remove id rem
           | _ ->
               raise (Error (cty.ctyp_loc, !env,
@@ -814,7 +813,7 @@ let build_or_pat env loc lid =
   let tyl = List.map (fun _ -> newvar()) decl.type_params in
   let row0 =
     let ty = expand_head env (newty(Tconstr(path, tyl, ref Mnil))) in
-    match ty.desc with
+    match get_desc ty with
       Tvariant row when static_row row -> row
     | _ -> raise(Error(lid.loc, env, Not_a_polymorphic_variant_type lid.txt))
   in
@@ -881,8 +880,8 @@ let rec expand_path env p =
   in
   match decl with
     Some {type_manifest = Some ty} ->
-      begin match repr ty with
-        {desc=Tconstr(p,_,_)} -> expand_path env p
+      begin match get_desc ty with
+        Tconstr(p,_,_) -> expand_path env p
       | _ -> assert false
       end
   | _ ->
@@ -896,7 +895,7 @@ let compare_type_path env tpath1 tpath2 =
 exception Wrong_name_disambiguation of Env.t * wrong_name
 
 let get_constr_type_path ty =
-  match (repr ty).desc with
+  match get_desc ty with
   | Tconstr(p, _, _) -> p
   | _ -> assert false
 
@@ -1493,7 +1492,7 @@ type abort_reason = Adds_constraints | Empty
    No variable information, as we only backtrack on
    patterns without variables (cf. assert statements). *)
 type state =
- { snapshot: Btype.snapshot;
+ { snapshot: snapshot;
    levels: Ctype.levels;
    env: Env.t; }
 let save_state env =
@@ -2506,16 +2505,16 @@ let rec type_approx env sexp =
 (* List labels in a function type, and whether return type is a variable *)
 let rec list_labels_aux env visited ls ty_fun =
   let ty = expand_head env ty_fun in
-  if List.memq ty visited then
+  if TypeSet.mem ty visited then
     List.rev ls, false
-  else match ty.desc with
+  else match get_desc ty with
     Tarrow (l, _, ty_res, _) ->
-      list_labels_aux env (ty::visited) (l::ls) ty_res
+      list_labels_aux env (TypeSet.add ty visited) (l::ls) ty_res
   | _ ->
       List.rev ls, is_Tvar ty
 
 let list_labels env ty =
-  wrap_trace_gadt_instances env (list_labels_aux env [] []) ty
+  wrap_trace_gadt_instances env (list_labels_aux env TypeSet.empty []) ty
 
 (* Check that all univars are safe in a type. Both exp.exp_type and
    ty_expected should already be generalized. *)
@@ -2523,7 +2522,7 @@ let check_univars env kind exp ty_expected vars =
   let pty = instance ty_expected in
   begin_def ();
   let exp_ty, vars =
-    match pty.desc with
+    match get_desc pty with
       Tpoly (body, tl) ->
         (* Enforce scoping for type_let:
            since body is not generic,  instance_poly only makes
@@ -2555,7 +2554,7 @@ let generalize_and_check_univars env kind exp ty_expected vars =
 
 let check_partial_application statement exp =
   let rec f delay =
-    let ty = (expand_head exp.exp_env exp.exp_type).desc in
+    let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
     let check_statement () =
       match ty with
       | Tconstr (p, _, _)  when Path.same p Predef.path_unit ->
@@ -2624,9 +2623,8 @@ let check_partial_application statement exp =
 (* Check that a type is generalizable at some level *)
 let generalizable level ty =
   let rec check ty =
-    let ty = repr ty in
     if not_marked_node ty then
-      if ty.level <= level then raise Exit else
+      if get_level ty <= level then raise Exit else
       (flip_mark_node ty; iter_type_expr check ty)
   in
   try check ty; unmark_type ty; true
@@ -2639,9 +2637,8 @@ let self_coercion = ref ([] : (Path.t * Location.t list ref) list)
 
 let contains_variant_either ty =
   let rec loop ty =
-    let ty = repr ty in
     if try_mark_node ty then
-      begin match ty.desc with
+      begin match get_desc ty with
         Tvariant row ->
           let row = row_repr row in
           if not (is_fixed row) then
@@ -2861,9 +2858,9 @@ and type_expect_
       Path.(Pdot (Pident (Ident.create_persistent "CamlinternalFormatBasics"),
                   "format6"))
     in
-    let is_format = match ty_exp.desc with
+    let is_format = match get_desc ty_exp with
       | Tconstr(path, _, _) when Path.same path fmt6_path ->
-        if !Clflags.principal && ty_exp.level <> generic_level then
+        if !Clflags.principal && get_level ty_exp <> generic_level then
           Location.prerr_warning loc
             (Warnings.Not_principal "this coercion to format6");
         true
@@ -2961,12 +2958,12 @@ and type_expect_
       assert (sargs <> []);
       let rec lower_args seen ty_fun =
         let ty = expand_head env ty_fun in
-        if List.memq ty seen then () else
-          match ty.desc with
+        if TypeSet.mem ty seen then () else
+          match get_desc ty with
             Tarrow (_l, ty_arg, ty_fun, _com) ->
               (try unify_var env (newvar()) ty_arg
                with Unify _ -> assert false);
-              lower_args (ty::seen) ty_fun
+              lower_args (TypeSet.add ty seen) ty_fun
           | _ -> ()
       in
       let type_sfunct sfunct =
@@ -2979,7 +2976,7 @@ and type_expect_
         end;
         let ty = instance funct.exp_type in
         end_def ();
-        wrap_trace_gadt_instances env (lower_args []) ty;
+        wrap_trace_gadt_instances env (lower_args TypeSet.empty) ty;
         funct
       in
       let funct, sargs =
@@ -3060,8 +3057,10 @@ and type_expect_
       (* Keep sharing *)
       let ty_expected0 = instance ty_expected in
       begin try match
-        sarg, expand_head env ty_expected, expand_head env ty_expected0 with
-      | Some sarg, {desc = Tvariant row}, {desc = Tvariant row0} ->
+        sarg, get_desc (expand_head env ty_expected),
+        get_desc (expand_head env ty_expected0)
+      with
+      | Some sarg, Tvariant row, Tvariant row0 ->
           let row = row_repr row and row0 = row_repr row0 in
           begin match row_field_repr (List.assoc l row.row_fields),
           row_field_repr (List.assoc l row0.row_fields) with
@@ -3378,9 +3377,9 @@ and type_expect_
             let arg = type_exp env sarg in
             end_def ();
             let tv = newvar () in
-            let gen = generalizable tv.level arg.exp_type in
+            let gen = generalizable (get_level tv) arg.exp_type in
             unify_var env tv arg.exp_type;
-            begin match arg.exp_desc, !self_coercion, (repr ty').desc with
+            begin match arg.exp_desc, !self_coercion, get_desc ty' with
               Texp_ident(_, _, {val_kind=Val_self _}), (path,r) :: _,
               Tconstr(path',_,_) when Path.same path path' ->
                 (* prerr_endline "self coercion"; *)
@@ -3456,7 +3455,7 @@ and type_expect_
               let (id, typ) =
                 filter_self_method env met Private meths privty
               in
-              if is_Tvar (repr typ) then
+              if is_Tvar typ then
                 Location.prerr_warning loc
                   (Warnings.Undeclared_virtual_method met);
               (Tmeth_val id, None, typ)
@@ -3526,17 +3525,17 @@ and type_expect_
           generalize_structure typ;
         end;
         let typ =
-          match repr typ with
-            {desc = Tpoly (ty, [])} ->
+          match get_desc typ with
+            Tpoly (ty, []) ->
               instance ty
-          | {desc = Tpoly (ty, tl); level = l} ->
-              if !Clflags.principal && l <> generic_level then
+          | Tpoly (ty, tl) ->
+              if !Clflags.principal && get_level typ <> generic_level then
                 Location.prerr_warning loc
                   (Warnings.Not_principal "this use of a polymorphic method");
               snd (instance_poly false tl ty)
-          | {desc = Tvar _} as ty ->
+          | Tvar _ ->
               let ty' = newvar () in
-              unify env (instance ty) (newty(Tpoly(ty',[])));
+              unify env (instance typ) (newty(Tpoly(ty',[])));
               (* if not !Clflags.nolabels then
                  Location.prerr_warning loc (Warnings.Unknown_method met); *)
               ty'
@@ -3563,7 +3562,7 @@ and type_expect_
                     Some
                       (Meths.fold (fun meth _meth_ty li -> meth::li) !meths [])
                 | None ->
-                    match (expand_head env obj.exp_type).desc with
+                    match get_desc (expand_head env obj.exp_type) with
                     | Tobject (fields, _) ->
                         let (fields, _) = Ctype.flatten_fields fields in
                         let collect_fields li (meth, meth_kind, _meth_ty) =
@@ -3656,7 +3655,7 @@ and type_expect_
       begin_def ();
       let context = Typetexp.narrow () in
       let modl = !type_module env smodl in
-      Mtype.lower_nongen ty.level modl.mod_type;
+      Mtype.lower_nongen (get_level ty) modl.mod_type;
       let pres =
         match modl.mod_type with
         | Mty_alias _ -> Mp_absent
@@ -3741,11 +3740,11 @@ and type_expect_
   | Pexp_poly(sbody, sty) ->
       if !Clflags.principal then begin_def ();
       let ty, cty =
-        match sty with None -> repr ty_expected, None
+        match sty with None -> ty_expected, None
         | Some sty ->
             let sty = Ast_helper.Typ.force_poly sty in
             let cty = Typetexp.transl_simple_type env false sty in
-            repr cty.ctyp_type, Some cty
+            cty.ctyp_type, Some cty
       in
       if !Clflags.principal then begin
         end_def ();
@@ -3755,7 +3754,7 @@ and type_expect_
         with_explanation (fun () ->
           unify_exp_types loc env (instance ty) (instance ty_expected));
       let exp =
-        match (expand_head env ty).desc with
+        match get_desc (expand_head env ty) with
           Tpoly (ty', []) ->
             let exp = type_expect env sbody (mk_expected ty') in
             { exp with exp_type = instance ty }
@@ -3800,10 +3799,10 @@ and type_expect_
          type. *)
       let seen = Hashtbl.create 8 in
       let rec replace t =
-        if Hashtbl.mem seen t.id then ()
+        if Hashtbl.mem seen (get_id t) then ()
         else begin
-          Hashtbl.add seen t.id ();
-          match t.desc with
+          Hashtbl.add seen (get_id t) ();
+          match get_desc t with
           | Tconstr (Path.Pident id', _, _) when id == id' -> link_type t ty
           | _ -> Btype.iter_type_expr replace t
         end
@@ -3822,15 +3821,16 @@ and type_expect_
             (Texp_newtype name, loc, sexp.pexp_attributes) :: body.exp_extra }
   | Pexp_pack m ->
       let (p, fl) =
-        match Ctype.expand_head env (instance ty_expected) with
-          {desc = Tpackage (p, fl)} ->
+        match get_desc (Ctype.expand_head env (instance ty_expected)) with
+          Tpackage (p, fl) ->
             if !Clflags.principal &&
-              (Ctype.expand_head env ty_expected).level < Btype.generic_level
+              get_level (Ctype.expand_head env ty_expected)
+                < Btype.generic_level
             then
               Location.prerr_warning loc
                 (Warnings.Not_principal "this module packing");
             (p, fl)
-        | {desc = Tvar _} ->
+        | Tvar _ ->
             raise (Error (loc, env, Cannot_infer_signature))
         | _ ->
             raise (Error (loc, env, Not_a_packed_module ty_expected))
@@ -3960,11 +3960,11 @@ and type_expect_
 and type_ident env ?(recarg=Rejected) lid =
   let (path, desc) = Env.lookup_value ~loc:lid.loc lid.txt env in
   let is_recarg =
-    match (repr desc.val_type).desc with
+    match get_desc desc.val_type with
     | Tconstr(p, _, _) -> Path.is_constructor_typath p
     | _ -> false
   in
-  begin match is_recarg, recarg, (repr desc.val_type).desc with
+  begin match is_recarg, recarg, get_desc desc.val_type with
   | _, Allowed, _
   | true, Required, _
   | false, Rejected, _ -> ()
@@ -4389,9 +4389,10 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
   let may_coerce =
     if not (is_inferred sarg) then None else
     let work () =
-      match expand_head env ty_expected' with
-        {desc = Tarrow(Nolabel,_,ty_res0,_); level} ->
-          Some (no_labels ty_res0, level)
+      let te = expand_head env ty_expected' in
+      match get_desc te with
+        Tarrow(Nolabel,_,ty_res0,_) ->
+          Some (no_labels ty_res0, get_level te)
       | _ -> None
     in
     (* Need to be careful not to expand local constraints here *)
@@ -4411,7 +4412,7 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
         generalize_structure texp.exp_type
       end;
       let rec make_args args ty_fun =
-        match (expand_head env ty_fun).desc with
+        match get_desc (expand_head env ty_fun) with
         | Tarrow (l,ty_arg,ty_fun,_) when is_optional l ->
             let ty = option_none env (instance ty_arg) sarg.pexp_loc in
             make_args ((l, Some ty) :: args) ty_fun
@@ -4427,11 +4428,11 @@ and type_argument ?explanation ?recarg env sarg ty_expected' ty_expected =
         texp
       end else begin
       let warn = !Clflags.principal &&
-        (lv <> generic_level || (repr ty_fun').level <> generic_level)
+        (lv <> generic_level || get_level ty_fun' <> generic_level)
       and ty_fun = instance ty_fun' in
       let ty_arg, ty_res =
-        match expand_head env ty_expected' with
-          {desc = Tarrow(Nolabel,ty_arg,ty_res,_)} -> ty_arg, ty_res
+        match get_desc (expand_head env ty_expected') with
+          Tarrow(Nolabel,ty_arg,ty_res,_) -> ty_arg, ty_res
         | _ -> assert false
       in
       unify_exp env {texp with exp_type = ty_fun} ty_expected;
@@ -4505,10 +4506,10 @@ and type_application env funct sargs =
   let type_unknown_arg (ty_fun, typed_args) (lbl, sarg) =
     let (ty_arg, ty_res) =
       let ty_fun = expand_head env ty_fun in
-      match ty_fun.desc with
+      match get_desc ty_fun with
       | Tvar _ ->
           let t1 = newvar () and t2 = newvar () in
-          if ty_fun.level >= t1.level &&
+          if get_level ty_fun >= get_level t1 &&
              not (is_prim ~name:"%identity" funct)
           then
             Location.prerr_warning sarg.pexp_loc
@@ -4524,7 +4525,7 @@ and type_application env funct sargs =
             result_type (!omitted_parameters @ !eliminated_optional_arguments)
               ty_fun
           in
-          match ty_res.desc with
+          match get_desc ty_res with
           | Tarrow _ ->
               if !Clflags.classic || not (has_label lbl ty_fun) then
                 raise (Error(sarg.pexp_loc, env,
@@ -4562,10 +4563,11 @@ and type_application env funct sargs =
   in
   let warned = ref false in
   let rec type_args args ty_fun ty_fun0 sargs =
-    match expand_head env ty_fun, expand_head env ty_fun0 with
-    | {desc=Tarrow (l, ty, ty_fun, com); level=lv} as ty_fun',
-      {desc=Tarrow (_, ty0, ty_fun0, _)}
+    let ty_fun' = expand_head env ty_fun in
+    match get_desc ty_fun', get_desc (expand_head env ty_fun0) with
+    | Tarrow (l, ty, ty_fun, com), Tarrow (_, ty0, ty_fun0, _)
       when sargs <> [] && commu_repr com = Cok ->
+        let lv = get_level ty_fun' in
         let may_warn loc w =
           if not !warned && !Clflags.principal && lv <> generic_level
           then begin
@@ -4768,7 +4770,7 @@ and type_statement ?explanation env sexp =
   let exp = type_exp env sexp in
   end_def();
   let ty = expand_head env exp.exp_type and tv = newvar() in
-  if is_Tvar ty && ty.level > tv.level then
+  if is_Tvar ty && get_level ty > get_level tv then
     Location.prerr_warning
       (final_subexpression exp).exp_loc
       Warnings.Nonreturning_statement;
@@ -4799,7 +4801,7 @@ and type_unpacks ?(in_function : (Location.t * type_expr) option)
                  (mkloc (Longident.Lident unpack.tu_name.txt)
                     unpack.tu_name.loc)))
       in
-      Mtype.lower_nongen ty.level modl.mod_type;
+      Mtype.lower_nongen (get_level ty) modl.mod_type;
       let pres =
         match modl.mod_type with
         | Mty_alias _ -> Mp_absent
@@ -5117,7 +5119,7 @@ and type_let
     List.iter2
       (fun pat binding ->
         let pat =
-          match pat.pat_type.desc with
+          match get_desc pat.pat_type with
           | Tpoly (ty, tl) ->
               {pat with pat_type =
                snd (instance_poly ~keep_names:true false tl ty)}
@@ -5242,7 +5244,7 @@ and type_let
     List.map2
       (fun {pvb_expr=sexp; pvb_attributes; _} (pat, slot) ->
         if is_recursive then current_slot := slot;
-        match pat.pat_type.desc with
+        match get_desc pat.pat_type with
         | Tpoly (ty, tl) ->
             if !Clflags.principal then begin_def ();
             let vars, ty' = instance_poly ~keep_names:true true tl ty in
@@ -5466,9 +5468,13 @@ let report_literal_type_constraint expected_type const =
   | _, _ -> []
 
 let report_literal_type_constraint const = function
-  | Some Errortrace.{ expected = { ty = { desc = Tconstr (typ, [], _) } } } ->
-      report_literal_type_constraint typ const
-  | Some _ | None -> []
+  | Some tr ->
+      begin match get_desc Errortrace.(tr.expected.ty) with
+        Tconstr (typ, [], _) ->
+          report_literal_type_constraint typ const
+      | _ -> []
+      end
+  | None -> []
 
 let report_expr_type_clash_hints exp diff =
   match exp with
@@ -5568,7 +5574,7 @@ let report_error ~loc env = function
         (function ppf ->
            fprintf ppf "but an expression was expected of type");
   | Apply_non_function typ ->
-      begin match (repr typ).desc with
+      begin match get_desc typ with
         Tarrow _ ->
           Location.errorf ~loc
             "@[<v>@[<2>This function has type@ %a@]\

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4494,7 +4494,7 @@ and type_application env funct sargs =
   (* funct.exp_type may be generic *)
   let result_type omitted ty_fun =
     List.fold_left
-      (fun ty_fun (l,ty,lv) -> newty2 lv (Tarrow(l,ty,ty_fun,Cok)))
+      (fun ty_fun (l,ty,lv) -> newty2 ~level:lv (Tarrow(l,ty,ty_fun,Cok)))
       ty_fun omitted
   in
   let has_label l ty_fun =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -800,10 +800,10 @@ let name_recursion sdecl id decl =
   | { type_kind = Type_abstract;
       type_manifest = Some ty;
       type_private = Private; } when is_fixed_type sdecl ->
-    let ty' = newty2 (get_level ty) (get_desc ty) in
+    let ty' = newty2 ~level:(get_level ty) (get_desc ty) in
     if Ctype.deep_occur ty ty' then
       let td = Tconstr(Path.Pident id, decl.type_params, ref Mnil) in
-      link_type ty (newty2 (get_level ty) td);
+      link_type ty (newty2 ~level:(get_level ty) td);
       {decl with type_manifest = Some ty'}
     else decl
   | _ -> decl

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -142,7 +142,11 @@ let get_unboxed_type_representation env ty =
 (* Determine if a type's values are represented by floats at run-time. *)
 let is_float env ty =
   match get_unboxed_type_representation env ty with
-    Some {desc = Tconstr(p, _, _); _} -> Path.same p Predef.path_float
+    Some ty' ->
+      begin match get_desc ty' with
+        Tconstr(p, _, _) -> Path.same p Predef.path_float
+      | _ -> false
+      end
   | _ -> false
 
 (* Determine if a type definition defines a fixed type. (PW) *)
@@ -174,10 +178,10 @@ let set_private_row env loc p decl =
     | Some t -> Ctype.expand_head env t
   in
   let rv =
-    match tm.desc with
+    match get_desc tm with
       Tvariant row ->
         let row = Btype.row_repr row in
-        Btype.set_type_desc tm
+        set_type_desc tm
           (Tvariant {row with row_fixed = Some Fixed_private});
         if Btype.static_row row then
           (* the syntax hinted at the existence of a row variable,
@@ -193,7 +197,7 @@ let set_private_row env loc p decl =
         r
     | _ -> assert false
   in
-  Btype.set_type_desc rv (Tconstr (p, decl.type_params, ref Mnil))
+  set_type_desc rv (Tconstr (p, decl.type_params, ref Mnil))
 
 (* Translate one type declaration *)
 
@@ -231,7 +235,7 @@ let transl_labels env closed lbls =
     List.map
       (fun ld ->
          let ty = ld.ld_type.ctyp_type in
-         let ty = match ty.desc with Tpoly(t,[]) -> t | _ -> ty in
+         let ty = match get_desc ty with Tpoly(t,[]) -> t | _ -> ty in
          {Types.ld_id = ld.ld_id;
           ld_mutable = ld.ld_mutable;
           ld_type = ty;
@@ -271,7 +275,7 @@ let make_constructor env type_path type_params sargs sret_type =
       let tret_type = transl_simple_type env false sret_type in
       let ret_type = tret_type.ctyp_type in
       (* TODO add back type_path as a parameter ? *)
-      begin match (Ctype.repr ret_type).desc with
+      begin match get_desc ret_type with
         | Tconstr (p', _, _) when Path.same type_path p' -> ()
         | _ ->
           let trace =
@@ -480,10 +484,9 @@ module TypeSet = Btype.TypeSet
 module TypeMap = Btype.TypeMap
 
 let rec check_constraints_rec env loc visited ty =
-  let ty = Ctype.repr ty in
   if TypeSet.mem ty !visited then () else begin
   visited := TypeSet.add ty !visited;
-  match ty.desc with
+  match get_desc ty with
   | Tconstr (path, args, _) ->
       let decl =
         try Env.find_type path env
@@ -586,7 +589,7 @@ let check_coherence env loc dpath decl =
   match decl with
     { type_kind = (Type_variant _ | Type_record _| Type_open);
       type_manifest = Some ty } ->
-      begin match (Ctype.repr ty).desc with
+      begin match get_desc ty with
         Tconstr(path, args, _) ->
           begin try
             let decl' = Env.find_type path env in
@@ -624,10 +627,9 @@ let check_abbrev env sdecl (id, decl) =
 let check_well_founded env loc path to_check ty =
   let visited = ref TypeMap.empty in
   let rec check ty0 parents ty =
-    let ty = Btype.repr ty in
     if TypeSet.mem ty parents then begin
       (*Format.eprintf "@[%a@]@." Printtyp.raw_type_expr ty;*)
-      if match ty0.desc with
+      if match get_desc ty0 with
       | Tconstr (p, _, _) -> Path.same p path
       | _ -> false
       then raise (Error (loc, Recursive_abbrev (Path.name path)))
@@ -643,7 +645,7 @@ let check_well_founded env loc path to_check ty =
     in
     if fini then () else
     let rec_ok =
-      match ty.desc with
+      match get_desc ty with
         Tconstr(p,_,_) ->
           !Clflags.recursive_types && Ctype.is_contractive env p
       | Tobject _ | Tvariant _ -> true
@@ -660,7 +662,7 @@ let check_well_founded env loc path to_check ty =
       with e ->
         visited := visited'; Some e
     in
-    match ty.desc with
+    match get_desc ty with
     | Tconstr(p, _, _) when arg_exn <> None || to_check p ->
         if to_check p then Option.iter raise arg_exn
         else Btype.iter_type_expr (check ty0 TypeSet.empty) ty;
@@ -699,13 +701,12 @@ let check_recursion ~orig_env env loc path decl to_check =
 
   if decl.type_params = [] then () else
 
-  let visited = ref [] in
+  let visited = ref TypeSet.empty in
 
   let rec check_regular cpath args prev_exp prev_expansions ty =
-    let ty = Ctype.repr ty in
-    if not (List.memq ty !visited) then begin
-      visited := ty :: !visited;
-      match ty.desc with
+    if not (TypeSet.mem ty !visited) then begin
+      visited := TypeSet.add ty !visited;
+      match get_desc ty with
       | Tconstr(path', args', _) ->
           if Path.same path path' then begin
             if not (Ctype.is_equal orig_env false args args') then
@@ -799,11 +800,10 @@ let name_recursion sdecl id decl =
   | { type_kind = Type_abstract;
       type_manifest = Some ty;
       type_private = Private; } when is_fixed_type sdecl ->
-    let ty = Ctype.repr ty in
-    let ty' = Btype.newty2 ty.level ty.desc in
+    let ty' = newty2 (get_level ty) (get_desc ty) in
     if Ctype.deep_occur ty ty' then
       let td = Tconstr(Path.Pident id, decl.type_params, ref Mnil) in
-      Btype.link_type ty (Btype.newty2 ty.level td);
+      link_type ty (newty2 (get_level ty) td);
       {decl with type_manifest = Some ty'}
     else decl
   | _ -> decl
@@ -1009,16 +1009,16 @@ let transl_extension_constructor ~scope env type_path type_params
           let vars =
             Ctype.free_variables (Btype.newgenty (Ttuple args))
           in
-            List.iter
-              (function {desc = Tvar (Some "_")} as ty
-                  when List.memq ty vars ->
-                    Btype.set_type_desc ty (Tvar None)
-                | _ -> ())
-              typext_params
+          List.iter
+            (fun ty ->
+              if get_desc ty = Tvar (Some "_")
+              && List.exists (eq_type ty) vars
+              then set_type_desc ty (Tvar None))
+            typext_params
         end;
         (* Ensure that constructor's type matches the type being extended *)
         let cstr_type_path, cstr_type_params =
-          match cdescr.cstr_res.desc with
+          match get_desc cdescr.cstr_res with
             Tconstr (p, _, _) ->
               let decl = Env.find_type p env in
                 p, decl.type_params
@@ -1055,8 +1055,8 @@ let transl_extension_constructor ~scope env type_path type_params
               Types.Cstr_tuple args
           | Some decl ->
               let tl =
-                match args with
-                | [ {desc=Tconstr(_, tl, _)} ] -> tl
+                match List.map get_desc args with
+                | [ Tconstr(_, tl, _) ] -> tl
                 | _ -> assert false
               in
               let decl = Ctype.instance_declaration decl in
@@ -1267,7 +1267,7 @@ let get_native_repr_attribute attrs ~global_repr =
     raise (Error (loc, Multiple_native_repr_attributes))
 
 let native_repr_of_type env kind ty =
-  match kind, (Ctype.expand_head_opt env ty).desc with
+  match kind, get_desc (Ctype.expand_head_opt env ty) with
   | Untagged, Tconstr (path, _, _) when Path.same path Predef.path_int ->
     Some Untagged_int
   | Unboxed, Tconstr (path, _, _) when Path.same path Predef.path_float ->
@@ -1313,7 +1313,7 @@ let make_native_repr env core_type ty ~global_repr =
     end
 
 let rec parse_native_repr_attributes env core_type ty ~global_repr =
-  match core_type.ptyp_desc, (Ctype.repr ty).desc,
+  match core_type.ptyp_desc, get_desc ty,
     get_native_repr_attribute core_type.ptyp_attributes ~global_repr:None
   with
   | Ptyp_arrow _, Tarrow _, Native_repr_attr_present kind  ->
@@ -1330,8 +1330,8 @@ let rec parse_native_repr_attributes env core_type ty ~global_repr =
 
 let check_unboxable env loc ty =
   let check_type acc ty : Path.Set.t =
-    let ty = Ctype.repr (Ctype.expand_head_opt env ty) in
-    try match ty.desc with
+    let ty = Ctype.expand_head_opt env ty in
+    try match get_desc ty with
       | Tconstr (p, _, _) ->
         let tydecl = Env.find_type p env in
         if tydecl.type_unboxed_default then
@@ -1635,15 +1635,15 @@ let explain_unbound ppf tv tl typ kwd lab =
 let explain_unbound_single ppf tv ty =
   let trivial ty =
     explain_unbound ppf tv [ty] (fun t -> t) "type" (fun _ -> "") in
-  match (Ctype.repr ty).desc with
+  match get_desc ty with
     Tobject(fi,_) ->
       let (tl, rv) = Ctype.flatten_fields fi in
-      if rv == tv then trivial ty else
+      if eq_type rv tv then trivial ty else
       explain_unbound ppf tv tl (fun (_,_,t) -> t)
         "method" (fun (lab,_,_) -> lab ^ ": ")
   | Tvariant row ->
       let row = Btype.row_repr row in
-      if row.row_more == tv then trivial ty else
+      if eq_type row.row_more tv then trivial ty else
       explain_unbound ppf tv row.row_fields
         (fun (_l,f) -> match Btype.row_field_repr f with
           Rpresent (Some t) -> t
@@ -1746,7 +1746,6 @@ let report_error ppf = function
                    for native-code compilation@]"
   | Unbound_type_var (ty, decl) ->
       fprintf ppf "@[A type variable is unbound in this type declaration";
-      let ty = Ctype.repr ty in
       begin match decl.type_kind, decl.type_manifest with
       | Type_variant (tl, _rep), _ ->
           explain_unbound_gen ppf ty tl (fun c ->

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -59,7 +59,8 @@ val check_coherence:
 val is_fixed_type : Parsetree.type_declaration -> bool
 
 (* for typeopt.ml *)
-val get_unboxed_type_representation: Env.t -> type_expr -> type_expr option
+val get_unboxed_type_representation:
+    Env.t -> type_expr -> type_expr option
 
 type native_repr_kind = Unboxed | Untagged
 

--- a/typing/typedecl_unboxed.ml
+++ b/typing/typedecl_unboxed.ml
@@ -25,8 +25,8 @@ type t =
    to the manifest type of private abbreviations. *)
 let rec get_unboxed_type_representation env ty fuel =
   if fuel < 0 then Unavailable else
-  let ty = Ctype.repr (Ctype.expand_head_opt env ty) in
-  match ty.desc with
+  let ty = Ctype.expand_head_opt env ty in
+  match get_desc ty with
   | Tconstr (p, args, _) ->
     begin match Env.find_type p env with
     | exception Not_found -> This ty
@@ -40,7 +40,7 @@ let rec get_unboxed_type_representation env ty fuel =
        | Type_variant ([{cd_args = Cstr_record [{ld_type = ty2; _}]; _}],
                        Variant_unboxed)}
       ->
-        let ty2 = match ty2.desc with Tpoly (t, _) -> t | _ -> ty2 in
+        let ty2 = match get_desc ty2 with Tpoly (t, _) -> t | _ -> ty2 in
         get_unboxed_type_representation env
           (Ctype.apply env type_params ty2 args) (fuel - 1)
     | _ -> This ty

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -370,7 +370,7 @@ let check_usage_of_path_of_substituted_item paths ~loc ~lid env super =
    T was not used as a path for a packed module
 *)
 let check_usage_of_module_types ~error ~paths ~loc env super =
-  let it_do_type_expr it ty = match ty.desc with
+  let it_do_type_expr it ty = match get_desc ty with
     | Tpackage (p, _) ->
        begin match List.find_opt (Path.same p) paths with
        | Some p -> raise (Error(loc,Lazy.force !env,error p))
@@ -471,7 +471,7 @@ let params_are_constrained =
   let rec loop = function
     | [] -> false
     | hd :: tl ->
-       match (Btype.repr hd).desc with
+       match get_desc hd with
        | Tvar _ -> List.memq hd tl || loop tl
        | _ -> true
   in
@@ -2191,8 +2191,8 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
         Ctype.generalize_structure exp.exp_type
       end;
       let mty =
-        match Ctype.expand_head env exp.exp_type with
-          {desc = Tpackage (p, fl)} ->
+        match get_desc (Ctype.expand_head env exp.exp_type) with
+          Tpackage (p, fl) ->
             if List.exists (fun (_n, t) -> Ctype.free_variables t <> []) fl then
               raise (Error (smod.pmod_loc, env,
                             Incomplete_packed_module exp.exp_type));
@@ -2202,7 +2202,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
               Location.prerr_warning smod.pmod_loc
                 (Warnings.Not_principal "this module unpacking");
             modtype_of_package env smod.pmod_loc p fl
-        | {desc = Tvar _} ->
+        | Tvar _ ->
             raise (Typecore.Error
                      (smod.pmod_loc, env, Typecore.Cannot_infer_signature))
         | _ ->

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -19,11 +19,13 @@ open Asttypes
 
 (* Type expressions for the core language *)
 
-type type_expr =
+type transient_expr =
   { mutable desc: type_desc;
     mutable level: int;
     mutable scope: int;
     id: int }
+
+and type_expr = transient_expr
 
 and type_desc =
     Tvar of string option
@@ -72,19 +74,13 @@ and commutable =
   | Cunknown
   | Clink of commutable ref
 
-module TypeOps = struct
+module TransientTypeOps = struct
   type t = type_expr
   let compare t1 t2 = t1.id - t2.id
   let hash t = t.id
   let equal t1 t2 = t1 == t2
 end
 
-module Private_type_expr = struct
-  let create desc ~level ~scope ~id = {desc; level; scope; id}
-  let set_desc ty d = ty.desc <- d
-  let set_level ty lv = ty.level <- lv
-  let set_scope ty sc = ty.scope <- sc
-end
 (* *)
 
 module Uid = struct
@@ -477,3 +473,217 @@ let signature_item_id = function
   | Sig_class (id, _, _, _)
   | Sig_class_type (id, _, _, _)
     -> id
+
+(* migrating repr from Btype.. *)
+
+(**** Definitions for backtracking ****)
+
+type change =
+    Ctype of type_expr * type_desc
+  | Ccompress of type_expr * type_desc * type_desc
+  | Clevel of type_expr * int
+  | Cscope of type_expr * int
+  | Cname of
+      (Path.t * type_expr list) option ref * (Path.t * type_expr list) option
+  | Crow of row_field option ref * row_field option
+  | Ckind of field_kind option ref * field_kind option
+  | Ccommu of commutable ref * commutable
+  | Cuniv of type_expr option ref * type_expr option
+
+type changes =
+    Change of change * changes ref
+  | Unchanged
+  | Invalid
+
+let trail = Local_store.s_table ref Unchanged
+
+let log_change ch =
+  let r' = ref Unchanged in
+  !trail := Change (ch, r');
+  trail := r'
+
+(**** Representative of a type ****)
+
+let rec field_kind_repr =
+  function
+    Fvar {contents = Some kind} -> field_kind_repr kind
+  | kind                        -> kind
+
+let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
+ function
+   {desc = Tlink t' as d'} ->
+     repr_link true t d' t'
+ | {desc = Tfield (_, k, _, t') as d'} when field_kind_repr k = Fabsent ->
+     repr_link true t d' t'
+ | t' ->
+     if compress then begin
+       log_change (Ccompress (t, t.desc, d)); t.desc <- d
+     end;
+     t'
+
+let repr t =
+  match t.desc with
+   Tlink t' as d ->
+     repr_link false t d t'
+ | Tfield (_, k, _, t') as d when field_kind_repr k = Fabsent ->
+     repr_link false t d t'
+ | _ -> t
+
+(* getters for type_expr *)
+
+let get_desc t = (repr t).desc
+let get_level t = (repr t).level
+let get_scope t = (repr t).scope
+let get_id t = (repr t).id
+
+(* transient type_expr *)
+
+module Transient_expr = struct
+  let create desc ~level ~scope ~id = {desc; level; scope; id}
+  let set_desc ty d = ty.desc <- d
+  let set_stub_desc ty d = assert (ty.desc = Tvar None); ty.desc <- d
+  let set_level ty lv = ty.level <- lv
+  let set_scope ty sc = ty.scope <- sc
+  let coerce ty = ty
+  let repr = repr
+  let type_expr ty = ty
+end
+
+(* Comparison for [type_expr]; cannot be used for functors *)
+
+let eq_type t1 t2 = repr t1 == repr t2
+let compare_type t1 t2 = compare (get_id t1) (get_id t2)
+
+(**** Some type creators ****)
+
+let new_id = Local_store.s_ref (-1)
+
+let create_expr = Transient_expr.create
+
+let newty3 ~level ~scope desc  =
+  incr new_id;
+  create_expr desc ~level ~scope ~id:!new_id
+
+let newty2 level desc =
+  newty3 ~level ~scope:Ident.lowest_scope desc
+
+                  (**********************************)
+                  (*  Utilities for backtracking    *)
+                  (**********************************)
+
+let undo_change = function
+    Ctype  (ty, desc) -> Transient_expr.set_desc ty desc
+  | Ccompress  (ty, desc, _) -> Transient_expr.set_desc ty desc
+  | Clevel (ty, level) -> Transient_expr.set_level ty level
+  | Cscope (ty, scope) -> Transient_expr.set_scope ty scope
+  | Cname  (r, v) -> r := v
+  | Crow   (r, v) -> r := v
+  | Ckind  (r, v) -> r := v
+  | Ccommu (r, v) -> r := v
+  | Cuniv  (r, v) -> r := v
+
+type snapshot = changes ref * int
+let last_snapshot = Local_store.s_ref 0
+
+let log_type ty =
+  if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))
+let link_type ty ty' =
+  let ty = repr ty in
+  let ty' = repr ty' in
+  log_type ty;
+  let desc = ty.desc in
+  Transient_expr.set_desc ty (Tlink ty');
+  (* Name is a user-supplied name for this unification variable (obtained
+   * through a type annotation for instance). *)
+  match desc, ty'.desc with
+    Tvar name, Tvar name' ->
+      begin match name, name' with
+      | Some _, None -> log_type ty'; Transient_expr.set_desc ty' (Tvar name)
+      | None, Some _ -> ()
+      | Some _, Some _ ->
+          if ty.level < ty'.level then
+            (log_type ty'; Transient_expr.set_desc ty' (Tvar name))
+      | None, None   -> ()
+      end
+  | _ -> ()
+  (* ; assert (check_memorized_abbrevs ()) *)
+  (*  ; check_expans [] ty' *)
+(* TODO: consider eliminating set_type_desc, replacing it with link types *)
+let set_type_desc ty td =
+  let ty = repr ty in
+  if td != ty.desc then begin
+    log_type ty;
+    Transient_expr.set_desc ty td
+  end
+(* TODO: separate set_level into two specific functions: *)
+(*  set_lower_level and set_generic_level *)
+let set_level ty level =
+  let ty = repr ty in
+  if level <> ty.level then begin
+    if ty.id <= !last_snapshot then log_change (Clevel (ty, ty.level));
+    Transient_expr.set_level ty level
+  end
+(* TODO: introduce a guard and rename it to set_higher_scope? *)
+let set_scope ty scope =
+  let ty = repr ty in
+  if scope <> ty.scope then begin
+    if ty.id <= !last_snapshot then log_change (Cscope (ty, ty.scope));
+    Transient_expr.set_scope ty scope
+  end
+let set_univar rty ty =
+  log_change (Cuniv (rty, !rty)); rty := Some ty
+let set_name nm v =
+  log_change (Cname (nm, !nm)); nm := v
+let set_row_field e v =
+  log_change (Crow (e, !e)); e := Some v
+let set_kind rk k =
+  log_change (Ckind (rk, !rk)); rk := Some k
+let set_commu rc c =
+  log_change (Ccommu (rc, !rc)); rc := c
+
+let snapshot () =
+  let old = !last_snapshot in
+  last_snapshot := !new_id;
+  (!trail, old)
+
+let rec rev_log accu = function
+    Unchanged -> accu
+  | Invalid -> assert false
+  | Change (ch, next) ->
+      let d = !next in
+      next := Invalid;
+      rev_log (ch::accu) d
+
+let backtrack ~cleanup_abbrev (changes, old) =
+  match !changes with
+    Unchanged -> last_snapshot := old
+  | Invalid -> failwith "Btype.backtrack"
+  | Change _ as change ->
+      cleanup_abbrev ();
+      let backlog = rev_log [] change in
+      List.iter undo_change backlog;
+      changes := Unchanged;
+      last_snapshot := old;
+      trail := changes
+
+let rec rev_compress_log log r =
+  match !r with
+    Unchanged | Invalid ->
+      log
+  | Change (Ccompress _, next) ->
+      rev_compress_log (r::log) next
+  | Change (_, next) ->
+      rev_compress_log log next
+
+let undo_compress (changes, _old) =
+  match !changes with
+    Unchanged
+  | Invalid -> ()
+  | Change _ ->
+      let log = rev_compress_log [] changes in
+      List.iter
+        (fun r -> match !r with
+          Change (Ccompress (ty, desc, d), next) when ty.desc == d ->
+            Transient_expr.set_desc ty desc; r := !next
+        | _ -> ())
+        log

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -557,7 +557,7 @@ end
 
 (* Comparison for [type_expr]; cannot be used for functors *)
 
-let eq_type t1 t2 = repr t1 == repr t2
+let eq_type t1 t2 = t1 == t2 || repr t1 == repr t2
 let compare_type t1 t2 = compare (get_id t1) (get_id t2)
 
 (**** Some type creators ****)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -570,7 +570,7 @@ let newty3 ~level ~scope desc  =
   incr new_id;
   create_expr desc ~level ~scope ~id:!new_id
 
-let newty2 level desc =
+let newty2 ~level desc =
   newty3 ~level ~scope:Ident.lowest_scope desc
 
                   (**********************************)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -509,24 +509,30 @@ let rec field_kind_repr =
     Fvar {contents = Some kind} -> field_kind_repr kind
   | kind                        -> kind
 
-let rec repr_link compress (t : type_expr) d : type_expr -> type_expr =
+let rec repr_link (t : type_expr) d : type_expr -> type_expr =
  function
    {desc = Tlink t' as d'} ->
-     repr_link true t d' t'
+     repr_link t d' t'
  | {desc = Tfield (_, k, _, t') as d'} when field_kind_repr k = Fabsent ->
-     repr_link true t d' t'
+     repr_link t d' t'
  | t' ->
-     if compress then begin
-       log_change (Ccompress (t, t.desc, d)); t.desc <- d
-     end;
+     log_change (Ccompress (t, t.desc, d));
+     t.desc <- d;
      t'
+
+let repr_link1 t = function
+   {desc = Tlink t' as d'} ->
+     repr_link t d' t'
+ | {desc = Tfield (_, k, _, t') as d'} when field_kind_repr k = Fabsent ->
+     repr_link t d' t'
+ | t' -> t'
 
 let repr t =
   match t.desc with
-   Tlink t' as d ->
-     repr_link false t d t'
- | Tfield (_, k, _, t') as d when field_kind_repr k = Fabsent ->
-     repr_link false t d t'
+   Tlink t' ->
+     repr_link1 t t'
+ | Tfield (_, k, _, t') when field_kind_repr k = Fabsent ->
+     repr_link1 t t'
  | _ -> t
 
 (* getters for type_expr *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -271,7 +271,7 @@ val create_expr: type_desc -> level: int -> scope: int -> id: int -> type_expr
 val newty3: level:int -> scope:int -> type_desc -> type_expr
         (** Create a type with a fresh id *) 
 
-val newty2: int -> type_desc -> type_expr
+val newty2: level:int -> type_desc -> type_expr
         (** Create a type with a fresh id and no scope *)
 
 val field_kind_repr: field_kind -> field_kind

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -269,7 +269,7 @@ val create_expr: type_desc -> level: int -> scope: int -> id: int -> type_expr
 (** Functions and definitions moved from Btype *)
 
 val newty3: level:int -> scope:int -> type_desc -> type_expr
-        (** Create a type with a fresh id *) 
+        (** Create a type with a fresh id *)
 
 val newty2: level:int -> type_desc -> type_expr
         (** Create a type with a fresh id and no scope *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -55,13 +55,9 @@ open Asttypes
 
     Note on mutability: TBD.
  *)
-type type_expr = private
-  { mutable desc: type_desc;
-    mutable level: int;
-    mutable scope: int;
-    id: int }
+type type_expr
 
-and type_desc =
+type type_desc =
   | Tvar of string option
   (** [Tvar (Some "a")] ==> ['a] or ['_a]
       [Tvar None]       ==> [_] *)
@@ -236,19 +232,60 @@ and commutable =
   | Cunknown
   | Clink of commutable ref
 
-module Private_type_expr : sig
-  val create : type_desc -> level: int -> scope: int -> id: int -> type_expr
-  val set_desc : type_expr -> type_desc -> unit
-  val set_level : type_expr -> int -> unit
-  val set_scope : type_expr -> int -> unit
+(* getters for type_expr; calls repr before answering a value *)
+
+val get_desc: type_expr -> type_desc
+val get_level: type_expr -> int
+val get_scope: type_expr -> int
+val get_id: type_expr -> int
+
+(* transient type_expr *)
+
+type transient_expr = private
+      { mutable desc: type_desc;
+        mutable level: int;
+        mutable scope: int;
+        id: int }
+
+module Transient_expr : sig
+  (* Operations on transient types *)
+  val create: type_desc -> level: int -> scope: int -> id: int -> transient_expr
+  val set_desc: transient_expr -> type_desc -> unit
+  val set_level: transient_expr -> int -> unit
+  val set_scope: transient_expr -> int -> unit
+  val repr: type_expr -> transient_expr
+  val type_expr: transient_expr -> type_expr
+  (* Operations on [type_expr] seen as [transient_expr] *)
+  val coerce: type_expr -> transient_expr
+  val set_stub_desc: type_expr -> type_desc -> unit
+      (* Instantiate a not yet instantiated stub *)
 end
 
-module TypeOps : sig
-  type t = type_expr
+val create_expr: type_desc -> level: int -> scope: int -> id: int -> type_expr
+
+(* Functions and definitions moved from Btype *)
+
+val newty3: level:int -> scope:int -> type_desc -> type_expr
+val newty2: int -> type_desc -> type_expr
+        (* Create a type with a fresh id *)
+
+val field_kind_repr: field_kind -> field_kind
+        (* Return the canonical representative of an object field
+           kind. *)
+
+(* Comparisons for functors *)
+
+module TransientTypeOps : sig
+  type t = transient_expr
   val compare : t -> t -> int
   val equal : t -> t -> bool
   val hash : t -> int
 end
+
+(* Comparison for [type_expr]; cannot be used for functors *)
+
+val eq_type: type_expr -> type_expr -> bool
+val compare_type: type_expr -> type_expr -> int
 
 (* *)
 
@@ -587,3 +624,35 @@ type label_description =
 val bound_value_identifiers: signature -> Ident.t list
 
 val signature_item_id : signature_item -> Ident.t
+
+(**** Utilities for backtracking ****)
+
+type snapshot
+        (* A snapshot for backtracking *)
+val snapshot: unit -> snapshot
+        (* Make a snapshot for later backtracking. Costs nothing *)
+val backtrack: cleanup_abbrev:(unit -> unit) -> snapshot -> unit
+        (* Backtrack to a given snapshot. Only possible if you have
+           not already backtracked to a previous snapshot.
+           Calls [cleanup_abbrev] internally *)
+val undo_compress: snapshot -> unit
+        (* Backtrack only path compression. Only meaningful if you have
+           not already backtracked to a previous snapshot.
+           Does not call [cleanup_abbrev] *)
+
+(* Functions to use when modifying a type (only Ctype?) *)
+val link_type: type_expr -> type_expr -> unit
+        (* Set the desc field of [t1] to [Tlink t2], logging the old
+           value if there is an active snapshot *)
+val set_type_desc: type_expr -> type_desc -> unit
+        (* Set directly the desc field, without sharing *)
+val set_level: type_expr -> int -> unit
+val set_scope: type_expr -> int -> unit
+val set_name:
+    (Path.t * type_expr list) option ref ->
+    (Path.t * type_expr list) option -> unit
+val set_row_field: row_field option ref -> row_field -> unit
+val set_univar: type_expr option ref -> type_expr -> unit
+val set_kind: field_kind option ref -> field_kind -> unit
+val set_commu: commutable ref -> commutable -> unit
+        (* Set references, logging the old value *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -232,15 +232,15 @@ and commutable =
   | Cunknown
   | Clink of commutable ref
 
-(* getters for type_expr; calls repr before answering a value *)
+(** Getters for type_expr; calls repr before answering a value *)
 
 val get_desc: type_expr -> type_desc
 val get_level: type_expr -> int
 val get_scope: type_expr -> int
 val get_id: type_expr -> int
 
-(* transient type_expr *)
-
+(** Transient [type_expr].
+    Should only be used immediately after [Transient_expr.repr] *)
 type transient_expr = private
       { mutable desc: type_desc;
         mutable level: int;
@@ -248,41 +248,45 @@ type transient_expr = private
         id: int }
 
 module Transient_expr : sig
-  (* Operations on transient types *)
+  (** Operations on [transient_expr] *)
+
   val create: type_desc -> level: int -> scope: int -> id: int -> transient_expr
   val set_desc: transient_expr -> type_desc -> unit
   val set_level: transient_expr -> int -> unit
   val set_scope: transient_expr -> int -> unit
   val repr: type_expr -> transient_expr
   val type_expr: transient_expr -> type_expr
-  (* Operations on [type_expr] seen as [transient_expr] *)
   val coerce: type_expr -> transient_expr
+      (** Coerce without normalizing with [repr] *)
+
   val set_stub_desc: type_expr -> type_desc -> unit
-      (* Instantiate a not yet instantiated stub *)
+      (** Instantiate a not yet instantiated stub.
+          Fail if already instantiated. *)
 end
 
 val create_expr: type_desc -> level: int -> scope: int -> id: int -> type_expr
 
-(* Functions and definitions moved from Btype *)
+(** Functions and definitions moved from Btype *)
 
 val newty3: level:int -> scope:int -> type_desc -> type_expr
+        (** Create a type with a fresh id *) 
+
 val newty2: int -> type_desc -> type_expr
-        (* Create a type with a fresh id *)
+        (** Create a type with a fresh id and no scope *)
 
 val field_kind_repr: field_kind -> field_kind
-        (* Return the canonical representative of an object field
-           kind. *)
-
-(* Comparisons for functors *)
+        (** Return the canonical representative of an object field kind. *)
 
 module TransientTypeOps : sig
+  (** Comparisons for functors *)
+
   type t = transient_expr
   val compare : t -> t -> int
   val equal : t -> t -> bool
   val hash : t -> int
 end
 
-(* Comparison for [type_expr]; cannot be used for functors *)
+(** Comparisons for [type_expr]; cannot be used for functors *)
 
 val eq_type: type_expr -> type_expr -> bool
 val compare_type: type_expr -> type_expr -> int


### PR DESCRIPTION
This PR was written in collaboration with @t6s .

This is a follow-up to the introduction of `private type_expr`.
We go further by making `type_expr` abstract, having the accessor functions (`get_desc`,`get_level`,...) systematically call `repr` before returning their result. This provides a clearer semantics for `type_expr`, independent of the physical  representation, which should simplify reasoning for everybody. In the future, this could also allow to replace the current in-place union-find by another mechanism.
This greatly increases the number of calls to `repr` (from 1.7x for coqtop to 3.7x for stdlib), but this also ensures that we never forget it. The performance measurements show a 5-10% overhead for `ocamlc`, but this goes down to 2-5% for `ocamlc.opt` (with one level of unrolling) (2% for coqc, 4% for lablgtk or ocamldoc).

The private `type_expr` is kept as `transient_expr`, with operations in module `Types.Transient_expr` and is used in a limited number of places. It is actually smaller than expected; the only place where it seems really necessary is to partly undo unification in `unify`. There may be a better way to provide error messages. Otherwise, this is mostly to be able to use `transient_expr` as an ordered type, for functors. As an exception, `Printtyp` uses extensively `transient_type`, as its role is to print the graph, using many tables; we made less efforts to avoid it, as correctness matters less there. 

This PR contains 4 commits:
* The first one makes `type_expr` abstract, introduces `transient_expr`, and uses `repr : type_expr -> transient_expr` for normalization. `repr` and logging/backtracking also move to `types.ml`. It shows that tracking normalization through types is useful, but painful whereas it is not really safe (a `transient_expr` can still be turned into a `Tlink` by a hidden side-effect), hence our choice to try the `always_repr` approach.
* The second one hides `repr` inside the `Transient_expr` module, and replaces almost all uses of `repr` by accessor functions. This creates an extensive abstraction barrier around `type_expr`.
* The third one fixes two bugs uncovered by the transition. One is that `expand_trace` keeps old expansions, which may create an incoherent trace if the type was modified (see the error message in `pr4018_bad.compilers.reference`). The other is that `copy_sep` should copy the proxy (end of the row) if it copies one of the fields (see `poly.ml`).
* The last one unrolls `repr_link` once to gain a few percents of performance.

In the process we also found a few places where `repr` was missing, in `Typedecl` for instance.

Some possible improvements are not done in this PR, and left for later:
* use a GADT to remove `Tlink` from the result of `get_desc`,
* replace `try_mark_node` by `try_logged_mark_node` everywhere.