### PR TITLE
OCaml manual: change the argument of functor BNF into Kleene plus form in the doc

### DIFF
--- a/manual/src/refman/modtypes.etex
+++ b/manual/src/refman/modtypes.etex
@@ -262,6 +262,17 @@ No restrictions are placed on the type of the functor argument; in
 particular, a functor may take another functor as argument
 (``higher-order'' functor).
 
+When the result module type is itself a functor,
+\begin{center}
+@'functor' '(' name_1 ':' module-type_1 ')' '->' \ldots '->'
+ 'functor' '(' name_n ':' module-type_n ')' '->' module-type@
+\end{center}
+one may use the abbreviated form
+\begin{center}
+@'functor' '(' name_1 ':' module-type_1 ')' \ldots
+           '(' name_n ':' module-type_n ')' '->' module-type@
+\end{center}
+
 \subsection{ss:mty-with}{The "with" operator}
 
 \ikwd{with\@\texttt{with}}

--- a/manual/src/refman/modules.etex
+++ b/manual/src/refman/modules.etex
@@ -228,6 +228,17 @@ resulting modules as results. No restrictions are placed on the type of the
 functor argument; in particular, a functor may take another functor as
 argument (``higher-order'' functor).
 
+When the result module expression is itself a functor,
+\begin{center}
+@'functor' '(' name_1 ':' module-type_1 ')' '->' \ldots '->'
+ 'functor' '(' name_n ':' module-type_n ')' '->' module-expr@
+\end{center}
+one may use the abbreviated form
+\begin{center}
+@'functor' '(' name_1 ':' module-type_1 ')' \ldots
+           '(' name_n ':' module-type_n ')' '->' module-expr@
+\end{center}
+
 \subsubsection*{sss:mexpr-functor-app}{Functor application}
 
 The expression @module-expr_1 '(' module-expr_2 ')'@ evaluates


### PR DESCRIPTION
The expression such as "module X = functor (A:S) (B:T) → struct…end" is supported by OCaml, but in the language reference doc it seems that only one argument is accepted by functor.  This PR just intends to change " functor ( module-name : module-type ) -> module-expr " to " functor **{**( module-name : module-type )**}<sup>+</sup>** -> module-expr" in the doc.