### PR TITLE
change GC slice computation to use Dolan's formula

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,10 @@ Working version
   (Stephen Dolan, review by Xavier Leroy, Guillaume Munch-Maccagnoni,
    Jacques-Henri Jourdan and Damien Doligez)
 
+- #10418: Rework the computation of GC slice work, and let the user control
+  the ratio of mark slice size to sweep slice size
+  (Damien Doligez, idea by Stephen Dolan, review by ...)
+
 - #10549: Stack overflow detection and naked pointers checking for ARM64
   (Xavier Leroy, review by Stephen Dolan)
 

--- a/man/ocamlrun.m
+++ b/man/ocamlrun.m
@@ -205,6 +205,11 @@ Note: this only applies to values allocated with
 (e.g. bigarrays).
 Default: 8192 bytes.
 .TP
+.BR r \ (mark_to_sweep_ratio)
+How much marking work each mark slice will do when sweep slices
+do 1000 units of sweeping work.
+Default: 333.
+.TP
 .BR v \ (verbose)
 What GC messages to print to stderr.  This is a sum of values selected
 from the following:

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -151,6 +151,8 @@ The following environment variables are also consulted:
   \item[l] ("stack_limit") The limit (in words) of the stack size. This is only
   relevant to the byte-code runtime, as the native code runtime uses the
   operating system's stack.
+  \item[r] ("mark_to_sweep_ratio") How much marking work each mark slice
+   will do when sweep slices do 1000 units of sweeping work.
   \item[v] ("verbose")  What GC messages to print to stderr.  This
   is a sum of values selected from the following:
   \begin{options}

