### PR TITLE
manual: enable {caml_example} in cmds/

### DIFF
--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -136,7 +136,8 @@ warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
 	 echo "%";\
 	 $(SET_LD_PATH) $(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
 	 | LC_ALL=C sed -e 's/^ *\([0-9][0-9]*\) *\[\([a-z][a-z-]*\)\]\(.*\)/\\item[\1 "\2"] \3/' \
-               -e 's/^ *\([0-9A-Z][0-9]*\) *\([^]].*\)/\\item[\1] \2/'\
+	                -e 's/^ *\([0-9A-Z][0-9]*\) *\([^]].*\)/\\item[\1] \2/'\
+	 | sed -e 's/@/\\@/g' \
 	) >$@
 #	sed --inplace is not portable, emulate
 	for i in 52 57; do\

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -7,7 +7,7 @@ SET_LD_PATH = CAML_LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
 
 TEXQUOTE = $(SRC)/runtime/ocamlrun ../tools/texquote2
 
-FILES = allfiles.tex biblio.tex foreword.tex version.tex warnings-help.etex ifocamldoc.tex
+FILES = allfiles.tex biblio.tex foreword.tex version.tex cmds/warnings-help.etex ifocamldoc.tex
 
 TEXINPUTS = ".:..:../refman:../refman/extensions:../library:../cmds:../tutorials:../../styles:"
 RELEASE = $$HOME/release/$${RELEASENAME}
@@ -127,7 +127,7 @@ etex-files: $(FILES)
 version.tex: $(SRC)/VERSION
 	sed -n -e '1s/^\([0-9]*\.[0-9]*\).*$$/\\def\\ocamlversion{\1}/p' $< > $@
 
-warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
+cmds/warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
 	(echo "% This file is generated from (ocamlc -warn-help)";\
 	 echo "% according to a rule in manual/src/Makefile.";\
 	 echo "% In particular, the reference to documentation sections";\

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -27,11 +27,6 @@ all: $(FILES)
 	$(TEXQUOTE) < $< > $*.texquote_error.tex
 	mv $*.texquote_error.tex $@
 
-warnings-help.etex: ../warnings-help.etex
-	cp $< $@
-
-
 .PHONY: clean
 clean:
 	rm -f *.tex
-	rm -f warnings-help.etex

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -15,31 +15,16 @@ FILES = comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   warnings-help.tex flambda.tex \
   afl-fuzz.tex instrumented-runtime.tex unified-options.tex
 
-WITH_TRANSF = top.tex intf-c.tex flambda.tex \
-  afl-fuzz.tex lexyacc.tex debugger.tex
-
-WITH_CAMLEXAMPLE = instrumented-runtime.tex ocamldoc.tex
-
-
 etex-files: $(FILES)
 all: $(FILES)
 
+%.gen.tex: %.etex
+	$(CAMLLATEX) $< -o $*_camltex.tex
+	$(TRANSF) < $*_camltex.tex > $*.transf_error.tex
+	mv $*.transf_error.tex $@
 
-%.tex: %.etex
+%.tex: %.gen.tex
 	$(TEXQUOTE) < $< > $*.texquote_error.tex
-	mv $*.texquote_error.tex $@
-
-$(WITH_TRANSF): %.tex: %.etex
-	$(TRANSF) < $< > $*.transf_error.tex
-	mv $*.transf_error.tex $*.transf_gen.tex
-	$(TEXQUOTE) < $*.transf_gen.tex > $*.texquote_error.tex
-	mv $*.texquote_error.tex $@
-
-$(WITH_CAMLEXAMPLE): %.tex: %.etex
-	$(CAMLLATEX) $< -o $*.gen.tex
-	$(TRANSF) < $*.gen.tex > $*.transf_error.tex
-	mv $*.transf_error.tex $*.transf_gen.tex
-	$(TEXQUOTE) < $*.transf_gen.tex > $*.texquote_error.tex
 	mv $*.texquote_error.tex $@
 
 warnings-help.etex: ../warnings-help.etex

--- a/manual/src/cmds/comp.etex
+++ b/manual/src/cmds/comp.etex
@@ -409,25 +409,19 @@ let dy { y; _ } = y (* explicit field elision: do not trigger warning 9 *)
   the future, by using the attribute "ocaml.warn_on_literal_pattern"
   (see the manual section on builtin attributes in
   \ref{ss:builtin-attributes}):
-\begin{verbatim}
-  type t =
-    | Foo of string [@ocaml.warn_on_literal_pattern]
-    | Bar of string
+\begin{caml_example*}{verbatim}[warning=52]
+type t =
+  | Foo of string [@ocaml.warn_on_literal_pattern]
+  | Bar of string
 
-  let no_warning = function
-    | Bar "specific value" -> 0
-    | _ -> 1
+let no_warning = function
+  | Bar "specific value" -> 0
+  | _ -> 1
 
-  let warning = function
-    | Foo "specific value" -> 0
-    | _ -> 1
-
->    | Foo "specific value" -> 0
->          ^^^^^^^^^^^^^^^^
-> Warning 52: Code should not depend on the actual values of
-> this constructor's arguments. They are only for information
-> and may change in future versions. (See manual section 8.5)
-\end{verbatim}
+let warning = function
+  | Foo "specific value" -> 0
+  | _ -> 1
+\end{caml_example*}
 
   In particular, all built-in exceptions with a string argument have
   this attribute set: "Invalid_argument", "Failure", "Sys_error" will

--- a/manual/src/cmds/unified-options.etex
+++ b/manual/src/cmds/unified-options.etex
@@ -684,13 +684,13 @@ invalid formats, as they will be rejected by future OCaml versions.
 \item["-unboxed-types"]
 When a type is unboxable (i.e. a record with a single argument or a
 concrete datatype with a single constructor of one argument) it will
-be unboxed unless annotated with "[@@ocaml.boxed]".
+be unboxed unless annotated with "[\@\@ocaml.boxed]".
 }%notop
 
 \notop{%
 \item["-no-unboxed-types"]
 When a type is unboxable  it will be boxed unless annotated with
-"[@@ocaml.unboxed]". This is the default.
+"[\@\@ocaml.unboxed]". This is the default.
 }%notop
 
 \item["-unsafe"]
