### PR TITLE
Compile with cmt files as input

### DIFF
--- a/.depend
+++ b/.depend
@@ -5848,6 +5848,7 @@ driver/compile_common.cmo : \
     utils/config.cmi \
     driver/compmisc.cmi \
     driver/compenv.cmi \
+    file_formats/cmt_format.cmi \
     utils/clflags.cmi \
     parsing/builtin_attributes.cmi \
     driver/compile_common.cmi
@@ -5868,6 +5869,7 @@ driver/compile_common.cmx : \
     utils/config.cmx \
     driver/compmisc.cmx \
     driver/compenv.cmx \
+    file_formats/cmt_format.cmx \
     utils/clflags.cmx \
     parsing/builtin_attributes.cmx \
     driver/compile_common.cmi

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -30,7 +30,7 @@ let read_magic_number ic =
 
 type binary_annots =
   | Packed of Types.signature * string list
-  | Implementation of structure
+  | Implementation of structure * module_coercion
   | Interface of signature
   | Partial_implementation of binary_part array
   | Partial_interface of binary_part array
@@ -91,7 +91,8 @@ let clear_part = function
 let clear_env binary_annots =
   if need_to_clear_env then
     match binary_annots with
-    | Implementation s -> Implementation (cenv.structure cenv s)
+    | Implementation (s, coercion) ->
+        Implementation (cenv.structure cenv s, coercion)
     | Interface s -> Interface (cenv.signature cenv s)
     | Packed _ -> binary_annots
     | Partial_implementation array ->

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -35,7 +35,7 @@ open Typedtree
 
 type binary_annots =
   | Packed of Types.signature * string list
-  | Implementation of structure
+  | Implementation of structure * module_coercion
   | Interface of signature
   | Partial_implementation of binary_part array
   | Partial_interface of binary_part array

--- a/tools/ocamlcmt.ml
+++ b/tools/ocamlcmt.ml
@@ -100,7 +100,7 @@ let print_info cmt =
 let generate_ml target_filename filename cmt =
   let (printer, ext) =
     match cmt.Cmt_format.cmt_annots with
-      | Cmt_format.Implementation typedtree ->
+      | Cmt_format.Implementation (typedtree, _coercion) ->
           (fun ppf -> Pprintast.structure ppf
                                         (Untypeast.untype_structure typedtree)),
           ".ml"

--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -174,7 +174,7 @@ let gen_annot target_filename ~sourcefile ~use_summaries annots =
   in
   let iter = iterator ~scope use_summaries in
   match annots with
-  | Implementation typedtree ->
+  | Implementation (typedtree, _coercion) ->
       iter.structure iter typedtree;
       Stypes.dump target_filename
   | Partial_implementation parts ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2837,9 +2837,11 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
           (fun () -> fprintf std_formatter "%a@."
               (Printtyp.printed_signature sourcefile) simple_sg
           );
-        gen_annot outputprefix sourcefile (Cmt_format.Implementation str);
+        let coercion = Tcoerce_none in
+        gen_annot outputprefix sourcefile
+          (Cmt_format.Implementation (str, coercion));
         { structure = str;
-          coercion = Tcoerce_none;
+          coercion;
           signature = simple_sg
         } (* result is ignored by Compile.implementation *)
       end else begin
@@ -2861,7 +2863,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
           (* It is important to run these checks after the inclusion test above,
              so that value declarations which are not used internally but
              exported are not reported as being unused. *)
-          let annots = Cmt_format.Implementation str in
+          let annots = Cmt_format.Implementation (str, coercion) in
           Cmt_format.save_cmt (outputprefix ^ ".cmt") modulename
             annots (Some sourcefile) initial_env None;
           gen_annot outputprefix sourcefile annots;
@@ -2889,7 +2891,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
               Env.save_signature ~alerts
                 simple_sg modulename (outputprefix ^ ".cmi")
             in
-            let annots = Cmt_format.Implementation str in
+            let annots = Cmt_format.Implementation (str, coercion) in
             Cmt_format.save_cmt  (outputprefix ^ ".cmt") modulename
               annots (Some sourcefile) initial_env (Some cmi);
             gen_annot outputprefix sourcefile annots


### PR DESCRIPTION
This is a prototype of https://github.com/ocaml/RFCs/pull/24.

The desired feature is to compile from source to `cmt`, and then `cmt` to
byte/native code. It's already possible to produce to stop after `cmt` files are
written using `-stop-after typing`. So this PR only implements resuming
compilation from the `cmt`.

To resume compilation from the `cmt`, I save the module coercion along side the
typedtree in the `cmt`.