### PR TITLE
minor fix: mkdir before copying CSS for webman

### DIFF
--- a/manual/src/html_processing/Makefile
+++ b/manual/src/html_processing/Makefile
@@ -26,7 +26,7 @@ $(WEBDIR)/%:
 $(WEBDIRMAN)/manual.css: scss/_common.scss scss/manual.scss | $(WEBDIRMAN)
 	sass scss/manual.scss > $(WEBDIRMAN)/manual.css
 
-$(WEBDIRAPI)/style.css: scss/_common.scss scss/style.scss | $(WEBDIRAPI)
+$(WEBDIRAPI)/style.css: scss/_common.scss scss/style.scss | $(WEBDIRAPI) $(WEBDIRCOMP)
 	sass scss/style.scss > $(WEBDIRAPI)/style.css
 	cp $(WEBDIRAPI)/style.css $(WEBDIRCOMP)/style.css
 


### PR DESCRIPTION
This patch fixes a small error when doing a clean build of webman. Currently `make web` on `manual` folder raises an no-directory error for `webman/api/compilerlibref`. Therefore I changed Makefile to create that directory beforehand.

## Reproducible Steps

The followings are reproducible steps on my environment for the error and error messages of the error.

```console
$ pwd
/mnt/c/Users/nek/dev/src/github.com/ocaml/ocaml
$ cd manual
$ make clean
$ make web

(some logs are omitted...)

make -C html_processing all
make[2]: Entering directory '/mnt/c/Users/nek/dev/src/github.com/ocaml/ocaml/manual/src/html_processing'
mkdir -p ../webman/manual
sass scss/manual.scss > ../webman/manual/manual.css
mkdir -p ../webman/api
sass scss/style.scss > ../webman/api/style.css
cp ../webman/api/style.css ../webman/api/compilerlibref/style.css
cp: cannot create regular file '../webman/api/compilerlibref/style.css': No such file or directory
make[2]: *** [Makefile:31: ../webman/api/style.css] Error 1
make[2]: Leaving directory '/mnt/c/Users/nek/dev/src/github.com/ocaml/ocaml/manual/src/html_processing'
make[1]: *** [Makefile:110: web] Error 2
make[1]: Leaving directory '/mnt/c/Users/nek/dev/src/github.com/ocaml/ocaml/manual/src'
make: *** [Makefile:22: web] Error 2
```

Environment: 50deeb2d87262a7d4f68675816119a89f2910914, GNU Make 4.2.1, Ubuntu 20.04 on WSL2 on Windows 10
