### PR TITLE
Generate full error traces during module inclusion

### DIFF
--- a/.depend
+++ b/.depend
@@ -689,6 +689,7 @@ typing/includecore.cmo : \
     typing/printtyp.cmi \
     typing/primitive.cmi \
     typing/path.cmi \
+    utils/misc.cmi \
     typing/ident.cmi \
     typing/errortrace.cmi \
     typing/env.cmi \
@@ -704,6 +705,7 @@ typing/includecore.cmx : \
     typing/printtyp.cmx \
     typing/primitive.cmx \
     typing/path.cmx \
+    utils/misc.cmx \
     typing/ident.cmx \
     typing/errortrace.cmx \
     typing/env.cmx \

--- a/.depend
+++ b/.depend
@@ -679,6 +679,7 @@ typing/includeclass.cmx : \
     typing/includeclass.cmi
 typing/includeclass.cmi : \
     typing/types.cmi \
+    typing/printtyp.cmi \
     parsing/location.cmi \
     typing/env.cmi \
     typing/ctype.cmi

--- a/.depend
+++ b/.depend
@@ -638,11 +638,13 @@ typing/envaux.cmi : \
 typing/errortrace.cmo : \
     typing/types.cmi \
     typing/path.cmi \
+    utils/misc.cmi \
     parsing/asttypes.cmi \
     typing/errortrace.cmi
 typing/errortrace.cmx : \
     typing/types.cmx \
     typing/path.cmx \
+    utils/misc.cmx \
     parsing/asttypes.cmi \
     typing/errortrace.cmi
 typing/errortrace.cmi : \

--- a/.depend
+++ b/.depend
@@ -638,13 +638,11 @@ typing/envaux.cmi : \
 typing/errortrace.cmo : \
     typing/types.cmi \
     typing/path.cmi \
-    utils/misc.cmi \
     parsing/asttypes.cmi \
     typing/errortrace.cmi
 typing/errortrace.cmx : \
     typing/types.cmx \
     typing/path.cmx \
-    utils/misc.cmx \
     parsing/asttypes.cmi \
     typing/errortrace.cmi
 typing/errortrace.cmi : \

--- a/Changes
+++ b/Changes
@@ -21,7 +21,7 @@ Working version
 
 - #10407: Produce more detailed error messages that contain full error traces
   when module inclusion fails.
-  (Antal Spector-Zabusky, NOT YET REVIEWED)
+  (Antal Spector-Zabusky, review by Florian Angeletti)
 
 ### Internal/compiler-libs changes:
 

--- a/Changes
+++ b/Changes
@@ -19,6 +19,10 @@ Working version
 - #10328: Give more precise error when disambiguation could not possibly work.
   (Leo White, review by Gabriel Scherer and Florian Angeletti)
 
+- #10407: Produce more detailed error messages that contain full error traces
+  when module inclusion fails.
+  (Antal Spector-Zabusky, NOT YET REVIEWED)
+
 ### Internal/compiler-libs changes:
 
 - #10433: Remove the distinction between 32-bit aligned and 64-bit aligned

--- a/testsuite/tests/printing-types/disambiguation.ml
+++ b/testsuite/tests/printing-types/disambiguation.ml
@@ -9,14 +9,16 @@ Error: Type declarations do not match:
          type !'a x = private [> `x ] constraint 'a = 'a x
        is not included in
          type 'a x
-       Their constraints differ.
+       Their parameters differ
+       The type 'b x as 'b is not equal to the type 'a
 |}, Principal{|
 Line 1:
 Error: Type declarations do not match:
          type !'a x = private 'a constraint 'a = [> `x ]
        is not included in
          type 'a x
-       Their constraints differ.
+       Their parameters differ
+       The type [> `x ] is not equal to the type 'a
 |}];;
 
 

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -322,9 +322,9 @@ Error: Signature mismatch:
          type ('a, 'b) bar += A of int
        Constructors do not match:
          A of float
-       is not compatible with:
+       is not the same as:
          A of int
-       The types are not equal.
+       The type float is not equal to the type int
 |}]
 
 module M : sig
@@ -348,9 +348,9 @@ Error: Signature mismatch:
          type ('a, 'b) bar += A of 'a
        Constructors do not match:
          A of 'b
-       is not compatible with:
+       is not the same as:
          A of 'a
-       The types are not equal.
+       The type 'b is not equal to the type 'a
 |}]
 
 module M : sig
@@ -374,9 +374,9 @@ Error: Signature mismatch:
          type ('a, 'b) bar = A of 'a
        Constructors do not match:
          A of 'a
-       is not compatible with:
+       is not the same as:
          A of 'a
-       The types are not equal.
+       The type 'a is not equal to the type 'b
 |}];;
 
 
@@ -401,9 +401,9 @@ Error: Signature mismatch:
          type ('a, 'b) bar += A : 'c -> ('c, 'd) bar
        Constructors do not match:
          A : 'd -> ('c, 'd) bar
-       is not compatible with:
+       is not the same as:
          A : 'c -> ('c, 'd) bar
-       The types are not equal.
+       The type 'd is not equal to the type 'c
 |}]
 
 (* Extensions can be rebound *)

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -117,7 +117,8 @@ Line 1, characters 0-37:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          ('a, 'a) foo
-       Their constraints differ.
+       Their parameters differ
+       The type 'a is not equal to the type 'b
 |}]
 
 (* Check that signatures can hide exstensibility *)

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -237,7 +237,7 @@ Error: Signature mismatch:
          type foo = M.foo = private ..
        is not included in
          type foo = ..
-       A private type would be revealed.
+       A private extensible variant would be revealed
 |}]
 
 

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -237,7 +237,7 @@ Error: Signature mismatch:
          type foo = M.foo = private ..
        is not included in
          type foo = ..
-       A private extensible variant would be revealed
+       A private extensible variant would be revealed.
 |}]
 
 

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -233,6 +233,9 @@ Error: Signature mismatch:
          val r : '_weak1 list ref
        is not included in
          val r : T.u list ref
+       The type 'weak1 list ref is not compatible with the type T.u list ref
+       This instance of T.u is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 module M = struct
@@ -264,4 +267,7 @@ Error: Signature mismatch:
          val r : '_weak2 list ref
        is not included in
          val r : T.t list ref
+       The type 'weak2 list ref is not compatible with the type T.t list ref
+       This instance of T.t is ambiguous:
+       it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -233,8 +233,9 @@ Error: Signature mismatch:
          val r : '_weak1 list ref
        is not included in
          val r : T.u list ref
-       The type 'weak1 list ref is not compatible with the type T.u list ref
-       This instance of T.u is ambiguous:
+       The type '_weak1 list ref is not compatible with the type T.u list ref
+       Type '_weak1 is not compatible with type T.u = T.t
+       This instance of T.t is ambiguous:
        it would escape the scope of its equation
 |}]
 
@@ -267,7 +268,8 @@ Error: Signature mismatch:
          val r : '_weak2 list ref
        is not included in
          val r : T.t list ref
-       The type 'weak2 list ref is not compatible with the type T.t list ref
-       This instance of T.t is ambiguous:
+       The type '_weak2 list ref is not compatible with the type T.t list ref
+       Type '_weak2 is not compatible with type T.t = T.u
+       This instance of T.u is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -20,7 +20,8 @@ Lines 4-5, characters 0-77:
 Error: This variant or record definition does not match that of type 'a t
        Constructors do not match:
          Same : 'l t -> 'l t
-       is not compatible with:
+       is not the same as:
          Same : 'l1 t -> 'l2 t
-       The types are not equal.
+       The type 'l t is not equal to the type 'l1 t
+       Type 'l is not equal to type 'l1
 |}];;

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -21,9 +21,10 @@ Lines 2-3, characters 2-37:
 Error: This variant or record definition does not match that of type X.t
        Constructors do not match:
          A : 'a * 'b * ('a -> unit) -> X.t
-       is not compatible with:
+       is not the same as:
          A : 'a * 'b * ('b -> unit) -> X.t
-       The types are not equal.
+       The type 'a -> unit is not equal to the type 'b -> unit
+       Type 'a is not equal to type 'b
 |}]
 
 (* would segfault

--- a/testsuite/tests/typing-gadts/return_type.ml
+++ b/testsuite/tests/typing-gadts/return_type.ml
@@ -1,0 +1,36 @@
+(* TEST
+   * expect
+*)
+
+type i = int
+
+type 'a t = T : i
+[%%expect{|
+type i = int
+Line 3, characters 16-17:
+3 | type 'a t = T : i
+                    ^
+Error: Constraints are not satisfied in this type.
+       Type i should be an instance of 'a t
+|}]
+
+type 'a t = T : i t
+type 'a s = 'a t = T : i t
+[%%expect{|
+type 'a t = T : i t
+Line 2, characters 23-26:
+2 | type 'a s = 'a t = T : i t
+                           ^^^
+Error: Constraints are not satisfied in this type.
+       Type i t should be an instance of 'a s
+|}]
+
+type 'a t = T : i s
+and  'a s = 'a t
+[%%expect{|
+Line 1, characters 16-19:
+1 | type 'a t = T : i s
+                    ^^^
+Error: Constraints are not satisfied in this type.
+       Type i s should be an instance of 'a t
+|}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1246,3 +1246,20 @@ Error: This expression has type a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}];;
+
+module M = struct
+  type t
+end
+type (_,_) eq = Refl: ('a,'a) eq
+let f (x:M.t) (y: (M.t, int -> int) eq) =
+  let Refl = y in
+  if true then x else fun x -> x + 1
+[%%expect{|
+module M : sig type t end
+type (_, _) eq = Refl : ('a, 'a) eq
+Line 7, characters 22-36:
+7 |   if true then x else fun x -> x + 1
+                          ^^^^^^^^^^^^^^
+Error: This function should have type int -> int
+       but its first argument is not labelled
+|}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1260,8 +1260,10 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 7, characters 22-36:
 7 |   if true then x else fun x -> x + 1
                           ^^^^^^^^^^^^^^
-Error: This function should have type int -> int
-       but its first argument is not labelled
+Error: This expression has type 'a -> 'b
+       but an expression was expected of type M.t = int -> int
+       This instance of int -> int is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1298,9 +1300,10 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 8, characters 2-3:
 8 |   z#m
       ^
-Error: This expression has type M.t
-       It has no method m
-Hint: Did you mean m?
+Error: This expression has type M.t but an expression was expected of type
+         < m : 'a; .. >
+       This instance of < m : int > is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1318,9 +1321,10 @@ type (_, _) eq = Refl : ('a, 'a) eq
 Line 8, characters 2-3:
 8 |   z#m
       ^
-Error: This expression has type M.t
-       It has no method m
-Hint: Did you mean m?
+Error: This expression has type M.t but an expression was expected of type
+         < m : 'a; .. >
+       This instance of < m : int > is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 type (_,_) eq = Refl: ('a,'a) eq
@@ -1343,8 +1347,10 @@ module M :
 Line 9, characters 4-5:
 9 |     z#b
         ^
-Error: This expression has type < m : int; .. >
-       It has no method b
+Error: This expression has type $C_'a = < b : bool >
+       but an expression was expected of type < b : 'a; .. >
+       This instance of < b : bool > is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 (* Check got/expected when the order changes *)
@@ -1368,6 +1374,8 @@ module M :
 Line 9, characters 4-5:
 9 |     z#b
         ^
-Error: This expression has type < m : int; .. >
-       It has no method b
+Error: This expression has type $C_'a = < b : bool >
+       but an expression was expected of type < b : 'a; .. >
+       This instance of < b : bool > is ambiguous:
+       it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1263,3 +1263,111 @@ Line 7, characters 22-36:
 Error: This function should have type int -> int
        but its first argument is not labelled
 |}]
+
+(* Check got/expected when the order changes *)
+module M = struct
+  type t
+end
+type (_,_) eq = Refl: ('a,'a) eq
+let f (x:M.t) (y: (M.t, int -> int) eq) =
+  let Refl = y in
+  if true then fun x -> x + 1 else x
+[%%expect{|
+module M : sig type t end
+type (_, _) eq = Refl : ('a, 'a) eq
+Line 7, characters 35-36:
+7 |   if true then fun x -> x + 1 else x
+                                       ^
+Error: This expression has type M.t = int -> int
+       but an expression was expected of type int -> int
+       This instance of int -> int is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+module M = struct
+  type t
+end
+type (_,_) eq = Refl: ('a,'a) eq
+let f w (x:M.t) (y: (M.t, <m:int>) eq) =
+  let Refl = y in
+  let z = if true then x else w in
+  z#m
+[%%expect{|
+module M : sig type t end
+type (_, _) eq = Refl : ('a, 'a) eq
+Line 8, characters 2-3:
+8 |   z#m
+      ^
+Error: This expression has type M.t
+       It has no method m
+Hint: Did you mean m?
+|}]
+
+(* Check got/expected when the order changes *)
+module M = struct
+  type t
+end
+type (_,_) eq = Refl: ('a,'a) eq
+let f w (x:M.t) (y: (M.t, <m:int>) eq) =
+  let Refl = y in
+  let z = if true then w else x in
+  z#m
+[%%expect{|
+module M : sig type t end
+type (_, _) eq = Refl : ('a, 'a) eq
+Line 8, characters 2-3:
+8 |   z#m
+      ^
+Error: This expression has type M.t
+       It has no method m
+Hint: Did you mean m?
+|}]
+
+type (_,_) eq = Refl: ('a,'a) eq
+module M = struct
+  type t = C : (<m:int; ..> as 'a) * ('a, <m:int; b:bool>) eq -> t
+end
+let f (C (x,y) : M.t) =
+  let g w =
+    let Refl = y in
+    let z = if true then w else x in
+    z#b
+  in ()
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+module M :
+  sig
+    type t =
+        C : (< m : int; .. > as 'a) * ('a, < b : bool; m : int >) eq -> t
+  end
+Line 9, characters 4-5:
+9 |     z#b
+        ^
+Error: This expression has type < m : int; .. >
+       It has no method b
+|}]
+
+(* Check got/expected when the order changes *)
+type (_,_) eq = Refl: ('a,'a) eq
+module M = struct
+  type t = C : (<m:int; ..> as 'a) * ('a, <m:int; b:bool>) eq -> t
+end
+let f (C (x,y) : M.t) =
+  let g w =
+    let Refl = y in
+    let z = if true then x else w in
+    z#b
+  in ()
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+module M :
+  sig
+    type t =
+        C : (< m : int; .. > as 'a) * ('a, < b : bool; m : int >) eq -> t
+  end
+Line 9, characters 4-5:
+9 |     z#b
+        ^
+Error: This expression has type < m : int; .. >
+       It has no method b
+|}]

--- a/testsuite/tests/typing-misc/deep.ml
+++ b/testsuite/tests/typing-misc/deep.ml
@@ -21,6 +21,8 @@ Error: Signature mismatch:
          val x : bool * string
        is not included in
          val x : bool * int
+       The type bool * string is not compatible with the type bool * int
+       Type string is not compatible with type int
 |}]
 
 module T : sig
@@ -42,6 +44,9 @@ Error: Signature mismatch:
          val f : int -> int
        is not included in
          val f : int -> (float * string option) list
+       The type int -> int is not compatible with the type
+         int -> (float * string option) list
+       Type int is not compatible with type (float * string option) list
 |}]
 
 (* Alpha-equivalence *)
@@ -64,6 +69,9 @@ Error: Signature mismatch:
          val f : 'c list * 'd option -> int
        is not included in
          val f : 'a list * 'b list -> int
+       The type 'a list * 'b option -> int is not compatible with the type
+         'a list * 'c list -> int
+       Type 'b option is not compatible with type 'c list
 |}]
 
 module T : sig
@@ -85,4 +93,6 @@ Error: Signature mismatch:
          type t = bool * float
        is not included in
          type t = int * float
+       The type bool * float is not equal to the type int * float
+       Type bool is not equal to type int
 |}]

--- a/testsuite/tests/typing-misc/deep.ml
+++ b/testsuite/tests/typing-misc/deep.ml
@@ -1,0 +1,88 @@
+(* TEST
+   * expect
+*)
+
+module M : sig
+  val x : bool * int
+end = struct
+  let x = false , "not an int"
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let x = false , "not an int"
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val x : bool * string end
+       is not included in
+         sig val x : bool * int end
+       Values do not match:
+         val x : bool * string
+       is not included in
+         val x : bool * int
+|}]
+
+module T : sig
+  val f : int -> (float * string option) list
+end = struct
+  let f x = x + List.length [0.0, Some true]
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f x = x + List.length [0.0, Some true]
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int end
+       is not included in
+         sig val f : int -> (float * string option) list end
+       Values do not match:
+         val f : int -> int
+       is not included in
+         val f : int -> (float * string option) list
+|}]
+
+(* Alpha-equivalence *)
+module T : sig
+  val f : ('a list * 'b list -> int)
+end = struct
+  let f : ('c list * 'd option  -> int) = assert false
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f : ('c list * 'd option  -> int) = assert false
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'c list * 'd option -> int end
+       is not included in
+         sig val f : 'a list * 'b list -> int end
+       Values do not match:
+         val f : 'c list * 'd option -> int
+       is not included in
+         val f : 'a list * 'b list -> int
+|}]
+
+module T : sig
+  type t = int * float
+end = struct
+  type t = bool * float
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = bool * float
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = bool * float end
+       is not included in
+         sig type t = int * float end
+       Type declarations do not match:
+         type t = bool * float
+       is not included in
+         type t = int * float
+|}]

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -31,6 +31,7 @@ Error: Signature mismatch:
          type t = A.t = A | B
        is not included in
          type t = int * string
+       The type A.t is not equal to the type int * string
 |}]
 
 module rec B : sig
@@ -62,6 +63,7 @@ Error: Signature mismatch:
          type 'a t = 'a B.t = A of 'a | B
        is not included in
          type 'a t = 'a
+       The type 'a B.t is not equal to the type 'a
 |}];;
 
 module rec C : sig
@@ -126,6 +128,7 @@ Error: Signature mismatch:
          type 'a t = 'a D.t = A of 'a | B
        is not included in
          type 'a t = int
+       The type 'a D.t is not equal to the type int
 |}];;
 
 module rec E : sig
@@ -157,6 +160,7 @@ Error: Signature mismatch:
          type 'a t = 'a E.t = A of 'a | B
        is not included in
          type 'a t = 'a constraint 'a = [> `Foo ]
+       The type 'a is not equal to the type [> `Foo ]
 |}];;
 
 module rec E2 : sig
@@ -188,6 +192,7 @@ Error: Signature mismatch:
          type 'a t = 'a E2.t = A of 'a | B
        is not included in
          type 'a t = [ `Foo ]
+       The type 'a E2.t is not equal to the type [ `Foo ]
 |}];;
 
 module rec E3 : sig
@@ -219,6 +224,7 @@ Error: Signature mismatch:
          type 'a t = 'a E3.t = A of 'a | B
        is not included in
          type 'a t = 'a constraint 'a = [< `Foo ]
+       The type 'a is not equal to the type [< `Foo ]
 |}];;
 
 
@@ -254,7 +260,7 @@ Error: Signature mismatch:
          type ('a, 'b) t = Foo of 'a
        Constructors do not match:
          Foo of 'b
-       is not compatible with:
+       is not the same as:
          Foo of 'a
-       The types are not equal.
+       The type 'b is not equal to the type 'a
 |}];;

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -34,6 +34,34 @@ Error: This function should have type unit -> unit
        but its first argument is labelled ?opt
 |}];;
 
+(* filter_arrow *)
+
+let (f : x:int -> int) = fun y -> y
+[%%expect{|
+Line 1, characters 25-35:
+1 | let (f : x:int -> int) = fun y -> y
+                             ^^^^^^^^^^
+Error: This function should have type x:int -> int
+       but its first argument is not labelled
+|}];;
+
+let (f : int -> int) = fun ~y -> y
+[%%expect{|
+Line 1, characters 23-34:
+1 | let (f : int -> int) = fun ~y -> y
+                           ^^^^^^^^^^^
+Error: This function should have type int -> int
+       but its first argument is labelled ~y
+|}];;
+
+let (f : x:int -> int) = fun ~y -> y
+[%%expect{|
+Line 1, characters 25-36:
+1 | let (f : x:int -> int) = fun ~y -> y
+                             ^^^^^^^^^^^
+Error: This function should have type x:int -> int
+       but its first argument is labelled ~y
+|}];;
 
 (* More examples *)
 

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -31,8 +31,7 @@ Line 1, characters 4-23:
 1 | foo (fun ?opt () -> ()) ;; (* fails *)
         ^^^^^^^^^^^^^^^^^^^
 Error: This function should have type unit -> unit
-       but its first argument is labeled ?opt
-       instead of being unlabeled
+       but its first argument is labeled ?opt instead of being unlabeled
 |}];;
 
 (* filter_arrow *)
@@ -43,8 +42,7 @@ Line 1, characters 25-35:
 1 | let (f : x:int -> int) = fun y -> y
                              ^^^^^^^^^^
 Error: This function should have type x:int -> int
-       but its first argument is unlabeled
-       instead of being labeled ~x
+       but its first argument is unlabeled instead of being labeled ~x
 |}];;
 
 let (f : int -> int) = fun ~y -> y
@@ -53,8 +51,7 @@ Line 1, characters 23-34:
 1 | let (f : int -> int) = fun ~y -> y
                            ^^^^^^^^^^^
 Error: This function should have type int -> int
-       but its first argument is labeled ~y
-       instead of being unlabeled
+       but its first argument is labeled ~y instead of being unlabeled
 |}];;
 
 let (f : x:int -> int) = fun ~y -> y
@@ -63,8 +60,7 @@ Line 1, characters 25-36:
 1 | let (f : x:int -> int) = fun ~y -> y
                              ^^^^^^^^^^^
 Error: This function should have type x:int -> int
-       but its first argument is labeled ~y
-       instead of ~x
+       but its first argument is labeled ~y instead of ~x
 |}];;
 
 (* More examples *)

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -31,7 +31,8 @@ Line 1, characters 4-23:
 1 | foo (fun ?opt () -> ()) ;; (* fails *)
         ^^^^^^^^^^^^^^^^^^^
 Error: This function should have type unit -> unit
-       but its first argument is labelled ?opt
+       but its first argument is labeled ?opt
+       instead of being unlabeled
 |}];;
 
 (* filter_arrow *)
@@ -42,7 +43,8 @@ Line 1, characters 25-35:
 1 | let (f : x:int -> int) = fun y -> y
                              ^^^^^^^^^^
 Error: This function should have type x:int -> int
-       but its first argument is not labelled
+       but its first argument is unlabeled
+       instead of being labeled ~x
 |}];;
 
 let (f : int -> int) = fun ~y -> y
@@ -51,7 +53,8 @@ Line 1, characters 23-34:
 1 | let (f : int -> int) = fun ~y -> y
                            ^^^^^^^^^^^
 Error: This function should have type int -> int
-       but its first argument is labelled ~y
+       but its first argument is labeled ~y
+       instead of being unlabeled
 |}];;
 
 let (f : x:int -> int) = fun ~y -> y
@@ -60,7 +63,8 @@ Line 1, characters 25-36:
 1 | let (f : x:int -> int) = fun ~y -> y
                              ^^^^^^^^^^^
 Error: This function should have type x:int -> int
-       but its first argument is labelled ~y
+       but its first argument is labeled ~y
+       instead of ~x
 |}];;
 
 (* More examples *)

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -26,6 +26,8 @@ Error: Signature mismatch:
          val f : t/1 -> unit
        is not included in
          val f : t/2 -> unit
+       The type t/1 -> unit is not compatible with the type t/2 -> unit
+       Type t/1 is not compatible with type t/2
        Line 6, characters 4-14:
          Definition of type t/1
        Line 2, characters 2-12:
@@ -52,9 +54,9 @@ Error: Signature mismatch:
          type u = A of t/2
        Constructors do not match:
          A of t/1
-       is not compatible with:
+       is not the same as:
          A of t/2
-       The types are not equal.
+       The type t/1 is not equal to the type t/2
        Line 4, characters 9-19:
          Definition of type t/1
        Line 2, characters 2-11:
@@ -121,9 +123,9 @@ Error: Signature mismatch:
          type t = A of T/2.t
        Constructors do not match:
          A of T/1.t
-       is not compatible with:
+       is not the same as:
          A of T/2.t
-       The types are not equal.
+       The type T/1.t is not equal to the type T/2.t
        Line 5, characters 6-34:
          Definition of module T/1
        Line 2, characters 2-30:
@@ -150,6 +152,9 @@ Error: Signature mismatch:
          val f : (module s/1) -> t/2 -> t/1
        is not included in
          val f : (module s/2) -> t/2 -> t/2
+       The type (module s/1) -> t/2 -> t/1 is not compatible with the type
+         (module s/2) -> t/2 -> t/2
+       Type (module s/1) is not compatible with type (module s/2)
        Line 5, characters 23-33:
          Definition of type t/1
        Line 3, characters 2-12:
@@ -180,6 +185,9 @@ Error: Signature mismatch:
          val f : a/2 -> 'a -> a/1
        is not included in
          val f : a/2 -> (module a) -> a/2
+       The type a/2 -> (module a) -> a/1 is not compatible with the type
+         a/2 -> (module a) -> a/2
+       Type a/1 is not compatible with type a/2
        Line 5, characters 12-22:
          Definition of type a/1
        Line 3, characters 2-12:
@@ -333,6 +341,7 @@ Error: Signature mismatch:
          type a = M/1.t
        is not included in
          type a = M/2.t
+       The type M/1.t is not equal to the type M/2.t
        Line 2, characters 14-42:
          Definition of module M/1
        File "_none_", line 1:
@@ -366,6 +375,9 @@ Error: Signature mismatch:
          val f : t/2 -> t/3 -> t/4 -> t/1
        is not included in
          val f : t/1 -> t/1 -> t/1 -> t/1
+       The type t/2 -> t/3 -> t/4 -> t/1 is not compatible with the type
+         t/1 -> t/1 -> t/1 -> t/1
+       Type t/2 is not compatible with type t/1
        Line 4, characters 0-10:
          Definition of type t/1
        Line 1, characters 0-10:

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -341,7 +341,7 @@ Error: Signature mismatch:
          type a = M/1.t
        is not included in
          type a = M/2.t
-       The type M/1.t is not equal to the type M/2.t
+       The type M/1.t = M/2.M.t is not equal to the type M/2.t
        Line 2, characters 14-42:
          Definition of module M/1
        File "_none_", line 1:

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -23,8 +23,10 @@ Error: Signature mismatch:
          type t = [ `T of t/2 ]
        is not included in
          type t = [ `T of t/1 ]
-       Line 1, characters 0-12:
-         Definition of type t/1
+       The type [ `T of t/1 ] is not equal to the type [ `T of t/2 ]
+       Types for tag `T are incompatible
        Line 4, characters 2-20:
+         Definition of type t/1
+       Line 1, characters 0-12:
          Definition of type t/2
 |}]

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -24,6 +24,7 @@ Error: Signature mismatch:
        is not included in
          type t = [ `T of t/1 ]
        The type [ `T of t/1 ] is not equal to the type [ `T of t/2 ]
+       Type t/1 = [ `T of t/1 ] is not equal to type t/2 = int
        Types for tag `T are incompatible
        Line 4, characters 2-20:
          Definition of type t/1

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -89,4 +89,9 @@ Error: Signature mismatch:
            [> `B of [> `BA | `BB of int list ] | `C of unit ]
        is not included in
          val a : t -> t
+       The type
+         [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ] ->
+         [> `B of [> `BA | `BB of int list ] | `C of unit ]
+       is not compatible with the type t -> t
+       Types for tag `BB are incompatible
 |}]

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -91,7 +91,10 @@ Error: Signature mismatch:
          val a : t -> t
        The type
          [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ] ->
-         [> `B of [> `BA | `BB of int list ] | `C of unit ]
+         ([> `B of [> `BA | `BB of int list ] | `C of unit ] as 'a)
        is not compatible with the type t -> t
+       Type [> `B of [> `BA | `BB of int list ] | `C of unit ] as 'a
+       is not compatible with type
+         t = [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]
        Types for tag `BB are incompatible
 |}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -197,7 +197,8 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          (int, [> `A ]) def
-       Their constraints differ.
+       Their parameters differ
+       The type int is not equal to the type 'a
 |}]
 
 type ('a,'b) kind = ('a, 'b) def = A constraint 'b = [> `A];;
@@ -220,7 +221,7 @@ Line 2, characters 0-37:
 Error: This variant or record definition does not match that of type d
        Fields do not match:
          y : int;
-       is not compatible with:
+       is not the same as:
          mutable y : int;
        This is mutable and the original is not.
 |}]
@@ -242,9 +243,9 @@ Line 1, characters 0-31:
 Error: This variant or record definition does not match that of type d
        Fields do not match:
          x : int;
-       is not compatible with:
+       is not the same as:
          x : float;
-       The types are not equal.
+       The type int is not equal to the type float
 |}]
 
 type mono = {foo:int}

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -25,6 +25,7 @@ Error: Signature mismatch:
          type t = X.t = A | B
        is not included in
          type t = int * bool
+       The type X.t is not equal to the type int * bool
 |}];;
 
 
@@ -65,7 +66,8 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
          (int, [> `A ]) def
-       Their constraints differ.
+       Their parameters differ
+       The type int is not equal to the type 'a
 |}]
 
 type ('a,'b) kind = ('a, 'b) def = {a:int} constraint 'b = [> `A];;
@@ -98,9 +100,9 @@ Line 1, characters 0-32:
 Error: This variant or record definition does not match that of type d
        Constructors do not match:
          X of int
-       is not compatible with:
+       is not the same as:
          X of float
-       The types are not equal.
+       The type int is not equal to the type float
 |}]
 
 type mono = Foo of float
@@ -145,7 +147,7 @@ Error: Signature mismatch:
          type t = Foo of int
        Constructors do not match:
          Foo : int -> t
-       is not compatible with:
+       is not the same as:
          Foo of int
        The first has explicit return type and the second doesn't.
 |}]

--- a/testsuite/tests/typing-modules-bugs/pr7414_2_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr7414_2_bad.compilers.reference
@@ -12,5 +12,8 @@ Error: Modules do not match:
        val r : '_weak1 list ref ref
      is not included in
        val r : Choice.t list ref ref
+     The type 'weak1 list ref ref is not compatible with the type
+       Choice.t list ref ref
+     The type constructor Choice.t would escape its scope
      File "pr7414_2_bad.ml", line 29, characters 2-31: Expected declaration
      File "pr7414_2_bad.ml", line 40, characters 8-9: Actual declaration

--- a/testsuite/tests/typing-modules-bugs/pr7414_2_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr7414_2_bad.compilers.reference
@@ -12,7 +12,7 @@ Error: Modules do not match:
        val r : '_weak1 list ref ref
      is not included in
        val r : Choice.t list ref ref
-     The type 'weak1 list ref ref is not compatible with the type
+     The type '_weak1 list ref ref is not compatible with the type
        Choice.t list ref ref
      The type constructor Choice.t would escape its scope
      File "pr7414_2_bad.ml", line 29, characters 2-31: Expected declaration

--- a/testsuite/tests/typing-modules-bugs/pr7414_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr7414_bad.compilers.reference
@@ -12,7 +12,7 @@ Error: Modules do not match:
        val r : '_weak1 list ref ref
      is not included in
        val r : Choice.t list ref ref
-     The type 'weak1 list ref ref is not compatible with the type
+     The type '_weak1 list ref ref is not compatible with the type
        Choice.t list ref ref
      The type constructor Choice.t would escape its scope
      File "pr7414_bad.ml", line 38, characters 2-31: Expected declaration

--- a/testsuite/tests/typing-modules-bugs/pr7414_bad.compilers.reference
+++ b/testsuite/tests/typing-modules-bugs/pr7414_bad.compilers.reference
@@ -12,5 +12,8 @@ Error: Modules do not match:
        val r : '_weak1 list ref ref
      is not included in
        val r : Choice.t list ref ref
+     The type 'weak1 list ref ref is not compatible with the type
+       Choice.t list ref ref
+     The type constructor Choice.t would escape its scope
      File "pr7414_bad.ml", line 38, characters 2-31: Expected declaration
      File "pr7414_bad.ml", line 33, characters 6-7: Actual declaration

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -97,9 +97,9 @@ Line 3, characters 23-33:
 Error: This variant or record definition does not match that of type u
        Constructors do not match:
          X of bool
-       is not compatible with:
+       is not the same as:
          X of int
-       The types are not equal.
+       The type bool is not equal to the type int
 |}];;
 
 (* PR#5815 *)
@@ -147,7 +147,7 @@ Error: Signature mismatch:
          type t += E
        Constructors do not match:
          E of int
-       is not compatible with:
+       is not the same as:
          E
        They have different arities.
 |}];;
@@ -168,9 +168,9 @@ Error: Signature mismatch:
          type t += E of char
        Constructors do not match:
          E of int
-       is not compatible with:
+       is not the same as:
          E of char
-       The types are not equal.
+       The type int is not equal to the type char
 |}];;
 
 module M : sig type t += C of int end = struct type t += E of int end;;
@@ -207,7 +207,7 @@ Error: Signature mismatch:
          type t += E of { x : int; }
        Constructors do not match:
          E of int
-       is not compatible with:
+       is not the same as:
          E of { x : int; }
        The second uses inline records and the first doesn't.
 |}];;

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -48,6 +48,7 @@ Error: Modules do not match:
        val equal : 'a -> 'a -> bool
      is not included in
        val equal : unit
+     The type 'a -> 'a -> bool is not compatible with the type unit
 |} ]
 
 

--- a/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
+++ b/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
@@ -21,7 +21,7 @@ Error: Signature mismatch:
          type t += F
        Constructors do not match:
          F of int
-       is not compatible with:
+       is not the same as:
          F
        They have different arities.
 |}];;

--- a/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
+++ b/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
@@ -40,7 +40,7 @@ Error: Signature mismatch:
          type t += private A
        is not included in
          type t += A
