### PR TITLE
Expose Oprint.escape_string as String.escape

### DIFF
--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -669,12 +669,10 @@ stdlib__Stream.cmx : stream.ml \
 stdlib__Stream.cmi : stream.mli
 stdlib__String.cmo : string.ml \
     stdlib.cmi \
-    stdlib__Char.cmi \
     stdlib__Bytes.cmi \
     stdlib__String.cmi
 stdlib__String.cmx : string.ml \
     stdlib.cmx \
-    stdlib__Char.cmx \
     stdlib__Bytes.cmx \
     stdlib__String.cmi
 stdlib__String.cmi : string.mli \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -669,10 +669,12 @@ stdlib__Stream.cmx : stream.ml \
 stdlib__Stream.cmi : stream.mli
 stdlib__String.cmo : string.ml \
     stdlib.cmi \
+    stdlib__Char.cmi \
     stdlib__Bytes.cmi \
     stdlib__String.cmi
 stdlib__String.cmx : string.ml \
     stdlib.cmx \
+    stdlib__Char.cmx \
     stdlib__Bytes.cmx \
     stdlib__String.cmi
 stdlib__String.cmi : string.mli \

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -172,6 +172,7 @@ let _escaped ?(escape_unicode=false) s =
     let a = char_code c in
     unsafe_set str !pos '\\';
     incr pos;
+
     unsafe_set str !pos (char_chr (48 + a / 100));
     incr pos;
     unsafe_set str !pos (char_chr (48 + (a / 10) mod 10));
