### PR TITLE
Implement int_of_string_opt in runtime without exception raising.

### DIFF
--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -115,7 +115,7 @@ static intnat parse_intnat_set_err(value s, int nbits, char* err_flag)
   return sign < 0 ? -((intnat) res) : (intnat) res;
 }
 
-static intnat parse_intnat_or_err(value s, int nbits, const char *errmsg) {
+static intnat parse_intnat_exn(value s, int nbits, const char *errmsg) {
   char err_flag = 0;
   intnat num = parse_intnat_set_err(s, nbits, &err_flag);
   if (err_flag) caml_failwith(errmsg);
@@ -144,7 +144,7 @@ CAMLprim value caml_int_compare(value v1, value v2)
 
 CAMLprim value caml_int_of_string(value s)
 {
-    return Val_long(parse_intnat_or_err(s, 8 * sizeof(value) - 1, INT_ERRMSG));
+    return Val_long(parse_intnat_exn(s, 8 * sizeof(value) - 1, INT_ERRMSG));
 }
 
 CAMLprim value caml_int_of_string_opt(value s)
@@ -353,7 +353,7 @@ CAMLprim value caml_int32_format(value fmt, value arg)
 
 CAMLprim value caml_int32_of_string(value s)
 {
-  return caml_copy_int32((int32_t) parse_intnat_or_err(s, 32, INT32_ERRMSG));
+  return caml_copy_int32((int32_t) parse_intnat_exn(s, 32, INT32_ERRMSG));
 }
 
 int32_t caml_int32_bits_of_float_unboxed(double d)
@@ -864,5 +864,5 @@ CAMLprim value caml_nativeint_format(value fmt, value arg)
 
 CAMLprim value caml_nativeint_of_string(value s)
 {
-  return caml_copy_nativeint(parse_intnat_or_err(s, 8 * sizeof(value), INTNAT_ERRMSG));
+  return caml_copy_nativeint(parse_intnat_exn(s, 8 * sizeof(value), INTNAT_ERRMSG));
 }

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -263,10 +263,7 @@ let string_of_int n =
 
 external int_of_string : string -> int = "caml_int_of_string"
 
-let int_of_string_opt s =
-  (* TODO: provide this directly as a non-raising primitive. *)
-  try Some (int_of_string s)
-  with Failure _ -> None
+external int_of_string_opt : string -> int option = "caml_int_of_string_opt"
 
 external string_get : string -> int -> char = "%string_safe_get"
 


### PR DESCRIPTION
## What
This addresses a TODO in `stdlib`.

In fact, there are a series of similar TODOs in `Nativeint.of_string_opt`, `Int32.of_string_opt`, `Int64.of_string_opt` and `Stdlib.float_of_string_opt`.

If the way I'm handling `int_of_string_opt` is acceptable, I think we can address the other TODOs in similar ways.

## How
The only "tricky" part about implementation is how to signal error in C. I chose to pass in a pointer to an error flag, and set it to signal error. The caller can initialize, pass in, and check the flag accordingly.
