### PR TITLE
Avoid Addr argument to caml_send*  (take 2)

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,6 +75,11 @@ Working version
   This allows stacktraces to work in gdb through C and OCaml calls.
   (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
 
+- #10461: in `caml_send*` helper functions, replace one argument that is
+  a derived pointer by two arguments, a base array and an integer offset.
+  (Vincent Laviron, review by Xavier Leroy)
+
+
 OCaml 4.13.0
 -------------
 


### PR DESCRIPTION
This is another follow-up to #10461.

As in @lthls 's original proposal, `caml_send*` no longer take a single "cache" argument that is a derived pointer, but they take a base array and an integer offset. 

What is new here is that we avoid keeping a derived pointer live altogether, since this interacts badly with the polling point that is automatically inserted in `caml_send`.
