### PR TITLE
Harden the rules for tabs in Makefiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -72,7 +72,7 @@ tools/mantis2gh_stripped.csv typo.missing-header
 /.depend.menhir          typo.prune
 
 # Makefiles may contain tabs
-Makefile*                typo.tab=may
+Makefile*                typo.makefile-whitespace=may
 
 asmcomp/*/emit.mlp       typo.tab=may typo.long-line=may
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ INCLUDES=-I utils -I parsing -I typing -I bytecomp -I file_formats \
 
 COMPFLAGS=-strict-sequence -principal -absname \
           -w +a-4-9-40-41-42-44-45-48-66-70 \
-	  -warn-error +a \
+          -warn-error +a \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 
@@ -852,7 +852,7 @@ parsing/parser.mli: boot/menhir/parser.mli
 
 beforedepend:: parsing/camlinternalMenhirLib.ml \
   parsing/camlinternalMenhirLib.mli \
-	parsing/parser.ml parsing/parser.mli
+  parsing/parser.ml parsing/parser.mli
 
 partialclean:: partialclean-menhir
 

--- a/Makefile
+++ b/Makefile
@@ -1109,8 +1109,8 @@ config.status:
 	@echo "- In file README.win32.adoc for Windows systems."
 	@echo "On Unix systems, if you've just unpacked the distribution,"
 	@echo "something like"
-	@echo "	./configure"
-	@echo "	make"
-	@echo "	make install"
+	@echo "  ./configure"
+	@echo "  make"
+	@echo "  make install"
 	@echo "should work."
 	@false

--- a/Makefile.common
+++ b/Makefile.common
@@ -50,10 +50,12 @@ endif
 OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun$(EXE)
 NEW_OCAMLRUN ?= $(ROOTDIR)/runtime/ocamlrun$(EXE)
 
-# Use boot/ocamlc.opt if available
-ifeq (0,$(shell \
+TEST_BOOT_OCAMLC_OPT = $(shell \
   test $(ROOTDIR)/boot/ocamlc.opt -nt $(ROOTDIR)/boot/ocamlc; \
-  echo $$?))
+  echo $$?)
+
+# Use boot/ocamlc.opt if available
+ifeq "$(TEST_BOOT_OCAMLC_OPT)" "0"
   BOOT_OCAMLC = $(ROOTDIR)/boot/ocamlc.opt
 else
   BOOT_OCAMLC = $(OCAMLRUN) $(ROOTDIR)/boot/ocamlc

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -27,8 +27,8 @@ build-all-asts:
 	@$(MAKE) --no-print-directory $(AST_FILES)
 
 CAMLC_DPARSETREE := \
-	$(OCAMLRUN) ./ocamlc -nostdlib -nopervasives \
-	  -stop-after parsing -dparsetree
+  $(OCAMLRUN) ./ocamlc -nostdlib -nopervasives \
+                       -stop-after parsing -dparsetree
 
 %.ml.ast: %.ml ocamlc
 	$(CAMLC_DPARSETREE) $< 2> $@ || exit 0

--- a/api_docgen/Makefile.docfiles
+++ b/api_docgen/Makefile.docfiles
@@ -35,24 +35,24 @@ str_MLIS := str.mli
 unix_MLIS := unix.mli unixLabels.mli
 dynlink_MLIS := dynlink.mli
 thread_MLIS := \
-	thread.mli condition.mli mutex.mli event.mli \
-	threadUnix.mli semaphore.mli
+  thread.mli condition.mli mutex.mli event.mli \
+  threadUnix.mli semaphore.mli
 
 STDLIB=$(filter-out stdlib__Pervasives, $(STDLIB_MODULES))
 
 stdlib_UNPREFIXED=$(filter-out pervasives, $(STDLIB_MODULE_BASENAMES))
 
 otherlibref= \
-	$(str_MLIS:%.mli=%) \
-	$(unix_MLIS:%.mli=%) \
-	$(dynlink_MLIS:%.mli=%) \
-	$(thread_MLIS:%.mli=%)
+  $(str_MLIS:%.mli=%) \
+  $(unix_MLIS:%.mli=%) \
+  $(dynlink_MLIS:%.mli=%) \
+  $(thread_MLIS:%.mli=%)
 libref_EXTRA=stdlib__pervasives
 libref_TEXT=Ocaml_operators Format_tutorial
 libref_C=$(call capitalize,$(libref) $(libref_EXTRA))
 
 PARSING_MLIS := $(call sort, \
-	$(notdir $(wildcard $(ROOTDIR)/parsing/*.mli))\
+  $(notdir $(wildcard $(ROOTDIR)/parsing/*.mli))\
 )
 UTILS_MLIS := $(call sort,$(notdir $(wildcard $(ROOTDIR)/utils/*.mli)))
 DRIVER_MLIS := pparse.mli

--- a/api_docgen/ocamldoc/Makefile
+++ b/api_docgen/ocamldoc/Makefile
@@ -27,8 +27,8 @@ texi: build/texi/stdlib.texi
 DOC_STDLIB_INCLUDES= $(addprefix -I , $(DOC_STDLIB_DIRS))
 
 DOC_ALL_INCLUDES = \
-	$(DOC_STDLIB_INCLUDES) \
-	$(addprefix -I ,$(DOC_COMPILERLIBS_DIRS))
+  $(DOC_STDLIB_INCLUDES) \
+  $(addprefix -I ,$(DOC_COMPILERLIBS_DIRS))
 
 libref=$(stdlib_UNPREFIXED) $(otherlibref)
 

--- a/api_docgen/odoc/Makefile
+++ b/api_docgen/odoc/Makefile
@@ -27,13 +27,13 @@ libref = $(STDLIB) $(otherlibref)
 
 # odoc needs a "page-" prefix for a mld documentation file
 define page_name
-	$(dir $1)page-$(notdir $1)
+  $(dir $1)page-$(notdir $1)
 endef
 
 define stdlib_prefix
-	$(if $(filter-out stdlib camlinternal%,$1),\
-	Stdlib.$(call capitalize,$1),\
-	$(call capitalize, $1))
+  $(if $(filter-out stdlib camlinternal%,$1),\
+  Stdlib.$(call capitalize,$1),\
+  $(call capitalize, $1))
 endef
 
 # define the right conditional for the manual
@@ -86,9 +86,9 @@ build/compilerlibref/%.odoc: %.cmti $(libref:%=build/libref/%.odoc) \
 ALL_TEXT = $(libref_TEXT:%=libref/%) $(compilerlibref_TEXT:%=compilerlibref/%)
 ALL_PAGE_TEXT=$(foreach mld,$(ALL_TEXT),$(call page_name,$(mld)))
 TARGET_UNITS= \
-	$(compilerlibref:%=compilerlibref/%) \
-	libref/stdlib $(otherlibref:%=libref/%) \
-	$(addprefix libref/,$(filter camlinternal%,$(STDLIB)))
+  $(compilerlibref:%=compilerlibref/%) \
+  libref/stdlib $(otherlibref:%=libref/%) \
+  $(addprefix libref/,$(filter camlinternal%,$(STDLIB)))
 ALL_UNITS = $(compilerlibref:%=compilerlibref/%) $(libref:%=libref/%)
 ALL_PAGED_DOC = $(TARGET_UNITS) $(ALL_PAGE_TEXT)
 
@@ -96,11 +96,11 @@ ALL_PAGED_DOC = $(TARGET_UNITS) $(ALL_PAGE_TEXT)
 # Note that we are using a dependency on the whole phase 1 rather than tracking
 # the individual file dependencies
 $(ALL_UNITS:%=build/%.odocl):%.odocl:%.odoc \
-	| $(ALL_PAGED_DOC:%=build/%.odoc)
+  | $(ALL_PAGED_DOC:%=build/%.odoc)
 	$(odoc) link -I build/libref -I build/compilerlibref $<
 
 $(ALL_PAGE_TEXT:%=build/%.odocl):%.odocl:%.odoc \
-	| $(ALL_PAGED_DOC:%=build/%.odoc)
+  | $(ALL_PAGED_DOC:%=build/%.odoc)
 	$(odoc) link -I build/libref -I build/compilerlibref $<
 
 # Rules for all three backends:
@@ -134,8 +134,8 @@ $(build/libref.html.stamp build/compilerlibref.html.stamp):
 
 # The stdlib index is generated from the list of stdlib modules.
 stdlib_INDEX=\
-	$(foreach m,$(stdlib_UNPREFIXED),$(call stdlib_prefix,$m))\
-	$(call capitalize, $(otherlibref))
+  $(foreach m,$(stdlib_UNPREFIXED),$(call stdlib_prefix,$m))\
+  $(call capitalize, $(otherlibref))
 build/libref.mld:
 	echo {0 OCaml standard library} {!modules:$(stdlib_INDEX)} > $@
 

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -24,111 +24,180 @@
 # linked in the archive, but they are marked as dependencies to ensure
 # that they are consistent with the interface digests in the archives.
 
-UTILS=utils/config.cmo utils/build_path_prefix_map.cmo utils/misc.cmo \
-  utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
-  utils/clflags.cmo utils/profile.cmo utils/local_store.cmo \
+UTILS = \
+  utils/config.cmo \
+  utils/build_path_prefix_map.cmo \
+  utils/misc.cmo \
+  utils/identifiable.cmo \
+  utils/numbers.cmo \
+  utils/arg_helper.cmo \
+  utils/clflags.cmo \
+  utils/profile.cmo \
+  utils/local_store.cmo \
   utils/load_path.cmo \
-  utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \
-  utils/consistbl.cmo utils/strongly_connected_components.cmo \
-  utils/targetint.cmo utils/int_replace_polymorphic_compare.cmo \
-  utils/domainstate.cmo utils/binutils.cmo utils/lazy_backtrack.cmo \
+  utils/terminfo.cmo \
+  utils/ccomp.cmo \
+  utils/warnings.cmo \
+  utils/consistbl.cmo \
+  utils/strongly_connected_components.cmo \
+  utils/targetint.cmo \
+  utils/int_replace_polymorphic_compare.cmo \
+  utils/domainstate.cmo \
+  utils/binutils.cmo \
+  utils/lazy_backtrack.cmo \
   utils/diffing.cmo
-UTILS_CMI=
+UTILS_CMI =
 
-PARSING=parsing/location.cmo parsing/longident.cmo \
-  parsing/docstrings.cmo parsing/syntaxerr.cmo \
+PARSING = \
+  parsing/location.cmo \
+  parsing/longident.cmo \
+  parsing/docstrings.cmo \
+  parsing/syntaxerr.cmo \
   parsing/ast_helper.cmo \
   parsing/pprintast.cmo \
-  parsing/camlinternalMenhirLib.cmo parsing/parser.cmo \
-  parsing/lexer.cmo parsing/parse.cmo parsing/printast.cmo \
-  parsing/ast_mapper.cmo parsing/ast_iterator.cmo parsing/attr_helper.cmo \
-  parsing/builtin_attributes.cmo parsing/ast_invariants.cmo parsing/depend.cmo
-PARSING_CMI=\
+  parsing/camlinternalMenhirLib.cmo \
+  parsing/parser.cmo \
+  parsing/lexer.cmo \
+  parsing/parse.cmo \
+  parsing/printast.cmo \
+  parsing/ast_mapper.cmo \
+  parsing/ast_iterator.cmo \
+  parsing/attr_helper.cmo \
+  parsing/builtin_attributes.cmo \
+  parsing/ast_invariants.cmo \
+  parsing/depend.cmo
+PARSING_CMI = \
   parsing/asttypes.cmi \
   parsing/parsetree.cmi
 
-TYPING=typing/ident.cmo typing/path.cmo \
-  typing/primitive.cmo typing/type_immediacy.cmo typing/types.cmo \
-  typing/btype.cmo typing/oprint.cmo \
-  typing/subst.cmo typing/predef.cmo \
-  typing/datarepr.cmo file_formats/cmi_format.cmo \
-  typing/persistent_env.cmo typing/env.cmo \
-  typing/typedtree.cmo typing/printtyped.cmo typing/ctype.cmo \
-  typing/printtyp.cmo typing/includeclass.cmo \
-  typing/mtype.cmo typing/envaux.cmo typing/includecore.cmo \
-  typing/tast_iterator.cmo typing/tast_mapper.cmo typing/stypes.cmo \
-  file_formats/cmt_format.cmo typing/cmt2annot.cmo typing/untypeast.cmo \
-  typing/includemod.cmo typing/includemod_errorprinter.cmo \
-  typing/typetexp.cmo typing/printpat.cmo \
-  typing/patterns.cmo typing/parmatch.cmo \
-  typing/typedecl_properties.cmo typing/typedecl_variance.cmo \
-  typing/typedecl_unboxed.cmo typing/typedecl_immediacy.cmo \
+TYPING = \
+  typing/ident.cmo \
+  typing/path.cmo \
+  typing/primitive.cmo \
+  typing/type_immediacy.cmo \
+  typing/types.cmo \
+  typing/btype.cmo \
+  typing/oprint.cmo \
+  typing/subst.cmo \
+  typing/predef.cmo \
+  typing/datarepr.cmo \
+  file_formats/cmi_format.cmo \
+  typing/persistent_env.cmo \
+  typing/env.cmo \
+  typing/typedtree.cmo \
+  typing/printtyped.cmo \
+  typing/ctype.cmo \
+  typing/printtyp.cmo \
+  typing/includeclass.cmo \
+  typing/mtype.cmo \
+  typing/envaux.cmo \
+  typing/includecore.cmo \
+  typing/tast_iterator.cmo \
+  typing/tast_mapper.cmo \
+  typing/stypes.cmo \
+  file_formats/cmt_format.cmo \
+  typing/cmt2annot.cmo \
+  typing/untypeast.cmo \
+  typing/includemod.cmo \
+  typing/includemod_errorprinter.cmo \
+  typing/typetexp.cmo \
+  typing/printpat.cmo \
+  typing/patterns.cmo \
+  typing/parmatch.cmo \
+  typing/typedecl_properties.cmo \
+  typing/typedecl_variance.cmo \
+  typing/typedecl_unboxed.cmo \
+  typing/typedecl_immediacy.cmo \
   typing/typedecl_separability.cmo \
-  typing/typedecl.cmo typing/typeopt.cmo \
-  typing/rec_check.cmo typing/typecore.cmo typing/typeclass.cmo \
+  typing/typedecl.cmo \
+  typing/typeopt.cmo \
+  typing/rec_check.cmo \
+  typing/typecore.cmo \
+  typing/typeclass.cmo \
   typing/typemod.cmo
-TYPING_CMI=\
+TYPING_CMI = \
   typing/annot.cmi \
   typing/outcometree.cmi
 
-LAMBDA=lambda/debuginfo.cmo \
-  lambda/lambda.cmo lambda/printlambda.cmo \
-  lambda/switch.cmo lambda/matching.cmo \
-  lambda/translobj.cmo lambda/translattribute.cmo \
-  lambda/translprim.cmo lambda/translcore.cmo \
-  lambda/translclass.cmo lambda/translmod.cmo \
-  lambda/simplif.cmo lambda/runtimedef.cmo
-LAMBDA_CMI=
+LAMBDA = \
+  lambda/debuginfo.cmo \
+  lambda/lambda.cmo \
+  lambda/printlambda.cmo \
+  lambda/switch.cmo \
+  lambda/matching.cmo \
+  lambda/translobj.cmo \
+  lambda/translattribute.cmo \
+  lambda/translprim.cmo \
+  lambda/translcore.cmo \
+  lambda/translclass.cmo \
+  lambda/translmod.cmo \
+  lambda/simplif.cmo \
+  lambda/runtimedef.cmo
+LAMBDA_CMI =
 
-COMP=\
-  bytecomp/meta.cmo bytecomp/opcodes.cmo \
-  bytecomp/bytesections.cmo bytecomp/dll.cmo \
+COMP = \
+  bytecomp/meta.cmo \
+  bytecomp/opcodes.cmo \
+  bytecomp/bytesections.cmo \
+  bytecomp/dll.cmo \
   bytecomp/symtable.cmo \
-  driver/pparse.cmo driver/compenv.cmo \
-  driver/main_args.cmo driver/compmisc.cmo \
+  driver/pparse.cmo \
+  driver/compenv.cmo \
+  driver/main_args.cmo \
+  driver/compmisc.cmo \
   driver/makedepend.cmo \
   driver/compile_common.cmo
-COMP_CMI=\
+COMP_CMI = \
   file_formats/cmo_format.cmi \
   file_formats/cmx_format.cmi \
   file_formats/cmxs_format.cmi
 # All file format descriptions (including cmx{,s}) are in the
 # ocamlcommon library so that ocamlobjinfo can depend on them.
 
-COMMON_CMI=$(UTILS_CMI) $(PARSING_CMI) $(TYPING_CMI) $(LAMBDA_CMI) $(COMP_CMI)
+COMMON_CMI = $(UTILS_CMI) $(PARSING_CMI) $(TYPING_CMI) $(LAMBDA_CMI) $(COMP_CMI)
 
-COMMON=$(UTILS) $(PARSING) $(TYPING) $(LAMBDA) $(COMP)
+COMMON = $(UTILS) $(PARSING) $(TYPING) $(LAMBDA) $(COMP)
 
-BYTECOMP=bytecomp/instruct.cmo bytecomp/bytegen.cmo \
-  bytecomp/printinstr.cmo bytecomp/emitcode.cmo \
-  bytecomp/bytelink.cmo bytecomp/bytelibrarian.cmo bytecomp/bytepackager.cmo \
-  driver/errors.cmo driver/compile.cmo driver/maindriver.cmo
-BYTECOMP_CMI=
+BYTECOMP = \
+  bytecomp/instruct.cmo \
+  bytecomp/bytegen.cmo \
+  bytecomp/printinstr.cmo \
+  bytecomp/emitcode.cmo \
+  bytecomp/bytelink.cmo \
+  bytecomp/bytelibrarian.cmo \
+  bytecomp/bytepackager.cmo \
+  driver/errors.cmo \
+  driver/compile.cmo \
+  driver/maindriver.cmo
+BYTECOMP_CMI =
 
-INTEL_ASM=\
+INTEL_ASM = \
   asmcomp/x86_proc.cmo \
   asmcomp/x86_dsl.cmo \
   asmcomp/x86_gas.cmo \
   asmcomp/x86_masm.cmo
-INTEL_ASM_CMI=\
+INTEL_ASM_CMI = \
   asmcomp/x86_ast.cmi
 
-ARCH_SPECIFIC_ASMCOMP=
-ARCH_SPECIFIC_ASMCOMP_CMI=
+ARCH_SPECIFIC_ASMCOMP =
+ARCH_SPECIFIC_ASMCOMP_CMI =
 ifeq ($(ARCH),i386)
-ARCH_SPECIFIC_ASMCOMP=$(INTEL_ASM)
-ARCH_SPECIFIC_ASMCOMP_CMI=$(INTEL_ASM_CMI)
+ARCH_SPECIFIC_ASMCOMP = $(INTEL_ASM)
+ARCH_SPECIFIC_ASMCOMP_CMI = $(INTEL_ASM_CMI)
 endif
 ifeq ($(ARCH),amd64)
-ARCH_SPECIFIC_ASMCOMP=$(INTEL_ASM)
-ARCH_SPECIFIC_ASMCOMP_CMI=$(INTEL_ASM_CMI)
+ARCH_SPECIFIC_ASMCOMP = $(INTEL_ASM)
+ARCH_SPECIFIC_ASMCOMP_CMI = $(INTEL_ASM_CMI)
 endif
 
-ASMCOMP=\
+ASMCOMP = \
   $(ARCH_SPECIFIC_ASMCOMP) \
   asmcomp/arch.cmo \
-  asmcomp/cmm.cmo asmcomp/printcmm.cmo \
-  asmcomp/reg.cmo asmcomp/mach.cmo asmcomp/proc.cmo \
+  asmcomp/cmm.cmo \
+  asmcomp/printcmm.cmo \
+  asmcomp/reg.cmo \
+  asmcomp/mach.cmo \
+  asmcomp/proc.cmo \
   asmcomp/afl_instrument.cmo \
   asmcomp/strmatch.cmo \
   asmcomp/cmmgen_state.cmo \
@@ -136,39 +205,53 @@ ASMCOMP=\
   asmcomp/cmmgen.cmo \
   asmcomp/cmm_invariants.cmo \
   asmcomp/interval.cmo \
-  asmcomp/printmach.cmo asmcomp/selectgen.cmo \
+  asmcomp/printmach.cmo \
+  asmcomp/selectgen.cmo \
   asmcomp/selection.cmo \
   asmcomp/comballoc.cmo \
-  asmcomp/CSEgen.cmo asmcomp/CSE.cmo \
+  asmcomp/CSEgen.cmo \
+  asmcomp/CSE.cmo \
   asmcomp/liveness.cmo \
-  asmcomp/spill.cmo asmcomp/split.cmo \
-  asmcomp/interf.cmo asmcomp/coloring.cmo \
+  asmcomp/spill.cmo \
+  asmcomp/split.cmo \
+  asmcomp/interf.cmo \
+  asmcomp/coloring.cmo \
   asmcomp/linscan.cmo \
-  asmcomp/reloadgen.cmo asmcomp/reload.cmo \
+  asmcomp/reloadgen.cmo \
+  asmcomp/reload.cmo \
   asmcomp/deadcode.cmo \
-  asmcomp/linear.cmo asmcomp/printlinear.cmo asmcomp/linearize.cmo \
+  asmcomp/linear.cmo \
+  asmcomp/printlinear.cmo \
+  asmcomp/linearize.cmo \
   file_formats/linear_format.cmo \
-  asmcomp/schedgen.cmo asmcomp/scheduling.cmo \
+  asmcomp/schedgen.cmo \
+  asmcomp/scheduling.cmo \
   asmcomp/branch_relaxation_intf.cmo \
   asmcomp/branch_relaxation.cmo \
-  asmcomp/emitaux.cmo asmcomp/emit.cmo asmcomp/asmgen.cmo \
-  asmcomp/asmlink.cmo asmcomp/asmlibrarian.cmo asmcomp/asmpackager.cmo \
-  driver/opterrors.cmo driver/optcompile.cmo driver/optmaindriver.cmo
-ASMCOMP_CMI=$(ARCH_SPECIFIC_ASMCOMP_CMI)
+  asmcomp/emitaux.cmo \
+  asmcomp/emit.cmo \
+  asmcomp/asmgen.cmo \
+  asmcomp/asmlink.cmo \
+  asmcomp/asmlibrarian.cmo \
+  asmcomp/asmpackager.cmo \
+  driver/opterrors.cmo \
+  driver/optcompile.cmo \
+  driver/optmaindriver.cmo
+ASMCOMP_CMI = $(ARCH_SPECIFIC_ASMCOMP_CMI)
 
 # Files under middle_end/ are not to reference files under asmcomp/.
 # This ensures that the middle end can be linked (e.g. for objinfo) even when
 # the native code compiler is not present for some particular target.
 
-MIDDLE_END_CLOSURE=\
+MIDDLE_END_CLOSURE = \
   middle_end/closure/closure.cmo \
   middle_end/closure/closure_middle_end.cmo
-MIDDLE_END_CLOSURE_CMI=
+MIDDLE_END_CLOSURE_CMI =
 
 # Owing to dependencies through [Compilenv], which would be
 # difficult to remove, some of the lower parts of Flambda (anything that is
 # saved in a .cmx file) have to be included in the [MIDDLE_END] stanza, below.
-MIDDLE_END_FLAMBDA=\
+MIDDLE_END_FLAMBDA = \
   middle_end/flambda/import_approx.cmo \
   middle_end/flambda/lift_code.cmo \
   middle_end/flambda/closure_conversion_aux.cmo \
@@ -207,11 +290,11 @@ MIDDLE_END_FLAMBDA=\
   middle_end/flambda/un_anf.cmo \
   middle_end/flambda/flambda_to_clambda.cmo \
   middle_end/flambda/flambda_middle_end.cmo
-MIDDLE_END_FLAMBDA_CMI=\
+MIDDLE_END_FLAMBDA_CMI = \
   middle_end/flambda/inlining_decision_intf.cmi \
   middle_end/flambda/simplify_boxed_integer_ops_intf.cmi
 
-MIDDLE_END=\
+MIDDLE_END = \
   middle_end/internal_variable_names.cmo \
   middle_end/linkage_name.cmo \
   middle_end/compilation_unit.cmo \
@@ -251,26 +334,44 @@ MIDDLE_END=\
   middle_end/compilenv.cmo \
   $(MIDDLE_END_CLOSURE) \
   $(MIDDLE_END_FLAMBDA)
-MIDDLE_END_CMI=\
+MIDDLE_END_CMI = \
   middle_end/backend_intf.cmi \
   $(MIDDLE_END_CLOSURE_CMI) \
   $(MIDDLE_END_FLAMBDA_CMI)
 
-OPTCOMP=$(MIDDLE_END) $(ASMCOMP)
-OPTCOMP_CMI=$(MIDDLE_END_CMI) $(ASMCOMP_CMI)
+OPTCOMP = $(MIDDLE_END) $(ASMCOMP)
+OPTCOMP_CMI = $(MIDDLE_END_CMI) $(ASMCOMP_CMI)
 
-TOPLEVEL=toplevel/genprintval.cmo toplevel/topcommon.cmo \
-  toplevel/byte/topeval.cmo toplevel/byte/trace.cmo toplevel/toploop.cmo \
-  toplevel/topdirs.cmo toplevel/byte/topmain.cmo
-TOPLEVEL_CMI=toplevel/topcommon.cmi toplevel/byte/topeval.cmi \
-  toplevel/byte/trace.cmi toplevel/toploop.cmi toplevel/topdirs.cmi \
+TOPLEVEL = \
+  toplevel/genprintval.cmo \
+  toplevel/topcommon.cmo \
+  toplevel/byte/topeval.cmo \
+  toplevel/byte/trace.cmo \
+  toplevel/toploop.cmo \
+  toplevel/topdirs.cmo \
+  toplevel/byte/topmain.cmo
+TOPLEVEL_CMI = \
+  toplevel/topcommon.cmi \
+  toplevel/byte/topeval.cmi \
+  toplevel/byte/trace.cmi \
+  toplevel/toploop.cmi \
+  toplevel/topdirs.cmi \
   toplevel/byte/topmain.cmi
 
-OPTTOPLEVEL=toplevel/genprintval.cmo toplevel/topcommon.cmo \
-  toplevel/native/topeval.cmo toplevel/native/trace.cmo toplevel/toploop.cmo \
-  toplevel/topdirs.cmo toplevel/native/topmain.cmo
-OPTTOPLEVEL_CMI=toplevel/topcommon.cmi toplevel/native/topeval.cmi \
-  toplevel/native/trace.cmi toplevel/toploop.cmi toplevel/topdirs.cmi \
+OPTTOPLEVEL = \
+  toplevel/genprintval.cmo \
+  toplevel/topcommon.cmo \
+  toplevel/native/topeval.cmo \
+  toplevel/native/trace.cmo \
+  toplevel/toploop.cmo \
+  toplevel/topdirs.cmo \
+  toplevel/native/topmain.cmo
+OPTTOPLEVEL_CMI = \
+  toplevel/topcommon.cmi \
+  toplevel/native/topeval.cmi \
+  toplevel/native/trace.cmi \
+  toplevel/toploop.cmi \
+  toplevel/topdirs.cmi \
   toplevel/native/topmain.cmi
 
 TOPLEVEL_SHARED_MLIS = topeval.mli trace.mli topmain.mli

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -25,14 +25,14 @@
 # that they are consistent with the interface digests in the archives.
 
 UTILS=utils/config.cmo utils/build_path_prefix_map.cmo utils/misc.cmo \
-	utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
-	utils/clflags.cmo utils/profile.cmo utils/local_store.cmo \
-	utils/load_path.cmo \
-	utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \
-	utils/consistbl.cmo utils/strongly_connected_components.cmo \
-	utils/targetint.cmo utils/int_replace_polymorphic_compare.cmo \
-	utils/domainstate.cmo utils/binutils.cmo utils/lazy_backtrack.cmo \
-        utils/diffing.cmo
+  utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
+  utils/clflags.cmo utils/profile.cmo utils/local_store.cmo \
+  utils/load_path.cmo \
+  utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \
+  utils/consistbl.cmo utils/strongly_connected_components.cmo \
+  utils/targetint.cmo utils/int_replace_polymorphic_compare.cmo \
+  utils/domainstate.cmo utils/binutils.cmo utils/lazy_backtrack.cmo \
+  utils/diffing.cmo
 UTILS_CMI=
 
 PARSING=parsing/location.cmo parsing/longident.cmo \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -30,7 +30,7 @@ OCAMLOPT=$(BEST_OCAMLOPT) -g -nostdlib -I $(ROOTDIR)/stdlib
 # COMPFLAGS should be in sync with the toplevel Makefile's COMPFLAGS.
 COMPFLAGS=-strict-sequence -principal -absname \
           -w +a-4-9-40-41-42-44-45-48-66-70 \
-	  -warn-error +A \
+          -warn-error +A \
           -bin-annot -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS += -O3

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -246,11 +246,11 @@ prims.c : primitives
 	 echo '#include "caml/prims.h"'; \
 	 sed -e 's/.*/extern value &();/' primitives; \
 	 echo 'c_primitive caml_builtin_cprim[] = {'; \
-	 sed -e 's/.*/	&,/' primitives; \
-	 echo '	 0 };'; \
+	 sed -e 's/.*/  &,/' primitives; \
+	 echo '  0 };'; \
 	 echo 'char * caml_names_of_builtin_cprim[] = {'; \
-	 sed -e 's/.*/	"&",/' primitives; \
-	 echo '	 0 };') > prims.c
+	 sed -e 's/.*/  "&",/' primitives; \
+	 echo '  0 };') > prims.c
 
 caml/opnames.h : caml/instruct.h
 	tr -d '\r' < $< | \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -143,7 +143,7 @@ installopt::
 # To help building mixed-mode libraries (OCaml + C)
 
 $(call byte_and_opt,ocamlmklib,config.cmo \
-	         build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo,)
+                    build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo,)
 
 # To make custom toplevels
 
