### PR TITLE
Implement caching of method lookups in Cmm

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1702,13 +1702,11 @@ let send kind met obj args dbg =
     generic_apply Asttypes.Mutable clos (obj :: args) dbg
   in
   bind "obj" obj (fun obj ->
-      match (kind : Lambda.meth_kind), args with
-        Self, _ ->
+      match (kind : Lambda.meth_kind) with
+        Self ->
           bind "met" (lookup_label obj met dbg)
             (call_met obj args)
-      | Cached, cache :: pos :: args ->
-          call_cached_method obj met cache pos args dbg
-      | _ ->
+      | Public ->
           bind "met" (lookup_tag obj met dbg)
             (call_met obj args))
 

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -289,11 +289,9 @@ val lookup_label : expression -> expression -> Debuginfo.t -> expression
     Arguments :
     - obj : the object from which to lookup
     - tag : the hash of the method name, as a tagged integer
-    - cache : the method cache array
-    - pos : the position of the cache entry in the cache array
     - args : the additional arguments to the method call *)
 val call_cached_method :
-  expression -> expression -> expression -> expression -> expression list ->
+  expression -> expression -> expression list ->
   Debuginfo.t -> expression
 
 (** Allocations *)

--- a/asmcomp/cmmgen_state.mli
+++ b/asmcomp/cmmgen_state.mli
@@ -45,3 +45,5 @@ val add_structured_constant : string -> Clambda.ustructured_constant -> unit
 
 (* Also looks up using Compilenv.structured_constant_of_symbol *)
 val structured_constant_of_sym : string -> Clambda.ustructured_constant option
+
+val next_method : unit -> int

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -560,7 +560,6 @@ let rec comp_expr env exp sz cont =
         end
       end
   | Lsend(kind, met, obj, args, _) ->
-      assert (kind <> Cached);
       let nargs = List.length args + 1 in
       let getmethod, args' =
         if kind = Self then (Kgetmethod, met::obj::args) else

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -251,14 +251,13 @@ type function_kind = Curried | Tupled
 
 type let_kind = Strict | Alias | StrictOpt
 
-type meth_kind = Self | Public | Cached
+type meth_kind = Self | Public
 
 let equal_meth_kind x y =
   match x, y with
   | Self, Self -> true
   | Public, Public -> true
-  | Cached, Cached -> true
-  | (Self | Public | Cached), _ -> false
+  | (Self | Public), _ -> false
 
 type shared_code = (int * int) list
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -242,7 +242,7 @@ type let_kind = Strict | Alias | StrictOpt
       we can discard e if x does not appear in e'
  *)
 
-type meth_kind = Self | Public | Cached
+type meth_kind = Self | Public
 
 val equal_meth_kind : meth_kind -> meth_kind -> bool
 

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -627,7 +627,7 @@ let rec lam ppf = function
       let args ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       let kind =
-        if k = Self then "self" else if k = Cached then "cache" else "" in
+        if k = Self then "self" else "" in
       fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind lam obj lam met args largs
   | Levent(expr, ev) ->
       let kind =

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -576,9 +576,6 @@ let rec builtin_meths self env env2 body =
   | Lsend(Public, met, arg, [], _) ->
       let s, args = conv arg in
       ("send_"^s, met :: args)
