### PR TITLE
Remove the Pidentity primitive

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -109,7 +109,7 @@ let rec is_tailcall = function
    from the tail call optimization? *)
 
 let preserve_tailcall_for_prim = function
-    Pidentity | Popaque | Pdirapply | Prevapply | Psequor | Psequand ->
+  | Popaque | Pdirapply | Prevapply | Psequor | Psequand ->
       true
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Psetglobal _
   | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _
@@ -671,7 +671,7 @@ let rec comp_expr env exp sz cont =
         in
         comp_init env sz decl_size
       end
-  | Lprim((Pidentity | Popaque), [arg], _) ->
+  | Lprim(Popaque, [arg], _) ->
       comp_expr env arg sz cont
   | Lprim(Pignore, [arg], _) ->
       comp_expr env arg sz (add_const_unit cont)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -109,7 +109,7 @@ let rec is_tailcall = function
    from the tail call optimization? *)
 
 let preserve_tailcall_for_prim = function
-  | Popaque | Pdirapply | Prevapply | Psequor | Psequand ->
+  | Popaque | Psequor | Psequand ->
       true
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Psetglobal _
   | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _
@@ -675,17 +675,6 @@ let rec comp_expr env exp sz cont =
       comp_expr env arg sz cont
   | Lprim(Pignore, [arg], _) ->
       comp_expr env arg sz (add_const_unit cont)
-  | Lprim(Pdirapply, [func;arg], loc)
-  | Lprim(Prevapply, [arg;func], loc) ->
-      let exp = Lapply{
-        ap_loc=loc;
-        ap_func=func;
-        ap_args=[arg];
-        ap_tailcall=Default_tailcall;
-        ap_inlined=Default_inline;
-        ap_specialised=Default_specialise;
-      } in
-      comp_expr env exp sz cont
   | Lprim(Pnot, [arg], _) ->
       let newcont =
         match cont with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -43,8 +43,6 @@ type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
   | Pignore
-  | Prevapply
-  | Pdirapply
     (* Globals *)
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -40,7 +40,6 @@ type is_safe =
   | Unsafe
 
 type primitive =
-  | Pidentity
   | Pbytes_to_string
   | Pbytes_of_string
   | Pignore
@@ -491,8 +490,6 @@ let shallow_iter ~tail ~non_tail:f = function
   | Lletrec(decl, body) ->
       tail body;
       List.iter (fun (_id, exp) -> f exp) decl
-  | Lprim (Pidentity, [l], _) ->
-      tail l
   | Lprim (Psequand, [l1; l2], _)
   | Lprim (Psequor, [l1; l2], _) ->
       f l1;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -49,8 +49,6 @@ type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
   | Pignore
-  | Prevapply
-  | Pdirapply
     (* Globals *)
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -46,7 +46,6 @@ type is_safe =
   | Unsafe
 
 type primitive =
-  | Pidentity
   | Pbytes_to_string
   | Pbytes_of_string
   | Pignore

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -147,7 +147,6 @@ let float_comparison ppf = function
   | CFnge -> fprintf ppf "!>=."
 
 let primitive ppf = function
-  | Pidentity -> fprintf ppf "id"
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
   | Pignore -> fprintf ppf "ignore"
@@ -345,7 +344,6 @@ let primitive ppf = function
   | Popaque -> fprintf ppf "opaque"
 
 let name_of_primitive = function
-  | Pidentity -> "Pidentity"
   | Pbytes_of_string -> "Pbytes_of_string"
   | Pbytes_to_string -> "Pbytes_to_string"
   | Pignore -> "Pignore"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -150,8 +150,6 @@ let primitive ppf = function
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
   | Pignore -> fprintf ppf "ignore"
-  | Prevapply -> fprintf ppf "revapply"
-  | Pdirapply -> fprintf ppf "dirapply"
   | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
   | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
   | Pmakeblock(tag, Immutable, shape) ->
@@ -347,8 +345,6 @@ let name_of_primitive = function
   | Pbytes_of_string -> "Pbytes_of_string"
   | Pbytes_to_string -> "Pbytes_to_string"
   | Pignore -> "Pignore"
-  | Prevapply -> "Prevapply"
-  | Pdirapply -> "Pdirapply"
   | Pgetglobal _ -> "Pgetglobal"
   | Psetglobal _ -> "Psetglobal"
   | Pmakeblock _ -> "Pmakeblock"

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -257,8 +257,6 @@ let simplify_exits lam =
             ap_inlined=Default_inline;
             ap_specialised=Default_specialise;
           }
