### PR TITLE
Fix mapping of intervals in Ast_mapper

### DIFF
--- a/Changes
+++ b/Changes
@@ -543,6 +543,10 @@ OCaml 4.13.0
 - #10307: Make build_other_constrs work with names instead of tags.
   (Nicolas Chataing, review by Florian Angeletti)
 
+- #10543: Fix Ast_mapper to apply the mapping function to the constants in
+  "interval" patterns `c1..c2`.
+  (Guillaume Petiot, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 ### Build system:
 
 - #10289, #10406: Do not print option documentation in usage messages.

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -486,7 +486,8 @@ module P = struct
     | Ppat_var s -> var ~loc ~attrs (map_loc sub s)
     | Ppat_alias (p, s) -> alias ~loc ~attrs (sub.pat sub p) (map_loc sub s)
     | Ppat_constant c -> constant ~loc ~attrs (sub.constant sub c)
-    | Ppat_interval (c1, c2) -> interval ~loc ~attrs c1 c2
+    | Ppat_interval (c1, c2) ->
+        interval ~loc ~attrs (sub.constant sub c1) (sub.constant sub c2)
     | Ppat_tuple pl -> tuple ~loc ~attrs (List.map (sub.pat sub) pl)
     | Ppat_construct (l, p) ->
         construct ~loc ~attrs (map_loc sub l)


### PR DESCRIPTION
The mapping function should be called on interval's constants (found while working on another PR that adds a location field to constants, on ocamlformat's forked parser). I don't think it's worth adding an entry in the changelog.