### PR TITLE
Tweak the configuration for the i386-static compiler

### DIFF
--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -51,7 +51,9 @@ EOF
     ;;
   i386)
     ./configure --build=x86_64-pc-linux-gnu --host=i386-linux \
-      CC='gcc -m32' AS='as --32' ASPP='gcc -m32 -c' \
+      CC='gcc -m32 -march=x86-64' \
+      AS='as --32' \
+      ASPP='gcc -m32 -march=x86-64 -c' \
       PARTIALLD='ld -r -melf_i386' \
       $configure_flags
     ;;

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -58,6 +58,20 @@ quote1 () {
 }
 
 #########################################################################
+# Display environment information
+uname -a
+for i in issue redhat-release ; do
+  if test -e /etc/$i ; then
+    echo "/etc/$i content:"
+    cat /etc/$i | sed -e 's/^/| /'
+  fi
+done
+if command -v gcc >/dev/null ; then
+  echo "gcc info:"
+  gcc --version --verbose 2>&1 | sed -e 's/^/| /'
+fi
+
+#########################################################################
 # be verbose
 set -x
 


### PR DESCRIPTION
Apropos https://github.com/ocaml/ocaml/pull/10195#issuecomment-832844175, an adjustment to the CI workflow. There doesn't appear to be an equivalent flag for `as` (cc @stedolan)

As it's the second time in as many days that I've been curious about the configuration of a precheck worker, there's a small addition to display some environment information at the start of precheck runs as well (cc @shindere)