-        (* Simplify %identity *)
-      | Pidentity, [e] -> e
 
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
@@ -675,8 +673,6 @@ let rec emit_tail_infos is_tail lambda =
   | Lletrec (bindings, body) ->
       List.iter (fun (_, lam) -> emit_tail_infos false lam) bindings;
       emit_tail_infos is_tail body
-  | Lprim (Pidentity, [arg], _) ->
-      emit_tail_infos is_tail arg
   | Lprim ((Pbytes_to_string | Pbytes_of_string), [arg], _) ->
       emit_tail_infos is_tail arg
   | Lprim (Psequand, [arg1; arg2], _)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -231,33 +231,6 @@ let simplify_exits lam =
   | Lprim(p, ll, loc) -> begin
     let ll = List.map (simplif ~try_depth) ll in
     match p, ll with
-        (* Simplify %revapply, for n-ary functions with n > 1 *)
-      | Prevapply, [x; Lapply ap]
-      | Prevapply, [x; Levent (Lapply ap,_)] ->
-        Lapply {ap with ap_args = ap.ap_args @ [x]; ap_loc = loc}
-      | Prevapply, [x; f] ->
-          Lapply {
-            ap_loc=loc;
-            ap_func=f;
-            ap_args=[x];
-            ap_tailcall=Default_tailcall;
-            ap_inlined=Default_inline;
-            ap_specialised=Default_specialise;
-          }
-        (* Simplify %apply, for n-ary functions with n > 1 *)
-      | Pdirapply, [Lapply ap; x]
-      | Pdirapply, [Levent (Lapply ap,_); x] ->
-        Lapply {ap with ap_args = ap.ap_args @ [x]; ap_loc = loc}
-      | Pdirapply, [f; x] ->
-          Lapply {
-            ap_loc=loc;
-            ap_func=f;
-            ap_args=[x];
-            ap_tailcall=Default_tailcall;
-            ap_inlined=Default_inline;
-            ap_specialised=Default_specialise;
-          }
-
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1068,17 +1068,6 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       Usequence(fst (close env arg), expr), approx
   | Lprim((Pbytes_to_string | Pbytes_of_string), [arg], _loc) ->
       close env arg
-  | Lprim(Pdirapply,[funct;arg], loc)
-  | Lprim(Prevapply,[arg;funct], loc) ->
-      close env
-        (Lapply{
-           ap_loc=loc;
-           ap_func=funct;
-           ap_args=[arg];
-           ap_tailcall=Default_tailcall;
-           ap_inlined=Default_inline;
-           ap_specialised=Default_specialise;
-         })
   | Lprim(Pgetglobal id, [], loc) ->
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1066,7 +1066,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   | Lprim(Pignore, [arg], _loc) ->
       let expr, approx = make_const_int 0 in
       Usequence(fst (close env arg), expr), approx
-  | Lprim((Pidentity | Pbytes_to_string | Pbytes_of_string), [arg], _loc) ->
+  | Lprim((Pbytes_to_string | Pbytes_of_string), [arg], _loc) ->
       close env arg
   | Lprim(Pdirapply,[funct;arg], loc)
   | Lprim(Prevapply,[arg;funct], loc) ->

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -147,7 +147,6 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pignore
   | Prevapply
   | Pdirapply
-  | Pidentity
   | Pgetglobal _
   | Psetglobal _
     ->

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -145,8 +145,6 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbytes_of_string
   | Pctconst _
   | Pignore
-  | Prevapply
-  | Pdirapply
   | Pgetglobal _
   | Psetglobal _
     ->

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -416,21 +416,6 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     in
     Flambda.create_let var defining_expr
       (name_expr (Const (Int 0)) ~name:Names.unit)
-  | Lprim (Pdirapply, [funct; arg], loc)
-  | Lprim (Prevapply, [arg; funct], loc) ->
-    let apply : Lambda.lambda_apply =
-      { ap_func = funct;
-        ap_args = [arg];
-        ap_loc = loc;
-        (* CR-someday lwhite: it would be nice to be able to give
-           application attributes to functions applied with the application
-           operators. *)
-        ap_tailcall = Default_tailcall;
-        ap_inlined = Default_inline;
-        ap_specialised = Default_specialise;
-      }
-    in
-    close t env (Lambda.Lapply apply)
   | Lprim (Praise kind, [arg], loc) ->
     let arg_var = Variable.create Names.raise_arg in
     let dbg = Debuginfo.from_location loc in

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -407,7 +407,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         (If_then_else (cond, arg2, Var const_false)))
   | Lprim ((Psequand | Psequor), _, _) ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"
