### PR TITLE
The OCAMLRUN build variable

### DIFF
--- a/Changes
+++ b/Changes
@@ -342,6 +342,10 @@ Working version
   (David Allsopp, report by Anders Jackson, review by Florian Angeletti and
    Gabriel Scherer)
 
+- #10366: Make it possible to use the OCAMLRUN variable to specify
+  which runtime to use while building the compilers (Sébastien Hinderer,
+  review by David Allsopp)
+
 ### Bug fixes:
 
 * #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section

--- a/Makefile
+++ b/Makefile
@@ -1057,15 +1057,13 @@ endif
 
 # Default rules
 
-.SUFFIXES: .ml .mli .cmo .cmi .cmx
-
-.ml.cmo:
+%.cmo: %.ml
 	$(CAMLC) $(COMPFLAGS) -c $< -I $(@D)
 
-.mli.cmi:
+%.cmi: %.mli
 	$(CAMLC) $(COMPFLAGS) -c $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(CAMLOPT) $(COMPFLAGS) $(OPTCOMPFLAGS) -c $< -I $(@D)
 
 partialclean::

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 include stdlib/StdlibModules
 
 CAMLC=$(BOOT_OCAMLC) -g -nostdlib -I boot -use-prims runtime/primitives
-CAMLOPT=$(CAMLRUN) ./ocamlopt$(EXE) -g -nostdlib -I stdlib -I otherlibs/dynlink
+CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) -g -nostdlib -I stdlib -I otherlibs/dynlink
 ARCHES=amd64 i386 arm arm64 power s390x riscv
 INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
         -I lambda -I middle_end -I middle_end/closure \
@@ -58,7 +58,7 @@ else
 OCAML_NATDYNLINKOPTS = -ccopt "$(NATDYNLINKOPTS)"
 endif
 
-CAMLDEP=$(CAMLRUN) boot/ocamlc -depend
+CAMLDEP=$(OCAMLRUN) boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 
@@ -165,7 +165,7 @@ core: coldstart
 
 # Check if fixpoint reached
 
-CMPBYT := $(CAMLRUN) tools/cmpbyt$(EXE)
+CMPBYT := $(OCAMLRUN) tools/cmpbyt$(EXE)
 
 .PHONY: compare
 compare:
@@ -195,7 +195,7 @@ promote-cross: promote-common
 # Promote the newly compiled system to the rank of bootstrap compiler
 # (Runs on the new runtime, produces code for the new runtime)
 .PHONY: promote
-promote: PROMOTE = $(CAMLRUN) tools/stripdebug
+promote: PROMOTE = $(OCAMLRUN) tools/stripdebug
 promote: promote-common
 	cp runtime/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 
@@ -243,7 +243,7 @@ coreboot:
 # Rebuild the library (using runtime/ocamlrun ./ocamlc)
 	$(MAKE) library-cross
 # Promote the new compiler and the new runtime
-	$(MAKE) CAMLRUN=runtime/ocamlrun$(EXE) promote
+	$(MAKE) OCAMLRUN=runtime/ocamlrun$(EXE) promote
 # Rebuild the core system
 	$(MAKE) partialclean
 	$(MAKE) core
@@ -621,7 +621,7 @@ ocaml.tmp: $(ocaml_dependencies)
 	$(CAMLC) $(LINKFLAGS) -I toplevel/byte -linkall -o $@ $^
 
 ocaml$(EXE): $(expunge) ocaml.tmp
-	- $(CAMLRUN) $^ $@ $(PERVASIVES)
+	- $(OCAMLRUN) $^ $@ $(PERVASIVES)
 
 partialclean::
 	rm -f ocaml$(EXE)
@@ -713,7 +713,7 @@ cvt_emit := tools/cvt_emit$(EXE)
 
 asmcomp/emit.ml: asmcomp/$(ARCH)/emit.mlp $(cvt_emit)
 	echo \# 1 \"$(ARCH)/emit.mlp\" > $@
-	$(CAMLRUN) $(cvt_emit) < $< >> $@ \
+	$(OCAMLRUN) $(cvt_emit) < $< >> $@ \
 	|| { rm -f $@; exit 2; }
 
 partialclean::
@@ -782,7 +782,7 @@ library: ocamlc
 .PHONY: library-cross
 library-cross:
 	$(MAKE) -C stdlib \