-       A private type would be revealed.
+       Private extension constructor(s) would be revealed.
 |}];;
 
 module M2 : sig type t += A end = struct type t += private A | B end;;
@@ -57,5 +57,5 @@ Error: Signature mismatch:
          type t += private A
        is not included in
          type t += A
-       A private type would be revealed.
+       Private extension constructor(s) would be revealed.
 |}];;

--- a/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
+++ b/testsuite/tests/typing-modules/extension_constructors_errors_test.ml
@@ -42,3 +42,20 @@ Error: Signature mismatch:
          type t += A
        A private type would be revealed.
 |}];;
+
+module M2 : sig type t += A end = struct type t += private A | B end;;
+[%%expect{|
+Line 1, characters 34-68:
+1 | module M2 : sig type t += A end = struct type t += private A | B end;;
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t += private A | B  end
+       is not included in
+         sig type t += A end
+       Extension declarations do not match:
+         type t += private A
+       is not included in
+         type t += A
+       A private type would be revealed.
+|}];;

--- a/testsuite/tests/typing-modules/functors.ml
+++ b/testsuite/tests/typing-modules/functors.ml
@@ -1617,11 +1617,9 @@ Error: The functor application is ill-typed.
             type t = Y of X.t
           Constructors do not match:
             Y of int
-          is not compatible with:
+          is not the same as:
             Y of X.t
-          The types are not equal.
-          Line 5, characters 0-32:
-            Definition of module X/1
+          The type int is not equal to the type X.t
        4. Modules do not match:
             Z : sig type t = Z.t = Z of int end
           is not included in
@@ -1632,9 +1630,9 @@ Error: The functor application is ill-typed.
             type t = Z of X.t
           Constructors do not match:
             Z of int
-          is not compatible with:
+          is not the same as:
             Z of X.t
-          The types are not equal.
+          The type int is not equal to the type X.t
 |}]
 
 (** Final state in the presence of extensions

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1054,6 +1054,70 @@ Error: Signature mismatch:
 |}];;
 
 module M : sig
+  type t = private [< `A | `B]
+end = struct
+  type t = private [`A | `B]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [`A | `B]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [ `A | `B ] end
+       is not included in
+         sig type t = private [< `A | `B ] end
+       Type declarations do not match:
+         type t = private [ `A | `B ]
+       is not included in
+         type t = private [< `A | `B ]
+|}];;
+
+module M : sig
+  type t = [`A | `B]
+end = struct
+  type t = private [`A | `B]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [`A | `B]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [ `A | `B ] end
+       is not included in
+         sig type t = [ `A | `B ] end
+       Type declarations do not match:
+         type t = private [ `A | `B ]
+       is not included in
+         type t = [ `A | `B ]
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = private [< `A | `B > `B]
+end = struct
+  type t = private [< `A | `B]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [< `A | `B]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `A | `B ] end
+       is not included in
+         sig type t = private [< `A | `B > `B ] end
+       Type declarations do not match:
+         type t = private [< `A | `B ]
+       is not included in
+         type t = private [< `A | `B > `B ]
+|}];;
+
+module M : sig
   type t = private <a : int; ..>
 end = struct
   type t = <b : int>

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -46,6 +46,29 @@ Error: Signature mismatch:
          type ('a, 'b) t = 'a * 'a
 |}];;
 
+type 'a x
+module M: sig
+  type ('a,'b,'c) t = ('a * 'b * 'c * 'b * 'a) x
+end = struct
+  type ('b,'c,'a) t = ('b * 'c * 'a * 'c * 'a) x
+end
+[%%expect{|
+type 'a x
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type ('b,'c,'a) t = ('b * 'c * 'a * 'c * 'a) x
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('b, 'c, 'a) t = ('b * 'c * 'a * 'c * 'a) x end
+       is not included in
+         sig type ('a, 'b, 'c) t = ('a * 'b * 'c * 'b * 'a) x end
+       Type declarations do not match:
+         type ('b, 'c, 'a) t = ('b * 'c * 'a * 'c * 'a) x
+       is not included in
+         type ('a, 'b, 'c) t = ('a * 'b * 'c * 'b * 'a) x
+|}]
+
 module M : sig
   type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>
 end = struct
@@ -537,6 +560,27 @@ Error: Signature mismatch:
        is not included in
          val f : s -> s
 |}];;
+
+module M : sig
+  val f : 'a -> float
+end = struct
+  let f : 'b -> int = fun _ -> 0
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f : 'b -> int = fun _ -> 0
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'b -> int end
+       is not included in
+         sig val f : 'a -> float end
+       Values do not match:
+         val f : 'b -> int
+       is not included in
+         val f : 'a -> float
+|}]
 
 module M : sig
   val x : 'a list ref
@@ -1235,4 +1279,312 @@ Error: Signature mismatch:
          type t = private s
        is not included in
          type t = private float
+|}];;
+
+module M : sig
+  type t = A
+end = struct
+  type t = private A
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private A
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private A end
+       is not included in
+         sig type t = A end
+       Type declarations do not match:
+         type t = private A
+       is not included in
+         type t = A
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = A | B
+end = struct
+  type t = private A | B
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private A | B
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private A | B end
+       is not included in
+         sig type t = A | B end
+       Type declarations do not match:
+         type t = private A | B
+       is not included in
+         type t = A | B
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = A of { x : int; y : bool }
+end = struct
+  type t = private A of { x : int; y : bool }
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private A of { x : int; y : bool }
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private A of { x : int; y : bool; } end
+       is not included in
+         sig type t = A of { x : int; y : bool; } end
+       Type declarations do not match:
+         type t = private A of { x : int; y : bool; }
+       is not included in
+         type t = A of { x : int; y : bool; }
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = { x : int; y : bool }
+end = struct
+  type t = private { x : int; y : bool }
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private { x : int; y : bool }
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private { x : int; y : bool; } end
+       is not included in
+         sig type t = { x : int; y : bool; } end
+       Type declarations do not match:
+         type t = private { x : int; y : bool; }
+       is not included in
+         type t = { x : int; y : bool; }
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = A
+end = struct
+  type t = private A | B
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private A | B
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private A | B end
+       is not included in
+         sig type t = A end
+       Type declarations do not match:
+         type t = private A | B
+       is not included in
+         type t = A
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = A | B
+end = struct
+  type t = private A
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private A
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private A end
+       is not included in
+         sig type t = A | B end
+       Type declarations do not match:
+         type t = private A
+       is not included in
+         type t = A | B
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = { x : int }
+end = struct
+  type t = private { x : int; y : bool }
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private { x : int; y : bool }
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private { x : int; y : bool; } end
+       is not included in
+         sig type t = { x : int; } end
+       Type declarations do not match:
+         type t = private { x : int; y : bool; }
+       is not included in
+         type t = { x : int; }
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = { x : int; y : bool }
+end = struct
+  type t = private { x : int }
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private { x : int }
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private { x : int; } end
+       is not included in
+         sig type t = { x : int; y : bool; } end
+       Type declarations do not match:
+         type t = private { x : int; }
+       is not included in
+         type t = { x : int; y : bool; }
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = A | B
+end = struct
+  type t = private { x : int; y : bool }
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private { x : int; y : bool }
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private { x : int; y : bool; } end
+       is not included in
+         sig type t = A | B end
+       Type declarations do not match:
+         type t = private { x : int; y : bool; }
+       is not included in
+         type t = A | B
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = { x : int; y : bool }
+end = struct
+  type t = private A | B
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private A | B
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private A | B end
+       is not included in
+         sig type t = { x : int; y : bool; } end
+       Type declarations do not match:
+         type t = private A | B
+       is not included in
+         type t = { x : int; y : bool; }
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = [`A]
+end = struct
+  type t = private [> `A | `B]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [> `A | `B]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [> `A | `B ] end
+       is not included in
+         sig type t = [ `A ] end
+       Type declarations do not match:
+         type t = private [> `A | `B ]
+       is not included in
+         type t = [ `A ]
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = [`A]
+end = struct
+  type t = private [< `A | `B]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [< `A | `B]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `A | `B ] end
+       is not included in
+         sig type t = [ `A ] end
+       Type declarations do not match:
+         type t = private [< `A | `B ]
+       is not included in
+         type t = [ `A ]
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = [`A]
+end = struct
+  type t = private [< `A | `B > `A]
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private [< `A | `B > `A]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private [< `A | `B > `A ] end
+       is not included in
+         sig type t = [ `A ] end
+       Type declarations do not match:
+         type t = private [< `A | `B > `A ]
+       is not included in
+         type t = [ `A ]
+       A private type would be revealed.
+|}];;
+
+module M : sig
+  type t = < m : int >
+end = struct
+  type t = private < m : int; .. >
+end;;
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = private < m : int; .. >
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = private < m : int; .. > end
+       is not included in
+         sig type t = < m : int > end
+       Type declarations do not match:
+         type t = private < m : int; .. >
+       is not included in
+         type t = < m : int >
+       A private type would be revealed.
 |}];;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -23,6 +23,8 @@ Error: Signature mismatch:
          type ('a, 'b) t = 'a * 'a
        is not included in
          type ('a, 'b) t = 'a * 'b
+       The type 'a * 'a is not equal to the type 'a * 'b
+       Type 'a is not equal to type 'b
 |}];;
 
 module M : sig
@@ -44,6 +46,8 @@ Error: Signature mismatch:
          type ('a, 'b) t = 'a * 'b
        is not included in
          type ('a, 'b) t = 'a * 'a
+       The type 'a * 'b is not equal to the type 'a * 'a
+       Type 'b is not equal to type 'a
 |}];;
 
 type 'a x
@@ -67,6 +71,9 @@ Error: Signature mismatch:
          type ('b, 'c, 'a) t = ('b * 'c * 'a * 'c * 'a) x
        is not included in
          type ('a, 'b, 'c) t = ('a * 'b * 'c * 'b * 'a) x
+       The type ('b * 'c * 'a * 'c * 'a) x is not equal to the type
+         ('b * 'c * 'a * 'c * 'b) x
+       Type 'a is not equal to type 'b
 |}]
 
 module M : sig
@@ -88,6 +95,11 @@ Error: Signature mismatch:
          type t = < m : 'a. 'a * ('a * 'b) > as 'b
        is not included in
          type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
+       The type < m : 'a. 'a * ('a * 'd) > as 'd is not equal to the type
+         < m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) >
+       The method m has type 'a. 'a * ('a * < m : 'a. 'b >) as 'b,
+       but the expected method type was 'c. 'c * ('b * < m : 'c. 'a >) as 'a
+       The universal variable 'b would escape its scope
 |}];;
 
 type s = private < m : int; .. >;;
@@ -114,6 +126,8 @@ Error: Signature mismatch:
          type t = < m : int >
        is not included in
          type t = s
+       The type < m : int > is not equal to the type s
+       The second object type has an abstract row, it cannot be closed
 |}];;
 
 module M : sig
@@ -135,6 +149,8 @@ Error: Signature mismatch:
          type t = s
        is not included in
          type t = < m : int >
+       The type s is not equal to the type < m : int >
+       The first object type has an abstract row, it cannot be closed
 |}];;
 
 module M : sig
@@ -161,9 +177,9 @@ Error: Signature mismatch:
          type t = Foo of int * float
        Constructors do not match:
          Foo of (int * int) * float
-       is not compatible with:
+       is not the same as:
          Foo of int * float
-       The types are not equal.
+       The type int * int is not equal to the type int
 |}];;
 
 module M : sig
@@ -185,6 +201,7 @@ Error: Signature mismatch:
          type t = int * float * int
        is not included in
          type t = int * float
+       The type int * float * int is not equal to the type int * float
 |}];;
 
 module M : sig
@@ -206,6 +223,9 @@ Error: Signature mismatch:
          type t = < f : float; n : int >
        is not included in
          type t = < m : float; n : int >
+       The type < f : float; n : int > is not equal to the type
+         < m : float; n : int >
+       The second object type has no method f
 |}];;
 
 module M : sig
@@ -227,6 +247,8 @@ Error: Signature mismatch:
          type t = < n : int >
        is not included in
          type t = < m : float; n : int >
+       The type < n : int > is not equal to the type < m : float; n : int >
+       The first object type has no method m
 |}];;
 
 module M4 : sig
@@ -248,6 +270,9 @@ Error: Signature mismatch:
          type t = < m : int; n : int >
        is not included in
          type t = < m : float * int; n : int >
+       The type < m : int; n : int > is not equal to the type
+         < m : float * int; n : int >
+       Types for method m are incompatible
 |}];;
 
 module M4 : sig
@@ -274,9 +299,11 @@ Error: Signature mismatch:
          type t = Foo of [ `Bar of string | `Foo of string ]
        Constructors do not match:
          Foo of [ `Bar of string ]
-       is not compatible with:
+       is not the same as:
          Foo of [ `Bar of string | `Foo of string ]
-       The types are not equal.
+       The type [ `Bar of string ] is not equal to the type
+         [ `Bar of string | `Foo of string ]
+       The first variant type does not allow tag(s) `Foo
 |}];;
 
 module M : sig
@@ -298,6 +325,8 @@ Error: Signature mismatch:
          type t = private [ `C ]
        is not included in
          type t = private [ `C of int ]
+       The type [ `C ] is not equal to the type [ `C of int ]
+       Types for tag `C are incompatible
 |}];;
 
 module M : sig
@@ -319,6 +348,8 @@ Error: Signature mismatch:
          type t = private [ `C of int ]
        is not included in
          type t = private [ `C ]
+       The type [ `C of int ] is not equal to the type [ `C ]
+       Types for tag `C are incompatible
 |}];;
 
 module M : sig
@@ -349,6 +380,8 @@ Error: Signature mismatch:
          type t = private [ `A of int ]
        is not included in
          type t = private [> `A of int ]
+       The type [ `A of int ] is not equal to the type [> `A of int ]
+       The second variant type is open and the first is not
 |}];;
 
 module M : sig
@@ -370,6 +403,8 @@ Error: Signature mismatch:
          type t = private [> `A of int ]
        is not included in
          type t = private [ `A of int ]
+       The type [> `A of int ] is not equal to the type [ `A of int ]
+       The first variant type is open and the second is not
 |}];;
 
 module M : sig
@@ -391,6 +426,9 @@ Error: Signature mismatch:
          type 'a t = 'a constraint 'a = [> `A of int ]
        is not included in
          type 'a t = 'a constraint 'a = [> `A of int | `B of int ]
+       The type [> `A of int ] is not equal to the type
+         [> `A of int | `B of int ]
+       The first variant type does not allow tag(s) `B
 |}];;
 
 module M : sig
@@ -412,6 +450,9 @@ Error: Signature mismatch:
          type 'a t = 'a constraint 'a = [> `A of int | `C of float ]
        is not included in
          type 'a t = 'a constraint 'a = [> `A of int ]
+       The type [> `A of int | `C of float ] is not equal to the type
+         [> `A of int ]
+       The second variant type does not allow tag(s) `C
 |}];;
 
 module M : sig
@@ -442,6 +483,7 @@ Error: Signature mismatch:
          type t = private [< `C of int & float ]
        is not included in
          type t = private [< `C ]
+       Types for tag `C are incompatible
 |}];;
 
 (********************************** Moregen ***********************************)
@@ -484,6 +526,9 @@ Error: Modules do not match:
        val r : '_weak1 list ref ref
      is not included in
        val r : Choice.t list ref ref
+     The type 'weak1 list ref ref is not compatible with the type
+       Choice.t list ref ref
+     The type constructor Choice.t would escape its scope
 |}];;
 
 module O = struct
@@ -510,6 +555,9 @@ Error: Signature mismatch:
          val f : (module s/1) -> unit
        is not included in
          val f : (module s/2) -> unit
+       The type (module s/1) -> unit is not compatible with the type
+         (module s/2) -> unit
+       Type (module s/1) is not compatible with type (module s/2)
        Line 6, characters 4-17:
          Definition of module type s/1
        Line 2, characters 2-15:
@@ -535,6 +583,12 @@ Error: Signature mismatch:
          val f : (< m : 'a. 'a * 'b > as 'b) -> unit
        is not included in
          val f : < m : 'b. 'b * < m : 'c. 'c * 'a > as 'a > -> unit
+       The type (< m : 'a. 'a * 'd > as 'd) -> unit
+       is not compatible with the type
+         < m : 'b. 'b * < m : 'c. 'c * 'e > as 'e > -> unit
+       The method m has type 'a. 'a * < m : 'a. 'b > as 'b,
+       but the expected method type was 'c. 'c * ('b * < m : 'c. 'a >) as 'a
+       The universal variable 'b would escape its scope
 |}];;
 
 type s = private < m : int; .. >;;
@@ -559,6 +613,9 @@ Error: Signature mismatch:
          val f : < m : int > -> < m : int >
        is not included in
          val f : s -> s
+       The type < m : int > -> < m : int > is not compatible with the type
+         s -> s
+       The second object type has an abstract row, it cannot be closed
 |}];;
 
 module M : sig
@@ -580,6 +637,8 @@ Error: Signature mismatch:
          val f : 'b -> int
        is not included in
          val f : 'a -> float
+       The type 'a -> int is not compatible with the type 'a -> float
+       Type int is not compatible with type float
 |}]
 
 module M : sig
@@ -601,6 +660,8 @@ Error: Signature mismatch:
          val x : '_weak2 list ref
        is not included in
          val x : 'a list ref
+       The type 'weak2 list ref is not compatible with the type 'a list ref
+       Type 'weak2 is not compatible with type 'a
 |}];;
 
 module M = struct let r = ref [] end;;
@@ -621,6 +682,8 @@ Error: Signature mismatch:
          val r : '_weak3 list ref
        is not included in
          val r : t list ref
+       The type 'weak3 list ref is not compatible with the type t list ref
+       The type constructor t would escape its scope
 |}];;
 
 type (_, _) eq = Refl : ('a, 'a) eq;;
@@ -662,6 +725,9 @@ Error: Signature mismatch:
          val r : '_weak4 list ref
        is not included in
          val r : T.s list ref
+       The type 'weak4 list ref is not compatible with the type T.s list ref
+       This instance of T.s is ambiguous:
+       it would escape the scope of its equation
 |}];;
 
 module M: sig
@@ -683,6 +749,8 @@ Error: Signature mismatch:
          val f : 'a -> 'a
        is not included in
          val f : int -> float
+       The type int -> int is not compatible with the type int -> float
+       Type int is not compatible with type float
 |}];;
 
 module M: sig
@@ -704,6 +772,9 @@ Error: Signature mismatch:
          val f : int * int -> int * int
        is not included in
          val f : int * float * int -> int -> int
+       The type int * int -> int * int is not compatible with the type
+         int * float * int -> int -> int
+       Type int * int is not compatible with type int * float * int
 |}];;
 
 module M: sig
@@ -725,6 +796,10 @@ Error: Signature mismatch:
          val f : < f : float; m : int > -> < f : float; m : int >
        is not included in
          val f : < m : int; n : float > -> < m : int; n : float >
+       The type < f : float; m : int > -> < f : float; m : int >
+       is not compatible with the type
+         < m : int; n : float > -> < m : int; n : float >
+       The second object type has no method f
 |}];;
 
 module M : sig
@@ -746,6 +821,9 @@ Error: Signature mismatch:
          val f : [ `Bar | `Foo ] -> unit
        is not included in
          val f : [ `Foo ] -> unit
+       The type [ `Bar | `Foo ] -> unit is not compatible with the type
+         [ `Foo ] -> unit
+       The second variant type does not allow tag(s) `Bar
 |}];;
 
 module M : sig
@@ -767,6 +845,9 @@ Error: Signature mismatch:
          val f : [< `Foo ] -> unit
        is not included in
          val f : [> `Foo ] -> unit
+       The type [< `Foo ] -> unit is not compatible with the type
+         [> `Foo ] -> unit
+       The second variant type is open and the first is not
 |}];;
 
 module M : sig
@@ -788,6 +869,9 @@ Error: Signature mismatch:
          val f : [< `Foo ] -> unit
        is not included in
          val f : [< `Bar | `Foo ] -> unit
+       The type [< `Foo ] -> unit is not compatible with the type
+         [< `Bar | `Foo ] -> unit
+       The first variant type does not allow tag(s) `Bar
 |}];;
 
 module M : sig
@@ -809,6 +893,9 @@ Error: Signature mismatch:
          val f : < m : 'a. [< `Foo ] as 'a > -> unit
        is not included in
          val f : < m : [< `Foo ] > -> unit
+       The type < m : 'a. [< `Foo ] as 'a > -> unit
+       is not compatible with the type < m : [< `Foo ] > -> unit
+       Types for method m are incompatible
 |}];;
 
 module M : sig
@@ -830,6 +917,9 @@ Error: Signature mismatch:
          val f : < m : [ `Foo ] > -> unit
        is not included in
          val f : < m : 'a. [< `Foo ] as 'a > -> unit
+       The type < m : [ `Foo ] > -> unit is not compatible with the type
+         < m : 'a. [< `Foo ] as 'a > -> unit
+       Types for method m are incompatible
 |}];;
 
 module M : sig
@@ -851,6 +941,9 @@ Error: Signature mismatch:
          val f : [< `C of int & float ] -> unit
        is not included in
          val f : [< `C ] -> unit
+       The type [< `C of & int & float ] -> unit
+       is not compatible with the type [< `C ] -> unit
+       Types for tag `C are incompatible
 |}];;
 
 module M : sig
@@ -872,6 +965,9 @@ Error: Signature mismatch:
          val f : [ `Foo of int ] -> unit
        is not included in
          val f : [ `Foo ] -> unit
+       The type [ `Foo of int ] -> unit is not compatible with the type
+         [ `Foo ] -> unit
+       Types for tag `Foo are incompatible
 |}];;
 
 module M : sig
@@ -893,6 +989,9 @@ Error: Signature mismatch:
          val f : [ `Foo ] -> unit
        is not included in
          val f : [ `Foo of int ] -> unit
+       The type [ `Foo ] -> unit is not compatible with the type
+         [ `Foo of int ] -> unit
+       Types for tag `Foo are incompatible
 |}];;
 
 module M : sig
@@ -923,6 +1022,10 @@ Error: Signature mismatch:
          val f : [> `Bar | `Foo ] -> unit
        is not included in
          val f : [< `Bar | `Baz | `Foo ] -> unit
+       The type [> `Bar | `Foo ] -> unit is not compatible with the type
+         [< `Bar | `Baz | `Foo ] -> unit
+       The tag `Foo is guaranteed to be present in the first variant type,
+       but not in the second
 |}];;
 
 (******************************* Type manifests *******************************)
@@ -946,6 +1049,7 @@ Error: Signature mismatch:
          type t = [ `C ]
        is not included in
          type t = private [< `A | `B ]
+       The constructor C is only present in the second declaration.
 |}];;
 
 module M : sig
@@ -967,6 +1071,7 @@ Error: Signature mismatch:
          type t = private [> `A ]
        is not included in
          type t = private [< `A | `B ]
+       The second is private and closed, but the first is not closed
 |}];;
 
 module M : sig
@@ -988,6 +1093,7 @@ Error: Signature mismatch:
          type t = [ `B ]
        is not included in
          type t = private [< `A | `B > `A ]
+       The constructor A is only present in the first declaration.
 |}];;
 
 module M : sig
@@ -1009,6 +1115,7 @@ Error: Signature mismatch:
          type t = [ `A ]
        is not included in
          type t = private [> `A of int ]
+       Types for tag `A are incompatible
 |}];;
 
 module M : sig
@@ -1030,6 +1137,7 @@ Error: Signature mismatch:
          type t = private [< `A of & int ]
        is not included in
          type t = private [< `A of int ]
+       Types for tag `A are incompatible
 |}];;
 
 
@@ -1052,6 +1160,7 @@ Error: Signature mismatch:
          type t = private [< `A ]
        is not included in
          type t = private [< `A of int ]
+       Types for tag `A are incompatible
 |}];;
 
 
@@ -1074,6 +1183,7 @@ Error: Signature mismatch:
          type t = private [< `A ]
        is not included in
          type t = private [< `A of int & float ]
+       Types for tag `A are incompatible
 |}];;
 
 module M : sig
@@ -1095,6 +1205,7 @@ Error: Signature mismatch:
          type t = [ `A of float ]
        is not included in
          type t = private [> `A of int ]
+       The type float is not equal to the type int
 |}];;
 
 module M : sig
@@ -1116,6 +1227,9 @@ Error: Signature mismatch:
          type t = private [ `A | `B ]
        is not included in
          type t = private [< `A | `B ]
+       The type [ `A | `B ] is not equal to the type [< `A | `B ]
+       The tag `B is guaranteed to be present in the first variant type,
+       but not in the second
 |}];;
 
 module M : sig
@@ -1159,6 +1273,8 @@ Error: Signature mismatch:
          type t = private [< `A | `B ]
        is not included in
          type t = private [< `A | `B > `B ]
+       The tag `B is present in the the second declaration,
+       but might not be in the the first
 |}];;
 
 module M : sig
@@ -1180,6 +1296,7 @@ Error: Signature mismatch:
          type t = < b : int >
        is not included in
          type t = private < a : int; .. >
+       The implementation is missing the method a
 |}];;
 
 module M : sig
@@ -1201,6 +1318,8 @@ Error: Signature mismatch:
          type t = < a : int >
        is not included in
          type t = private < a : float; .. >
+       The type int is not equal to the type float
+       Type int is not equal to type float
 |}];;
 
 type w = private float
@@ -1228,6 +1347,8 @@ Error: Signature mismatch:
          type t = private u
        is not included in
          type t = private int * (int * int)
+       The type int * q is not equal to the type int * (int * int)
+       Type q is not equal to type int * int
 |}];;
 
 type w = float
@@ -1255,6 +1376,8 @@ Error: Signature mismatch:
          type t = private u
        is not included in
          type t = private int * (int * int)
+       The type int * q is not equal to the type int * (int * int)
+       Type w is not equal to type int
 |}];;
 
 type s = private int
@@ -1279,6 +1402,7 @@ Error: Signature mismatch:
          type t = private s
        is not included in
          type t = private float
+       The type int is not equal to the type float
 |}];;
 
 module M : sig

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -526,7 +526,7 @@ Error: Modules do not match:
        val r : '_weak1 list ref ref
      is not included in
        val r : Choice.t list ref ref
-     The type 'weak1 list ref ref is not compatible with the type
+     The type '_weak1 list ref ref is not compatible with the type
        Choice.t list ref ref
      The type constructor Choice.t would escape its scope
 |}];;
@@ -615,6 +615,7 @@ Error: Signature mismatch:
          val f : s -> s
        The type < m : int > -> < m : int > is not compatible with the type
          s -> s
+       Type < m : int > is not compatible with type s = < m : int; .. >
        The second object type has an abstract row, it cannot be closed
 |}];;
 
@@ -660,8 +661,8 @@ Error: Signature mismatch:
          val x : '_weak2 list ref
        is not included in
          val x : 'a list ref
-       The type 'weak2 list ref is not compatible with the type 'a list ref
-       Type 'weak2 is not compatible with type 'a
+       The type '_weak2 list ref is not compatible with the type 'a list ref
+       Type '_weak2 is not compatible with type 'a
 |}];;
 
 module M = struct let r = ref [] end;;
@@ -682,7 +683,7 @@ Error: Signature mismatch:
          val r : '_weak3 list ref
        is not included in
          val r : t list ref
-       The type 'weak3 list ref is not compatible with the type t list ref
+       The type '_weak3 list ref is not compatible with the type t list ref
        The type constructor t would escape its scope
 |}];;
 
@@ -725,8 +726,9 @@ Error: Signature mismatch:
          val r : '_weak4 list ref
        is not included in
          val r : T.s list ref
-       The type 'weak4 list ref is not compatible with the type T.s list ref
-       This instance of T.s is ambiguous:
+       The type '_weak4 list ref is not compatible with the type T.s list ref
+       Type '_weak4 is not compatible with type T.s = T.t
+       This instance of T.t is ambiguous:
        it would escape the scope of its equation
 |}];;
 
@@ -1251,7 +1253,7 @@ Error: Signature mismatch:
          type t = private [ `A | `B ]
        is not included in
          type t = [ `A | `B ]
-       A private type would be revealed.
+       A private type abbreviation would be revealed
 |}];;
 
 module M : sig
@@ -1354,7 +1356,7 @@ Error: Signature mismatch:
 type w = float
 type q = (int * w)
 type u = private (int * q)
-module M : sig (* Confussing error message :( *)
+module M : sig
   type t = private (int * (int * int))
 end = struct
   type t = private u
@@ -1377,7 +1379,8 @@ Error: Signature mismatch:
        is not included in
          type t = private int * (int * int)
        The type int * q is not equal to the type int * (int * int)
-       Type w is not equal to type int
+       Type q = int * w is not equal to type int * int
+       Type w = float is not equal to type int
 |}];;
 
 type s = private int
@@ -1424,7 +1427,7 @@ Error: Signature mismatch:
          type t = private A
        is not included in
          type t = A
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 |}];;
 
 module M : sig
@@ -1446,7 +1449,7 @@ Error: Signature mismatch:
          type t = private A | B
        is not included in
          type t = A | B
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 |}];;
 
 module M : sig
@@ -1468,7 +1471,7 @@ Error: Signature mismatch:
          type t = private A of { x : int; y : bool; }
        is not included in
          type t = A of { x : int; y : bool; }
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 |}];;
 
 module M : sig
@@ -1490,7 +1493,7 @@ Error: Signature mismatch:
          type t = private { x : int; y : bool; }
        is not included in
          type t = { x : int; y : bool; }
-       A private type would be revealed.
+       A private record constructor would be revealed
 |}];;
 
 module M : sig
@@ -1512,7 +1515,7 @@ Error: Signature mismatch:
          type t = private A | B
        is not included in
          type t = A
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 |}];;
 
 module M : sig
@@ -1534,7 +1537,7 @@ Error: Signature mismatch:
          type t = private A
        is not included in
          type t = A | B
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 |}];;
 
 module M : sig
@@ -1556,7 +1559,7 @@ Error: Signature mismatch:
          type t = private { x : int; y : bool; }
        is not included in
          type t = { x : int; }
-       A private type would be revealed.
+       A private record constructor would be revealed
 |}];;
 
 module M : sig
@@ -1578,7 +1581,7 @@ Error: Signature mismatch:
          type t = private { x : int; }
        is not included in
          type t = { x : int; y : bool; }
-       A private type would be revealed.
+       A private record constructor would be revealed
 |}];;
 
 module M : sig
@@ -1600,7 +1603,7 @@ Error: Signature mismatch:
          type t = private { x : int; y : bool; }
        is not included in
          type t = A | B
-       A private type would be revealed.
+       Their kinds differ.
 |}];;
 
 module M : sig
@@ -1622,7 +1625,7 @@ Error: Signature mismatch:
          type t = private A | B
        is not included in
          type t = { x : int; y : bool; }
-       A private type would be revealed.
+       Their kinds differ.
 |}];;
 
 module M : sig
@@ -1644,7 +1647,7 @@ Error: Signature mismatch:
          type t = private [> `A | `B ]
        is not included in
          type t = [ `A ]
-       A private type would be revealed.
+       A private row type would be revealed
 |}];;
 
 module M : sig
@@ -1666,7 +1669,7 @@ Error: Signature mismatch:
          type t = private [< `A | `B ]
        is not included in
          type t = [ `A ]
-       A private type would be revealed.
+       A private row type would be revealed
 |}];;
 
 module M : sig
@@ -1688,7 +1691,7 @@ Error: Signature mismatch:
          type t = private [< `A | `B > `A ]
        is not included in
          type t = [ `A ]
-       A private type would be revealed.
+       A private row type would be revealed
 |}];;
 
 module M : sig
@@ -1710,5 +1713,5 @@ Error: Signature mismatch:
          type t = private < m : int; .. >
        is not included in
          type t = < m : int >
-       A private type would be revealed.
+       A private row type would be revealed
 |}];;

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -1253,7 +1253,7 @@ Error: Signature mismatch:
          type t = private [ `A | `B ]
        is not included in
          type t = [ `A | `B ]
-       A private type abbreviation would be revealed
+       A private type abbreviation would be revealed.
 |}];;
 
 module M : sig
@@ -1427,7 +1427,7 @@ Error: Signature mismatch:
          type t = private A
        is not included in
          type t = A
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 |}];;
 
 module M : sig
@@ -1449,7 +1449,7 @@ Error: Signature mismatch:
          type t = private A | B
        is not included in
          type t = A | B
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 |}];;
 
 module M : sig
@@ -1471,7 +1471,7 @@ Error: Signature mismatch:
          type t = private A of { x : int; y : bool; }
        is not included in
          type t = A of { x : int; y : bool; }
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 |}];;
 
 module M : sig
@@ -1493,7 +1493,7 @@ Error: Signature mismatch:
          type t = private { x : int; y : bool; }
        is not included in
          type t = { x : int; y : bool; }
-       A private record constructor would be revealed
+       A private record constructor would be revealed.
 |}];;
 
 module M : sig
@@ -1515,7 +1515,7 @@ Error: Signature mismatch:
          type t = private A | B
        is not included in
          type t = A
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 |}];;
 
 module M : sig
@@ -1537,7 +1537,7 @@ Error: Signature mismatch:
          type t = private A
        is not included in
          type t = A | B
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 |}];;
 
 module M : sig
@@ -1559,7 +1559,7 @@ Error: Signature mismatch:
          type t = private { x : int; y : bool; }
        is not included in
          type t = { x : int; }
-       A private record constructor would be revealed
+       A private record constructor would be revealed.
 |}];;
 
 module M : sig
@@ -1581,7 +1581,7 @@ Error: Signature mismatch:
          type t = private { x : int; }
        is not included in
          type t = { x : int; y : bool; }
-       A private record constructor would be revealed
+       A private record constructor would be revealed.
 |}];;
 
 module M : sig
@@ -1647,7 +1647,7 @@ Error: Signature mismatch:
          type t = private [> `A | `B ]
        is not included in
          type t = [ `A ]
-       A private row type would be revealed
+       A private row type would be revealed.
 |}];;
 
 module M : sig