--- a/runtime/HACKING.adoc
+++ b/runtime/HACKING.adoc
@@ -1,0 +1,285 @@
+= Hacking the runtime system
+
+This document tries to provides useful information about some aspects of
+the OCaml runtime system. It does not try to be exhaustive, and it will
+evolve over time.
+
+
+== OCaml GC Pacing
+
+The first part of this text gives a  general simplification of the
+computation of how much work the GC should do in a given slice.
+The second part removes some of the simplifying assumptions made
+in the first part.
+
+=== Current OCaml GC logic
+
+I'm going to make the following simplifying assumptions:
+
+* There aren't many custom_alloc_custom_mem blocks (caml_dependent_size
+~= 0)
+* There aren't many caml_alloc_custom blocks with nonzero mem/max
+(caml_extra_heap_resources ~= 0)
+* There are no manually triggered GC slices (howmuch = -1,
+caml_major_work_credit = 0)
+* The smoothing of slice amounts has no effect (filt_p ~= p)
+* There are few or no weak pointers and ephemerons (Phase_clean is
+negligible)
+* The number of roots is much smaller than the size of the heap
+(stat_heap_wsz + caml_incremental_roots_count ~= stat_heap_wsz)
+
+Under these assumptions, the calculations in caml_major_collection_slice
+simplify to the following. (For readability, I've removed `caml_`
+prefixes, casts, comments, logging, etc.)
+
+....
+p = allocated_words * 3 * (100 + percent_free)
+    / stat_heap_wsz / percent_free / 2;
+
+if (gc_phase == Phase_mark) {
+  computed_work = p * stat_heap_wsz * 250 / (100 + percent_free);
+}else{
+  computed_work = p * stat_heap_wsz * 5 / 3;
+}
+....
+
+Expanding `p`, we get:
+
+....
+if (gc_phase == Phase_mark) {
+  computed_work = allocated_words * 3 * 250 / (2 * percent_free);
+}else{
+  computed_work = allocated_words * 5 * (100 + percent_free) / (2 * percent_free);
+}
+....
+
+Note that the uses of stat_heap_wsz in p and in computed_work cancel
+out, so the amount of work done does not depend on the heap size.
+
+The `computed_work` is equal to `allocated_words` times a constant.
+Let's name these constants `m` and `s`. They represent the amount of
+work done per word of allocation during mark and sweep slices
+respectively, and their values are:
+
+....
+m = 3 * 250 / (2 * percent_free)
+s = 5 * (100 + percent_free) / (2 * percent_free)
+....
+
+The default percent_free = 80 gives m = 4.6875, s = 5.625.
+
+This is open-loop control: the parameters m and s are determined only
+from configuration (percent_free), and there is no feedback mechanism.
+The open-loop nature of this controller makes it much simpler to
+analyse.
+
+The interesting question is about the relationship between m, s,
+percent_free and the actual heap size.
+
+=== A major GC cycle
+
+As soon as a major GC cycle starts, the allocated data on the heap is
+snapshotted, dividing it into live data (reachable from the roots at the
+moment the cycle starts) and garbage (unreachable).
+
+Write L for the size of the live data. It is convenient to work in units
+of L, so let's measure the garbage as a proportion g of L, so that the
+allocated data at cycle start has size:
+
+....
+L + Lg
+....
+
+The value of L at any given moment is a property of the program,
+unaffected by GC decisions. However, the value of g at the start of the
+cycle is a function of GC decisions in previous cycles.
+
+The first phase is marking, as the collector determines what's live and
+what's garbage. The total amount of marking work to do is L (only live
+data need be marked), and since we do m marking work per word of
+allocation, we will allocate L/m words during the marking phase.
+
+At the end of marking, the amount of allocated data is maximal: we have
+been allocating during marking, but we have not yet begun to collect any
+garbage. The amount of allocated data here is:
+
+....
+L + Lg + L/m
+....
+
+Next, we begin sweeping. We must sweep the entire heap, and we do s
+sweeping per allocated word. By the end of sweeping, we have collected
+exactly Lg garbage, as none of the data allocated during marking or
+sweeping can be collected this cycle. This leaves the total amount of
+allocated data as the sum of live at the start, allocated during
+marking, and allocated during sweeping:
+
+....
+L + L/m + (L + Lg + L/m)/s
+....
+
+Finally, the next cycle begins, splitting the above into L' + L' g'.
+
+=== Steady-state and stability
+
+An important property is that if the amount of live data is constant,
+then the heap size should also be constant. So, taking L to be constant
+(L = L'), let's see what happens to g.
+
+....
+L + L g' = L + L/m + (L + Lg + L/m)/s
+
+g' = 1/m + (1 + g + 1/m)/s
+
+g' = 1/m + 1/s + g/s + 1/ms
+....
+
+This has the form of a linear recurrence g -> ag + b, where
+
+....
+a = 1/s
+b = 1/m + 1/s + 1/ms
+....
+
+This is stable as long as a < 1, and tends towards its unique fixpoint
+of b/(1-a), or:
+
+....
+(1/m + 1/s + 1/ms) / (1 - 1/s)
+....
+
+The stability condition is that s > 1: we must sweep faster than we're
+allocating, or sweeping won't terminate. There is no such condition on
+marking, as the amount of mark work is fixed at the start of the cycle.
+
+The ``overhead'' is the ratio of non-live heap to live heap. The heap is
+at its largest just at the end of marking, at which time the overhead is
+g + 1/m. In the steady state, that gives an overhead of:
+
+....
+(1/m + 1/s + 1/ms) / (1 - 1/s)  + 1 / m
+=
+(2/m + 1/s) / (1 - 1/s)
+....
+
+=== Choosing m and s
+
+With the current default values of m and s, we end up with an overhead
+of 0.735. We can choose a specific value of o by solving for m and s.
+
+There is one other parameter to pick: the ratio l between mark and sweep
+work. We choose m = ls, and try to pick l so that the amount of overhead
+per allocated word is approximately equal between marking and sweeping.
+That is, we try to ensure that doing l words of marking has about the
+same cost as doing 1 word of sweeping.
+
+I think we could experimentally determine a reasonable hardcoded value
+for l, although it will depend somewhat on the program behaviour (poor
+locality makes marking slower without affecting sweeping much, while a
+larger average object size speeds up sweeping without affecting marking
+much).
+
+Then, we can take:
+
+....
+s = 1 + (1 + 2/l) / o
+m = ls
+....
+
+=== How to deal with "out-of-heap resources" and "dependent memory"
+
+First of all, these are counted independently from the main heap, and
+according to the spec, their only effect should be to speed up the GC
+when these non-heap resources are allocated ``too fast'' with respect to
+heap memory.
+
+So we should compute a work amount for each (as we do for the heap) and
+then take the max of the three numbers.
+
+==== Out-of-heap resources:
+
+For each slice we get a number p between 0 and 1, and we promise to do
+(approximately) one GC cycle whenever the cumulated p values reach 1. If
+we call A the total size of the heap allocations in one GC cycle, and
+take p as equivalent to allocating Ap words in the heap, we will reach
+this target.
+
+We still need to figure out A from Dolan's m and s parameters. Assuming
+steady-state, this is simply
+
+....
+A = L/m + (L + Lg + L/m)s
+....
+
+where L is the amount of live data; assuming steady state, this is equal
+to both 1/(o+1) of the heap size and the amount of data marked in the
+previous GC cycle. Note that H/(o+1) is not a good approximation because
+it is quantized: the heap only grows or shrinks by large blocks so it
+doesn't give a good approximation of the live data. This is especially
+true when the amount of live data is very small because the heap size
+is then pegged to its minimum value. Programs with little live data
+would rightfully expect to have small GC overhead and we don't want
+to break this assumption. Fortunately, the "amount of data marked in
+the previous GC cycle" is available since #10194 so we'll use that.
+
+g is given above:
+
+....
+g = o - 1/m
+....
+
+The ``equivalent allocations'' E is then:
+
+....
+E = L (1/m + (1+o)/s) p
+  = H (1/(o+1)m + 1/s) p
+....
+
+and we will mark at least Em or sweep at least Es words.
+
+==== Dependent Memory
+
+When the GC slice runs, we have two pieces of information: 1. How much
+dependent memory is currently used (live + garbage) [C] 2. How much
+dependent memory was allocated since the previous slice [a]
+
+Let us call H the total heap size.
+
+We can compute R, the ratio of dependent memory to heap size, and note
+that marking w words on the heap will ``mark'' (on average) wR words of
+dependent memory, and similarly for sweeping.
+
+....
+R = C / H
+....
+
+The overhead parameter o is also used for dependent memory, so we can
+use the same m and s parameters that we use for the heap. We should then
+mark m or sweep s words of dependent memory for each word allocated in
+dependent memory, hence mark m/R or sweep s/R words of heap memory for
+each word allocated in dependent memory.
+
+=== Memory held by custom blocks (aka custom memory)
+
+When allocating a custom block the user can declare how much out-of-heap
+memory is held by this block. This is folded into out-of-heap resources
+with a denominator based on caml_custom_major_ratio. This user-provided
+parameter is the overhead in custom memory expressed as a proportion of
+total heap size: custom-garbage / H.
+
+There is a problem: if we have a small heap that commands a large amount
+of custom memory the GC will try hard to reduce the out-of-heap overhead
+to a ridiculously small amount and it will run much too fast.
+
+It would be nice to change it to get the same kind of behavior as
+dependent memory, but there is a difficulty: we don't know the total
+size of custom memory, so we can't compute the R ratio.
+
+A potential solution would be to use the ratio of allocations (between
+custom and heap) maybe averaged over a few GC cycles to smooth out any
+spikes. This is not done in this PR and for the moment we leave
+untouched the translation of custom allocations to out-of-heap
+resources.
+
+sources: Stephen Dolan https://gist.github.com/stedolan/52c13d6b1a30276db31ca98683c8db16
+and Damien Doligez https://github.com/ocaml/ocaml/pull/10418#issue-647624718

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -269,7 +269,7 @@ typedef uint64_t uintnat;
 /* Default allocation policy. */
 #define Allocation_policy_def caml_policy_best_fit
 
-/* Ratio of marking work to sweeping work. */
-#define Mark_to_sweep_ratio 0.33
+/* Ratio of marking work to sweeping work (in units of 1/1000). */
+#define Mark_to_sweep_ratio_def 333
 
 #endif /* CAML_CONFIG_H */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -269,4 +269,7 @@ typedef uint64_t uintnat;
 /* Default allocation policy. */
 #define Allocation_policy_def caml_policy_best_fit
 
+/* Ratio of marking work to sweeping work. */
+#define Mark_to_sweep_ratio 0.33
+
 #endif /* CAML_CONFIG_H */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -96,7 +96,7 @@ void caml_shrink_mark_stack ();
 void major_collection (void);
 void caml_finish_major_cycle (void);
 void caml_set_major_window (int);
-void set_caml_percent_free (uintnat);
+void caml_set_percent_free (uintnat);
 
 /* Forces finalisation of all heap-allocated values,
    disregarding both local and global roots.

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -49,7 +49,6 @@ extern int caml_gc_subphase;
 extern uintnat caml_allocated_words;
 extern double caml_extra_heap_resources;
 extern uintnat caml_dependent_size, caml_dependent_allocated;
-extern uintnat caml_fl_wsz_at_phase_change;
 extern int caml_ephe_list_pure;
 
 #define Phase_mark 0

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -79,6 +79,7 @@ extern double caml_major_ring[Max_major_window];
 extern int caml_major_ring_index;
 extern double caml_major_work_credit;
 extern double caml_gc_clock;
+extern uintnat caml_mark_to_sweep_ratio;
 
 /* [caml_major_gc_hook] is called just between the end of the mark
    phase and the beginning of the sweep phase of the major GC.

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -96,6 +96,7 @@ void caml_shrink_mark_stack ();
 void major_collection (void);
 void caml_finish_major_cycle (void);
 void caml_set_major_window (int);
+void set_caml_percent_free (uintnat);
 
 /* Forces finalisation of all heap-allocated values,
    disregarding both local and global roots.

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -361,7 +361,7 @@ CAMLprim value caml_gc_get(value v)
   CAMLparam0 ();   /* v is ignored */
   CAMLlocal1 (res);
 
-  res = caml_alloc_tuple (11);
+  res = caml_alloc_tuple (12);
   Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));          /* s */
   Store_field (res, 1, Val_long (caml_major_heap_increment));           /* i */
   Store_field (res, 2, Val_long (caml_percent_free));                   /* o */
