### PR TITLE
Clarify and fix construction of MKEXE in configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -804,7 +804,7 @@ runtime/caml/jumptbl.h : runtime/caml/instruct.h
 # to supply a host C compiler and different flags and a linking macro.
 SAK_CC ?= $(CC)
 SAK_CFLAGS ?= $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS)
-SAK_LINK ?= $(MKEXE_USING_COMPILER)
+SAK_LINK ?= $(MKEXE_VIA_CC)
 
 $(SAK): runtime/sak.$(O)
 	$(call SAK_LINK,$@,$^)
@@ -825,7 +825,7 @@ runtime/ocamlrun$(EXE): runtime/prims.$(O) runtime/libcamlrun.$(A)
 	$(MKEXE) -o $@ $^ $(BYTECCLIBS)
 
 runtime/ocamlruns$(EXE): runtime/prims.$(O) runtime/libcamlrun_non_shared.$(A)
-	$(call MKEXE_USING_COMPILER,$@,$^ $(BYTECCLIBS))
+	$(call MKEXE_VIA_CC,$@,$^ $(BYTECCLIBS))
 
 runtime/libcamlrun.$(A): $(libcamlrun_OBJECTS)
 	$(call MKLIB,$@, $^)

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -31,10 +31,6 @@ INSTALL_OCAMLNAT = @install_ocamlnat@
 DEP_CC=@DEP_CC@ -MM
 COMPUTE_DEPS=@compute_deps@
 
-# This is munged into utils/config.ml, not overridable by other parts of
-# the build system.
-OC_DLL_LDFLAGS=@oc_dll_ldflags@
-
 # Which tool to use to display differences between files
 DIFF=@DIFF@
 # Which flags to pass to the diff tool

--- a/Makefile.common
+++ b/Makefile.common
@@ -69,6 +69,7 @@ endif
 
 BOOT_OCAMLDEP = $(BOOT_OCAMLC) -depend
 
+FLEXLINK_CMD=flexlink
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
   FLEXLINK_ENV =
   CAMLOPT_CMD = $(CAMLOPT)
@@ -209,3 +210,9 @@ $(ROOTDIR)/%/sak$(EXE):
 ifneq "$(REQUIRES_CONFIGURATION)" ""
 $(ROOTDIR)/%/StdlibModules: $(SAK) ;
 endif
+
+# Used with the Microsoft toolchain to merge generated manifest files into
+# executables
+if_file_exists = ( test ! -f $(1) || $(2) && rm -f $(1) )
+MERGEMANIFESTEXE = $(call if_file_exists, $(1).manifest, \
+  mt -nologo -outputresource:$(1) -manifest $(1).manifest)

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -82,6 +82,7 @@ AS_HAS_DEBUG_PREFIX_MAP=@as_has_debug_prefix_map@
 # To support dynamic loading of shared libraries (they need to look at
 # our own symbols):
 OC_LDFLAGS=@oc_ldflags@
+OC_DLL_LDFLAGS=@oc_dll_ldflags@
 
 LDFLAGS?=@LDFLAGS@
 
@@ -203,7 +204,6 @@ OCAMLOPT_CPPFLAGS=@ocamlc_cppflags@
 NATIVECCLIBS=@nativecclibs@
 SYSTHREAD_SUPPORT=@systhread_support@
 PACKLD=@PACKLD@
-FLEXDLL_CHAIN=@flexdll_chain@
 CCOMPTYPE=@ccomptype@
 TOOLCHAIN=@toolchain@
 CMXS=@cmxs@
@@ -212,11 +212,15 @@ CMXS=@cmxs@
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 
+FLEXDLL_CHAIN=@flexdll_chain@
+FLEXLINK_FLAGS=@mkexe_extra_flags@
+
 MKEXE=@mkexe@
 MKDLL=@mksharedlib@
 MKMAINDLL=@mkmaindll@
-
 MKEXEDEBUGFLAG=@mkexedebugflag@
+MKEXE_VIA_CC=$(CC) $(OC_CFLAGS) $(CFLAGS) @mkexe_via_cc_ldflags@
+
 RUNTIMED=@debug_runtime@
 INSTRUMENTED_RUNTIME=@instrumented_runtime@
 INSTRUMENTED_RUNTIME_LIBS=@instrumented_runtime_libs@
@@ -247,23 +251,6 @@ FUNCTION_SECTIONS=@function_sections@
 AWK=@AWK@
 STDLIB_MANPAGES=@stdlib_manpages@
 NAKED_POINTERS=false
-
-### Native command to build ocamlrun.exe
-
-ifeq "$(TOOLCHAIN)" "msvc"
-  MERGEMANIFESTEXE=test ! -f $(1).manifest \
-          || mt -nologo -outputresource:$(1) -manifest $(1).manifest \
-          && rm -f $(1).manifest
-  MKEXE_USING_COMPILER=$(CC) $(OC_CFLAGS) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) \
-    /link /subsystem:console $(OC_LDFLAGS) $(LDFLAGS) && ($(MERGEMANIFESTEXE))
-else
-  MKEXE_USING_COMPILER=$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_LDFLAGS) $(LDFLAGS) \
-    $(OUTPUTEXE)$(1) $(2)
-endif # ifeq "$(TOOLCHAIN)" "msvc"
-
-FLEXLINK_FLAGS=@flexlink_flags@
-FLEXLINK_CMD=flexlink
-FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 
 # Deprecated variables
 