@@ -184,6 +185,8 @@ let _escaped ?(escape_unicode=false) s =
       (match unsafe_get s i with
        | '\"' | '\\' | '\n' | '\t' | '\r' | '\b' -> 2
        | ' ' .. '~' -> 1
+       | '\x80' .. '\xFF' ->
+         if escape_unicode then 4 else 1
        | _ -> 4)
   done;
   if !n = length s then copy s else begin

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -216,6 +216,39 @@ val escaped : bytes -> bytes
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
+val escaped_ascii : bytes -> bytes
+(** [escape_ascii s] is [s] with all characters outside the printable US-ASCII
+    range represented by escape sequences.
+
+    All characters outside the US-ASCII printable range \[0x20 .. 0x7E\] are
+    escaped, as well as backslash (0x2F) and double-quote (0x22).
+
+    The function {!Scanf.unescaped} is a left inverse of [escaped],
+    i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless
+    [escaped s] fails).
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
+val escaped_utf8 : bytes -> bytes
+(** [escape s] is [s] with special characters replaced with escape sequences,
+    following the lexical conventions of OCaml.
+
+    The following characters are escaped:
+    double quote (['\"'], newline (['\n']), carriage return (['\r']),
+    tab (['\t']), backspace (['\b']), DEL (0x7F),
+    and everything in the \[0x00 .. 0x1F\] range.
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
+(* Intentionally undocumented. *)
+val _escaped : ?escape_unicode:bool -> bytes -> bytes
+
 val index : bytes -> char -> int
 (** [index s c] returns the index of the first occurrence of byte [c]
     in [s].

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -216,6 +216,39 @@ val escaped : bytes -> bytes
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
+val escaped_ascii : bytes -> bytes
+(** [escape_ascii s] is [s] with all characters outside the printable US-ASCII
+    range represented by escape sequences.
+
+    All characters outside the US-ASCII printable range \[0x20 .. 0x7E\] are
+    escaped, as well as backslash (0x2F) and double-quote (0x22).
+
+    The function {!Scanf.unescaped} is a left inverse of [escaped],
+    i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless
+    [escaped s] fails).
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
+val escaped_utf8 : bytes -> bytes
+(** [escape s] is [s] with special characters replaced with escape sequences,
+    following the lexical conventions of OCaml.
+
+    The following characters are escaped:
+    double quote (['\"'], newline (['\n']), carriage return (['\r']),
+    tab (['\t']), backspace (['\b']), DEL (0x7F),
+    and everything in the \[0x00 .. 0x1F\] range.
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
+(* Intentionally undocumented. *)
+val _escaped : ?escape_unicode:bool -> bytes -> bytes
+
 val index : bytes -> char -> int
 (** [index s c] returns the index of the first occurrence of byte [c]
     in [s].

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -1369,7 +1369,7 @@ let fix_int_precision prec str =
 
 (* Escape a string according to the OCaml lexing convention. *)
 let string_to_caml_string str =
-  let str = String.escape_ascii str in
+  let str = String.escaped_ascii str in
   let l = String.length str in
   let res = Bytes.make (l + 2) '\"' in
   String.unsafe_blit str 0 res 1 l;

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -1369,7 +1369,7 @@ let fix_int_precision prec str =
 
 (* Escape a string according to the OCaml lexing convention. *)
 let string_to_caml_string str =
-  let str = String.escaped str in
+  let str = String.escape_ascii str in
   let l = String.length str in
   let res = Bytes.make (l + 2) '\"' in
   String.unsafe_blit str 0 res 1 l;

--- a/stdlib/scanf.ml
+++ b/stdlib/scanf.ml
@@ -1507,7 +1507,7 @@ let kscanf ib ef (Format (fmt, str)) =
     match try Args (make_scanf ib fmt readers) with
       | (Scan_failure _ | Failure _ | End_of_file) as exc -> Exc exc
       | Invalid_argument msg ->
-        invalid_arg (msg ^ " in format \"" ^ String.escaped str ^ "\"")
+        invalid_arg (msg ^ " in format \"" ^ String.escape_ascii str ^ "\"")
     with
       | Args args -> apply f args
       | Exc exc -> ef ib exc
@@ -1546,7 +1546,7 @@ let sscanf_format :
 
 
 let format_from_string s fmt =
-  sscanf_format ("\"" ^ String.escaped s ^ "\"") fmt (fun x -> x)
+  sscanf_format ("\"" ^ String.escape_ascii s ^ "\"") fmt (fun x -> x)
 
 
 let unescaped s =

--- a/stdlib/scanf.ml
+++ b/stdlib/scanf.ml
@@ -1507,7 +1507,7 @@ let kscanf ib ef (Format (fmt, str)) =
     match try Args (make_scanf ib fmt readers) with
       | (Scan_failure _ | Failure _ | End_of_file) as exc -> Exc exc
       | Invalid_argument msg ->
-        invalid_arg (msg ^ " in format \"" ^ String.escape_ascii str ^ "\"")
+        invalid_arg (msg ^ " in format \"" ^ String.escaped_ascii str ^ "\"")
     with
       | Args args -> apply f args
       | Exc exc -> ef ib exc
@@ -1546,7 +1546,7 @@ let sscanf_format :
 
 
 let format_from_string s fmt =
-  sscanf_format ("\"" ^ String.escape_ascii s ^ "\"") fmt (fun x -> x)
+  sscanf_format ("\"" ^ String.escaped_ascii s ^ "\"") fmt (fun x -> x)
 
 
 let unescaped s =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -123,6 +123,51 @@ let escaped s =
   in
   escape_if_needed s (length s) 0
 
+let escape_ascii = escaped
+
+let escape s =
+  (* Escape only C0 control characters (bytes <= 0x1F), DEL(0x7F), '\\'
+     and '"' *)
+   let n = ref 0 in
+  for i = 0 to length s - 1 do
+    n := !n +
+      (match unsafe_get s i with
+       | '\"' | '\\' | '\n' | '\t' | '\r' | '\b' -> 2
+       | '\x00' .. '\x1F'
+       | '\x7F' -> 4
+       | _ -> 1)
+  done;
+  if !n = length s then s else begin
+    let s' = B.create !n in
+    n := 0;
+    for i = 0 to length s - 1 do
+      begin match unsafe_get s i with
+      | ('\"' | '\\') as c ->
+          B.unsafe_set s' !n '\\'; incr n; B.unsafe_set s' !n c
+      | '\n' ->
+          B.unsafe_set s' !n '\\'; incr n; B.unsafe_set s' !n 'n'
+      | '\t' ->
+          B.unsafe_set s' !n '\\'; incr n; B.unsafe_set s' !n 't'
+      | '\r' ->
+          B.unsafe_set s' !n '\\'; incr n; B.unsafe_set s' !n 'r'
+      | '\b' ->
+          B.unsafe_set s' !n '\\'; incr n; B.unsafe_set s' !n 'b'
+      | '\x00' .. '\x1F' | '\x7F' as c ->
+          let a = Char.code c in
+          B.unsafe_set s' !n '\\';
+          incr n;
+          B.unsafe_set s' !n (Char.chr (48 + a / 100));
+          incr n;
+          B.unsafe_set s' !n (Char.chr (48 + (a / 10) mod 10));
+          incr n;
+          B.unsafe_set s' !n (Char.chr (48 + a mod 10));
+      | c -> B.unsafe_set s' !n c
+      end;
+      incr n
+    done;
+    B.to_string s'
+  end
+
 (* duplicated in bytes.ml *)
 let rec index_rec s lim i c =
   if i >= lim then raise Not_found else

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -265,8 +265,8 @@ val escaped : string -> string
     @deprecated Use {!String.escape_ascii} instead. *)
 
 val escape_ascii : string -> string
-(** [escaped s] is [s] with all characters outside the printable US-ASCII range
-    represented by escape sequences.
+(** [escape_ascii s] is [s] with all characters outside the printable US-ASCII
+    range represented by escape sequences.
 
     All characters outside the US-ASCII printable range \[0x20;0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
@@ -293,7 +293,6 @@ val escape : string -> string
     {!Sys.max_string_length} bytes.
 
     @since 4.14.0 *)
-
 
 val uppercase_ascii : string -> string
 (** [uppercase_ascii s] is [s] with all lowercase letters

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -249,8 +249,8 @@ val trim : string -> string
     @since 4.00.0 *)
 
 val escaped : string -> string
-(** [escaped s] is [s] with special characters represented by escape
-    sequences, following the lexical conventions of OCaml.
+(** [escaped s] is [s] with all characters outside the printable US-ASCII range
+    represented by escape sequences.
 
     All characters outside the US-ASCII printable range \[0x20;0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
@@ -260,7 +260,40 @@ val escaped : string -> string
     [escaped s] fails).
 
     @raise Invalid_argument if the result is longer than
-    {!Sys.max_string_length} bytes. *)
+    {!Sys.max_string_length} bytes.
+
+    @deprecated Use {!String.escape_ascii} instead. *)
+
+val escape_ascii : string -> string
+(** [escaped s] is [s] with all characters outside the printable US-ASCII range
+    represented by escape sequences.
+
+    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    escaped, as well as backslash (0x2F) and double-quote (0x22).
+
+    The function {!Scanf.unescaped} is a left inverse of [escaped],
+    i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless
+    [escaped s] fails).
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
+val escape : string -> string
+(** [escape s] is [s] with special characters replaced with escape sequences,
+    following the lexical conventions of OCaml.
+
+    The following characters are escaped:
+    double quote (['\"'], newline (['\n']), carriage return (['\r']),
+    tab (['\t\]), backspace (['\b']), DEL (0x7F),
+    and everything in the ['\x00' .. '\x1F'] range.
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
 
 val uppercase_ascii : string -> string
 (** [uppercase_ascii s] is [s] with all lowercase letters

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -260,9 +260,7 @@ val escaped : string -> string
     [escaped s] fails).
 
     @raise Invalid_argument if the result is longer than
-    {!Sys.max_string_length} bytes.
-
-    @deprecated Use {!String.escape_ascii} instead. *)
+    {!Sys.max_string_length} bytes. *)
 
 val escape_ascii : string -> string
 (** [escape_ascii s] is [s] with all characters outside the printable US-ASCII

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -262,11 +262,11 @@ val escaped : string -> string
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
-val escape_ascii : string -> string
+val escaped_ascii : string -> string
 (** [escape_ascii s] is [s] with all characters outside the printable US-ASCII
     range represented by escape sequences.
 
-    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    All characters outside the US-ASCII printable range \[0x20 .. 0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
@@ -278,14 +278,14 @@ val escape_ascii : string -> string
 
     @since 4.14.0 *)
 
-val escape : string -> string
+val escaped_utf8 : string -> string
 (** [escape s] is [s] with special characters replaced with escape sequences,
     following the lexical conventions of OCaml.
 
     The following characters are escaped:
     double quote (['\"'], newline (['\n']), carriage return (['\r']),
-    tab (['\t\]), backspace (['\b']), DEL (0x7F),
-    and everything in the ['\x00' .. '\x1F'] range.
+    tab (['\t']), backspace (['\b']), DEL (0x7F),
+    and everything in the \[0x00 .. 0x1F\] range.
 
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -265,8 +265,8 @@ val escaped : string -> string
     @deprecated Use {!String.escape_ascii} instead. *)
 
 val escape_ascii : string -> string
-(** [escaped s] is [s] with all characters outside the printable US-ASCII range
-    represented by escape sequences.
+(** [escape_ascii s] is [s] with all characters outside the printable US-ASCII
+    range represented by escape sequences.
 
     All characters outside the US-ASCII printable range \[0x20;0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
@@ -293,7 +293,6 @@ val escape : string -> string
     {!Sys.max_string_length} bytes.
 
     @since 4.14.0 *)
-
 
 val uppercase_ascii : string -> string
 (** [uppercase_ascii s] is [s] with all lowercase letters

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -249,8 +249,8 @@ val trim : string -> string
     @since 4.00.0 *)
 
 val escaped : string -> string
-(** [escaped s] is [s] with special characters represented by escape
-    sequences, following the lexical conventions of OCaml.
+(** [escaped s] is [s] with all characters outside the printable US-ASCII range
+    represented by escape sequences.
 
     All characters outside the US-ASCII printable range \[0x20;0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
@@ -260,7 +260,40 @@ val escaped : string -> string
     [escaped s] fails).
 
     @raise Invalid_argument if the result is longer than
-    {!Sys.max_string_length} bytes. *)
+    {!Sys.max_string_length} bytes.
+
+    @deprecated Use {!String.escape_ascii} instead. *)
+
+val escape_ascii : string -> string
+(** [escaped s] is [s] with all characters outside the printable US-ASCII range
+    represented by escape sequences.
+
+    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    escaped, as well as backslash (0x2F) and double-quote (0x22).
+
+    The function {!Scanf.unescaped} is a left inverse of [escaped],
+    i.e. [Scanf.unescaped (escaped s) = s] for any string [s] (unless
+    [escaped s] fails).
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
+val escape : string -> string
+(** [escape s] is [s] with special characters replaced with escape sequences,
+    following the lexical conventions of OCaml.
+
+    The following characters are escaped:
+    double quote (['\"'], newline (['\n']), carriage return (['\r']),
+    tab (['\t\]), backspace (['\b']), DEL (0x7F),
+    and everything in the ['\x00' .. '\x1F'] range.
+
+    @raise Invalid_argument if the result is longer than
+    {!Sys.max_string_length} bytes.
+
+    @since 4.14.0 *)
+
 
 val uppercase_ascii : string -> string
 (** [uppercase_ascii s] is [s] with all lowercase letters

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -260,9 +260,7 @@ val escaped : string -> string
     [escaped s] fails).
 
     @raise Invalid_argument if the result is longer than
-    {!Sys.max_string_length} bytes.
-
-    @deprecated Use {!String.escape_ascii} instead. *)
+    {!Sys.max_string_length} bytes. *)
 
 val escape_ascii : string -> string
 (** [escape_ascii s] is [s] with all characters outside the printable US-ASCII

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -262,11 +262,11 @@ val escaped : string -> string
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes. *)
 
-val escape_ascii : string -> string
+val escaped_ascii : string -> string
 (** [escape_ascii s] is [s] with all characters outside the printable US-ASCII
     range represented by escape sequences.
 
-    All characters outside the US-ASCII printable range \[0x20;0x7E\] are
+    All characters outside the US-ASCII printable range \[0x20 .. 0x7E\] are
     escaped, as well as backslash (0x2F) and double-quote (0x22).
 
     The function {!Scanf.unescaped} is a left inverse of [escaped],
@@ -278,14 +278,14 @@ val escape_ascii : string -> string
 
     @since 4.14.0 *)
 
-val escape : string -> string
+val escaped_utf8 : string -> string
 (** [escape s] is [s] with special characters replaced with escape sequences,
     following the lexical conventions of OCaml.
 
     The following characters are escaped:
     double quote (['\"'], newline (['\n']), carriage return (['\r']),
-    tab (['\t\]), backspace (['\b']), DEL (0x7F),
-    and everything in the ['\x00' .. '\x1F'] range.
+    tab (['\t']), backspace (['\b']), DEL (0x7F),
+    and everything in the \[0x00 .. 0x1F\] range.
 
     @raise Invalid_argument if the result is longer than
     {!Sys.max_string_length} bytes.

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -95,50 +95,6 @@ let parenthesize_if_neg ppf fmt v isneg =
   fprintf ppf fmt v;
   if isneg then pp_print_char ppf ')'
 
-let escape_string s =
-  (* Escape only C0 control characters (bytes <= 0x1F), DEL(0x7F), '\\'
-     and '"' *)
-   let n = ref 0 in
-  for i = 0 to String.length s - 1 do
-    n := !n +
-      (match String.unsafe_get s i with
-       | '\"' | '\\' | '\n' | '\t' | '\r' | '\b' -> 2
-       | '\x00' .. '\x1F'
-       | '\x7F' -> 4
-       | _ -> 1)
-  done;
-  if !n = String.length s then s else begin
-    let s' = Bytes.create !n in
-    n := 0;
-    for i = 0 to String.length s - 1 do
-      begin match String.unsafe_get s i with
-      | ('\"' | '\\') as c ->
-          Bytes.unsafe_set s' !n '\\'; incr n; Bytes.unsafe_set s' !n c
-      | '\n' ->
-          Bytes.unsafe_set s' !n '\\'; incr n; Bytes.unsafe_set s' !n 'n'
-      | '\t' ->
-          Bytes.unsafe_set s' !n '\\'; incr n; Bytes.unsafe_set s' !n 't'
-      | '\r' ->
-          Bytes.unsafe_set s' !n '\\'; incr n; Bytes.unsafe_set s' !n 'r'
-      | '\b' ->
-          Bytes.unsafe_set s' !n '\\'; incr n; Bytes.unsafe_set s' !n 'b'
-      | '\x00' .. '\x1F' | '\x7F' as c ->
-          let a = Char.code c in
-          Bytes.unsafe_set s' !n '\\';
-          incr n;
-          Bytes.unsafe_set s' !n (Char.chr (48 + a / 100));
-          incr n;
-          Bytes.unsafe_set s' !n (Char.chr (48 + (a / 10) mod 10));
-          incr n;
-          Bytes.unsafe_set s' !n (Char.chr (48 + a mod 10));
-      | c -> Bytes.unsafe_set s' !n c
-      end;
-      incr n
-    done;
-    Bytes.to_string s'
-  end
-
-
 let print_out_string ppf s =
   let not_escaped =
     (* let the user dynamically choose if strings should be escaped: *)
@@ -149,7 +105,7 @@ let print_out_string ppf s =
         | None -> true
         | Some f -> f in
   if not_escaped then
-    fprintf ppf "\"%s\"" (escape_string s)
+    fprintf ppf "\"%s\"" (String.escape s)
   else
     fprintf ppf "%S" s
 

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -105,7 +105,7 @@ let print_out_string ppf s =
         | None -> true
         | Some f -> f in
   if not_escaped then
-    fprintf ppf "\"%s\"" (String.escape s)
+    fprintf ppf "\"%s\"" (String.escaped_utf8 s)
   else
     fprintf ppf "%S" s
 


### PR DESCRIPTION
The motivation for is that the original `String.escaped` is overly aggressive and escapes everything except the printable ASCII range, which is a major inconvenience in a Unicode world.

Add a `String.escape_ascii` alias for the old `String.escaped` to simplify its eventual deprecation, in line with other ASCII-only functions (`lowercase_ascii` etc.).

Adding a deprecation warning to `String.escaped` (`[@@ocaml.deprecated "Use String.escape_ascii instead."]`) breaks the `stringLabels.ml` module when building with warning as an error option, so I only added a deprecation tag to the documentation comment.