### PR TITLE
Override instance variables in class types

### DIFF
--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -1234,7 +1234,11 @@ class type c = object
   val x : float
 end;;
 [%%expect {|
-class type c = object val x : float end
+Line 3, characters 2-15:
+3 |   val x : float
+      ^^^^^^^^^^^^^
+Error: The instance variable x has type float but is expected to have type
+         int
 |}];;
 
 class type c = object
@@ -1242,7 +1246,10 @@ class type c = object
   val mutable x : int
 end;;
 [%%expect {|
-class type c = object val mutable x : int end
+Line 3, characters 2-21:
+3 |   val mutable x : int
+      ^^^^^^^^^^^^^^^^^^^
+Error: The instance variable is immutable; it cannot be redefined as mutable
 |}];;
 
 class type c = object
@@ -1250,7 +1257,10 @@ class type c = object
   val x : int
 end;;
 [%%expect {|
-class type c = object val x : int end
+Line 3, characters 2-13:
+3 |   val x : int
+      ^^^^^^^^^^^
+Error: The instance variable is mutable; it cannot be redefined as immutable
 |}];;
 
 class type virtual c = object
@@ -1274,7 +1284,11 @@ class type virtual c = object
   val virtual x : float
 end;;
 [%%expect {|
-class type c = object val x : float end
+Line 3, characters 2-23:
+3 |   val virtual x : float
+      ^^^^^^^^^^^^^^^^^^^^^
+Error: The instance variable x has type float but is expected to have type
+         int
 |}];;
 
 class c = object

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3441,7 +3441,7 @@ let check_mutability mut mut' =
   | Mutable, Immutable | Immutable, Mutable ->
       raise (Add_instance_variable_failed (Mutability_mismatch mut))
 
-let add_instance_variable ~strict env label mut virt ty sign =
+let add_instance_variable env label mut virt ty sign =
   let vars = sign.csig_vars in
   let virt =
     match Vars.find label vars with
@@ -3451,12 +3451,11 @@ let add_instance_variable ~strict env label mut virt ty sign =
           | Concrete -> Concrete
           | Virtual -> virt
         in
-        if strict then begin
-          check_mutability mut mut';
-          match unify env ty ty' with
-          | () -> ()
-          | exception Unify trace ->
-              raise (Add_instance_variable_failed (Type_mismatch trace))
+        check_mutability mut mut';
+        begin match unify env ty ty' with
+        | () -> ()
+        | exception Unify trace ->
+          raise (Add_instance_variable_failed (Type_mismatch trace))
         end;
         virt
     | exception Not_found -> virt
@@ -3487,7 +3486,7 @@ let unify_self_types env sign1 sign2 =
     end
 
 (* Unify components of sign2 into sign1 *)
-let inherit_class_signature ~strict env sign1 sign2 =
+let inherit_class_signature env sign1 sign2 =
   unify_self_types env sign1 sign2;
   Meths.iter
     (fun label (priv, virt, ty) ->
@@ -3506,7 +3505,7 @@ let inherit_class_signature ~strict env sign1 sign2 =
     sign2.csig_meths;
   Vars.iter
     (fun label (mut, virt, ty) ->
-       match add_instance_variable ~strict env label mut virt ty sign1 with
+       match add_instance_variable env label mut virt ty sign1 with
        | () -> ()
        | exception Add_instance_variable_failed failure ->
            let failure = Instance_variable(label, failure) in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -346,8 +346,8 @@ type add_instance_variable_failure =
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
-val add_instance_variable : strict:bool -> Env.t ->
-  label -> mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
+val add_instance_variable : Env.t -> label -> mutable_flag ->
+  virtual_flag -> type_expr -> class_signature -> unit
 
 type inherit_class_signature_failure =
   | Self_type_mismatch of Errortrace.unification_error
@@ -356,8 +356,8 @@ type inherit_class_signature_failure =
 
 exception Inherit_class_signature_failed of inherit_class_signature_failure
 
-val inherit_class_signature : strict:bool -> Env.t ->
-  class_signature -> class_signature -> unit
+val inherit_class_signature : Env.t -> class_signature ->
+  class_signature -> unit
 
 val update_class_signature :
   Env.t -> class_signature -> label list * label list


### PR DESCRIPTION
This is a change that was extracted from #8516. It was generally approved of, but it's a breaking change so people wanted to discuss it separately.

Previously, the behaviour of instance variables in class types was pretty strange. Given two declarations of the same variable, the second declaration would partially override and partially shadow the first declaration. I presume this is a hangover from the
change in instance variable behaviour in OCaml 3.10. This commit brings the behaviour into line with the behaviour in classes -- the second definition overrides the first. It is more restrictive than the previous behaviour, so it is not backwards compatible, but it
is much more consistent.