### PR TITLE
CSS adjustments in post-processed HTML manual

### DIFF
--- a/Changes
+++ b/Changes
@@ -394,6 +394,9 @@ OCaml 4.13.0
 - #9632: Document incremental build solutions with opam
   (Vincent Laviron, review by Daniel Bünzli and Gabriel Scherer)
 
+- #10497: Styling changes in the post-processed HTML manual (webman)
+  (Wiktor Kuchta, review by Florian Angeletti)
+
 ### Compiler user-interface and warnings:
 
 - #1737, #2092, #7852, #7859, #10405, #10417: Update locations during

--- a/manual/src/html_processing/scss/_common.scss
+++ b/manual/src/html_processing/scss/_common.scss
@@ -19,6 +19,10 @@ $logo_height:67px;
 @import url(https://fonts.googleapis.com/css?family=Noticia+Text:400,400i,700);
 @import url(https://fonts.googleapis.com/css?family=Fira+Sans:400,400i,500,500i,600,600i,700,700i);
 
+$font-sans: "Fira Sans", Helvetica, Arial, sans-serif;
+$font-mono: "Fira Mono", courier, monospace;
+$font-serif: "Noticia Text", Georgia, serif;
+
 /* Reset */
 .pre,a,b,body,code,div,em,form,h1,h2,h3,h4,h5,h6,header,html,i,img,li,mark,menu,nav,object,output,p,pre,s,section,span,time,ul,td,var{
     margin:0;
@@ -47,7 +51,7 @@ html.smooth-scroll {
 }
 
 body{
-    font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+    font-family: $font-sans;
     text-align:left;
     color:#333;
     background:#fff
@@ -76,7 +80,7 @@ html {
     &>header {
 	margin-bottom: 30px;
 	nav {
-	    font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+	    font-family: $font-sans;
 	}
     }
 }
@@ -87,7 +91,7 @@ html {
     margin-right:4ex;
     margin-top:20px;
     margin-bottom:50px;
-    font-family:"Noticia Text",Georgia,serif;
+    font-family: $font-serif;
     line-height:1.5
 }
 
@@ -131,7 +135,7 @@ html {
 		padding-left:12px;
 	    }
 	    a {
-		font-family:"Fira Sans",sans-serif;
+		font-family: $font-sans;
 		font-size:.95em;
 		color:#333;
 		font-weight:400;
@@ -250,7 +254,7 @@ html {
     color:$logocolor;
     margin-right:4px;
     margin-left:-1em;
-    font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+    font-family: $font-sans;
     font-size:13px;
     vertical-align:1px;
 }
@@ -260,7 +264,7 @@ html {
     color:$logocolor;
     margin-right:4px;
     margin-left:-1em;
-    font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+    font-family: $font-sans;
     font-size:14px;
     vertical-align:1px;
 }

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -16,7 +16,7 @@
 	float:left;
 	color:#777;
 	cursor: context-menu;
-	font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+	font-family: $font-sans;
 	span{ /* menu icon */
 	    font-size:22px;
 	    margin-right:1ex;
@@ -63,7 +63,7 @@
 	font-size:smaller;
     }
     section>ul>li>a{ /* for Parts title */
-	font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+	font-family: $font-sans;
 	font-size:larger;
 	background:linear-gradient(to left,#fff 0,#ede8e5 100%);
     }
@@ -143,7 +143,7 @@ a.section-anchor{
     color:#d5d5d5
 }
 .h10,.h7,.h8,.h9,h1,h2,h3,h4,h5,h6{
-    font-family:"Fira Sans",Helvetica,Arial,sans-serif;
+    font-family: $font-sans;
     font-weight:400;
     margin:.5em 0 .5em 0;
     padding-top:.1em;
@@ -189,7 +189,7 @@ h2, h3, h4, h5 {
 	font-weight: 500;
 }
 .ocaml,.pre,code,pre,tt{
-    font-family:"Fira Mono",courier;
+    font-family: $font-mono;
     font-weight:400
 }
 .pre,pre{
@@ -273,7 +273,7 @@ blockquote.quote{
     }
 }
 #part-menu{
-    font-family:"Fira Sans";
+    font-family: $font-sans;
     text-align:right;
     list-style:none;
     overflow-y:hidden;
@@ -293,7 +293,7 @@ blockquote.quote{
 }
 span.c003{
     color:#564233;
-    font-family:"Fira Mono",courier;
+    font-family: $font-mono;
     border-radius:6px
 }
 div.caml-example.toplevel code.caml-input::before,
@@ -305,7 +305,7 @@ span.number{
     padding-right: 1ex;
 }
 span.c004, span.c005 {
-	font-family: "Fira Mono", courier, monospace;
+	font-family: $font-mono;
 }
 span.c003, span.c005 {
 	color: rgba(91, 33, 6, 0.87);
@@ -316,7 +316,7 @@ span.c002{
 span.c006{
     font-weight:700;
     color:#564233;
-    font-family:"Fira Mono",courier;
+    font-family: $font-mono;
 }
 span.c009{
     font-style:italic;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -316,6 +316,9 @@ span.authors{
     font-style:italic;
     background-color:inherit
 }
+span.c011 {
+	font-style: italic;
+}
 span.c013{
     font-weight:700
 }

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -266,7 +266,6 @@ h1 span{
     color: #d28853;
 }
 blockquote.quote{
-    margin:0;
     /*font-size: smaller;*/
     hr{
 	display:none;
@@ -321,6 +320,9 @@ span.c006{
     font-weight:700;
     color:#564233;
     font-family: $font-mono;
+}
+.c008 {
+	font-family: $font-sans;
 }
 span.c010 {
 	font-style: italic;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -291,6 +291,10 @@ blockquote.quote{
 .display {
 	margin: 0 auto;
 }
+.c001 {
+	border-spacing: 6px;
+	border-collapse: separate;
+}
 span.c003{
     color:#564233;
     font-family: $font-mono;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -318,11 +318,6 @@ span.c006{
     color:#564233;
     font-family: $font-mono;
 }
-span.c009{
-    font-style:italic;
-    background-color:#f3ece6;
-    border-radius:6px
-}
 span.c010 {
 	font-style: italic;
 }

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -342,6 +342,9 @@ span.c013{
 td .c014 {
 	font-weight: bold;
 }
+.cellpadding1 tr td {
+	padding: 1px 4px;
+}
 .caml-input{
     span.ocamlkeyword{
 	font-weight:500;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -347,6 +347,9 @@ span.c013{
 td .c014 {
 	font-weight: bold;
 }
+.c016 {
+	text-align: center;
+}
 .cellpadding1 tr td {
 	padding: 1px 4px;
 }

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -293,7 +293,13 @@ div.caml-example.toplevel div.caml-input::before{
 span.number{
     padding-right: 1ex;
 }
-span.c004, span.c002{
+span.c004, span.c005 {
+	font-family: "Fira Mono", courier, monospace;
+}
+span.c003, span.c005 {
+	color: rgba(91, 33, 6, 0.87);
+}
+span.c002{
     color:#888
 }
 span.c006{

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -331,6 +331,10 @@ span.c011 {
 span.c013{
     font-weight:700
 }
+.center table {
+	margin-left: inherit;
+	margin-right: inherit;
+}
 .caml-input{
     span.ocamlkeyword{
 	font-weight:500;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -304,7 +304,7 @@ div.caml-example.toplevel div.caml-input::before{
 span.number{
     padding-right: 1ex;
 }
-span.c004, span.c005 {
+span.c004, span.c005, span.c007 {
 	font-family: $font-mono;
 }
 span.c003, span.c005 {

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -334,6 +334,9 @@ span.authors{
 span.c011 {
 	font-style: italic;
 }
+.c012 {
+	font-style: italic;
+}
 span.c013{
     font-style: italic;
 }

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -329,7 +329,7 @@ span.c011 {
 	font-style: italic;
 }
 span.c013{
-    font-weight:700
+    font-style: italic;
 }
 .center table {
 	margin-left: inherit;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -280,6 +280,14 @@ blockquote.quote{
     color:#000;
     &::before{@include diamond}
 }
+.center {
+	text-align: center;
+	margin-left: auto;
+	margin-right: auto;
+}
+.display {
+	margin: 0 auto;
+}
 span.c003{
     color:#564233;
     font-family:"Fira Mono",courier;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -335,6 +335,9 @@ span.c013{
 	margin-left: inherit;
 	margin-right: inherit;
 }
+td .c014 {
+	font-weight: bold;
+}
 .caml-input{
     span.ocamlkeyword{
 	font-weight:500;

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -185,6 +185,9 @@ h3 code{
 h4{
     font-size:1.12em
 }
+h2, h3, h4, h5 {
+	font-weight: 500;
+}
 .ocaml,.pre,code,pre,tt{
     font-family:"Fira Mono",courier;
     font-weight:400

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -323,6 +323,9 @@ span.c009{
     background-color:#f3ece6;
     border-radius:6px
 }
+span.c010 {
+	font-style: italic;
+}
 span.authors{
     font-style:italic;
     background-color:inherit

--- a/manual/src/html_processing/scss/manual.scss
+++ b/manual/src/html_processing/scss/manual.scss
@@ -283,7 +283,6 @@ blockquote.quote{
 span.c003{
     color:#564233;
     font-family:"Fira Mono",courier;
-    background-color:#f3ece6;
     border-radius:6px
 }
 div.caml-example.toplevel code.caml-input::before,

--- a/manual/src/html_processing/scss/style.scss
+++ b/manual/src/html_processing/scss/style.scss
@@ -39,7 +39,7 @@
 
 .api {
     // font-size: 16px;
-    // font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+    // font-family: $font-sans;
     // text-align: left;
     // color: #333;
     // background: #FFFFFF;
@@ -259,7 +259,7 @@
     we restart the sequence there like h2  */
 
        h1, h2, h3, h4, h5, h6, .h7, .h8, .h9, .h10 {
-	font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+	font-family: $font-sans;
 	font-weight: 400;
 	margin: 0.5em 0 0.5em 0;
 	padding-top: 0.1em;
@@ -316,7 +316,7 @@
     /* Preformatted and code */
 
     tt, code, pre {
-	font-family: "Fira Mono", courier;
+	font-family: $font-mono;
 	font-weight: 400;
     }
 
@@ -705,7 +705,7 @@
     span.arrow {
 	font-size: 20px;
 	line-height: 8pt;
-	font-family: "Fira Mono";
+	font-family: $font-mono;
     }
     header dl dd, header dl dt {
 	display: inline-block;
@@ -742,7 +742,7 @@
     }
     
     ul.tutos_menu {
-	font-family: "Fira Sans";
+	font-family: $font-sans;
 	text-align: right;
 	list-style: none;
     }
@@ -756,7 +756,7 @@
     }
 
     span.c003 {
-	font-family: "Fira Mono", courier;
+	font-family: $font-mono;
 	background-color: #f3ece6;
 	border-radius: 6px;
     }

--- a/manual/src/html_processing/scss/style.scss
+++ b/manual/src/html_processing/scss/style.scss
@@ -793,8 +793,7 @@
 
     code span.constructor,
     .caml-input span.kw2 {
-	font-weight: 500;
-	color: #a28867;
+	color: #8d543c;
     }
 
     .caml-input span.numeric {


### PR DESCRIPTION
This is a couple of small CSS changes to make the manual more legible and consistent with the PDF and old HTML manuals. The commit messages say a bit more.

Screenshot sample: htmlman, current webman, my proposed changes to webman
![image](https://user-images.githubusercontent.com/35867657/128924556-f2727ceb-576e-4fd9-9ee0-0fbaa6c53dae.png)

  

