### PR TITLE
[RFC] Require 1003.1-2008 for libunix

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -572,3 +572,17 @@ AC_DEFUN([OCAML_POSIX_SUPPORT], [
    posix_2008_supported=yes],
   [AC_MSG_RESULT([no])
    posix_2008_supported=no])])
+
+AC_DEFUN([OCAML_POSIX_SUPPORT2], [
+  AC_MSG_CHECKING([for POSIX 1003.1-2001 support])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _POSIX_C_SOURCE 200112L
+#include <unistd.h>
+#if _POSIX_VERSION < 200112L
+#error POSIX 1003.1-2001 not supported
+#endif
+  ]])],
+  [AC_MSG_RESULT([yes])
+   posix_2001_supported=yes],
+  [AC_MSG_RESULT([no])
+   posix_2001_supported=no])])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -558,3 +558,17 @@ AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
    AC_MSG_RESULT([no])])
   LIBS="$saved_LIBS"
 ])
+
+AC_DEFUN([OCAML_POSIX_SUPPORT], [
+  AC_MSG_CHECKING([for POSIX 1003.1-2008 support])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _POSIX_C_SOURCE 200809L
+#include <unistd.h>
+#if _POSIX_VERSION < 200809L
+#error POSIX 1003.1-2008 not supported
+#endif
+  ]])],
+  [AC_MSG_RESULT([yes])
+   posix_2008_supported=yes],
+  [AC_MSG_RESULT([no])
+   posix_2008_supported=no])])

--- a/configure
+++ b/configure
@@ -16784,24 +16784,6 @@ fi
 fi
 
 
-ac_fn_c_check_func "$LINENO" "symlink" "ac_cv_func_symlink"
-if test "x$ac_cv_func_symlink" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "readlink" "ac_cv_func_readlink"
-if test "x$ac_cv_func_readlink" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "lstat" "ac_cv_func_lstat"
-if test "x$ac_cv_func_lstat" = xyes
-then :
-  printf "%s\n" "#define HAS_SYMLINK 1" >>confdefs.h
-
-fi
-
-fi
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "realpath" "ac_cv_func_realpath"
 if test "x$ac_cv_func_realpath" = xyes
 then :

--- a/configure
+++ b/configure
@@ -16642,29 +16642,6 @@ then :
 
 fi
 
-## socklen_t
-
-case $host in #(
-  *-*-mingw32|*-pc-windows) :
-    ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <ws2tcpip.h>
-"
-if test "x$ac_cv_type_socklen_t" = xyes
-then :
-  printf "%s\n" "#define HAS_SOCKLEN_T 1" >>confdefs.h
-
-fi
- ;; #(
-  *) :
-    ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <sys/socket.h>
-"
-if test "x$ac_cv_type_socklen_t" = xyes
-then :
-  printf "%s\n" "#define HAS_SOCKLEN_T 1" >>confdefs.h
-
-fi
- ;;
-esac
-
 ## Unix domain sockets support on Windows
 
 case $host in #(

--- a/configure
+++ b/configure
@@ -16810,32 +16810,6 @@ then :
 fi
 
 
-# wait
-ac_fn_c_check_func "$LINENO" "waitpid" "ac_cv_func_waitpid"
-if test "x$ac_cv_func_waitpid" = xyes
-then :
-
-    wait=true
-    printf "%s\n" "#define HAS_WAITPID 1" >>confdefs.h
-
-
-else $as_nop
-  wait=false
-fi
-
-
-# wait4
-ac_fn_c_check_func "$LINENO" "wait4" "ac_cv_func_wait4"
-if test "x$ac_cv_func_wait4" = xyes
-then :
-
-    has_wait=true
-    printf "%s\n" "#define HAS_WAIT4 1" >>confdefs.h
-
-
-fi
-
-
 ## getgroups
 ac_fn_c_check_func "$LINENO" "getgroups" "ac_cv_func_getgroups"
 if test "x$ac_cv_func_getgroups" = xyes

--- a/configure
+++ b/configure
@@ -16886,14 +16886,6 @@ fi
 fi
 
 
-ac_fn_c_check_func "$LINENO" "nanosleep" "ac_cv_func_nanosleep"
-if test "x$ac_cv_func_nanosleep" = xyes
-then :
-  printf "%s\n" "#define HAS_NANOSLEEP 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "symlink" "ac_cv_func_symlink"
 if test "x$ac_cv_func_symlink" = xyes
 then :

--- a/configure
+++ b/configure
@@ -14479,15 +14479,6 @@ then :
 fi
 
 
-ac_fn_c_check_header_compile "$LINENO" "sys/select.h" "ac_cv_header_sys_select_h" "#include <sys/types.h>
-"
-if test "x$ac_cv_header_sys_select_h" = xyes
-then :
-  printf "%s\n" "#define HAS_SYS_SELECT_H 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_header_compile "$LINENO" "stdatomic.h" "ac_cv_header_stdatomic_h" "$ac_includes_default"
 if test "x$ac_cv_header_stdatomic_h" = xyes
 then :
@@ -16865,27 +16856,6 @@ fi
 fi
 
 
-## select
-ac_fn_c_check_func "$LINENO" "select" "ac_cv_func_select"
-if test "x$ac_cv_func_select" = xyes
-then :
-  ac_fn_c_check_type "$LINENO" "fd_set" "ac_cv_type_fd_set" "
-#include <sys/types.h>
-#include <sys/select.h>
-
-"
-if test "x$ac_cv_type_fd_set" = xyes
-then :
-  printf "%s\n" "#define HAS_SELECT 1" >>confdefs.h
-
-    select=true
-else $as_nop
-  select=false
-fi
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "symlink" "ac_cv_func_symlink"
 if test "x$ac_cv_func_symlink" = xyes
 then :
@@ -16926,6 +16896,7 @@ else $as_nop
 fi
 
 
+# wait4
 ac_fn_c_check_func "$LINENO" "wait4" "ac_cv_func_wait4"
 if test "x$ac_cv_func_wait4" = xyes
 then :

--- a/configure
+++ b/configure
@@ -16739,14 +16739,6 @@ then :
 fi
 
 
-ac_fn_c_check_func "$LINENO" "lockf" "ac_cv_func_lockf"
-if test "x$ac_cv_func_lockf" = xyes
-then :
-  printf "%s\n" "#define HAS_LOCKF 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "getcwd" "ac_cv_func_getcwd"
 if test "x$ac_cv_func_getcwd" = xyes
 then :

--- a/configure
+++ b/configure
@@ -16674,14 +16674,6 @@ fi
  ;;
 esac
 
-ac_fn_c_check_func "$LINENO" "inet_aton" "ac_cv_func_inet_aton"
-if test "x$ac_cv_func_inet_aton" = xyes
-then :
-  printf "%s\n" "#define HAS_INET_ATON 1" >>confdefs.h
-
-fi
-
-
 ## Unix domain sockets support on Windows
 
 case $host in #(
@@ -16767,17 +16759,6 @@ then :
 
 else $as_nop
   ipv6=false
-fi
-
-fi
-
-if $ipv6
-then :
-  ac_fn_c_check_func "$LINENO" "inet_ntop" "ac_cv_func_inet_ntop"
-if test "x$ac_cv_func_inet_ntop" = xyes
-then :
-  printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h
-
 fi
 
 fi
@@ -19536,8 +19517,6 @@ case $host in #(
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_STRERROR 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_NICE 1" >>confdefs.h
  ;; #(

--- a/configure
+++ b/configure
@@ -16784,19 +16784,6 @@ fi
 fi
 
 
-ac_fn_c_check_func "$LINENO" "truncate" "ac_cv_func_truncate"
-if test "x$ac_cv_func_truncate" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "ftruncate" "ac_cv_func_ftruncate"
-if test "x$ac_cv_func_ftruncate" = xyes
-then :
-  printf "%s\n" "#define HAS_TRUNCATE 1" >>confdefs.h
-
-fi
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "symlink" "ac_cv_func_symlink"
 if test "x$ac_cv_func_symlink" = xyes
 then :

--- a/configure
+++ b/configure
@@ -13580,6 +13580,40 @@ printf "%s\n" "no" >&6; }
    posix_2008_supported=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+if test "$posix_2008_supported" = "no"
+then :
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for POSIX 1003.1-2001 support" >&5
+printf %s "checking for POSIX 1003.1-2001 support... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#define _POSIX_C_SOURCE 200112L
+#include <unistd.h>
+#if _POSIX_VERSION < 200112L
+#error POSIX 1003.1-2001 not supported
+#endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+   posix_2001_supported=yes
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+   posix_2001_supported=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
 
 otherlibraries="dynlink runtime_events"
 lib_dynlink=true

--- a/configure
+++ b/configure
@@ -17135,36 +17135,6 @@ else $as_nop
 printf "%s\n" "$as_me: Dynamic loading of shared libraries is not supported." >&6;}
 fi
 
-## mmap
-
-ac_fn_c_check_header_compile "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_mman_h" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "mmap" "ac_cv_func_mmap"
-if test "x$ac_cv_func_mmap" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "munmap" "ac_cv_func_munmap"
-if test "x$ac_cv_func_munmap" = xyes
-then :
-  printf "%s\n" "#define HAS_MMAP 1" >>confdefs.h
-
-fi
-
-fi
-
-fi
-
-
-## pwrite
-
-ac_fn_c_check_func "$LINENO" "pwrite" "ac_cv_func_pwrite"
-if test "x$ac_cv_func_pwrite" = xyes
-then :
-  printf "%s\n" "#define HAS_PWRITE 1" >>confdefs.h
-
-fi
-
-
 ## -fdebug-prefix-map support by the C compiler
 case $ocaml_cv_cc_vendor,$host in #(
   *,*-*-mingw32) :

--- a/configure
+++ b/configure
@@ -16771,42 +16771,6 @@ then :
 
 fi
 
-## utime
-## Note: this was defined in config/s-nt.h but the autoconf macros do not
-# seem to detect it properly on Windows so we hardcode the definition
-# of HAS_UTIME on Windows but this will probably need to be clarified
-case $host in #(
-  *-*-mingw32|*-pc-windows) :
-    printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_header_compile "$LINENO" "sys/types.h" "ac_cv_header_sys_types_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_types_h" = xyes
-then :
-  ac_fn_c_check_header_compile "$LINENO" "utime.h" "ac_cv_header_utime_h" "$ac_includes_default"
-if test "x$ac_cv_header_utime_h" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "utime" "ac_cv_func_utime"
-if test "x$ac_cv_func_utime" = xyes
-then :
-  printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
-
-fi
-
-fi
-
-fi
- ;;
-esac
-
-ac_fn_c_check_func "$LINENO" "utimes" "ac_cv_func_utimes"
-if test "x$ac_cv_func_utimes" = xyes
-then :
-  printf "%s\n" "#define HAS_UTIMES 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "fchmod" "ac_cv_func_fchmod"
 if test "x$ac_cv_func_fchmod" = xyes
 then :

--- a/configure
+++ b/configure
@@ -13587,7 +13587,12 @@ lib_runtime_events=true
 case $host,$enable_unix_lib,$posix_2008_supported in #(
   *,no,*) :
     ocamltest_libunix="None" ;; #(
-  *-*-mingw32,*,*|*-pc-windows,*,*|*,*,yes) :
+  *-*-mingw32,*,*|*-pc-windows,*,*|*,*,*) :
+    if test x"$posix_2008_support" = "xno"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: POSIX 1003.1-2008 compliance not detected; risking it" >&5
+printf "%s\n" "$as_me: WARNING: POSIX 1003.1-2008 compliance not detected; risking it" >&2;}
+fi
     enable_unix_lib=yes
     ac_config_files="$ac_config_files otherlibs/unix/META"
 
@@ -13599,11 +13604,6 @@ case $host,$enable_unix_lib,$posix_2008_supported in #(
     otherlibraries="$otherlibraries unix" ;; #(
   *,yes,no) :
     as_fn_error $? "libunix requires a POSIX 1003.1-2008 compliant host" "$LINENO" 5 ;; #(
-  *,*,no) :
-    enable_unix_lib=no
-    ocamltest_libunix="None"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: libunix will not be built" >&5
-printf "%s\n" "$as_me: WARNING: libunix will not be built" >&2;} ;; #(
   *) :
      ;;
 esac

--- a/configure
+++ b/configure
@@ -17670,26 +17670,6 @@ then :
 fi
 
 
-## posix_spawn
-
-ac_fn_c_check_header_compile "$LINENO" "spawn.h" "ac_cv_header_spawn_h" "$ac_includes_default"
-if test "x$ac_cv_header_spawn_h" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "posix_spawn" "ac_cv_func_posix_spawn"
-if test "x$ac_cv_func_posix_spawn" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "posix_spawnp" "ac_cv_func_posix_spawnp"
-if test "x$ac_cv_func_posix_spawnp" = xyes
-then :
-  printf "%s\n" "#define HAS_POSIX_SPAWN 1" >>confdefs.h
-
-fi
-
-fi
-
-fi
-
-
 ## ffs or _BitScanForward
 
 ac_fn_c_check_func "$LINENO" "ffs" "ac_cv_func_ffs"

--- a/configure
+++ b/configure
@@ -16747,14 +16747,6 @@ then :
 fi
 
 
-ac_fn_c_check_func "$LINENO" "mkfifo" "ac_cv_func_mkfifo"
-if test "x$ac_cv_func_mkfifo" = xyes
-then :
-  printf "%s\n" "#define HAS_MKFIFO 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "getcwd" "ac_cv_func_getcwd"
 if test "x$ac_cv_func_getcwd" = xyes
 then :

--- a/configure
+++ b/configure
@@ -16731,14 +16731,6 @@ fi
 
 fi
 
-ac_fn_c_check_func "$LINENO" "rewinddir" "ac_cv_func_rewinddir"
-if test "x$ac_cv_func_rewinddir" = xyes
-then :
-  printf "%s\n" "#define HAS_REWINDDIR 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_func "$LINENO" "getcwd" "ac_cv_func_getcwd"
 if test "x$ac_cv_func_getcwd" = xyes
 then :
@@ -16754,36 +16746,6 @@ then :
   printf "%s\n" "#define HAS_SYSTEM 1" >>confdefs.h
 
 fi