@@ -377,6 +377,7 @@ CAMLprim value caml_gc_get(value v)
   Store_field (res, 8, Val_long (caml_custom_major_ratio));             /* M */
   Store_field (res, 9, Val_long (caml_custom_minor_ratio));             /* m */
   Store_field (res, 10, Val_long (caml_custom_minor_max_bsz));          /* n */
+  Store_field (res, 11, Val_long (caml_mark_to_sweep_ratio));           /* r */
   CAMLreturn (res);
 }
 
@@ -421,6 +422,11 @@ static uintnat norm_custom_min (uintnat p)
   return Max (p, 1);
 }
 
+static uintnat norm_mark_to_sweep_ratio (uintnat r)
+{
+  return Max (r, 1);
+}
+
 CAMLprim value caml_gc_set(value v)
 {
   uintnat newpf, newpm;
@@ -428,6 +434,7 @@ CAMLprim value caml_gc_set(value v)
   asize_t newminwsz;
   uintnat newpolicy;
   uintnat new_custom_maj, new_custom_min, new_custom_sz;
+  uintnat new_mark_to_sweep_ratio;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_SET);
 
   caml_verb_gc = Long_val (Field (v, 3));
@@ -496,6 +503,17 @@ CAMLprim value caml_gc_set(value v)
       caml_gc_message (0x20, "New custom minor size limit: %"
                        ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                        caml_custom_minor_max_bsz);
