### PR TITLE
Correctly configure Cygwin when flexdll missing

### DIFF
--- a/Changes
+++ b/Changes
@@ -784,6 +784,9 @@ OCaml 4.13.0
   with -dsource
   (Matt Else, review by Florian Angeletti)
 
+- #10511: Cygwin ports now correctly configure when flexdll is not available.
+  (David Allsopp, review by Florian Angeletti)
+
 - #10550, #10551: fix pretty-print of gadt-pattern-with-type-vars
   (Chet Murthy, review by Gabriel Scherer)
 

--- a/configure
+++ b/configure
@@ -14051,7 +14051,7 @@ fi
   *-*-cygwin*) :
     mksharedlib='$(FLEXLINK)'
       mkmaindll='$(FLEXLINK) -maindll'
-      shared_libraries_supported=true ;; #(
+      shared_libraries_supported=$with_sharedlibs ;; #(
   powerpc-ibm-aix*) :
     case $ocaml_cv_cc_vendor in #(
   xlc*) :
@@ -14093,7 +14093,7 @@ fi
 
 natdynlink=false
 
-if test x"$enable_shared" != "xno"; then :
+if test x"$shared_libraries_supported" = 'xtrue'; then :
   case "$host" in #(
   *-*-cygwin*) :
     natdynlink=true ;; #(
@@ -15860,7 +15860,7 @@ esac
 ## shared library support
 if $shared_libraries_supported; then :
   case $host in #(
-  *-*-mingw32|*-pc-windows) :
+  *-*-mingw32|*-pc-windows|*-*-cygwin*) :
     supports_shared_libraries=$shared_libraries_supported; DLLIBS="" ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"

--- a/configure.ac
+++ b/configure.ac
@@ -960,7 +960,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [*-*-cygwin*],
       [mksharedlib='$(FLEXLINK)'
       mkmaindll='$(FLEXLINK) -maindll'
-      shared_libraries_supported=true],
+      shared_libraries_supported=$with_sharedlibs],
     [powerpc-ibm-aix*],
       [AS_CASE([$ocaml_cv_cc_vendor],
                [xlc*],
@@ -991,7 +991,7 @@ AS_IF([test -z "$mkmaindll"], [mkmaindll=$mksharedlib])
 
 natdynlink=false
 
-AS_IF([test x"$enable_shared" != "xno"],
+AS_IF([test x"$shared_libraries_supported" = 'xtrue'],
   [AS_CASE(["$host"],
     [*-*-cygwin*], [natdynlink=true],
     [*-*-mingw32], [natdynlink=true],
@@ -1616,7 +1616,7 @@ AS_CASE([$host],
 ## shared library support
 AS_IF([$shared_libraries_supported],
   [AS_CASE([$host],
-    [*-*-mingw32|*-pc-windows],
+    [*-*-mingw32|*-pc-windows|*-*-cygwin*],
       [supports_shared_libraries=$shared_libraries_supported; DLLIBS=""],
     [AC_CHECK_FUNC([dlopen],
       [supports_shared_libraries=true DLLIBS=""],


### PR DESCRIPTION
Spotted while reviewing an old opam bug, I think this may have been wrong since the autoconf switch.

On the Cygwin ports, if the flexdll package isn't installed and you haven't enabled the submodule, `configure` should assume `--disable-shared`. At present, it doesn't and `configure` erroneously finds `dlopen` (Cygwin has it, but we can't use it) and so enables dynamic linking and then the build fails as `runtime/unix.c` will try to include `flexdll.h`.

Shared library support is enabled via a slightly convoluted story of `$with_sharedlibs` leading to `$shared_libraries_supported` finally to `$supports_shared_libraries` with a sprinkling of `$enable_shared` here and there. @shindere and I have known for a while that that needed straightening out - the fixes here are minimal, but I have a follow-up PR (for trunk) which straightens that out to have just `$enable_shared` (which is the autoconf parameter) and `$supports_shared_libraries` (which gets fed into the build system).