### PR TITLE
Fix #8575: Surprising interaction between polymorphic variants and constructor disambiguation

### DIFF
--- a/Changes
+++ b/Changes
@@ -325,9 +325,9 @@ Working version
   when the systhreads library is loaded.
   (David Allsopp, report by Anton Bachin, review by Xavier Leroy)
 
-- #8575: Surprising interaction between polymorphic variants and constructor
-  disambiguation.
-  (Jacques Garrigue, report by Thomas Refis)
+- #8575, #10362: Surprising interaction between polymorphic variants and
+  constructor disambiguation.
+  (Jacques Garrigue, report and review by Thomas Refis)
 
 - #9936: Make sure that `List.([1;2;3])` is printed `[1;2;3]` in the toplevel
   by identifying lists by their types.

--- a/Changes
+++ b/Changes
@@ -325,6 +325,10 @@ Working version
   when the systhreads library is loaded.
   (David Allsopp, report by Anton Bachin, review by Xavier Leroy)
 
+- #8575: Surprising interaction between polymorphic variants and constructor
+  disambiguation.
+  (Jacques Garrigue, report by Thomas Refis)
+
 - #9936: Make sure that `List.([1;2;3])` is printed `[1;2;3]` in the toplevel
   by identifying lists by their types.
   (Florian Angeletti, review by Gabriel Scherer)

--- a/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr8575.ml
@@ -1,0 +1,36 @@
+(* TEST
+   * expect
+*)
+
+module A = struct type t = A | B let x = B end;;
+[%%expect{|
+module A : sig type t = A | B val x : t end
+|}]
+
+let test () =
+  match A.x with
+  | A as a -> `A_t a
+  | B when false -> `Onoes
+  | B -> if Random.bool () then `Onoes else `A_t B;;
+[%%expect{|
+val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
+|}, Principal{|
+Line 5, characters 49-50:
+5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
+                                                     ^
+Error: Unbound constructor B
+|}]
+
+let test () =
+  match A.x with
+  | B when false -> `Onoes
+  | A as a -> `A_t a
+  | B -> if Random.bool () then `Onoes else `A_t B;;
+[%%expect{|
+val test : unit -> [> `A_t of A.t | `Onoes ] = <fun>
+|}, Principal{|
+Line 5, characters 49-50:
+5 |   | B -> if Random.bool () then `Onoes else `A_t B;;
+                                                     ^
+Error: Unbound constructor B
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3008,7 +3008,7 @@ and type_expect_
       begin try match
         sarg, expand_head env ty_expected, expand_head env ty_expected0 with
       | Some sarg, {desc = Tvariant row}, {desc = Tvariant row0} ->
-          let row = row_repr row in
+          let row = row_repr row and row0 = row_repr row0 in
           begin match row_field_repr (List.assoc l row.row_fields),
           row_field_repr (List.assoc l row0.row_fields) with
             Rpresent (Some ty), Rpresent (Some ty0) ->


### PR DESCRIPTION
This fixes the strange behavior found in #8575.

```ocaml
module A = struct type t = A | B let x = B end;;
let test () =
    match A.x with
    | B when false -> `Onoes
    | A as a -> `A_t a
    | B -> if Random.bool () then `Onoes else `A_t B;;
                                                   ^
Error: Unbound constructor B
```
Should we make `row_desc` abstract too...

Note that in principal mode types from other branches are not propagated at all, so we get an error rather than a warning.