@@ -763,16 +763,16 @@ following:
 \begin{options}
 \item["+"\var{num}] Enable warning number \var{num}.
 \item["-"\var{num}] Disable warning number \var{num}.
-\item["@"\var{num}] Enable and mark as fatal warning number \var{num}.
+\item["\@"\var{num}] Enable and mark as fatal warning number \var{num}.
 \item["+"\var{num1}..\var{num2}] Enable warnings in the given range.
 \item["-"\var{num1}..\var{num2}] Disable warnings in the given range.
-\item["@"\var{num1}..\var{num2}] Enable and mark as fatal warnings in
+\item["\@"\var{num1}..\var{num2}] Enable and mark as fatal warnings in
 the given range.
 \item["+"\var{letter}] Enable the set of warnings corresponding to
 \var{letter}. The letter may be uppercase or lowercase.
 \item["-"\var{letter}] Disable the set of warnings corresponding to
 \var{letter}. The letter may be uppercase or lowercase.
-\item["@"\var{letter}] Enable and mark as fatal the set of warnings
+\item["\@"\var{letter}] Enable and mark as fatal the set of warnings
 corresponding to \var{letter}. The letter may be uppercase or
 lowercase.
 \item[\var{uppercase-letter}] Enable the set of warnings corresponding
@@ -787,7 +787,7 @@ mnemonic name (see below), as follows:
 \begin{options}
 \item["+"\var{name}] Enable warning \var{name}.
 \item["-"\var{name}] Disable warning \var{name}.
-\item["@"\var{name}] Enable and mark as fatal warning \var{name}.
+\item["\@"\var{name}] Enable and mark as fatal warning \var{name}.
 \end{options}
 
 Warning numbers, letters and names which are not currently defined are
@@ -810,7 +810,7 @@ emitted. The \var{warning-list} has the same meaning as for
 the "-w" option: a "+" sign (or an uppercase letter) marks the
 corresponding warnings as fatal, a "-"
 sign (or a lowercase letter) turns them back into non-fatal warnings,
-and a "@" sign both enables and marks as fatal the corresponding
+and a "\@" sign both enables and marks as fatal the corresponding
 warnings.
 
 Note: it is not recommended to use warning sets (i.e. letters) as


### PR DESCRIPTION
This work comes from #10140. It is currently a Draft PR because running the .etex preprocessing machinery on all .etex files in cmds/ seems to fail:

```
CAML_LD_LIBRARY_PATH=""../../../otherlibs/str:../../../otherlibs/unix"" ../../../runtime/ocamlrun ../../tools/transf < warnings-help_camltex.tex > warnings-help.transf_error.tex
Uncaught exception: Failure("lexing: empty token")
Fatal error: exception Failure("lexing: empty token")
make[1]: *** [Makefile:23: warnings-help.gen.tex] Error 2
```

This is the point where I stop and ask @Octachron for help.