### PR TITLE
toplevel: detect recursive definitions in #show

### DIFF
--- a/Changes
+++ b/Changes
@@ -413,6 +413,9 @@ Working version
 - #6985, #10385: remove all ghost row types from included modules
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #7453, #9828, #10416: fix #show for recursive types and modules
+  (Florian Angeletti, review by Gabriel Scherer)
+
 * #8857, #10220: Don't clobber GetLastError() in caml_leave_blocking_section
   when the systhreads library is loaded.
   (David Allsopp, report by Anton Bachin, review by Xavier Leroy)

--- a/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
+++ b/testsuite/tests/tool-toplevel/known-bugs/broken_rec_in_show.ml
@@ -10,9 +10,9 @@ type t = T of t;;
 type t = T of t
 |}]
 #show t;;
-(* this output is INCORRECT, it should not use nonrec *)
+(* this output is CORRECT, it should not use nonrec *)
 [%%expect{|
-type nonrec t = T of t
+type t = T of t
 |}];;
 
 type nonrec s = Foo of t;;
@@ -20,9 +20,9 @@ type nonrec s = Foo of t;;
 type nonrec s = Foo of t
 |}];;
 #show s;;
-(* this output is CORRECT, it uses nonrec *)
+(* this output is CORRECT, it elides the unnecessary nonrec keyword *)
 [%%expect{|
-type nonrec s = Foo of t
+type s = Foo of t
 |}];;
 
 
@@ -32,8 +32,6 @@ module M : sig type t val x : t end = struct type t = int let x = 0 end;;
 module M : sig type t val x : t end
 |}];;
 (* this output is CORRECT, it does not use 'rec' *)
-[%%expect{|
-|}];;
 
 module rec M : sig type t val x : M.t end = struct type t = int let x = 0 end;;
 (* this output is CORRECT . *)
@@ -41,7 +39,42 @@ module rec M : sig type t val x : M.t end = struct type t = int let x = 0 end;;
 module rec M : sig type t val x : M.t end
 |}];;
 #show_module M;;
-(* this output is INCORRECT, it should use 'rec' *)
+(* this output is CORRECT *)
 [%%expect{|
-module M : sig type t val x : M.t end
+module rec M : sig type t val x : M.t end
+|}];;
+
+
+(* Indirect recursion *)
+
+type t
+type f = [ `A of t ]
+type t = X of u | Y of [ f | `B ]  and u = Y of t;;
+
+[%%expect{|
+type t
+type f = [ `A of t ]
+type t = X of u | Y of [ `A of t/1 | `B ]
+and u = Y of t/2
+|}];;
+
+#show t;;
+(* this output is PARTIAL: t is mutually recursive with u *)
+[%%expect{|
+type nonrec t = X of u | Y of [ `A of t/2 | `B ]
+|}];;
+
+
+module rec M: sig type t = X of N.t end = M
+and N: sig type t = X of M.t end = N
+
+[%%expect{|
+module rec M : sig type t = X of N.t end
+and N : sig type t = X of M.t end
+|}];;
+
+(* this output is PARTIAL: M is mutually recursive with N *)
+#show M;;
+[%%expect{|
+module M : sig type t = X of N.t end
 |}];;

--- a/testsuite/tests/tool-toplevel/show.ml
+++ b/testsuite/tests/tool-toplevel/show.ml
@@ -40,7 +40,7 @@ type 'a option = None | Some of 'a
 
 #show option;;
 [%%expect {|
-type nonrec 'a option = None | Some of 'a
+type 'a option = None | Some of 'a
 |}];;
 
 #show Open_binary;;
@@ -59,7 +59,7 @@ type Stdlib.open_flag =
 
 #show open_flag;;
 [%%expect {|
-type nonrec open_flag =
+type open_flag =
     Open_rdonly
   | Open_wronly
   | Open_append
@@ -90,7 +90,7 @@ type extensible += B of int
 
 #show extensible;;
 [%%expect {|
-type nonrec extensible = ..
+type extensible = ..
 |}];;
 
 type 'a t = ..;;

--- a/testsuite/tests/tool-toplevel/show_short_paths.ml
+++ b/testsuite/tests/tool-toplevel/show_short_paths.ml
@@ -8,12 +8,12 @@
 
 #show list;;
 [%%expect {|
-type nonrec 'a list = [] | (::) of 'a * 'a list
+type 'a list = [] | (::) of 'a * 'a list
 |}];;
 
 type 'a t;;
 #show t;;
 [%%expect {|
 type 'a t
-type nonrec 'a t
+type 'a t
 |}];;

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1683,12 +1683,13 @@ let ident_sigitem = function
   | Types.Sig_typext (ident,_,_,_)   ->  {hide=false; ident }
 
 let hide ids env =
-    let hide_id id env =
-       if id.hide then
-         Env.add_type ~check:false (Ident.rename id.ident) dummy env
-       else env
-    in
-    List.fold_right hide_id ids env
+  let hide_id id env =
+    (* Global idents cannot be renamed *)
+    if id.hide && not (Ident.global id.ident) then
+      Env.add_type ~check:false (Ident.rename id.ident) dummy env
+    else env
+  in
+  List.fold_right hide_id ids env
 
 let with_hidden_items ids f =
   let with_hidden_in_printing_env ids f =


### PR DESCRIPTION
This PR fixes the printing of most recursive types and modules.
For instance,

```ocaml
type t = A of t;;
#show t;;
```
prints
>```ocaml
>type t = A of t
>```

and not
>```ocaml
>type nonrec t = A of t
>```

Similarly, the problematic 
```ocaml
include struct type t type u = [ `A of t ] end
include struct type t type v = [ `B of t ] end
type t = [ u | v ];;
#show t;;
```
is printed as
>```ocaml
> type nonrec t = [ `A of t/2 | `B of t/3 ]
>```
since the definition of `t` is not recursive, and they are too many non-recursive `t` appearing in this definition.

The recursivity detection is deliberately partial and only check for the presence of the current identifier in the displayed definition.
This should be mostly visible for recursive modules however.

Note that this PR also fixes the issue which surfaced in #9828 by making sure that `-short-paths` doesn't try to hide global identifiers.
