### PR TITLE
#6654, #9974: make include and with constraints aware of ghost components

### DIFF
--- a/.depend
+++ b/.depend
@@ -1014,6 +1014,7 @@ typing/printtyp.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
     typing/type_immediacy.cmi \
+    typing/signature_group.cmi \
     typing/primitive.cmi \
     typing/predef.cmi \
     typing/path.cmi \
@@ -1034,6 +1035,7 @@ typing/printtyp.cmx : \
     utils/warnings.cmx \
     typing/types.cmx \
     typing/type_immediacy.cmx \
+    typing/signature_group.cmx \
     typing/primitive.cmx \
     typing/predef.cmx \
     typing/path.cmx \
@@ -1109,6 +1111,18 @@ typing/rec_check.cmx : \
 typing/rec_check.cmi : \
     typing/typedtree.cmi \
     typing/ident.cmi
+typing/signature_group.cmo : \
+    typing/types.cmi \
+    typing/ident.cmi \
+    typing/btype.cmi \
+    typing/signature_group.cmi
+typing/signature_group.cmx : \
+    typing/types.cmx \
+    typing/ident.cmx \
+    typing/btype.cmx \
+    typing/signature_group.cmi
+typing/signature_group.cmi : \
+    typing/types.cmi
 typing/stypes.cmo : \
     typing/typedtree.cmi \
     typing/printtyp.cmi \
@@ -1563,6 +1577,7 @@ typing/typemod.cmo : \
     typing/typecore.cmi \
     typing/typeclass.cmi \
     typing/subst.cmi \
+    typing/signature_group.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
@@ -1596,6 +1611,7 @@ typing/typemod.cmx : \
     typing/typecore.cmx \
     typing/typeclass.cmx \
     typing/subst.cmx \
+    typing/signature_group.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \

--- a/Changes
+++ b/Changes
@@ -382,6 +382,16 @@ Working version
   in presence of a name collision.
   (Florian Angeletti, report by Thomas Refis, review by Gabriel Scherer)
 
+- #9974, #????: make `include` and with `constraints` handle correctly the
+  ghost components of signatures. For instance, in
+
+    include struct class c = object end end type c
+
+   the type `c` shadows the `class c` to avoid shadowing only the ghost type
+   c introduced by the class.
+  (Florian Angeletti and Gabriel Scherer, report by Eduardo Rafael,
+   review by ???)
+
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
   (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)
 

--- a/Changes
+++ b/Changes
@@ -367,6 +367,15 @@ Working version
 
 ### Bug fixes:
 
+- #6654, #9974, #10401: make `include` and with `constraints` handle correctly
+  the ghost components of signatures. For instance, in
+
+    include struct class c = object end end type c
+
+   the type `c` shadows the `class c` to avoid shadowing only the ghost type
+   c introduced by the class.
+  (Florian Angeletti, report by Eduardo Rafael, review by Gabriel Scherer)
+
 - #6985, #10385: remove all ghost row types from included modules
   (Florian Angeletti, review by Gabriel Scherer)
 
@@ -381,16 +390,6 @@ Working version
 - #8917, #8929, #9889, #10219: fix printing of nested recursive definitions
   in presence of a name collision.
   (Florian Angeletti, report by Thomas Refis, review by Gabriel Scherer)
-
-- #9974, #????: make `include` and with `constraints` handle correctly the
-  ghost components of signatures. For instance, in
-
-    include struct class c = object end end type c
-
-   the type `c` shadows the `class c` to avoid shadowing only the ghost type
-   c introduced by the class.
-  (Florian Angeletti and Gabriel Scherer, report by Eduardo Rafael,
-   review by ???)
 
 - #10005: Try expanding aliases in Ctype.nondep_type_rec
   (Stephen Dolan, review by Gabriel Scherer, Leo White and Xavier Leroy)

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -85,6 +85,7 @@ TYPING = \
   typing/persistent_env.cmo \
   typing/env.cmo \
   typing/typedtree.cmo \
+  typing/signature_group.cmo \
   typing/printtyped.cmo \
   typing/ctype.cmo \
   typing/printtyp.cmo \

--- a/dune
+++ b/dune
@@ -58,7 +58,7 @@
    ident path primitive types btype oprint subst predef datarepr
    cmi_format persistent_env env type_immediacy
    typedtree printtyped ctype printtyp includeclass mtype envaux includecore
-   tast_iterator tast_mapper cmt_format untypeast
+   tast_iterator tast_mapper signature_group cmt_format untypeast
    includemod includemod_errorprinter
    typetexp patterns printpat parmatch stypes typedecl typeopt rec_check
    typecore

--- a/testsuite/tests/shadow_include/ghosts.ml
+++ b/testsuite/tests/shadow_include/ghosts.ml
@@ -1,0 +1,39 @@
+(* TEST
+  * expect
+*)
+
+module C = struct
+  class c = object end
+end
+
+module R = struct
+  include C
+  type c
+end
+[%%expect {|
+module C : sig class c : object  end end
+module R : sig type c end
+|}]
+
+
+module CT = struct
+  include C
+  class type c = object end
+end
+[%%expect {|
+module CT : sig class type c = object  end end
+|}]
+
+
+module P = struct
+  type t = private < .. >
+end
+
+module M = struct
+  include P
+  type t = A
+end
+[%%expect {|
+module P : sig type t = private < .. > end
+module M : sig type t = A end
+|}]

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -140,11 +140,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module M/237 by M/254
+Error: Illegal shadowing of included module M/236 by M/253
        Line 2, characters 2-11:
-         Module M/237 came from this include
+         Module M/236 came from this include
        Line 3, characters 2-26:
-         The value ignore has no valid type if M/237 is shadowed
+         The value ignore has no valid type if M/236 is shadowed
 |}]
 
 
@@ -181,11 +181,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included module type T/324 by T/341
+Error: Illegal shadowing of included module type T/322 by T/339
        Line 2, characters 2-11:
