### PR TITLE
Fix configure on Windows with non C-locale characters

### DIFF
--- a/Changes
+++ b/Changes
@@ -708,6 +708,9 @@ OCaml 4.13.0
 - #10376: Link runtime libraries correctly on msvc64 in -output-complete-obj
   (David Allsopp, review by Gabriel Scherer)
 
+- #10380: Correct handling of UTF-8 paths in configure on Windows
+  (David Allsopp, review by Sébastien Hinderer)
+
 - #10449: Fix major GC work accounting (the GC was running too fast).
   (Damien Doligez, report by Stephen Dolan, review by Nicolás Ojeda Bär
    and Sadiq Jaffer)

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -201,7 +201,7 @@ Now run:
 
 for 32-bit, or:
 
-        ./configure --build=x86_64-unknown-cygwin --host=x86_64-pc-windows
+        ./configure --build=x86_64-pc-cygwin --host=x86_64-pc-windows
 
 for 64-bit.
 
@@ -266,7 +266,7 @@ Now run:
 
 for 32-bit, or:
 
-        ./configure --build=x86_64-unknown-cygwin --host=x86_64-w64-mingw32
+        ./configure --build=x86_64-pc-cygwin --host=x86_64-w64-mingw32
 
 for 64-bit.
 

--- a/configure
+++ b/configure
@@ -17799,7 +17799,7 @@ else
           && test "$host_vendor-$host_os" != "$build_vendor-$build_os" ; then :
   case $build in #(
   *-pc-cygwin) :
-    prefix=`cygpath -m "$prefix"` ;; #(
+    prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")" ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -1989,7 +1989,7 @@ AS_IF([test x"$prefix" = "xNONE"],
   [AS_IF([test x"$unix_or_win32" = "xwin32" \
           && test "$host_vendor-$host_os" != "$build_vendor-$build_os" ],
     [AS_CASE([$build],
-      [*-pc-cygwin], [prefix=`cygpath -m "$prefix"`])])])
+      [*-pc-cygwin], [prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")"])])])
 
 # Define a few macros that were defined in config/m-nt.h
 # but whose value is not guessed properly by configure

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -70,7 +70,7 @@ function set_configuration {
             dep='--disable-dependency-generation'
         ;;
         msvc64)
-            build='--build=x86_64-unknown-cygwin'
+            build='--build=x86_64-pc-cygwin'
             host='--host=x86_64-pc-windows'
             # Explicitly test dependency generation on msvc64
             dep='--enable-dependency-generation'

--- a/tools/ci/inria/bootstrap/script
+++ b/tools/ci/inria/bootstrap/script
@@ -160,7 +160,7 @@ case "${OCAML_ARCH}" in
     check_make_alldepend=true
   ;;
   mingw64)
-    build='--build=x86_64-unknown-cygwin'
+    build='--build=x86_64-pc-cygwin'
     host='--host=x86_64-w64-mingw32'
     instdir='C:/ocamlmgw64'
     cleanup=true
@@ -174,7 +174,7 @@ case "${OCAML_ARCH}" in
     cleanup=true
   ;;
   msvc64)
-    build='--build=x86_64-unknown-cygwin'
+    build='--build=x86_64-pc-cygwin'
     host='--host=x86_64-pc-windows'
     instdir='C:/ocamlms64'
     configure=nt

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -171,7 +171,7 @@ case "${OCAML_ARCH}" in
     check_make_alldepend=true
   ;;
   mingw64)
-    build='--build=x86_64-unknown-cygwin'
+    build='--build=x86_64-pc-cygwin'
     host='--host=x86_64-w64-mingw32'
     instdir='C:/ocamlmgw64'
     cleanup=true
@@ -184,7 +184,7 @@ case "${OCAML_ARCH}" in
     cleanup=true
   ;;
   msvc64)
-    build='--build=x86_64-unknown-cygwin'
+    build='--build=x86_64-pc-cygwin'
     host='--host=x86_64-pc-windows'
     instdir='C:/ocamlms64'
     cleanup=true


### PR DESCRIPTION
Picking a recent build on AppVeyor, you can see the [msvc64 job worked](https://ci.appveyor.com/project/avsm/ocaml/builds/38914886/job/lff98b9hyc4l0ksw?fullLog=true#L12665):

```
-=-=- install msvc64 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
make: Entering directory '/cygdrive/c/projects/🐫реализация-msvc64'
mkdir -p "C:/Program Files/Бактріан🐫/bin"
mkdir -p "C:/Program Files/Бактріан🐫/lib/ocaml"
mkdir -p "C:/Program Files/Бактріан🐫/lib/ocaml/stublibs"
```

but the [mingw32 job does not](https://ci.appveyor.com/project/avsm/ocaml/builds/38914886/job/9tvkphxc9gum85si?fullLog=true#L8155):

```
-=-=- install mingw32 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
make: Entering directory '/cygdrive/c/projects/🐫реализация-mingw32'
mkdir -p "C:/Program Files//bin"
mkdir -p "C:/Program Files//lib/ocaml"
mkdir -p "C:/Program Files//lib/ocaml/stublibs"
```

It turns out the reason msvc64 was working was because the `--build=` parameter was set to the wrong value in the AppVeyor script. The first commit fixes that, causing both builds to fail consistently.

The next commit then fixes the problem, which is that autoconf exports `LC_ALL=C` and this apparently breaks the `cygpath` call, causing it to return `C:/Program Files/` instead of `C:/Program Files/Бактріан🐫`