+    }
+  }
+
+  /* This field was added in 4.14.0 */
+  if (Wosize_val (v) >= 12){
+    new_mark_to_sweep_ratio = norm_mark_to_sweep_ratio(Long_val(Field(v,11)));
+    if (new_mark_to_sweep_ratio != caml_mark_to_sweep_ratio){
+      caml_mark_to_sweep_ratio = new_mark_to_sweep_ratio;
+      caml_gc_message (0x20, "New mark-to-sweep ratio: %"
+                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                       caml_mark_to_sweep_ratio);
     }
   }
 

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -438,7 +438,7 @@ CAMLprim value caml_gc_set(value v)
 
   newpf = norm_pfree (Long_val (Field (v, 2)));
   if (newpf != caml_percent_free){
-    set_caml_percent_free (newpf);
+    caml_set_percent_free (newpf);
     caml_gc_message (0x20, "New space overhead: %"
                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_percent_free);
   }
@@ -691,7 +691,7 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
   }
   caml_set_minor_heap_size (Bsize_wsize (norm_minsize (minor_size)));
   caml_major_heap_increment = major_incr;
-  set_caml_percent_free (norm_pfree (percent_fr));
+  caml_set_percent_free (norm_pfree (percent_fr));
   caml_percent_max = norm_pmax (percent_m);
   caml_set_allocation_policy (policy);
   caml_init_major_heap (major_bsize);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -438,7 +438,7 @@ CAMLprim value caml_gc_set(value v)
 
   newpf = norm_pfree (Long_val (Field (v, 2)));
   if (newpf != caml_percent_free){
-    caml_percent_free = newpf;
+    set_caml_percent_free (newpf);
     caml_gc_message (0x20, "New space overhead: %"
                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_percent_free);
   }
