### PR TITLE
Check row_more in nondep_type_rec

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,8 @@ Working version
 
 ### Bug fixes:
 
+- #10454: Check row_more in nondep_type_rec.
+  (Leo White, review by Thomas Refis)
 
 OCaml 4.13.0
 -------------

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -53,6 +53,6 @@ end
 module M :
   sig
     module F : functor (X : sig type t end) -> sig type t = X.t end
-    module Not_ok : sig type t = private X.t end
+    module Not_ok : sig type t end
   end
 |}]

--- a/testsuite/tests/typing-modules/nondep.ml
+++ b/testsuite/tests/typing-modules/nondep.ml
@@ -44,3 +44,15 @@ type 'a always_int = int
 module F : functor (X : sig type t end) -> sig type s = X.t always_int end
 module M : sig type s = int end
 |}]
+
+module M = struct
+  module F (X : sig type t end) = X
+  module Not_ok = F (struct type t = private [< `A] end)
+end
+[%%expect{|
+module M :
+  sig
+    module F : functor (X : sig type t end) -> sig type t = X.t end
+    module Not_ok : sig type t = private X.t end
+  end
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4802,7 +4802,9 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
             (* Register new type first for recursion *)
             TypeHash.add nondep_variants more ty';
             let static = static_row row in
-            let more' = if static then newgenty Tnil else more in
+            let more' =
+              if static then newgenty Tnil else nondep_type_rec env ids more
+            in
             (* Return a new copy *)
             let row =
               copy_row (nondep_type_rec env ids) true row true more' in


### PR DESCRIPTION
`nondep_type_rec` is not checking for the escaping paths in `row_more`. This allows functor parameters to escape their scope:

```ocaml
module M = struct
  module F (X : sig type t end) = X
  module Not_ok = F (struct type t = private [< `A] end)
end
[%%expect{|
module M :
  sig
    module F : functor (X : sig type t end) -> sig type t = X.t end
    module Not_ok : sig type t = private X.t end
  end
|}]
```

Note the appearance of `X` in the type of `M.Not_ok`.

This PR adds the appropriate check.