### PR TITLE
Propagate more information on blocks

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -391,9 +391,9 @@ let comp_primitive p args =
   | Pcompare_ints -> Kccall("caml_int_compare", 2)
   | Pcompare_floats -> Kccall("caml_float_compare", 2)
   | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
-  | Pfield (n, _sem) -> Kgetfield n
+  | Pfield ({ index = n; _ }, _sem) -> Kgetfield n
   | Pfield_computed _sem -> Kgetvectitem
-  | Psetfield(n, _ptr, _init) -> Ksetfield n
+  | Psetfield({ index = n; _ }, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem
   | Pfloatfield (n, _sem) -> Kgetfloatfield n
   | Psetfloatfield (n, _init) -> Ksetfloatfield n

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -871,7 +871,8 @@ let rec comp_expr env exp sz cont =
       List.iter
         (fun (n, act) -> act_consts.(n) <- store.act_store () act) sw.sw_consts;
       List.iter
-        (fun (n, act) -> act_blocks.(n) <- store.act_store () act) sw.sw_blocks;
+        (fun ({ sw_tag = tag; sw_size = _; }, act) ->
+          act_blocks.(tag) <- store.act_store () act) sw.sw_blocks;
 (* Compile and label actions *)
       let acts = store.act_get () in
 (*

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -340,6 +340,7 @@ and lambda_switch =
 and lambda_switch_block_key =
   { sw_tag : int;
     sw_size : int;
+    sw_mutability : Asttypes.mutable_flag;
   }
 
 and lambda_event =

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -43,6 +43,20 @@ type field_read_semantics =
   | Reads_agree
   | Reads_vary
 
+type block_size =
+  | Known of int
+  | Unknown
+
+type block_info =
+  { tag : int;
+    size : block_size;
+  }
+
+type field_info =
+  { index : int;
+    block_info : block_info;
+  }
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -52,9 +66,9 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int * field_read_semantics
+  | Pfield of field_info * field_read_semantics
   | Pfield_computed of field_read_semantics
-  | Psetfield of int * immediate_or_pointer * initialization_or_assignment
+  | Psetfield of field_info * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
@@ -650,7 +664,13 @@ let rec transl_address loc = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      Lprim(Pfield (pos, Reads_agree), [transl_address loc addr], loc)
+      let field_info = {
+        index = pos;
+        block_info = { tag = 0; size = Unknown; };
+      }
+      in
+      Lprim(Pfield (field_info, Reads_agree),
+            [transl_address loc addr], loc)
 
 let transl_path find loc env path =
   match find path env with
@@ -976,3 +996,5 @@ let max_arity () =
 
 let reset () =
   raise_count := 0
+
+let module_block_info : block_info = { tag = 0; size = Unknown; }

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -39,6 +39,10 @@ type is_safe =
   | Safe
   | Unsafe
 
+type field_read_semantics =
+  | Reads_agree
+  | Reads_vary
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -48,11 +52,11 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
-  | Pfield_computed
+  | Pfield of int * field_read_semantics
+  | Pfield_computed of field_read_semantics
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
-  | Pfloatfield of int
+  | Pfloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* Force lazy values *)
@@ -193,7 +197,6 @@ let equal_value_kind x y =
   | Pboxedintval bi1, Pboxedintval bi2 -> equal_boxed_integer bi1 bi2
   | Pintval, Pintval -> true
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
-
 
 type structured_constant =
     Const_base of constant
@@ -647,7 +650,7 @@ let rec transl_address loc = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      Lprim(Pfield pos, [transl_address loc addr], loc)
+      Lprim(Pfield (pos, Reads_agree), [transl_address loc addr], loc)
 
 let transl_path find loc env path =
   match find path env with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -317,8 +317,13 @@ and lambda_switch =
   { sw_numconsts: int;
     sw_consts: (int * lambda) list;
     sw_numblocks: int;
-    sw_blocks: (int * lambda) list;
+    sw_blocks: (lambda_switch_block_key * lambda) list;
     sw_failaction : lambda option}
+
+and lambda_switch_block_key =
+  { sw_tag : int;
+    sw_size : int;
+  }
 
 and lambda_event =
   { lev_loc: scoped_location;
@@ -742,7 +747,7 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Lswitch(arg, sw, loc) ->
         Lswitch(subst s l arg,
                 {sw with sw_consts = List.map (subst_case s l) sw.sw_consts;
-                        sw_blocks = List.map (subst_case s l) sw.sw_blocks;
+                        sw_blocks = List.map (subst_block_case s l) sw.sw_blocks;
                         sw_failaction = subst_opt s l sw.sw_failaction; },
                 loc)
     | Lstringswitch (arg,cases,default,loc) ->
@@ -805,6 +810,7 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
   and subst_decl s l (id, exp) = (id, subst s l exp)
   and subst_case s l (key, case) = (key, subst s l case)
   and subst_strcase s l (key, case) = (key, subst s l case)
+  and subst_block_case s l (key, case) = (key, subst s l case)
   and subst_opt s l = function
     | None -> None
     | Some e -> Some (subst s l e)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -998,3 +998,19 @@ let reset () =
   raise_count := 0
 
 let module_block_info : block_info = { tag = 0; size = Unknown; }
+
+let mod_field ?(read_semantics=Reads_agree) pos =
+  (* Note: In some occasions, size is actually available, but in general
+     coercions can reuse blocks if the indices are compatible, so the size is
+     only a minimal guaranteed size and may not reflect the actual block size.
+  *)
+  Pfield (
+    { index = pos;
+      block_info = module_block_info;
+    }, read_semantics)
+
+let mod_setfield pos =
+  Psetfield (
+    { index = pos;
+      block_info = module_block_info;
+    }, Pointer, Root_initialization)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -331,6 +331,7 @@ and lambda_switch =
 and lambda_switch_block_key =
   { sw_tag : int;
     sw_size : int;
+    sw_mutability : Asttypes.mutable_flag;
   }
 
 and lambda_event =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -46,8 +46,8 @@ type is_safe =
   | Unsafe
 
 type field_read_semantics =
-  | Reads_agree
-  | Reads_vary
+  | Reads_agree    (** Immutable read *)
+  | Reads_vary     (** Mutable read *)
 
 type block_size =
   | Known of int

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -49,6 +49,20 @@ type field_read_semantics =
   | Reads_agree
   | Reads_vary
 
+type block_size =
+  | Known of int
+  | Unknown
+
+type block_info =
+  { tag : int;
+    size : block_size;
+  }
+
+type field_info =
+  { index : int;
+    block_info : block_info;
+  }
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -58,9 +72,9 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int * field_read_semantics
+  | Pfield of field_info * field_read_semantics
   | Pfield_computed of field_read_semantics
-  | Psetfield of int * immediate_or_pointer * initialization_or_assignment
+  | Psetfield of field_info * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
   | Pfloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
@@ -462,3 +476,11 @@ val merge_inline_attributes
   -> inline_attribute option
 
 val reset: unit -> unit
+
+(* Info about module blocks.
+   Size is considered to be unknown in all cases,
+   because coercions can reuse longer but compatible module blocks,
+   so the actual size of a module block may be greater than what its
+   type would suggest.
+*)
+val module_block_info: block_info

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -307,8 +307,14 @@ and lambda_switch =
   { sw_numconsts: int;                  (* Number of integer cases *)
     sw_consts: (int * lambda) list;     (* Integer cases *)
     sw_numblocks: int;                  (* Number of tag block cases *)
-    sw_blocks: (int * lambda) list;     (* Tag block cases *)
+    sw_blocks: (lambda_switch_block_key * lambda) list;  (* Tag block cases *)
     sw_failaction : lambda option}      (* Action to take if failure *)
+
+and lambda_switch_block_key =
+  { sw_tag : int;
+    sw_size : int;
+  }
+
 and lambda_event =
   { lev_loc: scoped_location;
     lev_kind: lambda_event_kind;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -477,10 +477,13 @@ val merge_inline_attributes
 
 val reset: unit -> unit
 
-(* Info about module blocks.
+(** Helpers for module block accesses.
    Size is considered to be unknown in all cases,
    because coercions can reuse longer but compatible module blocks,
    so the actual size of a module block may be greater than what its
    type would suggest.
+   Module accesses are always immutable, except in translobj where the
+   method cache is stored in a mutable module field.
 *)
-val module_block_info: block_info
+val mod_field: ?read_semantics: field_read_semantics -> int -> primitive
+val mod_setfield: int -> primitive

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -45,6 +45,10 @@ type is_safe =
   | Safe
   | Unsafe
 
+type field_read_semantics =
+  | Reads_agree
+  | Reads_vary
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -54,11 +58,11 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
-  | Pfield_computed
+  | Pfield of int * field_read_semantics
+  | Pfield_computed of field_read_semantics
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
-  | Pfloatfield of int
+  | Pfloatfield of int * field_read_semantics
   | Psetfloatfield of int * initialization_or_assignment
   | Pduprecord of Types.record_representation * int
   (* External call *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1770,7 +1770,7 @@ let get_expr_args_constr ~scopes head (arg, _mut) rem =
       if pos > last_pos then
         argl
       else
-        (Lprim (Pfield pos, [ arg ], loc), binding_kind) :: make_args (pos + 1)
+        (Lprim (Pfield (pos, Reads_agree), [ arg ], loc), binding_kind) :: make_args (pos + 1)
     in
     make_args first_pos
   in
@@ -1798,7 +1798,9 @@ let get_expr_args_variant_constant = drop_expr_arg
 
 let get_expr_args_variant_nonconst ~scopes head (arg, _mut) rem =
   let loc = head_loc ~scopes head in
-  (Lprim (Pfield 1, [ arg ], loc), Alias) :: rem
+   (* CR mshinwell: Is this correct? *)
+   let sem = Reads_agree in
+  (Lprim (Pfield (1, sem), [ arg ], loc), Alias) :: rem
 
 let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
   let row = Btype.row_repr row in
@@ -1918,7 +1920,7 @@ let inline_lazy_force_cond arg loc =
                 ( Pintcomp Ceq,
                   [ tag_var; Lconst (Const_base (Const_int Obj.forward_tag)) ],
                   loc ),
-              Lprim (Pfield 0, [ varg ], loc),
+              Lprim (Pfield (0, Reads_vary), [ varg ], loc),
               Lifthenelse
                 (* if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
                 ( Lprim
@@ -1957,7 +1959,7 @@ let inline_lazy_force_switch arg loc =
                 sw_blocks =
                   [ ({ sw_tag = Obj.forward_tag;
                        sw_size = 1;
-                      }, Lprim (Pfield 0, [ varg ], loc));
+                      }, Lprim (Pfield (0, Reads_vary), [ varg ], loc));
                     ({ sw_tag = Obj.lazy_tag;
                        sw_size = 1;
                      }, Lapply
@@ -2020,7 +2022,7 @@ let get_expr_args_tuple ~scopes head (arg, _mut) rem =
     if pos >= arity then
       rem
     else
-      (Lprim (Pfield pos, [ arg ], loc), Alias) :: make_args (pos + 1)
+      (Lprim (Pfield (pos, Reads_agree), [ arg ], loc), Alias) :: make_args (pos + 1)
   in
   make_args 0
 
@@ -2060,14 +2062,19 @@ let get_expr_args_record ~scopes head (arg, _mut) rem =
       rem
     else
       let lbl = all_labels.(pos) in
+      let sem =
+        match lbl.lbl_mut with
+        | Immutable -> Reads_agree
+        | Mutable -> Reads_vary
+      in
       let access =
         match lbl.lbl_repres with
         | Record_regular
         | Record_inlined _ ->
-            Lprim (Pfield lbl.lbl_pos, [ arg ], loc)
+            Lprim (Pfield (lbl.lbl_pos, sem), [ arg ], loc)
         | Record_unboxed _ -> arg
-        | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
-        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1), [ arg ], loc)
+        | Record_float -> Lprim (Pfloatfield (lbl.lbl_pos, sem), [ arg ], loc)
+        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1, sem), [ arg ], loc)
       in
       let str =
         match lbl.lbl_mut with
@@ -2822,7 +2829,9 @@ let combine_constructor loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
                   nonconsts default
               in
-              Llet (Alias, Pgenval, tag, Lprim (Pfield 0, [ arg ], loc), tests)
+              Llet (Alias, Pgenval, tag,
+                    Lprim (Pfield (0, Reads_agree), [ arg ], loc),
+                    tests)
         in
         List.fold_right
           (fun (path, act) rem ->
@@ -2912,7 +2921,7 @@ let call_switcher_variant_constr loc fail arg int_lambda_list =
     ( Alias,
       Pgenval,
       v,
-      Lprim (Pfield 0, [ arg ], loc),
+      Lprim (Pfield (0, Reads_agree), [ arg ], loc),
       call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -563,9 +563,9 @@ let rec lam ppf = function
            fprintf ppf "@[<hv 1>case int %i:@ %a@]" n lam l)
          sw.sw_consts;
         List.iter
-          (fun (n, l) ->
+          (fun ({ sw_tag = tag; sw_size = _; }, l) ->
             if !spc then fprintf ppf "@ " else spc := true;
-            fprintf ppf "@[<hv 1>case tag %i:@ %a@]" n lam l)
+            fprintf ppf "@[<hv 1>case tag %i:@ %a@]" tag lam l)
           sw.sw_blocks ;
         begin match sw.sw_failaction with
         | None  -> ()

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -161,10 +161,11 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield (n, sem) -> fprintf ppf "field%a %i" field_read_semantics sem n
+  | Pfield ({index = n; block_info = _;}, sem) ->
+      fprintf ppf "field%a %i" field_read_semantics sem n
   | Pfield_computed sem ->
       fprintf ppf "field_computed%a" field_read_semantics sem
-  | Psetfield(n, ptr, init) ->
+  | Psetfield({index = n; block_info = _;}, ptr, init) ->
       let instr =
         match ptr with
         | Pointer -> "ptr"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -146,6 +146,11 @@ let float_comparison ppf = function
   | CFge -> fprintf ppf ">=."
   | CFnge -> fprintf ppf "!>=."
 
+let field_read_semantics ppf sem =
+  match sem with
+  | Reads_agree -> ()
+  | Reads_vary -> fprintf ppf "_mut"
+
 let primitive ppf = function
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
@@ -156,8 +161,9 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield n -> fprintf ppf "field %i" n
-  | Pfield_computed -> fprintf ppf "field_computed"
+  | Pfield (n, sem) -> fprintf ppf "field%a %i" field_read_semantics sem n
+  | Pfield_computed sem ->
+      fprintf ppf "field_computed%a" field_read_semantics sem
   | Psetfield(n, ptr, init) ->
       let instr =
         match ptr with
@@ -184,7 +190,8 @@ let primitive ppf = function
         | Assignment -> ""
       in
       fprintf ppf "setfield_%s%s_computed" instr init
-  | Pfloatfield n -> fprintf ppf "floatfield %i" n
+  | Pfloatfield (n, sem) ->
+      fprintf ppf "floatfield%a %i" field_read_semantics sem n
   | Psetfloatfield (n, init) ->
       let init =
         match init with
@@ -349,7 +356,7 @@ let name_of_primitive = function
   | Psetglobal _ -> "Psetglobal"
   | Pmakeblock _ -> "Pmakeblock"
   | Pfield _ -> "Pfield"
-  | Pfield_computed -> "Pfield_computed"
+  | Pfield_computed _ -> "Pfield_computed"
   | Psetfield _ -> "Psetfield"
   | Psetfield_computed _ -> "Psetfield_computed"
   | Pfloatfield _ -> "Pfloatfield"

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -43,7 +43,7 @@ let rec eliminate_ref id = function
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
   | Lprim(Pfield ({ index = 0; _ }, _), [Lvar v], _) when Ident.same v id ->
-      Lvar id
+      Lmutvar id
   | Lprim(Psetfield({index = 0; _ }, _, _), [Lvar v; e], _)
     when Ident.same v id ->
       Lassign(id, eliminate_ref id e)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -42,7 +42,7 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-  | Lprim(Pfield 0, [Lvar v], _) when Ident.same v id ->
+  | Lprim(Pfield (0, _sem), [Lvar v], _) when Ident.same v id ->
       Lmutvar id
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -656,8 +656,8 @@ let rec emit_tail_infos is_tail lambda =
       list_emit_tail_infos false l
   | Lswitch (lam, sw, _loc) ->
       emit_tail_infos false lam;
-      list_emit_tail_infos_fun snd is_tail sw.sw_consts;
-      list_emit_tail_infos_fun snd is_tail sw.sw_blocks;
+      list_emit_tail_infos_fun0 snd is_tail sw.sw_consts;
+      list_emit_tail_infos_fun1 snd is_tail sw.sw_blocks;
       Option.iter  (emit_tail_infos is_tail) sw.sw_failaction
   | Lstringswitch (lam, sw, d, _) ->
       emit_tail_infos false lam;
@@ -697,7 +697,10 @@ let rec emit_tail_infos is_tail lambda =
       emit_tail_infos is_tail lam
   | Lifused (_, lam) ->
       emit_tail_infos is_tail lam
-and list_emit_tail_infos_fun f is_tail =
+(* CR mshinwell: Why doesn't this generalise when eta expanded? *)
+and list_emit_tail_infos_fun0 f is_tail =
+  List.iter (fun x -> emit_tail_infos is_tail (f x))
+and list_emit_tail_infos_fun1 f is_tail =
   List.iter (fun x -> emit_tail_infos is_tail (f x))
 and list_emit_tail_infos is_tail =
   List.iter (emit_tail_infos is_tail)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -42,9 +42,10 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-  | Lprim(Pfield (0, _sem), [Lvar v], _) when Ident.same v id ->
-      Lmutvar id
-  | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
+  | Lprim(Pfield ({ index = 0; _ }, _), [Lvar v], _) when Ident.same v id ->
+      Lvar id
+  | Lprim(Psetfield({index = 0; _ }, _, _), [Lvar v; e], _)
+    when Ident.same v id ->
       Lassign(id, eliminate_ref id e)
   | Lprim(Poffsetref delta, [Lvar v], loc) when Ident.same v id ->
       Lassign(id, Lprim(Poffsetint delta, [Lmutvar id], loc))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -640,15 +640,10 @@ and transl_exp0 ~in_new_scope ~scopes e =
       | [] when pure = Alias -> transl_exp ~scopes e
       | _ ->
           let oid = Ident.create_local "open" in
-          let field_info pos =
-            { index = pos;
-              block_info = Lambda.module_block_info;
-            }
-          in
           let body, _ =
             List.fold_left (fun (body, pos) id ->
               Llet(Alias, Pgenval, id,
-                   Lprim(Pfield (field_info pos, Reads_agree), [Lvar oid],
+                   Lprim(mod_field pos, [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
             ) (transl_exp ~scopes e, 0)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -350,7 +350,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           Lconst(const_int n)
       | Cstr_unboxed ->
           (match ll with [v] -> v | _ -> assert false)
-      | Cstr_block { tag; size; } ->
+      | Cstr_block { tag; size; mutability = _; } ->
           assert (size = List.length ll);
           begin try
             Lconst(Const_block(tag, List.map extract_constant ll))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -335,11 +335,12 @@ and transl_exp0 ~in_new_scope ~scopes e =
           Lconst(const_int n)
       | Cstr_unboxed ->
           (match ll with [v] -> v | _ -> assert false)
-      | Cstr_block n ->
+      | Cstr_block { tag; size; } ->
+          assert (size = List.length ll);
           begin try
-            Lconst(Const_block(n, List.map extract_constant ll))
+            Lconst(Const_block(tag, List.map extract_constant ll))
           with Not_constant ->
-            Lprim(Pmakeblock(n, Immutable, Some shape), ll,
+            Lprim(Pmakeblock(tag, Immutable, Some shape), ll,
                   of_location ~scopes e.exp_loc)
           end
       | Cstr_extension(path, is_const) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -372,16 +372,21 @@ and transl_exp0 ~in_new_scope ~scopes e =
         fields representation extended_expression
   | Texp_field(arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
+      let sem =
+        match lbl.lbl_mut with
+        | Immutable -> Reads_agree
+        | Mutable -> Reads_vary
+      in
       begin match lbl.lbl_repres with
           Record_regular | Record_inlined _ ->
-          Lprim (Pfield lbl.lbl_pos, [targ],
+          Lprim (Pfield (lbl.lbl_pos, sem), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_unboxed _ -> targ
         | Record_float ->
-          Lprim (Pfloatfield lbl.lbl_pos, [targ],
+          Lprim (Pfloatfield (lbl.lbl_pos, sem), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_extension _ ->
-          Lprim (Pfield (lbl.lbl_pos + 1), [targ],
+          Lprim (Pfield (lbl.lbl_pos + 1, sem), [targ],
                  of_location ~scopes e.exp_loc)
       end
   | Texp_setfield(arg, _, lbl, newval) ->
@@ -481,7 +486,8 @@ and transl_exp0 ~in_new_scope ~scopes e =
       Lapply{
         ap_loc=loc;
         ap_func=
-          Lprim(Pfield 0, [transl_class_path loc e.exp_env cl], loc);
+          Lprim(Pfield (0, Reads_vary),
+              [transl_class_path loc e.exp_env cl], loc);
         ap_args=[lambda_unit];
         ap_tailcall=Default_tailcall;
         ap_inlined=Default_inline;
@@ -491,7 +497,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
       let var = transl_value_path loc e.exp_env path in
-      Lprim(Pfield_computed, [self; var], loc)
+      Lprim(Pfield_computed Reads_vary, [self; var], loc)
   | Texp_setinstvar(path_self, path, _, expr) ->
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
@@ -615,7 +621,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           let body, _ =
             List.fold_left (fun (body, pos) id ->
               Llet(Alias, Pgenval, id,
-                   Lprim(Pfield pos, [Lvar oid],
+                   Lprim(Pfield (pos, Reads_agree), [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
             ) (transl_exp ~scopes e, 0)
@@ -942,16 +948,21 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     let init_id = Ident.create_local "init" in
     let lv =
       Array.mapi
-        (fun i (_, definition) ->
+        (fun i (lbl, definition) ->
            match definition with
            | Kept typ ->
                let field_kind = value_kind env typ in
+               let sem =
+                 match lbl.lbl_mut with
+                 | Immutable -> Reads_agree
+                 | Mutable -> Reads_vary
+               in
                let access =
                  match repres with
-                   Record_regular | Record_inlined _ -> Pfield i
+                   Record_regular | Record_inlined _ -> Pfield (i, sem)
                  | Record_unboxed _ -> assert false
-                 | Record_extension _ -> Pfield (i + 1)
-                 | Record_float -> Pfloatfield i in
+                 | Record_extension _ -> Pfield (i + 1, sem)
+                 | Record_float -> Pfloatfield (i, sem) in
                Lprim(access, [Lvar init_id],
                      of_location ~scopes loc),
                field_kind

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -47,22 +47,6 @@ let cons_opt x_opt xs =
   | None -> xs
   | Some x -> x :: xs
 
-let mod_field pos =
-  (* Note: In some occasions, size is actually available, but in general
-     coercions can reuse blocks if the indices are compatible, so the size is
-     only a minimal guaranteed size and may not reflect the actual block size.
-  *)
-  Pfield (
-    { index = pos;
-      block_info = module_block_info;
-    }, Reads_agree)
-
-let mod_setfield pos =
-  Psetfield (
-    { index = pos;
-      block_info = module_block_info;
-    }, Pointer, Root_initialization)
-
 (* Keep track of the root path (from the root of the namespace to the
    currently compiled module expression).  Useful for naming extensions. *)
 

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -83,7 +83,7 @@ let rec apply_coercion loc strict restr arg =
       name_lambda strict arg (fun id ->
         let get_field pos =
           if pos < 0 then lambda_unit
-          else Lprim(Pfield pos,[Lvar id], loc)
+          else Lprim(Pfield (pos, Reads_agree),[Lvar id], loc)
         in
         let lam =
           Lprim(Pmakeblock(0, Immutable, None),
@@ -718,7 +718,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
                 Llet(Alias, Pgenval, id,
-                     Lprim(Pfield pos, [Lvar mid],
+                     Lprim(Pfield (pos, Reads_agree), [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
           in
@@ -747,7 +747,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
                   Llet(Alias, Pgenval, id,
-                      Lprim(Pfield pos, [Lvar mid],
+                      Lprim(Pfield (pos, Reads_agree), [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
@@ -966,7 +966,7 @@ let transl_store_subst = ref Ident.Map.empty
 
 let nat_toplevel_name id =
   try match Ident.Map.find id !transl_store_subst with
-    | Lprim(Pfield pos, [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
+    | Lprim(Pfield (pos, _), [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
     | _ -> raise Not_found
   with Not_found ->
     fatal_error("Translmod.nat_toplevel_name: " ^ Ident.unique_name id)
@@ -1202,7 +1202,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
+                  Llet(Alias, Pgenval, id, Lprim(Pfield (pos, Reads_agree), [Lvar mid],
                                                  of_location ~scopes loc),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  store_idents (pos + 1) idl))
@@ -1248,8 +1248,9 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
-                                                         loc),
+                          Llet(Alias, Pgenval, id,
+                               Lprim(Pfield (pos, Reads_agree),
+                                     [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
                     in
@@ -1283,7 +1284,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
       match cc with
         Tcoerce_none ->
           Ident.Map.add id
-            (Lprim(Pfield pos,
+            (Lprim(Pfield (pos, Reads_agree),
                    [Lprim(Pgetglobal glob, [], Loc_unknown)],
                    Loc_unknown))
             subst
@@ -1422,7 +1423,7 @@ let toplevel_name id =
 let toploop_getvalue id =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_getvalue_pos,
+    ap_func=Lprim(Pfield (toploop_getvalue_pos, Reads_agree),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
@@ -1435,7 +1436,7 @@ let toploop_getvalue id =
 let toploop_setvalue id lam =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_setvalue_pos,
+    ap_func=Lprim(Pfield (toploop_setvalue_pos, Reads_agree),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=
@@ -1446,7 +1447,7 @@ let toploop_setvalue id lam =
     ap_inlined=Default_inline;
     ap_specialised=Default_specialise;
   }
-
+  
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
@@ -1520,7 +1521,7 @@ let transl_toplevel_item ~scopes item =
           lambda_unit
       | id :: ids ->
           Lsequence(toploop_setvalue id
-                      (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                      (Lprim(Pfield (pos, Reads_agree), [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
       Llet(Strict, Pgenval, mid,
            transl_module ~scopes Tcoerce_none None modl, set_idents 0 ids)
@@ -1543,7 +1544,7 @@ let transl_toplevel_item ~scopes item =
                 lambda_unit
             | id :: ids ->
                 Lsequence(toploop_setvalue id
-                            (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                            (Lprim(Pfield (pos, Reads_agree), [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
           Llet(pure, Pgenval, mid,
@@ -1646,7 +1647,7 @@ let transl_store_package component_names target_name coercion =
                (fun pos _id ->
                  Lprim(Psetfield(pos, Pointer, Root_initialization),
                        [Lprim(Pgetglobal target_name, [], Loc_unknown);
-                        Lprim(Pfield pos, [Lvar blk], Loc_unknown)],
+                        Lprim(Pfield (pos, Reads_agree), [Lvar blk], Loc_unknown)],
                        Loc_unknown))
                0 pos_cc_list))
   (*

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -125,7 +125,12 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield (size, Reads_vary),
+  let field_info = {
+    index = size;
+    block_info = module_block_info;
+  }
+  in
+  method_cache := Lprim(Pfield (field_info, Reads_vary),
                         [Lprim(Pgetglobal glob, [], Loc_unknown)],
                         Loc_unknown);
   let expr = f arg in
@@ -133,7 +138,7 @@ let transl_store_label_init glob size f arg =
     if !method_count = 0 then (size, expr) else
     (size+1,
      Lsequence(
-     Lprim(Psetfield(size, Pointer, Root_initialization),
+     Lprim(Psetfield(field_info, Pointer, Root_initialization),
            [Lprim(Pgetglobal glob, [], Loc_unknown);
             Lprim (Pccall prim_makearray,
                    [int !method_count; int 0],

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -125,7 +125,7 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield size,
+  method_cache := Lprim(Pfield (size, Reads_vary),
                         [Lprim(Pgetglobal glob, [], Loc_unknown)],
                         Loc_unknown);
   let expr = f arg in

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -125,12 +125,7 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  let field_info = {
-    index = size;
-    block_info = module_block_info;
-  }
-  in
-  method_cache := Lprim(Pfield (field_info, Reads_vary),
+  method_cache := Lprim(mod_field ~read_semantics:Reads_vary size,
                         [Lprim(Pgetglobal glob, [], Loc_unknown)],
                         Loc_unknown);
   let expr = f arg in
@@ -138,7 +133,7 @@ let transl_store_label_init glob size f arg =
     if !method_count = 0 then (size, expr) else
     (size+1,
      Lsequence(
-     Lprim(Psetfield(field_info, Pointer, Root_initialization),
+     Lprim(mod_setfield size,
            [Lprim(Pgetglobal glob, [], Loc_unknown);
             Lprim (Pccall prim_makearray,
                    [int !method_count; int 0],

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -113,6 +113,21 @@ let gen_array_kind =
 let prim_sys_argv =
   Primitive.simple ~name:"caml_sys_argv" ~arity:1 ~alloc:true
 
+let field_unknown i =
+  { index = i;
+    block_info = { tag = 0; size = Unknown; };
+  }
+
+let field_ref =
+  { index = 0;
+    block_info = { tag = 0; size = Known 1; };
+  }
+
+let field_pair i =
+  { index = i;
+    block_info = { tag = 0; size = Known 2; };
+  }
+
 let primitives_table =
   create_hashtable 57 [
     "%identity", Identity;
@@ -127,9 +142,12 @@ let primitives_table =
     "%loc_POS", Loc Loc_POS;
     "%loc_MODULE", Loc Loc_MODULE;
     "%loc_FUNCTION", Loc Loc_FUNCTION;
-    "%field0", Primitive ((Pfield (0, Reads_vary)), 1);
-    "%field1", Primitive ((Pfield (1, Reads_vary)), 1);
-    "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
+    "%field0", Primitive ((Pfield (field_unknown 0, Reads_vary)), 1);
+    "%field1", Primitive ((Pfield (field_unknown 1, Reads_vary)), 1);
+    "%ref_field0", Primitive ((Pfield (field_ref, Reads_vary)), 1);
+    "%pair_field0", Primitive ((Pfield (field_pair 0, Reads_agree)), 1);
+    "%pair_field1", Primitive ((Pfield (field_pair 1, Reads_agree)), 1);
+    "%setfield0", Primitive ((Psetfield(field_unknown 0, Pointer, Assignment)), 2);
     "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
     "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
     "%raise", Raise Raise_regular;

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -127,8 +127,8 @@ let primitives_table =
     "%loc_POS", Loc Loc_POS;
     "%loc_MODULE", Loc Loc_MODULE;
     "%loc_FUNCTION", Loc Loc_FUNCTION;
-    "%field0", Primitive ((Pfield 0), 1);
-    "%field1", Primitive ((Pfield 1), 1);
+    "%field0", Primitive ((Pfield (0, Reads_vary)), 1);
+    "%field1", Primitive ((Pfield (1, Reads_vary)), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
     "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
     "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
@@ -791,7 +791,7 @@ let lambda_primitive_needs_event_after = function
   | Pbbswap _ -> true
 
   | Pbytes_to_string | Pbytes_of_string | Pignore | Psetglobal _
-  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed | Psetfield _
+  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Praise _
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1072,12 +1072,13 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield (n, _), [lam], loc) ->
+  | Lprim(Pfield ({ index = n; _ }, _), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield n, [ulam], dbg))
                             (field_approx n approx)
-  | Lprim(Psetfield(n, is_ptr, init), [Lprim(Pgetglobal id, [], _); lam], loc)->
+  | Lprim(Psetfield({ index = n; _ }, is_ptr, init),
+          [Lprim(Pgetglobal id, [], _); lam], loc) ->
       let (ulam, approx) = close env lam in
       if approx <> Value_unknown then
         (!global_approx).(n) <- approx;

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1072,7 +1072,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield n, [lam], loc) ->
+  | Lprim(Pfield (n, _), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield n, [ulam], dbg))

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1098,10 +1098,14 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
   | Lswitch(arg, sw, dbg) ->
       let fn fail =
         let (uarg, _) = close env arg in
+        let sw_blocks =
+          List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
+            sw.sw_blocks
+        in
         let const_index, const_actions, fconst =
           close_switch env sw.sw_consts sw.sw_numconsts fail
         and block_index, block_actions, fblock =
-          close_switch env sw.sw_blocks sw.sw_numblocks fail in
+          close_switch env sw_blocks sw.sw_numblocks fail in
         let ulam =
           Uswitch
             (uarg,

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -26,9 +26,9 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield (field, _sem) -> Pfield field
+  | Pfield ({ index = field; _ }, _) -> Pfield field
   | Pfield_computed _sem -> Pfield_computed
-  | Psetfield (field, imm_or_pointer, init_or_assign) ->
+  | Psetfield ({ index = field; _ }, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)
   | Psetfield_computed (imm_or_pointer, init_or_assign) ->
       Psetfield_computed (imm_or_pointer, init_or_assign)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -26,13 +26,13 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield field -> Pfield field
-  | Pfield_computed -> Pfield_computed
+  | Pfield (field, _sem) -> Pfield field
+  | Pfield_computed _sem -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)
   | Psetfield_computed (imm_or_pointer, init_or_assign) ->
       Psetfield_computed (imm_or_pointer, init_or_assign)
-  | Pfloatfield field -> Pfloatfield field
+  | Pfloatfield (field, _sem) -> Pfloatfield field
   | Psetfloatfield (field, init_or_assign) ->
       Psetfloatfield (field, init_or_assign)
   | Pduprecord (repr, size) -> Pduprecord (repr, size)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -486,7 +486,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     in
     let convert_key k =
       { Flambda.tag = k.Lambda.sw_tag;
-        Flambda.size = k.Lambda.sw_size
+        Flambda.size = k.Lambda.sw_size;
+        Flambda.mutability = k.Lambda.sw_mutability;
       }
     in
     Flambda.create_let scrutinee (Expr (close t env arg))

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -484,12 +484,16 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
       | None ->
           List.fold_left (fun set (i, _) -> I.Set.add i set) I.Set.empty cases
     in
+    let sw_blocks =
+      List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
+        sw.sw_blocks
+    in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (Switch (scrutinee,
         { numconsts = nums sw.sw_numconsts sw.sw_consts sw.sw_failaction;
           consts = List.map aux sw.sw_consts;
-          numblocks = nums sw.sw_numblocks sw.sw_blocks sw.sw_failaction;
-          blocks = List.map aux sw.sw_blocks;
+          numblocks = nums sw.sw_numblocks sw_blocks sw.sw_failaction;
+          blocks = List.map aux sw_blocks;
           failaction = Option.map (close t env) sw.sw_failaction;
         }))
   | Lstringswitch (arg, sw, def, _) ->

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -475,25 +475,31 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
           ~name:(Names.of_primitive lambda_p))
   | Lswitch (arg, sw, _loc) ->
     let scrutinee = Variable.create Names.switch in
-    let aux (i, lam) = i, close t env lam in
-    let nums sw_num cases default =
+    let nums getkey sw_num cases default =
       let module I = Numbers.Int in
       match default with
       | Some _ ->
           I.zero_to_n (sw_num - 1)
       | None ->
-          List.fold_left (fun set (i, _) -> I.Set.add i set) I.Set.empty cases
+          List.fold_left (fun set (i, _) -> I.Set.add (getkey i) set)
+            I.Set.empty cases
     in
-    let sw_blocks =
-      List.map (fun ({ Lambda. sw_tag; sw_size = _; }, arm) -> sw_tag, arm)
-        sw.sw_blocks
+    let convert_key k =
+      { Flambda.tag = k.Lambda.sw_tag;
+        Flambda.size = k.Lambda.sw_size
+      }
     in
     Flambda.create_let scrutinee (Expr (close t env arg))
       (Switch (scrutinee,
-        { numconsts = nums sw.sw_numconsts sw.sw_consts sw.sw_failaction;
-          consts = List.map aux sw.sw_consts;
-          numblocks = nums sw.sw_numblocks sw_blocks sw.sw_failaction;
-          blocks = List.map aux sw_blocks;
+        { numconsts =
+            nums (fun i -> i) sw.sw_numconsts sw.sw_consts sw.sw_failaction;
+          consts = List.map (fun (i, lam) -> i, close t env lam) sw.sw_consts;
+          numblocks =
+            nums (fun k -> k.Lambda.sw_tag)
+              sw.sw_numblocks sw.sw_blocks sw.sw_failaction;
+          blocks =
+            List.map (fun (k, lam) -> convert_key k, close t env lam)
+              sw.sw_blocks;
           failaction = Option.map (close t env) sw.sw_failaction;
         }))
   | Lstringswitch (arg, sw, def, _) ->

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -133,8 +133,13 @@ and switch = {
   numconsts : Numbers.Int.Set.t;
   consts : (int * t) list;
   numblocks : Numbers.Int.Set.t;
-  blocks : (int * t) list;
+  blocks : (switch_block_key * t) list;
   failaction : t option;
+}
+
+and switch_block_key = {
+  tag: int;
+  size: int;
 }
 
 and for_loop = {
@@ -271,7 +276,7 @@ let rec lam ppf (flam : t) =
         List.iter
           (fun (n, l) ->
              if !spc then fprintf ppf "@ " else spc := true;
-             fprintf ppf "@[<hv 1>case tag %i:@ %a@]" n lam l)
+             fprintf ppf "@[<hv 1>case tag %i (%i):@ %a@]" n.tag n.size lam l)
           sw.blocks ;
         begin match sw.failaction with
         | None  -> ()

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -138,8 +138,9 @@ and switch = {
 }
 
 and switch_block_key = {
-  tag: int;
-  size: int;
+  tag : int;
+  size : int;
+  mutability : Asttypes.mutable_flag;
 }
 
 and for_loop = {

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -338,8 +338,9 @@ and switch = {
 
 (** Equivalent to the similar type in [Lambda]. *)
 and switch_block_key = {
-  tag: int;
-  size: int;
+  tag : int;
+  size : int;
+  mutability : Asttypes.mutable_flag;
 }
 
 (** Equivalent to the similar type in [Lambda]. *)

--- a/middle_end/flambda/flambda.mli
+++ b/middle_end/flambda/flambda.mli
@@ -332,8 +332,14 @@ and switch = {
   numconsts : Numbers.Int.Set.t; (** Integer cases *)
   consts : (int * t) list; (** Integer cases *)
   numblocks : Numbers.Int.Set.t; (** Number of tag block cases *)
-  blocks : (int * t) list; (** Tag block cases *)
+  blocks : (switch_block_key * t) list; (** Tag block cases *)
   failaction : t option; (** Action to take if none matched *)
+}
+
+(** Equivalent to the similar type in [Lambda]. *)
+and switch_block_key = {
+  tag: int;
+  size: int;
 }
 
 (** Equivalent to the similar type in [Lambda]. *)

--- a/middle_end/flambda/flambda_invariants.ml
+++ b/middle_end/flambda/flambda_invariants.ml
@@ -212,7 +212,11 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       List.iter (fun (n, e) ->
           ignore_int n;
           loop env e)
-        (consts @ blocks);
+        consts;
+      List.iter (fun (k, e) ->
+          let _: Flambda.switch_block_key = k in
+          loop env e)
+        blocks;
       Option.iter (loop env) failaction
     | String_switch (arg, cases, e_opt) ->
       check_variable_is_bound env arg;

--- a/middle_end/flambda/flambda_iterators.ml
+++ b/middle_end/flambda/flambda_iterators.ml
@@ -101,9 +101,12 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
     else
       Let_mutable { mutable_let with body = new_body }
   | Switch (arg, sw) ->
-    let aux = map_snd_sharing (fun _ v -> f v) in
-    let new_consts = list_map_sharing aux sw.consts in
-    let new_blocks = list_map_sharing aux sw.blocks in
+    let new_consts =
+      list_map_sharing (map_snd_sharing (fun _ v -> f v)) sw.consts
+    in
+    let new_blocks =
+      list_map_sharing (map_snd_sharing (fun _ v -> f v)) sw.blocks
+    in
     let new_failaction = may_map_sharing f sw.failaction in
     if sw.failaction == new_failaction &&
        new_consts == sw.consts &&

--- a/middle_end/flambda/flambda_to_clambda.ml
+++ b/middle_end/flambda/flambda_to_clambda.ml
@@ -276,7 +276,10 @@ let rec to_clambda t env (flam : Flambda.t) : Clambda.ulambda =
         to_clambda_switch t env sw.consts sw.numconsts sw.failaction
       in
       let block_index, block_actions =
-        to_clambda_switch t env sw.blocks sw.numblocks sw.failaction
+        let blocks =
+          List.map (fun (b, branch) -> b.Flambda.tag, branch) sw.blocks
+        in
+        to_clambda_switch t env blocks sw.numblocks sw.failaction
       in
       Uswitch (subst_var env arg,
         { us_index_consts = const_index;

--- a/middle_end/flambda/flambda_utils.ml
+++ b/middle_end/flambda/flambda_utils.ml
@@ -225,11 +225,14 @@ and samebinding (v1, n1) (v2, n2) =
   Variable.equal v1 v2 && same_named n1 n2
 
 and sameswitch (fs1 : Flambda.switch) (fs2 : Flambda.switch) =
-  let samecase (n1, a1) (n2, a2) = n1 = n2 && same a1 a2 in
+  let samecase_const (n1, a1) (n2, a2) = n1 = n2 && same a1 a2 in
+  let samecase_block (k1, a1) (k2, a2) =
+    Flambda.(k1.tag = k2.tag && k1.size = k2.size) && same a1 a2
+  in
   Numbers.Int.Set.equal fs1.numconsts fs2.numconsts
     && Numbers.Int.Set.equal fs1.numblocks fs2.numblocks
-    && Misc.Stdlib.List.equal samecase fs1.consts fs2.consts
-    && Misc.Stdlib.List.equal samecase fs1.blocks fs2.blocks
+    && Misc.Stdlib.List.equal samecase_const fs1.consts fs2.consts
+    && Misc.Stdlib.List.equal samecase_block fs1.blocks fs2.blocks
     && Option.equal same fs1.failaction fs2.failaction
 
 let can_be_merged = same

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -189,9 +189,22 @@ let approx_for_allocated_const (const : Allocated_const.t) =
       A.value_immutable_float_array
         (Array.map A.value_float (Array.of_list a))
 
-type filtered_switch_branches =
+type 'key filtered_switch_branches =
   | Must_be_taken of Flambda.t
-  | Can_be_taken of (int * Flambda.t) list
+  | Can_be_taken of ('key * Flambda.t) list
+
+let rec filter_branches arg_approx filter branches compatible_branches =
+  match branches with
+  | [] -> Can_be_taken compatible_branches
+  | (c, lam) as branch :: branches ->
+      match filter arg_approx c with
+      | A.Cannot_be_taken ->
+          filter_branches arg_approx filter branches compatible_branches
+      | A.Can_be_taken ->
+          filter_branches arg_approx filter branches
+            (branch :: compatible_branches)
+      | A.Must_be_taken ->
+          Must_be_taken lam
 
 (* Determine whether a given closure ID corresponds directly to a variable
    (bound to a closure) in the given environment.  This happens when the body
@@ -1265,23 +1278,14 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
        [Switch].  (This should also make the [Let] that binds [arg] redundant,
        meaning that it too can be eliminated.) *)
     simplify_free_variable env arg ~f:(fun env arg arg_approx ->
-      let rec filter_branches filter branches compatible_branches =
-        match branches with
-        | [] -> Can_be_taken compatible_branches
-        | (c, lam) as branch :: branches ->
-          match filter arg_approx c with
-          | A.Cannot_be_taken ->
-            filter_branches filter branches compatible_branches
-          | A.Can_be_taken ->
-            filter_branches filter branches (branch :: compatible_branches)
-          | A.Must_be_taken ->
-            Must_be_taken lam
-      in
       let filtered_consts =
-        filter_branches A.potentially_taken_const_switch_branch sw.consts []
+        filter_branches arg_approx
+          A.potentially_taken_const_switch_branch sw.consts []
       in
       let filtered_blocks =
-        filter_branches A.potentially_taken_block_switch_branch sw.blocks []
+        filter_branches arg_approx
+          (fun c k -> A.potentially_taken_block_switch_branch c k.Flambda.tag)
+          sw.blocks []
       in
       begin match filtered_consts, filtered_blocks with
       | Must_be_taken _, Must_be_taken _ ->
@@ -1313,7 +1317,10 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
           lam, R.map_benefit r B.remove_branch
         | _ ->
           let env = E.inside_branch env in
-          let f (i, v) (acc, r) =
+          let f:
+            'k. ('k * Flambda.t) -> (('k * Flambda.t) list * R.t) ->
+            (('k * Flambda.t) list * R.t) =
+            fun (i, v) (acc, r) ->
             let approx = R.approx r in
             let lam, r = simplify env r v in
             (i, lam)::acc,

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -311,7 +311,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Psetglobal _ -> psetglobal
   | Pmakeblock _ -> pmakeblock
   | Pfield _ -> pfield
-  | Pfield_computed -> pfield_computed
+  | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
   | Psetfield_computed _ -> psetfield_computed
   | Pfloatfield _ -> pfloatfield
@@ -414,7 +414,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Psetglobal _ -> psetglobal_arg
   | Pmakeblock _ -> pmakeblock_arg
   | Pfield _ -> pfield_arg
-  | Pfield_computed -> pfield_computed_arg
+  | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg
   | Psetfield_computed _ -> psetfield_computed_arg
   | Pfloatfield _ -> pfloatfield_arg

--- a/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -19,5 +19,6 @@
               (let (*match* = (setfield_ptr 0 s "Hello World!"))
                 (makeblock 0)))
             (let
-              (drop = (function param 0) *match* = (apply drop (field 0 s)))
+              (drop = (function param 0)
+               *match* = (apply drop (field_mut 0 s)))
               (makeblock 0 A B f s drop))))))))

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -16,5 +16,7 @@
         (seq
           (ignore
             (let (*match* = (setfield_ptr 0 s "Hello World!")) (makeblock 0)))
-          (let (drop = (function param 0) *match* = (apply drop (field 0 s)))
+          (let
+            (drop = (function param 0)
+             *match* = (apply drop (field_mut 0 s)))
             (makeblock 0 A B f s drop)))))))

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
@@ -26,6 +26,6 @@
       (let
         (*match* =
            (apply (field 4 (global Anonymous!))
-             (field 0 (field 3 (global Anonymous!)))))
+             (field_mut 0 (field 3 (global Anonymous!)))))
         0)
       0)))

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -388,10 +388,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 | {type_kind = Type_variant (constr_list,rep)} ->
                     let unbx = (rep = Variant_unboxed) in
                     let tag =
-                      if unbx then Cstr_unboxed
+                      if unbx then Datarepr.Unboxed
                       else if O.is_block obj
-                      then Cstr_block(O.tag obj)
-                      else Cstr_constant(O.obj obj) in
+                      then Datarepr.Block(O.tag obj)
+                      else Datarepr.Constant(O.obj obj) in
                     let {cd_id;cd_args;cd_res} =
                       Datarepr.find_constr_by_tag tag constr_list in
                     let type_params =

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -76,7 +76,7 @@ let close_phrase lam =
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
-      Lprim (Pfield pos,
+      Lprim (mod_field pos,
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -110,6 +110,15 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
           | None -> ty_res
         in
         let (tag, descr_rem) =
+          let cstr_block ~size =
+            let tag =
+              Cstr_block {
+                tag = idx_nonconst;
+                size;
+              }
+            in
+            tag, describe_constructors idx_const (idx_nonconst+1) rem
+          in
           match cd_args, rep with
           | _, Variant_unboxed ->
             assert (rem = []);
@@ -117,9 +126,9 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
           | Cstr_tuple [], Variant_regular ->
              (Cstr_constant idx_const,
               describe_constructors (idx_const+1) idx_nonconst rem)
-          | _, Variant_regular  ->
-             (Cstr_block idx_nonconst,
-              describe_constructors idx_const (idx_nonconst+1) rem) in
+          | Cstr_tuple args, Variant_regular -> cstr_block ~size:(List.length args)
+          | Cstr_record args, Variant_regular -> cstr_block ~size:(List.length args)
+        in
         let cstr_name = Ident.name cd_id in
         let existentials, cstr_args, cstr_inlined =
           let representation =
@@ -213,17 +222,24 @@ let label_descrs ty_res lbls repres priv =
 
 exception Constr_not_found
 
+type constructor_tag_to_find =
+  | Constant of int
+  | Block of int
+  | Unboxed
+
 let rec find_constr tag num_const num_nonconst = function
     [] ->
       raise Constr_not_found
   | {cd_args = Cstr_tuple []; _} as c  :: rem ->
-      if tag = Cstr_constant num_const
+      if tag = Constant num_const
       then c
       else find_constr tag (num_const + 1) num_nonconst rem
   | c :: rem ->
-      if tag = Cstr_block num_nonconst || tag = Cstr_unboxed
-      then c
-      else find_constr tag num_const (num_nonconst + 1) rem
+      match tag with
+      | Block tag when tag = num_nonconst -> c
+      | Unboxed -> c
+      | Block _
+      | Constant _ -> find_constr tag num_const (num_nonconst + 1) rem
 
 let find_constr_by_tag tag cstrlist =
   find_constr tag 0 0 cstrlist

--- a/typing/datarepr.mli
+++ b/typing/datarepr.mli
@@ -32,8 +32,13 @@ val constructors_of_type:
 
 exception Constr_not_found
 
+type constructor_tag_to_find =
+  | Constant of int
+  | Block of int
+  | Unboxed
+
 val find_constr_by_tag:
-  constructor_tag -> constructor_declaration list ->
+  constructor_tag_to_find -> constructor_declaration list ->
     constructor_declaration
 
 val constructor_existentials :

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -800,45 +800,7 @@ let should_extend ext env = match ext with
       | Any -> assert false
       end
               end
-(*<<<<<<< HEAD
               
-=======
-
-type simple_constructor_tag =
-  | Constant of int
-  | Block of int
-
-module ConstructorTagHashtbl = Hashtbl.Make(
-  struct
-    type t = simple_constructor_tag
-    let hash = Hashtbl.hash
-    let equal = ( = )
-  end
-)
-
-(* complement constructor tags *)
-let complete_tags nconsts nconstrs tags =
-  let seen_const = Array.make nconsts false
-  and seen_constr = Array.make nconstrs false in
-  List.iter
-    (function
-      | Cstr_constant i -> seen_const.(i) <- true
-      | Cstr_block { tag; size = _; mutability = _ } ->
-          seen_constr.(tag) <- true
-      | _  -> assert false)
-    tags ;
-  let r = ConstructorTagHashtbl.create (nconsts+nconstrs) in
-  for i = 0 to nconsts-1 do
-    if not seen_const.(i) then
-      ConstructorTagHashtbl.add r (Constant i) ()
-  done ;
-  for i = 0 to nconstrs-1 do
-    if not seen_constr.(i) then
-      ConstructorTagHashtbl.add r (Block i) ()
-  done ;
-  r
-
->>>>>>> 900a11b9c... Propagate info on mutability in switches through lambda, flambda*)
 (* build a pattern from a constructor description *)
 let pat_of_constr ex_pat cstr =
   {ex_pat with pat_desc =

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -800,7 +800,45 @@ let should_extend ext env = match ext with
       | Any -> assert false
       end
               end
+(*<<<<<<< HEAD
               
+=======
+
+type simple_constructor_tag =
+  | Constant of int
+  | Block of int
+
+module ConstructorTagHashtbl = Hashtbl.Make(
+  struct
+    type t = simple_constructor_tag
+    let hash = Hashtbl.hash
+    let equal = ( = )
+  end
+)
+
+(* complement constructor tags *)
+let complete_tags nconsts nconstrs tags =
+  let seen_const = Array.make nconsts false
+  and seen_constr = Array.make nconstrs false in
+  List.iter
+    (function
+      | Cstr_constant i -> seen_const.(i) <- true
+      | Cstr_block { tag; size = _; mutability = _ } ->
+          seen_constr.(tag) <- true
+      | _  -> assert false)
+    tags ;
+  let r = ConstructorTagHashtbl.create (nconsts+nconstrs) in
+  for i = 0 to nconsts-1 do
+    if not seen_const.(i) then
+      ConstructorTagHashtbl.add r (Constant i) ()
+  done ;
+  for i = 0 to nconstrs-1 do
+    if not seen_constr.(i) then
+      ConstructorTagHashtbl.add r (Block i) ()
+  done ;
+  r
+
+>>>>>>> 900a11b9c... Propagate info on mutability in switches through lambda, flambda*)
 (* build a pattern from a constructor description *)
 let pat_of_constr ex_pat cstr =
   {ex_pat with pat_desc =

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -799,8 +799,8 @@ let should_extend ext env = match ext with
       | Constant _ | Tuple _ | Variant _ | Record _ | Array _ | Lazy -> false
       | Any -> assert false
       end
-end
-
+              end
+              
 (* build a pattern from a constructor description *)
 let pat_of_constr ex_pat cstr =
   {ex_pat with pat_desc =
@@ -869,7 +869,7 @@ let complete_constrs constr used_constrs =
   let used_constrs = ConstructorSet.of_list used_constrs in
   let others =
     List.filter
-      (fun cnstr -> not (ConstructorSet.mem cnstr used_constrs))
+    (fun cnstr -> not (ConstructorSet.mem cnstr used_constrs))
       constrs in
   (* Split constructors to put constant ones first *)
   let const, nonconst =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -424,6 +424,7 @@ and constructor_tag =
   | Cstr_block of {                     (* Regular constructor (a block) *)
       tag : int;
       size : int;
+      mutability : Asttypes.mutable_flag;
     }
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
   | Cstr_extension of Path.t * bool     (* Extension constructor
@@ -432,9 +433,9 @@ and constructor_tag =
 let equal_tag t1 t2 =
   match (t1, t2) with
   | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
-  | Cstr_block { tag = tag1; size = size1; },
-      Cstr_block { tag = tag2; size = size2; } ->
-    tag1 = tag2 && size1 = size2
+  | Cstr_block { tag = tag1; size = size1; mutability = mutability1},
+      Cstr_block { tag = tag2; size = size2; mutability = mutability2} ->
+    tag1 = tag2 && size1 = size2 && mutability1 = mutability2
   | Cstr_unboxed, Cstr_unboxed -> true
   | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
       Path.same path1 path2 && b1 = b2

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -421,7 +421,10 @@ type constructor_description =
 
 and constructor_tag =
     Cstr_constant of int                (* Constant constructor (an int) *)
-  | Cstr_block of int                   (* Regular constructor (a block) *)
+  | Cstr_block of {                     (* Regular constructor (a block) *)
+      tag : int;
+      size : int;
+    }
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)
@@ -429,7 +432,9 @@ and constructor_tag =
 let equal_tag t1 t2 =
   match (t1, t2) with
   | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
-  | Cstr_block i1, Cstr_block i2 -> i2 = i1
+  | Cstr_block { tag = tag1; size = size1; },
+      Cstr_block { tag = tag2; size = size2; } ->
+    tag1 = tag2 && size1 = size2
   | Cstr_unboxed, Cstr_unboxed -> true
   | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
       Path.same path1 path2 && b1 = b2

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -554,7 +554,10 @@ type constructor_description =
 
 and constructor_tag =
     Cstr_constant of int                (* Constant constructor (an int) *)
-  | Cstr_block of int                   (* Regular constructor (a block) *)
+  | Cstr_block of {                     (* Regular constructor (a block) *)
+      tag : int;
+      size : int;
+    }
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -557,6 +557,7 @@ and constructor_tag =
   | Cstr_block of {                     (* Regular constructor (a block) *)
       tag : int;
       size : int;
+      mutability : Asttypes.mutable_flag;
     }
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
   | Cstr_extension of Path.t * bool     (* Extension constructor


### PR DESCRIPTION
This PR is a rebase of commits from #8958 and the flambda 2 stable branch.

The aim of the PR is to be able to use this information about block size and tag to detect more precisely the case where an allocation is redundant.

This will allow us to improve #8958 by handling more cases where we didn't know the tag like records, tuples, and variants without a switch.

One known drawback of this PR is that it can lose sharing between branches that read the same field of blocks with different tags or sizes. We are open to suggestions to make the fields optional, with a compiler flag to enable or disable this information. This could recover the sharing for the users that don't need our planned optimizations.

This PR doesn't contain any optimisations, but we still think it is worth submitting it separately.

This is joint work with @lthls .