--- a/configure
+++ b/configure
@@ -754,7 +754,6 @@ force_instrumented_runtime
 compute_deps
 stdlib_manpages
 PACKLD
-flexlink_flags
 flexdll_chain
 afl
 function_sections
@@ -811,6 +810,8 @@ oc_cppflags
 oc_cflags
 toolchain
 ccomptype
+mkexe_via_cc_ldflags
+mkexe_extra_flags
 mkexedebugflag
 mkexe
 fpic
@@ -831,7 +832,6 @@ libext
 OBJEXT
 exeext
 ac_tool_prefix
-DIRECT_CPP
 DIFF_FLAGS
 CC
 OCAML_VERSION_SHORT
@@ -2781,14 +2781,17 @@ $as_echo "$as_me: Configuring OCaml version 5.0.0+dev0-2021-11-05" >&6;}
 ## Command-line arguments passed to configure
 CONFIGURE_ARGS="$*"
 
-# Command to build executalbes
-# In general this command is supposed to use the CFLAGs- and LDFLAGS-
-# related variables (OC_CFLAGS and OC_LDFLAGS for ocaml-specific
-# flags, CFLAGS and LDFLAGS for generic flags chosen by the user), but
-# at the moment they are not taken into account on Windows, because
-# flexlink, which is used to build executables on this platform, can
-# not handle them.
-mkexe="\$(CC) \$(OC_CFLAGS) \$(CFLAGS) \$(OC_LDFLAGS) \$(LDFLAGS)"
+# Command to build executables
+# Ultimately, MKEXE may build an executable using the C compiler or it may use
+# a wrapper for a linker (i.e. flexlink). The build system must therefore not
+# rely on $CFLAGS because these cannot be processed by flexlink (and are not
+# passed)
+mkexe_cmd='$(CC)'
+mkexe_cflags='$(OC_CFLAGS) $(CFLAGS)'
+mkexe_extra_flags=''
+mkexe_via_cc_extra_cmd=''
+mkexe_ldflags_prefix=''
+mkexe_via_cc_ldflags_prefix=''
 
 # Flags for building executable files with debugging symbols
 mkexedebugflag="-g"
@@ -2919,8 +2922,8 @@ OCAML_VERSION_SHORT=5.0
 
 
 
- # TODO: rename this variable
 
+ # TODO: rename this variable
 
 
 
@@ -12532,6 +12535,7 @@ case $host in #(
   # So we let them do, at the moment
   *-pc-windows) :
 
+      mkexe_via_cc_extra_cmd=' && $(call MERGEMANIFESTEXE,$(1))'
       libext=lib
       AR=""
       if test "$host_cpu" = "x86_64" ; then :
@@ -12895,26 +12899,26 @@ fi
 case $host in #(
   i686-*-cygwin) :
     flexdll_chain='cygwin'
-    flexlink_flags="-chain $flexdll_chain -merge-manifest -stack 16777216" ;; #(
+    mkexe_extra_flags='-merge-manifest -stack 16777216' ;; #(
   x86_64-*-cygwin) :
     flexdll_chain='cygwin64'
-    flexlink_flags="-chain $flexdll_chain -merge-manifest -stack 16777216" ;; #(
+    mkexe_extra_flags='-merge-manifest -stack 16777216' ;; #(
   *-*-cygwin*) :
     as_fn_error $? "unknown cygwin variant" "$LINENO" 5 ;; #(
   i686-w64-mingw32) :
     flexdll_chain='mingw'
-    flexlink_flags="-chain $flexdll_chain -stack 16777216" ;; #(
+    mkexe_extra_flags='-stack 16777216' ;; #(
   x86_64-w64-mingw32) :
     flexdll_chain='mingw64'
-    flexlink_flags="-chain $flexdll_chain -stack 33554432" ;; #(
+    mkexe_extra_flags='-stack 33554432' ;; #(
   i686-pc-windows) :
     flexdll_chain='msvc'
-    flexlink_flags="-merge-manifest -stack 16777216" ;; #(
+    mkexe_extra_flags='-merge-manifest -stack 16777216' ;; #(
   x86_64-pc-windows) :
     flexdll_chain='msvc64'
-    flexlink_flags="-x64 -merge-manifest -stack 33554432" ;; #(
+    mkexe_extra_flags='-merge-manifest -stack 33554432' ;; #(
   *) :
-     ;;
+    flexdll_chain='' ;;
 esac
 
 if test x"$supports_shared_libraries" != 'xfalse'; then :
@@ -13219,7 +13223,7 @@ esac
 
 case $cc_basename,$host in #(
   *,x86_64-*-darwin*) :
