### PR TITLE
Collapse applications from %apply primitives

### DIFF
--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -349,6 +349,8 @@ val lambda_unit: lambda
 val name_lambda: let_kind -> lambda -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda
 
+val collapse_apply : lambda_apply -> lambda
+
 val iter_head_constructor: (lambda -> unit) -> lambda -> unit
 (** [iter_head_constructor f lam] apply [f] to only the first level of
     sub expressions of [lam]. It does not recursively traverse the

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -682,22 +682,14 @@ and transl_apply ~scopes
       lam sargs loc
   =
   let lapply funct args =
-    match funct with
-      Lsend(k, lmet, lobj, largs, _) ->
-        Lsend(k, lmet, lobj, largs @ args, loc)
-    | Levent(Lsend(k, lmet, lobj, largs, _), _) ->
-        Lsend(k, lmet, lobj, largs @ args, loc)
-    | Lapply ap ->
-        Lapply {ap with ap_args = ap.ap_args @ args; ap_loc = loc}
-    | lexp ->
-        Lapply {
-          ap_loc=loc;
-          ap_func=lexp;
-          ap_args=args;
-          ap_tailcall=tailcall;
-          ap_inlined=inlined;
-          ap_specialised=specialised;
-        }
+    Lambda.collapse_apply {
+      ap_loc=loc;
+      ap_func=funct;
+      ap_args=args;
+      ap_tailcall=tailcall;
+      ap_inlined=inlined;
+      ap_specialised=specialised;
+    }
   in
   let rec build_apply lam args = function
       (None, optional) :: l ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -708,7 +708,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
   | Identity, [arg] -> arg
   | Apply, [func; arg]
   | Revapply, [arg; func] ->
-      Lapply {
+      Lambda.collapse_apply {
         ap_func = func;
         ap_args = [arg];
         ap_loc = loc;


### PR DESCRIPTION
Since #10379 applications resulting from the `( @@ )` and `( |> )` operators are not collapsed anymore. This wasn't intended, so I'm proposing to fix it.
Note that conversations around #10507 seem to show that the old behaviour is not necessarily the expected one, and I've added a comment that also describes why the old behaviour may not always be what we want (in the case of normal applications).