@@ -1669,7 +1669,7 @@ Error: Signature mismatch:
          type t = private [< `A | `B ]
        is not included in
          type t = [ `A ]
-       A private row type would be revealed
+       A private row type would be revealed.
 |}];;
 
 module M : sig
@@ -1691,7 +1691,7 @@ Error: Signature mismatch:
          type t = private [< `A | `B > `A ]
        is not included in
          type t = [ `A ]
-       A private row type would be revealed
+       A private row type would be revealed.
 |}];;
 
 module M : sig
@@ -1713,5 +1713,5 @@ Error: Signature mismatch:
          type t = private < m : int; .. >
        is not included in
          type t = < m : int >
-       A private row type would be revealed
+       A private row type would be revealed.
 |}];;

--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -149,9 +149,9 @@ Error: In this `with' constraint, the new definition of t
          type t = X of int | Y of float
        Constructors do not match:
          X of x
-       is not compatible with:
+       is not the same as:
          X of int
-       The types are not equal.
+       The type x is not equal to the type int
 |}]
 
 (** First class module types require an identity *)

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -125,6 +125,9 @@ Error: Signature mismatch:
          type s = t
        is not included in
          type s = private [ `Bar of int | `Foo of 'a -> int ] as 'a
+       The type [ `Bar of int | `Foo of t -> int ] is not equal to the type
+         [ `Bar of int | `Foo of 'a -> int ] as 'a
+       Types for tag `Foo are incompatible
 |}]
 
 (* nondep_type_decl + nondep_type_rec *)

--- a/testsuite/tests/typing-modules/pr10399.ml
+++ b/testsuite/tests/typing-modules/pr10399.ml
@@ -41,4 +41,6 @@ Error: Signature mismatch:
            val o : t
          end
        Values do not match: val o : c is not included in val o : t
+       The type c is not compatible with the type t
+       The second object type has no method y
 |}]

--- a/testsuite/tests/typing-modules/pr10399.ml
+++ b/testsuite/tests/typing-modules/pr10399.ml
@@ -1,0 +1,44 @@
+(* TEST
+ * expect
+*)
+
+(* From jctis: <https://github.com/ocaml/ocaml/issues/10399> *)
+
+module PR10399 : sig
+  type t = < x : int >
+
+  class c : object method x : int method y : bool end
+
+  val o : t
+end = struct
+  type t = < x : int >
+
+  class c = object method x = 3 method y = true end
+
+  let o = new c
+end
+
+[%%expect{|
+Lines 7-13, characters 6-3:
+ 7 | ......struct
+ 8 |   type t = < x : int >
+ 9 |
+10 |   class c = object method x = 3 method y = true end
+11 |
+12 |   let o = new c
+13 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type t = < x : int >
+           class c : object method x : int method y : bool end
+           val o : c
+         end
+       is not included in
+         sig
+           type t = < x : int >
+           class c : object method x : int method y : bool end
+           val o : t
+         end
+       Values do not match: val o : c is not included in val o : t
+|}]

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -24,4 +24,5 @@ Error: Signature mismatch:
          type t = X.t = A | B
        is not included in
          type t = int * bool
+       The type X.t is not equal to the type int * bool
 |}];;

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -323,7 +323,9 @@ Line 15, characters 0-69:
 Error: This variant or record definition does not match that of type M.t
        Constructors do not match:
          E of (MkT(M.T).t, MkT(M.T).t) eq
-       is not compatible with:
+       is not the same as:
          E of (MkT(Desc).t, MkT(Desc).t) eq
-       The types are not equal.
+       The type (MkT(M.T).t, MkT(M.T).t) eq is not equal to the type
+         (MkT(Desc).t, MkT(Desc).t) eq
+       Type MkT(M.T).t is not equal to type MkT(Desc).t
 |}]

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -327,5 +327,6 @@ Error: This variant or record definition does not match that of type M.t
          E of (MkT(Desc).t, MkT(Desc).t) eq
        The type (MkT(M.T).t, MkT(M.T).t) eq is not equal to the type
          (MkT(Desc).t, MkT(Desc).t) eq
-       Type MkT(M.T).t is not equal to type MkT(Desc).t
+       Type MkT(M.T).t = Set.Make(M.Term0).t is not equal to type
+         MkT(Desc).t = Set.Make(Desc).t
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -31,7 +31,7 @@ Error: This variant or record definition does not match that of type M1.t
          E of M1.x
        is not the same as:
          E of M1.y
-       The type M1.x is not equal to the type M1.y
+       The type M1.x = int is not equal to the type M1.y = bool
 |}]
 
 let bool_of_int x =
@@ -84,5 +84,5 @@ Error: This variant or record definition does not match that of type M1.t
        is not the same as:
          E of (M1.x, M1.y) eq
        The type (M1.x, M1.x) eq is not equal to the type (M1.x, M1.y) eq
-       Type M1.x is not equal to type M1.y
+       Type M1.x = int is not equal to type M1.y = bool
 |}]

--- a/testsuite/tests/typing-modules/pr7851.ml
+++ b/testsuite/tests/typing-modules/pr7851.ml
@@ -29,9 +29,9 @@ Line 1, characters 0-58:
 Error: This variant or record definition does not match that of type M1.t
        Constructors do not match:
          E of M1.x
-       is not compatible with:
+       is not the same as:
          E of M1.y
-       The types are not equal.
+       The type M1.x is not equal to the type M1.y
 |}]
 
 let bool_of_int x =
@@ -81,7 +81,8 @@ Line 1, characters 0-58:
 Error: This variant or record definition does not match that of type M1.t
        Constructors do not match:
          E of (M1.x, M1.x) eq
-       is not compatible with:
+       is not the same as:
          E of (M1.x, M1.y) eq
-       The types are not equal.
+       The type (M1.x, M1.x) eq is not equal to the type (M1.x, M1.y) eq
+       Type M1.x is not equal to type M1.y
 |}]

--- a/testsuite/tests/typing-modules/records_errors_test.ml
+++ b/testsuite/tests/typing-modules/records_errors_test.ml
@@ -42,9 +42,11 @@ Error: Signature mismatch:
          }
        Fields do not match:
          f0 : unit * unit * unit * float * unit * unit * unit;
-       is not compatible with:
+       is not the same as:
          f0 : unit * unit * unit * int * unit * unit * unit;
-       The types are not equal.
+       The type unit * unit * unit * float * unit * unit * unit
+       is not equal to the type unit * unit * unit * int * unit * unit * unit
+       Type float is not equal to type int
 |}];;
 
 
@@ -88,7 +90,7 @@ Error: Signature mismatch:
          }
        Fields do not match:
          f0 : unit * unit * unit * float * unit * unit * unit;
-       is not compatible with:
+       is not the same as:
          mutable f0 : unit * unit * unit * int * unit * unit * unit;
        The second is mutable and the first is not.
 |}];;

--- a/testsuite/tests/typing-modules/variants_errors_test.ml
+++ b/testsuite/tests/typing-modules/variants_errors_test.ml
@@ -26,9 +26,9 @@ Error: Signature mismatch:
          type t = Foo of int * int
        Constructors do not match:
          Foo of float * int
-       is not compatible with:
+       is not the same as:
          Foo of int * int
-       The types are not equal.
+       The type float is not equal to the type int
 |}];;
 
 module M2 : sig
@@ -55,7 +55,7 @@ Error: Signature mismatch:
          type t = Foo of int * int
        Constructors do not match:
          Foo of float
-       is not compatible with:
+       is not the same as:
          Foo of int * int
        They have different arities.
 |}];;
@@ -84,13 +84,13 @@ Error: Signature mismatch:
          type t = Foo of { x : int; y : int; }
        Constructors do not match:
          Foo of { x : float; y : int; }
-       is not compatible with:
+       is not the same as:
          Foo of { x : int; y : int; }
        Fields do not match:
          x : float;
-       is not compatible with:
+       is not the same as:
          x : int;
-       The types are not equal.
+       The type float is not equal to the type int
 |}];;
 
 module M4 : sig
@@ -117,7 +117,7 @@ Error: Signature mismatch:
          type t = Foo of { x : int; y : int; }
        Constructors do not match:
          Foo of float
-       is not compatible with:
+       is not the same as:
          Foo of { x : int; y : int; }
        The second uses inline records and the first doesn't.
 |}];;
@@ -146,7 +146,7 @@ Error: Signature mismatch:
          type 'a t = Foo : int -> int t
        Constructors do not match:
          Foo of 'a
-       is not compatible with:
+       is not the same as:
          Foo : int -> int t
        The second has explicit return type and the first doesn't.
 |}];;
@@ -172,9 +172,9 @@ Error: Signature mismatch:
          type ('a, 'b) t = A of 'a
        Constructors do not match:
          A of 'b
-       is not compatible with:
+       is not the same as:
          A of 'a
-       The types are not equal.
+       The type 'b is not equal to the type 'a
 |}];;
 
 module M : sig
@@ -198,7 +198,7 @@ Error: Signature mismatch:
          type ('a, 'b) t = A of 'a
        Constructors do not match:
          A of 'a
-       is not compatible with:
+       is not the same as:
          A of 'a
-       The types are not equal.
+       The type 'a is not equal to the type 'b
 |}];;

--- a/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference
@@ -14,10 +14,12 @@ Error: The class type
            val l :
              [ `Abs of
                  string *
-                 ([ `Abs of string * expr | `App of 'a * exp ] as 'b)
-             | `App of expr * expr ] as 'a
+                 ([> `App of
+                       [ `Abs of string * 'a | `App of expr * expr ] * exp ]
+                  as 'a)
+             | `App of expr * expr ]
            val r : exp
-           method eval : (string, exp) Hashtbl.t -> 'b
+           method eval : (string, exp) Hashtbl.t -> 'a
          end
        is not matched by the class type exp
        The class type
@@ -25,22 +27,22 @@ Error: The class type
            val l :
              [ `Abs of
                  string *
-                 ([ `Abs of string * expr | `App of 'a * exp ] as 'b)
-             | `App of expr * expr ] as 'a
+                 ([> `App of
+                       [ `Abs of string * 'a | `App of expr * expr ] * exp ]
+                  as 'a)
+             | `App of expr * expr ]
            val r : exp
-           method eval : (string, exp) Hashtbl.t -> 'b
+           method eval : (string, exp) Hashtbl.t -> 'a
          end
        is not matched by the class type
          object method eval : (string, exp) Hashtbl.t -> expr end
        The method eval has type
          (string, exp) Hashtbl.t ->
-         ([ `Abs of string * expr
-          | `App of [ `Abs of string * 'a | `App of expr * expr ] * exp ]
+         ([> `App of [ `Abs of string * 'a | `App of expr * expr ] * exp ]
           as 'a)
        but is expected to have type (string, exp) Hashtbl.t -> expr
        Type
-         [ `Abs of string * expr
-         | `App of [ `Abs of string * 'a | `App of expr * expr ] * exp ]
+         [> `App of [ `Abs of string * 'a | `App of expr * expr ] * exp ]
          as 'a
        is not compatible with type
          expr = [ `Abs of string * expr | `App of expr * expr ] 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -702,7 +702,10 @@ Error: Signature mismatch:
          val f : (#c as 'a) -> 'a
        is not included in
          val f : #c -> #c
-       The type (#c as 'a) -> 'a is not compatible with the type 'a -> #c
+       The type (#c as 'a) -> 'a is not compatible with the type
+         'a -> (#c as 'b)
+       Type 'a = < m : 'a; .. > is not compatible with type
+         'b = < m : 'b; .. >
        Type 'a is not compatible with type 'b
 |}];;
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -702,6 +702,8 @@ Error: Signature mismatch:
          val f : (#c as 'a) -> 'a
        is not included in
          val f : #c -> #c
+       The type (#c as 'a) -> 'a is not compatible with the type 'a -> #c
+       Type 'a is not compatible with type 'b
 |}];;
 
 module M = struct type t = int class t () = object end end;;

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -13,3 +13,24 @@ Error: The type of this class,
        contains non-collapsible conjunctive types in constraints.
        Type int is not compatible with type float
 |}]
+
+class type ct = object
+  method x : int
+end
+
+class c (y : 'a * float) : ct = object
+  method x = y
+end
+[%%expect{|
+class type ct = object method x : int end
+Lines 5-7, characters 32-3:
+5 | ................................object
+6 |   method x = y
+7 | end
+Error: The class type object method x : 'a * float end
+       is not matched by the class type ct
+       The class type object method x : 'a * float end
+       is not matched by the class type object method x : int end
+       The method x has type 'a * float but is expected to have type int
+       Type 'a * float is not compatible with type int
+|}]

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -40,8 +40,7 @@ let foo = 42#m;;
 Line 1, characters 10-12:
 1 | let foo = 42#m;;
               ^^
-Error: This expression has type int
-       It has no method m
+Error: This expression is not an object; it has type int
 |}]
 
 let foo = object (self) method foo = self#bar end;;

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -34,3 +34,21 @@ Error: The class type object method x : 'a * float end
        The method x has type 'a * float but is expected to have type int
        Type 'a * float is not compatible with type int
 |}]
+
+let foo = 42#m;;
+[%%expect{|
+Line 1, characters 10-12:
+1 | let foo = 42#m;;
+              ^^
+Error: This expression has type int
+       It has no method m
+|}]
+
+let foo = object (self) method foo = self#bar end;;
+[%%expect{|
+Line 1, characters 37-41:
+1 | let foo = object (self) method foo = self#bar end;;
+                                         ^^^^
+Error: This expression has type < foo : 'a >
+       It has no method bar
+|}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1177,6 +1177,12 @@ Error: Signature mismatch:
          val f : (< m : 'a. 'a * ('a * 'b) > as 'b) -> unit
        is not included in
          val f : < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) > -> unit
+       The type (< m : 'a. 'a * ('a * 'd) > as 'd) -> unit
+       is not compatible with the type
+         < m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) > -> unit
+       The method m has type 'a. 'a * ('a * < m : 'a. 'b >) as 'b,
+       but the expected method type was 'c. 'c * ('b * < m : 'c. 'a >) as 'a
+       The universal variable 'b would escape its scope
 |}];;
 
 module M : sig type 'a t type u = <m: 'a. 'a t> end
@@ -1569,6 +1575,11 @@ Error: Values do not match:
        is not included in
          val f :
            < m : 'a. [< `Bar | `Foo of 'b & int ] as 'c > -> < m : 'b. 'c >
+       The type
+         < m : 'a. [< `Bar | `Foo of 'b & int ] as 'c > -> < m : 'b. 'c >
+       is not compatible with the type
+         < m : 'a. [< `Bar | `Foo of 'b & int ] as 'd > -> < m : 'b. 'd >
+       Types for tag `Foo are incompatible
 |}]
 
 (* PR#6171 *)

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -26,9 +26,9 @@ Error: Signature mismatch:
          val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit
        is not included in
          val write : [< `A of string | `B of int ] -> unit
-       The type ([< `A of 'weak2 | `B of 'weak3 ] as 'a) -> unit
+       The type (_[< `A of '_weak2 | `B of '_weak3 ] as 'a) -> unit
        is not compatible with the type
          ([< `A of string | `B of int ] as 'b) -> unit
-       Type [< `A of 'weak2 | `B of 'weak3 ] as 'a
+       Type _[< `A of '_weak2 | `B of '_weak3 ] as 'a
        is not compatible with type [< `A of string | `B of int ] as 'b
 |}]

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -26,4 +26,9 @@ Error: Signature mismatch:
          val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit
        is not included in
          val write : [< `A of string | `B of int ] -> unit
+       The type ([< `A of 'weak2 | `B of 'weak3 ] as 'a) -> unit
+       is not compatible with the type
+         ([< `A of string | `B of int ] as 'b) -> unit
+       Type [< `A of 'weak2 | `B of 'weak3 ] as 'a
+       is not compatible with type [< `A of string | `B of int ] as 'b
 |}]

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -30,6 +30,7 @@ Error: Signature mismatch:
          type t = M2.t
        is not included in
          type t = private M3.t
+       The type M2.t is not equal to the type M3.t
 Line 1, characters 44-45:
 1 | module M4 : sig type t = private M3.t end = M;; (* fails *)
                                                 ^
@@ -42,6 +43,7 @@ Error: Signature mismatch:
          type t = < m : int >
        is not included in
          type t = private M3.t
+       The type < m : int > is not equal to the type M3.t
 Line 1, characters 44-46:
 1 | module M4 : sig type t = private M3.t end = M1;; (* might be ok *)
                                                 ^^
@@ -54,6 +56,7 @@ Error: Signature mismatch:
          type t = M1.t
        is not included in
          type t = private M3.t
+       The type M1.t is not equal to the type M3.t
 module M5 : sig type t = private M1.t end
 Line 1, characters 53-55:
 1 | module M6 : sig type t = private < n:int; .. > end = M1;; (* fails *)
@@ -67,6 +70,7 @@ Error: Signature mismatch:
          type t = M1.t
        is not included in
          type t = private < n : int; .. >
+       The implementation is missing the method n
 Line 3, characters 2-51:
 3 |   struct type t = int let f (x : int) = (x : t) end;; (* must fail *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,6 +83,7 @@ Error: Signature mismatch:
          type t = int
        is not included in
          type t = private Foobar.t
+       The type int is not equal to the type Foobar.t
 module M : sig type t = private T of int val mk : int -> t end
 module M1 : sig type t = M.t val mk : int -> t end
 module M2 : sig type t = M.t val mk : int -> t end
@@ -117,7 +122,8 @@ Error: Type declarations do not match:
          type !'a t = private 'a constraint 'a = < x : int; .. >
        is not included in
          type 'a t
-       Their constraints differ.
+       Their parameters differ
+       The type < x : int; .. > is not equal to the type 'a
 type 'a t = private 'a constraint 'a = < x : int; .. >
 type t = [ `Closed ]
 type nonrec t = private [> t ]

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -92,7 +92,7 @@ Line 3, characters 4-27:
 3 |     type t = M.t = T of int
         ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 module M5 : sig type t = M.t = private T of int val mk : int -> t end
 module M6 : sig type t = private T of int val mk : int -> t end
 module M' :

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -92,7 +92,7 @@ Line 3, characters 4-27:
 3 |     type t = M.t = T of int
         ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 module M5 : sig type t = M.t = private T of int val mk : int -> t end
 module M6 : sig type t = private T of int val mk : int -> t end
 module M' :

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -30,6 +30,7 @@ Error: Signature mismatch:
          type t = M2.t
        is not included in
          type t = private M3.t
+       The type M2.t is not equal to the type M3.t
 Line 1, characters 44-45:
 1 | module M4 : sig type t = private M3.t end = M;; (* fails *)
                                                 ^
@@ -42,6 +43,7 @@ Error: Signature mismatch:
          type t = < m : int >
        is not included in
          type t = private M3.t
+       The type < m : int > is not equal to the type M3.t
 Line 1, characters 44-46:
 1 | module M4 : sig type t = private M3.t end = M1;; (* might be ok *)
                                                 ^^
@@ -54,6 +56,7 @@ Error: Signature mismatch:
          type t = M1.t
        is not included in
          type t = private M3.t
+       The type M1.t is not equal to the type M3.t
 module M5 : sig type t = private M1.t end
 Line 1, characters 53-55:
 1 | module M6 : sig type t = private < n:int; .. > end = M1;; (* fails *)
@@ -67,6 +70,7 @@ Error: Signature mismatch:
          type t = M1.t
        is not included in
          type t = private < n : int; .. >
+       The implementation is missing the method n
 Line 3, characters 2-51:
 3 |   struct type t = int let f (x : int) = (x : t) end;; (* must fail *)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,6 +83,7 @@ Error: Signature mismatch:
          type t = int
        is not included in
          type t = private Foobar.t
+       The type int is not equal to the type Foobar.t
 module M : sig type t = private T of int val mk : int -> t end
 module M1 : sig type t = M.t val mk : int -> t end
 module M2 : sig type t = M.t val mk : int -> t end
@@ -117,7 +122,8 @@ Error: Type declarations do not match:
          type !'a t = private < x : int; .. > constraint 'a = 'a t
        is not included in
          type 'a t
-       Their constraints differ.
+       Their parameters differ
+       The type 'b t as 'b is not equal to the type 'a
 type 'a t = private 'a constraint 'a = < x : int; .. >
 type t = [ `Closed ]
 type nonrec t = private [> t ]

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -92,7 +92,7 @@ Line 3, characters 4-27:
 3 |     type t = M.t = T of int
         ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
-       A private type would be revealed.
+       Private variant constructor(s) would be revealed
 module M5 : sig type t = M.t = private T of int val mk : int -> t end
 module M6 : sig type t = private T of int val mk : int -> t end
 module M' :

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -92,7 +92,7 @@ Line 3, characters 4-27:
 3 |     type t = M.t = T of int
         ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
-       Private variant constructor(s) would be revealed
+       Private variant constructor(s) would be revealed.
 module M5 : sig type t = M.t = private T of int val mk : int -> t end
 module M6 : sig type t = private T of int val mk : int -> t end
 module M' :

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -96,6 +96,7 @@ Error: Signature mismatch:
          type t = int
        is not included in
          type t = string
+       The type t is not equal to the type string
 module A : sig module B : sig type t = T end end
 module M2 : sig type u = A.B.t type foo = int type v = u end
 

--- a/testsuite/tests/typing-short-paths/short-paths.ml
+++ b/testsuite/tests/typing-short-paths/short-paths.ml
@@ -57,6 +57,10 @@ module N2 = struct type u = v and v = M1.v end;;
 module type PR6566 = sig type t = string end;;
 module PR6566 = struct type t = int end;;
 module PR6566' : PR6566 = PR6566;;
+(* Short-paths is currently a bit overzealous with this error message: we print
+   "The type t is not equal to the type string" instead of "The type int is not
+   equal to the type string".  This is correct, but less clear than it could
+   be. *)
 
 module A = struct module B = struct type t = T end end;;
 module M2 = struct type u = A.B.t type foo = int type v = A.B.t end;;

--- a/testsuite/tests/typing-sigsubst/test_locations.compilers.reference
+++ b/testsuite/tests/typing-sigsubst/test_locations.compilers.reference
@@ -7,6 +7,7 @@ Error: Signature mismatch:
          type elt = String.t
        is not included in
          type elt = unit
+       The type String.t is not equal to the type unit
        File "test_loc_type_eq.ml", line 1, characters 31-46:
          Expected declaration
        File "test_functor.ml", line 8, characters 45-61: Actual declaration
@@ -26,6 +27,7 @@ Error: Signature mismatch:
          type elt = String.t
        is not included in
          type elt = unit
+       The type String.t is not equal to the type unit
        File "test_loc_modtype_type_eq.ml", line 1, characters 36-51:
          Expected declaration
        File "test_functor.ml", line 8, characters 45-61: Actual declaration
@@ -45,6 +47,8 @@ Error: Signature mismatch:
          val create : elt -> t
        is not included in
          val create : unit -> t
+       The type elt -> t is not compatible with the type unit -> t
+       Type elt is not compatible with type unit 
        File "test_loc_type_subst.ml", line 1, characters 11-47:
          Expected declaration
        File "test_functor.ml", line 5, characters 2-23: Actual declaration
@@ -64,6 +68,8 @@ Error: Signature mismatch:
          val create : elt -> t
        is not included in
          val create : unit -> t
+       The type elt -> t is not compatible with the type unit -> t
+       Type elt is not compatible with type unit 
        File "test_loc_modtype_type_subst.ml", line 1, characters 16-52:
          Expected declaration
        File "test_functor.ml", line 5, characters 2-23: Actual declaration

--- a/testsuite/tests/typing-sigsubst/test_locations.compilers.reference
+++ b/testsuite/tests/typing-sigsubst/test_locations.compilers.reference
@@ -7,7 +7,7 @@ Error: Signature mismatch:
          type elt = String.t
        is not included in
          type elt = unit
-       The type String.t is not equal to the type unit
+       The type String.t = string is not equal to the type unit
        File "test_loc_type_eq.ml", line 1, characters 31-46:
          Expected declaration
        File "test_functor.ml", line 8, characters 45-61: Actual declaration
@@ -27,7 +27,7 @@ Error: Signature mismatch:
          type elt = String.t
        is not included in
          type elt = unit
-       The type String.t is not equal to the type unit
+       The type String.t = string is not equal to the type unit
        File "test_loc_modtype_type_eq.ml", line 1, characters 36-51:
          Expected declaration
        File "test_functor.ml", line 8, characters 45-61: Actual declaration
@@ -48,7 +48,7 @@ Error: Signature mismatch:
        is not included in
          val create : unit -> t
        The type elt -> t is not compatible with the type unit -> t
-       Type elt is not compatible with type unit 
+       Type elt = string is not compatible with type unit 
        File "test_loc_type_subst.ml", line 1, characters 11-47:
          Expected declaration
        File "test_functor.ml", line 5, characters 2-23: Actual declaration
@@ -69,7 +69,7 @@ Error: Signature mismatch:
        is not included in
          val create : unit -> t
        The type elt -> t is not compatible with the type unit -> t
-       Type elt is not compatible with type unit 
+       Type elt = string is not compatible with type unit 
        File "test_loc_modtype_type_subst.ml", line 1, characters 16-52:
          Expected declaration
        File "test_functor.ml", line 5, characters 2-23: Actual declaration

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -119,6 +119,7 @@ Error: Signature mismatch:
          external f : int -> (int [@untagged]) = "f" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
+       The two primitives' results have different representations
 |}]
 
 module Bad2 : sig
@@ -141,6 +142,7 @@ Error: Signature mismatch:
          external f : (int [@untagged]) -> int = "f" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
+       The two primitives' 1st arguments have different representations
 |}]
 
 module Bad3 : sig
@@ -163,6 +165,7 @@ Error: Signature mismatch:
          external f : (int [@untagged]) -> int = "f" "f_nat"
        is not included in
          external f : int -> int = "a" "a_nat"
+       The names of the primitives are not the same
 |}]
 
 module Bad4 : sig
@@ -185,6 +188,7 @@ Error: Signature mismatch:
          external f : float -> (float [@unboxed]) = "f" "f_nat"
        is not included in
          external f : float -> float = "f" "f_nat"
+       The two primitives' results have different representations
 |}]
 
 module Bad5 : sig
@@ -207,6 +211,7 @@ Error: Signature mismatch:
          external f : (float [@unboxed]) -> float = "f" "f_nat"
        is not included in
          external f : float -> float = "f" "f_nat"
+       The two primitives' 1st arguments have different representations
 |}]
 
 module Bad6 : sig
@@ -229,6 +234,7 @@ Error: Signature mismatch:
          external f : (float [@unboxed]) -> float = "f" "f_nat"
        is not included in
          external f : float -> float = "a" "a_nat"
+       The names of the primitives are not the same
 |}]
 
 module Bad7 : sig
@@ -251,6 +257,7 @@ Error: Signature mismatch:
          external f : int -> int = "f" "f_nat" [@@noalloc]
        is not included in
          external f : int -> int = "f" "f_nat"
+       The first primitive is [@@noalloc] but the second is not
 |}]
 
 (* Bad: attributes in the interface but not in the implementation *)
@@ -275,6 +282,7 @@ Error: Signature mismatch:
          external f : int -> int = "f" "f_nat"
        is not included in
          external f : int -> (int [@untagged]) = "f" "f_nat"
+       The two primitives' results have different representations
 |}]
 
 module Bad9 : sig
@@ -297,6 +305,7 @@ Error: Signature mismatch:
          external f : int -> int = "f" "f_nat"
        is not included in
          external f : (int [@untagged]) -> int = "f" "f_nat"
+       The two primitives' 1st arguments have different representations
 |}]
 
 module Bad10 : sig
@@ -319,6 +328,7 @@ Error: Signature mismatch:
          external f : int -> int = "a" "a_nat"
        is not included in
          external f : (int [@untagged]) -> int = "f" "f_nat"
+       The names of the primitives are not the same
 |}]
 
 module Bad11 : sig
@@ -341,6 +351,7 @@ Error: Signature mismatch:
          external f : float -> float = "f" "f_nat"
        is not included in
          external f : float -> (float [@unboxed]) = "f" "f_nat"
+       The two primitives' results have different representations
 |}]
 
 module Bad12 : sig
@@ -363,6 +374,7 @@ Error: Signature mismatch:
          external f : float -> float = "f" "f_nat"
        is not included in
          external f : (float [@unboxed]) -> float = "f" "f_nat"
+       The two primitives' 1st arguments have different representations
 |}]
 
 module Bad13 : sig
@@ -385,6 +397,7 @@ Error: Signature mismatch:
          external f : float -> float = "a" "a_nat"
        is not included in
          external f : (float [@unboxed]) -> float = "f" "f_nat"
+       The names of the primitives are not the same
 |}]
 
 module Bad14 : sig
@@ -407,6 +420,7 @@ Error: Signature mismatch:
          external f : int -> int = "f" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat" [@@noalloc]
+       The second primitive is [@@noalloc] but the first is not
 |}]
 
 (* Bad: claiming something is a primitive when it isn't *)
@@ -431,6 +445,7 @@ Error: Signature mismatch:
          val f : int -> int
        is not included in
          external f : int -> int = "f" "f_nat"
+       The definition is not a primitive
 |}]
 
 (* Good: not claiming something is a primitive when it is *)
@@ -470,6 +485,7 @@ Error: Signature mismatch:
          external f : int -> int = "gg" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
+       The names of the primitives are not the same
 |}]
 
 module Bad18 : sig
@@ -492,6 +508,7 @@ Error: Signature mismatch:
          external f : int -> int = "f" "gg_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
+       The native names of the primitives are not the same
 |}]
 
 module Bad19 : sig
@@ -514,6 +531,7 @@ Error: Signature mismatch:
          external f : int -> int = "gg" "gg_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
+       The names of the primitives are not the same
 |}]
 
 (* Bad: mismatched arities *)
@@ -544,6 +562,8 @@ Error: Signature mismatch:
          external f : int -> int -> int = "f" "f_nat"
        is not included in
          external f : int -> int -> int = "f" "f_nat"
+       The syntactic arities of these primitives were not the same
+       (They must have the same number of ->s present in the source)
 |}]
 
 module Bad21 : sig
@@ -571,6 +591,8 @@ Error: Signature mismatch:
          external f : int -> int_int = "f" "f_nat"
        is not included in
          external f : int -> int -> int = "f" "f_nat"
+       The syntactic arities of these primitives were not the same
+       (They must have the same number of ->s present in the source)
 |}]
 
 (* This will fail with a *type* error, instead of an arity mismatch *)
@@ -594,6 +616,8 @@ Error: Signature mismatch:
          external f : int -> int -> int = "f" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
+       The type int -> int -> int is not compatible with the type int -> int
+       Type int -> int is not compatible with type int
 |}]
 
 (* Bad: unboxed or untagged with the wrong type *)

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -122,6 +122,28 @@ Error: Signature mismatch:
 |}]
 
 module Bad2 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  external f : (int [@untagged]) -> int = "f" "f_nat"
+end;;
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : (int [@untagged]) -> int = "f" "f_nat"
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : (int [@untagged]) -> int = "f" "f_nat" end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : (int [@untagged]) -> int = "f" "f_nat"
+       is not included in
+         external f : int -> int = "f" "f_nat"
+|}]
+
+module Bad3 : sig
   external f : int -> int = "a" "a_nat"
 end = struct
   external f : (int [@untagged]) -> int = "f" "f_nat"
@@ -143,7 +165,7 @@ Error: Signature mismatch:
          external f : int -> int = "a" "a_nat"
 |}]
 
-module Bad3 : sig
+module Bad4 : sig
   external f : float -> float = "f" "f_nat"
 end = struct
   external f : float -> (float [@unboxed]) = "f" "f_nat"
@@ -165,7 +187,29 @@ Error: Signature mismatch:
          external f : float -> float = "f" "f_nat"
 |}]
 
-module Bad4 : sig
+module Bad5 : sig
+  external f : float -> float = "f" "f_nat"
+end = struct
+  external f : (float [@unboxed]) -> float = "f" "f_nat"
+end;;
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : (float [@unboxed]) -> float = "f" "f_nat"
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
+       is not included in
+         sig external f : float -> float = "f" "f_nat" end
+       Values do not match:
+         external f : (float [@unboxed]) -> float = "f" "f_nat"
+       is not included in
+         external f : float -> float = "f" "f_nat"
+|}]
+
+module Bad6 : sig
   external f : float -> float = "a" "a_nat"
 end = struct
   external f : (float [@unboxed]) -> float = "f" "f_nat"
@@ -187,9 +231,31 @@ Error: Signature mismatch:
          external f : float -> float = "a" "a_nat"
 |}]
 
+module Bad7 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  external f : int -> int = "f" "f_nat" [@@noalloc]
+end;;
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int = "f" "f_nat" [@@noalloc]
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int = "f" "f_nat" [@@noalloc] end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int = "f" "f_nat" [@@noalloc]
+       is not included in
+         external f : int -> int = "f" "f_nat"
+|}]
+
 (* Bad: attributes in the interface but not in the implementation *)
 
-module Bad5 : sig
+module Bad8 : sig
   external f : int -> (int [@untagged]) = "f" "f_nat"
 end = struct
   external f : int -> int = "f" "f_nat"
@@ -211,7 +277,29 @@ Error: Signature mismatch:
          external f : int -> (int [@untagged]) = "f" "f_nat"
 |}]
 
-module Bad6 : sig
+module Bad9 : sig
+  external f : (int [@untagged]) -> int = "f" "f_nat"
+end = struct
+  external f : int -> int = "f" "f_nat"
+end;;
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int = "f" "f_nat"
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int = "f" "f_nat" end
+       is not included in
+         sig external f : (int [@untagged]) -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int = "f" "f_nat"
+       is not included in
+         external f : (int [@untagged]) -> int = "f" "f_nat"
+|}]
+
+module Bad10 : sig
   external f : (int [@untagged]) -> int = "f" "f_nat"
 end = struct
   external f : int -> int = "a" "a_nat"
@@ -233,7 +321,7 @@ Error: Signature mismatch:
          external f : (int [@untagged]) -> int = "f" "f_nat"
 |}]
 
