### PR TITLE
asmcomp/dune: fix build on RISC-V

### DIFF
--- a/asmcomp/dune
+++ b/asmcomp/dune
@@ -21,6 +21,7 @@
           (glob_files arm64/*.ml)
           (glob_files i386/*.ml)
           (glob_files power/*.ml)
+          (glob_files riscv/*.ml)
           (glob_files s390x/*.ml))
  (action  (bash "cp `grep '^ARCH=' %{conf} | cut -d'=' -f2`/*.ml .")))
 
@@ -33,6 +34,7 @@
           arm64/emit.mlp
           i386/emit.mlp
           power/emit.mlp
+          riscv/emit.mlp
           s390x/emit.mlp)
  (action
    (progn


### PR DESCRIPTION
dune build @libs was failing with
```
        bash asmcomp/CSE.ml,asmcomp/arch.ml,asmcomp/proc.ml,asmcomp/reload.ml,asmcomp/scheduling.ml,asmcomp/selection.ml (exit 1)
(cd _build/default/asmcomp && /bin/bash -e -u -o pipefail -c 'cp `grep '\''^ARCH='\'' ../Makefile.config | cut -d'\''='\'' -f2`/*.ml .')
cp: cannot stat 'riscv/*.ml': No such file or directory
        bash asmcomp/contains-input-name,asmcomp/emit.ml (exit 1)
(cd _build/default/asmcomp && /bin/bash -e -u -o pipefail -c '../tools/cvt_emit.exe < `cat contains-input-name`') > _build/default/asmcomp/emit.ml
/bin/bash: line 1: riscv/emit.mlp: No such file or directory
```

This doesn't affect the main build, just the use of `merlin`/`ocaml-lsp`