### PR TITLE
Fix handling of exception-raising specific operations during liveness analysis

### DIFF
--- a/Changes
+++ b/Changes
@@ -432,10 +432,11 @@ Working version
   (David Allsopp, review by Nicolás Ojeda Bär)
 
 - #10339, #10354, #10387: Fix handling of exception-raising specific
-   operations during spilling and liveness analysis.
+  operations during spilling and liveness analysis.
   (This bug affects ARM and ARM64.)
-   In passing, refactor Proc.op_is_pure and Mach.operation_can_raise.
-  (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan)
+  In passing, refactor Proc.op_is_pure and Mach.operation_can_raise.
+  (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan
+   and Mark Shinwell)
 
 - #10371: no longer generatd useless `.cds` file when using
   `-output-complete-exe`.

--- a/Changes
+++ b/Changes
@@ -431,8 +431,9 @@ Working version
 - #10351: Fix DLL loading with binutils 2.36+ on mingw-w64
   (David Allsopp, review by Nicolás Ojeda Bär)
 
-- #10339, #10354: Fix handling of exception-raising specific
-   operations during spilling.  (This bug affects ARM and ARM64.)
+- #10339, #10354, #10387: Fix handling of exception-raising specific
+   operations during spilling and liveness analysis.
+  (This bug affects ARM and ARM64.)
    In passing, refactor Proc.op_is_pure and Mach.operation_can_raise.
   (Xavier Leroy, report by Richard Bornat, review by Stephen Dolan)
 


### PR DESCRIPTION
This is a follow-up to 15e635462 and #10354.

During liveness analysis, use the `Mach.operation_can_raise` predicate instead of an ad-hoc pattern matching to spot operations where the variables live at entry to the enclosing exception handler must also be live.

The ad-hoc pattern matching was missing the `Ishiftcheckbound` specific operations of ARM and ARM64.  (Same bug as #10339.)
