### PR TITLE
webman: Remove chapter number on subsubsection correctly

### DIFF
--- a/manual/src/html_processing/src/process_manual.ml
+++ b/manual/src/html_processing/src/process_manual.ml
@@ -136,7 +136,7 @@ let load_html file =
                  (regexp (">[0-9]+\\.\\([0-9]+\\)" ^ preg_anyspace)))
       {|><span class="number">\1</span>|}
     |> Re.Str.(global_replace
-                 (regexp ("[0-9]+\\.\\([0-9]+\\.[0-9]+\\)" ^ preg_anyspace)))
+                 (regexp ("[0-9]+\\.\\([0-9]+\\(\\.[0-9]+\\)+\\)" ^ preg_anyspace)))
       {|<span class="number">\1</span>|}
 
     (* The API (libref and compilerlibref directories) should be separate


### PR DESCRIPTION
I noticed that the webman of OCaml 4.12, which is introduced by <https://github.com/ocaml/ocaml/pull/9755>, accidentally removes the subsection number instead of the chapter number if subsubsection is used. For example, the original string `15.2.4.1` is converted to `15.4.1`, not `2.4.1`: https://ocaml.org/releases/4.12/htmlman/ocamldoc.html#sss:ocamldoc-list

This is because a regexp which is used by the removal matches the space symbols `preg_anyspace` after the string but the regexp does not expect subsubsection. So I fixed the regexp to match any sub(sub)+sections.

Currently only `ocamldoc.etex` uses subsubsection. And I confirmed that this change only affects `ocamldoc.html`: <https://gist.github.com/nekketsuuu/6d4f7e08d161e51e8b2caf33355a81a6>.