### PR TITLE
Refactor `caml_sys_random_seed`

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ Working version
   type
   (Nicolas Chataing, review by Gabriel Scherer)
 
+- #10472: refactor caml_sys_random_seed to ease future Multicore changes
+  (Gabriel Scherer, review by Xavier Leroy)
+
 ### Build system:
 
 ### Bug fixes:

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -561,18 +561,11 @@ CAMLprim value caml_sys_time(value unit)
 
 #ifdef _WIN32
 extern int caml_win32_random_seed (intnat data[16]);
-#endif
-
-CAMLprim value caml_sys_random_seed (value unit)
-{
-  intnat data[16];
-  int n, i;
-  value res;
-#ifdef _WIN32
-  n = caml_win32_random_seed(data);
 #else
+int caml_unix_random_seed(intnat data[16])
+{
   int fd;
-  n = 0;
+  int n = 0;
   /* Try /dev/urandom first */
   fd = open("/dev/urandom", O_RDONLY, 0);
   if (fd != -1) {
@@ -598,6 +591,19 @@ CAMLprim value caml_sys_random_seed (value unit)
     data[n++] = getppid();
 #endif
   }
+  return n;
+}
+#endif
+
+CAMLprim value caml_sys_random_seed (value unit)
+{
+  intnat data[16];
+  int n, i;
+  value res;
+#ifdef _WIN32
+  n = caml_win32_random_seed(data);
+#else
+  n = caml_unix_random_seed(data);
 #endif
   /* Convert to an OCaml array of ints */
   res = caml_alloc_small(n, 0);


### PR DESCRIPTION
The current implementation of `caml_sys_random_seed` is hard to extend: it is not obvious how to extend the seeding with new information without risking array overflow. This was an issue in https://github.com/ocaml-multicore/ocaml-multicore/pull/582 . The present (small) PR refactors `caml_sys_random_seed` to make it easy to extend with new seed components.

cc @xavierleroy I guess?