### PR TITLE
Rewrite get_unboxed_type_representation using a terminating algorithm instead of fuel.

### DIFF
--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -40,6 +40,7 @@ module TypeMap = struct
   include TransientTypeMap
   let add ty = wrap_repr add ty
   let find ty = wrap_repr find ty
+  let mem ty = wrap_repr mem ty
   let singleton ty = wrap_repr singleton ty
   let fold f = TransientTypeMap.fold (wrap_type_expr f)
 end
@@ -47,6 +48,7 @@ module TransientTypeHash = Hashtbl.Make(TransientTypeOps)
 module TypeHash = struct
   include TransientTypeHash
   let add hash = wrap_repr (add hash)
+  let mem hash = wrap_repr (mem hash)
   let find hash = wrap_repr (find hash)
   let iter f = TransientTypeHash.iter (wrap_type_expr f)
 end

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -34,6 +34,7 @@ module TypeMap : sig
                      and type 'a t = 'a TransientTypeMap.t
   val add: type_expr -> 'a -> 'a t -> 'a t
   val find: type_expr -> 'a t -> 'a
+  val mem: type_expr -> 'a t -> bool
   val singleton: type_expr -> 'a -> 'a t
   val fold: (type_expr -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
 end
@@ -41,6 +42,7 @@ module TypeHash : sig
   include Hashtbl.S with type key = transient_expr
   val add: 'a t -> type_expr -> 'a -> unit
   val find: 'a t -> type_expr -> 'a
+  val mem : 'a t -> type_expr -> bool
   val iter: (type_expr -> 'a -> unit) -> 'a t -> unit
 end
 module TypePairs : sig

--- a/typing/typedecl_unboxed.ml
+++ b/typing/typedecl_unboxed.ml
@@ -16,38 +16,90 @@
 
 open Types
 
+module Callstack = struct
+  type t = Path.t list
+
+  module TypeMap = Btype.TypeMap
+  type map = t TypeMap.t
+
+  let visit p callstack : t =
+    p :: callstack
+
+  let visited p callstack =
+    List.exists (Path.same p) callstack
+
+  let head (callstacks : map) ty =
+    TypeMap.find ty callstacks
+
+  let rec extend callstacks ty new_callstack =
+    if TypeMap.mem ty callstacks then callstacks
+    else
+      let callstacks = TypeMap.add ty new_callstack callstacks in
+      Btype.fold_type_expr (fun callstacks ty' ->
+        extend callstacks ty' new_callstack
+      ) callstacks ty
+
+  let fill ty callstack = extend TypeMap.empty ty callstack
+
+  let expand_head_opt env ty callstacks =
+    let head_callstack = head callstacks ty in
+    let ty = Ctype.expand_head_opt env ty in
+    ty, extend callstacks ty head_callstack
+
+  let apply env params (ty, callstacks) args current_callstack =
+    let ty = Ctype.apply env params ty args in
+    (ty, extend callstacks ty current_callstack)
+end
+
 type t =
   | Unavailable
   | This of type_expr
   | Only_on_64_bits of type_expr
 
+let check_annotated ty callstacks =
+  let hash = Btype.TypeHash.create 42 in
+  let rec loop ty =
+    if Btype.TypeHash.mem hash ty then ()
+    else begin
+      Btype.TypeHash.add hash ty ();
+      assert (Btype.TypeMap.mem ty callstacks);
+      Btype.iter_type_expr loop ty;
+    end
+  in loop ty
+
 (* We use the Ctype.expand_head_opt version of expand_head to get access
    to the manifest type of private abbreviations. *)
-let rec get_unboxed_type_representation env ty fuel =
-  if fuel < 0 then Unavailable else
-  let ty = Ctype.expand_head_opt env ty in
+let rec get_unboxed_type_representation env ty callstacks =
+  let ty, callstacks = Callstack.expand_head_opt env ty callstacks in
+  check_annotated ty callstacks;
   match get_desc ty with
   | Tconstr (p, args, _) ->
-    begin match Env.find_type p env with
-    | exception Not_found -> This ty
-    | {type_immediate = Always; _} ->
-        This Predef.type_int
-    | {type_immediate = Always_on_64bits; _} ->
-        Only_on_64_bits Predef.type_int
-    | {type_params; type_kind =
-         Type_record ([{ld_type = ty2; _}], Record_unboxed _)
-       | Type_variant ([{cd_args = Cstr_tuple [ty2]; _}], Variant_unboxed)
-       | Type_variant ([{cd_args = Cstr_record [{ld_type = ty2; _}]; _}],
-                       Variant_unboxed)}
-      ->
-        let ty2 = match get_desc ty2 with Tpoly (t, _) -> t | _ -> ty2 in
-        get_unboxed_type_representation env
-          (Ctype.apply env type_params ty2 args) (fuel - 1)
-    | _ -> This ty
-    end
+    let head_callstack = Callstack.head callstacks ty in
+    if Callstack.visited p head_callstack then
+      Unavailable
+    else
+      let current_callstack = Callstack.visit p head_callstack in
+      begin match Env.find_type p env with
+      | exception Not_found -> This ty
+      | {type_immediate = Always; _} ->
+          This Predef.type_int
+      | {type_immediate = Always_on_64bits; _} ->
+          Only_on_64_bits Predef.type_int
+      | {type_params; type_kind =
+           Type_record ([{ld_type = ty2; _}], Record_unboxed _)
+         | Type_variant ([{cd_args = Cstr_tuple [ty2]; _}], Variant_unboxed)
+         | Type_variant ([{cd_args = Cstr_record [{ld_type = ty2; _}]; _}],
+                         Variant_unboxed)}
+        ->
+          let ty2 = match get_desc ty2 with Tpoly (t, _) -> t | _ -> ty2 in
+          let (ty2, callstacks) = Callstack.apply
+            env type_params (ty2, callstacks) args current_callstack in
+          get_unboxed_type_representation env ty2 callstacks
+      | _ -> This ty
+      end
   | _ -> This ty
 
 let get_unboxed_type_representation env ty =
-  (* Do not give too much fuel: PR#7424 *)
-  get_unboxed_type_representation env ty 100
+  let callstacks = Callstack.fill ty [] in
+  get_unboxed_type_representation env ty callstacks
 ;;


### PR DESCRIPTION
This PR proposes to rewrite `get_unboxed_type_representation` in `Typedecl_unboxed`, based on the algorithm presented in http://gallium.inria.fr/~scherer/research/constructor-unboxing/constructor-unboxing-ml-workshop-2021.pdf.

Following #10337, we were obliged to redefine the `mem` function from `Btype.TypeMap` and `Btype.TypeHash` to incorporate the `repr` normalisation. This is maybe something that we want to generalize from said modules?

Also we were unsure how to test this function properly. The function principal use is to later compute the immediacy of a type. Maybe the testsuite related to immediacy suffices in this case?

With @gasche.