@@ -691,7 +691,7 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
   }
   caml_set_minor_heap_size (Bsize_wsize (norm_minsize (minor_size)));
   caml_major_heap_increment = major_incr;
-  caml_percent_free = norm_pfree (percent_fr);
+  set_caml_percent_free (norm_pfree (percent_fr));
   caml_percent_max = norm_pmax (percent_m);
   caml_set_allocation_policy (policy);
   caml_init_major_heap (major_bsize);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -925,7 +925,7 @@ static void sweep_slice (intnat work)
   caml_gc_sweep_hp = sweep_hp;
 }
 
-void set_caml_percent_free (uintnat pf)
+void caml_set_percent_free (uintnat pf)
 {
   double o, lambda, s, m;
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -927,11 +927,13 @@ static void sweep_slice (intnat work)
 
 void set_caml_percent_free (uintnat pf)
 {
+  double o, lambda, s, m;
+
   caml_percent_free = pf;
-  double o = caml_percent_free / 100.;
-  double lambda = Mark_to_sweep_ratio;
-  double s = 1 + (1 + 2 / lambda) / o;
-  double m = lambda * s;
+  o = caml_percent_free / 100.;
+  lambda = Mark_to_sweep_ratio;
+  s = 1 + (1 + 2 / lambda) / o;
+  m = lambda * s;
   s_factor = s;
   m_factor = m;
   ooh_ratio = 1/(o+1)/m + 1/s;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -61,7 +61,6 @@ int caml_gc_phase;        /* always Phase_mark, Pase_clean,
 uintnat caml_allocated_words;
 uintnat caml_dependent_size, caml_dependent_allocated;
 double caml_extra_heap_resources;
-uintnat caml_fl_wsz_at_phase_change = 0;
 
 extern value caml_fl_merge;  /* Defined in freelist.c. */
 
@@ -427,7 +426,6 @@ static void init_sweep_phase(void)
   caml_gc_phase = Phase_sweep;
   sweep_chunk = caml_heap_start;
   caml_gc_sweep_hp = sweep_chunk;
-  caml_fl_wsz_at_phase_change = caml_fl_cur_wsz;
   if (caml_major_gc_hook) (*caml_major_gc_hook)();
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -53,6 +53,7 @@ struct mark_stack {
 uintnat caml_percent_free;
 static uintnat marked_words = 1000, prev_marked_words, heap_wsz_at_cycle_start;
 static double s_factor, m_factor, ooh_ratio;
+uintnat caml_mark_to_sweep_ratio = Mark_to_sweep_ratio_def;
 uintnat caml_major_heap_increment;
 CAMLexport char *caml_heap_start;
 char *caml_gc_sweep_hp;
@@ -929,13 +930,15 @@ void caml_set_percent_free (uintnat pf)
   double o, lambda, s, m;
 
   caml_percent_free = pf;
+  lambda = caml_mark_to_sweep_ratio / 1000.;
   o = caml_percent_free / 100.;
-  lambda = Mark_to_sweep_ratio;
   s = 1 + (1 + 2 / lambda) / o;
   m = lambda * s;
   s_factor = s;
   m_factor = m;
   ooh_ratio = 1/m + (1+o)/s;
+  caml_gc_message (0x40, "parameters for GC pacing: m=%.3f, s=%.3f\n",
+                   m_factor, s_factor);
 }
 
 /* The main entry point for the major GC. Called about once for each

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -123,6 +123,7 @@ void caml_parse_ocamlrunparam(void)
       case 'o': scanmult (opt, &caml_init_percent_free); break;
       case 'O': scanmult (opt, &caml_init_max_percent_free); break;
       case 'p': scanmult (opt, &p); caml_parser_trace = (p != 0); break;
+      case 'r': scanmult (opt, &caml_mark_to_sweep_ratio); break;
       case 'R': break; /*  see stdlib/hashtbl.mli */
       case 's': scanmult (opt, &caml_init_minor_heap_wsz); break;
       case 't': scanmult (opt, &caml_trace_level); break;

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -46,6 +46,7 @@ type control = {
   custom_major_ratio : int;
   custom_minor_ratio : int;
   custom_minor_max_size : int;
+  mark_to_sweep_ratio : int;
 }
 
 external stat : unit -> stat = "caml_gc_stat"

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -237,6 +237,15 @@ type control =
         [caml_alloc_custom_mem] (e.g. bigarrays).
         Default: 8192 bytes.
         @since 4.08.0 *)
+
+    mark_to_sweep_ratio : int;
+    (** How much marking work each mark slice will do when sweep slices
+        do 1000 units of sweeping work. Because one unit of marking work
+        usually takes more time than one unit of sweeping work, this
+        parameter can be used to balance the latencies of the mark slices
+        and the sweep slices.
+        Default: 333.
+        @since 4.14.0 *)
   }
 (** The GC parameters are given as a [control] record.  Note that
     these parameters can also be initialised by setting the

--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -37,4 +37,3 @@ let _ =
   assert (g2.custom_minor_max_size = g1.custom_minor_max_size);
   assert (g2.mark_to_sweep_ratio = g1.mark_to_sweep_ratio);
   ()
-

--- a/testsuite/tests/regression/pr9326/gc_set.ml
+++ b/testsuite/tests/regression/pr9326/gc_set.ml
@@ -20,7 +20,9 @@ let _ =
            window_size = g1.window_size;
            custom_major_ratio = g1.custom_major_ratio;
            custom_minor_ratio = g1.custom_minor_ratio;
-           custom_minor_max_size = g1.custom_minor_max_size };
+           custom_minor_max_size = g1.custom_minor_max_size;
+           mark_to_sweep_ratio = g1.mark_to_sweep_ratio;
+         };
   let g2 = Gc.get() in
   assert (g2.minor_heap_size = min_heap_sz);
   assert (g2.major_heap_increment = maj_heap_inc);