-         Module type T/324 came from this include
+         Module type T/322 came from this include
        Line 3, characters 2-39:
-         The module F has no valid type if T/324 is shadowed
+         The module F has no valid type if T/322 is shadowed
 |}]
 
 module type Extension = sig
@@ -198,11 +198,11 @@ end
 Line 4, characters 2-11:
 4 |   include S
       ^^^^^^^^^
-Error: Illegal shadowing of included type ext/360 by ext/377
+Error: Illegal shadowing of included type ext/357 by ext/374
        Line 2, characters 2-11:
-         Type ext/360 came from this include
+         Type ext/357 came from this include
        Line 3, characters 14-16:
-         The extension constructor C2 has no valid type if ext/360 is shadowed
+         The extension constructor C2 has no valid type if ext/357 is shadowed
 |}]
 
 module type Class = sig

--- a/testsuite/tests/typing-modules/with_ghosts.ml
+++ b/testsuite/tests/typing-modules/with_ghosts.ml
@@ -1,0 +1,31 @@
+(* TEST
+   * expect
+*)
+
+(**
+   Check the behavior of with constraints with respect to
+    ghost type items introduced for class and class types
+ *)
+
+module type s = sig
+  class type c = object method m: int end
+end with type c := <m : int >
+[%%expect {|
+Lines 6-8, characters 16-29:
+6 | ................sig
+7 |   class type c = object method m: int end
+8 | end with type c := <m : int >
+Error: The signature constrained by `with' has no component named c
+|}]
+
+
+module type s = sig
+  class type ct = object method m: int end
+end with type ct := <m : int >
+[%%expect {|
+Lines 1-3, characters 16-30:
+1 | ................sig
+2 |   class type ct = object method m: int end
+3 | end with type ct := <m : int >
+Error: The signature constrained by `with' has no component named ct
+|}]

