### PR TITLE
fix pretty-print of gadt-pattern-with-type-vars (issue #10550)

### DIFF
--- a/Changes
+++ b/Changes
@@ -107,6 +107,8 @@ Working version
 - #10542: Fix detection of immediate64 types through unboxed types.
   (Leo White, review by Stephen Dolan and Gabriel Scherer)
 
+- #10550: fix pretty-print of gadt-pattern-with-type-vars (Chet Murthy)
+
 OCaml 4.13.0
 -------------
 

--- a/Changes
+++ b/Changes
@@ -107,8 +107,6 @@ Working version
 - #10542: Fix detection of immediate64 types through unboxed types.
   (Leo White, review by Stephen Dolan and Gabriel Scherer)
 
-- #10550: fix pretty-print of gadt-pattern-with-type-vars (Chet Murthy)
-
 OCaml 4.13.0
 -------------
 
@@ -702,6 +700,9 @@ OCaml 4.13.0
 - #10468: Correctly pretty print local type substitution, e.g. type t := ...,
   with -dsource
   (Matt Else, review by Florian Angeletti)
+
+- #10550, #10551: fix pretty-print of gadt-pattern-with-type-vars
+  (Chet Murthy, review by Gabriel Scherer)
 
 OCaml 4.12, maintenance version
 -------------------------------

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -95,6 +95,8 @@ let needs_parens txt =
 let needs_spaces txt =
   first_is '*' txt || last_is '*' txt
 
+let string_loc ppf x = fprintf ppf "%s" x.txt
+
 (* add parentheses to binders when they are in fact infix or prefix operators *)
 let protect_ident ppf txt =
   let format : (_, _, _) format =
@@ -446,7 +448,7 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
                pp f "%a@;%a"  longident_loc li (simple_pattern ctxt) x
            | Some (vl, x) ->
                pp f "%a@ (type %a)@;%a" longident_loc li
-                 (list ~sep:"@ " tyvar_loc) vl
+                 (list ~sep:"@ " string_loc) vl
                  (simple_pattern ctxt) x
            | None -> pp f "%a" longident_loc li)
     | _ -> simple_pattern ctxt f x

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7441,3 +7441,5 @@ f object method f = 1 end
 let g y =
   let f ~y = y + 1 in
   f ~(y:int)
+
+let goober a = match a with C (type a b) y -> y


### PR DESCRIPTION
This fixes the pretty-printing issue #10550 (issue text below for reference).

Ocaml version: OCaml 4.13.0~alpha2
OS Version: Ubuntu 20.04.2 LTS
Arch: amd64

Synopsis: I construct a little program snippet to exercise the new syntax for binding type-vars in a GADT match.  Pprintast produces bad output which is not parseable.  I'll look into the cause and hopefully soon attach a PR, but I figured it's probably -really- simple, so somebody who's shooting these things might be able to shoot it much faster than I could.

```
#require "compiler-libs.common" ;;
let s = "match x with C (type a b) x -> x" in
let lb = Lexing.from_string s in
lb |> Parse.implementation |> Pprintast.string_of_structure |> print_string
;;
```
produces output
```
;;match x with | C (type 'a 'b) x -> x- : unit = ()
# 
```
Notice that the type-vars are now polymorphic vars.  This text is not parseable.

I'll look into it soon, once I get Camlp5 upgraded to work with 4.13.0.

P.S. obviously I'm using `findlib`, but otherwise, no other special libraries: I made sure to test in a fresh toplevel with only findlib loaded.