### PR TITLE
unify fields on Tpackage

### DIFF
--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -176,10 +176,10 @@ let subst_type env t =
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in
           Btype.set_type_desc t (Types.Tconstr (new_p, l, a))
-      | Types.Tpackage (p, n, l) ->
+      | Types.Tpackage (p, fl) ->
           let new_p =
             Odoc_name.to_path (full_module_type_name env (Odoc_name.from_path p)) in
-          Btype.set_type_desc t (Types.Tpackage (new_p, n, l))
+          Btype.set_type_desc t (Types.Tpackage (new_p, fl))
       | Types.Tobject (_, ({contents=Some(p,tyl)} as r)) ->
           let new_p =
             Odoc_name.to_path (full_type_name env (Odoc_name.from_path p)) in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -324,7 +324,8 @@ let rec fold_type_expr f init ty =
   | Tpoly (ty, tyl)     ->
     let result = f init ty in
     List.fold_left f result tyl
-  | Tpackage (_, _, l)  -> List.fold_left f init l
+  | Tpackage (_, fl)  ->
+    List.fold_left (fun result (_n, ty) -> f result ty) init fl
 
 let iter_type_expr f ty =
   fold_type_expr (fun () v -> f v) () ty
@@ -442,7 +443,7 @@ let type_iterators =
     match ty.desc with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
-    | Tpackage (p, _, _) ->
+    | Tpackage (p, _) ->
         it.it_path p
     | Tvariant row ->
         Option.iter (fun (p,_) -> it.it_path p) (row_repr row).row_name
@@ -503,7 +504,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
   | Tpoly (ty, tyl)     ->
       let tyl = List.map f tyl in
       Tpoly (f ty, tyl)
-  | Tpackage (p, n, l)  -> Tpackage (p, n, List.map f l)
+  | Tpackage (p, fl)  -> Tpackage (p, List.map (fun (n, ty) -> (n, f ty)) fl)
 
 (* Utilities for copying *)
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -388,7 +388,7 @@ val maybe_pointer_type : Env.t -> type_expr -> bool
 
 (* Stubs *)
 val package_subtype :
-    (Env.t -> Path.t -> Longident.t list -> type_expr list ->
-      Path.t -> Longident.t list -> type_expr list -> bool) ref
+    (Env.t -> Path.t -> (Longident.t * type_expr) list ->
+      Path.t -> (Longident.t * type_expr) list -> bool) ref
 
 val mcomp : Env.t -> type_expr -> type_expr -> unit

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -328,15 +328,15 @@ and print_simple_out_type ppf =
   | Otyp_abstract | Otyp_open
   | Otyp_sum _ | Otyp_manifest (_, _) -> ()
   | Otyp_record lbls -> print_record_decl ppf lbls
-  | Otyp_module (p, n, tyl) ->
+  | Otyp_module (p, fl) ->
       fprintf ppf "@[<1>(module %a" print_ident p;
       let first = ref true in
-      List.iter2
-        (fun s t ->
+      List.iter
+        (fun (s, t) ->
           let sep = if !first then (first := false; "with") else "and" in
           fprintf ppf " %s type %s = %a" sep s print_out_type t
         )
-        n tyl;
+        fl;
       fprintf ppf ")@]"
   | Otyp_attribute (t, attr) ->
       fprintf ppf "@[<1>(%a [@@%s])@]" print_out_type t attr.oattr_name

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -75,7 +75,7 @@ type out_type =
   | Otyp_variant of
       bool * out_variant * bool * (string list) option
   | Otyp_poly of string list * out_type
-  | Otyp_module of out_ident * string list * out_type list
+  | Otyp_module of out_ident * (string * out_type) list
   | Otyp_attribute of out_type * out_attribute
 
 and out_variant =

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -198,8 +198,9 @@ let rec typexp copy_scope s ty =
          | Type_function { params; body } ->
             Tlink (!ctype_apply_env_empty params body args)
          end
-      | Tpackage(p, n, tl) ->
-          Tpackage(modtype_path s p, n, List.map (typexp copy_scope s) tl)
+      | Tpackage(p, fl) ->
+          Tpackage(modtype_path s p,
+                    List.map (fun (n, ty) -> (n, typexp copy_scope s ty)) fl)
       | Tobject (t1, name) ->
           let t1' = typexp copy_scope s t1 in
           let name' =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3755,25 +3755,25 @@ and type_expect_
             exp_extra =
             (Texp_newtype name, loc, sexp.pexp_attributes) :: body.exp_extra }
   | Pexp_pack m ->
-      let (p, nl) =
+      let (p, fl) =
         match Ctype.expand_head env (instance ty_expected) with
-          {desc = Tpackage (p, nl, _tl)} ->
+          {desc = Tpackage (p, fl)} ->
             if !Clflags.principal &&
               (Ctype.expand_head env ty_expected).level < Btype.generic_level
             then
               Location.prerr_warning loc
                 (Warnings.Not_principal "this module packing");
-            (p, nl)
+            (p, fl)
         | {desc = Tvar _} ->
             raise (Error (loc, env, Cannot_infer_signature))
         | _ ->
             raise (Error (loc, env, Not_a_packed_module ty_expected))
       in