-module Bad7 : sig
+module Bad11 : sig
   external f : float -> (float [@unboxed]) = "f" "f_nat"
 end = struct
   external f : float -> float = "f" "f_nat"
@@ -255,7 +343,29 @@ Error: Signature mismatch:
          external f : float -> (float [@unboxed]) = "f" "f_nat"
 |}]
 
-module Bad8 : sig
+module Bad12 : sig
+  external f : (float [@unboxed]) -> float = "f" "f_nat"
+end = struct
+  external f : float -> float = "f" "f_nat"
+end;;
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : float -> float = "f" "f_nat"
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : float -> float = "f" "f_nat" end
+       is not included in
+         sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
+       Values do not match:
+         external f : float -> float = "f" "f_nat"
+       is not included in
+         external f : (float [@unboxed]) -> float = "f" "f_nat"
+|}]
+
+module Bad13 : sig
   external f : (float [@unboxed]) -> float = "f" "f_nat"
 end = struct
   external f : float -> float = "a" "a_nat"
@@ -275,6 +385,215 @@ Error: Signature mismatch:
          external f : float -> float = "a" "a_nat"
        is not included in
          external f : (float [@unboxed]) -> float = "f" "f_nat"
+|}]
+
+module Bad14 : sig
+  external f : int -> int = "f" "f_nat" [@@noalloc]
+end = struct
+  external f : int -> int = "f" "f_nat"
+end;;
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int = "f" "f_nat"
+5 | end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int = "f" "f_nat" end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" [@@noalloc] end
+       Values do not match:
+         external f : int -> int = "f" "f_nat"
+       is not included in
+         external f : int -> int = "f" "f_nat" [@@noalloc]
+|}]
+
+(* Bad: claiming something is a primitive when it isn't *)
+
+module Bad15 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  let f x = x + 1
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f x = x + 1
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : int -> int end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         val f : int -> int
+       is not included in
+         external f : int -> int = "f" "f_nat"
+|}]
+
+(* Good: not claiming something is a primitive when it is *)
+
+module Good16 : sig
+  val f : int -> int
+end = struct
+  external f : int -> int = "f" "f_nat"
+end
+(* The expected error here is that "f" isn't defined -- that means typechecking
+   succeeded *)
+
+[%%expect{|
+Line 1:
+Error: The external function `f' is not available
+|}]
+
+(* Bad: mismatched names and native names *)
+
+module Bad17 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  external f : int -> int = "gg" "f_nat"
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int = "gg" "f_nat"
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int = "gg" "f_nat" end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int = "gg" "f_nat"
+       is not included in
+         external f : int -> int = "f" "f_nat"
+|}]
+
+module Bad18 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  external f : int -> int = "f" "gg_nat"
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int = "f" "gg_nat"
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int = "f" "gg_nat" end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int = "f" "gg_nat"
+       is not included in
+         external f : int -> int = "f" "f_nat"
+|}]
+
+module Bad19 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  external f : int -> int = "gg" "gg_nat"
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int = "gg" "gg_nat"
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int = "gg" "gg_nat" end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int = "gg" "gg_nat"
+       is not included in
+         external f : int -> int = "f" "f_nat"
+|}]
+
+(* Bad: mismatched arities *)
+
+(* NB: The compiler checks primitive arities *syntactically*, based on the
+   number of arrows it sees.  Thus, hiding function types behind type synonyms
+   will produce an error about the primitive arities not matching, even when the
+   types agree. *)
+
+module Bad20 : sig
+  type int_int := int -> int
+  external f : int -> int_int = "f" "f_nat"
+end = struct
+  external f : int -> int -> int = "f" "f_nat"
+end
+
+[%%expect{|
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   external f : int -> int -> int = "f" "f_nat"
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int -> int = "f" "f_nat" end
+       is not included in
+         sig external f : int -> int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int -> int = "f" "f_nat"
+       is not included in
+         external f : int -> int -> int = "f" "f_nat"
+|}]
+
+module Bad21 : sig
+  external f : int -> int -> int = "f" "f_nat"
+end = struct
+  type int_int = int -> int
+  external f : int -> int_int = "f" "f_nat"
+end
+
+[%%expect{|
+Lines 3-6, characters 6-3:
+3 | ......struct
+4 |   type int_int = int -> int
+5 |   external f : int -> int_int = "f" "f_nat"
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type int_int = int -> int
+           external f : int -> int_int = "f" "f_nat"
+         end
+       is not included in
+         sig external f : int -> int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int_int = "f" "f_nat"
+       is not included in
+         external f : int -> int -> int = "f" "f_nat"
+|}]
+
+(* This will fail with a *type* error, instead of an arity mismatch *)
+module Bad22 : sig
+  external f : int -> int = "f" "f_nat"
+end = struct
+  external f : int -> int -> int = "f" "f_nat"
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external f : int -> int -> int = "f" "f_nat"
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig external f : int -> int -> int = "f" "f_nat" end
+       is not included in
+         sig external f : int -> int = "f" "f_nat" end
+       Values do not match:
+         external f : int -> int -> int = "f" "f_nat"
+       is not included in
+         external f : int -> int = "f" "f_nat"
 |}]
 
 (* Bad: unboxed or untagged with the wrong type *)

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -563,7 +563,7 @@ Error: Signature mismatch:
        is not included in
          external f : int -> int -> int = "f" "f_nat"
        The syntactic arities of these primitives were not the same
-       (They must have the same number of ->s present in the source)
+       (They must have the same number of arrows present in the source)
 |}]
 
 module Bad21 : sig
@@ -592,7 +592,7 @@ Error: Signature mismatch:
        is not included in
          external f : int -> int -> int = "f" "f_nat"
        The syntactic arities of these primitives were not the same
-       (They must have the same number of ->s present in the source)
+       (They must have the same number of arrows present in the source)
 |}]
 
 (* This will fail with a *type* error, instead of an arity mismatch *)

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -445,7 +445,7 @@ Error: Signature mismatch:
          val f : int -> int
        is not included in
          external f : int -> int = "f" "f_nat"
-       The implementation is not a primitive
+       The implementation is not a primitive.
 |}]
 
 (* Good: not claiming something is a primitive when it is *)
@@ -562,8 +562,8 @@ Error: Signature mismatch:
          external f : int -> int -> int = "f" "f_nat"
        is not included in
          external f : int -> int -> int = "f" "f_nat"
-       The syntactic arities of these primitives were not the same
-       (They must have the same number of arrows present in the source)
+       The syntactic arities of these primitives were not the same.
+       (They must have the same number of arrows present in the source.)
 |}]
 
 module Bad21 : sig
@@ -591,8 +591,8 @@ Error: Signature mismatch:
          external f : int -> int_int = "f" "f_nat"
        is not included in
          external f : int -> int -> int = "f" "f_nat"
-       The syntactic arities of these primitives were not the same
-       (They must have the same number of arrows present in the source)
+       The syntactic arities of these primitives were not the same.
+       (They must have the same number of arrows present in the source.)
 |}]
 
 (* This will fail with a *type* error, instead of an arity mismatch *)

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -445,7 +445,7 @@ Error: Signature mismatch:
          val f : int -> int
        is not included in
          external f : int -> int = "f" "f_nat"
-       The definition is not a primitive
+       The implementation is not a primitive
 |}]
 
 (* Good: not claiming something is a primitive when it is *)

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -36,4 +36,7 @@ Error: Signature mismatch:
          val f : fpclass -> Stdlib.fpclass
        is not included in
          val f : fpclass -> fpclass
+       The type fpclass -> Stdlib.fpclass is not compatible with the type
+         fpclass -> fpclass
+       Type Stdlib.fpclass is not compatible with type fpclass
 |}]

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -171,6 +171,8 @@ let _ = add_directive "mod_use" (Directive_string (dir_mod_use std_out))
 
 (* Install, remove a printer *)
 
+exception Bad_printing_function
+
 let filter_arrow ty =
   let ty = Ctype.expand_head !toplevel_env ty in
   match ty.desc with
@@ -179,10 +181,10 @@ let filter_arrow ty =
 
 let rec extract_last_arrow desc =
   match filter_arrow desc with
-  | None -> raise (Ctype.Unify [])
+  | None -> raise Bad_printing_function
   | Some (_, r as res) ->
       try extract_last_arrow r
-      with Ctype.Unify _ -> res
+      with Bad_printing_function -> res
 
 let extract_target_type ty = fst (extract_last_arrow ty)
 let extract_target_parameters ty =
@@ -211,9 +213,14 @@ let printer_type ppf typename =
 let match_simple_printer_type desc printer_type =
   Ctype.begin_def();
   let ty_arg = Ctype.newvar() in
-  Ctype.unify !toplevel_env
-    (Ctype.newconstr printer_type [ty_arg])
-    (Ctype.instance desc.val_type);
+  begin try
+    (* Only the call to [Ctype.unify] can actually fail *)
+    Ctype.unify !toplevel_env
+      (Ctype.newconstr printer_type [ty_arg])
+      (Ctype.instance desc.val_type);
+  with Ctype.Unify _ ->
+    raise Bad_printing_function
+  end;
   Ctype.end_def();
   Ctype.generalize ty_arg;
   (ty_arg, None)
@@ -229,13 +236,18 @@ let match_generic_printer_type desc path args printer_type =
       (fun ty_arg ty -> Ctype.newty (Tarrow (Asttypes.Nolabel, ty_arg, ty,
                                              Cunknown)))
       ty_args (Ctype.newconstr printer_type [ty_target]) in
-  Ctype.unify !toplevel_env
-    ty_expected
-    (Ctype.instance desc.val_type);
+  begin try
+    (* Only the call to [Ctype.unify] can actually fail *)
+    Ctype.unify !toplevel_env
+      ty_expected
+      (Ctype.instance desc.val_type);
+  with Ctype.Unify _ ->
+    raise Bad_printing_function
+  end;
   Ctype.end_def();
   Ctype.generalize ty_expected;
   if not (Ctype.all_distinct_vars !toplevel_env args) then
-    raise (Ctype.Unify []);
+    raise Bad_printing_function;
   (ty_expected, Some (path, ty_args))
 
 let match_printer_type ppf desc =
@@ -243,10 +255,10 @@ let match_printer_type ppf desc =
   let printer_type_old = printer_type ppf "printer_type_old" in
   try
     (match_simple_printer_type desc printer_type_new, false)
-  with Ctype.Unify _ ->
+  with Bad_printing_function ->
     try
       (match_simple_printer_type desc printer_type_old, true)
-    with Ctype.Unify _ as exn ->
+    with Bad_printing_function as exn ->
       match extract_target_parameters desc.val_type with
       | None -> raise exn
       | Some (path, args) ->
@@ -258,8 +270,8 @@ let find_printer_type ppf lid =
   | (path, desc) -> begin
     match match_printer_type ppf desc with
     | (ty_arg, is_old_style) -> (ty_arg, path, is_old_style)
-    | exception Ctype.Unify _ ->
-      fprintf ppf "%a has a wrong type for a printing function.@."
+    | exception Bad_printing_function ->
+      fprintf ppf "%a has the wrong type for a printing function.@."
       Printtyp.longident lid;
       raise Exit
   end

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -214,7 +214,6 @@ let match_simple_printer_type desc printer_type =
   Ctype.begin_def();
   let ty_arg = Ctype.newvar() in
   begin try
-    (* Only the call to [Ctype.unify] can actually fail *)
     Ctype.unify !toplevel_env
       (Ctype.newconstr printer_type [ty_arg])
       (Ctype.instance desc.val_type);
@@ -237,7 +236,6 @@ let match_generic_printer_type desc path args printer_type =
                                              Cunknown)))
       ty_args (Ctype.newconstr printer_type [ty_target]) in
   begin try
-    (* Only the call to [Ctype.unify] can actually fail *)
     Ctype.unify !toplevel_env
       ty_expected
       (Ctype.instance desc.val_type);

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3426,14 +3426,8 @@ let filter_method env name priv ty =
 let check_filter_method env name priv ty =
   ignore(filter_method env name priv ty)
 
-exception Self_has_no_such_method
-
 let filter_self_method env lab priv meths ty =
-  let ty' =
-    try filter_method env lab priv ty
-    with Filter_method_failed Not_a_method -> raise Self_has_no_such_method
-       | Filter_method_failed _            -> assert false
-  in
+  let ty' = filter_method env lab priv ty in
   try
     Meths.find lab !meths
   with Not_found ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -43,7 +43,7 @@ open Local_store
      class do not depend on sharing thanks to constrained
      abbreviations. (Of course, even if some sharing is lost, typing
      will still be correct.)
-   - All nodes of a type have a level : that way, one know whether a
+   - All nodes of a type have a level : that way, one knows whether a
      node need to be duplicated or not when instantiating a type.
    - Levels of a type are decreasing (generic level being considered
      as greatest).
@@ -57,16 +57,16 @@ open Local_store
 
 (**** Errors ****)
 
-exception Unify_trace    of unification Errortrace.t
-exception Equality_trace of comparison  Errortrace.t
-exception Moregen_trace  of comparison  Errortrace.t
+exception Unify_trace    of unification trace
+exception Equality_trace of comparison  trace
+exception Moregen_trace  of comparison  trace
 
 exception Unify    of unification_error
 exception Equality of equality_error
 exception Moregen  of moregen_error
-exception Subtype  of Errortrace.Subtype.t * unification_error
+exception Subtype  of Subtype.error * unification_error
 
-exception Escape of desc Errortrace.escape
+exception Escape of type_expr escape
 
 (* For local use: throw the appropriate exception.  Can be passed into local
    functions as a parameter *)
@@ -78,7 +78,7 @@ type _ trace_exn =
 let raise_trace_for
       (type variant)
       (tr_exn : variant trace_exn)
-      (tr     : variant Errortrace.t) : 'a =
+      (tr     : variant trace) : 'a =
   match tr_exn with
   | Unify    -> raise (Unify_trace    tr)
   | Equality -> raise (Equality_trace tr)
@@ -98,7 +98,7 @@ exception Public_method_to_private_method
 
 let escape kind = {kind; context = None}
 let escape_exn kind = Escape (escape kind)
-let scope_escape_exn ty = escape_exn (Equation (short ty))
+let scope_escape_exn ty = escape_exn (Equation ty)
 let raise_escape_exn kind = raise (escape_exn kind)
 let raise_scope_escape_exn ty = raise (scope_escape_exn ty)
 
@@ -945,6 +945,24 @@ let lower_contravariant env ty =
   simple_abbrevs := Mnil;
   lower_contravariant env !nongen_level (Hashtbl.create 7) false ty
 
+(* Generalize a class type *)
+let rec generalize_class_type gen =
+  function
+    Cty_constr (_, params, cty) ->
+      List.iter gen params;
+      generalize_class_type gen cty
+  | Cty_signature {csig_self = sty; csig_vars = vars; csig_inher = inher} ->
+      gen sty;
+      Vars.iter (fun _ (_, _, ty) -> gen ty) vars;
+      List.iter (fun (_,tl) -> List.iter gen tl) inher
+  | Cty_arrow (_, ty, cty) ->
+      gen ty;
+      generalize_class_type gen cty
+
+let generalize_class_type vars =
+  let gen = if vars then generalize else generalize_structure in
+  generalize_class_type gen
+
 (* Correct the levels of type [ty]. *)
 let correct_levels ty =
   duplicate_type ty
@@ -1474,7 +1492,6 @@ let instance_label fixed lbl =
 (* NB: since this is [unify_var], it raises [Unify], not [Unify_trace] *)
 let unify_var' = (* Forward declaration *)
   ref (fun _env _ty1 _ty2 -> assert false)
-
 
 let subst env level priv abbrev ty params args body =
   if List.length params <> List.length args then raise Cannot_subst;
@@ -2114,20 +2131,36 @@ let rec has_cached_expansion p abbrev =
 
 (**** Transform error trace ****)
 (* +++ Move it to some other place ? *)
+(* That's hard to do because it relies on the expansion machinery in Ctype,
+   but still might be nice. *)
+
+let expand_type env ty =
+  { ty       = repr ty;
+    expanded = full_expand ~may_forget_scope:true env ty }
 
 let expand_any_trace map env trace =
-  let expand_desc x = match x.Errortrace.expanded with
-    | None ->
-      let expanded = full_expand ~may_forget_scope:true env x.t in
-      Errortrace.{ t = repr x.t; expanded = Some expanded }
-    | Some _ -> x in
-  map expand_desc trace
+  map (expand_type env) trace
 
 let expand_trace env trace =
   expand_any_trace Errortrace.map env trace
 
 let expand_subtype_trace env trace =
   expand_any_trace Subtype.map env trace
+
+(* [expand_trace] takes care of most of the expansion in this file, but we
+   occasionally need to build [Errortrace.error]s in other ways/elsewhere, so we
+   expose some machinery for doing so
+*)
+
+(* Equivalent to [expand_trace env [Diff {got; expected}]] for a single
+   element *)
+let expanded_diff env ~got ~expected =
+  Diff (map_diff (expand_type env) {got; expected})
+
+(* Diff while transforming a [type_expr] into an [expanded_type] without
+   expanding *)
+let unexpanded_diff ~got ~expected =
+  Diff (map_diff unexpanded_type {got; expected})
 
 (**** Unification ****)
 
@@ -2706,7 +2739,7 @@ let rec unify (env:Env.t ref) t1 t2 =
     reset_trace_gadt_instances reset_tracing;
   with Unify_trace trace ->
     reset_trace_gadt_instances reset_tracing;
-    raise_trace_for Unify (Errortrace.diff t1 t2 :: trace)
+    raise_trace_for Unify (Diff {got = t1; expected = t2} :: trace)
 
 and unify2 env t1 t2 =
   (* Second step: expansion of abbreviations *)
@@ -2949,7 +2982,7 @@ and unify_fields env ty1 ty2 =          (* Optimization *)
     unify env (build_fields l1 miss1 va) rest2;
     unify env rest1 (build_fields l2 miss2 va);
     List.iter
-      (fun (n, k1, t1, k2, t2) ->
+      (fun (name, k1, t1, k2, t2) ->
         unify_kind k1 k2;
         try
           if !trace_gadt_instances then begin
@@ -2959,7 +2992,7 @@ and unify_fields env ty1 ty2 =          (* Optimization *)
           unify env t1 t2
         with Unify_trace trace ->
           raise_trace_for Unify
-            (Errortrace.incompatible_fields n t1 t2 :: trace)
+            (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
       )
       pairs
   with exn ->
@@ -3218,7 +3251,7 @@ let unify_var env t1 t2 =
       with Unify_trace trace ->
         reset_trace_gadt_instances reset_tracing;
         let expanded_trace =
-          expand_trace env @@ Errortrace.diff t1 t2 :: trace
+          expand_trace env @@ Diff { got = t1; expected = t2 } :: trace
         in
         raise (Unify {trace = expanded_trace})
       end
@@ -3313,7 +3346,7 @@ let filter_method env name priv ty =
     | _ ->
         raise_unexplained_for Unify
   with Unify_trace trace ->
-    raise (Unify {trace})
+    raise (Unify {trace = expand_trace env trace})
 
 let check_filter_method env name priv ty =
   ignore(filter_method env name priv ty)
@@ -3421,7 +3454,7 @@ let rec moregen inst_nongen type_pairs env t1 t2 =
               raise_unexplained_for Moregen
         end
   with Moregen_trace trace ->
-    raise_trace_for Moregen (Errortrace.diff t1 t2 :: trace)
+    raise_trace_for Moregen (Diff {got = t1; expected = t2} :: trace)
 
 
 and moregen_list inst_nongen type_pairs env tl1 tl2 =
@@ -3442,12 +3475,12 @@ and moregen_fields inst_nongen type_pairs env ty1 ty2 =
     (build_fields (repr ty2).level miss2 rest2);
 
   List.iter
-    (fun (n, k1, t1, k2, t2) ->
+    (fun (name, k1, t1, k2, t2) ->
        (* The below call should never throw [Public_method_to_private_method] *)
        moregen_kind k1 k2;
        try moregen inst_nongen type_pairs env t1 t2 with Moregen_trace trace ->
          raise_trace_for Moregen
-           (Errortrace.incompatible_fields n t1 t2 :: trace)
+           (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace)
     )
     pairs
 
@@ -3594,7 +3627,8 @@ let moregeneral env inst_nongen pat_sch subj_sch =
      then copied with [duplicate_type].  That way, its levels won't be
      changed.
   *)
-  let subj = duplicate_type (instance subj_sch) in
+  let subj_inst = instance subj_sch in
+  let subj = duplicate_type subj_inst in
   current_level := generic_level;
   (* Duplicate generic variables *)
   let patt = instance pat_sch in
@@ -3604,7 +3638,15 @@ let moregeneral env inst_nongen pat_sch subj_sch =
        try
          moregen inst_nongen (TypePairs.create 13) env patt subj
        with Moregen_trace trace ->
-         raise (Moregen {trace}))
+         (* In order to properly detect and print weak variables when printing
+            this error, we need to regeneralize the levels of the types after
+            they were instantiated at [generic_level - 1] above.  Because
+            [moregen] does some unification that we need to preserve for more
+            legible error messages, we have to manually perform the
+            rengeneralization rather than backtracking. *)
+         current_level := generic_level - 2;
+         generalize subj_inst;
+         raise (Moregen {trace = expand_trace env trace}))
     ~always:(fun () -> current_level := old_level)
 
 let is_moregeneral env inst_nongen pat_sch subj_sch =
@@ -3653,7 +3695,7 @@ let all_distinct_vars env vars =
       (tyl := ty :: !tyl; is_Tvar ty))
     vars
 
-let matches env ty ty' =
+let matches ~expand_error_trace env ty ty' =
   let snap = snapshot () in
   let vars = rigidify ty in
   cleanup_abbrev ();
@@ -3661,7 +3703,12 @@ let matches env ty ty' =
   | () ->
       if not (all_distinct_vars env vars) then begin
         backtrack snap;
-        raise (Matches_failure (env, {trace = [Errortrace.diff ty ty']}))
+        let diff =
+          if expand_error_trace
+          then expanded_diff env
+          else unexpanded_diff
+        in
+        raise (Matches_failure (env, {trace = [diff ~got:ty ~expected:ty']}))
       end;
       backtrack snap
   | exception Unify err ->
@@ -3669,7 +3716,7 @@ let matches env ty ty' =
       raise (Matches_failure (env, err))
 
 let does_match env ty ty' =
-  match matches env ty ty' with
+  match matches ~expand_error_trace:false env ty ty' with
   | () -> true
   | exception Matches_failure (_, _) -> false
 
@@ -3767,7 +3814,7 @@ let rec eqtype rename type_pairs subst env t1 t2 =
               raise_unexplained_for Equality
         end
   with Equality_trace trace ->
-    raise_trace_for Equality (Errortrace.diff t1 t2 :: trace)
+    raise_trace_for Equality (Diff {got = t1; expected = t2} :: trace)
 
 and eqtype_list rename type_pairs subst env tl1 tl2 =
   if List.length tl1 <> List.length tl2 then
@@ -3794,13 +3841,13 @@ and eqtype_fields rename type_pairs subst env ty1 ty2 =
   | (_, (n, _, _)::_) -> raise_for Equality (Obj (Missing_field (First, n)))
   | [], [] ->
       List.iter
-        (function (n, k1, t1, k2, t2) ->
+        (function (name, k1, t1, k2, t2) ->
            eqtype_kind k1 k2;
            try
              eqtype rename type_pairs subst env t1 t2;
            with Equality_trace trace ->
              raise_trace_for Equality
-               (Errortrace.incompatible_fields n t1 t2 :: trace))
+               (incompatible_fields ~name ~got:t1 ~expected:t2 :: trace))
         pairs
 
 and eqtype_kind k1 k2 =
@@ -3809,7 +3856,9 @@ and eqtype_kind k1 k2 =
   match k1, k2 with
   | (Fvar _, Fvar _)
   | (Fpresent, Fpresent) -> ()
-  | _                    -> assert false
+  | _                    -> raise_unexplained_for Unify
+                            (* It's probably not possible to hit this case with
+                               real OCaml code *)
 
 and eqtype_row rename type_pairs subst env row1 row2 =
   (* Try expansion, needed when called from Includecore.type_manifest *)
@@ -3911,7 +3960,7 @@ let equal env rename tyl1 tyl2 =
   try eqtype_list rename (TypePairs.create 11) subst env tyl1 tyl2
   with Equality_trace trace ->
     normalize_subst subst;
-    raise (Equality {subst = !subst; trace})
+    raise (Equality {trace = expand_trace env trace; subst = !subst})
 
 let is_equal env rename tyl1 tyl2 =
   match equal env rename tyl1 tyl2 with
@@ -4085,6 +4134,18 @@ let match_class_types ?(trace=true) env pat_sch subj_sch =
     | error ->
         CM_Class_type_mismatch (env, patt, subj)::error
   in
+  begin match res with
+  | []   -> ()
+  | _::_ ->
+    (* If [res] is nonempty, we've found an error.  In order to properly detect
+       and print weak variables when printing this error, we need to
+       regeneralize the levels of the types after they were instantiated at
+       [generic_level - 1] above.  Because we may do unification that we need to
+       preserve for more legible error messages, we have to manually perform the
+       rengeneralization rather than backtracking. *)
+    current_level := generic_level - 2;
+    generalize_class_type true subj_inst;
+  end;
   current_level := old_level;
   res
 
@@ -4466,8 +4527,9 @@ let enlarge_type env ty =
 
 let subtypes = TypePairs.create 17
 
-let subtype_error env trace =
-  raise (Subtype (expand_subtype_trace env (List.rev trace), {trace=[]}))
+let subtype_error ~env ~trace ~unification_trace =
+  raise (Subtype (expand_subtype_trace env (List.rev trace),
+                  {trace=unification_trace}))
 
 let rec subtype_rec env trace t1 t2 cstrs =
   let t1 = repr t1 in
@@ -4484,8 +4546,18 @@ let rec subtype_rec env trace t1 t2 cstrs =
         (trace, t1, t2, !univar_pairs)::cstrs
     | (Tarrow(l1, t1, u1, _), Tarrow(l2, t2, u2, _)) when l1 = l2
       || !Clflags.classic && not (is_optional l1 || is_optional l2) ->
-        let cstrs = subtype_rec env (Subtype.diff t2 t1::trace) t2 t1 cstrs in
-        subtype_rec env (Subtype.diff u1 u2::trace) u1 u2 cstrs
+        let cstrs =
+          subtype_rec
+            env
+            (Subtype.Diff {got = t2; expected = t1} :: trace)
+            t2 t1
+            cstrs
+        in
+        subtype_rec
+          env
+          (Subtype.Diff {got = u1; expected = u2} :: trace)
+          u1 u2
+          cstrs
     | (Ttuple tl1, Ttuple tl2) ->
         subtype_list env trace tl1 tl2 cstrs
     | (Tconstr(p1, [], _), Tconstr(p2, [], _)) when Path.same p1 p2 ->
@@ -4506,10 +4578,20 @@ let rec subtype_rec env trace t1 t2 cstrs =
                 if cn then
                   (trace, newty2 t1.level (Ttuple[t1]),
                    newty2 t2.level (Ttuple[t2]), !univar_pairs) :: cstrs
-                else subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
+                else
+                  subtype_rec
+                    env
+                    (Subtype.Diff {got = t1; expected = t2} :: trace)
+                    t1 t2
+                    cstrs
               else
                 if cn
-                then subtype_rec env (Subtype.diff t2 t1::trace) t2 t1 cstrs
+                then
+                  subtype_rec
+                    env
+                    (Subtype.Diff {got = t2; expected = t1} :: trace)
+                    t2 t1
+                    cstrs
                 else cstrs)
             cstrs decl.type_variance (List.combine tl1 tl2)
         with Not_found ->
@@ -4573,9 +4655,14 @@ let rec subtype_rec env trace t1 t2 cstrs =
 
 and subtype_list env trace tl1 tl2 cstrs =
   if List.length tl1 <> List.length tl2 then
-    subtype_error env trace;
+    subtype_error ~env ~trace ~unification_trace:[];
   List.fold_left2
-    (fun cstrs t1 t2 -> subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs)
+    (fun cstrs t1 t2 ->
+       subtype_rec
+         env
+         (Subtype.Diff { got = t1; expected = t2 } :: trace)
+         t1 t2
+         cstrs)
     cstrs tl1 tl2
 
 and subtype_fields env trace ty1 ty2 cstrs =
@@ -4586,7 +4673,11 @@ and subtype_fields env trace ty1 ty2 cstrs =
   let cstrs =
     if rest2.desc = Tnil then cstrs else
     if miss1 = [] then
-      subtype_rec env (Subtype.diff rest1 rest2::trace) rest1 rest2 cstrs
+      subtype_rec
+        env
+        (Subtype.Diff {got = rest1; expected = rest2} :: trace)
+        rest1 rest2
+        cstrs
     else
       (trace, build_fields (repr ty1).level miss1 rest1, rest2,
        !univar_pairs) :: cstrs
@@ -4598,8 +4689,12 @@ and subtype_fields env trace ty1 ty2 cstrs =
   in
   List.fold_left
     (fun cstrs (_, _k1, t1, _k2, t2) ->
-      (* These fields are always present *)
-      subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs)
+       (* These fields are always present *)
+       subtype_rec
+         env
+         (Subtype.Diff {got = t1; expected = t2} :: trace)
+         t1 t2
+         cstrs)
     cstrs pairs
 
 and subtype_row env trace row1 row2 cstrs =
@@ -4612,7 +4707,11 @@ and subtype_row env trace row1 row2 cstrs =
   and more2 = repr row2.row_more in
   match more1.desc, more2.desc with
     Tconstr(p1,_,_), Tconstr(p2,_,_) when Path.same p1 p2 ->
-      subtype_rec env (Subtype.diff more1 more2::trace) more1 more2 cstrs
+      subtype_rec
+        env
+        (Subtype.Diff {got = more1; expected = more2} :: trace)
+        more1 more2
+        cstrs
   | (Tvar _|Tconstr _|Tnil), (Tvar _|Tconstr _|Tnil)
     when row1.row_closed && r1 = [] ->
       List.fold_left
@@ -4621,16 +4720,29 @@ and subtype_row env trace row1 row2 cstrs =
             (Rpresent None|Reither(true,_,_,_)), Rpresent None ->
               cstrs
           | Rpresent(Some t1), Rpresent(Some t2) ->
-              subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
+              subtype_rec
+                env
+                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                t1 t2
+                cstrs
           | Reither(false, t1::_, _, _), Rpresent(Some t2) ->
-              subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
+              subtype_rec
+                env
+                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                t1 t2
+                cstrs
           | Rabsent, _ -> cstrs
           | _ -> raise Exit)
         cstrs pairs
   | Tunivar _, Tunivar _
     when row1.row_closed = row2.row_closed && r1 = [] && r2 = [] ->
       let cstrs =
-        subtype_rec env (Subtype.diff more1 more2::trace) more1 more2 cstrs in
+        subtype_rec
+          env
+          (Subtype.Diff {got = more1; expected = more2} :: trace)
+          more1 more2
+          cstrs
+      in
       List.fold_left
         (fun cstrs (_,f1,f2) ->
           match row_field_repr f1, row_field_repr f2 with
@@ -4640,7 +4752,11 @@ and subtype_row env trace row1 row2 cstrs =
               cstrs
           | Rpresent(Some t1), Rpresent(Some t2)
           | Reither(false,[t1],_,_), Reither(false,[t2],_,_) ->
-              subtype_rec env (Subtype.diff t1 t2::trace) t1 t2 cstrs
+              subtype_rec
+                env
+                (Subtype.Diff {got = t1; expected = t2} :: trace)
+                t1 t2
+                cstrs
           | _ -> raise Exit)
         cstrs pairs
   | _ ->
@@ -4650,15 +4766,16 @@ let subtype env ty1 ty2 =
   TypePairs.clear subtypes;
   univar_pairs := [];
   (* Build constraint set. *)
-  let cstrs = subtype_rec env [Subtype.diff ty1 ty2] ty1 ty2 [] in
+  let cstrs =
+    subtype_rec env [Subtype.Diff {got = ty1; expected = ty2}] ty1 ty2 []
+  in
   TypePairs.clear subtypes;
   (* Enforce constraints. *)
   function () ->
     List.iter
       (function (trace0, t1, t2, pairs) ->
          try unify_pairs (ref env) t1 t2 pairs with Unify {trace} ->
-           raise (Subtype (expand_subtype_trace env (List.rev trace0),
-                           {trace = List.tl trace})))
+           subtype_error ~env ~trace:trace0 ~unification_trace:(List.tl trace))
       (List.rev cstrs)
 
                               (*******************)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -193,18 +193,18 @@ val expand_head_opt: Env.t -> type_expr -> type_expr
 (** The compiler's own version of [expand_head] necessary for type-based
     optimisations. *)
 
-(* Expansion of types for error traces; lives here instead of in [Errortrace]
-   because the expansion machinery lives here. *)
+(** Expansion of types for error traces; lives here instead of in [Errortrace]
+    because the expansion machinery lives here. *)
 
-(* Create an [Errortrace.Diff] by expanding the two types *)
+(** Create an [Errortrace.Diff] by expanding the two types *)
 val expanded_diff :
   Env.t ->
   got:type_expr -> expected:type_expr ->
   (Errortrace.expanded_type, 'variant) Errortrace.elt
 
-(* Create an [Errortrace.Diff] by *duplicating* the two types, so that each
-   one's expansion is identical to itself.  Despite the name, does create
-   [Errortrace.expanded_type]s. *)
+(** Create an [Errortrace.Diff] by *duplicating* the two types, so that each
+    one's expansion is identical to itself.  Despite the name, does create
+    [Errortrace.expanded_type]s. *)
 val unexpanded_diff :
   got:type_expr -> expected:type_expr ->
   (Errortrace.expanded_type, 'variant) Errortrace.elt

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -246,7 +246,7 @@ val deep_occur: type_expr -> type_expr -> bool
 val filter_self_method:
         Env.t -> string -> private_flag -> (Ident.t * type_expr) Meths.t ref ->
         type_expr -> Ident.t * type_expr
-        (* Raises [Self_has_no_such_method] instead of [Unify], and only if the
+        (* Raises [Filter_method_failed] instead of [Unify], and only if the
            self type is closed at this point. *)
 val moregeneral: Env.t -> bool -> type_expr -> type_expr -> unit
         (* Check if the first type scheme is more general than the second. *)
@@ -285,8 +285,6 @@ type filter_method_failure =
   | Not_an_object of type_expr
 
 exception Filter_method_failed of filter_method_failure
-
-exception Self_has_no_such_method
 
 type class_match_failure =
     CM_Virtual_class

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -20,16 +20,17 @@ open Types
 
 module TypePairs : Hashtbl.S with type key = type_expr * type_expr
 
-exception Unify of Errortrace.unification Errortrace.t
-exception Equality of Errortrace.comparison Errortrace.t
-exception Moregen of Errortrace.comparison Errortrace.t
-exception Subtype of Errortrace.Subtype.t * Errortrace.unification Errortrace.t
+exception Unify    of Errortrace.unification_error
+exception Equality of Errortrace.equality_error
+exception Moregen  of Errortrace.moregen_error
+exception Subtype  of Errortrace.Subtype.t * Errortrace.unification_error
+
 exception Escape of Errortrace.desc Errortrace.escape
 
 exception Tags of label * label
 exception Cannot_expand
 exception Cannot_apply
-exception Matches_failure of Env.t * Errortrace.unification Errortrace.t
+exception Matches_failure of Env.t * Errortrace.unification_error
   (* Raised from [matches], hence the odd name *)
 exception Incompatible
   (* Raised from [mcomp] *)
@@ -239,22 +240,14 @@ val does_match: Env.t -> type_expr -> type_expr -> bool
 val reify_univars : Env.t -> Types.type_expr -> Types.type_expr
         (* Replaces all the variables of a type by a univar. *)
 
-type class_match_failure_trace_type =
-  | CM_Equality
-  | CM_Moregen
-
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
-  | CM_Type_parameter_mismatch of Env.t * Errortrace.comparison Errortrace.t
+  | CM_Type_parameter_mismatch of Env.t * Errortrace.equality_error
   | CM_Class_type_mismatch of Env.t * class_type * class_type
-  | CM_Parameter_mismatch of Env.t * Errortrace.comparison Errortrace.t
-  | CM_Val_type_mismatch of
-      class_match_failure_trace_type *
-      string * Env.t * Errortrace.comparison Errortrace.t
-  | CM_Meth_type_mismatch of
-      class_match_failure_trace_type *
-      string * Env.t * Errortrace.comparison Errortrace.t
+  | CM_Parameter_mismatch of Env.t * Errortrace.moregen_error
+  | CM_Val_type_mismatch of string * Env.t * Errortrace.comparison_error
+  | CM_Meth_type_mismatch of string * Env.t * Errortrace.comparison_error
   | CM_Non_mutable_value of string
   | CM_Non_concrete_value of string
   | CM_Missing_value of string
@@ -264,6 +257,7 @@ type class_match_failure =
   | CM_Public_method of string
   | CM_Private_method of string
   | CM_Virtual_method of string
+
 val match_class_types:
     ?trace:bool -> Env.t -> class_type -> class_type -> class_match_failure list
         (* Check if the first class type is more general than the second. *)

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -85,6 +85,7 @@ type 'variety variant =
   | Fixed_row :
       position * fixed_row_case * fixed_explanation -> unification variant
   (* Equality & Moregen *)
+  | Presence_not_guaranteed_for : position * string -> comparison variant
   | Openness : position (* Always [Second] for Moregen *) -> comparison variant
 
 type 'variety obj =
@@ -140,6 +141,21 @@ let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
   | x -> x
 
 let swap_trace e = List.map swap_elt e
+
+type unification_error = { trace : unification t } [@@unboxed]
+
+type equality_error =
+  { trace : comparison t;
+    subst : (type_expr * type_expr) list }
+
+type moregen_error = { trace : comparison t } [@@unboxed]
+
+type comparison_error =
+  | Equality_error of equality_error
+  | Moregen_error  of moregen_error
+
+let swap_unification_error ({trace} : unification_error) =
+  ({trace = swap_trace trace} : unification_error)
 
 module Subtype = struct
   type 'a elt =

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -28,19 +28,17 @@ let print_pos ppf = function
   | First -> fprintf ppf "first"
   | Second -> fprintf ppf "second"
 
-type desc = { t: type_expr; expanded: type_expr option }
-type 'a diff = { got: 'a; expected: 'a}
+type expanded_type = { ty: type_expr; expanded: type_expr }
 
-let short t = { t; expanded = None }
+let unexpanded_type ty = { ty; expanded = ty }
+
+type 'a diff = { got: 'a; expected: 'a }
+
 let map_diff f r =
   (* ordering is often meaningful when dealing with type_expr *)
   let got = f r.got in
   let expected = f r.expected in
-  { got; expected}
-
-let flatten_desc f x = match x.expanded with
-  | None -> f x.t x.t
-  | Some expanded -> f x.t expanded
+  { got; expected }
 
 let swap_diff x = { got = x.expected; expected = x.got }
 
@@ -57,6 +55,11 @@ type 'a escape_kind =
 type 'a escape =
   { kind : 'a escape_kind;
     context : type_expr option }
+
+let map_escape f esc =
+  {esc with kind = match esc.kind with
+     | Equation eq -> Equation (f eq)
+     | (Constructor _ | Univ _ | Self | Module_type _ | Constraint) as c -> c}
 
 let explain trace f =
   let rec explain = function
@@ -106,10 +109,10 @@ type ('a, 'variety) elt =
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) elt
 
-type 'variety t =
-  (desc, 'variety) elt list
+type ('a, 'variety) t = ('a, 'variety) elt list
 
-let diff got expected = Diff (map_diff short { got; expected })
+type 'variety trace = (type_expr,     'variety) t
+type 'variety error = (expanded_type, 'variety) t
 
 let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Diff x -> Diff (map_diff f x)
@@ -121,12 +124,8 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
 
 let map f t = List.map (map_elt f) t
 
-(* Convert desc to type_expr * type_expr *)
-let flatten f = map (flatten_desc f)
-
-let incompatible_fields name got expected =
+let incompatible_fields ~name ~got ~expected =
   Incompatible_fields { name; diff={got; expected} }
-
 
 let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
   | Diff x -> Diff (swap_diff x)
@@ -142,13 +141,13 @@ let swap_elt (type variety) : ('a, variety) elt -> ('a, variety) elt = function
 
 let swap_trace e = List.map swap_elt e
 
-type unification_error = { trace : unification t } [@@unboxed]
+type unification_error = { trace : unification error } [@@unboxed]
 
 type equality_error =
-  { trace : comparison t;
+  { trace : comparison error;
     subst : (type_expr * type_expr) list }
 
-type moregen_error = { trace : comparison t } [@@unboxed]
+type moregen_error = { trace : comparison error } [@@unboxed]
 
 type comparison_error =
   | Equality_error of equality_error
@@ -161,14 +160,13 @@ module Subtype = struct
   type 'a elt =
     | Diff of 'a diff
 
-  type t = desc elt list
+  type 'a t = 'a elt list
 
-  let diff got expected = Diff (map_diff short {got;expected})
+  type trace = type_expr     t
+  type error = expanded_type t
 
   let map_elt f = function
     | Diff x -> Diff (map_diff f x)
 
   let map f t = List.map (map_elt f) t
-
-  let flatten f t = map (flatten_desc f) t
 end

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -150,19 +150,16 @@ type equality_error =
 type moregen_error = { trace : comparison error } [@@unboxed]
 
 let unification_error ~trace : unification_error =
-  if trace = []
-  then Misc.fatal_error "Unification error trace was empty"
-  else { trace }
+  assert (trace <> []);
+  { trace }
 
 let equality_error ~trace ~subst : equality_error =
-  if trace = []
-  then Misc.fatal_error "Equality error trace was empty"
-  else { trace; subst }
+    assert (trace <> []);
+    { trace; subst }
 
 let moregen_error ~trace : moregen_error =
-  if trace = []
-  then Misc.fatal_error "Moregen error trace was empty"
-  else { trace }
+  assert (trace <> []);
+  { trace }
 
 type comparison_error =
   | Equality_error of equality_error
@@ -187,9 +184,8 @@ module Subtype = struct
     ; unification_trace : unification error }
 
   let error ~trace ~unification_trace =
-    if trace = []
-    then Misc.fatal_error "Subtype error trace was empty"
-    else { trace; unification_trace }
+  assert (trace <> []);
+  { trace; unification_trace }
 
   let map_elt f = function
     | Diff x -> Diff (map_diff f x)

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -149,6 +149,21 @@ type equality_error =
 
 type moregen_error = { trace : comparison error } [@@unboxed]
 
+let unification_error ~trace : unification_error =
+  if trace = []
+  then Misc.fatal_error "Unification error trace was empty"
+  else { trace }
+
+let equality_error ~trace ~subst : equality_error =
+  if trace = []
+  then Misc.fatal_error "Equality error trace was empty"
+  else { trace; subst }
+
+let moregen_error ~trace : moregen_error =
+  if trace = []
+  then Misc.fatal_error "Moregen error trace was empty"
+  else { trace }
+
 type comparison_error =
   | Equality_error of equality_error
   | Moregen_error  of moregen_error
@@ -162,8 +177,19 @@ module Subtype = struct
 
   type 'a t = 'a elt list
 
-  type trace = type_expr     t
-  type error = expanded_type t
+  type trace       = type_expr t
+  type error_trace = expanded_type t
+
+  type unification_error_trace = unification error (** To avoid shadowing *)
+
+  type nonrec error =
+    { trace             : error_trace
+    ; unification_trace : unification error }
+
+  let error ~trace ~unification_trace =
+    if trace = []
+    then Misc.fatal_error "Subtype error trace was empty"
+    else { trace; unification_trace }
 
   let map_elt f = function
     | Diff x -> Diff (map_diff f x)

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -30,7 +30,7 @@ let print_pos ppf = function
 
 type expanded_type = { ty: type_expr; expanded: type_expr }
 
-let unexpanded_type ty = { ty; expanded = ty }
+let trivial_expansion ty = { ty; expanded = ty }
 
 type 'a diff = { got: 'a; expected: 'a }
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -66,6 +66,7 @@ type 'variety variant =
   | Fixed_row :
       position * fixed_row_case * fixed_explanation -> unification variant
   (* Equality & Moregen *)
+  | Presence_not_guaranteed_for : position * string -> comparison variant
   | Openness : position (* Always [Second] for Moregen *) -> comparison variant
 
 type 'variety obj =
@@ -101,6 +102,30 @@ val map : ('a -> 'b) -> ('a, 'variety) elt list -> ('b, 'variety) elt list
 val incompatible_fields : string -> type_expr -> type_expr -> (desc, _) elt
 
 val swap_trace : 'variety t -> 'variety t
+
+(* The traces (['variety t]) are the core error types.  However, we bundle them
+   up into three "top-level" error types, which are used elsewhere:
+   [unification_error], [equality_error], and [moregen_error].  In the case of
+   [equality_error], this has to bundle in extra information; in general, it
+   distinguishes the three types of errors and allows us to distinguish traces
+   that are being built (or processed) from those that are complete and have
+   become the final error. *)
+
+type unification_error = { trace : unification t } [@@unboxed]
+
+type equality_error =
+  { trace : comparison t;
+    subst : (type_expr * type_expr) list }
+
+type moregen_error = { trace : comparison t } [@@unboxed]
+
+(* Wraps up the two different kinds of [comparison] errors in one type *)
+type comparison_error =
+  | Equality_error of equality_error
+  | Moregen_error  of moregen_error
+
+(* Lift [swap_trace] to [unification_error] *)
+val swap_unification_error : unification_error -> unification_error
 
 module Subtype : sig
   type 'a elt =

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -22,8 +22,16 @@ type position = First | Second
 val swap_position : position -> position
 val print_pos : Format.formatter -> position -> unit
 
-type desc = { t: type_expr; expanded: type_expr option }
-type 'a diff = { got: 'a; expected: 'a}
+type expanded_type = { ty: type_expr; expanded: type_expr }
+
+(** [unexpanded_type ty] creates an [expanded_type] whose expansion is also
+    [ty].  Usually, you want [Ctype.expand_type] instead, since the expansion
+    carries useful information; however, in certain circumstances, the error is
+    about the expansion of the type, meaning that actually performing the
+    expansion produces more confusing or inaccurate output. *)
+val unexpanded_type : type_expr -> expanded_type
+
+type 'a diff = { got: 'a; expected: 'a }
 
 (** [map_diff f {expected;got}] is [{expected=f expected; got=f got}] *)
 val map_diff: ('a -> 'b) -> 'a diff -> 'b diff
@@ -43,7 +51,7 @@ type 'a escape =
   { kind : 'a escape_kind;
     context : type_expr option }
 
-val short : type_expr -> desc
+val map_escape : ('a -> 'b) -> 'a escape -> 'b escape
 
 val explain: 'a list ->
   (prev:'a option -> 'a -> 'b option) ->
@@ -86,22 +94,17 @@ type ('a, 'variety) elt =
   (* Unification & Moregen; included in Equality for simplicity *)
   | Rec_occur : type_expr * type_expr -> ('a, _) elt
 
-type 'variety t =
-  (desc, 'variety) elt list
+type ('a, 'variety) t = ('a, 'variety) elt list
 
-val diff : type_expr -> type_expr -> (desc, _) elt
+type 'variety trace = (type_expr,     'variety) t
+type 'variety error = (expanded_type, 'variety) t
 
-(** [flatten f trace] flattens all elements of type {!desc} in
-    [trace] to either [f x.t expanded] if [x.expanded=Some expanded]
-    or [f x.t x.t] otherwise *)
-val flatten :
-  (type_expr -> type_expr -> 'a) -> 'variety t -> ('a, 'variety) elt list
+val map : ('a -> 'b) -> ('a, 'variety) t -> ('b, 'variety) t
 
-val map : ('a -> 'b) -> ('a, 'variety) elt list -> ('b, 'variety) elt list
+val incompatible_fields :
+  name:string -> got:type_expr -> expected:type_expr -> (type_expr, _) elt
 
-val incompatible_fields : string -> type_expr -> type_expr -> (desc, _) elt
-
-val swap_trace : 'variety t -> 'variety t
+val swap_trace : ('a, 'variety) t -> ('a, 'variety) t
 
 (* The traces (['variety t]) are the core error types.  However, we bundle them
    up into three "top-level" error types, which are used elsewhere:
@@ -111,13 +114,13 @@ val swap_trace : 'variety t -> 'variety t
    that are being built (or processed) from those that are complete and have
    become the final error. *)
 
-type unification_error = { trace : unification t } [@@unboxed]
+type unification_error = { trace : unification error } [@@unboxed]
 
 type equality_error =
-  { trace : comparison t;
+  { trace : comparison error;
     subst : (type_expr * type_expr) list }
 
-type moregen_error = { trace : comparison t } [@@unboxed]
+type moregen_error = { trace : comparison error } [@@unboxed]
 
 (* Wraps up the two different kinds of [comparison] errors in one type *)
 type comparison_error =
@@ -131,11 +134,10 @@ module Subtype : sig
   type 'a elt =
     | Diff of 'a diff
 
-  type t = desc elt list
+  type 'a t = 'a elt list
 
-  val diff: type_expr -> type_expr -> desc elt
+  type trace = type_expr     t
+  type error = expanded_type t
 
-  val flatten : (type_expr -> type_expr -> 'a) -> t -> 'a elt list
-
-  val map : (desc -> desc) -> desc elt list -> desc elt list
+  val map : ('a -> 'b) -> 'a t -> 'b t
 end

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -24,12 +24,12 @@ val print_pos : Format.formatter -> position -> unit
 
 type expanded_type = { ty: type_expr; expanded: type_expr }
 
-(** [unexpanded_type ty] creates an [expanded_type] whose expansion is also
+(** [trivial_expansion ty] creates an [expanded_type] whose expansion is also
     [ty].  Usually, you want [Ctype.expand_type] instead, since the expansion
     carries useful information; however, in certain circumstances, the error is
     about the expansion of the type, meaning that actually performing the
     expansion produces more confusing or inaccurate output. *)
-val unexpanded_type : type_expr -> expanded_type
+val trivial_expansion : type_expr -> expanded_type
 
 type 'a diff = { got: 'a; expected: 'a }
 

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -49,7 +49,7 @@ let rec hide_params = function
   | cty -> cty
 *)
 
-let include_err ppf =
+let include_err mode ppf =
   function
   | CM_Virtual_class ->
       fprintf ppf "A class cannot be changed from virtual to concrete"
@@ -57,7 +57,7 @@ let include_err ppf =
       fprintf ppf
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (env, err) ->
-      Printtyp.report_equality_error ppf env err
+      Printtyp.report_equality_error ppf mode env err
         (function ppf ->
           fprintf ppf "A type parameter has type")
         (function ppf ->
@@ -70,19 +70,19 @@ let include_err ppf =
           "is not matched by the class type"
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (env, err) ->
-      Printtyp.report_moregen_error ppf env err
+      Printtyp.report_moregen_error ppf mode env err
         (function ppf ->
           fprintf ppf "A parameter has type")
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Val_type_mismatch (lab, env, err) ->
-      Printtyp.report_comparison_error ppf env err
+      Printtyp.report_comparison_error ppf mode env err
         (function ppf ->
           fprintf ppf "The instance variable %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Meth_type_mismatch (lab, env, err) ->
-      Printtyp.report_comparison_error ppf env err
+      Printtyp.report_comparison_error ppf mode env err
         (function ppf ->
           fprintf ppf "The method %s@ has type" lab)
         (function ppf ->
@@ -108,9 +108,9 @@ let include_err ppf =
   | CM_Private_method lab ->
       fprintf ppf "@[The private method %s cannot become public@]" lab
 
-let report_error ppf = function
+let report_error mode ppf = function
   |  [] -> ()
   | err :: errs ->
       let print_errs ppf errs =
-         List.iter (fun err -> fprintf ppf "@ %a" include_err err) errs in
-      fprintf ppf "@[<v>%a%a@]" include_err err print_errs errs
+        List.iter (fun err -> fprintf ppf "@ %a" (include_err mode) err) errs in
+      fprintf ppf "@[<v>%a%a@]" (include_err mode) err print_errs errs

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -49,10 +49,6 @@ let rec hide_params = function
   | cty -> cty
 *)
 
-let report_error_for = function
-  | CM_Equality -> Printtyp.report_equality_error
-  | CM_Moregen  -> Printtyp.report_moregen_error
-
 let include_err ppf =
   function
   | CM_Virtual_class ->
@@ -60,8 +56,8 @@ let include_err ppf =
   | CM_Parameter_arity_mismatch _ ->
       fprintf ppf
         "The classes do not have the same number of type parameters"
-  | CM_Type_parameter_mismatch (env, trace) ->
-      Printtyp.report_equality_error ppf env trace
+  | CM_Type_parameter_mismatch (env, err) ->
+      Printtyp.report_equality_error ppf env err
         (function ppf ->
           fprintf ppf "A type parameter has type")
         (function ppf ->
@@ -73,20 +69,20 @@ let include_err ppf =
           Printtyp.class_type cty1
           "is not matched by the class type"
           Printtyp.class_type cty2)
-  | CM_Parameter_mismatch (env, trace) ->
-      Printtyp.report_moregen_error ppf env trace
+  | CM_Parameter_mismatch (env, err) ->
+      Printtyp.report_moregen_error ppf env err
         (function ppf ->
           fprintf ppf "A parameter has type")
         (function ppf ->
           fprintf ppf "but is expected to have type")
-  | CM_Val_type_mismatch (trace_type, lab, env, trace) ->
-      report_error_for trace_type ppf env trace
+  | CM_Val_type_mismatch (lab, env, err) ->
+      Printtyp.report_comparison_error ppf env err
         (function ppf ->
           fprintf ppf "The instance variable %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
-  | CM_Meth_type_mismatch (trace_type, lab, env, trace) ->
-      report_error_for trace_type  ppf env trace
+  | CM_Meth_type_mismatch (lab, env, err) ->
+      Printtyp.report_comparison_error ppf env err
         (function ppf ->
           fprintf ppf "The method %s@ has type" lab)
         (function ppf ->

--- a/typing/includeclass.mli
+++ b/typing/includeclass.mli
@@ -29,4 +29,5 @@ val class_declarations:
   Env.t -> class_declaration -> class_declaration ->
   class_match_failure list
 
-val report_error: formatter -> class_match_failure list -> unit
+val report_error :
+  Printtyp.type_or_scheme -> formatter -> class_match_failure list -> unit

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -197,8 +197,8 @@ let report_primitive_mismatch first second ppf err =
   | Name ->
       pr "The names of the primitives are not the same"
   | Arity ->
-      pr "The syntactic arities of these primitives were not the same@ \
-          (They must have the same number of arrows present in the source)"
+      pr "The syntactic arities of these primitives were not the same.@ \
+          (They must have the same number of arrows present in the source.)"
   | No_alloc ord ->
       pr "%s primitive is [@@@@noalloc] but %s is not"
         (String.capitalize_ascii (choose ord first second))
@@ -218,7 +218,7 @@ let report_value_mismatch first second env ppf err =
   | Primitive_mismatch pm ->
       report_primitive_mismatch first second ppf pm
   | Not_a_primitive ->
-      pr "The implementation is not a primitive"
+      pr "The implementation is not a primitive."
   | Type trace ->
       Printtyp.report_moregen_error ppf Type_scheme env trace
         (fun ppf -> Format.fprintf ppf "The type")
@@ -237,7 +237,7 @@ let report_privacy_mismatch ppf err =
     | Private_record_type        -> true,  "record constructor"
     | Private_extensible_variant -> true,  "extensible variant"
     | Private_row_type           -> true,  "row type"
-  in Format.fprintf ppf "%s %s would be revealed"
+  in Format.fprintf ppf "%s %s would be revealed."
        (if singular then "A private" else "Private")
        item
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -66,7 +66,7 @@ let primitive_descriptions pd1 pd2 =
 type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
-  | Type of Env.t * Errortrace.comparison Errortrace.t
+  | Type of Errortrace.moregen_error
 
 exception Dont_match of value_mismatch
 
@@ -80,7 +80,7 @@ let value_descriptions ~loc env name
     vd1.val_attributes vd2.val_attributes
     name;
   match Ctype.moregeneral env true vd1.val_type vd2.val_type with
-  | exception Ctype.Moregen trace -> raise (Dont_match (Type (env, trace)))
+  | exception Ctype.Moregen err -> raise (Dont_match (Type err))
   | () -> begin
       match (vd1.val_kind, vd2.val_kind) with
       | (Val_prim p1, Val_prim p2) -> begin
@@ -105,7 +105,8 @@ let private_flags decl1 decl2 =
   | Private, Public ->
       decl2.type_kind = Type_abstract &&
       (decl2.type_manifest = None || decl1.type_kind <> Type_abstract)
-  | _, _ -> true
+  | _, _ ->
+      true
 
 (* Inclusion between manifest types (particularly for private row types) *)
 
@@ -131,7 +132,7 @@ let choose_other ord first second =
   | Second -> choose First first second
 
 type label_mismatch =
-  | Type of Env.t * Errortrace.comparison Errortrace.t
+  | Type of Errortrace.equality_error
   | Mutability of position
 
 type record_mismatch =
@@ -143,7 +144,7 @@ type record_mismatch =
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
-  | Type of Env.t * Errortrace.comparison Errortrace.t
+  | Type of Errortrace.equality_error
   | Arity
   | Inline_record of record_mismatch
   | Kind of position
@@ -164,22 +165,22 @@ type extension_constructor_mismatch =
                             * constructor_mismatch
 
 type private_variant_mismatch =
-  | Openness
+  | Only_outer_closed (* It's only dangerous in one direction *)
   | Missing of position * string
   | Presence of string
   | Incompatible_types_for of string
-  | Types of Env.t * Errortrace.comparison Errortrace.t
+  | Types of Errortrace.equality_error
 
 type private_object_mismatch =
   | Missing of string
-  | Types of Env.t * Errortrace.comparison Errortrace.t
+  | Types of Errortrace.equality_error
 
 type type_mismatch =
   | Arity
   | Privacy
   | Kind
-  | Constraint of Env.t * Errortrace.comparison Errortrace.t
-  | Manifest of Env.t * Errortrace.comparison Errortrace.t
+  | Constraint of Errortrace.equality_error
+  | Manifest of Errortrace.equality_error
   | Private_variant of type_expr * type_expr * private_variant_mismatch
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance
@@ -188,25 +189,63 @@ type type_mismatch =
   | Unboxed_representation of position
   | Immediate of Type_immediacy.Violation.t
 
-let report_label_mismatch first second ppf err =
+let report_primitive_mismatch first second ppf err =
   let pr fmt = Format.fprintf ppf fmt in
+  match (err : primitive_mismatch) with
+  | Name ->
+      pr "The names of the primitives are not the same"
+  | Arity ->
+      pr "The syntactic arities of these primitives were not the same@ \
+          (They must have the same number of ->s present in the source)"
+  | No_alloc ord ->
+      pr "%s primitive is [@@@@noalloc] but %s is not"
+        (String.capitalize_ascii (choose ord first second))
+        (choose_other ord first second)
+  | Native_name ->
+      pr "The native names of the primitives are not the same"
+  | Result_repr ->
+      pr "The two primitives' results have different representations"
+  | Argument_repr n ->
+      pr "The two primitives' %d%s arguments have different representations"
+        n (Misc.ordinal_suffix n)
+
+let report_value_mismatch first second env ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  pr "@ ";
+  match (err : value_mismatch) with
+  | Primitive_mismatch pm ->
+      report_primitive_mismatch first second ppf pm
+  | Not_a_primitive ->
+      pr "The definition is not a primitive"
+  | Type trace ->
+      Printtyp.report_moregen_error ppf env trace
+        (fun ppf -> Format.fprintf ppf "The type")
+        (fun ppf -> Format.fprintf ppf "is not compatible with the type")
+
+let report_type_inequality env ppf err =
+  Printtyp.report_equality_error ppf env err
+    (fun ppf -> Format.fprintf ppf "The type")
+    (fun ppf -> Format.fprintf ppf "is not equal to the type")
+
+let report_label_mismatch first second env ppf err =
   match (err : label_mismatch) with
-  | Type _ -> pr "The types are not equal."
+  | Type err ->
+      report_type_inequality env ppf err
   | Mutability ord ->
-      pr "%s is mutable and %s is not."
-        (String.capitalize_ascii  (choose ord first second))
+      Format.fprintf ppf "%s is mutable and %s is not."
+        (String.capitalize_ascii (choose ord first second))
         (choose_other ord first second)
 
-let report_record_mismatch first second decl ppf err =
+let report_record_mismatch first second decl env ppf err =
   let pr fmt = Format.fprintf ppf fmt in
   match err with
   | Label_mismatch (l1, l2, err) ->
       pr
-        "@[<hv>Fields do not match:@;<1 2>%a@ is not compatible with:\
+        "@[<hv>Fields do not match:@;<1 2>%a@ is not the same as:\
          @;<1 2>%a@ %a@]"
         Printtyp.label l1
         Printtyp.label l2
-        (report_label_mismatch first second) err
+        (report_label_mismatch first second env) err
   | Label_names (n, name1, name2) ->
       pr "@[<hv>Fields number %i have different names, %s and %s.@]"
         n (Ident.name name1) (Ident.name name2)
@@ -218,12 +257,12 @@ let report_record_mismatch first second decl ppf err =
         (choose ord first second) decl
         "uses unboxed float representation"
 
-let report_constructor_mismatch first second decl ppf err =
+let report_constructor_mismatch first second decl env ppf err =
   let pr fmt  = Format.fprintf ppf fmt in
   match (err : constructor_mismatch) with
-  | Type _ -> pr "The types are not equal."
+  | Type err -> report_type_inequality env ppf err
   | Arity -> pr "They have different arities."
-  | Inline_record err -> report_record_mismatch first second decl ppf err
+  | Inline_record err -> report_record_mismatch first second decl env ppf err
   | Kind ord ->
       pr "%s uses inline records and %s doesn't."
         (String.capitalize_ascii (choose ord first second))
@@ -233,16 +272,16 @@ let report_constructor_mismatch first second decl ppf err =
         (String.capitalize_ascii (choose ord first second))
         (choose_other ord first second)
 
-let report_variant_mismatch first second decl ppf err =
+let report_variant_mismatch first second decl env ppf err =
   let pr fmt = Format.fprintf ppf fmt in
   match (err : variant_mismatch) with
   | Constructor_mismatch (c1, c2, err) ->
       pr
-        "@[<hv>Constructors do not match:@;<1 2>%a@ is not compatible with:\
+        "@[<hv>Constructors do not match:@;<1 2>%a@ is not the same as:\
          @;<1 2>%a@ %a@]"
         Printtyp.constructor c1
         Printtyp.constructor c2
-        (report_constructor_mismatch first second decl) err
+        (report_constructor_mismatch first second decl env) err
   | Constructor_names (n, name1, name2) ->
       pr "Constructors number %i have different names, %s and %s."
         n (Ident.name name1) (Ident.name name2)
@@ -250,30 +289,68 @@ let report_variant_mismatch first second decl ppf err =
       pr "The constructor %s is only present in %s %s."
         (Ident.name s) (choose ord first second) decl
 
-let report_extension_constructor_mismatch first second decl ppf err =
+let report_extension_constructor_mismatch first second decl env ppf err =
   let pr fmt = Format.fprintf ppf fmt in
   match (err : extension_constructor_mismatch) with
   | Constructor_privacy -> pr "A private type would be revealed."
   | Constructor_mismatch (id, ext1, ext2, err) ->
-      pr "@[<hv>Constructors do not match:@;<1 2>%a@ is not compatible with:\
+      pr "@[<hv>Constructors do not match:@;<1 2>%a@ is not the same as:\
           @;<1 2>%a@ %a@]"
         (Printtyp.extension_only_constructor id) ext1
         (Printtyp.extension_only_constructor id) ext2
-        (report_constructor_mismatch first second decl) err
+        (report_constructor_mismatch first second decl env) err
 
-let report_type_mismatch0 first second decl ppf err =
+let report_private_variant_mismatch first second decl env ppf err =
   let pr fmt = Format.fprintf ppf fmt in
+  match (err : private_variant_mismatch) with
+  | Only_outer_closed ->
+      (* It's only dangerous in one direction, so we don't have a position *)
+      pr "%s is private and closed, but %s is not closed"
+        (String.capitalize_ascii second) first
+  | Missing (ord, name) ->
+      pr "The constructor %s is only present in %s %s."
+        name (choose ord first second) decl
+  | Presence s ->
+      pr "The tag `%s is present in the %s %s,@ but might not be in the %s"
+        s second decl first
+  | Incompatible_types_for s -> pr "Types for tag `%s are incompatible" s
+  | Types err ->
+      report_type_inequality env ppf err
+
+let report_private_object_mismatch env ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  match (err : private_object_mismatch) with
+  | Missing s -> pr "The implementation is missing the method %s" s
+  | Types err -> report_type_inequality env ppf err
+
+let report_type_mismatch first second decl env ppf err =
+  let pr fmt = Format.fprintf ppf fmt in
+  pr "@ ";
   match err with
-  | Arity -> pr "They have different arities."
-  | Privacy -> pr "A private type would be revealed."
-  | Kind -> pr "Their kinds differ."
-  | Constraint _ -> pr "Their constraints differ."
-  | Manifest _ -> ()
-  | Private_variant _ -> ()
-  | Private_object _ -> ()
-  | Variance -> pr "Their variances do not agree."
-  | Record_mismatch err -> report_record_mismatch first second decl ppf err
-  | Variant_mismatch err -> report_variant_mismatch first second decl ppf err
+  | Arity ->
+      pr "They have different arities."
+  | Privacy ->
+      pr "A private type would be revealed."
+  | Kind ->
+      pr "Their kinds differ."
+  | Constraint err ->
+      (* This error can come from implicit parameter disagreement or from
+         explicit `constraint`s.  Both affect the parameters, hence this choice
+         of explanatory text *)
+      pr "Their parameters differ@,";
+      report_type_inequality env ppf err
+  | Manifest err ->
+      report_type_inequality env ppf err
+  | Private_variant (_ty1, _ty2, mismatch) ->
+      report_private_variant_mismatch first second decl env ppf mismatch
+  | Private_object (_ty1, _ty2, mismatch) ->
+      report_private_object_mismatch env ppf mismatch
+  | Variance ->
+      pr "Their variances do not agree."
+  | Record_mismatch err ->
+      report_record_mismatch first second decl env ppf err
+  | Variant_mismatch err ->
+      report_variant_mismatch first second decl env ppf err
   | Unboxed_representation ord ->
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
@@ -287,13 +364,6 @@ let report_type_mismatch0 first second decl ppf err =
           pr "%s is not a type that is always immediate on 64 bit platforms."
             first
 
-let report_type_mismatch first second decl ppf err =
-  match err with
-  | Manifest _ -> ()
-  | Private_variant _ -> ()
-  | Private_object _ -> ()
-  | _ -> Format.fprintf ppf "@ %a" (report_type_mismatch0 first second decl) err
-
 let rec compare_constructor_arguments ~loc env params1 params2 arg1 arg2 =
   match arg1, arg2 with
   | Types.Cstr_tuple arg1, Types.Cstr_tuple arg2 ->
@@ -302,7 +372,7 @@ let rec compare_constructor_arguments ~loc env params1 params2 arg1 arg2 =
       else begin
         (* Ctype.equal must be called on all arguments at once, cf. PR#7378 *)
         match Ctype.equal env true (params1 @ arg1) (params2 @ arg2) with
-        | exception Ctype.Equality trace -> Some (Type (env, trace))
+        | exception Ctype.Equality err -> Some (Type err)
         | () -> None
       end
   | Types.Cstr_record l1, Types.Cstr_record l2 ->
@@ -316,7 +386,7 @@ and compare_constructors ~loc env params1 params2 res1 res2 args1 args2 =
   match res1, res2 with
   | Some r1, Some r2 -> begin
       match Ctype.equal env true [r1] [r2] with
-      | exception Ctype.Equality trace -> Some (Type (env, trace))
+      | exception Ctype.Equality err -> Some (Type err)
       | () -> compare_constructor_arguments ~loc env [r1] [r2] args1 args2
     end
   | Some _, None -> Some (Explicit_return_type First)
@@ -372,8 +442,7 @@ and compare_labels env params1 params2
     let tl1 = params1 @ [ld1.ld_type] in
     let tl2 = params2 @ [ld2.ld_type] in
     match Ctype.equal env true tl1 tl2 with
-    | exception Ctype.Equality trace ->
-        Some (Type (env, trace) : label_mismatch)
+    | exception Ctype.Equality err -> Some (Type err : label_mismatch)
     | () -> None
   end
 
@@ -432,7 +501,7 @@ let private_variant env row1 params1 row2 params2 =
       Ctype.merge_row_fields row1.row_fields row2.row_fields
     in
     let err =
-      if row2.row_closed && not row1.row_closed then Some Openness
+      if row2.row_closed && not row1.row_closed then Some Only_outer_closed
       else begin
         match row2.row_closed, Ctype.filter_row_fields false r1 with
         | true, (s, _) :: _ ->
@@ -459,8 +528,8 @@ let private_variant env row1 params1 row2 params2 =
       match pairs with
       | [] -> begin
           match Ctype.equal env true tl1 tl2 with
-          | exception Ctype.Equality trace ->
-              Some (Types (env, trace) : private_variant_mismatch)
+          | exception Ctype.Equality err ->
+              Some (Types err : private_variant_mismatch)
           | () -> None
         end
       | (s, f1, f2) :: pairs -> begin
@@ -512,7 +581,7 @@ let private_object env fields1 params1 fields2 params2 =
   in
   begin
     match Ctype.equal env true (params1 @ tl1) (params2 @ tl2) with
-    | exception Ctype.Equality trace -> Some (Types (env, trace))
+    | exception Ctype.Equality err -> Some (Types err)
     | () -> None
   end
 
@@ -556,7 +625,7 @@ let type_manifest env ty1 params1 ty2 params2 priv2 kind2 =
         else
           Ctype.equal env true (params1 @ [ty1]) (params2 @ [ty2])
       with
-      | exception Ctype.Equality err -> Some (Manifest(env,err))
+      | exception Ctype.Equality err -> Some (Manifest err)
       | () -> None
     end
 
@@ -574,7 +643,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
       (_, None) ->
         begin
           match Ctype.equal env true decl1.type_params decl2.type_params with
-          | exception Ctype.Equality trace -> Some (Constraint(env, trace))
+          | exception Ctype.Equality err -> Some (Constraint err)
           | () -> None
         end
     | (Some ty1, Some ty2) ->
@@ -585,10 +654,10 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           Btype.newgenty (Tconstr(path, decl2.type_params, ref Mnil))
         in
         match Ctype.equal env true decl1.type_params decl2.type_params with
-        | exception Ctype.Equality trace -> Some (Constraint(env, trace))
+        | exception Ctype.Equality err -> Some (Constraint err)
         | () ->
           match Ctype.equal env false [ty1] [ty2] with
-          | exception Ctype.Equality trace -> Some (Manifest(env, trace))
+          | exception Ctype.Equality err -> Some (Manifest err)
           | () -> None
   in
   if err <> None then err else
@@ -682,8 +751,8 @@ let extension_constructors ~loc env ~mark id ext1 ext2 =
   let tl1 = ty1 :: ext1.ext_type_params in
   let tl2 = ty2 :: ext2.ext_type_params in
   match Ctype.equal env true tl1 tl2 with
-  | exception Ctype.Equality trace ->
-      Some (Constructor_mismatch (id, ext1, ext2, Type(env, trace)))
+  | exception Ctype.Equality err ->
+      Some (Constructor_mismatch (id, ext1, ext2, Type err))
   | () ->
     let r =
       compare_constructors ~loc env

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -218,14 +218,14 @@ let report_value_mismatch first second env ppf err =
   | Primitive_mismatch pm ->
       report_primitive_mismatch first second ppf pm
   | Not_a_primitive ->
-      pr "The definition is not a primitive"
+      pr "The implementation is not a primitive"
   | Type trace ->
-      Printtyp.report_moregen_error ppf Scheme env trace
+      Printtyp.report_moregen_error ppf Type_scheme env trace
         (fun ppf -> Format.fprintf ppf "The type")
         (fun ppf -> Format.fprintf ppf "is not compatible with the type")
 
 let report_type_inequality env ppf err =
-  Printtyp.report_equality_error ppf Scheme env err
+  Printtyp.report_equality_error ppf Type_scheme env err
     (fun ppf -> Format.fprintf ppf "The type")
     (fun ppf -> Format.fprintf ppf "is not equal to the type")
 
@@ -522,17 +522,17 @@ let privacy_mismatch env decl1 decl2 =
       | Type_abstract, Type_abstract
         when Option.is_some decl2.type_manifest -> begin
           match decl1.type_manifest with
-          | Some ty1 -> Some begin
+          | Some ty1 -> begin
             let ty1 = Ctype.expand_head env ty1 in
             match ty1.desc with
             | Tvariant row when Btype.is_constr_row ~allow_ident:true
                                   (Btype.row_more row) ->
-                Private_row_type
+                Some Private_row_type
             | Tobject (fi, _) when Btype.is_constr_row ~allow_ident:true
                                      (snd (Ctype.flatten_fields fi)) ->
-                Private_row_type
+                Some Private_row_type
             | _ ->
-                Private_type_abbreviation
+                Some Private_type_abbreviation
             end
           | None ->
               None

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -35,6 +35,14 @@ type value_mismatch =
 
 exception Dont_match of value_mismatch
 
+(* Documents which kind of private thing would be revealed *)
+type privacy_mismatch =
+  | Private_type_abbreviation
+  | Private_variant_type
+  | Private_record_type
+  | Private_extensible_variant
+  | Private_row_type
+
 type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
@@ -79,7 +87,7 @@ type private_object_mismatch =
 
 type type_mismatch =
   | Arity
-  | Privacy
+  | Privacy of privacy_mismatch
   | Kind
   | Constraint of Errortrace.equality_error
   | Manifest of Errortrace.equality_error

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -31,12 +31,12 @@ type primitive_mismatch =
 type value_mismatch =
   | Primitive_mismatch of primitive_mismatch
   | Not_a_primitive
-  | Type of Env.t * Errortrace.comparison Errortrace.t
+  | Type of Errortrace.moregen_error
 
 exception Dont_match of value_mismatch
 
 type label_mismatch =
-  | Type of Env.t * Errortrace.comparison Errortrace.t
+  | Type of Errortrace.equality_error
   | Mutability of position
 
 type record_mismatch =
@@ -46,7 +46,7 @@ type record_mismatch =
   | Unboxed_float_representation of position
 
 type constructor_mismatch =
-  | Type of Env.t * Errortrace.comparison Errortrace.t
+  | Type of Errortrace.equality_error
   | Arity
   | Inline_record of record_mismatch
   | Kind of position
@@ -67,22 +67,22 @@ type extension_constructor_mismatch =
                             * constructor_mismatch
 
 type private_variant_mismatch =
-  | Openness
+  | Only_outer_closed
   | Missing of position * string
   | Presence of string
   | Incompatible_types_for of string
-  | Types of Env.t * Errortrace.comparison Errortrace.t
+  | Types of Errortrace.equality_error
 
 type private_object_mismatch =
   | Missing of string
-  | Types of Env.t * Errortrace.comparison Errortrace.t
+  | Types of Errortrace.equality_error
 
 type type_mismatch =
   | Arity
   | Privacy
   | Kind
-  | Constraint of Env.t * Errortrace.comparison Errortrace.t
-  | Manifest of Env.t * Errortrace.comparison Errortrace.t
+  | Constraint of Errortrace.equality_error
+  | Manifest of Errortrace.equality_error
   | Private_variant of type_expr * type_expr * private_variant_mismatch
   | Private_object of type_expr * type_expr * private_object_mismatch
   | Variance
@@ -110,7 +110,17 @@ val class_types:
         Env.t -> class_type -> class_type -> bool
 *)
 
-val report_type_mismatch:
-    string -> string -> string -> Format.formatter -> type_mismatch -> unit
-val report_extension_constructor_mismatch: string -> string -> string ->
+val report_value_mismatch :
+  string -> string ->
+  Env.t ->
+  Format.formatter -> value_mismatch -> unit
+
+val report_type_mismatch :
+  string -> string -> string ->
+  Env.t ->
+  Format.formatter -> type_mismatch -> unit
+
+val report_extension_constructor_mismatch :
+  string -> string -> string ->
+  Env.t ->
   Format.formatter -> extension_constructor_mismatch -> unit

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -60,7 +60,7 @@ module Error = struct
   let sdiff x y = {got=x; expected=y; symptom=()}
 
   type core_sigitem_symptom =
-    | Value_descriptions of value_description core_diff
+    | Value_descriptions of (value_description, Includecore.value_mismatch) diff
     | Type_declarations of (type_declaration, Includecore.type_mismatch) diff
     | Extension_constructors of
         (extension_constructor, Includecore.extension_constructor_mismatch) diff
@@ -159,8 +159,8 @@ let value_descriptions ~loc env ~mark subst id vd1 vd2 =
   let vd2 = Subst.value_description subst vd2 in
   try
     Ok (Includecore.value_descriptions ~loc env (Ident.name id) vd1 vd2)
-  with Includecore.Dont_match _err ->
-    Error Error.(Core (Value_descriptions (sdiff vd1 vd2)))
+  with Includecore.Dont_match err ->
+    Error Error.(Core (Value_descriptions (diff vd1 vd2 err)))
 
 (* Inclusion between type declarations *)
 

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -45,7 +45,8 @@ module Error: sig
     | Unit
 
   type core_sigitem_symptom =
-    | Value_descriptions of Types.value_description core_diff
+    | Value_descriptions of
+        (Types.value_description, Includecore.value_mismatch) diff
     | Type_declarations of
         (Types.type_declaration, Includecore.type_mismatch) diff
     | Extension_constructors of

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -653,7 +653,7 @@ let core env id x =
         (Printtyp.tree_of_cltype_declaration id diff.got Trec_first)
         !Oprint.out_sig_item
         (Printtyp.tree_of_cltype_declaration id diff.expected Trec_first)
-        Includeclass.report_error diff.symptom
+        (Includeclass.report_error Scheme) diff.symptom
         Printtyp.Conflicts.print_explanations
   | Err.Class_declarations {got;expected;symptom} ->
       let t1 = Printtyp.tree_of_class_declaration id got Trec_first in
@@ -663,7 +663,7 @@ let core env id x =
          %a@;<1 -2>does not match@ %a@]@ %a%t"
         !Oprint.out_sig_item t1
         !Oprint.out_sig_item t2
-        Includeclass.report_error symptom
+        (Includeclass.report_error Scheme) symptom
         Printtyp.Conflicts.print_explanations
 
 let missing_field ppf item =

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -653,7 +653,7 @@ let core env id x =
         (Printtyp.tree_of_cltype_declaration id diff.got Trec_first)
         !Oprint.out_sig_item
         (Printtyp.tree_of_cltype_declaration id diff.expected Trec_first)
-        (Includeclass.report_error Scheme) diff.symptom
+        (Includeclass.report_error Type_scheme) diff.symptom
         Printtyp.Conflicts.print_explanations
   | Err.Class_declarations {got;expected;symptom} ->
       let t1 = Printtyp.tree_of_class_declaration id got Trec_first in
@@ -663,7 +663,7 @@ let core env id x =
          %a@;<1 -2>does not match@ %a@]@ %a%t"
         !Oprint.out_sig_item t1
         !Oprint.out_sig_item t2
