### PR TITLE
Fix destroyed_at_c_call on RISC-V

### DIFF
--- a/Changes
+++ b/Changes
@@ -104,6 +104,9 @@ Working version
 - #10244: Optimise Int32.unsigned_to_int
   (Fabian Hemmer, review by Stephen Dolan and Xavier Leroy)
 
+- #10349: Fix destroyed_at_c_call on RISC-V
+  (Mark Shinwell, review by Nicolás Ojeda Bär)
+
 ### Type system:
 
 * #10081: Typecheck `x |> f` and `f @@ x` as `(f x)`

--- a/asmcomp/riscv/proc.ml
+++ b/asmcomp/riscv/proc.ml
@@ -233,9 +233,10 @@ let regs_are_volatile _ = false
 (* Registers destroyed by operations *)
 
 let destroyed_at_c_call =
-  (* s0-s11 and fs0-fs11 are callee-save *)
+  (* s0-s11 and fs0-fs11 are callee-save.  However s2 needs to be in this
+     list since it is clobbered by caml_c_call itself. *)
   Array.of_list(List.map phys_reg
-    [0; 1; 2; 3; 4; 5; 6; 7; 16; 17; 18; 19; 20; 22;
+    [0; 1; 2; 3; 4; 5; 6; 7; 8; 16; 17; 18; 19; 20; 22;
      100; 101; 102; 103; 104; 105; 106; 107; 110; 111; 112; 113; 114; 115; 116;
      117; 128; 129; 130; 131])
 


### PR DESCRIPTION
The register `s2` is clobbered by `caml_c_call` yet is not in the `destroyed_at_c_call` array.  This patch fixes this, which will hopefully also fix the random segfaults on the RISC-V CI workers.

Thanks to @nojb who does a very good job as a `gdbserver`.