### PR TITLE
RISC-V: add CFI directives

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,6 +44,10 @@ Working version
 
 ### Bug fixes:
 
+- #10473: Add CFI directives to RISC-V runtime and asmcomp.
+  This allows stacktraces to work in gdb through C and OCaml calls.
+  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
+
 OCaml 4.13.0
 -------------
 

--- a/asmcomp/riscv/emit.mlp
+++ b/asmcomp/riscv/emit.mlp
@@ -102,6 +102,12 @@ let emit_stack_adjustment = function
       `	li	{emit_reg reg_tmp}, {emit_int n}\n`;
       `	add	sp, sp, {emit_reg reg_tmp}\n`
 
+(* Adjust stack_offset and emit corresponding CFI directive *)
+
+let adjust_stack_offset env delta =
+  env.stack_offset <- env.stack_offset + delta;
+  cfi_adjust_cfa_offset delta
+
 let emit_mem_op op src ofs =
   if is_immediate ofs then
     `	{emit_string op}	{emit_string src}, {emit_int ofs}(sp)\n`
@@ -237,7 +243,11 @@ let emit_instr env i =
       assert (env.f.fun_prologue_required);
       let n = frame_size env in
       emit_stack_adjustment (-n);
-      if env.f.fun_contains_calls then store_ra n
+      if n > 0 then cfi_adjust_cfa_offset n;
+      if env.f.fun_contains_calls then begin
+        store_ra n;
+        cfi_offset ~reg:1 (* ra *) ~offset:(-size_addr)
+      end;
   | Lop(Imove | Ispill | Ireload) ->
       let src = i.arg.(0) and dst = i.res.(0) in
       if src.loc <> dst.loc then begin
@@ -301,7 +311,7 @@ let emit_instr env i =
   | Lop(Istackoffset n) ->
       assert (n mod 16 = 0);
       emit_stack_adjustment (-n);
-      env.stack_offset <- env.stack_offset + n
+      adjust_stack_offset env n
   | Lop(Iload(Single, Iindexed ofs, _mut)) ->
       `	flw	{emit_reg i.res.(0)}, {emit_int ofs}({emit_reg i.arg.(0)})\n`;
       `	fcvt.d.s	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
@@ -489,18 +499,18 @@ let emit_instr env i =
   | Ladjust_trap_depth { delta_traps } ->
       (* each trap occupes 16 bytes on the stack *)
       let delta = 16 * delta_traps in
-      env.stack_offset <- env.stack_offset + delta
+      adjust_stack_offset env delta
   | Lpushtrap {lbl_handler} ->
       `	la	{emit_reg reg_tmp}, {emit_label lbl_handler}\n`;
       `	addi	sp, sp, -16\n`;
-      env.stack_offset <- env.stack_offset + 16;
+      adjust_stack_offset env 16;
       emit_store reg_tmp size_addr;
       emit_store reg_trap 0;
       `	mv	{emit_reg reg_trap}, sp\n`
   | Lpoptrap ->
       emit_load reg_trap 0;
       `	addi	sp, sp, 16\n`;
-      env.stack_offset <- env.stack_offset - 16
+      adjust_stack_offset env (-16)
   | Lraise k ->
       begin match k with
       | Lambda.Raise_regular ->
@@ -534,9 +544,11 @@ let fundecl fundecl =
   `	.align	2\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
   emit_debug_info fundecl.fun_dbg;
+  cfi_startproc();
   emit_all env fundecl.fun_body;
   List.iter emit_call_gc env.call_gc_sites;
   List.iter emit_call_bound_error env.bound_error_sites;
+  cfi_endproc();
   `	.size	{emit_symbol fundecl.fun_name}, .-{emit_symbol fundecl.fun_name}\n`;
   (* Emit the float literals *)
   if env.float_literals <> [] then begin

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -41,6 +41,9 @@
         .type name, @function; \
 name:
 
+#define END_FUNCTION(name) \
+        .size name, .-name
+
 #if defined(__PIC__)
         .option pic
 #define PLT(r) r@plt
@@ -173,7 +176,7 @@ FUNCTION(caml_call_gc)
         LOAD    ra, 0x8(sp)
         addi    sp, sp, 0x170
         ret
