### PR TITLE
fix work accounting in marking phase

### DIFF
--- a/Changes
+++ b/Changes
@@ -582,6 +582,9 @@ OCaml 4.13.0
 - #10376: Link runtime libraries correctly on msvc64 in -output-complete-obj
   (David Allsopp, review by Gabriel Scherer)
 
+- #xxx: Fix major GC work accounting (the GC was running too fast).
+  (Damien Doligez, report by Stephen Dolan, review by xxx)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -463,7 +463,7 @@ Caml_inline void mark_slice_darken(struct mark_stack* stk, value v, mlsize_t i,
       if( Tag_hd(chd) < No_scan_tag ) {
         mark_stack_push(stk, child, 0, work);
       } else {
-        *work -= 1; /* Account for header */
+        *work -= Whsize_hd (chd);
       }
     }
   }


### PR DESCRIPTION
This is a follow-up to https://github.com/ocaml/ocaml/pull/10195#issuecomment-823270816 and https://github.com/ocaml/ocaml/pull/10195#issuecomment-826855394.

The way `work` is counted in the mark phase has been wrong since 4.12 (#9756). For no-scan blocks, it was counting only the header, when it was supposed to count the whole block.

The number of major collections shows that the fix is working (and I checked that it matches the pre-4.12 behavior):
![image](https://user-images.githubusercontent.com/19104/121328451-a03fd980-c914-11eb-8ff2-e2081b7f434b.png)

The run-time show a lot of variance, with a slight advantage to the fixed version:
![image](https://user-images.githubusercontent.com/19104/121328701-d67d5900-c914-11eb-94d6-57a908df3924.png)

And of course the heap size gets larger in some cases:
![image](https://user-images.githubusercontent.com/19104/121328812-f280fa80-c914-11eb-8da3-6c72945bed69.png)

This fix should be cherry-picked to 4.12 and 4.13. Not sure what to do with `Changes`, as there is no section for 4.12.1.