--- a/testsuite/tests/typing-modules/with_ghosts.ml
+++ b/testsuite/tests/typing-modules/with_ghosts.ml
@@ -29,3 +29,24 @@ Lines 1-3, characters 16-30:
 3 | end with type ct := <m : int >
 Error: The signature constrained by `with' has no component named ct
 |}]
+
+(** Check that we keep the same structure even after replacing a ghost item *)
+
+module type s = sig
+  type top
+  and t = private < .. >
+  and mid
+  and u = private < .. >
+  and v
+end with type t = private < .. >
+    with type u = private < .. >
+[%%expect {|
+module type s =
+  sig
+    type top
+    and t = private < .. >
+    and mid
+    and u = private < .. >
+    and v
+  end
+|}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1672,6 +1672,16 @@ let dummy =
 (** we hide items being defined from short-path to avoid shortening
     [type t = Path.To.t] into [type t = t].
 *)
+
+let ident_sigitem = function
+  | Types.Sig_type(ident,_,_,_) ->  {hide=true;ident}
+  | Types.Sig_class(ident,_,_,_)
+  | Types.Sig_class_type (ident,_,_,_)
+  | Types.Sig_module(ident,_, _,_,_)
+  | Types.Sig_value (ident,_,_)
+  | Types.Sig_modtype (ident,_,_)
+  | Types.Sig_typext (ident,_,_,_)   ->  {hide=false; ident }
+
 let hide ids env =
     let hide_id id env =
        if id.hide then
@@ -1690,91 +1700,8 @@ let with_hidden_items ids f =
     Naming_context.with_hidden ids f
 
 
-(** Classes and class types generate ghosts signature items, we group them
-    together before printing *)
-type syntactic_sig_item =
-  {
-    src: Types.signature_item;
-    post_ghosts: Types.signature_item list
-    (** ghost classes types are post-declared *);
-  }
-type rec_item_group =
-  | Not_rec of syntactic_sig_item
-  | Rec_group of (bound_ident list * syntactic_sig_item list)
-
-(** Private row types are manifested as a sequence of definitions
-    preceding a recursive group, we collect them and separate them from the
-    syntatic recursive group. *)
-type syntatic_rec_item_group =
-  { pre_ghosts: Types.signature_item list; group:rec_item_group }
-
-let group_syntactic_items x =
-  let rec group ~acc = function
-    | Sig_class _ as src :: rem ->
-       let ctydecl, tydecl1, tydecl2, rem =
-         match rem with
-         | cty :: tydecl1 :: tydecl2 :: rem -> cty, tydecl1, tydecl2, rem
-         | _ ->  (* a class declaration for [c] is followed by the ghost
-                    declarations of class type [c], and types [c] and [#c] *)
-            assert false
-       in
-        let s_elt =
-          { src; post_ghosts= [ctydecl; tydecl1; tydecl2]}
-        in
-        group ~acc:(s_elt :: acc) rem
-    | Sig_class_type _ as src :: rem ->
-       let tydecl1, tydecl2, rem =
-         match rem with
-         | tydecl1 :: tydecl2 :: rem -> tydecl1, tydecl2, rem
-         | _ ->  (* a class type declaration for [ct] is followed by the ghost
-                    declarations of types [ct] and [#ct] *)
-            assert false
-       in
-       group
-         ~acc:({src; post_ghosts = [tydecl1; tydecl2]}::acc)
-         rem
-    | (Sig_module _ | Sig_value _ | Sig_type _ | Sig_typext _
-      | Sig_modtype _ as src)  :: rem ->
-        group ~acc:({src; post_ghosts=[]} :: acc) rem
-    | [] -> List.rev acc in
-  group  ~acc:[] x
-
 let add_sigitem env x =
-  Env.add_signature (x.src :: x.post_ghosts) env
-
-let recursive_sigitem = function
-  | Sig_type(ident, _, rs, _) -> Some({hide=true;ident},rs)
-  | Sig_class(ident,_,rs,_) | Sig_class_type (ident,_,rs,_)
-  | Sig_module(ident, _, _, rs, _) -> Some ({hide=false;ident},rs)
-  | Sig_value _ | Sig_modtype _ | Sig_typext _  -> None
-
-let group_recursive_items x =
-  let rec_group pre ids group =
-    let group = Rec_group(List.rev ids, List.rev group) in
-    { pre_ghosts=List.rev pre; group } in
-  let rec not_in_group ~pre acc = function
-  | [] ->
-      (* ghost private row declarations precede a syntactic type declaration *)
-      assert ( pre = [] );
-      List.rev acc
-  | {src=Sig_type(id,_,_,_) as row; _ } :: rest
-       when is_row_name (Ident.name id) ->
-     not_in_group ~pre:(row::pre) acc rest
-  | elt :: rest ->
-      match recursive_sigitem elt.src with
-      | None | Some (_,Trec_not) ->
-         let sgroup = { pre_ghosts=List.rev pre; group=Not_rec elt } in
-         not_in_group ~pre:[] (sgroup::acc) rest
-      | Some (id, (Trec_first | Trec_next) )  ->
-         in_group ~pre [id] [elt] acc rest
-  and in_group ~pre ids group acc = function
-  | [] -> List.rev (rec_group pre ids group :: acc)
-  | elt :: rest as all ->
-      match recursive_sigitem elt.src with
-      | Some (id, Trec_next) -> in_group ~pre (id::ids) (elt::group) acc rest
-      | None | Some (_,(Trec_not|Trec_first)) ->
-          not_in_group ~pre:[] (rec_group pre ids group::acc) all in
-  not_in_group ~pre:[] [] x
+  Env.add_signature (Signature_group.flatten x) env
 
 let rec tree_of_modtype ?(ellipsis=false) = function
   | Mty_ident p ->
@@ -1811,7 +1738,7 @@ and tree_of_signature sg =
     ) sg
 
 and tree_of_signature_rec env' sg =
-  let structured = group_recursive_items (group_syntactic_items sg) in
+  let structured = List.of_seq (Signature_group.seq sg) in
   let collect_trees_of_rec_group group =
     let env = !printing_env in
     let env', group_trees =
@@ -1823,12 +1750,14 @@ and tree_of_signature_rec env' sg =
   set_printing_env env';
   List.map collect_trees_of_rec_group structured
 
-and trees_of_recursive_sigitem_group env syntactic_group =
-  let display x = x.src, tree_of_sigitem x.src in
+and trees_of_recursive_sigitem_group env
+    (syntactic_group: Signature_group.rec_group) =
+  let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem x.src in
   let env = Env.add_signature syntactic_group.pre_ghosts env in
   match syntactic_group.group with
   | Not_rec x -> add_sigitem env x, [display x]
-  | Rec_group (ids,items) ->
+  | Rec_group items ->
+      let ids = List.map (fun x -> ident_sigitem x.Signature_group.src) items in
       List.fold_left add_sigitem env items,
       with_hidden_items ids (fun () -> List.map display items)
 

--- a/typing/signature_group.ml
+++ b/typing/signature_group.ml
@@ -117,7 +117,7 @@ let update_rec_next rs rem =
 
 type 'a in_place_patch = {
   ghosts: Types.signature;
-  replace_by: Types.signature;
+  replace_by: Types.signature_item option;
   info: 'a;
 }
 
@@ -138,10 +138,14 @@ let replace_in_place f sg =
         | Some { info; ghosts; replace_by } ->
             let after = List.concat_map flatten q @ sg in
             let after = match recursive_sigitem a.src, replace_by with
-              | None, _ | _, _ :: _ -> after
-              | Some (_,rs), [] -> update_rec_next rs after
+              | None, _ | _, Some _ -> after
+              | Some (_,rs), None -> update_rec_next rs after
             in
-            let sg = List.rev_append (replace_by @ commit ghosts) after in
+            let before = match replace_by with
+              | None -> commit ghosts
+              | Some x -> x :: commit ghosts
+            in
+            let sg = List.rev_append before after in
             Some(info, sg)
         | None ->
             let before_group =

--- a/typing/signature_group.ml
+++ b/typing/signature_group.ml
@@ -1,0 +1,116 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Florian Angeletti, projet Cambium, Inria Paris                        *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Fold on a signature by syntactic group of items *)
+
+(** Classes and class types generate ghosts signature items, we group them
+    together before printing *)
+type sig_item =
+  {
+    src: Types.signature_item;
+    post_ghosts: Types.signature_item list
+    (** ghost classes types are post-declared *);
+  }
+let flatten x = x.src :: x.post_ghosts
+
+type core_rec_group =
+  | Not_rec of sig_item
+  | Rec_group of sig_item list
+
+let rec_items = function
+  | Not_rec x -> [x]
+  | Rec_group x -> x
+
+(** Private row types are manifested as a sequence of definitions
+    preceding a recursive group, we collect them and separate them from the
+    syntatic recursive group. *)
+type rec_group =
+  { pre_ghosts: Types.signature_item list; group:core_rec_group }
+
+let take n seq =
+  let rec aux l rem n seq =
+    if n = 0 then List.rev l, rem, seq else
+      match seq () with
+      | Seq.Nil -> assert false
+      | Seq.Cons((x,rem),next) ->
+          aux (x::l) rem (n-1) next
+  in
+  aux [] [] n seq
+
+let rec partial_lists l () = match l with
+  | [] -> Seq.Nil
+  | a :: q -> Seq.Cons((a,q), partial_lists q)
+
+let rec item_seq seq () =
+  match seq () with
+  | Seq.Nil -> Seq.Nil
+  | Seq.Cons((x,q), seq) ->
+    match x with
+    | Types.Sig_class _ as src ->
+        let ghosts, q, seq = take 3 seq in
+        (* a class declaration for [c] is followed by the ghost
+           declarations of class type [c], and types [c] and [#c] *)
+        Seq.Cons(({ src; post_ghosts=ghosts},q), item_seq seq)
+    | Types.Sig_class_type _ as src ->
+        let ghosts, q, seq = take 2 seq in
+        (* a class type declaration for [ct] is followed by the ghost
+           declarations of types [ct] and [#ct] *)
+        Seq.Cons(({src; post_ghosts = ghosts},q), item_seq seq)
+    | Types.(Sig_module _ | Sig_value _ | Sig_type _ | Sig_typext _
+            | Sig_modtype _ as src) ->
+        Seq.Cons(({src; post_ghosts=[]},q), item_seq seq)
+
+
+let recursive_sigitem = function
+  | Types.Sig_type(ident, _, rs, _)
+  | Types.Sig_class(ident,_,rs,_)
+  | Types.Sig_class_type (ident,_,rs,_)
+  | Types.Sig_module(ident, _, _, rs, _) -> Some (ident,rs)
+  | Types.(Sig_value _ | Sig_modtype _ | Sig_typext _ )  -> None
+
+let group_seq x =
+  let cons_group q pre group seq =
+    let group = Rec_group (List.rev group) in
+    Seq.Cons(({ pre_ghosts=List.rev pre; group },q), seq)
+  in
+  let rec not_in_group pre seq () = match seq () with
+    | Seq.Nil ->
+        assert (pre=[]);
+        Seq.Nil
+    | Seq.Cons((elt,q), seq) ->
+        match recursive_sigitem elt.src with
+        | Some (id, _) when Btype.is_row_name (Ident.name id) ->
+            not_in_group (elt.src::pre) seq ()
+        | None | Some (_, Types.Trec_not) ->
+            let sgroup = { pre_ghosts=List.rev pre; group=Not_rec elt } in
+            Seq.Cons((sgroup,q), not_in_group [] seq)
+        | Some (id, Types.(Trec_first | Trec_next) )  ->
+            in_group q ~pre ~ids:[id] ~group:[elt] seq ()
+  and in_group q ~pre ~ids ~group seq () = match seq () with
+    | Seq.Nil ->
+        cons_group [] pre group (fun () -> Seq.Nil)
+    | Seq.Cons((elt,qnext),next) ->
+        match recursive_sigitem elt.src with
+        | Some (id, Types.Trec_next) ->
+            in_group qnext ~pre ~ids:(id::ids) ~group:(elt::group) next ()
+        | None | Some (_, Types.(Trec_not|Trec_first)) ->
+            cons_group q pre group (not_in_group [] seq)
+  in
+  not_in_group [] x
+
+let full_seq l = l |> partial_lists |> item_seq |> group_seq
+let seq l = Seq.map fst (full_seq l)
+let iter f l = Seq.iter f (seq l)
+let fold f acc l = Seq.fold_left f acc (seq l)

--- a/typing/signature_group.ml
+++ b/typing/signature_group.ml
@@ -115,10 +115,9 @@ let update_rec_next rs rem =
           Types.Sig_module (id, pres, mty, rs, priv) :: rem
       | _ -> rem
 
-type 'a in_place_patch = {
+type in_place_patch = {
   ghosts: Types.signature;
   replace_by: Types.signature_item option;
-  info: 'a;
 }
 
 
@@ -135,7 +134,7 @@ let replace_in_place f sg =
     | [] -> next_group f (commit ghosts) sg
     | a :: q ->
         match f ~rec_group:q ~ghosts a.src with
-        | Some { info; ghosts; replace_by } ->
+        | Some (info, {ghosts; replace_by}) ->
             let after = List.concat_map flatten q @ sg in
             let after = match recursive_sigitem a.src, replace_by with
               | None, _ | _, Some _ -> after

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -1,0 +1,43 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Florian Angeletti, projet Cambium, Inria Paris                        *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Fold on a signature by syntactic group of items *)
+
+(** Classes and class types generate ghosts signature items, we group them
+    together before printing *)
+type sig_item =
+  {
+    src: Types.signature_item;
+    post_ghosts: Types.signature_item list
+    (** ghost classes types are post-declared *);
+  }
+val flatten: sig_item -> Types.signature
+
+type core_rec_group =
+  | Not_rec of sig_item
+  | Rec_group of sig_item list
+val rec_items: core_rec_group -> sig_item list
+
+(** Private row types are manifested as a sequence of definitions
+    preceding a recursive group, we collect them and separate them from the
+    syntatic recursive group. *)
+type rec_group =
+  { pre_ghosts: Types.signature_item list; group:core_rec_group }
+
+val full_seq: Types.signature -> (rec_group * Types.signature) Seq.t
+val seq: Types.signature -> rec_group Seq.t
+
+val iter: (rec_group -> unit) -> Types.signature -> unit
+val fold: ('acc -> rec_group -> 'acc) -> 'acc -> Types.signature -> 'acc

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -13,41 +13,72 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Fold on a signature by syntactic group of items *)
+(** Iterate on signature by syntactic group of items
+
+    Classes, class types and private row types adds ghost components to
+    the signature where they are defined.
+
+    When editing or printing a signature it is therefore important to
+    identify those ghost components.
+
+    This module provides type grouping together ghost components
+    with the corresponding core item (or recursive group) and
+    the corresponding iterators.
+*)
 
 (** Classes and class types generate ghosts signature items, we group them
     together before printing *)
 type sig_item =
   {
-    src: Types.signature_item;
+    src: Types.signature_item (** the syntactic item *)
+;
     post_ghosts: Types.signature_item list
     (** ghost classes types are post-declared *);
   }
+
+(** [flatten sig_item] is [x.src :: x.post_ghosts] *)
 val flatten: sig_item -> Types.signature
 
+(** A group of mutually recursive definition *)
 type core_rec_group =
   | Not_rec of sig_item
   | Rec_group of sig_item list
+
+(** [rec_items group] is the list of sig_items in the group *)
 val rec_items: core_rec_group -> sig_item list
 
-(** Private row types are manifested as a sequence of definitions
+(** Private #row types are manifested as a sequence of definitions
     preceding a recursive group, we collect them and separate them from the
     syntatic recursive group. *)
 type rec_group =
   { pre_ghosts: Types.signature_item list; group:core_rec_group }
 
+(** The sequence [seq signature] iterates over [signature] {!rec_group} by
+    {!rec_group}.
+    The second element of the tuple in the {!full_seq} case is the not-yet
+    traversed part of the signature.
+*)
 val full_seq: Types.signature -> (rec_group * Types.signature) Seq.t
 val seq: Types.signature -> rec_group Seq.t
 
 val iter: (rec_group -> unit) -> Types.signature -> unit
 val fold: ('acc -> rec_group -> 'acc) -> 'acc -> Types.signature -> 'acc
 
+(** Describe how to amend one element of a signature *)
 type 'a in_place_patch = {
-  ghosts: Types.signature;
-  replace_by: Types.signature;
-  info: 'a;
+  ghosts: Types.signature; (** updated list of ghost items *)
+  replace_by: Types.signature; (** replacement for the selected item *)
+  info: 'a; (** some more data to return to the outer scope *)
 }
 
+(**
+  [!replace_in_place patch sg] replaces the first element of the signature
+   for which [patch ~rec_group ~ghosts component] returns [Some patch].
+   The [rec_group] argument is the remaining part of the mutually
+   recursive group of [component].
+   The [ghosts] list is the current prefix of ghost components associated to
+   [component]
+*)
 val replace_in_place:
   ( rec_group:sig_item list -> ghosts:Types.signature -> Types.signature_item
     -> 'a in_place_patch option )

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -67,7 +67,8 @@ val fold: ('acc -> rec_group -> 'acc) -> 'acc -> Types.signature -> 'acc
 (** Describe how to amend one element of a signature *)
 type 'a in_place_patch = {
   ghosts: Types.signature; (** updated list of ghost items *)
-  replace_by: Types.signature; (** replacement for the selected item *)
+  replace_by: Types.signature_item option;
+  (** replacement for the selected item *)
   info: 'a; (** some more data to return to the outer scope *)
 }
 

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -41,3 +41,14 @@ val seq: Types.signature -> rec_group Seq.t
 
 val iter: (rec_group -> unit) -> Types.signature -> unit
 val fold: ('acc -> rec_group -> 'acc) -> 'acc -> Types.signature -> 'acc
+
+type 'a in_place_patch = {
+  ghosts: Types.signature;
+  replace_by: Types.signature;
+  info: 'a;
+}
+
+val replace_in_place:
+  ( rec_group:sig_item list -> ghosts:Types.signature -> Types.signature_item
+    -> 'a in_place_patch option )
+  -> Types.signature -> ('a * Types.signature) option

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -65,16 +65,15 @@ val iter: (rec_group -> unit) -> Types.signature -> unit
 val fold: ('acc -> rec_group -> 'acc) -> 'acc -> Types.signature -> 'acc
 
 (** Describe how to amend one element of a signature *)
-type 'a in_place_patch = {
+type in_place_patch = {
   ghosts: Types.signature; (** updated list of ghost items *)
   replace_by: Types.signature_item option;
   (** replacement for the selected item *)
-  info: 'a; (** some more data to return to the outer scope *)
 }
 
 (**
   [!replace_in_place patch sg] replaces the first element of the signature
-   for which [patch ~rec_group ~ghosts component] returns [Some patch].
+   for which [patch ~rec_group ~ghosts component] returns [Some (value,patch)].
    The [rec_group] argument is the remaining part of the mutually
    recursive group of [component].
    The [ghosts] list is the current prefix of ghost components associated to
@@ -82,5 +81,5 @@ type 'a in_place_patch = {
 *)
 val replace_in_place:
   ( rec_group:sig_item list -> ghosts:Types.signature -> Types.signature_item
-    -> 'a in_place_patch option )
+    -> ('a * in_place_patch) option )
   -> Types.signature -> ('a * Types.signature) option

--- a/typing/signature_group.mli
+++ b/typing/signature_group.mli
@@ -58,7 +58,7 @@ type rec_group =
     The second element of the tuple in the {!full_seq} case is the not-yet
     traversed part of the signature.
 *)
-val full_seq: Types.signature -> (rec_group * Types.signature) Seq.t
+val next: Types.signature -> (rec_group * Types.signature) option
 val seq: Types.signature -> rec_group Seq.t
 
 val iter: (rec_group -> unit) -> Types.signature -> unit

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -944,10 +944,20 @@ let approx_modtype env smty =
 module Signature_names : sig
   type t
 
+ type shadowable =
+    {
+      self: Ident.t;
+      group: Ident.t list;
+      (** group includes the element itself and all elements
+                that should be removed at the same time
+      *)
+      loc:Location.t;
+    }
+
   type info = [
     | `Exported
     | `From_open
-    | `Shadowable of Ident.t * Location.t
+    | `Shadowable of shadowable
     | `Substituted_away of Subst.t
     | `Unpackable_modtype_substituted_away of Ident.t * Subst.t
   ]
@@ -963,14 +973,24 @@ module Signature_names : sig
   val check_class_type: ?info:info -> t -> Location.t -> Ident.t -> unit
 
   val check_sig_item:
-    ?info:info -> t -> Location.t -> Types.signature_item -> unit
+    ?info:info -> t -> Location.t -> Signature_group.rec_group -> unit
 
   val simplify: Env.t -> t -> Types.signature -> Types.signature
 end = struct
 
+  type shadowable =
+    {
+      self: Ident.t;
+      group: Ident.t list;
+      (** group includes the element itself and all elements
+                that should be removed at the same time
+      *)
+      loc:Location.t;
+    }
+
   type bound_info = [
     | `Exported