-        .size   caml_call_gc, .-caml_call_gc
+END_FUNCTION(caml_call_gc)
 
 /* Call a C function from OCaml */
 /* Function to call is in ARG */
@@ -193,7 +196,7 @@ FUNCTION(caml_c_call)
         LOAD    ALLOC_PTR, Caml_state(young_ptr)
         /* Return */
         jr      s2
-        .size   caml_c_call, .-caml_c_call
+END_FUNCTION(caml_c_call)
 
 /* Raise an exception from OCaml */
 FUNCTION(caml_raise_exn)
@@ -217,7 +220,7 @@ FUNCTION(caml_raise_exn)
         /* Restore exception bucket and raise */
         mv      a0, s2
         j       1b
-        .size   caml_raise_exn, .-caml_raise_exn
+END_FUNCTION(caml_raise_exn)
 
         .globl  caml_reraise_exn
         .type   caml_reraise_exn, @function
@@ -245,7 +248,7 @@ FUNCTION(caml_raise_exception)
         call    PLT(caml_stash_backtrace)
         mv      a0, s2
         j       1b
-        .size   caml_raise_exception, .-caml_raise_exception
+END_FUNCTION(caml_raise_exception)
 
 /* Start the OCaml program */
 
@@ -347,7 +350,7 @@ FUNCTION(caml_start_program)
         ret
         .type   .Lcaml_retaddr, @function
         .size   .Lcaml_retaddr, .-.Lcaml_retaddr
-        .size   caml_start_program, .-caml_start_program
+END_FUNCTION(caml_start_program)
 
         .align  2
 .Ltrap_handler:
@@ -355,7 +358,7 @@ FUNCTION(caml_start_program)
         ori     a0, a0, 2
         j       .Lreturn_result
         .type   .Ltrap_handler, @function
-        .size   .Ltrap_handler, .-.Ltrap_handler
+END_FUNCTION(.Ltrap_handler)
 
 /* Callback from C to OCaml */
 
@@ -367,7 +370,7 @@ FUNCTION(caml_callback_asm)
                             /* a1 = closure environment */
         LOAD    ARG, 0(a1)  /* code pointer */
         j       .Ljump_to_caml
-        .size   caml_callback_asm, .-caml_callback_asm
+END_FUNCTION(caml_callback_asm)
 
 FUNCTION(caml_callback2_asm)
         /* Initial shuffling of arguments */
@@ -379,7 +382,7 @@ FUNCTION(caml_callback2_asm)
         mv      a2, TMP
         la      ARG, caml_apply2
         j       .Ljump_to_caml
-        .size   caml_callback2_asm, .-caml_callback2_asm
+END_FUNCTION(caml_callback2_asm)
 
 FUNCTION(caml_callback3_asm)
         /* Initial shuffling of arguments */
@@ -391,14 +394,14 @@ FUNCTION(caml_callback3_asm)
         LOAD    a2, 16(a2)
         la      ARG, caml_apply3
         j       .Ljump_to_caml
-        .size   caml_callback3_asm, .-caml_callback3_asm
+END_FUNCTION(caml_callback3_asm)
 
 FUNCTION(caml_ml_array_bound_error)
         /* Load address of [caml_array_bound_error] in ARG */
         la      ARG, caml_array_bound_error
         /* Call that function */
         tail    caml_c_call
-        .size   caml_ml_array_bound_error, .-caml_ml_array_bound_error
+END_FUNCTION(caml_ml_array_bound_error)
 
         .globl  caml_system__code_end
 caml_system__code_end:

--- a/runtime/riscv.S
+++ b/runtime/riscv.S
@@ -16,6 +16,8 @@
 /* Asm part of the runtime system, RISC-V processor, 64-bit mode */
 /* Must be preprocessed by cpp */
 
+#include "caml/m.h"
+
 #define ARG_DOMAIN_STATE_PTR t0
 #define DOMAIN_STATE_PTR s11
 #define TRAP_PTR s1
@@ -25,6 +27,20 @@
 
 #define STORE sd
 #define LOAD ld
