### PR TITLE
Diffing for mismatches in variant and record declarations

### DIFF
--- a/.depend
+++ b/.depend
@@ -59,10 +59,13 @@ utils/consistbl.cmx : \
 utils/consistbl.cmi : \
     utils/misc.cmi
 utils/diffing.cmo : \
+    utils/misc.cmi \
     utils/diffing.cmi
 utils/diffing.cmx : \
+    utils/misc.cmx \
     utils/diffing.cmi
-utils/diffing.cmi :
+utils/diffing.cmi : \
+    utils/misc.cmi
 utils/domainstate.cmo : \
     utils/domainstate.cmi
 utils/domainstate.cmx : \

--- a/.depend
+++ b/.depend
@@ -708,7 +708,6 @@ typing/includecore.cmo : \
     typing/errortrace.cmi \
     typing/env.cmi \
     utils/diffing_with_keys.cmi \
-    utils/diffing.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/btype.cmi \
@@ -726,7 +725,6 @@ typing/includecore.cmx : \
     typing/errortrace.cmx \
     typing/env.cmx \
     utils/diffing_with_keys.cmx \
-    utils/diffing.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/btype.cmx \

--- a/.depend
+++ b/.depend
@@ -66,6 +66,16 @@ utils/diffing.cmx : \
     utils/diffing.cmi
 utils/diffing.cmi : \
     utils/misc.cmi
+utils/diffing_with_keys.cmo : \
+    utils/misc.cmi \
+    utils/diffing.cmi \
+    utils/diffing_with_keys.cmi
+utils/diffing_with_keys.cmx : \
+    utils/misc.cmx \
+    utils/diffing.cmx \
+    utils/diffing_with_keys.cmi
+utils/diffing_with_keys.cmi : \
+    utils/diffing.cmi
 utils/domainstate.cmo : \
     utils/domainstate.cmi
 utils/domainstate.cmx : \
@@ -697,6 +707,8 @@ typing/includecore.cmo : \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
+    utils/diffing_with_keys.cmi \
+    utils/diffing.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/btype.cmi \
@@ -713,6 +725,8 @@ typing/includecore.cmx : \
     typing/ident.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \
+    utils/diffing_with_keys.cmx \
+    utils/diffing.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/btype.cmx \
@@ -726,7 +740,8 @@ typing/includecore.cmi : \
     parsing/location.cmi \
     typing/ident.cmi \
     typing/errortrace.cmi \
-    typing/env.cmi
+    typing/env.cmi \
+    utils/diffing_with_keys.cmi
 typing/includemod.cmo : \
     typing/types.cmi \
     typing/typedtree.cmi \

--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
 - #10328: Give more precise error when disambiguation could not possibly work.
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
+- #10361: Improve error messages for mismatched record and variant
+  definitions.
+  (Florian Angeletti, review by Gabriel Radanne and Gabriel Scherer)
+
 - #10407: Produce more detailed error messages that contain full error traces
   when module inclusion fails.
   (Antal Spector-Zabusky, review by Florian Angeletti)
@@ -381,11 +385,6 @@ OCaml 4.13.0
 
 - #10232: Warning for unused record fields.
   (Leo White, review by Florian Angeletti)
-
-- #?????: Improve error messages for mismatched record and variant
-  definitions.
-  (Florian Angeletti, review by ???)
-
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -382,6 +382,11 @@ OCaml 4.13.0
 - #10232: Warning for unused record fields.
   (Leo White, review by Florian Angeletti)
 
+- #?????: Improve error messages for mismatched record and variant
+  definitions.
+  (Florian Angeletti, review by ???)
+
+
 ### Internal/compiler-libs changes:
 
 - #9243, simplify parser rules for array indexing operations

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -45,7 +45,8 @@ UTILS = \
   utils/domainstate.cmo \
   utils/binutils.cmo \
   utils/lazy_backtrack.cmo \
-  utils/diffing.cmo
+  utils/diffing.cmo \
+  utils/diffing_with_keys.cmo
 UTILS_CMI =
 
 PARSING = \

--- a/dune
+++ b/dune
@@ -45,7 +45,7 @@
    config build_path_prefix_map misc identifiable numbers arg_helper clflags
    profile terminfo ccomp warnings consistbl strongly_connected_components
    targetint load_path int_replace_polymorphic_compare binutils local_store
-   lazy_backtrack diffing
+   lazy_backtrack diffing diffing_with_keys
 
    ;; PARSING
    location longident docstrings syntaxerr ast_helper camlinternalMenhirLib

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -267,6 +267,5 @@ Line 1, characters 0-30:
 1 | type perm = d = {y:int; x:int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       1. Fields have different names, x and y.
-       2. Fields have different names, y and x.
+       Fields x and y have been swapped.
 |}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -232,7 +232,7 @@ Line 1, characters 0-28:
 1 | type missing = d = { x:int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       The field y is only present in the original definition.
+       An extra field, y, is provided in the original definition.
 |}]
 
 type wrong_type = d = {x:float}
@@ -241,11 +241,8 @@ Line 1, characters 0-31:
 1 | type wrong_type = d = {x:float}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       Fields do not match:
-         x : int;
-       is not the same as:
-         x : float;
-       The type int is not equal to the type float
+       1. An extra field, x, is provided in the original definition.
+       2. Fields have different names, y and x.
 |}]
 
 type mono = {foo:int}
@@ -266,5 +263,6 @@ Line 1, characters 0-30:
 1 | type perm = d = {y:int; x:int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       Fields number 1 have different names, x and y.
+       1. Fields have different names, x and y.
+       2. Fields have different names, y and x.
 |}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -241,8 +241,12 @@ Line 1, characters 0-31:
 1 | type wrong_type = d = {x:float}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       1. An extra field, x, is provided in the original definition.
-       2. Fields have different names, y and x.
+       1. Fields do not match:
+         x : int;
+       is not the same as:
+         x : float;
+       The type int is not equal to the type float
+       2. An extra field, y, is provided in the original definition.
 |}]
 
 type mono = {foo:int}

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -89,7 +89,7 @@ Line 3, characters 0-27:
 3 | type missing = d = X of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       The constructor Y is only present in the original definition.
+       An extra constructor, Y, is provided in the original definition.
 |}]
 
 type wrong_type = d = X of float
@@ -98,11 +98,8 @@ Line 1, characters 0-32:
 1 | type wrong_type = d = X of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       Constructors do not match:
-         X of int
-       is not the same as:
-         X of float
-       The type int is not equal to the type float
+       1. An extra constructor, X, is provided in the original definition.
+       2. Constructors have different names, Y and X.
 |}]
 
 type mono = Foo of float
@@ -123,7 +120,8 @@ Line 1, characters 0-35:
 1 | type perm = d = Y of int | X of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       Constructors number 1 have different names, X and Y.
+       1. Constructors have different names, X and Y.
+       2. Constructors have different names, Y and X.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -98,8 +98,12 @@ Line 1, characters 0-32:
 1 | type wrong_type = d = X of float
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       1. An extra constructor, X, is provided in the original definition.
-       2. Constructors have different names, Y and X.
+       1. Constructors do not match:
+         X of int
+       is not the same as:
+         X of float
+       The type int is not equal to the type float
+       2. An extra constructor, Y, is provided in the original definition.
 |}]
 
 type mono = Foo of float

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -124,8 +124,7 @@ Line 1, characters 0-35:
 1 | type perm = d = Y of int | X of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type d
