### PR TITLE
Tidy-up the testsuite/manual commands

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -85,14 +85,6 @@ ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif
 
-# This used to live in Makefile.config - it's only used now by the manual's
-# build system.
-ifeq "$(UNIX_OR_WIN32)" "win32"
-  SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
-else # ifeq "$(UNIX_OR_WIN32)" "win32"
-  SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
-endif # ifeq "$(UNIX_OR_WIN32)" "win32"
-
 # Escape special characters in the argument string.
 # There are four characters that need escaping:
 # - backslash and ampersand, which are special in the replacement text

--- a/Makefile.common
+++ b/Makefile.common
@@ -85,6 +85,14 @@ ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif
 
+# This used to live in Makefile.config - it's only used now by the manual's
+# build system.
+ifeq "$(UNIX_OR_WIN32)" "win32"
+  SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+else # ifeq "$(UNIX_OR_WIN32)" "win32"
+  SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
+endif # ifeq "$(UNIX_OR_WIN32)" "win32"
+
 # Escape special characters in the argument string.
 # There are four characters that need escaping:
 # - backslash and ampersand, which are special in the replacement text

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -258,18 +258,6 @@ else
     $(OUTPUTEXE)$(1) $(2)
 endif # ifeq "$(TOOLCHAIN)" "msvc"
 
-# The following variables were defined only in the Windows-specific makefiles.
-# They were not defined by the configure script used on Unix systems,
-# so we also make sure to provide them only under Windows
-# User code should absolutely not rely on their presence because
-# in the future their definition may be moved to a more private part of
-# the compiler's build system
-ifeq "$(UNIX_OR_WIN32)" "win32"
-  SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
-else # ifeq "$(UNIX_OR_WIN32)" "win32"
-  SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
-endif # ifeq "$(UNIX_OR_WIN32)" "win32"
-
 FLEXLINK_FLAGS=@flexlink_flags@
 FLEXLINK_CMD=flexlink
 FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -266,12 +266,10 @@ endif # ifeq "$(TOOLCHAIN)" "msvc"
 # the compiler's build system
 ifeq "$(UNIX_OR_WIN32)" "win32"
   CYGPATH=cygpath -m
-  FIND=/usr/bin/find
   SORT=/usr/bin/sort
   SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
 else # ifeq "$(UNIX_OR_WIN32)" "win32"
   CYGPATH=echo
-  FIND=find
   SORT=sort
   SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
 endif # ifeq "$(UNIX_OR_WIN32)" "win32"

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -266,14 +266,13 @@ endif # ifeq "$(TOOLCHAIN)" "msvc"
 # the compiler's build system
 ifeq "$(UNIX_OR_WIN32)" "win32"
   CYGPATH=cygpath -m
-  DIFF=/usr/bin/diff -q --strip-trailing-cr
   FIND=/usr/bin/find
   SORT=/usr/bin/sort
   SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
 else # ifeq "$(UNIX_OR_WIN32)" "win32"
-  # On Unix, make sure FLEXLINK is defined but empty
-  SORT=sort
   CYGPATH=echo
+  FIND=find
+  SORT=sort
   SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
 endif # ifeq "$(UNIX_OR_WIN32)" "win32"
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -265,12 +265,8 @@ endif # ifeq "$(TOOLCHAIN)" "msvc"
 # in the future their definition may be moved to a more private part of
 # the compiler's build system
 ifeq "$(UNIX_OR_WIN32)" "win32"
-  CYGPATH=cygpath -m
-  SORT=/usr/bin/sort
   SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
 else # ifeq "$(UNIX_OR_WIN32)" "win32"
-  CYGPATH=echo
-  SORT=sort
   SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
 endif # ifeq "$(UNIX_OR_WIN32)" "win32"
 

--- a/manual/src/Makefile
+++ b/manual/src/Makefile
@@ -3,7 +3,6 @@ SRC = $(abspath ../..)
 
 export LD_LIBRARY_PATH   ?= "$(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/"
 export DYLD_LIBRARY_PATH ?= "$(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/"
-SET_LD_PATH = CAML_LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
 
 TEXQUOTE = $(SRC)/runtime/ocamlrun ../tools/texquote2
 
@@ -136,7 +135,7 @@ cmds/warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
 	 echo "% are inserted through the Makefile, which should be updated";\
 	 echo "% when a new warning is documented.";\
 	 echo "%";\
