### PR TITLE
Don't try to build systhreads if unix isn't being built

### DIFF
--- a/configure
+++ b/configure
@@ -12629,6 +12629,7 @@ esac
 
 otherlibraries="dynlink"
 if test x"$enable_unix_lib" != "xno"; then :
+  enable_unix_lib=yes
   if test x"$enable_bigarray_lib" != "xno"; then :
   otherlibraries="$otherlibraries $unixlib bigarray"
 else
@@ -16593,12 +16594,16 @@ esac
 
 ## Determine if the POSIX threads library is supported
 
-if test x"$enable_systhreads" = "xno"; then :
-  systhread_support=false
-  { $as_echo "$as_me:${as_lineno-$LINENO}: the Win32/POSIX threads library is disabled" >&5
-$as_echo "$as_me: the Win32/POSIX threads library is disabled" >&6;}
-else
-  case $host in #(
+case $enable_systhreads,$enable_unix_lib in #(
+  yes,no) :
+    systhread_support=false
+    as_fn_error $? "the Win32/POSIX threads library requires the unix library" "$LINENO" 5 ;; #(
+  no,*|*,no) :
+    systhread_support=false
+    { $as_echo "$as_me:${as_lineno-$LINENO}: the Win32/POSIX threads library is disabled" >&5
+$as_echo "$as_me: the Win32/POSIX threads library is disabled" >&6;} ;; #(
+  *) :
+    case $host in #(
   *-*-mingw32|*-pc-windows) :
     systhread_support=true
       otherlibraries="$otherlibraries systhreads"
@@ -17288,8 +17293,8 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
  ;;
+esac ;;
 esac
-fi
 
 ## Does the assembler support debug prefix map and CFI directives
 as_has_debug_prefix_map=false

--- a/configure.ac
+++ b/configure.ac
@@ -527,7 +527,8 @@ AS_CASE([$host],
 
 otherlibraries="dynlink"
 AS_IF([test x"$enable_unix_lib" != "xno"],
-  [AS_IF([test x"$enable_bigarray_lib" != "xno"],
+  [enable_unix_lib=yes
+  AS_IF([test x"$enable_bigarray_lib" != "xno"],
     [otherlibraries="$otherlibraries $unixlib bigarray"],
     [otherlibraries="$otherlibraries $unixlib"])])
 AS_IF([test x"$enable_str_lib" != "xno"],
@@ -1773,9 +1774,13 @@ AS_CASE([$arch,$system],
 
 ## Determine if the POSIX threads library is supported
 
-AS_IF([test x"$enable_systhreads" = "xno"],
-  [systhread_support=false
-  AC_MSG_NOTICE([the Win32/POSIX threads library is disabled])],
+AS_CASE([$enable_systhreads,$enable_unix_lib],
+  [yes,no],
+    [systhread_support=false
+    AC_MSG_ERROR([the Win32/POSIX threads library requires the unix library])],
+  [no,*|*,no],
+    [systhread_support=false
+    AC_MSG_NOTICE([the Win32/POSIX threads library is disabled])],
   [AS_CASE([$host],
     [*-*-mingw32|*-pc-windows],
       [systhread_support=true


### PR DESCRIPTION
I've occasionally stung myself with this before, but hadn't got around to fixing it until I did it again today...

The systhreads library requires the Unix library, so this PR changes `configure` to automatically disable it if `--disable-unix-lib` is given and, as with other configuration options, displays an error if `--disable-unix-lib --enable-systhreads` is given.