### PR TITLE
More precise warning 51 about tail calls

### DIFF
--- a/.depend
+++ b/.depend
@@ -6037,6 +6037,7 @@ driver/optmaindriver.cmo : \
     driver/makedepend.cmi \
     driver/main_args.cmi \
     parsing/location.cmi \
+    lambda/lambda.cmi \
     middle_end/flambda/import_approx.cmi \
     utils/config.cmi \
     driver/compmisc.cmi \
@@ -6057,6 +6058,7 @@ driver/optmaindriver.cmx : \
     driver/makedepend.cmx \
     driver/main_args.cmx \
     parsing/location.cmx \
+    lambda/lambda.cmx \
     middle_end/flambda/import_approx.cmx \
     utils/config.cmx \
     driver/compmisc.cmx \

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -155,17 +155,17 @@ let incoming ofs = Incoming ofs
 let outgoing ofs = Outgoing ofs
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
-let max_arguments_for_tailcalls = 8
+let max_arguments_for_tailcalls = 16
 
 let loc_arguments arg =
-    calling_conventions 0 7 100 112 outgoing arg
+    calling_conventions 0 15 100 112 outgoing arg
 
 let loc_parameters arg =
-  let (loc, _ofs) = calling_conventions 0 7 100 112 incoming arg
+  let (loc, _ofs) = calling_conventions 0 15 100 112 incoming arg
   in loc
 
 let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 7 100 112 not_supported res
+  let (loc, _ofs) = calling_conventions 0 15 100 112 not_supported res
   in loc
 
 (* C calling conventions for ELF32:

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -128,14 +128,14 @@ let incoming ofs = Incoming ofs
 let outgoing ofs = Outgoing ofs
 let not_supported _ofs = fatal_error "Proc.loc_results: cannot call"
 
-let max_arguments_for_tailcalls = 5
+let max_arguments_for_tailcalls = 8
 
 let loc_arguments arg =
-  calling_conventions 0 4 100 103 outgoing 0 arg
+  calling_conventions 0 7 100 103 outgoing 0 arg
 let loc_parameters arg =
-  let (loc, _ofs) = calling_conventions 0 4 100 103 incoming 0 arg in loc
+  let (loc, _ofs) = calling_conventions 0 7 100 103 incoming 0 arg in loc
 let loc_results res =
-  let (loc, _ofs) = calling_conventions 0 4 100 103 not_supported 0 res in loc
+  let (loc, _ofs) = calling_conventions 0 7 100 103 not_supported 0 res in loc
 
 (*   C calling conventions under SVR4:
      use GPR 2-6 and FPR 0,2,4,6 just like ML calling conventions.

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -37,6 +37,7 @@ let backend = (module Backend : Backend_intf.S)
 module Options = Main_args.Make_optcomp_options (Main_args.Default.Optmain)
 let main argv ppf =
   native_code := true;
+  Lambda.set_num_parameter_regs Proc.max_arguments_for_tailcalls;
   let program = "ocamlopt" in
   match
     Compenv.readenv ppf Before_args;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -970,5 +970,18 @@ let max_arity () =
   (* 126 = 127 (the maximal number of parameters supported in C--)
            - 1 (the hidden parameter containing the environment) *)
 
+let num_param_regs = ref 0
+
+let set_num_parameter_regs n =
+  assert (n > 0); num_param_regs := n
+
+let max_arguments_for_tailcalls () =
+  if !Clflags.native_code then begin
+    let n = !num_param_regs in
+    assert (n > 0); n - 1
+    (* -1 for the hidden parameter containing the environment *)
+  end else
+    max_int
+
 let reset () =
   raise_count := 0

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -434,6 +434,16 @@ val max_arity : unit -> int
       This is unlimited ([max_int]) for bytecode, but limited
       (currently to 126) for native code. *)
 
+val max_arguments_for_tailcalls : unit -> int
+  (** Maximal number of arguments for a tail call.
+      This is unlimited ([max_int]) for bytecode, but limited
+      by the number of registers available for parameter passing
+      (minus one) in native code.  If more arguments are provided,
+      the backend can turn the tail call into a normal call. *)
+
+val set_num_parameter_regs : int -> unit
+  (** Record the number of registers available for parameter passing. *)
+
 (***********************)
 (* For static failures *)
 (***********************)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -648,13 +648,6 @@ let rec emit_tail_infos is_tail lambda =
   | Lconst _ -> ()
   | Lapply ap ->
       begin
-        (* Note: is_tail does not take backend-specific logic into
-           account (maximum number of parameters, etc.)  so it may
-           over-approximate tail-callness.
-
-           Trying to do something more fine-grained would result in
-           different warnings depending on whether the native or
-           bytecode compiler is used. *)
         let maybe_warn ~is_tail ~expect_tail =
           if is_tail <> expect_tail then
             Location.prerr_warning (to_location ap.ap_loc)
@@ -662,6 +655,9 @@ let rec emit_tail_infos is_tail lambda =
         match ap.ap_tailcall with
         | Default_tailcall -> ()
         | Tailcall_expectation expect_tail ->
+            let is_tail =
+              is_tail
+              && List.length ap.ap_args <= max_arguments_for_tailcalls () in
             maybe_warn ~is_tail ~expect_tail
       end;
       emit_tail_infos false ap.ap_func;


### PR DESCRIPTION
As reported in #10424, calls annotated with `[@ocaml.tailcall]` can emit no warning, yet be turned into non-tail calls by the ocamlopt back-end, if too many arguments are provided and some of them need to be passed on stack.

This PR takes into account the number of registers available for argument passing, warning about a potential non-tail call if the number of arguments exceeds the number of registers minus 1.  (Minus one for the implicit environment argument.)
     
The warning is conservative but not exact.  Here are two false alarms:
- Tail calls to self are always correctly implemented by the back-end (as a jump to the function entry point).  It's only tail calls to other functions or to unknown functions that cause problems.
- If the function called does not need the "self" environment parameter one more register is available for passing normal parameters.

The text of the warning is rather bad and could use an @Octachron touch.

In passing, this PR also increases the number of registers used for parameter passing on zSystems/s390x (from 5 to 8) and on POWER (from 8 to 16).
