### PR TITLE
Fix caml_sys_time on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -438,6 +438,10 @@ Working version
 - #7453, #9828, #10416: fix #show for recursive types and modules
   (Florian Angeletti, review by Gabriel Scherer)
 
+* #7469, #10408: Sys.time now returns processor time on Windows (previously
+  returned wall-clock time)
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
 * #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section
   when the systhreads library is loaded.
   (David Allsopp, report by Anton Bachin, review by Xavier Leroy)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -294,6 +294,8 @@ extern double caml_log1p(double);
 #define mktemp_os _wmktemp
 #define fopen_os _wfopen
 
+#define clock_os caml_win32_clock
+
 #define caml_stat_strdup_os caml_stat_wcsdup
 #define caml_stat_strconcat_os caml_stat_wcsconcat
 
@@ -329,6 +331,8 @@ extern double caml_log1p(double);
 #define strcpy_os strcpy
 #define mktemp_os mktemp
 #define fopen_os fopen
+
+#define clock_os clock
 
 #define caml_stat_strdup_os caml_stat_strdup
 #define caml_stat_strconcat_os caml_stat_strconcat

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -19,6 +19,8 @@
 #define CAML_OSDEPS_H
 
 #ifdef _WIN32
+#include <time.h>
+
 extern unsigned short caml_win32_major;
 extern unsigned short caml_win32_minor;
 extern unsigned short caml_win32_build;
@@ -130,6 +132,8 @@ CAMLextern int win_wide_char_to_multi_byte(const wchar_t* s,
 CAMLextern int caml_win32_isatty(int fd);
 
 CAMLextern void caml_expand_command_line (int *, wchar_t ***);
+
+CAMLextern clock_t caml_win32_clock(void);
 
 #endif /* _WIN32 */
 

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -536,7 +536,7 @@ double caml_sys_time_include_children_unboxed(value include_children)
   #else
     /* clock() is standard ANSI C. We have no way of getting
        subprocess times in this branch. */
-    return (double)clock() / CLOCKS_PER_SEC;
+    return (double)clock_os() / CLOCKS_PER_SEC;
   #endif
 #endif
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1019,3 +1019,26 @@ int caml_num_rows_fd(int fd)
 {
   return -1;
 }
+
+/* UCRT clock function returns wall-clock time */
+CAMLexport clock_t caml_win32_clock(void)
+{
+  FILETIME c, e, stime, utime;
+  ULARGE_INTEGER tmp;
+  ULONGLONG total, clocks_per_sec;
+
+  if (!(GetProcessTimes(GetCurrentProcess(), &c, &e, &stime, &utime))) {
+    return (clock_t)(-1);
+  }
+
+  tmp.u.LowPart = stime.dwLowDateTime;
+  tmp.u.HighPart = stime.dwHighDateTime;
+  total = tmp.QuadPart;
+  tmp.u.LowPart = utime.dwLowDateTime;
+  tmp.u.HighPart = utime.dwHighDateTime;
+  total += tmp.QuadPart;
+
+  /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */
+  clocks_per_sec = INT64_LITERAL(10000000U) / (ULONGLONG)CLOCKS_PER_SEC;
+  return (clock_t)(total / clocks_per_sec);
+}


### PR DESCRIPTION
Now returns processor time instead of wall clock time (MSCRT clock function doesn't conform with ISO C)

Fixes #7469