-  | Lsend(Cached, met, arg, [_;_], _) ->
-      let s, args = conv arg in
-      ("send_"^s, met :: args)
   | Lfunction {kind = Curried; params = [x, _]; body} ->
       let rec enter self = function
         | Lprim(Parraysetu _, [Lvar s; Lvar n; Lvar x'], _)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -470,9 +470,8 @@ and transl_exp0 ~in_new_scope ~scopes e =
         match met with
           Tmeth_val id -> Lsend (Self, Lvar id, obj, [], loc)
         | Tmeth_name nm ->
-            let (tag, cache) = Translobj.meth obj nm in
-            let kind = if cache = [] then Public else Cached in
-            Lsend (kind, tag, obj, cache, loc)
+            let tag = Translobj.meth_tag nm in
+            Lsend (Public, tag, obj, [], loc)
       in
       event_after ~scopes e lam
   | Texp_new (cl, {Location.loc=loc}, _) ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1379,7 +1379,8 @@ let transl_store_gen ~scopes module_name ({ str_items = str }, restr) topl =
           (transl_exp ~scopes expr)
     | str -> transl_store_structure ~scopes module_id map prims aliases str
   in
-  transl_store_label_init module_id size f str
+  let expr, size = transl_label_init (fun () -> f str, size) in
+  size, expr
   (*size, transl_label_init (transl_store_structure module_id map prims str)*)
 
 let transl_store_phrases module_name str =

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -38,56 +38,13 @@ let share c =
 
 (* Collect labels *)
 
-let cache_required = ref false
-let method_cache = ref lambda_unit
-let method_count = ref 0
-let method_table = ref []
-
 let meth_tag s = Lconst(Const_base(Const_int(Btype.hash_variant s)))
 
-let next_cache tag =
-  let n = !method_count in
-  incr method_count;
-  (tag, [!method_cache; Lconst(Const_base(Const_int n))])
-
-let rec is_path = function
-    Lvar _ | Lprim (Pgetglobal _, [], _) | Lconst _ -> true
-  | Lprim (Pfield _, [lam], _) -> is_path lam
-  | Lprim ((Parrayrefu _ | Parrayrefs _), [lam1; lam2], _) ->
-      is_path lam1 && is_path lam2
-  | _ -> false
-
-let meth obj lab =
-  let tag = meth_tag lab in
-  if not (!cache_required && !Clflags.native_code) then (tag, []) else
-  if not (is_path obj) then next_cache tag else
-  try
-    let r = List.assoc obj !method_table in
-    try
-      (tag, List.assoc tag !r)
-    with Not_found ->
-      let p = next_cache tag in
-      r := p :: !r;
-      p
-  with Not_found ->
-    let p = next_cache tag in
-    method_table := (obj, ref [p]) :: !method_table;
-    p
-
 let reset_labels () =
-  Hashtbl.clear consts;
-  method_count := 0;
-  method_table := []
-
-(* Insert labels *)
-
-let int n = Lconst (Const_base (Const_int n))
-
-let prim_makearray =
-  Primitive.simple ~name:"caml_make_vect" ~arity:2 ~alloc:true
+  Hashtbl.clear consts
 
 (* Also use it for required globals *)
-let transl_label_init_general f =
+let transl_label_init f =
   let expr, size = f () in
   let expr =
     Hashtbl.fold
@@ -103,56 +60,10 @@ let transl_label_init_general f =
   reset_labels ();
   expr, size
 
-let transl_label_init_flambda f =
-  assert(Config.flambda);
-  let method_cache_id = Ident.create_local "method_cache" in
-  method_cache := Lvar method_cache_id;
-  (* Calling f (usually Translmod.transl_struct) requires the
-     method_cache variable to be initialised to be able to generate
-     method accesses. *)
-  let expr, size = f () in
-  let expr =
-    if !method_count = 0 then expr
-    else
-      Llet (Strict, Pgenval, method_cache_id,
-        Lprim (Pccall prim_makearray,
-               [int !method_count; int 0],
-               Loc_unknown),
-        expr)
-  in
-  transl_label_init_general (fun () -> expr, size)
-
-let transl_store_label_init glob size f arg =
-  assert(not Config.flambda);
-  assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield size,
-                        [Lprim(Pgetglobal glob, [], Loc_unknown)],
-                        Loc_unknown);
-  let expr = f arg in
-  let (size, expr) =
-    if !method_count = 0 then (size, expr) else
-    (size+1,
-     Lsequence(
-     Lprim(Psetfield(size, Pointer, Root_initialization),
-           [Lprim(Pgetglobal glob, [], Loc_unknown);
-            Lprim (Pccall prim_makearray,
-                   [int !method_count; int 0],
-                   Loc_unknown)],
-           Loc_unknown),
-     expr))
-  in
-  let lam, size = transl_label_init_general (fun () -> (expr, size)) in
-  size, lam
-
-let transl_label_init f =
-  if !Clflags.native_code then
-    transl_label_init_flambda f
-  else
-    transl_label_init_general f
-
 (* Share classes *)
 
 let wrapping = ref false
+let cache_required = ref false
 let top_env = ref Env.empty
 let classes = ref []
 let method_ids = ref Ident.Set.empty
@@ -189,10 +100,6 @@ let oo_wrap env req f x =
 
 let reset () =
   Hashtbl.clear consts;
-  cache_required := false;
-  method_cache := lambda_unit;
-  method_count := 0;
-  method_table := [];
   wrapping := false;
   top_env := Env.empty;
   classes := [];

--- a/lambda/translobj.mli
+++ b/lambda/translobj.mli
@@ -18,12 +18,10 @@ open Lambda
 val oo_prim: string -> lambda
 
 val share: structured_constant -> lambda
-val meth: lambda -> string -> lambda * lambda list
+val meth_tag: string -> lambda
 
 val reset_labels: unit -> unit
 val transl_label_init: (unit -> lambda * 'a) -> lambda * 'a
-val transl_store_label_init:
-    Ident.t -> int -> ('a -> lambda) -> 'a -> int * lambda
 
 val method_ids: Ident.Set.t ref (* reset when starting a new wrapper *)
 

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -694,12 +694,8 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       Lsend(Public, meth, obj, [], loc)
   | Send_self, [obj; meth] ->
       Lsend(Self, meth, obj, [], loc)
-  | Send_cache, [obj; meth; cache; pos] ->
-      (* Cached mode only works in the native backend *)
-      if !Clflags.native_code then
-        Lsend(Cached, meth, obj, [cache; pos], loc)
-      else
-        Lsend(Public, meth, obj, [], loc)
+  | Send_cache, [obj; meth; _cache; _pos] ->
+      Lsend(Public, meth, obj, [], loc)
   | Frame_pointers, [] ->
       let frame_pointers =
         if !Clflags.native_code && Config.with_frame_pointers then 1 else 0

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -360,6 +360,9 @@ let new_const_symbol () =
   incr const_label;
   make_symbol (Some (Int.to_string !const_label))
 
+let method_cache_symbol () =
+  make_symbol (Some "method_cache")
+
 let snapshot () = !structured_constants
 let backtrack s = structured_constants := s
 

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -121,6 +121,8 @@ val clear_structured_constants: unit -> unit
 val structured_constant_of_symbol:
   string -> Clambda.ustructured_constant option
 
+val method_cache_symbol: unit -> string
+
 val add_exported_constant: string -> unit
         (* clambda-only *)
 type structured_constants

--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -220,7 +220,6 @@ let rec lam ppf (flam : t) =
       match kind with
       | Self -> "self"
       | Public -> "public"
-      | Cached -> "cached"
     in
     fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind
       Variable.print obj Variable.print meth

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -228,10 +228,7 @@ and lam ppf = function
   | Usend (k, met, obj, largs, _) ->
       let args ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      let kind =
-        if k = Lambda.Self then "self"
-        else if k = Lambda.Cached then "cache"
-        else "" in
+      let kind = if k = Lambda.Self then "self" else "" in
       fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind lam obj lam met args largs
   | Uunreachable ->
       fprintf ppf "unreachable"


### PR DESCRIPTION
I had too much free time, and ended up implementing an alternative solution to #10461.

This completely removes the cache-related optimisations from Lambda, and pushes them to Cmm instead.
This has the advantage of allowing the use of a fully static array, that does not need to be tracked by the GC, so we can mark the pointers with type `Int` instead of `Addr`.

There are a few things to look at for reviewers:
- There isn't a distinction between `Public` and `Cached` method calls anymore, all `Public` method calls will use a cached lookup.
- There was an optimisation to share cache entries for lookups of the same method in the same object (when the object is a simple enough term). I haven't tried to reproduce that.
- I've kept the `cache_required` boolean reference in `translobj.ml` because it seems to have a non-trivial impact on the code of `translclass.ml`. I'd like to see that reference removed, but I'd need a better understanding of the code of `translclass.ml`.

Preliminary benchmarks (similar to the ones I ran in #10461) show a small speedup for all numbers of arguments compared to trunk (around 5% faster).