### PR TITLE
Improve type variable name generation and recursive type detection when printing type errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -165,6 +165,12 @@ Working version
   (Armaël Guéneau, review by Gabriel Scherer,
    split off from #9118 by Kate Deplaix, report by Ricardo M. Correia)
 
+- #10488: Improve type variable name generation and recursive type detection
+  when printing type errors; this ensures that the names given to type variables
+  are always reused in the following portion of the trace and also removes
+  spurious `as 'a`s in types.
+  (Antal Spector-Zabusky, review by Florian Angeletti)
+
 ### Internal/compiler-libs changes:
 
 - #1599: add unset directive to ocamltest to clear environment variables before

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -280,7 +280,6 @@ odoc_dot.cmx : \
     odoc_info.cmx
 odoc_env.cmo : \
     ../typing/types.cmi \
-    ../typing/printtyp.cmi \
     ../typing/predef.cmi \
     ../typing/path.cmi \
     odoc_name.cmi \
@@ -288,7 +287,6 @@ odoc_env.cmo : \
     odoc_env.cmi
 odoc_env.cmx : \
     ../typing/types.cmx \
-    ../typing/printtyp.cmx \
     ../typing/predef.cmx \
     ../typing/path.cmx \
     odoc_name.cmx \
@@ -816,7 +814,6 @@ odoc_types.cmi : \
     ../parsing/location.cmi
 odoc_value.cmo : \
     ../typing/types.cmi \
-    ../typing/printtyp.cmi \
     odoc_types.cmi \
     odoc_parameter.cmo \
     odoc_name.cmi \
@@ -824,7 +821,6 @@ odoc_value.cmo : \
     ../parsing/asttypes.cmi
 odoc_value.cmx : \
     ../typing/types.cmx \
-    ../typing/printtyp.cmx \
     odoc_types.cmx \
     odoc_parameter.cmx \
     odoc_name.cmx \

--- a/ocamldoc/odoc_env.ml
+++ b/ocamldoc/odoc_env.ml
@@ -163,7 +163,6 @@ let subst_type env t =
   print_env_types env ;
   print_newline ();
 *)
-  Printtyp.mark_loops t;
   let deja_vu = ref [] in
   let rec iter t =
     if List.memq t !deja_vu then () else begin

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -39,8 +39,7 @@ let (modtype_fmt, flush_modtype_fmt) = new_fmt ()
 
 
 let string_of_type_expr t =
-  Printtyp.mark_loops t;
-  Printtyp.type_scheme_max ~b_reset_names: false type_fmt t;
+  Printtyp.shared_type_scheme type_fmt t;
   flush_type_fmt ()
 
 exception Use_code of string

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -52,17 +52,16 @@ let raw_string_of_type_list sep type_list =
     | Types.Tsubst _ -> assert false
   in
   let print_one_type variance t =
-    Printtyp.mark_loops t;
     if need_parent t then
       (
        Format.fprintf fmt "(%s" variance;
-       Printtyp.type_scheme_max ~b_reset_names: false fmt t;
+       Printtyp.shared_type_scheme fmt t;
        Format.fprintf fmt ")"
       )
     else
       (
        Format.fprintf fmt "%s" variance;
-       Printtyp.type_scheme_max ~b_reset_names: false fmt t
+       Printtyp.shared_type_scheme fmt t
       )
   in
   begin match type_list with

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -99,7 +99,6 @@ let parameter_list_from_arrows typ =
    parameter names from the .ml and the type from the .mli file. *)
 let dummy_parameter_list typ =
   let normal_name = Odoc_misc.label_name in
-  Printtyp.mark_loops typ;
   let liste_param = parameter_list_from_arrows typ in
   let rec iter (label, t) =
     match Types.get_desc t with

--- a/testsuite/tests/typing-gadts/pr5689.ml
+++ b/testsuite/tests/typing-gadts/pr5689.ml
@@ -103,10 +103,10 @@ type _ linkp2 = Kind : 'a linkp -> ([< inkind ] as 'a) linkp2
 Line 7, characters 35-43:
 7 |     | (Kind _, Ast_Text txt)    -> Text txt
                                        ^^^^^^^^
-Error: This expression has type ([< inkind > `Nonlink ] as 'a) inline_t
+Error: This expression has type [< inkind > `Nonlink ] inline_t
        but an expression was expected of type a inline_t
-       Type 'a = [< `Link | `Nonlink > `Nonlink ] is not compatible with type
-         a = [< `Link | `Nonlink ]
+       Type [< inkind > `Nonlink ] = [< `Link | `Nonlink > `Nonlink ]
+       is not compatible with type a = [< `Link | `Nonlink ]
        The second variant type is bound to $'a,
        it may not allow the tag(s) `Nonlink
 |}];;

--- a/testsuite/tests/typing-gadts/pr5948.ml
+++ b/testsuite/tests/typing-gadts/pr5948.ml
@@ -42,9 +42,9 @@ type _ wrapPoly =
 Line 25, characters 23-27:
 25 |     | WrapPoly ATag -> intA
                             ^^^^
-Error: This expression has type ([< `TagA of 'b ] as 'a) -> 'b
+Error: This expression has type [< `TagA of 'a ] -> 'a
        but an expression was expected of type a -> int
-       Type [< `TagA of 'b ] as 'a is not compatible with type
+       Type [< `TagA of 'a ] is not compatible with type
          a = [< `TagA of int | `TagB ]
        The first variant type does not allow tag(s) `TagB
 |}];;

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -24,8 +24,8 @@ Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> f x;;
                                ^
 Error: This expression has type a t but an expression was expected of type
-         (< .. > as 'a) t
-       Type a is not compatible with type < .. > as 'a
+         < .. > t
+       Type a is not compatible with type < .. >
 |}];;
 
 let _ = fun (x : a t) -> g x;;
@@ -34,8 +34,8 @@ Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> g x;;
                                ^
 Error: This expression has type a t but an expression was expected of type
-         ([< `b ] as 'a) t
-       Type a is not compatible with type [< `b ] as 'a
+         [< `b ] t
+       Type a is not compatible with type [< `b ]
 |}];;
 
 let _ = fun (x : a t) -> h x;;
@@ -44,6 +44,6 @@ Line 1, characters 27-28:
 1 | let _ = fun (x : a t) -> h x;;
                                ^
 Error: This expression has type a t but an expression was expected of type
-         ([> `b ] as 'a) t
-       Type a is not compatible with type [> `b ] as 'a
+         [> `b ] t
+       Type a is not compatible with type [> `b ]
 |}];;

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -91,9 +91,9 @@ Error: Signature mismatch:
          val a : t -> t
        The type
          [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ] ->