@@ -273,8 +273,8 @@ $(call byte_and_opt,primreq,$(primreq),)
 LINTAPIDIFF=$(ROOTDIR)/compilerlibs/ocamlcommon.cmxa \
         $(ROOTDIR)/compilerlibs/ocamlbytecomp.cmxa \
         $(ROOTDIR)/compilerlibs/ocamlmiddleend.cmxa \
-	$(ROOTDIR)/otherlibs/str/str.cmxa \
-	lintapidiff.cmx
+        $(ROOTDIR)/otherlibs/str/str.cmxa \
+        lintapidiff.cmx
 
 lintapidiff.opt$(EXE): INCLUDES+= -I $(ROOTDIR)/otherlibs/str
 lintapidiff.opt$(EXE): $(LINTAPIDIFF)

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -303,9 +303,48 @@ EXIT_CODE=0
           }
         }
 
-        BEGIN { state = "(first line)"; }
+        BEGIN { state = "(first line)"; in_recipe = 0; in_continuation = 0; }
 
-        match($0, /\t/) {
+        # Makefile recipe automaton
+
+        # in_continuation == 1 if the line ends with a backslash
+        # in_recipe is:
+        #   0 - not in a recipe
+        #   1 - target line scanned, but not yet seen first recipe line
+        #   2 - scanning recipe lines
+
+        # Non-recipe line
+        match($0, /^[^\t#] *[^# ]/) {
+          if (!in_continuation) {
+            if (!match($0, /^(ifn?eq|else|endif)/)) {
+              in_recipe = 0;
+            }
+          }
+        }
+
+        # target: or target:: line
+        match($0, /^[^#]*[^:#]::?($|[^=])/) {
+          if (!in_continuation) {
+            in_recipe = 1;
+          }
+        }
+
+        match($0, /^\t[^\t]+$/) {
+          if (in_recipe == 0 \
+              || in_recipe == 1 && in_continuation \
+              || is_err("makefile-whitespace")) {
+            err("tab", "TAB character(s)");
+          } else {
+            ++ counts["makefile-whitespace"];
+            in_recipe = 2;
+          }
+        }
+
+        match($0, /.$/) {
+          in_continuation = (substr($0, length($0)) == "\\");
+        }
+
+        match($0, /.\t/) {
           err("tab", "TAB character(s)");
           t = utf8_decode($0);
           if (more_columns(t, 80)){


### PR DESCRIPTION
Tabs are of course the bringers of war and general pestilence, we permit them only where working around them would be too hard or impossible.

However, at present once we permit tabs, we just allow them anywhere. This creates an occasional whitespace mess in Makefile definitions, as we have in the root Makefile, for example:

```
COMPFLAGS=-strict-sequence -principal -absname \
          -w +a-4-9-40-41-42-44-45-48-66-70 \
<TAB>  -warn-error +a \
          -bin-annot -safe-string -strict-formats $(INCLUDES)
```

We should either have tabs on each line or that stray `<TAB>` should be eight spaces. It's only a small itch, but it's an itch nonetheless. This PR:

- Stops including tab characters in `runtime/prims.c` (which is generated)
- Removes tabs from the message displayed if you forgot to `configure`
- Refactors a multiline `ifeq` in `Makefile.common` to be a single line. I expect @shindere will like that change regardless, but here it also allows the property that `ifeq`/`ifneq` is always on one line and it's the only place in the entire build system where we were doing this.
- Removes stray tabs from the Makefiles

Finally, just enough knowledge is added to `check-typo` to enforce this - so now a _single_ tab character is permitted at the start of recipe lines only.

There is a further change which could be made: we are inconsistent on the use of tabs when splitting recipe lines over multiple lines:

```
target:
<TAB>command \
<TAB>parameter1 \
  parameter2 \
<TAB>parameter2
```

Only permitting `<TAB>` at the start of the recipe line involves deleting `in_recipe == 1 && ` in the change below. _Requiring_ a `<TAB>` at the start of every line in a recipe adds a further 3 lines to the script. However, we're _really_ inconsistent with that, so it's a big whitespace change in the repo where this PR at present is not.