-        (Includeclass.report_error Scheme) symptom
+        (Includeclass.report_error Type_scheme) symptom
         Printtyp.Conflicts.print_explanations
 
 let missing_field ppf item =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2427,7 +2427,7 @@ module Subtype = struct
         txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr_sub  = prepare_trace             prepare_expansion tr_sub  in
+      let tr_sub = prepare_trace prepare_expansion tr_sub in
       let tr_unif = prepare_unification_trace prepare_expansion tr_unif in
       let keep_first = match tr_unif with
         | [Obj _ | Variant _ | Escape _ ] | [] -> true

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1031,11 +1031,15 @@ let reset_and_mark_loops_list tyl =
 (* Disabled in classic mode when printing an unification error *)
 let print_labels = ref true
 
-let rec tree_of_typexp sch ty =
+(* When printing a type scheme, we print weak names.  When printing a plain
+   type, we do not.  This type controls that behavior *)
+type type_or_scheme = Type | Scheme
+
+let rec tree_of_typexp mode ty =
   let ty = repr ty in
   let px = proxy ty in
   if Names.has_name px && not (List.memq px !delayed) then
-   let mark = is_non_gen sch ty in
+   let mark = is_non_gen mode ty in
    let name = Names.name_of_type
                 (if mark then Names.new_weak_name ty else Names.new_name)
                 px