-
-ac_fn_c_check_func "$LINENO" "fchmod" "ac_cv_func_fchmod"
-if test "x$ac_cv_func_fchmod" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "fchown" "ac_cv_func_fchown"
-if test "x$ac_cv_func_fchown" = xyes
-then :
-  printf "%s\n" "#define HAS_FCHMOD 1" >>confdefs.h
-
-fi
-
-fi
-
-
-ac_fn_c_check_func "$LINENO" "realpath" "ac_cv_func_realpath"
-if test "x$ac_cv_func_realpath" = xyes
-then :
-  printf "%s\n" "#define HAS_REALPATH 1" >>confdefs.h
-
-fi
-
-
-## getgroups
-ac_fn_c_check_func "$LINENO" "getgroups" "ac_cv_func_getgroups"
-if test "x$ac_cv_func_getgroups" = xyes
-then :
-  printf "%s\n" "#define HAS_GETGROUPS 1" >>confdefs.h
-
-fi
-
 
 ## setgroups
 ac_fn_c_check_func "$LINENO" "setgroups" "ac_cv_func_setgroups"
@@ -16803,56 +16765,6 @@ then :
 fi
 
 
-## termios
-
-ac_fn_c_check_header_compile "$LINENO" "termios.h" "ac_cv_header_termios_h" "$ac_includes_default"
-if test "x$ac_cv_header_termios_h" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "tcgetattr" "ac_cv_func_tcgetattr"
-if test "x$ac_cv_func_tcgetattr" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "tcsetattr" "ac_cv_func_tcsetattr"
-if test "x$ac_cv_func_tcsetattr" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "tcsendbreak" "ac_cv_func_tcsendbreak"
-if test "x$ac_cv_func_tcsendbreak" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "tcflush" "ac_cv_func_tcflush"
-if test "x$ac_cv_func_tcflush" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "tcflow" "ac_cv_func_tcflow"
-if test "x$ac_cv_func_tcflow" = xyes
-then :
-  printf "%s\n" "#define HAS_TERMIOS 1" >>confdefs.h
-
-fi
-
-fi
-
-fi
-
-fi
-
-fi
-
-fi
-
-
-## setitimer
-
-ac_fn_c_check_func "$LINENO" "setitimer" "ac_cv_func_setitimer"
-if test "x$ac_cv_func_setitimer" = xyes
-then :
-
-    setitimer=true
-    printf "%s\n" "#define HAS_SETITIMER 1" >>confdefs.h
-
-
-else $as_nop
-  setitimer=false
-fi
-
-
 ## gettimeofday
 
 ac_fn_c_check_func "$LINENO" "gettimeofday" "ac_cv_func_gettimeofday"
@@ -16865,41 +16777,6 @@ then :
 
 else $as_nop
   gettimeofday=false
-fi
-
-
-## mktime
-
-ac_fn_c_check_func "$LINENO" "mktime" "ac_cv_func_mktime"
-if test "x$ac_cv_func_mktime" = xyes
-then :
-  printf "%s\n" "#define HAS_MKTIME 1" >>confdefs.h
-
-fi
-
-
-## setsid
-
-case $host in #(
-  *-cygwin|*-*-mingw32|*-pc-windows) :
-     ;; #(
-  *) :
-    ac_fn_c_check_func "$LINENO" "setsid" "ac_cv_func_setsid"
-if test "x$ac_cv_func_setsid" = xyes
-then :
-  printf "%s\n" "#define HAS_SETSID 1" >>confdefs.h
-
-fi
- ;;
-esac
-
-## putenv
-
-ac_fn_c_check_func "$LINENO" "putenv" "ac_cv_func_putenv"
-if test "x$ac_cv_func_putenv" = xyes
-then :
-  printf "%s\n" "#define HAS_PUTENV 1" >>confdefs.h
-
 fi
 
 
@@ -17572,16 +17449,6 @@ ac_fn_c_check_func "$LINENO" "mkstemp" "ac_cv_func_mkstemp"
 if test "x$ac_cv_func_mkstemp" = xyes
 then :
   printf "%s\n" "#define HAS_MKSTEMP 1" >>confdefs.h
-
-fi
-
-
-## nice
-
-ac_fn_c_check_func "$LINENO" "nice" "ac_cv_func_nice"
-if test "x$ac_cv_func_nice" = xyes
-then :
-  printf "%s\n" "#define HAS_NICE 1" >>confdefs.h
 
 fi
 
@@ -19257,17 +19124,11 @@ case $host in #(
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_STRERROR 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_NICE 1" >>confdefs.h
  ;; #(
   *-pc-windows) :
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_STRERROR 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_NICE 1" >>confdefs.h
  ;; #(
   *-*-solaris*) :
     # This is required as otherwise floats are printed

--- a/configure
+++ b/configure
@@ -13549,24 +13549,64 @@ case $host in #(
     exeext='' ;;
 esac
 
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for POSIX 1003.1-2008 support" >&5
+printf %s "checking for POSIX 1003.1-2008 support... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#define _POSIX_C_SOURCE 200809L
+#include <unistd.h>
+#if _POSIX_VERSION < 200809L
+#error POSIX 1003.1-2008 not supported
+#endif
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+   posix_2008_supported=yes
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+   posix_2008_supported=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
 otherlibraries="dynlink runtime_events"
 lib_dynlink=true
 lib_runtime_events=true
-if test x"$enable_unix_lib" != "xno"
-then :
-  enable_unix_lib=yes
-  ac_config_files="$ac_config_files otherlibs/unix/META"
+case $host,$enable_unix_lib,$posix_2008_supported in #(
+  *,no,*) :
+    ocamltest_libunix="None" ;; #(
+  *-*-mingw32,*,*|*-pc-windows,*,*|*,*,yes) :
+    enable_unix_lib=yes
+    ac_config_files="$ac_config_files otherlibs/unix/META"
 
-  otherlibraries="$otherlibraries unix"
-  lib_unix=true
-  ocamltest_unix_impl="real"
-  ocamltest_unix_name="unix"
-  ocamltest_unix_path='$(ROOTDIR)/otherlibs/unix'
-  ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '
-else $as_nop
-  ocamltest_libunix="None"
-fi
-
+    lib_unix=true
+    ocamltest_unix_impl="real"
+    ocamltest_unix_name="unix"
+    ocamltest_unix_path='$(ROOTDIR)/otherlibs/unix'
+    ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '
+    otherlibraries="$otherlibraries unix" ;; #(
+  *,yes,no) :
+    as_fn_error $? "libunix requires a POSIX 1003.1-2008 compliant host" "$LINENO" 5 ;; #(
+  *,*,no) :
+    enable_unix_lib=no
+    ocamltest_libunix="None"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: libunix will not be built" >&5
+printf "%s\n" "$as_me: WARNING: libunix will not be built" >&2;} ;; #(
+  *) :
+     ;;
+esac
 if test x"$enable_str_lib" != "xno"
 then :
   otherlibraries="$otherlibraries str"

--- a/configure
+++ b/configure
@@ -16926,38 +16926,6 @@ else $as_nop
 fi
 
 
-## gethostname
-# Note: detection fails on Windows so hardcoding the result
-# (should be debugged later)
-case $host in #(
-  *-*-mingw32|*-pc-windows) :
-    printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_func "$LINENO" "gethostname" "ac_cv_func_gethostname"
-if test "x$ac_cv_func_gethostname" = xyes
-then :
-  printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
-
-fi
- ;;
-esac
-
-## uname
-
-ac_fn_c_check_header_compile "$LINENO" "sys/utsname.h" "ac_cv_header_sys_utsname_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_utsname_h" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "uname" "ac_cv_func_uname"
-if test "x$ac_cv_func_uname" = xyes
-then :
-  printf "%s\n" "#define HAS_UNAME 1" >>confdefs.h
-
-fi
-
-fi
-
-
 ## gettimeofday
 
 ac_fn_c_check_func "$LINENO" "gettimeofday" "ac_cv_func_gettimeofday"

--- a/configure.ac
+++ b/configure.ac
@@ -1660,23 +1660,6 @@ AC_CHECK_FUNC([symlink],
 
 AC_CHECK_FUNC([realpath], [AC_DEFINE([HAS_REALPATH])])
 
-# wait
-AC_CHECK_FUNC(
-  [waitpid],
-  [
-    wait=true
-    AC_DEFINE([HAS_WAITPID])
-  ],
-  [wait=false])
-
-# wait4
-AC_CHECK_FUNC(
-  [wait4],
-  [
-    has_wait=true
-    AC_DEFINE([HAS_WAIT4])
-  ])
-
 ## getgroups
 AC_CHECK_FUNC([getgroups], [AC_DEFINE([HAS_GETGROUPS])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -619,6 +619,7 @@ AS_CASE([$host],
   [exeext=''])
 
 OCAML_POSIX_SUPPORT
+AS_IF([test "$posix_2008_supported" = "no"], [OCAML_POSIX_SUPPORT2])
 
 otherlibraries="dynlink runtime_events"
 lib_dynlink=true

--- a/configure.ac
+++ b/configure.ac
@@ -1848,12 +1848,6 @@ AC_CHECK_HEADER([sys/shm.h],
 
 AC_CHECK_FUNC([execvpe], [AC_DEFINE([HAS_EXECVPE])])
 
-## posix_spawn
-
-AC_CHECK_HEADER([spawn.h],
-  [AC_CHECK_FUNC([posix_spawn],
-    [AC_CHECK_FUNC([posix_spawnp], [AC_DEFINE([HAS_POSIX_SPAWN])])])])
-
 ## ffs or _BitScanForward
 
 AC_CHECK_FUNC([ffs], [AC_DEFINE([HAS_FFS])])

--- a/configure.ac
+++ b/configure.ac
@@ -1645,8 +1645,6 @@ AC_CHECK_FUNC([rewinddir], [AC_DEFINE([HAS_REWINDDIR])])
 
 AC_CHECK_FUNC([lockf], [AC_DEFINE([HAS_LOCKF])])
 
-AC_CHECK_FUNC([mkfifo], [AC_DEFINE([HAS_MKFIFO])])
-
 AC_CHECK_FUNC([getcwd], [AC_DEFINE([HAS_GETCWD])])
 
 AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])

--- a/configure.ac
+++ b/configure.ac
@@ -1774,16 +1774,6 @@ AS_IF([$supports_shared_libraries],
   AC_DEFINE([SUPPORT_DYNAMIC_LINKING])],
   [AC_MSG_NOTICE([Dynamic loading of shared libraries is not supported.])])
 
-## mmap
-
-AC_CHECK_HEADER([sys/mman.h],
-  [AC_CHECK_FUNC([mmap],
-    [AC_CHECK_FUNC([munmap], [AC_DEFINE([HAS_MMAP])])])])
-
-## pwrite
-
-AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE])])
-
 ## -fdebug-prefix-map support by the C compiler
 AS_CASE([$ocaml_cv_cc_vendor,$host],
   [*,*-*-mingw32], [cc_has_debug_prefix_map=false],

--- a/configure.ac
+++ b/configure.ac
@@ -1641,43 +1641,15 @@ AS_IF([$ipv6],
 AS_IF([$ipv6],
   [AC_CHECK_FUNC([inet_pton], [], [ipv6=false])])
 
-AC_CHECK_FUNC([rewinddir], [AC_DEFINE([HAS_REWINDDIR])])
-
 AC_CHECK_FUNC([getcwd], [AC_DEFINE([HAS_GETCWD])])
 
 AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])
-
-AC_CHECK_FUNC([fchmod],
-  [AC_CHECK_FUNC([fchown], [AC_DEFINE([HAS_FCHMOD])])])
-
-AC_CHECK_FUNC([realpath], [AC_DEFINE([HAS_REALPATH])])
-
-## getgroups
-AC_CHECK_FUNC([getgroups], [AC_DEFINE([HAS_GETGROUPS])])
 
 ## setgroups
 AC_CHECK_FUNC([setgroups], [AC_DEFINE([HAS_SETGROUPS])])
 
 ## initgroups
 AC_CHECK_FUNC([initgroups], [AC_DEFINE([HAS_INITGROUPS])])
-
-## termios
-
-AC_CHECK_HEADER([termios.h],
-  [AC_CHECK_FUNC([tcgetattr],
-    [AC_CHECK_FUNC([tcsetattr],
-      [AC_CHECK_FUNC([tcsendbreak],
-        [AC_CHECK_FUNC([tcflush],
-          [AC_CHECK_FUNC([tcflow], [AC_DEFINE([HAS_TERMIOS])])])])])])])
-
-## setitimer
-
-AC_CHECK_FUNC([setitimer],
-  [
-    setitimer=true
-    AC_DEFINE([HAS_SETITIMER])
-  ],
-  [setitimer=false])
 
 ## gettimeofday
 
@@ -1687,20 +1659,6 @@ AC_CHECK_FUNC([gettimeofday],
     AC_DEFINE([HAS_GETTIMEOFDAY])
   ],
   [gettimeofday=false])
-
-## mktime
-
-AC_CHECK_FUNC([mktime], [AC_DEFINE([HAS_MKTIME])])
-
-## setsid
-
-AS_CASE([$host],
-  [*-cygwin|*-*-mingw32|*-pc-windows], [],
-  [AC_CHECK_FUNC([setsid], [AC_DEFINE([HAS_SETSID])])])
-
-## putenv
-
-AC_CHECK_FUNC([putenv], [AC_DEFINE([HAS_PUTENV])])
 
 ## setenv and unsetenv
 
@@ -1812,10 +1770,6 @@ AS_CASE([$ac_cv_func_which_gethostbyaddr_r],
 ## mkstemp
 
 AC_CHECK_FUNC([mkstemp], [AC_DEFINE([HAS_MKSTEMP])])
-
-## nice
-
-AC_CHECK_FUNC([nice], [AC_DEFINE([HAS_NICE])])
 
 ## dup3
 
@@ -2137,13 +2091,10 @@ AS_IF([test x"$prefix" = "xNONE"],
 AS_CASE([$host],
   [*-*-mingw32],
     [AC_DEFINE([HAS_BROKEN_PRINTF])
-    AC_DEFINE([HAS_STRERROR])
-    AC_DEFINE([HAS_IPV6])
-    AC_DEFINE([HAS_NICE])],
+    AC_DEFINE([HAS_STRERROR])],
   [*-pc-windows],
     [AC_DEFINE([HAS_BROKEN_PRINTF])
-    AC_DEFINE([HAS_STRERROR])
-    AC_DEFINE([HAS_NICE])],
+    AC_DEFINE([HAS_STRERROR])],
   [*-*-solaris*],
     # This is required as otherwise floats are printed
     # as "Infinity" and "Inf" instead of the expected "inf"

--- a/configure.ac
+++ b/configure.ac
@@ -1654,10 +1654,6 @@ AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])
 AC_CHECK_FUNC([fchmod],
   [AC_CHECK_FUNC([fchown], [AC_DEFINE([HAS_FCHMOD])])])
 
-AC_CHECK_FUNC([symlink],
-  [AC_CHECK_FUNC([readlink],
-    [AC_CHECK_FUNC([lstat], [AC_DEFINE([HAS_SYMLINK])])])])
-
 AC_CHECK_FUNC([realpath], [AC_DEFINE([HAS_REALPATH])])
 
 ## getgroups

