### PR TITLE
Revert "Remove propagation from previous branches (#9811)" in trunk

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,13 +95,6 @@ OCaml 4.13.0
   existentials freshly introduced by GADT constructors.
   (Jacques Garrigue, review by Leo White and Gabriel Scherer)
 
-* #9811: remove propagation from previous branches
-  Type information inferred from previous branches was propagated in
-  non-principal mode. Revert this for better compatibility with
-  -principal mode.
-  For the time being, infringing code should result in a principality warning.
-  (Jacques Garrigue, review by Thomas Refis and Gabriel Scherer)
-
 - #10174: Make Tsubst more robust by avoiding strange workarounds
   (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer and
    Florian Angeletti)

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -47,13 +47,6 @@ let f (type t) (x : t) (tag : t ty) =
   | Bool -> x
 ;;
 [%%expect{|
-Lines 2-4, characters 2-13:
-2 | ..match tag with
-3 |   | Int -> x > 0
-4 |   | Bool -> x
-Warning 18 [not-principal]:
-  The return type of this pattern-matching is ambiguous.
-  Please add a type annotation, as the choice of `bool' is not principal.
 val f : 't -> 't ty -> bool = <fun>
 |}, Principal{|
 Line 4, characters 12-13:

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -628,15 +628,6 @@ let f (type a) (x : a t) y =
     in M.z
 ;; (* fails because of aliasing... *)
 [%%expect{|
-Lines 2-4, characters 2-10:
-2 | ..match x with Int ->
-3 |     let module M = struct type b = a let z = (y : b) end
-4 |     in M.z
-Warning 18 [not-principal]:
-  The return type of this pattern-matching is ambiguous.
-  Please add a type annotation, as the choice of `a' is not principal.
-val f : 'a t -> 'a -> 'a = <fun>
-|}, Principal{|
 Line 3, characters 46-47:
 3 |     let module M = struct type b = a let z = (y : b) end
                                                   ^

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -361,13 +361,6 @@ module Propagation = struct
 end
 ;;
 [%%expect{|
-Lines 11-13, characters 12-20:
-11 | ............match x with
-12 |     | IntLit n -> (n : s )
-13 |     | BoolLit b -> b
-Warning 18 [not-principal]:
-  The return type of this pattern-matching is ambiguous.
-  Please add a type annotation, as the choice of `s' is not principal.
 module Propagation :
   sig
     type _ t = IntLit : int -> int t | BoolLit : bool -> bool t


### PR DESCRIPTION
This PR cherry-picks the revert of #9811 from the improvements of #10364.

This change has already been reverted in the 4.12 branch but it was left in trunk with the hope that we we would find a better solution than the revert.

If I understand correctly, @garrigue 's point of view is that this better solution consists in improving the error message in the `-principal` mode while keeping the propagation of type information between branches in non-principal mode for the sake of backward compatibility.

On the other side, @trefis's opinion is that it might be better to remove the propagation altogether and fixes the few libraries and programs affected by this change.

This PR is mostly here to track this discussion and see if other people (@gasche , @lpw25 ?) have a strong opinion on this matter.
