### PR TITLE
error messages: tweak for unknown constructors or fields

### DIFF
--- a/Changes
+++ b/Changes
@@ -415,6 +415,10 @@ Working version
   `-output-complete-exe`.
   (Nicolás Ojeda Bär, review by David Allsopp)
 
+- #????, tweak error message for unknown variant constructors
+  or record fields in type-directed disambiguation
+  (Florian Angeletti, report by Hongbo Zhang , review by ???)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -172,7 +172,7 @@ Line 3, characters 22-26:
                           ^^^^
 Error: This variant expression is expected to have type unit
          because it is in the result of a conditional with no else branch
-       The constructor :: does not belong to type unit
+       There is no constructor :: within type unit
 |}];;
 
 (function
@@ -196,5 +196,5 @@ Line 1, characters 35-39:
                                        ^^^^
 Error: This variant expression is expected to have type unit
          because it is in the result of a conditional with no else branch
-       The constructor true does not belong to type unit
+       There is no constructor true within type unit
 |}]

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -30,7 +30,7 @@ Line 1, characters 11-15:
 1 | let x: t = Alph;;
                ^^^^
 Error: This variant expression is expected to have type t
-       The constructor Alph does not belong to type t
+       There is no constructor Alph within type t
 Hint: Did you mean Aleph or Alpha?
 |}]
 
@@ -41,7 +41,7 @@ Line 2, characters 12-16:
 2 | let y : w = Alha;;
                 ^^^^
 Error: This variant expression is expected to have type M.w
-       The constructor Alha does not belong to type M.w
+       There is no constructor Alha within type M.w
 Hint: Did you mean Alpha?
 |}]
 
@@ -51,7 +51,7 @@ Line 1, characters 11-14:
 1 | let z: t = Bet;;
                ^^^
 Error: This variant expression is expected to have type t
-       The constructor Bet does not belong to type t
+       There is no constructor Bet within type t
 Hint: Did you mean Beth?
 |}]
 
@@ -65,7 +65,7 @@ Line 3, characters 9-13:
 3 | let g = (Gamm:t);;
              ^^^^
 Error: This variant expression is expected to have type t
-       The constructor Gamm does not belong to type t
+       There is no constructor Gamm within type t
 Hint: Did you mean Gamma?
 |}];;
 
@@ -75,7 +75,7 @@ Line 1, characters 6-15:
 1 | raise Not_Found;;
           ^^^^^^^^^
 Error: This variant expression is expected to have type exn
-       The constructor Not_Found does not belong to type exn
+       There is no constructor Not_Found within type exn
 Hint: Did you mean Not_found?
 |}]
 
@@ -156,7 +156,7 @@ Line 7, characters 13-17:
 7 | let x: P.p = Alha;;
                  ^^^^
 Error: This variant expression is expected to have type P.p
-       The constructor Alha does not belong to type x
+       There is no constructor Alha within type x
 Hint: Did you mean Alpha?
 |}]
 
@@ -170,7 +170,7 @@ Line 3, characters 13-14:
 3 | let y: N.s = T ;;
                  ^
 Error: This variant expression is expected to have type N.s
-       The constructor T does not belong to type M.t
+       There is no constructor T within type M.t
 |}]
 
 (** Pattern matching *)
@@ -197,7 +197,7 @@ Line 3, characters 8-12:
 3 |   raise Locl;;
             ^^^^
 Error: This variant expression is expected to have type exn
-       The constructor Locl does not belong to type exn
+       There is no constructor Locl within type exn
 Hint: Did you mean Local?
 |}]
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -391,7 +391,7 @@ Line 5, characters 28-29:
 5 |   let f = function A -> 1 | B -> 2
                                 ^
 Error: This variant pattern is expected to have type a
-       The constructor B does not belong to type a
+       There is no constructor B within type a
 |}];;
 
 module PR6849 = struct

--- a/testsuite/tests/typing-short-paths/errors.ml
+++ b/testsuite/tests/typing-short-paths/errors.ml
@@ -15,7 +15,7 @@ Line 5, characters 14-15:
 5 | let x : M.t = S
                   ^
 Error: This variant expression is expected to have type t
-       The constructor S does not belong to type t
+       There is no constructor S within type t
 |}]
 
 module M = struct

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -324,7 +324,7 @@ Line 4, characters 22-23:
 4 |   let b : bar = {x=3; y=4}
                           ^
 Error: This record expression is expected to have type bar
-       The field y does not belong to type bar
+       There is no field y within type bar
 |}]
 
 module M = struct type foo = {x:int;y:int} end;;
@@ -404,7 +404,7 @@ Line 3, characters 44-45:
 3 |   let f r = ignore (r: foo); {r with x = 2; z = 3}
                                                 ^
 Error: This record expression is expected to have type M.foo
-       The field z does not belong to type M.foo
+       There is no field z within type M.foo
 |}]
 module M = struct
   include M
@@ -432,7 +432,7 @@ Line 3, characters 45-46:
 3 |   let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                                  ^
 Error: This record expression is expected to have type M.foo
-       The field a does not belong to type M.foo
+       There is no field a within type M.foo
 |}]
 module F7 = struct
   open M
@@ -454,7 +454,7 @@ Line 4, characters 18-19:
 4 |   let r: other = {x=1; y=2}
                       ^
 Error: This record expression is expected to have type M.other
-       The field x does not belong to type M.other
+       There is no field x within type M.other
 |}]
 
 module A = struct type t = {x: int} end
@@ -483,7 +483,7 @@ Line 3, characters 19-22:
 3 |   let a : t = {x=1;yyz=2}
                        ^^^
 Error: This record expression is expected to have type t
-       The field yyz does not belong to type t
+       There is no field yyz within type t
 Hint: Did you mean yyy?
 |}]
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5550,7 +5550,7 @@ let report_error ~loc env = function
           end else begin
             fprintf ppf
               "@[@[<2>%s type@ %a%t@]@ \
-               The %s %s does not belong to type %a@]"
+               There is no %s %s within type %a@]"
               eorp Printtyp.type_expr ty
               (report_type_expected_explanation_opt explanation)
               (Datatype_kind.label_name kind)


### PR DESCRIPTION
This nano-pull request replaces

>  The constructor X does not belong to type t

by

>  There is no constructor X within type t


The first sentence could be read as

> The constructor X exists, but it is not defined by type t

whereas the compiler doesn't know (and cannot fully know)  if `X` exists somewhere or not.

Thus the updated wording tries to avoid making any statement on the ontological status of `X`
and merely states that we looked for `X` within type `t` and didn't find the constructor there.

Close #10253 