### PR TITLE
Deprecate the Stream and Genlex stdlib modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,11 @@ Working version
   is actually a suffix of `name` and raises Invalid_argument otherwise.
   (Xavier Leroy, report by whitequark, review by David Allsopp)
 
+* #10482: mark the Stream and Genlex modules as deprecated, in preparation
+  for a future removal.  These modules (without deprecation alert)
+  are now provided by the camlp-streams library.
+  (Xavier Leroy, review by Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 - #10192: Add support for Unix domain sockets on Windows and use them

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -37,5 +37,7 @@ case $1 in
   stdlib__Float.cm[ox]) echo ' -nolabels -no-alias-deps';;
   stdlib__Oo.cmi) echo ' -no-principal';;
     # preserve structure sharing in Oo.copy (PR#9767)
+  stdlib__Genlex.cm[iox]) echo ' -w -3';;
+    # ignore the "deprecated" alert on the Stream module
   *) echo ' ';;
 esac

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1397,6 +1397,7 @@ module Format       = Format
 module Fun          = Fun
 module Gc           = Gc
 module Genlex       = Genlex
+[@@deprecated "Use the camlp-streams library instead."]
 module Hashtbl      = Hashtbl
 module Int          = Int
 module Int32        = Int32
@@ -1429,6 +1430,7 @@ module Set          = Set
 module Stack        = Stack
 module StdLabels    = StdLabels
 module Stream       = Stream
+[@@deprecated "Use the camlp-streams library instead."]
 module String       = String
 module StringLabels = StringLabels
 module Sys          = Sys

--- a/testsuite/tests/lib-stream/count_concat_bug.ml
+++ b/testsuite/tests/lib-stream/count_concat_bug.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flags = "-w -3"
    include testing
 *)
 

--- a/testsuite/tests/lib-stream/mpr7769.ml
+++ b/testsuite/tests/lib-stream/mpr7769.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flags = "-w -3"
    readonly_files = "mpr7769.txt"
 *)
 


### PR DESCRIPTION
The core OCaml development team decided to remove the Stream and Genlex modules from the standard library, making them available in a separate library [camlp-streams](https://github.com/ocaml/camlp-streams) instead.

(Rationale: these two modules are tightly connected with Camlp4/Camlp5 stream parsers and printers, but not really usable by themselves.   With minor changes to Camlp4 and Camlp5, the separate library camlp-streams can be automatically pulled in programs that use Camlp4/Camlp5 parsers.)

To ease the transition, this PR adds a "deprecated" alert to the Stream and Genlex stdlib modules.

If the PR is merged soon, the deprecation will become active in OCaml 4.14, to be released early 2022.  Removal of Stream and Genlex could take place one year after.

