### PR TITLE
Fix testsuite MKDLL for bootstrapped flexlink

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -21,7 +21,10 @@ FIND=find
 ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common
 
-OCAMLTESTDIR_CYGPATH=$(shell $(CYGPATH) $(BASEDIR)/$(DIR)/_ocamltest)
+BASEDIR_HOST := $(shell $(CYGPATH) "$(BASEDIR)")
+ROOTDIR_HOST := $(BASEDIR_HOST)/$(ROOTDIR)
+
+OCAMLTESTDIR = $(BASEDIR_HOST)/$(DIR)/_ocamltest
 
 failstamp := failure.stamp
 
@@ -46,9 +49,9 @@ else # Windows
   ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
     FLEXLINK_ENV =
   else
-    ROOT := $(shell cd .. && pwd| cygpath -m -f -)
     FLEXLINK_ENV = \
-      OCAML_FLEXLINK="$(ROOT)/boot/ocamlrun $(ROOT)/flexdll/flexlink.exe"
+      OCAML_FLEXLINK="$(ROOTDIR_HOST)/boot/ocamlrun \
+                      $(ROOTDIR_HOST)/flexdll/flexlink.exe"
   endif
 endif
 
@@ -59,8 +62,8 @@ else
     ocamltest := MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) $(ocamltest_program)
   else
     FLEXLINK_DLL_LDFLAGS=$(if $(OC_DLL_LDFLAGS), -link "$(OC_DLL_LDFLAGS)")
-    MKDLL=$(WINROOTDIR)/boot/ocamlrun $(WINROOTDIR)/flexdll/flexlink.exe \
-                                     $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
+    MKDLL=$(ROOTDIR_HOST)/boot/ocamlrun $(ROOTDIR_HOST)/flexdll/flexlink.exe \
+                                       $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
 
     ocamltest := $(FLEXLINK_ENV) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
                                  $(ocamltest_program)
@@ -247,7 +250,7 @@ exec-one:
 	@if $(ocamltest) -list-tests $(DIR) >/dev/null 2>&1; then \
 	  echo "Running tests from '$$DIR' ..."; \
 	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR_CYGPATH)"; \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)"; \
 	else \
 	  for dir in $(DIR)/*; do \
 	    if [ -d $$dir ]; then \
@@ -291,7 +294,7 @@ promote:
 	fi
 	@if $(ocamltest) -list-tests $(DIR) >/dev/null 2>&1; then \
 	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR_CYGPATH)" \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(OCAMLTESTDIR)" \
 	    PROMOTE="true"; \
 	else \
 	  cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) promote; \


### PR DESCRIPTION
#10045 has revealed a mistake I missed when reviewing #10335. #10045 starts running the lib-dynlink-csharp on mingw - this isn't the problem itself, it's that it's the only test which uses `${mkdll}` and we only test the FlexDLL bootstrap on mingw32.

This was a bit too fiddly to separate out into commits, but here's the thought process:
- `MKDLL` referred to `WINROOTDIR` which isn't defined anywhere
- In fixing it, I've refactored slightly so that `cygpath` is only ever called once (it's just `echo` on a non-Windows build)
- In doing that, I tidied up the definition of `OCAML_FLEXLINK` to use the same cygpath call