### PR TITLE
Refactor and correct the "is pure" and "can raise" tests over target-specific operations

### DIFF
--- a/Changes
+++ b/Changes
@@ -371,6 +371,12 @@ Working version
 - #10351: Fix DLL loading with binutils 2.36+ on mingw-w64
   (David Allsopp, review by Nicolás Ojeda Bär)
 
+- #10339, #10354: Fix handling of exception-raising specific
+   operations during spilling.  (This bug affects ARM and ARM64.)
+   In passing, refactor Proc.op_is_pure and Mach.operation_can_raise.
+  (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan)
+
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -134,7 +134,20 @@ let print_specific_operation printreg op ppf arg =
   | Izextend32 ->
       fprintf ppf "zextend32 %a" printreg arg.(0)
 
+(* Are we using the Windows 64-bit ABI? *)
+
 let win64 =
   match Config.system with
   | "win64" | "mingw64" | "cygwin" -> true
   | _                   -> false
+
+(* Specific operations that are pure *)
+
+let operation_is_pure = function
+  | Ilea _ | Ibswap _ | Isqrtf | Isextend32 | Izextend32 -> true
+  | Ifloatarithmem _ | Ifloatsqrtf _ -> true
+  | _ -> false
+
+(* Specific operations that can raise *)
+
+let operation_can_raise _ = false

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -348,17 +348,6 @@ let max_register_pressure = function
     if fp then [| 12; 15 |] else [| 13; 15 |]
   | _ -> if fp then [| 12; 16 |] else [| 13; 16 |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers). *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
-  | Ispecific(Ilea _|Isextend32|Izextend32) -> true
-  | Ispecific _ -> false
-  | _ -> true
-
 (* Layout of the stack frame *)
 
 let frame_required fd =

--- a/asmcomp/arm/arch.ml
+++ b/asmcomp/arm/arch.ml
@@ -262,3 +262,15 @@ let is_immediate n =
     s := !s + 2
   done;
   !s <= m
+
+(* Specific operations that are pure *)
+
+let operation_is_pure = function
+  | Ishiftcheckbound _ -> false
+  | _ -> true
+
+(* Specific operations that can raise *)
+
+let operation_can_raise = function
+  | Ishiftcheckbound _ -> true
+  | _ -> false

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -329,16 +329,6 @@ let max_register_pressure = function
   | Iintop Imulh when !arch < ARMv6 -> [| 8; 16; 32 |]
   | _ -> [| 9; 16; 32 |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers). *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
-  | Ispecific(Ishiftcheckbound _) -> false
-  | _ -> true
-
 (* Layout of the stack *)
 
 let frame_required fd =

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -241,3 +241,23 @@ let logical_imm_length x =
 
 let is_logical_immediate x =
   x <> 0n && x <> -1n && run_automata (logical_imm_length x) 0 x
+
+(* Specific operations that are pure *)
+
+let operation_is_pure = function
+  | Ifar_alloc _
+  | Ifar_intop_checkbound
+  | Ifar_intop_imm_checkbound _
+  | Ishiftcheckbound _
+  | Ifar_shiftcheckbound _ -> false
+  | _ -> true
+
+(* Specific operations that can raise *)
+
+let operation_can_raise = function
+  | Ifar_alloc _
+  | Ifar_intop_checkbound
+  | Ifar_intop_imm_checkbound _
+  | Ishiftcheckbound _
+  | Ifar_shiftcheckbound _ -> true
+  | _ -> false

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -280,16 +280,6 @@ let max_register_pressure = function
   | Iload(Single, _) | Istore(Single, _, _) -> [| 23; 31 |]
   | _ -> [| 23; 32 |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers). *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque
-  | Ispecific(Ishiftcheckbound _) -> false
-  | _ -> true
-
 (* Layout of the stack *)
 let frame_required fd =
   fd.fun_contains_calls

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -43,7 +43,7 @@ let rec deadcode i =
       { i; regs; exits = Int.Set.empty; }
   | Iop op ->
       let s = deadcode i.next in
-      if Proc.op_is_pure op                     (* no side effects *)
+      if operation_is_pure op                  (* no side effects *)
       && Reg.disjoint_set_array s.regs i.res   (* results are not used after *)
       && not (Proc.regs_are_volatile i.arg)    (* no stack-like hard reg *)
       && not (Proc.regs_are_volatile i.res)    (*            is involved *)

