### PR TITLE
Support both quoting styles in ocamltest

### DIFF
--- a/ocamltest/ocamltest_stdlib.ml
+++ b/ocamltest/ocamltest_stdlib.ml
@@ -65,20 +65,33 @@ module String = struct
       end else begin
         let j = i+1 in
         match s.[i] with
-          | '\'' -> f (not quote) w ws j
+          | '\''
+          | '"' as c ->
+            begin
+              match quote with
+              | None ->
+                (* Begin quoted word *)
+                f (Some c) w ws j
+              | Some quote_char when quote_char = c ->
+                (* End quoted word *)
+                f None w ws j
+              | _ ->
+                (* Continue string *)
+                f quote (w ^ (string_of_char c)) ws j
+            end
           | ' ' ->
             begin
-              if quote
-              then f true (w ^ (string_of_char ' ')) ws j
+              if quote <> None
+              then f quote (w ^ (string_of_char ' ')) ws j
               else begin
                 if w=""
-                then f false w ws j
-                else f false "" (w::ws) j
+                then f None w ws j
+                else f None "" (w::ws) j
               end
             end
           | _ as c -> f quote (w ^ (string_of_char c)) ws j
       end in
-    if l=0 then [] else f false "" [] 0
+    if l=0 then [] else f None "" [] 0
 end
 
 module Sys = struct


### PR DESCRIPTION
ocamltest splits the words of a command recognising single quotes as 'joining words'. This is not sufficient for using `${mkexe}` on Windows.

`${mkexe}` us derived from here in `configure.ac`:
https://github.com/ocaml/ocaml/blob/eaf2aaf96d4c6e4569a3280fc8d7988581d844ab/configure.ac#L717

The double-quotes given are there both for GNU make (via `$(MKEXE)`) and `Ccomp` (via `Config.mkexe`). In both those cases the string gets passed to a shell and so the double-quotes have the desired effect. For ocamltest, which executes the first word directly, this causes `"-municode"` (on mingw64) to be passed _literally_ to gcc, which of course complains.

This patch simply allows `Ocamltest_stdlib.String.words` to treat both `"` and `'` as a quoting spaces. FWIW, it's implemented in shell style (so you can `"concatenate"'strings'`), but with no escape character. In theory it could be enabled for Windows-only, but as this is used for parsing `script = ` lines and so forth, we are in complete.

Note that it's not possible to use single quotes the definition of `mkexe` because cmd doesn't recognise them.