### PR TITLE
PDF manual: use microtype package, don't use ae package

### DIFF
--- a/manual/src/macros.hva
+++ b/manual/src/macros.hva
@@ -295,6 +295,7 @@
 
 %%% Missing macro
 \newcommand{\DeclareUnicodeCharacter}[2]{}
+\newcommand{\DisableLigatures}[1]{}
 
 \ifocamldoc
 \newcommand{\stddocitem}[2]{\libdocitem{#1}{#2}}

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -3,6 +3,7 @@
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
+\usepackage{microtype}
 % HEVEA\@def@charset{UTF-8}%
 % Unicode character declarations
 \DeclareUnicodeCharacter{207A}{{}^{+}}
@@ -27,6 +28,10 @@
 \usepackage{changepage}
 \fi
 \input{macros.tex}
+
+% No ligatures in typewriter font
+\DisableLigatures{encoding = T1, family = tt* }
+
 % Listing environments
 \lstnewenvironment{camloutput}{
   \lstset{

--- a/manual/src/manual.tex
+++ b/manual/src/manual.tex
@@ -1,5 +1,5 @@
 \documentclass[11pt]{book}
-\usepackage{ae}
+\usepackage{lmodern}% for T1 encoding and support of bold ttfamily
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
@@ -21,7 +21,6 @@
 % Package for code examples:
 \usepackage{listings}
 \usepackage{alltt}
-\usepackage{lmodern}% for supporting bold ttfamily in code examples
 \usepackage[normalem]{ulem}% for underlining errors in code examples
 \input{ifocamldoc}
 \ifocamldoc\else


### PR DESCRIPTION
The `microtype` package is used to turn ligatures off in typewriter font, fixing #10513.  It also promises  "subliminal refinements towards typographical perfection", which is too good to pass.

The `ae` package is shadowed by the `lmodern` package used later.