--- a/configure.ac
+++ b/configure.ac
@@ -1654,9 +1654,6 @@ AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])
 AC_CHECK_FUNC([fchmod],
   [AC_CHECK_FUNC([fchown], [AC_DEFINE([HAS_FCHMOD])])])
 
-AC_CHECK_FUNC([truncate],
-  [AC_CHECK_FUNC([ftruncate], [AC_DEFINE([HAS_TRUNCATE])])])
-
 AC_CHECK_FUNC([symlink],
   [AC_CHECK_FUNC([readlink],
     [AC_CHECK_FUNC([lstat], [AC_DEFINE([HAS_SYMLINK])])])])

--- a/configure.ac
+++ b/configure.ac
@@ -975,9 +975,6 @@ AC_CHECK_HEADER([pthread_np.h],[AC_DEFINE([HAS_PTHREAD_NP_H])])
 AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],
   [#include <sys/types.h>])
 
-AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H])], [],
-  [#include <sys/types.h>])
-
 AC_CHECK_HEADER([stdatomic.h], [AC_DEFINE([HAS_STDATOMIC_H])])
 
 AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H])])
@@ -1681,15 +1678,6 @@ AC_CHECK_FUNC([fchmod],
 AC_CHECK_FUNC([truncate],
   [AC_CHECK_FUNC([ftruncate], [AC_DEFINE([HAS_TRUNCATE])])])
 
-## select
-AC_CHECK_FUNC([select],
-  [AC_CHECK_TYPE([fd_set],
-    [AC_DEFINE([HAS_SELECT])
-    select=true], [select=false], [
-#include <sys/types.h>
-#include <sys/select.h>
-  ])])
-
 AC_CHECK_FUNC([symlink],
   [AC_CHECK_FUNC([readlink],
     [AC_CHECK_FUNC([lstat], [AC_DEFINE([HAS_SYMLINK])])])])
@@ -1705,6 +1693,7 @@ AC_CHECK_FUNC(
   ],
   [wait=false])
 
+# wait4
 AC_CHECK_FUNC(
   [wait4],
   [

--- a/configure.ac
+++ b/configure.ac
@@ -1619,8 +1619,6 @@ AS_CASE([$host],
   [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T])], [],
     [#include <sys/socket.h>])])
 
-AC_CHECK_FUNC([inet_aton], [AC_DEFINE([HAS_INET_ATON])])
-
 ## Unix domain sockets support on Windows
 
 AS_CASE([$host],
@@ -1654,9 +1652,6 @@ AS_IF([$ipv6],
 
 AS_IF([$ipv6],
   [AC_CHECK_FUNC([inet_pton], [], [ipv6=false])])
-
-AS_IF([$ipv6],
-  [AC_CHECK_FUNC([inet_ntop], [AC_DEFINE([HAS_IPV6])])])
 
 AC_CHECK_FUNC([rewinddir], [AC_DEFINE([HAS_REWINDDIR])])
 
@@ -2238,7 +2233,6 @@ AS_CASE([$host],
   [*-pc-windows],
     [AC_DEFINE([HAS_BROKEN_PRINTF])
     AC_DEFINE([HAS_STRERROR])
-    AC_DEFINE([HAS_IPV6])
     AC_DEFINE([HAS_NICE])],
   [*-*-solaris*],
     # This is required as otherwise floats are printed

--- a/configure.ac
+++ b/configure.ac
@@ -1707,18 +1707,6 @@ AC_CHECK_FUNC([setitimer],
   ],
   [setitimer=false])
 
-## gethostname
-# Note: detection fails on Windows so hardcoding the result
-# (should be debugged later)
-AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME])],
-  [AC_CHECK_FUNC([gethostname], [AC_DEFINE([HAS_GETHOSTNAME])])])
-
-## uname
-
-AC_CHECK_HEADER([sys/utsname.h],
-  [AC_CHECK_FUNC([uname], [AC_DEFINE([HAS_UNAME])])])
-
 ## gettimeofday
 
 AC_CHECK_FUNC([gettimeofday],

--- a/configure.ac
+++ b/configure.ac
@@ -1607,15 +1607,6 @@ AS_CASE([$host],
 
 AS_IF([$sockets], [AC_DEFINE([HAS_SOCKETS])])
 
-## socklen_t
-
-AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows],
-    [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T])], [],
-      [#include <ws2tcpip.h>])],
-  [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T])], [],
-    [#include <sys/socket.h>])])
-
 ## Unix domain sockets support on Windows
 
 AS_CASE([$host],

--- a/configure.ac
+++ b/configure.ac
@@ -1651,18 +1651,6 @@ AC_CHECK_FUNC([getcwd], [AC_DEFINE([HAS_GETCWD])])
 
 AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])
 
