### PR TITLE
Reraise sigsegv

### DIFF
--- a/Changes
+++ b/Changes
@@ -93,6 +93,15 @@ Working version
   of the current overhead.
   (Damien Doligez, review by Stephen Dolan)
 
+- #10409: Fix a bug where a SIGSEGV signal could be ignored by the
+   runtime and execution continue in an inconsistent state. Also,
+   prevent replacing the own signal handlers of the runtime for
+   SIGSEGV, SIGFPE and SIGTRAP with Sys.signal, to prevent similar
+   inconsistent state. Sys.signal will now raise an Invalid_argument
+   exception if you try to do so.
+  (Guillaume Munch-Maccagnoni, report by Martin Jambon, review by
+   Stephen Dolan and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 - #1400: Add an optional invariants check on Cmm, which can be activated

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -133,6 +133,12 @@ let macos = make
     "on a MacOS system"
     "not on a MacOS system")
 
+let not_macos = make
+  "not-macos"
+  (Actions_helpers.pass_or_skip (not (Ocamltest_config.system = macos_system))
+    "not on a MacOS system"
+    "on a MacOS system")
+
 let arch32 = make
   "arch32"
   (Actions_helpers.pass_or_skip (Sys.word_size = 32)
@@ -294,6 +300,7 @@ let _ =
     bsd;
     not_bsd;
     macos;
+    not_macos;
     arch32;
     arch64;
     has_symlink;

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -111,6 +111,17 @@ int caml_set_signal_action(int signo, int action)
   signal_handler act;
 #endif
 
+  /* Never replace our own handlers of synchronous signals */
+  switch(signo) {
+  case SIGSEGV:
+  case SIGFPE:
+#ifdef SIGTRAP
+  case SIGTRAP:
+#endif
+    caml_invalid_argument("Sys.signal: signal reserved");
+    break;
+  }
+
 #ifdef POSIX_SIGNALS
   switch(action) {
   case 0:

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -32,6 +32,7 @@
   #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
   #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.gregs[REG_CR2])
+  #define INFO_CODE (info->si_code)
 
 /****************** AMD64, MacOSX */
 
@@ -62,6 +63,7 @@
   #define CONTEXT_YOUNG_PTR (CONTEXT_STATE.CONTEXT_REG(r15))
   #define CONTEXT_SP (CONTEXT_STATE.CONTEXT_REG(rsp))
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
   #define RETURN_AFTER_STACK_OVERFLOW
 
@@ -85,6 +87,7 @@
   #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.arm_fp)
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.arm_r8)
   #define CONTEXT_FAULTING_ADDRESS ((char *) context->uc_mcontext.fault_address)
+  #define INFO_CODE (info->si_code)
 
 /****************** ARM64, Linux */
 
@@ -105,6 +108,7 @@
   #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.regs[26])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.regs[27])
   #define CONTEXT_FAULTING_ADDRESS ((char *) context->uc_mcontext.fault_address)
+  #define INFO_CODE (info->si_code)
 
 /****************** ARM64, FreeBSD */
 
@@ -125,7 +129,7 @@
   #define CONTEXT_EXCEPTION_POINTER (context->uc_mcontext.mc_gpregs.gp_x[26])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.mc_gpregs.gp_x[27])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
-
+  #define INFO_CODE (info->si_code)
 
 /****************** AMD64, Solaris x86 */
 
@@ -146,6 +150,7 @@
   #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /****************** AMD64, OpenBSD */
 
@@ -163,6 +168,7 @@
  #define CONTEXT_SP (context->sc_rsp)
  #define CONTEXT_YOUNG_PTR (context->sc_r15)
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+ #define INFO_CODE (info->si_code)
 
 /****************** AMD64, NetBSD */
 
@@ -181,6 +187,7 @@
  #define CONTEXT_SP (_UC_MACHINE_SP(context))
  #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+ #define INFO_CODE (info->si_code)
 
 /****************** I386, Linux */
 
@@ -197,6 +204,7 @@
   #define CONTEXT_PC (context->uc_mcontext.gregs[REG_EIP])
   #define CONTEXT_SP (context->uc_mcontext.gregs[REG_ESP])
   #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.cr2)
+  #define INFO_CODE (info->si_code)
 
 /****************** I386, BSD_ELF */
 
@@ -223,6 +231,7 @@
   #define CONTEXT_SP (context->sc_esp)
  #endif
  #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+ #define INFO_CODE (info->si_code)
 
 /****************** I386, BSD */
 
@@ -236,6 +245,7 @@
      sigact.sa_flags = SA_SIGINFO
 
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /****************** I386, MacOS X */
 
@@ -263,6 +273,7 @@
   #define CONTEXT_PC (CONTEXT_STATE.CONTEXT_REG(eip))
   #define CONTEXT_SP (CONTEXT_STATE.CONTEXT_REG(esp))
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /****************** I386, Solaris x86 */
 
@@ -276,6 +287,7 @@
     sigact.sa_flags = SA_SIGINFO
 
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /****************** PowerPC, MacOS X */
 
@@ -318,6 +330,7 @@
   #define CONTEXT_YOUNG_PTR (CONTEXT_STATE.CONTEXT_REG(r31))
   #define CONTEXT_SP (CONTEXT_STATE.CONTEXT_REG(r1))
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /****************** PowerPC 32 bits, ELF (Linux) */
 
@@ -353,6 +366,7 @@
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gp_regs[31])
   #define CONTEXT_SP (context->uc_mcontext.gp_regs[1])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /****************** PowerPC, NetBSD */
 
@@ -372,6 +386,7 @@
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.__gregs[_REG_R31])
   #define CONTEXT_SP (_UC_MACHINE_SP(context))
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 
 /****************** PowerPC, other BSDs */
@@ -408,6 +423,7 @@
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[11])
   #define CONTEXT_SP (context->uc_mcontext.gregs[15])
   #define CONTEXT_FAULTING_ADDRESS ((char *) info->si_addr)
+  #define INFO_CODE (info->si_code)
 
 /******************** Default */
 

--- a/testsuite/tests/lib-unix/kill/unix_kill_segv.ml
+++ b/testsuite/tests/lib-unix/kill/unix_kill_segv.ml
@@ -1,0 +1,17 @@
+(* TEST
+   include unix
+   * libunix
+   ** not-macos
+   *** bytecode
+   *** native
+
+  (* Test fails on MacOS, see runtime/signals_nat.c. *)
+*)
+
+let () =
+  match Unix.fork () with
+  | 0 -> Unix.kill (Unix.getpid ()) Sys.sigsegv
+  | pid -> (
+      if Unix.wait () <> (pid, Unix.WSIGNALED Sys.sigsegv)
+      then failwith "Survived SIGSEGV"
+    )


### PR DESCRIPTION
@mjambon reported the following behaviour at https://discuss.ocaml.org/t/delivering-sigsegv-to-self-in-native-code/7837: OCaml apparently ignores SIGSEGV signals it receives if it was not due to a real segfault. This hides in fact a bug: after receiving the signal, OCaml disables its segv signal handler and expects the signal to arise again. This does not happen and the execution continues in an invalid state. The first commit fixes this behaviour by re-raising SIGSEGV from the signal handler.

The second commit addresses a similar inconsistent state that arises if the user changes the behaviour on SIGSEGV, SIGFPE and SIGTRAP using `Sys.signal`, for which OCaml can install its own handlers. `Sys.signal` will now raise an `Invalid_argument` exception instead. This is not expected to break programs: it has never been possible to do anything useful with `Sys.signal` on synchronous signals.