### PR TITLE
st_stubs.c: fix initialization of thread ID when a thread starts

### DIFF
--- a/Changes
+++ b/Changes
@@ -630,6 +630,15 @@ OCaml 4.13.0
   with -dsource
   (Matt Else, review by Florian Angeletti)
 
+OCaml 4.12, maintenance version
+-------------------------------
+
+### Bug fixes:
+
+- #10478: Fix segfault under Windows due to a mistaken initialization of thread
+  ID when a thread starts.
+  (David Allsopp, Nicolás Ojeda Bär, review by Xavier Leroy)
+
 OCaml 4.12.0 (24 February 2021)
 -------------------------------
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -532,9 +532,9 @@ static ST_THREAD_FUNCTION caml_thread_start(void * arg)
 
   /* Associate the thread descriptor with the thread */
   st_tls_set(thread_descriptor_key, (void *) th);
-  st_thread_set_id(Ident(th->descr));
   /* Acquire the global mutex */
   caml_leave_blocking_section();
+  st_thread_set_id(Ident(th->descr));
   caml_setup_stack_overflow_detection();
 #ifdef NATIVE_CODE
   /* Setup termination handler (for caml_thread_exit) */


### PR DESCRIPTION
Fixes #10477 

The crashing example given in #10477 runs "forever" with this fix, which is also [suggested](https://github.com/ocaml/ocaml/issues/10477#issuecomment-868638872) by @dra27.