-## utime
-## Note: this was defined in config/s-nt.h but the autoconf macros do not
-# seem to detect it properly on Windows so we hardcode the definition
-# of HAS_UTIME on Windows but this will probably need to be clarified
-AS_CASE([$host],
-  [*-*-mingw32|*-pc-windows], [AC_DEFINE([HAS_UTIME])],
-  [AC_CHECK_HEADER([sys/types.h],
-    [AC_CHECK_HEADER([utime.h],
-      [AC_CHECK_FUNC([utime], [AC_DEFINE([HAS_UTIME])])])])])
-
-AC_CHECK_FUNC([utimes], [AC_DEFINE([HAS_UTIMES])])
-
 AC_CHECK_FUNC([fchmod],
   [AC_CHECK_FUNC([fchown], [AC_DEFINE([HAS_FCHMOD])])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -625,8 +625,10 @@ lib_dynlink=true
 lib_runtime_events=true
 AS_CASE([$host,$enable_unix_lib,$posix_2008_supported],
   [*,no,*], [ocamltest_libunix="None"],
-  [*-*-mingw32,*,*|*-pc-windows,*,*|*,*,yes],
-    [enable_unix_lib=yes
+  [*-*-mingw32,*,*|*-pc-windows,*,*|*,*,*],
+    [AS_IF([test x"$posix_2008_support" = "xno"],
+      [AC_MSG_WARN([POSIX 1003.1-2008 compliance not detected; risking it])])
+    enable_unix_lib=yes
     AC_CONFIG_FILES([otherlibs/unix/META])
     lib_unix=true
     ocamltest_unix_impl="real"
@@ -635,11 +637,7 @@ AS_CASE([$host,$enable_unix_lib,$posix_2008_supported],
     ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '
     otherlibraries="$otherlibraries unix"],
   [*,yes,no],
-    [AC_MSG_ERROR([libunix requires a POSIX 1003.1-2008 compliant host])],
-  [*,*,no],
-    [enable_unix_lib=no
-    ocamltest_libunix="None"
-    AC_MSG_WARN([libunix will not be built])])
+    [AC_MSG_ERROR([libunix requires a POSIX 1003.1-2008 compliant host])])
 AS_IF([test x"$enable_str_lib" != "xno"],
   [otherlibraries="$otherlibraries str"
   lib_str=true

--- a/configure.ac
+++ b/configure.ac
@@ -1643,8 +1643,6 @@ AS_IF([$ipv6],
 
 AC_CHECK_FUNC([rewinddir], [AC_DEFINE([HAS_REWINDDIR])])
 
-AC_CHECK_FUNC([lockf], [AC_DEFINE([HAS_LOCKF])])
-
 AC_CHECK_FUNC([getcwd], [AC_DEFINE([HAS_GETCWD])])
 
 AC_CHECK_DECL([system], [AC_DEFINE([HAS_SYSTEM])], [], [[#include <stdlib.h>]])

--- a/configure.ac
+++ b/configure.ac
@@ -1690,8 +1690,6 @@ AC_CHECK_FUNC([select],
 #include <sys/select.h>
   ])])
 
-AC_CHECK_FUNC([nanosleep], [AC_DEFINE([HAS_NANOSLEEP])])
-
 AC_CHECK_FUNC([symlink],
   [AC_CHECK_FUNC([readlink],
     [AC_CHECK_FUNC([lstat], [AC_DEFINE([HAS_SYMLINK])])])])

--- a/configure.ac
+++ b/configure.ac
@@ -618,20 +618,28 @@ AS_CASE([$host],
     [exeext=".exe"],
   [exeext=''])
 
+OCAML_POSIX_SUPPORT
+
 otherlibraries="dynlink runtime_events"
 lib_dynlink=true
 lib_runtime_events=true
-AS_IF([test x"$enable_unix_lib" != "xno"],
-  [enable_unix_lib=yes
-  AC_CONFIG_FILES([otherlibs/unix/META])
-  otherlibraries="$otherlibraries unix"
-  lib_unix=true
-  ocamltest_unix_impl="real"
-  ocamltest_unix_name="unix"
-  ocamltest_unix_path='$(ROOTDIR)/otherlibs/unix'
-  ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '],
-  [ocamltest_libunix="None"])
-
+AS_CASE([$host,$enable_unix_lib,$posix_2008_supported],
+  [*,no,*], [ocamltest_libunix="None"],
+  [*-*-mingw32,*,*|*-pc-windows,*,*|*,*,yes],
+    [enable_unix_lib=yes
+    AC_CONFIG_FILES([otherlibs/unix/META])
+    lib_unix=true
+    ocamltest_unix_impl="real"
+    ocamltest_unix_name="unix"
+    ocamltest_unix_path='$(ROOTDIR)/otherlibs/unix'
+    ocamltest_unix_include='-I $(ROOTDIR)/otherlibs/unix '
+    otherlibraries="$otherlibraries unix"],
+  [*,yes,no],
+    [AC_MSG_ERROR([libunix requires a POSIX 1003.1-2008 compliant host])],
+  [*,*,no],
+    [enable_unix_lib=no
+    ocamltest_libunix="None"
+    AC_MSG_WARN([libunix will not be built])])
 AS_IF([test x"$enable_str_lib" != "xno"],
   [otherlibraries="$otherlibraries str"
   lib_str=true

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -15,9 +15,7 @@
 
 /* POSIX thread implementation of the "st" interface */
 
-#ifdef HAS_SYS_SELECT_H
 #include <sys/select.h>
-#endif
 
 Caml_inline void st_msleep(int msec)
 {

--- a/otherlibs/unix/accept_unix.c
+++ b/otherlibs/unix/accept_unix.c
@@ -20,9 +20,6 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_accept(value cloexec, value sock)
@@ -54,10 +51,3 @@ CAMLprim value caml_unix_accept(value cloexec, value sock)
   Field(res, 1) = a;
   CAMLreturn(res);
 }
-
-#else
-
-CAMLprim value caml_unix_accept(value cloexec, value sock)
-{ caml_invalid_argument("accept not implemented"); }
-
-#endif

--- a/otherlibs/unix/access.c
+++ b/otherlibs/unix/access.c
@@ -21,18 +21,15 @@
 #include <caml/osdeps.h>
 #include "unixsupport.h"
 
-#ifdef HAS_UNISTD
-# include <unistd.h>
+#ifndef _WIN32
+#  include <unistd.h>
 #else
-# ifndef _WIN32
-#  include <sys/file.h>
-# endif
-# ifndef R_OK
-#   define R_OK    4/* test for read permission */
-#   define W_OK    2/* test for write permission */
-#   define X_OK    1/* test for execute (search) permission */
-#   define F_OK    0/* test for presence of file */
-# endif
+#  ifndef R_OK
+#    define R_OK 4 /* test for read permission */
+#    define W_OK 2 /* test for write permission */
+#    define X_OK 1 /* test for execute (search) permission */
+#    define F_OK 0 /* test for presence of file */
+#  endif
 #endif
 
 static int access_permission_table[] = {
@@ -40,7 +37,7 @@ static int access_permission_table[] = {
   W_OK,
 #ifdef _WIN32
   /* Since there is no concept of execute permission on Windows,
-     we fall b+ack to the read permission */
+     we fall back to the read permission */
   R_OK,
 #else
   X_OK,

--- a/otherlibs/unix/addrofstr.c
+++ b/otherlibs/unix/addrofstr.c
@@ -22,7 +22,6 @@
 CAMLprim value caml_unix_inet_addr_of_string(value s)
 {
   if (! caml_string_is_c_safe(s)) caml_failwith("inet_addr_of_string");
-#if defined(HAS_IPV6)
 #ifdef _WIN32
  {
   CAMLparam1(s);
@@ -69,21 +68,6 @@ CAMLprim value caml_unix_inet_addr_of_string(value s)
     return caml_unix_alloc_inet6_addr(&address6);
   else
     caml_failwith("inet_addr_of_string");
- }
-#endif
-#elif defined(HAS_INET_ATON)
- {
-  struct in_addr address;
-  if (inet_aton(String_val(s), &address) == 0)
-    caml_failwith("inet_addr_of_string");
-  return caml_unix_alloc_inet_addr(&address);
- }
-#else
- {
-  struct in_addr address;
-  address.s_addr = inet_addr(String_val(s));
-  if (address.s_addr == (uint32_t) -1) caml_failwith("inet_addr_of_string");
-  return caml_unix_alloc_inet_addr(&address);
  }
 #endif
 }

--- a/otherlibs/unix/addrofstr.c
+++ b/otherlibs/unix/addrofstr.c
@@ -17,9 +17,6 @@
 #include <caml/memory.h>
 #include <caml/fail.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_inet_addr_of_string(value s)
@@ -90,10 +87,3 @@ CAMLprim value caml_unix_inet_addr_of_string(value s)
  }
 #endif
 }
-
-#else
-
-CAMLprim value caml_unix_inet_addr_of_string(value s)
-{ caml_invalid_argument("inet_addr_of_string not implemented"); }
-
-#endif

--- a/otherlibs/unix/bind_unix.c
+++ b/otherlibs/unix/bind_unix.c
@@ -16,9 +16,6 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_bind(value socket, value address)
@@ -32,10 +29,3 @@ CAMLprim value caml_unix_bind(value socket, value address)
   if (ret == -1) caml_uerror("bind", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_bind(value socket, value address)
-{ caml_invalid_argument("bind not implemented"); }
-
-#endif

--- a/otherlibs/unix/channels_unix.c
+++ b/otherlibs/unix/channels_unix.c
@@ -22,11 +22,8 @@
 #include <caml/io.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
 #include <sys/socket.h>
 #include "socketaddr.h"
-#endif
 
 /* Check that the given file descriptor has "stream semantics" and
    can therefore be used as part of buffered I/O.  Things that
@@ -43,7 +40,6 @@ static int caml_unix_check_stream_semantics(int fd)
   case S_IFREG: case S_IFCHR: case S_IFIFO:
     /* These have stream semantics */
     return 0;
-#ifdef HAS_SOCKETS
   case S_IFSOCK: {
     int so_type;
     socklen_param_type so_type_len = sizeof(so_type);
@@ -56,7 +52,6 @@ static int caml_unix_check_stream_semantics(int fd)
       return EINVAL;
     }
     }
-#endif
   default:
     /* All other file types are suspect: block devices, directories,
        symbolic links, whatnot. */

--- a/otherlibs/unix/closedir.c
+++ b/otherlibs/unix/closedir.c
@@ -19,11 +19,7 @@
 #include "unixsupport.h"
 #include <errno.h>
 #include <sys/types.h>
-#ifdef HAS_DIRENT
 #include <dirent.h>
-#else
-#include <sys/dir.h>
-#endif
 
 CAMLprim value caml_unix_closedir(value vd)
 {

--- a/otherlibs/unix/connect_unix.c
+++ b/otherlibs/unix/connect_unix.c
@@ -17,9 +17,6 @@
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_connect(value socket, value address)
@@ -35,10 +32,3 @@ CAMLprim value caml_unix_connect(value socket, value address)
   if (retcode == -1) caml_uerror("connect", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_connect(value socket, value address)
-{ caml_invalid_argument("connect not implemented"); }
-
-#endif

--- a/otherlibs/unix/envir_unix.c
+++ b/otherlibs/unix/envir_unix.c
@@ -15,9 +15,7 @@
 
 #include <caml/config.h>
 
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <sys/types.h>
 #ifdef HAS_GETAUXVAL
 #include <sys/auxv.h>

--- a/otherlibs/unix/fchmod.c
+++ b/otherlibs/unix/fchmod.c
@@ -20,8 +20,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#ifdef HAS_FCHMOD
-
 CAMLprim value caml_unix_fchmod(value fd, value perm)
 {
   int result;
@@ -31,10 +29,3 @@ CAMLprim value caml_unix_fchmod(value fd, value perm)
   if (result == -1) caml_uerror("fchmod", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_fchmod(value fd, value perm)
-{ caml_invalid_argument("fchmod not implemented"); }
-
-#endif

--- a/otherlibs/unix/fchown.c
+++ b/otherlibs/unix/fchown.c
@@ -18,8 +18,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#ifdef HAS_FCHMOD
-
 CAMLprim value caml_unix_fchown(value fd, value uid, value gid)
 {
   int result;
@@ -29,10 +27,3 @@ CAMLprim value caml_unix_fchown(value fd, value uid, value gid)
   if (result == -1) caml_uerror("fchown", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_fchown(value fd, value uid, value gid)
-{ caml_invalid_argument("fchown not implemented"); }
-
-#endif

--- a/otherlibs/unix/fcntl.c
+++ b/otherlibs/unix/fcntl.c
@@ -16,9 +16,7 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
 #ifndef O_NONBLOCK

--- a/otherlibs/unix/ftruncate.c
+++ b/otherlibs/unix/ftruncate.c
@@ -23,8 +23,6 @@
 #include "unixsupport.h"
 #include <unistd.h>
 
-#ifdef HAS_TRUNCATE
-
 CAMLprim value caml_unix_ftruncate(value fd, value len)
 {
   int result;
@@ -45,13 +43,3 @@ CAMLprim value caml_unix_ftruncate_64(value fd, value len)
   if (result == -1) caml_uerror("ftruncate", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_ftruncate(value fd, value len)
-{ caml_invalid_argument("ftruncate not implemented"); }
-
-CAMLprim value caml_unix_ftruncate_64(value fd, value len)
-{ caml_invalid_argument("ftruncate not implemented"); }
-
-#endif

--- a/otherlibs/unix/ftruncate.c
+++ b/otherlibs/unix/ftruncate.c
@@ -21,9 +21,7 @@
 #include <caml/io.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 
 #ifdef HAS_TRUNCATE
 

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -23,7 +23,7 @@
 #include "unixsupport.h"
 #include "cst2constr.h"
 
-#if defined(HAS_SOCKETS) && defined(HAS_IPV6)
+#ifdef HAS_IPV6
 
 #include "socketaddr.h"
 #ifndef _WIN32

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -22,9 +22,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 #include "cst2constr.h"
-
-#ifdef HAS_IPV6
-
 #include "socketaddr.h"
 #ifndef _WIN32
 #include <sys/types.h>
@@ -128,10 +125,3 @@ CAMLprim value caml_unix_getaddrinfo(value vnode, value vserv, value vopts)
   }
   CAMLreturn(vres);
 }
-
-#else
-
-CAMLprim value caml_unix_getaddrinfo(value vnode, value vserv, value vopts)
-{ caml_invalid_argument("getaddrinfo not implemented"); }
-
-#endif

--- a/otherlibs/unix/getcwd.c
+++ b/otherlibs/unix/getcwd.c
@@ -33,8 +33,6 @@
 #endif
 #endif
 
-#ifdef HAS_GETCWD
-
 CAMLprim value caml_unix_getcwd(value unit)
 {
   char_os buff[PATH_MAX];
@@ -43,10 +41,3 @@ CAMLprim value caml_unix_getcwd(value unit)
   if (ret == 0) caml_uerror("getcwd", Nothing);
   return caml_copy_string_of_os(buff);
 }
-
-#else
-
-CAMLprim value caml_unix_getcwd(value unit)
-{ caml_invalid_argument("getcwd not implemented"); }
-
-#endif

--- a/otherlibs/unix/getcwd.c
+++ b/otherlibs/unix/getcwd.c
@@ -20,17 +20,10 @@
 #include <caml/fail.h>
 #include <caml/osdeps.h>
 #include "unixsupport.h"
+#include <limits.h>
 
-#if !defined (_WIN32) && !macintosh
-#include <sys/param.h>
-#endif
-
-#ifndef PATH_MAX
-#ifdef MAXPATHLEN
-#define PATH_MAX MAXPATHLEN
-#else
-#define PATH_MAX 512
-#endif
+#if defined(_WIN32) && !defined(PATH_MAX)
+#define PATH_MAX MAX_PATH
 #endif
 
 CAMLprim value caml_unix_getcwd(value unit)

--- a/otherlibs/unix/getgroups.c
+++ b/otherlibs/unix/getgroups.c
@@ -20,9 +20,7 @@
 #ifdef HAS_GETGROUPS
 
 #include <sys/types.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <limits.h>
 #include "unixsupport.h"
 

--- a/otherlibs/unix/getgroups.c
+++ b/otherlibs/unix/getgroups.c
@@ -17,8 +17,6 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 
-#ifdef HAS_GETGROUPS
-
 #include <sys/types.h>
 #include <unistd.h>
 #include <limits.h>
@@ -38,10 +36,3 @@ CAMLprim value caml_unix_getgroups(value unit)
     Field(res, i) = Val_int(gidset[i]);
   return res;
 }
-
-#else
-
-CAMLprim value caml_unix_getgroups(value unit)
-{ caml_invalid_argument("getgroups not implemented"); }
-
-#endif

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -20,9 +20,6 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 #ifndef _WIN32
 #include <sys/types.h>
@@ -174,13 +171,3 @@ CAMLprim value caml_unix_gethostbyname(value name)
   if (hp == (struct hostent *) NULL) caml_raise_not_found();
   return alloc_host_entry(hp);
 }
-
-#else
-
-CAMLprim value caml_unix_gethostbyaddr(value name)
-{ caml_invalid_argument("gethostbyaddr not implemented"); }
-
-CAMLprim value caml_unix_gethostbyname(value name)
-{ caml_invalid_argument("gethostbyname not implemented"); }
-
-#endif

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -84,7 +84,6 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
   struct hostent * hp;
   int addr_type = AF_INET;
   socklen_t addr_len = 4;
-#if HAS_IPV6
   struct in6_addr in6;
   if (caml_string_length(a) == 16) {
     addr_type = AF_INET6;
@@ -92,12 +91,9 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
     in6 = GET_INET6_ADDR(a);
     adr = (char *)&in6;
   } else {
-#endif
     in4 = GET_INET_ADDR(a);
     adr = (char *)&in4;
-#if HAS_IPV6
   }
-#endif
 #if HAS_GETHOSTBYADDR_R == 7
   struct hostent h;
   char buffer[NETDB_BUFFER_SIZE];

--- a/otherlibs/unix/gethostname.c
+++ b/otherlibs/unix/gethostname.c
@@ -21,8 +21,6 @@
 #endif
 #include "unixsupport.h"
 
-#ifdef HAS_GETHOSTNAME
-
 #ifndef MAXHOSTNAMELEN
 #define MAXHOSTNAMELEN 256
 #endif
@@ -34,23 +32,3 @@ CAMLprim value caml_unix_gethostname(value unit)
   name[MAXHOSTNAMELEN-1] = 0;
   return caml_copy_string(name);
 }
-
-#else
-#ifdef HAS_UNAME
-
-#include <sys/utsname.h>
-
-CAMLprim value caml_unix_gethostname(value unit)
-{
-  struct utsname un;
-  uname(&un);
-  return copy_string(un.nodename);
-}
-
-#else
-
-CAMLprim value caml_unix_gethostname(value unit)
-{ caml_invalid_argument("gethostname not implemented"); }
-
-#endif
-#endif

--- a/otherlibs/unix/getnameinfo.c
+++ b/otherlibs/unix/getnameinfo.c
@@ -21,7 +21,7 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#if defined(HAS_SOCKETS) && defined(HAS_IPV6)
+#ifdef HAS_IPV6
 
 #include "socketaddr.h"
 #ifndef _WIN32

--- a/otherlibs/unix/getnameinfo.c
+++ b/otherlibs/unix/getnameinfo.c
@@ -20,9 +20,6 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_IPV6
-
 #include "socketaddr.h"
 #ifndef _WIN32
 #include <sys/types.h>
@@ -59,10 +56,3 @@ CAMLprim value caml_unix_getnameinfo(value vaddr, value vopts)
   Field(vres, 1) = vserv;
   CAMLreturn(vres);
 }
-
-#else
-
-CAMLprim value caml_unix_getnameinfo(value vaddr, value vopts)
-{ caml_invalid_argument("getnameinfo not implemented"); }
-
-#endif

--- a/otherlibs/unix/getpeername_unix.c
+++ b/otherlibs/unix/getpeername_unix.c
@@ -16,9 +16,6 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_getpeername(value sock)
@@ -32,10 +29,3 @@ CAMLprim value caml_unix_getpeername(value sock)
   if (retcode == -1) caml_uerror("getpeername", Nothing);
   return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
 }
-
-#else
-
-CAMLprim value caml_unix_getpeername(value sock)
-{ caml_invalid_argument("getpeername not implemented"); }
-
-#endif

--- a/otherlibs/unix/getproto.c
+++ b/otherlibs/unix/getproto.c
@@ -19,8 +19,6 @@
 #include <caml/memory.h>
 #include "unixsupport.h"
 
-#ifdef HAS_SOCKETS
-
 #ifndef _WIN32
 #include <netdb.h>
 #endif
@@ -56,13 +54,3 @@ CAMLprim value caml_unix_getprotobynumber(value proto)
   if (entry == (struct protoent *) NULL) caml_raise_not_found();
   return alloc_proto_entry(entry);
 }
-
-#else
-
-CAMLprim value caml_unix_getprotobynumber(value proto)
-{ caml_invalid_argument("getprotobynumber not implemented"); }
-
-CAMLprim value caml_unix_getprotobyname(value name)
-{ caml_invalid_argument("getprotobyname not implemented"); }
-
-#endif

--- a/otherlibs/unix/getserv.c
+++ b/otherlibs/unix/getserv.c
@@ -18,9 +18,6 @@
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include <sys/types.h>
 
 #ifndef _WIN32
@@ -64,13 +61,3 @@ CAMLprim value caml_unix_getservbyport(value port, value proto)
   if (entry == (struct servent *) NULL) caml_raise_not_found();
   return alloc_service_entry(entry);
 }
-
-#else
-
-CAMLprim value caml_unix_getservbyport(value port, value proto)
-{ caml_invalid_argument("getservbyport not implemented"); }
-
-CAMLprim value caml_unix_getservbyname(value name, value proto)
-{ caml_invalid_argument("getservbyname not implemented"); }
-
-#endif

--- a/otherlibs/unix/getsockname_unix.c
+++ b/otherlibs/unix/getsockname_unix.c
@@ -16,9 +16,6 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_getsockname(value sock)
@@ -32,10 +29,3 @@ CAMLprim value caml_unix_getsockname(value sock)
   if (retcode == -1) caml_uerror("getsockname", Nothing);
   return caml_unix_alloc_sockaddr(&addr, addr_len, -1);
 }
-
-#else
-
-CAMLprim value caml_unix_getsockname(value sock)
-{ caml_invalid_argument("getsockname not implemented"); }
-
-#endif

--- a/otherlibs/unix/gmtime.c
+++ b/otherlibs/unix/gmtime.c
@@ -57,8 +57,6 @@ CAMLprim value caml_unix_localtime(value t)
   return alloc_tm(tm);
 }
 
-#ifdef HAS_MKTIME
-
 CAMLprim value caml_unix_mktime(value t)
 {
   CAMLparam0();
@@ -85,10 +83,3 @@ CAMLprim value caml_unix_mktime(value t)
   Field(res, 1) = tmval;
   CAMLreturn(res);
 }
-
-#else
-
-CAMLprim value caml_unix_mktime(value t)
-{ caml_invalid_argument("mktime not implemented"); }
-
-#endif

--- a/otherlibs/unix/initgroups.c
+++ b/otherlibs/unix/initgroups.c
@@ -20,9 +20,7 @@
 #ifdef HAS_INITGROUPS
 
 #include <sys/types.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <errno.h>
 #include <limits.h>
 #include <grp.h>

--- a/otherlibs/unix/itimer.c
+++ b/otherlibs/unix/itimer.c
@@ -19,8 +19,6 @@
 #include <caml/memory.h>
 #include "unixsupport.h"
 
-#ifdef HAS_SETITIMER
-
 #include <math.h>
 #include <sys/time.h>
 
@@ -64,12 +62,3 @@ CAMLprim value caml_unix_getitimer(value which)
     caml_uerror("getitimer", Nothing);
   return caml_unix_convert_itimer(&val);
 }
-
-#else
-
-CAMLprim value caml_unix_setitimer(value which, value newval)
-{ caml_invalid_argument("setitimer not implemented"); }
-CAMLprim value caml_unix_getitimer(value which)
-{ caml_invalid_argument("getitimer not implemented"); }
-
-#endif

--- a/otherlibs/unix/listen_unix.c
+++ b/otherlibs/unix/listen_unix.c
@@ -16,9 +16,6 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include <sys/socket.h>
 
 CAMLprim value caml_unix_listen(value sock, value backlog)
@@ -27,10 +24,3 @@ CAMLprim value caml_unix_listen(value sock, value backlog)
     caml_uerror("listen", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_listen(value sock, value backlog)
-{ caml_invalid_argument("listen not implemented"); }
-
-#endif

--- a/otherlibs/unix/lockf_unix.c
+++ b/otherlibs/unix/lockf_unix.c
@@ -20,8 +20,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#if defined(F_GETLK) && defined(F_SETLK) && defined(F_SETLKW)
-
 CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
 {
   struct flock l;
@@ -83,27 +81,3 @@ CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
   if (ret == -1) caml_uerror("lockf", Nothing);
   return Val_unit;
 }
-
-#else
-
-#ifdef HAS_LOCKF
-#include <unistd.h>
-
-static int lock_command_table[] = {
-  F_ULOCK, F_LOCK, F_TLOCK, F_TEST, F_LOCK, F_TLOCK
-};
-
-CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
-{
-  if (lockf(Int_val(fd), lock_command_table[Int_val(cmd)], Long_val(span))
-      == -1) caml_uerror("lockf", Nothing);
-  return Val_unit;
-}
-
-#else
-
-CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
-{ caml_invalid_argument("lockf not implemented"); }
-
-#endif
-#endif

--- a/otherlibs/unix/lockf_unix.c
+++ b/otherlibs/unix/lockf_unix.c
@@ -87,14 +87,7 @@ CAMLprim value caml_unix_lockf(value fd, value cmd, value span)
 #else
 
 #ifdef HAS_LOCKF
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#else
-#define F_ULOCK 0
-#define F_LOCK 1
-#define F_TLOCK 2
-#define F_TEST 3
-#endif
 
 static int lock_command_table[] = {
   F_ULOCK, F_LOCK, F_TLOCK, F_TEST, F_LOCK, F_TLOCK

--- a/otherlibs/unix/lseek_unix.c
+++ b/otherlibs/unix/lseek_unix.c
@@ -24,10 +24,6 @@
 #include "unixsupport.h"
 #include <unistd.h>
 
-#ifndef EOVERFLOW
-#define EOVERFLOW ERANGE
-#endif
-
 static int seek_command_table[] = {
   SEEK_SET, SEEK_CUR, SEEK_END
 };

--- a/otherlibs/unix/lseek_unix.c
+++ b/otherlibs/unix/lseek_unix.c
@@ -22,14 +22,7 @@
 #include <caml/io.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#else
-#define SEEK_SET 0
-#define SEEK_CUR 1
-#define SEEK_END 2
-#endif
 
 #ifndef EOVERFLOW
 #define EOVERFLOW ERANGE

--- a/otherlibs/unix/lseek_win32.c
+++ b/otherlibs/unix/lseek_win32.c
@@ -17,21 +17,9 @@
 #include <caml/alloc.h>
 #include "unixsupport.h"
 
-#ifdef HAS_UNISTD
-#include <unistd.h>
-#else
-#define SEEK_SET 0
-#define SEEK_CUR 1
-#define SEEK_END 2
-#endif
-
 static DWORD seek_command_table[] = {
   FILE_BEGIN, FILE_CURRENT, FILE_END
 };
-
-#ifndef INVALID_SET_FILE_POINTER
-#define INVALID_SET_FILE_POINTER (-1)
-#endif
 
 static __int64 caml_set_file_pointer(HANDLE h, __int64 dist, DWORD mode)
 {

--- a/otherlibs/unix/mkfifo.c
+++ b/otherlibs/unix/mkfifo.c
@@ -21,8 +21,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#ifdef HAS_MKFIFO
-
 CAMLprim value caml_unix_mkfifo(value path, value mode)
 {
   CAMLparam2(path, mode);
@@ -38,36 +36,3 @@ CAMLprim value caml_unix_mkfifo(value path, value mode)
     caml_uerror("mkfifo", path);
   CAMLreturn(Val_unit);
 }
-
-#else
-
-#include <sys/types.h>
-#include <sys/stat.h>
-
-#ifdef S_IFIFO
-
-CAMLprim value caml_unix_mkfifo(value path, value mode)
-{
-  CAMLparam2(path, mode);
-  char * p;
-  int ret;
-  caml_unix_check_path(path, "mkfifo");
-  p = caml_stat_strdup(String_val(path));
-  caml_enter_blocking_section();
-  ret = mknod(p, (Int_val(mode) & 07777) | S_IFIFO, 0);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
-  if (ret == -1)
-    caml_uerror("mkfifo", path);
-  CAMLreturn(Val_unit);
-}
-
-#else
-
-CAMLprim value caml_unix_mkfifo(value path, value mode)
-{
-  caml_invalid_argument("mkfifo not implemented");
-}
-
-#endif
-#endif

--- a/otherlibs/unix/mmap_unix.c
+++ b/otherlibs/unix/mmap_unix.c
@@ -30,20 +30,12 @@
 
 #include <errno.h>
 #include <unistd.h>
-#ifdef HAS_MMAP
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#endif
 
 /* Defined in [mmap_ba.c] */
 extern value caml_unix_mapped_alloc(int, int, void *, intnat *);
-
-#if defined(HAS_MMAP)
-
-#ifndef MAP_FAILED
-#define MAP_FAILED ((void *) -1)
-#endif
 
 /* [caml_grow_file] function contributed by Gerd Stolpmann (PR#5543). */
 
@@ -55,27 +47,8 @@ static int caml_grow_file(int fd, file_offset size)
   /* First use pwrite for growing - it is a conservative method, as it
      can never happen that we shrink by accident
    */
-#ifdef HAS_PWRITE
   c = 0;
   p = pwrite(fd, &c, 1, size - 1);
-#else
-
-  /* Emulate pwrite with lseek. This should only be necessary on ancient
-     systems nowadays
-   */
-  file_offset currpos;
-  currpos = lseek(fd, 0, SEEK_CUR);
-  if (currpos != -1) {
-    p = lseek(fd, size - 1, SEEK_SET);
-    if (p != -1) {
-      c = 0;
-      p = write(fd, &c, 1);
-      if (p != -1)
-        p = lseek(fd, currpos, SEEK_SET);
-    }
-  }
-  else p=-1;
-#endif
 #ifdef HAS_TRUNCATE
   if (p == -1 && errno == ESPIPE) {
     /* Plan B. Check if at least ftruncate is possible. There are
@@ -171,17 +144,6 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   return caml_unix_mapped_alloc(flags, num_dims, addr, dim);
 }
 
-#else
-
-CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
-                                  value vshared, value vdim, value vpos)
-{
-  caml_invalid_argument("Unix.map_file: not supported");
-  return Val_unit;
-}
-
-#endif
-
 CAMLprim value caml_unix_map_file_bytecode(value * argv, int argn)
 {
   return caml_unix_map_file(argv[0], argv[1], argv[2],
@@ -190,15 +152,11 @@ CAMLprim value caml_unix_map_file_bytecode(value * argv, int argn)
 
 void caml_ba_unmap_file(void * addr, uintnat len)
 {
-#if defined(HAS_MMAP)
   uintnat page = sysconf(_SC_PAGESIZE);
   uintnat delta = (uintnat) addr % page;
   if (len == 0) return;         /* PR#5463 */
   addr = (void *)((uintnat)addr - delta);
   len  = len + delta;
-#if defined(_POSIX_SYNCHRONIZED_IO)
   msync(addr, len, MS_ASYNC);   /* PR#3571 */
-#endif
   munmap(addr, len);
-#endif
 }

--- a/otherlibs/unix/mmap_unix.c
+++ b/otherlibs/unix/mmap_unix.c
@@ -49,7 +49,6 @@ static int caml_grow_file(int fd, file_offset size)
    */
   c = 0;
   p = pwrite(fd, &c, 1, size - 1);
-#ifdef HAS_TRUNCATE
   if (p == -1 && errno == ESPIPE) {
     /* Plan B. Check if at least ftruncate is possible. There are
        some non-seekable descriptor types that do not support pwrite
@@ -59,7 +58,6 @@ static int caml_grow_file(int fd, file_offset size)
      */
     p = ftruncate(fd, size);
   }
-#endif
   return p;
 }
 

--- a/otherlibs/unix/mmap_unix.c
+++ b/otherlibs/unix/mmap_unix.c
@@ -29,9 +29,7 @@
 #include "unixsupport.h"
 
 #include <errno.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #ifdef HAS_MMAP
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/otherlibs/unix/nice.c
+++ b/otherlibs/unix/nice.c
@@ -16,9 +16,7 @@
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
 #include <errno.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 
 CAMLprim value caml_unix_nice(value incr)
 {

--- a/otherlibs/unix/nice.c
+++ b/otherlibs/unix/nice.c
@@ -22,11 +22,7 @@ CAMLprim value caml_unix_nice(value incr)
 {
   int ret;
   errno = 0;
-#ifdef HAS_NICE
   ret = nice(Int_val(incr));
-#else
-  ret = 0;
-#endif
   if (ret == -1 && errno != 0) caml_uerror("nice", Nothing);
   return Val_int(ret);
 }

--- a/otherlibs/unix/open_unix.c
+++ b/otherlibs/unix/open_unix.c
@@ -20,19 +20,12 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 #include <string.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
-#ifndef O_NONBLOCK
-#define O_NONBLOCK O_NDELAY
-#endif
+/* O_DSYNC and O_RSYNC are part of POSIX Synchronized IO option */
 #ifndef O_DSYNC
 #define O_DSYNC 0
-#endif
-#ifndef O_SYNC
-#define O_SYNC 0
 #endif
 #ifndef O_RSYNC
 #define O_RSYNC 0

--- a/otherlibs/unix/opendir.c
+++ b/otherlibs/unix/opendir.c
@@ -19,11 +19,7 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 #include <sys/types.h>
-#ifdef HAS_DIRENT
 #include <dirent.h>
-#else
-#include <sys/dir.h>
-#endif
 
 CAMLprim value caml_unix_opendir(value path)
 {

--- a/otherlibs/unix/putenv.c
+++ b/otherlibs/unix/putenv.c
@@ -26,8 +26,6 @@
 
 #include "unixsupport.h"
 
-#ifdef HAS_PUTENV
-
 CAMLprim value caml_unix_putenv(value name, value val)
 {
   char * s;
@@ -46,10 +44,3 @@ CAMLprim value caml_unix_putenv(value name, value val)
   }
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_putenv(value name, value val)
-{ caml_invalid_argument("putenv not implemented"); }
-
-#endif

--- a/otherlibs/unix/readdir.c
+++ b/otherlibs/unix/readdir.c
@@ -20,13 +20,8 @@
 #include "unixsupport.h"
 #include <errno.h>
 #include <sys/types.h>
-#ifdef HAS_DIRENT
 #include <dirent.h>
 typedef struct dirent directory_entry;
-#else
-#include <sys/dir.h>
-typedef struct direct directory_entry;
-#endif
 
 CAMLprim value caml_unix_readdir(value vd)
 {

--- a/otherlibs/unix/readlink_unix.c
+++ b/otherlibs/unix/readlink_unix.c
@@ -22,15 +22,8 @@
 #ifdef HAS_SYMLINK
 
 #include <sys/param.h>
+#include <limits.h>
 #include "unixsupport.h"
-
-#ifndef PATH_MAX
-#ifdef MAXPATHLEN
-#define PATH_MAX MAXPATHLEN
-#else
-#define PATH_MAX 512
-#endif
-#endif
 
 CAMLprim value caml_unix_readlink(value path)
 {

--- a/otherlibs/unix/readlink_unix.c
+++ b/otherlibs/unix/readlink_unix.c
@@ -18,9 +18,6 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
-
-#ifdef HAS_SYMLINK
-
 #include <sys/param.h>
 #include <limits.h>
 #include "unixsupport.h"
@@ -41,10 +38,3 @@ CAMLprim value caml_unix_readlink(value path)
   buffer[len] = '\0';
   CAMLreturn(caml_copy_string(buffer));
 }
-
-#else
-
-CAMLprim value caml_unix_readlink(value path)
-{ caml_invalid_argument("readlink not implemented"); }
-
-#endif

--- a/otherlibs/unix/realpath_unix.c
+++ b/otherlibs/unix/realpath_unix.c
@@ -19,8 +19,6 @@
 #include <caml/fail.h>
 #include "unixsupport.h"
 
-#ifdef HAS_REALPATH
-
 CAMLprim value caml_unix_realpath (value p)
 {
   CAMLparam1 (p);
@@ -34,10 +32,3 @@ CAMLprim value caml_unix_realpath (value p)
   free (r);
   CAMLreturn (rp);
 }
-
-#else
-
-CAMLprim value caml_unix_realpath (value p)
-{ caml_invalid_argument ("realpath not implemented"); }
-
-#endif

--- a/otherlibs/unix/rewinddir.c
+++ b/otherlibs/unix/rewinddir.c
@@ -20,8 +20,6 @@
 #include <sys/types.h>
 #include <dirent.h>
 
-#ifdef HAS_REWINDDIR
-
 CAMLprim value caml_unix_rewinddir(value vd)
 {
   DIR * d = DIR_Val(vd);
@@ -29,10 +27,3 @@ CAMLprim value caml_unix_rewinddir(value vd)
   rewinddir(d);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_rewinddir(value d)
-{ caml_invalid_argument("rewinddir not implemented"); }
-
-#endif

--- a/otherlibs/unix/rewinddir.c
+++ b/otherlibs/unix/rewinddir.c
@@ -18,11 +18,7 @@
 #include "unixsupport.h"
 #include <errno.h>
 #include <sys/types.h>
-#ifdef HAS_DIRENT
 #include <dirent.h>
-#else
-#include <sys/dir.h>
-#endif
 
 #ifdef HAS_REWINDDIR
 

--- a/otherlibs/unix/select_unix.c
+++ b/otherlibs/unix/select_unix.c
@@ -19,14 +19,9 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SELECT
-
 #include <sys/types.h>
 #include <sys/time.h>
-#ifdef HAS_SYS_SELECT_H
 #include <sys/select.h>
-#endif
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
@@ -101,11 +96,3 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   Field(res, 2) = exceptfds;
   CAMLreturn(res);
 }
-
-#else
-
-CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
-                           value timeout)
-{ caml_invalid_argument("select not implemented"); }
-
-#endif

--- a/otherlibs/unix/sendrecv_unix.c
+++ b/otherlibs/unix/sendrecv_unix.c
@@ -20,8 +20,6 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
 #include "socketaddr.h"
 
 static int msg_flag_table[] = {
@@ -121,26 +119,3 @@ CAMLprim value caml_unix_sendto(value *argv, int argc)
   return caml_unix_sendto_native
            (argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
 }
-
-#else
-
-CAMLprim value caml_unix_recv(value sock, value buff, value ofs, value len,
-                         value flags)
-{ caml_invalid_argument("recv not implemented"); }
-
-CAMLprim value caml_unix_recvfrom(value sock, value buff, value ofs, value len,
-                             value flags)
-{ caml_invalid_argument("recvfrom not implemented"); }
-
-CAMLprim value caml_unix_send(value sock, value buff, value ofs, value len,
-                         value flags)
-{ caml_invalid_argument("send not implemented"); }
-
-CAMLprim value caml_unix_sendto_native(value sock, value buff, value ofs,
-                                       value len, value flags, value dest)
-{ caml_invalid_argument("sendto not implemented"); }
-
-CAMLprim value caml_unix_sendto(value *argv, int argc)
-{ caml_invalid_argument("sendto not implemented"); }
-
-#endif

--- a/otherlibs/unix/setgroups.c
+++ b/otherlibs/unix/setgroups.c
@@ -21,9 +21,7 @@
 #ifdef HAS_SETGROUPS
 
 #include <sys/types.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <limits.h>
 #include <grp.h>
 #include "unixsupport.h"

--- a/otherlibs/unix/setsid.c
+++ b/otherlibs/unix/setsid.c
@@ -20,12 +20,7 @@
 
 CAMLprim value caml_unix_setsid(value unit)
 {
-#ifdef HAS_SETSID
   pid_t pid = setsid();
   if (pid == (pid_t)(-1)) caml_uerror("setsid", Nothing);
   return Val_long(pid);
-#else
-  caml_invalid_argument("setsid not implemented");
-  return Val_unit;
-#endif
 }

--- a/otherlibs/unix/setsid.c
+++ b/otherlibs/unix/setsid.c
@@ -16,9 +16,7 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 
 CAMLprim value caml_unix_setsid(value unit)
 {

--- a/otherlibs/unix/shutdown_unix.c
+++ b/otherlibs/unix/shutdown_unix.c
@@ -16,9 +16,6 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include <sys/socket.h>
 
 static int shutdown_command_table[] = {
@@ -31,10 +28,3 @@ CAMLprim value caml_unix_shutdown(value sock, value cmd)
     caml_uerror("shutdown", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_shutdown(value sock, value cmd)
-{ caml_invalid_argument("shutdown not implemented"); }
-
-#endif

--- a/otherlibs/unix/sleep_unix.c
+++ b/otherlibs/unix/sleep_unix.c
@@ -19,19 +19,11 @@
 
 #include <errno.h>
 #include <time.h>
-#ifdef HAS_SELECT
-#include <sys/types.h>
-#include <sys/time.h>
-#ifdef HAS_SYS_SELECT_H
-#include <sys/select.h>
-#endif
-#endif
 
 CAMLprim value caml_unix_sleep(value duration)
 {
   double d = Double_val(duration);
   if (d < 0.0) return Val_unit;
-#if defined(HAS_NANOSLEEP)
   {
     struct timespec t;
     int ret;
@@ -48,29 +40,5 @@ CAMLprim value caml_unix_sleep(value duration)
     } while (ret == -1 && errno == EINTR);
     if (ret == -1) caml_uerror("sleep", Nothing);
   }
-#elif defined(HAS_SELECT)
-  {
-    struct timeval t;
-    int ret;
-    t.tv_sec = (time_t) d;
-    t.tv_usec = (d - t.tv_sec) * 1e6;
-    do {
-      caml_enter_blocking_section();
-      ret = select(0, NULL, NULL, NULL, &t);
-      /* MPR#7903: same comment as above */
-      caml_leave_blocking_section();
-    } while (ret == -1 && errno == EINTR);
-    if (ret == -1) caml_uerror("sleep", Nothing);
-  }
-#else
-  /* Fallback implementation, resolution 1 second only.
-     We cannot reliably iterate until sleep() returns 0, because the
-     remaining time returned by sleep() is generally rounded up. */
-  {
-    caml_enter_blocking_section();
-    sleep ((unsigned int) d);
-    caml_leave_blocking_section();
-  }
-#endif
   return Val_unit;
 }

--- a/otherlibs/unix/socket_unix.c
+++ b/otherlibs/unix/socket_unix.c
@@ -21,14 +21,7 @@
 #include <sys/socket.h>
 
 int caml_unix_socket_domain_table[] = {
-  PF_UNIX, PF_INET,
-#if defined(HAS_IPV6)
-  PF_INET6
-#elif defined(PF_UNSPEC)
-  PF_UNSPEC
-#else
-  0
-#endif
+  PF_UNIX, PF_INET, PF_INET6
 };
 
 int caml_unix_socket_type_table[] = {

--- a/otherlibs/unix/socket_unix.c
+++ b/otherlibs/unix/socket_unix.c
@@ -17,9 +17,6 @@
 #include <caml/fail.h>
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include <sys/types.h>
 #include <sys/socket.h>
 
@@ -55,11 +52,3 @@ CAMLprim value caml_unix_socket(value cloexec, value domain,
 #endif
   return Val_int(retcode);
 }
-
-#else
-
-CAMLprim value caml_unix_socket(value cloexec, value domain,
-                           value type,value proto)
-{ caml_invalid_argument("socket not implemented"); }
-
-#endif

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -19,9 +19,6 @@
 #include <caml/memory.h>
 #include <errno.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 #ifdef _WIN32
@@ -166,5 +163,3 @@ value caml_unix_alloc_sockaddr(union sock_addr_union * adr /*in*/,
   }
   CAMLreturn(res);
 }
-
-#endif

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -36,16 +36,12 @@ CAMLexport value caml_unix_alloc_inet_addr(struct in_addr * a)
   return res;
 }
 
-#ifdef HAS_IPV6
-
 CAMLexport value caml_unix_alloc_inet6_addr(struct in6_addr * a)
 {
   value res;
   res = caml_alloc_initialized_string(16, (char *)a);
   return res;
 }
-
-#endif
 
 void caml_unix_get_sockaddr(value mladr,
                        union sock_addr_union * adr /*out*/,
@@ -72,7 +68,6 @@ void caml_unix_get_sockaddr(value mladr,
       break;
     }
   case 1:                       /* ADDR_INET */
-#ifdef HAS_IPV6
     if (caml_string_length(Field(mladr, 0)) == 16) {
       memset(&adr->s_inet6, 0, sizeof(struct sockaddr_in6));
       adr->s_inet6.sin6_family = AF_INET6;
@@ -84,7 +79,6 @@ void caml_unix_get_sockaddr(value mladr,
       *adr_len = sizeof(struct sockaddr_in6);
       break;
     }
-#endif
     memset(&adr->s_inet, 0, sizeof(struct sockaddr_in));
     adr->s_inet.sin_family = AF_INET;
     adr->s_inet.sin_addr = GET_INET_ADDR(Field(mladr, 0));
@@ -148,7 +142,6 @@ value caml_unix_alloc_sockaddr(union sock_addr_union * adr /*in*/,
       Field(res,1) = Val_int(ntohs(adr->s_inet.sin_port));
       break;
     }
-#ifdef HAS_IPV6
   case AF_INET6:
     { a = caml_unix_alloc_inet6_addr(&adr->s_inet6.sin6_addr);
       res = caml_alloc_small(2, 1);
@@ -156,7 +149,6 @@ value caml_unix_alloc_sockaddr(union sock_addr_union * adr /*in*/,
       Field(res,1) = Val_int(ntohs(adr->s_inet6.sin6_port));
       break;
     }
-#endif
   default:
     if (close_on_error != -1) close (close_on_error);
     caml_unix_error(EAFNOSUPPORT, "", Nothing);

--- a/otherlibs/unix/socketaddr.h
+++ b/otherlibs/unix/socketaddr.h
@@ -52,11 +52,7 @@ union sock_addr_union {
   struct sockaddr_in6 s_inet6;
 };
 
-#ifdef HAS_SOCKLEN_T
 typedef socklen_t socklen_param_type;
-#else
-typedef int socklen_param_type;
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/otherlibs/unix/socketaddr.h
+++ b/otherlibs/unix/socketaddr.h
@@ -49,9 +49,7 @@ union sock_addr_union {
   struct sockaddr s_gen;
   struct sockaddr_un s_unix;
   struct sockaddr_in s_inet;
-#ifdef HAS_IPV6
   struct sockaddr_in6 s_inet6;
-#endif
 };
 
 #ifdef HAS_SOCKLEN_T
@@ -80,7 +78,6 @@ extern value caml_unix_alloc_sockaddr (union sock_addr_union * addr /*in*/,
 extern value caml_unix_alloc_inet_addr (struct in_addr * inaddr);
 #define GET_INET_ADDR(v) (*((struct in_addr *) (v)))
 
-#ifdef HAS_IPV6
 extern value caml_unix_alloc_inet6_addr (struct in6_addr * inaddr);
 #define GET_INET6_ADDR(v) (*((struct in6_addr *) (v)))
 
@@ -88,7 +85,6 @@ extern value caml_unix_alloc_inet6_addr (struct in6_addr * inaddr);
 #ifndef CAML_BUILDING_UNIX
 #define alloc_inet6_addr caml_unix_alloc_inet6_addr
 #endif /* CAML_BUILDING_UNIX */
-#endif /* HAS_IPV6 */
 
 #ifdef __cplusplus
 }

--- a/otherlibs/unix/socketpair_unix.c
+++ b/otherlibs/unix/socketpair_unix.c
@@ -17,9 +17,6 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include <sys/socket.h>
 
 extern int caml_unix_socket_domain_table[], caml_unix_socket_type_table[];
@@ -47,11 +44,3 @@ CAMLprim value caml_unix_socketpair(value cloexec, value domain,
   Field(res,1) = Val_int(sv[1]);
   return res;
 }
-
-#else
-
-CAMLprim value caml_unix_socketpair(value cloexec, value domain, value type,
-                               value proto)
-{ caml_invalid_argument("socketpair not implemented"); }
-
-#endif

--- a/otherlibs/unix/socketpair_win32.c
+++ b/otherlibs/unix/socketpair_win32.c
@@ -19,9 +19,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 #include <errno.h>
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 #include <ws2tcpip.h>
 
@@ -196,5 +193,3 @@ CAMLprim value caml_unix_socketpair(value cloexec, value domain, value type,
 }
 
 #endif  /* HAS_SOCKETPAIR */
-
-#endif  /* HAS_SOCKETS */

--- a/otherlibs/unix/sockopt_unix.c
+++ b/otherlibs/unix/sockopt_unix.c
@@ -19,78 +19,17 @@
 #include <caml/fail.h>
 #include "unixsupport.h"
 
-#ifdef HAS_SOCKETS
-
 #include <errno.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>
+#include <netinet/in.h>
 
 #include "socketaddr.h"
 
-#ifndef SO_DEBUG
-#define SO_DEBUG (-1)
-#endif
-#ifndef SO_BROADCAST
-#define SO_BROADCAST (-1)
-#endif
-#ifndef SO_REUSEADDR
-#define SO_REUSEADDR (-1)
-#endif
 #ifndef SO_REUSEPORT
 #define SO_REUSEPORT (-1)
-#endif
-#ifndef SO_KEEPALIVE
-#define SO_KEEPALIVE (-1)
-#endif
-#ifndef SO_DONTROUTE
-#define SO_DONTROUTE (-1)
-#endif
-#ifndef SO_OOBINLINE
-#define SO_OOBINLINE (-1)
-#endif
-#ifndef SO_ACCEPTCONN
-#define SO_ACCEPTCONN (-1)
-#endif
-#ifndef SO_SNDBUF
-#define SO_SNDBUF (-1)
-#endif
-#ifndef SO_RCVBUF
-#define SO_RCVBUF (-1)
-#endif
-#ifndef SO_ERROR
-#define SO_ERROR (-1)
-#endif
-#ifndef SO_TYPE
-#define SO_TYPE (-1)
-#endif
-#ifndef SO_RCVLOWAT
-#define SO_RCVLOWAT (-1)
-#endif
-#ifndef SO_SNDLOWAT
-#define SO_SNDLOWAT (-1)
-#endif
-#ifndef SO_LINGER
-#define SO_LINGER (-1)
-#endif
-#ifndef SO_RCVTIMEO
-#define SO_RCVTIMEO (-1)
-#endif
-#ifndef SO_SNDTIMEO
-#define SO_SNDTIMEO (-1)
-#endif
-#ifndef TCP_NODELAY
-#define TCP_NODELAY (-1)
-#endif
-#ifndef SO_ERROR
-#define SO_ERROR (-1)
-#endif
-#ifndef IPPROTO_IPV6
-#define IPPROTO_IPV6 (-1)
-#endif
-#ifndef IPV6_V6ONLY
-#define IPV6_V6ONLY (-1)
 #endif
 
 enum option_type {
@@ -291,14 +230,3 @@ CAMLprim value caml_unix_setsockopt(value vty, value vsocket, value voption,
                              vsocket,
                              val);
 }
-
-#else
-
-CAMLprim value caml_unix_getsockopt(value vty, value socket, value option)
-{ caml_invalid_argument("getsockopt not implemented"); }
-
-CAMLprim value caml_unix_setsockopt(value vty, value socket, value option,
-                                    value val)
-{ caml_invalid_argument("setsockopt not implemented"); }
-
-#endif

--- a/otherlibs/unix/spawn.c
+++ b/otherlibs/unix/spawn.c
@@ -19,9 +19,6 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include "unixsupport.h"
-
-#ifdef HAS_POSIX_SPAWN
-
 #include <spawn.h>
 
 extern char ** environ;
@@ -80,86 +77,3 @@ CAMLprim value caml_unix_spawn(value executable, /* string */
   if (r != 0) caml_unix_error(r, "create_process", executable);
   return Val_long(pid);
 }
-
-#else
-
-/* Fallback implementation based on fork() and exec() */
-
-#ifndef HAS_EXECVPE
-extern int caml_unix_execvpe_emulation(const char * name,
-                                  char * const argv[],
-                                  char * const envp[]);
-#endif
-
-/* Exit code used for the child process to report failure to exec */
-/* This is consistent with system() and allowed by posix_spawn() specs */
-
-#define ERROR_EXIT_STATUS 127
-
-CAMLprim value caml_unix_spawn(value executable, /* string */
-                          value args,       /* string array */
-                          value optenv,     /* string array option */
-                          value usepath,    /* bool */
-                          value redirect)   /* int array (size 3) */
-{
-  char ** argv;
-  char ** envp;
-  const char * path;
-  pid_t pid;
-  int src, dst, i;
-
-  caml_unix_check_path(executable, "create_process");
-  path = String_val(executable);
-  argv = caml_unix_cstringvect(args, "create_process");
-  if (Is_some(optenv)) {
-    envp = caml_unix_cstringvect(Some_val(optenv), "create_process");
-  } else {
-    envp = NULL;
-  }
-  pid = fork();
-  if (pid != 0) {
-    /* This is the parent process */
-    caml_unix_cstringvect_free(argv);
-    if (envp != NULL) caml_unix_cstringvect_free(envp);
-    if (pid == -1) caml_uerror("create_process", executable);
-    return Val_long(pid);
-  }
-  /* This is the child process */
-  /* Perform the redirections for stdin, stdout, stderr */
-  for (dst = 0; dst <= 2; dst++) {
-    /* File descriptor [redirect.(dst)] becomes file descriptor [dst] */
-    src = Int_val(Field(redirect, dst));
-    if (src != dst) {
-      if (dup2(src, dst) == -1) _exit(ERROR_EXIT_STATUS);
-      /* Close [src] if this is its last use */
-      for (i = dst + 1; i <= 2; i++) {
-        if (src == Int_val(Field(redirect, i))) goto dontclose;
-      }
-      if (close(src) == -1) _exit(ERROR_EXIT_STATUS);
-    dontclose:
-      /*skip*/;
-    }
-  }
-  /* Transfer control to the executable */
-  if (Bool_val(usepath)) {
-    if (envp == NULL) {
-      execvp(path, argv);
-    } else {
-#ifdef HAS_EXECVPE
-      execvpe(path, argv, envp);
-#else
-      caml_unix_execvpe_emulation(path, argv, envp);
-#endif
-    }
-  } else {
-    if (envp == NULL) {
-      execv(path, argv);
-    } else {
-      execve(path, argv, envp);
-    }
-  }
-  /* If we get here, the exec*() call failed. */
-  _exit(ERROR_EXIT_STATUS);
-}
-
-#endif

--- a/otherlibs/unix/stat_unix.c
+++ b/otherlibs/unix/stat_unix.c
@@ -27,19 +27,6 @@
 #include "unixsupport.h"
 #include "cst2constr.h"
 
-#ifndef S_IFLNK
-#define S_IFLNK 0
-#endif
-#ifndef S_IFIFO
-#define S_IFIFO 0
-#endif
-#ifndef S_IFSOCK
-#define S_IFSOCK 0
-#endif
-#ifndef S_IFBLK
-#define S_IFBLK 0
-#endif
-
 static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };

--- a/otherlibs/unix/stat_unix.c
+++ b/otherlibs/unix/stat_unix.c
@@ -107,11 +107,7 @@ CAMLprim value caml_unix_lstat(value path)
   caml_unix_check_path(path, "lstat");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-#ifdef HAS_SYMLINK
   ret = lstat(p, &buf);
-#else
-  ret = stat(p, &buf);
-#endif
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_uerror("lstat", path);
@@ -158,11 +154,7 @@ CAMLprim value caml_unix_lstat_64(value path)
   caml_unix_check_path(path, "lstat");
   p = caml_stat_strdup(String_val(path));
   caml_enter_blocking_section();
-#ifdef HAS_SYMLINK
   ret = lstat(p, &buf);
-#else
-  ret = stat(p, &buf);
-#endif
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) caml_uerror("lstat", path);

--- a/otherlibs/unix/stat_unix.c
+++ b/otherlibs/unix/stat_unix.c
@@ -40,10 +40,6 @@
 #define S_IFBLK 0
 #endif
 
-#ifndef EOVERFLOW
-#define EOVERFLOW ERANGE
-#endif
-
 static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };

--- a/otherlibs/unix/strofaddr.c
+++ b/otherlibs/unix/strofaddr.c
@@ -17,9 +17,6 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include "unixsupport.h"
-
-#ifdef HAS_SOCKETS
-
 #include "socketaddr.h"
 
 CAMLprim value caml_unix_string_of_inet_addr(value a)
@@ -65,10 +62,3 @@ CAMLprim value caml_unix_string_of_inet_addr(value a)
   if (res == NULL) caml_uerror("string_of_inet_addr", Nothing);
   return caml_copy_string(res);
 }
-
-#else
-
-CAMLprim value caml_unix_string_of_inet_addr(value a)
-{ caml_invalid_argument("string_of_inet_addr not implemented"); }
-
-#endif

--- a/otherlibs/unix/strofaddr.c
+++ b/otherlibs/unix/strofaddr.c
@@ -22,7 +22,6 @@
 CAMLprim value caml_unix_string_of_inet_addr(value a)
 {
   char * res;
-#ifdef HAS_IPV6
 #ifdef _WIN32
   char buffer[64];
   union sock_addr_union sa;
@@ -55,9 +54,6 @@ CAMLprim value caml_unix_string_of_inet_addr(value a)
     res = (char *)
       inet_ntop(AF_INET, (const void *) &GET_INET_ADDR(a),
                 buffer, sizeof(buffer));
-#endif
-#else
-  res = inet_ntoa(GET_INET_ADDR(a));
 #endif
   if (res == NULL) caml_uerror("string_of_inet_addr", Nothing);
   return caml_copy_string(res);

--- a/otherlibs/unix/symlink_unix.c
+++ b/otherlibs/unix/symlink_unix.c
@@ -19,8 +19,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#ifdef HAS_SYMLINK
-
 CAMLprim value caml_unix_symlink(value to_dir, value path1, value path2)
 {
   CAMLparam3(to_dir, path1, path2);
@@ -46,16 +44,3 @@ CAMLprim value caml_unix_has_symlink(value unit)
   CAMLparam0();
   CAMLreturn(Val_true);
 }
-
-#else
-
-CAMLprim value caml_unix_symlink(value to_dir, value path1, value path2)
-{ caml_invalid_argument("symlink not implemented"); }
-
-CAMLprim value caml_unix_has_symlink(value unit)
-{
-  CAMLparam0();
-  CAMLreturn(Val_false);
-}
-
-#endif

--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -17,9 +17,6 @@
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include "unixsupport.h"
-
-#ifdef HAS_TERMIOS
-
 #include <termios.h>
 #include <errno.h>
 
@@ -367,25 +364,3 @@ CAMLprim value caml_unix_tcflow(value fd, value action)
     caml_uerror("tcflow", Nothing);
   return Val_unit;
 }
-
-#else
-
-CAMLprim value caml_unix_tcgetattr(value fd)
-{ caml_invalid_argument("tcgetattr not implemented"); }
-
-CAMLprim value caml_unix_tcsetattr(value fd, value when, value arg)
-{ caml_invalid_argument("tcsetattr not implemented"); }
-
-CAMLprim value caml_unix_tcsendbreak(value fd, value delay)
-{ caml_invalid_argument("tcsendbreak not implemented"); }
-
-CAMLprim value caml_unix_tcdrain(value fd)
-{ caml_invalid_argument("tcdrain not implemented"); }
-
-CAMLprim value caml_unix_tcflush(value fd, value queue)
-{ caml_invalid_argument("tcflush not implemented"); }
-
-CAMLprim value caml_unix_tcflow(value fd, value action)
-{ caml_invalid_argument("tcflow not implemented"); }
-
-#endif

--- a/otherlibs/unix/times_unix.c
+++ b/otherlibs/unix/times_unix.c
@@ -20,14 +20,11 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/times.h>
-#ifdef HAS_GETRUSAGE
 #include <sys/time.h>
 #include <sys/resource.h>
-#endif
 
 CAMLprim value caml_unix_times(value unit)
 {
-#ifdef HAS_GETRUSAGE
 
   value res;
   struct rusage ru;
@@ -41,27 +38,4 @@ CAMLprim value caml_unix_times(value unit)
   Store_double_field (res, 2, ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6);
   Store_double_field (res, 3, ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
   return res;
-
-#else
-
-#ifndef CLK_TCK
-#ifdef HZ
-#define CLK_TCK HZ
-#else
-#define CLK_TCK 60
-#endif
-#endif
-
-  value res;
-  struct tms buffer;
-
-  times(&buffer);
-  res = caml_alloc_small(4 * Double_wosize, Double_array_tag);
-  Store_double_field(res, 0, (double) buffer.tms_utime / CLK_TCK);
-  Store_double_field(res, 1, (double) buffer.tms_stime / CLK_TCK);
-  Store_double_field(res, 2, (double) buffer.tms_cutime / CLK_TCK);
-  Store_double_field(res, 3, (double) buffer.tms_cstime / CLK_TCK);
-  return res;
-
-#endif
 }

--- a/otherlibs/unix/truncate_unix.c
+++ b/otherlibs/unix/truncate_unix.c
@@ -24,8 +24,6 @@
 #include "unixsupport.h"
 #include <unistd.h>
 
-#ifdef HAS_TRUNCATE
-
 CAMLprim value caml_unix_truncate(value path, value len)
 {
   CAMLparam2(path, len);
@@ -58,13 +56,3 @@ CAMLprim value caml_unix_truncate_64(value path, value vlen)
     caml_uerror("truncate", path);
   CAMLreturn(Val_unit);
 }
-
-#else
-
-CAMLprim value caml_unix_truncate(value path, value len)
-{ caml_invalid_argument("truncate not implemented"); }
-
-CAMLprim value caml_unix_truncate_64(value path, value len)
-{ caml_invalid_argument("truncate not implemented"); }
-
-#endif

--- a/otherlibs/unix/truncate_unix.c
+++ b/otherlibs/unix/truncate_unix.c
@@ -22,9 +22,7 @@
 #include <caml/signals.h>
 #include <caml/io.h>
 #include "unixsupport.h"
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 
 #ifdef HAS_TRUNCATE
 

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -30,9 +30,7 @@
 #include <ws2tcpip.h>
 #include <wspiapi.h>
 #else /* Unix */
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #endif
 
 #ifdef __cplusplus

--- a/otherlibs/unix/unixsupport_unix.c
+++ b/otherlibs/unix/unixsupport_unix.c
@@ -24,217 +24,24 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#ifndef E2BIG
-#define E2BIG (-1)
-#endif
-#ifndef EACCES
-#define EACCES (-1)
-#endif
-#ifndef EAGAIN
-#define EAGAIN (-1)
-#endif
-#ifndef EBADF
-#define EBADF (-1)
-#endif
-#ifndef EBUSY
-#define EBUSY (-1)
-#endif
-#ifndef ECHILD
-#define ECHILD (-1)
-#endif
-#ifndef EDEADLK
-#define EDEADLK (-1)
-#endif
-#ifndef EDOM
-#define EDOM (-1)
-#endif
-#ifndef EEXIST
-#define EEXIST (-1)
-#endif
-
-#ifndef EFAULT
-#define EFAULT (-1)
-#endif
-#ifndef EFBIG
-#define EFBIG (-1)
-#endif
-#ifndef EINTR
-#define EINTR (-1)
-#endif
-#ifndef EINVAL
-#define EINVAL (-1)
-#endif
-#ifndef EIO
-#define EIO (-1)
-#endif
-#ifndef EISDIR
-#define EISDIR (-1)
-#endif
-#ifndef EMFILE
-#define EMFILE (-1)
-#endif
-#ifndef EMLINK
-#define EMLINK (-1)
-#endif
-#ifndef ENAMETOOLONG
-#define ENAMETOOLONG (-1)
-#endif
-#ifndef ENFILE
-#define ENFILE (-1)
-#endif
-#ifndef ENODEV
-#define ENODEV (-1)
-#endif
-#ifndef ENOENT
-#define ENOENT (-1)
-#endif
-#ifndef ENOEXEC
-#define ENOEXEC (-1)
-#endif
-#ifndef ENOLCK
-#define ENOLCK (-1)
-#endif
-#ifndef ENOMEM
-#define ENOMEM (-1)
-#endif
-#ifndef ENOSPC
-#define ENOSPC (-1)
-#endif
-#ifndef ENOSYS
-#define ENOSYS (-1)
-#endif
-#ifndef ENOTDIR
-#define ENOTDIR (-1)
-#endif
-#ifndef ENOTEMPTY
-#define ENOTEMPTY (-1)
-#endif
-#ifndef ENOTTY
-#define ENOTTY (-1)
-#endif
-#ifndef ENXIO
-#define ENXIO (-1)
-#endif
-#ifndef EPERM
-#define EPERM (-1)
-#endif
-#ifndef EPIPE
-#define EPIPE (-1)
-#endif
-#ifndef ERANGE
-#define ERANGE (-1)
-#endif
-#ifndef EROFS
-#define EROFS (-1)
-#endif
-#ifndef ESPIPE
-#define ESPIPE (-1)
-#endif
-#ifndef ESRCH
-#define ESRCH (-1)
-#endif
-#ifndef EXDEV
-#define EXDEV (-1)
-#endif
-#ifndef EWOULDBLOCK
-#define EWOULDBLOCK (-1)
-#endif
-#ifndef EINPROGRESS
-#define EINPROGRESS (-1)
-#endif
-#ifndef EALREADY
-#define EALREADY (-1)
-#endif
-#ifndef ENOTSOCK
-#define ENOTSOCK (-1)
-#endif
-#ifndef EDESTADDRREQ
-#define EDESTADDRREQ (-1)
-#endif
-#ifndef EMSGSIZE
-#define EMSGSIZE (-1)
-#endif
-#ifndef EPROTOTYPE
-#define EPROTOTYPE (-1)
-#endif
-#ifndef ENOPROTOOPT
-#define ENOPROTOOPT (-1)
-#endif
-#ifndef EPROTONOSUPPORT
-#define EPROTONOSUPPORT (-1)
-#endif
+/* Not in POSIX (scheduled for Issue 8: see #1067) */
 #ifndef ESOCKTNOSUPPORT
 #define ESOCKTNOSUPPORT (-1)
 #endif
-#ifndef EOPNOTSUPP
-#  ifdef ENOTSUP
-#    define EOPNOTSUPP ENOTSUP
-#  else
-#    define EOPNOTSUPP (-1)
-#  endif
-#endif
+/* Not in POSIX (usually same as EAFNOSUPPORT) */
 #ifndef EPFNOSUPPORT
 #define EPFNOSUPPORT (-1)
 #endif
-#ifndef EAFNOSUPPORT
-#define EAFNOSUPPORT (-1)
-#endif
-#ifndef EADDRINUSE
-#define EADDRINUSE (-1)
-#endif
-#ifndef EADDRNOTAVAIL
-#define EADDRNOTAVAIL (-1)
-#endif
-#ifndef ENETDOWN
-#define ENETDOWN (-1)
-#endif
-#ifndef ENETUNREACH
-#define ENETUNREACH (-1)
-#endif
-#ifndef ENETRESET
-#define ENETRESET (-1)
-#endif
-#ifndef ECONNABORTED
-#define ECONNABORTED (-1)
-#endif
-#ifndef ECONNRESET
-#define ECONNRESET (-1)
-#endif
-#ifndef ENOBUFS
-#define ENOBUFS (-1)
-#endif
-#ifndef EISCONN
-#define EISCONN (-1)
-#endif
-#ifndef ENOTCONN
-#define ENOTCONN (-1)
-#endif
+/* ESHUTDOWN and ETOOMANYREFS are Linux-specific */
 #ifndef ESHUTDOWN
 #define ESHUTDOWN (-1)
 #endif
 #ifndef ETOOMANYREFS
 #define ETOOMANYREFS (-1)
 #endif
-#ifndef ETIMEDOUT
-#define ETIMEDOUT (-1)
-#endif
-#ifndef ECONNREFUSED
-#define ECONNREFUSED (-1)
-#endif
+/* Not in POSIX (known documentation issue) */
 #ifndef EHOSTDOWN
 #define EHOSTDOWN (-1)
-#endif
-#ifndef EHOSTUNREACH
-#define EHOSTUNREACH (-1)
-#endif
-#ifndef ENOTEMPTY
-#define ENOTEMPTY (-1)
-#endif
-#ifndef ELOOP
-#define ELOOP (-1)
-#endif
-#ifndef EOVERFLOW
-#define EOVERFLOW (-1)
 #endif
 
 static int error_table[] = {
@@ -255,11 +62,6 @@ value caml_unix_error_of_code (int errcode)
 {
   int errconstr;
   value err;
-
-#if defined(ENOTSUP) && (EOPNOTSUPP != ENOTSUP)
-  if (errcode == ENOTSUP)
-    errcode = EOPNOTSUPP;
-#endif
 
   errconstr =
       caml_unix_cst_to_constr(errcode, error_table,

--- a/otherlibs/unix/unixsupport_unix.c
+++ b/otherlibs/unix/unixsupport_unix.c
@@ -21,9 +21,7 @@
 #include "unixsupport.h"
 #include "cst2constr.h"
 #include <errno.h>
-#ifdef HAS_UNISTD
 #include <unistd.h>
-#endif
 #include <fcntl.h>
 
 #ifndef E2BIG

--- a/otherlibs/unix/utimes_unix.c
+++ b/otherlibs/unix/utimes_unix.c
@@ -22,8 +22,6 @@
 #include <caml/osdeps.h>
 #include "unixsupport.h"
 
-#if defined(HAS_UTIMES)
-
 #include <sys/types.h>
 #include <sys/time.h>
 
@@ -54,41 +52,3 @@ CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
   if (ret == -1) caml_uerror("utimes", path);
   CAMLreturn(Val_unit);
 }
-
-#elif defined(HAS_UTIME)
-
-#include <sys/types.h>
-#include <utime.h>
-
-CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
-{
-  CAMLparam3(path, atime, mtime);
-  struct utimbuf times, * t;
-  char * p;
-  int ret;
-  double at, mt;
-  caml_unix_check_path(path, "utimes");
-  at = Double_val(atime);
-  mt = Double_val(mtime);
-  if (at == 0.0 && mt == 0.0) {
-    t = NULL;
-  } else {
-    times.actime = at;
-    times.modtime = mt;
-    t = &times;
-  }
-  p = caml_stat_strdup(String_val(path));
-  caml_enter_blocking_section();
-  ret = utime(p, t);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
-  if (ret == -1) caml_uerror("utimes", path);
-  CAMLreturn(Val_unit);
-}
-
-#else
-
-CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
-{ caml_invalid_argument("utimes not implemented"); }
-
-#endif

--- a/otherlibs/unix/wait.c
+++ b/otherlibs/unix/wait.c
@@ -25,16 +25,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#if !(defined(WIFEXITED) && defined(WEXITSTATUS) && defined(WIFSTOPPED) && \
-      defined(WSTOPSIG) && defined(WTERMSIG))
-/* Assume old-style V7 status word */
-#define WIFEXITED(status) (((status) & 0xFF) == 0)
-#define WEXITSTATUS(status) (((status) >> 8) & 0xFF)
-#define WIFSTOPPED(status) (((status) & 0xFF) == 0xFF)
-#define WSTOPSIG(status) (((status) >> 8) & 0xFF)
-#define WTERMSIG(status) ((status) & 0x3F)
-#endif
-
 #define TAG_WEXITED 0
 #define TAG_WSIGNALED 1
 #define TAG_WSTOPPED 2
@@ -77,12 +67,6 @@ CAMLprim value caml_unix_wait(value unit)
   return alloc_process_status(pid, status);
 }
 
-#if defined(HAS_WAITPID) || defined(HAS_WAIT4)
-
-#ifndef HAS_WAITPID
-#define waitpid(pid,status,opts) wait4(pid,status,opts,NULL)
-#endif
-
 static int wait_flag_table[] = {
   WNOHANG, WUNTRACED
 };
@@ -98,10 +82,3 @@ CAMLprim value caml_unix_waitpid(value flags, value pid_req)
   if (pid == -1) caml_uerror("waitpid", Nothing);
   return alloc_process_status(pid, status);
 }
-
-#else
-
-CAMLprim value caml_unix_waitpid(value flags, value pid_req)
-{ caml_invalid_argument("waitpid not implemented"); }
-
-#endif

--- a/otherlibs/unix/write_unix.c
+++ b/otherlibs/unix/write_unix.c
@@ -20,13 +20,6 @@
 #include <caml/signals.h>
 #include "unixsupport.h"
 
-#ifndef EAGAIN
-#define EAGAIN (-1)
-#endif
-#ifndef EWOULDBLOCK
-#define EWOULDBLOCK (-1)
-#endif
-
 CAMLprim value caml_unix_write(value fd, value buf, value vofs, value vlen)
 {
   CAMLparam1(buf);

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -93,11 +93,6 @@
 /* Define HAS_SOCKETPAIR if you have the socketpair function. Only
    relevant on Windows. */
 
-#undef HAS_SOCKLEN_T
-
-/* Define HAS_SOCKLEN_T if the type socklen_t is defined in
-   /usr/include/sys/socket.h. */
-
 #undef HAS_AFUNIX_H
 
 /* Define HAS_AFUNIX_H if you have <afunix.h>. */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -161,9 +161,6 @@
 /* Define HAS_SYS_SELECT_H if /usr/include/sys/select.h exists
    and should be included before using select(). */
 
-#undef HAS_NANOSLEEP
-/* Define HAS_NANOSLEEP if you have nanosleep(). */
-
 #undef HAS_SYMLINK
 
 /* Define HAS_SYMLINK if you have symlink() and readlink() and lstat(). */
@@ -184,6 +181,7 @@
 #undef HAS_SETGROUPS
 
 /* Define HAS_SETGROUPS if you have setgroups(). */
+/* Define HAS_WAIT4 if you have wait4(). */
 
 #undef HAS_INITGROUPS
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -210,13 +210,6 @@
 
 /* Define HAS_STRTOD_L if you have strtod_l */
 
-#undef HAS_MMAP
-
-/* Define HAS_MMAP if you have the include file <sys/mman.h> and the
-   functions mmap() and munmap(). */
-
-#undef HAS_PWRITE
-
 #undef HAS_NANOSECOND_STAT
 
 #undef HAS_GETHOSTBYNAME_R

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -143,12 +143,6 @@
 #undef HAS_REALPATH
 /* Define HAS_REALPATH if you have realpath(). */
 
-#undef HAS_WAIT4
-#undef HAS_WAITPID
-
-/* Define HAS_WAIT4 if you have wait4().
-   Define HAS_WAITPID if you have waitpid(). */
-
 #undef HAS_GETGROUPS
 
 /* Define HAS_GETGROUPS if you have getgroups(). */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -136,10 +136,6 @@
 
 /* Define HAS_FCHMOD if you have fchmod() and fchown(). */
 
-#undef HAS_SYMLINK
-
-/* Define HAS_SYMLINK if you have symlink() and readlink() and lstat(). */
-
 #undef HAS_REALPATH
 /* Define HAS_REALPATH if you have realpath(). */
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -152,15 +152,6 @@
 /* Define HAS_TRUNCATE if you have truncate() and
    ftruncate(). */
 
-#undef HAS_SELECT
-
-/* Define HAS_SELECT if you have select(). */
-
-#undef HAS_SYS_SELECT_H
-
-/* Define HAS_SYS_SELECT_H if /usr/include/sys/select.h exists
-   and should be included before using select(). */
-
 #undef HAS_SYMLINK
 
 /* Define HAS_SYMLINK if you have symlink() and readlink() and lstat(). */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -176,14 +176,6 @@
 
 /* Define HAS_SETITIMER if you have setitimer(). */
 
-#undef HAS_GETHOSTNAME
-
-/* Define HAS_GETHOSTNAME if you have gethostname(). */
-
-#undef HAS_UNAME
-
-/* Define HAS_UNAME if you have uname(). */
-
 #undef HAS_GETTIMEOFDAY
 
 /* Define HAS_GETTIMEOFDAY if you have gettimeofday(). */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -120,10 +120,6 @@
 
 /* Define HAS_LOCKF if the library provides the lockf() function. */
 
-#undef HAS_MKFIFO
-
-/* Define HAS_MKFIFO if the library provides the mkfifo() function. */
-
 #undef HAS_GETCWD
 
 /* Define HAS_GETCWD if the library provides the getcwd() function. */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -231,8 +231,6 @@
 
 #undef HAS_EXECVPE
 
-#undef HAS_POSIX_SPAWN
-
 #undef HAS_FFS
 #undef HAS_BITSCANFORWARD
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -132,12 +132,6 @@
 
 /* Define HAS_SYSTEM if the library provides the system() function. */
 
-#undef HAS_UTIME
-#undef HAS_UTIMES
-
-/* Define HAS_UTIME if you have /usr/include/utime.h and the library
-   provides utime(). Define HAS_UTIMES if the library provides utimes(). */
-
 #undef HAS_FCHMOD
 
 /* Define HAS_FCHMOD if you have fchmod() and fchown(). */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -116,10 +116,6 @@
 
 /* Define HAS_REWINDDIR if you have rewinddir(). */
 
-#undef HAS_LOCKF
-
-/* Define HAS_LOCKF if the library provides the lockf() function. */
-
 #undef HAS_GETCWD
 
 /* Define HAS_GETCWD if the library provides the getcwd() function. */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -136,11 +136,6 @@
 
 /* Define HAS_FCHMOD if you have fchmod() and fchown(). */
 
-#undef HAS_TRUNCATE
-
-/* Define HAS_TRUNCATE if you have truncate() and
-   ftruncate(). */
-
 #undef HAS_SYMLINK
 
 /* Define HAS_SYMLINK if you have symlink() and readlink() and lstat(). */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -112,10 +112,6 @@
    Otherwise, we'll load /usr/include/sys/dir.h, and readdir() is expected to
    return a struct direct *. */
 
-#undef HAS_REWINDDIR
-
-/* Define HAS_REWINDDIR if you have rewinddir(). */
-
 #undef HAS_GETCWD
 
 /* Define HAS_GETCWD if the library provides the getcwd() function. */
@@ -124,50 +120,17 @@
 
 /* Define HAS_SYSTEM if the library provides the system() function. */
 
-#undef HAS_FCHMOD
-
-/* Define HAS_FCHMOD if you have fchmod() and fchown(). */
-
-#undef HAS_REALPATH
-/* Define HAS_REALPATH if you have realpath(). */
-
-#undef HAS_GETGROUPS
-
-/* Define HAS_GETGROUPS if you have getgroups(). */
-
 #undef HAS_SETGROUPS
 
 /* Define HAS_SETGROUPS if you have setgroups(). */
-/* Define HAS_WAIT4 if you have wait4(). */
 
 #undef HAS_INITGROUPS
 
 /* Define HAS_INITGROUPS if you have initgroups(). */
 
-#undef HAS_TERMIOS
-
-/* Define HAS_TERMIOS if you have /usr/include/termios.h and it is
-   Posix-compliant. */
-
-#undef HAS_SETITIMER
-
-/* Define HAS_SETITIMER if you have setitimer(). */
-
 #undef HAS_GETTIMEOFDAY
 
 /* Define HAS_GETTIMEOFDAY if you have gettimeofday(). */
-
-#undef HAS_MKTIME
-
-/* Define HAS_MKTIME if you have mktime(). */
-
-#undef HAS_SETSID
-
-/* Define HAS_SETSID if you have setsid(). */
-
-#undef HAS_PUTENV
-
-/* Define HAS_PUTENV if you have putenv(). */
 
 #undef HAS_SETENV_UNSETENV
 
@@ -204,10 +167,6 @@
    (7 is the Solaris version, 8 is the Linux version). */
 
 #undef HAS_MKSTEMP
-
-#undef HAS_NICE
-
-/* Define HAS_NICE if you have nice(). */
 
 #undef HAS_DUP3
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -102,10 +102,6 @@
 
 /* Define HAS_AFUNIX_H if you have <afunix.h>. */
 
-#undef HAS_INET_ATON
-
-#undef HAS_IPV6
-
 #undef HAS_STDINT_H
 
 #undef HAS_PTHREAD_NP_H


### PR DESCRIPTION
Continuing from https://github.com/ocaml/ocaml/pull/10397#issuecomment-877166823, a brief Sunday musing on the amount of code which we could drop by requiring Issue 7 for libunix. I've marked the PR as draft partly for discussion and partly because if we do adopt it, the `configure` checks are not yet correct. However, this does all pass precheck as it stands.

The Unix library builds with either:
- Issue 7 (1003.1-2008) with XSI, and the spawn, IPv6 and timers optional extensions (`_POSIX_VERSION >= 200809L`, `_XOPEN_VERSION >= 700` plus `_POSIX_IPV6` and `_POSIX_SPAWN`).
- Issue 6 (1003.1-2001) with XSI, and the spawn, IPv6, timers, synchronized IO and any of mapped files, shared memory objects or typed memory objects optional extensions (`_POSIX_VERSION >= 200112L`, `_XOPEN_VERSION >= 600` plus `_POSIX_IPV6`, `_POSIX_SPAWN`, `_POSIX_TIMERS`~, `_POSIX_SYNCHRONIZED_IO`~ and `_POSIX_MAPPED_FILES | _POSIX_SHARED_MEMORY_OBJECTS | _POSIX_TYPED_MEMORY_OBJECTS`)

We couldn't entirely go all-in on 1003-1.2008 because at least macOS and FreeBSD (or at least FreeBSD on the precheck workers) have everything needed, but only report 1003-1.2001.

The removal of emulation modes which are presumably not really being tested anywhere is quite tempting, as is the reduction in the number of tests needed in `configure` (POSIX clearly defines these feature probing macros, so it'd be nice, and quicker, to adopt them).

References: [Issue 6 (2004)](https://pubs.opengroup.org/onlinepubs/009695399/) and [Issue 7 (2008)](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/). I have checked the definition and conformance level of each macro/function check which has been removed, and I believe all the changes are correct.