### PR TITLE
Two (more) tweaks to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
       id: manual
       run: >-
         tools/ci/actions/check-manual-modified.sh
+        '${{ github.ref }}'
         '${{ github.event_name }}'
         '${{ github.event.pull_request.base.ref }}'
         '${{ github.event.pull_request.base.sha }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
     - name: Packages
       run: |
         sudo apt-get update -y && sudo apt-get install -y texlive-latex-extra texlive-fonts-recommended hevea sass

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Changes updated
         run: >-
           tools/ci/actions/check-changes-modified.sh
+          '${{ github.ref }}'
           'pull_request'
           '${{ github.event.pull_request.base.ref }}'
           '${{ github.event.pull_request.base.sha }}'
@@ -36,6 +37,7 @@ jobs:
       - name: configure correctly generated
         run: >-
           tools/ci/actions/check-configure.sh
+          '${{ github.ref }}'
           '${{ github.event_name }}'
           '${{ github.event.pull_request.base.ref }}'
           '${{ github.event.pull_request.base.sha }}'
@@ -50,6 +52,7 @@ jobs:
       - name: check-typo revered
         run: >-
           tools/ci/actions/check-typo.sh
+          '${{ github.ref }}'
           '${{ github.event_name }}'
           '${{ github.event.pull_request.base.ref }}'
           '${{ github.event.pull_request.base.sha }}'

--- a/tools/ci/actions/check-manual-modified.sh
+++ b/tools/ci/actions/check-manual-modified.sh
@@ -17,7 +17,7 @@ set -e
 
 # Test whether the manual/ has been touched by this PR.
 
-if [[ $1 = 'push' && ${10} = 'ocaml/ocaml' ]]; then
+if [[ $1 = 'push' && ${11} = 'ocaml/ocaml' ]]; then
   # Always build the manual for pushes to ocaml/ocaml
   result=true
 else

--- a/tools/ci/actions/deepen-fetch.sh
+++ b/tools/ci/actions/deepen-fetch.sh
@@ -26,19 +26,21 @@
 
 # GitHub Actions doesn't support the ternary operator, so the dance is done here
 # Each script has:
-#   $1 - event type ('pull_request' or 'push')
-#   $2 - upstream branch name
-#   $3 - upstream branch SHA
-#   $4 - PR branch name
-#   $5 - PR SHA
-#   $6 - full ref being pushed
-#   $7 - upstream SHA prior to push
-#   $8 - repeats $6
-#   $9 - upstream SHA after the push
-if [[ $1 = 'pull_request' ]]; then
-  shift 1
+#   $1 - ref to fetch when deepening
+#   $2 - event type ('pull_request' or 'push')
+#   $3 - upstream branch name
+#   $4 - upstream branch SHA
+#   $5 - PR branch name
+#   $6 - PR SHA
+#   $7 - full ref being pushed
+#   $8 - upstream SHA prior to push
+#   $9 - repeats $7
+#  $10 - upstream SHA after the push
+FETCH_REF="${1}"
+if [[ $2 = 'pull_request' ]]; then
+  shift 2
 else
-  shift 5
+  shift 6
 fi
 
 # Record FETCH_HEAD (if it hasn't been by a previous step)
@@ -72,8 +74,8 @@ if ! git merge-base "$UPSTREAM_HEAD" "$PR_HEAD" &> /dev/null; then
 
   while ! git merge-base "$UPSTREAM_HEAD" "$PR_HEAD" &> /dev/null
   do
-    echo " - $MSG by $DEEPEN commits"
-    git fetch origin --deepen=$DEEPEN "$UPSTREAM_BRANCH" &> /dev/null
+    echo " - $MSG by $DEEPEN commits from $FETCH_REF"
+    git fetch origin --deepen=$DEEPEN "$FETCH_REF" &> /dev/null
     MSG='Further deepening'
     ((DEEPEN*=2))
   done


### PR DESCRIPTION
#10336 uses the `tools/ci/actions/deepen-fetch.sh` script from the Hygiene workflow. It's therefore not worth having the full-flambda job do a shallow-clone by default, so the first commit updates it to pull 50 commits, same as the hygiene workflow does.

However, the lack of that surfaced the failure in https://github.com/ocaml/ocaml/pull/10349/checks?check_run_id=2361230815 which reveals that the fix I pushed in https://github.com/ocaml/ocaml/commit/3ef9ce800fea63c90294fe306e552b4b5fafaa1a for a similar failure in #9331 was not the correct one.

The second commit is the correct fix - the actual fetch should be done from `github.ref`, since unless the PR is from within the same repository (which it isn't normally), `$PR_HEAD` is not a valid ref. The fix I pushed before fixed #9331 because what deepening was actually `trunk`, what went wrong in #10336 is that because the checkout was shallow, it needed to deepen the PR branch, which wasn't being fetched, so the loop didn't terminate until it overflowed.