-    | `Shadowable of Ident.t * Location.t
+    | `Shadowable of shadowable
   ]
 
   type info = [
@@ -1054,12 +1074,14 @@ end = struct
         let name = Ident.name id in
         match Hashtbl.find_opt tbl name with
         | None -> Hashtbl.add tbl name bound_info
-        | Some (`Shadowable (shadowed_id, shadowed_loc)) ->
+        | Some (`Shadowable s) ->
             Hashtbl.replace tbl name bound_info;
             let reason = Shadowed_by (id, loc) in
+            List.iter (fun shadowed_id ->
             to_be_removed.hide <-
-              Ident.Map.add shadowed_id (cl, shadowed_loc, reason)
+              Ident.Map.add shadowed_id (cl, s.loc, reason)
                 to_be_removed.hide
+              ) s.group
         | Some `Exported ->
             raise(Error(loc, Env.empty, Repeated_name(cl, name)))
 
@@ -1067,7 +1089,7 @@ end = struct
     let info =
       match info with
       | Some i -> i
-      | None -> `Shadowable (id, loc)
+      | None -> `Shadowable {self=id; group=[id]; loc}
     in
     check Sig_component_kind.Value t loc id info
   let check_type ?(info=`Exported) t loc id =
@@ -1083,24 +1105,35 @@ end = struct
   let check_class_type ?(info=`Exported) t loc id =
     check Sig_component_kind.Class_type t loc id info
 
-  let check_sig_item ?info names loc component =
-    let component_kind, id =
-      let open Sig_component_kind in
-      match component with
-      | Sig_type(id, _, _, _) -> Type, id
-      | Sig_module(id, _, _, _, _) -> Module, id
-      | Sig_modtype(id, _, _) -> Module_type, id
-      | Sig_typext(id, _, _, _) -> Extension_constructor, id
-      | Sig_value (id, _, _) -> Value, id
-      | Sig_class (id, _, _, _) -> Class, id
-      | Sig_class_type (id, _, _, _) -> Class_type, id
-    in
+  let classify =
+    let open Sig_component_kind in
+    function
+    | Sig_type(id, _, _, _) -> Type, id
+    | Sig_module(id, _, _, _, _) -> Module, id
+    | Sig_modtype(id, _, _) -> Module_type, id
+    | Sig_typext(id, _, _, _) -> Extension_constructor, id
+    | Sig_value (id, _, _) -> Value, id
+    | Sig_class (id, _, _, _) -> Class, id
+    | Sig_class_type (id, _, _, _) -> Class_type, id
+
+  let check_item ?info names loc kind id ids =
     let info =
       match info with
-      | None -> `Shadowable (id, loc)
+      | None -> `Shadowable {self=id; group=ids; loc}
       | Some i -> i
     in
-    check component_kind names loc id info
+    check kind names loc id info
+
+  let check_sig_item ?info names loc (item:Signature_group.rec_group) =
+    let check ?info names loc item =
+      let all = List.map classify (Signature_group.flatten item) in
+      let group = List.map snd all in
+      List.iter (fun (kind,id) -> check_item ?info names loc kind id group)
+        all
+    in
+    (* we can ignore x.pre_ghosts: they are eliminated by strengthening, and
+       thus never appear in includes *)
+     List.iter (check ?info names loc) (Signature_group.rec_items item.group)
 
   (*
     Before applying local module type substitutions where the
@@ -1569,7 +1602,9 @@ and transl_signature env sg =
             let scope = Ctype.create_scope () in
             let sg, newenv = Env.enter_signature ~scope
                        (extract_sig env smty.pmty_loc mty) env in
-            List.iter (Signature_names.check_sig_item names item.psig_loc) sg;
+            Signature_group.iter
+              (Signature_names.check_sig_item names item.psig_loc)
+              sg;
             let incl =
               { incl_mod = tmty;
                 incl_type = sg;
@@ -2325,7 +2360,7 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
       | Some false | None -> Some `From_open, Hidden
       | Some true -> None, Exported
     in
-    List.iter (Signature_names.check_sig_item ?info names loc) sg;
+    Signature_group.iter (Signature_names.check_sig_item ?info names loc) sg;
     let sg =
       List.map (function
         | Sig_value(id, vd, _) -> Sig_value(id, vd, visibility)
@@ -2606,7 +2641,7 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr =
         (* Rename all identifiers bound by this signature to avoid clashes *)
         let sg, new_env = Env.enter_signature ~scope
             (extract_sig_open env smodl.pmod_loc modl.mod_type) env in
-        List.iter (Signature_names.check_sig_item names loc) sg;
+        Signature_group.iter (Signature_names.check_sig_item names loc) sg;
         let incl =
           { incl_mod = modl;
             incl_type = sg;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -241,32 +241,20 @@ let check_recmod_typedecls env decls =
 
 (* Merge one "with" constraint in a signature *)
 
-let rec add_rec_types env = function
-    Sig_type(id, decl, Trec_next, _) :: rem ->
-      add_rec_types (Env.add_type ~check:true id decl env) rem
-  | _ -> env
-
-let check_type_decl env loc id row_id newdecl decl rs rem =
+let check_type_decl env loc id row_id newdecl decl rec_group =
   let env = Env.add_type ~check:true id newdecl env in
   let env =
     match row_id with
     | None -> env
     | Some id -> Env.add_type ~check:false id newdecl env
   in
-  let env = if rs = Trec_not then env else add_rec_types env rem in
+  let env =
+    let add_sigitem env x =
+      Env.add_signature Signature_group.(x.src :: x.post_ghosts) env
+    in
+    List.fold_left add_sigitem env rec_group in
   Includemod.type_declarations ~mark:Mark_both ~loc env id newdecl decl;
   Typedecl.check_coherence env loc (Path.Pident id) newdecl
-
-let update_rec_next rs rem =
-  match rs with
-    Trec_next -> rem
-  | Trec_first | Trec_not ->
-      match rem with
-        Sig_type (id, decl, Trec_next, priv) :: rem ->
-          Sig_type (id, decl, rs, priv) :: rem
-      | Sig_module (id, pres, mty, Trec_next, priv) :: rem ->
-          Sig_module (id, pres, mty, rs, priv) :: rem
-      | _ -> rem
 
 let make_variance p n i =
   let open Variance in
@@ -511,12 +499,27 @@ let merge_constraint initial_env loc sg lid constr =
   in
   let real_ids = ref [] in
   let unpackable_modtype = ref None in
-  let rec merge sig_env sg namelist row_id =
-    match (sg, namelist, constr) with
-      ([], _, _) ->
-        raise(Error(loc, sig_env, With_no_component lid.txt))
-    | (Sig_type(id, decl, rs, priv) :: rem, [s],
-       With_type ({ptype_kind = Ptype_abstract} as sdecl))
+  let split_row_id s ghosts =
+    let srow = s ^ "#row" in
+    let row_id_list, ghosts =
+      let split x = match x with
+        | Sig_type(id,_,_,_) when Ident.name id = srow -> Either.Left id
+        | item -> Either.Right item
+      in
+      List.partition_map split ghosts
+    in
+    match row_id_list with
+    | [] -> None, ghosts
+    | [a] -> Some a, ghosts
+    | _  -> assert false
+  in
+  let rec patch_item constr namelist sig_env ~rec_group ~ghosts item =
+    let return ?(ghosts=ghosts) ?(replace_by=[]) info =
+      Some {Signature_group.info; ghosts=ghosts; replace_by}
+    in
+    match item, namelist, constr with
+    | Sig_type(id, decl, rs, priv), [s],
+       With_type ({ptype_kind = Ptype_abstract} as sdecl)
       when Ident.name id = s && Typedecl.is_fixed_type sdecl ->
         let decl_row =
           let arity = List.length sdecl.ptype_params in
@@ -557,33 +560,36 @@ let merge_constraint initial_env loc sg lid constr =
           Typedecl.transl_with_constraint id ~fixed_row_path:(Pident id_row)
             ~sig_env ~sig_decl:decl ~outer_env:initial_env sdecl in
         let newdecl = tdecl.typ_type in
-        check_type_decl sig_env sdecl.ptype_loc id row_id newdecl decl rs rem;
+        let row_id, ghosts = split_row_id s ghosts in
+        check_type_decl sig_env sdecl.ptype_loc id row_id newdecl decl
+          rec_group;
         let decl_row = {decl_row with type_params = newdecl.type_params} in
         let rs' = if rs = Trec_first then Trec_not else rs in
-        (Pident id, lid, Twith_type tdecl),
-        Sig_type(id_row, decl_row, rs', priv)
-        :: Sig_type(id, newdecl, rs, priv)
-        :: rem
-    | (Sig_type(id, sig_decl, rs, priv) :: rem , [s],
-       (With_type sdecl | With_typesubst sdecl as constr))
+        return ~ghosts
+          ~replace_by:[ Sig_type(id, newdecl, rs, priv);
+                        Sig_type(id_row, decl_row, rs', priv)
+                      ]
+          (Pident id, lid, Twith_type tdecl)
+    | Sig_type(id, sig_decl, rs, priv) , [s],
+       (With_type sdecl | With_typesubst sdecl as constr)
       when Ident.name id = s ->
         let tdecl =
           Typedecl.transl_with_constraint id
             ~sig_env ~sig_decl ~outer_env:initial_env sdecl in
         let newdecl = tdecl.typ_type and loc = sdecl.ptype_loc in
-        check_type_decl sig_env loc id row_id newdecl sig_decl rs rem;
+        let row_id, ghosts = split_row_id s ghosts in
+        check_type_decl sig_env loc id row_id newdecl sig_decl rec_group;
         begin match constr with
           With_type _ ->
-            (Pident id, lid, Twith_type tdecl),
-            Sig_type(id, newdecl, rs, priv) :: rem
+            return ~ghosts
+              ~replace_by:[Sig_type(id, newdecl, rs, priv)]
+              (Pident id, lid, Twith_type tdecl)
         | (* With_typesubst *) _ ->
             real_ids := [Pident id];
-            (Pident id, lid, Twith_typesubst tdecl),
-            update_rec_next rs rem
+            return ~ghosts (Pident id, lid, Twith_typesubst tdecl)
         end
-    | (Sig_modtype(id, mtd, priv) :: rem, [s],
-       (With_modtype mty | With_modtypesubst mty)
-      )
+    | Sig_modtype(id, mtd, priv), [s],
+      (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
         let () = match mtd.mtd_type with
           | None -> ()
@@ -600,8 +606,9 @@ let merge_constraint initial_env loc sg lid constr =
               mtd_loc = loc;
             }
           in
-          (Pident id, lid, Twith_modtype mty),
-          Sig_modtype(id, mtd', priv) :: rem
+          return
+            ~replace_by:[Sig_modtype(id, mtd', priv)]
+            (Pident id, lid, Twith_modtype mty)
         else begin
           let path = Pident id in
           real_ids := [path];
@@ -609,14 +616,10 @@ let merge_constraint initial_env loc sg lid constr =
           | Mty_ident _ -> ()
           | mty -> unpackable_modtype := Some mty
           end;
-          (Pident id, lid, Twith_modtypesubst mty),
-          rem
+          return (Pident id, lid, Twith_modtypesubst mty)
         end
-    | (Sig_type(id, _, _, _) :: rem, [s], (With_type _ | With_typesubst _))
-      when Ident.name id = s ^ "#row" ->
-        merge sig_env rem namelist (Some id)
-    | (Sig_module(id, pres, md, rs, priv) :: rem, [s],
-       With_module {lid=lid'; md=md'; path; remove_aliases})
+    | Sig_module(id, pres, md, rs, priv), [s],
+      With_module {lid=lid'; md=md'; path; remove_aliases}
       when Ident.name id = s ->
         let mty = md'.md_type in
         let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
@@ -624,18 +627,18 @@ let merge_constraint initial_env loc sg lid constr =
         let newmd = Mtype.strengthen_decl ~aliasable:false sig_env md'' path in
         ignore(Includemod.modtypes  ~mark:Mark_both ~loc sig_env
                  newmd.md_type md.md_type);
-        (Pident id, lid, Twith_module (path, lid')),
-        Sig_module(id, pres, newmd, rs, priv) :: rem
-    | (Sig_module(id, _, md, rs, _) :: rem, [s], With_modsubst (lid',path,md'))
+        return
+          ~replace_by:[Sig_module(id, pres, newmd, rs, priv)]
+          (Pident id, lid, Twith_module (path, lid'))
+    | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
       when Ident.name id = s ->
         let aliasable = not (Env.is_functor_arg path sig_env) in
         ignore
           (Includemod.strengthened_module_decl ~loc ~mark:Mark_both
              ~aliasable sig_env md' path md);
         real_ids := [Pident id];
-        (Pident id, lid, Twith_modsubst (path, lid')),
-        update_rec_next rs rem
-    | (Sig_module(id, _, md, rs, priv) as item :: rem, s :: namelist, constr)
+        return (Pident id, lid, Twith_modsubst (path, lid'))
+    | Sig_module(id, _, md, rs, priv) as item, s :: namelist, constr
       when Ident.name id = s ->
         let sg = extract_sig sig_env loc md.md_type in
         let ((path, _, tcstr), newsg) = merge_signature sig_env sg namelist in
@@ -651,15 +654,15 @@ let merge_constraint initial_env loc sg lid constr =
               let newmd = {md with md_type = Mty_signature newsg} in
               Sig_module(id, Mp_present, newmd, rs, priv)
         in
-        (path, lid, tcstr),
-        item :: rem
-    | (item :: rem, _, _) ->
-        let (cstr, items) = merge sig_env rem namelist row_id
-        in
-        cstr, item :: items
+        return ~replace_by:[item] (path, lid, tcstr)
+    | _ -> None
   and merge_signature env sg namelist =
     let sig_env = Env.add_signature sg env in
-    merge sig_env sg namelist None
+    match
+      Signature_group.replace_in_place (patch_item constr namelist sig_env) sg
+    with
+    | Some (x,sg) -> x, sg
+    | None -> raise(Error(loc, sig_env, With_no_component lid.txt))
   in
   try
     let names = Longident.flatten lid.txt in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1148,7 +1148,7 @@ end = struct
           lst
       ) to_remove.hide []
     in
-    let aux component sg =
+    let simplify_item (component: Types.signature_item) =
       let user_kind, user_id, user_loc =
         let open Sig_component_kind in
         match component with
@@ -1161,7 +1161,7 @@ end = struct
         | Sig_class_type (id, ct, _, _) -> Class_type, id, ct.clty_loc
       in
       if Ident.Map.mem user_id to_remove.hide then
-        sg
+        None
       else begin
         let component =
           if to_remove.subst == Subst.identity then
@@ -1206,10 +1206,10 @@ end = struct
               in
               raise (Error(err_loc, env, Cannot_hide_id hiding_error))
         in
-        component :: sg
+        Some component
       end
     in
-    List.fold_right aux sg []
+    List.filter_map simplify_item sg
 end
 
 let has_remove_aliases_attribute attr =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -511,7 +511,7 @@ let merge_constraint initial_env loc sg lid constr =
   in
   let rec patch_item constr namelist sig_env ~rec_group ~ghosts item =
     let return ?(ghosts=ghosts) ~replace_by info =
-      Some {Signature_group.info; ghosts=ghosts; replace_by}
+      Some (info, {Signature_group.ghosts; replace_by})
     in
     match item, namelist, constr with
     | Sig_type(id, decl, rs, priv), [s],


### PR DESCRIPTION
 Classes, class types and private row types add ghost components to the signature where they are defined.

For instance,
```ocaml
module type s = sig
  class c: object end
end
```
is expanded in the typed signature to
```ocaml
module type s = sig
    class c: object end
    class type c= object end
    type c
    type #c
end
```

When editing or printing a signature it is therefore important to identify those ghost components.

Before this PR, the logic to recognize ghost components was reimplemented (or forgotten) in few different places.
This PR (in collaboration with @gasche) proposes to centralize this logic in a new `Signature_group` group module.
This module provides signature iterators that works of group of core component and associated ghost components. 

Once defined, those iterators have be reused to deal in a unified way with ghost components in printing, shadowing included components and editing signature with `with_constraint`.

## Printing (e3af864)

For `Printtyp`, this PR is merely using the new iterator which are a slightly less specialized version of the pre-existing code.

## Shadowing included components (206fbfa) 

Using structured iterators make it easier to remove all components of a (real+ghost) group:
```ocaml
 include sig class c: object end end type c
```
now results with the `type c` shadowing the whole class `c`, ghost class type `c` etc... rather than silently erasing the ghost type `c` of the class.
In other words, the following code type checks:
```ocaml
module Ok: sig
  include sig class c: object end end type c
end =
struct type c end
```
We could be less lenient and raises an error however.
This is implemented by remembering the full group of core and ghost components for shadowable items, and removing all of them simultaneously when needed.
  
## Editing signature through a `with` constraint (9ce0b9b , c52f1d0)  

Inversely, once ghost components are identified, we can make sure that  `with` constraint cannot edit them.
For instance, trying to steal the ghost type of a component
```ocaml
  module type a = sig class type ct = object end end with type ct := < >
``` 
raises an error
>```
> Error: The signature constrained by `with' has no component named ct
>```
with this PR rather than an `assert false` in `Subst`.
This is kind of solving #6654 by keeping more consistently ghost component out of sight of users.

The implementation simply move the `editing in place` logic of `Typemod.merge_constraint` to `Signature_group` and let
`Typemod.merge_constraint` focuses on the type system.

Fix #9974 (really this time!)