### PR TITLE
Support clever expansion of gadt equations in presence of local module

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,10 @@ Working version
 
 ### Bug fixes:
 
+- #10348: Expand GADT equations lazily during unification to avoid ambiguity
+  (Jacques Garrigue, review by Leo White)
+
+
 OCaml 5.0
 ---------
 
@@ -1562,9 +1566,6 @@ OCaml 4.13.0 (24 September 2021)
   In passing, refactor Proc.op_is_pure and Mach.operation_can_raise.
   (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan
    and Mark Shinwell)
-
-- #10348: Expand GADT equations lazily during unification to avoid ambiguity
-  (Jacques Garrigue, review by Leo White)
 
 - #10371: no longer generatd useless `.cds` file when using
   `-output-complete-exe`.

--- a/Changes
+++ b/Changes
@@ -1563,6 +1563,9 @@ OCaml 4.13.0 (24 September 2021)
   (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan
    and Mark Shinwell)
 
+- #10348: Expand GADT equations lazily during unification to avoid ambiguity
+  (Jacques Garrigue, review by Leo White)
+
 - #10371: no longer generatd useless `.cds` file when using
   `-output-complete-exe`.
   (Nicolás Ojeda Bär, review by David Allsopp)

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -116,8 +116,8 @@ let f (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
 3 |   | Refl, [(_ : a) | (_ : b)] -> []
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       This instance of b is ambiguous:
+Error: This pattern matches values of type (a, b) eq * a list
+       This instance of a is ambiguous:
        it would escape the scope of its equation
 |}]
 
@@ -130,8 +130,8 @@ let g1 (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
 3 |   | Refl, [(_ : a) | (_ : b)] -> []
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       This instance of b is ambiguous:
+Error: This pattern matches values of type (a, b) eq * a list
+       This instance of a is ambiguous:
        it would escape the scope of its equation
 |}]
 
@@ -158,8 +158,8 @@ let h1 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
 4 |   | Refl, [(_ : a) | (_ : b)] -> []
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       This instance of b is ambiguous:
+Error: This pattern matches values of type (a, b) eq * a list
+       This instance of a is ambiguous:
        it would escape the scope of its equation
 |}]
 
@@ -172,8 +172,8 @@ let h2 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
 4 |   | Refl, [(_ : a) | (_ : b)] -> []
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       This instance of b is ambiguous:
+Error: This pattern matches values of type (a, b) eq * a list
+       This instance of a is ambiguous:
        it would escape the scope of its equation
 |}]
 
@@ -232,9 +232,8 @@ Error: Signature mismatch:
        Values do not match:
          val r : '_weak1 list ref
        is not included in
-         val r : T.u list ref
-       The type '_weak1 list ref is not compatible with the type T.u list ref
-       Type '_weak1 is not compatible with type T.u = T.t
+         val r : T.t list ref
+       The type '_weak1 list ref is not compatible with the type T.t list ref
        This instance of T.t is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -220,8 +220,8 @@ let simple_merged_annotated_return (type a) (t : a t) (a : a) =
 Line 3, characters 12-20:
 3 |   | IntLit, (3 as x)
                 ^^^^^^^^
-Error: This pattern matches values of type a
-       This instance of a is ambiguous:
+Error: This pattern matches values of type int
+       This instance of int is ambiguous:
        it would escape the scope of its equation
 |}]
 

