### PR TITLE
Seq.concat (+ Seq.concat_map as alias to Seq.flat_map)

### DIFF
--- a/Changes
+++ b/Changes
@@ -149,6 +149,11 @@ Working version
   (Oghenevwogaga Ebresafe, review by Nicolás Ojeda Bär,
   Gabriel Scherer and Xavier Van de Woestyne)
 
+- #10352: Seq.(concat : 'a t t -> 'a t)
+  Seq.concat_map as an alias to Seq.flat_map,
+  (Gabriel Scherer, review by Ulugbek Abdullaev and Daniel Bünzli
+   and Nicolás Ojeda Bär and Florian Angeletti)
+
 ### Other libraries:
 
 - #10047: Add `Unix.realpath`

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -50,16 +50,17 @@ let rec filter f seq () = match seq() with
       then Cons (x, filter f next)
       else filter f next ()
 
+let rec concat seq () = match seq () with
+  | Nil -> Nil
+  | Cons (x, next) ->
+     append x (concat next) ()
+
 let rec flat_map f seq () = match seq () with
   | Nil -> Nil
   | Cons (x, next) ->
-    flat_map_app f (f x) next ()
+    append (f x) (flat_map f next) ()
 
-(* this is [append seq (flat_map f tail)] *)
-and flat_map_app f seq tail () = match seq () with
-  | Nil -> flat_map f tail ()
-  | Cons (x, next) ->
-    Cons (x, flat_map_app f next tail)
+let concat_map = flat_map
 
 let fold_left f acc seq =
   let rec aux f acc seq = match seq () with

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -68,11 +68,23 @@ val filter_map : ('a -> 'b option) -> 'a t -> 'b t
     This transformation is lazy, it only applies when the result is
     traversed. *)
 
+val concat : 'a t t -> 'a t
+(** concatenate a sequence of sequences.
+
+    @since 4.13
+ *)
+
 val flat_map : ('a -> 'b t) -> 'a t -> 'b t
 (** Map each element to a subsequence, then return each element of this
     sub-sequence in turn.
     This transformation is lazy, it only applies when the result is
     traversed. *)
+
+val concat_map : ('a -> 'b t) -> 'a t -> 'b t
+(** Alias for {!flat_map}.
+
+    @since 4.13
+*)
 
 val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** Traverse the sequence from left to right, combining each element with the

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -35,4 +35,11 @@ let () =
   ()
 ;;
 
+(* concat *)
+let () =
+  assert (
+      List.concat [[1]; []; [2; 3];]
+      = (let (!?) = List.to_seq in
+         List.of_seq (Seq.concat !?[!?[1]; !?[]; !?[2; 3]])))
+
 let () = print_endline "OK";;


### PR DESCRIPTION
```ocaml
Seq.concat : 'a Seq.t Seq.t -> 'a Seq.t

Seq.concat_map = Seq.flat_map
```

In #10177 I proposed two functions, `Seq.delay` which was the original motivation for the PR, and `Seq.concat` which I added to write a natural testcase for `Seq.delay`. It turns out that people are happy with `Seq.concat` (after some renaming by @dbuenzli and reviewing by @ulugbekna) and confused by `Seq.delay`, so the present PR offers `Seq.concat` by itself.

Note: originally I named the function `Seq.flatten` which I think is fine, but `Seq.concat` seems to gather more consensus. (So I added `concat_map` as an alias to `flat_map` to avoid bad surprises.)