### PR TITLE
toplevel: show "#help;; for help" in startup message

### DIFF
--- a/Changes
+++ b/Changes
@@ -117,6 +117,9 @@ Working version
 - #10565: Toplevel value printing: truncate strings only after 8 bytes.
   (Wiktor Kuchta, review by Xavier Leroy)
 
+- #10527: Show "#help;; for help" at toplevel startup
+  (Wiktor Kuchta, review by David Allsopp and Florian Angeletti)
+
 ### Debugging:
 
 - #10517, #10594: when running ocamldebug on a program linked with the

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -187,7 +187,7 @@ let loop ppf =
   Clflags.debug := true;
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
-    fprintf ppf "        OCaml version %s%s%s@.@."
+    fprintf ppf "OCaml version %s%s%s@.Enter #help;; for help.@.@."
       Config.version
       (if Topeval.implementation_label = "" then "" else " - ")
       Topeval.implementation_label;


### PR DESCRIPTION
When a user runs `ocaml` (the obvious thing to run after installing OCaml), they will see

    OCaml version 4.14.0
    Enter #help;; for help.

instead of

          OCaml version 4.14.0

`#help;;` will not only show other directives, but a first-time user might pick up that `;;` is used to terminate toplevel phrases in general.