-    mkexe="$mkexe -Wl,-no_compact_unwind";
+    oc_ldflags='-Wl,-no_compact_unwind';
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   *,aarch64-*-darwin*|arm64-*-darwin*) :
@@ -13230,11 +13234,11 @@ case $cc_basename,$host in #(
   *,*-*-cygwin*) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries; then :
-  mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
-      mkexedebugflag="-link -g"
-else
-  mkexe="$mkexe -Wl,--stack,16777216"
-      oc_ldflags="-Wl,--stack,16777216"
+  mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+      mkexe_cflags=''
+      mkexe_ldflags_prefix='-link '
+      mkexe_extra_flags=''
+      oc_ldflags='-Wl,--stack,16777216'
 
 fi
     ostype="Cygwin" ;; #(
@@ -13245,24 +13249,27 @@ fi
   *) :
      ;;
 esac
-    mkexedebugflag="-link -g"
     ostype="Win32"
     toolchain="mingw"
-    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cflags=''
+    mkexe_ldflags_prefix='-link '
     oc_ldflags='-municode'
     SO="dll" ;; #(
   *,*-pc-windows) :
     toolchain=msvc
     ostype="Win32"
-    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cflags=''
+    mkexe_ldflags_prefix='-link '
+    mkexe_via_cc_ldflags_prefix='/link '
     oc_ldflags='/ENTRY:wmainCRTStartup'
     mkexedebugflag='' ;; #(
   *,x86_64-*-linux*) :
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   xlc*,powerpc-ibm-aix*) :
-    mkexe="$mkexe "
-     oc_ldflags="-brtl -bexpfull"
+    oc_ldflags='-brtl -bexpfull'
     $as_echo "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
   gcc*,powerpc-*-linux*) :
@@ -14071,39 +14078,37 @@ natdynlinkopts=""
 if test x"$enable_shared" != "xno"; then :
   case $host in #(
   x86_64-apple-darwin*) :
-    mksharedlib="$CC -shared \
-                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
-                   \$(LDFLAGS)"
+    mksharedlib='$(CC) -shared '\
+'-undefined dynamic_lookup -Wl,-no_compact_unwind'
       supports_shared_libraries=true ;; #(
   aarch64-apple-darwin*|arm64-apple-darwin*) :
-    mksharedlib="$CC -shared \
-                   -undefined dynamic_lookup \$(LDFLAGS)"
+    mksharedlib='$(CC) -shared -undefined dynamic_lookup'
       supports_shared_libraries=true ;; #(
   *-*-mingw32) :
-    mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'
+    mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
+      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'
       if test -n "$oc_dll_ldflags"; then :
 
         mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""
 fi ;; #(
   *-pc-windows) :
-    mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll' ;; #(
+    mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
+      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)' ;; #(
   *-*-cygwin*) :
-    mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll' ;; #(
+    mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
+      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)' ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
-    mksharedlib="$CC -qmkshrobj -G \$(LDFLAGS)"
+    mksharedlib='$(CC) -qmkshrobj -G'
                 supports_shared_libraries=true ;; #(
   *) :
      ;;
 esac ;; #(
   *-*-solaris*) :
     sharedlib_cflags="-fPIC"
-      mksharedlib="$CC -shared"
+      mksharedlib='$(CC) -shared'
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       supports_shared_libraries=true ;; #(
@@ -14112,13 +14117,13 @@ esac ;; #(
     sharedlib_cflags="-fPIC"
        case $cc_basename,$host in #(
   *gcc*,powerpc-*-linux*) :
-    mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)" ;; #(
+    mksharedlib='$(CC) -shared -mbss-plt' ;; #(
   *,i[3456]86-*) :
     # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
-           mksharedlib="$CC -shared \$(LDFLAGS) -Wl,-z,notext" ;; #(
+           mksharedlib='$(CC) -shared -Wl,-z,notext' ;; #(
   *) :
-    mksharedlib="$CC -shared \$(LDFLAGS)" ;;
+    mksharedlib='$(CC) -shared' ;;
 esac
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
@@ -18071,6 +18076,15 @@ fi
 # Do not permanently cache the result of flexdll.h
 unset ac_cv_header_flexdll_h
 
+# Just before config.status is generated, determine the final values for MKEXE,
+# MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
+# $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
+# $mksharedlib - the full linking command for DLLs
+# $mkmaindll - the full linking command for main program in DLL
+# $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
+# $(OC_DLL_LDFLAGS) and can be overidden in the build.
+
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure
@@ -18179,6 +18193,62 @@ LIBOBJS=$ac_libobjs
 
 LTLIBOBJS=$ac_ltlibobjs
 