+
+#if defined(ASM_CFI_SUPPORTED)
+#define CFI_STARTPROC .cfi_startproc
+#define CFI_ENDPROC .cfi_endproc
+#define CFI_ADJUST(n) .cfi_adjust_cfa_offset n
+#define CFI_REGISTER(r1,r2) .cfi_register r1,r2
+#define CFI_OFFSET(r,n) .cfi_offset r,n
+#else
+#define CFI_STARTPROC
+#define CFI_ENDPROC
+#define CFI_ADJUST(n)
+#define CFI_REGISTER(r1,r2)
+#define CFI_OFFSET(r,n)
+#endif
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -39,9 +55,11 @@
         .align 2; \
         .globl name; \
         .type name, @function; \
-name:
+name:; \
+        CFI_STARTPROC
 
 #define END_FUNCTION(name) \
+        CFI_ENDPROC; \
         .size name, .-name
 
 #if defined(__PIC__)
@@ -69,7 +87,9 @@ FUNCTION(caml_call_gc)
             20 caller-save float regs) * 8 */
         /* + 1 for alignment */
         addi    sp, sp, -0x170
+        CFI_ADJUST(0x170)
         STORE   ra, 0x8(sp)
+        CFI_OFFSET(ra, -0x170+8)
         /* Save allocatable integer registers on the stack,
            in the order given in proc.ml */
         STORE   a0, 0x10(sp)
@@ -175,6 +195,7 @@ FUNCTION(caml_call_gc)
         /* Free stack space and return to caller */
         LOAD    ra, 0x8(sp)
         addi    sp, sp, 0x170
+        CFI_ADJUST(-0x170)
         ret
 END_FUNCTION(caml_call_gc)
 
@@ -184,6 +205,7 @@ END_FUNCTION(caml_call_gc)
 FUNCTION(caml_c_call)
         /* Preserve return address in callee-save register s2 */
         mv      s2, ra
+        CFI_REGISTER(ra, s2)
         /* Record lowest stack address and return address */
         STORE   ra, Caml_state(last_return_address)
         STORE   sp, Caml_state(bottom_of_stack)
@@ -209,6 +231,7 @@ FUNCTION(caml_raise_exn)
         LOAD    TMP, 8(sp)
         LOAD    TRAP_PTR, 0(sp)
         addi    sp, sp, 16
+        CFI_ADJUST(-16)
         jr      TMP
 2:      /* Preserve exception bucket in callee-save register s2 */
         mv      s2, a0
@@ -239,6 +262,7 @@ FUNCTION(caml_raise_exception)
         LOAD    TMP, 8(sp)
         LOAD    TRAP_PTR, 0(sp)
         addi    sp, sp, 16
+        CFI_ADJUST(-16)
         jr      TMP
 2:      /* Preserve exception bucket in callee-save register s2 */
         mv      s2, a0
@@ -261,7 +285,9 @@ FUNCTION(caml_start_program)
 .Ljump_to_caml:
         /* Set up stack frame and save callee-save registers */
         addi    sp, sp, -0xd0
+        CFI_ADJUST(0xd0)
         STORE   ra, 0xc0(sp)
+        CFI_OFFSET(ra, -0xd0+0xc0)
         STORE   s0, 0x0(sp)
         STORE   s1, 0x8(sp)
         STORE   s2, 0x10(sp)
@@ -287,6 +313,7 @@ FUNCTION(caml_start_program)
         fsd     fs10, 0xb0(sp)
         fsd     fs11, 0xb8(sp)
         addi    sp, sp, -32
+        CFI_ADJUST(32)
         /* Load domain state pointer from argument */
         mv      DOMAIN_STATE_PTR, ARG_DOMAIN_STATE_PTR
         /* Setup a callback link on the stack */
@@ -298,6 +325,7 @@ FUNCTION(caml_start_program)
         STORE   TMP, 16(sp)
         /* set up a trap frame */
         addi    sp, sp, -16
+        CFI_ADJUST(16)
         LOAD    TMP, Caml_state(exception_pointer)
         STORE   TMP, 0(sp)
         lla     TMP, .Ltrap_handler
@@ -310,6 +338,7 @@ FUNCTION(caml_start_program)
         LOAD    TMP, 0(sp)
         STORE   TMP, Caml_state(exception_pointer)
         addi    sp, sp, 16