--- a/asmcomp/i386/arch.ml
+++ b/asmcomp/i386/arch.ml
@@ -162,3 +162,15 @@ let stack_alignment =
   | "win32" -> 4     (* MSVC *)
   | _ -> 16
   (* PR#6038: GCC and Clang seem to require 16-byte alignment nowadays *)
+
+(* Specific operations that are pure *)
+
+let operation_is_pure = function
+  | Ilea _ -> true
+  | _ -> false
+(* x87 floating-point operations are not pure because they push and pop
+   on the FP stack as a side effect *)
+
+(* Specific operations that can raise *)
+
+let operation_can_raise _ = false

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -226,17 +226,6 @@ let max_register_pressure = function
     Iintoffloat -> [| 6; max_int |]
   | _ -> [|7; max_int |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers).  *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
-  | Ispecific(Ilea _) -> true
-  | Ispecific _ -> false
-  | _ -> true
-
 (* Layout of the stack frame *)
 
 let frame_required fd =

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -44,7 +44,7 @@ let rec live i finally =
       Reg.set_of_array i.arg
   | Iop op ->
       let after = live i.next finally in
-      if Proc.op_is_pure op                    (* no side effects *)
+      if operation_is_pure op                  (* no side effects *)
       && Reg.disjoint_set_array after i.res    (* results are not used after *)
       && not (Proc.regs_are_volatile i.arg)    (* no stack-like hard reg *)
       && not (Proc.regs_are_volatile i.res)    (*            is involved *)

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -156,9 +156,17 @@ let rec instr_iter f i =
       | _ ->
           instr_iter f i.next
 
+let operation_is_pure = function
+  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
+  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
+  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
+  | Ispecific sop -> Arch.operation_is_pure sop
+  | _ -> true
+
 let operation_can_raise op =
   match op with
   | Icall_ind | Icall_imm _ | Iextcall _
   | Iintop (Icheckbound) | Iintop_imm (Icheckbound, _)
   | Ialloc _ -> true
+  | Ispecific sop -> Arch.operation_can_raise sop
   | _ -> false

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -112,4 +112,11 @@ val instr_cons_debug:
         instruction -> instruction
 val instr_iter: (instruction -> unit) -> instruction -> unit
 
+val operation_is_pure : operation -> bool
+  (** Returns [true] if the given operation only produces a result
+      in its destination registers, but has no side effects whatsoever:
+      it doesn't raise exceptions, it doesn't modify already-allocated
+      blocks, it doesn't adjust the stack frame, etc. *)
+
 val operation_can_raise : operation -> bool
+  (** Returns [true] if the given operation can raise an exception. *)

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -115,3 +115,11 @@ let print_specific_operation printreg op ppf arg =
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
   | Ialloc_far { bytes; _ } ->
       fprintf ppf "alloc_far %d" bytes
+
+(* Specific operations that are pure *)
+
+let operation_is_pure _ = true
+
+(* Specific operations that can raise *)
+
+let operation_can_raise _ = false

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -118,8 +118,12 @@ let print_specific_operation printreg op ppf arg =
 
 (* Specific operations that are pure *)
 
-let operation_is_pure _ = true
+let operation_is_pure = function
+  | Ialloc_far _ -> false
+  | _ -> true
 
 (* Specific operations that can raise *)
 
-let operation_can_raise _ = false
+let operation_can_raise = function
+  | Ialloc_far _ -> true
+  | _ -> false

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -319,17 +319,6 @@ let max_register_pressure = function
     Iextcall _ -> [| 14; 18 |]
   | _ -> [| 23; 30 |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers). *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
-  | Ispecific(Imultaddf | Imultsubf) -> true
-  | Ispecific _ -> false
-  | _ -> true
-
 (* Layout of the stack *)
 
 (* See [reserved_stack_space] in emit.mlp. *)

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -58,9 +58,6 @@ val destroyed_at_reloadretaddr : Reg.t array
 (* Volatile registers: those that change value when read *)
 val regs_are_volatile: Reg.t array -> bool
 
-(* Pure operations *)
-val op_is_pure: Mach.operation -> bool
-
 (* Info for laying out the stack frame *)
 val frame_required : Mach.fundecl -> bool
 

--- a/asmcomp/riscv/arch.ml
+++ b/asmcomp/riscv/arch.ml
@@ -82,3 +82,11 @@ let print_specific_operation printreg op ppf arg =
   | Imultsubf true ->
       fprintf ppf "-f (%a *f %a -f %a)"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
+
+(* Specific operations that are pure *)
+
+let operation_is_pure _ = true
+
+(* Specific operations that can raise *)
+
+let operation_can_raise _ = false

--- a/asmcomp/riscv/proc.ml
+++ b/asmcomp/riscv/proc.ml
@@ -267,16 +267,6 @@ let max_register_pressure = function
   | Iextcall _ -> [| 9; 12 |]
   | _ -> [| 23; 30 |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers). *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
-  | Ispecific(Imultaddf _ | Imultsubf _) -> true
-  | _ -> true
-
 (* Layout of the stack *)
 
 let frame_required fd =

--- a/asmcomp/s390x/arch.ml
+++ b/asmcomp/s390x/arch.ml
@@ -87,3 +87,11 @@ let print_specific_operation printreg op ppf arg =
   | Imultsubf ->
       fprintf ppf "%a *f %a -f %a"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
+
+(* Specific operations that are pure *)
+
+let operation_is_pure _ = true
+
+(* Specific operations that can raise *)
+
+let operation_can_raise _ = false

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -209,16 +209,6 @@ let max_register_pressure = function
     Iextcall _ -> [| 4; 7 |]
   | _ -> [| 9; 15 |]
 
-(* Pure operations (without any side effect besides updating their result
-   registers). *)
-
-let op_is_pure = function
-  | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
-  | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) | Iopaque -> false
-  | Ispecific(Imultaddf | Imultsubf) -> true
-  | _ -> true
-
 (* Layout of the stack *)
 
 let frame_required fd =

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -301,16 +301,13 @@ let rec spill i finally =
       let before1 = Reg.diff_set_array after i.res in
       (instr_cons i.desc i.arg i.res new_next,
        Reg.add_set_array before1 i.res)
-  | Iop _ ->
+  | Iop op ->
       let (new_next, after) = spill i.next finally in
       let before1 = Reg.diff_set_array after i.res in
       let before =
-        match i.desc with
-          Iop(Icall_ind) | Iop(Icall_imm _) | Iop(Iextcall _) | Iop(Ialloc _)
-        | Iop(Iintop (Icheckbound)) | Iop(Iintop_imm(Icheckbound, _)) ->
-            Reg.Set.union before1 !spill_at_raise
-        | _ ->
-            before1 in
+        if operation_can_raise op
+        then Reg.Set.union before1 !spill_at_raise
+        else before1 in
       (instr_cons_debug i.desc i.arg i.res i.dbg
                   (add_spills (Reg.inter_set_array after i.res) new_next),
        before)

--- a/testsuite/tests/asmcomp/try_checkbound.ml
+++ b/testsuite/tests/asmcomp/try_checkbound.ml
@@ -1,0 +1,12 @@
+(* TEST *)
+
+(* See PR#10339 *)
+
+let access (a: string array) n =
+  try
+    ignore (a.(n)); -1
+  with _ ->
+    n
+
+let _ =
+  assert (access [||] 1 = 1)


### PR DESCRIPTION
The ARM and ARM64 architectures have `Ishiftcheckbound` specific instructions that can raise an `Invalid_argument` exception.  The insertion of spill code in `asmcomp/spill.ml` didn't take this into account, resulting in issue #10339.  The `Mach.operation_can_raise` predicate didn't take this into account either.

This pull request fixes #10339 by
1. adding a `Arch.operation_can_raise` test to every platform, handling the platform-specific operations,
2. fixing `Mach.operation_can_raise` in the `Ispecific` case, and
3. using `Mach.operation_can_raise` instead of an ad-hoc, incorrect pattern matching during spill code insertion.

While I was at it, I refactored `Proc.op_is_pure` along the same lines: a platform-dependent part in `Arch.operation_is_pure` and a generic part in `Mach.operation_is_pure`.  This avoids duplication of platform-independent code in the platform-dependent `proc.ml` files.

The first commit is the refactoring of the two predicates ("is pure" and "can raise").  The second commit is the actual fix for #10339, with a regression test as a bonus.  CI precheck passes.

Fixes: #10339