-	  $(BOOT_FLEXLINK_CMD) CAMLRUN=../runtime/ocamlrun$(EXE) all
+	  $(BOOT_FLEXLINK_CMD) OCAMLRUN=../runtime/ocamlrun$(EXE) all
 
 .PHONY: libraryopt
 libraryopt:

--- a/Makefile
+++ b/Makefile
@@ -1037,7 +1037,7 @@ toplevel/native/topeval.cmx: otherlibs/dynlink/dynlink.cmxa
 make_opcodes := tools/make_opcodes$(EXE)
 
 bytecomp/opcodes.ml: runtime/caml/instruct.h $(make_opcodes)
-	runtime/ocamlrun$(EXE) $(make_opcodes) -opcodes < $< > $@
+	$(NEW_OCAMLRUN) $(make_opcodes) -opcodes < $< > $@
 
 bytecomp/opcodes.mli: bytecomp/opcodes.ml
 	$(CAMLC) -i $< > $@

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
 COMPLIBDIR=$(LIBDIR)/compiler-libs
 
 TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
-RUNTOP=./runtime/ocamlrun$(EXE) ./ocaml$(EXE) \
+RUNTOP = $(OCAMLRUN) ./ocaml$(EXE) \
   -nostdlib -I stdlib -I toplevel \
   -noinit $(TOPFLAGS) $(TOPINCLUDES)
 NATRUNTOP=./ocamlnat$(EXE) \

--- a/Makefile.best_binaries
+++ b/Makefile.best_binaries
@@ -40,7 +40,7 @@ choose_best = $(strip $(if \
    $(and $(USE_BEST_BINARIES),$(wildcard $(ROOTDIR)/$1.opt$(EXE)),$(strip \
       $(call check_not_stale,$1$(EXE),$1.opt$(EXE)))), \
     $(ROOTDIR)/$1.opt$(EXE), \
-    $(CAMLRUN) $(ROOTDIR)/$1$(EXE)))
+    $(OCAMLRUN) $(ROOTDIR)/$1$(EXE)))
 
 BEST_OCAMLC := $(call choose_best,ocamlc)
 BEST_OCAMLOPT := $(call choose_best,ocamlopt)
@@ -50,7 +50,7 @@ BEST_OCAMLLEX := $(call choose_best,lex/ocamllex)
 # is not built yet, using the bootstrap compiler.
 
 # Unlike other tools, there is no risk of mixing incompatible
