### PR TITLE
Add missing `Format.pp_print_bytes` function.

### DIFF
--- a/Changes
+++ b/Changes
@@ -195,6 +195,9 @@ Working version
 - #10389, #10391, #10392: Add {Int,Int32,Int64,Nativeint}.{min,max}.
   (Nicolás Ojeda Bär and Alain Frisch, review by Xavier Leroy)
 
+- #10430: Add Format.print_bytes and Format.pp_print_bytes.
+  (Gabriel Radanne, review by Gabriel Scherer and David Allsopp)
+
 ### Other libraries:
 
 - #10047: Add `Unix.realpath`

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -278,6 +278,7 @@ stdlib__Format.cmo : format.ml \
     stdlib__Either.cmi \
     camlinternalFormatBasics.cmi \
     camlinternalFormat.cmi \
+    stdlib__Bytes.cmi \
     stdlib__Buffer.cmi \
     stdlib__Format.cmi
 stdlib__Format.cmx : format.ml \
@@ -291,6 +292,7 @@ stdlib__Format.cmx : format.ml \
     stdlib__Either.cmx \
     camlinternalFormatBasics.cmx \
     camlinternalFormat.cmx \
+    stdlib__Bytes.cmx \
     stdlib__Buffer.cmx \
     stdlib__Format.cmi
 stdlib__Format.cmi : format.mli \

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -636,6 +636,8 @@ let pp_print_as state isize s =
 let pp_print_string state s =
   pp_print_as state (String.length s) s
 
+let pp_print_bytes state s =
+  pp_print_as state (Bytes.length s) (Bytes.to_string s)
 
 (* To format an integer. *)
 let pp_print_int state i = pp_print_string state (Int.to_string i)
@@ -1114,6 +1116,7 @@ and open_stag = pp_open_stag std_formatter
 and close_stag = pp_close_stag std_formatter
 and print_as = pp_print_as std_formatter
 and print_string = pp_print_string std_formatter
+and print_bytes = pp_print_bytes std_formatter
 and print_int = pp_print_int std_formatter
 and print_float = pp_print_float std_formatter
 and print_char = pp_print_char std_formatter

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -221,6 +221,12 @@ val pp_print_string : formatter -> string -> unit
 val print_string : string -> unit
 (** [pp_print_string ppf s] prints [s] in the current pretty-printing box. *)
 
+val pp_print_bytes : formatter -> bytes -> unit
+val print_bytes : bytes -> unit
+(** [pp_print_bytes ppf b] prints [b] in the current pretty-printing box.
+    @since 4.13.0
+*)
+
 val pp_print_as : formatter -> int -> string -> unit
 val print_as : int -> string -> unit
 (** [pp_print_as ppf len s] prints [s] in the current pretty-printing box.


### PR DESCRIPTION
I was quite surprised to see that there was no function to print bytes using Format ... so here it is. 

Using `Bytes.to_string` seems best here, since we could have a delay between passing the bytes to Format and actually printing, so the lifetime situation is not clear enough to allow us to use `Bytes.unsafe_to_string`. People who are looking for high throughput output and want to eschew a copy can roll the unsafe version themselves (and are probably using bigstrings instead already anyway).