### PR TITLE
Correctly pretty print `Psig_typesubst`

### DIFF
--- a/Changes
+++ b/Changes
@@ -599,6 +599,10 @@ OCaml 4.13.0
 - #10454: Check row_more in nondep_type_rec.
   (Leo White, review by Thomas Refis)
 
+- #10468: Correctly pretty print local type substitution, e.g. type t := ...,
+  with -dsource
+  (Matt Else, review by Florian Angeletti)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1108,7 +1108,10 @@ and signature_item ctxt f x : unit =
   | Psig_type (rf, l) ->
       type_def_list ctxt f (rf, true, l)
   | Psig_typesubst l ->
-      type_def_list ctxt f (Nonrecursive, false, l)
+      (* Psig_typesubst is never recursive, but we specify [Recursive] here to
+         avoid printing a [nonrec] flag, which would be rejected by the parser.
+      *)
+      type_def_list ctxt f (Recursive, false, l)
   | Psig_value vd ->
       let intro = if vd.pval_prim = [] then "val" else "external" in
       pp f "@[<2>%s@ %a@ :@ %a@]%a" intro

--- a/testsuite/tests/parsing/pr10468.ml
+++ b/testsuite/tests/parsing/pr10468.ml
@@ -1,0 +1,14 @@
+(* TEST
+    flags = "-dsource"
+    * expect
+*)
+
+module type S = sig
+  type t
+  type t' := t
+end
+[%%expect {|
+
+module type S  = sig type t type t' := t end;;
+module type S = sig type t end
+|}]


### PR DESCRIPTION
I originally submitted this change to ocaml-ppx/ppxlib#261, @xclerc pointed out that this file originally comes from the OCaml compiler. This patch is essentially identical.

pprintast.ml was previously incorrectly pretty printing the following AST:

```ocaml
type t
type other := t
```

as

```ocaml
type t
type nonrec other := t
```

The nonrec isn't required here, and will just be rejected by the OCaml compiler. This PR updates pprintast to correctly omit this flag.