-# bootrap-compiler and host-compiler object files, as ocamldep only
+# bootstrap-compiler and host-compiler object files, as ocamldep only
 # produces text output.
 BEST_OCAMLDEP := $(strip $(if \
    $(and $(USE_BEST_BINARIES),$(wildcard $(ROOTDIR)/ocamlc.opt$(EXE)),$(strip \

--- a/Makefile.common
+++ b/Makefile.common
@@ -41,13 +41,13 @@ FLEXDLL_SUBMODULE_PRESENT =
 endif
 
 # Use boot/ocamlc.opt if available
-CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
+OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
 ifeq (0,$(shell \
   test $(ROOTDIR)/boot/ocamlc.opt -nt $(ROOTDIR)/boot/ocamlc; \
   echo $$?))
   BOOT_OCAMLC = $(ROOTDIR)/boot/ocamlc.opt
 else
-  BOOT_OCAMLC = $(CAMLRUN) $(ROOTDIR)/boot/ocamlc
+  BOOT_OCAMLC = $(OCAMLRUN) $(ROOTDIR)/boot/ocamlc
 endif
 
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
@@ -126,7 +126,7 @@ endef # PROGRAM_SYNONYM
 
 # Lexer generation
 
-BOOT_OCAMLLEX ?= $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+BOOT_OCAMLLEX ?= $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
 
 # Default value for OCAMLLEX
 # In those directories where this needs to be overriden, the overriding

--- a/Makefile.common
+++ b/Makefile.common
@@ -40,8 +40,17 @@ else
 FLEXDLL_SUBMODULE_PRESENT =
 endif
 
-# Use boot/ocamlc.opt if available
+# Variables used to represent the OCaml runtime system
+# Most of the time, boot/ocamlrun and runtime/ocamlrun are the same.
+# However, under some circumstances it is important to be able to
+# distinguish one from the other, hence these two variables.
+# Boot/ocamlrun is the most frequently used in the build system, so
+# we use OCAMLRUN to designate it and keep NEW_OCAMLRUN to refer
+# to runtime/ocamlrun, because it's less frequently used.
 OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
+NEW_OCAMLRUN ?= $(ROOTDIR)/runtime/ocamlrun$(EXE)
+
+# Use boot/ocamlc.opt if available
 ifeq (0,$(shell \
   test $(ROOTDIR)/boot/ocamlc.opt -nt $(ROOTDIR)/boot/ocamlc; \
   echo $$?))

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -27,7 +27,7 @@ build-all-asts:
 	@$(MAKE) --no-print-directory $(AST_FILES)
 
 CAMLC_DPARSETREE := \
-	$(CAMLRUN) ./ocamlc -nostdlib -nopervasives \
+	$(OCAMLRUN) ./ocamlc -nostdlib -nopervasives \
 	  -stop-after parsing -dparsetree
 
 %.ml.ast: %.ml ocamlc

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -62,13 +62,10 @@ clean::
 	rm -f ocamldebug ocamldebug.exe
 	rm -f *.cmo *.cmi
 
-.SUFFIXES:
-.SUFFIXES: .ml .cmo .mli .cmi
-
-.ml.cmo:
+%.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.mli.cmi:
+%.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<
 
 depend: beforedepend

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -28,7 +28,7 @@ OCAMLYACCFLAGS = -v
 
 CAMLC = $(BOOT_OCAMLC) -strict-sequence -nostdlib \
         -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
-CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -nostdlib -I $(ROOTDIR)/stdlib
+CAMLOPT = $(OCAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48-70 -warn-error +A \
             -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS =

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -68,16 +68,13 @@ clean::
 
 beforedepend:: lexer.ml
 
-.SUFFIXES:
-.SUFFIXES: .ml .cmo .mli .cmi .cmx
-
-.ml.cmo:
+%.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.mli.cmi:
+%.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(CAMLOPT) -c $(COMPFLAGS) $<
 
 depend: beforedepend

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -5,10 +5,10 @@ LD_PATH = "$(ROOTDIR)/otherlibs/str:$(ROOTDIR)/otherlibs/unix"
 
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
-  $(CAMLRUN) $(ROOTDIR)/tools/caml-tex \
+  $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
   -repo-root $(ROOTDIR) -n 80 -v false
-TEXQUOTE = $(CAMLRUN) $(TOOLS)/texquote2
-TRANSF = $(SET_LD_PATH) $(CAMLRUN) $(TOOLS)/transf
+TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
+TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
 
 FILES = comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   ocamldep.tex profil.tex debugger.tex ocamldoc.tex \

--- a/manual/src/cmds/ocamldep.etex
+++ b/manual/src/cmds/ocamldep.etex
@@ -174,15 +174,14 @@ prog2: $(PROG2_OBJS)
         $(OCAMLOPT) -o prog2 $(OCAMLFLAGS) $(PROG2_OBJS)
 
 # Common rules
-.SUFFIXES: .ml .mli .cmo .cmi .cmx
 
-.ml.cmo:
+%.cmo: %.ml
         $(OCAMLC) $(OCAMLFLAGS) -c $<
 
-.mli.cmi:
+%.cmi: %.mli
         $(OCAMLC) $(OCAMLFLAGS) -c $<
 
-.ml.cmx:
+%.cmx: %.ml
         $(OCAMLOPT) $(OCAMLOPTFLAGS) -c $<
 
 # Clean up

--- a/manual/src/refman/Makefile
+++ b/manual/src/refman/Makefile
@@ -5,10 +5,10 @@ LD_PATH = "$(ROOTDIR)/otherlibs/str:$(ROOTDIR)/otherlibs/unix"
 
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
-  $(CAMLRUN) $(ROOTDIR)/tools/caml-tex \
+  $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
   -repo-root $(ROOTDIR) -n 80 -v false
-TEXQUOTE = $(CAMLRUN) $(TOOLS)/texquote2
-TRANSF = $(SET_LD_PATH) $(CAMLRUN) $(TOOLS)/transf
+TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
+TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
 
 EXTENSION_FILES = letrecvalues.tex recursivemodules.tex locallyabstract.tex \
   firstclassmodules.tex moduletypeof.tex signaturesubstitution.tex \

--- a/manual/src/tutorials/Makefile
+++ b/manual/src/tutorials/Makefile
@@ -5,10 +5,10 @@ LD_PATH = "$(ROOTDIR)/otherlibs/str:$(ROOTDIR)/otherlibs/unix"
 
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
-  $(CAMLRUN) $(ROOTDIR)/tools/caml-tex \
+  $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
   -repo-root $(ROOTDIR) -n 80 -v false
-TEXQUOTE = $(CAMLRUN) $(TOOLS)/texquote2
-TRANSF = $(SET_LD_PATH) $(CAMLRUN) $(TOOLS)/transf
+TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
+TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
 
 
 FILES = coreexamples.tex lablexamples.tex objectexamples.tex \

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -23,7 +23,7 @@ cross-reference-checker: cross_reference_checker.ml
 .PHONY: check-cross-references
 check-cross-references: cross-reference-checker
 	$(SET_LD_PATH) \
-	  $(CAMLRUN) ./cross-reference-checker \
+	  $(OCAMLRUN) ./cross-reference-checker \
 	  -auxfile $(MANUAL)/texstuff/manual.aux \
 	  $(ROOTDIR)/utils/warnings.ml \
 	  $(ROOTDIR)/driver/main_args.ml \

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -206,18 +206,16 @@ DEPEND_PREREQS = $(LEXERS:.mll=.ml) \
 # generic rules :
 #################
 
-.SUFFIXES: .ml .mli .cmo .cmi .cmx .cmxs
-
-.ml.cmo:
+%.cmo: %.ml
 	$(OCAMLC) $(COMPFLAGS) -c $<
 
-.mli.cmi:
+%.cmi: %.mli
 	$(OCAMLC)  $(COMPFLAGS) -c $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(OCAMLOPT) $(COMPFLAGS) -c $<
 
-.ml.cmxs:
+%.cmxs: %.ml
 	$(OCAMLOPT_CMD) -shared -o $@ $(COMPFLAGS) $<
 
 # Installation targets

--- a/ocamldoc/Makefile.best_ocamldoc
+++ b/ocamldoc/Makefile.best_ocamldoc
@@ -13,8 +13,6 @@
 #*                                                                        *
 #**************************************************************************
 
-
-OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
 OCAMLDOC=$(ROOTDIR)/ocamldoc/ocamldoc$(EXE)
 OCAMLDOC_OPT=$(ROOTDIR)/ocamldoc/ocamldoc.opt$(EXE)
 

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -127,15 +127,13 @@ clean:: partialclean
 	rm -f *.dll *.so *.a *.lib *.o *.obj
 	rm -rf $(DEPDIR)
 
-.SUFFIXES: .ml .mli .cmi .cmo .cmx
-
-.mli.cmi:
+%.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmo:
+%.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
 ifeq "$(COMPUTE_DEPS)" "true"

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -35,7 +35,7 @@ COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error +A -bin-annot -g \
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
-MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib
+MKLIB=$(OCAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 
 # Variables that must be defined by individual libraries:
 # LIBNAME

--- a/otherlibs/bigarray/Makefile
+++ b/otherlibs/bigarray/Makefile
@@ -21,6 +21,6 @@ include ../Makefile.otherlibs.common
 .PHONY: depend
 
 depend:
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
 include .depend

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -289,13 +289,11 @@ depend: beforedepend
 
 include .depend
 
-.SUFFIXES: .ml .mli .cmi .cmo .cmx
-
-.mli.cmi:
+%.cmi: %.mli
 	$(OCAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmo:
+%.cmo: %.ml
 	$(OCAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(OCAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -281,9 +281,9 @@ DEPEND_DUMMY_FILES=\
 
 depend: beforedepend
 	touch $(DEPEND_DUMMY_FILES)
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
 	  -I byte -bytecode *.mli *.ml byte/dynlink.ml > .depend
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash \
 	  -I native -native *.ml native/dynlink.ml >> .depend
 	rm -f $(DEPEND_DUMMY_FILES)
 

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -26,6 +26,6 @@ str.cmx: str.cmi
 
 .PHONY: depend
 depend:
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
 include .depend

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -142,15 +142,13 @@ installopt:
 	  "$(INSTALL_THREADSLIBDIR)"
 	cd "$(INSTALL_THREADSLIBDIR)" && $(RANLIB) threads.$(A)
 
-.SUFFIXES: .ml .mli .cmo .cmi .cmx
-
-.mli.cmi:
+%.cmi: %.mli
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmo:
+%.cmo: %.ml
 	$(CAMLC) -c $(COMPFLAGS) $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
 DEP_FILES := st_stubs.b.$(D)

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -34,7 +34,7 @@ LIBS = -nostdlib -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
 CAMLC=$(BEST_OCAMLC) $(LIBS)
 CAMLOPT=$(BEST_OCAMLOPT) $(LIBS)
 
-MKLIB=$(CAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
+MKLIB=$(OCAMLRUN) $(ROOTDIR)/tools/ocamlmklib$(EXE)
 COMPFLAGS=-w +33..39 -warn-error +A -g -bin-annot -safe-string
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
@@ -172,6 +172,6 @@ $(foreach object_type, b n, $(eval $(call GEN_RULE,$(object_type))))
 
 .PHONY: depend
 depend:
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
 include .depend

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -51,6 +51,6 @@ include ../Makefile.otherlibs.common
 
 .PHONY: depend
 depend:
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash *.mli *.ml > .depend
 
 include .depend

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -64,7 +64,7 @@ $(UNIX_FILES) $(UNIX_CAML_FILES): %: ../unix/%
 
 .PHONY: depend
 depend: $(ALL_FILES) $(UNIX_CAML_FILES) unix.ml
-	$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash $(UNIX_CAML_FILES) \
+	$(OCAMLRUN) $(ROOTDIR)/boot/ocamlc -depend -slash $(UNIX_CAML_FILES) \
 	  unix.ml > .depend
 
 include .depend

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -210,8 +210,6 @@ clean::
 clean::
 	rm -f $(CAMLHEADERS)
 
-.SUFFIXES: .mli .ml .cmi .cmo .cmx
-
 export AWK
 
 %.cmi: %.mli

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -20,7 +20,7 @@ include $(ROOTDIR)/Makefile.common
 TARGET_BINDIR ?= $(BINDIR)
 
 COMPILER=$(ROOTDIR)/ocamlc$(EXE)
-CAMLC=$(CAMLRUN) $(COMPILER)
+CAMLC=$(OCAMLRUN) $(COMPILER)
 COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48-70 \
           -g -warn-error +A -bin-annot -nostdlib -principal \
           -safe-string -strict-formats
@@ -28,7 +28,7 @@ ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3
 endif
 OPTCOMPILER=$(ROOTDIR)/ocamlopt
-CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
+CAMLOPT=$(OCAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(BOOT_OCAMLC) -depend
 DEPFLAGS=-slash
 
@@ -240,7 +240,7 @@ stdlib__%.cmx:
 	           -o $@ -c $(filter %.ml, $^)
 
 # Dependencies on the compiler
-COMPILER_DEPS=$(filter-out -use-prims $(CAMLRUN), $(CAMLC))
+COMPILER_DEPS=$(filter-out -use-prims $(OCAMLRUN), $(CAMLC))
 $(OBJS) std_exit.cmo: $(COMPILER_DEPS)
 $(OBJS:.cmo=.cmi) std_exit.cmi: $(COMPILER_DEPS)
 $(OBJS:.cmo=.cmx) std_exit.cmx: $(OPTCOMPILER)

--- a/testsuite/tests/tool-ocamldep-modalias/Makefile.build
+++ b/testsuite/tests/tool-ocamldep-modalias/Makefile.build
@@ -68,10 +68,8 @@ include depend.mk
 clean:
 	rm -f *.cm* lib.ml
 
-.SUFFIXES: .ml .cmo .cmx
-
-.ml.cmo:
+%.cmo: %.ml
 	$(OCAMLC) -c $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(OCAMLOPT) -c $<

--- a/testsuite/tests/tool-ocamldep-modalias/Makefile.build2
+++ b/testsuite/tests/tool-ocamldep-modalias/Makefile.build2
@@ -56,10 +56,8 @@ include depend.mk2
 clean:
 	rm -f *.cm* lib.ml
 
-.SUFFIXES: .ml .cmo .cmx
-
-.ml.cmo:
+%.cmo: %.ml
 	$(OCAMLC) -no-alias-deps -c $<
 
-.ml.cmx:
+%.cmx: %.ml
 	$(OCAMLOPT) -no-alias-deps -c $<

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -320,7 +320,7 @@ caml_tex := caml-tex$(EXE)
 
 $(caml_tex): INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str $(UNIXLIB))
 $(caml_tex): $(caml_tex_files)
-	$(ROOTDIR)/runtime/ocamlrun$(EXE) $(ROOTDIR)/ocamlc$(EXE) -nostdlib \
+	$(OCAMLRUN) $(ROOTDIR)/ocamlc$(EXE) -nostdlib \
 	                            -I $(ROOTDIR)/stdlib $(LINKFLAGS) -linkall \
 	                            -o $@ -no-alias-deps $^
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -73,7 +73,8 @@ endef
 
 CAMLC = $(BOOT_OCAMLC) -g -nostdlib -I $(ROOTDIR)/boot \
         -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
-CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) -g -nostdlib -I $(ROOTDIR)/stdlib
+CAMLOPT = $(OCAMLRUN) $(ROOTDIR)/ocamlopt$(EXE) \
+  -g -nostdlib -I $(ROOTDIR)/stdlib
 INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp \
                        middle_end middle_end/closure middle_end/flambda \
                        middle_end/flambda/base_types driver toplevel \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -237,7 +237,7 @@ $(make_opcodes): make_opcodes.ml
 	$(CAMLC) $< -o $@
 
 opnames.ml: $(ROOTDIR)/runtime/caml/instruct.h $(make_opcodes)
-	$(ROOTDIR)/runtime/ocamlrun$(EXE) $(make_opcodes) -opnames < $< > $@
+	$(NEW_OCAMLRUN) $(make_opcodes) -opnames < $< > $@
 
 clean::
 	rm -f opnames.ml make_opcodes make_opcodes.exe make_opcodes.ml

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -318,11 +318,14 @@ caml_tex_files := \
 
 caml_tex := caml-tex$(EXE)
 
+# caml-tex uses str.cma and unix.cma and so must be compiled with
+# $(ROOTDIR)/ocamlc not $(ROOTDIR)/boot/ocamlc since the boot
+# compiler does not necessarily have the correct shared library
+# configuration.
 $(caml_tex): INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str $(UNIXLIB))
 $(caml_tex): $(caml_tex_files)
-	$(OCAMLRUN) $(ROOTDIR)/ocamlc$(EXE) -nostdlib \
-	                            -I $(ROOTDIR)/stdlib $(LINKFLAGS) -linkall \
-	                            -o $@ -no-alias-deps $^
+	$(OCAMLRUN) $(ROOTDIR)/ocamlc$(EXE) -nostdlib -I $(ROOTDIR)/stdlib \
+	  $(LINKFLAGS) -linkall -o $@ -no-alias-deps $^
 
 # we need str and unix which depend on the bytecode version of other tools
 # thus we delay building caml-tex to the opt.opt stage


### PR DESCRIPTION
This PR makes it possible to use the OCAMLRUN variable to specify
which runtime to use while building the compilers.

Mostly, it renames the CAMLRUN variable to OCAMLRUN (@dra27) and
attempts to make sure this is used consistently through all the
build system.

There may still be places to tune, especially in connection with FlexDLL,
that's one example of situation where @dra27's sharp eyes would be very
helpful.

3 remarks are due.

 1. The PR starts with something unrelated, namely the replacement of our oldish `.SUFFIXES` rules by pattern-rules in a few places. I checked that this changes absolutely nothing to the build, but this part does still have a user-visible consequence, since such rules were also used in the manual, in the part on ocamldep. I could isolate this in a dedicated PR, but frankly it didn't feel worth it (but I can still do so if asked to).
 2. In two places, I changed the runtime used: it was `runtime/ocamlrun` which was hard-coded and, after this PR, it will be `boot/ocamlrun` which will be used by default, see the relevant commit message for the details. I think this change should be painless and even consider that the former situation was kind of an error, an oversight.
 3. This PR introduces the `NEW_OCAMLRUN` variable, that defaults to `runtime/ocamlrun` because it didn't seem possible to do without that, especially during the bootstrap.

So far, I have checked that:

 * The bootstrap still works
 * `make OCAMLRUN=/foo/bar/ocamlrun` indeed uses that runtime everywhere.