### PR TITLE
Add {Int,Int32,Int64,Nativeint}.{min,max}

### DIFF
--- a/Changes
+++ b/Changes
@@ -162,6 +162,9 @@ Working version
 - #882: Add fold_left, fold_right, exists and for_all to String/Bytes
   (Yotam Barnoy, review by Alain Frisch and Jeremy Yallop)
 
+- #10391: Add {Int,Int32,Int64,Nativeint}.{min,max}.
+  (Nicolás Ojeda Bär, review by Xavier Leroy)
+
 ### Other libraries:
 
 - #10047: Add `Unix.realpath`

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -3,6 +3,7 @@ stdlib__Arg.cmo : arg.ml \
     stdlib__String.cmi \
     stdlib__Printf.cmi \
     stdlib__List.cmi \
+    stdlib__Int.cmi \
     stdlib__Buffer.cmi \
     stdlib__Array.cmi \
     stdlib__Arg.cmi
@@ -11,6 +12,7 @@ stdlib__Arg.cmx : arg.ml \
     stdlib__String.cmx \
     stdlib__Printf.cmx \
     stdlib__List.cmx \
+    stdlib__Int.cmx \
     stdlib__Buffer.cmx \
     stdlib__Array.cmx \
     stdlib__Arg.cmi
@@ -80,12 +82,14 @@ stdlib__Bytes.cmo : bytes.ml \
     stdlib__Sys.cmi \
     stdlib.cmi \
     stdlib__Seq.cmi \
+    stdlib__Int.cmi \
     stdlib__Char.cmi \
     stdlib__Bytes.cmi
 stdlib__Bytes.cmx : bytes.ml \
     stdlib__Sys.cmx \
     stdlib.cmx \
     stdlib__Seq.cmx \
+    stdlib__Int.cmx \
     stdlib__Char.cmx \
     stdlib__Bytes.cmi
 stdlib__Bytes.cmi : bytes.mli \
@@ -213,6 +217,7 @@ stdlib__Ephemeron.cmo : ephemeron.ml \
     stdlib__Random.cmi \
     stdlib__Obj.cmi \
     stdlib__Lazy.cmi \
+    stdlib__Int.cmi \
     stdlib__Hashtbl.cmi \
     stdlib__Array.cmi \
     stdlib__Ephemeron.cmi
@@ -222,6 +227,7 @@ stdlib__Ephemeron.cmx : ephemeron.ml \
     stdlib__Random.cmx \
     stdlib__Obj.cmx \
     stdlib__Lazy.cmx \
+    stdlib__Int.cmx \
     stdlib__Hashtbl.cmx \
     stdlib__Array.cmx \
     stdlib__Ephemeron.cmi
@@ -338,6 +344,7 @@ stdlib__Hashtbl.cmo : hashtbl.ml \
     stdlib__Random.cmi \
     stdlib__Obj.cmi \
     stdlib__Lazy.cmi \
+    stdlib__Int.cmi \
     stdlib__Array.cmi \
     stdlib__Hashtbl.cmi
 stdlib__Hashtbl.cmx : hashtbl.ml \
@@ -347,6 +354,7 @@ stdlib__Hashtbl.cmx : hashtbl.ml \
     stdlib__Random.cmx \
     stdlib__Obj.cmx \
     stdlib__Lazy.cmx \
+    stdlib__Int.cmx \
     stdlib__Array.cmx \
     stdlib__Hashtbl.cmi
 stdlib__Hashtbl.cmi : hashtbl.mli \
@@ -387,12 +395,14 @@ stdlib__Lazy.cmi : lazy.mli \
 stdlib__Lexing.cmo : lexing.ml \
     stdlib__Sys.cmi \
     stdlib__String.cmi \
+    stdlib__Int.cmi \
     stdlib__Bytes.cmi \
     stdlib__Array.cmi \
     stdlib__Lexing.cmi
 stdlib__Lexing.cmx : lexing.ml \
     stdlib__Sys.cmx \
     stdlib__String.cmx \