@@ -1046,8 +1050,8 @@ let rec tree_of_typexp sch ty =
     match ty.desc with
     | Tvar _ ->
         (*let lev =
-          if is_non_gen sch ty then "/" ^ Int.to_string ty.level else "" in*)
-        let non_gen = is_non_gen sch ty in
+          if is_non_gen mode ty then "/" ^ Int.to_string ty.level else "" in*)
+        let non_gen = is_non_gen mode ty in
         let name_gen =
           if non_gen then Names.new_weak_name ty else Names.new_name
         in
@@ -1061,17 +1065,18 @@ let rec tree_of_typexp sch ty =
             match (repr ty1).desc with
             | Tconstr(path, [ty], _)
               when Path.same path Predef.path_option ->
-                tree_of_typexp sch ty
+                tree_of_typexp mode ty
             | _ -> Otyp_stuff "<hidden>"
-          else tree_of_typexp sch ty1 in
-        Otyp_arrow (lab, t1, tree_of_typexp sch ty2)
+          else tree_of_typexp mode ty1 in
+        Otyp_arrow (lab, t1, tree_of_typexp mode ty2)
     | Ttuple tyl ->
-        Otyp_tuple (tree_of_typlist sch tyl)
+        Otyp_tuple (tree_of_typlist mode tyl)
     | Tconstr(p, tyl, _abbrev) ->
         let p', s = best_type_path p in
         let tyl' = apply_subst s tyl in
