### PR TITLE
Add missing Iopaque case to Proc.op_is_pure for RISC-V

### DIFF
--- a/asmcomp/riscv/proc.ml
+++ b/asmcomp/riscv/proc.ml
@@ -272,7 +272,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
   | Ispecific(Imultaddf _ | Imultsubf _) -> true
   | _ -> true
 


### PR DESCRIPTION
This should fix the Jenkins CI failure caused by #9412.  (It's also a good example of why exhaustive matches are beneficial!)

Incidentally there was also a segfault on the RISC-V worker, I think for the same change, but @nojb tells me this is an existing transient problem.  I have suggested we retrieve the build tree and core dump for further analysis.