+    stdlib__Int.cmx \
     stdlib__Bytes.cmx \
     stdlib__Array.cmx \
     stdlib__Lexing.cmi
@@ -581,6 +591,7 @@ stdlib__Scanf.cmo : scanf.ml \
     stdlib.cmi \
     stdlib__Printf.cmi \
     stdlib__List.cmi \
+    stdlib__Int.cmi \
     camlinternalFormatBasics.cmi \
     camlinternalFormat.cmi \
     stdlib__Bytes.cmi \
@@ -591,6 +602,7 @@ stdlib__Scanf.cmx : scanf.ml \
     stdlib.cmx \
     stdlib__Printf.cmx \
     stdlib__List.cmx \
+    stdlib__Int.cmx \
     camlinternalFormatBasics.cmx \
     camlinternalFormat.cmx \
     stdlib__Bytes.cmx \
@@ -695,12 +707,14 @@ stdlib__Unit.cmi : unit.mli
 stdlib__Weak.cmo : weak.ml \
     stdlib__Sys.cmi \
     stdlib__Obj.cmi \
+    stdlib__Int.cmi \
     stdlib__Hashtbl.cmi \
     stdlib__Array.cmi \
     stdlib__Weak.cmi
 stdlib__Weak.cmx : weak.ml \
     stdlib__Sys.cmx \
     stdlib__Obj.cmx \
+    stdlib__Int.cmx \
     stdlib__Hashtbl.cmx \
     stdlib__Array.cmx \
     stdlib__Weak.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -35,8 +35,8 @@
 # with lowercase first letters). These must be listed in dependency order.
 STDLIB_MODULE_BASENAMES=\
   camlinternalFormatBasics camlinternalAtomic \
-  stdlib pervasives seq option either result bool char uchar \
-  sys list bytes string unit marshal obj array float int int32 int64 nativeint \
+  stdlib pervasives int seq option either result bool char uchar \
+  sys list bytes string unit marshal obj array float int32 int64 nativeint \
   lexing parsing set map stack queue camlinternalLazy lazy stream buffer \
   camlinternalFormat printf arg atomic \
   printexc fun gc digest random hashtbl weak \

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -339,8 +339,8 @@ let second_word s =
 
 let max_arg_len cur (kwd, spec, doc) =
   match spec with
-  | Symbol _ -> max cur (String.length kwd)
-  | _ -> max cur (String.length kwd + second_word doc)
+  | Symbol _ -> Int.max cur (String.length kwd)
+  | _ -> Int.max cur (String.length kwd + second_word doc)
 
 
 let replace_leading_tab s =
@@ -355,7 +355,7 @@ let add_padding len ksd =
       ksd
   | (kwd, (Symbol _ as spec), msg) ->
       let cutcol = second_word msg in
-      let spaces = String.make ((max 0 (len - cutcol)) + 3) ' ' in
+      let spaces = String.make ((Int.max 0 (len - cutcol)) + 3) ' ' in
       (kwd, spec, "\n" ^ spaces ^ replace_leading_tab msg)
   | (kwd, spec, msg) ->
       let cutcol = second_word msg in
@@ -373,7 +373,7 @@ let add_padding len ksd =
 let align ?(limit=max_int) speclist =
   let completed = add_help speclist in
   let len = List.fold_left max_arg_len 0 completed in
-  let len = min len limit in
+  let len = Int.min len limit in
   List.map (add_padding len) completed
 
 let trim_cr s =

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -84,7 +84,7 @@ let extend s left right =
   let len = length s ++ left ++ right in
   let r = create len in
   let (srcoff, dstoff) = if left < 0 then -left, 0 else 0, left in
-  let cpylen = min (length s - srcoff) (len - dstoff) in
+  let cpylen = Int.min (length s - srcoff) (len - dstoff) in
   if cpylen > 0 then unsafe_blit s srcoff r dstoff cpylen;
   r
 