@@ -32,4 +34,7 @@ let _ =
   assert (g2.window_size = g1.window_size);
   assert (g2.custom_major_ratio = g1.custom_major_ratio);
   assert (g2.custom_minor_ratio = g1.custom_minor_ratio);
-  assert (g2.custom_minor_max_size = g1.custom_minor_max_size)
+  assert (g2.custom_minor_max_size = g1.custom_minor_max_size);
+  assert (g2.mark_to_sweep_ratio = g1.mark_to_sweep_ratio);
+  ()
+


### PR DESCRIPTION
# Introduction

Our starting point is Stephen Dolan's very well-written analysis of how the GC currently computes its slice size and how this computation can be simplified: [[1]](https://gist.github.com/stedolan/52c13d6b1a30276db31ca98683c8db16). Please read it before continuing with this PR.

We want to simplify the GC pacing code by using Dolan's formulas, but we still need to figure out how to deal with "out-of-heap resources", "custom memory" and "dependent memory" because we need to take them into account to compute the GC slice size.


# How to deal with "out-of-heap resources" and "dependent memory"

First of all, these are counted independently from the main heap, and according to the spec, their only effect should be to speed up the GC when these non-heap resources are allocated "too fast" with respect to heap memory.

So we should compute a work amount for each (as we do for the heap) and then take the max of the three numbers.


