### PR TITLE
Have update_scope_rec only recurse in principal mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -410,7 +410,8 @@ Working version
   or record fields in type-directed disambiguation
   (Florian Angeletti, report by Hongbo Zhang, review by Gabriel Scherer)
 
-* #10277: Need to detect ambiguity recursively inside types in principal mode
+* #10277, #10383: Need to detect ambiguity recursively inside types to
+  guarantee principality (affects only principal mode)
   (Jacques Garrigue, review by Thomas Refis and Leo White)
 
 - #10283, #10284: Enforce right-to-left evaluation order for Lstaticraise

--- a/Changes
+++ b/Changes
@@ -412,7 +412,7 @@ Working version
 
 * #10277, #10383: Need to detect ambiguity recursively inside types to
   guarantee principality (affects only principal mode)
-  (Jacques Garrigue, review by Thomas Refis and Leo White)
+  (Jacques Garrigue, review by Thomas Refis, Leo White and Kate Deplaix)
 
 - #10283, #10284: Enforce right-to-left evaluation order for Lstaticraise
   (Vincent Laviron, report by Github user Ngoguey42, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -410,7 +410,7 @@ Working version
   or record fields in type-directed disambiguation
   (Florian Angeletti, report by Hongbo Zhang, review by Gabriel Scherer)
 
-- #10277: Need to detect ambiguity recursively inside types
+* #10277: Need to detect ambiguity recursively inside types in principal mode
   (Jacques Garrigue, review by Thomas Refis and Leo White)
 
 - #10283, #10284: Enforce right-to-left evaluation order for Lstaticraise

--- a/testsuite/tests/typing-gadts/ambivalent_apply.ml
+++ b/testsuite/tests/typing-gadts/ambivalent_apply.ml
@@ -22,6 +22,8 @@ Error: This expression has type b = int
 let f (type a b) (w1 : (a, b -> b) eq) (w2 : (a, int -> int) eq) (g : a) =
    let Refl = w2 in let Refl = w1 in g 3;;
 [%%expect{|
+val f : ('a, 'b -> 'b) eq -> ('a, int -> int) eq -> 'a -> int = <fun>
+|}, Principal{|
 Line 2, characters 37-40:
 2 |    let Refl = w2 in let Refl = w1 in g 3;;
                                          ^^^

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1095,6 +1095,13 @@ Line 3, characters 2-26:
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type < bar : int; foo : int; .. >
        but an expression was expected of type 'a
+       The type constructor $1 would escape its scope
+|}, Principal{|
+Line 3, characters 2-26:
+3 |   (x:<foo:int;bar:int;..>)
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type < bar : int; foo : int; .. >
+       but an expression was expected of type 'a
        This instance of $1 is ambiguous:
        it would escape the scope of its equation
 |}];;
@@ -1112,6 +1119,8 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
   x, x#foo, x#bar
 ;;
 [%%expect{|
+val g : 't -> 't int_foo -> 't int_bar -> 't * int * int = <fun>
+|}, Principal{|
 Line 3, characters 5-10:
 3 |   x, x#foo, x#bar
          ^^^^^

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -848,9 +848,10 @@ let check_scope_escape env level ty =
 let rec update_scope scope ty =
   let ty = repr ty in
   if ty.scope < scope then begin
-   if ty.level < scope then raise (Trace.scope_escape ty);
-   set_scope ty scope;
-   iter_type_expr (update_scope scope) ty
+    if ty.level < scope then raise (Trace.scope_escape ty);
+    set_scope ty scope;
+    (* Only recurse in principal mode as this is not necessary for soundness *)
+    if !Clflags.principal then iter_type_expr (update_scope scope) ty
   end
 
 (* Note: the level of a type constructor must be greater than its binding


### PR DESCRIPTION
The recursion added in #10277 seems to have broken dune among others.
An analysis of the unification/expansion algorithms shows that recursion is only needed for principality and not for soundness so, at least for now, it seems more reasonable to keep the original behavior in non-principal mode.

(Checking the scope is needed for soundness, to ensure that no change on the type introduced through unification/expansion is visible from outside the branch that introduced the equation that made this change possible. However it is sufficient to check it on the node on which the equation was used, since one side of the equation has to be a non-parametric abstract type.)