-         ([> `B of [> `BA | `BB of int list ] | `C of unit ] as 'a)
+         [> `B of [> `BA | `BB of int list ] | `C of unit ]
        is not compatible with the type t -> t
-       Type [> `B of [> `BA | `BB of int list ] | `C of unit ] as 'a
+       Type [> `B of [> `BA | `BB of int list ] | `C of unit ]
        is not compatible with type
          t = [ `A of int | `B of [ `BA | `BB of unit list ] | `C of unit ]
        Types for tag `BB are incompatible

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -96,7 +96,7 @@ Line 3, characters 22-23:
                           ^
 Error: This expression has type t1 but an expression was expected of type t2
        The method m has type 'c. 'c * ('a * < m : 'c. 'b >) as 'b,
-       but the expected method type was 'a. 'a * ('a * < m : 'a. 'b >) as 'b
+       but the expected method type was 'a. 'a * ('a * < m : 'a. 'd >) as 'd
        The universal variable 'a would escape its scope
 |}]
 

--- a/testsuite/tests/typing-modules/inclusion_errors.ml
+++ b/testsuite/tests/typing-modules/inclusion_errors.ml
@@ -97,8 +97,8 @@ Error: Signature mismatch:
          type t = < m : 'b. 'b * ('b * < m : 'c. 'c * 'a > as 'a) >
        The type < m : 'a. 'a * ('a * 'd) > as 'd is not equal to the type
          < m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) >
-       The method m has type 'a. 'a * ('a * < m : 'a. 'b >) as 'b,
-       but the expected method type was 'c. 'c * ('b * < m : 'c. 'a >) as 'a
+       The method m has type 'a. 'a * ('a * < m : 'a. 'f >) as 'f,
+       but the expected method type was 'c. 'c * ('b * < m : 'c. 'g >) as 'g
        The universal variable 'b would escape its scope
 |}];;
 
@@ -586,8 +586,8 @@ Error: Signature mismatch:
        The type (< m : 'a. 'a * 'd > as 'd) -> unit
        is not compatible with the type
          < m : 'b. 'b * < m : 'c. 'c * 'e > as 'e > -> unit
-       The method m has type 'a. 'a * < m : 'a. 'b > as 'b,
-       but the expected method type was 'c. 'c * ('b * < m : 'c. 'a >) as 'a
+       The method m has type 'a. 'a * < m : 'a. 'f > as 'f,
+       but the expected method type was 'c. 'c * ('b * < m : 'c. 'g >) as 'g
        The universal variable 'b would escape its scope
 |}];;
 

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -3,8 +3,7 @@ File "pr4018_bad.ml", line 42, characters 11-17:
                 ^^^^^^
 Error: This type entity = < destroy_subject : id subject; entity_id : id >
        should be an instance of type
-         < destroy_subject : < add_observer : 'a entity_container -> 'c; .. >
-                             as 'b;
+         < destroy_subject : < add_observer : 'a entity_container -> 'b; .. >;
            .. >
          as 'a
        Type
@@ -12,9 +11,12 @@ Error: This type entity = < destroy_subject : id subject; entity_id : id >
            < add_observer : (id subject, id) observer -> unit;
              notify_observers : id -> unit >
        is not compatible with type
-         < add_observer : 'a entity_container -> 'c; .. > as 'b 
+         < add_observer : < destroy_subject : 'c; .. > entity_container -> 'b;
+           .. >
+         as 'c 
        Type (id subject, id) observer = < notify : id subject -> id -> unit >
        is not compatible with type
-         'a entity_container =
-           < add_entity : 'a -> 'c; notify : 'a -> id -> unit > 
+         (< destroy_subject : < add_observer : 'd -> 'b; .. >; .. > as 'a)
+         entity_container as 'd =
+           < add_entity : 'a -> 'b; notify : 'a -> id -> unit > 
        Types for method add_observer are incompatible

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -588,7 +588,8 @@ Error: This expression has type
        but an expression was expected of type
          #comparable as 'a = < cmp : 'a -> int; .. >
        Type int_comparable = < cmp : int_comparable -> int; x : int >
-       is not compatible with type 'a = < cmp : 'a -> int; .. >
+       is not compatible with type
+         #comparable as 'a = < cmp : 'a -> int; .. >
        The first object type has no method setx
 |}];;   (* Error; strange message with -principal *)
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -699,10 +699,9 @@ Error: Signature mismatch:
          val f : (#c as 'a) -> 'a
        is not included in
          val f : #c -> #c
-       The type (#c as 'a) -> 'a is not compatible with the type
-         'a -> (#c as 'b)
-       Type 'a = < m : 'a; .. > is not compatible with type
-         'b = < m : 'b; .. >
+       The type (#c as 'a) -> 'a is not compatible with the type #c -> #c
+       Type #c as 'a = < m : 'a; .. > is not compatible with type
+         #c as 'b = < m : 'b; .. >
        Type 'a is not compatible with type 'b
 |}];;
 
@@ -1013,12 +1012,12 @@ Lines 3-5, characters 8-3:
 3 | ........object (self)
 4 |   method m = self
 5 | end..
-Error: The class type object ('a) method m : 'a end
+Error: The class type object ('a) method m : < m : 'a; .. > as 'a end
        is not matched by the class type
          object method m : < m : 'a > as 'a end
        The method m has type < m : 'a; .. > as 'a
        but is expected to have type < m : 'b > as 'b
-       Type 'a is not compatible with type <  > as 'b
+       Type 'a is not compatible with type <  >
 |}];;
 
 class c :
@@ -1071,7 +1070,8 @@ class c : object('self) method m : < m : 'a; x : int; ..> -> unit as 'a end =
 Line 2, characters 4-52:
 2 |     object (_ : 'self) method m (_ : 'self) = () end;;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The class type object ('a) method m : 'a -> unit end
+Error: The class type
+         object ('a) method m : (< m : 'a -> unit; .. > as 'a) -> unit end
        is not matched by the class type
          object method m : < m : 'a; x : int; .. > -> unit as 'a end
        The method m has type (< m : 'a -> unit; .. > as 'a) -> unit

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -196,9 +196,9 @@ Line 3, characters 36-41:
 Error: This expression has type
          < redrawWidget : parameter_contains_self -> unit; .. >
        but an expression was expected of type
-         < redrawWidget : (< invalidate : unit; .. > as 'a) -> unit; .. >
+         < redrawWidget : < invalidate : unit; .. > -> unit; .. >
        Type parameter_contains_self = < invalidate : unit >
-       is not compatible with type < invalidate : unit; .. > as 'a
+       is not compatible with type < invalidate : unit; .. >
        Self type cannot be unified with a closed object type
 |}]
 
@@ -212,9 +212,9 @@ Line 3, characters 26-31:
 Error: This expression has type
          < redrawWidget : parameter_contains_self -> unit; .. >
        but an expression was expected of type
-         < redrawWidget : (< invalidate : unit; .. > as 'a) -> unit; .. >
+         < redrawWidget : < invalidate : unit; .. > -> unit; .. >
        Type parameter_contains_self = < invalidate : unit >
-       is not compatible with type < invalidate : unit; .. > as 'a
+       is not compatible with type < invalidate : unit; .. >
        Self type cannot be unified with a closed object type
 |}]
 
@@ -259,9 +259,9 @@ Line 3, characters 36-41:
 Error: This expression has type
          < redrawWidget : parameter_contains_self -> unit; .. >
        but an expression was expected of type
-         < redrawWidget : (< invalidate : unit; .. > as 'a) -> unit; .. >
+         < redrawWidget : < invalidate : unit; .. > -> unit; .. >
        Type parameter_contains_self = < invalidate : unit >
-       is not compatible with type < invalidate : unit; .. > as 'a
+       is not compatible with type < invalidate : unit; .. >
        Self type cannot be unified with a closed object type
 |}]
 

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -38,8 +38,8 @@ Line 4, characters 49-50:
                                                      ^
 Error: This expression has type < a : 'a; b : 'a >
        but an expression was expected of type < a : 'a; b : 'a0. 'a0 >
-       The method b has type 'a, but the expected method type was 'a. 'a
-       The universal variable 'a would escape its scope
+       The method b has type 'a, but the expected method type was 'a0. 'a0
+       The universal variable 'a0 would escape its scope
 |}]
 
 
@@ -58,9 +58,9 @@ Lines 5-7, characters 10-5:
 5 | ..........(object
 6 |     method f _ = 0
 7 |  end)..
-Error: This expression has type < f : 'a -> int >
+Error: This expression has type < f : 'b -> int >
        but an expression was expected of type t_a
-       The method f has type 'a -> int, but the expected method type was
+       The method f has type 'b -> int, but the expected method type was
        'a. 'a -> int
        The universal variable 'a would escape its scope
 |}
@@ -77,9 +77,9 @@ val f : uv -> int = <fun>
 Line 4, characters 11-49:
 4 | let () = f ( `A (object method f _ = 0 end): _ v);;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type 'a v but an expression was expected of type
+Error: This expression has type 'b v but an expression was expected of type
          uv
-       The method f has type 'a -> int, but the expected method type was
+       The method f has type 'b -> int, but the expected method type was
        'a. 'a -> int
        The universal variable 'a would escape its scope
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1129,9 +1129,9 @@ Error: This expression has type < m : 'a. 'a * < m : 'a * 'b > > as 'b
        but an expression was expected of type
          < m : 'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd) >
        The method m has type
-       'a. 'a * (< m : 'a * < m : 'c. 'c * 'b > > as 'b),
+       'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd),
        but the expected method type was
-       'c. 'c * < m : 'a * < m : 'c. 'b > > as 'b
+       'c. 'c * < m : 'a * < m : 'c. 'e > > as 'e
        The universal variable 'a would escape its scope
 |}];;
 
@@ -1179,8 +1179,8 @@ Error: Signature mismatch:
        The type (< m : 'a. 'a * ('a * 'd) > as 'd) -> unit
        is not compatible with the type
          < m : 'b. 'b * ('b * < m : 'c. 'c * 'e > as 'e) > -> unit
-       The method m has type 'a. 'a * ('a * < m : 'a. 'b >) as 'b,
-       but the expected method type was 'c. 'c * ('b * < m : 'c. 'a >) as 'a
+       The method m has type 'a. 'a * ('a * < m : 'a. 'f >) as 'f,
+       but the expected method type was 'c. 'c * ('b * < m : 'c. 'g >) as 'g
        The universal variable 'b would escape its scope
 |}];;
 
@@ -1254,8 +1254,7 @@ Lines 2-3, characters 2-47:
 3 |     :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)..
 Error: Type < m : 'a. (< p : int; .. > as 'a) -> int > is not a subtype of
          < m : 'b. (< p : int; q : int; .. > as 'b) -> int >
-       Type < p : int; q : int; .. > as 'c is not a subtype of
-         < p : int; .. > as 'd
+       Type < p : int; q : int; .. > is not a subtype of < p : int; .. >
 |}];;
 
 (* Keep sharing the epsilons *)
@@ -1886,7 +1885,7 @@ Line 1, characters 17-18:
                      ^
 Error: This expression has type u but an expression was expected of type v
        The method m has type 'a s list * < m : 'b > as 'b,
-       but the expected method type was 'a. 'a s list * < m : 'a. 'b > as 'b
+       but the expected method type was 'a. 'a s list * < m : 'a. 'c > as 'c
        The universal variable 'a would escape its scope
 |}]
 

--- a/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml
@@ -26,9 +26,8 @@ Error: Signature mismatch:
          val write : _[< `A of '_weak2 | `B of '_weak3 ] -> unit
        is not included in
          val write : [< `A of string | `B of int ] -> unit
-       The type (_[< `A of '_weak2 | `B of '_weak3 ] as 'a) -> unit
-       is not compatible with the type
-         ([< `A of string | `B of int ] as 'b) -> unit
-       Type _[< `A of '_weak2 | `B of '_weak3 ] as 'a
-       is not compatible with type [< `A of string | `B of int ] as 'b
+       The type _[< `A of '_weak2 | `B of '_weak3 ] -> unit
+       is not compatible with the type [< `A of string | `B of int ] -> unit
+       Type _[< `A of '_weak2 | `B of '_weak3 ] is not compatible with type
+         [< `A of string | `B of int ]
 |}]

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -780,6 +780,8 @@ let best_type_path p =
 
 (* Print a type expression *)
 
+let proxy ty = Transient_expr.repr (proxy ty)
+
 (* When printing a type scheme, we print weak names.  When printing a plain
    type, we do not.  This type controls that behavior *)
 type type_or_scheme = Type | Type_scheme
@@ -789,13 +791,52 @@ let is_non_gen mode ty =
   | Type_scheme -> is_Tvar ty && get_level ty <> generic_level
   | Type        -> false
 
+let nameable_row row =
+  row_name row <> None &&
+  List.for_all
+    (fun (_, f) ->
+       match row_field_repr f with
+       | Reither(c, l, _, _) ->
+           row_closed row && if c then l = [] else List.length l = 1
+       | _ -> true)
+    (row_fields row)
+
+let iter_type_expr_for_printing f ty =
+  match get_desc ty with
+  | Tconstr(p, tyl, _) ->
+      let (_p', s) = best_type_path p in
+      List.iter f (apply_subst s tyl)
+  | Tvariant row -> begin
+      match row_name row with
+      | Some(_p, tyl) when nameable_row row ->
+          List.iter f tyl
+      | _ ->
+          iter_row f row
+    end
+  | Tobject (fi, nm) -> begin
+      match !nm with
+      | None ->
+          let fields, _ = flatten_fields fi in
+          List.iter
+            (fun (_, kind, ty) ->
+               if field_kind_repr kind = Fpresent then
+                 f ty)
+            fields
+      | Some (_, l) ->
+          List.iter f (List.tl l)
+    end
+  | Tfield(_, kind, ty1, ty2) ->
+      if field_kind_repr kind = Fpresent then
+        f ty1;
+      f ty2
+  | _ ->
+      Btype.iter_type_expr f ty
+
 module Names : sig
   val reset_names : unit -> unit
 
-  val add_named_var : transient_expr -> unit
+  val add_named_vars : type_expr -> unit
   val add_subst : (type_expr * type_expr) list -> unit
-
-  val has_name : transient_expr -> bool
 
   val new_name : unit -> string
   val new_weak_name : type_expr -> unit -> string
@@ -819,20 +860,37 @@ end = struct
   let name_subst = ref ([] : (transient_expr * transient_expr) list)
   let name_counter = ref 0
   let named_vars = ref ([] : string list)
+  let visited_for_named_vars = ref ([] : transient_expr list)
 
   let weak_counter = ref 1
   let weak_var_map = ref TypeMap.empty
   let named_weak_vars = ref String.Set.empty
 
   let reset_names () =
-    names := []; name_subst := []; name_counter := 0; named_vars := []
+    names := [];
+    name_subst := [];
+    name_counter := 0;
+    named_vars := [];
+    visited_for_named_vars := []
 
-  let add_named_var ty =
-    match ty.desc with
+  let add_named_var tty =
+    match tty.desc with
       Tvar (Some name) | Tunivar (Some name) ->
         if List.mem name !named_vars then () else
         named_vars := name :: !named_vars
     | _ -> ()
+
+  let rec add_named_vars ty =
+    let tty = Transient_expr.repr ty in
+    let px = proxy ty in
+    if not (List.memq px !visited_for_named_vars) then begin
+      visited_for_named_vars := px :: !visited_for_named_vars;
+      match tty.desc with
+      | Tvar _ | Tunivar _ ->
+          add_named_var tty
+      | _ ->
+          iter_type_expr_for_printing add_named_vars ty
+    end
 
   let rec substitute ty =
     match List.assq ty !name_subst with
@@ -844,9 +902,6 @@ end = struct
       List.map (fun (t1,t2) -> Transient_expr.repr t1, Transient_expr.repr t2)
         subst
       @ !name_subst
-
-  let has_name ty =
-    List.mem_assq (substitute ty) !names
 
   let name_is_already_used name =
     List.mem name !named_vars
@@ -933,23 +988,31 @@ end = struct
     weak_var_map := m
 end
 
+let reserve_names ty =
+  normalize_type ty;
+  Names.add_named_vars ty
+
 let visited_objects = ref ([] : transient_expr list)
 let aliased = ref ([] : transient_expr list)
 let delayed = ref ([] : transient_expr list)
+let printed_aliases = ref ([] : transient_expr list)
 
 let add_delayed t =
   if not (List.memq t !delayed) then delayed := t :: !delayed
 
-let proxy ty = Transient_expr.repr (proxy ty)
+let is_aliased_proxy px = List.memq px !aliased
 
-let is_aliased_proxy px =
-  List.memq px !aliased
 let add_alias_proxy px =
-  if not (List.memq px !aliased) then begin
-    aliased := px :: !aliased;
-    Names.add_named_var px
-  end
+  if not (is_aliased_proxy px) then
+    aliased := px :: !aliased
+
 let add_alias ty = add_alias_proxy (proxy ty)
+
+let add_printed_alias_proxy px =
+  Names.check_name_of_type px;
+  printed_aliases := px :: !printed_aliases
+
+let add_printed_alias ty = add_printed_alias_proxy (proxy ty)
 
 let aliasable ty =
   match get_desc ty with
@@ -958,77 +1021,39 @@ let aliasable ty =
       not (is_nth (snd (best_type_path p)))
   | _ -> true
 
-let namable_row row =
-  row_name row <> None &&
-  List.for_all
-    (fun (_, f) ->
-       match row_field_repr f with
-       | Reither(c, l, _, _) ->
-           row_closed row && if c then l = [] else List.length l = 1
-       | _ -> true)
-    (row_fields row)
+let should_visit_object ty =
+  match get_desc ty with
+  | Tvariant row -> not (static_row row)
+  | Tobject _ -> opened_object ty
+  | _ -> false
 
 let rec mark_loops_rec visited ty =
+  let tty = Transient_expr.repr ty in
   let px = proxy ty in
   if List.memq px visited && aliasable ty then add_alias_proxy px else
     let visited = px :: visited in
-    let tty = Transient_expr.repr ty in
     match tty.desc with
-    | Tvar _ -> Names.add_named_var tty
-    | Tarrow(_, ty1, ty2, _) ->
-        mark_loops_rec visited ty1; mark_loops_rec visited ty2
-    | Ttuple tyl -> List.iter (mark_loops_rec visited) tyl
-    | Tconstr(p, tyl, _) ->
-        let (_p', s) = best_type_path p in
-        List.iter (mark_loops_rec visited) (apply_subst s tyl)
-    | Tpackage (_, fl) ->
-        List.iter (fun (_n, ty) -> mark_loops_rec visited ty) fl
-    | Tvariant row ->
-        if List.memq px !visited_objects then add_alias_proxy px else
-         begin
-          if not (static_row row) then
+    | Tvariant _ | Tobject _ ->
+        if List.memq px !visited_objects then add_alias_proxy px else begin
+          if should_visit_object ty then
             visited_objects := px :: !visited_objects;
-          match row_name row with
-          | Some(_p, tyl) when namable_row row ->
-              List.iter (mark_loops_rec visited) tyl
-          | _ ->
-              iter_row (mark_loops_rec visited) row
-         end
-    | Tobject (fi, nm) ->
-        if List.memq px !visited_objects then add_alias_proxy px else
-         begin
-          if opened_object ty then
-            visited_objects := px :: !visited_objects;
-          begin match !nm with
-          | None ->
-              let fields, _ = flatten_fields fi in
-              List.iter
-                (fun (_, kind, ty) ->
-                  if field_kind_repr kind = Fpresent then
-                    mark_loops_rec visited ty)
-                fields
-          | Some (_, l) ->
-              List.iter (mark_loops_rec visited) (List.tl l)
-          end
+          iter_type_expr_for_printing (mark_loops_rec visited) ty
         end
-    | Tfield(_, kind, ty1, ty2) when field_kind_repr kind = Fpresent ->
-        mark_loops_rec visited ty1; mark_loops_rec visited ty2
-    | Tfield(_, _, _, ty2) ->
-        mark_loops_rec visited ty2
-    | Tnil -> ()
-    | Tsubst _ -> ()  (* we do not print arguments *)
-    | Tlink _ -> fatal_error "Printtyp.mark_loops_rec (2)"
-    | Tpoly (ty, tyl) ->
-        List.iter (fun t -> add_alias t) tyl;
+    | Tpoly(ty, tyl) ->
+        List.iter add_alias tyl;
         mark_loops_rec visited ty
-    | Tunivar _ -> Names.add_named_var tty
+    | _ ->
+        iter_type_expr_for_printing (mark_loops_rec visited) ty
 
 let mark_loops ty =
-  normalize_type ty;
   mark_loops_rec [] ty;;
 
+let prepare_type ty =
+  reserve_names ty;
+  mark_loops ty;;
+
 let reset_loop_marks () =
-  visited_objects := []; aliased := []; delayed := []
+  visited_objects := []; aliased := []; delayed := []; printed_aliases := []
 
 let reset_except_context () =
   Names.reset_names (); reset_loop_marks ()
@@ -1037,18 +1062,15 @@ let reset () =
   reset_naming_context (); Conflicts.reset ();
   reset_except_context ()
 
-let reset_and_mark_loops ty =
-  reset_except_context (); mark_loops ty
-
-let reset_and_mark_loops_list tyl =
-  reset_except_context (); List.iter mark_loops tyl
+let prepare_for_printing tyl =
+  reset_except_context (); List.iter prepare_type tyl
 
 (* Disabled in classic mode when printing an unification error *)
 let print_labels = ref true
 
 let rec tree_of_typexp mode ty =
   let px = proxy ty in
-  if Names.has_name px && not (List.memq px !delayed) then
+  if List.memq px !printed_aliases && not (List.memq px !delayed) then
    let mark = is_non_gen mode ty in
    let name = Names.name_of_type
                 (if mark then Names.new_weak_name ty else Names.new_name)
@@ -1102,7 +1124,7 @@ let rec tree_of_typexp mode ty =
             fields in
         let all_present = List.length present = List.length fields in
         begin match name with
-        | Some(p, tyl) when namable_row row ->
+        | Some(p, tyl) when nameable_row row ->
             let (p', s) = best_type_path p in
             let id = tree_of_path Type p' in
             let args = tree_of_typlist mode (apply_subst s tyl) in
@@ -1164,7 +1186,7 @@ let rec tree_of_typexp mode ty =
   in
   if List.memq px !delayed then delayed := List.filter ((!=) px) !delayed;
   if is_aliased_proxy px && aliasable ty then begin
-    Names.check_name_of_type px;
+    add_printed_alias_proxy px;
     Otyp_alias (pr_typ (), Names.name_of_type Names.new_name px) end
   else pr_typ ()
 
@@ -1227,17 +1249,26 @@ and tree_of_typfields mode rest = function
 let typexp mode ppf ty =
   !Oprint.out_type ppf (tree_of_typexp mode ty)
 
-let marked_type_expr ppf ty = typexp Type ppf ty
+let prepared_type_expr ppf ty = typexp Type ppf ty
 
 let type_expr ppf ty =
   (* [type_expr] is used directly by error message printers,
      we mark eventual loops ourself to avoid any misuse and stack overflow *)
-  reset_and_mark_loops ty;
-  marked_type_expr ppf ty
+  prepare_for_printing [ty];
+  prepared_type_expr ppf ty
 
-and type_sch ppf ty = typexp Type_scheme ppf ty
+let named_type_expr ppf ty =
+  reset_loop_marks ();
+  mark_loops ty;
+  prepared_type_expr ppf ty
 
-and type_scheme ppf ty = reset_and_mark_loops ty; typexp Type_scheme ppf ty
+let shared_type_scheme ppf ty =
+  prepare_type ty;
+  typexp Type_scheme ppf ty
+
+let type_scheme ppf ty =
+  prepare_for_printing [ty];
+  typexp Type_scheme ppf ty
 
 let type_path ppf p =
   let (p', s) = best_type_path p in
@@ -1245,14 +1276,8 @@ let type_path ppf p =
   let t = tree_of_path Type p in
   !Oprint.out_ident ppf t
 
-(* Maxence *)
-let type_scheme_max ?(b_reset_names=true) ppf ty =
-  if b_reset_names then Names.reset_names () ;
-  typexp Type_scheme ppf ty
-(* End Maxence *)
-
 let tree_of_type_scheme ty =
-  reset_and_mark_loops ty;
+  prepare_for_printing [ty];
   tree_of_typexp Type_scheme ty
 
 (* Print one type declaration *)
@@ -1281,9 +1306,9 @@ let filter_params tyl =
       [] tyl
   in List.rev params
 
-let mark_loops_constructor_arguments = function
-  | Cstr_tuple l -> List.iter mark_loops l
-  | Cstr_record l -> List.iter (fun l -> mark_loops l.ld_type) l
+let prepare_type_constructor_arguments = function
+  | Cstr_tuple l -> List.iter prepare_type l
+  | Cstr_record l -> List.iter (fun l -> prepare_type l.ld_type) l
 
 let rec tree_of_type_decl id decl =
 
@@ -1303,8 +1328,8 @@ let rec tree_of_type_decl id decl =
   end;
 
   List.iter add_alias params;
-  List.iter mark_loops params;
-  List.iter Names.check_name_of_type (List.map proxy params);
+  List.iter prepare_type params;
+  List.iter add_printed_alias params;
   let ty_manifest =
     match decl.type_manifest with
     | None -> None
@@ -1320,7 +1345,7 @@ let rec tree_of_type_decl id decl =
               end
           | _ -> ty
         in
-        mark_loops ty;
+        prepare_type ty;
         Some ty
   in
   begin match decl.type_kind with
@@ -1328,11 +1353,11 @@ let rec tree_of_type_decl id decl =
   | Type_variant (cstrs, _rep) ->
       List.iter
         (fun c ->
-           mark_loops_constructor_arguments c.cd_args;
-           Option.iter mark_loops c.cd_res)
+           prepare_type_constructor_arguments c.cd_args;
+           Option.iter prepare_type c.cd_res)
         cstrs
   | Type_record(l, _rep) ->
-      List.iter (fun l -> mark_loops l.ld_type) l
+      List.iter (fun l -> prepare_type l.ld_type) l
   | Type_open -> ()
   end;
 
@@ -1473,10 +1498,10 @@ let tree_of_extension_constructor id ext es =
   let ty_name = Path.name ext.ext_type_path in
   let ty_params = filter_params ext.ext_type_params in
   List.iter add_alias ty_params;
-  List.iter mark_loops ty_params;
-  List.iter Names.check_name_of_type (List.map proxy ty_params);
-  mark_loops_constructor_arguments ext.ext_args;
-  Option.iter mark_loops ext.ext_ret_type;
+  List.iter prepare_type ty_params;
+  List.iter add_printed_alias ty_params;
+  prepare_type_constructor_arguments ext.ext_args;
+  Option.iter prepare_type ext.ext_ret_type;
   let type_param =
     function
     | Otyp_var (_, id) -> id
@@ -1556,7 +1581,7 @@ let method_type priv ty =
 
 let prepare_method _lab (priv, _virt, ty) =
   let ty, _ = method_type priv ty in
-  mark_loops ty
+  prepare_type ty
 
 let tree_of_method mode (lab, priv, virt, ty) =
   let (ty, tyl) = method_type priv ty in
@@ -1573,16 +1598,16 @@ let rec prepare_class_type params = function
       || not (List.for_all is_Tvar params)
       || List.exists (deep_occur row) tyl
       then prepare_class_type params cty
-      else List.iter mark_loops tyl
+      else List.iter prepare_type tyl
   | Cty_signature sign ->
       (* Self may have a name *)
       let px = proxy sign.csig_self_row in
       if List.memq px !visited_objects then add_alias_proxy px
       else visited_objects := px :: !visited_objects;
-      Vars.iter (fun _ (_, _, ty) -> mark_loops ty) sign.csig_vars;
+      Vars.iter (fun _ (_, _, ty) -> prepare_type ty) sign.csig_vars;
       Meths.iter prepare_method sign.csig_meths
   | Cty_arrow (_, ty, cty) ->
-      mark_loops ty;
+      prepare_type ty;
       prepare_class_type params cty
 
 let rec tree_of_class_type mode params =
@@ -1673,10 +1698,10 @@ let tree_of_class_declaration id cl rs =
   List.iter add_alias params;
   prepare_class_type params cl.cty_type;
   let px = proxy (Btype.self_type_row cl.cty_type) in
-  List.iter mark_loops params;
+  List.iter prepare_type params;
 
-  List.iter Names.check_name_of_type (List.map proxy params);
-  if is_aliased_proxy px then Names.check_name_of_type px;
+  List.iter add_printed_alias params;
+  if is_aliased_proxy px then add_printed_alias_proxy px;
 
   let vir_flag = cl.cty_new = None in
   Osig_class
@@ -1695,10 +1720,10 @@ let tree_of_cltype_declaration id cl rs =
   List.iter add_alias params;
   prepare_class_type params cl.clty_type;
   let px = proxy (Btype.self_type_row cl.clty_type) in
-  List.iter mark_loops params;
+  List.iter prepare_type params;
 
-  List.iter Names.check_name_of_type (List.map proxy params);
-  if is_aliased_proxy px then Names.check_name_of_type px;
+  List.iter add_printed_alias params;
+  if is_aliased_proxy px then add_printed_alias_proxy px;
 
   let sign = Btype.signature_of_class_type cl.clty_type in
   let has_virtual_vars =
@@ -1986,9 +2011,12 @@ let same_path t t' =
 type 'a diff = Same of 'a | Diff of 'a * 'a
 
 let trees_of_type_expansion mode Errortrace.{ty = t; expanded = t'} =
+  reset_loop_marks ();
+  mark_loops t;
   if same_path t t'
   then begin add_delayed (proxy t); Same (tree_of_typexp mode t) end
-  else
+  else begin
+    mark_loops t';
     let t' = if proxy t == proxy t' then unalias t' else t' in
     (* beware order matter due to side effect,
        e.g. when printing object types *)
@@ -1996,6 +2024,7 @@ let trees_of_type_expansion mode Errortrace.{ty = t; expanded = t'} =
     let second = tree_of_typexp mode t' in
     if first = second then Same first
     else Diff(first,second)
+  end
 
 let type_expansion ppf = function
   | Same t -> !Oprint.out_type ppf t
@@ -2097,14 +2126,14 @@ let hide_variant_name t =
 
 let prepare_expansion Errortrace.{ty; expanded} =
   let expanded = hide_variant_name expanded in
-  mark_loops ty;
-  if not (same_path ty expanded) then mark_loops expanded;
+  reserve_names ty;
+  if not (same_path ty expanded) then reserve_names expanded;
   Errortrace.{ty; expanded}
 
 let may_prepare_expansion compact (Errortrace.{ty; expanded} as ty_exp) =
   match get_desc expanded with
     Tvariant _ | Tobject _ when compact ->
-      mark_loops ty; Errortrace.{ty; expanded = ty}
+      reserve_names ty; Errortrace.{ty; expanded = ty}
   | _ -> prepare_expansion ty_exp
 
 let print_path p = Format.dprintf "%a" !Oprint.out_ident (tree_of_path Type p)
@@ -2155,8 +2184,9 @@ let explain_fixed_row pos expl = match expl with
   | Fixed_private ->
     dprintf "The %a variant type is private" Errortrace.print_pos pos
   | Univar x ->
+    reserve_names x;
     dprintf "The %a variant type is bound to the universal type variable %a"
-      Errortrace.print_pos pos type_expr x
+      Errortrace.print_pos pos named_type_expr x
   | Reified p ->
     dprintf "The %a variant type is bound to %t"
       Errortrace.print_pos pos (print_path p)
@@ -2200,9 +2230,11 @@ let explain_variant (type variety) : variety Errortrace.variant -> _ = function
              Errortrace.print_pos (Errortrace.swap_position pos))
 
 let explain_escape pre = function
-  | Errortrace.Univ u -> Some(
-      dprintf "%t@,The universal variable %a would escape its scope"
-        pre type_expr u)
+  | Errortrace.Univ u ->
+      reserve_names u;
+      Some(
+        dprintf "%t@,The universal variable %a would escape its scope"
+          pre named_type_expr u)
   | Errortrace.Constructor p -> Some(
       dprintf
         "%t@,@[The type constructor@;<1 2>%a@ would escape its scope@]"
@@ -2213,11 +2245,13 @@ let explain_escape pre = function
         "%t@,@[The module type@;<1 2>%a@ would escape its scope@]"
         pre path p
     )
-  | Errortrace.Equation Errortrace.{ty = _; expanded = t} -> Some(
-      dprintf "%t @,@[<hov>This instance of %a is ambiguous:@ %s@]"
-        pre type_expr t
-        "it would escape the scope of its equation"
-    )
+  | Errortrace.Equation Errortrace.{ty = _; expanded = t} ->
+      reserve_names t;
+      Some(
+        dprintf "%t @,@[<hov>This instance of %a is ambiguous:@ %s@]"
+          pre named_type_expr t
+          "it would escape the scope of its equation"
+      )
   | Errortrace.Self ->
       Some (dprintf "%t@,Self type cannot escape its class" pre)
   | Errortrace.Constraint ->
@@ -2244,11 +2278,14 @@ let explanation (type variety) intro prev env
     let pre =
       match context, kind, prev with
       | Some ctx, _, _ ->
-        dprintf "@[%t@;<1 2>%a@]" intro type_expr ctx
+        reserve_names ctx;
+        dprintf "@[%t@;<1 2>%a@]" intro named_type_expr ctx
       | None, Univ _, Some(Errortrace.Incompatible_fields {name; diff}) ->
+        reserve_names diff.got;
+        reserve_names diff.expected;
         dprintf "@,@[The method %s has type@ %a,@ \
                  but the expected method type was@ %a@]"
-          name type_expr diff.got type_expr diff.expected
+          name named_type_expr diff.got named_type_expr diff.expected
       | _ -> ignore
     in
     explain_escape pre kind
@@ -2259,11 +2296,17 @@ let explanation (type variety) intro prev env
   | Errortrace.Obj o ->
     explain_object o
   | Errortrace.Rec_occur(x,y) ->
-    reset_and_mark_loops y;
+    reserve_names x;
+    reserve_names y;
     begin match get_desc x with
     | Tvar _ | Tunivar _  ->
-        Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
-               type_expr x type_expr y)
+        Some(fun ppf ->
+          reset_loop_marks ();
+          mark_loops x;
+          mark_loops y;
+          dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
+            prepared_type_expr x prepared_type_expr y
+            ppf)
     | _ ->
         (* We had a delayed unification of the type variable with
            a non-variable after the occur check. *)

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -93,29 +93,37 @@ module Conflicts: sig
 end
 
 val reset: unit -> unit
-val mark_loops: type_expr -> unit
-val reset_and_mark_loops: type_expr -> unit
-val reset_and_mark_loops_list: type_expr list -> unit
 
+(** Print out a type.  This type expression will not share type variable names
+    with any other type expressions; this function resets the global printing
+    state first.  If you want multiple types to use common names for type
+    variables, see [prepare_for_printing] and [prepared_type_expr].  *)
 val type_expr: formatter -> type_expr -> unit
-val marked_type_expr: formatter -> type_expr -> unit
-(** The function [type_expr] is the safe version of the pair
-    [(typed_expr, marked_type_expr)]:
-    it takes care of marking loops in the type expression and resetting
-    type variable names before printing.
-      Contrarily, the function [marked_type_expr] should only be called on
-    type expressions whose loops have been marked or it may stackoverflow
-    (see #8860 for examples).
- *)
+
+(** [prepare_for_printing] resets the global printing environment, a la [reset],
+    and prepares the types for printing by reserving names and marking loops.
+    Any type variables that are shared between multiple types in the input list
+    will be given the same name when printed with [prepared_type_expr]. *)
+val prepare_for_printing: type_expr list -> unit
+val prepared_type_expr: formatter -> type_expr -> unit
+(** The function [prepared_type_expr] is a less-safe but more-flexible version
+    of [type_expr] that should only be called on [type_expr]s that have been
+    passed to [prepare_for_printing].  Unlike [type_expr], this function does no
+    extra work before printing a type; in particular, this means that any loops
+    in the type expression may cause a stack overflow (see #8860) since this
+    function does not mark any loops.  The benefit of this is that if multiple
+    type expressions are prepared simultaneously and then printed with
+    [prepared_type_expr], they will use the same names for the same type
+    variables. *)
 
 val constructor_arguments: formatter -> constructor_arguments -> unit
 val tree_of_type_scheme: type_expr -> out_type
-val type_sch : formatter -> type_expr -> unit
 val type_scheme: formatter -> type_expr -> unit
-(* Maxence *)
-val type_scheme_max: ?b_reset_names: bool ->
-        formatter -> type_expr -> unit
-(* End Maxence *)
+val shared_type_scheme: formatter -> type_expr -> unit
+(** [shared_type_scheme] is very similar to [type_scheme], but does not reset
+    the printing context first.  Odds are, you're looking for [type_scheme]
+    instead. *)
+
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
 val value_description: Ident.t -> formatter -> value_description -> unit
 val label : formatter -> label_declaration -> unit

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -94,10 +94,12 @@ end
 
 val reset: unit -> unit
 
-(** Print out a type.  This type expression will not share type variable names
-    with any other type expressions; this function resets the global printing
-    state first.  If you want multiple types to use common names for type
-    variables, see [prepare_for_printing] and [prepared_type_expr].  *)
+(** Print out a type.  This will pick names for type variables, and will not
+    reuse names for common type variables shared across multiple type
+    expressions.  (It will also reset the printing state, which matters for
+    other type formatters such as [prepared_type_expr].)  If you want multiple
+    types to use common names for type variables, see [prepare_for_printing] and
+    [prepared_type_expr].  *)
 val type_expr: formatter -> type_expr -> unit
 
 (** [prepare_for_printing] resets the global printing environment, a la [reset],
@@ -121,8 +123,10 @@ val tree_of_type_scheme: type_expr -> out_type
 val type_scheme: formatter -> type_expr -> unit
 val shared_type_scheme: formatter -> type_expr -> unit
 (** [shared_type_scheme] is very similar to [type_scheme], but does not reset
-    the printing context first.  Odds are, you're looking for [type_scheme]
-    instead. *)
+    the printing context first.  This is intended to be used in cases where the
+    printing should have a particularly wide context, such as documentation
+    generators; most use cases, such as error messages, have narrower contexts
+    for which [type_scheme] is better suited. *)
 
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
 val value_description: Ident.t -> formatter -> value_description -> unit

--- a/typing/stypes.ml
+++ b/typing/stypes.ml
@@ -157,10 +157,9 @@ let print_info pp prev_loc ti =
       end;
       output_string pp "type(\n";
       printtyp_reset_maybe loc;
-      Printtyp.mark_loops typ;
       Format.pp_print_string Format.str_formatter "  ";
       Printtyp.wrap_printing_env ~error:false env
-                       (fun () -> Printtyp.type_sch Format.str_formatter typ);
+        (fun () -> Printtyp.shared_type_scheme Format.str_formatter typ);
       Format.pp_print_newline Format.str_formatter ();
       let s = Format.flush_str_formatter () in
       output_string pp s;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1972,7 +1972,7 @@ let report_error env ppf = function
         (function ppf ->
            fprintf ppf "but is expected to have type")
   | Unexpected_field (ty, lab) ->
-      Printtyp.reset_and_mark_loops ty;
+      Printtyp.prepare_for_printing [ty];
       fprintf ppf
         "@[@[<2>This object is expected to have type :@ %a@]\
          @ This type does not have a method %s."
@@ -2003,7 +2003,7 @@ let report_error env ppf = function
       Printtyp.longident cl
   | Abbrev_type_clash (abbrev, actual, expected) ->
       (* XXX Afficher une trace ? | Print a trace? *)
-      Printtyp.reset_and_mark_loops_list [abbrev; actual; expected];
+      Printtyp.prepare_for_printing [abbrev; actual; expected];
       fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
        but is used with type@ %a@]"
         !Oprint.out_type (Printtyp.tree_of_typexp Type abbrev)
@@ -2046,7 +2046,7 @@ let report_error env ppf = function
         (function ppf ->
            fprintf ppf "does not meet its constraint: it should be")
   | Bad_parameters (id, params, cstrs) ->
-      Printtyp.reset_and_mark_loops_list [params; cstrs];
+      Printtyp.prepare_for_printing [params; cstrs];
       fprintf ppf
         "@[The abbreviation %a@ is used with parameters@ %a@ \
            which are incompatible with constraints@ %a@]"
@@ -2061,14 +2061,13 @@ let report_error env ppf = function
       let print_reason ppf (ty0, real, lab, ty) =
         let ty1 =
           if real then ty0 else Btype.newgenty(Tobject(ty0, ref None)) in
-        List.iter Printtyp.mark_loops [ty; ty1];
+        Printtyp.prepare_for_printing [ty; ty1];
         fprintf ppf
           "The method %s@ has type@;<1 2>%a@ where@ %a@ is unbound"
           lab
           !Oprint.out_type (Printtyp.tree_of_typexp Type ty)
           !Oprint.out_type (Printtyp.tree_of_typexp Type ty0)
       in
-      Printtyp.reset ();
       fprintf ppf
         "@[<v>@[Some type variables are unbound in this type:@;<1 2>%t@]@ \
               @[%a@]@]"

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1632,16 +1632,16 @@ let explain_unbound_gen ppf tv tl typ kwd pr =
     let ti = List.find (fun ti -> Ctype.deep_occur tv (typ ti)) tl in
     let ty0 = (* Hack to force aliasing when needed *)
       Btype.newgenty (Tobject(tv, ref None)) in
-    Printtyp.reset_and_mark_loops_list [typ ti; ty0];
+    Printtyp.prepare_for_printing [typ ti; ty0];
     fprintf ppf
       ".@ @[<hov2>In %s@ %a@;<1 -2>the variable %a is unbound@]"
-      kwd pr ti Printtyp.marked_type_expr tv
+      kwd pr ti Printtyp.prepared_type_expr tv
   with Not_found -> ()
 
 let explain_unbound ppf tv tl typ kwd lab =
   explain_unbound_gen ppf tv tl typ kwd
     (fun ppf ti ->
-       fprintf ppf "%s%a" (lab ti) Printtyp.marked_type_expr (typ ti)
+       fprintf ppf "%s%a" (lab ti) Printtyp.prepared_type_expr (typ ti)
     )
 
 let explain_unbound_single ppf tv ty =
@@ -1710,8 +1710,7 @@ let report_error ppf = function
       let comma ppf () = Format.fprintf ppf ",@;<1 2>" in
       let pp_expansions ppf expansions =
         Format.(pp_print_list ~pp_sep:comma pp_expansion) ppf expansions in
-      Printtyp.reset_and_mark_loops used_as;
-      Printtyp.mark_loops defined_as;
+      Printtyp.prepare_for_printing [used_as; defined_as];
       Printtyp.Naming_context.reset ();
       begin match expansions with
       | [] ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -764,7 +764,7 @@ let report_error env ppf = function
          l l
   | Constructor_mismatch (ty, ty') ->
       wrap_printing_env ~error:true env (fun ()  ->
-        Printtyp.reset_and_mark_loops_list [ty; ty'];
+        Printtyp.prepare_for_printing [ty; ty'];
         fprintf ppf "@[<hov>%s %a@ %s@ %a@]"
           "This variant type contains a constructor"
           !Oprint.out_type (tree_of_typexp Type ty)


### PR DESCRIPTION
### Introduction

This PR improves how types in type errors are printed in two ways:

1. A given type variable name (`'a`, `'b`, etc.) will now only be used for one variable in any given trace (across types), and won’t be reused on a later line.

2. Recursive type detection in types, which produces `as`-clauses, is now more targeted and won’t introduce extra spurious `as`-types or reference them on later lines.

As an example of the type variable name generation change, consider the following code (from `testsuite/tests/typing-modules/inclusion_errors.ml`):

```ocaml
module M : sig
  type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)>
end = struct
  type t = <m : 'a. 'a * ('a * 'foo)> as 'foo
end;;
```

While this code is very dense, we can see the improvement in the error message by considering a diff between the old and new error messages, which differ only in variable names; the lines with changes are **bolded**, with deleted text from the old version is ~~struck out~~, and inserted text from the new version <ins>underlined</ins> (unless your browser uses different styles):

<pre><code>Error: Signature mismatch:
       Modules do not match:
         sig type t = &lt; m : 'a. 'a * ('a * 'b) &gt; as 'b end
       is not included in
         sig type t = &lt; m : 'b. 'b * ('b * &lt; m : 'c. 'c * 'a &gt; as 'a) &gt; end
       Type declarations do not match:
         type t = &lt; m : 'a. 'a * ('a * 'b) &gt; as 'b
       is not included in
         type t = &lt; m : 'b. 'b * ('b * &lt; m : 'c. 'c * 'a &gt; as 'a) &gt;
       The type &lt; m : 'a. 'a * ('a * 'd) &gt; as 'd is not equal to the type
         &lt; m : 'b. 'b * ('b * &lt; m : 'c. 'c * 'e &gt; as 'e) &gt;
<strong>       The method m has type 'a. 'a * ('a * &lt; m : 'a. <del>'b</del><ins>'f</ins> &gt;) as <del>'b</del><ins>'f</ins>,
       but the expected method type was 'c. 'c * ('b * &lt; m : 'c. <del>'a</del><ins>'g</ins> &gt;) as <del>'a</del><ins>'g</ins></strong>
       The universal variable 'b would escape its scope</code></pre>

We are now avoiding overloading the meaning of the type variables `'b` and `'a` between lines, instead using `'f` and `'g`, to avoid confusion between the different possible referents of the name.

As an example of the change to the detection of recursive types, consider the following code (from `testsuite/tests/typing-misc/pr7103.ml`):

```ocaml
type 'a t
type a
let f : < .. > t -> unit = fun _ -> ();;
let _ = fun (x : a t) -> f x;;
```

This now produces the following error:

```
Error: This expression has type a t but an expression was expected of type
         < .. > y
       Type a is not compatible with type < .. > 
```

This differs from the previous error by dropping spurious unused `as 'a`s; the previous error message, with deleted fragments ~~struck out~~, was

<pre><code>Error: This expression has type a t but an expression was expected of type
         <del>(</del>&lt; .. &gt;<del> as 'a)</del> t
       Type a is not compatible with type &lt; .. &gt;<del> as 'a</del> </code></pre>

### Code changes

The reason these changes are connected is that they both have to do with exactly how and when we traverse the type before printing it.  Previously, recursive type detection and type variable name generation were done in the same pass, in `Printtyp.mark_loops_rec`.  However, we want to handle these two things differently.

1. First, we want to generate every name in the whole error trace up front, without resetting any state.  This ensures that we don’t generate the same name twice.
2. Second, we want to mark loops separately for each type right before we print them.  This ensures that we don’t accidentally create an `as 'a` reference because a type is mentioned on a later line.

The major changes this PR makes are to `Printtyp`; they are mostly internal, but since it does update the API, there are some changes to other files.

* We split `mark_loops` into `reserve_names` (implemented via the new function `Names.add_named_vars`) and `mark_loops` (still implemented via `mark_loops_rec)`; the former handles names, and the latter now only handles loops (as its name indicates).  This was done in terms of a shared case analysis function, `Printtyp.iter_type_expr_for_printing`, à la `Btype.iter_type_expr`.

* Within `Printtyp`, we use the new `named_type_expr` printer, which does not reset names but does reset and mark loops (recursive types).  This allows us to reserve names in one pass, and then print with `named_type_expr` to do the loop marking individually.

* We change the external printing API to remove `mark_loops`, `reset_and_mark_loops`, `reset_and_mark_loops_list`, `type_sch`, and `type_scheme_max`, and replace them with the following functions:
  
    + `prepare_for_printing : type_expr list -> unit`, which does the old work of `reset_and_mark_loops_list` and supersedes the old loop-marking functions.
    + `prepared_type_expr`, which is a renaming of `marked_type_expr` to go with `prepare_for_printing`; now that `prepare_for_printing` is the only external way to mark loops, `prepared_type_expr` should only be called on types which were passed to it.
    + `shared_type_scheme`, which is a renaming of `type_sch` (and `type_scheme_max`, which was only ever called with `b_reset_names:false`), and is only used in `Stypes` and ocamldoc.
  
  The normal `type_expr` printer is still available and unchanged.

### Detailed, file-by-file changes

This section documents the changes I made to every file, batching together related changes; it is not required reading, but hopefully helps review.  There is nothing after this section in this PR, so if you don’t want to read the gory details, you can stop now.

The interesting changes are all in `typing/printtyp.ml`; all the other changes are knock-on effects of the semantics or API change.

* `ocamldoc/` *(modified)*:
  
  Updated ocamldoc to the new API by: (1) removing unncessary calls to `Printtyp.mark_loops` which were handled by the formatters; and
  (2) replacing `Printtyp.type_scheme_max ~b_reset_names: false` with `Printtyp.shared_type_scheme`.
  
  *Files modified:*
  + `ocamldoc/odoc_env.ml`
  + `ocamldoc/odoc_print.ml`
  + `ocamldoc/odoc_str.ml`
  + `ocamldoc/odoc_value.ml`

* `testsuite/tests/` *(modified)*:
  
  Better error messages in test output.
  
  *Files modified:*
  + `testsuite/tests/typing-gadts/pr5689.ml`
  + `testsuite/tests/typing-gadts/pr5948.ml`
  + `testsuite/tests/typing-misc/pr7103.ml`
  + `testsuite/tests/typing-misc/pr7668_bad.ml`
  + `testsuite/tests/typing-misc/printing.ml`
  + `testsuite/tests/typing-modules/inclusion_errors.ml`
  + `testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference`
  + `testsuite/tests/typing-objects/Exemples.ml`
  + `testsuite/tests/typing-objects/Tests.ml`
  + `testsuite/tests/typing-poly/error_messages.ml`
  + `testsuite/tests/typing-poly/poly.ml`
  + `testsuite/tests/typing-polyvariants-bugs/pr7817_bad.ml`

* `typing/printtyp.ml` *(modified)*:
  
  Updated the printing code as described above.  In slightly more detail:
  
  1. Created `iter_type_expr_for_printing`, a case analysis function that pulls out the core recursion pattern of the old `mark_loops_rec`.  NB: This involved moving an existing rebinding of the name `proxy` up earlier in the file; this isn’t new, so do not be alarmed.
  
  2. Split out `Names.add_named_vars` from `mark_loops_rec`, and implemented both in terms of `iter_type_expr_for_printing`.
  
  3. Replaced post calls to `mark_loops` with `prepare_type`, which both marks loops *and* reserves names.
  
  4. Created `named_type_expr`, a printer halfway in between `type_expr` (which resets everything) and `prepared_type_expr` (formerly `marked_type_expr`, which resets nothing) that only resets and marks loops but does not touch names.
  
  5. Replaced `Names.has_name` with a new `printed_aliases` ref, to more accurately track when names were being presented to the user.
  
  6. Marked loops (with `reset_loop_marks ()` and `mark_loops`) at the start of `trees_of_type_expansion`.
  
  7. Reserved names (with `reserve_names`) in most parts of the trace-printing code where we formerly marked loops, and switched to printing with `named_type_expr`.  (In the `Rec_occur` case, we instead mark the loops in the same context, as the two types are connected, and use `prepared_type_expr`.)

* `typing/printtyp.mli` *(modified)*:
  
  Update the API of `Printtyp` as described above.  In particular:
  
  1. Delete the old functions for explicitly doing loop marking (`mark_loops`, `reset_and_mark_loops`, `reset_and_mark_loops_list`).
  
  2. Introduce a new function, `prepare_for_printing`, for resetting the state and simultaneously preparing a few types for printing; this is something like the old `reset_and_mark_loops_list`.
  
  3. Switch from the two formatter `type_expr` and `marked_type_expr` to the two printers `type_expr` and `prepared_type_expr`; the latter is now more explicitly only to be used right after `prepare_for_printing`.
  
  4. Replace `type_sch` and `type_scheme_max` with `shared_type_scheme`.

* `typing/stypes.ml` *(modified)*:
  
  Updated the printing code to the new API by (1) removing an unnecessary call to `Printtyp.mark_loops` which was handled by the formatter; and (2) replacing `Printtyp.type_sch` with its new name, `Printtyp.shared_type_scheme`.  This is very similar to the changes to ocamldoc.

* `typing/type*.ml` *(modified)*:
  
  Updated the printing code to the new API by switching `Printtyp.{reset_and_mark_loops_list,mark_loops}` to `Printtyp.prepare_for_printing`, switching `Printtyp.marked_type_expr` to `Printtyp.prepared_type_expr`, and dropping one extra call to `Printtyp.reset` that was unnecessary.

  *Files modified:*
  + `typing/typeclass.ml`
  + `typing/typedecl.ml`
  + `typing/typetexp.ml`