### PR TITLE
Abstract wmain/main difference with main_os

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -481,7 +481,8 @@ let link_bytecode_as_c tolink outfile with_main =
 \n#endif\
 \n#include <caml/mlvalues.h>\
 \n#include <caml/startup.h>\
-\n#include <caml/sys.h>\n";
+\n#include <caml/sys.h>\
+\n#include <caml/misc.h>\n";
        output_string outchan "static int caml_code[] = {\n";
        Symtable.init();
        clear_crc_interfaces ();
@@ -512,11 +513,7 @@ let link_bytecode_as_c tolink outfile with_main =
        (* The entry point *)
        if with_main then begin
          output_string outchan "\
-\n#ifdef _WIN32\
-\nint wmain(int argc, wchar_t **argv)\
-\n#else\
-\nint main(int argc, char **argv)\
-\n#endif\
+\nint main_os(int argc, char_os **argv)\
 \n{\
 \n  caml_byte_program_mode = COMPLETE_EXE;\
 \n  caml_startup_code(caml_code, sizeof(caml_code),\

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -278,6 +278,8 @@ extern double caml_log1p(double);
 
 #ifdef CAML_INTERNALS
 #define T(x) L ## x
+
+#define main_os wmain
 #endif
 
 #define access_os _waccess
@@ -316,6 +318,8 @@ extern double caml_log1p(double);
 
 #ifdef CAML_INTERNALS
 #define T(x) x
+
+#define main_os main
 #endif
 
 #define access_os access

--- a/runtime/main.c
+++ b/runtime/main.c
@@ -27,11 +27,7 @@
 #include <windows.h>
 #endif
 
-#ifdef _WIN32
-int wmain(int argc, wchar_t **argv)
-#else
-int main(int argc, char **argv)
-#endif
+int main_os(int argc, char_os **argv)
 {
 #ifdef _WIN32
   /* Expand wildcards and diversions in command line */

--- a/runtime/sak.c
+++ b/runtime/sak.c
@@ -129,11 +129,7 @@ void add_stdlib_prefix(int count, char_os **names)
   }
 }
 
-#ifdef _WIN32
-int wmain(int argc, wchar_t **argv)
-#else
-int main(int argc, char **argv)
-#endif
+int main_os(int argc, char_os **argv)
 {
   if (argc == 3 && !strcmp_os(argv[1], T("encode-C-literal"))) {
     encode_C_literal(argv[2]);

--- a/testsuite/tests/embedded/cmmain.c
+++ b/testsuite/tests/embedded/cmmain.c
@@ -15,16 +15,14 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#define CAML_INTERNALS
+#include <caml/misc.h>
 #include <caml/callback.h>
 
 extern int fib(int n);
 extern char * format_result(int n);
 
-#ifdef _WIN32
-int wmain(int argc, wchar_t ** argv)
-#else
-int main(int argc, char ** argv)
-#endif
+int main_os(int argc, char_os ** argv)
 {
   printf("Initializing OCaml code...\n");
 

--- a/testsuite/tests/output-complete-obj/test.ml_stub.c
+++ b/testsuite/tests/output-complete-obj/test.ml_stub.c
@@ -1,14 +1,12 @@
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/callback.h>
 #include <caml/memory.h>
+#include <caml/misc.h>
 
-#ifdef _WIN32
-int wmain(int argc, wchar_t ** argv){
-#else
-int main(int argc, char ** argv){
-#endif
-
+int main_os(int argc, char_os **argv)
+{
   caml_startup(argv);
   return 0;
 }

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -30,6 +30,7 @@
 #include "caml/config.h"
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
+#include "caml/misc.h"
 
 #define caml_stat_strdup strdup
 

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -420,11 +420,7 @@ void open_files(void)
       open_error(interface_file_name);
 }
 
-#ifdef _WIN32
-int wmain(int argc, wchar_t **argv)
-#else
-int main(int argc, char **argv)
-#endif
+int main_os(int argc, char_os **argv)
 {
     set_signals();
     getargs(argc, argv);


### PR DESCRIPTION
This is a bit of possible tidying up which came out of revising #10451. There are quite a few places where we end up with a `#ifdef` soup to toggle between Windows `wmain` entry-point and Unix's `main` entry-point.

`main_os` doesn't have to be inside `CAML_INTERNALS` (the other `_os` functions aren't) - if it weren't, then the two testsuite files wouldn't need to define it

The `#include`s to `caml/main.h` outside the testsuite are just making the use of the header explicit - it was relied on before both in bytelink and ocamlyacc since they already use `char_os`.