-  | Lprim ((Pidentity | Pbytes_to_string | Pbytes_of_string), [arg], _) ->
+  | Lprim ((Pbytes_to_string | Pbytes_of_string), [arg], _) ->
     close t env arg
   | Lprim (Pignore, [arg], _) ->
     let var = Variable.create Names.ignore in

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -107,7 +107,6 @@ let pbytessetu = "Pbytessetu"
 let pccall = "Pccall"
 let pctconst = "Pctconst"
 let pcvtbint = "Pcvtbint"
-let pdirapply = "Pdirapply"
 let pdivbint = "Pdivbint"
 let pdivfloat = "Pdivfloat"
 let pdivint = "Pdivint"
@@ -152,7 +151,6 @@ let porbint = "Porbint"
 let porint = "Porint"
 let praise = "Praise"
 let predef_exn = "predef_exn"
-let prevapply = "Prevapply"
 let project_closure = "project_closure"
 let psequand = "Psequand"
 let psequor = "Psequor"
@@ -208,7 +206,6 @@ let pbytessetu_arg = "Pbytessetu_arg"
 let pccall_arg = "Pccall_arg"
 let pctconst_arg = "Pctconst_arg"
 let pcvtbint_arg = "Pcvtbint_arg"
-let pdirapply_arg = "Pdirapply_arg"
 let pdivbint_arg = "Pdivbint_arg"
 let pdivfloat_arg = "Pdivfloat_arg"
 let pdivint_arg = "Pdivint_arg"
@@ -251,7 +248,6 @@ let popaque_arg = "Popaque_arg"
 let porbint_arg = "Porbint_arg"
 let porint_arg = "Porint_arg"
 let praise_arg = "Praise_arg"
-let prevapply_arg = "Prevapply_arg"
 let psequand_arg = "Psequand_arg"
 let psequor_arg = "Psequor_arg"
 let psetfield_arg = "Psetfield_arg"
@@ -311,8 +307,6 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbytes_of_string -> pbytes_of_string
   | Pbytes_to_string -> pbytes_to_string
   | Pignore -> pignore
-  | Prevapply -> prevapply
-  | Pdirapply -> pdirapply
   | Pgetglobal _ -> pgetglobal
   | Psetglobal _ -> psetglobal
   | Pmakeblock _ -> pmakeblock
@@ -416,8 +410,6 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbytes_of_string -> pbytes_of_string_arg
   | Pbytes_to_string -> pbytes_to_string_arg
   | Pignore -> pignore_arg
-  | Prevapply -> prevapply_arg
-  | Pdirapply -> pdirapply_arg
   | Pgetglobal _ -> pgetglobal_arg
   | Psetglobal _ -> psetglobal_arg
   | Pmakeblock _ -> pmakeblock_arg

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -119,7 +119,6 @@ let pfloatcomp = "Pfloatcomp"
 let pfloatfield = "Pfloatfield"
 let pfloatofint = "Pfloatofint"
 let pgetglobal = "Pgetglobal"
-let pidentity = "Pidentity"
 let pignore = "Pignore"
 let pint_as_pointer = "Pint_as_pointer"
 let pintcomp = "Pintcomp"
@@ -221,7 +220,6 @@ let pfloatcomp_arg = "Pfloatcomp_arg"
 let pfloatfield_arg = "Pfloatfield_arg"
 let pfloatofint_arg = "Pfloatofint_arg"
 let pgetglobal_arg = "Pgetglobal_arg"
-let pidentity_arg = "Pidentity_arg"
 let pignore_arg = "Pignore_arg"
 let pint_as_pointer_arg = "Pint_as_pointer_arg"
 let pintcomp_arg = "Pintcomp_arg"
@@ -310,7 +308,6 @@ let anon_fn_with_loc (sloc: Lambda.scoped_location) =
       (Filename.basename file) line pp_chars
 
 let of_primitive : Lambda.primitive -> string = function
-  | Pidentity -> pidentity
   | Pbytes_of_string -> pbytes_of_string
   | Pbytes_to_string -> pbytes_to_string
   | Pignore -> pignore
@@ -416,7 +413,6 @@ let of_primitive : Lambda.primitive -> string = function
   | Popaque -> popaque
 
 let of_primitive_arg : Lambda.primitive -> string = function
-  | Pidentity -> pidentity_arg
   | Pbytes_of_string -> pbytes_of_string_arg
   | Pbytes_to_string -> pbytes_to_string_arg
   | Pignore -> pignore_arg


### PR DESCRIPTION
This removes the `Pidentity` primitive, which was always simplified by all backends immediately and unconditionally.

I've left the `Pbytes_to_string` and `Pbytes_of_string` alone, because although they're also ultimately the identity on all our backends I think js_of_ocaml needs to know about them.