+
+
+  # Construct $mkexe
+  mkexe="$mkexe_cmd"
+  if test -n "$mkexe_cflags"; then :
+  mkexe="$mkexe $mkexe_cflags"
+fi
+  if test -n "$mkexe_extra_flags"; then :
+  mkexe="$mkexe $mkexe_extra_flags"
+fi
+  # If $mkexe_ldflags_prefix is given, apply it to $oc_ldflags and $oc_dllflags
+  # and ensure that LDFLAGS is passed using it. This is used for flexlink. where
+  # linker flags need to be prefixed with -link.
+  if test -n "$mkexe_ldflags_prefix"; then :
+
+    if test -n "$mkexedebugflag"; then :
+  mkexedebugflag="${mkexe_ldflags_prefix}${mkexedebugflag}"
+fi
+    mkdll_ldflags="\$(if \$(LDFLAGS), \
+\$(addprefix ${mkexe_ldflags_prefix},\$(LDFLAGS)))"
+    mkexe=\
+"${mkexe} \$(addprefix ${mkexe_ldflags_prefix},\$(OC_LDFLAGS))${mkdll_ldflags}"
+    mkdll_ldflags="\$(addprefix ${mkexe_ldflags_prefix},\$(OC_DLL_LDFLAGS)) \
+${mkdll_ldflags}"
+
+else
+
+    mkdll_ldflags='$(OC_DLL_LDFLAGS) $(LDFLAGS)'
+    mkexe="${mkexe} \$(OC_LDFLAGS) \$(LDFLAGS)"
+
+fi
+  mksharedlib="$mksharedlib $mkdll_ldflags"
+  mkmaindll="$mkmaindll $mkdll_ldflags"
+  # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
+  # the msvc ports.
+  if test -n "$mkexe_via_cc_ldflags_prefix"; then :
+
+    mkexe_via_cc_ldflags=\
+"\$(addprefix ${mkexe_via_cc_ldflags_prefix},\$(OC_LDFLAGS) \$(LDFLAGS))"
+
+else
+
+    mkexe_via_cc_ldflags='$(OC_LDFLAGS) $(LDFLAGS)'
+
+fi
+  # cl requires linker flags after the objects.
+  if test "$ccomptype" = 'msvc'; then :
+  mkexe_via_cc_ldflags=\
+"\$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"
+else
+  mkexe_via_cc_ldflags=\
+"$mkexe_via_cc_ldflags \$(OUTPUTEXE)\$(1) \$(2)"
+fi
+  if test -n "$mkexe_via_cc_extra_cmd"; then :
+  mkexe_via_cc_ldflags="$mkexe_via_cc_ldflags $mkexe_via_cc_extra_cmd"
+fi
 
 
 : "${CONFIG_STATUS=./config.status}"

--- a/configure.ac
+++ b/configure.ac
@@ -30,14 +30,17 @@ AC_MSG_NOTICE([Configuring OCaml version AC_PACKAGE_VERSION])
 ## Command-line arguments passed to configure
 CONFIGURE_ARGS="$*"
 
-# Command to build executalbes
-# In general this command is supposed to use the CFLAGs- and LDFLAGS-
-# related variables (OC_CFLAGS and OC_LDFLAGS for ocaml-specific
-# flags, CFLAGS and LDFLAGS for generic flags chosen by the user), but
-# at the moment they are not taken into account on Windows, because
-# flexlink, which is used to build executables on this platform, can
-# not handle them.
-mkexe="\$(CC) \$(OC_CFLAGS) \$(CFLAGS) \$(OC_LDFLAGS) \$(LDFLAGS)"
+# Command to build executables
+# Ultimately, MKEXE may build an executable using the C compiler or it may use
+# a wrapper for a linker (i.e. flexlink). The build system must therefore not
+# rely on $CFLAGS because these cannot be processed by flexlink (and are not
+# passed)
+mkexe_cmd='$(CC)'
+mkexe_cflags='$(OC_CFLAGS) $(CFLAGS)'
+mkexe_extra_flags=''
+mkexe_via_cc_extra_cmd=''
+mkexe_ldflags_prefix=''
+mkexe_via_cc_ldflags_prefix=''
 
 # Flags for building executable files with debugging symbols
 mkexedebugflag="-g"
@@ -84,7 +87,6 @@ AC_SUBST([DIFF_FLAGS])
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-AC_SUBST([DIRECT_CPP])
 AC_SUBST([ac_tool_prefix])
 AC_SUBST([exeext])
 AC_SUBST([OBJEXT])
@@ -105,6 +107,8 @@ AC_SUBST([syslib])
 AC_SUBST([fpic])
 AC_SUBST([mkexe])
 AC_SUBST([mkexedebugflag])
+AC_SUBST([mkexe_extra_flags])
+AC_SUBST([mkexe_via_cc_ldflags])
 AC_SUBST([ccomptype])
 AC_SUBST([toolchain])
 AC_SUBST([oc_cflags])
@@ -161,7 +165,6 @@ AC_SUBST([flat_float_array])
 AC_SUBST([function_sections])
 AC_SUBST([afl])
 AC_SUBST([flexdll_chain])
-AC_SUBST([flexlink_flags])
 AC_SUBST([PACKLD])
 AC_SUBST([stdlib_manpages])
 AC_SUBST([compute_deps])
