### PR TITLE
output-complete-exe: do not generate .cds file

### DIFF
--- a/Changes
+++ b/Changes
@@ -408,6 +408,9 @@ Working version
    In passing, refactor Proc.op_is_pure and Mach.operation_can_raise.
   (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan)
 
+- #10371: no longer generatd useless `.cds` file when using
+  `-output-complete-exe`.
+  (Nicolás Ojeda Bär, review by David Allsopp)
 
 OCaml 4.12.0 (24 February 2021)
 -------------------------------

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -562,7 +562,7 @@ let link_bytecode_as_c tolink outfile with_main =
 \n}\
 \n#endif\n";
     );
-  if !Clflags.debug then
+  if not with_main && !Clflags.debug then
     output_cds_file ((Filename.chop_extension outfile) ^ ".cds")
 
 (* Build a custom runtime *)


### PR DESCRIPTION
When generating bytecode in the form of a C file, the compiler is able to generate a side file (with extension `.cds`) which can be used to transmit debugging information to `ocamldebug`. This file is currently being generated when compiling with `-output-complete-exe` even though it is useless in this case. This PR disables the generation in this case.

Incidentally, `-output-complete-exe` binaries currently do not include any debugging info which is bad. A potential fix is being (slowly) worked on in #10159.

Fixes #10370 

