### PR TITLE
Add set_uncaught_exception_handler to systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,7 +16,7 @@ Working version
 
 - #10469: Add Thread.set_uncaught_exception_handler and
   Thread.default_uncaught_exception_handler.
-  (Enguerrand Decorne)
+  (Enguerrand Decorne, review by David Allsopp)
 
 ### Tools:
 

--- a/Changes
+++ b/Changes
@@ -14,6 +14,10 @@ Working version
   to emulate Unix.socketpair (only available on Windows 1803+)
   (Antonin Décimo, review by David Allsopp)
 
+- #10469: Add Thread.set_uncaught_exception_handler and
+  Thread.default_uncaught_exception_handler.
+  (Enguerrand Decorne)
+
 ### Tools:
 
 ### Manual and documentation:

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -53,12 +53,12 @@ let create fn arg =
           !uncaught_exception_handler exn
         with exn' ->
           Printf.eprintf
-            "Fatal error in thread %d : %s\n"
-             (id (self ())) (Printexc.to_string exn);
+            "Thread %d killed on uncaught exception %s\n"
+            (id (self ())) (Printexc.to_string exn);
           Printexc.print_raw_backtrace stderr raw_backtrace;
           Printf.eprintf
-            "Fatal error in uncaught exception handler : %s\n"
-            (Printexc.to_string exn');
+            "Thread %d uncaught exception handler raised %s\n"
+            (id (self ())) (Printexc.to_string exn');
           Printexc.print_backtrace stdout;
           flush stderr)
 

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -145,3 +145,16 @@ val wait_signal : int list -> int
    Signal handlers attached to the signals in [sigs] will not
    be invoked.  The signals [sigs] are expected to be blocked before
    calling [wait_signal]. *)
+
+(** {1 Uncaught exceptions} *)
+
+val default_uncaught_exception_handler : exn -> unit
+(** [Thread.default_uncaught_exception_handler] will print the thread's id,
+    exception and backtrace (if available). *)
+
+val set_uncaught_exception_handler : (exn -> unit) -> unit
+(** [Thread.set_uncaught_exception_handler fn] registers [fn] as the handler
+    for uncaught exceptions.
+
+    If the newly set uncaught exception handler raise an exception,
+    {!default_uncaught_exception_handler} will be called. *)

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -12,4 +12,4 @@ Raised by primitive operation at Callstack.f0 in file "callstack.ml", line 11, c
 Called from Callstack.f1 in file "callstack.ml", line 12, characters 27-32
 Called from Callstack.f2 in file "callstack.ml", line 13, characters 27-32
 Called from Callstack.f3 in file "callstack.ml", line 14, characters 27-32
-Called from Thread.create.(fun) in file "thread.ml", line 41, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.ml
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.ml
@@ -14,16 +14,19 @@ include systhreads
 
 let () = Printexc.record_backtrace true
 
+exception UncaughtHandlerExn
+exception CallbackExn
+
 let handler exn =
   let id = Thread.self () |> Thread.id in
   let msg = Printexc.to_string exn in
   Printf.eprintf "[thread %d] caught %s\n" id msg;
   Printexc.print_backtrace stderr;
   flush stderr;
-  raise exn
+  raise UncaughtHandlerExn
 
 let fn () = Printexc.raise_with_backtrace
-              Not_found
+              CallbackExn
               (Printexc.get_raw_backtrace ())
 
 let _ =

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.ml
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.ml
@@ -1,0 +1,34 @@
+(* TEST
+
+flags = "-g"
+ocamlrunparam += ",b=1"
+
+* hassysthreads
+include systhreads
+** bytecode
+** native
+
+*)
+
+(* Testing if uncaught exception handlers are behaving properly  *)
+
+let () = Printexc.record_backtrace true
+
+let handler exn =
+  let id = Thread.self () |> Thread.id in
+  let msg = Printexc.to_string exn in
+  Printf.eprintf "[thread %d] caught %s\n" id msg;
+  Printexc.print_backtrace stderr;
+  flush stderr;
+  raise exn
+
+let fn () = Printexc.raise_with_backtrace
+              Not_found
+              (Printexc.get_raw_backtrace ())
+
+let _ =
+  let th = Thread.create fn () in
+  Thread.join th;
+  Thread.set_uncaught_exception_handler handler;
+  let th = Thread.create fn () in
+  Thread.join th

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,12 +1,12 @@
-Thread 1 killed on uncaught exception Not_found
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 25, characters 12-111
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
-[thread 2] caught Not_found
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 25, characters 12-111
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
-Fatal error in thread 2 : Not_found
-Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 25, characters 12-111
-Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
-Fatal error in uncaught exception handler : Not_found
-Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 23, characters 2-11
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 10-41
+Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Called from Thread.create.(fun) in file "thread.ml", line 51, characters 8-14
+[thread 2] caught Uncaught_exception_handler.CallbackExn
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Called from Thread.create.(fun) in file "thread.ml", line 51, characters 8-14
+Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
+Called from Thread.create.(fun) in file "thread.ml", line 51, characters 8-14
+Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
+Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-26
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 10-41

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,12 +1,12 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 51, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 51, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 28, characters 12-113
-Called from Thread.create.(fun) in file "thread.ml", line 51, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-26
-Called from Thread.create.(fun) in file "thread.ml", line 57, characters 10-41
+Called from Thread.create.(fun) in file "thread.ml", line 53, characters 10-41

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,0 +1,12 @@
+Thread 1 killed on uncaught exception Not_found
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 25, characters 12-111
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+[thread 2] caught Not_found
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 25, characters 12-111
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Fatal error in thread 2 : Not_found
+Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", line 25, characters 12-111
+Called from Thread.create.(fun) in file "thread.ml", line 47, characters 8-14
+Fatal error in uncaught exception handler : Not_found
+Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 23, characters 2-11
+Called from Thread.create.(fun) in file "thread.ml", line 53, characters 10-41


### PR DESCRIPTION
# Introduction and goal

This PR introduces `Thread.set_uncaught_exception_handler` and subsequently, `Thread.default_uncaught_exception_handler`, as suggested in #6813.

The idea is to allow an user to set their own handlers in the case an exception is raised by a thread. (as is possible through Printexc in a non-systhreads context.)

# Implementation

The change is kept minimal, by introducing a ref in the Thread module (_à-la-Printexc_) and allowing the user to set it, whether it be by a new function, or by re-setting it to `Thread.default_uncaught_exception_handler`.

`Thread.create` will now use this handler if the callback were ever to raise an exception, and there is a failsafe printing both exceptions and their respective backtraces in case the handler itself raise an exception.

I also added a simple test to check that all behaviors are working appropriately. (default handler, custom handler, and when a custom handler raises an exception.)

## About the current (default) uncaught exception handler.

I'm a bit split about whether the use of `Printexc` utilities here are fine, as the way `systhreads` currently handle the uncaught exception section of the code is written [in the c stubs](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/systhreads/st_stubs.c#L675).
Is there a specific reason for the default handler to be written in C?
I am thinking that this function could as well be rewritten in OCaml (and this code maybe predates the right `Printexc` utilities)
(if that's the case and if it is desirable, I am willing to contribute this as well, in this PR or another)