--- a/testsuite/tests/typing-gadts/pr10348.ml
+++ b/testsuite/tests/typing-gadts/pr10348.ml
@@ -1,0 +1,50 @@
+(* TEST
+   * expect
+*)
+
+
+type (_, _) eq = Refl : ('a, 'a) eq;;
+
+let foo (type a) (x : (a, int) eq) (a : a) p =
+  let module M = struct type t = a let x : t = a end in
+  if p then a else M.x;;
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+val foo : ('a, int) eq -> 'a -> bool -> 'a = <fun>
+|}]
+
+let foo (type a) (x : (a, int) eq) (a : a) p =
+  let module M = struct type t = a let x : t = a end in
+  let Refl = x in
+  if p then a else M.x;;
+[%%expect{|
+val foo : ('a, int) eq -> 'a -> bool -> 'a = <fun>
+|}]
+
+let foo (type a) (x : (a, int) eq) (a : a) p =
+  let module M = struct type 'a t = a let x : 'a t = a end in
+  let Refl = x in
+  if p then a else M.x;;
+[%%expect{|
+val foo : ('a, int) eq -> 'a -> bool -> 'a = <fun>
+|}]
+
+let foo (type a) (x : (a, int) eq) (a : a) p =
+  let module M = struct type 'a t = 'a let x : a t = a end in
+  let Refl = x in
+  if p then a else M.x;;
+[%%expect{|
+val foo : ('a, int) eq -> 'a -> bool -> 'a = <fun>
+|}]
+
+type ('a,'b) fst = 'a
+
+let foo4 (type a) (x : (a, int) eq) (a : a) p =
+  let module M : sig type t = (a,bool) fst val x : t end =
+    struct type t = (a,bool) fst let x = a end in
+  let Refl = x in
+  if p then a else M.x;;
+[%%expect{|
+type ('a, 'b) fst = 'a
+val foo4 : ('a, int) eq -> 'a -> bool -> 'a = <fun>
+|}]

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -22,8 +22,8 @@ type ('a, 'b) eq = Refl : ('a, 'a) eq
 Line 4, characters 4-29:
 4 |   | Refl, [(_ : a) | (_ : b)] -> []
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       This instance of b is ambiguous:
+Error: This pattern matches values of type (a, b) eq * a list
+       This instance of a is ambiguous:
        it would escape the scope of its equation
 |}]
 let fails (type a b) (x : (a, b) eq) =
@@ -35,8 +35,8 @@ let fails (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
 3 |   | Refl, [(_ : a) | (_ : b)] -> []
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       This instance of b is ambiguous:
+Error: This pattern matches values of type (a, b) eq * a list
+       This instance of a is ambiguous:
        it would escape the scope of its equation
 |}]
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -459,8 +459,7 @@ let test : type a. a t -> a = fun x ->
 Line 2, characters 30-42:
 2 |   let r = match x with Int -> ky 1 (1 : a)  (* fails *)
                                   ^^^^^^^^^^^^
-Error: This expression has type a = int
-       but an expression was expected of type 'a
+Error: This expression has type int but an expression was expected of type 'a
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -573,8 +572,7 @@ val either : 'a -> 'a -> 'a = <fun>
 Line 3, characters 44-45:
 3 |   match v with Int -> let y = either 1 x in y
                                                 ^
-Error: This expression has type a = int
-       but an expression was expected of type 'a
+Error: This expression has type int but an expression was expected of type 'a
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -629,15 +627,9 @@ let f (type a) (x : a t) y =
   match x with Int ->
     let module M = struct type b = a let z = (y : b) end
     in M.z
-;; (* fails because of aliasing... *)
+;;
 [%%expect{|
-Line 3, characters 46-47:
-3 |     let module M = struct type b = a let z = (y : b) end
-                                                  ^
-Error: This expression has type a = int
-       but an expression was expected of type b = int
-       This instance of int is ambiguous:
-       it would escape the scope of its equation
+val f : 'a t -> 'a -> 'a = <fun>
 |}];;
 
 let f (type a) (x : a t) y =
@@ -1183,7 +1175,6 @@ Line 5, characters 24-25:
                             ^
 Error: This expression has type b = int
        but an expression was expected of type a = int
-       Type b = int is not compatible with type int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1201,7 +1192,6 @@ Line 5, characters 24-25:
                             ^
 Error: This expression has type b = int
        but an expression was expected of type a = int
-       Type int is not compatible with type a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1217,7 +1207,6 @@ Line 4, characters 19-20:
                        ^
 Error: This expression has type b = int
        but an expression was expected of type a = int
-       Type a = int is not compatible with type a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -725,9 +725,8 @@ Error: Signature mismatch:
        Values do not match:
          val r : '_weak4 list ref
        is not included in
-         val r : T.s list ref
-       The type '_weak4 list ref is not compatible with the type T.s list ref
-       Type '_weak4 is not compatible with type T.s = T.t
+         val r : T.t list ref
+       The type '_weak4 list ref is not compatible with the type T.t list ref
        This instance of T.t is ambiguous:
        it would escape the scope of its equation
 |}];;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2162,13 +2162,6 @@ let reify env t =
   in
   iterator t
 
-let is_public_type env p =
-  try
-    let decl = Env.find_type p env in
-    decl.type_kind = Type_abstract &&
-    decl.type_private = Public
-  with Not_found -> false
-
 let find_expansion_scope env path =
   let decl = Env.find_type path env in
   if decl.type_manifest = None then generic_level
@@ -2653,7 +2646,7 @@ and unify2_rec env t10 t1 t20 t2 =
   if unify_eq t1 t2 then () else
   try match (get_desc t1, get_desc t2) with
   | (Tconstr (p1, tl1, a1), Tconstr (p2, tl2, a2)) ->
