### PR TITLE
Give caml_send* arguments the correct types(take 2)

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,6 +75,11 @@ Working version
   This allows stacktraces to work in gdb through C and OCaml calls.
   (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
 
+- #10461: `caml_send*` helper functions take derived pointers as arguments.
+  Those must be declared with type Addr instead of Val.
+  (Vincent Laviron, review by Xavier Leroy)
+
+
 OCaml 4.13.0
 -------------
 

--- a/Changes
+++ b/Changes
@@ -75,9 +75,11 @@ Working version
   This allows stacktraces to work in gdb through C and OCaml calls.
   (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
 
-- #10461: `caml_send*` helper functions take derived pointers as arguments.
-  Those must be declared with type Addr instead of Val.
-  (Vincent Laviron, review by Xavier Leroy)
+- #10461, #10498: `caml_send*` helper functions take derived pointers
+  as arguments.  Those must be declared with type Addr instead of Val.
+  Moreover, poll point insertion must be disabled for `caml_send*`,
+  otherwise the derived pointer is live across a poll point.
+  (Vincent Laviron and Xavier Leroy, review by Xavier Leroy and Sadiq Jaffer)
 
 
 OCaml 4.13.0

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1865,7 +1865,7 @@ let send_function arity =
   let cache = cache in
   let fun_name = "caml_send" ^ Int.to_string arity in
   let fun_args =
-    [obj, typ_val; tag, typ_int; cache, typ_val]
+    [obj, typ_val; tag, typ_int; cache, typ_addr]
     @ List.map (fun id -> (id, typ_val)) (List.tl args) in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in
   Cfunction

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -24,6 +24,7 @@ module String = Misc.Stdlib.String
 
 let function_is_assumed_to_never_poll func =
   String.starts_with ~prefix:"caml_apply" func
+  || String.starts_with ~prefix:"caml_send" func
 
 (* Detection of recursive handlers that are not guaranteed to poll
    at every loop iteration. *)


### PR DESCRIPTION
This is a follow-up to #10461.

One of the arguments to `cam_send*` is a derived pointer.  It must therefore be declared with type Addr.

The derived pointer is live throughout a loop.  If we let the Polling pass have its way, it inserts an Ipoll instruction in this loop, and the derived pointer is live across the Ipoll, which is wrong and rejected at compile-time.

We instruct the Polling pass to not add poll points to caml_send* functions, just like it does not add poll points to caml_apply* functions.  This fixes the issue and seems to be safe, as caml_send* cannot cause an infinite loop by itself.