-      let (modl, tl') = !type_package env m p nl in
+      let (modl, fl') = !type_package env m p fl in
       rue {
         exp_desc = Texp_pack modl;
         exp_loc = loc; exp_extra = [];
-        exp_type = newty (Tpackage (p, nl, tl'));
+        exp_type = newty (Tpackage (p, fl'));
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_open (od, e) ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -212,8 +212,8 @@ val type_object:
   (Env.t -> Location.t -> Parsetree.class_structure ->
    Typedtree.class_structure * Types.class_signature * string list) ref
 val type_package:
-  (Env.t -> Parsetree.module_expr -> Path.t -> Longident.t list ->
-  Typedtree.module_expr * type_expr list) ref
+  (Env.t -> Parsetree.module_expr -> Path.t -> (Longident.t * type_expr) list ->
+  Typedtree.module_expr * (Longident.t * type_expr) list) ref
 
 val constant: Parsetree.constant -> (Asttypes.constant, error) result
 

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -133,9 +133,8 @@ let rec immediate_subtypes : type_expr -> type_expr list = fun ty ->
      on which immediate_subtypes is called from [check_type] *)
   | Tarrow(_,ty1,ty2,_) ->
       [ty1; ty2]
-  | Ttuple(tys)
-  | Tpackage(_,_,tys) ->
-      tys
+  | Ttuple(tys) -> tys
+  | Tpackage(_, fl) -> (snd (List.split fl))
   | Tobject(row,class_ty) ->
       let class_subtys =
         match !class_ty with
@@ -415,14 +414,14 @@ let check_type
     | (Tvariant(_)        , Sep    )
     | (Tobject(_,_)       , Sep    )
     | ((Tnil | Tfield _)  , Sep    )
-    | (Tpackage(_,_,_)    , Sep    ) -> empty
+    | (Tpackage(_,_)      , Sep    ) -> empty
     (* "Deeply separable" case for these same constructors. *)
     | (Tarrow _           , Deepsep)
     | (Ttuple _           , Deepsep)
     | (Tvariant(_)        , Deepsep)
     | (Tobject(_,_)       , Deepsep)
     | ((Tnil | Tfield _)  , Deepsep)
-    | (Tpackage(_,_,_)    , Deepsep) ->
+    | (Tpackage(_,_)      , Deepsep) ->
         let tys = immediate_subtypes ty in
         let on_subtype context ty =
           context ++ check_type (Hyps.guard hyps) ty Deepsep in

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -119,11 +119,11 @@ let compute_variance env visited vari ty =
     | Tpoly (ty, _) ->
         compute_same ty
     | Tvar _ | Tnil | Tlink _ | Tunivar _ -> ()
-    | Tpackage (_, _, tyl) ->
+    | Tpackage (_, fl) ->
         let v =
           Variance.(if mem Pos vari || mem Neg vari then full else unknown)
         in
-        List.iter (compute_variance_rec v) tyl
+        List.iter (fun (_, ty) -> compute_variance_rec v ty) fl
   in
   compute_variance_rec vari ty
 

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -53,7 +53,7 @@ val type_open_:
         *)
 val modtype_of_package:
         Env.t -> Location.t ->
-        Path.t -> Longident.t list -> type_expr list -> module_type
+        Path.t -> (Longident.t * type_expr) list -> module_type
 
 val path_of_module : Typedtree.module_expr -> Path.t option
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -38,7 +38,7 @@ and type_desc =
   | Tvariant of row_desc
   | Tunivar of string option
   | Tpoly of type_expr * type_expr list
-  | Tpackage of Path.t * Longident.t list * type_expr list
+  | Tpackage of Path.t * (Longident.t * type_expr) list
 
 and row_desc =
     { row_fields: (label * row_field) list;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -129,7 +129,7 @@ and type_desc =
       where 'a1 ... 'an are names given to types in tyl
       and occurrences of those types in ty. *)
 
-  | Tpackage of Path.t * Longident.t list * type_expr list
+  | Tpackage of Path.t * (Longident.t * type_expr) list
   (** Type of a first-class module (a.k.a package). *)
 
 (** [  `X | `Y ]       (row_closed = true)

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -507,8 +507,7 @@ and transl_type_aux env policy styp =
                           ) l in
       let path = !transl_modtype_longident styp.ptyp_loc env p.txt in
       let ty = newty (Tpackage (path,
-                       List.map (fun (s, _pty) -> s.txt) l,
-                       List.map (fun (_,cty) -> cty.ctyp_type) ptys))
+                       List.map (fun (s, cty) -> (s.txt, cty.ctyp_type)) ptys))
       in
       ctyp (Ttyp_package {
             pack_path = path;


### PR DESCRIPTION
##  Goal

The goal here is to highlight the invariant, that both lists will always have the same length, it was really weird to me at first that they were separated while on the Typedtree and Parsetree they're unified.

## Code quality

### Pros

It guarantees the invariant on the type level, which is almost always a win. It reduces the number of parameters in a couple of places like `type_package` and `unify_package`.

### Cons

`type_package` and `complete_type_list` now receives and returns the full field list, including the type, this could be solved, but I thought it was a reasonable choice to avoid any performance degradation during unification.

## Performance

Hopefully it doesn't change anything, but what I could think of is below.

### Pros

Reduces the number of operations happening in a couple of places by half, as the data needs to be iterated only once.

No `List.combine` or `List.split` required, I think because of this the overall allocations will go down, especially as that was happening in quite a few places called by `unify_package`, but I may be wrong here.

### Cons

When a map was happening only on the types there is additional allocation, as now it needs to allocate 2 additional words to make the tuple.

During reading an additional dereference will happens, because the tuple is present, hopefully this is mitigated because of memory locality.
