### PR TITLE
Add doc for ocamldoc's cross-ref with text

### DIFF
--- a/manual/src/cmds/ocamldoc.etex
+++ b/manual/src/cmds/ocamldoc.etex
@@ -779,6 +779,7 @@ inline-text: {{inline-text-element}}
         in \ref{sss:ocamldoc-target-specific-syntax}) \\
 @||@&@ '{!' string '}' @ & insert a cross-reference to an element
         (see section \ref{sss:ocamldoc-crossref} for the syntax of cross-references).\\
+@||@&@ '{{!' string '}' inline-text '}' @ & put a cross-reference on the given text. \\
 @||@&@ '{!modules:' string string ... '}' @ & insert an index table
 for the given module names. Used in HTML only.\\
 @||@&@ '{!indexlist}' @ & insert a table of links to the various indexes

--- a/manual/src/cmds/ocamldoc.etex
+++ b/manual/src/cmds/ocamldoc.etex
@@ -779,7 +779,7 @@ inline-text: {{inline-text-element}}
         in \ref{sss:ocamldoc-target-specific-syntax}) \\
 @||@&@ '{!' string '}' @ & insert a cross-reference to an element
         (see section \ref{sss:ocamldoc-crossref} for the syntax of cross-references).\\
-@||@&@ '{{!' string '}' inline-text '}' @ & put a cross-reference on the given text. \\
+@||@&@ '{{!' string '}' inline-text '}' @ & insert a cross-reference with the given text. \\
 @||@&@ '{!modules:' string string ... '}' @ & insert an index table
 for the given module names. Used in HTML only.\\
 @||@&@ '{!indexlist}' @ & insert a table of links to the various indexes


### PR DESCRIPTION
The command ocamldoc can shows a text with a cross-reference to an element, which is implemented by this commit e904577b6b0e68911c9169eb7c1629f6f3b9534c in 2009. I noticed that this feature is not mentioned in our manual, so I added it.

Even though ocamldoc is in maintenance mode, this syntax guide is referenced by [odoc's README.md](https://github.com/ocaml/odoc/blob/244b5317d05eaa2815f8f5bd0fbc23e9caafd129/README.md) for now and odoc also [supports this syntax](https://github.com/ocaml-doc/odoc-parser/blob/c5ce41b1e1841a2005bb3c4ca3bf1f77876d509d/src/syntax.ml#L137-L157). Therefore, I think this modification will be helpful both for ocamldoc users and for odoc users.