### PR TITLE
Add emitenv and cmm_invariants to dune file

### DIFF
--- a/dune
+++ b/dune
@@ -145,13 +145,15 @@
  (wrapped false)
  (flags (:standard -principal -nostdlib))
  (libraries stdlib ocamlcommon ocamlmiddleend)
- (modules_without_implementation x86_ast)
+ (modules_without_implementation x86_ast emitenv)
  (modules
    ;; asmcomp/
    afl_instrument arch asmgen asmlibrarian asmlink asmpackager branch_relaxation
    branch_relaxation_intf cmm_helpers cmm cmmgen cmmgen_state coloring comballoc
+   cmm_invariants
    CSE CSEgen
    deadcode domainstate emit emitaux interf interval linear linearize linscan
+   emitenv
    liveness mach printcmm printlinear printmach proc reg reload reloadgen
    schedgen scheduling selectgen selection spill split
    strmatch x86_ast x86_dsl x86_gas x86_masm x86_proc


### PR DESCRIPTION
As suggested in https://github.com/ocaml/ocaml/pull/8936#issuecomment-831101603, this fixed `dune build @libs` failure described in https://github.com/ocaml/ocaml/pull/8936#issuecomment-831090290. 