### PR TITLE
Run the Polling pass earlier

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -139,7 +139,9 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   fd_cmm
   ++ Profile.record ~accumulate:true "cmm_invariants" (cmm_invariants ppf_dump)
   ++ Profile.record ~accumulate:true "selection"
-                                (Selection.fundecl ~future_funcnames:funcnames)
+                    (Selection.fundecl ~future_funcnames:funcnames)
+  ++ Profile.record ~accumulate:true "polling"
+                    (Polling.instrument_fundecl ~future_funcnames:funcnames)
   ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf_dump dump_combine "After allocation combining"
@@ -147,8 +149,6 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
   ++ pass_dump_if ppf_dump dump_cse "After CSE"
   ++ Profile.record ~accumulate:true "liveness" liveness
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
-  ++ Profile.record ~accumulate:true "polling"
-          (Polling.instrument_fundecl ~future_funcnames:funcnames)
   ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
   ++ Profile.record ~accumulate:true "spill" Spill.fundecl
   ++ Profile.record ~accumulate:true "liveness" liveness


### PR DESCRIPTION
Inserting poll point adds new control paths: a poll can raise an exception that is handled by a try...with in the same function.

As shown by #10520, this can invalidate optimizations performed before poll point insertion, such as dead code elimination.

This commit moves the Polling pass just after the Selection pass, before all optimization passes.

Fixes: #10520 . To be backported to 4.13.
