### PR TITLE
Remove Typecore.create_package_type, unused helper

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2582,17 +2582,6 @@ let generalizable level ty =
 (* Hack to allow coercion of self. Will clean-up later. *)
 let self_coercion = ref ([] : (Path.t * Location.t list ref) list)
 
-(* Helpers for packaged modules. *)
-let create_package_type loc env (p, l) =
-  let s = !Typetexp.transl_modtype_longident loc env p in
-  let fields = List.map (fun (name, ct) ->
-                           name, Typetexp.transl_simple_type env false ct) l in
-  let ty = newty (Tpackage (s,
-                    List.map fst l,
-                   List.map (fun (_, cty) -> cty.ctyp_type) fields))
-  in
-   (s, fields, ty)
-
 (* Helpers for type_cases *)
 
 let contains_variant_either ty =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -215,10 +215,6 @@ val type_package:
   (Env.t -> Parsetree.module_expr -> Path.t -> Longident.t list ->
   Typedtree.module_expr * type_expr list) ref
 
-val create_package_type : Location.t -> Env.t ->
-  Longident.t * (Longident.t * Parsetree.core_type) list ->
-  Path.t * (Longident.t * Typedtree.core_type) list * Types.type_expr
-
 val constant: Parsetree.constant -> (Asttypes.constant, error) result
 
 val check_recursive_bindings : Env.t -> Typedtree.value_binding list -> unit


### PR DESCRIPTION
This is probably deadcode for a while, noticed it when trying to change `Tpackage`.
