### PR TITLE
Correct rules in Makefile.compilerlibs

### DIFF
--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -279,6 +279,7 @@ OPTTOPLEVEL_CMI=toplevel/topcommon.cmi toplevel/native/topeval.cmi \
 
 TOPLEVEL_SHARED_MLIS = topeval.mli trace.mli topmain.mli
 TOPLEVEL_SHARED_CMIS = $(TOPLEVEL_SHARED_MLIS:%.mli=%.cmi)
+TOPLEVEL_SHARED_ARTEFACTS = $(TOPLEVEL_SHARED_MLIS) $(TOPLEVEL_SHARED_CMIS)
 
 $(addprefix toplevel/byte/, $(TOPLEVEL_SHARED_CMIS)):\
 toplevel/byte/%.cmi: toplevel/%.cmi
@@ -289,13 +290,12 @@ toplevel/native/%.cmi: toplevel/%.cmi
 	cp $< toplevel/$*.mli $(@D)
 
 beforedepend::
-	cp $(addprefix toplevel/, $(TOPLEVEL_SHARED_MLIS)) toplevel/byte
-	cp $(addprefix toplevel/, $(TOPLEVEL_SHARED_MLIS)) toplevel/native
+	cd toplevel ; cp $(TOPLEVEL_SHARED_MLIS) byte/
+	cd toplevel ; cp $(TOPLEVEL_SHARED_MLIS) native/
 
 partialclean::
-	rm -f $(foreach ext, byte native, \
-    $(addprefix toplevel/$(ext)/, $(TOPLEVEL_SHARED_MLIS)) \
-                                  $(TOPLEVEL_SHARED_CMIS))
+	cd toplevel/byte ; rm -f $(TOPLEVEL_SHARED_ARTEFACTS)
+	cd toplevel/native ; rm -f $(TOPLEVEL_SHARED_ARTEFACTS)
 
 $(COMMON:.cmo=.cmx) $(BYTECOMP:.cmo=.cmx) $(OPTCOMP:.cmo=.cmx): ocamlopt$(EXE)
 $(OPTTOPLEVEL:.cmo=.cmx): ocamlopt$(EXE)

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -278,24 +278,24 @@ OPTTOPLEVEL_CMI=toplevel/topcommon.cmi toplevel/native/topeval.cmi \
   toplevel/native/topmain.cmi
 
 TOPLEVEL_SHARED_MLIS = topeval.mli trace.mli topmain.mli
+TOPLEVEL_SHARED_CMIS = $(TOPLEVEL_SHARED_MLIS:%.mli=%.cmi)
 
-$(TOPLEVEL_SHARED_MLIS:%.mli=toplevel/byte/%.cmi):\
+$(addprefix toplevel/byte/, $(TOPLEVEL_SHARED_CMIS)):\
 toplevel/byte/%.cmi: toplevel/%.cmi
 	cp $< toplevel/$*.mli $(@D)
 
-$(TOPLEVEL_SHARED_MLIS:%.mli=toplevel/native/%.cmi):\
+$(addprefix toplevel/native/, $(TOPLEVEL_SHARED_CMIS)):\
 toplevel/native/%.cmi: toplevel/%.cmi
 	cp $< toplevel/$*.mli $(@D)
 
 beforedepend::
-	cp $(TOPLEVEL_SHARED_MLIS:%=toplevel/%) toplevel/byte
-	cp $(TOPLEVEL_SHARED_MLIS:%=toplevel/%) toplevel/native
+	cp $(addprefix toplevel/, $(TOPLEVEL_SHARED_MLIS)) toplevel/byte
+	cp $(addprefix toplevel/, $(TOPLEVEL_SHARED_MLIS)) toplevel/native
 
 partialclean::
-	rm -f $(TOPLEVEL_SHARED_MLIS:%.mli=\
-	        toplevel/byte/%.mli toplevel/byte/%.cmi)
-	rm -f $(TOPLEVEL_SHARED_MLIS:%.mli=\
-	        toplevel/native/%.mli toplevel/native/%.cmi)
+	rm -f $(foreach ext, byte native, \
+    $(addprefix toplevel/$(ext)/, $(TOPLEVEL_SHARED_MLIS)) \
+                                  $(TOPLEVEL_SHARED_CMIS))
 
 $(COMMON:.cmo=.cmx) $(BYTECOMP:.cmo=.cmx) $(OPTCOMP:.cmo=.cmx): ocamlopt$(EXE)
 $(OPTTOPLEVEL:.cmo=.cmx): ocamlopt$(EXE)


### PR DESCRIPTION
#10061 added `Makefile` substitutions of the form `$(VAR:prefix%suffix=...)` which doesn't work - substitutions in make can be at the prefix _or_ the suffix but not both.

The `partialclean` part is already covered by:
https://github.com/ocaml/ocaml/blob/2c85ab7344c0ccba7699523f56916d91aad665a5/Makefile#L1079-L1086

(although FWIW I prefer artefacts being explicitly deleted)