-      if Path.same p1 p2 && tl1 = [] && tl2 = [] && is_public_type !env p1
+      if Path.same p1 p2 && tl1 = [] && tl2 = []
       && not (has_cached_expansion p1 !a1 || has_cached_expansion p2 !a2)
       then begin
         update_level_for Unify !env (get_level t1) t2;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2162,13 +2162,17 @@ let reify env t =
   in
   iterator t
 
-let is_newtype env p =
+let is_public_type env p =
   try
     let decl = Env.find_type p env in
-    decl.type_expansion_scope <> Btype.lowest_level &&
     decl.type_kind = Type_abstract &&
     decl.type_private = Public
   with Not_found -> false
+
+let find_expansion_scope env path =
+  let decl = Env.find_type path env in
+  if decl.type_manifest = None then generic_level
+  else decl.type_expansion_scope
 
 let non_aliasable p decl =
   (* in_pervasives p ||  (subsumed by in_current_module) *)
@@ -2427,9 +2431,6 @@ let find_lowest_level ty =
     end
   in find ty; unmark_type ty; !lowest
 
-let find_expansion_scope env path =
-  (Env.find_type path env).type_expansion_scope
-
 let add_gadt_equation env source destination =
   (* Format.eprintf "@[add_gadt_equation %s %a@]@."
     (Path.name source) !Btype.print_raw destination; *)
@@ -2636,18 +2637,8 @@ let rec unify (env:Env.t ref) t1 t2 =
         update_level_for Unify !env (get_level t1) t2;
         update_scope_for Unify (get_scope t1) t2;
         link_type t1 t2
-    | (Tconstr (p1, [], _), Tconstr (p2, [], _))
-      when Env.has_local_constraints !env
-      && is_newtype !env p1 && is_newtype !env p2 ->
-        (* Do not use local constraints more than necessary *)
-        begin try
-          if find_expansion_scope !env p1 > find_expansion_scope !env p2 then
-            unify env t1 (try_expand_safe !env t2)
-          else
-            unify env (try_expand_safe !env t1) t2
-        with Cannot_expand ->
-          unify2 env t1 t2
-        end
+    | (Tconstr _, Tconstr _) when Env.has_local_constraints !env ->
+        unify2_rec env t1 t1 t2 t2
     | _ ->
         unify2 env t1 t2
     end;
@@ -2656,13 +2647,34 @@ let rec unify (env:Env.t ref) t1 t2 =
     reset_trace_gadt_instances reset_tracing;
     raise_trace_for Unify (Diff {got = t1; expected = t2} :: trace)
 
-and unify2 env t1 t2 =
+and unify2 env t1 t2 = unify2_expand env t1 t1 t2 t2
+
+and unify2_rec env t10 t1 t20 t2 =
+  if unify_eq t1 t2 then () else
+  try match (get_desc t1, get_desc t2) with
+  | (Tconstr (p1, tl1, a1), Tconstr (p2, tl2, a2)) ->
+      if Path.same p1 p2 && tl1 = [] && tl2 = [] && is_public_type !env p1
+      && not (has_cached_expansion p1 !a1 || has_cached_expansion p2 !a2)
+      then begin
+        update_level_for Unify !env (get_level t1) t2;
+        update_scope_for Unify (get_scope t1) t2;
+        link_type t1 t2
+      end else
+        if find_expansion_scope !env p1 > find_expansion_scope !env p2
+        then unify2_rec env t10 t1 t20 (try_expand_safe !env t2)
+        else unify2_rec env t10 (try_expand_safe !env t1) t20 t2
+  | _ ->
+      raise Cannot_expand
+  with Cannot_expand ->
+    unify2_expand env t10 t1 t20 t2
+
+and unify2_expand env t1 t1' t2 t2' =
   (* Second step: expansion of abbreviations *)
   (* Expansion may change the representative of the types. *)
-  ignore (expand_head_unif !env t1);
-  ignore (expand_head_unif !env t2);
-  let t1' = expand_head_unif !env t1 in
-  let t2' = expand_head_unif !env t2 in
+  ignore (expand_head_unif !env t1');
+  ignore (expand_head_unif !env t2');
+  let t1' = expand_head_unif !env t1' in
+  let t2' = expand_head_unif !env t2' in
   let lv = Int.min (get_level t1') (get_level t2') in
   let scope = Int.max (get_scope t1') (get_scope t2') in
   update_level_for Unify !env lv t2;


### PR DESCRIPTION
@lpw25 remarked in #10277 that when combining local modules with GADTs, one could end up expanding a local equation during unification, leading to a spurious error.

This fixes that by allowing the special case for unification of two abstract local types to be used for other types too.