### PR TITLE
Fix the dune build

### DIFF
--- a/dune
+++ b/dune
@@ -156,7 +156,9 @@
    emit emitaux emitenv
    interf interval
    linear linearize linscan
-   liveness mach printcmm printlinear printmach proc reg reload reloadgen
+   liveness mach
+   polling printcmm printlinear printmach proc
+   reg reload reloadgen
    schedgen scheduling selectgen selection spill split
    strmatch x86_ast x86_dsl x86_gas x86_masm x86_proc
 

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -37,7 +37,5 @@ case $1 in
   stdlib__Float.cm[ox]) echo ' -nolabels -no-alias-deps';;
   stdlib__Oo.cmi) echo ' -no-principal';;
     # preserve structure sharing in Oo.copy (PR#9767)
-  stdlib__Genlex.cm[iox]) echo ' -w -3';;
-    # ignore the "deprecated" alert on the Stream module
   *) echo ' ';;
 esac

--- a/stdlib/genlex.ml
+++ b/stdlib/genlex.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@ocaml.warning "-3"] (* ignore deprecation warning about module Stream *)
+
 type token =
     Kwd of string
   | Ident of string

--- a/stdlib/genlex.mli
+++ b/stdlib/genlex.mli
@@ -45,6 +45,8 @@
    ["-pp"] command-line switch of the compilers.
 *)
 
+[@@@ocaml.warning "-3"] (* ignore deprecation warning about module Stream *)
+
 (** The type of tokens. The lexical classes are: [Int] and [Float]
    for integer and floating-point numbers; [String] for
    string literals, enclosed in double quotes; [Char] for


### PR DESCRIPTION
I use the dune build to get Merlin support on the compiler codebase. See [HACKING.adoc: Using Merlin](https://github.com/ocaml/ocaml/blob/trunk/HACKING.adoc#using-merlin).