@@ -479,6 +482,7 @@ AS_CASE([$host],
   # So we let them do, at the moment
   [*-pc-windows],
     [
+      mkexe_via_cc_extra_cmd=' && $(call MERGEMANIFESTEXE,$(1))'
       libext=lib
       AR=""
       AS_IF([test "$host_cpu" = "x86_64" ],
@@ -687,24 +691,25 @@ AS_IF([test x"$enable_shared" = "xno"],
 AS_CASE([$host],
   [i686-*-cygwin],
     [flexdll_chain='cygwin'
-    flexlink_flags="-chain $flexdll_chain -merge-manifest -stack 16777216"],
+    mkexe_extra_flags='-merge-manifest -stack 16777216'],
   [x86_64-*-cygwin],
     [flexdll_chain='cygwin64'
-    flexlink_flags="-chain $flexdll_chain -merge-manifest -stack 16777216"],
+    mkexe_extra_flags='-merge-manifest -stack 16777216'],
   [*-*-cygwin*],
     [AC_MSG_ERROR([unknown cygwin variant])],
   [i686-w64-mingw32],
     [flexdll_chain='mingw'
-    flexlink_flags="-chain $flexdll_chain -stack 16777216"],
+    mkexe_extra_flags='-stack 16777216'],
   [x86_64-w64-mingw32],
     [flexdll_chain='mingw64'
-    flexlink_flags="-chain $flexdll_chain -stack 33554432"],
+    mkexe_extra_flags='-stack 33554432'],
   [i686-pc-windows],
     [flexdll_chain='msvc'
-    flexlink_flags="-merge-manifest -stack 16777216"],
+    mkexe_extra_flags='-merge-manifest -stack 16777216'],
   [x86_64-pc-windows],
     [flexdll_chain='msvc64'
-    flexlink_flags="-x64 -merge-manifest -stack 33554432"])
+    mkexe_extra_flags='-merge-manifest -stack 33554432'],
+  [flexdll_chain=''])
 
 AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
   AC_MSG_CHECKING([for flexdll sources])
