### PR TITLE
toplevel: fix the printing of list abbreviations.

### DIFF
--- a/Changes
+++ b/Changes
@@ -360,9 +360,9 @@ Working version
   in presence of a name collision.
   (Florian Angeletti, report by Thomas Refis, review by Gabriel Scherer)
 
-- #9936: Make sure that `List.([1;2;3])` is printed `[1;2;3]` in the toplevel
-  by identifying lists by their types.
-  (Florian Angeletti, review by Gabriel Scherer)
+- #9936, #???: Make sure that `List.([1;2;3])` is printed `[1;2;3]` in
+  the toplevel by identifying lists by their types in case of re-exports.
+  (Florian Angeletti, review by Gabriel Scherer and Leo White)
 
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
   (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)

--- a/testsuite/tests/tool-toplevel/exotic_lists.compilers.reference
+++ b/testsuite/tests/tool-toplevel/exotic_lists.compilers.reference
@@ -7,4 +7,6 @@ L.(::) ([1; 2],
 module L : sig type 'a t = 'a list = [] | (::) of 'a * 'a t end
 - : int L.t L.t = [[1]; [2]; [3]; [4]; [5]]
 - : int L.t = [1; 2; 3; 4; 5]
+module List_abbrev : sig type ('a, 'b) t = ('a * 'b option) option list end
+val l : (int, 'a) List_abbrev.t = [None; Some (0, None)]
 

--- a/testsuite/tests/tool-toplevel/exotic_lists.ml
+++ b/testsuite/tests/tool-toplevel/exotic_lists.ml
@@ -15,3 +15,9 @@ end;;
 L.[[1];[2];[3];[4];[5]];;
 open L;;
 [1;2;3;4;5];;
+
+module List_abbrev = struct
+  type ('a,'b) t = ('a * 'b option) option list
+end
+let l: _ List_abbrev.t = [None; Some(0,None)]
+;;


### PR DESCRIPTION
This PR fixes a mistake that I added when improving the printing of re-exported lists.
The new code handle correctly  (and separately) both list abbreviation (`type ('a,'b) t = ('a option * 'b) list`) and re-export of the list type (in particular `List.([1;2;3])`). 