### PR TITLE
Mention binutils as installation prerequisites

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -20,6 +20,9 @@
 * Under Cygwin, the `gcc-core` package is required. `flexdll` is also necessary
   for shared library support.
 
+* Binutils including `ar`, `ranlib`, and `strip` are required if your
+  distribution does not already provide them with the C compiler.
+
 == Configuration
 
 From the top directory, do:


### PR DESCRIPTION
Related: #10431 

`ar` (and `ranlib` unless there's some fallback?) is used in `MKLIB` defined by `configure` and used in makefiles eg. `runtime/Makefile`
`strip` is used in `stdlib/Makefile`