## Out-of-heap resources:

For each slice we get a number p between 0 and 1, and we promise to do (approximately) one GC cycle whenever the cumulated p values reach 1. If we call A the total size of the heap allocations in one GC cycle, and take p as equivalent to allocating Ap words in the heap, we will reach this target.

We still need to figure out A from Dolan's m and s parameters. Assuming steady-state, this is simply
```
A = L/m + (L + Lg + L/m)/s
```
where L is the amount of live data; assuming steady state, this is equal to both 1/(o+1) of the heap size and the amount of data marked in the previous GC cycle.
g is given by [[1]](https://gist.github.com/stedolan/52c13d6b1a30276db31ca98683c8db16):
```
g = o - 1/m
```

The "equivalent allocations" E is then:
```
E = L (1/m + (1+o)/s) p
  = H (1/(o+1)m + 1/s) p
```
and we will mark at least Em or sweep at least Es words.

## Dependent Memory

When the GC slice runs, we have two pieces of information:
1. How much dependent memory is currently used (live + garbage) [C]
2. How much dependent memory was allocated since the previous slice [a]

Let us call H the total heap size.

We can compute R, the ratio of dependent memory to heap size, and note that marking w words on the heap will "mark" (on average) wR words of dependent memory, and similarly for sweeping.
```
R = C / H
```

The overhead parameter o is also used for dependent memory, so we can use the same m and s parameters that we use for the heap. We should then mark m or sweep s words of dependent memory for each word allocated in dependent memory, hence mark m/R or sweep s/R words of heap memory for each word allocated in dependent memory.


# Memory held by custom blocks (aka custom memory)

When allocating a custom block the user can declare how much out-of-heap memory is held by this block. This is folded into out-of-heap resources with a denominator based on caml_custom_major_ratio. This user-provided parameter is the overhead in custom memory expressed as a proportion of total heap size: custom-garbage / H.

There is a problem: if we have a small heap that commands a large amount of custom memory the GC will try hard to reduce the out-of-heap overhead to a ridiculously small amount and it will run much too fast.

It would be nice to change it to get the same kind of behavior as dependent memory, but there is a difficulty: we don't know the total size of custom memory, so we can't compute the R ratio.

A potential solution would be to use the ratio of allocations (between custom and heap) maybe averaged over a few GC cycles to smooth out any spikes. This is not done in this PR and for the moment we leave untouched the translation of custom allocations to out-of-heap resources.

# To do
- [x] Find a good value for the mark-to-sweep ratio