-        if is_nth s && not (tyl'=[]) then tree_of_typexp sch (List.hd tyl') else
-        Otyp_constr (tree_of_path Type p', tree_of_typlist sch tyl')
+        if is_nth s && not (tyl'=[])
+        then tree_of_typexp mode (List.hd tyl')
+        else Otyp_constr (tree_of_path Type p', tree_of_typlist mode tyl')
     | Tvariant row ->
         let row = row_repr row in
         let fields =
@@ -1091,47 +1096,47 @@ let rec tree_of_typexp sch ty =
         | Some(p, tyl) when namable_row row ->
             let (p', s) = best_type_path p in
             let id = tree_of_path Type p' in
-            let args = tree_of_typlist sch (apply_subst s tyl) in
+            let args = tree_of_typlist mode (apply_subst s tyl) in
             let out_variant =
               if is_nth s then List.hd args else Otyp_constr (id, args) in
             if row.row_closed && all_present then
               out_variant
             else
-              let non_gen = is_non_gen sch px in
+              let non_gen = is_non_gen mode px in
               let tags =
                 if all_present then None else Some (List.map fst present) in
               Otyp_variant (non_gen, Ovar_typ out_variant, row.row_closed, tags)
         | _ ->
             let non_gen =
-              not (row.row_closed && all_present) && is_non_gen sch px in
-            let fields = List.map (tree_of_row_field sch) fields in
+              not (row.row_closed && all_present) && is_non_gen mode px in
+            let fields = List.map (tree_of_row_field mode) fields in
             let tags =
               if all_present then None else Some (List.map fst present) in
             Otyp_variant (non_gen, Ovar_fields fields, row.row_closed, tags)
         end
     | Tobject (fi, nm) ->
-        tree_of_typobject sch fi !nm
+        tree_of_typobject mode fi !nm
     | Tnil | Tfield _ ->
-        tree_of_typobject sch ty None
+        tree_of_typobject mode ty None
     | Tsubst _ ->
         (* This case should only happen when debugging the compiler *)
         Otyp_stuff "<Tsubst>"
     | Tlink _ ->
         fatal_error "Printtyp.tree_of_typexp"
     | Tpoly (ty, []) ->
-        tree_of_typexp sch ty
+        tree_of_typexp mode ty
     | Tpoly (ty, tyl) ->
         (*let print_names () =
           List.iter (fun (_, name) -> prerr_string (name ^ " ")) !names;
           prerr_string "; " in *)
         let tyl = List.map repr tyl in
-        if tyl = [] then tree_of_typexp sch ty else begin
+        if tyl = [] then tree_of_typexp mode ty else begin
           let old_delayed = !delayed in
           (* Make the names delayed, so that the real type is
              printed once when used as proxy *)
           List.iter add_delayed tyl;
           let tl = List.map (Names.name_of_type Names.new_name) tyl in
-          let tr = Otyp_poly (tl, tree_of_typexp sch ty) in
+          let tr = Otyp_poly (tl, tree_of_typexp mode ty) in
           (* Forget names when we leave scope *)
           Names.remove_names tyl;
           delayed := old_delayed; tr
@@ -1143,7 +1148,7 @@ let rec tree_of_typexp sch ty =
           List.map
             (fun (li, ty) -> (
               String.concat "." (Longident.flatten li),
-              tree_of_typexp sch ty
+              tree_of_typexp mode ty
             )) fl in
         Otyp_module (tree_of_path Module_type p, fl)
   in
@@ -1153,20 +1158,20 @@ let rec tree_of_typexp sch ty =
     Otyp_alias (pr_typ (), Names.name_of_type Names.new_name px) end
   else pr_typ ()
 
-and tree_of_row_field sch (l, f) =
+and tree_of_row_field mode (l, f) =
   match row_field_repr f with
   | Rpresent None | Reither(true, [], _, _) -> (l, false, [])
-  | Rpresent(Some ty) -> (l, false, [tree_of_typexp sch ty])
+  | Rpresent(Some ty) -> (l, false, [tree_of_typexp mode ty])
   | Reither(c, tyl, _, _) ->
       if c (* contradiction: constant constructor with an argument *)
-      then (l, true, tree_of_typlist sch tyl)
-      else (l, false, tree_of_typlist sch tyl)
+      then (l, true, tree_of_typlist mode tyl)
+      else (l, false, tree_of_typlist mode tyl)
   | Rabsent -> (l, false, [] (* actually, an error *))
 
-and tree_of_typlist sch tyl =
-  List.map (tree_of_typexp sch) tyl
+and tree_of_typlist mode tyl =
+  List.map (tree_of_typexp mode) tyl
 
-and tree_of_typobject sch fi nm =
+and tree_of_typobject mode fi nm =
   begin match nm with
   | None ->
       let pr_fields fi =
@@ -1181,12 +1186,12 @@ and tree_of_typobject sch fi nm =
         let sorted_fields =
           List.sort
             (fun (n, _) (n', _) -> String.compare n n') present_fields in
-        tree_of_typfields sch rest sorted_fields in
+        tree_of_typfields mode rest sorted_fields in
       let (fields, rest) = pr_fields fi in
       Otyp_object (fields, rest)
   | Some (p, ty :: tyl) ->
-      let non_gen = is_non_gen sch (repr ty) in
-      let args = tree_of_typlist sch tyl in
+      let non_gen = is_non_gen mode (repr ty) in
+      let args = tree_of_typlist mode tyl in
       let (p', s) = best_type_path p in
       assert (s = Id);
       Otyp_class (non_gen, tree_of_path Type p', args)
@@ -1194,28 +1199,30 @@ and tree_of_typobject sch fi nm =
       fatal_error "Printtyp.tree_of_typobject"
   end
 
-and is_non_gen sch ty =
-    sch && is_Tvar ty && ty.level <> generic_level
+and is_non_gen mode ty =
+  match mode with
+  | Scheme -> is_Tvar ty && ty.level <> generic_level
+  | Type   -> false
 
-and tree_of_typfields sch rest = function
+and tree_of_typfields mode rest = function
   | [] ->
       let rest =
         match rest.desc with
-        | Tvar _ | Tunivar _ -> Some (is_non_gen sch rest)
+        | Tvar _ | Tunivar _ -> Some (is_non_gen mode rest)
         | Tconstr _ -> Some false
         | Tnil -> None
         | _ -> fatal_error "typfields (1)"
       in
       ([], rest)
   | (s, t) :: l ->
-      let field = (s, tree_of_typexp sch t) in
-      let (fields, rest) = tree_of_typfields sch rest l in
+      let field = (s, tree_of_typexp mode t) in
+      let (fields, rest) = tree_of_typfields mode rest l in
       (field :: fields, rest)
 
-let typexp sch ppf ty =
-  !Oprint.out_type ppf (tree_of_typexp sch ty)
+let typexp mode ppf ty =
+  !Oprint.out_type ppf (tree_of_typexp mode ty)
 
-let marked_type_expr ppf ty = typexp false ppf ty
+let marked_type_expr ppf ty = typexp Type ppf ty
 
 let type_expr ppf ty =
   (* [type_expr] is used directly by error message printers,
@@ -1223,9 +1230,9 @@ let type_expr ppf ty =
   reset_and_mark_loops ty;
   marked_type_expr ppf ty
 
-and type_sch ppf ty = typexp true ppf ty
+and type_sch ppf ty = typexp Scheme ppf ty
 
-and type_scheme ppf ty = reset_and_mark_loops ty; typexp true ppf ty
+and type_scheme ppf ty = reset_and_mark_loops ty; typexp Scheme ppf ty
 
 let type_path ppf p =
   let (p', s) = best_type_path p in
@@ -1236,10 +1243,10 @@ let type_path ppf p =
 (* Maxence *)
 let type_scheme_max ?(b_reset_names=true) ppf ty =
   if b_reset_names then Names.reset_names () ;
-  typexp true ppf ty
+  typexp Scheme ppf ty
 (* End Maxence *)
 
-let tree_of_type_scheme ty = reset_and_mark_loops ty; tree_of_typexp true ty
+let tree_of_type_scheme ty = reset_and_mark_loops ty; tree_of_typexp Scheme ty
 
 (* Print one type declaration *)
 
@@ -1248,8 +1255,8 @@ let tree_of_constraints params =
     (fun ty list ->
        let ty' = unalias ty in
        if proxy ty != proxy ty' then
-         let tr = tree_of_typexp true ty in
-         (tr, tree_of_typexp true ty') :: list
+         let tr = tree_of_typexp Scheme ty in
+         (tr, tree_of_typexp Scheme ty') :: list
        else list)
     params []
 
@@ -1360,13 +1367,13 @@ let rec tree_of_type_decl id decl =
         decl.type_params decl.type_variance
     in
     (Ident.name id,
-     List.map2 (fun ty cocn -> type_param (tree_of_typexp false ty), cocn)
+     List.map2 (fun ty cocn -> type_param (tree_of_typexp Type ty), cocn)
        params vari)
   in
   let tree_of_manifest ty1 =
     match ty_manifest with
     | None -> ty1
-    | Some ty -> Otyp_manifest (tree_of_typexp false ty, ty1)
+    | Some ty -> Otyp_manifest (tree_of_typexp Type ty, ty1)
   in
   let (name, args) = type_defined decl in
   let constraints = tree_of_constraints params in
@@ -1376,7 +1383,7 @@ let rec tree_of_type_decl id decl =
         begin match ty_manifest with
         | None -> (Otyp_abstract, Public, false)
         | Some ty ->
-            tree_of_typexp false ty, decl.type_private, false
+            tree_of_typexp Type ty, decl.type_private, false
         end
     | Type_variant (cstrs, rep) ->
         tree_of_manifest (Otyp_sum (List.map tree_of_constructor cstrs)),
@@ -1400,7 +1407,7 @@ let rec tree_of_type_decl id decl =
       otype_cstrs = constraints }
 
 and tree_of_constructor_arguments = function
-  | Cstr_tuple l -> tree_of_typlist false l
+  | Cstr_tuple l -> tree_of_typlist Type l
   | Cstr_record l -> [ Otyp_record (List.map tree_of_label l) ]
 
 and tree_of_constructor cd =
@@ -1410,12 +1417,12 @@ and tree_of_constructor cd =
   | None -> (name, arg (), None)
   | Some res ->
       Names.with_local_names (fun () ->
-        let ret = tree_of_typexp false res in
+        let ret = tree_of_typexp Type res in
         let args = arg () in
         (name, args, Some ret))
 
 and tree_of_label l =
-  (Ident.name l.ld_id, l.ld_mutable = Mutable, tree_of_typexp false l.ld_type)
+  (Ident.name l.ld_id, l.ld_mutable = Mutable, tree_of_typexp Type l.ld_type)
 
 let constructor ppf c =
   reset_except_context ();
@@ -1442,7 +1449,7 @@ let extension_constructor_args_and_ret_type_subtree ext_args ext_ret_type =
   | None -> (tree_of_constructor_arguments ext_args, None)
   | Some res ->
       Names.with_local_names (fun () ->
-        let ret = tree_of_typexp false res in
+        let ret = tree_of_typexp Type res in
         let args = tree_of_constructor_arguments ext_args in
         (args, Some ret))
 
@@ -1461,7 +1468,7 @@ let tree_of_extension_constructor id ext es =
     | _ -> "?"
   in
   let ty_params =
-    List.map (fun ty -> type_param (tree_of_typexp false ty)) ty_params
+    List.map (fun ty -> type_param (tree_of_typexp Type ty)) ty_params
   in
   let name = Ident.name id in
   let args, ret =
@@ -1528,13 +1535,13 @@ let method_type (_, kind, ty) =
     Fpresent, {desc=Tpoly(ty, tyl)} -> (ty, tyl)
   | _       , ty                    -> (ty, [])
 
-let tree_of_metho sch concrete csil (lab, kind, ty) =
+let tree_of_metho mode concrete csil (lab, kind, ty) =
   if lab <> dummy_method then begin
     let kind = field_kind_repr kind in
     let priv = kind <> Fpresent in
     let virt = not (Concr.mem lab concrete) in
     let (ty, tyl) = method_type (lab, kind, ty) in
-    let tty = tree_of_typexp sch ty in
+    let tty = tree_of_typexp mode ty in
     Names.remove_names tyl;
     Ocsg_method (lab, priv, virt, tty) :: csil
   end
@@ -1563,17 +1570,17 @@ let rec prepare_class_type params = function
       mark_loops ty;
       prepare_class_type params cty
 
-let rec tree_of_class_type sch params =
+let rec tree_of_class_type mode params =
   function
   | Cty_constr (p', tyl, cty) ->
       let sty = Ctype.self_type cty in
       if List.memq (proxy sty) !visited_objects
       || not (List.for_all is_Tvar params)
       then
-        tree_of_class_type sch params cty
+        tree_of_class_type mode params cty
       else
         let namespace = Namespace.best_class_namespace p' in
-        Octy_constr (tree_of_path namespace p', tree_of_typlist true tyl)
+        Octy_constr (tree_of_path namespace p', tree_of_typlist Scheme tyl)
   | Cty_signature sign ->
       let sty = repr sign.csig_self in
       let self_ty =
@@ -1598,12 +1605,12 @@ let rec tree_of_class_type sch params =
       let csil =
         List.fold_left
           (fun csil (l, m, v, t) ->
-            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp sch t)
+            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp mode t)
             :: csil)
           csil all_vars
       in
       let csil =
-        List.fold_left (tree_of_metho sch sign.csig_concr) csil fields
+        List.fold_left (tree_of_metho mode sign.csig_concr) csil fields
       in
       Octy_signature (self_ty, List.rev csil)
   | Cty_arrow (l, ty, cty) ->
@@ -1614,18 +1621,18 @@ let rec tree_of_class_type sch params =
        if is_optional l then
          match (repr ty).desc with
          | Tconstr(path, [ty], _) when Path.same path Predef.path_option ->
-             tree_of_typexp sch ty
+             tree_of_typexp mode ty
          | _ -> Otyp_stuff "<hidden>"
-       else tree_of_typexp sch ty in
-      Octy_arrow (lab, tr, tree_of_class_type sch params cty)
+       else tree_of_typexp mode ty in
+      Octy_arrow (lab, tr, tree_of_class_type mode params cty)
 
 let class_type ppf cty =
   reset ();
   prepare_class_type [] cty;
-  !Oprint.out_class_type ppf (tree_of_class_type false [] cty)
+  !Oprint.out_class_type ppf (tree_of_class_type Type [] cty)
 
 let tree_of_class_param param variance =
-  (match tree_of_typexp true param with
+  (match tree_of_typexp Scheme param with
     Otyp_var (_, s) -> s
   | _ -> "?"),
   if is_Tvar (repr param) then Asttypes.(NoVariance, NoInjectivity)
@@ -1654,7 +1661,7 @@ let tree_of_class_declaration id cl rs =
   Osig_class
     (vir_flag, Ident.name id,
      List.map2 tree_of_class_param params (class_variance cl.cty_variance),
-     tree_of_class_type true params cl.cty_type,
+     tree_of_class_type Scheme params cl.cty_type,
      tree_of_rec rs)
 
 let class_declaration id ppf cl =
@@ -1687,7 +1694,7 @@ let tree_of_cltype_declaration id cl rs =
   Osig_class_type
     (virt, Ident.name id,
      List.map2 tree_of_class_param params (class_variance cl.clty_variance),
-     tree_of_class_type true params cl.clty_type,
+     tree_of_class_type Scheme params cl.clty_type,
      tree_of_rec rs)
 
 let cltype_declaration id ppf cl =
@@ -1893,7 +1900,7 @@ let modtype_declaration id ppf decl =
 (* Refresh weak variable map in the toplevel *)
 let refresh_weak () =
   Names.refresh_weak (fun t name (m,s) ->
-    if is_non_gen true (repr t) then
+    if is_non_gen Scheme (repr t) then
       begin
         TypeMap.add t name m,
         String.Set.add name s
@@ -1932,7 +1939,25 @@ let printed_signature sourcefile ppf sg =
   end;
   fprintf ppf "%a" print_signature t
 
-(* Print an unification error *)
+(* Trace-specific printing *)
+
+(* A configuration type that controls which trace we print.  This could be
+   exposed, but we instead expose three separate
+   [report_{unification,equality,moregen}_error] functions.  This also lets us
+   give the unification case an extra optional argument without adding it to the
+   equality and moregen cases. *)
+type 'variety trace_format =
+  | Unification : Errortrace.unification trace_format
+  | Equality    : Errortrace.comparison  trace_format
+  | Moregen     : Errortrace.comparison  trace_format
+
+let incompatibility_phrase (type variety) : variety trace_format -> string =
+  function
+  | Unification -> "is not compatible with type"
+  | Equality    -> "is not equal to type"
+  | Moregen     -> "is not compatible with type"
+
+(* Print a unification error *)
 
 let same_path t t' =
   let t = repr t and t' = repr t' in
@@ -1953,15 +1978,15 @@ let same_path t t' =
 
 type 'a diff = Same of 'a | Diff of 'a * 'a
 
-let trees_of_type_expansion (t,t') =
+let trees_of_type_expansion mode Errortrace.{ty = t; expanded = t'} =
   if same_path t t'
-  then begin add_delayed (proxy t); Same (tree_of_typexp false t) end
+  then begin add_delayed (proxy t); Same (tree_of_typexp mode t) end
   else
     let t' = if proxy t == proxy t' then unalias t' else t' in
     (* beware order matter due to side effect,
        e.g. when printing object types *)
-    let first = tree_of_typexp false t in
-    let second = tree_of_typexp false t' in
+    let first = tree_of_typexp mode t in
+    let second = tree_of_typexp mode t' in
     if first = second then Same first
     else Diff(first,second)
 
@@ -1970,7 +1995,8 @@ let type_expansion ppf = function
   | Diff(t,t') ->
       fprintf ppf "@[<2>%a@ =@ %a@]"  !Oprint.out_type t  !Oprint.out_type t'
 
-let trees_of_trace = List.map (Errortrace.map_diff trees_of_type_expansion)
+let trees_of_trace mode =
+  List.map (Errortrace.map_diff (trees_of_type_expansion mode))
 
 let trees_of_type_path_expansion (tp,tp') =
   if Path.same tp tp' then Same(tree_of_path Type tp) else
@@ -2003,28 +2029,13 @@ type printing_status =
       type error.
   *)
 
-let diff_printing_status { Errortrace.got=t1, t1'; expected=t2, t2'} =
+let diff_printing_status Errortrace.{ got      = {ty = t1; expanded = t1'};
+                                      expected = {ty = t2; expanded = t2'} } =
   if  is_constr_row ~allow_ident:true t1'
    || is_constr_row ~allow_ident:true t2'
   then Discard
   else if same_path t1 t1' && same_path t2 t2' then Optional_refinement
   else Keep
-
-(* A configuration type that controls which trace we print.  This could be
-   exposed, but we instead expose three separate
-   [report_{unification,equality,moregen}_error] functions.  This also lets us
-   give the unification case an extra optional argument without adding it to the
-   equality and moregen cases. *)
-type 'variety trace_format =
-  | Unification : Errortrace.unification trace_format
-  | Equality    : Errortrace.comparison  trace_format
-  | Moregen     : Errortrace.comparison  trace_format
-
-let incompatibility_phrase (type variety) : variety trace_format -> string =
-  function
-  | Unification -> "is not compatible with type"
-  | Equality    -> "is not equal to type"
-  | Moregen     -> "is not compatible with type"
 
 let printing_status = function
   | Errortrace.Diff d -> diff_printing_status d
@@ -2046,11 +2057,14 @@ let prepare_any_trace printing_status tr =
   | elt :: rem -> elt :: List.fold_right clean_trace rem []
 
 let prepare_trace f tr =
-  prepare_any_trace printing_status (Errortrace.flatten f tr)
+  prepare_any_trace printing_status (Errortrace.map f tr)
 
 (** Keep elements that are not [Diff _ ] and take the decision
     for the last element, require a prepared trace *)
-let rec filter_trace trace_format keep_last = function
+let rec filter_trace
+          (trace_format : 'variety trace_format)
+          keep_last
+  : ('a, 'variety) Errortrace.t -> _ = function
   | [] -> []
   | [Errortrace.Diff d as elt]
     when printing_status elt = Optional_refinement ->
@@ -2071,17 +2085,17 @@ let hide_variant_name t =
                    row_more = newvar2 (row_more row).level})
   | _ -> t
 
-let prepare_expansion (t, t') =
-  let t' = hide_variant_name t' in
-  mark_loops t;
-  if not (same_path t t') then mark_loops t';
-  (t, t')
+let prepare_expansion Errortrace.{ty; expanded} =
+  let expanded = hide_variant_name expanded in
+  mark_loops ty;
+  if not (same_path ty expanded) then mark_loops expanded;
+  Errortrace.{ty; expanded}
 
-let may_prepare_expansion compact (t, t') =
-  match (repr t').desc with
+let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
+  match (repr expanded).desc with
     Tvariant _ | Tobject _ when compact ->
-      mark_loops t; (t, t)
-  | _ -> prepare_expansion (t, t')
+      mark_loops ty; Errortrace.{ty; expanded = ty}
+  | _ -> prepare_expansion ty_exp
 
 let print_path p = Format.dprintf "%a" !Oprint.out_ident (tree_of_path Type p)
 
@@ -2189,7 +2203,7 @@ let explain_escape pre = function
         "%t@,@[The module type@;<1 2>%a@ would escape its scope@]"
         pre path p
     )
-  | Errortrace.Equation (_,t) -> Some(
+  | Errortrace.Equation Errortrace.{ty = _; expanded = t} -> Some(
       dprintf "%t @,@[<hov>This instance of %a is ambiguous:@ %s@]"
         pre type_expr t
         "it would escape the scope of its equation"
@@ -2213,10 +2227,10 @@ let explain_object (type variety) : variety Errortrace.obj -> _ = function
       Some (dprintf "@,Self type cannot be unified with a closed object type")
 
 let explanation (type variety) intro prev env
-  : ('a, variety) Errortrace.elt -> _ = function
-  | Errortrace.Diff { Errortrace.got = _,s; expected = _,t } ->
-    explanation_diff env s t
-  | Errortrace.Escape {kind;context} ->
+  : (Errortrace.expanded_type, variety) Errortrace.elt -> _ = function
+  | Errortrace.Diff {got; expected} ->
+    explanation_diff env got.expanded expected.expanded
+  | Errortrace.Escape {kind; context} ->
     let pre =
       match context, kind, prev with
       | Some ctx, _, _ ->
@@ -2276,26 +2290,32 @@ let prepare_expansion_head empty_tr = function
       Some (Errortrace.map_diff (may_prepare_expansion empty_tr) d)
   | _ -> None
 
-let head_error_printer txt_got txt_but = function
+let head_error_printer mode txt_got txt_but = function
   | None -> ignore
   | Some d ->
-      let d = Errortrace.map_diff trees_of_type_expansion d in
+      let d = Errortrace.map_diff (trees_of_type_expansion mode) d in
       dprintf "%t@;<1 2>%a@ %t@;<1 2>%a"
         txt_got type_expansion d.Errortrace.got
         txt_but type_expansion d.Errortrace.expected
 
 let warn_on_missing_defs env ppf = function
   | None -> ()
-  | Some {Errortrace.got=te1,_; expected=te2,_ } ->
+  | Some Errortrace.{got      = {ty=te1; expanded=_};
+                     expected = {ty=te2; expanded=_} } ->
       warn_on_missing_def env ppf te1;
       warn_on_missing_def env ppf te2
 
 (* [subst] comes out of equality, and is [[]] otherwise *)
-let error trace_format subst env tr txt1 ppf txt2 ty_expect_explanation =
+let error trace_format mode subst env tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   (* We want to substitute in the opposite order from [Eqtype] *)
   Names.add_subst (List.map (fun (ty1,ty2) -> ty2,ty1) subst);
-  let tr = prepare_trace (fun t t' -> t, hide_variant_name t') tr in
+  let tr =
+    prepare_trace
+      (fun ty_exp ->
+         Errortrace.{ty_exp with expanded = hide_variant_name ty_exp.expanded})
+      tr
+  in
   let mis = mismatch txt1 env tr in
   match tr with
   | [] -> assert false
@@ -2305,8 +2325,8 @@ let error trace_format subst env tr txt1 ppf txt2 ty_expect_explanation =
       let tr = filter_trace trace_format (mis = None) tr in
       let head = prepare_expansion_head (tr=[]) elt in
       let tr = List.map (Errortrace.map_diff prepare_expansion) tr in
-      let head_error = head_error_printer txt1 txt2 head in
-      let tr = trees_of_trace tr in
+      let head_error = head_error_printer mode txt1 txt2 head in
+      let tr = trees_of_trace mode tr in
       fprintf ppf
         "@[<v>\
           @[%t%t@]%a%t\
@@ -2323,24 +2343,32 @@ let error trace_format subst env tr txt1 ppf txt2 ty_expect_explanation =
       print_labels := true;
       raise exn
 
-let report_error trace_format ppf env tr
+let report_error trace_format ppf mode env tr
       ?(subst = [])
       ?(type_expected_explanation = fun _ -> ())
       txt1 txt2 =
-  wrap_printing_env env (fun () -> error trace_format subst env tr txt1 ppf txt2
-                                     type_expected_explanation)
-    ~error:true
+  wrap_printing_env ~error:true env (fun () ->
+    error trace_format mode subst env tr txt1 ppf txt2
+      type_expected_explanation)
 
-let report_unification_error ppf env ({trace} : Errortrace.unification_error) =
-  report_error Unification ppf env ?subst:None trace
-let report_equality_error ppf env ({subst; trace} : Errortrace.equality_error) =
-  report_error Equality ppf env ~subst ?type_expected_explanation:None trace
-let report_moregen_error ppf env ({trace} : Errortrace.moregen_error) =
-  report_error Moregen ppf env ?subst:None ?type_expected_explanation:None trace
+let report_unification_error
+      ppf env ({trace} : Errortrace.unification_error) =
+  report_error Unification ppf Type env
+    ?subst:None trace
 
-let report_comparison_error ppf env = function
-  | Errortrace.Equality_error error -> report_equality_error ppf env error
-  | Errortrace.Moregen_error  error -> report_moregen_error  ppf env error
+let report_equality_error
+      ppf mode env ({subst; trace} : Errortrace.equality_error) =
+  report_error Equality ppf mode env
+    ~subst ?type_expected_explanation:None trace
+
+let report_moregen_error
+      ppf mode env ({trace} : Errortrace.moregen_error) =
+  report_error Moregen ppf mode env
+    ?subst:None ?type_expected_explanation:None trace
+
+let report_comparison_error ppf mode env = function
+  | Errortrace.Equality_error error -> report_equality_error ppf mode env error
+  | Errortrace.Moregen_error  error -> report_moregen_error  ppf mode env error
 
 module Subtype = struct
   (* There's a frustrating amount of code duplication between this module and
@@ -2355,7 +2383,7 @@ module Subtype = struct
   let prepare_unification_trace = prepare_trace
 
   let prepare_trace f tr =
-    prepare_any_trace printing_status (Errortrace.Subtype.flatten f tr)
+    prepare_any_trace printing_status (Errortrace.Subtype.map f tr)
 
   let trace filter_trace get_diff fst keep_last txt ppf tr =
     print_labels := not !Clflags.classic;
@@ -2363,7 +2391,7 @@ module Subtype = struct
       | elt :: tr' ->
         let diffed_elt = get_diff elt in
         let tr =
-          trees_of_trace
+          trees_of_trace Type
           @@ List.map (Errortrace.map_diff prepare_expansion)
           @@ filter_trace keep_last tr' in
         let tr =
@@ -2390,23 +2418,19 @@ module Subtype = struct
 
   let unification_get_diff = function
     | Errortrace.Diff diff ->
-        Some (Errortrace.map_diff trees_of_type_expansion diff)
+        Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
     | _ -> None
 
   let subtype_get_diff = function
     | Errortrace.Subtype.Diff diff ->
-        Some (Errortrace.map_diff trees_of_type_expansion diff)
+        Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
 
   let report_error
         ppf env tr1 txt1 ({trace=tr2} : Errortrace.unification_error) =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr1 =
-        prepare_trace (fun t t' -> prepare_expansion (t, t')) tr1
-      in
-      let tr2 =
-        prepare_unification_trace (fun t t' -> prepare_expansion (t, t')) tr2
-      in
+      let tr1 = prepare_trace prepare_expansion tr1 in
+      let tr2 = prepare_unification_trace prepare_expansion tr2 in
       let keep_first = match tr2 with
         | [Obj _ | Variant _ | Escape _ ] | [] -> true
         | _ -> false in
@@ -2446,8 +2470,8 @@ let report_ambiguous_type_error ppf env tp0 tpl txt1 txt2 txt3 =
 (* Adapt functions to exposed interface *)
 let tree_of_path = tree_of_path Other
 let tree_of_modtype = tree_of_modtype ~ellipsis:false
-let type_expansion ty ppf ty' =
-  type_expansion ppf (trees_of_type_expansion (ty,ty'))
+let type_expansion mode ppf ty_exp =
+  type_expansion ppf (trees_of_type_expansion mode ty_exp)
 let tree_of_type_declaration ident td rs =
   with_hidden_items [{hide=true; ident}]
     (fun () -> tree_of_type_declaration ident td rs)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2421,21 +2421,25 @@ module Subtype = struct
         Some (Errortrace.map_diff (trees_of_type_expansion Type) diff)
 
   let report_error
-        ppf env tr1 txt1 ({trace=tr2} : Errortrace.unification_error) =
+        ppf
+        env
+        (Errortrace.Subtype.{trace = tr_sub; unification_trace = tr_unif})
+        txt1 =
     wrap_printing_env ~error:true env (fun () ->
       reset ();
-      let tr1 = prepare_trace prepare_expansion tr1 in
-      let tr2 = prepare_unification_trace prepare_expansion tr2 in
-      let keep_first = match tr2 with
+      let tr_sub  = prepare_trace             prepare_expansion tr_sub  in
+      let tr_unif = prepare_unification_trace prepare_expansion tr_unif in
+      let keep_first = match tr_unif with
         | [Obj _ | Variant _ | Escape _ ] | [] -> true
         | _ -> false in
       fprintf ppf "@[<v>%a"
-        (trace filter_subtype_trace subtype_get_diff true keep_first txt1) tr1;
-      if tr2 = [] then fprintf ppf "@]" else
-        let mis = mismatch (dprintf "Within this type") env tr2 in
+        (trace filter_subtype_trace subtype_get_diff true keep_first txt1)
+        tr_sub;
+      if tr_unif = [] then fprintf ppf "@]" else
+        let mis = mismatch (dprintf "Within this type") env tr_unif in
         fprintf ppf "%a%t%t@]"
           (trace filter_unification_trace unification_get_diff false
-             (mis = None) "is not compatible with type") tr2
+             (mis = None) "is not compatible with type") tr_unif
           (explain mis)
           Conflicts.print_explanations
     )

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -160,8 +160,10 @@ val functor_parameters:
   ('b -> Format.formatter -> unit) ->
   (Ident.t option * 'b) list -> Format.formatter -> unit
 
+type type_or_scheme = Type | Scheme
+
 val tree_of_signature: Types.signature -> out_sig_item list
-val tree_of_typexp: bool -> type_expr -> out_type
+val tree_of_typexp: type_or_scheme -> type_expr -> out_type
 val modtype_declaration: Ident.t -> formatter -> modtype_declaration -> unit
 val class_type: formatter -> class_type -> unit
 val tree_of_class_declaration:
@@ -170,34 +172,38 @@ val class_declaration: Ident.t -> formatter -> class_declaration -> unit
 val tree_of_cltype_declaration:
     Ident.t -> class_type_declaration -> rec_status -> out_sig_item
 val cltype_declaration: Ident.t -> formatter -> class_type_declaration -> unit
-val type_expansion: type_expr -> Format.formatter -> type_expr -> unit
-val prepare_expansion: type_expr * type_expr -> type_expr * type_expr
+val type_expansion :
+  type_or_scheme -> Format.formatter -> Errortrace.expanded_type -> unit
+val prepare_expansion: Errortrace.expanded_type -> Errortrace.expanded_type
 val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
 
 val report_unification_error :
-  formatter -> Env.t ->
-  Errortrace.unification_error ->
+  formatter ->
+  Env.t -> Errortrace.unification_error ->
   ?type_expected_explanation:(formatter -> unit) ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
 val report_equality_error :
-  formatter -> Env.t ->
-  Errortrace.equality_error ->
+  formatter ->
+  type_or_scheme ->
+  Env.t -> Errortrace.equality_error ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
 val report_moregen_error :
-  formatter -> Env.t ->
-  Errortrace.moregen_error ->
+  formatter ->
+  type_or_scheme ->
+  Env.t -> Errortrace.moregen_error ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
 val report_comparison_error :
-  formatter -> Env.t ->
-  Errortrace.comparison_error ->
+  formatter ->
+  type_or_scheme ->
+  Env.t -> Errortrace.comparison_error ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
@@ -205,7 +211,7 @@ module Subtype : sig
   val report_error :
     formatter ->
     Env.t ->
-    Errortrace.Subtype.t ->
+    Errortrace.Subtype.error ->
     string ->
     Errortrace.unification_error ->
     unit

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -113,7 +113,6 @@ val tree_of_type_scheme: type_expr -> out_type
 val type_sch : formatter -> type_expr -> unit
 val type_scheme: formatter -> type_expr -> unit
 (* Maxence *)
-val reset_names: unit -> unit
 val type_scheme_max: ?b_reset_names: bool ->
         formatter -> type_expr -> unit
 (* End Maxence *)
@@ -179,20 +178,26 @@ val report_ambiguous_type_error:
 
 val report_unification_error :
   formatter -> Env.t ->
-  Errortrace.unification Errortrace.t ->
+  Errortrace.unification_error ->
   ?type_expected_explanation:(formatter -> unit) ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
 val report_equality_error :
   formatter -> Env.t ->
-  Errortrace.comparison Errortrace.t ->
+  Errortrace.equality_error ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
 val report_moregen_error :
   formatter -> Env.t ->
-  Errortrace.comparison Errortrace.t ->
+  Errortrace.moregen_error ->
+  (formatter -> unit) -> (formatter -> unit) ->
+  unit
+
+val report_comparison_error :
+  formatter -> Env.t ->
+  Errortrace.comparison_error ->
   (formatter -> unit) -> (formatter -> unit) ->
   unit
 
@@ -202,7 +207,7 @@ module Subtype : sig
     Env.t ->
     Errortrace.Subtype.t ->
     string ->
-    Errortrace.unification Errortrace.t ->
+    Errortrace.unification_error ->
     unit
 end
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -213,7 +213,6 @@ module Subtype : sig
     Env.t ->
     Errortrace.Subtype.error ->
     string ->
-    Errortrace.unification_error ->
     unit
 end
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -160,7 +160,7 @@ val functor_parameters:
   ('b -> Format.formatter -> unit) ->
   (Ident.t option * 'b) list -> Format.formatter -> unit
 
-type type_or_scheme = Type | Scheme
+type type_or_scheme = Type | Type_scheme
 
 val tree_of_signature: Types.signature -> out_sig_item list
 val tree_of_typexp: type_or_scheme -> type_expr -> out_type

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -295,7 +295,10 @@ let inheritance self_type env ovf concr_meths warn_vals loc parent =
         | Diff _ :: Incompatible_fields {name = n; _ } :: rem ->
             raise (Error(loc,
                          env,
-                         Field_type_mismatch ("method", n, {trace = rem})))
+                         Field_type_mismatch(
+                           "method",
+                           n,
+                           Errortrace.unification_error ~trace:rem)))
         | _ -> assert false
       end;
 
@@ -1713,8 +1716,8 @@ let check_coercions env { id; id_loc; clty; ty_id; cltydef; obj_id; obj_abbr;
         | _ -> assert false
       in
       begin try Ctype.subtype env cl_ty obj_ty ()
-      with Ctype.Subtype (err1, err2) ->
-        raise(Typecore.Error(loc, env, Typecore.Not_subtype(err1, err2)))
+      with Ctype.Subtype err ->
+        raise(Typecore.Error(loc, env, Typecore.Not_subtype err))
       end;
       if not (Ctype.opened_object cl_ty) then
         raise(Error(loc, env, Cannot_coerce_self obj_ty))

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -90,8 +90,8 @@ val type_classes :
 *)
 
 type error =
-  | Unconsistent_constraint of Errortrace.unification Errortrace.t
-  | Field_type_mismatch of string * string * Errortrace.unification Errortrace.t
+  | Unconsistent_constraint of Errortrace.unification_error
+  | Field_type_mismatch of string * string * Errortrace.unification_error
   | Structure_expected of class_type
   | Cannot_apply of class_type
   | Apply_wrong_label of arg_label
@@ -100,10 +100,10 @@ type error =
   | Unbound_class_2 of Longident.t
   | Unbound_class_type_2 of Longident.t
   | Abbrev_type_clash of type_expr * type_expr * type_expr
-  | Constructor_type_mismatch of string * Errortrace.unification Errortrace.t
+  | Constructor_type_mismatch of string * Errortrace.unification_error
   | Virtual_class of bool * bool * string list * string list
   | Parameter_arity_mismatch of Longident.t * int * int
-  | Parameter_mismatch of Errortrace.unification Errortrace.t
+  | Parameter_mismatch of Errortrace.unification_error
   | Bad_parameters of Ident.t * type_expr * type_expr
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
@@ -111,8 +111,8 @@ type error =
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
-      Ident.t * Types.class_declaration * Errortrace.unification Errortrace.t
-  | Final_self_clash of Errortrace.unification Errortrace.t
+      Ident.t * Types.class_declaration * Errortrace.unification_error
+  | Final_self_clash of Errortrace.unification_error
   | Mutability_mismatch of string * mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1343,7 +1343,7 @@ let check_scope_escape loc env level ty =
   with Escape esc ->
     (* We don't expand the type here because if we do, we might expand to the
        type that escaped, leading to confusing error messages. *)
-    let trace = Errortrace.[Escape (map_escape unexpanded_type esc)] in
+    let trace = Errortrace.[Escape (map_escape trivial_expansion esc)] in
     raise (Error(loc, env, Pattern_type_clash({trace}, None)))
 
 type pattern_checking_mode =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -113,6 +113,7 @@ type error =
   | Name_type_mismatch of
       Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
+  | Not_an_object of type_expr * type_forcing_context option
   | Undefined_method of type_expr * string * string list option
   | Undefined_inherited_method of string * string list
   | Virtual_class of Longident.t
@@ -121,13 +122,19 @@ type error =
   | Private_constructor of constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
-  | Not_subtype of Errortrace.Subtype.error * Errortrace.unification_error
+  | Not_subtype of Errortrace.Subtype.error
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
       Errortrace.expanded_type * Errortrace.unification_error * bool
-  | Too_many_arguments of bool * type_expr * type_forcing_context option
-  | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
+  | Not_a_function of type_expr * type_forcing_context option
+  | Too_many_arguments of type_expr * type_forcing_context option
+  | Abstract_wrong_label of
+      { got           : arg_label
+      ; expected      : arg_label
+      ; expected_type : type_expr
+      ; explanation   : type_forcing_context option
+      }
   | Scoping_let_module of string * type_expr
   | Not_a_polymorphic_variant_type of Longident.t
   | Incoherent_label_order
@@ -1344,7 +1351,9 @@ let check_scope_escape loc env level ty =
     (* We don't expand the type here because if we do, we might expand to the
        type that escaped, leading to confusing error messages. *)
     let trace = Errortrace.[Escape (map_escape trivial_expansion esc)] in
-    raise (Error(loc, env, Pattern_type_clash({trace}, None)))
+    raise (Error(loc,
+                 env,
+                 Pattern_type_clash(Errortrace.unification_error ~trace, None)))
 
 type pattern_checking_mode =
   | Normal
@@ -2531,11 +2540,12 @@ let check_univars env kind exp ty_expected vars =
   let ty, complete = polyfy env exp_ty vars in
   if not complete then
     let ty_expected = instance ty_expected in
-    raise (Error (exp.exp_loc,
-                  env,
-                  Less_general(kind,
-                               {trace = [Ctype.expanded_diff env
-                                           ~got:ty ~expected:ty_expected]})))
+    raise (Error(exp.exp_loc,
+                 env,
+                 Less_general(kind,
+                              Errortrace.unification_error
+                                ~trace:[Ctype.expanded_diff env
+                                          ~got:ty ~expected:ty_expected])))
 
 let generalize_and_check_univars env kind exp ty_expected vars =
   generalize exp.exp_type;
@@ -3392,9 +3402,9 @@ and type_expect_
                   if not gen && !Clflags.principal then
                     Location.prerr_warning loc
                       (Warnings.Not_principal "this ground coercion");
-                with Subtype (tr1, tr2) ->
+                with Subtype err ->
                   (* prerr_endline "coercion failed"; *)
-                  raise(Error(loc, env, Not_subtype(tr1, tr2)))
+                  raise (Error(loc, env, Not_subtype err))
                 end;
             | _ ->
                 let ty, b = enlarge_type env ty' in
@@ -3416,8 +3426,8 @@ and type_expect_
             begin try
               let force'' = subtype env ty ty' in
               force (); force' (); force'' ()
-            with Subtype (tr1, tr2) ->
-              raise(Error(loc, env, Not_subtype(tr1, tr2)))
+            with Subtype err ->
+              raise (Error(loc, env, Not_subtype err))
             end;
             end_def ();
             generalize_structure ty;
@@ -3539,22 +3549,37 @@ and type_expect_
           exp_type = typ;
           exp_attributes = sexp.pexp_attributes;
           exp_env = env }
-      with Unify _ ->
-        let valid_methods =
-          match !obj_meths with
-          | Some meths ->
-             Some (Meths.fold (fun meth _meth_ty li -> meth::li) !meths [])
-          | None ->
-             match (expand_head env obj.exp_type).desc with
-             | Tobject (fields, _) ->
-                let (fields, _) = Ctype.flatten_fields fields in
-                let collect_fields li (meth, meth_kind, _meth_ty) =
-                  if meth_kind = Fpresent then meth::li else li in
-                Some (List.fold_left collect_fields [] fields)
-             | _ -> None
+      with (Filter_method_failed _ | Self_has_no_such_method) as err ->
+        let err =
+          match err with
+          | Filter_method_failed err -> err
+          | Self_has_no_such_method -> Not_a_method
+          | _ -> assert false
         in
-        raise(Error(e.pexp_loc, env,
-                    Undefined_method (obj.exp_type, met, valid_methods)))
+        let error =
+          match err with
+          | Unification_error err ->
+              Expr_type_clash(err, explanation, None)
+          | Not_an_object ty ->
+              Not_an_object(ty, explanation)
+          | Not_a_method ->
+              let valid_methods =
+                match !obj_meths with
+                | Some meths ->
+                    Some
+                      (Meths.fold (fun meth _meth_ty li -> meth::li) !meths [])
+                | None ->
+                    match (expand_head env obj.exp_type).desc with
+                    | Tobject (fields, _) ->
+                        let (fields, _) = Ctype.flatten_fields fields in
+                        let collect_fields li (meth, meth_kind, _meth_ty) =
+                          if meth_kind = Fpresent then meth::li else li in
+                        Some (List.fold_left collect_fields [] fields)
+                    | _ -> None
+              in
+              Undefined_method(obj.exp_type, met, valid_methods)
+        in
+        raise (Error(e.pexp_loc, env, error))
       end
   | Pexp_new cl ->
       let (cl_path, cl_decl) = Env.lookup_class ~loc:cl.loc cl.txt env in
@@ -3984,16 +4009,19 @@ and type_function ?(in_function : (Location.t * type_expr) option)
   if separate then begin_def ();
   let (ty_arg, ty_res) =
     try filter_arrow env (instance ty_expected) arg_label
-    with Unify _ ->
-      match expand_head env ty_expected with
-        {desc = Tarrow _} as ty ->
-          raise(Error(loc, env,
-                      Abstract_wrong_label(arg_label, ty, explanation)))
-      | _ ->
-          raise(Error(loc_fun, env,
-                      Too_many_arguments (in_function <> None,
-                                          ty_fun,
-                                          explanation)))
+    with Filter_arrow_failed err ->
+      let err = match err with
+        | Unification_error unif_err ->
+            Expr_type_clash(unif_err, explanation, None)
+        | Label_mismatch { got; expected; expected_type} ->
+            Abstract_wrong_label { got; expected; expected_type; explanation }
+        | Not_a_function -> begin
+            match in_function with
+            | Some _ -> Too_many_arguments(ty_fun, explanation)
+            | None   -> Not_a_function(ty_fun, explanation)
+          end
+      in
+      raise (Error(loc_fun, env, err))
   in
   let ty_arg =
     if is_optional arg_label then
@@ -4641,7 +4669,7 @@ and type_application env funct sargs =
   let is_ignore funct =
     is_prim ~name:"%ignore" funct &&
     (try ignore (filter_arrow env (instance funct.exp_type) Nolabel); true
-     with Unify _ -> false)
+     with Filter_arrow_failed _ -> false)
   in
   match sargs with
   | (* Special case for ignore: avoid discarding warning *)
@@ -5622,6 +5650,13 @@ let report_error ~loc env = function
       ) ()
   | Invalid_format msg ->
       Location.errorf ~loc "%s" msg
+  | Not_an_object (ty, explanation) ->
+    Location.error_of_printer ~loc (fun ppf () ->
+      fprintf ppf "This expression is not an object;@ \
+                   it has type %a"
+        Printtyp.type_expr ty;
+      report_type_expected_explanation_opt explanation ppf
+    ) ()
   | Undefined_method (ty, me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
         Printtyp.wrap_printing_env ~error:true env (fun () ->
@@ -5648,9 +5683,9 @@ let report_error ~loc env = function
       ) ()
   | Instance_variable_not_mutable v ->
       Location.errorf ~loc "The instance variable %s is not mutable" v
-  | Not_subtype(tr1, tr2) ->
+  | Not_subtype err ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.Subtype.report_error ppf env tr1 "is not a subtype of" tr2
+        Printtyp.Subtype.report_error ppf env err "is not a subtype of"
       ) ()
   | Outside_class ->
       Location.errorf ~loc
@@ -5675,30 +5710,36 @@ let report_error ~loc env = function
             "Hint: Consider using a fully explicit coercion"
             "of the form: `(foo : ty1 :> ty2)'."
       ) ()
-  | Too_many_arguments (in_function, ty, explanation) ->
-      if in_function then begin
-        Location.errorf ~loc
-          "This function expects too many arguments,@ \
-           it should have type@ %a%t"
-          Printtyp.type_expr ty
-          (report_type_expected_explanation_opt explanation)
-      end else begin
-        Location.errorf ~loc
-          "This expression should not be a function,@ \
-           the expected type is@ %a%t"
-          Printtyp.type_expr ty
-          (report_type_expected_explanation_opt explanation)
-      end
-  | Abstract_wrong_label (l, ty, explanation) ->
-      let label_mark = function
-        | Nolabel -> "but its first argument is not labelled"
-        | l -> sprintf "but its first argument is labelled %s"
-                       (prefixed_label_name l) in
+  | Not_a_function (ty, explanation) ->
       Location.errorf ~loc
-        "@[<v>@[<2>This function should have type@ %a%t@]@,%s@]"
+        "This expression should not be a function,@ \
+         the expected type is@ %a%t"
         Printtyp.type_expr ty
         (report_type_expected_explanation_opt explanation)
-        (label_mark l)
+  | Too_many_arguments (ty, explanation) ->
+      Location.errorf ~loc
+        "This function expects too many arguments,@ \
+         it should have type@ %a%t"
+        Printtyp.type_expr ty
+        (report_type_expected_explanation_opt explanation)
+  | Abstract_wrong_label {got; expected; expected_type; explanation} ->
+      let label ~long = function
+        | Nolabel -> "unlabeled"
+        | l       -> (if long then "labeled " else "") ^ prefixed_label_name l
+      in
+      let second_long = match got, expected with
+        | Nolabel, _ | _, Nolabel -> true
+        | _                       -> false
+      in
+      Location.errorf ~loc
+        "@[<v>@[<2>This function should have type@ %a%t@]@,\
+         but its first argument is %s@ \
+         instead of %s%s@]"
+        Printtyp.type_expr expected_type
+        (report_type_expected_explanation_opt explanation)
+        (label ~long:true got)
+        (if second_long then "being " else "")
+        (label ~long:second_long expected)
   | Scoping_let_module(id, ty) ->
       Location.errorf ~loc
         "This `let module' expression has type@ %a@ \

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3549,13 +3549,7 @@ and type_expect_
           exp_type = typ;
           exp_attributes = sexp.pexp_attributes;
           exp_env = env }
-      with (Filter_method_failed _ | Self_has_no_such_method) as err ->
-        let err =
-          match err with
-          | Filter_method_failed err -> err
-          | Self_has_no_such_method -> Not_a_method
-          | _ -> assert false
-        in
+      with Filter_method_failed err ->
         let error =
           match err with
           | Unification_error err ->
@@ -5733,8 +5727,7 @@ let report_error ~loc env = function
       in
       Location.errorf ~loc
         "@[<v>@[<2>This function should have type@ %a%t@]@,\
-         but its first argument is %s@ \
-         instead of %s%s@]"
+         @[but its first argument is %s@ instead of %s%s@]@]"
         Printtyp.type_expr expected_type
         (report_type_expected_explanation_opt explanation)
         (label ~long:true got)

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -157,6 +157,7 @@ type error =
   | Name_type_mismatch of
       Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
+  | Not_an_object of type_expr * type_forcing_context option
   | Undefined_method of type_expr * string * string list option
   | Undefined_inherited_method of string * string list
   | Virtual_class of Longident.t
@@ -165,13 +166,19 @@ type error =
   | Private_constructor of constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
-  | Not_subtype of Errortrace.Subtype.error * Errortrace.unification_error
+  | Not_subtype of Errortrace.Subtype.error
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
       Errortrace.expanded_type * Errortrace.unification_error * bool
-  | Too_many_arguments of bool * type_expr * type_forcing_context option
-  | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
+  | Not_a_function of type_expr * type_forcing_context option
+  | Too_many_arguments of type_expr * type_forcing_context option
+  | Abstract_wrong_label of
+      { got           : arg_label
+      ; expected      : arg_label
+      ; expected_type : type_expr
+      ; explanation   : type_forcing_context option
+      }
   | Scoping_let_module of string * type_expr
   | Not_a_polymorphic_variant_type of Longident.t
   | Incoherent_label_order

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -165,11 +165,11 @@ type error =
   | Private_constructor of constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
-  | Not_subtype of Errortrace.Subtype.t * Errortrace.unification_error
+  | Not_subtype of Errortrace.Subtype.error * Errortrace.unification_error
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
-      type_expr * type_expr * Errortrace.unification_error * bool
+      Errortrace.expanded_type * Errortrace.unification_error * bool
   | Too_many_arguments of bool * type_expr * type_forcing_context option
   | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
   | Scoping_let_module of string * type_expr

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -138,15 +138,15 @@ val self_coercion : (Path.t * Location.t list ref) list ref
 
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
-  | Label_mismatch of Longident.t * Errortrace.unification Errortrace.t
+  | Label_mismatch of Longident.t * Errortrace.unification_error
   | Pattern_type_clash :
-      Errortrace.unification Errortrace.t * _ Typedtree.pattern_desc option
+      Errortrace.unification_error * _ Typedtree.pattern_desc option
       -> error
-  | Or_pattern_type_clash of Ident.t * Errortrace.unification Errortrace.t
+  | Or_pattern_type_clash of Ident.t * Errortrace.unification_error
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
-      Errortrace.unification Errortrace.t * type_forcing_context option
+      Errortrace.unification_error * type_forcing_context option
       * Typedtree.expression_desc option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr * bool
@@ -165,17 +165,17 @@ type error =
   | Private_constructor of constructor_description * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of string
-  | Not_subtype of Errortrace.Subtype.t * Errortrace.unification Errortrace.t
+  | Not_subtype of Errortrace.Subtype.t * Errortrace.unification_error
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
-      type_expr * type_expr * Errortrace.unification Errortrace.t * bool
+      type_expr * type_expr * Errortrace.unification_error * bool
   | Too_many_arguments of bool * type_expr * type_forcing_context option
   | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
   | Scoping_let_module of string * type_expr
   | Not_a_polymorphic_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * Errortrace.unification Errortrace.t
+  | Less_general of string * Errortrace.unification_error
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
@@ -195,9 +195,9 @@ type error =
   | Illegal_letrec_pat
   | Illegal_letrec_expr
   | Illegal_class_expr
-  | Letop_type_clash of string * Errortrace.unification Errortrace.t
-  | Andop_type_clash of string * Errortrace.unification Errortrace.t
-  | Bindings_type_clash of Errortrace.unification Errortrace.t
+  | Letop_type_clash of string * Errortrace.unification_error
+  | Andop_type_clash of string * Errortrace.unification_error
+  | Bindings_type_clash of Errortrace.unification_error
   | Unbound_existential of Ident.t list * type_expr
   | Missing_type_constraint
   | Wrong_expected_kind of wrong_kind_sort * wrong_kind_context * type_expr

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -282,7 +282,9 @@ let make_constructor env type_path type_params sargs sret_type =
                ~got:ret_type
                ~expected:(Ctype.newconstr type_path type_params)]
           in
-          raise (Error (sret_type.ptyp_loc, Constraint_failed (env, {trace})))
+          raise (Error(sret_type.ptyp_loc,
+                       Constraint_failed(env,
+                                         Errortrace.unification_error ~trace)))
       end;
       widen z;
       targs, Some tret_type, args, Some ret_type

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -33,10 +33,10 @@ type error =
   | Duplicate_label of string
   | Recursive_abbrev of string
   | Cycle_in_def of string * type_expr
-  | Definition_mismatch of type_expr * Includecore.type_mismatch option
-  | Constraint_failed of Env.t * Errortrace.unification Errortrace.t
-  | Inconsistent_constraint of Env.t * Errortrace.unification Errortrace.t
-  | Type_clash of Env.t * Errortrace.unification Errortrace.t
+  | Definition_mismatch of type_expr * Env.t * Includecore.type_mismatch option
+  | Constraint_failed of Env.t * Errortrace.unification_error
+  | Inconsistent_constraint of Env.t * Errortrace.unification_error
+  | Type_clash of Env.t * Errortrace.unification_error
   | Non_regular of {
       definition: Path.t;
       used_as: type_expr;
@@ -48,9 +48,9 @@ type error =
   | Unbound_type_var of type_expr * type_declaration
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
-  | Extension_mismatch of Path.t * Includecore.type_mismatch
+  | Extension_mismatch of Path.t * Env.t * Includecore.type_mismatch
   | Rebind_wrong_type of
-      Longident.t * Env.t * Errortrace.unification Errortrace.t
+      Longident.t * Env.t * Errortrace.unification_error
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error
@@ -131,8 +131,8 @@ let update_type temp_env env id loc =
   | Some ty ->
       let params = List.map (fun _ -> Ctype.newvar ()) decl.type_params in
       try Ctype.unify env (Ctype.newconstr path params) ty
-      with Ctype.Unify trace ->
-        raise (Error(loc, Type_clash (env, trace)))
+      with Ctype.Unify err ->
+        raise (Error(loc, Type_clash (env, err)))
 
 let get_unboxed_type_representation env ty =
   match Typedecl_unboxed.get_unboxed_type_representation env ty with
@@ -274,11 +274,13 @@ let make_constructor env type_path type_params sargs sret_type =
       begin match (Ctype.repr ret_type).desc with
         | Tconstr (p', _, _) when Path.same type_path p' -> ()
         | _ ->
-          raise (Error (sret_type.ptyp_loc,
-                        Constraint_failed
-                          (env, [Errortrace.diff
-                                   ret_type
-                                   (Ctype.newconstr type_path type_params)])))
+          raise (Error
+                   (sret_type.ptyp_loc,
+                    Constraint_failed
+                      (env, {trace =
+                               [Errortrace.diff
+                                  ret_type
+                                  (Ctype.newconstr type_path type_params)]})))
       end;
       widen z;
       targs, Some tret_type, args, Some ret_type
@@ -432,8 +434,8 @@ let transl_declaration env sdecl (id, uid) =
       (fun (cty, cty', loc) ->
         let ty = cty.ctyp_type in
         let ty' = cty'.ctyp_type in
-        try Ctype.unify env ty ty' with Ctype.Unify tr ->
-          raise(Error(loc, Inconsistent_constraint (env, tr))))
+        try Ctype.unify env ty ty' with Ctype.Unify err ->
+          raise(Error(loc, Inconsistent_constraint (env, err))))
       cstrs;
     Ctype.end_def ();
   (* Add abstract row *)
@@ -486,8 +488,8 @@ let rec check_constraints_rec env loc visited ty =
       let ty' = Ctype.newconstr path (Ctype.instance_list decl.type_params) in
       begin
         try Ctype.matches env ty ty'
-        with Ctype.Matches_failure (env, trace) ->
-          raise (Error(loc, Constraint_failed (env, trace)))
+        with Ctype.Matches_failure (env, err) ->
+          raise (Error(loc, Constraint_failed (env, err)))
       end;
       List.iter (check_constraints_rec env loc visited) args
   | Tpoly (ty, tl) ->
@@ -585,8 +587,8 @@ let check_coherence env loc dpath decl =
               then Some Includecore.Arity
               else begin
                 match Ctype.equal env false args decl.type_params with
-                | exception Ctype.Equality trace ->
-                    Some (Includecore.Constraint (env, trace))
+                | exception Ctype.Equality err ->
+                    Some (Includecore.Constraint err)
                 | () ->
                     Includecore.type_declarations ~loc ~equality:true env
                       ~mark:true
@@ -598,11 +600,11 @@ let check_coherence env loc dpath decl =
               end
             in
             if err <> None then
-              raise(Error(loc, Definition_mismatch (ty, err)))
+              raise(Error(loc, Definition_mismatch (ty, env, err)))
           with Not_found ->
             raise(Error(loc, Unavailable_type_constructor path))
           end
-      | _ -> raise(Error(loc, Definition_mismatch (ty, None)))
+      | _ -> raise(Error(loc, Definition_mismatch (ty, env, None)))
       end
   | _ -> ()
 
@@ -721,8 +723,8 @@ let check_recursion ~orig_env env loc path decl to_check =
                 Ctype.instance_parameterized_type params0 body0 in
               begin
                 try List.iter2 (Ctype.unify orig_env) params args'
-                with Ctype.Unify trace ->
-                  raise (Error(loc, Constraint_failed (orig_env, trace)));
+                with Ctype.Unify err ->
+                  raise (Error(loc, Constraint_failed (orig_env, err)));
               end;
               check_regular path' args
                 (path' :: prev_exp) ((ty,body) :: prev_expansions)
@@ -990,9 +992,9 @@ let transl_extension_constructor ~scope env type_path type_params
         begin
           try
             Ctype.unify env cstr_res res
-          with Ctype.Unify trace ->
+          with Ctype.Unify err ->
             raise (Error(lid.loc,
-                     Rebind_wrong_type(lid.txt, env, trace)))
+                     Rebind_wrong_type(lid.txt, env, err)))
         end;
         (* Remove "_" names from parameters used in the constructor *)
         if not cdescr.cstr_generalized then begin
@@ -1138,7 +1140,7 @@ let transl_type_extension extend env loc styext =
   in
   begin match err with
   | None -> ()
-  | Some err -> raise (Error(loc, Extension_mismatch (type_path, err)))
+  | Some err -> raise (Error(loc, Extension_mismatch (type_path, env, err)))
   end;
   let ttype_params = make_params env styext.ptyext_params in
   let type_params = List.map (fun (cty, _) -> cty.ctyp_type) ttype_params in
@@ -1454,16 +1456,16 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   if arity_ok then
     List.iter2 (fun (cty, _) tparam ->
       try Ctype.unify_var env cty.ctyp_type tparam
-      with Ctype.Unify tr ->
-        raise(Error(cty.ctyp_loc, Inconsistent_constraint (env, tr)))
+      with Ctype.Unify err ->
+        raise(Error(cty.ctyp_loc, Inconsistent_constraint (env, err)))
     ) tparams sig_decl.type_params;
   List.iter (fun (cty, cty', loc) ->
     (* Note: constraints must also be enforced in [sig_env] because
        they may contain parameter variables from [tparams]
        that have now be unified in [sig_env]. *)
     try Ctype.unify env cty.ctyp_type cty'.ctyp_type
-    with Ctype.Unify tr ->
-      raise(Error(loc, Inconsistent_constraint (env, tr)))
+    with Ctype.Unify err ->
+      raise(Error(loc, Inconsistent_constraint (env, err)))
   ) constraints;
   let priv =
     if sdecl.ptype_private = Private then Private else
@@ -1664,19 +1666,20 @@ let report_error ppf = function
   | Cycle_in_def (s, ty) ->
       fprintf ppf "@[<v>The definition of %s contains a cycle:@ %a@]"
         s Printtyp.type_expr ty
-  | Definition_mismatch (ty, None) ->
+  | Definition_mismatch (ty, _env, None) ->
       fprintf ppf "@[<v>@[<hov>%s@ %s@;<1 2>%a@]@]"
         "This variant or record definition" "does not match that of type"
         Printtyp.type_expr ty
-  | Definition_mismatch (ty, Some err) ->
+  | Definition_mismatch (ty, env, Some err) ->
       fprintf ppf "@[<v>@[<hov>%s@ %s@;<1 2>%a@]%a@]"
         "This variant or record definition" "does not match that of type"
         Printtyp.type_expr ty
-        (Includecore.report_type_mismatch "the original" "this" "definition")
+        (Includecore.report_type_mismatch
+           "the original" "this" "definition" env)
         err
-  | Constraint_failed (env, trace) ->
+  | Constraint_failed (env, err) ->
       fprintf ppf "@[<v>Constraints are not satisfied in this type.@ ";
-      Printtyp.report_unification_error ppf env trace
+      Printtyp.report_unification_error ppf env err
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "should be an instance of");
       fprintf ppf "@]"
@@ -1715,14 +1718,14 @@ let report_error ppf = function
             !Oprint.out_type (Printtyp.tree_of_typexp false used_as)
             pp_expansions expansions
       end
-  | Inconsistent_constraint (env, trace) ->
+  | Inconsistent_constraint (env, err) ->
       fprintf ppf "@[<v>The type constraints are not consistent.@ ";
-      Printtyp.report_unification_error ppf env trace
+      Printtyp.report_unification_error ppf env err
         (fun ppf -> fprintf ppf "Type")
         (fun ppf -> fprintf ppf "is not compatible with type");
       fprintf ppf "@]"
-  | Type_clash (env, trace) ->
-      Printtyp.report_unification_error ppf env trace
+  | Type_clash (env, err) ->
+      Printtyp.report_unification_error ppf env err
         (function ppf ->
            fprintf ppf "This type constructor expands to type")
         (function ppf ->
@@ -1768,15 +1771,15 @@ let report_error ppf = function
         "Type definition"
         Printtyp.path path
         "is not extensible"
-  | Extension_mismatch (path, err) ->
+  | Extension_mismatch (path, env, err) ->
       fprintf ppf "@[<v>@[<hov>%s@ %s@;<1 2>%s@]%a@]"
         "This extension" "does not match the definition of type"
         (Path.name path)
         (Includecore.report_type_mismatch
-           "the type" "this extension" "definition")
+           "the type" "this extension" "definition" env)
         err
-  | Rebind_wrong_type (lid, env, trace) ->
-      Printtyp.report_unification_error ppf env trace
+  | Rebind_wrong_type (lid, env, err) ->
+      Printtyp.report_unification_error ppf env err
         (function ppf ->
            fprintf ppf "The constructor %a@ has type"
              Printtyp.longident lid)
@@ -1803,14 +1806,6 @@ let report_error ppf = function
         | false, true  -> inj ^ "contravariant"
         | false, false -> if inj = "" then "unrestricted" else inj
       in
-      let suffix n =
-        let teen = (n mod 100)/10 = 1 in
-        match n mod 10 with
-        | 1 when not teen -> "st"
-        | 2 when not teen -> "nd"
-        | 3 when not teen -> "rd"
-        | _ -> "th"
-      in
       (match n with
        | Variance_not_reflected ->
            fprintf ppf "@[%s@ %s@ It"
@@ -1828,7 +1823,7 @@ let report_error ppf = function
            fprintf ppf "@[%s@ %s@ The %d%s type parameter"
              "In this definition, expected parameter"
              "variances are not satisfied."
-             n (suffix n));
+             n (Misc.ordinal_suffix n));
       (match n with
        | No_variable -> ()
        | _ ->

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -70,10 +70,10 @@ type error =
   | Duplicate_label of string
   | Recursive_abbrev of string
   | Cycle_in_def of string * type_expr
-  | Definition_mismatch of type_expr * Includecore.type_mismatch option
-  | Constraint_failed of Env.t * Errortrace.unification Errortrace.t
-  | Inconsistent_constraint of Env.t * Errortrace.unification Errortrace.t
-  | Type_clash of Env.t * Errortrace.unification Errortrace.t
+  | Definition_mismatch of type_expr * Env.t * Includecore.type_mismatch option
+  | Constraint_failed of Env.t * Errortrace.unification_error
+  | Inconsistent_constraint of Env.t * Errortrace.unification_error
+  | Type_clash of Env.t * Errortrace.unification_error
   | Non_regular of {
       definition: Path.t;
       used_as: type_expr;
@@ -85,9 +85,9 @@ type error =
   | Unbound_type_var of type_expr * type_declaration
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
-  | Extension_mismatch of Path.t * Includecore.type_mismatch
+  | Extension_mismatch of Path.t * Env.t * Includecore.type_mismatch
   | Rebind_wrong_type of
-      Longident.t * Env.t * Errortrace.unification Errortrace.t
+      Longident.t * Env.t * Errortrace.unification_error
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Variance of Typedecl_variance.error

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -746,9 +746,9 @@ let report_error env ppf = function
         Printtyp.reset_and_mark_loops_list [ty; ty'];
         fprintf ppf "@[<hov>%s %a@ %s@ %a@]"
           "This variant type contains a constructor"
-          !Oprint.out_type (tree_of_typexp false ty)
+          !Oprint.out_type (tree_of_typexp Type ty)
           "which should be"
-           !Oprint.out_type (tree_of_typexp false ty'))
+           !Oprint.out_type (tree_of_typexp Type ty'))
   | Not_a_variant ty ->
       fprintf ppf
         "@[The type %a@ does not expand to a polymorphic variant type@]"

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -50,8 +50,8 @@ type error =
   | Bound_type_variable of string
   | Recursive_type
   | Unbound_row_variable of Longident.t
-  | Type_mismatch of Errortrace.unification Errortrace.t
-  | Alias_type_mismatch of Errortrace.unification Errortrace.t
+  | Type_mismatch of Errortrace.unification_error
+  | Alias_type_mismatch of Errortrace.unification_error
   | Present_has_conjunction of string
   | Present_has_no_type of string
   | Constructor_mismatch of type_expr * type_expr

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -597,6 +597,14 @@ let cut_at s c =
   let pos = String.index s c in
   String.sub s 0 pos, String.sub s (pos+1) (String.length s - pos - 1)
 
+let ordinal_suffix n =
+  let teen = (n mod 100)/10 = 1 in
+  match n mod 10 with
+  | 1 when not teen -> "st"
+  | 2 when not teen -> "nd"
+  | 3 when not teen -> "rd"
+  | _ -> "th"
+
 (* Color handling *)
 module Color = struct
   (* use ANSI color codes, see https://en.wikipedia.org/wiki/ANSI_escape_code *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -351,6 +351,12 @@ val cut_at : string -> char -> string * string
    @since 4.01
 *)
 
+val ordinal_suffix : int -> string
+(** [ordinal_suffix n] is the appropriate suffix to append to the numeral [n] as
+    an ordinal number: [1] -> ["st"], [2] -> ["nd"], [3] -> ["rd"],
+    [4] -> ["th"], and so on.  Handles larger numbers (e.g., [42] -> ["nd"]) and
+    the numbers 11--13 (which all get ["th"]) correctly. *)
+
 (* Color handling *)
 module Color : sig
   type color =


### PR DESCRIPTION
### Introduction

This PR produces more detailed error messages during various kinds of module inclusion, taking advantage of the new structured error trace generation from #10170.  Previously, these errors were “shallow”, ending as soon as there was an incompatibility; this patch makes them “deep”, reporting the *reasons* for those problems.  For example, consider the following module:

```ocaml
module M : sig
  val x : bool * int
end = struct
  let x = false , "not an int"
end
```

This now produces the following error:

<pre><code>Error: Signature mismatch:
       Modules do not match:
         sig val x : bool * string end
       is not included in
         sig val x : bool * int end
       Values do not match:
         val x : bool * string
       is not included in
         val x : bool * int
<strong>       The type bool * string is not compatible with the type bool * int
       Type string is not compatible with type int</strong></code></pre>

The last two bolded lines are new in this patch.  Previously, the error message stopped two lines earlier, omitting the key detail that the reason there is an error is specifically that `string` is not equal to `int`.

This change brings module errors in line with ordinary type errors; indeed, the new, bolded part of the module inclusion error corresponds directly to the error trace produced for ordinary type errors.  For example, in

```ocaml
let y = false, "still not an int" in
(y : bool * int)
```

the resulting error is

```
Error: This expression has type bool * string
       but an expression was expected of type bool * int
       Type string is not compatible with type int 
```

(These examples were also the example in #10170’s “Eventual goals” section, and the module `M` above now lives in the test suite as the first example in `testsuite/tests/typing-misc/deep.ml`.)

These improved error messages are generated for both moregen and type equality, and show up for every kind of module inclusion error: not just values with a different type in the signature, but constructors with different arguments, types with different parameters, classes with different methods, primitives with different names, and so on.

### Code changes

This PR makes the following large-scale changes to the code:

* The `Errortrace.t` type, which wrapped up the three kinds of error traces into a single GADT, is now no longer passed around directly.  Instead, `Errortrace` exposes three new types, one for each kind of error: `unification_error`, `equality_error`, and `moregen_error`.  Each of these record types contains a corresponding trace (`t`) in the field named `trace`; the `equality_error` also contains a substitution (`subst`).  All types that contain explanations of errors contain these `_error` types (or the sum type `comparison_error` that wraps an `equality_error` or a `moregen_error`) instead of raw traces; traces are only handled directly if they’re being built (as in `typing/ctype.ml`) or consumed (as in `typing/printtyp.ml`).  This also meant changing a number of variable names from `trace` or `tr` to `err`.  The advantage of this change is that we can bundle the extra information we need into `equality_error`, and also that we can tell the three kinds of errors apart more directly.
  
* The environment (`Env.t`) is propagated into the printing functions from outside, rather than maintaining duplicate copies of the environment alongside various errors.

* There is new text for printing out new kinds of moregen and equality errors that were previously not printed, and the moregen and equality errors themselves have their traces printed.  Some text was changed slightly (constructor mismatches went from “is not compatible with” to “is not the same as”).

* A few new tests were added; these tests confirm that we print out longer traces for inclusion errors and catch some specific error cases that didn’t previously have tests.

* Some code in `toplevel/topdirs.ml` was changed to use a local exception type instead of `Ctype.Unify` (not directly related to the printing, but part of the global exception inspection that was necessary for some of the other changes).

The changes are structured into two commits: first, a commit that adds the new tests; and second, a commit that makes the actual code changes and updates all the necessary tests.

### Detailed, file-by-file changes

This section documents the changes I made to every file, since this PR touches so many of them; it is not required reading, but hopefully helps review.  There is nothing after this section in this PR, so if you don’t want to read the gory details, you can stop now.

The key files to look at are, in roughly descending order, `typing/includecore.ml`, `typing/ctype.ml`, and `typing/errortrace.mli`, as well as, to a lesser extent, their `.mli` (or `.ml`) files.  The test file which contains the greatest number of changed error messages is `testsuite/tests/typing-modules/inclusion_errors.ml`; all of the test files except for the four with new tests from the first commit just contain improved error messages.

* `.depend` *(modified)*:
  
  Inessential changes, autogenerated.

* `Changes` *(modified)*:
  
  The proposed change description (currently lacking “reviewed-by” information).

* `testsuite/tests/printing-types/disambiguation.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-extensions/extensions.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-extensions/open_types.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-gadts/ambiguity.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-gadts/pr7160.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-gadts/pr7378.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-misc/deep.ml` *(new)*:
  
  New tests that generate type errors within more complex types during module inclusion (e.g., the initial example in this PR), showing that we generate full traces for module inclusion.

* `testsuite/tests/typing-misc/enrich_typedecl.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-misc/pr6416.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-misc/pr6634.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-misc/pr7668_bad.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-misc/records.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-misc/variant.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules-bugs/pr7414_2_bad.compilers.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules-bugs/pr7414_bad.compilers.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/Test.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/applicative_functor_type.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/extension_constructors_errors_test.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/functors.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/inclusion_errors.ml` *(modified)*:
  
  New test cases and better error messages in test output.  Since I was improving module inclusion errors, this is the file with by far the highest number of improved errors, as well as with errors for the most different inclusion cases.  I also added three new tests that show how inclusion of private polymorphic variant types can fail; these don’t reflect new behavior, just new error messages.

* `testsuite/tests/typing-modules/module_type_substitution.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/nondep_private_abbrev.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/pr10399.ml` *(new)*:
  
  This is a new test showing the new error traces, copied from issue #10399 by @jctis; the old error for this case was reported as a bug, and so I have copied the test case here so that we can see the improvement.

* `testsuite/tests/typing-modules/pr6394.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/pr7818.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/pr7851.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/records_errors_test.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-modules/variants_errors_test.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-objects-bugs/pr3968_bad.compilers.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-objects/Tests.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-poly/poly.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-private/private.compilers.principal.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-private/private.compilers.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-short-paths/short-paths.compilers.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-sigsubst/test_locations.compilers.reference` *(modified)*:
  
  Better error messages in test output.

* `testsuite/tests/typing-unboxed/test.ml` *(modified)*:
  
  New test cases and better error messages in test output.  This file contains a number of errors where primitives’ definitions and signatures are incompatible; I added 14 more test cases for cases that were already caught but now have more detailed error messages.  (One of these test cases, `Good16`, tests a case where we do *not* raise a primitive-mismatch error).  I also had to renumber the various <code>Bad<em>N</em></code> modules, which contributes to some noise in the diff.

* `testsuite/tests/typing-warnings/pr6587.ml` *(modified)*:
  
  Better error messages in test output.

* `toplevel/topdirs.ml` *(modified)*:
  
  This file raised `Ctype.Unify` with an empty trace to record issues when trying to install a printing function; I replaced this with a custom exception, `Bad_printing_function`.  The original use of `Ctype.Unify` was understandable, as unification was in fact invoked; however, instead of conjuring empty unification traces, I caught and replaced the exceptions coming out of `Ctype.unify`.

* `typing/ctype.ml` *(modified)*:
  
  The biggest structural change to this file is that the exceptions `Unify`, `Equality`, and `Moregen` were each split into two pieces: `Unify_trace`, `Equality_trace` and `Moregen_trace`, which like the old exceptions contain raw traces (i.e., `Errortrace.t`) but are not exported; and `Unify`, `Equality`, and `Moregen`, which are exported and contain the new `_error` types from `Errortrace` (`unification_error`, `equality_error`, and `moregen_error`).  This split is between “internal” and “external” errors: the `_trace` errors are used internally in unification, equality, and moregen, and the public-facing entry points rewrap these into the `_error`-based exceptions.  The `raise_for` family of functions (`raise_trace_for`, `raise_unexplained_for`, `occur_for`, …) raise `_trace` exceptions now; these are caught and converted to the top-level exceptions in `unify`, `unify_var`, `equal`, and `moregeneral`.  Within this file, no part of the implementation of unification, equality, or moregen ever catches the top-level `Unify`, `Equality`, and `Moregen` exceptions, with one exception: `subst` is implemented in terms of a forward reference to `unify_var` (now stored in a reference named `unify_var'` instead of `unify'`), and so it catches `Unify`.  The other functions that have to be aware of raising `Unify` are the specialized unification functions `filter_arrow` and `filter_method`, which can raise `Unify` and the latter of which can rewrap a `Unify_trace` into `Unify`.
  
  When transforming an `Equality_trace` exception into an `Equality` exception, we also have to include the substitution; because this is built mutably, this involves saving the substitution reference before performing the equality comparison and dereferencing it on failure.  This is most clearly done in `equal`, but is also done in other functions later in the file that invoke `eqtype` and catch `Equality_trace`.
  
  In addition to these changes, we apply the new `_error` types everywhere: the `Subtype` and `Matches_failure` exceptions use them instead of traces; the `class_match_failure` type contains them instead of traces; and because the `class_match_failure` type contains `comparison_error` in particular, we can also drop the `class_match_failure_trace_type` type entirely.
  
  There were also some functionality changes to some functions in this file: we generate more precise traces in `moregen_row` and `eqtype_row`.  These functions matched on the presences of corresponding constructors in two polymorphic variants, and raised exceptions on failure; however, the exceptions were being caught and rewrapped in the wrong places.  This only became visible now when we were printing out the traces, so we pushed the `try … with …` blocks that wrapped the trace with `Variant (Incompatible_types_for l)` inwards and used more specific errors in other cases, including the new `Presence_not_guaranteed_for` error.  In `moregen_row`, we also had to roll back a `link_type` for better printing.

* `typing/ctype.mli` *(modified)*:
  
  Errors in this file now use the new error types from `Errortrace` instead of raw traces:
  
  - The `Unify`, `Equality`, and `Moregen` exceptions now contain the new whole-error types `Errortrace.unification_error`,`Errortrace.equality_error`, and `Errortrace.moregen_error`, respectively, instead of just traces.
  - Similarly, the `Subtype` and `Matches_failure` exceptions contain `Errortrace.unification_error` instead of unification traces.
  - The `class_match_failure` error type now contains `Errortrace.equality_error`, `Errortrace.moregen_error`, and `Errortrace.comparison_error` instead of error traces; the use of `Errortrace.comparison_error` also allows us to drop the `class_match_failure_trace_type` type entirely.

* `typing/errortrace.ml` *(modified)*:
  
  The changes here are the same as those to `typing/errortrace.mli`, which see: the additions of (1) new top-level error types and their attendant support; and (2) a new error case for equality and moregen.  Because these are public-facing changes, I have documented them in `typing/errortrace.mli`.

* `typing/errortrace.mli` *(modified)*:
  
  There were two major changes in this file: the additions of (1) new top-level error types and their attendant support; and (2) a new error case for equality and moregen.
  
  For the first change, I added three new types, one for each kind of error that contains a trace (i.e., a `'variant Errortrace.t` for some `'variant`): `unification_error`, `equality_error`, and `moregen_error`.  The traces from #10170 are still the core of the errors; however, since they only have a 2-way GADT distinction, and more importantly since the type equality case requires extra information (see below), we bundle them into three “top-level” error types.  The distinction is that `'variety Errortrace.t` values are currently being either built or processed, whereas <code><em>*</em>_error</code> values are whole, complete error messages.
  
  All three of these types contain a trace, as the record field `trace`; `equality_error` also contains a substitution, in order to report error messages with more type variable names that more accurately reflect the original source.
  
  To support these new error types, I also added `comparison_error`, which wraps both `equality_error` and `moregen_error` the way that the `comparison t` trace type used to; and I added `swap_unification_error`, which just lifts `swap_trace` to the new `unification_error` type.
  
  The second change is the addition of the `Presence_not_guaranteed_for` error case, which shows up when the presence variables of polymorphic variants disagree between the structure and the signature in an incompatible way; see `ctype.ml` for where it’s raised.

* `typing/includeclass.ml` *(modified)*:
  
  The printing code was updated to use the new `equality_error` and `moregen_error` types, including renaming local variables named `trace` to `err`.

* `typing/includecore.ml` *(modified)*:
  
  This file contains the bulk of the new text for the new error messages.  This means new printers for `primitive_mismatch`, `value_mismatch`, `private_variant_mismatch`, and `private_object_mismatch`; updating printing text elsewhere; and calls to these new functions, particularly from `report_type_mismatch` (which merged with `report_type_mismatch0`).  The error reporting functions were also updated to propagate the environment (`Env.t`) in from outside, rather than pulling it from the mismatch values.
  
  This file also contains updates to the “mismatch” types that record error reasons, which come in three varieties: first, the `Env.t`s were dropped, since the desired environment is propagated in from the printing functions and should not be duplicated here; second, the direct `Errortrace.t`s were replaced with `Errortrace.moregen_error` or `Errortrace.equality_error`, as appropriate; and third, the constructor `Openness` of `private_variant_mismatch` was renamed to `Only_outer_closed` to more accurately reflect its meaning.  These changes also required updating later parts of the file to handle the new `Ctype.Equality` error and build these new mismatch values with just the `equality_error` rather than with the trace and the available environment.

* `typing/includecore.mli` *(modified)*:
  
  This file contains the interface-side versions of the above changes to `typing/includecore.ml`.  First, the mismatch types were updated, as described above, to (1) remove `Env.t`s; (2) replace `Errortrace.t`s with either `Errortrace.moregen_error` or `Errortrace.equality_error`; and (3) rename the `Openness` constructor of `private_variant_mismatch` to `Only_outer_closed`.  Second, the two exposed error-reporting functions, `report_type_mismatch` and `report_extension_constructor_mismatch`, gained an `Env.t` parameter.  And third, we now expose `report_value_mismatch` as well.

* `typing/includemod.ml` *(modified)*:
  
  This file now propagates moregen traces raised when a value has the wrong signature.  These errors are captured by the `Value_descriptions` error case (in the `Error.core_sigitem_symptom` type); this constructor now carries an `Includecore.value_mismatch` value, which itself contains an `Errortrace.moregen_error` or other appropriate error information.  When created, this mismatch information is included in the constructor

* `typing/includemod.mli` *(modified)*:
  
  This file contains just the update to the `Value_descriptions` constructor from `typing/includemode.ml` (not the code to fill it); this constructor, which reflects disagreements between a value’s type and its type in the signature, now contains an explanation for the error, an `Includecore.value_mismatch` value.

* `typing/includemod_errorprinter.ml` *(modified)*:
  
  This file now prints out the details of the `Includemod.Error.Value_descriptions` error, which reflects a disagreement between a value’s type and the type for it in the signature, using the new function `Includecore.report_value_mismatch`.  It also propagates the environment in from the outside, rather than requiring every error to have a duplicate copy.

* `typing/printtyp.ml` *(modified)*:
  
  I updated the name-printing machinery in this file by (1) wrapping it into a local module called `Names`, and (2) adding support for applying a substitution before looking up names.  The first change allowed the mutable state to be encapsulated together, and required exposing a couple new functions to support existing direct queries to the mutable `names` list or similar; it also required updating the names of many function calls later in the file to refer to `Names.foo` instead of `foo`.  The second change allowed for superior printing of equality errors, and is how we leverage the `subst` of `equality_error`s; before trying to get the name of a type, we first apply the substitution, which can produce a better name for the user.  By applying these substitutions lazily rather than eagerly, we don’t overgenerate names and produce stray names such as `'a0` without a corresponding `'a`.
  
  I also updated the printing code.  I provided a new error message for the new `Presence_not_guaranteed_for` error message (see `typing/errortrace.mli`).  I also gave the generic `error` and `report_error` functions a new `subst` parameter to support the substitutions coming out of equality, which uses the new `Names.add_subst` function.  Finally, I updated the error-reporting functions (`report_unification_error`, `report_equality_error`, `report_moregen_error`, and `Subtype.report_error` to take the the new error types instead of traces (i.e., to take `Errortrace.unification_error`, `Errortrace.equality_error`, and `Errortrace.moregen_error`).  (This is also where `report_equality_error` gets its substitution from; no other error-reporting functions provide substitutions.)  I also added a new `report_comparison_error` function to print out the new `Errortrace.comparison_error` sum type.

* `typing/printtyp.mli` *(modified)*:
  
  The error-reporting functions (`report_unification_error`, `report_equality_error`, `report_moregen_error`, and `Subtype.report_error`) take the new error types instead of traces (i.e., to take `Errortrace.unification_error`, `Errortrace.equality_error`, and `Errortrace.moregen_error`).  I also added `report_comparison_error` to print out the new `Errortrace.comparison_error` sum type.

* `typing/typeclass.ml` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.  This also required refactoring the code in this file that used these errors to be aware of this.  In particular, the code built these error explanations now uses the new `Ctype.Unify` (or `Ctype.Subtype`) error, which often just involved renaming a variable named `trace` (or `tr`) to `err` but not always.

* `typing/typeclass.mli` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.

* `typing/typecore.ml` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.  This also required refactoring the code in this file that used these errors to be aware of this.  In particular, the code built these error explanations now uses the new `Ctype.Unify` error, which often just involved renaming a variable named `trace` (or `tr`) to `err` but not always.

* `typing/typecore.mli` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.

* `typing/typedecl.ml` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.  This also required refactoring the code in this file that used these errors to be aware of this.  In particular, the code built these error explanations now uses the new `Ctype.Unify` error, which often just involved renaming a variable named `trace` (or `tr`) to `err` but not always.
  
  Additionally, some of the errors in this file now contain an `Env.t`, and the printing code in this file was also taught to propagate the environment more deeply.  This supports the changes in `Includecore` that keep the environment coming in from this outer layer rather than maintaining duplicates.
  
  Finally, the local function `suffix` for generating the appropriate ordinal suffix for numbers – `"st"` for `1`, `21`, …; `"nd"` for `2`, `22`, …; `"rd"` for `3`, `23`, …; and `"th"` for everything else – was moved to `utils/misc.ml` and renamed `ordinal_suffix` so it could be used elsewhere.

* `typing/typedecl.mli` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.  Some of them also now contain an `Env.t` for printing purposes that they did not before.

* `typing/typetexp.ml` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.  This also required refactoring the code in this file that used these errors to be aware of this.  In particular, the code built these error explanations now uses the new `Ctype.Unify` error, which often just involved renaming a variable named `trace` (or `tr`) to `err` but not always.
  
  Additionally, a call to `Ctype.expand_head` was formerly guarded by `try … with …`, but this function cannot throw, so the `try … with …` was removed.

* `typing/typetexp.mli` *(modified)*:
  
  This file’s errors now use `Errortrace.unification_error` instead of carrying around a trace (i.e., an `Errortrace.unification Errortrace.t`) directly.

* `utils/misc.ml` *(modified)*:
  
  Added the function `ordinal_suffix` for generating the appropriate ordinal suffix for numbers – `"st"` for `1`, `21`, …; `"nd"` for `2`, `22`, …; `"rd"` for `3`, `23`, …; and `"th"` for everything else.  This function was originally a local function named `suffix` in `typing/typedecl.ml`.

* `utils/misc.mli` *(modified)*:
  
  Added the function `ordinal_suffix` for generating the appropriate ordinal suffix for numbers – `"st"` for `1`, `21`, …; `"nd"` for `2`, `22`, …; `"rd"` for `3`, `23`, …; and `"th"` for everything else.  This function was originally a local function named `suffix` in `typing/typedecl.ml`.