### PR TITLE
Make build_other_constrs work with names instead of tags.

### DIFF
--- a/Changes
+++ b/Changes
@@ -370,6 +370,9 @@ Working version
   (Antal Spector-Zabusky and Mekhrubon Tuarev, review by Leo White,
   Florian Angeletti, and Jacques Garrigue)
 
+- #10307: Make build_other_constrs work with names instead of tags.
+  (Nicolas Chataing, review by Florian Angeletti)
+
 ### Build system:
 
 - #10289, #10406: Do not print option documentation in usage messages.

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2589,13 +2589,13 @@ let rec list_as_pat = function
 
 let complete_pats_constrs = function
   | constr :: _ as constrs ->
-      let name_of_constr constr =
-        constr.pat_desc.cstr_name in
+      let constr_of_pat cstr_pat =
+        cstr_pat.pat_desc in
       let pat_of_constr cstr =
         let open Patterns.Head in
         to_omega_pattern { constr with pat_desc = Construct cstr } in
       List.map pat_of_constr
-        (complete_constrs constr (List.map name_of_constr constrs))
+        (complete_constrs constr (List.map constr_of_pat constrs))
   | _ -> assert false
 
 (*

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2589,13 +2589,13 @@ let rec list_as_pat = function
 
 let complete_pats_constrs = function
   | constr :: _ as constrs ->
-      let tag_of_constr constr =
-        constr.pat_desc.cstr_tag in
+      let name_of_constr constr =
+        constr.pat_desc.cstr_name in
       let pat_of_constr cstr =
         let open Patterns.Head in
         to_omega_pattern { constr with pat_desc = Construct cstr } in
       List.map pat_of_constr
-        (complete_constrs constr (List.map tag_of_constr constrs))
+        (complete_constrs constr (List.map name_of_constr constrs))
   | _ -> assert false
 
 (*

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -862,14 +862,14 @@ module ConstructorSet = Set.Make(struct
   let compare c1 c2 = String.compare c1.cstr_name c2.cstr_name
 end)
 
-(* Sends back a pattern that complements the given constructors all_constrs *)
-let complete_constrs constr all_constrs =
+(* Sends back a pattern that complements the given constructors used_constrs *)
+let complete_constrs constr used_constrs =
   let c = constr.pat_desc in
   let constrs = get_variant_constructors constr.pat_env c.cstr_res in
-  let all_constrs = ConstructorSet.of_list all_constrs in
+  let used_constrs = ConstructorSet.of_list used_constrs in
   let others =
     List.filter
-      (fun cnstr -> not (ConstructorSet.mem cnstr all_constrs))
+      (fun cnstr -> not (ConstructorSet.mem cnstr used_constrs))
       constrs in
   (* Split constructors to put constant ones first *)
   let const, nonconst =
@@ -887,8 +887,8 @@ let build_other_constrs env p =
           match q.pat_desc with
           | Construct c -> c
           | _ -> fatal_error "Parmatch.get_constr" in
-        let all_names =  List.map (fun (p,_) -> get_constr p) env in
-        pat_of_constrs p (complete_constrs constr all_names)
+        let used_constrs =  List.map (fun (p,_) -> get_constr p) env in
+        pat_of_constrs p (complete_constrs constr used_constrs)
   | _ -> extra_pat
 
 (* Auxiliary for build_other *)

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -862,7 +862,7 @@ module ConstructorSet = Set.Make(struct
   let compare c1 c2 = String.compare c1.cstr_name c2.cstr_name
 end)
 
-(* Sends back a pattern that complements constructor names all_names *)
+(* Sends back a pattern that complements the given constructors all_constrs *)
 let complete_constrs constr all_constrs =
   let c = constr.pat_desc in
   let constrs = get_variant_constructors constr.pat_env c.cstr_res in
@@ -871,6 +871,7 @@ let complete_constrs constr all_constrs =
     List.filter
       (fun cnstr -> not (ConstructorSet.mem cnstr all_constrs))
       constrs in
+  (* Split constructors to put constant ones first *)
   let const, nonconst =
     List.partition (fun cnstr -> cnstr.cstr_arity = 0) others in
   const @ nonconst

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -68,7 +68,7 @@ val set_args_erase_mutable : pattern -> pattern list -> pattern list
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :
     constructor_description pattern_data ->
-    string list ->
+    constructor_description list ->
     constructor_description list
 
 (** [ppat_of_type] builds an untyped pattern from its expected type,

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -68,7 +68,7 @@ val set_args_erase_mutable : pattern -> pattern list -> pattern list
 val pat_of_constr : pattern -> constructor_description -> pattern
 val complete_constrs :
     constructor_description pattern_data ->
-    constructor_tag list ->
+    string list ->
     constructor_description list
 
 (** [ppat_of_type] builds an untyped pattern from its expected type,


### PR DESCRIPTION
Using tags is fragile in presence of Cstr_unboxed. This PR differentiates constructors using name instead.