### PR TITLE
Change inlining cost of flambda switches.

### DIFF
--- a/Changes
+++ b/Changes
@@ -588,6 +588,10 @@ OCaml 4.13.0
   "interval" patterns `c1..c2`.
   (Guillaume Petiot, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #7449 #10458: Change the size heuristics of switch in flambda to avoid
+  inlining too large jump tables. (Pierre Chambart, review by Gabriel Scherer,
+  report by Mark Hayden)
+
 ### Build system:
 
 - #10289, #10406: Do not print option documentation in usage messages.

--- a/middle_end/flambda/inlining_cost.ml
+++ b/middle_end/flambda/inlining_cost.ml
@@ -89,8 +89,12 @@ let lambda_smaller' lam ~than:threshold =
       List.iter (fun (_, lam) -> lambda_named_size lam) bindings;
       lambda_size body
     | Switch (_, sw) ->
-      let aux = function _::_::_ -> size := !size + 5 | _ -> () in
-      aux sw.consts; aux sw.blocks;
+      let cost cases =
+        let size = List.length cases in
+        if size <= 1 then 0
+        else 3 + size
+      in
+      size := !size + cost sw.consts + cost sw.blocks;
       List.iter (fun (_, lam) -> lambda_size lam) sw.consts;
       List.iter (fun (_, lam) -> lambda_size lam) sw.blocks;
       Option.iter lambda_size sw.failaction


### PR DESCRIPTION
The cost of a switch didn't really depend on its size. This reflects a bit better that large switch are not necessarily worth inlining.
The added branches cost less than the first ones because in a jump table adding more branches only requires adding a new entry to the table.

This fixes #7449