### PR TITLE
Call the partial linker correctly on msvc

### DIFF
--- a/Changes
+++ b/Changes
@@ -426,6 +426,9 @@ Working version
   `-output-complete-exe`.
   (Nicolás Ojeda Bär, review by David Allsopp)
 
+- #10376: Link runtime libraries correctly on msvc64 in -output-complete-obj
+  (David Allsopp, review by Gabriel Scherer)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -149,16 +149,14 @@ let create_archive archive file_list =
 
 let expand_libname cclibs =
   cclibs |> List.map (fun cclib ->
-    if String.length cclib < 2 || String.sub cclib 0 2 <> "-l"
-    then cclib
-    else begin
+    if String.starts_with ~prefix:"-l" cclib then
       let libname =
         "lib" ^ String.sub cclib 2 (String.length cclib - 2) ^ Config.ext_lib in
       try
         Load_path.find libname
       with Not_found ->
         libname
-    end)
+    else cclib)
 
 type link_mode =
   | Exe

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -25,7 +25,6 @@ val run_command: string -> unit
 val compile_file:
   ?output:string -> ?opt:string -> ?stable_name:string -> string -> int
 val create_archive: string -> string list -> int
-val expand_libname: string -> string
 val quote_files: string list -> string
 val quote_optfile: string option -> string
 (*val make_link_options: string list -> string*)


### PR DESCRIPTION
At present, with MSVC OCaml:

```
ocaml -output-complete-obj -o bar.obj foo.ml
LINK : warning LNK4044: unrecognized option '/lcamlrun'; ignored
```

which comes from here:
https://github.com/ocaml/ocaml/blob/eaf2aaf96d4c6e4569a3280fc8d7988581d844ab/bytecomp/bytelink.ml#L718-L724

Before flexlink was merged in 3958a92c729c6588bdd4a39d6d8bc5dadb00b3de, `Ccomp.expand_libname` was used to deal with this situation. `expand_libname` has been happily sat as dead code for 14 years, but now takes on fresh purpose. It's not totally clear to me if the removal of it in 2007 was a mistake or if it was just the omission to restore it in https://github.com/ocaml/ocaml/issues/6797.

I have updated `Ccomp.expand_libname` to match the style of the still-used `remove_Wl` below it. The function changes type and, as it's not been used for 14 years, I switched it to be private.

No test added because tests/output-complete-obj/test.ml will test this when this and a string of other PRs are merged!