### PR TITLE
Build system: remove now useless line from Makefile.config.in

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -264,7 +264,6 @@ endif # ifeq "$(TOOLCHAIN)" "msvc"
 # in the future their definition may be moved to a more private part of
 # the compiler's build system
 ifeq "$(UNIX_OR_WIN32)" "win32"
-  OTOPDIR=$(WINTOPDIR)
   CYGPATH=cygpath -m
   DIFF=/usr/bin/diff -q --strip-trailing-cr
   FIND=/usr/bin/find


### PR DESCRIPTION
The two variables mentionned on this line, WINTOPDIR and OTOPDIR,
are not used any more so it seems it's safe to remove this line.

Cc @dra27