### PR TITLE
Fix mingw-w64 DLL support with binutils 2.36+

### DIFF
--- a/Changes
+++ b/Changes
@@ -360,6 +360,9 @@ Working version
   (Vincent Laviron, report by Yawar Amin and Nicolás Ojeda Bär, review by
    Jacques Garrigue)
 
+- #10351: Fix DLL loading with binutils 2.36+ on mingw-w64
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -78,7 +78,7 @@ CAMLdeprecated_typedef(addr, char *);
 
 #ifndef CAMLDLLIMPORT
   #if defined(SUPPORT_DYNAMIC_LINKING) && defined(ARCH_SIXTYFOUR) \
-      && defined(__CYGWIN__)
+      && (defined(__CYGWIN__) || defined(__MINGW32__))
     #define CAMLDLLIMPORT __declspec(dllimport)
   #else
     #define CAMLDLLIMPORT


### PR DESCRIPTION
The default base address for executables and images on x86_64 for PE is now always set a 4GiB+ address, which virtually guarantees that stub libraries will be loaded more than 2GiB away from the executable.

Adopt the same approach as Cygwin64. For now, MSVC64 continues to use the forced base address.

This piggy-backs on the work done for Cygwin64 in 4.12 in #9927. I propose merging this to 4.12, but for the 4.11 and earlier the fix will live in flexlink using the same `-Xlinker -image-base -Xlinker 0x10000`  trick that Cygwin64 used to use and msvc64 still uses (for now).