### PR TITLE
stdlib: add `List.is_empty`

### DIFF
--- a/Changes
+++ b/Changes
@@ -308,6 +308,9 @@ OCaml 4.14.0
 - #10786: The implementation of Complex.norm now uses Float.hypot.
   (Christophe Troestler, review by David Allsopp and Xavier Leroy)
 
+- #10464: Add List.is_empty.
+  (Craig Ferguson, review by David Allsopp)
+
 ### Other libraries:
 
 - #10192: Add support for Unix domain sockets on Windows and use them

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -547,7 +547,9 @@ let rec compare_length_with l n =
     if n <= 0 then 1 else
       compare_length_with l (n-1)
 
-let is_empty l = (l = [])
+let is_empty = function
+  | [] -> true
+  | _ :: _ -> false
 
 (** {1 Comparison} *)
 

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -547,6 +547,8 @@ let rec compare_length_with l n =
     if n <= 0 then 1 else
       compare_length_with l (n-1)
 
+let is_empty l = (l = [])
+
 (** {1 Comparison} *)
 
 (* Note: we are *not* shortcutting the list by using

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -57,6 +57,12 @@ val compare_length_with : 'a list -> int -> int
    @since 4.05.0
  *)
 
+val is_empty : 'a list -> bool
+(** [is_empty l] is true if and only if [l] has no elements. It is equivalent to
+    [compare_length_with l 0 = 0].
+    @since 5.00.0
+ *)
+
 val cons : 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
     @since 4.03.0 (4.05.0 in ListLabels)

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -60,7 +60,7 @@ val compare_length_with : 'a list -> int -> int
 val is_empty : 'a list -> bool
 (** [is_empty l] is true if and only if [l] has no elements. It is equivalent to
     [compare_length_with l 0 = 0].
-    @since 5.00.0
+    @since 5.1
  *)
 
 val cons : 'a -> 'a list -> 'a list

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -57,6 +57,12 @@ val compare_length_with : 'a list -> len:int -> int
    @since 4.05.0
  *)
 
+val is_empty : 'a list -> bool
+(** [is_empty l] is true if and only if [l] has no elements. It is equivalent to
+    [compare_length_with l 0 = 0].
+    @since 5.00.0
+ *)
+
 val cons : 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
     @since 4.03.0 (4.05.0 in ListLabels)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -60,7 +60,7 @@ val compare_length_with : 'a list -> len:int -> int
 val is_empty : 'a list -> bool
 (** [is_empty l] is true if and only if [l] has no elements. It is equivalent to
     [compare_length_with l 0 = 0].
-    @since 5.00.0
+    @since 5.1
  *)
 
 val cons : 'a -> 'a list -> 'a list

--- a/testsuite/tests/lib-list/test.ml
+++ b/testsuite/tests/lib-list/test.ml
@@ -82,6 +82,10 @@ let () =
   assert (List.compare_length_with [1] 0 > 0);
   assert (List.compare_length_with ['1'] 1 = 0);
   assert (List.compare_length_with ['1'] 2 < 0);
+
+  assert (List.is_empty []);
+  assert (not (List.is_empty [1]));
+
   assert (List.filter_map string_of_even_opt l = ["0";"2";"4";"6";"8"]);
   assert (List.concat_map (fun i -> [i; i+1]) [1; 5] = [1; 2; 5; 6]);
   assert (

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -159,7 +159,7 @@
                 (apply f (field_imm 0 param) (field_imm 1 param)))
             map =
               (function f l
-                (apply (field_imm 18 (global Stdlib__List!))
+                (apply (field_imm 19 (global Stdlib__List!))
                   (apply uncurry f) l)))
            (makeblock 0
              (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
@@ -198,7 +198,7 @@
                     (apply f (field_imm 0 param) (field_imm 1 param)))
                 map =
                   (function f l
-                    (apply (field_imm 18 (global Stdlib__List!))
+                    (apply (field_imm 19 (global Stdlib__List!))
                       (apply uncurry f) l)))
                (makeblock 0
                  (makeblock 0 (apply map eta_gen_cmp vec)


### PR DESCRIPTION
Adds a fairly self-explanatory function:

```ocaml
val is_empty : _ list -> bool
```

This can be found in both [`containers`](http://c-cube.github.io/ocaml-containers/3.4/containers/CCList/index.html#val-is_empty) and [`base`](https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/List/index.html#val-is_empty).

The rationale for proposing it is that I see it hand-rolled as `List.length l = 0` relatively frequently in the wild, which is inefficient. It's possible to use `l = []` instead, but I think a dedicated function would encourage users to fall into this more efficient pattern organically. (Plus, some codebases intentionally put barriers in the way of polymorphic equality.)

Notes on consistency:
- we already have `Map.is_empty`;
- there's an [outstanding issue](https://github.com/ocaml/ocaml/issues/7445) regarding `{String,Bytes,Array}.is_empty`, with the concensus being that these should be implemented in terms of compiler primitives;
- there's perhaps a case to be made for `Seq.is_empty` too, though it does force an unused element. (Containers and Base provide it.)