### PR TITLE
Fix private polymorphic variant inclusion

### DIFF
--- a/testsuite/tests/typing-modules/private.ml
+++ b/testsuite/tests/typing-modules/private.ml
@@ -1,0 +1,18 @@
+(* TEST
+  * expect
+ *)
+
+module M :
+     sig type t = private [< `A | `B of string] end
+= struct type t = [`A|`B of string] end;;
+[%%expect]
+
+module M = struct type header_item_tag =
+    [ `CO | `HD | `Other of string | `PG | `RG | `SQ ]
+end;;
+[%%expect]
+
+module M' : sig type header_item_tag =
+    private [< `CO | `HD | `Other of string | `PG | `RG | `SQ ]
+end = M;;
+[%%expect]

--- a/testsuite/tests/typing-modules/private.ml
+++ b/testsuite/tests/typing-modules/private.ml
@@ -5,14 +5,27 @@
 module M :
      sig type t = private [< `A | `B of string] end
 = struct type t = [`A|`B of string] end;;
-[%%expect]
+[%%expect{|
+module M : sig type t = private [< `A | `B of string ] end
+|}]
 
 module M = struct type header_item_tag =
     [ `CO | `HD | `Other of string | `PG | `RG | `SQ ]
 end;;
-[%%expect]
+[%%expect{|
+module M :
+  sig
+    type header_item_tag = [ `CO | `HD | `Other of string | `PG | `RG | `SQ ]
+  end
+|}]
 
 module M' : sig type header_item_tag =
     private [< `CO | `HD | `Other of string | `PG | `RG | `SQ ]
 end = M;;
-[%%expect]
+[%%expect{|
+module M' :
+  sig
+    type header_item_tag = private
+        [< `CO | `HD | `Other of string | `PG | `RG | `SQ ]
+  end
+|}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -474,8 +474,8 @@ let private_variant env row1 params1 row2 params2 =
               | Some _, None | None, Some _ ->
                   Some (Incompatible_types_for s)
             end
-          | Rpresent to1, Reither(const2, tl2, _, _) -> begin
-              match to1, const2, tl2 with
+          | Rpresent to1, Reither(const2, tl2', _, _) -> begin
+              match to1, const2, tl2' with
               | Some t1, false, [t2] -> loop (t1 :: tl1) (t2 :: tl2) pairs
               | None, true, [] -> loop tl1 tl2 pairs
               | _, _, _ -> Some (Incompatible_types_for s)

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -474,8 +474,8 @@ let private_variant env row1 params1 row2 params2 =
               | Some _, None | None, Some _ ->
                   Some (Incompatible_types_for s)
             end
-          | Rpresent to1, Reither(const2, tl2', _, _) -> begin
-              match to1, const2, tl2' with
+          | Rpresent to1, Reither(const2, ts2, _, _) -> begin
+              match to1, const2, ts2 with
               | Some t1, false, [t2] -> loop (t1 :: tl1) (t2 :: tl2) pairs
               | None, true, [] -> loop tl1 tl2 pairs
               | _, _, _ -> Some (Incompatible_types_for s)


### PR DESCRIPTION
A bug in polymorphic variant inclusion was breaking biocaml.
This fixes the name shadowing that caused the bug.

The bug was introduced by the refactoring in e87be3919.