@@ -418,7 +418,7 @@ let of_seq i =
   let buf = ref (make 256 '\000') in
   let resize () =
     (* resize *)
-    let new_len = min (2 * length !buf) Sys.max_string_length in
+    let new_len = Int.min (2 * length !buf) Sys.max_string_length in
     if length !buf = new_len then failwith "Bytes.of_seq: cannot grow bytes";
     let new_buf = make new_len '\000' in
     blit !buf 0 new_buf 0 !n;

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -260,7 +260,7 @@ let buffer_check_size buf overhead =
   let len = Bytes.length buf.bytes in
   let min_len = buf.ind + overhead in
   if min_len > len then (
-    let new_len = max (len * 2) min_len in
+    let new_len = Int.max (len * 2) min_len in
     let new_str = Bytes.create new_len in
     Bytes.blit buf.bytes 0 new_str 0 len;
     buf.bytes <- new_str;

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -345,7 +345,7 @@ module GenHashTable = struct
 
     let stats h =
       let mbl =
-        Array.fold_left (fun m b -> max m (bucket_length 0 b)) 0 h.data in
+        Array.fold_left (fun m b -> Int.max m (bucket_length 0 b)) 0 h.data in
       let histo = Array.make (mbl + 1) 0 in
       Array.iter
         (fun b ->
@@ -366,7 +366,7 @@ module GenHashTable = struct
     let stats_alive h =
       let size = ref 0 in
       let mbl =
-        Array.fold_left (fun m b -> max m (bucket_length_alive 0 b)) 0 h.data in
+        Array.fold_left (fun m b -> Int.max m (bucket_length_alive 0 b)) 0 h.data in
       let histo = Array.make (mbl + 1) 0 in
       Array.iter
         (fun b ->

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -366,7 +366,8 @@ module GenHashTable = struct
     let stats_alive h =
       let size = ref 0 in
       let mbl =
-        Array.fold_left (fun m b -> Int.max m (bucket_length_alive 0 b)) 0 h.data in
+        Array.fold_left
+          (fun m b -> Int.max m (bucket_length_alive 0 b)) 0 h.data in
       let histo = Array.make (mbl + 1) 0 in
       Array.iter
         (fun b ->

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -270,7 +270,7 @@ let break_new_line state (before, offset, after) width =
   state.pp_is_new_line <- true;
   let indent = state.pp_margin - width + offset in
   (* Don't indent more than pp_max_indent. *)
-  let real_indent = min state.pp_max_indent indent in
+  let real_indent = Int.min state.pp_max_indent indent in
   state.pp_current_indent <- real_indent;
   state.pp_space_left <- state.pp_margin - state.pp_current_indent;
   pp_output_indent state state.pp_current_indent;
@@ -806,8 +806,8 @@ let pp_set_margin state n =
       (* If possible maintain pp_min_space_left to its actual value,
          if this leads to a too small max_indent, take half of the
          new margin, if it is greater than 1. *)
-       max (max (state.pp_margin - state.pp_min_space_left)
-                (state.pp_margin / 2)) 1 in
+       Int.max (Int.max (state.pp_margin - state.pp_min_space_left)
+                  (state.pp_margin / 2)) 1 in
     (* Rebuild invariants. *)
     pp_set_max_indent state new_max_indent
 

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -236,7 +236,7 @@ let rec bucket_length accu = function
 
 let stats h =
   let mbl =
-    Array.fold_left (fun m b -> max m (bucket_length 0 b)) 0 h.data in
+    Array.fold_left (fun m b -> Int.max m (bucket_length 0 b)) 0 h.data in
   let histo = Array.make (mbl + 1) 0 in
   Array.iter
     (fun b ->

--- a/stdlib/int.ml
+++ b/stdlib/int.ml
@@ -48,3 +48,6 @@ let of_string s = try Some (int_of_string s) with Failure _ -> None
 
 external format_int : string -> int -> string = "caml_format_int"
 let to_string x = format_int "%d" x
+
+let min (x : int) (y : int) = if x <= y then x else y
+let max (x : int) (y : int) = if x >= y then x else y

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -144,7 +144,9 @@ val to_string : int -> string
 (** [to_string x] is the written representation of [x] in decimal. *)
 
 val min : int -> int -> int
-(** Return the smaller of the two integers. *)
+(** Return the smaller of the two integers.
+    @since 4.13.0 *)
 
 val max : int -> int -> int
-(** Return the greater of the two integers. *)
+(** Return the greater of the two integers.
+    @since 4.13.0 *)

--- a/stdlib/int.mli
+++ b/stdlib/int.mli
@@ -142,3 +142,9 @@ val of_string : string -> int option
 
 val to_string : int -> string
 (** [to_string x] is the written representation of [x] in decimal. *)
+
+val min : int -> int -> int
+(** Return the smaller of the two integers. *)
+
+val max : int -> int -> int
+(** Return the greater of the two integers. *)

--- a/stdlib/int32.ml
+++ b/stdlib/int32.ml
@@ -99,3 +99,6 @@ let unsigned_div n d =
 
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
+
+let min (x : t) (y : t) = if x <= y then x else y
+let max (x : t) (y : t) = if x >= y then x else y

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -215,6 +215,12 @@ val equal: t -> t -> bool
 (** The equal function for int32s.
     @since 4.03.0 *)
 
+val min: t -> t -> t
+(** Return the smaller of the two 32-bit integers. *)
+
+val max: t -> t -> t
+(** Return the greater of the two 32-bit integers. *)
+
 (**/**)
 
 (** {1 Deprecated functions} *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -216,10 +216,12 @@ val equal: t -> t -> bool
     @since 4.03.0 *)
 
 val min: t -> t -> t
-(** Return the smaller of the two 32-bit integers. *)
+(** Return the smaller of the two 32-bit integers.
+    @since 4.13.0 *)
 
 val max: t -> t -> t
-(** Return the greater of the two 32-bit integers. *)
+(** Return the greater of the two 32-bit integers.
+    @since 4.13.0 *)
 
 (**/**)
 

--- a/stdlib/int64.ml
+++ b/stdlib/int64.ml
@@ -98,3 +98,6 @@ let unsigned_div n d =
 
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
+
+let min (x : t) (y : t) = if x <= y then x else y
+let max (x : t) (y : t) = if x >= y then x else y

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -234,6 +234,12 @@ val equal: t -> t -> bool
 (** The equal function for int64s.
     @since 4.03.0 *)
 
+val min : t -> t -> t
+(** Return the smaller of the two 64-bit integers. *)
+
+val max : t -> t -> t
+(** Return the greater of the two 64-bit integers. *)
+
 (**/**)
 
 (** {1 Deprecated functions} *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -235,10 +235,12 @@ val equal: t -> t -> bool
     @since 4.03.0 *)
 
 val min : t -> t -> t
-(** Return the smaller of the two 64-bit integers. *)
+(** Return the smaller of the two 64-bit integers.
+    @since 4.13.0 *)
 
 val max : t -> t -> t
-(** Return the greater of the two 64-bit integers. *)
+(** Return the greater of the two 64-bit integers.
+    @since 4.13.0 *)
 
 (**/**)
 

--- a/stdlib/lexing.ml
+++ b/stdlib/lexing.ml
@@ -109,7 +109,7 @@ let lex_refill read_fun aux_buffer lexbuf =
          space since n <= String.length aux_buffer <= String.length buffer.
          Watch out for string length overflow, though. *)
       let newlen =
-        min (2 * Bytes.length lexbuf.lex_buffer) Sys.max_string_length in
+        Int.min (2 * Bytes.length lexbuf.lex_buffer) Sys.max_string_length in
       if lexbuf.lex_buffer_len - lexbuf.lex_start_pos + n > newlen
       then failwith "Lexing.lex_refill: cannot grow buffer";
       let newbuf = Bytes.create newlen in

--- a/stdlib/nativeint.ml
+++ b/stdlib/nativeint.ml
@@ -88,3 +88,6 @@ let unsigned_div n d =
 
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
+
+let min (x : t) (y : t) = if x <= y then x else y
+let max (x : t) (y : t) = if x >= y then x else y

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -226,10 +226,12 @@ val equal: t -> t -> bool
     @since 4.03.0 *)
 
 val min : t -> t -> t
-(** Return the smaller of the two native integers. *)
+(** Return the smaller of the two native integers.
+    @since 4.13.0 *)
 
 val max : t -> t -> t
-(** Return the greater of the two native integers. *)
+(** Return the greater of the two native integers.
+    @since 4.13.0 *)
 
 (**/**)
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -225,6 +225,12 @@ val equal: t -> t -> bool
 (** The equal function for native ints.
     @since 4.03.0 *)
 
+val min : t -> t -> t
+(** Return the smaller of the two native integers. *)
+
+val max : t -> t -> t
+(** Return the greater of the two native integers. *)
+
 (**/**)
 
 (** {1 Deprecated functions} *)

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -49,7 +49,7 @@ module State = struct
       s.st.(i) <- i;
     done;
     let accu = ref "x" in
-    for i = 0 to 54 + max 55 l do
+    for i = 0 to 54 + Int.max 55 l do
       let j = i mod 55 in
       let k = i mod l in
       accu := combine !accu seed.(k);

--- a/stdlib/scanf.ml
+++ b/stdlib/scanf.ml
@@ -808,7 +808,7 @@ let scan_float width precision ib =
   match c with
   | '.' ->
     let width = Scanning.store_char width ib c in
-    let precision = min width precision in
+    let precision = Int.min width precision in
     let width = width - (precision - scan_fractional_part precision ib) in
     scan_exponent_part width ib, precision
   | _ ->
@@ -853,7 +853,7 @@ let scan_hex_float width precision ib =
               match Scanning.peek_char ib with
               | 'p' | 'P' -> width
               | _ ->
-                let precision = min width precision in
+                let precision = Int.min width precision in
                 width - (precision - scan_hexadecimal_int precision ib)
           )
           | _ -> width in
@@ -886,7 +886,7 @@ let scan_caml_float_rest width precision ib =
     let width = Scanning.store_char width ib c in
     (* The effective width available for scanning the fractional part is
        the minimum of declared precision and width left. *)
-    let precision = min width precision in
+    let precision = Int.min width precision in
     (* After scanning the fractional part with [precision] provisional width,
        [width_precision] is left. *)
     let width_precision = scan_fractional_part precision ib in
@@ -922,7 +922,7 @@ let scan_caml_float width precision ib =
             match Scanning.peek_char ib with
             | 'p' | 'P' -> width
             | _ ->
-              let precision = min width precision in
+              let precision = Int.min width precision in
               width - (precision - scan_hexadecimal_int precision ib)
         )
         | 'p' | 'P' -> width

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -175,7 +175,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     Array.fold_right (count_bucket 0) t.table 0
 
 
-  let next_sz n = min (3 * n / 2 + 3) Sys.max_array_length
+  let next_sz n = Int.min (3 * n / 2 + 3) Sys.max_array_length
   let prev_sz n = ((n - 3) * 2 + 2) / 3
 
   let test_shrink_bucket t =
@@ -238,7 +238,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     let rec loop i =
       if i >= sz then begin
         let newsz =
-          min (3 * sz / 2 + 3) (Sys.max_array_length - additional_values)
+          Int.min (3 * sz / 2 + 3) (Sys.max_array_length - additional_values)
         in
         if newsz <= sz then failwith "Weak.Make: hash bucket cannot grow more";
         let newbucket = weak_create newsz in


### PR DESCRIPTION
Fixes #10389 

- The first commit adds the new functions
- The second commit (optional) uses them in the rest of the stdlib