@@ -781,7 +786,7 @@ AS_CASE([$flexdir,$supports_shared_libraries,$flexlink,$host],
 
 AS_CASE([$cc_basename,$host],
   [*,x86_64-*-darwin*],
-    [mkexe="$mkexe -Wl,-no_compact_unwind";
+    [oc_ldflags='-Wl,-no_compact_unwind';
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [*,aarch64-*-darwin*|arm64-*-darwin*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
@@ -789,32 +794,36 @@ AS_CASE([$cc_basename,$host],
   [*,*-*-cygwin*],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
-      [mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
-      mkexedebugflag="-link -g"],
-      [mkexe="$mkexe -Wl,--stack,16777216"
-      oc_ldflags="-Wl,--stack,16777216"]
+      [mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+      mkexe_cflags=''
+      mkexe_ldflags_prefix='-link ']
+      [mkexe_extra_flags=''
+      oc_ldflags='-Wl,--stack,16777216']
     )
     ostype="Cygwin"],
   [*,*-*-mingw32],
     [AS_CASE([$host],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
-    mkexedebugflag="-link -g"
     ostype="Win32"
     toolchain="mingw"
-    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cflags=''
+    mkexe_ldflags_prefix='-link '
     oc_ldflags='-municode'
     SO="dll"],
   [*,*-pc-windows],
     [toolchain=msvc
     ostype="Win32"
-    mkexe='$(FLEXLINK) -exe $(if $(OC_LDFLAGS),-link "$(OC_LDFLAGS)")'
+    mkexe_cmd='$(FLEXLINK_CMD) -exe -chain $(FLEXDLL_CHAIN)'
+    mkexe_cflags=''
+    mkexe_ldflags_prefix='-link '
+    mkexe_via_cc_ldflags_prefix='/link '
     oc_ldflags='/ENTRY:wmainCRTStartup'
     mkexedebugflag=''],
   [*,x86_64-*-linux*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
   [xlc*,powerpc-ibm-aix*],
-    [mkexe="$mkexe "
-     oc_ldflags="-brtl -bexpfull"
+    [oc_ldflags='-brtl -bexpfull'
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [gcc*,powerpc-*-linux*],
     [oc_ldflags="-mbss-plt"],
@@ -924,34 +933,32 @@ natdynlinkopts=""
 AS_IF([test x"$enable_shared" != "xno"],
   [AS_CASE([$host],
     [x86_64-apple-darwin*],
-      [mksharedlib="$CC -shared \
-                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
-                   \$(LDFLAGS)"
+      [mksharedlib='$(CC) -shared '\
+'-undefined dynamic_lookup -Wl,-no_compact_unwind'
       supports_shared_libraries=true],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
-      [mksharedlib="$CC -shared \
-                   -undefined dynamic_lookup \$(LDFLAGS)"
+      [mksharedlib='$(CC) -shared -undefined dynamic_lookup'
       supports_shared_libraries=true],
     [*-*-mingw32],
-      [mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'
+      [mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
+      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'
       AS_IF([test -n "$oc_dll_ldflags"],[
         mksharedlib="$mksharedlib -link \"$oc_dll_ldflags\""
         mkmaindll="$mkmaindll -link \"$oc_dll_ldflags\""])],
     [*-pc-windows],
-      [mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'],
+      [mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
+      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'],
     [*-*-cygwin*],
-      [mksharedlib='$(FLEXLINK)'
-      mkmaindll='$(FLEXLINK) -maindll'],
+      [mksharedlib='$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN)'
+      mkmaindll='$(FLEXLINK_CMD) -maindll -chain $(FLEXDLL_CHAIN)'],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],
-               [mksharedlib="$CC -qmkshrobj -G \$(LDFLAGS)"
+               [mksharedlib='$(CC) -qmkshrobj -G'
                 supports_shared_libraries=true])],
     [*-*-solaris*],
       [sharedlib_cflags="-fPIC"
-      mksharedlib="$CC -shared"
+      mksharedlib='$(CC) -shared'
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
       supports_shared_libraries=true],
@@ -960,12 +967,12 @@ AS_IF([test x"$enable_shared" != "xno"],
       [sharedlib_cflags="-fPIC"
        AS_CASE([$cc_basename,$host],
            [*gcc*,powerpc-*-linux*],
-           [mksharedlib="$CC -shared -mbss-plt \$(LDFLAGS)"],
+           [mksharedlib='$(CC) -shared -mbss-plt'],
            [[*,i[3456]86-*]],
            # Disable DT_TEXTREL warnings on Linux and BSD i386
            # See https://github.com/ocaml/ocaml/issues/9800
-           [mksharedlib="$CC -shared \$(LDFLAGS) -Wl,-z,notext"],
-           [mksharedlib="$CC -shared \$(LDFLAGS)"])
+           [mksharedlib='$(CC) -shared -Wl,-z,notext'],
+           [mksharedlib='$(CC) -shared'])
       oc_ldflags="$oc_ldflags -Wl,-E"
       rpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
@@ -2054,5 +2061,55 @@ AS_IF([test x"$enable_stdlib_manpages" != "xno"],
 
 # Do not permanently cache the result of flexdll.h
 unset ac_cv_header_flexdll_h
+
+# Just before config.status is generated, determine the final values for MKEXE,
+# MKDLL, MKMAINDLL and MKEXE_VIA_CC. The final variables controlling these are:
+# $mkexe - the linking commmand and munged CFLAGS + any extra flexlink flags
+# $mksharedlib - the full linking command for DLLs
+# $mkmaindll - the full linking command for main program in DLL
+# $oc_ldflags and $oc_dll_ldflags are handled as $(OC_LDFLAGS) and
+# $(OC_DLL_LDFLAGS) and can be overidden in the build.
+AC_CONFIG_COMMANDS_PRE([
+  # Construct $mkexe
+  mkexe="$mkexe_cmd"
+  AS_IF([test -n "$mkexe_cflags"],
+    [mkexe="$mkexe $mkexe_cflags"])
+  AS_IF([test -n "$mkexe_extra_flags"],
+    [mkexe="$mkexe $mkexe_extra_flags"])
+  # If $mkexe_ldflags_prefix is given, apply it to $oc_ldflags and $oc_dllflags
+  # and ensure that LDFLAGS is passed using it. This is used for flexlink. where
+  # linker flags need to be prefixed with -link.
+  AS_IF([test -n "$mkexe_ldflags_prefix"],[
+    AS_IF([test -n "$mkexedebugflag"],
+      [mkexedebugflag="${mkexe_ldflags_prefix}${mkexedebugflag}"])
+    mkdll_ldflags="\$(if \$(LDFLAGS), \
+\$(addprefix ${mkexe_ldflags_prefix},\$(LDFLAGS)))"
+    mkexe=\
+"${mkexe} \$(addprefix ${mkexe_ldflags_prefix},\$(OC_LDFLAGS))${mkdll_ldflags}"
+    mkdll_ldflags="\$(addprefix ${mkexe_ldflags_prefix},\$(OC_DLL_LDFLAGS)) \
+${mkdll_ldflags}"
+  ],[
+    mkdll_ldflags='$(OC_DLL_LDFLAGS) $(LDFLAGS)'
+    mkexe="${mkexe} \$(OC_LDFLAGS) \$(LDFLAGS)"
+  ])
+  mksharedlib="$mksharedlib $mkdll_ldflags"
+  mkmaindll="$mkmaindll $mkdll_ldflags"
+  # Do similarly with $mkexe_via_cc_ldflags_prefix, but this is only needed for
+  # the msvc ports.
+  AS_IF([test -n "$mkexe_via_cc_ldflags_prefix"],[
+    mkexe_via_cc_ldflags=\
+"\$(addprefix ${mkexe_via_cc_ldflags_prefix},\$(OC_LDFLAGS) \$(LDFLAGS))"
+  ],[
+    mkexe_via_cc_ldflags='$(OC_LDFLAGS) $(LDFLAGS)'
+  ])
+  # cl requires linker flags after the objects.
+  AS_IF([test "$ccomptype" = 'msvc'],
+    [mkexe_via_cc_ldflags=\
+"\$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"],
+    [mkexe_via_cc_ldflags=\
+"$mkexe_via_cc_ldflags \$(OUTPUTEXE)\$(1) \$(2)"])
+  AS_IF([test -n "$mkexe_via_cc_extra_cmd"],
+    [mkexe_via_cc_ldflags="$mkexe_via_cc_ldflags $mkexe_via_cc_extra_cmd"])
+])
 
 AC_OUTPUT

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -157,7 +157,7 @@ camlhead%: tmphead%.exe
 # Again, pattern weirdness here means that the dot is always present so that
 # tmpheader.exe matches.
 tmpheader%exe: $(HEADERPROGRAM)%$(O)
-	$(call MKEXE_USING_COMPILER,$@,$^)
+	$(call MKEXE_VIA_CC,$@,$^)
 # FIXME This is wrong - mingw could invoke strip; MSVC equivalent?
 ifneq "$(UNIX_OR_WIN32)" "win32"
 	strip $@
@@ -175,7 +175,7 @@ camlheader_ur: camlheader
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
 tmptargetcamlheader%exe: $(TARGETHEADERPROGRAM)%$(O)
-	$(call MKEXE_USING_COMPILER,$@,$^)
+	$(call MKEXE_VIA_CC,$@,$^)
 	strip $@
 
 $(TARGETHEADERPROGRAM)%$(O): $(HEADERPROGRAM).c

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -72,18 +72,18 @@ ifeq "$(wildcard $(ROOTDIR_HOST)/flexlink.opt$(EXE))" ""
                     $(ROOTDIR_HOST)/boot/flexlink.byte$(EXE)"
   MKDLL=$(ROOTDIR_HOST)/boot/ocamlrun$(EXE) \
         $(ROOTDIR_HOST)/boot/flexlink.byte$(EXE) \
-        $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
+        -chain $(FLEXDLL_CHAIN) $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
   MKEXE=$(ROOTDIR_HOST)/boot/ocamlrun$(EXE) \
         $(ROOTDIR_HOST)/boot/flexlink.byte$(EXE) \
-        $(FLEXLINK_FLAGS) -exe $(FLEXLINK_EXE_LDFLAGS)
+        -exe -chain $(FLEXDLL_CHAIN) $(FLEXLINK_FLAGS) $(FLEXLINK_EXE_LDFLAGS)
 else
   FLEXLINK_ENV = \
     OCAML_FLEXLINK="$(ROOTDIR_HOST)/flexlink.opt$(EXE) \
       -I $(ROOTDIR_HOST)/stdlib/flexdll"
   MKDLL=$(ROOTDIR_HOST)/flexlink.opt$(EXE) -I $(ROOTDIR_HOST)/stdlib/flexdll \
-        $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
+        -chain $(FLEXDLL_CHAIN) $(FLEXLINK_FLAGS) $(FLEXLINK_DLL_LDFLAGS)
   MKEXE=$(ROOTDIR_HOST)/flexlink.opt$(EXE) -I $(ROOTDIR_HOST)/stdlib/flexdll \
-        $(FLEXLINK_FLAGS) -exe $(FLEXLINK_EXE_LDFLAGS)
+        -exe -chain $(FLEXDLL_CHAIN) $(FLEXLINK_FLAGS) $(FLEXLINK_EXE_LDFLAGS)
 endif # ifeq "$(wildcard $(ROOTDIR_HOST)/flexlink.opt$(EXE))" ""
 endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "false"
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -34,8 +34,10 @@ SUBST_QUOTE2=\
   -e 's!%%$1%%!$(if $2,$(call SED_ESCAPE,"$(call OCAML_ESCAPE,$2)"))!'
 SUBST_QUOTE=$(call SUBST_QUOTE2,$1,$($1))
 
-FLEXLINK_LDFLAGS=$(if $(OC_LDFLAGS), -link "$(OC_LDFLAGS)")
-FLEXLINK_DLL_LDFLAGS=$(if $(OC_DLL_LDFLAGS), -link "$(OC_DLL_LDFLAGS)")
+prefix_and_quote = $(if $(1), $(2)$(if $(word 2,$(1)),"$(1)",$(1)))
+
+FLEXLINK_LDFLAGS = $(call prefix_and_quote,$(OC_LDFLAGS),-link $(EMPTY))
+FLEXLINK_DLL_LDFLAGS = $(call prefix_and_quote,$(OC_DLL_LDFLAGS),-link $(EMPTY))
 
 config_main.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile config.common.ml
 	sed $(call SUBST,AFL_INSTRUMENT) \
@@ -57,6 +59,7 @@ config_main.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile config.common.ml
 	    $(call SUBST,WITH_CMM_INVARIANTS) \
 	    $(call SUBST_STRING,FLEXLINK_FLAGS) \
 	    $(call SUBST_QUOTE,FLEXDLL_DIR) \
+	    $(call SUBST_STRING,FLEXDLL_CHAIN) \
 	    $(call SUBST,HOST) \
 	    $(call SUBST_STRING,BINDIR) \
 	    $(call SUBST_STRING,LIBDIR) \

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -47,21 +47,21 @@ let mksharedlibrpath = "%%MKSHAREDLIBRPATH%%"
 let ar = "%%ARCMD%%"
 let supports_shared_libraries = %%SUPPORTS_SHARED_LIBRARIES%%
 let mkdll, mkexe, mkmaindll =
-  (* @@DRA Cygwin - but only if shared libraries are enabled, which we
-     should be able to detect? *)
   if Sys.win32 || Sys.cygwin && supports_shared_libraries then
-    try
+    let flexlink =
       let flexlink =
-        let flexlink = Sys.getenv "OCAML_FLEXLINK" in
-        let f i =
-          let c = flexlink.[i] in
-          if c = '/' && Sys.win32 then '\\' else c in
-        (String.init (String.length flexlink) f) ^ " %%FLEXLINK_FLAGS%%" in
-      flexlink ^ "%%FLEXLINK_DLL_LDFLAGS%%",
-      flexlink ^ " -exe%%FLEXLINK_LDFLAGS%%",
-      flexlink ^ " -maindll%%FLEXLINK_DLL_LDFLAGS%%"
-    with Not_found ->
-      "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
+        Option.value ~default:"flexlink" (Sys.getenv_opt "OCAML_FLEXLINK")
+      in
+      let f i =
+        let c = flexlink.[i] in
+        if c = '/' && Sys.win32 then '\\' else c
+      in
+      String.init (String.length flexlink) f
+    in
+    let flags = " -chain %%FLEXDLL_CHAIN%% %%FLEXLINK_FLAGS%%" in
+    flexlink ^ flags ^ "%%FLEXLINK_DLL_LDFLAGS%%",
+    flexlink ^ " -exe" ^ flags ^ "%%FLEXLINK_LDFLAGS%%",
+    flexlink ^ " -maindll" ^ flags ^ "%%FLEXLINK_DLL_LDFLAGS%%"
   else
     "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
 


### PR DESCRIPTION
This is a long overdue overhaul of the way `$(MKEXE)` is constructed. `$(MKEXE)` either builds an executable using the C compiler (Unix, and Cygwin in non-shared mode) or it's a call to a linker wrapper (flexlink). There's also the separate `$(MKEXE_USING_COMPILER)` which is needed for the bytecode startup header and for building the non-shared runtime when bootstrapping flexlink.

At present, there's a lot of subtlety embedded in both `configure.ac` and `Makefile.config.in` (for example, the fact that the Microsoft linker requires linker flags _after_ objects, not before, is encoded in `Makefile.config.in` and not mentioned) and a few latent bugs (for example, the handling of `$(LDFLAGS)` is missing on the flexlink paths). There's also a lot of "weirdness" about argument prefixing - for example, the Unicode startup instruction (`-municode`) should be passed directly to gcc in `$(MKEXE_USING_COMPILER)` but prefixed `-link ` when passed to flexlink. However, in the msvc ports, the equivalent `/ENTRY:wmainCRTStartup` must be passed prefixed `-link ` to flexlink _and also prefixed_ `-link`/`/link` to cl. There is also the question of `$(CFLAGS)`, which may be used when `$(MKEXE)` is a C compiler, but cannot be passed to flexlink, which doesn't call the C compiler.

Ultimately, I expect to remove this confusion by changing flexlink to cease being a wrapper around the linker and instead a compilation step to generate the required startup objects. However, this work is un-designed and un-scheduled, so we the mess could do with dealing with. The present code also severely complicates some other simplifications in the build system for the generation of `utils/config.ml` and `ocamltest/ocamltest_config.ml`.

My solution here is to change the way `$mkexe` is constructed in `configure.ac`. `configure` now considers `$mkexe_cmd` - the _command_ to be executed (which might include parameters). The _variables_ which are to be passed to it are considered at the end of the process, just before `config.status` is generated (this is what `AC_CONFIG_COMMANDS_PRE` does). This allows all of the computations in the main body of configure to consider the flags only, and not how they will be passed - for example, `$mkexedebugflag` is now `-g` at all times (or _cleared_ in MSVC, where it can't be used) and then only at the end do we worry about whether it needs to be prefixed `-link`.

I've renamed `MKEXE_USING_COMPILER` to be more explicit about how it really works - it is now `MKEXE_VIA_CC`. I've attempted with comments before the `AC_CONFIG_COMMANDS_PRE` call to explain the variables which are constructed. A nice side-effect of this, if we also move the testsuite/manual commands (as suggested in https://github.com/ocaml/ocaml/pull/10411#issue-644187437) is that `Makefile.config` no longer contains `if` statements - it's actually a configuration file.

Along the way, `$(OC_LDFLAGS)` and `$(LDFLAGS)` are now correct handled by flexlink.

This has been through precheck, but it should obviously go through again once reviewed.