-	 $(SET_LD_PATH) $(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
+	 $(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
 	 | LC_ALL=C sed -e 's/^ *\([0-9][0-9]*\) *\[\([a-z][a-z-]*\)\]\(.*\)/\\item[\1 "\2"] \3/' \
 	                -e 's/^ *\([0-9A-Z][0-9]*\) *\([^]].*\)/\\item[\1] \2/'\
 	 | sed -e 's/@/\\@/g' \

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -1,12 +1,11 @@
 ROOTDIR = ../../..
 include $(ROOTDIR)/Makefile.common
 
-LD_PATH = "$(ROOTDIR)/otherlibs/str:$(ROOTDIR)/otherlibs/unix"
+LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
 TOOLS = ../../tools
-CAMLLATEX = $(SET_LD_PATH) \
-  $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
-  -repo-root $(ROOTDIR) -n 80 -v false
+CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
+  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/src/cmds/Makefile
+++ b/manual/src/cmds/Makefile
@@ -8,7 +8,7 @@ CAMLLATEX = $(SET_LD_PATH) \
   $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
   -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
-TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
+TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 
 FILES = comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   ocamldep.tex profil.tex debugger.tex ocamldoc.tex \

--- a/manual/src/refman/Makefile
+++ b/manual/src/refman/Makefile
@@ -1,12 +1,11 @@
 ROOTDIR = ../../..
 include $(ROOTDIR)/Makefile.common
 
-LD_PATH = "$(ROOTDIR)/otherlibs/str:$(ROOTDIR)/otherlibs/unix"
+LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
 TOOLS = ../../tools
-CAMLLATEX = $(SET_LD_PATH) \
-  $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
-  -repo-root $(ROOTDIR) -n 80 -v false
+CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
+  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/src/refman/Makefile
+++ b/manual/src/refman/Makefile
@@ -8,7 +8,7 @@ CAMLLATEX = $(SET_LD_PATH) \
   $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
   -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
-TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
+TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 
 EXTENSION_FILES = letrecvalues.tex recursivemodules.tex locallyabstract.tex \
   firstclassmodules.tex moduletypeof.tex signaturesubstitution.tex \

--- a/manual/src/tutorials/Makefile
+++ b/manual/src/tutorials/Makefile
@@ -1,12 +1,11 @@
 ROOTDIR = ../../..
 include $(ROOTDIR)/Makefile.common
 
-LD_PATH = "$(ROOTDIR)/otherlibs/str:$(ROOTDIR)/otherlibs/unix"
+LD_PATH = $(ROOTDIR)/otherlibs/str $(ROOTDIR)/otherlibs/unix
 
 TOOLS = ../../tools
-CAMLLATEX = $(SET_LD_PATH) \
-  $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
-  -repo-root $(ROOTDIR) -n 80 -v false
+CAMLLATEX = $(OCAMLRUN) $(addprefix -I ,$(LD_PATH)) \
+  $(ROOTDIR)/tools/caml-tex -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/src/tutorials/Makefile
+++ b/manual/src/tutorials/Makefile
@@ -8,7 +8,7 @@ CAMLLATEX = $(SET_LD_PATH) \
   $(OCAMLRUN) $(ROOTDIR)/tools/caml-tex \
   -repo-root $(ROOTDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
-TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
+TRANSF = $(OCAMLRUN) $(TOOLS)/transf
 
 
 FILES = coreexamples.tex lablexamples.tex objectexamples.tex \

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -22,8 +22,7 @@ cross-reference-checker: cross_reference_checker.ml
 # check cross-references between the manual and error messages
 .PHONY: check-cross-references
 check-cross-references: cross-reference-checker
-	$(SET_LD_PATH) \
-	  $(OCAMLRUN) ./cross-reference-checker \
+	$(OCAMLRUN) ./cross-reference-checker \
 	  -auxfile $(MANUAL)/texstuff/manual.aux \
 	  $(ROOTDIR)/utils/warnings.ml \
 	  $(ROOTDIR)/driver/main_args.ml \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -322,7 +322,7 @@ tools:
 clean:
 	@$(MAKE) -C lib clean
 	@cd tools && $(MAKE) BASEDIR=$(BASEDIR) clean
-	$(FIND) . -name '*_ocamltest*' | xargs rm -rf
+	find . -name '*_ocamltest*' | xargs rm -rf
 	rm -f $(failstamp)
 
 .PHONY: report

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -17,7 +17,6 @@
 
 BASEDIR := $(shell pwd)
 
-FIND=find
 ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -20,6 +20,16 @@ BASEDIR := $(shell pwd)
 ROOTDIR = ..
 include $(ROOTDIR)/Makefile.common
 
+ifeq "$(UNIX_OR_WIN32)" "win32"
+  CYGPATH=cygpath -m
+  # Ensure that the test runners definitely use Cygwin's sort and not the
+  # Windows sort command
+  SORT=/usr/bin/sort
+else
+  CYGPATH=echo
+  SORT=sort
+endif
+
 BASEDIR_HOST := $(shell $(CYGPATH) "$(BASEDIR)")
 ROOTDIR_HOST := $(BASEDIR_HOST)/$(ROOTDIR)
 


### PR DESCRIPTION
A small piece of tidying spun out from various other bits of build-system-related work.

`DIFF` is no longer used anywhere, so remove the Windows-specific command (`diff` is invoked directly by `ocamltest`).

Move the default for `FIND` from `testsuite/Makefile` to `Makefile.config.in` so that both the Windows and Unix variants are in the same file

`SET_LD_PATH` is only used by the manual build system; `SORT`, `DIFF` and `CYGPATH` are only used by the testsuite so these definitions could finally move to their respective Makefiles?