### PR TITLE
#6985 extended: ghost row types should stay hidden

### DIFF
--- a/Changes
+++ b/Changes
@@ -348,6 +348,9 @@ Working version
 
 ### Bug fixes:
 
+- #6985, #10385: remove all ghost row types from included modules
+  (Florian Angeletti, review by Gabriel Scherer)
+
 * #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section
   when the systhreads library is loaded.
   (David Allsopp, report by Anton Bachin, review by Xavier Leroy)

--- a/testsuite/tests/typing-modules-bugs/pr6985_extended.ml
+++ b/testsuite/tests/typing-modules-bugs/pr6985_extended.ml
@@ -1,0 +1,30 @@
+(* TEST
+  * expect
+*)
+
+
+
+module Root = struct
+  type u
+  and t = private < .. >
+end
+
+module Trunk = struct
+  include Root
+  type t = A
+  type u
+end
+
+module M: sig
+  module type s = module type of Trunk
+end = struct
+  module type s = sig
+    type t = A
+    type u
+  end
+end
+[%%expect {|
+module Root : sig type u and t = private < .. > end
+module Trunk : sig type t = A type u end
+module M : sig module type s = sig type t = A type u end end
+|}]

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -54,9 +54,8 @@ and strengthen_sig ~aliasable env sg p =
     [] -> []
   | (Sig_value(_, _, _) as sigelt) :: rem ->
       sigelt :: strengthen_sig ~aliasable env rem p
-  | Sig_type(id, {type_kind=Type_abstract}, _, _) ::
-    (Sig_type(id', {type_private=Private}, _, _) :: _ as rem)
-    when Ident.name id = Ident.name id' ^ "#row" ->
+  | Sig_type(id, {type_kind=Type_abstract}, _, _) :: rem
+    when Btype.is_row_name (Ident.name id) ->
       strengthen_sig ~aliasable env rem p
   | Sig_type(id, decl, rs, vis) :: rem ->
       let newdecl =


### PR DESCRIPTION
This PR fixes a lapse in `Mtype.strengthen_sig` that makes it possible to observe a ghost row type (e.g. `t#row`) with the following sequence of events:

```ocaml
module Root = struct
  (* type t#row *)
  type u
  and t = private < .. >
end

module Trunk = struct
  include Root (* type t#row = Root.t#row *)
  type t = A
  type u
end

module M: module type of Trunk = struct
    type t = A
    type u
end
```
>```
> Error: Signature mismatch:
>       Modules do not match:
>         sig type t = A type u end
>       is not included in
>         sig type t = A type u end
>       The type `t#row' is required but not provided
>```

The problem stems from the strengthening of signatures in `Mtype.strenghtenen_sig` that was only conditionally removing ghost row types when they were immediately followed by their core type.
However, ghost and core types are not immediate neighbor in a recursive definition (like the one in `Root`).

This PR fixes this issue by removing all ghost row items from a strengthened signature unconditionally.
(This is extracted from a in-progress work with @gasche to fix #9774)