-       1. Constructors have different names, X and Y.
-       2. Constructors have different names, Y and X.
+       Constructors X and Y have been swapped.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -147,11 +147,16 @@ Error: In this `with' constraint, the new definition of t
          type t = X of x | Y of y
        is not included in
          type t = X of int | Y of float
-       Constructors do not match:
+       1. Constructors do not match:
          X of x
        is not the same as:
          X of int
        The type x is not equal to the type int
+       2. Constructors do not match:
+         Y of y
+       is not the same as:
+         Y of float
+       The type y is not equal to the type float
 |}]
 
 (** First class module types require an identity *)

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -40,13 +40,20 @@ Error: Signature mismatch:
            f0 : unit * unit * unit * int * unit * unit * unit;
            f1 : unit * unit * unit * int * unit * unit * unit;
          }
-       Fields do not match:
+       1. Fields do not match:
          f0 : unit * unit * unit * float * unit * unit * unit;
        is not the same as:
          f0 : unit * unit * unit * int * unit * unit * unit;
        The type unit * unit * unit * float * unit * unit * unit
        is not equal to the type unit * unit * unit * int * unit * unit * unit
        Type float is not equal to type int
+       2. Fields do not match:
+         f1 : unit * unit * unit * string * unit * unit * unit;
+       is not the same as:
+         f1 : unit * unit * unit * int * unit * unit * unit;
+       The type unit * unit * unit * string * unit * unit * unit
+       is not equal to the type unit * unit * unit * int * unit * unit * unit
+       Type string is not equal to type int
 |}];;
 
 
@@ -88,11 +95,18 @@ Error: Signature mismatch:
            mutable f0 : unit * unit * unit * int * unit * unit * unit;
            f1 : unit * unit * unit * int * unit * unit * unit;
          }
-       Fields do not match:
+       1. Fields do not match:
          f0 : unit * unit * unit * float * unit * unit * unit;
        is not the same as:
          mutable f0 : unit * unit * unit * int * unit * unit * unit;
        The second is mutable and the first is not.
+       2. Fields do not match:
+         f1 : unit * unit * unit * string * unit * unit * unit;
+       is not the same as:
+         f1 : unit * unit * unit * int * unit * unit * unit;
+       The type unit * unit * unit * string * unit * unit * unit
+       is not equal to the type unit * unit * unit * int * unit * unit * unit
+       Type string is not equal to type int
 |}];;
 
 module M3 : sig
@@ -114,7 +128,7 @@ Error: Signature mismatch:
          type t = { f1 : unit; }
        is not included in
          type t = { f0 : unit; }
-       Fields number 1 have different names, f1 and f0.
+       Fields have different names, f1 and f0.
 |}];;
 
 module M4 : sig
@@ -136,5 +150,5 @@ Error: Signature mismatch:
          type t = { f0 : unit; }
        is not included in
          type t = { f0 : unit; f1 : unit; }
-       The field f1 is only present in the second declaration.
+       A field, f1, is missing in the first declaration.
 |}];;

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -152,3 +152,141 @@ Error: Signature mismatch:
          type t = { f0 : unit; f1 : unit; }
        A field, f1, is missing in the first declaration.
 |}];;
+
+
+(** Random additions and deletions of fields *)
+
+module Addition : sig
+  type t = {a : unit; b : unit; c : unit; d : unit}
+end = struct
+  type t = {a : unit; b : unit; beta : unit; c : unit; d: unit}
+end
+[%%expect {|
+Lines 5-7, characters 6-3:
+5 | ......struct
+6 |   type t = {a : unit; b : unit; beta : unit; c : unit; d: unit}
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = { a : unit; b : unit; beta : unit; c : unit; d : unit; }
+         end
+       is not included in
+         sig type t = { a : unit; b : unit; c : unit; d : unit; } end
+       Type declarations do not match:
+         type t = { a : unit; b : unit; beta : unit; c : unit; d : unit; }
+       is not included in
+         type t = { a : unit; b : unit; c : unit; d : unit; }
+       An extra field, beta, is provided in the first declaration.
+|}]
+
+
+module Deletion : sig
+  type t = {a : unit; b : unit; c : unit; d : unit}
+end = struct
+  type t = {a : unit; c : unit; d : unit}
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = {a : unit; c : unit; d : unit}
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { a : unit; c : unit; d : unit; } end
+       is not included in
+         sig type t = { a : unit; b : unit; c : unit; d : unit; } end
+       Type declarations do not match:
+         type t = { a : unit; c : unit; d : unit; }
+       is not included in
+         type t = { a : unit; b : unit; c : unit; d : unit; }
+       A field, b, is missing in the first declaration.
+|}]
+
+
+module Multi: sig
+  type t = {
+    a : unit;
+    b : unit;
+    c : unit;
+    d : unit;
+    e : unit;
+    f : unit;
+    g : unit
+  }
+end = struct
+  type t = {
+    a : unit;
+    b : unit;
+    beta: int;
+    c : unit;
+    d : unit;
+    f : unit;
+    g : unit;
+    phi : unit;
+  }
+end
+
+[%%expect {|
+Lines 11-22, characters 6-3:
+11 | ......struct
+12 |   type t = {
+13 |     a : unit;
+14 |     b : unit;
+15 |     beta: int;
+...
+19 |     g : unit;
+20 |     phi : unit;
+21 |   }
+22 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = {
+             a : unit;
+             b : unit;
+             beta : int;
+             c : unit;
+             d : unit;
+             f : unit;
+             g : unit;
+             phi : unit;
+           }
+         end
+       is not included in
+         sig
+           type t = {
+             a : unit;
+             b : unit;
+             c : unit;
+             d : unit;
+             e : unit;
+             f : unit;
+             g : unit;
+           }
+         end
+       Type declarations do not match:
+         type t = {
+           a : unit;
+           b : unit;
+           beta : int;
+           c : unit;
+           d : unit;
+           f : unit;
+           g : unit;
+           phi : unit;
+         }
+       is not included in
+         type t = {
+           a : unit;
+           b : unit;
+           c : unit;
+           d : unit;
+           e : unit;
+           f : unit;
+           g : unit;
+         }
+       3. An extra field, beta, is provided in the first declaration.
+       6. A field, e, is missing in the first declaration.
+       9. An extra field, phi, is provided in the first declaration.
+|}]

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -202,3 +202,124 @@ Error: Signature mismatch:
          A of 'a
        The type 'a is not equal to the type 'b
 |}];;
+
+
+
+(** Random additions and deletions of constructors *)
+
+module Addition : sig
+  type t =
+    | A
+    | B
+    | C
+    | D
+end = struct
+  type t =
+    | A
+    | B
+    | Beta
+    | C
+    | D
+end
+[%%expect {|
+Lines 9-16, characters 6-3:
+ 9 | ......struct
+10 |   type t =
+11 |     | A
+12 |     | B
+13 |     | Beta
+14 |     | C
+15 |     | D
+16 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A | B | Beta | C | D end
+       is not included in
+         sig type t = A | B | C | D end
+       Type declarations do not match:
+         type t = A | B | Beta | C | D
+       is not included in
+         type t = A | B | C | D
+       An extra constructor, Beta, is provided in the first declaration.
+|}]
+
+
+module Addition : sig
+  type t =
+    | A
+    | B
+    | C
+    | D
+end = struct
+  type t =
+    | A
+    | B
+    | D
+end
+[%%expect {|
+Lines 7-12, characters 6-3:
+ 7 | ......struct
+ 8 |   type t =
+ 9 |     | A
+10 |     | B
+11 |     | D
+12 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A | B | D end
+       is not included in
+         sig type t = A | B | C | D end
+       Type declarations do not match:
+         type t = A | B | D
+       is not included in
+         type t = A | B | C | D
+       A constructor, C, is missing in the first declaration.
+|}]
+
+
+module Multi: sig
+  type t =
+    | A
+    | B
+    | C
+    | D
+    | E
+    | F
+    | G
+end = struct
+  type t =
+    | A
+    | B
+    | Beta
+    | C
+    | D
+    | F
+    | G
+    | Phi
+end
+
+[%%expect {|
+Lines 10-20, characters 6-3:
+10 | ......struct
+11 |   type t =
+12 |     | A
+13 |     | B
+14 |     | Beta
+...
+17 |     | F
+18 |     | G
+19 |     | Phi
+20 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A | B | Beta | C | D | F | G | Phi end
+       is not included in
+         sig type t = A | B | C | D | E | F | G end
+       Type declarations do not match:
+         type t = A | B | Beta | C | D | F | G | Phi
+       is not included in
+         type t = A | B | C | D | E | F | G
+       3. An extra constructor, Beta, is provided in the first declaration.
+       6. A constructor, E, is missing in the first declaration.
+       9. An extra constructor, Phi, is provided in the first declaration.
+|}]

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -320,6 +320,93 @@ Error: Signature mismatch:
        is not included in
          type t = A | B | C | D | E | F | G
        3. An extra constructor, Beta, is provided in the first declaration.
-       6. A constructor, E, is missing in the first declaration.
-       9. An extra constructor, Phi, is provided in the first declaration.
+       5. A constructor, E, is missing in the first declaration.
+       8. An extra constructor, Phi, is provided in the first declaration.
+|}]
+
+
+(** Swaps and moves *)
+
+module Swap : sig
+  type t =
+    | A
+    | E
+    | C
+    | D
+    | B
+end = struct
+  type t =
+    | Alpha
+    | B
+    | C
+    | D
+    | E
+end
+[%%expect {|
+Lines 10-17, characters 6-3:
+10 | ......struct
+11 |   type t =
+12 |     | Alpha
+13 |     | B
+14 |     | C
+15 |     | D
+16 |     | E
+17 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Alpha | B | C | D | E end
+       is not included in
+         sig type t = A | E | C | D | B end
+       Type declarations do not match:
+         type t = Alpha | B | C | D | E
+       is not included in
+         type t = A | E | C | D | B
+       1. Constructors have different names, Alpha and A.
+       2<->5. Constructors B and E have been swapped.
+|}]
+
+
+module Move: sig
+  type t =
+    | A of int
+    | B
+    | C
+    | D
+    | E
+    | F
+end = struct
+  type t =
+    | A of float
+    | B
+    | D
+    | E
+    | F
+    | C
+end
+[%%expect {|
+Lines 9-17, characters 6-3:
+ 9 | ......struct
+10 |   type t =
+11 |     | A of float
+12 |     | B
+13 |     | D
+14 |     | E
+15 |     | F
+16 |     | C
+17 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A of float | B | D | E | F | C end
+       is not included in
+         sig type t = A of int | B | C | D | E | F end
+       Type declarations do not match:
+         type t = A of float | B | D | E | F | C
+       is not included in
+         type t = A of int | B | C | D | E | F
+       1. Constructors do not match:
+         A of float
+       is not the same as:
+         A of int
+       The type float is not equal to the type int
+       3->6. Constructor C has been moved from position 3 to 6.
 |}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -475,11 +475,11 @@ module Record_diffing = struct
     | Keep (x,y,_) ->
         (* We need to add equality between existential type parameters
            (in inline records) *)
-        (snd x).ld_type::params1, (snd y).ld_type::params2
+        x.data.ld_type::params1, y.data.ld_type::params2
 
   let test _loc env (params1,params2)
-      (pos, lbl1: Diff.left)
-      (_, lbl2: Diff.right)
+      ({pos; data=lbl1}: Diff.left)
+      ({data=lbl2; _ }: Diff.right)
     =
     let name1, name2 = Ident.name lbl1.ld_id, Ident.name lbl2.ld_id in
     if  name1 <> name2 then
@@ -626,7 +626,9 @@ module Variant_diffing = struct
     | Change _ -> 10
 
 
-  let test loc env (params1,params2) (pos,cd1: D.left) (_,cd2: D.right) =
+  let test loc env (params1,params2)
+      ({pos; data=cd1}: D.left)
+      ({data=cd2; _}: D.right) =
     let name1, name2 = Ident.name cd1.cd_id, Ident.name cd2.cd_id in
     if  name1 <> name2 then
       let types_match =

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -68,11 +68,10 @@ type constructor_mismatch =
   | Explicit_return_type of position
 
 type variant_mismatch =
-  | Constructor_mismatch of constructor_declaration
-                            * constructor_declaration
+  | Constructor_mismatch of Types.constructor_declaration
+                            * Types.constructor_declaration
                             * constructor_mismatch
-  | Constructor_names of int * Ident.t * Ident.t
-  | Constructor_missing of position * Ident.t
+  | Constructor_names of Ident.t * Ident.t
 
 type extension_constructor_mismatch =
   | Constructor_privacy
@@ -80,6 +79,9 @@ type extension_constructor_mismatch =
                             * extension_constructor
                             * extension_constructor
                             * constructor_mismatch
+type variant_change =
+  (Types.constructor_declaration, Types.constructor_declaration,
+   Asttypes.label, variant_mismatch) Diffing.change
 
 type private_variant_mismatch =
   | Only_outer_closed
@@ -102,7 +104,7 @@ type type_mismatch =
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance
   | Record_mismatch of record_mismatch
-  | Variant_mismatch of variant_mismatch
+  | Variant_mismatch of variant_change list
   | Unboxed_representation of position
   | Immediate of Type_immediacy.Violation.t
 

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -47,16 +47,23 @@ type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
 
+type field_mismatch =
+  | Kind_mismatch of
+      Types.label_declaration * Types.label_declaration * label_mismatch
+  | Name_mismatch of Ident.t * Ident.t
+
+type record_change =
+  (Types.label_declaration, Types.label_declaration,
+   type_expr list * type_expr list, field_mismatch) Diffing.change
+
 type record_mismatch =
-  | Label_mismatch of label_declaration * label_declaration * label_mismatch
-  | Label_names of int * Ident.t * Ident.t
-  | Label_missing of position * Ident.t
+  | Label_mismatch of record_change list
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
   | Type of Errortrace.equality_error
   | Arity
-  | Inline_record of record_mismatch
+  | Inline_record of record_change list
   | Kind of position
   | Explicit_return_type of position
 

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -48,7 +48,7 @@ type label_mismatch =
   | Mutability of position
 
 type record_change =
-  (Types.label_declaration, label_mismatch) Diffing_with_keys.change
+  (Types.label_declaration as 'ld, 'ld, label_mismatch) Diffing_with_keys.change
 
 type record_mismatch =
   | Label_mismatch of record_change list
@@ -68,7 +68,7 @@ type extension_constructor_mismatch =
                             * extension_constructor
                             * constructor_mismatch
 type variant_change =
-  (Types.constructor_declaration, constructor_mismatch)
+  (Types.constructor_declaration as 'cd, 'cd, constructor_mismatch)
     Diffing_with_keys.change
 
 type private_variant_mismatch =

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -50,7 +50,8 @@ type label_mismatch =
 type field_mismatch =
   | Kind_mismatch of
       Types.label_declaration * Types.label_declaration * label_mismatch
-  | Name_mismatch of Ident.t * Ident.t
+  | Name_mismatch of { types_match:bool; left:Ident.t; right:Ident.t }
+
 
 type record_change =
   (Types.label_declaration, Types.label_declaration,
@@ -71,7 +72,7 @@ type variant_mismatch =
   | Constructor_mismatch of Types.constructor_declaration
                             * Types.constructor_declaration
                             * constructor_mismatch
-  | Constructor_names of Ident.t * Ident.t
+  | Constructor_names of { types_match:bool; left:Ident.t; right:Ident.t }
 
 type extension_constructor_mismatch =
   | Constructor_privacy

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -47,15 +47,8 @@ type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
 
-type field_mismatch =
-  | Kind_mismatch of
-      Types.label_declaration * Types.label_declaration * label_mismatch
-  | Name_mismatch of { types_match:bool; left:Ident.t; right:Ident.t }
-
-
 type record_change =
-  (Types.label_declaration, Types.label_declaration,
-   type_expr list * type_expr list, field_mismatch) Diffing.change
+  (Types.label_declaration, label_mismatch) Diffing_with_keys.change
 
 type record_mismatch =
   | Label_mismatch of record_change list
@@ -68,12 +61,6 @@ type constructor_mismatch =
   | Kind of position
   | Explicit_return_type of position
 
-type variant_mismatch =
-  | Constructor_mismatch of Types.constructor_declaration
-                            * Types.constructor_declaration
-                            * constructor_mismatch
-  | Constructor_names of { types_match:bool; left:Ident.t; right:Ident.t }
-
 type extension_constructor_mismatch =
   | Constructor_privacy
   | Constructor_mismatch of Ident.t
@@ -81,8 +68,8 @@ type extension_constructor_mismatch =
                             * extension_constructor
                             * constructor_mismatch
 type variant_change =
-  (Types.constructor_declaration, Types.constructor_declaration,
-   Asttypes.label, variant_mismatch) Diffing.change
+  (Types.constructor_declaration, constructor_mismatch)
+    Diffing_with_keys.change
 
 type private_variant_mismatch =
   | Only_outer_closed

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -217,22 +217,30 @@ exception Apply_error of {
 val expand_module_alias: Env.t -> Path.t -> Types.module_type
 
 module Functor_inclusion_diff: sig
+  module Defs: sig
+    type left = Types.functor_parameter
+    type right = left
+    type eq = Typedtree.module_coercion
+    type diff = (Types.functor_parameter, unit) Error.functor_param_symptom
+    type state
+  end
   val diff: Env.t ->
-           Types.functor_parameter list * Types.module_type ->
-           Types.functor_parameter list * Types.module_type ->
-           (Types.functor_parameter, Types.functor_parameter,
-            Typedtree.module_coercion,
-            (Types.functor_parameter, 'c) Error.functor_param_symptom)
-           Diffing.patch
+    Types.functor_parameter list * Types.module_type ->
+    Types.functor_parameter list * Types.module_type ->
+    Diffing.Define(Defs).patch
 end
 
 module Functor_app_diff: sig
+  module Defs: sig
+    type left = Error.functor_arg_descr * Types.module_type
+    type right = Types.functor_parameter
+    type eq = Typedtree.module_coercion
+    type diff = (Error.functor_arg_descr, unit) Error.functor_param_symptom
+    type state
+  end
   val diff:
     Env.t ->
     f:Types.module_type ->
     args:(Error.functor_arg_descr * Types.module_type) list ->
-    (Error.functor_arg_descr * Types.module_type,
-     Types.functor_parameter, Typedtree.module_coercion,
-     (Error.functor_arg_descr, 'a) Error.functor_param_symptom)
-      Diffing.patch
+    Diffing.Define(Defs).patch
 end

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -366,18 +366,6 @@ end
 module Functor_suberror = struct
   open Err
 
-  let style = function
-    | Diffing.Keep _ -> Misc.Color.[ FG Green ]
-    | Diffing.Delete _ -> Misc.Color.[ FG Red; Bold]
-    | Diffing.Insert _ -> Misc.Color.[ FG Red; Bold]
-    | Diffing.Change _ -> Misc.Color.[ FG Magenta; Bold]
-
-  let prefix ppf (pos, p) =
-    let sty = style p in
-    Format.pp_open_stag ppf (Misc.Color.Style sty);
-    Format.fprintf ppf "%i." pos;
-    Format.pp_close_stag ppf ()
-
   let param_id x = match x.With_shorthand.item with
     | Types.Named (Some _ as x,_) -> x
     | Types.(Unit | Named(None,_)) -> None
@@ -385,7 +373,7 @@ module Functor_suberror = struct
   (** Print the list of params with style *)
   let pretty_params sep proj printer patch =
     let elt (x,param) =
-      let sty = style x in
+      let sty = Diffing.style x in
       Format.dprintf "%a%t%a"
         Format.pp_open_stag (Misc.Color.Style sty)
         (printer param)
@@ -533,10 +521,10 @@ module Functor_suberror = struct
   end
 
   let subcase sub ~expansion_token env (pos, diff) =
-    Location.msg "%a%a%a %a@[<hv 2>%t@]%a"
+    Location.msg "%a%a%a%a@[<hv 2>%t@]%a"
       Format.pp_print_tab ()
       Format.pp_open_tbox ()
-      prefix (pos, diff)
+      Diffing.prefix (pos, diff)
       Format.pp_set_tab ()
       (Printtyp.wrap_printing_env env ~error:true
          (fun () -> sub ~expansion_token env diff)

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -264,6 +264,7 @@ module With_shorthand = struct
     | Unneeded -> "..."
 
   (** Add shorthands to a patch *)
+  open Diffing
   let patch ctx p =
     let add_shorthand side pos mty =
       {name = (make side pos); item = mty }
@@ -271,16 +272,16 @@ module With_shorthand = struct
     let aux i d =
       let pos = i + 1 in
       let d = match d with
-        | Diffing.Insert mty ->
-            Diffing.Insert (add_shorthand Expected pos mty)
-        | Diffing.Delete mty ->
-            Diffing.Delete (add_shorthand (elide_if_app ctx Got) pos mty)
-        | Diffing.Change (g, e, p) ->
-            Diffing.Change
+        | Insert mty ->
+            Insert (add_shorthand Expected pos mty)
+        | Delete mty ->
+            Delete (add_shorthand (elide_if_app ctx Got) pos mty)
+        | Change (g, e, p) ->
+            Change
               (add_shorthand Got pos g,
                add_shorthand Expected pos e, p)
-        | Diffing.Keep (g, e, p) ->
-            Diffing.Keep (add_shorthand Got pos g,
+        | Keep (g, e, p) ->
+            Keep (add_shorthand Got pos g,
                           add_shorthand (elide_if_app ctx Expected) pos e, p)
       in
       pos, d
@@ -383,12 +384,12 @@ module Functor_suberror = struct
     Printtyp.functor_parameters ~sep elt params
 
   let expected d =
-    let extract = function
-      | Diffing.Insert mty
-      | Diffing.Keep(_,mty,_)
-      | Diffing.Change (_,mty,_) as x ->
+    let extract: _ Diffing.change -> _ = function
+      | Insert mty
+      | Keep(_,mty,_)
+      | Change (_,mty,_) as x ->
           Some (param_id mty,(x, mty))
-      | Diffing.Delete _ -> None
+      | Delete _ -> None
     in
     pretty_params space extract With_shorthand.qualified_param d
 
@@ -406,12 +407,12 @@ module Functor_suberror = struct
   module Inclusion = struct
 
     let got d =
-      let extract = function
-      | Diffing.Delete mty
-      | Diffing.Keep (mty,_,_)
-      | Diffing.Change (mty,_,_) as x ->
+      let extract: _ Diffing.change -> _ = function
+      | Delete mty
+      | Keep (mty,_,_)
+      | Change (mty,_,_) as x ->
           Some (param_id mty,(x,mty))
-      | Diffing.Insert _ -> None
+      | Insert _ -> None
       in
       pretty_params space extract With_shorthand.qualified_param d
 
@@ -460,12 +461,12 @@ module Functor_suberror = struct
       |> prepare_patch ~drop:true ~ctx:App
 
     let got d =
-      let extract = function
-        | Diffing.Delete mty
-        | Diffing.Keep (mty,_,_)
-        | Diffing.Change (mty,_,_) as x ->
+      let extract: _ Diffing.change -> _ = function
+        | Delete mty
+        | Keep (mty,_,_)
+        | Change (mty,_,_) as x ->
             Some (None,(x,mty))
-        | Diffing.Insert _ -> None
+        | Insert _ -> None
       in
       pretty_params space extract With_shorthand.arg d
 
@@ -804,13 +805,14 @@ and module_type_decl ~expansion_token ~env ~before ~ctx id diff =
           :: before
       end
 
-and functor_arg_diff ~expansion_token env = function
-  | Diffing.Insert mty -> Functor_suberror.Inclusion.insert mty
-  | Diffing.Delete mty -> Functor_suberror.Inclusion.delete mty
-  | Diffing.Keep (x, y, _) ->  Functor_suberror.Inclusion.ok x y
-  | Diffing.Change (_, _, Err.Incompatible_params (i,_)) ->
+and functor_arg_diff ~expansion_token env (patch: _ Diffing.change) =
+  match patch with
+  | Insert mty -> Functor_suberror.Inclusion.insert mty
+  | Delete mty -> Functor_suberror.Inclusion.delete mty
+  | Keep (x, y, _) ->  Functor_suberror.Inclusion.ok x y
+  | Change (_, _, Err.Incompatible_params (i,_)) ->
       Functor_suberror.Inclusion.incompatible i
-  | Diffing.Change (g, e,  Err.Mismatch mty_diff) ->
+  | Change (g, e,  Err.Mismatch mty_diff) ->
       let more () =
         subcase_list @@
         module_type_symptom ~eqmode:false ~expansion_token ~env ~before:[]
@@ -818,13 +820,14 @@ and functor_arg_diff ~expansion_token env = function
       in
       Functor_suberror.Inclusion.diff g e more
 
-let functor_app_diff ~expansion_token env = function
-  | Diffing.Insert mty ->  Functor_suberror.App.insert mty
-  | Diffing.Delete mty ->  Functor_suberror.App.delete mty
-  | Diffing.Keep (x, y, _) ->  Functor_suberror.App.ok x y
-  | Diffing.Change (_, _, Err.Incompatible_params (i,_)) ->
+let functor_app_diff ~expansion_token env  (patch: _ Diffing.change) =
+  match patch with
+  | Insert mty ->  Functor_suberror.App.insert mty
+  | Delete mty ->  Functor_suberror.App.delete mty
+  | Keep (x, y, _) ->  Functor_suberror.App.ok x y
+  | Change (_, _, Err.Incompatible_params (i,_)) ->
       Functor_suberror.App.incompatible i
-  | Diffing.Change (g, e,  Err.Mismatch mty_diff) ->
+  | Change (g, e,  Err.Mismatch mty_diff) ->
       let more () =
         subcase_list @@
         module_type_symptom ~eqmode:false ~expansion_token ~env ~before:[]
@@ -888,9 +891,9 @@ let report_apply_error ~loc env (lid_app, mty_f, args) =
   match d with
   (* We specialize the one change and one argument case to remove the
      presentation of the functor arguments *)
-  | [ _,  Diffing.Change (_, _, Err.Incompatible_params (i,_)) ] ->
+  | [ _,  Change (_, _, Err.Incompatible_params (i,_)) ] ->
       Location.errorf ~loc "%t" (Functor_suberror.App.incompatible i)
-  | [ _, Diffing.Change (g, e,  Err.Mismatch mty_diff) ] ->
+  | [ _, Change (g, e,  Err.Mismatch mty_diff) ] ->
       let more () =
         subcase_list @@
         module_type_symptom ~eqmode:false ~expansion_token:true ~env ~before:[]

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -373,7 +373,7 @@ module Functor_suberror = struct
   (** Print the list of params with style *)
   let pretty_params sep proj printer patch =
     let elt (x,param) =
-      let sty = Diffing.style x in
+      let sty = Diffing.(style @@ classify x) in
       Format.dprintf "%a%t%a"
         Format.pp_open_stag (Misc.Color.Style sty)
         (printer param)
@@ -524,7 +524,7 @@ module Functor_suberror = struct
     Location.msg "%a%a%a%a@[<hv 2>%t@]%a"
       Format.pp_print_tab ()
       Format.pp_open_tbox ()
-      Diffing.prefix (pos, diff)
+      Diffing.prefix (pos, Diffing.classify diff)
       Format.pp_set_tab ()
       (Printtyp.wrap_printing_env env ~error:true
          (fun () -> sub ~expansion_token env diff)

--- a/utils/diffing.ml
+++ b/utils/diffing.ml
@@ -370,11 +370,23 @@ let variadic_diff ~weight ~test ~(update:_ update) state line column =
   |> construct_patch
 
 
+type change_kind =
+  | Deletion
+  | Insertion
+  | Modification
+  | Preservation
+
+let classify = function
+  | Delete _ -> Deletion
+  | Insert _ -> Insertion
+  | Change _ -> Modification
+  | Keep _ -> Preservation
+
 let style = function
-  | Keep _ -> Misc.Color.[ FG Green ]
-  | Delete _ -> Misc.Color.[ FG Red; Bold]
-  | Insert _ -> Misc.Color.[ FG Red; Bold]
-  | Change _ -> Misc.Color.[ FG Magenta; Bold]
+  | Preservation -> Misc.Color.[ FG Green ]
+  | Deletion -> Misc.Color.[ FG Red; Bold]
+  | Insertion -> Misc.Color.[ FG Red; Bold]
+  | Modification -> Misc.Color.[ FG Magenta; Bold]
 
 let prefix ppf (pos, p) =
   let sty = style p in

--- a/utils/diffing.ml
+++ b/utils/diffing.ml
@@ -368,3 +368,22 @@ let variadic_diff ~weight ~test ~(update:_ update) state line column =
   let fullstate = { line; column; state } in
   compute_matrix ~weight ~test ~update fullstate
   |> construct_patch
+
+
+let style = function
+  | Keep _ -> Misc.Color.[ FG Green ]
+  | Delete _ -> Misc.Color.[ FG Red; Bold]
+  | Insert _ -> Misc.Color.[ FG Red; Bold]
+  | Change _ -> Misc.Color.[ FG Magenta; Bold]
+
+let prefix ppf (pos, p) =
+  let sty = style p in
+  Format.pp_open_stag ppf (Misc.Color.Style sty);
+  Format.fprintf ppf "%i. " pos;
+  Format.pp_close_stag ppf ()
+
+  let default_weight = function
+    | Insert _ -> 10
+    | Delete _ -> 10
+    | Change _ -> 10
+    | Keep _ -> 0

--- a/utils/diffing.ml
+++ b/utils/diffing.ml
@@ -28,28 +28,65 @@
 
 *)
 
+(** Shared types *)
+type change_kind =
+  | Deletion
+  | Insertion
+  | Modification
+  | Preservation
+
+let style = function
+  | Preservation -> Misc.Color.[ FG Green ]
+  | Deletion -> Misc.Color.[ FG Red; Bold]
+  | Insertion -> Misc.Color.[ FG Red; Bold]
+  | Modification -> Misc.Color.[ FG Magenta; Bold]
+
+let prefix ppf (pos, p) =
+  let sty = style p in
+  Format.pp_open_stag ppf (Misc.Color.Style sty);
+  Format.fprintf ppf "%i. " pos;
+  Format.pp_close_stag ppf ()
+
+
 let (let*) = Option.bind
 let (let+) x f = Option.map f x
 let (let*!) x f = Option.iter f x
 
-type ('left, 'right, 'eq, 'diff) change =
+module type Defs = sig
+  type left
+  type right
+  type eq
+  type diff
+  type state
+end
+
+type ('left,'right,'eq,'diff) change =
   | Delete of 'left
   | Insert of 'right
-  | Keep of 'left * 'right * 'eq
+  | Keep of 'left * 'right *' eq
   | Change of 'left * 'right * 'diff
 
-type ('l, 'r, 'eq, 'diff) patch = ('l, 'r, 'eq, 'diff) change list
+let classify = function
+    | Delete _ -> Deletion
+    | Insert _ -> Insertion
+    | Change _ -> Modification
+    | Keep _ -> Preservation
 
-let map f g = function
-  | Delete x -> Delete (f x)
-  | Insert x -> Insert (g x)
-  | Keep (x,y,k) -> Keep (f x, g y, k)
-  | Change (x,y,k) -> Change (f x, g y, k)
+module Define(D:Defs) = struct
+  open D
 
-type ('st,'left,'right) full_state = {
-  line: 'left array;
-  column: 'right array;
-  state: 'st
+type nonrec change = (left,right,eq,diff) change
+
+type patch = change list
+module type S = sig
+  val diff: state -> left array -> right array -> patch
+end
+
+
+type full_state = {
+  line: left array;
+  column: right array;
+  state: state
 }
 
 (* The matrix supporting our dynamic programming implementation.
@@ -65,49 +102,48 @@ module Matrix : sig
 
   type shape = { l : int ; c : int }
 
-  type ('state,'left,'right,'eq,'diff) t
+  type  t
 
-  val make : shape -> ('st,'l,'r,'e,'d) t
-  val reshape : shape -> ('st,'l,'r,'e,'d) t -> ('st,'l,'r,'e,'d) t
+  val make : shape ->  t
+  val reshape : shape ->  t ->  t
 
   (** accessor functions *)
-  val diff : (_,'l,'r,'e,'d) t -> int -> int -> ('l,'r,'e,'d) change option
-  val state :
-    ('st,'l,'r,'e,'d) t -> int -> int -> ('st, 'l, 'r) full_state option
-  val weight : _ t -> int -> int -> int
+  val diff : t -> int -> int ->  change option
+  val state : t -> int -> int -> full_state option
+  val weight : t -> int -> int -> int
 
-  val line : (_,'l,_,_,_) t -> int -> int -> 'l option
-  val column : (_,_,'r,_,_) t -> int -> int -> 'r option
+  val line : t -> int -> int -> left option
+  val column : t -> int -> int -> right option
 
   val set :
-    ('st,'l,'r,'e,'d) t -> int -> int ->
-    diff:('l,'r,'e,'d) change option ->
+    t -> int -> int ->
+    diff:change option ->
     weight:int ->
-    state:('st, 'l, 'r) full_state ->
+    state:full_state ->
     unit
 
   (** the shape when starting filling the matrix *)
-  val shape : _ t -> shape
+  val shape : t -> shape
 
   (** [shape m i j] is the shape as seen from the state at position (i,j)
       after some possible extensions
   *)
-  val shape_at : _ t -> int -> int -> shape option
+  val shape_at : t -> int -> int -> shape option
 
   (** the maximal shape on the whole matrix *)
-  val real_shape : _ t -> shape
+  val real_shape : t -> shape
 
   (** debugging printer *)
-  val[@warning "-32"] pp : Format.formatter -> _ t -> unit
+  val[@warning "-32"] pp : Format.formatter -> t -> unit
 
 end = struct
 
   type shape = { l : int ; c : int }
 
-  type ('state,'left,'right,'eq,'diff) t =
-    { states: ('state,'left,'right) full_state option array array;
+  type  t =
+    { states: full_state option array array;
       weight: int array array;
-      diff: ('left,'right,'eq,'diff) change option array array;
+      diff:  change option array array;
       columns: int;
       lines: int;
     }
@@ -189,100 +225,6 @@ end = struct
 
 end
 
-(* Computation of new cells *)
-
-let select_best_proposition l =
-  let compare_proposition curr prop =
-    match curr, prop with
-    | None, o | o, None -> o
-    | Some (curr_m, curr_res), Some (m, res) ->
-        Some (if curr_m <= m then curr_m, curr_res else m,res)
-  in
-  List.fold_left compare_proposition None l
-
-(* Boundary cell update *)
-let compute_column0 ~weight ~update tbl i =
-  let*! st = Matrix.state tbl (i-1) 0 in
-  let*! line = Matrix.line tbl (i-1) 0 in
-  let diff = Delete line in
-  Matrix.set tbl i 0
-    ~weight:(weight diff + Matrix.weight tbl (i-1) 0)
-    ~state:(update diff st)
-    ~diff:(Some diff)
-
-let compute_line0 ~weight ~update tbl j =
-  let*! st = Matrix.state tbl 0 (j-1) in
-  let*! column = Matrix.column tbl 0 (j-1) in
-  let diff = Insert column in
-  Matrix.set tbl 0 j
-    ~weight:(weight diff + Matrix.weight tbl 0 (j-1))
-    ~state:(update diff st)
-    ~diff:(Some diff)
-
-let compute_inner_cell ~weight ~test ~update tbl i j =
-  let compute_proposition i j diff =
-    let* diff = diff in
-    let+ localstate = Matrix.state tbl i j in
-    weight diff + Matrix.weight tbl i j, (diff, localstate)
-  in
-  let del =
-    let diff = let+ x = Matrix.line tbl (i-1) j in Delete x in
-    compute_proposition (i-1) j diff
-  in
-  let insert =
-    let diff = let+ x = Matrix.column tbl i (j-1) in Insert x in
-    compute_proposition i (j-1) diff
-  in
-  let diag =
-    let diff =
-      let* state = Matrix.state tbl (i-1) (j-1) in
-      let* line = Matrix.line tbl (i-1) (j-1) in
-      let* column = Matrix.column tbl (i-1) (j-1) in
-      match test state.state line column with
-      | Ok ok -> Some (Keep (line, column, ok))
-      | Error err -> Some (Change (line, column, err))
-    in
-    compute_proposition (i-1) (j-1) diff
-  in
-  let*! newweight, (diff, localstate) =
-    select_best_proposition [diag;del;insert]
-  in
-  let state = update diff localstate in
-  Matrix.set tbl i j ~weight:newweight ~state ~diff:(Some diff)
-
-let compute_cell ~weight ~test ~update m i j =
-  match i, j with
-  | _ when Matrix.diff m i j <> None -> ()
-  | 0,0 -> ()
-  | 0,j -> compute_line0 ~update ~weight m j
-  | i,0 -> compute_column0 ~update ~weight m i;
-  | _ -> compute_inner_cell ~weight ~test ~update m i j
-
-(* Filling the matrix
-
-   We fill the whole matrix, as in vanilla Wagner-Fischer.
-   At this point, the lists in some states might have been extended.
-   If any list have been extended, we need to reshape the matrix
-   and repeat the process
-*)
-let compute_matrix ~weight ~test ~update state0 =
-  let m0 = Matrix.make { l = 0 ; c = 0 } in
-  Matrix.set m0 0 0 ~weight:0 ~state:state0 ~diff:None;
-  let rec loop m =
-    let shape = Matrix.shape m in
-    let new_shape = Matrix.real_shape m in
-    if new_shape.l > shape.l || new_shape.c > shape.c then
-      let m = Matrix.reshape new_shape m in
-      for i = 0 to new_shape.l do
-        for j = 0 to new_shape.c do
-          compute_cell ~update ~test ~weight m i j
-        done
-      done;
-      loop m
-    else
-      m
-  in
-  loop m0
 
 (* Building the patch.
 
@@ -334,68 +276,172 @@ let construct_patch m0 =
   in
   aux [] (select_final_state m0)
 
-let diff ~weight ~test ~update state line column =
-  let update d fs = { fs with state = update d fs.state } in
-  let fullstate = { line; column; state } in
-  compute_matrix ~weight ~test ~update fullstate
-  |> construct_patch
+(* Computation of new cells *)
 
-type ('l, 'r, 'e, 'd, 'state) update =
-  | Without_extensions of (('l,'r,'e,'d) change -> 'state -> 'state)
-  | With_left_extensions of
-      (('l,'r,'e,'d) change -> 'state -> 'state * 'l array)
-  | With_right_extensions of
-      (('l,'r,'e,'d) change -> 'state -> 'state * 'r array)
+let select_best_proposition l =
+  let compare_proposition curr prop =
+    match curr, prop with
+    | None, o | o, None -> o
+    | Some (curr_m, curr_res), Some (m, res) ->
+        Some (if curr_m <= m then curr_m, curr_res else m,res)
+  in
+  List.fold_left compare_proposition None l
 
-let variadic_diff ~weight ~test ~(update:_ update) state line column =
+  module type Full_core = sig
+    type update_result
+    type update_state
+    val weight: change -> int
+    val test: state -> left -> right -> (eq, diff) result
+    val update: change -> update_state -> update_result
+  end
+
+module Generic
+    (X: Full_core
+     with type update_result := full_state
+      and type update_state := full_state) = struct
+  open X
+
+  (* Boundary cell update *)
+  let compute_column0  tbl i =
+    let*! st = Matrix.state tbl (i-1) 0 in
+    let*! line = Matrix.line tbl (i-1) 0 in
+    let diff = Delete line in
+    Matrix.set tbl i 0
+      ~weight:(weight diff + Matrix.weight tbl (i-1) 0)
+      ~state:(update diff st)
+      ~diff:(Some diff)
+
+  let compute_line0 tbl j =
+    let*! st = Matrix.state tbl 0 (j-1) in
+    let*! column = Matrix.column tbl 0 (j-1) in
+    let diff = Insert column in
+    Matrix.set tbl 0 j
+      ~weight:(weight diff + Matrix.weight tbl 0 (j-1))
+      ~state:(update diff st)
+      ~diff:(Some diff)
+
+let compute_inner_cell tbl i j =
+  let compute_proposition i j diff =
+    let* diff = diff in
+    let+ localstate = Matrix.state tbl i j in
+    weight diff + Matrix.weight tbl i j, (diff, localstate)
+  in
+  let del =
+    let diff = let+ x = Matrix.line tbl (i-1) j in Delete x in
+    compute_proposition (i-1) j diff
+  in
+  let insert =
+    let diff = let+ x = Matrix.column tbl i (j-1) in Insert x in
+    compute_proposition i (j-1) diff
+  in
+  let diag =
+    let diff =
+      let* state = Matrix.state tbl (i-1) (j-1) in
+      let* line = Matrix.line tbl (i-1) (j-1) in
+      let* column = Matrix.column tbl (i-1) (j-1) in
+      match test state.state line column with
+      | Ok ok -> Some (Keep (line, column, ok))
+      | Error err -> Some (Change (line, column, err))
+    in
+    compute_proposition (i-1) (j-1) diff
+  in
+  let*! newweight, (diff, localstate) =
+    select_best_proposition [diag;del;insert]
+  in
+  let state = update diff localstate in
+  Matrix.set tbl i j ~weight:newweight ~state ~diff:(Some diff)
+
+let compute_cell  m i j =
+  match i, j with
+  | _ when Matrix.diff m i j <> None -> ()
+  | 0,0 -> ()
+  | 0,j -> compute_line0 m j
+  | i,0 -> compute_column0  m i;
+  | _ -> compute_inner_cell m i j
+
+(* Filling the matrix
+
+   We fill the whole matrix, as in vanilla Wagner-Fischer.
+   At this point, the lists in some states might have been extended.
+   If any list have been extended, we need to reshape the matrix
+   and repeat the process
+*)
+let compute_matrix state0 =
+  let m0 = Matrix.make { l = 0 ; c = 0 } in
+  Matrix.set m0 0 0 ~weight:0 ~state:state0 ~diff:None;
+  let rec loop m =
+    let shape = Matrix.shape m in
+    let new_shape = Matrix.real_shape m in
+    if new_shape.l > shape.l || new_shape.c > shape.c then
+      let m = Matrix.reshape new_shape m in
+      for i = 0 to new_shape.l do
+        for j = 0 to new_shape.c do
+          compute_cell m i j
+        done
+      done;
+      loop m
+    else
+      m
+  in
+  loop m0
+ end
+
+
+  module type Parameters = Full_core with type update_state := state
+
+  module Simple(X:Parameters with type update_result := state) = struct
+    module Internal = Generic(struct
+        let test = X.test
+        let weight = X.weight
+        let update d fs = { fs with state = X.update d fs.state }
+      end)
+
+    let diff state line column =
+      let fullstate = { line; column; state } in
+      Internal.compute_matrix fullstate
+      |> construct_patch
+  end
+
+
   let may_append x = function
     | [||] -> x
-    | y -> Array.append x y in
-  let update = match update with
-    | Without_extensions up ->
-        fun d fs ->
-          let state = up d fs.state in
-          { fs with state }
-    | With_left_extensions up ->
-        fun d fs ->
-          let state, a = up d fs.state in
+    | y -> Array.append x y
+
+
+  module Left_variadic
+      (X:Parameters with type update_result := state * left array) = struct
+    open X
+
+    module Internal = Generic(struct
+        let test = X.test
+        let weight = X.weight
+        let update d fs =
+          let state, a = update d fs.state in
           { fs with state ; line = may_append fs.line a }
-    | With_right_extensions up ->
-        fun d fs ->
-          let state, a = up d fs.state in
+      end)
+
+    let diff state line column =
+      let fullstate = { line; column; state } in
+      Internal.compute_matrix fullstate
+      |> construct_patch
+  end
+
+  module Right_variadic
+      (X:Parameters with type update_result := state * right array) = struct
+    open X
+
+    module Internal = Generic(struct
+        let test = X.test
+        let weight = X.weight
+        let update d fs =
+          let state, a = update d fs.state in
           { fs with state ; column = may_append fs.column a }
-  in
-  let fullstate = { line; column; state } in
-  compute_matrix ~weight ~test ~update fullstate
-  |> construct_patch
+      end)
 
+    let diff state line column =
+      let fullstate = { line; column; state } in
+      Internal.compute_matrix fullstate
+      |> construct_patch
+  end
 
-type change_kind =
-  | Deletion
-  | Insertion
-  | Modification
-  | Preservation
-
-let classify = function
-  | Delete _ -> Deletion
-  | Insert _ -> Insertion
-  | Change _ -> Modification
-  | Keep _ -> Preservation
-
-let style = function
-  | Preservation -> Misc.Color.[ FG Green ]
-  | Deletion -> Misc.Color.[ FG Red; Bold]
-  | Insertion -> Misc.Color.[ FG Red; Bold]
-  | Modification -> Misc.Color.[ FG Magenta; Bold]
-
-let prefix ppf (pos, p) =
-  let sty = style p in
-  Format.pp_open_stag ppf (Misc.Color.Style sty);
-  Format.fprintf ppf "%i. " pos;
-  Format.pp_close_stag ppf ()
-
-  let default_weight = function
-    | Insert _ -> 10
-    | Delete _ -> 10
-    | Change _ -> 10
-    | Keep _ -> 0
+end

--- a/utils/diffing.mli
+++ b/utils/diffing.mli
@@ -110,3 +110,10 @@ val variadic_diff :
   test:('state -> 'l -> 'r -> ('eq, 'diff) result) ->
   update:('l, 'r, 'eq, 'diff, 'state) update ->
   'state -> 'l array -> 'r array -> ('l, 'r, 'eq, 'diff) patch
+
+
+val default_weight : _ change -> int
+
+(** Printing default function *)
+val prefix: Format.formatter -> (int *  _ change) -> unit
+val style: _ change -> Misc.Color.style list

--- a/utils/diffing.mli
+++ b/utils/diffing.mli
@@ -59,71 +59,90 @@
 
 *)
 
-(** The type of potential changes on a list. *)
-type ('left, 'right, 'eq, 'diff) change =
-  | Delete of 'left
-  | Insert of 'right
-  | Keep of 'left * 'right * 'eq
-  | Change of 'left * 'right * 'diff
+(** The core types of a diffing implementation *)
+module type Defs = sig
+  type left
+  type right
+  type eq
+  (** Detailled equality trace *)
 
+  type diff
+  (** Detailled difference trace *)
 
-val map :
-  ('l1 -> 'l2) -> ('r1 -> 'r2) ->
-  ('l1, 'r1, 'eq, 'diff) change ->
-  ('l2, 'r2, 'eq, 'diff) change
+  type state
+  (** environment of a partial patch *)
+end
 
-(** A patch is an ordered list of changes. *)
-type ('l, 'r, 'eq, 'diff) patch = ('l, 'r, 'eq, 'diff) change list
-
-(** [diff ~weight ~test ~update state l r] computes
-    the diff between [l] and [r], using the initial state [state].
-    - [test st xl xr] tests if the elements [xl] and [xr] are
-      compatible ([Ok]) or not ([Error]).
-    - [weight ch] returns the weight of the change [ch].
-      Used to find the smallest patch.
-    - [update ch st] returns the new state after applying a change.
-*)
-val diff :
-  weight:(('l, 'r, 'eq, 'diff) change -> int) ->
-  test:('state -> 'l -> 'r -> ('eq, 'diff) result) ->
-  update:(('l, 'r, 'eq, 'diff) change -> 'state -> 'state) ->
-  'state -> 'l array -> 'r array -> ('l, 'r, 'eq, 'diff) patch
-
-(** {1 Variadic diffing}
-
-    Variadic diffing allows to expand the lists being diffed during diffing.
-*)
-
-type ('l, 'r, 'e, 'd, 'state) update =
-  | Without_extensions of (('l,'r,'e,'d) change -> 'state -> 'state)
-  | With_left_extensions of
-      (('l,'r,'e,'d) change -> 'state -> 'state * 'l array)
-  | With_right_extensions of
-      (('l,'r,'e,'d) change -> 'state -> 'state * 'r array)
-
-(** [variadic_diff ~weight ~test ~update state l r] behaves as [diff]
-    with the following difference:
-    - [update] must now be an {!update} which indicates in which direction
-      the expansion takes place.
-*)
-val variadic_diff :
-  weight:(('l, 'r, 'eq, 'diff) change -> int) ->
-  test:('state -> 'l -> 'r -> ('eq, 'diff) result) ->
-  update:('l, 'r, 'eq, 'diff, 'state) update ->
-  'state -> 'l array -> 'r array -> ('l, 'r, 'eq, 'diff) patch
-
-
-val default_weight : _ change -> int
-
-(** Printing default function *)
+(** The kind of changes which is used to share printing and styling
+    across implementation*)
 type change_kind =
   | Deletion
   | Insertion
   | Modification
   | Preservation
-
-val classify: _ change -> change_kind
 val prefix: Format.formatter -> (int * change_kind) -> unit
 val style: change_kind -> Misc.Color.style list
 
-(** Enriched analysis in presence of keys *)
+
+type ('left,'right,'eq,'diff) change =
+  | Delete of 'left
+  | Insert of 'right
+  | Keep of 'left * 'right *' eq
+  | Change of 'left * 'right * 'diff
+
+val classify: _ change -> change_kind
+
+(** [Define(Defs)] creates the diffing types from the types
+    defined in [Defs] and the functors that need to be instantatied
+    with the diffing algorithm parameters
+*)
+module Define(D:Defs): sig
+  open D
+
+  (** The type of potential changes on a list. *)
+  type nonrec change = (left,right,eq,diff) change
+  type patch = change list
+  (** A patch is an ordered list of changes. *)
+
+  module type Parameters = sig
+    type update_result
+
+    val weight: change -> int
+    (** [weight ch] returns the weight of the change [ch].
+        Used to find the smallest patch. *)
+
+    val test: state -> left -> right -> (eq, diff) result
+    (**
+       [test st xl xr] tests if the elements [xl] and [xr] are
+        co  mpatible ([Ok]) or not ([Error]).
+    *)
+
+    val update: change -> state -> update_result
+    (**  [update ch st] returns the new state after applying a change.
+         The [update_result] type also contains expansions in the variadic
+         case.
+     *)
+  end
+
+  module type S = sig
+    val diff: state -> left array -> right array -> patch
+    (** [diff state l r] computes the optimal patch between [l] and [r],
+        using the initial state [state].
+    *)
+  end
+
+
+  module Simple: (Parameters with type update_result := state) -> S
+
+  (** {1 Variadic diffing}
+
+      Variadic diffing allows to expand the lists being diffed during diffing.
+      in one specific direction.
+  *)
+  module Left_variadic:
+    (Parameters with type update_result := state * left array) -> S
+
+  module Right_variadic:
+    (Parameters with type update_result := state * right array) -> S
+
+end

--- a/utils/diffing.mli
+++ b/utils/diffing.mli
@@ -66,6 +66,7 @@ type ('left, 'right, 'eq, 'diff) change =
   | Keep of 'left * 'right * 'eq
   | Change of 'left * 'right * 'diff
 
+
 val map :
   ('l1 -> 'l2) -> ('r1 -> 'r2) ->
   ('l1, 'r1, 'eq, 'diff) change ->
@@ -115,5 +116,14 @@ val variadic_diff :
 val default_weight : _ change -> int
 
 (** Printing default function *)
-val prefix: Format.formatter -> (int *  _ change) -> unit
-val style: _ change -> Misc.Color.style list
+type change_kind =
+  | Deletion
+  | Insertion
+  | Modification
+  | Preservation
+
+val classify: _ change -> change_kind
+val prefix: Format.formatter -> (int * change_kind) -> unit
+val style: change_kind -> Misc.Color.style list
+
+(** Enriched analysis in presence of keys *)

--- a/utils/diffing_with_keys.ml
+++ b/utils/diffing_with_keys.ml
@@ -1,0 +1,143 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+
+type 'a with_pos = int * 'a
+let with_pos l = List.mapi (fun n x -> n+1,x) l
+let pos (x,_) = x
+let data (_,x) = x
+let mk_pos pos data = pos, data
+
+type ('a,'b) mismatch =
+  | Name of {pos:int; got:string; expected:string; types_match:bool}
+  | Type of {pos:int; got:'a; expected:'a; reason:'b}
+
+type ('a,'b) change =
+  | Change of ('a,'b) mismatch
+  | Swap of { pos: int * int; first: string; last: string }
+  | Move of {name:string; got:int; expected:int}
+  | Insert of {pos:int; insert:'a}
+  | Delete of {pos:int; delete:'a}
+
+let prefix ppf x =
+  let kind = match x with
+    | Change _ | Swap _ | Move _ -> Diffing.Modification
+    | Insert _ -> Diffing.Insertion
+    | Delete _ -> Diffing.Deletion
+  in
+  let style k ppf inner =
+    let sty = Diffing.style k in
+    Format.pp_open_stag ppf (Misc.Color.Style sty);
+    Format.kfprintf (fun ppf -> Format.pp_close_stag ppf () ) ppf inner
+  in
+  match x with
+  | Change (Name {pos; _ } | Type {pos; _})
+  | Insert { pos; _ } | Delete { pos; _ } ->
+      style kind ppf "%i. " pos
+  | Swap { pos = left, right; _ } ->
+      style kind ppf "%i<->%i. " left right
+  | Move { got; expected; _ } ->
+      style kind ppf "%i->%i. " expected got
+
+module Swap = Map.Make(struct
+    type t = string * string
+    let compare: t -> t -> int = Stdlib.compare
+  end)
+module Move = Misc.Stdlib.String.Map
+
+type ('a,'state) partial_edge =
+  | Left of int * 'state * 'a
+  | Right of int * 'state * 'a
+  | Both of 'state * 'a * 'a
+
+let edge key state x y =
+  let kx, ky = key (data x), key (data y) in
+  if kx <= ky then
+    (kx,ky), Left (pos x, state, (x,y))
+  else
+    (ky,kx), Right(pos x,state, (x,y))
+
+let add_edge ex ey = match ex, ey with
+  | ex, None -> Some ex
+  | Left (lpos, lstate, l), Some Right (rpos, rstate,r)
+  | Right (rpos, rstate,r), Some Left (lpos, lstate, l) ->
+      let state = if lpos < rpos then rstate else lstate in
+      Some (Both (state,l,r))
+  | Both _ as b, _ | _, Some (Both _ as b)  -> Some b
+  | l, _ -> Some l
+
+let exchanges ~update ~key state changes =
+  let add (state,(swaps,moves)) d =
+    update d state,
+    match d with
+    | Diffing.Change (x,y,_) ->
+        let k, edge = edge key state x y in
+        Swap.update k (add_edge edge) swaps, moves
+    | Diffing.Insert nx ->
+        let k = key (data nx) in
+        let edge = Right (pos nx, state,nx) in
+        swaps, Move.update k (add_edge edge) moves
+    | Diffing.Delete nx ->
+        let k, edge = key (data nx), Left (pos nx, state, nx) in
+        swaps, Move.update k (add_edge edge) moves
+    | _ -> swaps, moves
+  in
+  List.fold_left add (state,(Swap.empty,Move.empty)) changes
+
+
+let swap key test swaps x y =
+  let kx, ky = key (data x), key (data y) in
+  let key = if kx <= ky then kx, ky else ky, kx in
+  match Swap.find_opt key swaps with
+  | None | Some (Left _ | Right _)-> None
+  | Some Both (state, (ll,lr),(rl,rr)) ->
+      match test state ll rr,  test state lr rl with
+      | Ok _, Ok _ ->
+          Some (mk_pos (pos ll) kx, mk_pos (pos rl) ky)
+      | Error _, _ | _, Error _ -> None
+
+let move key test moves x =
+  let name = key (data x) in
+  match Move.find_opt name moves with
+  | None | Some (Left _ | Right _)-> None
+  | Some Both (state,got,expected) ->
+      match test state got expected with
+      | Ok _ ->
+          Some (Move {name; got=pos got; expected=pos expected})
+      | Error _ -> None
+
+let refine ~key ~update ~test state patch =
+  let _, (swaps, moves) = exchanges ~key ~update state patch in
+  let filter = function
+    | Diffing.Keep _ -> None
+    | Diffing.Insert x ->
+        begin match move key test moves x with
+        | Some _ as move -> move
+        | None -> Some (Insert {pos=pos x;insert=data x})
+        end
+    | Diffing.Delete x ->
+        begin match move key test moves x with
+        | Some _ -> None
+        | None -> Some (Delete {pos=pos x;delete=data x})
+        end
+    | Diffing.Change(x,y, reason) ->
+        match swap key test swaps x y with
+        | Some ((pos1,first),(pos2,last)) ->
+            if pos x = pos1 then
+              Some (Swap { pos = pos1, pos2; first; last})
+            else None
+        | None -> Some (Change reason)
+  in
+  List.filter_map filter patch

--- a/utils/diffing_with_keys.ml
+++ b/utils/diffing_with_keys.ml
@@ -20,16 +20,17 @@ let pos (x,_) = x
 let data (_,x) = x
 let mk_pos pos data = pos, data
 
-type ('a,'b) mismatch =
+(** Composite change and mismatches *)
+type ('l,'r,'diff) mismatch =
   | Name of {pos:int; got:string; expected:string; types_match:bool}
-  | Type of {pos:int; got:'a; expected:'a; reason:'b}
+  | Type of {pos:int; got:'l; expected:'r; reason:'diff}
 
-type ('a,'b) change =
-  | Change of ('a,'b) mismatch
+type ('l,'r,'diff) change =
+  | Change of ('l,'r,'diff) mismatch
   | Swap of { pos: int * int; first: string; last: string }
   | Move of {name:string; got:int; expected:int}
-  | Insert of {pos:int; insert:'a}
-  | Delete of {pos:int; delete:'a}
+  | Insert of {pos:int; insert:'r}
+  | Delete of {pos:int; delete:'l}
 
 let prefix ppf x =
   let kind = match x with
@@ -51,93 +52,160 @@ let prefix ppf x =
   | Move { got; expected; _ } ->
       style kind ppf "%i->%i. " expected got
 
+
+
+(** To detect [move] and [swaps], we are using the fact that
+    there are 2-cycles in the graph of name renaming.
+    - [Change (x,y,_) is then an edge from
+      [key_left x] to [key_right y].
+    - [Insert x] is an edge between the special node epsilon and
+      [key_left x]
+    - [Delete x] is an edge between [key_right] and the epsilon node
+      Since for 2-cycle, knowing one edge is enough to identify the cycle
+      it might belong to, we are using maps of partial 2-cycles.
+*)
+module Two_cycle: sig
+  type t = private (string * string)
+  val create: string -> string -> t
+end = struct
+  type t = string * string
+  let create kx ky =
+    if kx <= ky then kx, ky else ky, kx
+end
 module Swap = Map.Make(struct
-    type t = string * string
+    type t = Two_cycle.t
     let compare: t -> t -> int = Stdlib.compare
   end)
 module Move = Misc.Stdlib.String.Map
 
-type ('a,'state) partial_edge =
-  | Left of int * 'state * 'a
-  | Right of int * 'state * 'a
-  | Both of 'state * 'a * 'a
 
-let edge key state x y =
-  let kx, ky = key (data x), key (data y) in
-  if kx <= ky then
-    (kx,ky), Left (pos x, state, (x,y))
-  else
-    (ky,kx), Right(pos x,state, (x,y))
+module Define(D:Diffing.Defs with type eq := unit) = struct
 
-let add_edge ex ey = match ex, ey with
-  | ex, None -> Some ex
-  | Left (lpos, lstate, l), Some Right (rpos, rstate,r)
-  | Right (rpos, rstate,r), Some Left (lpos, lstate, l) ->
-      let state = if lpos < rpos then rstate else lstate in
-      Some (Both (state,l,r))
-  | Both _ as b, _ | _, Some (Both _ as b)  -> Some b
-  | l, _ -> Some l
+  module Internal_defs = struct
+    type left = D.left with_pos
+    type right = D.right with_pos
+    type diff =  (D.left, D.right, D.diff) mismatch
+    type eq = unit
+    type state = D.state
+  end
+  module Diff = Diffing.Define(Internal_defs)
 
-let exchanges ~update ~key state changes =
-  let add (state,(swaps,moves)) d =
-    update d state,
-    match d with
-    | Diffing.Change (x,y,_) ->
-        let k, edge = edge key state x y in
-        Swap.update k (add_edge edge) swaps, moves
-    | Diffing.Insert nx ->
-        let k = key (data nx) in
-        let edge = Right (pos nx, state,nx) in
-        swaps, Move.update k (add_edge edge) moves
-    | Diffing.Delete nx ->
-        let k, edge = key (data nx), Left (pos nx, state, nx) in
-        swaps, Move.update k (add_edge edge) moves
-    | _ -> swaps, moves
-  in
-  List.fold_left add (state,(Swap.empty,Move.empty)) changes
+  type left = Internal_defs.left
+  type right = Internal_defs.right
+  type diff = (D.left, D.right, D.diff) mismatch
+  type composite_change = (D.left,D.right,D.diff) change
+  type nonrec change = (left, right, unit, diff) Diffing.change
+  type patch = composite_change list
 
+  module type Parameters = sig
+    include Diff.Parameters with type update_result := D.state
+    val key_left: D.left -> string
+    val key_right: D.right -> string
+  end
 
-let swap key test swaps x y =
-  let kx, ky = key (data x), key (data y) in
-  let key = if kx <= ky then kx, ky else ky, kx in
-  match Swap.find_opt key swaps with
-  | None | Some (Left _ | Right _)-> None
-  | Some Both (state, (ll,lr),(rl,rr)) ->
-      match test state ll rr,  test state lr rl with
-      | Ok _, Ok _ ->
-          Some (mk_pos (pos ll) kx, mk_pos (pos rl) ky)
-      | Error _, _ | _, Error _ -> None
+  module Simple(Impl:Parameters) = struct
+    open Impl
 
-let move key test moves x =
-  let name = key (data x) in
-  match Move.find_opt name moves with
-  | None | Some (Left _ | Right _)-> None
-  | Some Both (state,got,expected) ->
-      match test state got expected with
-      | Ok _ ->
-          Some (Move {name; got=pos got; expected=pos expected})
-      | Error _ -> None
+    (** Partial 2-cycles *)
+    type ('l,'r) partial_cycle =
+      | Left of int * D.state * 'l
+      | Right of int * D.state * 'r
+      | Both of D.state * 'l * 'r
 
-let refine ~key ~update ~test state patch =
-  let _, (swaps, moves) = exchanges ~key ~update state patch in
-  let filter = function
-    | Diffing.Keep _ -> None
-    | Diffing.Insert x ->
-        begin match move key test moves x with
-        | Some _ as move -> move
-        | None -> Some (Insert {pos=pos x;insert=data x})
-        end
-    | Diffing.Delete x ->
-        begin match move key test moves x with
-        | Some _ -> None
-        | None -> Some (Delete {pos=pos x;delete=data x})
-        end
-    | Diffing.Change(x,y, reason) ->
-        match swap key test swaps x y with
-        | Some ((pos1,first),(pos2,last)) ->
-            if pos x = pos1 then
-              Some (Swap { pos = pos1, pos2; first; last})
-            else None
-        | None -> Some (Change reason)
-  in
-  List.filter_map filter patch
+    (** Compute the partial cycle and edge associated to an edge *)
+    let edge state (x:left) (y:right) =
+      let kx, ky = key_left (data x), key_right (data y) in
+      let edge =
+        if kx <= ky then
+          Left (pos x, state, (x,y))
+        else
+          Right (pos x,state, (x,y))
+      in
+      Two_cycle.create kx ky, edge
+
+    let merge_edge ex ey = match ex, ey with
+      | ex, None -> Some ex
+      | Left (lpos, lstate, l), Some Right (rpos, rstate,r)
+      | Right (rpos, rstate,r), Some Left (lpos, lstate, l) ->
+          let state = if lpos < rpos then rstate else lstate in
+          Some (Both (state,l,r))
+      | Both _ as b, _ | _, Some (Both _ as b)  -> Some b
+      | l, _ -> Some l
+
+    let two_cycles state changes =
+      let add (state,(swaps,moves)) (d:change) =
+        update d state,
+        match d with
+        | Change (x,y,_) ->
+            let k, edge = edge state x y in
+            Swap.update k (merge_edge edge) swaps, moves
+        | Insert nx ->
+            let k = key_right (data nx) in
+            let edge = Right (pos nx, state,nx) in
+            swaps, Move.update k (merge_edge edge) moves
+        | Delete nx ->
+            let k, edge = key_left (data nx), Left (pos nx, state, nx) in
+            swaps, Move.update k (merge_edge edge) moves
+        | _ -> swaps, moves
+      in
+      List.fold_left add (state,(Swap.empty,Move.empty)) changes
+
+    (** Check if an edge belongs to a known 2-cycle *)
+    let swap swaps x y =
+      let kx, ky = key_left (data x), key_right (data y) in
+      let key = Two_cycle.create kx ky in
+      match Swap.find_opt key swaps with
+      | None | Some (Left _ | Right _)-> None
+      | Some Both (state, (ll,lr),(rl,rr)) ->
+          match test state ll rr,  test state rl lr with
+          | Ok _, Ok _ ->
+              Some (mk_pos (pos ll) kx, mk_pos (pos rl) ky)
+          | Error _, _ | _, Error _ -> None
+
+    let move moves x =
+      let name =
+        match x with
+        | Either.Left x -> key_left (data x)
+        | Either.Right x -> key_right (data x)
+      in
+      match Move.find_opt name moves with
+      | None | Some (Left _ | Right _)-> None
+      | Some Both (state,got,expected) ->
+          match test state got expected with
+          | Ok _ ->
+              Some (Move {name; got=pos got; expected=pos expected})
+          | Error _ -> None
+
+    let refine state patch =
+      let _, (swaps, moves) = two_cycles state patch in
+      let filter: change -> composite_change option = function
+        | Keep _ -> None
+        | Insert x ->
+            begin match move moves (Either.Right x) with
+            | Some _ as move -> move
+            | None -> Some (Insert {pos=pos x;insert=data x})
+            end
+        | Delete x ->
+            begin match move moves (Either.Left x) with
+            | Some _ -> None
+            | None -> Some (Delete {pos=pos x;delete=data x})
+            end
+        | Change(x,y, reason) ->
+            match swap swaps x y with
+            | Some ((pos1,first),(pos2,last)) ->
+                if pos x = pos1 then
+                  Some (Swap { pos = pos1, pos2; first; last})
+                else None
+            | None -> Some (Change reason)
+      in
+      List.filter_map filter patch
+
+    let diff state left right =
+      let left = with_pos left in
+      let right = with_pos right in
+      let module Raw = Diff.Simple(Impl) in
+      let raw = Raw.diff state (Array.of_list left) (Array.of_list right) in
+      refine state raw
+
+  end
+end

--- a/utils/diffing_with_keys.mli
+++ b/utils/diffing_with_keys.mli
@@ -29,7 +29,7 @@
 
 *)
 
-type 'a with_pos = int * 'a
+type 'a with_pos = {pos: int; data:'a}
 val with_pos: 'a list -> 'a with_pos list
 
 type ('l,'r,'diff) mismatch =

--- a/utils/diffing_with_keys.mli
+++ b/utils/diffing_with_keys.mli
@@ -1,0 +1,54 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, projet Cambium, Inria Paris             *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(**
+
+   When diffing lists where each element has a distinct key, we can refine
+   the diffing patch by introducing two composite edit moves: swaps and moves.
+
+   [Swap]s exchange the position of two elements. [Swap] cost is set to
+   [2 * change - epsilon].
+   [Move]s change the position of one element. [Move] cost is set to
+   [delete + addition - epsilon].
+
+   When the cost [delete + addition] is greater than [change] and with those
+   specific weights, the optimal patch with [Swap]s and [Move]s can be computed
+   directly and cheaply from the original optimal patch.
+
+*)
+
+type 'a with_pos = int * 'a
+val with_pos: 'a list -> 'a with_pos list
+
+type ('a,'b) mismatch =
+  | Name of {pos:int; got:string; expected:string; types_match:bool}
+  | Type of {pos:int; got:'a; expected:'a; reason:'b}
+
+type ('a,'b) change =
+  | Change of ('a,'b) mismatch
+  | Swap of { pos: int * int; first: string; last: string }
+  | Move of {name:string; got:int; expected:int}
+  | Insert of {pos:int; insert:'a}
+  | Delete of {pos:int; delete:'a}
+
+val refine:
+  key:('a -> string) ->
+  update:('ch -> 'state -> 'state) ->
+  test:('state -> 'a with_pos -> 'a with_pos -> (_, _) result) ->
+  'state ->
+  (('a with_pos,'a with_pos,_,('a,'b) mismatch) Diffing.change as 'ch) list ->
+  ('a, 'b) change list
+
+val prefix: Format.formatter -> ('a,'b) change -> unit


### PR DESCRIPTION
This PR applies the recently added diffing mechanism to the error messages for mismatches in record and variant declarations in order to obtain friendly error messages when someone adds, changes or deletes a few fields or constructors in a type declaration and forget to update the corresponding interface file or a type declaration re-export.

This PR is the result of a discussion with @dra27 after #10073 where we ended up moving a constructor to avoid an unfriendly error message:

>```
>File "src/unix/lwt_unix.cppo.mli", lines 1020-1030, characters 0-13:
>Error: This variant or record definition does not match that of type
>         Unix.socket_bool_option
>       Constructors number 4 have different names, SO_REUSEPORT and SO_KEEPALIVE.
>```

Here the real issue here was the recently added `SO_REUSEPORT` constructor. Moving the new constructor to the end of type declaration solved this specific issue

>```
>File "src/unix/lwt_unix.cppo.mli", lines 1020-1030, characters 0-13:
>Error: This variant or record definition does not match that of type
>         Unix.socket_bool_option
>       The constructor SO_REUSEPORT is only present in the original definition.
>```

But with the new diffing mechanism, we have the opportunity to improve the error message in the former case too. With this PR, the error message in presence of a single erroneous addition or deletion is simplified to
```ocaml
module M: sig
  type t = A | New | B | C
end = struct
  type t = A | B | C
end
```
>```
>       ...
>       Type declarations do not match:
>         type t = A | B | C
>       is not included in
>         type t = A | New | B | C
>       A constructor, New, is missing in the first declaration.
>```

from

>```
>       ...
>       Type declarations do not match:
>         type t = A | B | C
>       is not included in
>         type t = A | New | B | C
>       Constructors number 2 have different names, B and New.
>```

The case where the error could be interpreted as a single name and/or type change is not altered.

For more involved errors, this PR reuses the scheme used for functor applications:
![err_msg](https://user-images.githubusercontent.com/7689388/115529596-541cd500-a293-11eb-8082-c1e424181e6c.png)


This is slightly less colorful than the functor case, since this PR does not alter the printing of type declaration in Oprint.

## Implementation

The implementation is quite straightforward this time: the comparison functions for single constructor and field in `Includecore` are mostly moved around. The full variant and record declaration comparison functions are rewired to use the new `Diffing` module rather than doing the analysis on their own. Finally, the last change in `Includecore` are printing functions.