+        CFI_ADJUST(-16)
 .Lreturn_result:        /* pop callback link, restoring global variables */
         LOAD    TMP, 0(sp)
         STORE   TMP, Caml_state(bottom_of_stack)
@@ -318,6 +347,7 @@ FUNCTION(caml_start_program)
         LOAD    TMP, 16(sp)
         STORE   TMP, Caml_state(gc_regs)
         addi    sp, sp, 32
+        CFI_ADJUST(-32)
         /* Update allocation pointer */
         STORE   ALLOC_PTR, Caml_state(young_ptr)
         /* reload callee-save registers and return */
@@ -347,6 +377,7 @@ FUNCTION(caml_start_program)
         fld     fs10, 0xb0(sp)
         fld     fs11, 0xb8(sp)
         addi    sp, sp, 0xd0
+        CFI_ADJUST(-0xd0)
         ret
         .type   .Lcaml_retaddr, @function
         .size   .Lcaml_retaddr, .-.Lcaml_retaddr
@@ -354,6 +385,7 @@ END_FUNCTION(caml_start_program)
 
         .align  2
 .Ltrap_handler:
+        CFI_STARTPROC
         STORE   TRAP_PTR, Caml_state(exception_pointer)
         ori     a0, a0, 2
         j       .Lreturn_result


### PR DESCRIPTION
While trying to track down a bug (dune hanging while building Coq) in OCaml 4.12.0 on RISC-V I noticed that gdb stacktraces were not working.
Adding CFI directives makes stacktraces work, this patch series is based on how CFI directives are emitted in arm64/emit.mlp and the placement of CFI directives in runtime/amd64.S and runtime/riscv.S. It only adds minimal CFI directives needed to make stacktraces work: on amd64 I see there are CFI_OFFSET directives also for nearly all stack pushes in the runtime, I haven't added those yet (I think they'll be useful in the future once OCaml gains more dwarf support for describing locations of values in registers).

Here is an example stacktrace (ignore the DWARF errors from the C code, those are also present in pure C):
```
  (gdb) bt
#0  0x0000003ff7ea6014 in __GI___clock_nanosleep (clock_id=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, 
    flags=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, 
    req=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, 
    rem=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:43
#1  0x0000003ff7ea9862 in __GI___nanosleep (req=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, 
    rem=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at ../sysdeps/unix/sysv/linux/nanosleep.c:25
#2  0x0000002aaab3ecfa in unix_sleep (duration=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at sleep.c:42
#3  0x0000002aaab57768 in caml_c_call ()
#4  0x0000002aaab08bc4 in camlUnix__sleep_977 () at unix.ml:451
#5  0x0000002aaab07714 in camlX__bar_127 () at x.ml:3
#6  0x0000002aaab07770 in camlX__entry () at x.ml:11
#7  0x0000002aaab053b0 in caml_program ()
#8  0x0000002aaab5783a in caml_start_program ()
#9  0x0000002aaab57a78 in caml_startup_common (argv=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, 
    pooling=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at startup_nat.c:158
#10 0x0000002aaab57ad4 in caml_startup_exn (argv=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at startup_nat.c:163
#11 caml_startup (argv=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at startup_nat.c:168
#12 caml_main (argv=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at startup_nat.c:175
#13 0x0000002aaab0500a in main (argc=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, 
    argv=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at main.c:41
```

OCaml code:
```
let foo x =
  let r = x + 7 in
  Unix.sleep 1;
  r

let bar y =
  for i = 1 to 100000 do
    ignore (foo (y * 5) + 6)
  done

let () = bar 42
```
`ocamlopt unix.cmxa x.ml -g -o ./x`

The testsuite still passes with these changes (although I don't think it has tests for CFI, they also all passed previously):
```
Summary:
  2887 tests passed
   37 tests skipped
    0 tests failed
  100 tests not started (parent test skipped or failed)
    0 unexpected errors
  3024 tests considered
```

Tested on RISC-V unmatched:
```
processor       : 0
hart            : 3
isa             : rv64imafdc
mmu             : sv39
uarch           : sifive,u74-mc
```

I can't reproduce the original issue I was having with Dune on trunk anymore, but the CFI directives are still useful for having stacktraces in gdb.