### PR TITLE
Buffer documenation tweaks

### DIFF
--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -17,7 +17,7 @@
 
    This module implements buffers that automatically expand
    as necessary.  It provides accumulative concatenation of strings
-   in quasi-linear time (instead of quadratic time when strings are
+   in linear time (instead of quadratic time when strings are
    concatenated pairwise). For example:
 
 {[


### PR DESCRIPTION
"byte buffers" instead of "buffers" quickly dispels any idea that we're talking about some kind of element type-generic buffers.

"linear time" was changed to "quasi-linear time" in a5eb7789. Apparently quasi-linear means O(n (log n)^k). I think k=0, so it's not necessary. If the total length of the strings is n then the appending itself will have a time cost of n. Additionally we will use at most n(2+1+1/2+1/4+...))= 4n time for reallocating the buffer when it's too small, as at the end it will be of size at most 2n and it always at least doubles in length.

"amortized linear time" also doesn't seem to make sense here.